### PR TITLE
Changing test parameters to avoid failure on 32bit

### DIFF
--- a/photutils/tests/test_aperture_photometry.py
+++ b/photutils/tests/test_aperture_photometry.py
@@ -359,7 +359,7 @@ class TestEllipticalAnnulus(BaseTestAperturePhotometry):
         position = (20., 20.)
         a_in = 5.
         a_out = 8.
-        b_out = 6.
+        b_out = 5.
         theta = -np.pi / 4.
         self.aperture = EllipticalAnnulus(position, a_in, a_out, b_out, theta)
         self.area = np.pi * (a_out * b_out) - np.pi * (a_in * b_out * a_in / a_out)


### PR DESCRIPTION
This adjustment of the aperture parameter makes to tests to pass on a 32bit setup. 

The discrepancy between 32/64 bit is most probably due to float precision. Some aperture parametrisations don't behave the same way on 32bit and 64bit for the pixels where the aperture goes through a pixel centre. Affects methods `center` and `subpixel`, see more discussion in [#242].

Closes #242.