### PR TITLE
Adding conda channels to CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
+        - CONDA_CHANNELS='astropy-ci-extras'
 
     matrix:
         # Make sure that egg_info works without dependencies


### PR DESCRIPTION
Conda channels now need to be explicitly listed, ci-helpers won't add astropy and astropy-ci-extras by default in the future astropy/ci-helpers#128.