### PR TITLE
Bundle imageutils for photutils 0.1 release

### DIFF
--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -978,7 +978,7 @@ class RectangularAperture(PixelAperture):
 
         if method in ('center', 'subpixel'):
             if method == 'center': subpixels = 1
-            if method == 'subpixel': from imageutils import downsample
+            if method == 'subpixel': from .extern.imageutils import downsample
 
             for i in range(len(flux)):
                 x_size = ((x_pmax[i] - x_pmin[i]) /

--- a/photutils/aperture_funcs.py
+++ b/photutils/aperture_funcs.py
@@ -200,7 +200,7 @@ def do_elliptical_photometry(data, positions, extents, a, b, theta,
 
     if method == 'center' or method == 'subpixel':
         if method == 'center': subpixels = 1
-        if method == 'subpixel': from imageutils import downsample
+        if method == 'subpixel': from .extern.imageutils import downsample
 
         for i in range(len(flux)):
             x_size = ((x_pmax[i] - x_pmin[i]) /

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from imageutils import img_stats
+from ..extern.imageutils import sigmaclip_stats
 
 __all__ = ['detect_sources', 'find_peaks']
 
@@ -71,9 +71,9 @@ def detect_sources(data, snr_threshold, npixels, filter_fwhm=None,
     """
 
     from scipy import ndimage
-    bkgrd, median, bkgrd_rms = img_stats(data, image_mask=mask,
-                                         mask_val=mask_val, sig=sig,
-                                         iters=iters)
+    bkgrd, median, bkgrd_rms = sigmaclip_stats(data, image_mask=mask,
+                                               mask_val=mask_val, sigma=sig,
+                                               iters=iters)
     assert npixels > 0, 'npixels must be a positive integer'
     assert int(npixels) == npixels, 'npixels must be a positive integer'
 
@@ -201,8 +201,8 @@ def find_peaks(data, snr_threshold, min_distance=5, exclude_border=True,
     """
     from skimage.feature import peak_local_max
 
-    bkgrd, median, bkgrd_rms = img_stats(data, image_mask=mask,
-                                         mask_val=mask_val, sig=sig,
+    bkgrd, median, bkgrd_rms = sigmaclip_stats(data, image_mask=mask,
+                                         mask_val=mask_val, sigma=sig,
                                          iters=iters)
     level = bkgrd + (bkgrd_rms * snr_threshold)
     return peak_local_max(data, min_distance=min_distance,

--- a/photutils/detection/lacosmic.py
+++ b/photutils/detection/lacosmic.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-import imageutils
+from ..extern import imageutils
 from astropy import log
 
 __all__ = ['lacosmic']

--- a/photutils/extern/imageutils/__init__.py
+++ b/photutils/extern/imageutils/__init__.py
@@ -1,0 +1,12 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Image processing utilities for Astropy.
+"""
+
+from .scale_image import *
+from .array_utils import *
+from .sampling import *
+
+__all__ = ['find_cutlevels', 'normalize_image', 'scale_image',
+           'sigmaclip_stats', 'downsample', 'upsample', 'extract_array_2d',
+           'add_array_2d', 'subpixel_indices', 'mask_to_mirrored_num']

--- a/photutils/extern/imageutils/array_utils.py
+++ b/photutils/extern/imageutils/array_utils.py
@@ -1,0 +1,238 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module includes helper functions for array operations.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import numpy as np
+import copy
+
+__all__ = ['extract_array_2d', 'add_array_2d', 'subpixel_indices',
+           'mask_to_mirrored_num']
+
+__doctest_skip__ = ['*']
+
+
+def _get_slices(large_array_shape, small_array_shape, position):
+    """
+    Get slices for the overlapping part of a small and a large array.
+
+    Given a certain position of the center of the small array, with
+    respect to the large array, four slices are computed, which can be
+    used to extract, add or subtract the small array at the given
+    position. This function takes care of the correct behavior at the
+    boundaries, where the small array is cut of appropriately.
+
+    Parameters
+    ----------
+    large_array_shape : tuple
+        Shape of the large array.
+    small_array_shape : tuple
+        Shape of the small array.
+    position : tuple, (x, y)
+        Position of the small array's center, with respect
+        to the large array.
+
+    Returns
+    -------
+    s_y : slice
+        Slice in y direction for the large array.
+    s_x : slice
+        Slice in x direction for the large array.
+    b_y : slice
+        Slice in y direction for the small array.
+    b_x : slice
+        Slice in x direction for the small array.
+    """
+    # Get edge coordinates
+    y_min = int(position[1] + 0.5) - small_array_shape[0] // 2
+    x_min = int(position[0] + 0.5) - small_array_shape[1] // 2
+    y_max = int(position[1] + 0.5) + small_array_shape[0] // 2 + 1
+    x_max = int(position[0] + 0.5) + small_array_shape[1] // 2 + 1
+
+    # Set up slices in x direction
+    s_x = slice(max(0, x_min), min(large_array_shape[1], x_max))
+    b_x = slice(max(0, -x_min), min(large_array_shape[1] - x_min,
+                                    x_max - x_min))
+
+    # Set up slices in y direction
+    s_y = slice(max(0, y_min), min(large_array_shape[0], y_max))
+    b_y = slice(max(0, -y_min), min(large_array_shape[0] - y_min,
+                                    y_max - y_min))
+    return s_y, s_x, b_y, b_x
+
+
+def extract_array_2d(array_large, shape, position):
+    """
+    Extract smaller array of given shape and position out of a larger array.
+
+    Parameters
+    ----------
+    array_large : ndarray
+        Array to extract another array from.
+    shape : tuple
+        Shape of the extracted array.
+    position : tuple, (x, y)
+        Position of the small array's center, with respect
+        to the large array.
+
+    Examples
+    --------
+    We consider a large array of zeros with the shape 11x10 and a small
+    array of ones with a shape of 3x4:
+
+    >>> import numpy as np
+    >>> from photutils.utils import extract_array_2d
+    >>> large_array = np.zeros((11, 10))
+    >>> large_array[4:9, 4:9] = np.ones((5, 5))
+    >>> extract_array_2d(large_array, (3, 4), (7, 7))
+    array([[ 1.,  1.,  1.,  1.,  0.],
+           [ 1.,  1.,  1.,  1.,  0.],
+           [ 1.,  1.,  1.,  1.,  0.]])
+    """
+    # Check if larger array is really larger
+    if array_large.shape >= shape:
+        s_y, s_x, _, _ = _get_slices(array_large.shape, shape, position)
+        return array_large[s_y, s_x]
+    else:
+        raise Exception("Can't extract array. Shape too large.")
+
+
+def add_array_2d(array_large, array_small, position):
+    """
+    Add a smaller 2D array at a given position in a larger 2D array.
+
+    Parameters
+    ----------
+    array_large : ndarray
+        Large array.
+    array_small : ndarray
+        Small array to add.
+    position : tuple, (x, y)
+        Position of the small array's center, with respect
+        to the large array.
+
+    Examples
+    --------
+    We consider a large array of zeros with the shape 5x5 and a small
+    array of ones with a shape of 3x3:
+
+    >>> import numpy as np
+    >>> from photutils.utils import add_array_2d
+    >>> large_array = np.zeros((5, 5))
+    >>> small_array = np.ones((3, 3))
+    >>> add_array_2d(large_array, small_array, (2, 1))
+    array([[ 0.,  1.,  1.,  1.,  0.],
+           [ 0.,  1.,  1.,  1.,  0.],
+           [ 0.,  1.,  1.,  1.,  0.],
+           [ 0.,  0.,  0.,  0.,  0.],
+           [ 0.,  0.,  0.,  0.,  0.]])
+    """
+    # Check if larger array is really larger
+    if array_large.shape >= array_small.shape:
+        s_y, s_x, b_y, b_x = _get_slices(array_large.shape,
+                                         array_small.shape, position)
+        array_large[s_y, s_x] += array_small[b_y, b_x]
+        return array_large
+    else:
+        raise Exception("Can't add array. Small array too large.")
+
+
+def subpixel_indices(position, subsampling):
+    """
+    Convert decimal points to indices, given a subsampling factor.
+
+    Parameters
+    ----------
+    position : ndarray [x, y]
+        Positions in pixels.
+    subsampling : int
+        Subsampling factor per pixel.
+    """
+    # Get decimal points
+    x_frac, y_frac = np.modf((position[0] + 0.5,
+                             position[1] + 0.5))[0]
+
+    # Convert to int
+    x_sub = np.int(x_frac * subsampling)
+    y_sub = np.int(y_frac * subsampling)
+    return x_sub, y_sub
+
+
+def mask_to_mirrored_num(image, mask_image, center_position, bbox=None):
+    """
+    Replace masked pixels with the value of the pixel mirrored across a
+    given ``center_position``.  If the mirror pixel is unavailable (i.e.
+    itself masked or outside of the image), then the masked pixel value
+    is set to zero.
+
+    Parameters
+    ----------
+    image : `numpy.ndarray`, 2D
+        The 2D array of the image.
+
+    mask_image : array-like, bool
+        A boolean mask with the same shape as ``image``, where a `True`
+        value indicates the corresponding element of ``image`` is
+        considered bad.
+
+    center_position : 2-tuple
+        (x, y) center coordinates around which masked pixels will be
+        mirrored.
+
+    bbox : list, tuple, `numpy.ndarray`, optional
+        The bounding box (x_min, x_max, y_min, y_max) over which to
+        replace masked pixels.
+
+    Returns
+    -------
+    result : `numpy.ndarray`, 2D
+        A 2D array with replaced masked pixels.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from imageutils import mask_to_mirrored_num
+    >>> image = np.arange(16).reshape(4, 4)
+    >>> mask = np.zeros_like(image, dtype=bool)
+    >>> mask[0, 0] = True
+    >>> mask[1, 1] = True
+    >>> mask_to_mirrored_num(image, mask, (1.5, 1.5))
+    array([[15,  1,  2,  3],
+           [ 4, 10,  6,  7],
+           [ 8,  9, 10, 11],
+           [12, 13, 14, 15]])
+    """
+
+    if bbox is None:
+        ny, nx = image.shape
+        bbox = [0, nx, 0, ny]
+    subdata = copy.deepcopy(image[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1])
+    submask = mask_image[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1]
+    y_masked, x_masked = np.nonzero(submask)
+    x_mirror = (2 * (center_position[0] - bbox[0])
+                - x_masked + 0.5).astype('int32')
+    y_mirror = (2 * (center_position[1] - bbox[2])
+                - y_masked + 0.5).astype('int32')
+
+    # Reset mirrored pixels that go out of the image.
+    outofimage = ((x_mirror < 0) | (y_mirror < 0) |
+                  (x_mirror >= subdata.shape[1]) |
+                  (y_mirror >= subdata.shape[0]))
+    if outofimage.any():
+        x_mirror[outofimage] = x_masked[outofimage].astype('int32')
+        y_mirror[outofimage] = y_masked[outofimage].astype('int32')
+
+    subdata[y_masked, x_masked] = subdata[y_mirror, x_mirror]
+
+    # Set pixels that mirrored to another masked pixel to zero.
+    # This will also set to zero any pixels that mirrored out of
+    # the image.
+    mirror_is_masked = submask[y_mirror, x_mirror]
+    x_bad = x_masked[mirror_is_masked]
+    y_bad = y_masked[mirror_is_masked]
+    subdata[y_bad, x_bad] = 0.0
+
+    outimage = copy.deepcopy(image)
+    outimage[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1] = subdata
+    return outimage

--- a/photutils/extern/imageutils/sampling.pyx
+++ b/photutils/extern/imageutils/sampling.pyx
@@ -1,0 +1,122 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+#cython: boundscheck=False
+#cython: wraparound=False
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import numpy as np
+
+cimport cython
+cimport numpy as np
+DTYPE = np.float
+ctypedef np.float_t DTYPE_t
+
+__all__ = ['downsample', 'upsample']
+
+
+def downsample(np.ndarray[DTYPE_t, ndim=2] array, int block_size):
+    """
+    downsample(np.ndarray[DTYPE_t, ndim=2] array, int block_size)
+
+    Downsample an image by block summing image pixels.  This process
+    conserves image flux.  If the dimensions of ``image`` are not a
+    whole-multiple of ``block_size``, the extra rows/columns will not be
+    included in the output downsampled image.
+
+    This function is similar to the `scikit-image`_ `block_reduce`_
+    function, which is more flexible, but slower than `downsample`.
+
+    .. _scikit-image: http://scikit-image.org/
+    .. _block_reduce: http://scikit-image.org/docs/dev/api/skimage.measure.html#skimage.measure.block_reduce
+
+    Parameters
+    ----------
+    image : array_like, float
+        The 2D array of the image.
+
+    block_size : int
+        Downsampling integer factor along each axis.
+
+    Returns
+    -------
+    output : array_like
+        The 2D array of the resampled image.
+
+    See Also
+    --------
+    upsample
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from photutils import utils
+    >>> img = np.arange(16.).reshape((4, 4))
+    >>> utils.downsample(img, 2)
+    array([[ 10.,  18.],
+           [ 42.,  50.]])
+    """
+
+    cdef int nx = array.shape[1]
+    cdef int ny = array.shape[0]
+    cdef int nx_new = nx // block_size
+    cdef int ny_new = ny // block_size
+    cdef unsigned int i, j, ii, jj
+    cdef np.ndarray[DTYPE_t, ndim=2] result = np.zeros([ny_new, nx_new],
+                                                       dtype=DTYPE)
+    for i in range(nx_new):
+        for j in range(ny_new):
+            for ii in range(block_size):
+                for jj in range(block_size):
+                    result[j, i] += array[j * block_size + jj,
+                                          i * block_size + ii]
+    return result
+
+
+def upsample(np.ndarray[DTYPE_t, ndim=2] array, int block_size):
+    """
+    upsample(np.ndarray[DTYPE_t, ndim=2] array, int block_size)
+    
+    Upsample an image by block replicating image pixels.  To conserve
+    image flux, the block-replicated image is then divided by
+    ``block_size**2``.
+
+    Parameters
+    ----------
+    image : array_like, float
+        The 2D array of the image.
+
+    block_size : int
+        Upsampling integer factor along each axis.
+
+    Returns
+    -------
+    output : array_like
+        The 2D array of the resampled image.
+
+    See Also
+    --------
+    downsample
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from photutils import utils
+    >>> img = np.array([[0., 1.], [2., 3.]])
+    >>> utils.upsample(img, 2)
+    array([[ 0.  ,  0.  ,  0.25,  0.25],
+           [ 0.  ,  0.  ,  0.25,  0.25],
+           [ 0.5 ,  0.5 ,  0.75,  0.75],
+           [ 0.5 ,  0.5 ,  0.75,  0.75]])
+    """
+
+    cdef int nx = array.shape[1]
+    cdef int ny = array.shape[0]
+    cdef int nx_new = nx * block_size
+    cdef int ny_new = ny * block_size
+    cdef unsigned int i, j
+    cdef np.ndarray[DTYPE_t, ndim=2] result = np.zeros((ny_new, nx_new),
+                                                       dtype=DTYPE)
+    cdef float block_size_sq = block_size * block_size
+    for i in range(nx_new):
+        for j in range(ny_new):
+            result[j, i] += array[j // block_size, i // block_size]
+    return result / block_size_sq

--- a/photutils/extern/imageutils/scale_image.py
+++ b/photutils/extern/imageutils/scale_image.py
@@ -1,0 +1,267 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import numpy as np
+from astropy.stats import sigma_clip
+
+__all__ = ['find_cutlevels', 'normalize_image', 'scale_image',
+           'sigmaclip_stats']
+
+
+def find_cutlevels(image, min_percent=None, max_percent=None, percent=None):
+    """
+    Find pixel values of the minimum and maximum image cut levels from
+    percentiles of the image values.
+
+    Parameters
+    ----------
+    image : array_like
+        The 2D array of the image.
+
+    min_percent : float, optional
+        The percentile value used to determine the pixel value of
+        minimum cut level.  The default is 0.0.  ``min_percent``
+        overrides ``percent``.
+
+    max_percent : float, optional
+        The percentile value used to determine the pixel value of
+        maximum cut level.  The default is 100.0.  ``max_percent``
+        overrides ``percent``.
+
+    percent : float, optional
+        The percentage of the image values used to determine the pixel
+        values of the minimum and maximum cut levels.  The lower cut
+        level will set at the ``(100 - percent) / 2`` percentile, while
+        the upper cut level will be set at the ``(100 + percent) / 2``
+        percentile.  The default is 100.0.  ``percent`` is ignored if
+        either ``min_percent`` or ``max_percent`` is input.
+
+    Returns
+    -------
+    cutlevels : 2-tuple of floats
+        The pixel values of the minimum and maximum cut levels.
+    """
+
+    if percent is not None:
+        assert (percent >= 0) and (percent <= 100.0), \
+            'percent must be >= 0 and <= 100.0'
+        if min_percent is None and max_percent is None:
+            min_percent = (100.0 - float(percent)) / 2.0
+            max_percent = 100.0 - min_percent
+    if min_percent is None:
+        min_percent = 0.0
+    assert min_percent >= 0, 'min_percent must be >= 0'
+    min_cut = np.percentile(image, min_percent)
+    if max_percent is None:
+        max_percent = 100.0
+    assert max_percent <= 100.0, 'max_percent must be <= 100.0'
+    max_cut = np.percentile(image, max_percent)
+    assert min_percent <= max_percent, 'min_percent must be <= max_percent'
+    return min_cut, max_cut
+
+
+def normalize_image(image, min_cut=None, max_cut=None, min_percent=None,
+                    max_percent=None, percent=None):
+    """
+    Rescale image values between minimum and maximum cut levels to
+    values between 0 and 1, inclusive.
+
+    Parameters
+    ----------
+    image : array_like
+        The 2D array of the image.
+
+    min_cut : float, optional
+        The pixel value of the minimum cut level.  Data values less than
+        ``min_cut`` will set to ``min_cut`` before scaling the image.
+        The default is the image minimum.  ``min_cut`` overrides
+        ``min_percent``.
+
+    max_cut : float, optional
+        The pixel value of the maximum cut level.  Data values greater
+        than ``min_cut`` will set to ``min_cut`` before scaling the
+        image.  The default is the image maximum.  ``max_cut`` overrides
+        ``max_percent``.
+
+    min_percent : float, optional
+        The percentile value used to determine the pixel value of
+        minimum cut level.  The default is 0.0.  ``min_percent``
+        overrides ``percent``.
+
+    max_percent : float, optional
+        The percentile value used to determine the pixel value of
+        maximum cut level.  The default is 100.0.  ``max_percent``
+        overrides ``percent``.
+
+    percent : float, optional
+        The percentage of the image values used to determine the pixel
+        values of the minimum and maximum cut levels.  The lower cut
+        level will set at the ``(100 - percent) / 2`` percentile, while
+        the upper cut level will be set at the ``(100 + percent) / 2``
+        percentile.  The default is 100.0.  ``percent`` is ignored if
+        either ``min_percent`` or ``max_percent`` is input.
+
+    Returns
+    -------
+    image : ndarray
+        The normalized image with a minimum of 0.0 and a maximum of 1.0.
+
+    cutlevels : 2-tuple of floats
+        The pixel values of the minimum and maximum cut levels.
+    """
+
+    from skimage import exposure
+    image = np.asarray(image)
+    if min_cut is not None and max_cut is not None:
+        cutlevels = (min_cut, max_cut)
+    else:
+        cutlevels = find_cutlevels(image, min_percent=min_percent,
+                                   max_percent=max_percent, percent=percent)
+    # now override percentiles if either min_cut or max_cut is set
+    if min_cut is not None:
+        cutlevels[0] = min_cut
+    if max_cut is not None:
+        cutlevels[1] = max_cut
+    assert cutlevels[0] <= cutlevels[1], 'minimum cut must be <= maximum cut'
+    image_norm = exposure.rescale_intensity(image, in_range=cutlevels,
+                                            out_range=(0, 1))
+    return image_norm, cutlevels
+
+
+def scale_image(image, scale='linear', power=1.0, noise_level=None,
+                min_cut=None, max_cut=None, min_percent=None,
+                max_percent=None, percent=None):
+    """
+    Perform scaling/stretching of an image between minimum and maximum
+    cut levels.
+
+    Parameters
+    ----------
+    image : array_like
+        The 2D array of the image.
+
+    scale : {{'linear', 'sqrt', 'power', log', 'asinh'}}
+        The scaling/stretch function to apply to the image.  The default
+        is 'linear'.
+
+    power : float, optional
+        The power index for the image scaling.  The default is 1.0.
+
+    noise_level : float, optional
+        The noise level of the image.  Pixel values less than
+        ``noise_level`` will approximately be linearly scaled, while
+        pixel values greater than ``noise_level`` will approximately be
+        logarithmically scaled.  If ``noise_level`` is not input, an
+        estimate of the 2-sigma level above the background will be used.
+
+    min_cut : float, optional
+        The pixel value of the minimum cut level.  Data values less than
+        ``min_cut`` will set to ``min_cut`` before scaling the image.
+        The default is the image minimum.  ``min_cut`` overrides
+        ``min_percent``.
+
+    max_cut : float, optional
+        The pixel value of the maximum cut level.  Data values greater
+        than ``min_cut`` will set to ``min_cut`` before scaling the
+        image.  The default is the image maximum.  ``max_cut`` overrides
+        ``max_percent``.
+
+    min_percent : float, optional
+        The percentile value used to determine the pixel value of
+        minimum cut level.  The default is 0.0.  ``min_percent``
+        overrides ``percent``.
+
+    max_percent : float, optional
+        The percentile value used to determine the pixel value of
+        maximum cut level.  The default is 100.0.  ``max_percent``
+        overrides ``percent``.
+
+    percent : float, optional
+        The percentage of the image values used to determine the pixel
+        values of the minimum and maximum cut levels.  The lower cut
+        level will set at the ``(100 - percent) / 2`` percentile, while
+        the upper cut level will be set at the ``(100 + percent) / 2``
+        percentile.  The default is 100.0.  ``percent`` is ignored if
+        either ``min_percent`` or ``max_percent`` is input.
+
+    Returns
+    -------
+    image : ndarray
+        The 2D array of the scaled/stretched image with a minimum of 0.0
+        and a maximum of 1.0.
+    """
+
+    image_norm, cutlevels = normalize_image(image, min_cut=min_cut,
+                                            max_cut=max_cut,
+                                            min_percent=min_percent,
+                                            max_percent=max_percent,
+                                            percent=percent)
+    if scale == 'linear':
+        return image_norm
+    elif scale == 'sqrt':
+        return np.sqrt(image_norm)
+    elif scale == 'power':
+        return image_norm ** power
+    elif scale == 'log':
+        return np.log10(image_norm + 1.0) / np.log10(2.0)
+    elif scale == 'asinh':
+        if noise_level is None:
+            mean, median, stddev = sigmaclip_stats(image, sigma=3.0)
+            noise_level = mean + (2.0 * stddev)   # 2 sigma above background
+        min_cut, max_cut = cutlevels
+        z = (noise_level - min_cut) / (max_cut - min_cut)
+        if z == 0.0:    # avoid zero division
+            z = 1.e-2
+        return np.arcsinh(image_norm / z) / np.arcsinh(1.0 / z)
+    else:
+        raise ValueError('scale type is unknown')
+
+
+def sigmaclip_stats(image, image_mask=None, mask_val=None, sigma=3.0,
+                    iters=None):
+    """
+    Calculate sigma-clipped statistics of an image.  For example,
+    sigma-clipped statistics can be used to estimate the background and
+    background noise in an image.
+
+    Parameters
+    ----------
+    image : array_like
+        The 2D array of the image.
+
+    image_mask : array_like, bool, optional
+        A boolean mask with the same shape as ``image``, where a `True`
+        value indicates the corresponding element of ``image`` is
+        invalid.  Masked pixels are ignored when computing the image
+        statistics.
+
+    mask_val : float, optional
+        An image data value (e.g., ``0.0``) that is ignored when
+        computing the image statistics.  ``mask_val`` will be ignored if
+        ``image_mask`` is input.
+
+    sigma : float, optional
+        The number of standard deviations to use as the clipping limit.
+
+    iters : float, optional
+       The number of clipping iterations to perform, or `None` to clip
+       until convergence is achieved (i.e. continue until the last
+       iteration clips nothing).
+
+    Returns
+    -------
+    mean, median, stddev : floats
+        The mean, median, and standard deviation of the sigma-clipped
+        image.
+    """
+
+    if image_mask is not None:
+        assert image_mask.dtype == np.bool, \
+            'image_mask must be a boolean ndarray'
+        image = image[~image_mask]
+    if mask_val is not None and image_mask is None:
+        idx = (image != mask_val).nonzero()
+        image = image[idx]
+    image_clip = sigma_clip(image, sig=sigma, iters=iters)
+    goodvals = image_clip.data[~image_clip.mask]
+    return np.mean(goodvals), np.median(goodvals), np.std(goodvals)

--- a/photutils/extern/imageutils/tests/__init__.py
+++ b/photutils/extern/imageutils/tests/__init__.py
@@ -1,0 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This packages contains affiliated package tests.
+"""

--- a/photutils/extern/imageutils/tests/setup_package.py
+++ b/photutils/extern/imageutils/tests/setup_package.py
@@ -1,0 +1,3 @@
+def get_package_data():
+    return {
+        _ASTROPY_PACKAGE_NAME_ + '.tests': ['coveragerc']}

--- a/photutils/extern/imageutils/tests/test_array_utils.py
+++ b/photutils/extern/imageutils/tests/test_array_utils.py
@@ -1,0 +1,127 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
+from ..array_utils import (extract_array_2d, add_array_2d, subpixel_indices,
+                           mask_to_mirrored_num)
+
+test_positions = [(10.52, 3.12), (5.62, 12.97), (31.33, 31.77),
+                  (0.46, 0.94), (20.45, 12.12), (42.24, 24.42)]
+
+test_position_indices = [(0, 3), (0, 2), (4, 1),
+                         (4, 2), (4, 3), (3, 4)]
+
+test_slices = [slice(10.52, 3.12), slice(5.62, 12.97),
+               slice(31.33, 31.77), slice(0.46, 0.94),
+               slice(20.45, 12.12), slice(42.24, 24.42)]
+
+subsampling = 5
+
+
+def test_extract_array_2d():
+    """
+    Test extract_array utility function.
+
+    Test by extracting an array of ones out of an array of zeros.
+    """
+    large_test_array = np.zeros((11, 11))
+    small_test_array = np.ones((5, 5))
+    large_test_array[3:8, 3:8] = small_test_array
+    extracted_array = extract_array_2d(large_test_array, (5, 5), (5, 5))
+    assert np.all(extracted_array == small_test_array)
+
+
+def test_add_array_2d():
+    """
+    Test add_array_2D utility function.
+
+    Test by adding an array of ones out of an array of zeros.
+    """
+    large_test_array = np.zeros((11, 11))
+    small_test_array = np.ones((5, 5))
+    large_test_array_ref = large_test_array.copy()
+    large_test_array_ref[3:8, 3:8] += small_test_array
+
+    added_array = add_array_2d(large_test_array, small_test_array, (5, 5))
+    assert np.all(added_array == large_test_array_ref)
+
+
+@pytest.mark.parametrize(('position', 'subpixel_index'),
+                         zip(test_positions, test_position_indices))
+def test_subpixel_indices(position, subpixel_index):
+    """
+    Test subpixel_indices utility function.
+
+    Test by asserting that the function returns correct results for
+    given test values.
+    """
+    assert subpixel_indices(position, subsampling) == subpixel_index
+
+
+def test_mask_to_mirrored_num():
+    """
+    Test mask_to_mirrored_num.
+    """
+    center = (1.5, 1.5)
+    data = np.arange(16).reshape(4, 4)
+    mask = np.zeros_like(data, dtype=bool)
+    mask[0, 0] = True
+    mask[1, 1] = True
+    data_ref = data.copy()
+    data_ref[0, 0] = data[3, 3]
+    data_ref[1, 1] = data[2, 2]
+    mirror_data = mask_to_mirrored_num(data, mask, center)
+    assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)
+
+
+def test_mask_to_mirrored_num_range():
+    """
+    Test mask_to_mirrored_num when mirrored pixels are outside of the
+    image.
+    """
+    center = (2.5, 2.5)
+    data = np.arange(16).reshape(4, 4)
+    mask = np.zeros_like(data, dtype=bool)
+    mask[0, 0] = True
+    mask[1, 1] = True
+    data_ref = data.copy()
+    data_ref[0, 0] = 0.
+    data_ref[1, 1] = 0.
+    mirror_data = mask_to_mirrored_num(data, mask, center)
+    assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)
+
+
+def test_mask_to_mirrored_num_masked():
+    """
+    Test mask_to_mirrored_num when mirrored pixels are also masked.
+    """
+    center = (0.5, 0.5)
+    data = np.arange(16).reshape(4, 4)
+    data[0, 0] = 100
+    mask = np.zeros_like(data, dtype=bool)
+    mask[0, 0] = True
+    mask[1, 1] = True
+    data_ref = data.copy()
+    data_ref[0, 0] = 0.
+    data_ref[1, 1] = 0.
+    mirror_data = mask_to_mirrored_num(data, mask, center)
+    assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)
+
+
+def test_mask_to_mirrored_num_bbox():
+    """
+    Test mask_to_mirrored_num with a bounding box.
+    """
+    center = (1.5, 1.5)
+    data = np.arange(16).reshape(4, 4)
+    data[0, 0] = 100
+    mask = np.zeros_like(data, dtype=bool)
+    mask[0, 0] = True
+    mask[1, 1] = True
+    data_ref = data.copy()
+    data_ref[1, 1] = data[2, 2]
+    bbox = (1, 2, 1, 2)
+    mirror_data = mask_to_mirrored_num(data, mask, center, bbox=bbox)
+    assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)

--- a/photutils/extern/imageutils/tests/test_sampling.py
+++ b/photutils/extern/imageutils/tests/test_sampling.py
@@ -1,0 +1,105 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+import numpy as np
+from numpy.testing import assert_allclose
+from ..sampling import downsample, upsample
+
+DATA1 = np.array([[0., 1.], [2., 3.]])
+DATA2 = np.array([[0., 0., 0.25, 0.25],
+                  [0., 0., 0.25, 0.25],
+                  [0.5, 0.5, 0.75, 0.75],
+                  [0.5, 0.5, 0.75, 0.75]])
+DATA3 = np.array([[0., 0., 0., 1., 1., 1.],
+                  [0., 0., 0., 1., 1., 1.],
+                  [0., 0., 0., 1., 1., 1.],
+                  [2., 2., 2., 3., 3., 3.],
+                  [2., 2., 2., 3., 3., 3.],
+                  [2., 2., 2., 3., 3., 3.]])
+DATA4 = np.array([[0., 0., 0.25, 0.25, 1.],
+                  [0., 0., 0.25, 0.25, 2.],
+                  [0.5, 0.5, 0.75, 0.75, 3.],
+                  [0.5, 0.5, 0.75, 0.75, 4.],
+                  [5.5, 5.5, 5.75, 5.75, 5.]])
+
+
+class TestUpsample(object):
+    """Test upsampling of images."""
+    def test_factor1(self):
+        """Test upsampling of an image by a factor of 1."""
+        img = upsample(DATA1, 1)
+        assert_allclose(img, DATA1, rtol=0, atol=1e-6)
+
+    def test_factor2(self):
+        """Test upsampling of an image by a factor of 2."""
+        img = upsample(DATA1, 2)
+        assert_allclose(img, DATA2, rtol=0, atol=1e-6)
+
+    def test_factor3(self):
+        """Test upsampling of an image by a factor of 3."""
+        img = upsample(DATA1*9., 3)
+        assert_allclose(img, DATA3, rtol=0, atol=1e-6)
+
+
+class TestDownsample(object):
+    """Test downsampling of images."""
+    def test_factor1(self):
+        """Test downsampling of an image by a factor of 1."""
+        img = downsample(DATA1, 1)
+        assert_allclose(img, DATA1, rtol=0, atol=1e-6)
+
+    def test_factor2_2x2(self):
+        """Test downsampling of a 2x2 image by a factor of 2."""
+        img = downsample(DATA1, 2)
+        assert_allclose(img, np.array([[6.]]), rtol=0, atol=1e-6)
+
+    def test_factor2(self):
+        """Test downsampling of an image by a factor of 2."""
+        img = downsample(DATA2, 2)
+        assert_allclose(img, DATA1, rtol=0, atol=1e-6)
+
+    def test_factor3(self):
+        """Test downsampling of an image by a factor of 3."""
+        img = downsample(DATA3/9., 3)
+        assert_allclose(img, DATA1, rtol=0, atol=1e-6)
+
+    def test_factor2_roundtrip(self):
+        """
+        Test roundtrip of upsampling then downsampling of an image by a
+        factor of 2.
+        """
+        img = downsample(upsample(DATA1, 2), 2)
+        assert_allclose(img, DATA1, rtol=0, atol=1e-6)
+
+    def test_factor3_roundtrip(self):
+        """
+        Test roundtrip of upsampling then downsampling of an image by a
+        factor of 3.
+        """
+        img = downsample(upsample(DATA1, 3), 3)
+        assert_allclose(img, DATA1, rtol=0, atol=1e-6)
+
+    def test_factor3_4x4size(self):
+        """
+        Test downsampling when image dimensions are not a whole multiple
+        of factor.  A 4x4 image downsampled by a factor of 3.
+        """
+        img = downsample(DATA2, 3)
+        assert_allclose(img, np.array([[2.25]]), rtol=0, atol=1e-6)
+
+    def test_factor2_5x5size(self):
+        """
+        Test downsampling when image dimensions are not a whole multiple
+        of factor.  A 5x5 image downsampled by a factor of 2.
+        """
+        img = downsample(DATA4, 2)
+        assert_allclose(img, DATA1, rtol=0, atol=1e-6)
+
+    def test_factor4_6x6size(self):
+        """
+        Test downsampling when image dimensions are not a whole multiple
+        of factor.  A 6x6 image downsampled by a factor for 4.
+        """
+        img = downsample(DATA3, 4)
+        assert_allclose(img, np.array([[12.]]), rtol=0, atol=1e-6)

--- a/photutils/extern/imageutils/tests/test_scale_image.py
+++ b/photutils/extern/imageutils/tests/test_scale_image.py
@@ -1,0 +1,84 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+from astropy.tests.helper import pytest
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+from .. import find_cutlevels, scale_image, sigmaclip_stats
+try:
+    import skimage
+    HAS_SKIMAGE = True
+except ImportError:
+    HAS_SKIMAGE = False
+
+
+DATA = np.array([0, 1., 2.])
+DATASCL = 0.5 * DATA
+
+
+class TestImgCuts(object):
+    def test_find_cutlevels(self):
+        data = np.arange(101)
+
+        mincut, maxcut = find_cutlevels(data, min_percent=20)
+        assert_equal([mincut, maxcut], [20, 100])
+
+        mincut, maxcut = find_cutlevels(data, max_percent=80)
+        assert_equal([mincut, maxcut], [0, 80])
+
+        mincut, maxcut = find_cutlevels(data, min_percent=20, max_percent=80)
+        assert_equal([mincut, maxcut], [20, 80])
+
+        mincut, maxcut = find_cutlevels(data, percent=90)
+        assert_equal([mincut, maxcut], [5, 95])
+
+        mincut, maxcut = find_cutlevels(data, min_percent=20, max_percent=80,
+                                        percent=90)
+        assert_equal([mincut, maxcut], [20, 80])
+
+
+@pytest.mark.skipif('not HAS_SKIMAGE')
+class TestImageScaling(object):
+    def test_linear(self):
+        """Test linear scaling."""
+        img = scale_image(DATA, scale='linear')
+        assert_allclose(img, DATASCL, atol=0, rtol=1.e-5)
+
+    def test_sqrt(self):
+        """Test sqrt scaling."""
+        img = scale_image(DATA, scale='sqrt')
+        assert_allclose(img, np.sqrt(DATASCL), atol=0, rtol=1.e-5)
+
+    def test_power(self):
+        """Test power scaling."""
+        power = 3.0
+        img = scale_image(DATA, scale='power', power=power)
+        assert_allclose(img, DATASCL**power, atol=0, rtol=1.e-5)
+
+    def test_log(self):
+        """Test log10 scaling."""
+        img = scale_image(DATA, scale='log')
+        ref = np.log10(DATASCL + 1.0) / np.log10(2.0)
+        assert_allclose(img, ref, atol=0, rtol=1.e-5)
+
+    def test_asinh(self):
+        """Test arcsinh scaling."""
+        img = scale_image(DATA, scale='asinh')
+        mean, median, stddev = sigmaclip_stats(DATA, sigma=3.0)
+        z = (mean + (2.0 * stddev)) / 2.
+        ref = np.arcsinh(DATASCL / z) / np.arcsinh(1.0 / z)
+        assert_allclose(img, ref, atol=0, rtol=1.e-5)
+
+    def test_asinh_noiselevel(self):
+        """Test arcsinh scaling."""
+        img = scale_image(DATA, scale='asinh', noise_level=1.0)
+        z = 0.5
+        ref = np.arcsinh(DATASCL / z) / np.arcsinh(1.0 / z)
+        assert_allclose(img, ref, atol=0, rtol=1.e-5)
+
+    def test_asinh_noiselevel_zeroz(self):
+        """Test arcsinh scaling."""
+        img = scale_image(DATA, scale='asinh', noise_level=0.0)
+        z = 1.e-2
+        ref = np.arcsinh(DATASCL / z) / np.arcsinh(1.0 / z)
+        assert_allclose(img, ref, atol=0, rtol=1.e-5)

--- a/photutils/psf.py
+++ b/photutils/psf.py
@@ -9,8 +9,8 @@ from astropy.modeling.parameters import Parameter
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling import Fittable2DModel
-from imageutils import (extract_array_2d, subpixel_indices, add_array_2d,
-                        mask_to_mirrored_num)
+from .extern.imageutils import (extract_array_2d, subpixel_indices, add_array_2d,
+                                mask_to_mirrored_num)
 
 
 __all__ = ['DiscretePRF', 'create_prf', 'psf_photometry',


### PR DESCRIPTION
As discussed in https://github.com/astropy/imageutils/issues/15, for the photutils 0.1 release we should bundle `imageutils` in `photutils/extern`, because it will not be available in the Astropy core as `astropy.image` yet.

Technically this can be done by copying over files into `photutils/extern` or maybe by creating a git submodule in `photutils/extern` ... to be investigated / discussed here.

cc @larrybradley @astrofrog 
