### PR TITLE
Fixing links for helpers 1.2

### DIFF
--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -297,7 +297,7 @@ class CircularAperture(PixelAperture):
 
     Raises
     ------
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If the radius is negative.
     """
 
@@ -438,9 +438,9 @@ class CircularAnnulus(PixelAperture):
 
     Raises
     ------
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If inner radius (``r_in``) is greater than outer radius (``r_out``).
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If inner radius is negative.
     """
 
@@ -603,7 +603,7 @@ class EllipticalAperture(PixelAperture):
 
     Raises
     ------
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If either axis (``a`` or ``b``) is negative.
 
     """
@@ -775,10 +775,10 @@ class EllipticalAnnulus(PixelAperture):
 
     Raises
     ------
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If inner semimajor axis (``a_in``) is greater than outer semimajor
         axis (``a_out``).
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If either the inner semimajor axis (``a_in``) or the outer semiminor
         axis (``b_out``) is negative.
     """
@@ -949,7 +949,7 @@ class RectangularAperture(PixelAperture):
 
     Raises
     ------
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If either width (``w``) or height (``h``) is negative.
     """
 
@@ -1142,9 +1142,9 @@ class RectangularAnnulus(PixelAperture):
 
     Raises
     ------
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If inner width (``w_in``) is greater than outer width (``w_out``).
-    ValueError : `~.exceptions.ValueError`
+    ValueError : `ValueError`
         If either the inner width (``w_in``) or the outer height (``h_out``)
         is negative.
     """

--- a/photutils/utils/prepare_data.py
+++ b/photutils/utils/prepare_data.py
@@ -40,10 +40,9 @@ def calc_total_error(data, bkg_error, effective_gain):
 
     Notes
     -----
-    To use units, ``data``, ``bkg_error``, and ``effective_gain`` must
-    *all* be `~astropy.units.Quantity` objects.  A
-    `~.exceptions.ValueError` will be raised if only some of the inputs
-    are `~astropy.units.Quantity` objects.
+    To use units, ``data``, ``bkg_error``, and ``effective_gain`` must *all*
+    be `~astropy.units.Quantity` objects.  A `ValueError` will be raised if
+    only some of the inputs are `~astropy.units.Quantity` objects.
 
     The total error array, :math:`\sigma_{\mathrm{tot}}` is:
 


### PR DESCRIPTION
This should fix the failing sphinx builds. And from now on we can build the docs in either py2 or py3.

What do you prefer @larrybradley, should we switch over to py3? If yes, then we should do it on RTD, too and older older releases may may fail with it...