### PR TITLE
Mark tests that require scikit-image

### DIFF
--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -4,13 +4,14 @@ from __future__ import (absolute_import, division, print_function,
 from astropy.tests.helper import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
-import itertools
 from ..core import detect_sources, find_peaks
+
 try:
     import scipy
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
+
 try:
     import skimage
     HAS_SKIMAGE = True
@@ -62,12 +63,12 @@ class TestDetectSources(object):
     def test_npix1_error(self):
         """Test if AssertionError raises if npixel is non-integer."""
         with pytest.raises(AssertionError):
-            segm = detect_sources(DATA, 1, 0.1)
+            detect_sources(DATA, 1, 0.1)
 
     def test_npix2_error(self):
         """Test if AssertionError raises if npixel is negative."""
         with pytest.raises(AssertionError):
-            segm = detect_sources(DATA, 1, -1)
+            detect_sources(DATA, 1, -1)
 
     def test_mask_val(self):
         """Test detection with mask_val."""
@@ -94,6 +95,7 @@ class TestDetectSources(object):
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif('not HAS_SKIMAGE')
 class TestFindPeaks(object):
     def test_find_peaks(self):
         """Test basic peak detection."""

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -8,11 +8,19 @@ import numpy as np
 from astropy.table import Table
 from numpy.testing import assert_allclose
 from ..findstars import daofind, irafstarfind
+
 try:
     import scipy
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
+
+try:
+    import skimage
+    HAS_SKIMAGE = True
+except ImportError:
+    HAS_SKIMAGE = False
+
 
 VALS1 = [0.5, 1.0, 2.0, 5.0, 10.0]
 VALS2 = [1.3, 1.5, 2.0, 5.0, 10.0]
@@ -176,10 +184,11 @@ class TestDAOFind(SetupData):
                         np.array(t).view(np.float))
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif('not HAS_SKIMAGE')
 class TestIRAFStarFind(SetupData):
     @pytest.mark.parametrize(('fwhm', 'sigma_radius'),
                              list(itertools.product(VALS1, VALS2)))
-    @pytest.mark.skipif('not HAS_SCIPY')
     def test_isf_ellrotobj(self, fwhm, sigma_radius):
         self._setup()
         threshold = 5.0
@@ -192,7 +201,6 @@ class TestIRAFStarFind(SetupData):
                         np.array(t).view(np.float))
 
     @pytest.mark.parametrize(('threshold'), THRESHOLDS)
-    @pytest.mark.skipif('not HAS_SCIPY')
     def test_isf_ellrotobj_threshold(self, threshold):
         self._setup()
         fwhm = 3.0


### PR DESCRIPTION
@larrybradley Does this look OK?
(I got some test errors for a Python where I had `scipy`, but not `scikit-image` installed.
