### PR TITLE
Remove the "effective_gain" keyword from the photometry routines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 General
 ^^^^^^^
 
-- Drop numpy 1.6 support, minimal required version is now numpy 1.7. [#327]
+- Drop numpy 1.6 support, minimal required version is now numpy 1.7.
+  [#327]
 
 New Features
 ^^^^^^^^^^^^
@@ -35,6 +36,13 @@ New Features
 API changes
 ^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Removed the ``effective_gain`` keyword from
+    ``aperture_photometry``.  Users must now input the total error,
+    which can be calculating using the ``calc_total_error`` function.
+    [#368]
+
 - ``photutils.background``
 
   - For the background classes, the ``filter_shape`` keyword was
@@ -43,6 +51,23 @@ API changes
     ``background_rms_low_res`` class attributes were renamed to
     ``background_mesh2d`` and ``background_rms_mesh2d``, respectively.
     [#355]
+
+- ``photutils.psf``
+
+  - Removed the ``effective_gain`` keyword from ``psf_photometry``.
+    Users must now input the total error, which can be calculating using
+    the ``calc_total_error`` function. [#368]
+
+- ``photutils.segmentation``
+
+  - Removed the ``effective_gain`` keyword from ``SourceProperties``
+    and ``source_properties``.  Users must now input the total error,
+    which can be calculating using the ``calc_total_error`` function.
+    [#368]
+
+- ``photutils.utils``
+
+  - Renamed ``calculate_total_error`` to ``calc_total_error``. [#368]
 
 
 0.2.2 (unreleased)

--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -299,14 +299,14 @@ individual sources or such noise is irrelevant.  However, it is often
 the case that one has calculated a smooth "background-only error"
 array, which by design doesn't include increased noise on bright
 pixels.  To include Poisson noise from the sources, we can use the
-:func:`~photutils.utils.calculate_total_error` function.  For example,
+:func:`~photutils.utils.calc_total_error` function.  For example,
 suppose we have a function ``background()`` that calculates the
 position-dependent background level and rms of our data::
 
-    >>> from photutils.utils import calculate_total_error
+    >>> from photutils.utils import calc_total_error
     >>> effective_gain = 1.5
     >>> sky_level, sky_sigma = background(data)  # function returns two arrays   # doctest: +SKIP
-    >>> error = calculate_total_error(data, sky_sigma, effective_gain)
+    >>> error = calc_total_error(data, sky_sigma, effective_gain)
     >>> phot_table = aperture_photometry(data - sky_level, apertures,
     ...                                  error=error)   # doctest: +SKIP
 

--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -305,10 +305,10 @@ position-dependent background level and rms of our data::
 
     >>> from photutils.utils import calc_total_error
     >>> effective_gain = 1.5
-    >>> sky_level, sky_sigma = background(data)  # function returns two arrays   # doctest: +SKIP
-    >>> error = calc_total_error(data, sky_sigma, effective_gain)
+    >>> sky_level, sky_sigma = background(data)  # function returns two arrays    # doctest: +SKIP
+    >>> error = calc_total_error(data, sky_sigma, effective_gain)    # doctest: +SKIP
     >>> phot_table = aperture_photometry(data - sky_level, apertures,
-    ...                                  error=error)   # doctest: +SKIP
+    ...                                  error=error)    # doctest: +SKIP
 
 .. note::
 

--- a/docs/photutils/segmentation.rst
+++ b/docs/photutils/segmentation.rst
@@ -247,7 +247,7 @@ Photometric Errors
 :func:`~photutils.segmentation.source_properties` requires inputting a
 *total* error array, i.e. the background-only error plus Poisson noise
 due to individual sources.  The
-:func:`~photutils.utils.calculate_total_error` function can be used to
+:func:`~photutils.utils.calc_total_error` function can be used to
 calculate the total error array from a background-only error array and
 an effective gain.
 
@@ -266,10 +266,10 @@ we set it to 500 seconds):
 
 .. doctest-requires:: scipy, skimage
 
-    >>> from photutils.utils import calculate_total_error
+    >>> from photutils.utils import calc_total_error
     >>> labels = [1, 5, 20, 50, 75, 80]
     >>> effective_gain = 500.
-    >>> error = calculate_total_error(data, bkg.background_rms, effective_gain)
+    >>> error = calc_total_error(data, bkg.background_rms, effective_gain)
     >>> props = source_properties(data, segm, labels=labels, error=error)
     >>> columns = ['id', 'xcentroid', 'ycentroid', 'source_sum',
     ...            'source_sum_err']

--- a/docs/photutils/segmentation.rst
+++ b/docs/photutils/segmentation.rst
@@ -244,21 +244,21 @@ calculate background properties with each source segment:
 Photometric Errors
 ^^^^^^^^^^^^^^^^^^
 
-With :func:`~photutils.segmentation.source_properties` we can use the
-background-only error image and an effective gain to estimate the
-error in the photometry.  Like the aperture photometry
-:ref:`error_estimation`, the
-:func:`~photutils.segmentation.source_properties` ``error`` keyword
-can either specify the total error array (i.e., it includes Poisson
-noise due to individual sources or such noise is irrelevant) or it can
-specify the background-only noise.  In the later case, we can specify
-the ``effective_gain``, which is the ratio of counts (electrons or
-photons) to the units of the data, to explicitly include Poisson noise
-from the sources.  The ``effective_gain`` can be a 2D gain image with
-the same shape as the ``data``.  This is useful with mosaic images
-that have variable depths (i.e., exposure times) across the field. For
-example, one should use an exposure-time map as the ``effective_gain``
-for a variable depth mosaic image in count-rate units.
+:func:`~photutils.segmentation.source_properties` requires inputting a
+*total* error array, i.e. the background-only error plus Poisson noise
+due to individual sources.  The
+:func:`~photutils.utils.calculate_total_error` function can be used to
+calculate the total error array from a background-only error array and
+an effective gain.
+
+The ``effective_gain``, which is the ratio of counts (electrons or
+photons) to the units of the data, is used to include the Poisson
+noise from the sources.  ``effective_gain`` can either be a scalar
+value or a 2D image with the same shape as the ``data``.  A 2D image
+is useful with mosaic images that have variable depths (i.e., exposure
+times) across the field. For example, one should use an exposure-time
+map as the ``effective_gain`` for a variable depth mosaic image in
+count-rate units.
 
 Let's assume our synthetic data is in units of electrons per second.
 In that case, the ``effective_gain`` should be the exposure time (here
@@ -266,10 +266,11 @@ we set it to 500 seconds):
 
 .. doctest-requires:: scipy, skimage
 
+    >>> from photutils.utils import calculate_total_error
     >>> labels = [1, 5, 20, 50, 75, 80]
-    >>> props = source_properties(data, segm, labels=labels,
-    ...                            error=bkg.background_rms,
-    ...                            effective_gain=500.)
+    >>> effective_gain = 500.
+    >>> error = calculate_total_error(data, bkg.background_rms, effective_gain)
+    >>> props = source_properties(data, segm, labels=labels, error=error)
     >>> columns = ['id', 'xcentroid', 'ycentroid', 'source_sum',
     ...            'source_sum_err']
     >>> tbl = properties_table(props, columns=columns)

--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -1422,8 +1422,8 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
         The pixel-wise Gaussian 1-sigma errors of the input ``data``.
         ``error`` is assumed to include *all* sources of error,
         including the Poisson error of the sources (see
-        `~photutils.utils.calculate_total_error`) .  ``error`` must have
-        the same shape as the input ``data``.
+        `~photutils.utils.calc_total_error`) .  ``error`` must have the
+        same shape as the input ``data``.
     mask : array_like (bool), optional
         Mask to apply to the data.  Masked pixels are excluded/ignored.
     method : str, optional

--- a/photutils/aperture_core.py
+++ b/photutils/aperture_core.py
@@ -127,8 +127,8 @@ class PixelAperture(Aperture):
         """
 
     @abc.abstractmethod
-    def do_photometry(self, data, error=None, effective_gain=None,
-                      pixelwise_error=True, method='exact', subpixels=5):
+    def do_photometry(self, data, error=None, pixelwise_error=True,
+                      method='exact', subpixels=5):
         """Sum flux within aperture(s).
 
         Parameters
@@ -138,17 +138,13 @@ class PixelAperture(Aperture):
         error : array_like, optional
             Error in each pixel, interpreted as Gaussian 1-sigma uncertainty.
             ``error`` has to have the same shape as ``data``.
-        effective_gain : array_like, optional
-            Ratio of counts (e.g., electrons or photons) to units of the
-            data (e.g., ADU), for the purpose of calculating Poisson
-            error from the object itself. ``effective_gain`` must have
-            the same shape as ``data``.
         pixelwise_error : bool, optional
-            For ``error`` and/or ``effective_gain`` arrays. If `True`,
-            assume ``error`` and/or ``effective_gain`` vary
-            significantly within an aperture: sum contribution from each
-            pixel. If `False`, assume ``error`` and ``effective_gain``
-            do not vary significantly within an aperture.
+            If `True`, assume ``error`` varies significantly within an
+            aperture and sum the contribution from each pixel. If
+            `False`, assume ``error`` does not vary significantly within
+            an aperture and use the single value of ``error`` at the
+            center of each aperture as the value for the entire
+            aperture.  Default is `True`.
         method : str, optional
             Method to use for determining overlap between the aperture
             and pixels.  Options include ['center', 'subpixel',
@@ -338,8 +334,8 @@ class CircularAperture(PixelAperture):
             patch = mpatches.Circle(position, self.r, **kwargs)
             ax.add_patch(patch)
 
-    def do_photometry(self, data, error=None, effective_gain=None,
-                      pixelwise_error=True, method='exact', subpixels=5):
+    def do_photometry(self, data, error=None, pixelwise_error=True,
+                      method='exact', subpixels=5):
 
         if method not in ('center', 'subpixel', 'exact'):
             raise ValueError('{0} method not supported for aperture class '
@@ -347,7 +343,6 @@ class CircularAperture(PixelAperture):
 
         flux = do_circular_photometry(data, self.positions,
                                       self.r, error=error,
-                                      effective_gain=effective_gain,
                                       pixelwise_error=pixelwise_error,
                                       method=method,
                                       subpixels=subpixels)
@@ -467,8 +462,8 @@ class CircularAnnulus(PixelAperture):
     def area(self):
         return math.pi * (self.r_out ** 2 - self.r_in ** 2)
 
-    def do_photometry(self, data, error=None, effective_gain=None,
-                      pixelwise_error=True, method='exact', subpixels=5):
+    def do_photometry(self, data, error=None, pixelwise_error=True,
+                      method='exact', subpixels=5):
 
         if method not in ('center', 'subpixel', 'exact'):
             raise ValueError('{0} method not supported for aperture class '
@@ -476,7 +471,6 @@ class CircularAnnulus(PixelAperture):
 
         flux = do_circular_photometry(data, self.positions,
                                       self.r_out, error=error,
-                                      effective_gain=effective_gain,
                                       pixelwise_error=pixelwise_error,
                                       method=method,
                                       subpixels=subpixels,
@@ -632,8 +626,8 @@ class EllipticalAperture(PixelAperture):
     def area(self):
         return math.pi * self.a * self.b
 
-    def do_photometry(self, data, error=None, effective_gain=None,
-                      pixelwise_error=True, method='exact', subpixels=5):
+    def do_photometry(self, data, error=None, pixelwise_error=True,
+                      method='exact', subpixels=5):
 
         if method not in ('center', 'subpixel', 'exact'):
             raise ValueError('{0} method not supported for aperture class '
@@ -642,7 +636,6 @@ class EllipticalAperture(PixelAperture):
         flux = do_elliptical_photometry(data, self.positions,
                                         self.a, self.b, self.theta,
                                         error=error,
-                                        effective_gain=effective_gain,
                                         pixelwise_error=pixelwise_error,
                                         method=method,
                                         subpixels=subpixels)
@@ -839,8 +832,8 @@ class EllipticalAnnulus(PixelAperture):
             patch = mpatches.PathPatch(path, **kwargs)
             ax.add_patch(patch)
 
-    def do_photometry(self, data, error=None, effective_gain=None,
-                      pixelwise_error=True, method='exact', subpixels=5):
+    def do_photometry(self, data, error=None, pixelwise_error=True,
+                      method='exact', subpixels=5):
 
         if method not in ('center', 'subpixel', 'exact'):
             raise ValueError('{0} method not supported for aperture class '
@@ -849,7 +842,6 @@ class EllipticalAnnulus(PixelAperture):
         flux = do_elliptical_photometry(data, self.positions,
                                         self.a_out, self.b_out, self.theta,
                                         error=error,
-                                        effective_gain=effective_gain,
                                         pixelwise_error=pixelwise_error,
                                         method=method,
                                         subpixels=subpixels,
@@ -1006,8 +998,8 @@ class RectangularAperture(PixelAperture):
                                        **kwargs)
             ax.add_patch(patch)
 
-    def do_photometry(self, data, error=None, effective_gain=None,
-                      pixelwise_error=True, method='subpixel', subpixels=5):
+    def do_photometry(self, data, error=None, pixelwise_error=True,
+                      method='subpixel', subpixels=5):
 
         if method == 'exact':
             warnings.warn("'exact' method is not implemented, defaults to "
@@ -1023,7 +1015,6 @@ class RectangularAperture(PixelAperture):
         flux = do_rectangular_photometry(data, self.positions,
                                          self.w, self.h, self.theta,
                                          error=error,
-                                         effective_gain=effective_gain,
                                          pixelwise_error=pixelwise_error,
                                          method=method,
                                          subpixels=subpixels)
@@ -1223,8 +1214,8 @@ class RectangularAnnulus(PixelAperture):
             patch = mpatches.PathPatch(path, **kwargs)
             ax.add_patch(patch)
 
-    def do_photometry(self, data, error=None, effective_gain=None,
-                      pixelwise_error=True, method='subpixel', subpixels=5):
+    def do_photometry(self, data, error=None, pixelwise_error=True,
+                      method='subpixel', subpixels=5):
 
         if method == 'exact':
             warnings.warn("'exact' method is not implemented, defaults to "
@@ -1238,7 +1229,6 @@ class RectangularAnnulus(PixelAperture):
         flux = do_rectangular_photometry(data, self.positions,
                                          self.w_out, self.h_out, self.theta,
                                          error=error,
-                                         effective_gain=effective_gain,
                                          pixelwise_error=pixelwise_error,
                                          method=method, subpixels=subpixels,
                                          w_in=self.w_in)
@@ -1266,9 +1256,9 @@ class RectangularAnnulus(PixelAperture):
                                               w_in=self.w_in)
 
 
-def _prepare_photometry_input(data, unit, wcs, mask, error, effective_gain,
-                              pixelwise_error):
-    '''Parse photometry input.
+def _prepare_photometry_input(data, unit, wcs, mask, error, pixelwise_error):
+    """
+    Parse photometry input.
 
     Photometry routines accept a wide range of inputs, e.g. ``data``
     could be (among others)  a numpy array, or a fits HDU.
@@ -1292,8 +1282,8 @@ def _prepare_photometry_input(data, unit, wcs, mask, error, effective_gain,
     wcs_transformation : `~astropy.wcs.WCS` instance or None
     mask : np.array or None
     error : `~astropy.units.Quantity` instance or None
-    effective_gain : `~astropy.units.Quantity` instance or None
-    '''
+    """
+
     dataunit = None
     datamask = None
     wcs_transformation = wcs
@@ -1379,10 +1369,8 @@ def _prepare_photometry_input(data, unit, wcs, mask, error, effective_gain,
                 mask = np.logical_or(mask, datamask)
 
     # Check whether we really need to calculate pixelwise errors, even if
-    # requested.  If neither error nor effective_gain is an array, then it's
-    # not neeed.
-    if ((error is None) or (np.isscalar(error) and effective_gain is None) or
-            (np.isscalar(error) and np.isscalar(effective_gain))):
+    # requested.  If error is not an array, then it's not needed.
+    if (error is None) or (np.isscalar(error)):
         pixelwise_error = False
 
     # Check error shape.
@@ -1401,32 +1389,13 @@ def _prepare_photometry_input(data, unit, wcs, mask, error, effective_gain,
             raise ValueError('shapes of error array and data array must'
                              ' match')
 
-    # Check effective_gain shape.
-    if effective_gain is not None:
-        # effective_gain doesn't do anything without error set, so raise an
-        # exception. (TODO: instead, should we just set effective_gain = None
-        # and ignore it?)
-        if error is None:
-            raise ValueError('effective_gain requires error')
-
-        if isinstance(effective_gain, u.Quantity):
-            if np.isscalar(effective_gain.value):
-                effective_gain = u.Quantity(np.broadcast_arrays(
-                    effective_gain, data), unit=effective_gain.unit)[0]
-
-        elif np.isscalar(effective_gain):
-            effective_gain = np.broadcast_arrays(effective_gain, data)[0]
-        if effective_gain.shape != data.shape:
-            raise ValueError('shapes of effective_gain array and data array '
-                             'must match')
-
-    return data, wcs_transformation, mask, error, effective_gain, pixelwise_error
+    return data, wcs_transformation, mask, error, pixelwise_error
 
 
 @support_nddata
 def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
-                        effective_gain=None, mask=None, method='exact',
-                        subpixels=5, pixelwise_error=True):
+                        mask=None, method='exact', subpixels=5,
+                        pixelwise_error=True):
     """
     Sum flux within an aperture at the given position(s).
 
@@ -1449,16 +1418,12 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
     wcs : `~astropy.wcs.WCS`, optional
         Use this as the wcs transformation. It overrides any wcs transformation
         passed along with ``data`` either in the header or in an attribute.
-    error : float or array_like, optional
-        Error in each pixel, interpreted as Gaussian 1-sigma uncertainty.
-    effective_gain : float or array_like, optional
-        Ratio of counts (e.g., electrons or photons) to units of the
-        data (e.g., ADU), for the purpose of calculating Poisson error
-        from the object itself. If ``effective_gain`` is `None`
-        (default), ``error`` is assumed to include all uncertainty in
-        each pixel. If ``effective_gain`` is given, ``error`` is assumed
-        to be the "background error" only (not accounting for Poisson
-        error in the flux in the apertures).
+    error : array_like or `~astropy.units.Quantity`, optional
+        The pixel-wise Gaussian 1-sigma errors of the input ``data``.
+        ``error`` is assumed to include *all* sources of error,
+        including the Poisson error of the sources (see
+        `~photutils.utils.calculate_total_error`) .  ``error`` must have
+        the same shape as the input ``data``.
     mask : array_like (bool), optional
         Mask to apply to the data.  Masked pixels are excluded/ignored.
     method : str, optional
@@ -1484,12 +1449,10 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
         each dimension). That is, each pixel is divided into
         ``subpixels ** 2`` subpixels.
     pixelwise_error : bool, optional
-        For ``error`` and/or ``effective_gain`` arrays. If `True`,
-        assume ``error`` and/or ``effective_gain`` vary significantly
-        within an aperture: sum contribution from each pixel. If
-        `False`, assume ``error`` and ``effective_gain`` do not vary
-        significantly within an aperture. Use the single value of
-        ``error`` and/or ``effective_gain`` at the center of each
+        If `True`, assume ``error`` varies significantly within an
+        aperture and sum the contribution from each pixel. If `False`,
+        assume ``error`` does not vary significantly within an aperture
+        and use the single value of ``error`` at the center of each
         aperture as the value for the entire aperture.  Default is
         `True`.
 
@@ -1516,8 +1479,8 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
     This function is decorated with `~astropy.nddata.support_nddata` and
     thus supports `~astropy.nddata.NDData` objects as input.
     """
-    data, wcs_transformation, mask, error, effective_gain, pixelwise_error = \
-        _prepare_photometry_input(data, unit, wcs, mask, error, effective_gain,
+    data, wcs_transformation, mask, error, pixelwise_error = \
+        _prepare_photometry_input(data, unit, wcs, mask, error,
                                   pixelwise_error)
 
     # masked values are replaced with zeros, so they do not contribute
@@ -1577,7 +1540,6 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
 
     photometry_result = ap.do_photometry(data, method=method,
                                          subpixels=subpixels, error=error,
-                                         effective_gain=effective_gain,
                                          pixelwise_error=pixelwise_error)
     if error is None:
         phot_col_names = ('aperture_sum', )
@@ -1590,7 +1552,6 @@ def aperture_photometry(data, apertures, unit=None, wcs=None, error=None,
                        'version': 'astropy: {0}, photutils: {1}'
                        .format(astropy_version, photutils_version),
                        'calling_args': ('method={0}, subpixels={1}, '
-                                        'error={2}, effective_gain={3}, '
-                                        'pixelwise_error={4}')
+                                        'error={2}, pixelwise_error={3}')
                        .format(method, subpixels, error is not None,
-                               effective_gain is not None, pixelwise_error)})
+                               pixelwise_error)})

--- a/photutils/aperture_funcs.py
+++ b/photutils/aperture_funcs.py
@@ -67,8 +67,8 @@ def get_phot_extents(data, positions, extents):
     return ood_filter, pixel_extent, phot_extent
 
 
-def find_fluxvar(data, fraction, error, flux, effective_gain, imin, imax,
-                 jmin, jmax, pixelwise_error):
+def find_fluxvar(data, fraction, error, flux, imin, imax, jmin, jmax,
+                 pixelwise_error):
 
     if isinstance(error, u.Quantity):
         zero_variance = 0 * error.unit**2
@@ -77,12 +77,7 @@ def find_fluxvar(data, fraction, error, flux, effective_gain, imin, imax,
 
     if pixelwise_error:
 
-        subvariance = error[jmin:jmax,
-                            imin:imax] ** 2
-
-        if effective_gain is not None:
-            subvariance += (data[jmin:jmax, imin:imax] /
-                            effective_gain[jmin:jmax, imin:imax])
+        subvariance = error[jmin:jmax, imin:imax] ** 2
 
         # Make sure variance is > 0
         fluxvar = np.maximum(np.sum(subvariance * fraction), zero_variance)
@@ -95,16 +90,11 @@ def find_fluxvar(data, fraction, error, flux, effective_gain, imin, imax,
         fluxvar = np.maximum(local_error ** 2 * np.sum(fraction),
                              zero_variance)
 
-        if effective_gain is not None:
-            local_effective_gain = effective_gain[
-                int((jmin + jmax) / 2 + 0.5), int((imin + imax) / 2 + 0.5)]
-            fluxvar += flux / local_effective_gain
-
     return fluxvar
 
 
-def do_circular_photometry(data, positions, radius, error, effective_gain,
-                           pixelwise_error, method, subpixels, r_in=None):
+def do_circular_photometry(data, positions, radius, error, pixelwise_error,
+                           method, subpixels, r_in=None):
 
     extents = np.zeros((len(positions), 4), dtype=int)
 
@@ -169,8 +159,8 @@ def do_circular_photometry(data, positions, radius, error, effective_gain,
             if error is not None:
 
                 fluxvar[i] = find_fluxvar(data, fraction, error, flux[i],
-                                          effective_gain, x_min[i], x_max[i],
-                                          y_min[i], y_max[i], pixelwise_error)
+                                          x_min[i], x_max[i], y_min[i],
+                                          y_max[i], pixelwise_error)
 
     if error is None:
         return (flux, )
@@ -239,8 +229,7 @@ def get_circular_fractions(data, positions, radius, method, subpixels,
 
 
 def do_elliptical_photometry(data, positions, a, b, theta, error,
-                             effective_gain, pixelwise_error, method,
-                             subpixels, a_in=None):
+                             pixelwise_error, method, subpixels, a_in=None):
 
     extents = np.zeros((len(positions), 4), dtype=int)
 
@@ -310,8 +299,8 @@ def do_elliptical_photometry(data, positions, a, b, theta, error,
 
             if error is not None:
                 fluxvar[i] = find_fluxvar(data, fraction, error, flux[i],
-                                          effective_gain, x_min[i], x_max[i],
-                                          y_min[i], y_max[i], pixelwise_error)
+                                          x_min[i], x_max[i], y_min[i],
+                                          y_max[i], pixelwise_error)
 
     if error is None:
         return (flux, )
@@ -387,8 +376,8 @@ def get_elliptical_fractions(data, positions, a, b, theta,
 
 
 def do_rectangular_photometry(data, positions, w, h, theta, error,
-                              effective_gain, pixelwise_error, method,
-                              subpixels, reduce='sum', w_in=None):
+                              pixelwise_error, method, subpixels,
+                              reduce='sum', w_in=None):
 
     extents = np.zeros((len(positions), 4), dtype=int)
 
@@ -450,8 +439,7 @@ def do_rectangular_photometry(data, positions, w, h, theta, error,
                                       x_min[i]:x_max[i]] * fraction)
                 if error is not None:
                     fluxvar[i] = find_fluxvar(data, fraction, error,
-                                              flux[i], effective_gain,
-                                              x_min[i], x_max[i],
+                                              flux[i], x_min[i], x_max[i],
                                               y_min[i], y_max[i],
                                               pixelwise_error)
 

--- a/photutils/psf/core.py
+++ b/photutils/psf/core.py
@@ -659,8 +659,8 @@ def psf_photometry(data, positions, psf, fitshape=None,
         The pixel-wise Gaussian 1-sigma errors of the input ``data``.
         ``error`` is assumed to include *all* sources of error,
         including the Poisson error of the sources (see
-        `~photutils.utils.calculate_total_error`) .  ``error`` must have
-        the same shape as the input ``data``.
+        `~photutils.utils.calc_total_error`) .  ``error`` must have the
+        same shape as the input ``data``.
     mask : array_like (bool), optional
         Mask to apply to the data.  Masked pixels are excluded/ignored.
     pixelwise_error : bool, optional

--- a/photutils/psf/core.py
+++ b/photutils/psf/core.py
@@ -596,7 +596,7 @@ def prepare_psf_model(psfmodel, xname=None, yname=None, fluxname=None,
 @support_nddata
 def psf_photometry(data, positions, psf, fitshape=None,
                    fitter=LevMarLSQFitter(),
-                   unit=None, wcs=None, error=None, effective_gain=None,
+                   unit=None, wcs=None, error=None,
                    mask=None, pixelwise_error=True,
                    mode='sequential',
                    store_fit_info=False):
@@ -656,26 +656,19 @@ def psf_photometry(data, positions, psf, fitshape=None,
         Use this as the wcs transformation. It overrides any wcs transformation
         passed along with ``data`` either in the header or in an attribute.
     error : float or array_like, optional
-        Error in each pixel, interpreted as Gaussian 1-sigma uncertainty.
-    effective_gain : float or array_like, optional
-        Ratio of counts (e.g., electrons or photons) to units of the
-        data (e.g., ADU), for the purpose of calculating Poisson error
-        from the object itself. If ``effective_gain`` is `None`
-        (default), ``error`` is assumed to include all uncertainty in
-        each pixel. If ``effective_gain`` is given, ``error`` is assumed
-        to be the "background error" only (not accounting for Poisson
-        error in the flux in the apertures).
+        The pixel-wise Gaussian 1-sigma errors of the input ``data``.
+        ``error`` is assumed to include *all* sources of error,
+        including the Poisson error of the sources (see
+        `~photutils.utils.calculate_total_error`) .  ``error`` must have
+        the same shape as the input ``data``.
     mask : array_like (bool), optional
         Mask to apply to the data.  Masked pixels are excluded/ignored.
     pixelwise_error : bool, optional
-        For ``error`` and/or ``effective_gain`` arrays. If `True`,
-        assume ``error`` and/or ``effective_gain`` vary significantly
-        within an aperture: sum contribution from each pixel. If
-        `False`, assume ``error`` and ``effective_gain`` do not vary
-        significantly within an aperture. Use the single value of
-        ``error`` and/or ``effective_gain`` at the center of each
-        aperture as the value for the entire aperture.  Default is
-        `True`.
+        If `True`, assume ``error`` varies significantly across the PSF
+        and sum contribution from each pixel. If `False`,
+        assume ``error`` does not vary significantly across the PSF
+        and use the single value of ``error`` at the center of each
+        PSF.  Default is `True`.
     mode : {'sequential'}
         One of the following modes to do PSF/PRF photometry:
             * 'sequential' (default)
@@ -705,15 +698,16 @@ def psf_photometry(data, positions, psf, fitshape=None,
     This function is decorated with `~astropy.nddata.support_nddata` and
     thus supports `~astropy.nddata.NDData` objects as input.
     """
-    data, wcs_transformation, mask, error, effective_gain, pixelwise_error \
-        = _prepare_photometry_input(data, unit, wcs, mask, error, effective_gain,
-                                    pixelwise_error)
+
+    (data, wcs_transformation, mask, error, pixelwise_error ) = (
+        _prepare_photometry_input(data, unit, wcs, mask, error,
+                                  pixelwise_error))
 
     # As long as models don't support quantities, we'll break that apart
     fluxunit = data.unit
     data = np.array(data)
 
-    if (error is not None) or (effective_gain is not None):
+    if (error is not None):
         warnings.warn('Uncertainties are not yet supported in PSF fitting.',
                       AstropyUserWarning)
     weights = np.ones_like(data)

--- a/photutils/segmentation.py
+++ b/photutils/segmentation.py
@@ -651,9 +651,9 @@ class SourceProperties(object):
         The pixel-wise Gaussian 1-sigma errors of the input ``data``.
         ``error`` is assumed to include *all* sources of error,
         including the Poisson error of the sources (see
-        `~photutils.utils.calculate_total_error`) .  ``error`` must have
-        the same shape as the input ``data``.  See the Notes section
-        below for details on the error propagation.
+        `~photutils.utils.calc_total_error`) .  ``error`` must have the
+        same shape as the input ``data``.  See the Notes section below
+        for details on the error propagation.
 
     mask : array_like (bool), optional
         A boolean mask with the same shape as ``data`` where a `True`
@@ -1544,9 +1544,9 @@ def source_properties(data, segment_img, error=None, mask=None,
         The pixel-wise Gaussian 1-sigma errors of the input ``data``.
         ``error`` is assumed to include *all* sources of error,
         including the Poisson error of the sources (see
-        `~photutils.utils.calculate_total_error`) .  ``error`` must have
-        the same shape as the input ``data``.  See the Notes section
-        below for details on the error propagation.
+        `~photutils.utils.calc_total_error`) .  ``error`` must have the
+        same shape as the input ``data``.  See the Notes section below
+        for details on the error propagation.
 
     mask : array_like (bool), optional
         A boolean mask with the same shape as ``data`` where a `True`

--- a/photutils/tests/test_aperture_photometry.py
+++ b/photutils/tests/test_aperture_photometry.py
@@ -91,9 +91,9 @@ def test_aperture_pixel_positions():
 
 class BaseTestAperturePhotometry(object):
 
-    def test_scalar_error_no_effective_gain(self):
+    def test_scalar_error(self):
 
-        # Scalar error, no effective_gain.
+        # Scalar error
         error = 1.
         if not hasattr(self, 'mask'):
             mask = None
@@ -126,101 +126,9 @@ class BaseTestAperturePhotometry(object):
                             atol=0.1)
         assert np.all(table1['aperture_sum_err'] < table3['aperture_sum_err'])
 
-    def test_scalar_error_scalar_effective_gain(self):
+    def test_array_error(self):
 
-        # Scalar error, scalar effective_gain.
-        error = 1.
-        effective_gain = 1.
-        if not hasattr(self, 'mask'):
-            mask = None
-        else:
-            mask = self.mask
-
-        table1 = aperture_photometry(self.data, self.aperture,
-                                     method='center', mask=mask, error=error,
-                                     effective_gain=effective_gain)
-        table2 = aperture_photometry(self.data, self.aperture,
-                                     method='subpixel', subpixels=12,
-                                     mask=mask, error=error,
-                                     effective_gain=effective_gain)
-        table3 = aperture_photometry(self.data, self.aperture, method='exact',
-                                     mask=mask, error=error,
-                                     effective_gain=effective_gain)
-
-        if not isinstance(self.aperture,
-                          (RectangularAperture, RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum'], self.true_flux)
-            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                            atol=0.1)
-        assert np.all(table1['aperture_sum'] < table3['aperture_sum'])
-
-        true_error = np.sqrt(self.area + self.true_flux)
-        if not isinstance(self.aperture,
-                          (RectangularAperture, RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum_err'], true_error)
-            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                            atol=0.1)
-        assert np.all(table1['aperture_sum_err'] < table3['aperture_sum_err'])
-
-    def test_quantity_scalar_error_scalar_effective_gain(self):
-
-        # Scalar error, scalar effective_gain.
-        error = u.Quantity(1.)
-        effective_gain = u.Quantity(1.)
-        if not hasattr(self, 'mask'):
-            mask = None
-        else:
-            mask = self.mask
-
-        table1 = aperture_photometry(self.data, self.aperture,
-                                     method='center', mask=mask, error=error,
-                                     effective_gain=effective_gain)
-        assert np.all(table1['aperture_sum'] < self.true_flux)
-
-        true_error = np.sqrt(self.area + self.true_flux)
-        assert np.all(table1['aperture_sum_err'] < true_error)
-
-    def test_scalar_error_array_effective_gain(self):
-
-        # Scalar error, Array effective_gain.
-        error = 1.
-        effective_gain = np.ones(self.data.shape, dtype=np.float)
-        if not hasattr(self, 'mask'):
-            mask = None
-            true_error = np.sqrt(self.area + self.true_flux)
-        else:
-            mask = self.mask
-            # 1 masked pixel
-            true_error = np.sqrt(self.area - 1 + self.true_flux)
-
-        table1 = aperture_photometry(self.data, self.aperture,
-                                     method='center', mask=mask, error=error,
-                                     effective_gain=effective_gain)
-        table2 = aperture_photometry(self.data, self.aperture,
-                                     method='subpixel', subpixels=12,
-                                     mask=mask, error=error,
-                                     effective_gain=effective_gain)
-        table3 = aperture_photometry(self.data, self.aperture,
-                                     method='exact', mask=mask, error=error,
-                                     effective_gain=effective_gain)
-
-        if not isinstance(self.aperture,
-                          (RectangularAperture, RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum'], self.true_flux)
-            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                            atol=0.1)
-        assert np.all(table1['aperture_sum'] < table3['aperture_sum'])
-
-        if not isinstance(self.aperture,
-                          (RectangularAperture, RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum_err'], true_error)
-            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                            atol=0.1)
-        assert np.all(table1['aperture_sum_err'] < table3['aperture_sum_err'])
-
-    def test_array_error_no_effective_gain(self):
-
-        # Array error, no effective_gain.
+        # Array error
         error = np.ones(self.data.shape, dtype=np.float)
         if not hasattr(self, 'mask'):
             mask = None
@@ -240,43 +148,6 @@ class BaseTestAperturePhotometry(object):
         table3 = aperture_photometry(self.data,
                                      self.aperture, method='exact',
                                      mask=mask, error=error)
-
-        if not isinstance(self.aperture, (RectangularAperture,
-                                          RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum'], self.true_flux)
-            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                            atol=0.1)
-        assert np.all(table1['aperture_sum'] < table3['aperture_sum'])
-
-        if not isinstance(self.aperture, (RectangularAperture,
-                                          RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum_err'], true_error)
-            assert_allclose(table2['aperture_sum_err'],
-                            table3['aperture_sum_err'], atol=0.1)
-        assert np.all(table1['aperture_sum_err'] < table3['aperture_sum_err'])
-
-    def test_array_error_array_effective_gain(self):
-
-        error = np.ones(self.data.shape, dtype=np.float)
-        effective_gain = np.ones(self.data.shape, dtype=np.float)
-        if not hasattr(self, 'mask'):
-            mask = None
-            true_error = np.sqrt(self.area + self.true_flux)
-        else:
-            mask = self.mask
-            # 1 masked pixel
-            true_error = np.sqrt(self.area - 1 + self.true_flux)
-
-        table1 = aperture_photometry(self.data, self.aperture,
-                                     method='center', mask=mask, error=error,
-                                     effective_gain=effective_gain)
-        table2 = aperture_photometry(self.data, self.aperture,
-                                     method='subpixel', subpixels=12,
-                                     mask=mask, error=error,
-                                     effective_gain=effective_gain)
-        table3 = aperture_photometry(self.data, self.aperture, method='exact',
-                                     mask=mask, error=error,
-                                     effective_gain=effective_gain)
 
         if not isinstance(self.aperture, (RectangularAperture,
                                           RectangularAnnulus)):

--- a/photutils/utils/prepare_data.py
+++ b/photutils/utils/prepare_data.py
@@ -41,9 +41,9 @@ def calc_total_error(data, bkg_error, effective_gain):
     Notes
     -----
     To use units, ``data``, ``bkg_error``, and ``effective_gain`` must
-    *all* be `~astropy.units.Quantity` objects.  A `ValueError` will be
-    raised if only some of the inputs are `~astropy.units.Quantity`
-    objects.
+    *all* be `~astropy.units.Quantity` objects.  A
+    `~.exceptions.ValueError` will be raised if only some of the inputs
+    are `~astropy.units.Quantity` objects.
 
     The total error array, :math:`\sigma_{\mathrm{tot}}` is:
 

--- a/photutils/utils/tests/test_prepare_data.py
+++ b/photutils/utils/tests/test_prepare_data.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
-from .. import calculate_total_error
+from .. import calc_total_error
 
 SHAPE = (5, 5)
 DATAVAL = 2.
@@ -20,26 +20,22 @@ WRONG_SHAPE = np.ones((2, 2))
 class TestCalculateTotalError(object):
     def test_error_shape(self):
         with pytest.raises(ValueError):
-            calculate_total_error(DATA, error=WRONG_SHAPE,
-                                  effective_gain=EFFGAIN)
+            calc_total_error(DATA, error=WRONG_SHAPE, effective_gain=EFFGAIN)
 
     def test_gain_shape(self):
         with pytest.raises(ValueError):
-            calculate_total_error(DATA, error=ERROR,
-                                  effective_gain=WRONG_SHAPE)
+            calc_total_error(DATA, error=ERROR, effective_gain=WRONG_SHAPE)
 
     @pytest.mark.parametrize('effective_gain', (0, -1))
     def test_gain_le_zero(self, effective_gain):
         with pytest.raises(ValueError):
-            calculate_total_error(DATA, error=ERROR,
-                                  effective_gain=effective_gain)
+            calc_total_error(DATA, error=ERROR, effective_gain=effective_gain)
 
     def test_gain_scalar(self):
-        error_tot = calculate_total_error(DATA, error=ERROR,
-                                          effective_gain=2.)
+        error_tot = calc_total_error(DATA, error=ERROR, effective_gain=2.)
         assert_allclose(error_tot, np.sqrt(2.) * ERROR)
 
     def test_gain_array(self):
-        error_tot = calculate_total_error(DATA, error=ERROR,
-                                          effective_gain=EFFGAIN)
+        error_tot = calc_total_error(DATA, error=ERROR,
+                                     effective_gain=EFFGAIN)
         assert_allclose(error_tot, np.sqrt(2.) * ERROR)

--- a/photutils/utils/tests/test_prepare_data.py
+++ b/photutils/utils/tests/test_prepare_data.py
@@ -11,7 +11,7 @@ DATAVAL = 2.
 DATA = np.ones(SHAPE) * DATAVAL
 MASK = np.zeros_like(DATA, dtype=bool)
 MASK[2, 2] = True
-ERROR = np.ones(SHAPE)
+BKG_ERROR = np.ones(SHAPE)
 EFFGAIN = np.ones(SHAPE) * DATAVAL
 BACKGROUND = np.ones(SHAPE)
 WRONG_SHAPE = np.ones((2, 2))
@@ -20,22 +20,21 @@ WRONG_SHAPE = np.ones((2, 2))
 class TestCalculateTotalError(object):
     def test_error_shape(self):
         with pytest.raises(ValueError):
-            calc_total_error(DATA, error=WRONG_SHAPE, effective_gain=EFFGAIN)
+            calc_total_error(DATA, WRONG_SHAPE, EFFGAIN)
 
     def test_gain_shape(self):
         with pytest.raises(ValueError):
-            calc_total_error(DATA, error=ERROR, effective_gain=WRONG_SHAPE)
+            calc_total_error(DATA, BKG_ERROR, WRONG_SHAPE)
 
     @pytest.mark.parametrize('effective_gain', (0, -1))
     def test_gain_le_zero(self, effective_gain):
         with pytest.raises(ValueError):
-            calc_total_error(DATA, error=ERROR, effective_gain=effective_gain)
+            calc_total_error(DATA, BKG_ERROR, effective_gain)
 
     def test_gain_scalar(self):
-        error_tot = calc_total_error(DATA, error=ERROR, effective_gain=2.)
-        assert_allclose(error_tot, np.sqrt(2.) * ERROR)
+        error_tot = calc_total_error(DATA, BKG_ERROR, 2.)
+        assert_allclose(error_tot, np.sqrt(2.) * BKG_ERROR)
 
     def test_gain_array(self):
-        error_tot = calc_total_error(DATA, error=ERROR,
-                                     effective_gain=EFFGAIN)
-        assert_allclose(error_tot, np.sqrt(2.) * ERROR)
+        error_tot = calc_total_error(DATA, BKG_ERROR, EFFGAIN)
+        assert_allclose(error_tot, np.sqrt(2.) * BKG_ERROR)

--- a/photutils/utils/tests/test_prepare_data.py
+++ b/photutils/utils/tests/test_prepare_data.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
+import astropy.units as u
 from .. import calc_total_error
 
 SHAPE = (5, 5)
@@ -38,3 +39,34 @@ class TestCalculateTotalError(object):
     def test_gain_array(self):
         error_tot = calc_total_error(DATA, BKG_ERROR, EFFGAIN)
         assert_allclose(error_tot, np.sqrt(2.) * BKG_ERROR)
+
+    def test_units(self):
+        units = u.electron / u.s
+        error_tot1 = calc_total_error(DATA * units, BKG_ERROR * units,
+                                      EFFGAIN * u.s)
+        assert error_tot1.unit == units
+        error_tot2 = calc_total_error(DATA, BKG_ERROR, EFFGAIN)
+        assert_allclose(error_tot1.value, error_tot2)
+
+    def test_error_units(self):
+        units = u.electron / u.s
+        with pytest.raises(ValueError):
+            calc_total_error(DATA * units, BKG_ERROR * u.electron,
+                             EFFGAIN * u.s)
+
+    def test_effgain_units(self):
+        units = u.electron / u.s
+        with pytest.raises(u.UnitsError):
+            calc_total_error(DATA * units, BKG_ERROR * units, EFFGAIN * u.km)
+
+    def test_missing_bkgerror_units(self):
+        units = u.electron / u.s
+        with pytest.raises(ValueError):
+            calc_total_error(DATA * units, BKG_ERROR, EFFGAIN * u.s)
+
+    def test_missing_effgain_units(self):
+        units = u.electron / u.s
+        with pytest.raises(ValueError):
+            calc_total_error(DATA * units, BKG_ERROR * units,
+                             EFFGAIN)
+


### PR DESCRIPTION
This PR implements https://github.com/astropy/photutils/issues/178.  The ``effective_gain`` keyword is removed from all photometry routines, which now require the user to input the total (1-sigma std.) error.  The total error can be calculated using ``photutils.utils.calc_total_error``, which combines a "background-only" error array with the source Poisson noise using the ``effective_gain``.