### PR TITLE
Handling of optional dependencies

### DIFF
--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -63,11 +63,8 @@ def detect_sources(image, snr_threshold, npixels, filter_fwhm=None,
     segment_image :  array_like
         A 2D segmentation image of integers indicating segment labels.
     """
+    from scipy import ndimage
 
-    try:
-        from scipy import ndimage
-    except ImportError:
-        raise ImportError('detect_sources requires scipy.')
     bkgrd, median, bkgrd_rms = img_stats(image, image_mask=image_mask,
                                          mask_val=mask_val, sig=sig,
                                          iters=iters)
@@ -195,11 +192,7 @@ def find_peaks(image, snr_threshold, min_distance=5, exclude_border=True,
     function returns the coordinates of peaks where dilated image =
     original.
     """
-
-    try:
-        from skimage.feature import peak_local_max
-    except ImportError:
-        raise ImportError('find_peaks requires scikit-image.')
+    from skimage.feature import peak_local_max
 
     bkgrd, median, bkgrd_rms = img_stats(image, image_mask=image_mask,
                                          mask_val=mask_val, sig=sig,

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -445,11 +445,8 @@ def _findobjs(data, kernel, threshold):
         A list of ``findstars._ImgCutout`` objects containing the image
         cutout for each source.
     """
+    from scipy import ndimage
 
-    try:
-        from scipy import ndimage
-    except ImportError:
-        raise ImportError('daofind and irafstarfind require scipy.')
     # TODO: astropy's convolve fails with zero-sum kernels (use scipy for now)
     # https://github.com/astropy/astropy/issues/1647
     # convimg = astropy.nddata.convolve(data, kernel, boundary='fill',
@@ -558,11 +555,8 @@ def _irafstarfind_moments(imgcutout, kernel, sky):
     table : `astropy.table.Table`
         A table of the object parameters.
     """
+    from skimage.measure import moments, moments_central
 
-    try:
-        from skimage.measure import moments, moments_central
-    except ImportError:
-        raise ImportError('irafstarfind requires scikit-image.')
     result = defaultdict(list)
     img = np.array(imgcutout.data * kernel.mask) - sky
     img = np.where(img > 0, img, 0)    # starfind discards negative pixels

--- a/photutils/detection/morphology.py
+++ b/photutils/detection/morphology.py
@@ -29,14 +29,13 @@ def centroid_com(data, data_mask=None):
     centroid : tuple
         (x, y) coordinates of the centroid.
     """
-    try:
-        from skimage.measure import moments
-    except ImportError:
-        raise ImportError('centroid_com requires scikit-image.')
+    from skimage.measure import moments
+
     if data_mask is not None:
         if data.shape != data_mask.shape:
             raise ValueError('data and data_mask must have the same shape')
         data[data_mask] = 0.
+
     m = moments(data, 1)
     xcen = m[1, 0] / m[0, 0]
     ycen = m[0, 1] / m[0, 0]
@@ -196,11 +195,7 @@ def shape_params(data, data_mask=None):
         * ``linear_eccen`` : linear eccentricity is the distance between
           the object center and either of its two ellipse foci.
     """
-
-    try:
-        from skimage.measure import moments, moments_central
-    except ImportError:
-        raise ImportError('shape_params requires scikit-image.')
+    from skimage.measure import moments, moments_central
 
     if data_mask is not None:
         if data.shape != data_mask.shape:

--- a/photutils/psf.py
+++ b/photutils/psf.py
@@ -232,11 +232,9 @@ class GaussianPSF(Fittable2DModel):
 
     def __init__(self, sigma, amplitude=1, x_0=0, y_0=0):
         if self._erf is None:
-            try:
-                from scipy.special import erf
-                self.__class__._erf = erf
-            except (ValueError, ImportError):
-                raise ImportError("Gaussian PSF model requires scipy.")
+            from scipy.special import erf
+            self.__class__._erf = erf
+
         constraints = {'fixed': {'x_0': True, 'y_0': True, 'sigma': True}}
         super(GaussianPSF, self).__init__(param_dim=1, sigma=sigma,
                                           x_0=x_0, y_0=y_0,

--- a/photutils/utils/scale_img.py
+++ b/photutils/utils/scale_img.py
@@ -165,11 +165,8 @@ def rescale_img(image, min_cut=None, max_cut=None, min_percent=None,
         ``max_cut``), which are the output scaled image and the minimum
         and maximum cut levels.
     """
+    from skimage import exposure
 
-    try:
-        from skimage import exposure
-    except ImportError:
-        raise ImportError('The image scaling functions require scikit-image.')
     image = image.astype(np.float64)
     min_cut, max_cut = find_imgcuts(image, min_cut=min_cut, max_cut=max_cut,
                                     min_percent=min_percent,


### PR DESCRIPTION
A large fraction of `photutils` functionality requires `scipy` and / or `scikit-image` as optional dependencies.

@larrybradley I don't see any advantage to putting every import statement for the optional dependencies into a try ... except block and raising a custom `ImportError` that basically says the same thing. Would the change in 253703e be OK with you?

It would be nice if we had a decorator like

```
requires('skimage', '0.9', '... comment ...')
```

that would declare optional dependencies for functions or classes and put this info in the HTML docs.
@eteq @astrofrog Does it exist or is planned for Astropy?
