### PR TITLE
Skipping doctest line in background.rst

### DIFF
--- a/docs/photutils/background.rst
+++ b/docs/photutils/background.rst
@@ -87,7 +87,7 @@ deviation to estimate the background noise level give values that are
 larger than the true value of 2::
 
     >>> from astropy.stats import biweight_midvariance, mad_std
-    >>> print(biweight_midvariance(data))
+    >>> print(biweight_midvariance(data))   # doctest: +SKIP
     2.22011175104
     >>> print(mad_std(data))    # doctest: +FLOAT_CMP
     2.1443728009


### PR DESCRIPTION
as biweight_midvariance slightly changed in astropy dev (here: https://github.com/astropy/astropy/pull/5127), and now the result is astropy version dependent and causing travis failures, e.g https://travis-ci.org/astropy/photutils/builds/141789234

