### PR TITLE
Test failure in PSF/PRF photometry with latest Numpy

### DIFF
--- a/photutils/arrayutils.py
+++ b/photutils/arrayutils.py
@@ -2,9 +2,11 @@
 """
 This module includes helper functions for array operations.
 """
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 import numpy as np
 
-__all__ = ['extract_array_2D', 'add_array_2D', 'subpixel_indices']
+__all__ = ['extract_array_2d', 'add_array_2d', 'subpixel_indices', 'fix_prf_nan']
 
 
 def _get_slices(large_array_shape, small_array_shape, position):
@@ -73,12 +75,11 @@ def extract_array_2d(array_large, shape, position):
     We consider a large array of zeros with the shape 21x21 and a small
     array of ones with a shape of 9x9:
 
-        >>> import numpy as np
-        >>> from photutils.arrayutils import extract_array_2D
-        >>> large_array = np.zeros((21, 21))
-        >>> large_array[6:14, 6:14] = np.ones((9, 9))
-        >>> extract_array_2D(large_array, (9, 9), (10, 10))
-    
+    >>> import numpy as np
+    >>> from photutils.arrayutils import extract_array_2d
+    >>> large_array = np.zeros((21, 21))
+    >>> large_array[6:14, 6:14] = np.ones((9, 9))
+    >>> extract_array_2d(large_array, (9, 9), (10, 10))
     """
     # Check if larger array is really larger
     if array_large.shape >= shape:
@@ -107,12 +108,11 @@ def add_array_2d(array_large, array_small, position):
     We consider a large array of zeros with the shape 21x21 and a small
     array of ones with a shape of 9x9:
 
-        >>> import numpy as np
-        >>> from photutils.arrayutils import add_array_2D
-        >>> large_array = np.zeros((21, 21))
-        >>> small_array = np.ones((9, 9))
-        >>> add_array_2D(large_array, small_array, (10, 10))
-    
+    >>> import numpy as np
+    >>> from photutils.arrayutils import add_array_2d
+    >>> large_array = np.zeros((21, 21))
+    >>> small_array = np.ones((9, 9))
+    >>> add_array_2d(large_array, small_array, (10, 10))
     """
     # Check if larger array is really larger
     if array_large.shape >= array_small.shape:

--- a/photutils/psf.py
+++ b/photutils/psf.py
@@ -9,9 +9,9 @@ from astropy.modeling import fitting
 from astropy.modeling.parameters import Parameter
 
 try:
-    from astropy.modeling.core import Fittable2DModel
+    from astropy.modeling import Fittable2DModel
 except ImportError:
-    from astropy.modeling.core import Parametric2DModel as  Fittable2DModel
+    from astropy.modeling import Parametric2DModel as Fittable2DModel
     
     
 from .arrayutils import (extract_array_2d, subpixel_indices,

--- a/photutils/tests/test_psf_photometry.py
+++ b/photutils/tests/test_psf_photometry.py
@@ -8,7 +8,7 @@ from astropy.tests.helper import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.convolution.utils import discretize_model
 
-from photutils.psf import create_prf, DiscretePRF, psf_photometry, GaussianPSF
+from ..psf import create_prf, DiscretePRF, psf_photometry, GaussianPSF
 
 try:
     from scipy import optimize
@@ -19,7 +19,7 @@ except ImportError:
 
 psf_size = 11
 gaussian_width = 1.
-image_size = 101.
+image_size = 101
 
 # Position and fluxes of tes sources
 positions = [(50, 50), (23, 83), (12, 80), (86, 84)]


### PR DESCRIPTION
```
_________________________ ERROR collecting photutils/tests/test_psf_photometry.py __________________________
photutils/tests/test_psf_photometry.py:34: in <module>
>   image = np.zeros((image_size, image_size))
E   DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
```

This is with the latest Numpy dev version.
