### PR TITLE
Ensure that PixelAperture.positions is at least 2D

### DIFF
--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -41,7 +41,7 @@ def _sanitize_pixel_positions(positions):
 
     if isinstance(positions, u.Quantity):
         if positions.unit is u.pixel:
-            positions = positions.value
+            positions = np.atleast_2d(positions.value)
         else:
             raise u.UnitsError("positions should be in pixel units")
     elif isinstance(positions, (list, tuple, np.ndarray)):

--- a/photutils/tests/test_aperture_photometry.py
+++ b/photutils/tests/test_aperture_photometry.py
@@ -85,8 +85,8 @@ def test_aperture_pixel_positions():
     ap2 = CircularAperture(pos2, r)
     ap3 = CircularAperture(pos3, r)
 
-    assert_allclose([pos1], ap1.positions)
-    assert_allclose(pos2.value, ap2.positions)
+    assert_allclose(np.atleast_2d(pos1), ap1.positions)
+    assert_allclose(np.atleast_2d(pos2.value), ap2.positions)
     assert_allclose(pos3_pairs, ap3.positions)
 
 


### PR DESCRIPTION
This PR fixes an inconsistency where a scalar `Quantity` input position remains a scalar in the aperture `.positions` attribute:
```
pos1 = u.Quantity((10, 20), unit=u.pixel)
ap1 = CircularAperture(pos1, r=3)
ap1.positions
array([ 10.,  20.])
```

but for a non-`Quantity` scalar, `.positions` is always a 2D array, which is the expected behavior:
```
pos2 = (10, 20)
ap2 = CircularAperture(pos2, r=3)
ap2.positions
array([[ 10.,  20.]])
```

This PR ensures that `.positions` is always at least 2D.