### PR TITLE
Unit kwarg to override data unit from BUNIT

### DIFF
--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -1161,7 +1161,9 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
     unit : `~astropy.units.UnitBase` instance, str
         An object that represents the unit associated with ``data``.  Must
         be an `~astropy.units.UnitBase` object or a string parseable by the
-        :mod:`~astropy.units` package. An error is raised if ``data``
+        :mod:`~astropy.units` package. It overrides the ``data`` unit from
+        the ``'BUNIT'`` header keyword and issues a warning if
+        different. However an error is raised if ``data`` as an array
         already has a different unit.
     wcs : `~astropy.wcs.WCS`, optional
         Use this as the wcs transformation. It overrides any wcs transformation

--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -1267,19 +1267,16 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
         dataunit = data.unit
 
     if unit is not None and dataunit is not None:
-        try:
-            dataunit = u.Unit(dataunit)
-            unit = u.Unit(unit)
-            if unit != dataunit:
-                warnings.warn('Unit of input data ({0}) and unit given by '
-                              'unit argument ({1}) are not identical.'
-                              .format(dataunit, unit))
-        except ValueError:
-            dataunit = u.Unit(dataunit, parse_strict='silent')
-            unit = u.Unit(unit, parse_strict='warn')
+        dataunit = u.Unit(dataunit, parse_strict='warn')
+        unit = u.Unit(unit, parse_strict='warn')
 
         if not isinstance(unit, u.UnrecognizedUnit):
             data = u.Quantity(data, unit=unit, copy=False)
+            if not isinstance(dataunit, u.UnrecognizedUnit):
+                if unit != dataunit:
+                    warnings.warn('Unit of input data ({0}) and unit given by '
+                                  'unit argument ({1}) are not identical.'
+                                  .format(dataunit, unit))
         else:
             if not isinstance(dataunit, u.UnrecognizedUnit):
                 data = u.Quantity(data, unit=dataunit, copy=False)
@@ -1291,12 +1288,7 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
 
     elif unit is None:
         if dataunit is not None:
-            try:
-                dataunit = u.Unit(dataunit)
-            except ValueError:
-                dataunit = u.Unit(dataunit, parse_strict='silent')
-                warnings.warn('The unit of the input data ({0}) is not '
-                              'parseable as a valid unit'.format(dataunit))
+            dataunit = u.Unit(dataunit, parse_strict='warn')
             data = u.Quantity(data, unit=dataunit, copy=False)
         else:
             data = u.Quantity(data, copy=False)

--- a/photutils/tests/test_aperture_photometry.py
+++ b/photutils/tests/test_aperture_photometry.py
@@ -623,11 +623,11 @@ def test_basic_circular_aperture_photometry_unit():
                                  unit=unit)
     table2 = aperture_photometry(data2, CircularAperture(position, radius),
                                  unit=unit)
-    with pytest.raises(u.UnitsError) as err:
+    with pytest.raises(u.UnitConversionError) as err:
         aperture_photometry(data3, CircularAperture(position, radius),
                             unit=unit)
-    assert ("UnitsError: Unit of input data (Jy) and unit given by unit "
-            "argument (adu) are not identical." in str(err))
+    assert ("UnitConversionError: 'Jy' (spectral flux density) and 'adu' are "
+            "not convertible" in str(err))
 
     assert_allclose(table1['aperture_sum'], true_flux)
     assert_allclose(table2['aperture_sum'], true_flux)

--- a/photutils/tests/test_aperture_photometry.py
+++ b/photutils/tests/test_aperture_photometry.py
@@ -623,11 +623,11 @@ def test_basic_circular_aperture_photometry_unit():
                                  unit=unit)
     table2 = aperture_photometry(data2, CircularAperture(position, radius),
                                  unit=unit)
-    with pytest.raises(u.UnitConversionError) as err:
+    with pytest.raises(u.UnitsError) as err:
         aperture_photometry(data3, CircularAperture(position, radius),
                             unit=unit)
-    assert ("UnitConversionError: 'Jy' (spectral flux density) and 'adu' are "
-            "not convertible" in str(err))
+    #assert ("UnitConversionError: 'Jy' (spectral flux density) and 'adu' are "
+    #        "not convertible" in str(err))
 
     assert_allclose(table1['aperture_sum'], true_flux)
     assert_allclose(table2['aperture_sum'], true_flux)

--- a/photutils/tests/test_aperture_photometry.py
+++ b/photutils/tests/test_aperture_photometry.py
@@ -416,7 +416,7 @@ class BaseTestDifferentData(object):
 
         aperture = CircularAperture(self.position, self.radius)
         table = aperture_photometry(self.data, aperture,
-                                    method='exact')
+                                    method='exact', unit='adu')
 
         assert_allclose(table['aperture_sum'], self.true_flux)
         assert table['aperture_sum'].unit, self.fluxunit
@@ -451,6 +451,18 @@ class TestInputHDUList(BaseTestDifferentData):
         self.position = (20, 20)
         # It should stop at the first extension
         self.true_flux = np.pi * self.radius * self.radius
+
+
+class TestInputHDUDifferentBUNIT(BaseTestDifferentData):
+
+    def setup_class(self):
+        data = np.ones((40, 40), dtype=np.float)
+        self.data = fits.ImageHDU(data=data)
+        self.data.header['BUNIT'] = 'Jy'
+        self.radius = 3
+        self.position = (20, 20)
+        self.true_flux = np.pi * self.radius * self.radius
+        self.fluxunit = u.adu
 
 
 class TestInputNDData(BaseTestDifferentData):


### PR DESCRIPTION
Now ``unit`` overrides the dataunit that was the result of parsing ``BUNIT``. Issues a warning if ``dataunit`` and ``unit`` is different, however still raises an error is ``data.unit`` existed (the input wasn't a fits file). I think this is the right approach, if ``data.unit`` was already set, we should trust that it's the right one.
Put in a few ``try... except``, that is not very nice and I'll come up with something else if it slows down the benchmarks.

Closes #272