### PR TITLE
Add imageutils as a dependency for photutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ install:
     # ASTROPY
     - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
     - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
+    # TODO: remove the following line once imageutils is moved to the Astropy core
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+http://github.com/astropy/imageutils.git#egg=imageutils; fi
 
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ intersphinx_mapping['astropy'] = ('http://docs.astropy.org/en/latest/', None)
 
 # Extend astropy intersphinx_mapping with packages we use here
 intersphinx_mapping['skimage'] = ('http://scikit-image.org/docs/stable/', None)
+intersphinx_mapping['imageutils'] = ('http://imageutils.readthedocs.org/en/latest/', None)
 
 
 # List of patterns, relative to source directory, that match files and

--- a/docs/photutils/index.rst
+++ b/docs/photutils/index.rst
@@ -11,18 +11,21 @@ The `photutils` package is destined to implement functions for
   (e.g., centroid and shape parameters)
 * performing photometry (both aperture and PSF)
 
-.. note::
+Dependencies
+------------
 
-    It is possible that `photutils` will eventually be merged into
-    ``astropy`` as ``astropy.photometry``.
+`photutils` requires the following packages to be available:
 
-.. note::
+* `numpy <http://www.numpy.org/>`__
+* `astropy <http://www.astropy.org/>`__
+* `imageutils <https://imageutils.readthedocs.org/en/latest/imageutils/index.html>`__
+  (planned to be included in the Astropy core as ``astropy.image`` before the 1.0 release)
 
-    `photutils` requires `numpy <http://www.numpy.org/>`__ and
-    `astropy <http://www.astropy.org/>`__ to be installed.
-    Some functionality is only available if `scipy <http://www.scipy.org/>`__ or
-    `scikit-image <http://scikit-image.org/>`__ are installed, users are
-    encouraged to install those optional dependencies.
+Some functionality is only available if the following optional dependencies are installed:
+
+* `scipy <http://www.scipy.org/>`__
+* `scikit-image <http://scikit-image.org/>`__
+* `matplotlib <http://matplotlib.org/>`__
 
 Getting Started
 ---------------

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -4,3 +4,4 @@ matplotlib
 Cython
 scikit-image
 -e git+http://github.com/astropy/astropy.git#egg=astropy
+-e git+http://github.com/astropy/imageutils.git#egg=imageutils


### PR DESCRIPTION
I suggest we make https://github.com/astropy/imageutils a required dependency for photutils.
This will allow us to move the image utils functions we have in [photutils/utils](https://github.com/astropy/photutils/tree/master/photutils/utils) to `imageutils` and simply import it in `photutils` without having to do the [optional import dance](http://astropy.readthedocs.org/en/latest/development/testguide.html#tests-requiring-optional-dependencies).

The plan is to propose `imageutils` to be moved into the Astropy core in a month or two, so I don't see any issue with temporarily depending on this package.

@astrofrog @eteq @larrybradley OK?
