### PR TITLE
Adapt to Astropy rename NonLinearLSQFitter to LevMarLSQFitter

### DIFF
--- a/photutils/detection/morphology.py
+++ b/photutils/detection/morphology.py
@@ -2,7 +2,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from astropy.modeling import models, fitting
+from astropy.modeling import models
+
+# TODO: remove try ... except when Astropy 0.3 support is dropped
+try:
+    from astropy.modeling.fitting import LevMarLSQFitter
+except ImportError:
+    from astropy.modeling.fitting import NonLinearLSQFitter as LevMarLSQFitter
+
 
 __all__ = ['centroid_com', 'gaussian1d_moments',
            'centroid_1dg', 'centroid_2dg',
@@ -93,9 +100,9 @@ def centroid_1dg(data, data_err=None, data_mask=None):
     for (data, weights) in zip(gaussians, data_weights):
         params_init = gaussian1d_moments(data)
         g_init = models.Gaussian1D(*params_init)
-        f = fitting.NonLinearLSQFitter()
+        fitter = LevMarLSQFitter()
         x = np.arange(data.size)
-        g_fit = f(g_init, x, data, weights=weights)
+        g_fit = fitter(g_init, x, data, weights=weights)
         centroid.append(g_fit.mean.value)
     return centroid
 
@@ -158,9 +165,9 @@ def fit_2dgaussian(data, data_err=None, data_mask=None):
     g_init = models.Gaussian2D(amplitude, gparams['xcen'], gparams['ycen'],
                                gparams['major_axis'], gparams['minor_axis'],
                                theta=gparams['pa'])
-    f = fitting.NonLinearLSQFitter()
+    fitter = LevMarLSQFitter()
     y, x = np.indices(data.shape)
-    gfit = f(g_init, x, y, data, weights=weights)
+    gfit = fitter(g_init, x, y, data, weights=weights)
     return gfit
 
 

--- a/photutils/psf.py
+++ b/photutils/psf.py
@@ -4,10 +4,15 @@
 from __future__ import division
 
 import numpy as np
-
-from astropy.modeling import fitting
 from astropy.modeling.parameters import Parameter
 
+# TODO: remove try ... except when Astropy 0.3 support is dropped
+try:
+    from astropy.modeling.fitting import LevMarLSQFitter
+except ImportError:
+    from astropy.modeling.fitting import NonLinearLSQFitter as LevMarLSQFitter
+
+# TODO: remove try ... except when Astropy 0.3 support is dropped
 try:
     from astropy.modeling import Fittable2DModel
 except ImportError:
@@ -86,7 +91,7 @@ class DiscretePRF(Fittable2DModel):
         super(DiscretePRF, self).__init__(param_dim=1, x_0=x_0, y_0=y_0,
                                           amplitude=amplitude, **constraints)
         self.linear = True
-        self.fitter = fitting.NonLinearLSQFitter()
+        self.fitter = LevMarLSQFitter()
 
         # Fix position per default
         self.x_0.fixed = True
@@ -242,7 +247,7 @@ class GaussianPSF(Fittable2DModel):
 
         # Default size is 8 * sigma
         self.shape = (int(8 * sigma) + 1, int(8 * sigma) + 1)
-        self.fitter = fitting.NonLinearLSQFitter()
+        self.fitter = LevMarLSQFitter()
 
         # Fix position per default
         self.x_0.fixed = True


### PR DESCRIPTION
At the moment all tests in `photutils/detection/tests/test_morphology.py`, `photutils/tests/test_psf_photometry.py` and `photutils/tests/test_psfs.py` fail like this:

```
>       self.fitter = fitting.NonLinearLSQFitter()
E       AttributeError: 'module' object has no attribute 'NonLinearLSQFitter'
```

https://travis-ci.org/astropy/photutils/jobs/27266795#L603

The reason is that `NonLinearLSQFitter` was renamed to [LevMarLSQFitter](http://astropy.readthedocs.org/en/latest/api/astropy.modeling.fitting.LevMarLSQFitter.html)  in https://github.com/astropy/astropy/pull/2441 .

Once Astropy 0.4 is released we decided to only support the new version, but if the call signature didn't change we could just support both.
