### PR TITLE
Add changelog page to docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,4 +30,10 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Bundled copy of astropy-helpers upgraded to v1.0. [#251]
+- Update astropy-helpers to v1.0.2 [#260]
+
+0.1 (December 22, 2014)
+-----------------------
+
+photutils 0.1 was released on December 22, 2014.
+It requires Astropy version 0.4 or later.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,7 @@
+.. _changelog:
+
+*********
+Changelog
+*********
+
+.. include:: ../CHANGES.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,6 +174,8 @@ if eval(setup_cfg.get('edit_on_github')):
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
 
+github_issues_url = 'https://github.com/astropy/photutils/issues/'
+
 autodoc_docstring_signature = True
 
 nitpicky = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ reports, comments, and help with development are very welcome.
     photutils/install.rst
     photutils/overview.rst
     photutils/getting_started.rst
+    changelog
 
 .. note::
 


### PR DESCRIPTION
This PR adds the changes pages to the docs, so that it's more easily found by users.
It includes the top-level `CHANGES.rst` file, just like Astropy does it.
