### PR TITLE
Use external ci-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,9 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install'
         - PIP_INSTALL='pip install'
-        - INSTALL_OPTIONAL=true
-        - OPTIONAL_DEPENDENCIES='scipy scikit-image matplotlib'
+        - CONDA_ADDITIONAL_DEPENDENCIES='Cython'
+        - PIP_ADDITIONAL_DEPENDENCIES='pytest-xdist'
+        - CONDA_OPTIONAL_DEPENDENCIES='scipy scikit-image matplotlib'
     matrix:
         - SETUP_CMD='egg_info'
 
@@ -88,14 +89,8 @@ before_install:
 install:
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
-    # OPTIONAL DEPENDENCIES
-    # Here you can add any dependencies your package may have.
-    # Python packages listed in $OPTIONAL_PACKAGES and are available through
-    # conda are already installed.
-    # Any other package can be installed with pip, etc here:
-    # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
+    # OPTIONAL_DEPENDENCIES
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         - NUMPY_VERSION=1.9
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
-        - PIP_DEPENDENCIES='pytest-xdist'
+        - PIP_DEPENDENCIES=''
 
     matrix:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,24 +77,8 @@ matrix:
 
 before_install:
 
-    # Use utf8 encoding. Should be default, but this is insurance against
-    # future changes
-    - export PYTHONIOENCODING=UTF8
-
-    # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-      else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-      fi
-
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda info -a
-
+    - git clone git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
     # Make sure that interactive matplotlib backends work
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     matrix:
 
         # Make sure that egg_info works without dependencies
-        - SETUP_CMD='egg_info' CONDA_DEPENDENCIES=''
+        - SETUP_CMD='egg_info'
 
         # Try all python versions with the latest numpy
         - SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
         - INSTALL_OPTIONAL=true
+        - OPTIONAL_DEPENDENCIES='scipy scikit-image matplotlib'
     matrix:
         - SETUP_CMD='egg_info'
 
@@ -79,38 +80,22 @@ before_install:
 
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+
     # Make sure that interactive matplotlib backends work
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
 
 install:
 
-    # CONDA
-    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
-    - source activate test
-
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
-    # ASTROPY
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
-
     # OPTIONAL DEPENDENCIES
-    # Here you can add any dependencies your package may have. You can use
-    # conda for packages available through conda, or pip for any other
-    # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
-    # install since this ensures Numpy does not get automatically upgraded.
-    - if [[ $SETUP_CMD != egg_info ]] && $INSTALL_OPTIONAL; then $CONDA_INSTALL numpy=$NUMPY_VERSION scipy scikit-image matplotlib; fi
+    # Here you can add any dependencies your package may have.
+    # Python packages listed in $OPTIONAL_PACKAGES and are available through
+    # conda are already installed.
+    # Any other package can be installed with pip, etc here:
     # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
-
-    # DOCUMENTATION DEPENDENCIES
-    # build_sphinx needs sphinx and matplotlib (for plot_directive).
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
-
-    # COVERAGE DEPENDENCIES
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.9
         - ASTROPY_VERSION=stable
-        - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
+        - CONDA_INSTALL='conda install'
         - PIP_INSTALL='pip install'
         - INSTALL_OPTIONAL=true
         - OPTIONAL_DEPENDENCIES='scipy scikit-image matplotlib'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ env:
         - CONDA_ADDITIONAL_DEPENDENCIES='Cython'
         - PIP_ADDITIONAL_DEPENDENCIES='pytest-xdist'
         - CONDA_OPTIONAL_DEPENDENCIES='scipy scikit-image matplotlib'
+        - PIP_OPTIONAL_DEPENDENCIES=''
+
     matrix:
         - SETUP_CMD='egg_info'
 
@@ -65,9 +67,9 @@ matrix:
 
         # Try with optional dependencies disabled
         - python: 2.7
-          env: SETUP_CMD='test' INSTALL_OPTIONAL=false
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES=$CONDA_ADDITIONAL_DEPENDENCIES
         - python: 3.4
-          env: SETUP_CMD='test' INSTALL_OPTIONAL=false
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES=$CONDA_ADDITIONAL_DEPENDENCIES
 
         # Try older numpy versions
         - python: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   global:
       PYTHON: "C:\\conda"
-      MINICONDA_VERSION: "3.5.5"
+      MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
@@ -17,7 +17,7 @@ environment:
         ASTROPY_VERSION: "1.0"
         NUMPY_VERSION: "1.9.1"
 
-      - PYTHON_VERSION: "2.7"
+      - PYTHON_VERSION: "3.4"
         ASTROPY_VERSION: "1.0"
         NUMPY_VERSION: "1.9.1"
 
@@ -28,6 +28,7 @@ install:
     - "git clone git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - "activate test"
 
 # Not a .NET project, we build photutils in the install step instead
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
+      CONDA_ADDITIONAL_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib"
 
   matrix:
       - PYTHON_VERSION: "2.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,24 +24,11 @@ platform:
     -x64
 
 install:
-    # Install miniconda using a powershell script.
-    - "powershell ./.install-miniconda.ps1"
+    - "git clone git://github.com/astropy/ci-helpers.git"
+    - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-    # Install the build and runtime dependencies of the project.
-    - "conda update --yes conda"
-    # Create a conda environment using the astropy bonus packages
-    - "conda create -q --yes -n test -c astropy-ci-extras python=%PYTHON_VERSION%"
-    - "activate test"
-
-    # Check that we have the expected version of Python
-    - "python --version"
-
-    # Install specified version of numpy and dependencies
-    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython scipy jinja2 scikit-image matplotlib"
-    - "conda install -q --yes -c astropy-ci-extras astropy=%ASTROPY_VERSION%"
-
-# Not a .NET project, we build SunPy in the install step instead
+# Not a .NET project, we build photutils in the install step instead
 build: false
 
 test_script:


### PR DESCRIPTION
This is the prototype for the usage of the new ci-helpers package to setup the conda environments for travis and appveyor.

cc @astrofrog