### PR TITLE
made _convolve_data public and renamed filter_data

### DIFF
--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -10,7 +10,7 @@ from astropy.stats import sigma_clipped_stats, gaussian_fwhm_to_sigma
 from astropy.convolution import Gaussian2DKernel
 from ..segmentation import SegmentationImage
 from ..morphology import cutout_footprint, fit_2dgaussian
-from ..utils.convolution import _convolve_data
+from ..utils.convolution import filter_data
 from ..utils.wcs_helpers import pixel_to_icrs_coords
 
 import astropy
@@ -238,7 +238,7 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         raise ValueError('npixels must be a positive integer, got '
                          '"{0}"'.format(npixels))
 
-    image = (_convolve_data(
+    image = (filter_data(
         data, filter_kernel, mode='constant', fill_value=0.0,
         check_normalization=True) > threshold)
 

--- a/photutils/detection/deblend.py
+++ b/photutils/detection/deblend.py
@@ -113,7 +113,7 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     labels = np.atleast_1d(labels)
 
     data = filter_data(data, filter_kernel, mode='constant',
-                          fill_value=0.0)
+                       fill_value=0.0)
 
     last_label = segment_img.max
     segm_deblended = deepcopy(segment_img)

--- a/photutils/detection/deblend.py
+++ b/photutils/detection/deblend.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import warnings
 import numpy as np
 from astropy.utils.exceptions import AstropyUserWarning
-from .core import _convolve_data, detect_sources
+from .core import filter_data, detect_sources
 from ..segmentation import SegmentationImage
 
 
@@ -112,7 +112,7 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
         labels = segment_img.labels
     labels = np.atleast_1d(labels)
 
-    data = _convolve_data(data, filter_kernel, mode='constant',
+    data = filter_data(data, filter_kernel, mode='constant',
                           fill_value=0.0)
 
     last_label = segment_img.max

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -20,7 +20,7 @@ from astropy.table import Column, Table
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import deprecated
 from astropy.stats import gaussian_fwhm_to_sigma
-from .core import _convolve_data, find_peaks
+from .core import filter_data, find_peaks
 
 
 __all__ = ['DAOStarFinder', 'IRAFStarFinder', 'StarFinderBase',
@@ -426,7 +426,7 @@ def _findobjs(data, threshold, kernel, min_separation=None,
                     x_kernradius:x_kernradius + data.shape[1]] = data
         data = data_padded
 
-    convolved_data = _convolve_data(data, kernel.kern, mode='constant',
+    convolved_data = filter_data(data, kernel.kern, mode='constant',
                                     fill_value=0.0, check_normalization=False)
 
     if not exclude_border:

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -427,7 +427,7 @@ def _findobjs(data, threshold, kernel, min_separation=None,
         data = data_padded
 
     convolved_data = filter_data(data, kernel.kern, mode='constant',
-                                    fill_value=0.0, check_normalization=False)
+                                 fill_value=0.0, check_normalization=False)
 
     if not exclude_border:
         # keep border=0 in convolved data

--- a/photutils/segmentation.py
+++ b/photutils/segmentation.py
@@ -1687,9 +1687,9 @@ def source_properties(data, segment_img, error=None, mask=None,
 
     # filter the data once, instead of repeating for each source
     if filter_kernel is not None:
-        filtered_data = filter_data(data, filter_kernel, mode='constant',
-                                       fill_value=0.0,
-                                       check_normalization=True)
+        filtered_data = filter_data(
+            data, filter_kernel, mode='constant',
+            fill_value=0.0, check_normalization=True)
     else:
         filtered_data = None
 

--- a/photutils/segmentation.py
+++ b/photutils/segmentation.py
@@ -8,7 +8,7 @@ from astropy.table import Table
 from astropy.utils import lazyproperty
 import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
-from .utils.convolution import _convolve_data
+from .utils.convolution import filter_data
 from .utils.prepare_data import _prepare_data
 
 
@@ -1687,7 +1687,7 @@ def source_properties(data, segment_img, error=None, mask=None,
 
     # filter the data once, instead of repeating for each source
     if filter_kernel is not None:
-        filtered_data = _convolve_data(data, filter_kernel, mode='constant',
+        filtered_data = filter_data(data, filter_kernel, mode='constant',
                                        fill_value=0.0,
                                        check_normalization=True)
     else:

--- a/photutils/utils/__init__.py
+++ b/photutils/utils/__init__.py
@@ -6,3 +6,4 @@ from .check_random_state import *
 from .colormaps import *
 from .interpolation import *
 from .prepare_data import *
+from .convolution import *

--- a/photutils/utils/convolution.py
+++ b/photutils/utils/convolution.py
@@ -6,8 +6,9 @@ import warnings
 from astropy.convolution import Kernel2D
 from astropy.utils.exceptions import AstropyUserWarning
 
+__all__ = ['filter_data']
 
-def _convolve_data(data, kernel, mode='constant', fill_value=0.0,
+def filter_data(data, kernel, mode='constant', fill_value=0.0,
                    check_normalization=False):
     """
     Convolve a 2D image with a 2D kernel.

--- a/photutils/utils/convolution.py
+++ b/photutils/utils/convolution.py
@@ -9,7 +9,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 __all__ = ['filter_data']
 
 def filter_data(data, kernel, mode='constant', fill_value=0.0,
-                   check_normalization=False):
+                check_normalization=False):
     """
     Convolve a 2D image with a 2D kernel.
 


### PR DESCRIPTION
I've made _convolve_data public and renamed it filter_data. This will serve as a convenience function for users who would like to inspect their images at each step of their pipeline. This is a follow-up to PR  #397. 

Thanks 