### PR TITLE
Exclude extern folder from coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ distribute-*.tar.gz
 .project
 .pydevproject
 .settings
+.idea
+
 
 # Mac OSX
 .DS_Store

--- a/photutils/tests/coveragerc
+++ b/photutils/tests/coveragerc
@@ -9,6 +9,7 @@ omit =
     photutils/*setup*
     photutils/*tests/*
     photutils/version*
+    photutils/extern/*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
This PR excludes the `photutils/extern` folder from the coverage analysis and report.

Here's an example of our current coverage report which includes the `photutils/extern/wcs_utils.py` file:
https://coveralls.io/files/388352704

@astrofrog @larrybradley OK?
