### PR TITLE
setting fill=False as default for aperture plot()

### DIFF
--- a/photutils/aperture.py
+++ b/photutils/aperture.py
@@ -164,7 +164,7 @@ class CircularAperture(Aperture):
         import matplotlib.patches as mpatches
         ax = plt.gca()
         for position in self.positions:
-            patch = mpatches.Circle(position, self.r, **kwargs)
+            patch = mpatches.Circle(position, self.r, fill=False, **kwargs)
             ax.add_patch(patch)
 
 
@@ -260,7 +260,7 @@ class CircularAnnulus(Aperture):
             patch_outer = mpatches.CirclePolygon(position, self.r_out,
                                                  resolution=resolution)
             path = _make_annulus_path(patch_inner, patch_outer)
-            patch = mpatches.PathPatch(path, **kwargs)
+            patch = mpatches.PathPatch(path, fill=False, **kwargs)
             ax.add_patch(patch)
 
 
@@ -364,7 +364,7 @@ class EllipticalAperture(Aperture):
         theta_deg = self.theta * 180. / np.pi
         for position in self.positions:
             patch = mpatches.Ellipse(position, self.a, self.b, theta_deg,
-                                     **kwargs)
+                                     fill=False, **kwargs)
             ax.add_patch(patch)
 
 
@@ -488,11 +488,11 @@ class EllipticalAnnulus(Aperture):
         theta_deg = self.theta * 180. / np.pi
         for position in self.positions:
             patch_inner = mpatches.Ellipse(position, self.a_in, self.b_in,
-                                           theta_deg, **kwargs)
+                                           theta_deg, fill=False, **kwargs)
             patch_outer = mpatches.Ellipse(position, self.a_out, self.b_out,
-                                           theta_deg, **kwargs)
+                                           theta_deg, fill=False, **kwargs)
             path = _make_annulus_path(patch_inner, patch_outer)
-            patch = mpatches.PathPatch(path, **kwargs)
+            patch = mpatches.PathPatch(path, fill=False, **kwargs)
             ax.add_patch(patch)
 
 
@@ -610,7 +610,7 @@ class RectangularAperture(Aperture):
         theta_deg = self.theta * 180. / np.pi
         for position in positions:
             patch = mpatches.Rectangle(position, self.w, self.h, theta_deg,
-                                       **kwargs)
+                                       fill=False, **kwargs)
             ax.add_patch(patch)
 
 

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -59,7 +59,7 @@ def make_gaussian_image(shape, table):
         for source in table:
             aperture = CircularAperture((source['x_0'], source['y_0']),
                                         3 * source['sigma'])
-            aperture.plot(color='white', fill=False)
+            aperture.plot(color='white')
     """
 
     y, x = np.indices(shape)


### PR DESCRIPTION
As asked in #113, `fill=False` is set. I can't think any situation where this isn't the desired setting.
