### PR TITLE
Fixing missing coordinate unit in aperture_photometry return for single ...

### DIFF
--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -1356,7 +1356,7 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
         if len(pixelpositions) > 1 and pixelpositions[0].size >= 2:
             coord_columns = (pixpos[0], pixpos[1], positions)
         else:
-            coord_columns = ((pixpos[0],), (pixpos[1],), (positions,))
+            coord_columns = (pixpos[0], pixpos[1], (positions, ))
         coord_col_names = ('xcenter', 'ycenter', 'center_input')
     else:
         pixelpositions = ap.positions * u.pixel


### PR DESCRIPTION
...positions

Sadly `hub` is not working out of the box, thus I couldn't attached this directly to #212. 
Part of the problem causing this bug was that the inner container of `SkyCoord` is not as consistent as `Quantity`'s for single and multiple elements. I'm not sure whether this is a feature or just accidental, if the latter I'll open an issue for it in core. 

```
In [325]: coord_columns_m
Out[324]: 
(<Quantity [ 99., 99.] pix>,
 <Quantity [ 49., 49.] pix>,
 <SkyCoord (ICRS): (ra, dec) in deg
     [(0.0, 0.0), (0.0, 0.0)]>)  

In [325]: coord_columns_s
Out[325]: 
(<Quantity [ 99.] pix>,
 <Quantity [ 49.] pix>,
 <SkyCoord (ICRS): ra=0.0 deg, dec=0.0 deg>)
```

fixes #212
