### PR TITLE
Make PixelAperture.area an abstract method and a lazyproperty

### DIFF
--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -240,7 +240,7 @@ tables::
 
 To calculate the mean local background within the circular annulus
 aperture, we need to divide its sum by its area, which can be
-calculated using the :meth:`~photutils.CircularAnnulus.area` method::
+calculated using the `~photutils.CircularAnnulus.area` property::
 
     >>> bkg_mean = phot_table['aperture_sum_bkg'] / annulus_apertures.area
 
@@ -461,22 +461,21 @@ simply requires the definition of a new `~photutils.Aperture`
 subclass.
 
 All `~photutils.Aperture` subclasses must implement only two methods,
-``do_photometry(data)`` and ``plot()``.  They can optionally
-implement a third method, ``area()``.
+``do_photometry(data)`` and ``plot()``, and an ``area``
+`lazyproperty`_.
 
 * ``do_photometry(data)``: A method to sum the pixel values within the
   defined aperture.
 * ``plot()``: A method to plot the aperture on a `matplotlib`_ Axes
   instance.
-* ``area()``: If convenient to calculate, this returns the area of the
-  aperture.  This speeds computation in certain situations (such as a
-  scalar error).
+* ``area()``: A `lazyproperty`_ to return the area of the aperture.
 
 Note that all x and y coordinates here refer to the fast and slow
 (second and first) axis of the data array respectively.  See
 :ref:`coordinate-conventions`.
 
 .. _matplotlib: http://matplotlib.org
+.. _lazyproperty: http://astropy.readthedocs.org/en/stable/api/astropy.utils.misc.lazyproperty.html?highlight=lazyproperty
 
 See Also
 --------

--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -15,6 +15,7 @@ from astropy.table import Table
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
 from astropy.extern import six
+from astropy.utils import lazyproperty
 from astropy.utils.misc import InheritDocstrings
 from astropy.utils.exceptions import AstropyUserWarning
 from .aperture_funcs import (do_circular_photometry, do_elliptical_photometry,
@@ -284,6 +285,7 @@ class CircularAperture(PixelAperture):
 
         self.positions = _sanitize_pixel_positions(positions)
 
+    @lazyproperty
     def area(self):
         return math.pi * self.r ** 2
 
@@ -420,6 +422,7 @@ class CircularAnnulus(PixelAperture):
 
         self.positions = _sanitize_pixel_positions(positions)
 
+    @lazyproperty
     def area(self):
         return math.pi * (self.r_out ** 2 - self.r_in ** 2)
 
@@ -572,6 +575,7 @@ class EllipticalAperture(PixelAperture):
 
         self.positions = _sanitize_pixel_positions(positions)
 
+    @lazyproperty
     def area(self):
         return math.pi * self.a * self.b
 
@@ -741,6 +745,7 @@ class EllipticalAnnulus(PixelAperture):
 
         self.positions = _sanitize_pixel_positions(positions)
 
+    @lazyproperty
     def area(self):
         return math.pi * (self.a_out * self.b_out - self.a_in * self.b_in)
 
@@ -893,6 +898,7 @@ class RectangularAperture(PixelAperture):
 
         self.positions = _sanitize_pixel_positions(positions)
 
+    @lazyproperty
     def area(self):
         return self.w * self.h
 
@@ -1077,6 +1083,7 @@ class RectangularAnnulus(PixelAperture):
 
         self.positions = _sanitize_pixel_positions(positions)
 
+    @lazyproperty
     def area(self):
         """
         Returns

--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -193,7 +193,8 @@ class PixelAperture(Aperture):
             if input ``error`` is not `None`.
         """
 
-    def area():
+    @abc.abstractmethod
+    def area(self):
         """
         Area of aperture.
 

--- a/photutils/tests/test_aperture_photometry.py
+++ b/photutils/tests/test_aperture_photometry.py
@@ -53,7 +53,7 @@ def test_inside_array_simple(aperture_class, params):
     table2 = aperture_photometry(data, aperture, method='subpixel',
                                  subpixels=10)
     table3 = aperture_photometry(data, aperture, method='exact', subpixels=10)
-    true_flux = aperture.area()
+    true_flux = aperture.area
 
     if not isinstance(aperture, (RectangularAperture, RectangularAnnulus)):
         assert_allclose(table3['aperture_sum'], true_flux)


### PR DESCRIPTION
Note that placing `@lazyproperty` on the `@abc.abstractmethod` doesn't require it to be a lazyproperty in the subclasses.  I couldn't find a way to to that, but `@abc.abstractmethod` will at least require an `area` method in any pixel Aperture subclasses.

This PR incorporates @cdeil's commit in #223 to make `area()` and abstract method.