### PR TITLE
Change centroid functions output to be in (y, x) order

### DIFF
--- a/docs/photutils/morphology.rst
+++ b/docs/photutils/morphology.rst
@@ -33,21 +33,21 @@ subtract the background)::
 
 .. doctest-requires:: skimage
 
-    >>> x1, y1 = centroid_com(data)
-    >>> print(x1, y1)    # doctest: +FLOAT_CMP
-    (13.93157998341213, 17.051234441067088)
+    >>> y1, x1 = centroid_com(data)
+    >>> print(y1, x1)    # doctest: +FLOAT_CMP
+    (17.051234441067088, 13.93157998341213)
 
 .. doctest-requires:: scipy
 
-    >>> x2, y2 = centroid_1dg(data)
-    >>> print(x2, y2)    # doctest: +FLOAT_CMP
-    (14.040352707371396, 16.962306463644801)
+    >>> y2, x2 = centroid_1dg(data)
+    >>> print(y2, x2)    # doctest: +FLOAT_CMP
+    (16.962306463644801, 14.040352707371396)
 
 .. doctest-requires:: scipy, skimage
 
-    >>> x3, y3 = centroid_2dg(data)
-    >>> print(x3, y3)    # doctest: +FLOAT_CMP
-    (14.002212073733611, 16.996134592982017)
+    >>> y3, x3 = centroid_2dg(data)
+    >>> print(y3, x3)    # doctest: +FLOAT_CMP
+    (16.996134592982017, 14.002212073733611)
 
 Now let's plot the results.  Because the centroids are all very
 similar, we also include an inset plot zoomed in near the centroid:
@@ -86,9 +86,9 @@ similar, we also include an inset plot zoomed in near the centroid:
                                       centroid_2dg)
     import matplotlib.pyplot as plt
     data = make_4gaussians_image()[43:79, 76:104]    # extract single object
-    x1, y1 = centroid_com(data)
-    x2, y2 = centroid_1dg(data)
-    x3, y3 = centroid_2dg(data)
+    y1, x1 = centroid_com(data)
+    y2, x2 = centroid_1dg(data)
+    y3, x3 = centroid_2dg(data)
     fig, ax = plt.subplots(1, 1)
     ax.imshow(data, origin='lower', cmap='Greys_r')
     marker = '+'

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -114,16 +114,16 @@ def centroid_com(data, mask=None):
 
     Returns
     -------
-    xcen, ycen : float
-        (x, y) coordinates of the centroid.
+    ycen, xcen : float
+        (y, x) coordinates of the centroid.
     """
 
     from skimage.measure import moments
     data = _convert_image(data, mask=mask)
     m = moments(data, 1)
-    xcen = m[1, 0] / m[0, 0]
     ycen = m[0, 1] / m[0, 0]
-    return xcen, ycen
+    xcen = m[1, 0] / m[0, 0]
+    return ycen, xcen
 
 
 def gaussian1d_moments(data, mask=None):

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -189,17 +189,17 @@ def marginalize_data2d(data, error=None, mask=None):
 
     if error is not None:
         marginal_error = np.array(
-            [np.sqrt(np.sum(error**2, axis=i)) for i in [0, 1]])
+            [np.sqrt(np.sum(error**2, axis=i)) for i in [1, 0]])
     else:
         marginal_error = [None, None]
 
     if mask is not None:
         mask = np.asanyarray(mask)
-        marginal_mask = [np.sum(mask, axis=i).astype(np.bool) for i in [0, 1]]
+        marginal_mask = [np.sum(mask, axis=i).astype(np.bool) for i in [1, 0]]
     else:
         marginal_mask = [None, None]
 
-    marginal_data = [np.sum(data, axis=i) for i in [0, 1]]
+    marginal_data = [np.sum(data, axis=i) for i in [1, 0]]
 
     return marginal_data, marginal_error, marginal_mask
 

--- a/photutils/morphology.py
+++ b/photutils/morphology.py
@@ -223,8 +223,8 @@ def centroid_1dg(data, error=None, mask=None):
 
     Returns
     -------
-    xcen, ycen : float
-        (x, y) coordinates of the centroid.
+    ycen, xcen : float
+        (y, x) coordinates of the centroid.
     """
 
     mdata, merror, mmask = marginalize_data2d(data, error=error, mask=mask)
@@ -272,12 +272,12 @@ def centroid_2dg(data, error=None, mask=None):
 
     Returns
     -------
-    xcen, ycen : float
-        (x, y) coordinates of the centroid.
+    ycen, xcen : float
+        (y, x) coordinates of the centroid.
     """
 
     gfit = fit_2dgaussian(data, error=error, mask=mask)
-    return gfit.x_mean_1.value, gfit.y_mean_1.value
+    return gfit.y_mean_1.value, gfit.x_mean_1.value
 
 
 def fit_2dgaussian(data, error=None, mask=None):

--- a/photutils/tests/test_morphology.py
+++ b/photutils/tests/test_morphology.py
@@ -36,11 +36,11 @@ def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
                        y_stddev=y_stddev, theta=theta)
     y, x = np.mgrid[0:50, 0:50]
     data = model(x, y)
-    xc, yc = centroid_com(data)
+    yc, xc = centroid_com(data)
     assert_allclose([xc_ref, yc_ref], [xc, yc], rtol=0, atol=1.e-3)
-    xc2, yc2 = centroid_1dg(data)
+    yc2, xc2 = centroid_1dg(data)
     assert_allclose([xc_ref, yc_ref], [xc2, yc2], rtol=0, atol=1.e-3)
-    xc3, yc3 = centroid_2dg(data)
+    yc3, xc3 = centroid_2dg(data)
     assert_allclose([xc_ref, yc_ref], [xc3, yc3], rtol=0, atol=1.e-3)
 
 
@@ -54,9 +54,9 @@ def test_centroids_witherror(xc_ref, yc_ref, x_stddev, y_stddev, theta):
     y, x = np.mgrid[0:50, 0:50]
     data = model(x, y)
     error = np.sqrt(data)
-    xc2, yc2 = centroid_1dg(data, error=error)
+    yc2, xc2 = centroid_1dg(data, error=error)
     assert_allclose([xc_ref, yc_ref], [xc2, yc2], rtol=0, atol=1.e-3)
-    xc3, yc3 = centroid_2dg(data, error=error)
+    yc3, xc3 = centroid_2dg(data, error=error)
     assert_allclose([xc_ref, yc_ref], [xc3, yc3], rtol=0, atol=1.e-3)
 
 
@@ -69,11 +69,11 @@ def test_centroids_withmask():
     mask = np.zeros_like(data, dtype=bool)
     data[0, 0] = 1.
     mask[0, 0] = True
-    xc, yc = centroid_com(data, mask=mask)
+    yc, xc = centroid_com(data, mask=mask)
     assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-    xc2, yc2 = centroid_1dg(data, mask=mask)
+    yc2, xc2 = centroid_1dg(data, mask=mask)
     assert_allclose([xc2, yc2], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-    xc3, yc3 = centroid_2dg(data, mask=mask)
+    yc3, xc3 = centroid_2dg(data, mask=mask)
     assert_allclose([xc3, yc3], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
 
 
@@ -85,7 +85,7 @@ def test_centroids_mask():
     centroid = centroid_com(data, mask=None)
     centroid_mask = centroid_com(data, mask=mask)
     assert_allclose([0.5, 0.5], centroid, rtol=0, atol=1.e-6)
-    assert_allclose([0.5, 0.0], centroid_mask, rtol=0, atol=1.e-6)
+    assert_allclose([0.0, 0.5], centroid_mask, rtol=0, atol=1.e-6)
 
 
 @pytest.mark.skipif('not HAS_SKIMAGE')


### PR DESCRIPTION
This makes the centroid functions consistent with `SegmentProperties` centroids.