### PR TITLE
checkimage_name option for detect_sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ New Features
 
   - Added new ``make_source_mask`` convenience function. [#355]
 
+  - Added ``checkimage_name`` option to ``detect_sources``, which 
+    gives to option to save the filtered image for inspection. 
+
 - ``photutils.psf``
 
   - Added the ``param_uncert`` keyword to ``psf_photometry`` so that

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -135,7 +135,7 @@ def detect_threshold(data, snr, background=None, error=None, mask=None,
 
 
 def detect_sources(data, threshold, npixels, filter_kernel=None,
-                   connectivity=8):
+                   connectivity=8, checkimage_name=None):
     """
     Detect sources above a specified threshold value in an image and
     return a `~photutils.segmentation.SegmentationImage` object.
@@ -176,6 +176,11 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         (default).  4-connected pixels touch along their edges.
         8-connected pixels touch along their edges or corners.  For
         reference, SExtractor uses 8-connected pixels.
+
+    checkimage_name : string, optional
+        Fits file name for the filtered "check image". If None, 
+        the filtered image will not be saved. If the file already
+        exists, it will be overwritten. 
 
     Returns
     -------
@@ -238,9 +243,14 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         raise ValueError('npixels must be a positive integer, got '
                          '"{0}"'.format(npixels))
 
-    image = (_convolve_data(
-        data, filter_kernel, mode='constant', fill_value=0.0,
-        check_normalization=True) > threshold)
+    convolved_image = _convolve_data(data, filter_kernel, mode='constant', 
+                      fill_value=0.0, check_normalization=True)
+
+    if checkimage_name is not None:
+        from astropy.io import fits
+        fits.writeto(checkimage_name, convolved_image, clobber=True)
+
+    image =  convolved_image > threshold
 
     if connectivity == 4:
         selem = ndimage.generate_binary_structure(2, 1)


### PR DESCRIPTION
Hello, 

I've added an option (checkimage_name) to save the filtered image generated by detect_sources. This is an option that SExtractor offers, which I find very useful as a sanity check. 

I think my changes are simple and self-explanatory, but this is my first pull request, so please let me know if should have done something differently.

Thanks, 
Johnny