### PR TITLE
Update sigma clipping based on updated astropy

### DIFF
--- a/photutils/background.py
+++ b/photutils/background.py
@@ -7,9 +7,11 @@ from astropy.stats import sigma_clip
 from astropy.utils import lazyproperty
 import warnings
 
+import astropy
+ASTROPY_LT_1P1 = [int(x) for x in astropy.__version__.split('.')[:2]] < [1, 1]
+
 
 __all__ = ['Background']
-
 
 __doctest_requires__ = {('Background'): ['scipy']}
 
@@ -215,10 +217,16 @@ class Background(object):
         del data_ma
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            self.data_sigclip = sigma_clip(
-                data_rebin, sig=self.sigclip_sigma, axis=2,
-                iters=self.sigclip_iters, cenfunc=np.ma.median,
-                varfunc=np.ma.var)
+            if ASTROPY_LT_1P1:
+                self.data_sigclip = sigma_clip(
+                    data_rebin, sig=self.sigclip_sigma, axis=2,
+                    iters=self.sigclip_iters, cenfunc=np.ma.median,
+                    varfunc=np.ma.var)
+            else:
+                self.data_sigclip = sigma_clip(
+                    data_rebin, sigma=self.sigclip_sigma, axis=2,
+                    iters=self.sigclip_iters, cenfunc=np.ma.median,
+                    stdfunc=np.std)
         del data_rebin
 
     def _filter_meshes(self, data_low_res):

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -10,12 +10,16 @@ from astropy.stats import sigma_clipped_stats
 from ..morphology import cutout_footprint, fit_2dgaussian
 from ..utils.wcs_helpers import pixel_to_icrs_coords
 
+import astropy
+ASTROPY_LT_1P1 = [int(x) for x in astropy.__version__.split('.')[:2]] < [1, 1]
+
 
 __all__ = ['detect_threshold', 'detect_sources', 'find_peaks']
 
 
+
 def detect_threshold(data, snr, background=None, error=None, mask=None,
-                     mask_val=None, sigclip_sigma=3.0, sigclip_iters=None):
+                     mask_value=None, sigclip_sigma=3.0, sigclip_iters=None):
     """
     Calculate a pixel-wise threshold image to be used to detect sources.
 
@@ -51,10 +55,10 @@ def detect_threshold(data, snr, background=None, error=None, mask=None,
         Masked pixels are ignored when computing the image background
         statistics.
 
-    mask_val : float, optional
+    mask_value : float, optional
         An image data value (e.g., ``0.0``) that is ignored when
-        computing the image background statistics.  ``mask_val`` will be
-        ignored if ``mask`` is input.
+        computing the image background statistics.  ``mask_value`` will
+        be ignored if ``mask`` is input.
 
     sigclip_sigma : float, optional
         The number of standard deviations to use as the clipping limit
@@ -78,17 +82,24 @@ def detect_threshold(data, snr, background=None, error=None, mask=None,
 
     Notes
     -----
-    The ``mask``, ``mask_val``, ``sigclip_sigma``, and ``sigclip_iters``
-    inputs are used only if it is necessary to estimate ``background``
-    or ``error`` using sigma-clipped background statistics.  If
-    ``background`` and ``error`` are both input, then ``mask``,
-    ``mask_val``, ``sigclip_sigma``, and ``sigclip_iters`` are ignored.
+    The ``mask``, ``mask_value``, ``sigclip_sigma``, and
+    ``sigclip_iters`` inputs are used only if it is necessary to
+    estimate ``background`` or ``error`` using sigma-clipped background
+    statistics.  If ``background`` and ``error`` are both input, then
+    ``mask``, ``mask_value``, ``sigclip_sigma``, and ``sigclip_iters``
+    are ignored.
     """
 
     if background is None or error is None:
-        data_mean, data_median, data_std = sigma_clipped_stats(
-            data, mask=mask, mask_val=mask_val, sigma=sigclip_sigma,
-            iters=sigclip_iters)
+        # TODO: remove when astropy 1.1 is released
+        if ASTROPY_LT_1P1:
+            data_mean, data_median, data_std = sigma_clipped_stats(
+                data, mask=mask, mask_val=mask_value, sigma=sigclip_sigma,
+                iters=sigclip_iters)
+        else:
+            data_mean, data_median, data_std = sigma_clipped_stats(
+                data, mask=mask, mask_value=mask_value, sigma=sigclip_sigma,
+                iters=sigclip_iters)
         bkgrd_image = np.zeros_like(data) + data_mean
         bkgrdrms_image = np.zeros_like(data) + data_std
 

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 from ..core import detect_threshold, detect_sources, find_peaks
 
+
 try:
     import scipy
     HAS_SCIPY = True
@@ -87,9 +88,9 @@ class TestDetectThreshold(object):
         ref = 12. * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
-    def test_mask_val(self):
-        """Test detection with mask_val."""
-        threshold = detect_threshold(DATA, snr=1.0, mask_val=0.0)
+    def test_mask_value(self):
+        """Test detection with mask_value."""
+        threshold = detect_threshold(DATA, snr=1.0, mask_value=0.0)
         ref = 2. * np.ones((3, 3))
         assert_array_equal(threshold, ref)
 
@@ -106,9 +107,9 @@ class TestDetectThreshold(object):
         assert_array_equal(threshold, ref)
 
     def test_image_mask_override(self):
-        """Test that image_mask overrides mask_val."""
+        """Test that image_mask overrides mask_value."""
         mask = REF3.astype(np.bool)
-        threshold = detect_threshold(DATA, snr=0.1, error=0, mask_val=0.0,
+        threshold = detect_threshold(DATA, snr=0.1, error=0, mask_value=0.0,
                                      mask=mask, sigclip_sigma=10,
                                      sigclip_iters=1)
         ref = np.ones((3, 3))


### PR DESCRIPTION
Tests are currently failing because of changes in `sigma_clip` and `sigma_clipped_stats` in astropy master.  There is also a small bug in astropy's `sigma_clip` that I need to fix where a scalar mask is returned when no values are clipped.  In that case `ma.data[~ma.mask]` doesn't give the desired result.