### PR TITLE
Import astropy_helpers from inside the docs/ directory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,15 @@ import datetime
 import os
 import sys
 
+try:
+    import astropy_helpers
+except ImportError:
+    # Building from inside the docs/ directory?
+    if os.path.basename(os.getcwd()) == 'docs':
+        a_h_path = os.path.abspath(os.path.join('..', 'astropy_helpers'))
+        if os.path.isdir(a_h_path):
+            sys.path.insert(1, a_h_path)
+
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
 


### PR DESCRIPTION
This is required to build the documentation with the local `astropy_helpers` subpackage.   Or, are we now requiring `astropy_helpers` be installed as a package?

CC: @astrofrog
