### PR TITLE
Allow subpixel precision in find_peaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,3 +12,14 @@ New Features
 
   - ``find_peaks`` now returns an Astropy Table containing the (x, y)
     positions and peak values. [#240]
+
+  - ``find_peaks`` has new ``mask``, ``error``, ``wcs`` and ``subpixel``
+    precision options. [#244]
+
+- ``photutils.morphology``
+
+  - Added new ``GaussianConst1D`` and ``GaussianConst2D`` models [#244].
+
+  - Added new ``marginalize_data2d`` function [#244].
+
+  - Added new ``cutout_footprint`` function [#244].

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ except ImportError:
 
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
+from astropy.extern import six
 
 # Get configuration information from setup.cfg
 from distutils import config
@@ -176,3 +177,11 @@ if eval(setup_cfg.get('edit_on_github')):
 autodoc_docstring_signature = True
 
 nitpicky = True
+nitpick_ignore = []
+
+for line in open('nitpick-exceptions'):
+    if line.strip() == "" or line.startswith("#"):
+        continue
+    dtype, target = line.split(None, 1)
+    target = target.strip()
+    nitpick_ignore.append((dtype, six.u(target)))

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -1,0 +1,2 @@
+# photutils.morphology
+py:class photutils.morphology.CompoundModel1

--- a/docs/photutils/detection.rst
+++ b/docs/photutils/detection.rst
@@ -253,7 +253,7 @@ sigma above the background and a separated by a least 2 pixels:
     >>> data = make_100gaussians_image()
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)
     >>> threshold = median + (10.0 * std)
-    >>> tbl = find_peaks(data, threshold, min_separation=2)
+    >>> tbl = find_peaks(data, threshold, box_size=5)
     >>> print(tbl[:10])    # print only the first 10 peaks
     x_peak y_peak   peak_value
     ------ ------ -------------
@@ -290,7 +290,7 @@ And let's plot the location of the detected peaks in the image:
     data = make_100gaussians_image()
     mean, median, std = sigma_clipped_stats(data, sigma=3.0)
     threshold = median + (10.0 * std)
-    tbl = find_peaks(data, threshold, min_separation=2)
+    tbl = find_peaks(data, threshold, box_size=5)
 
     from astropy.visualization import SqrtStretch
     from astropy.visualization.mpl_normalize import ImageNormalize

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -381,16 +381,15 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         x_centroid, y_centroid = [], []
         fit_peak_values = []
         for (y_peak, x_peak) in zip(y_peaks, x_peaks):
-            region = cutout_footprint(data, (x_peak, y_peak),
-                                      box_size=box_size, footprint=footprint,
-                                      mask=mask, error=error)
-            gaussian_fit = fit_2dgaussian(region[0], mask=region[1],
-                                          error=region[2])
+            rdata, rmask, rerror, slc = cutout_footprint(
+                data, (x_peak, y_peak), box_size=box_size,
+                footprint=footprint, mask=mask, error=error)
+            gaussian_fit = fit_2dgaussian(rdata, mask=rmask, error=rerror)
             if gaussian_fit is None:
                 x_cen, y_cen, fit_peak_value = np.nan, np.nan, np.nan
             else:
-                x_cen = region[3][1].start + gaussian_fit.x_mean_1.value
-                y_cen = region[3][0].start + gaussian_fit.y_mean_1.value
+                x_cen = slc[1].start + gaussian_fit.x_mean_1.value
+                y_cen = slc[0].start + gaussian_fit.y_mean_1.value
                 fit_peak_value = (gaussian_fit.amplitude_0.value +
                                   gaussian_fit.amplitude_1.value)
             x_centroid.append(x_cen)

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -253,7 +253,8 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
 
 
 def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
-               border_width=None, npeaks=np.inf, subpixel=False, wcs=None):
+               border_width=None, npeaks=np.inf, subpixel=False, error=None,
+               wcs=None):
     """
     Find local peaks in an image that are above above a specified
     threshold value.
@@ -313,6 +314,11 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         2D Gaussian.  In this case, the fitted local centroid and peak
         amplitude will also be returned in the output table.
 
+    error : array_like, optional
+        The 2D array of the 1-sigma errors of the input ``data``.
+        ``error`` is used only to weight the 2D Gaussian fit performed
+        when ``subpixel=True``.
+
     wcs : `~astropy.wcs.WCS`
         The WCS transformation to use to convert from pixel coordinates
         to ICRS world coordinates.  If `None`, then the world
@@ -369,7 +375,8 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         fit_peak_values = []
         for (y_peak, x_peak) in zip(y_peaks, x_peaks):
             xcen, ycen, peakval = centroid_footprint(
-                data, (x_peak, y_peak), box_size, footprint, mask)
+                data, (x_peak, y_peak), box_size=box_size,
+                footprint=footprint, mask=mask, error=error)
             x_centroid.append(xcen)
             y_centroid.append(ycen)
             fit_peak_values.append(peakval)

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -385,10 +385,13 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
                                       mask=mask, error=error)
             gaussian_fit = fit_2dgaussian(region[0], mask=region[1],
                                           error=region[2])
-            x_cen = region[3][1].start + gaussian_fit.x_mean_1.value
-            y_cen = region[3][0].start + gaussian_fit.y_mean_1.value
-            fit_peak_value = (gaussian_fit.amplitude_0.value +
-                              gaussian_fit.amplitude_1.value)
+            if gaussian_fit is None:
+                x_cen, y_cen, fit_peak_value = np.nan, np.nan, np.nan
+            else:
+                x_cen = region[3][1].start + gaussian_fit.x_mean_1.value
+                y_cen = region[3][0].start + gaussian_fit.y_mean_1.value
+                fit_peak_value = (gaussian_fit.amplitude_0.value +
+                                  gaussian_fit.amplitude_1.value)
             x_centroid.append(x_cen)
             y_centroid.append(y_cen)
             fit_peak_values.append(fit_peak_value)

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -386,8 +386,9 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
                 region_mask = np.zeros_like(region, dtype=np.bool)
             footprint_mask = footprint_mask[slices_small]  # trim if necessary
             region_mask = np.logical_or(region_mask, footprint_mask)
-            gaussian_fit = fit_2dgaussian(region, mask=region_mask)
-            fit_peak_value.append(gaussian_fit.amplitude.value)
+            bkg = np.nanmin(region)
+            gaussian_fit = fit_2dgaussian(region - bkg, mask=region_mask)
+            fit_peak_value.append(gaussian_fit.amplitude.value + bkg)
             x_centroid.append(slices_large[1].start +
                               gaussian_fit.x_mean.value)
             y_centroid.append(slices_large[0].start +

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -274,8 +274,9 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     When using subpixel precision (``subpixel=True``), then a cutout of
     the specified ``box_size`` or ``footprint`` will be taken centered
     on each peak and fit with a 2D Gaussian (plus a constant).  In this
-    case, the fitted local centroid and peak amplitude will also be
-    returned in the output table.
+    case, the fitted local centroid and peak value (the Gaussian
+    amplitude plus the background constant) will also be returned in the
+    output table.
 
     Parameters
     ----------
@@ -317,8 +318,8 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         If `True`, then a cutout of the specified ``box_size`` or
         ``footprint`` will be taken centered on each peak and fit with a
         2D Gaussian (plus a constant).  In this case, the fitted local
-        centroid and peak amplitude will also be returned in the output
-        table.
+        centroid and peak value (the Gaussian amplitude plus the
+        background constant) will also be returned in the output table.
 
     error : array_like, optional
         The 2D array of the 1-sigma errors of the input ``data``.

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -386,13 +386,12 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
                 region_mask = np.zeros_like(region, dtype=np.bool)
             footprint_mask = footprint_mask[slices_small]  # trim if necessary
             region_mask = np.logical_or(region_mask, footprint_mask)
-            bkg = np.nanmin(region)
-            gaussian_fit = fit_2dgaussian(region - bkg, mask=region_mask)
-            fit_peak_value.append(gaussian_fit.amplitude.value + bkg)
+            gaussian_fit = fit_2dgaussian(region, mask=region_mask)
+            fit_peak_value.append(gaussian_fit.amplitude_1.value)
             x_centroid.append(slices_large[1].start +
-                              gaussian_fit.x_mean.value)
+                              gaussian_fit.x_mean_1.value)
             y_centroid.append(slices_large[0].start +
-                              gaussian_fit.y_mean.value)
+                              gaussian_fit.y_mean_1.value)
 
         columns = (x_peaks, y_peaks, peak_values, x_centroid, y_centroid,
                    fit_peak_value)

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -266,7 +266,7 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     as a square box.  ``footprint`` is a boolean array where `True`
     values specify the region shape.
 
-    If mulitple pixels within a local region have identical intensities,
+    If multiple pixels within a local region have identical intensities,
     then the coordinates of all such pixels are returned.  Otherwise,
     there will be only one peak pixel per local region.  Thus, the
     defined region effectively imposes a minimum separation between

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -328,18 +328,19 @@ def find_peaks(data, threshold, box_size=3, footprint=None,
         data_max = ndimage.maximum_filter(data, size=box_size,
                                           mode='constant', cval=0.0)
 
-    peak_data = data.copy()
-    peak_data *= (data == data_max)
+    peak_data = (data == data_max)   # good pixels, where max-filter data
+                                     # != data
 
     if border_width is not None:
         for i in range(peak_data.ndim):
             peak_data = peak_data.swapaxes(0, i)
-            peak_data[:border_width] = 0.
-            peak_data[-border_width:] = 0.
+            peak_data[:border_width] = False
+            peak_data[-border_width:] = False
             peak_data = peak_data.swapaxes(0, i)
 
-    y_peaks, x_peaks = (peak_data > threshold).nonzero()
-    peak_values = peak_data[y_peaks, x_peaks]
+    peak_data *= (data > threshold)
+    y_peaks, x_peaks = peak_data.nonzero()
+    peak_values = data[y_peaks, x_peaks]
 
     if len(x_peaks) > npeaks:
         idx = np.argsort(peak_values)[::-1][:npeaks]

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -388,8 +388,7 @@ def _findobjs(data, threshold, kernel, min_separation=None,
         else:
             from skimage.morphology import disk
             footprint = disk(min_separation)
-        tbl = find_peaks(convolved_data, threshold,
-                         exclude_border=exclude_border, footprint=footprint)
+        tbl = find_peaks(convolved_data, threshold, footprint=footprint)
         coords = np.transpose([tbl['y_peak'], tbl['x_peak']])
     else:
         object_slices = ndimage.find_objects(object_labels)

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -207,6 +207,13 @@ class TestFindPeaks(object):
         assert_array_equal(tbl['y_peak'], PEAKREF1[:, 0])
         assert_array_equal(tbl['peak_value'], [1., 1.])
 
+    def test_subpixel_regionsize(self):
+        """Test that data cutout has at least 6 values."""
+        tbl = find_peaks(PEAKDATA, 0.1, box_size=2, subpixel=True)
+        assert np.all(np.isnan(tbl['x_centroid']))
+        assert np.all(np.isnan(tbl['y_centroid']))
+        assert np.all(np.isnan(tbl['fit_peak_value']))
+
     def test_mask(self):
         """Test with mask."""
         mask = np.zeros_like(PEAKDATA, dtype=bool)
@@ -216,6 +223,11 @@ class TestFindPeaks(object):
         assert_array_equal(tbl['x_peak'], PEAKREF1[1, 0])
         assert_array_equal(tbl['y_peak'], PEAKREF1[1, 1])
         assert_array_equal(tbl['peak_value'], 1.0)
+
+    def test_maskshape(self):
+        """Test if make shape doesn't match data shape."""
+        with pytest.raises(ValueError):
+            find_peaks(PEAKDATA, 0.1, mask=np.ones((5, 5)))
 
     def test_npeaks(self):
         """Test npeaks."""
@@ -250,4 +262,8 @@ class TestFindPeaks(object):
         from astropy.wcs import WCS
         hdu = make_4gaussians_image(hdu=True, wcs=True)
         wcs = WCS(hdu.header)
-        tbl = find_peaks(hdu.data, 100, wcs=wcs)
+        tbl = find_peaks(hdu.data, 100, wcs=wcs, subpixel=True)
+        cols = ['icrs_ra_peak', 'icrs_dec_peak', 'icrs_ra_centroid',
+                'icrs_dec_centroid']
+        for col in cols:
+            assert col in tbl.colnames

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -207,6 +207,16 @@ class TestFindPeaks(object):
         assert_array_equal(tbl['y_peak'], PEAKREF1[:, 0])
         assert_array_equal(tbl['peak_value'], [1., 1.])
 
+    def test_mask(self):
+        """Test with mask."""
+        mask = np.zeros_like(PEAKDATA, dtype=bool)
+        mask[0, 0] = True
+        tbl = find_peaks(PEAKDATA, 0.1, box_size=3, mask=mask)
+        assert len(tbl) == 1
+        assert_array_equal(tbl['x_peak'], PEAKREF1[1, 0])
+        assert_array_equal(tbl['y_peak'], PEAKREF1[1, 1])
+        assert_array_equal(tbl['peak_value'], 1.0)
+
     def test_npeaks(self):
         """Test npeaks."""
         tbl = find_peaks(PEAKDATA, 0.1, box_size=3, npeaks=1)
@@ -233,3 +243,11 @@ class TestFindPeaks(object):
         tbl1 = find_peaks(PEAKDATA, 0.1, box_size=5.)
         tbl2 = find_peaks(PEAKDATA, 0.1, box_size=5.5)
         assert_array_equal(tbl1, tbl2)
+
+    def test_wcs(self):
+        """Test with WCS."""
+        from photutils.datasets import make_4gaussians_image
+        from astropy.wcs import WCS
+        hdu = make_4gaussians_image(hdu=True, wcs=True)
+        wcs = WCS(hdu.header)
+        tbl = find_peaks(hdu.data, 100, wcs=wcs)

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -26,7 +26,6 @@ REF3 = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
 
 PEAKDATA = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1]]).astype(np.float)
 PEAKREF1 = np.array([[0, 0], [2, 2]])
-PEAKREF2 = np.array([]).reshape(0, 2)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -194,44 +193,43 @@ class TestDetectSources(object):
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_SKIMAGE')
 class TestFindPeaks(object):
-    def test_find_peaks(self):
-        """Test basic peak detection."""
-        tbl = find_peaks(PEAKDATA, 0.1, min_separation=1,
-                         exclude_border=False)
+    def test_box_size(self):
+        """Test with box_size."""
+        tbl = find_peaks(PEAKDATA, 0.1, box_size=3)
         assert_array_equal(tbl['x_peak'], PEAKREF1[:, 1])
         assert_array_equal(tbl['y_peak'], PEAKREF1[:, 0])
         assert_array_equal(tbl['peak_value'], [1., 1.])
 
-    def test_segment_image(self):
-        segm = PEAKDATA.copy()
-        tbl = find_peaks(PEAKDATA, 0.1, min_separation=1,
-                         exclude_border=False, segment_image=segm)
+    def test_footprint(self):
+        """Test with footprint."""
+        tbl = find_peaks(PEAKDATA, 0.1, footprint=np.ones((3, 3)))
         assert_array_equal(tbl['x_peak'], PEAKREF1[:, 1])
         assert_array_equal(tbl['y_peak'], PEAKREF1[:, 0])
+        assert_array_equal(tbl['peak_value'], [1., 1.])
 
-    def test_segment_image_npeaks(self):
-        segm = PEAKDATA.copy()
-        tbl = find_peaks(PEAKDATA, 0.1, min_separation=1,
-                         exclude_border=False, segment_image=segm, npeaks=1)
+    def test_npeaks(self):
+        """Test npeaks."""
+        tbl = find_peaks(PEAKDATA, 0.1, box_size=3, npeaks=1)
         assert_array_equal(tbl['x_peak'], PEAKREF1[1, 1])
         assert_array_equal(tbl['y_peak'], PEAKREF1[1, 0])
 
-    def test_segment_image_shape(self):
-        segm = np.zeros((2, 2))
-        with pytest.raises(ValueError):
-            find_peaks(PEAKDATA, 0.1, segment_image=segm)
-
-    def test_exclude_border(self):
-        """Test exclude_border."""
-        tbl = find_peaks(PEAKDATA, 0.1, min_separation=1, exclude_border=True)
+    def test_border_width(self):
+        """Test border exclusion."""
+        tbl = find_peaks(PEAKDATA, 0.1, box_size=3, border_width=3)
         assert_array_equal(len(tbl), 0)
 
     def test_zerodet(self):
         """Test with large threshold giving no sources."""
-        tbl = find_peaks(PEAKDATA, 5., min_separation=1, exclude_border=True)
+        tbl = find_peaks(PEAKDATA, 5., box_size=3, border_width=3)
         assert_array_equal(len(tbl), 0)
 
-    def test_min_separation_int(self):
-        tbl1 = find_peaks(PEAKDATA, 0.1, min_separation=2.)
-        tbl2 = find_peaks(PEAKDATA, 0.1, min_separation=2.5)
+    def test_constant_data(self):
+        """Test constant data."""
+        tbl = find_peaks(np.ones((5, 5)), 0.1, box_size=3.)
+        assert_array_equal(len(tbl), 0)
+
+    def test_box_size_int(self):
+        """Test non-integer box_size."""
+        tbl1 = find_peaks(PEAKDATA, 0.1, box_size=5.)
+        tbl2 = find_peaks(PEAKDATA, 0.1, box_size=5.5)
         assert_array_equal(tbl1, tbl2)

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -14,19 +14,44 @@ from .segmentation import SegmentProperties
 import warnings
 
 
-__all__ = ['GaussianConst1D', 'GaussianConst2D', 'centroid_com',
-           'gaussian1d_moments', 'marginalize_data2d', 'centroid_1dg',
-           'centroid_2dg', 'fit_2dgaussian', 'data_properties',
-           'cutout_footprint']
+__all__ = ['GaussianConst2D', 'centroid_com', 'gaussian1d_moments',
+           'marginalize_data2d', 'centroid_1dg', 'centroid_2dg',
+           'fit_2dgaussian', 'data_properties', 'cutout_footprint']
 
 
-class GaussianConst1D(Const1D + Gaussian1D):
-    """A 1D Gaussian plus a constant."""
+class _GaussianConst1D(Const1D + Gaussian1D):
+    """A 1D Gaussian plus a constant model."""
 
 
 class GaussianConst2D(Const2D + Gaussian2D):
-    """A 2D Gaussian plus a constant."""
+    """
+    A 2D Gaussian plus a constant model.
 
+    Parameters
+    ----------
+    amplitude_0 : float
+        Value of the constant.
+    amplitude_1 : float
+        Amplitude of the Gaussian.
+    x_mean_1 : float
+        Mean of the Gaussian in x.
+    y_mean_1 : float
+        Mean of the Gaussian in y.
+    x_stddev_1 : float
+        Standard deviation of the Gaussian in x.
+        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
+        matrix (``cov_matrix``) is input.
+    y_stddev_1 : float
+        Standard deviation of the Gaussian in y.
+        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
+        matrix (``cov_matrix``) is input.
+    theta_1 : float, optional
+        Rotation angle in radians. The rotation angle increases
+        counterclockwise.
+    cov_matrix_1 : ndarray, optional
+        A 2x2 covariance matrix. If specified, overrides the ``x_stddev``,
+        ``y_stddev``, and ``theta`` specification.
+    """
 
 def _convert_image(data, mask=None):
     """
@@ -219,7 +244,7 @@ def centroid_1dg(data, error=None, mask=None):
     centroid = []
     for (mdata_i, mweights_i, mmask_i) in zip(mdata, mweights, mmask):
         params_init = gaussian1d_moments(mdata_i, mask=mmask_i)
-        g_init = GaussianConst1D(const_init, *params_init)
+        g_init = _GaussianConst1D(const_init, *params_init)
         fitter = LevMarLSQFitter()
         x = np.arange(mdata_i.size)
         g_fit = fitter(g_init, x, mdata_i, weights=mweights_i)
@@ -272,7 +297,7 @@ def fit_2dgaussian(data, error=None, mask=None):
 
     Returns
     -------
-    result : `GaussianConst2D` instance
+    result : A `GaussianConst2D` model instance.
         The best-fitting Gaussian 2D model.
     """
 

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -53,7 +53,7 @@ def _convert_image(data, mask=None):
     except TypeError:    # pragma: no cover
         image = np.asarray(data).astype(np.float)    # for numpy <= 1.6
     if mask is not None:
-        mask = np.asarray(mask)
+        mask = np.asanyarray(mask)
         if data.shape != mask.shape:
             raise ValueError('data and mask must have the same shape')
         image[mask] = 0.0
@@ -110,6 +110,7 @@ def gaussian1d_moments(data, mask=None):
     """
 
     if mask is not None:
+        mask = np.asanyarray(mask)
         data = data.copy()
         data[mask] = 0.
     x = np.arange(data.size)
@@ -150,6 +151,7 @@ def centroid_1dg(data, error=None, mask=None):
         marginal_weights = [None, None]
 
     if mask is not None:
+        mask = np.asanyarray(mask)
         marginal_mask = [mask.sum(axis=i).astype(np.bool) for i in [0, 1]]
         if error is None:
             marginal_weights = np.array(
@@ -228,6 +230,7 @@ def fit_2dgaussian(data, error=None, mask=None):
         weights = None
 
     if mask is not None:
+        mask = np.asanyarray(mask)
         if weights is None:
             weights = np.ones_like(data)
         # down-weight masked pixels

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -136,7 +136,30 @@ def gaussian1d_moments(data, mask=None):
 
 def marginalize_data2d(data, error=None, mask=None):
     """
-    Generate the marginal x and y distributions from a 2D distribution.
+    Generate the marginal x and y distributions from a 2D data array.
+
+    Parameters
+    ----------
+    data : array_like
+        The 2D data array.
+
+    error : array_like, optional
+        The 2D array of the 1-sigma errors of the input ``data``.
+
+    mask : array_like (bool), optional
+        A boolean mask, with the same shape as ``data``, where a `True`
+        value indicates the corresponding element of ``data`` is masked.
+
+    Returns
+    -------
+    marginal_data : list of `~numpy.ndarray`
+        The marginal y and x distributions of the input ``data``.
+
+    marginal_error : list of `~numpy.ndarray`
+        The marginal y and x distributions of the input ``error``.
+
+    marginal_mask : list of `~numpy.ndarray` (bool)
+        The marginal y and x distributions of the input ``mask``.
     """
 
     if error is not None:
@@ -249,7 +272,7 @@ def fit_2dgaussian(data, error=None, mask=None):
 
     Returns
     -------
-    result : `~astropy.modeling.functional_models.Gaussian2D` instance
+    result : `GaussianConst2D` instance
         The best-fitting Gaussian 2D model.
     """
 
@@ -317,8 +340,8 @@ def data_properties(data, mask=None, background=None):
 
     Returns
     -------
-    result : `photutils.segmentation.SegmentProperties` instance
-        A `photutils.segmentation.SegmentProperties` object.
+    result : `~photutils.segmentation.SegmentProperties` instance
+        A `~photutils.segmentation.SegmentProperties` object.
     """
 
     segment_image = np.ones(data.shape, dtype=np.int)
@@ -364,6 +387,21 @@ def cutout_footprint(data, position, box_size=3, footprint=None, mask=None,
 
     error : array_like, optional
         The 2D array of the 1-sigma errors of the input ``data``.
+
+    Returns
+    -------
+    region_data : `~numpy.ndarray`
+        The ``data`` cutout.
+
+    region_mask : `~numpy.ndarray`
+        The ``mask`` cutout.
+
+    region_error : `~numpy.ndarray`
+        The ``error`` cutout.
+
+    slices : tuple of slices
+        Slices in each dimension of the ``data`` array used to define
+        the cutout region.
     """
 
     if len(position) != 2:

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from astropy.modeling.models import Gaussian1D, Gaussian2D, Const1D, Const2D
 from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.nddata.utils import overlap_slices
 from .segmentation import SegmentProperties
 
 
@@ -78,7 +79,7 @@ def centroid_footprint(data, (x, y), box_size=3, footprint=None, mask=None):
         footprint_mask = np.zeros(cutout_shape, dtype=np.bool)
     else:
         cutout_shape = footprint.shape
-        footprint_mask = (footprint == False)
+        footprint_mask = (footprint is False)
 
     slices_large, slices_small = overlap_slices(
         data.shape, cutout_shape, (x, y))

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -116,7 +116,7 @@ def gaussian1d_moments(data, mask=None):
     x = np.arange(data.size)
     xc = np.sum(x * data) / np.sum(data)
     stddev = np.sqrt(abs(np.sum(data * (x - xc)**2) / np.sum(data)))
-    amplitude = np.ptp(data)
+    amplitude = np.nanmax(data)
     return amplitude, xc, stddev
 
 
@@ -237,7 +237,7 @@ def fit_2dgaussian(data, error=None, mask=None):
         weights[mask] = 1.e-20
 
     props = data_properties(data, mask=mask)
-    init_amplitude = np.ptp(data)
+    init_amplitude = np.nanmax(data)
     g_init = models.Gaussian2D(
         init_amplitude, props.xcentroid.value, props.ycentroid.value,
         props.semimajor_axis_sigma.value, props.semiminor_axis_sigma.value,

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -11,6 +11,7 @@ from astropy.modeling.models import Gaussian1D, Gaussian2D, Const1D, Const2D
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import overlap_slices
 from .segmentation import SegmentProperties
+import warnings
 
 
 __all__ = ['GaussianConst1D', 'GaussianConst2D', 'centroid_com',
@@ -252,10 +253,9 @@ def fit_2dgaussian(data, error=None, mask=None):
         The best-fitting Gaussian 2D model.
     """
 
-    # data must have a least 7 values to fit a 2D Gaussian plus a constant
     if data.size < 7:
-        print('boo')
-        print(len(data))
+        warnings.warn('data array must have a least 7 values to fit a 2D '
+                      'Gaussian plus a constant')
         return None
 
     if error is not None:

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -280,15 +280,6 @@ def fit_2dgaussian(data, error=None, mask=None):
                             props.semiminor_axis_sigma.value,
                             props.orientation.value])
 
-    # if any init_values are np.nan, then estimate the initial parameters
-    # using the marginal distributions
-    if np.any(~np.isfinite(init_values)):
-        mdata, merror, mmask = marginalize_data2d(data, error=error,
-                                                  mask=mask)
-        x_ampl, x_mean, x_stddev = gaussian1d_moments(mdata[0], mask=mmask[0])
-        y_ampl, y_mean, y_stddev = gaussian1d_moments(mdata[1], mask=mmask[1])
-        init_values = np.array([x_mean, y_mean, x_stddev, y_stddev, 0.])
-
     init_const = 0.    # subtracted data minimum above
     init_amplitude = np.nanmax(data) - np.nanmin(data)
     g_init = GaussianConst2D(init_const, init_amplitude, *init_values)

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -381,7 +381,7 @@ def cutout_footprint(data, position, box_size=3, footprint=None, mask=None,
         footprint = np.asanyarray(footprint, dtype=bool)
 
     slices_large, slices_small = overlap_slices(data.shape, footprint.shape,
-                                                position)
+                                                position[::-1])
     region_data = data[slices_large]
 
     if error is not None:

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -252,6 +252,10 @@ def fit_2dgaussian(data, error=None, mask=None):
         The best-fitting Gaussian 2D model.
     """
 
+    # data must have a least 7 values to fit a 2D Gaussian plus a constant
+    if len(data) < 7:
+        return None
+
     if error is not None:
         weights = 1.0 / error
     else:

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -253,7 +253,9 @@ def fit_2dgaussian(data, error=None, mask=None):
     """
 
     # data must have a least 7 values to fit a 2D Gaussian plus a constant
-    if len(data) < 7:
+    if data.size < 7:
+        print('boo')
+        print(len(data))
         return None
 
     if error is not None:

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -70,7 +70,8 @@ def _convert_image(data, mask=None):
     return image
 
 
-def centroid_footprint(data, (x, y), box_size=3, footprint=None, mask=None):
+def centroid_footprint(data, (x, y), box_size=3, footprint=None, mask=None,
+                       error=None):
     """
     Centroid around given position
     """
@@ -88,9 +89,14 @@ def centroid_footprint(data, (x, y), box_size=3, footprint=None, mask=None):
         region_mask = mask[slices_large]
     else:
         region_mask = np.zeros_like(region, dtype=np.bool)
+    if error is not None:
+        region_error = error[slices_large]
+    else:
+        region_error = None
     footprint_mask = footprint_mask[slices_small]    # trim if necessary
     region_mask = np.logical_or(region_mask, footprint_mask)
-    gaussian_fit = fit_2dgaussian(region, mask=region_mask)
+    gaussian_fit = fit_2dgaussian(region, mask=region_mask,
+                                  error=region_error)
     x_centroid = slices_large[1].start + gaussian_fit.x_mean_1.value
     y_centroid = slices_large[0].start + gaussian_fit.y_mean_1.value
 

--- a/photutils/tests/test_morphology.py
+++ b/photutils/tests/test_morphology.py
@@ -8,8 +8,7 @@ import itertools
 from ..morphology import (centroid_com, centroid_1dg, centroid_2dg,
                           gaussian1d_moments, data_properties,
                           fit_2dgaussian, cutout_footprint)
-from astropy.modeling import models
-from astropy.convolution.kernels import Gaussian2DKernel
+from astropy.modeling.models import Gaussian1D, Gaussian2D
 try:
     import skimage
     HAS_SKIMAGE = True
@@ -33,8 +32,8 @@ DATA[1, 1] = 2.
     list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
 @pytest.mark.skipif('not HAS_SKIMAGE')
 def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
-    model = models.Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
-                              y_stddev=y_stddev, theta=theta)
+    model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
+                       y_stddev=y_stddev, theta=theta)
     y, x = np.mgrid[0:50, 0:50]
     data = model(x, y)
     xc, yc = centroid_com(data)
@@ -50,8 +49,8 @@ def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
     list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
 @pytest.mark.skipif('not HAS_SKIMAGE')
 def test_centroids_witherror(xc_ref, yc_ref, x_stddev, y_stddev, theta):
-    model = models.Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
-                              y_stddev=y_stddev, theta=theta)
+    model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
+                       y_stddev=y_stddev, theta=theta)
     y, x = np.mgrid[0:50, 0:50]
     data = model(x, y)
     error = np.sqrt(data)
@@ -63,9 +62,10 @@ def test_centroids_witherror(xc_ref, yc_ref, x_stddev, y_stddev, theta):
 
 @pytest.mark.skipif('not HAS_SKIMAGE')
 def test_centroids_withmask():
-    size = 9
-    xc_ref, yc_ref = (size - 1) / 2, (size - 1) / 2
-    data = Gaussian2DKernel(1., x_size=size, y_size=size).array
+    xc_ref, yc_ref = 24.7, 25.2
+    model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=5.0, y_stddev=5.0)
+    y, x = np.mgrid[0:50, 0:50]
+    data = model(x, y)
     mask = np.zeros_like(data, dtype=bool)
     data[0, 0] = 1.
     mask[0, 0] = True
@@ -115,7 +115,7 @@ def test_data_properties():
 def test_gaussian1d_moments():
     x = np.arange(100)
     desired = (75, 50, 5)
-    g = models.Gaussian1D(*desired)
+    g = Gaussian1D(*desired)
     data = g(x)
     result = gaussian1d_moments(data)
     assert_allclose(result, desired, rtol=0, atol=1.e-6)

--- a/photutils/utils/wcs_helpers.py
+++ b/photutils/utils/wcs_helpers.py
@@ -3,7 +3,7 @@
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import UnitSphericalRepresentation
-from astropy.wcs.utils import skycoord_to_pixel
+from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 
 skycoord_to_pixel_mode = 'all'
 
@@ -90,3 +90,39 @@ def assert_angle(name, q):
             raise ValueError("{0} should have angular units".format(name))
     else:
         raise TypeError("{0} should be a Quantity instance".format(name))
+
+
+def pixel_to_icrs_coords(x, y, wcs):
+    """
+    Convert pixel coordinates to ICRS Right Ascension and Declination.
+
+    This is merely a convenience function to extract RA and Dec. from a
+    `~astropy.coordinates.SkyCoord` instance so they can be put in
+    separate columns in a `~astropy.table.Table`.
+
+    Parameters
+    ----------
+    x : float or array-like
+        The x pixel coordinate.
+
+    y : float or array-like
+        The y pixel coordinate.
+
+    wcs : `~astropy.wcs.WCS`
+        The WCS transformation to use to convert from pixel coordinates
+        to ICRS world coordinates.
+        `~astropy.table.Table`.
+
+    Returns
+    -------
+    ra : `~astropy.units.Quantity`
+        The ICRS Right Ascension in degrees.
+
+    dec : `~astropy.units.Quantity`
+        The ICRS Right Ascension in degrees.
+    """
+
+    icrs_coords = pixel_to_skycoord(x, y, wcs, origin=1).icrs
+    icrs_ra = icrs_coords.ra.degree * u.deg
+    icrs_dec = icrs_coords.dec.degree * u.deg
+    return icrs_ra, icrs_dec

--- a/photutils/utils/wcs_helpers.py
+++ b/photutils/utils/wcs_helpers.py
@@ -119,7 +119,7 @@ def pixel_to_icrs_coords(x, y, wcs):
         The ICRS Right Ascension in degrees.
 
     dec : `~astropy.units.Quantity`
-        The ICRS Right Ascension in degrees.
+        The ICRS Declination in degrees.
     """
 
     icrs_coords = pixel_to_skycoord(x, y, wcs, origin=1).icrs


### PR DESCRIPTION
This PR implements #235.  If `subpixel=True` then the output `Table` also includes the centroid and fitted peak amplitude in addition to the (integer) peak pixel position and value.

I still need to add some tests.

This PR also removes the `segment_image` option, since one should now use `segment_properties()` when working with segmentation images.