### PR TITLE
Update mask docs

### DIFF
--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -272,8 +272,7 @@ With the mask image and the default ``mask_method``
 
 With the mask image and ``mask_method='interpolation'``::
 
-  >>> t3, d3 = aperture_photometry(data, (2, 2), ('circular', 2), mask=mask,
-  >>>                              mask_method='interpolation')
+  >>> t3, d3 = aperture_photometry(data, (2, 2), ('circular', 2), mask=mask, mask_method='interpolation')
   >>> print t3['aperture_sum']
    aperture_sum
   -------------


### PR DESCRIPTION
This PR updates the mask documentation, removing the mirroring and adding the new `mask_method` options with some examples.

Merge only after https://github.com/astropy/photutils/pull/133 is merged.
