### PR TITLE
daofind - small change in documentation

### DIFF
--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -215,7 +215,7 @@ def daofind(data, fwhm, threshold, sigma_radius=1.5, ratio=1.0, theta=0.0,
 
     sigma_radius : float, optional
         The truncation radius of the Gaussian kernel in units of sigma
-        (standard deviation) [``1 sigma = FWHM / 2.0*sqrt(2.0*log(2.0))``].
+        (standard deviation) [``1 sigma = FWHM / (2.0*sqrt(2.0*log(2.0)))``].
 
     ratio : float, optional
         The ratio of the minor to major axis of the Gaussian kernel.


### PR DESCRIPTION
I added `()` in the explanation for the FWHM. The spaces in the formula already indicated that the entire `2.0*sqrt(2.0*log(2.0))` should be part of the denominator, but since this looks like a formula in code we should make it mathematically right by setting the required parenthses.
