### PR TITLE
Enabling container based travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
 language: python
 
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
+# The apt packages below are needed for sphinx builds, which can no longer
+# be installed with sudo apt-get.
+addons:
+    apt:
+        packages:
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
+
 python:
     - 2.6
     - 2.7
@@ -73,12 +85,6 @@ before_install:
     - ./miniconda.sh -b
     - export PATH=/home/travis/miniconda/bin:$PATH
     - conda update --yes conda
-
-    # UPDATE APT-GET LISTINGS
-    - sudo apt-get update
-
-    # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
 
     # Make sure that interactive matplotlib backends work
     - export DISPLAY=:99.0


### PR DESCRIPTION
Enabling container based travis builds significantly speeded up the test runtimes for the astropy builds astropy/astropy#3944. This PR tests whether we fall in the same case with ``photutils`` as the current builds take around 2hr. 

I think  switching to pip from conda might have been a major player in this, too, I'll test this hypothesis later either in this PR or in a new one.

