### PR TITLE
Cache SegmentationImage properties 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New Features
   - Added ``copy`` and ``area`` methods and a ``areas`` property to
     ``SegmentationImage``. [#331]
 
+  - SegmentationImage properties are now cached to significantly
+    improve performance. [#361]
+
 - ``photutils.background``
 
   - Added new ``BackgroundBase`` and ``BackgroundIDW`` classes and

--- a/photutils/detection/deblend.py
+++ b/photutils/detection/deblend.py
@@ -139,8 +139,10 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
         if source_deblended.nlabels > 1:
             # replace the original source with the deblended source
             source_mask = (source_deblended.data > 0)
-            segm_deblended._data[source_slice][source_mask] = (
+            data = segm_deblended.data
+            data[source_slice][source_mask] = (
                 source_deblended.data[source_mask] + last_label)
+            segm_deblended.data = data    # needed to call data setter
             last_label += source_deblended.nlabels
 
     if relabel:

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -324,3 +324,4 @@ class TestMakeSourceMask(object):
         sigma = 2 * gaussian_fwhm_to_sigma
         kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
         mask2 = make_source_mask(self.data, 5, 10, filter_kernel=kernel)
+        assert_allclose(mask1, mask2)

--- a/photutils/segmentation.py
+++ b/photutils/segmentation.py
@@ -41,10 +41,7 @@ class SegmentationImage(object):
 
     def __init__(self, data):
 
-        if np.min(data) < 0:
-            raise ValueError('The segmentation image cannot contain '
-                             'negative integers.')
-        self._data = np.asanyarray(data, dtype=np.int)
+        self.data = np.asanyarray(data, dtype=np.int)
 
     @property
     def data(self):
@@ -56,8 +53,11 @@ class SegmentationImage(object):
 
     @data.setter
     def data(self, value):
-        # be sure to delete any lazy properties to reset their values.
+        if np.min(value) < 0:
+            raise ValueError('The segmentation image cannot contain '
+                             'negative integers.')
         self._data = value
+        # be sure to delete any lazy properties to reset their values.
         del (self.data_masked, self.shape, self.labels, self.nlabels,
              self.max, self.slices, self.areas, self.is_sequential)
 

--- a/photutils/segmentation.py
+++ b/photutils/segmentation.py
@@ -225,12 +225,16 @@ class SegmentationImage(object):
             If the input ``label`` is invalid.
         """
 
-        if label == 0 and not allow_zero:
-            raise ValueError('label "0" is reserved for the background')
+        if label == 0:
+            if allow_zero:
+                return
+            else:
+                raise ValueError('label "0" is reserved for the background')
+
         if label < 0:
             raise ValueError('label must be a positive integer, got '
                              '"{0}"'.format(label))
-        if label not in self.data:
+        if label not in self.labels:
             raise ValueError('label "{0}" is not in the segmentation '
                              'image'.format(label))
 

--- a/photutils/tests/test_segmentation.py
+++ b/photutils/tests/test_segmentation.py
@@ -66,7 +66,7 @@ class TestSegmentationImage(object):
         segm = SegmentationImage(self.data)
         segm2 = segm.copy()
         assert segm.data is not segm2.data
-        assert segm.labels is not segm.labels
+        assert segm.labels is not segm2.labels
         segm.data[0, 0] = 100.
         assert segm.data[0, 0] != segm2.data[0, 0]
 

--- a/photutils/tests/test_segmentation.py
+++ b/photutils/tests/test_segmentation.py
@@ -56,11 +56,11 @@ class TestSegmentationImage(object):
                      [7, 0, 0, 0, 0, 5],
                      [7, 7, 0, 5, 5, 5],
                      [7, 7, 0, 0, 5, 5]]
+        self.segm = SegmentationImage(self.data)
 
     def test_array(self):
-        segm = SegmentationImage(self.data)
-        assert_allclose(segm.data, segm.array)
-        assert_allclose(segm.data, segm.__array__())
+        assert_allclose(self.segm.data, self.segm.array)
+        assert_allclose(self.segm.data, self.segm.__array__())
 
     def test_copy(self):
         segm = SegmentationImage(self.data)
@@ -77,48 +77,39 @@ class TestSegmentationImage(object):
 
     def test_zero_label(self):
         with pytest.raises(ValueError):
-            segm = SegmentationImage(self.data)
-            segm.check_label(0)
+            self.segm.check_label(0)
 
     def test_negative_label(self):
         with pytest.raises(ValueError):
-            segm = SegmentationImage(self.data)
-            segm.check_label(-1)
+            self.segm.check_label(-1)
 
     def test_invalid_label(self):
         with pytest.raises(ValueError):
-            segm = SegmentationImage(self.data)
-            segm.check_label(2)
+            self.segm.check_label(2)
 
     def test_data_masked(self):
-        segm = SegmentationImage(self.data)
-        assert isinstance(segm.data_masked, np.ma.MaskedArray)
-        assert np.ma.count(segm.data_masked) == 18
-        assert np.ma.count_masked(segm.data_masked) == 18
+        assert isinstance(self.segm.data_masked, np.ma.MaskedArray)
+        assert np.ma.count(self.segm.data_masked) == 18
+        assert np.ma.count_masked(self.segm.data_masked) == 18
 
     def test_labels(self):
-        segm = SegmentationImage(self.data)
-        assert_allclose(segm.labels, [1, 3, 4, 5, 7])
+        assert_allclose(self.segm.labels, [1, 3, 4, 5, 7])
 
     def test_nlabels(self):
-        segm = SegmentationImage(self.data)
-        assert segm.nlabels == 5
+        assert self.segm.nlabels == 5
 
     def test_max(self):
-        segm = SegmentationImage(self.data)
-        assert segm.max == 7
+        assert self.segm.max == 7
 
     def test_areas(self):
-        segm = SegmentationImage(self.data)
         expected = np.array([18, 2, 0, 2, 3, 6, 0, 5])
-        assert_allclose(segm.areas, expected)
+        assert_allclose(self.segm.areas, expected)
 
     def test_area(self):
-        segm = SegmentationImage(self.data)
         expected = np.array([18, 2, 0, 2, 3, 6, 0, 5])
-        assert segm.area(0) == expected[0]
+        assert self.segm.area(0) == expected[0]
         labels = [3, 1, 4]
-        assert_allclose(segm.area(labels), expected[labels])
+        assert_allclose(self.segm.area(labels), expected[labels])
 
     def test_outline_segments(self):
         if SKIMAGE_LT_0P11:


### PR DESCRIPTION
This PR significantly improves the performance of segmentation-based photometry by caching (using astropy's `@lazyproperty`) `SegmentationImage` properties.  This PR also adds a few source deblending tests.
