### PR TITLE
Fixed #208

### DIFF
--- a/photutils/psf.py
+++ b/photutils/psf.py
@@ -490,13 +490,13 @@ def create_prf(data, positions, size, fluxes=None, mask=None, mode='mean',
                     # Replace NaN values by mirrored value, with respect
                     # to the prf's center
                     if fix_nan:
-                        prf_nan = np.isnan(extracted_prf)
+                        prf_nan = extracted_prf.mask
                         if prf_nan.any():
-                            if prf_nan.sum() > 3 or prf_nan[size / 2, size / 2]:
+                            if prf_nan.sum() > 3 or prf_nan[size // 2, size // 2]:
                                 continue
                             else:
                                 extracted_prf = mask_to_mirrored_num(
-                                    extracted_prf, prf_nan)
+                                    extracted_prf, prf_nan, (size // 2, size // 2))
                     # Normalize and add extracted PRF to data cube
                     if fluxes is None:
                         extracted_prf_norm = np.ma.copy(extracted_prf) / np.ma.sum(extracted_prf)

--- a/photutils/tests/test_psf_photometry.py
+++ b/photutils/tests/test_psf_photometry.py
@@ -66,7 +66,7 @@ def test_create_prf_nan():
     image_nan = image.copy()
     image_nan[52, 52] = np.nan
     image_nan[52, 48] = np.nan
-    prf = create_prf(image_nan, positions, psf_size, subsampling=1)
+    prf = create_prf(image_nan, positions, psf_size, subsampling=1, fix_nan=True)
     assert not np.isnan(prf._prf_array[0, 0]).any()
 
 


### PR DESCRIPTION
This fixes issue #208. `np.isnan` doesn't work on masked arrays, that's why `mask_to_mirrored_num` wasn't called. As the code was changed to completely use masked arrays now, the mask_to_mirrored_num` function may not even be necessary. But I think we'll keep it as an option.
