### PR TITLE
Add a way to get fitted params uncertainties in psf_photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,10 @@ New Features
   - SegmentationImage properties are now cached to significantly
     improve performance. [#361]
 
+- ``photutils.psf_photometry``
+
+  - Added the option ``param_uncert`` so that users can easily get
+    uncertainties on fitted parameters. [#358]
 
 API changes
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,7 @@ New Features
 - ``photutils.psf_photometry``
 
   - Added the option ``param_uncert`` so that users can easily get
-    uncertainties on fitted parameters. [#358]
+    uncertainties on fitted parameters. [#376]
 
 API changes
 ^^^^^^^^^^^

--- a/photutils/psf/funcs.py
+++ b/photutils/psf/funcs.py
@@ -179,8 +179,9 @@ def psf_photometry(data, positions, psf, fitshape=None,
         parameters of the ``psf`` model that are not fixed.
     psf : `astropy.modeling.Fittable2DModel` instance
         PSF or PRF model to fit the data. Could be one of the models in this
-        package like `~photutils.psf.DiscretePRF`,
-        `~photutils.psf.IntegratedGaussianPRF`, or any other suitable 2D model.
+        package like `~photutils.psf.sandbox.DiscretePRF`,
+        `~photutils.psf.models.IntegratedGaussianPRF`, or any other suitable
+        2D model.
         This function needs to identify three parameters (position of center in
         x and y coordinates and the flux) in order to set them to suitable
         starting values for each fit. The names of these parameters can be given

--- a/photutils/psf/funcs.py
+++ b/photutils/psf/funcs.py
@@ -180,7 +180,7 @@ def psf_photometry(data, positions, psf, fitshape=None,
     psf : `astropy.modeling.Fittable2DModel` instance
         PSF or PRF model to fit the data. Could be one of the models in this
         package like `~photutils.psf.sandbox.DiscretePRF`,
-        `~photutils.psf.models.IntegratedGaussianPRF`, or any other suitable
+        `~photutils.psf.IntegratedGaussianPRF`, or any other suitable
         2D model.
         This function needs to identify three parameters (position of center in
         x and y coordinates and the flux) in order to set them to suitable

--- a/photutils/psf/tests/test_psf_photometry.py
+++ b/photutils/psf/tests/test_psf_photometry.py
@@ -198,6 +198,7 @@ def test_psf_photometry_uncertainties():
     assert_equal('flux_fit_uncertainty' in f.colnames, False)
 
 # test in case fitter does not have 'param_cov' key
+@pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_PYTEST_GEQ_28')
 def test_psf_photometry_uncertainties_warning_check():
     psf = IntegratedGaussianPRF(sigma=GAUSSIAN_WIDTH)

--- a/photutils/psf/tests/test_psf_photometry.py
+++ b/photutils/psf/tests/test_psf_photometry.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 import warnings
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils import minversion
 
 from astropy.tests.helper import pytest
 from astropy.modeling.models import Gaussian2D
@@ -22,7 +23,7 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-if pytest.__version__ >= '2.8':
+if minversion(pytest, '2.8'):
     HAS_PYTEST_GEQ_28 = True
 else:
     HAS_PYTEST_GEQ_28 = False

--- a/photutils/psf/tests/test_psf_photometry.py
+++ b/photutils/psf/tests/test_psf_photometry.py
@@ -22,6 +22,11 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
+if pytest.__version__ >= '2.8':
+    HAS_PYTEST_GEQ_28 = True
+else:
+    HAS_PYTEST_GEQ_28 = False
+
 
 PSF_SIZE = 11
 GAUSSIAN_WIDTH = 1.
@@ -192,7 +197,9 @@ def test_psf_photometry_uncertainties():
                  f['y_0_fit_uncertainty'].all() < 10.0, True)
     assert_equal('flux_fit_uncertainty' in f.colnames, False)
 
-    # test in case fitter does not have 'param_cov' key
+# test in case fitter does not have 'param_cov' key
+@pytest.mark.skipif('not HAS_PYTEST_GEQ_28')
+def test_psf_photometry_uncertainties_warning_check():
     psf = IntegratedGaussianPRF(sigma=GAUSSIAN_WIDTH)
     with pytest.warns(AstropyUserWarning):
         f = psf_photometry(image, INTAB, psf, fitter=SLSQPLSQFitter(),


### PR DESCRIPTION
This is just a rebased version of [#358](https://github.com/astropy/photutils/pull/358). I messed up #358 when I was rebasing :|

cc @eteq, @hamogu, @bsipocz 