### PR TITLE
Update .travis.yml to use wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,48 +5,105 @@ python:
     - 2.7
     - 3.2
     - 3.3
-
+    # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
-    # try all python versions with the latest stable numpy and astropy
-    - ASTROPY_VERSION=stable NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+    global:
+        - PIP_WHEEL_COMMAND="pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel --use-mirrors"
+    matrix:
+        - SETUP_CMD='egg_info' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
 
 matrix:
     include:
-        - python: 2.7
-          # opdeps needed because the matplotlib sphinx extension requires them
-          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='build_sphinx -w -n'
 
-        # try alternate numpy versions with the latest stable astropy
+        # Do a coverage test in Python 2
         - python: 2.7
-          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.8.0 SETUP_CMD='test --coverage' OPTIONAL_DEPS=true
+
+        # Check for sphinx doc build warnings - we do this first because it
+        # runs for a long time
         - python: 2.7
-          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.5.1 SETUP_CMD='test'
+          env: SETUP_CMD='build_sphinx -w -n' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=true
+          # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
+
+        # Try all python versions with the latest numpy
+        - python: 2.6
+          env: SETUP_CMD='test --parallel=8' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
+        - python: 2.7
+          env: SETUP_CMD='test --parallel=8' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
+        # There is a bug in pytest-xdist that prevents it from working
+        # on Python 3.x.  See:
+        # https://bitbucket.org/hpk42/pytest/issue/301/internal-error-during-test-collecting
         - python: 3.2
-          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
-        # numpy < 1.6 does not work on py 3.x
-
-        # try latest developer version of astropy
-        - python: 2.7
-          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+          env: SETUP_CMD='test' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
         - python: 3.3
-          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+          env: SETUP_CMD='test' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=false
+
+        # Now try do scipy on 2.7 and an appropriate 3.x build (with latest numpy)
+        - python: 2.7
+          env: SETUP_CMD='test --parallel=8' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
+        - python: 3.2
+          env: SETUP_CMD='test' NUMPY_VERSION=1.8.0 OPTIONAL_DEPS=true LC_CTYPE=C.ascii
+
+        # Try alternate numpy versions
+        #- python: 3.2
+        #  env: NUMPY_VERSION=1.6.2 SETUP_CMD='test --parallel=8' OPTIONAL_DEPS=false
+        #- python: 2.7
+        #  env: NUMPY_VERSION=1.5.1 SETUP_CMD='test --parallel=8' OPTIONAL_DEPS=false
 
 before_install:
-   # We do this to make sure we get the dependencies so pip works below
-   - sudo apt-get update -qq
-   - sudo apt-get install -qq python-numpy python-sphinx cython libatlas-dev liblapack-dev gfortran
-   - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install -qq python-sphinx graphviz texlive-latex-extra dvipng python-matplotlib; fi
+
+    # Use utf8 encoding. Should be default, but this is insurance against
+    # future changes
+    - export PYTHONIOENCODING=UTF8
+
+    # Install the pip that supports wheel
+    - pip install setuptools --upgrade
+    - pip install pip --upgrade
+    - pip install wheel
+
+    # We do this to make sure we get dependencies so pip works below
+    # Note that travis does *not* use python packages installed via apt - it
+    # does all the building in an isolated virtualenv
+    - sudo apt-get update
+
+    # CORE DEPENDENCIES
+    - sudo apt-get install python-numpy cython libatlas-dev liblapack-dev gfortran
+
+    # OPTIONAL DEPENDENCIES
+    - if $OPTIONAL_DEPS; then sudo apt-get install python-scipy; fi
+
+    # DOCUMENTATION DEPENDENCIES
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install python-sphinx graphviz texlive-latex-extra dvipng python-matplotlib python-scipy; fi
+
 
 install:
-   - export PYTHONIOENCODING=UTF8 # just in case
-   - pip -q install --upgrade "numpy==$NUMPY_VERSION" --use-mirrors
-   - pip -q install --upgrade Cython --use-mirrors
-   - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install sphinx==1.1.3 --use-mirrors; fi
-   - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install matplotlib --use-mirrors; fi
 
-   - if [[ $ASTROPY_VERSION == stable ]]; then pip -q install astropy --use-mirrors; fi
-   - if [[ $ASTROPY_VERSION == development ]]; then pip -q install git+http://github.com/astropy/astropy.git#egg=astropy --use-mirrors; fi
+    # CORE DEPENDENCIES
+    # These command run pip first trying a wheel, and then falling back on
+    # source build
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND --upgrade "numpy==$NUMPY_VERSION"; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "Cython==0.20.1"; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "pytest==2.5.1"; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "pytest-xdist==1.10"; fi
+    - $PIP_WHEEL_COMMAND "astropy"
+
+    # OPTIONAL DEPENDENCIES
+    - if $OPTIONAL_DEPS; then $PIP_WHEEL_COMMAND "scipy==0.13.3"; fi
+    - if $OPTIONAL_DEPS; then $PIP_WHEEL_COMMAND "scikit-image==0.9.3"; fi
+
+    # DOCUMENTATION DEPENDENCIES
+    # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
+    # this matplotlib will *not* work with py 3.x, but our sphinx build is
+    # currently 2.7, so that's fine
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_WHEEL_COMMAND "Sphinx==1.2.1"; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_WHEEL_COMMAND "matplotlib==1.3.0"; fi
+
+    # COVERAGE DEPENDENCIES
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_WHEEL_COMMAND "pytest-cov" ; fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_WHEEL_COMMAND "coveralls"; fi
 
 script:
-   - python setup.py $SETUP_CMD
+    - python setup.py $SETUP_CMD
 
+after_success:
+  - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls; fi


### PR DESCRIPTION
This PR updates the travis-ci tests to use wheels.

It should also run a test with numpy 1.8 and thus reveal issue #29.
