### PR TITLE
Pass pixel connectivity to the watershed algorithm in source deblending

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Bug Fixes
   - Fixed an issue to update segmentation image slices after
     deblending. [#340]
 
+  - Fixed source deblending to pass the pixel connectivity to the
+    watershed algorithm. [#347]
+
 
 0.2.1 (2016-01-15)
 ------------------


### PR DESCRIPTION
This PR fixes #341.  The issue was the pixel connectivity wasn't being passed to the watershed algorithm.