### PR TITLE
Fix normalization for rectangular and elliptical regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,3 +40,9 @@ Bug Fixes
   - ``overlap_area_triangle_unit_circle`` handles correctly a corner case
     in some i386 systems where the area of the aperture was not computed
     correctly. [#242]
+
+  - ``rectangular_overlap_grid`` and ``elliptical_overlap_grid`` fixes to
+    normalization of subsampled pixels. [#265]
+
+  - ``overlap_area_triangle_unit_circle`` handles correctly the case where
+    a line segment intersects at a triangle vertex. [#277]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.aperture_photometry``
+
+  - Fixed an issue where ``np.nan`` or ``np.inf`` were not properly
+    masked. [#267]
+
 - ``photutils.detection``
 
   - ``find_peaks`` now returns an Astropy Table containing the (x, y)
@@ -30,7 +35,13 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Bundled copy of astropy-helpers upgraded to v1.0. [#251]
+- Update astropy-helpers to v1.0.2 [#260]
+
+0.1 (December 22, 2014)
+-----------------------
+
+photutils 0.1 was released on December 22, 2014.
+It requires Astropy version 0.4 or later.
 
 Bug Fixes
 ^^^^^^^^^

--- a/photutils/geometry/core.pyx
+++ b/photutils/geometry/core.pyx
@@ -121,7 +121,6 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
     dy = y2 - y1
 
     if fabs(dx) < tolerance and fabs(dy) < tolerance:
-
         inter.p1.x = 2.
         inter.p1.y = 2.
         inter.p2.x = 2.
@@ -135,7 +134,6 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
 
         # Find the determinant of the quadratic equation
         delta = 1. + a * a - b * b
-
         if delta > 0.:  # solutions exist
 
             delta = sqrt(delta)
@@ -146,7 +144,6 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
             inter.p2.y = a * inter.p2.x + b
 
         else:  # no solution, return values > 1
-
             inter.p1.x = 2.
             inter.p1.y = 2.
             inter.p2.x = 2.
@@ -171,7 +168,6 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
             inter.p2.x = a * inter.p2.y + b
 
         else:  # no solution, return values > 1
-
             inter.p1.x = 2.
             inter.p1.y = 2.
             inter.p2.x = 2.
@@ -252,6 +248,7 @@ cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, d
 
     cdef double d1, d2, d3
     cdef bool in1, in2, in3
+    cdef bool on1, on2, on3
     cdef double area
     cdef double PI = np.pi
     cdef intersections inter
@@ -297,13 +294,11 @@ cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, d
         area = area_triangle(x1, y1, x2, y2, x3, y3)
 
     elif in2 or on2:
-
         # If vertex 1 or 2 are on the edge of the circle, then we use the dot
         # product to vertex 3 to determine whether an intersection takes place.
         intersect13 = not on1 or x1 * (x3 - x1) + y1 * (y3 - y1) < 0.
         intersect23 = not on2 or x2 * (x3 - x2) + y2 * (y3 - y2) < 0.
-
-        if intersect13 and intersect23:
+        if intersect13 and intersect23 and not on2:
             pt1 = circle_segment_single2(x1, y1, x3, y3)
             pt2 = circle_segment_single2(x2, y2, x3, y3)
             area = area_triangle(x1, y1, x2, y2, pt1.x, pt1.y) \
@@ -320,6 +315,9 @@ cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, d
         else:
             area = area_arc_unit(x1, y1, x2, y2)
 
+    elif on1:
+        # The triangle is outside the circle
+        area = 0.0
     elif in1:
         # Check for intersections of far side with circle
         inter = circle_segment(x2, y2, x3, y3)

--- a/photutils/geometry/elliptical_overlap.pyx
+++ b/photutils/geometry/elliptical_overlap.pyx
@@ -110,7 +110,7 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
                     else:
                         frac[j, i] = elliptical_overlap_single_subpixel(
                             pxmin, pymin, pxmax, pymax, rx, ry, theta,
-                            subpixels) * norm
+                            subpixels)
     return frac
 
 

--- a/photutils/geometry/rectangular_overlap.pyx
+++ b/photutils/geometry/rectangular_overlap.pyx
@@ -86,7 +86,7 @@ def rectangular_overlap_grid(double xmin, double xmax, double ymin,
             pymax = pymin + dy
             frac[j, i] = rectangular_overlap_single_subpixel(
                 pxmin, pymin, pxmax, pymax, width, height, theta,
-                subpixels) / (dx * dy)
+                subpixels)
 
     return frac
 

--- a/photutils/geometry/tests/__init__.py
+++ b/photutils/geometry/tests/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/photutils/geometry/tests/test_circular_overlap_grid.py
+++ b/photutils/geometry/tests/test_circular_overlap_grid.py
@@ -1,0 +1,23 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import division
+
+import itertools
+from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
+from .. import circular_overlap_grid
+
+grid_sizes = [50, 500, 1000]
+circ_sizes = [0.2, 0.4, 0.8]
+use_exact = [0, 1]
+subsamples = [1, 5, 10]
+
+arg_list = ['grid_size', 'circ_size', 'use_exact', 'subsample']
+
+@pytest.mark.parametrize(('grid_size', 'circ_size', 'use_exact', 'subsample'),
+                         list(itertools.product(grid_sizes, circ_sizes, use_exact, subsamples)))
+def test_circular_overlap_grid(grid_size, circ_size, use_exact, subsample):
+    """
+    Test normalization of the overlap grid to make sure that a fully enclosed pixel has a value of 1.0.
+    """
+    g = circular_overlap_grid(-1.0, 1.0, -1.0, 1.0, grid_size, grid_size, circ_size, use_exact, subsample)
+    assert_allclose(g.max(), 1.0)

--- a/photutils/geometry/tests/test_elliptical_overlap_grid.py
+++ b/photutils/geometry/tests/test_elliptical_overlap_grid.py
@@ -1,0 +1,25 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import division
+
+import itertools
+from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
+from .. import elliptical_overlap_grid
+
+grid_sizes = [50, 500, 1000]
+maj_sizes = [0.2, 0.4, 0.8]
+min_sizes = [0.2, 0.4, 0.8]
+angles = [0.0, 0.5, 1.0]
+use_exact = [0, 1]
+subsamples = [1, 5, 10]
+
+arg_list = ['grid_size', 'maj_size', 'min_size', 'angle', 'use_exact', 'subsample']
+
+@pytest.mark.parametrize(('grid_size', 'maj_size', 'min_size', 'angle', 'use_exact', 'subsample'),
+                         list(itertools.product(grid_sizes, maj_sizes, min_sizes, angles, use_exact, subsamples)))
+def test_elliptical_overlap_grid(grid_size, maj_size, min_size, angle, use_exact, subsample):
+    """
+    Test normalization of the overlap grid to make sure that a fully enclosed pixel has a value of 1.0.
+    """
+    g = elliptical_overlap_grid(-1.0, 1.0, -1.0, 1.0, grid_size, grid_size, maj_size, min_size, angle, use_exact, subsample)
+    assert_allclose(g.max(), 1.0)

--- a/photutils/geometry/tests/test_rectangular_overlap_grid.py
+++ b/photutils/geometry/tests/test_rectangular_overlap_grid.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import division
+
+import itertools
+from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
+from .. import rectangular_overlap_grid
+
+grid_sizes = [50, 500, 1000]
+rect_sizes = [0.2, 0.4, 0.8]
+angles = [0.0, 0.5, 1.0]
+subsamples = [1, 5, 10]
+arg_list = ['grid_size', 'rect_size', 'angle', 'subsample']
+
+@pytest.mark.parametrize(('grid_size', 'rect_size', 'angle', 'subsample'),
+                         list(itertools.product(grid_sizes, rect_sizes, angles, subsamples)))
+def test_rectangular_overlap_grid(grid_size, rect_size, angle, subsample):
+    """
+    Test normalization of the overlap grid to make sure that a fully enclosed pixel has a value of 1.0.
+    """
+    g = rectangular_overlap_grid(-1.0, 1.0, -1.0, 1.0, grid_size, grid_size, rect_size, rect_size, angle, 0, subsample)
+    assert_allclose(g.max(), 1.0)


### PR DESCRIPTION
The problem I reported in #265 was due to the pixel normalization being done twice, once in ``rectangular_overlap_single_subpixel`` and again in ``rectangular_overlap_grid``.  I have removed the 2nd one and now the results are what I expected. 