### PR TITLE
Additions to docs/rtd-pip-requirements for readthedocs

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,3 +1,6 @@
 numpy
+scipy
+matplotlib
 Cython
+scikit-image
 -e git+http://github.com/astropy/astropy.git#egg=astropy


### PR DESCRIPTION
After merging #44 there's now this error on readthedocs:

```
/var/build/user_builds/photutils/envs/latest/src/astropy/astropy/sphinx/conf.py:156: UserWarning: matplotlib's plot_directive could not be imported. Inline plots will not be included in the output
  "Inline plots will not be included in the output")
WARNING: ConfigurationDefaultMissingWarning: Could not determine version of package photutils Cannot install default profile. If you are importing from source, this is expected. [photutils._astropy_init]
/var/build/user_builds/photutils/checkouts/latest/docs/photutils/findstars.rst:59: ERROR: Unknown directive type "plot".
```

See full log here: https://readthedocs.org/builds/photutils/1390241/
And the image [here](http://photutils.readthedocs.org/en/latest/photutils/findstars.html) doesn't appear.

I think all that's missing is adding `matplotlib` to the `docs/rtd-pip-requirements` file, so I'll try that now and also add `scipy` and `scikit-image` because the example plotting code runs `daofind` and will need those.

cc @larrybradley 
