### PR TITLE
Print scikit-image version in test log

### DIFF
--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -11,5 +11,7 @@ enable_deprecations_as_exceptions()
 # Add scikit-image to test header information
 try:
     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+    del PYTEST_HEADER_MODULES['h5py']
+
 except NameError:  # astropy < 1.0
     pass


### PR DESCRIPTION
Currently `python setup.py test` prints the availability and version of packages used by Astropy to the console:

```
Numpy: 1.8.1
Scipy: 0.14.0
Matplotlib: not available
h5py: not available
```

@bsipocz For `photutils` it would be nice if this included `scikit-image` ... could you please try and figure out what needs to be done to get this printed?
(It will help with user bug reports we receive in the future.)
