### PR TITLE
Glitch in background estimation docs

### DIFF
--- a/docs/photutils/background.rst
+++ b/docs/photutils/background.rst
@@ -107,8 +107,8 @@ levels::
 
     >>> from photutils.extern.imageutils.stats import sigma_clipped_stats
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)
-    >>> print(median, median, std)    # doctest: +FLOAT_CMP
-    (5.15557244947, 5.15557244947, 2.09393539966)
+    >>> print(mean, median, std)    # doctest: +FLOAT_CMP
+    (5.19888175541, 5.15557244947, 2.09393539966)
 
 
 Masking Sources


### PR DESCRIPTION
While playing around with photutils 0.1, I spotted this tiny glitch in the docs.

(PS: Thanks for the first release!)
