### PR TITLE
find_peaks works well with a threshold array

### DIFF
--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -295,8 +295,11 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     data : array_like
         The 2D array of the image.
 
-    threshold : float
-        The data value to be used for the detection threshold.
+    threshold : float or array-like
+        The data value or pixel-wise data values to be used for the
+        detection threshold.  A 2D ``threshold`` must have the same
+        shape as ``data``.  See `detect_threshold` for one way to create
+        a ``threshold`` image.
 
     box_size : scalar or tuple, optional
         The size of the local region to search for peaks at every point


### PR DESCRIPTION
I originally planned to implement a way where the detection threshold could be an array for `find_peaks` (which sounds like a simple extension of the existing algorithm, since find_peaks works local anyway), but then I found that that works already.
Thus, I now only propose this minor update to the docs.

[skip ci]