### PR TITLE
Make PixelAperture.area an abstract method

### DIFF
--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -191,7 +191,8 @@ class PixelAperture(Aperture):
             if input ``error`` is not `None`.
         """
 
-    def area():
+    @abc.abstractmethod
+    def area(self):
         """
         Area of aperture.
 


### PR DESCRIPTION
@bsipocz @astrofrog Does it make sense to make PixelAperture.area an abstract method?

All tests pass before or after this change ... I made it because my editor was complaining here about the missing `self`.