### PR TITLE
Updating versions for CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.10
+        - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - PIP_DEPENDENCIES=''
@@ -76,11 +76,17 @@ matrix:
 
         # Try older numpy versions
         - python: 2.7
+          env: NUMPY_VERSION=1.10 SETUP_CMD='test'
+        - python: 2.7
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.8 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
+
+        # Try numpy pre-release
+        - python: 3.5
+          env: NUMPY_VERSION=prerelease
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - PIP_DEPENDENCIES=''
+        - SETUP_CMD='test'
 
     matrix:
 
@@ -85,6 +86,12 @@ matrix:
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
 
         # Try numpy pre-release
+        - python: 3.5
+          env: NUMPY_VERSION=prerelease
+
+    allow_failures:
+        # The build with numpy v1.11.1rc1 halts in the middle without
+        # showing any obvious reason, thus allowing it to fail for now.
         - python: 3.5
           env: NUMPY_VERSION=prerelease
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,12 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "1.0"
-        NUMPY_VERSION: "1.10"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
 
       - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "1.0"
-        NUMPY_VERSION: "1.9"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
 
 platform:
     -x64


### PR DESCRIPTION
Update numpy and astropy versions for both travis and appveyor, and adding a build against the numpy prerelease for travis (as well as the now old 1.10).