### PR TITLE
Update astropy-helpers to 1.0.5 (and fix failing tests)

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -409,7 +409,7 @@ class _Bootstrapper(object):
     def get_index_dist(self):
         if not self.download:
             log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
-            return False
+            return None
 
         log.warn(
             "Downloading {0!r}; run setup.py with the --offline option to "

--- a/docs/photutils/background.rst
+++ b/docs/photutils/background.rst
@@ -105,9 +105,9 @@ provides a better estimate of the background and background noise
 levels::
 
     >>> from astropy.stats import sigma_clipped_stats
-    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)
+    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, iters=5)
     >>> print(mean, median, std)    # doctest: +FLOAT_CMP
-    (5.19888175541, 5.15557244947, 2.09393539966)
+    (5.1991386516217908, 5.1555874333582912, 2.0942752121329691)
 
 
 Masking Sources

--- a/docs/photutils/morphology.rst
+++ b/docs/photutils/morphology.rst
@@ -139,7 +139,7 @@ sigma-clipped statistics:
     >>> from astropy.stats import sigma_clipped_stats
     >>> from photutils.morphology import data_properties
     >>> from photutils import properties_table
-    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)
+    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, iters=5)
     >>> data -= median    # subtract background
     >>> props = data_properties(data)
     >>> columns = ['id', 'xcentroid', 'ycentroid', 'semimajor_axis_sigma',
@@ -149,7 +149,7 @@ sigma-clipped statistics:
      id   xcentroid     ycentroid   ... semiminor_axis_sigma  orientation
              pix           pix      ...         pix               rad
     --- ------------- ------------- ... -------------------- -------------
-      1 14.0192015504 16.9885140744 ...         3.7763953673 1.05053207277
+      1 14.0225090502 16.9901801466 ...        3.69777618702 1.04943689372
 
 Now let's use the measured morphological properties to define an
 approximate isophotal ellipse for the source:

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.table import Table
 import astropy.units as u
 from .. import (make_noise_image, make_poisson_noise, make_gaussian_sources,
@@ -58,7 +58,7 @@ def test_make_noise_image_unit():
     image = make_noise_image(shape, 'gaussian', mean=0., stddev=2., unit=unit)
     assert image.shape == shape
     assert image.unit == unit
-    assert_allclose(image.mean(), 0., atol=1.)
+    assert_quantity_allclose(image.mean(), 0.*unit, atol=1.*unit)
 
 
 def test_make_poisson_noise():
@@ -84,7 +84,7 @@ def test_make_poisson_noise_unit():
     result = make_poisson_noise(data)
     assert result.shape == shape
     assert result.unit == unit
-    assert_allclose(result.mean(), 1., atol=1.)
+    assert_quantity_allclose(result.mean(), 1.*unit, atol=1.*unit)
 
 
 def test_make_gaussian_sources():
@@ -124,7 +124,7 @@ def test_make_gaussian_sources_unit():
     image = make_gaussian_sources(shape, TABLE, unit=unit)
     assert image.shape == shape
     assert image.unit == unit
-    assert_allclose(image.sum(), TABLE['flux'].sum())
+    assert_quantity_allclose(image.sum(), TABLE['flux'].sum()*unit)
 
 
 def test_make_random_gaussians():

--- a/photutils/tests/test_aperture_photometry.py
+++ b/photutils/tests/test_aperture_photometry.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
+from astropy.tests.helper import assert_quantity_allclose
 import astropy.units as u
 from astropy.io import fits
 from astropy.nddata import NDData
@@ -84,9 +85,9 @@ def test_aperture_pixel_positions():
     ap2 = CircularAperture(pos2, r)
     ap3 = CircularAperture(pos3, r)
 
-    assert np.allclose(pos1, ap1.positions)
-    assert np.allclose(pos2, ap2.positions)
-    assert np.allclose(pos3_pairs, ap3.positions)
+    assert_allclose([pos1], ap1.positions)
+    assert_allclose(pos2.value, ap2.positions)
+    assert_allclose(pos3_pairs, ap3.positions)
 
 
 class BaseTestAperturePhotometry(object):

--- a/photutils/tests/test_segmentation.py
+++ b/photutils/tests/test_segmentation.py
@@ -3,9 +3,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.modeling import models
 from astropy.table import Table
+import astropy.units as u
 from astropy.utils.misc import isiterable
 import astropy.wcs as WCS
 from ..segmentation import (SegmentProperties, segment_properties,
@@ -131,17 +132,22 @@ class TestSegmentPropertiesFunction(object):
     def test_properties(self):
         props = segment_properties(IMAGE, SEGM)
         assert props[0].id == 1
-        assert_allclose(props[0].xcentroid, XCEN, rtol=1.e-2)
-        assert_allclose(props[0].ycentroid, YCEN, rtol=1.e-2)
+        assert_quantity_allclose(props[0].xcentroid, XCEN*u.pix,
+                                 rtol=1.e-2)
+        assert_quantity_allclose(props[0].ycentroid, YCEN*u.pix,
+                                 rtol=1.e-2)
         assert_allclose(props[0].segment_sum, IMAGE[IMAGE >= THRESHOLD].sum())
-        assert_allclose(props[0].semimajor_axis_sigma, MAJOR_SIG, rtol=1.e-2)
-        assert_allclose(props[0].semiminor_axis_sigma, MINOR_SIG, rtol=1.e-2)
-        assert_allclose(props[0].orientation, THETA, rtol=1.e-3)
-        assert_allclose(props[0].bbox, [35, 25, 70, 77])
-        assert_allclose(props[0].area, 1058.0)
-        assert_allclose(len(props[0].values), props[0].area)
+        assert_quantity_allclose(props[0].semimajor_axis_sigma,
+                                 MAJOR_SIG*u.pix, rtol=1.e-2)
+        assert_quantity_allclose(props[0].semiminor_axis_sigma,
+                                 MINOR_SIG*u.pix, rtol=1.e-2)
+        assert_quantity_allclose(props[0].orientation, THETA*u.rad,
+                                 rtol=1.e-3)
+        assert_allclose(props[0].bbox.value, [35, 25, 70, 77])
+        assert_quantity_allclose(props[0].area, 1058.0*u.pix**2)
+        assert_allclose(len(props[0].values), props[0].area.value)
         assert_allclose(len(props[0].coords), 2)
-        assert_allclose(len(props[0].coords[0]), props[0].area)
+        assert_allclose(len(props[0].coords[0]), props[0].area.value)
 
         properties = ['background_atcentroid', 'background_mean',
                       'eccentricity', 'ellipticity', 'elongation',
@@ -205,13 +211,16 @@ class TestSegmentPropertiesFunction(object):
         props = segment_properties(IMAGE, SEGM, error=error,
                                    effective_gain=effective_gain,
                                    background=background)
-        assert_allclose(props[0].xcentroid, XCEN, rtol=1.e-2)
-        assert_allclose(props[0].ycentroid, YCEN, rtol=1.e-2)
-        assert_allclose(props[0].semimajor_axis_sigma, MAJOR_SIG, rtol=1.e-2)
-        assert_allclose(props[0].semiminor_axis_sigma, MINOR_SIG, rtol=1.e-2)
-        assert_allclose(props[0].orientation, THETA, rtol=1.e-3)
-        assert_allclose(props[0].bbox, [35, 25, 70, 77])
-        assert_allclose(props[0].area, 1058.0)
+        assert_quantity_allclose(props[0].xcentroid, XCEN*u.pix, rtol=1.e-2)
+        assert_quantity_allclose(props[0].ycentroid, YCEN*u.pix, rtol=1.e-2)
+        assert_quantity_allclose(props[0].semimajor_axis_sigma,
+                                 MAJOR_SIG*u.pix, rtol=1.e-2)
+        assert_quantity_allclose(props[0].semiminor_axis_sigma,
+                                 MINOR_SIG*u.pix, rtol=1.e-2)
+        assert_quantity_allclose(props[0].orientation, THETA*u.rad,
+                                 rtol=1.e-3)
+        assert_allclose(props[0].bbox.value, [35, 25, 70, 77])
+        assert_allclose(props[0].area.value, 1058.0)
         if background is None:
             background_sum = 0.
         else:
@@ -219,7 +228,7 @@ class TestSegmentPropertiesFunction(object):
         true_sum = IMAGE[IMAGE >= THRESHOLD].sum() - background_sum
         assert_allclose(props[0].segment_sum, true_sum)
         if effective_gain is None:
-            true_error = np.sqrt(props[0].area) * error_value
+            true_error = np.sqrt(props[0].area.value) * error_value
         else:
             true_error = np.sqrt(((props[0].segment_sum + background_sum) /
                                   effective_gain) +
@@ -243,10 +252,10 @@ class TestSegmentPropertiesFunction(object):
         mask[0, 1] = True
         segm = data.astype(np.int)
         props = segment_properties(data, segm, mask=mask)
-        assert_allclose(props[0].xcentroid, 1)
-        assert_allclose(props[0].ycentroid, 1)
+        assert_allclose(props[0].xcentroid.value, 1)
+        assert_allclose(props[0].ycentroid.value, 1)
         assert_allclose(props[0].segment_sum, 1)
-        assert_allclose(props[0].area, 1)
+        assert_allclose(props[0].area.value, 1)
 
     def test_effective_gain_negative(self, effective_gain=-1):
         error = np.ones_like(IMAGE) * 2.


### PR DESCRIPTION
The failing doc tests in https://github.com/astropy/photutils/pull/284 and https://github.com/astropy/photutils/issues/285 are not due to the `astropy-helpers` update.  They occurred because the `sigma_clipped_stats` `iters` default value changed from `None` to `5` in `astropy dev`.  In this PR, I explicitly set `iters=5` so all versions of `astropy` are happy.