### PR TITLE
Adding travis builds against LTS astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,11 +58,13 @@ matrix:
         - python: 3.3
           env: SETUP_CMD='test' NUMPY_VERSION=1.9
 
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
+        # Try Astropy development and LTS versions
         - python: 3.5
           env: ASTROPY_VERSION=development SETUP_CMD='test'
+        - python: 2.7
+          env: ASTROPY_VERSION=lts SETUP_CMD='test'
+        - python: 3.5
+          env: ASTROPY_VERSION=lts SETUP_CMD='test'
 
         # Try with optional dependencies disabled
         - python: 2.7


### PR DESCRIPTION
Closes #289.

The PR also removes duplicated py2.7 and astropy development build.