### PR TITLE
Add PixelAperture and SkyAperture to __all__

### DIFF
--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -199,7 +199,6 @@ class PixelAperture(Aperture):
                 'pixel_extent': [x_min, x_max, y_min, y_max],
                 'phot_extent': [x_pmin, x_pmax, y_pmin, y_pmax]}
 
-    @abc.abstractmethod
     def area():
         """
         Area of aperture.


### PR DESCRIPTION
also make `area()` an abstractmethod.  This is a partial fix for https://github.com/astropy/photutils/issues/152.
