### PR TITLE
findstars oop interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,11 @@ API changes
 
   - Renamed ``calculate_total_error`` to ``calc_total_error``. [#368]
 
+- ``photutils.detection``
+
+  - Changed finding algorithm implementations (daofind and iraf's star find)
+    from functional to object-oriented style. Deprecate old style. [#379]
+
 
 0.2.2 (unreleased)
 ------------------

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -1,2 +1,7 @@
 # photutils.morphology
 py:class photutils.morphology.CompoundModel1
+
+# photutils.detection
+py:class photutils.detection.findstars.StarFinderBase
+py:class photutils.detection.findstars.DAOStarFinder
+py:class photutils.detection.findstars.IRAFStarFinder

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -1,7 +1,2 @@
 # photutils.morphology
 py:class photutils.morphology.CompoundModel1
-
-# photutils.detection
-py:class photutils.detection.findstars.StarFinderBase
-py:class photutils.detection.findstars.DAOStarFinder
-py:class photutils.detection.findstars.IRAFStarFinder

--- a/docs/photutils/detection.rst
+++ b/docs/photutils/detection.rst
@@ -61,7 +61,7 @@ background:
 .. doctest-requires:: scipy, skimage
 
     >>> from photutils import DAOStarFinder
-    >>> daofind = DAOStarFinder(fwhm=3.0, threshold=5.*std)
+    >>> daofind = DAOStarFinder(fwhm=3.0, threshold=5.*std)    # doctest: +REMOTE_DATA
     >>> sources = daofind(data - median)    # doctest: +REMOTE_DATA
     >>> print(sources)    # doctest: +REMOTE_DATA
      id   xcentroid     ycentroid   ...  peak       flux           mag

--- a/docs/photutils/detection.rst
+++ b/docs/photutils/detection.rst
@@ -22,8 +22,8 @@ Detecting Stars
 Photutils includes two widely-used tools that are used to detect stars
 in an image, `DAOFIND`_ and IRAF's `starfind`_.
 
-:class:`~photutils.DAOStarFinder` is a class which provides an implementation
-of the `DAOFIND`_ algorithm (`Stetson 1987, PASP 99, 191
+:class:`~photutils.DAOStarFinder` is a class which provides an
+implementation of the `DAOFIND`_ algorithm (`Stetson 1987, PASP 99, 191
 <http://adsabs.harvard.edu/abs/1987PASP...99..191S>`_).  It searches
 images for local density maxima that have a peak amplitude greater
 than a specified threshold (the threshold is applied to a convolved
@@ -32,13 +32,13 @@ kernel.  :class:`~photutils.DAOStarFinder` also provides an estimate of the
 objects' roundness and sharpness, whose lower and upper bounds can be
 specified.
 
-:class:`~photutils.IRAFStarFinder` is a class which implements IRAF's
-`starfind`_ algorithm.  It is similar to :class:`~photutils.DAOStarFinder`,
-but it always uses a 2D circular Gaussian kernel, while
-:class:`~photutils.DAOStarFinder` can use an elliptical Gaussian kernel.
-:class:`~photutils.IRAFStarFinder` is also different in that it
-calculates the objects' centroid, roundness, and sharpness using image
-moments.
+:class:`~photutils.IRAFStarFinder` is a class which implements
+IRAF's `starfind`_ algorithm.  It is similar to
+:class:`~photutils.DAOStarFinder`, but it always uses a 2D circular
+Gaussian kernel, while :class:`~photutils.DAOStarFinder` can use an
+elliptical Gaussian kernel. :class:`~photutils.IRAFStarFinder` is
+also different in that it calculates the objects' centroid, roundness, and
+sharpness using image moments.
 
 As an example, let's load an image from the bundled datasets and
 select a subset of the image.  We will estimate the background and

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -22,7 +22,7 @@ from astropy.stats import gaussian_fwhm_to_sigma
 from .core import _convolve_data, find_peaks
 
 
-__all__ = ['DAOStarFinder', 'daofind', 'IRAFStarFinder', 'irafstarfind']
+__all__ = ['DAOStarFinder', 'IRAFStarFinder', 'daofind', 'irafstarfind']
 
 
 @deprecated(0.3, alternative='DAOStarFinder')
@@ -47,7 +47,7 @@ def irafstarfind(data, threshold, fwhm, sigma_radius=1.5, minsep_fwhm=2.5,
 
 class StarFinderBase(object):
     """
-    Base abstract class for Finders.
+    Base abstract class for Star Finders.
     """
     __metaclass__ = abc.ABCMeta
 

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -22,7 +22,8 @@ from astropy.stats import gaussian_fwhm_to_sigma
 from .core import _convolve_data, find_peaks
 
 
-__all__ = ['DAOStarFinder', 'IRAFStarFinder', 'daofind', 'irafstarfind']
+__all__ = ['DAOStarFinder', 'IRAFStarFinder', 'StarFinderBase',
+           'daofind', 'irafstarfind']
 
 
 @deprecated(0.3, alternative='DAOStarFinder')

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -2,10 +2,10 @@
 """
 This module implements classes, called Finders, for detecting stars in an
 astronomical image. The general convention is that all Finders are subclasses
-of an abstract class called StarFinder and should be callable classes.
-Additionally, StarFinder defines two abstract methods, namely, find_stars and
-__call__. In general, find_stars implements an algorithm for detecting stars
-and __call__ invokes find_stars to return stars positions estimatives. 
+of an abstract class called StarFinderBase and should be callable classes.
+Additionally, StarFinderBase defines the method find_stars as abstract.
+In general, find_stars implements an algorithm for detecting stars
+and __call__ invokes find_stars to return stars positions estimates. 
 """
 
 from __future__ import (absolute_import, division, print_function,
@@ -45,7 +45,7 @@ def irafstarfind(data, threshold, fwhm, sigma_radius=1.5, minsep_fwhm=2.5,
     return finder(data)
 
 
-class StarFinder:
+class StarFinderBase(object):
     """
     Base abstract class for Finders.
     """
@@ -57,7 +57,7 @@ class StarFinder:
         pass
 
 
-class DAOStarFinder(StarFinder):
+class DAOStarFinder(StarFinderBase):
     """
     Detect stars in an image using the DAOFIND algorithm.
 
@@ -225,7 +225,7 @@ class DAOStarFinder(StarFinder):
         return tbl
 
 
-class IRAFStarFinder(StarFinder):
+class IRAFStarFinder(StarFinderBase):
     """
     Detect stars in an image using IRAF's "starfind" algorithm.
 

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -14,9 +14,6 @@ from astropy.stats import gaussian_fwhm_to_sigma
 from .core import _convolve_data, find_peaks
 
 
-__all__ = ['daofind', 'irafstarfind']
-
-
 class StarFinder(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __call__(self, data):
@@ -156,9 +153,6 @@ class DAOFind(StarFinder):
         self.exclude_border = exclude_border
 
     def __call__(self, data):
-        return self._daofind(self, data)
-
-    def _daofind(self, data):
         daofind_kernel = _FindObjKernel(self.fwhm, self.ratio, self.theta,
                                         self.sigma_radius)
         self.threshold *= daofind_kernel.relerr
@@ -303,9 +297,6 @@ class IRAFStarFind(StarFinder):
         self.exclude_border = exclude_border
 
     def __call__(self, data):
-        return self.irafstarfind(self, data)
-
-    def _irafstarfind(self, data):
         starfind_kernel = _FindObjKernel(self.fwhm, ratio=1.0, theta=0.0,
                                          sigma_radius=self.sigma_radius)
         min_separation = max(2, int((fwhm * minsep_fwhm) + 0.5))

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 import warnings
 import math
 import numpy as np
+import abc
 from astropy.table import Column, Table
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.stats import gaussian_fwhm_to_sigma
@@ -15,6 +16,13 @@ from .core import _convolve_data, find_peaks
 
 __all__ = ['daofind', 'irafstarfind']
 
+
+class StarFinder(metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    __call__(self, data):
+        """Find potential stars in the given data."""
+        pass
 
 def daofind(data, threshold, fwhm, ratio=1.0, theta=0.0, sigma_radius=1.5,
             sharplo=0.2, sharphi=1.0, roundlo=-1.0, roundhi=1.0, sky=0.0,

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -6,9 +6,10 @@ import itertools
 import warnings
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, catch_warnings
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from ..findstars import daofind, irafstarfind
 from ..findstars import DAOStarFinder, IRAFStarFinder
 from ...datasets import make_100gaussians_image
@@ -48,8 +49,11 @@ class TestDAOStarFinder(object):
                         np.array(t_ref).astype(np.float))
 
     # test for the deprecated daofind
-    def test_dep_daofind(self, threhsold, fwhm):
-        t = daofind(DATA, threshold, fwhm, sigma_radius=1.5)
+    @pytest.mark.parametrize(('threshold', 'fwhm'),
+                             list(itertools.product(THRESHOLDS, FWHMS)))
+    def test_dep_daofind(self, threshold, fwhm):
+        with catch_warnings(AstropyDeprecationWarning):
+            t = daofind(DATA, threshold, fwhm, sigma_radius=1.5)
         datafn = ('daofind_test_thresh{0:04.1f}_fwhm{1:04.1f}'
                   '.txt'.format(threshold, fwhm))
         datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
@@ -66,8 +70,9 @@ class TestDAOStarFinder(object):
 
     # test for the deprecated daofind
     def test_dep_daofind_include_border(self):
-        t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
-                    exclude_border=False)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
+                        exclude_border=False)
         assert len(t) == 20
 
     def test_daofind_exclude_border(self):
@@ -78,8 +83,9 @@ class TestDAOStarFinder(object):
 
     # test for the deprecated daofind
     def test_dep_daofind_exclude_border(self):
-        t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
-                    exclude_border=True)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
+                        exclude_border=True)
         assert len(t) == 19
 
     def test_daofind_nosources(self):
@@ -91,7 +97,8 @@ class TestDAOStarFinder(object):
     # test for the deprecated daofind
     def test_dep_daofind_nosources(self):
         data = np.ones((3, 3))
-        t = daofind(data, threshold=10, fwhm=1)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = daofind(data, threshold=10, fwhm=1)
         assert len(t) == 0
 
     def test_daofind_sharpness(self):
@@ -103,7 +110,8 @@ class TestDAOStarFinder(object):
     # test for the deprecated daofind
     def test_dep_daofind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        t = daofind(DATA, threshold=50, fwhm=1.0, sharplo=1.)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = daofind(DATA, threshold=50, fwhm=1.0, sharplo=1.)
         assert len(t) == 0
 
     def test_daofind_roundness(self):
@@ -115,7 +123,8 @@ class TestDAOStarFinder(object):
     # test for the deprecated daofind
     def test_dep_daofind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        t = daofind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = daofind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
         assert len(t) == 0
 
     def test_daofind_flux_negative(self):
@@ -131,7 +140,8 @@ class TestDAOStarFinder(object):
         """Test handling of negative flux (here created by large sky)."""
         data = np.ones((5, 5))
         data[2, 2] = 10.
-        t = daofind(data, threshold=0.1, fwhm=1.0, sky=10)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = daofind(data, threshold=0.1, fwhm=1.0, sky=10)
         assert not np.isfinite(t['mag'])
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -150,8 +160,11 @@ class TestIRAFStarFinder(object):
                         np.array(t_ref).astype(np.float))
 
     # test for the deprecated irafstarfind
+    @pytest.mark.parametrize(('threshold', 'fwhm'),
+                             list(itertools.product(THRESHOLDS, FWHMS)))
     def test_dep_irafstarfind(self, threshold, fwhm):
-        t = irafstarfind(DATA, threshold, fwhm, sigma_radius=1.5)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = irafstarfind(DATA, threshold, fwhm, sigma_radius=1.5)
         datafn = ('irafstarfind_test_thresh{0:04.1f}_fwhm{1:04.1f}'
                   '.txt'.format(threshold, fwhm))
         datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
@@ -168,7 +181,8 @@ class TestIRAFStarFinder(object):
     # test for the deprecated irafstarfind
     def test_dep_irafstarfind_nosources(self):
         data = np.ones((3, 3))
-        t = irafstarfinde(data, threshold=10, fwhm=1)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = irafstarfind(data, threshold=10, fwhm=1)
         assert len(t) == 0
 
     def test_irafstarfind_sharpness(self):
@@ -180,7 +194,8 @@ class TestIRAFStarFinder(object):
     # test for the deprecated irafstarfind
     def test_dep_irafstarfind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        t = irafstarfind(DATA, threshold=50, fwhm=1.0, sharplo=2.)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = irafstarfind(DATA, threshold=50, fwhm=1.0, sharplo=2.)
         assert len(t) == 0
 
     def test_irafstarfind_roundness(self):
@@ -192,7 +207,8 @@ class TestIRAFStarFinder(object):
     # test for the deprecated irafstarfind
     def test_dep_irafstarfind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        t = irafstarfind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = irafstarfind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
         assert len(t) == 0
 
     def test_irafstarfind_sky(self):
@@ -202,7 +218,8 @@ class TestIRAFStarFinder(object):
 
     # test for the deprecated irafstarfind
     def test_dep_irafstarfind_sky(self):
-        t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=10.)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=10.)
         assert len(t) == 4
 
     def test_irafstarfind_largesky(self):
@@ -212,6 +229,6 @@ class TestIRAFStarFinder(object):
     
     # test for the deprecated irafstarfind
     def test_dep_irafstarfind_largesky(self):
-        t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=100.)
+        with catch_warnings(AstropyDeprecationWarning):
+            t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=100.)
         assert len(t) == 0
-    

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
+from ..findstars import daofind, irafstarfind
 from ..findstars import DAOStarFinder, IRAFStarFinder
 from ...datasets import make_100gaussians_image
 
@@ -46,10 +47,27 @@ class TestDAOStarFinder(object):
         assert_allclose(np.array(t).astype(np.float),
                         np.array(t_ref).astype(np.float))
 
+    # test for the deprecated daofind
+    def test_dep_daofind(self, threhsold, fwhm):
+        t = daofind(DATA, threshold, fwhm, sigma_radius=1.5)
+        datafn = ('daofind_test_thresh{0:04.1f}_fwhm{1:04.1f}'
+                  '.txt'.format(threshold, fwhm))
+        datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
+        t_ref = Table.read(datafn, format='ascii')
+        assert_allclose(np.array(t).astype(np.float),
+                        np.array(t_ref).astype(np.float))
+
+
     def test_daofind_include_border(self):
         starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
                                    exclude_border=False)
         t = starfinder(DATA)
+        assert len(t) == 20
+
+    # test for the deprecated daofind
+    def test_dep_daofind_include_border(self):
+        t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
+                    exclude_border=False)
         assert len(t) == 20
 
     def test_daofind_exclude_border(self):
@@ -58,10 +76,22 @@ class TestDAOStarFinder(object):
         t = starfinder(DATA)
         assert len(t) == 19
 
+    # test for the deprecated daofind
+    def test_dep_daofind_exclude_border(self):
+        t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
+                    exclude_border=True)
+        assert len(t) == 19
+
     def test_daofind_nosources(self):
         data = np.ones((3, 3))
         starfinder = DAOStarFinder(threshold=10, fwhm=1)
         t = starfinder(data)
+        assert len(t) == 0
+
+    # test for the deprecated daofind
+    def test_dep_daofind_nosources(self):
+        data = np.ones((3, 3))
+        t = daofind(data, threshold=10, fwhm=1)
         assert len(t) == 0
 
     def test_daofind_sharpness(self):
@@ -70,10 +100,22 @@ class TestDAOStarFinder(object):
         t = starfinder(DATA)
         assert len(t) == 0
 
+    # test for the deprecated daofind
+    def test_dep_daofind_sharpness(self):
+        """Sources found, but none pass the sharpness criteria."""
+        t = daofind(DATA, threshold=50, fwhm=1.0, sharplo=1.)
+        assert len(t) == 0
+
     def test_daofind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
         starfinder = DAOStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
         t = starfinder(DATA)
+        assert len(t) == 0
+
+    # test for the deprecated daofind
+    def test_dep_daofind_roundness(self):
+        """Sources found, but none pass the roundness criteria."""
+        t = daofind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
         assert len(t) == 0
 
     def test_daofind_flux_negative(self):
@@ -84,6 +126,13 @@ class TestDAOStarFinder(object):
         t = starfinder(data)
         assert not np.isfinite(t['mag'])
 
+    # test for the deprecated daofind
+    def test_dep_daofind_flux_negative(self):
+        """Test handling of negative flux (here created by large sky)."""
+        data = np.ones((5, 5))
+        data[2, 2] = 10.
+        t = daofind(data, threshold=0.1, fwhm=1.0, sky=10)
+        assert not np.isfinite(t['mag'])
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_SKIMAGE')
@@ -100,10 +149,26 @@ class TestIRAFStarFinder(object):
         assert_allclose(np.array(t).astype(np.float),
                         np.array(t_ref).astype(np.float))
 
+    # test for the deprecated irafstarfind
+    def test_dep_irafstarfind(self, threshold, fwhm):
+        t = irafstarfind(DATA, threshold, fwhm, sigma_radius=1.5)
+        datafn = ('irafstarfind_test_thresh{0:04.1f}_fwhm{1:04.1f}'
+                  '.txt'.format(threshold, fwhm))
+        datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
+        t_ref = Table.read(datafn, format='ascii')
+        assert_allclose(np.array(t).astype(np.float),
+                        np.array(t_ref).astype(np.float))
+        
     def test_irafstarfind_nosources(self):
         data = np.ones((3, 3))
         starfinder = IRAFStarFinder(threshold=10, fwhm=1)
         t = starfinder(data) 
+        assert len(t) == 0
+
+    # test for the deprecated irafstarfind
+    def test_dep_irafstarfind_nosources(self):
+        data = np.ones((3, 3))
+        t = irafstarfinde(data, threshold=10, fwhm=1)
         assert len(t) == 0
 
     def test_irafstarfind_sharpness(self):
@@ -112,10 +177,22 @@ class TestIRAFStarFinder(object):
         t = starfinder(DATA)
         assert len(t) == 0
 
+    # test for the deprecated irafstarfind
+    def test_dep_irafstarfind_sharpness(self):
+        """Sources found, but none pass the sharpness criteria."""
+        t = irafstarfind(DATA, threshold=50, fwhm=1.0, sharplo=2.)
+        assert len(t) == 0
+
     def test_irafstarfind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
         starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
         t = starfinder(DATA)
+        assert len(t) == 0
+
+    # test for the deprecated irafstarfind
+    def test_dep_irafstarfind_roundness(self):
+        """Sources found, but none pass the roundness criteria."""
+        t = irafstarfind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
         assert len(t) == 0
 
     def test_irafstarfind_sky(self):
@@ -123,7 +200,18 @@ class TestIRAFStarFinder(object):
         t = starfinder(DATA)
         assert len(t) == 4
 
+    # test for the deprecated irafstarfind
+    def test_dep_irafstarfind_sky(self):
+        t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=10.)
+        assert len(t) == 4
+
     def test_irafstarfind_largesky(self):
         starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
         t = starfinder(DATA)
         assert len(t) == 0
+    
+    # test for the deprecated irafstarfind
+    def test_dep_irafstarfind_largesky(self):
+        t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=100.)
+        assert len(t) == 0
+    

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
-from ..findstars import daofind, irafstarfind
+from ..findstars import DAOStarFinder, IRAFStarFinder
 from ...datasets import make_100gaussians_image
 
 try:
@@ -33,11 +33,12 @@ warnings.simplefilter('always', AstropyUserWarning)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_SKIMAGE')
-class TestDAOFind(object):
+class TestDAOStarFinder(object):
     @pytest.mark.parametrize(('threshold', 'fwhm'),
                              list(itertools.product(THRESHOLDS, FWHMS)))
     def test_daofind(self, threshold, fwhm):
-        t = daofind(DATA, threshold, fwhm, sigma_radius=1.5)
+        starfinder = DAOStarFinder(threshold, fwhm, sigma_radius=1.5)
+        t = starfinder(DATA)
         datafn = ('daofind_test_thresh{0:04.1f}_fwhm{1:04.1f}'
                   '.txt'.format(threshold, fwhm))
         datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
@@ -46,45 +47,52 @@ class TestDAOFind(object):
                         np.array(t_ref).astype(np.float))
 
     def test_daofind_include_border(self):
-        t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
-                    exclude_border=False)
+        starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
+                                   exclude_border=False)
+        t = starfinder(DATA)
         assert len(t) == 20
 
     def test_daofind_exclude_border(self):
-        t = daofind(DATA, threshold=10, fwhm=2, sigma_radius=1.5,
-                    exclude_border=True)
+        starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
+                                   exclude_border=True)
+        t = starfinder(DATA)
         assert len(t) == 19
 
     def test_daofind_nosources(self):
         data = np.ones((3, 3))
-        t = daofind(data, threshold=10, fwhm=1)
+        starfinder = DAOStarFinder(threshold=10, fwhm=1)
+        t = starfinder(data)
         assert len(t) == 0
 
     def test_daofind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        t = daofind(DATA, threshold=50, fwhm=1.0, sharplo=1.)
+        starfinder = DAOStarFinder(threshold=50, fwhm=1.0, sharplo=1.)
+        t = starfinder(DATA)
         assert len(t) == 0
 
     def test_daofind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        t = daofind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
+        starfinder = DAOStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
+        t = starfinder(DATA)
         assert len(t) == 0
 
     def test_daofind_flux_negative(self):
         """Test handling of negative flux (here created by large sky)."""
         data = np.ones((5, 5))
         data[2, 2] = 10.
-        t = daofind(data, threshold=0.1, fwhm=1.0, sky=10)
+        starfinder = DAOStarFinder(threshold=0.1, fwhm=1.0, sky=10)
+        t = starfinder(data)
         assert not np.isfinite(t['mag'])
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_SKIMAGE')
-class TestIRAFStarFind(object):
+class TestIRAFStarFinder(object):
     @pytest.mark.parametrize(('threshold', 'fwhm'),
                              list(itertools.product(THRESHOLDS, FWHMS)))
     def test_irafstarfind(self, threshold, fwhm):
-        t = irafstarfind(DATA, threshold, fwhm, sigma_radius=1.5)
+        starfinder = IRAFStarFinder(threshold, fwhm, sigma_radius=1.5)
+        t = starfinder(DATA)
         datafn = ('irafstarfind_test_thresh{0:04.1f}_fwhm{1:04.1f}'
                   '.txt'.format(threshold, fwhm))
         datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
@@ -94,23 +102,28 @@ class TestIRAFStarFind(object):
 
     def test_irafstarfind_nosources(self):
         data = np.ones((3, 3))
-        t = irafstarfind(data, threshold=10, fwhm=1)
+        starfinder = IRAFStarFinder(threshold=10, fwhm=1)
+        t = starfinder(data) 
         assert len(t) == 0
 
     def test_irafstarfind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        t = irafstarfind(DATA, threshold=50, fwhm=1.0, sharplo=2.)
+        starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, sharplo=2.)
+        t = starfinder(DATA)
         assert len(t) == 0
 
     def test_irafstarfind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        t = irafstarfind(DATA, threshold=50, fwhm=1.0, roundlo=1.)
+        starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
+        t = starfinder(DATA)
         assert len(t) == 0
 
     def test_irafstarfind_sky(self):
-        t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=10.)
+        starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=10.)
+        t = starfinder(DATA)
         assert len(t) == 4
 
     def test_irafstarfind_largesky(self):
-        t = irafstarfind(DATA, threshold=25.0, fwhm=2.0, sky=100.)
+        starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
+        t = starfinder(DATA)
         assert len(t) == 0


### PR DESCRIPTION
Hi all,

this is an attempt to change the interface of the findstars module, so that it will be in accordance to what was discussed during the JWST code sprint.

With this OOP interface, users will have to create instances of ``DAOStarFinder`` or ``IRAFStarFinder`` which are classes that basically encapsulates the FIND algorithm from DAOPHOT and the starfind algorithm from IRAF, respectively.

The functional interface will still be available to users, however a deprecation warning will be raised.

cc @hamogu @bsipocz @eteq @larrybradley 