### PR TITLE
Add benchmarks for aperture photometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 
 # Other generated files
 */version.py
+benchmarks/_results
 
 # Sphinx
 _build

--- a/benchmarks/bench_aperture.py
+++ b/benchmarks/bench_aperture.py
@@ -1,22 +1,51 @@
 """Run benchmarks for aperture photometry functions."""
 
 import time
+import os
+import glob
 import argparse
+from collections import OrderedDict
 import numpy as np
 import photutils
-from collections import OrderedDict
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("-l", "--label", dest="label", default=None, 
                     help="Save results to a pickle with this label, so that"
-                    "they can be displayed later")
+                    "they can be displayed later. Pickles are save in a "
+                    "'_results' directory in the same parent directory as "
+                    "this script.")
 parser.add_argument("-s", "--show", dest="show", action="store_true",
                     default=False, help="Show all results from previously "
-                    "labeled runs.")
+                    "labeled runs")
+parser.add_argument("-d", "--delete", dest="delete_label", default=None,
+                    help="Delete saved results with the given label "
+                    "(or 'all' to delete all results). Do not run any "
+                    "benchmarks.")
 args = parser.parse_args()
 
 if args.show and args.label:
     parser.error("--label doesn't do anything when --show is specified.")
+if args.delete_label and (args.label or args.show):
+    parser.error("--label and --show do not do anything when --delete is "
+                 "specified.")
+
+resultsdir = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                          '_results', 'aperture'))
+piknames = glob.glob(os.path.join(resultsdir, '*.pik'))
+
+# Delete saved results, if requested.
+if args.delete_label is not None:
+    if args.delete_label.lower() == 'all':
+        for pikname in piknames:
+            os.remove(pikname)
+    else:
+        try:
+            os.remove(os.path.join(resultsdir,
+                                   '{0}.pik'.format(args.delete_label)))
+        except OSError:
+            raise ValueError('No such label exists: {0}'
+                             .format(args.delete_label))
+    exit()
 
 c = OrderedDict()
 
@@ -155,25 +184,20 @@ if not args.show:
 
     # If a label was specified, save results to a pickle.
     if args.label is not None:
-        import os
         import pickle
-
-        pikname = '_results/aperture/{0}.pik'.format(args.label)
-        if not os.path.exists('_results/aperture'):
-            os.makedirs('_results/aperture')
+        pikname = os.path.join(resultsdir, '{0}.pik'.format(args.label))
+        if not os.path.exists(resultsdir):
+            os.makedirs(resultsdir)
         outfile = open(pikname, 'w')
         pickle.dump(results, outfile)
         outfile.close()
 
 if args.show:
-
-    import glob
-    import os.path
     import pickle
 
     # Load pickled results
     results = OrderedDict()
-    piknames = glob.glob('_results/aperture/*.pik')
+    piknames = glob.glob(os.path.join(resultsdir, '*.pik'))
     for pikname in piknames:
         label = os.path.basename(pikname)[:-4]
         infile = open(pikname, 'r')


### PR DESCRIPTION
This is something that I've been using to more easily compare benchmark results between different git branches. It incorporates @astrofrog's benchmarks gist into a script that can save results to disk under a label, to be recalled later. I've found it useful to have on hand and we might want to include it in the repo.
