### PR TITLE
adding link to code in the index docs page

### DIFF
--- a/docs/photutils/index.rst
+++ b/docs/photutils/index.rst
@@ -11,6 +11,11 @@ The `photutils` package is destined to implement functions for
   (e.g., centroid and shape parameters)
 * performing photometry (both aperture and PSF)
 
+The code and the documentation are available at the following links:
+
+* Code: https://github.com/astropy/photutils
+* Docs: https://photutils.readthedocs.org/
+
 Dependencies
 ------------
 


### PR DESCRIPTION
The link to the actual photutils code is very well hidden in the `datasets` page, so I added a link to the github page to the top of the index page, too.
