### PR TITLE
build_sphinx doesn't work on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,10 @@ matrix:
         # may run for a long time
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx -w'
+        # TODO: update astropy-helpers ans add `-w` option once this has been released
+        # https://github.com/astropy/astropy-helpers/pull/123
         - python: 3.4
-          env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx -w'
+          env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx'
 
         # Try Astropy development version
         - python: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
         # may run for a long time
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx -w'
+        - python: 3.4
+          env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx -w'
 
         # Try Astropy development version
         - python: 3.3
@@ -112,9 +114,7 @@ install:
     # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
 
     # DOCUMENTATION DEPENDENCIES
-    # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
-    # this matplotlib will *not* work with py 3.x, but our sphinx build is
-    # currently 2.7, so that's fine
+    # build_sphinx needs sphinx and matplotlib (for plot_directive).
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -304,7 +304,7 @@ def _do_download(version='', find_links=None, index_url=None):
             allow_hosts = None
         # Annoyingly, setuptools will not handle other arguments to
         # Distribution (such as options) before handling setup_requires, so it
-        # is not straightfoward to programmatically augment the arguments which
+        # is not straightforward to programmatically augment the arguments which
         # are passed to easy_install
         class _Distribution(Distribution):
             def get_option_dict(self, command_name):
@@ -405,7 +405,7 @@ def _check_submodule(path, use_git=True, offline=False):
     Check if the given path is a git submodule.
 
     See the docstrings for ``_check_submodule_using_git`` and
-    ``_check_submodule_no_git`` for futher details.
+    ``_check_submodule_no_git`` for further details.
     """
 
     if use_git:
@@ -512,7 +512,7 @@ def _check_submodule_no_git(path):
 
     # This is a minimal reader for gitconfig-style files.  It handles a few of
     # the quirks that make gitconfig files incompatible with ConfigParser-style
-    # files, but does not support the full gitconfig syntaix (just enough
+    # files, but does not support the full gitconfig syntax (just enough
     # needed to read a .gitmodules file).
     gitmodules_fileobj = io.StringIO()
 


### PR DESCRIPTION
For me this doesn't work with Python 3.4 and Astropy master:
```
$ python setup.py build_sphinx
...
  File "/Users/deil/code/photutils/astropy_helpers/astropy_helpers/sphinx/ext/automodsumm.py", line 203, in run
    self.arguments = [' '.join(clsnms).decode('utf-8')]
AttributeError: 'str' object has no attribute 'decode'
```
(see full traceback [here](https://gist.github.com/cdeil/99c717f807e0017246a9#file-gistfile1-txt-L83).)

Can someone confirm this issue?
I'll try running the sphinx build with Python 3 on travis-ci and then update the `astropy-helpers` pointer to the latest 0.4.4 release (see [astropy-helpers on pypi](https://pypi.python.org/pypi/astropy-helpers/)) to see if that is the issue.