### PR TITLE
Update RTD links

### DIFF
--- a/LONG_DESCRIPTION.rst
+++ b/LONG_DESCRIPTION.rst
@@ -1,6 +1,6 @@
 
 * Code: https://github.com/astropy/photutils
-* Docs: https://photutils.readthedocs.org/
+* Docs: https://photutils.readthedocs.io/
 
 **Photutils** is an in-development `affiliated package
 <http://www.astropy.org/affiliated/index.html>`_ of `Astropy

--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,11 @@ Photutils
     :alt: Latest release
 
 .. image:: https://readthedocs.org/projects/photutils/badge/?version=stable
-    :target: http://photutils.readthedocs.org/en/stable/
+    :target: http://photutils.readthedocs.io/en/stable/
     :alt: Stable Documentation Status
 
 .. image:: https://readthedocs.org/projects/photutils/badge/?version=latest
-    :target: http://photutils.readthedocs.org/en/latest/
+    :target: http://photutils.readthedocs.io/en/latest/
     :alt: Latest Documentation Status
 
 .. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,10 +99,10 @@ Photutils follows the same workflow and coding guidelines as
 contributing fixes, code, or documentation (no git or GitHub
 experience necessary):
 
-* `How to make a code contribution <http://astropy.readthedocs.org/en/stable/development/workflow/development_workflow.html>`_
+* `How to make a code contribution <http://astropy.readthedocs.io/en/stable/development/workflow/development_workflow.html>`_
 
 * `Coding Guidelines <http://docs.astropy.org/en/latest/development/codeguide.html>`_
 
-* `Try the development version <http://astropy.readthedocs.org/en/stable/development/workflow/get_devel_version.html>`_
+* `Try the development version <http://astropy.readthedocs.io/en/stable/development/workflow/get_devel_version.html>`_
 
 * `Developer Documentation <http://docs.astropy.org/en/latest/#developer-documentation>`_

--- a/docs/photutils/overview.rst
+++ b/docs/photutils/overview.rst
@@ -16,7 +16,7 @@ The code and the documentation are available at the following links:
 
 * Code: https://github.com/astropy/photutils
 * Issue Tracker: https://github.com/astropy/photutils/issues
-* Documentation: https://photutils.readthedocs.org/
+* Documentation: https://photutils.readthedocs.io/
 
 
 .. _coordinate-conventions:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ description = An Astropy package for photometry
 author = The Photutils Developers
 author_email = astropy.team@gmail.com
 license = BSD
-url = http://photutils.readthedocs.org/
+url = http://photutils.readthedocs.io/
 edit_on_github = False
 github_project = astropy/photutils
 


### PR DESCRIPTION
Updates the RTD links from `readthedocs.org` to `readthedocs.io`.