### PR TITLE
Added tests and minor changes to psf.py

### DIFF
--- a/photutils/psf.py
+++ b/photutils/psf.py
@@ -200,7 +200,7 @@ class GaussianPSF(Fittable2DModel):
     ----------
     sigma : float
         Width of the Gaussian PSF.
-    flux : float (default 1)
+    amplitude : float (default 1)
         Total flux integrated over the entire PSF.
     x_0 : float (default 0)
         Position of the peak in x direction.
@@ -231,14 +231,14 @@ class GaussianPSF(Fittable2DModel):
     Where ``erf`` denotes the error function and ``F`` to total
     integrated flux..
     """
-    flux = Parameter('flux')
+    amplitude = Parameter('amplitude')
     x_0 = Parameter('x_0')
     y_0 = Parameter('y_0')
     sigma = Parameter('sigma')
 
     _erf = None
 
-    def __init__(self, sigma, flux=1, x_0=0, y_0=0):
+    def __init__(self, sigma, amplitude=1, x_0=0, y_0=0):
         if self._erf is None:
             from scipy.special import erf
             self.__class__._erf = erf
@@ -246,7 +246,7 @@ class GaussianPSF(Fittable2DModel):
         constraints = {'fixed': {'x_0': True, 'y_0': True, 'sigma': True}}
         super(GaussianPSF, self).__init__(n_models=1, sigma=sigma,
                                           x_0=x_0, y_0=y_0,
-                                          flux=flux, **constraints)
+                                          amplitude=amplitude, **constraints)
 
         # Default size is 8 * sigma
         self.shape = (int(8 * sigma) + 1, int(8 * sigma) + 1)
@@ -256,11 +256,11 @@ class GaussianPSF(Fittable2DModel):
         self.x_0.fixed = True
         self.y_0.fixed = True
 
-    def eval(self, x, y, flux, x_0, y_0, sigma):
+    def eval(self, x, y, amplitude, x_0, y_0, sigma):
         """
         Model function Gaussian PSF model.
         """
-        return (flux / 4 *
+        return (amplitude / 4 *
                 ((self._erf((x - x_0 + 0.5) / (np.sqrt(2) * sigma)) -
                   self._erf((x - x_0 - 0.5) / (np.sqrt(2) * sigma))) *
                  (self._erf((y - y_0 + 0.5) / (np.sqrt(2) * sigma)) -
@@ -308,7 +308,7 @@ class GaussianPSF(Fittable2DModel):
             y = extract_array_2d(indices[0], self.shape, position)
             x = extract_array_2d(indices[1], self.shape, position)
             m = self.fitter(self, x, y, sub_array_data)
-            return m.flux.value
+            return m.amplitude.value
         else:
             return 0
 
@@ -542,11 +542,14 @@ def subtract_psf(data, psf, positions, fluxes, mask=None):
     """
     # Set up indices
     indices = np.indices(data.shape)
-
+    data_ = data.copy()
     # Loop over position
     for i, position in enumerate(positions):
         y = extract_array_2d(indices[0], psf.shape, position)
         x = extract_array_2d(indices[1], psf.shape, position)
-        psf_image = psf.eval(x, y, fluxes[i], position[0], position[1])
-        data = add_array_2d(data, -psf_image, position)
-    return data
+        psf.amplitude.value = fluxes[i]
+        psf.x_0.value = position[0]
+        psf.y_0.value = position[1]
+        psf_image = psf(x, y)
+        data_ = add_array_2d(data_, -psf_image, position)
+    return data_

--- a/photutils/tests/test_psf_photometry.py
+++ b/photutils/tests/test_psf_photometry.py
@@ -8,7 +8,7 @@ from astropy.tests.helper import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.convolution.utils import discretize_model
 
-from ..psf import create_prf, DiscretePRF, psf_photometry, GaussianPSF
+from ..psf import create_prf, DiscretePRF, psf_photometry, GaussianPSF, subtract_psf
 
 try:
     from scipy import optimize
@@ -17,29 +17,29 @@ except ImportError:
     HAS_SCIPY = False
 
 
-psf_size = 11
-gaussian_width = 1.
-image_size = 101
+PSF_SIZE = 11
+GAUSSIAN_WIDTH = 1.
+IMAGE_SIZE = 101
 
-# Position and fluxes of test sources
-positions = [(50, 50), (23, 83), (12, 80), (86, 84)]
-fluxes = [np.pi * 10, 3.654, 20., 80 / np.sqrt(3)]
+# Position and FLUXES of test sources
+POSITIONS = [(50, 50), (23, 83), (12, 80), (86, 84)]
+FLUXES = [np.pi * 10, 3.654, 20., 80 / np.sqrt(3)]
 
 # Create test psf
-psf_model = Gaussian2D(1. / (2 * np.pi * gaussian_width ** 2), psf_size // 2,
-                       psf_size // 2, gaussian_width, gaussian_width)
-test_psf = discretize_model(psf_model, (0, psf_size), (0, psf_size),
+psf_model = Gaussian2D(1. / (2 * np.pi * GAUSSIAN_WIDTH ** 2), PSF_SIZE // 2,
+                       PSF_SIZE // 2, GAUSSIAN_WIDTH, GAUSSIAN_WIDTH)
+test_psf = discretize_model(psf_model, (0, PSF_SIZE), (0, PSF_SIZE),
                             mode='oversample')
 
 # Set up grid for test image
-image = np.zeros((image_size, image_size))
+image = np.zeros((IMAGE_SIZE, IMAGE_SIZE))
 
 # Add sources to test image
-for i, position in enumerate(positions):
+for flux, position in zip(FLUXES, POSITIONS):
     x, y = position
-    model = Gaussian2D(fluxes[i] / (2 * np.pi * gaussian_width ** 2),
-                       x, y, gaussian_width, gaussian_width)
-    image += discretize_model(model, (0, image_size), (0, image_size),
+    model = Gaussian2D(flux / (2 * np.pi * GAUSSIAN_WIDTH ** 2),
+                       x, y, GAUSSIAN_WIDTH, GAUSSIAN_WIDTH)
+    image += discretize_model(model, (0, IMAGE_SIZE), (0, IMAGE_SIZE),
                               mode='oversample')
 
 
@@ -47,7 +47,7 @@ def test_create_prf_mean():
     """
     Check if create_prf works correctly on simulated data.
     """
-    prf = create_prf(image, positions, psf_size, subsampling=1, mode='mean')
+    prf = create_prf(image, POSITIONS, PSF_SIZE, subsampling=1, mode='mean')
     assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
 
 
@@ -55,7 +55,7 @@ def test_create_prf_median():
     """
     Check if create_prf works correctly on simulated data.
     """
-    prf = create_prf(image, positions, psf_size, subsampling=1, mode='median')
+    prf = create_prf(image, POSITIONS, PSF_SIZE, subsampling=1, mode='median')
     assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
 
 
@@ -66,16 +66,16 @@ def test_create_prf_nan():
     image_nan = image.copy()
     image_nan[52, 52] = np.nan
     image_nan[52, 48] = np.nan
-    prf = create_prf(image_nan, positions, psf_size, subsampling=1,
+    prf = create_prf(image_nan, POSITIONS, PSF_SIZE, subsampling=1,
                      fix_nan=True)
     assert not np.isnan(prf._prf_array[0, 0]).any()
 
 
 def test_create_prf_flux():
     """
-    Check if create_prf works correctly when fluxes are specified.
+    Check if create_prf works correctly when FLUXES are specified.
     """
-    prf = create_prf(image, positions, psf_size, fluxes=fluxes, subsampling=1)
+    prf = create_prf(image, POSITIONS, PSF_SIZE, fluxes=FLUXES, subsampling=1)
     assert_allclose(prf._prf_array[0, 0].sum(), 1)
     assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
 
@@ -86,8 +86,8 @@ def test_discrete_prf_fit():
     Check if fitting of discrete PSF model works.
     """
     prf = DiscretePRF(test_psf, subsampling=1)
-    prf.x_0 = psf_size // 2
-    prf.y_0 = psf_size // 2
+    prf.x_0 = PSF_SIZE // 2
+    prf.y_0 = PSF_SIZE // 2
 
     # test_psf is normalized to unity
     data = 10 * test_psf
@@ -102,8 +102,42 @@ def test_psf_photometry_discrete():
     Test psf_photometry with discrete PRF model.
     """
     prf = DiscretePRF(test_psf, subsampling=1)
-    f = psf_photometry(image, positions, prf)
-    assert_allclose(f, fluxes, rtol=1E-6)
+    f = psf_photometry(image, POSITIONS, prf)
+    assert_allclose(f, FLUXES, rtol=1E-6)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_tune_coordinates():
+    """
+    Test psf_photometry with discrete PRF model and tune_coordinates=True.
+    """
+    prf = DiscretePRF(test_psf, subsampling=1)
+    # Shift all sources by 0.3 pixels
+    positions = [(_[0] + 0.3, _[1] + 0.3) for _ in POSITIONS]
+    f = psf_photometry(image, positions, prf, tune_coordinates=True)
+    assert_allclose(f, FLUXES, rtol=1E-6)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_psf_boundary():
+    """
+    Test psf_photometry with discrete PRF model at the boundary of the data.
+    """
+    prf = DiscretePRF(test_psf, subsampling=1)
+    # Shift all sources by 0.3 pixels
+    f = psf_photometry(image, [(1, 1)], prf)
+    assert f == 0
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_psf_boundary_gaussian():
+    """
+    Test psf_photometry with discrete PRF model at the boundary of the data.
+    """
+    psf = GaussianPSF(GAUSSIAN_WIDTH)
+    # Shift all sources by 0.3 pixels
+    f = psf_photometry(image, [(1, 1)], psf)
+    assert f == 0
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -111,6 +145,16 @@ def test_psf_photometry_gaussian():
     """
     Test psf_photometry with Gaussian PSF model.
     """
-    prf = GaussianPSF(gaussian_width)
-    f = psf_photometry(image, positions, prf)
-    assert_allclose(f, fluxes, rtol=1E-3)
+    prf = GaussianPSF(GAUSSIAN_WIDTH)
+    f = psf_photometry(image, POSITIONS, prf)
+    assert_allclose(f, FLUXES, rtol=1E-3)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_subtract_psf():
+    """
+    Test subtract_psf
+    """
+    prf = DiscretePRF(test_psf, subsampling=1)
+    residuals = subtract_psf(image, prf, POSITIONS, FLUXES)
+    assert_allclose(residuals, np.zeros_like(image), atol=1E-6)


### PR DESCRIPTION
This PR inlcudes a few more tests for psf photometry and a few minor changes to `psf.py`. I renamed the `flux` parameter of the `GaussianPSF` to `amplitude`, which makes it consistent with the `DiscretePRF` and `astropy.modeling`.  `subtract_psf`subtracted from the data array itsself, instead of working on a copy of the data. This has changed now.  Furthermore I renamed the `eval` function to `evaluate`, to follow the changes in `astropy.modeling`. 
