### PR TITLE
Adding requirements of skimage for daofind tests

### DIFF
--- a/docs/photutils/getting_started.rst
+++ b/docs/photutils/getting_started.rst
@@ -24,6 +24,8 @@ estimated using the median absolution deviation of the image.  The
 parameters of the detected sources are returned as an Astropy
 `~astropy.table.Table`:
 
+.. doctest-requires:: scipy, skimage
+
     >>> from photutils import daofind
     >>> from astropy.stats import median_absolute_deviation as mad
     >>> from photutils.extern.stats import mad_std
@@ -49,6 +51,8 @@ we now compute the sum of the pixel values in circular apertures with
 a radius of 4 pixels.  The :func:`~photutils.aperture_photometry`
 function returns an Astropy `~astropy.table.Table` with the results of
 the photometry:
+
+.. doctest-requires:: scipy, skimage
 
     >>> from photutils import aperture_photometry, CircularAperture
     >>> positions = (sources['xcentroid'], sources['ycentroid'])    # doctest: +REMOTE_DATA

--- a/docs/photutils/morphology.rst
+++ b/docs/photutils/morphology.rst
@@ -43,7 +43,7 @@ subtract the background)::
     >>> print(x2, y2)    # doctest: +FLOAT_CMP
     (14.035151484100131, 16.967749965238156)
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
     >>> x3, y3 = centroid_2dg(data)
     >>> print(x3, y3)    # doctest: +FLOAT_CMP

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -32,6 +32,7 @@ warnings.simplefilter('always', AstropyUserWarning)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif('not HAS_SKIMAGE')
 class TestDAOFind(object):
     @pytest.mark.parametrize(('threshold', 'fwhm'),
                              list(itertools.product(THRESHOLDS, FWHMS)))


### PR DESCRIPTION
Tests are failing when the ``scikit-image`` package isn't available.