### PR TITLE
Adding photutils version number to testing header

### DIFF
--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -2,7 +2,17 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
+import os
 from astropy.tests.pytest_plugins import *
+
+# This is to figure out the photutil version, rather than using Astropy's
+from . import version
+
+try:
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version.version
+except NameError:
+    pass
 
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
@@ -10,5 +20,5 @@ enable_deprecations_as_exceptions()
 
 # Add scikit-image to test header information
 PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
-PYTEST_HEADER_MODULES['astropy'] = 'astropy'
+PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
 del PYTEST_HEADER_MODULES['h5py']


### PR DESCRIPTION
Currently the testing doesn't print out the version number of ``photutils`` anywhere in the header only Astropy's. 
This is the package side change, the feature is introduced in https://github.com/astropy/astropy/pull/3543

With this change the tests start as:
```
======================================= test session starts =======================================
platform darwin -- Python 2.7.5 -- pytest-2.5.1

Running tests with photutils version 0.2.dev1345.
Running tests in photutils /Users/bsipocz/munka/devel/photutils/docs.

Platform: Darwin-10.8.0-x86_64-i386-32bit
...
```
