### PR TITLE
Changing more .view to .astype

### DIFF
--- a/photutils/aperture.py
+++ b/photutils/aperture.py
@@ -694,9 +694,9 @@ def aperture_photometry(data, apertures, error=None, gain=None,
 
             # Corresponding coordinates mirrored across xc, yc
             x_mirror = (2 * (apertures.positions[j][0] - extent[0])
-                        - x_masked + 0.5).view('int32')
+                        - x_masked + 0.5).astype('int32')
             y_mirror = (2 * (apertures.positions[j][1] - extent[2])
-                        - y_masked + 0.5).view('int32')
+                        - y_masked + 0.5).astype('int32')
 
             # reset pixels that go out of the image.
             outofimage = ((x_mirror < 0) |


### PR DESCRIPTION
More `.view` problems in `aperture.py` causing a bug in the masked photometry. 

(Size of `x_mirror` on line 696 gets twice the desired as the code asks for a `.view(int32)` of a float64, which  gives back two elements for each element in the original array.)

Should be merged before PR #77, as it depends on it.
