### PR TITLE
Revised algorithm to no longer be affected by floating point precision

### DIFF
--- a/photutils/elliptical_exact.pyx
+++ b/photutils/elliptical_exact.pyx
@@ -67,6 +67,7 @@ def circle_line(double x1, double y1, double x2, double y2):
     '''Intersection of a line defined by two points with a unit circle'''
 
     cdef double a, b, delta, dx, dy
+    cdef double xi1, yi1, xi2, yi2
 
     dx = x2 - x1
     dy = y2 - y1


### PR DESCRIPTION
Given the floating point issues in #15 and #16, I tried to revise how the algorithm works for exact elliptical aperture photometry, in order to no longer be affected so much by floating point accuracy (e.g. 1e-17 vs 0, etc.). Let's see if this passes on Travis.
