### PR TITLE
Drop Astropy 0.4 support?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,11 @@ install:
 
     # ASTROPY
     - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
+    # TODO: Change back to installing astropy via conda once 1.0 is availabl in conda:
+    # https://github.com/astropy/photutils/issues/246#issuecomment-72016716
+    # - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $PIP_INSTALL --pre astropy; fi
 
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use


### PR DESCRIPTION
@larrybradley asked at https://github.com/astropy/photutils/pull/244#issuecomment-71912476 whether we should drop Astropy 0.4 support in `photutils` and then make a photutils 0.2 release in the coming months with Astropy 1.0 as a requirement.

I'm +1, there's some things in `modeling`, `nddata` and `table` and `visualization` that are nice to have and I think it would be good to have less old versions of stuff in `photutils/extern`.

@astrofrog @bsipocz OK or do you want to keep Astropy 0.4 compatibility for photutils 0.2 for some reason?