### PR TITLE
Add skimage to doctest-requires

### DIFF
--- a/docs/photutils/detection.rst
+++ b/docs/photutils/detection.rst
@@ -25,7 +25,7 @@ Getting Started
 Create an image with a single 2D circular Gaussian source to represent
 a star and find it in the image using ``daofind``:
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
   >>> import numpy as np
   >>> import photutils

--- a/docs/photutils/findstars.rst
+++ b/docs/photutils/findstars.rst
@@ -13,7 +13,7 @@ Examples
 Create an image with a single 2D circular Gaussian source to represent
 a star and find it in the image using ``daofind``:
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
   >>> import numpy as np
   >>> import photutils
@@ -28,7 +28,7 @@ a star and find it in the image using ``daofind``:
 
 Search the same image, but using ``irafstarfind``:
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
   >>> tbl2 = photutils.irafstarfind(img, 3.0, 1.0)
   >>> tbl2.pprint(max_width=-1)
@@ -41,7 +41,7 @@ Create an image with three 2D circular Gaussian source to represent
 stars, find them in the image using ``daofind``, and display the
 results in a browser with interactive searching and sorting:
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
   >>> import numpy as np
   >>> import photutils
@@ -86,7 +86,7 @@ of the found sources:
 Finally, filter the catalog to include only sources with a peak flux > 200
 (resulting in only two sources):
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
   >>> newtbl = tbl[tbl['peak'] > 200]
   >>> newtbl.show_in_browser(jsviewer=True)   # doctest: +SKIP


### PR DESCRIPTION
This PR fixes an issue where doctests were failing if `scikit-image` was not installed.

This also uncovered a bug in `doctest-requires` (https://github.com/astropy/astropy/pull/2818) that needs to be fixed before this PR.
