### PR TITLE
Simplify API of photometry functions

### DIFF
--- a/photutils/aperture_funcs.py
+++ b/photutils/aperture_funcs.py
@@ -4,13 +4,70 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import numpy as np
 import math
+
+import numpy as np
 import warnings
 import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = []
+
+
+def get_phot_extents(data, positions, extents):
+    """
+    Get the photometry extents and check if the apertures is fully out of data.
+
+    Parameters
+    ----------
+    data : array_like
+        The 2-d array on which to perform photometry.
+
+    Returns
+    -------
+    extents : dict
+        The ``extents`` dictionary contains 3 elements:
+
+        * ``'ood_filter'``
+            A boolean array with `True` elements where the aperture is
+            falling out of the data region.
+        * ``'pixel_extent'``
+            x_min, x_max, y_min, y_max : Refined extent of apertures with
+            data coverage.
+        * ``'phot_extent'``
+            x_pmin, x_pmax, y_pmin, y_pmax: Extent centered to the 0, 0
+            positions as required by the `~photutils.geometry` functions.
+    """
+
+    # Check if an aperture is fully out of data
+    ood_filter = np.logical_or(extents[:, 0] >= data.shape[1],
+                               extents[:, 1] <= 0)
+    np.logical_or(ood_filter, extents[:, 2] >= data.shape[0],
+                  out=ood_filter)
+    np.logical_or(ood_filter, extents[:, 3] <= 0, out=ood_filter)
+
+    # TODO check whether it makes sense to have negative pixel
+    # coordinate, one could imagine a stackes image where the reference
+    # was a bit offset from some of the images? Or in those cases just
+    # give Skycoord to the Aperture and it should deal with the
+    # conversion for the actual case?
+    x_min = np.maximum(extents[:, 0], 0)
+    x_max = np.minimum(extents[:, 1], data.shape[1])
+    y_min = np.maximum(extents[:, 2], 0)
+    y_max = np.minimum(extents[:, 3], data.shape[0])
+
+    x_pmin = x_min - positions[:, 0] - 0.5
+    x_pmax = x_max - positions[:, 0] - 0.5
+    y_pmin = y_min - positions[:, 1] - 0.5
+    y_pmax = y_max - positions[:, 1] - 0.5
+
+    # TODO: check whether any pixel is nan in data[y_min[i]:y_max[i],
+    # x_min[i]:x_max[i])), if yes return something valid rather than nan
+
+    pixel_extent = [x_min, x_max, y_min, y_max]
+    phot_extent = [x_pmin, x_pmax, y_pmin, y_pmax]
+
+    return ood_filter, pixel_extent, phot_extent
 
 
 def find_fluxvar(data, fraction, error, flux, gain, imin, imax, jmin, jmax, pixelwise_error):
@@ -42,13 +99,17 @@ def find_fluxvar(data, fraction, error, flux, gain, imin, imax, jmin, jmax, pixe
     return fluxvar
 
 
-def do_circular_photometry(data, positions, extents, radius,
+def do_circular_photometry(data, positions, radius,
                            error, gain, pixelwise_error, method, subpixels, r_in=None):
 
+    extents = np.zeros((len(positions), 4), dtype=int)
 
-    ood_filter = extents['ood_filter']
-    extent = extents['pixel_extent']
-    phot_extent = extents['phot_extent']
+    extents[:,0] = positions[:,0] - radius + 0.5
+    extents[:,1] = positions[:,0] + radius + 1.5
+    extents[:,2] = positions[:,1] - radius + 0.5
+    extents[:,3] = positions[:,1] + radius + 1.5
+
+    ood_filter, extent, phot_extent = get_phot_extents(data, positions, extents)
 
     flux = u.Quantity(np.zeros(len(positions), dtype=np.float), unit=data.unit)
 
@@ -112,12 +173,20 @@ def do_circular_photometry(data, positions, extents, radius,
         return (flux, np.sqrt(fluxvar))
 
 
-def do_elliptical_photometry(data, positions, extents, a, b, theta,
+def do_elliptical_photometry(data, positions, a, b, theta,
                              error, gain, pixelwise_error, method, subpixels, a_in=None):
 
-    ood_filter = extents['ood_filter']
-    extent = extents['pixel_extent']
-    phot_extent = extents['phot_extent']
+    extents = np.zeros((len(positions), 4), dtype=int)
+
+    # TODO: we can be more efficient in terms of bounding box
+    radius = max(a, b)
+
+    extents[:,0] = positions[:,0] - radius + 0.5
+    extents[:,1] = positions[:,0] + radius + 1.5
+    extents[:,2] = positions[:,1] - radius + 0.5
+    extents[:,3] = positions[:,1] + radius + 1.5
+
+    ood_filter, extent, phot_extent = get_phot_extents(data, positions, extents)
 
     flux = u.Quantity(np.zeros(len(positions), dtype=np.float), unit=data.unit)
 
@@ -209,13 +278,21 @@ def rectangular_overlap(x_pmin, x_pmax, y_pmin, y_pmax, nx, ny,
     return downsample(in_aper, subpixels)
 
 
-def do_rectangular_photometry(data, positions, extents, w, h, theta,
+def do_rectangular_photometry(data, positions, w, h, theta,
                               error, gain, pixelwise_error, method, subpixels,
                               reduce='sum', w_in=None):
 
-    ood_filter = extents['ood_filter']
-    extent = extents['pixel_extent']
-    phot_extent = extents['phot_extent']
+    extents = np.zeros((len(positions), 4), dtype=int)
+
+    # TODO: this is an overestimate by up to sqrt(2) unless theta = 45 deg
+    radius = max(h, w) * (2 ** -0.5)
+
+    extents[:,0] = positions[:,0] - radius + 0.5
+    extents[:,1] = positions[:,0] + radius + 1.5
+    extents[:,2] = positions[:,1] - radius + 0.5
+    extents[:,3] = positions[:,1] + radius + 1.5
+
+    ood_filter, extent, phot_extent = get_phot_extents(data, positions, extents)
 
     flux = u.Quantity(np.zeros(len(positions), dtype=np.float), unit=data.unit)
 


### PR DESCRIPTION
**This relies on #165 and #166 which should be merged first, then this rebased**

This moves get_phot_extent to aperture_funcs so as to avoid having to pass `extents` to the photometry functions - this will make it easier to use drop-in replacements for the core photoemtry, such as SEP. I also vectorized the calculation of the extents.

To see the relevant changes here (without #165 and #166) see 19aa574367cb384e0fe0bdc4179b68429fe2dc89

cc @larrybradley @bsipocz @cdeil @eteq
