### PR TITLE
Modifications from #385

### DIFF
--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -23,7 +23,7 @@ class DAOPhotPSFPhotometry(object):
     iterations is reached.
     """
 
-    def __init__(self, grouper, bkg_estimator, psf_model, fitshape, find=None,
+    def __init__(self, grouper, bkg_estimator, psf_model, fitshape, finder=None,
                  fitter=LevMarLSQFitter(), niters=3, aperture_radius=None):
         """
         Parameters
@@ -61,10 +61,10 @@ class DAOPhotPSFPhotometry(object):
             same along both axes. E.g., 5 is the same as (5, 5), which means to
             fit only at the following relative pixel positions: [-2, -1, 0, 1, 2].
             If an array, each element of ``fitshape`` must be an odd number.
-        find : callable or instance of any `~photutils.detection.StarFinderBase` subclasses
-            ``find`` should be able to identify stars, i.e. compute a rough
+        finder : callable or instance of any `~photutils.detection.StarFinderBase` subclasses
+            ``finder`` should be able to identify stars, i.e. compute a rough
             estimate of the centroids, in a given 2D image.
-            ``find`` receives as input a 2D image an return an
+            ``finder`` receives as input a 2D image an return an
             `~astropy.table.Table` object which contains columns with names:
             ``id``, ``xcentroid``, ``ycentroid``, and ``flux``. In which
             ``id`` is an interger-valued column starting from ``1``,
@@ -97,7 +97,7 @@ class DAOPhotPSFPhotometry(object):
             Available at: http://adsabs.harvard.edu/abs/1987PASP...99..191S
         """
 
-        self.find = find
+        self.finder = finder
         self.grouper = grouper
         self.bkg_estimator = bkg_estimator
         self.psf_model = psf_model
@@ -246,7 +246,7 @@ class DAOPhotPSFPhotometry(object):
                           names=('x_0', 'y_0', 'flux_0'),
                           dtype=('f8', 'f8', 'f8'))
 
-            sources = self.find(residual_image)
+            sources = self.finder(residual_image)
 
             apertures = CircularAperture((sources['xcentroid'],
                                           sources['ycentroid']),
@@ -270,7 +270,7 @@ class DAOPhotPSFPhotometry(object):
 
                 outtab = vstack([outtab, result_tab])
 
-                sources = self.find(residual_image)
+                sources = self.finder(residual_image)
 
                 if len(sources) > 0:
                     apertures = CircularAperture((sources['xcentroid'],

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -23,15 +23,15 @@ class DAOPhotPSFPhotometry(object):
     iterations is reached.
     """
 
-    def __init__(self, group, bkg, psf, fitshape, find=None,
+    def __init__(self, grouper, bkg, psf, fitshape, find=None,
                  fitter=LevMarLSQFitter(), niters=3, aperture_radius=None):
         """
         Parameters
         ----------
-        group : callable or instance of any `~photutils.psf.GroupStarsBase` subclasses
-            ``group`` should be able to decide whether a given star overlaps
+        grouper : callable or instance of any `~photutils.psf.GroupStarsBase` subclasses
+            ``grouper`` should be able to decide whether a given star overlaps
             with any other and label them as beloging to the same group.
-            ``group`` receives as input an `~astropy.table.Table` object with
+            ``grouper`` receives as input an `~astropy.table.Table` object with
             columns named as ``id``, ``x_0``, ``y_0``, in which ``x_0`` and
             ``y_0`` have the same meaning of ``xcentroid`` and ``ycentroid``.
             This callable must return an `~astropy.table.Table` with columns
@@ -97,7 +97,7 @@ class DAOPhotPSFPhotometry(object):
         """
 
         self.find = find
-        self.group = group
+        self.grouper = grouper
         self.bkg = bkg
         self.psf = psf
         self.fitter = fitter
@@ -193,8 +193,8 @@ class DAOPhotPSFPhotometry(object):
         Perform PSF photometry in ``image``. This method assumes that
         ``psf`` has centroids and flux parameters which will be fitted to the
         data provided in ``image``. A compound model, in fact a sum of
-        ``psf``, will be fitted to groups of starts automatically identified
-        by ``group``. Also, ``image`` is not assumed to be background
+        ``psf``, will be fitted to groups of stars automatically identified
+        by ``grouper``. Also, ``image`` is not assumed to be background
         subtracted.
         If positions are not ``None`` then this method performs forced PSF
         photometry, i.e., the positions are assumed to be known with high
@@ -257,7 +257,7 @@ class DAOPhotPSFPhotometry(object):
                                              sources['aperture_flux']])
                 intab = vstack([intab, init_guess_tab])
 
-                star_groups = self.group(init_guess_tab)
+                star_groups = self.grouper(init_guess_tab)
 
                 result_tab, residual_image = self.nstar(residual_image,
                                                         star_groups)
@@ -288,7 +288,7 @@ class DAOPhotPSFPhotometry(object):
                           data=[positions['x_0'], positions['y_0'],
                           positions['flux_0']])
 
-            star_groups = self.group(intab)
+            star_groups = self.grouper(intab)
             outtab, residual_image = self.nstar(residual_image, star_groups)
             outtab = hstack([intab, outtab])
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -257,7 +257,7 @@ class DAOPhotPSFPhotometry(object):
 
             sources['aperture_flux'] = aperture_photometry(residual_image, apertures)['aperture_sum']
             n = 1
-            while(len(sources) > 0 and (self.niters is not None and n <= self.niters)):
+            while(len(sources) > 0 and (self.niters is None or n <= self.niters)):
                 init_guess_tab = Table(names=['x_0', 'y_0', 'flux_0'],
                                        data=[sources['xcentroid'],
                                              sources['ycentroid'],

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -138,7 +138,7 @@ class DAOPhotPSFPhotometry(object):
 
         # assume a lone value should mean both axes
         if value.shape == ():
-            value = (value, value)
+            value = np.array((value, value))
 
         if value.size == 2:
             if np.all(value) > 0:
@@ -442,9 +442,9 @@ class DAOPhotPSFPhotometry(object):
             group_psf = None
             for i in range(len(self.star_group)):
                 psf_to_add = self.psf_model.copy()
-                psf_to_add.flux = self.star_group['flux_0'][i+1]
-                psf_to_add.x_0 = self.star_group['x_0'][i+1]
-                psf_to_add.y_0 = self.star_group['y_0'][i+1]
+                psf_to_add.flux = self.star_group['flux_0'][i]
+                psf_to_add.x_0 = self.star_group['x_0'][i]
+                psf_to_add.y_0 = self.star_group['y_0'][i]
 
                 if group_psf is None:
                     # this is the first one only

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -22,16 +22,17 @@ class DAOPhotPSFPhotometry(object):
     more stars are detected or a given number of iterations is reached.
     """
 
-    def __init__(self, grouper, bkg_estimator, psf_model, fitshape, finder=None,
+    def __init__(self, group_maker, bkg_estimator, psf_model, fitshape, finder=None,
                  fitter=LevMarLSQFitter(), niters=3, aperture_radius=None):
         """
         Parameters
         ----------
-        grouper : callable or instance of any `~photutils.psf.GroupStarsBase` subclasses
-            ``grouper`` should be able to decide whether a given star overlaps
-            with any other and label them as beloging to the same group.
-            ``grouper`` receives as input an `~astropy.table.Table` object with
-            columns named as ``id``, ``x_0``, ``y_0``, in which ``x_0`` and
+        group_maker : callable or `~photutils.psf.GroupStarsBase`
+            ``group_maker`` should be able to decide whether a given star
+            overlaps with any other and label them as beloging to the same
+            group.
+            ``group_maker`` receives as input an `~astropy.table.Table` object
+            with columns named as ``id``, ``x_0``, ``y_0``, in which ``x_0`` and
             ``y_0`` have the same meaning of ``xcentroid`` and ``ycentroid``.
             This callable must return an `~astropy.table.Table` with columns
             ``id``, ``x_0``, ``y_0``, and ``group_id``. The column
@@ -101,7 +102,7 @@ class DAOPhotPSFPhotometry(object):
         """
 
         self.finder = finder
-        self.grouper = grouper
+        self.group_maker = group_maker
         self.bkg_estimator = bkg_estimator
         self.psf_model = psf_model
         self.fitter = fitter
@@ -199,7 +200,7 @@ class DAOPhotPSFPhotometry(object):
         ``psf_model`` has centroids and flux parameters which will be fitted to
         the data provided in ``image``. A compound model, in fact a sum of
         ``psf_model``, will be fitted to groups of stars automatically
-        identified by ``grouper``. Also, ``image`` is not assumed to be
+        identified by ``group_maker``. Also, ``image`` is not assumed to be
         background subtracted.
         If positions are not ``None`` then this method performs forced PSF
         photometry, i.e., the positions are assumed to be known with high
@@ -264,7 +265,7 @@ class DAOPhotPSFPhotometry(object):
                                              sources['aperture_flux']])
                 intab = vstack([intab, init_guess_tab])
 
-                star_groups = self.grouper(init_guess_tab)
+                star_groups = self.group_maker(init_guess_tab)
 
                 result_tab, residual_image = self.nstar(residual_image,
                                                         star_groups)
@@ -295,7 +296,7 @@ class DAOPhotPSFPhotometry(object):
                           data=[positions['x_0'], positions['y_0'],
                           positions['flux_0']])
 
-            star_groups = self.grouper(intab)
+            star_groups = self.group_maker(intab)
             outtab, residual_image = self.nstar(residual_image, star_groups)
             outtab = hstack([intab, outtab])
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -23,7 +23,7 @@ class DAOPhotPSFPhotometry(object):
     iterations is reached.
     """
 
-    def __init__(self, grouper, bkg, psf, fitshape, find=None,
+    def __init__(self, grouper, bkg_estimator, psf, fitshape, find=None,
                  fitter=LevMarLSQFitter(), niters=3, aperture_radius=None):
         """
         Parameters
@@ -39,9 +39,9 @@ class DAOPhotPSFPhotometry(object):
             ``group_id`` should cotain integers starting from ``1`` that
             indicate which group a given source belongs to. See, e.g.,
             `~photutils.psf.DAOGroup`.
-        bkg : callable or instance of any `~photutils.BackgroundBase` subclasses
-            ``bkg`` should be able to compute either a scalar background or a
-            2D background of a given 2D image. See, e.g.,
+        bkg_estimator : callable or instance of any `~photutils.BackgroundBase` subclass
+            ``bkg_estimator`` should be able to compute either a scalar
+            background or a 2D background of a given 2D image. See, e.g.,
             `~photutils.background.MedianBackground`.
         psf : `astropy.modeling.Fittable2DModel` instance
             PSF or PRF model to fit the data. Could be one of the models in
@@ -98,7 +98,7 @@ class DAOPhotPSFPhotometry(object):
 
         self.find = find
         self.grouper = grouper
-        self.bkg = bkg
+        self.bkg_estimator = bkg_estimator
         self.psf = psf
         self.fitter = fitter
         self.niters = niters
@@ -223,7 +223,7 @@ class DAOPhotPSFPhotometry(object):
             and the original image.
         """
 
-        residual_image = image - self.bkg(image)
+        residual_image = image - self.bkg_estimator(image)
 
         if self.aperture_radius is None:
             if hasattr(self.psf, 'fwhm'):

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -17,10 +17,9 @@ __all__ = ['DAOPhotPSFPhotometry']
 class DAOPhotPSFPhotometry(object):
     """
     This class implements the DAOPHOT algorithm proposed by Stetson
-    (1987) to perform point spread function photometry in crowded fields,
-    which consists basically in applying the loop FIND, GROUP, NSTAR,
-    SUBTRACT, FIND until no more stars are detected or a given number of
-    iterations is reached.
+    (1987) to perform point spread function photometry in crowded fields. This
+    consists of applying the loop FIND, GROUP, NSTAR, SUBTRACT, FIND until no
+    more stars are detected or a given number of iterations is reached.
     """
 
     def __init__(self, grouper, bkg_estimator, psf_model, fitshape, finder=None,
@@ -60,14 +59,14 @@ class DAOPhotPSFPhotometry(object):
             to collect the data to do the fitting. Can be an integer to be the
             same along both axes. E.g., 5 is the same as (5, 5), which means to
             fit only at the following relative pixel positions: [-2, -1, 0, 1, 2].
-            If an array, each element of ``fitshape`` must be an odd number.
+            Each element of ``fitshape`` must be an odd number.
         finder : callable or instance of any `~photutils.detection.StarFinderBase` subclasses
             ``finder`` should be able to identify stars, i.e. compute a rough
             estimate of the centroids, in a given 2D image.
             ``finder`` receives as input a 2D image an return an
             `~astropy.table.Table` object which contains columns with names:
             ``id``, ``xcentroid``, ``ycentroid``, and ``flux``. In which
-            ``id`` is an interger-valued column starting from ``1``,
+            ``id`` is an integer-valued column starting from ``1``,
             ``xcentroid`` and ``ycentroid`` are center position estimates of
             the sources and ``flux`` contains flux estimates of the sources.
             See, e.g., `~photutils.detection.DAOStarFinder`.
@@ -76,11 +75,12 @@ class DAOPhotPSFPhotometry(object):
             and/or flux of the identified sources. See
             `~astropy.modeling.fitting` for more details on fitters.
         niters : int
-            Number of iterations to perform the loop FIND, GROUP, SUBTRACT,
+            Number of iterations to perform of the loop FIND, GROUP, SUBTRACT,
             NSTAR.
         aperture_radius : float
             The radius (in units of pixels) used to compute initial estimates
-            for the fluxes of sources. If ``None``, one fwhm will be used.
+            for the fluxes of sources. If ``None``, one FWHM will be used if it
+            can be determined from the ```psf_model``.
 
         Notes
         -----
@@ -139,12 +139,10 @@ class DAOPhotPSFPhotometry(object):
                     self._fitshape = tuple(value)
                 else:
                     raise ValueError('fitshape must be odd integer-valued, '
-                                     'received fitshape = {}'\
-                                     .format(value))
+                                     'received fitshape = {}'.format(value))
             else:
                 raise ValueError('fitshape must have positive elements, '
-                                 'received fitshape = {}'\
-                                 .format(value))
+                                 'received fitshape = {}'.format(value))
         else:
             raise ValueError('fitshape must have two dimensions, '
                              'received fitshape = {}'.format(value))
@@ -233,8 +231,7 @@ class DAOPhotPSFPhotometry(object):
             if hasattr(self.psf_model, 'fwhm'):
                 self.aperture_radius = self.psf_model.fwhm.value
             elif hasattr(self.psf_model, 'sigma'):
-                self.aperture_radius = self.psf_model.sigma.value*\
-                                       gaussian_sigma_to_fwhm
+                self.aperture_radius = self.psf_model.sigma.value * gaussian_sigma_to_fwhm
 
         if positions is None:
             outtab = Table([[], [], [], [], [], []],
@@ -411,7 +408,7 @@ class DAOPhotPSFPhotometry(object):
 
     class GroupPSF(object):
         """
-        Construct a joint PSF model which consists in a sum of `self.psf_model`
+        Construct a joint PSF model which consists of a sum of `self.psf_model`
         whose parameters are given in `star_group`.
 
         Attributes

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -54,11 +54,12 @@ class DAOPhotPSFPhotometry(object):
             parameters should be given as ``x_0``, ``y_0`` and ``flux``.
             `~photutils.psf.prepare_psf_model` can be used to prepare any 2D
             model to match this assumption.
-        fitshape : array-like
+        fitshape : int or length-2 array-like
             Rectangular shape around the center of a star which will be used
-            to collect the data to do the fitting, e.g. (5, 5) means to take
-            the following relative pixel positions: [-2, -1, 0, 1, 2].
-            Each element of ``fitshape`` must be an odd number.
+            to collect the data to do the fitting. Can be an integer to be the
+            same along both axes. E.g., 5 is the same as (5, 5), which means to
+            fit only at the following relative pixel positions: [-2, -1, 0, 1, 2].
+            If an array, each element of ``fitshape`` must be an odd number.
         find : callable or instance of any `~photutils.detection.StarFinderBase` subclasses
             ``find`` should be able to identify stars, i.e. compute a rough
             estimate of the centroids, in a given 2D image.
@@ -126,6 +127,11 @@ class DAOPhotPSFPhotometry(object):
     @fitshape.setter
     def fitshape(self, value):
         value = np.asarray(value)
+
+        # assume a lone value should mean both axes
+        if value.shape == ():
+            value = (value, value)
+
         if value.size == 2:
             if np.all(value) > 0:
                 if np.all(value % 2) == 1:

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -39,10 +39,11 @@ class DAOPhotPSFPhotometry(object):
             ``group_id`` should cotain integers starting from ``1`` that
             indicate which group a given source belongs to. See, e.g.,
             `~photutils.psf.DAOGroup`.
-        bkg_estimator : callable or instance of any `~photutils.BackgroundBase` subclass
+        bkg_estimator : callable, instance of any `~photutils.BackgroundBase` subclass, or None
             ``bkg_estimator`` should be able to compute either a scalar
             background or a 2D background of a given 2D image. See, e.g.,
-            `~photutils.background.MedianBackground`.
+            `~photutils.background.MedianBackground`.  Can be None to do no
+            background subtraction.
         psf : `astropy.modeling.Fittable2DModel` instance
             PSF or PRF model to fit the data. Could be one of the models in
             this package like `~photutils.psf.sandbox.DiscretePRF`,
@@ -223,7 +224,10 @@ class DAOPhotPSFPhotometry(object):
             and the original image.
         """
 
-        residual_image = image - self.bkg_estimator(image)
+        if self.bkg_estimator is None:
+            residual_image = image.copy()
+        else:
+            residual_image = image - self.bkg_estimator(image)
 
         if self.aperture_radius is None:
             if hasattr(self.psf, 'fwhm'):

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -432,19 +432,17 @@ class DAOPhotPSFPhotometry(object):
                 models.
             """
 
-            psf_class = type(self.psf_model)
-            group_psf = psf_class(sigma=self.psf_model.sigma.value,
-                                  flux=self.star_group['flux_0'][0],
-                                  x_0=self.star_group['x_0'][0],
-                                  y_0=self.star_group['y_0'][0],
-                                  fixed=self.psf_model.fixed, tied=self.psf_model.tied,
-                                  bounds=self.psf_model.bounds)
-            for i in range(len(self.star_group) - 1):
-                group_psf += psf_class(sigma=self.psf_model.sigma.value,
-                                       flux=self.star_group['flux_0'][i+1],
-                                       x_0=self.star_group['x_0'][i+1],
-                                       y_0=self.star_group['y_0'][i+1],
-                                       fixed=self.psf_model.fixed,
-                                       tied=self.psf_model.tied,
-                                       bounds=self.psf_model.bounds)
+            group_psf = None
+            for i in range(len(self.star_group)):
+                psf_to_add = self.psf_model.copy()
+                psf_to_add.flux = self.star_group['flux_0'][i+1]
+                psf_to_add.x_0 = self.star_group['x_0'][i+1]
+                psf_to_add.y_0 = self.star_group['y_0'][i+1]
+
+                if group_psf is None:
+                    # this is the first one only
+                    group_psf = psf_to_add
+                else:
+                    group_psf += psf_to_add
+
             return group_psf

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -181,6 +181,9 @@ class TestDAOPhotPSFPhotometryAttributes(object):
         with pytest.raises(ValueError):
             phot.niters = 0
 
+        # test that it's OK to set niters to None
+        phot.niters = None
+
     def test_fitshape_exceptions(self):
         daofind = DAOStarFinder(threshold=5.0,
                                 fwhm=gaussian_sigma_to_fwhm)
@@ -191,9 +194,17 @@ class TestDAOPhotPSFPhotometryAttributes(object):
         phot = DAOPhotPSFPhotometry(finder=daofind, group_maker=daogroup, bkg_estimator=median_bkg,
                                     psf_model=psf_model, fitter=fitter, niters=1.1,
                                     fitshape=(11, 11))
+
+        # first make sure setting to a scalar does the right thing (and makes
+        # no errors)
+        phot.fitshape = 11
+        assert np.all(phot.fitshape == (11, 11))
+
         # test that a ValuError is raised if fitshape has even components
         with pytest.raises(ValueError):
             phot.fitshape = (2, 2)
+        with pytest.raises(ValueError):
+            phot.fitshape = 2
 
         # test that a ValuError is raised if fitshape has non positive
         # components

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -74,7 +74,11 @@ sources2['group_id'] = [1, 1, 1, 1]
 @pytest.mark.xfail('not HAS_SCIPY or not HAS_MIN_ASTROPY')
 @pytest.mark.parametrize("sigma_psf, sources",
                          [(sigma_psfs[0], sources1),
-                          (sigma_psfs[1], sources2)])
+                          (sigma_psfs[1], sources2),
+                          # these ensure that the test *fails* if the model PSFs
+                          # are the wrong shape
+                          pytest.mark.xfail((sigma_psfs[0]/1.2, sources1)),
+                          pytest.mark.xfail((sigma_psfs[1]*1.2, sources2))])
 def test_complete_photometry_oneiter(sigma_psf, sources):
     """
     Tests in an image with a group of two overlapped stars and an

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -28,207 +28,189 @@ else:
     HAS_MIN_ASTROPY = True
 
 
-@pytest.mark.xfail('not HAS_SCIPY or not HAS_MIN_ASTROPY')
-class TestDAOPhotPSFPhotometry(object):
-    def test_complete_photometry_one(self):
-        """
-        Tests in an image with a group of two overlapped stars and an
-        isolated one.
-        """
-        sigma_psf = 2.0
-        sources = Table()
-        sources['flux'] = [800, 1000, 1200]
-        sources['x_mean'] = [13, 18, 25]
-        sources['y_mean'] = [16, 16, 25]
-        sources['x_stddev'] = [sigma_psf, sigma_psf, sigma_psf]
-        sources['y_stddev'] = sources['x_stddev']
-        sources['theta'] = [0, 0, 0]
-        sources['id'] = [1, 2, 3]
-        sources['group_id'] = [1, 1, 2]
-        tshape = (32, 32)
-
-        # generate image with read-out noise (Gaussian) and
-        # background noise (Poisson)
-        image = (make_gaussian_sources(tshape, sources) +
-                 make_noise_image(tshape, type='poisson', mean=6.,
-                                  random_state=1) +
-                 make_noise_image(tshape, type='gaussian', mean=0.,
-                                  stddev=2., random_state=1))
-
-        bkgrms = StdBackgroundRMS(sigma=3.)
-        std = bkgrms(image)
-
-        daofind = DAOStarFinder(threshold=5.0*std,
-                                fwhm=sigma_psf*gaussian_sigma_to_fwhm)
-        daogroup = DAOGroup(1.5*sigma_psf*gaussian_sigma_to_fwhm)
-        median_bkg = MedianBackground(sigma=3.)
-        psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
-        fitter = LevMarLSQFitter()
-        photometry = DAOPhotPSFPhotometry(finder=daofind, group_maker=daogroup,
-                                          bkg_estimator=median_bkg,
-                                          psf_model=psf_model, fitter=fitter,
-                                          niters=1, fitshape=(11, 11))
-
-        result_tab, residual_image = photometry(image)
-
-        assert_allclose(result_tab['x_fit'], sources['x_mean'], rtol=1e-1)
-        assert_allclose(result_tab['y_fit'], sources['y_mean'], rtol=1e-1)
-        assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
-        assert_array_equal(result_tab['id'], sources['id'])
-        assert_array_equal(result_tab['group_id'], sources['group_id'])
-        assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
-
-        # test fixed photometry
-        psf_model.x_0.fixed = True
-        psf_model.y_0.fixed = True
-        # this also tests the other form of `fitshape`
-        photometry = DAOPhotPSFPhotometry(group_maker=daogroup, bkg_estimator=median_bkg,
-                                          psf_model=psf_model, fitter=LevMarLSQFitter(),
-                                          fitshape=(11, 11))
-
-        pos = Table(names=['x_0', 'y_0'], data=[sources['x_mean'],
-                                                sources['y_mean']])
-        result_tab, residual_image = photometry(image, pos)
-
-        assert_array_equal(result_tab['x_fit'], sources['x_mean'])
-        assert_array_equal(result_tab['y_fit'], sources['y_mean'])
-        assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
-        assert_array_equal(result_tab['id'], sources['id'])
-        assert_array_equal(result_tab['group_id'], sources['group_id'])
-        assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
-
-    def test_complete_photometry_two(self):
-        """
-        Tests in an image with one single group with four stars.
-        """
-        sigma_psf = 2.0
-        sources = Table()
-        sources['flux'] = [700, 800, 700, 800]
-        sources['x_mean'] = [12, 17, 12, 17]
-        sources['y_mean'] = [15, 15, 20, 20]
-        sources['x_stddev'] = sigma_psf*np.ones(4)
-        sources['y_stddev'] = sources['x_stddev']
-        sources['theta'] = [0, 0, 0, 0]
-        sources['id'] = [1, 2, 3, 4]
-        sources['group_id'] = [1, 1, 1, 1]
-        tshape = (32, 32)
-
-        image = (make_gaussian_sources(tshape, sources) +
-                 make_noise_image(tshape, type='poisson', mean=6.,
-                                  random_state=1) +
-                 make_noise_image(tshape, type='gaussian', mean=0.,
-                                  stddev=2., random_state=1))
-
-        bkgrms = StdBackgroundRMS(sigma=3.)
-        std = bkgrms(image)
-
-        daofind = DAOStarFinder(threshold=5.0*std,
-                                fwhm=sigma_psf*gaussian_sigma_to_fwhm)
-        daogroup = DAOGroup(1.5*sigma_psf*gaussian_sigma_to_fwhm)
-        median_bkg = MedianBackground(sigma=3.)
-        psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
-        fitter = LevMarLSQFitter()
-        phot = DAOPhotPSFPhotometry(finder=daofind, group_maker=daogroup,
-                                    bkg_estimator=median_bkg, psf_model=psf_model,
-                                    fitter=fitter,
-                                    niters=1, fitshape=(11, 11))
-
-        result_tab, residual_image = phot(image)
-
-        assert_allclose(result_tab['x_fit'], sources['x_mean'], rtol=1e-1)
-        assert_allclose(result_tab['y_fit'], sources['y_mean'], rtol=1e-1)
-        assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
-        assert_array_equal(result_tab['id'], sources['id'])
-        assert_array_equal(result_tab['group_id'], sources['group_id'])
-        assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
-
-        # test fixed photometry
-        psf_model.x_0.fixed = True
-        psf_model.y_0.fixed = True
-        phot = DAOPhotPSFPhotometry(group_maker=daogroup, bkg_estimator=median_bkg,
-                                    psf_model=psf_model, fitter=LevMarLSQFitter(),
-                                    fitshape=(11, 11))
-
-        pos = Table(names=['x_0', 'y_0'], data=[sources['x_mean'],
-                                                sources['y_mean']])
-        result_tab, residual_image = phot(image, pos)
-
-        assert_array_equal(result_tab['x_fit'], sources['x_mean'])
-        assert_array_equal(result_tab['y_fit'], sources['y_mean'])
-        assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
-        assert_array_equal(result_tab['id'], sources['id'])
-        assert_array_equal(result_tab['group_id'], sources['group_id'])
-        assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
+def make_fiducial_phot_obj(std=1, sigma_psf=1):
+    """
+    Produces a baseline DAOPhotPSFPhotometry object which is then modified as-needed
+    in specific tests below
+    """
+    daofind = DAOStarFinder(threshold=5.0*std, fwhm=sigma_psf*gaussian_sigma_to_fwhm)
+    daogroup = DAOGroup(1.5*sigma_psf*gaussian_sigma_to_fwhm)
+    median_bkg = MedianBackground(sigma=3.)
+    psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
+    fitter = LevMarLSQFitter()
+    return DAOPhotPSFPhotometry(finder=daofind, group_maker=daogroup, bkg_estimator=median_bkg,
+                                psf_model=psf_model, fitter=fitter, niters=1,
+                                fitshape=(11, 11))
 
 
 @pytest.mark.xfail('not HAS_SCIPY or not HAS_MIN_ASTROPY')
-class TestDAOPhotPSFPhotometryAttributes(object):
-    def test_niters_exceptions(self):
-        daofind = DAOStarFinder(threshold=5.0,
-                                fwhm=gaussian_sigma_to_fwhm)
-        daogroup = DAOGroup(1.5*gaussian_sigma_to_fwhm)
-        median_bkg = MedianBackground(sigma=3.)
-        psf_model = IntegratedGaussianPRF(sigma=1.)
-        fitter = LevMarLSQFitter()
-        phot = DAOPhotPSFPhotometry(finder=daofind, group_maker=daogroup, bkg_estimator=median_bkg,
-                                    psf_model=psf_model, fitter=fitter, niters=1.1,
-                                    fitshape=(11, 11))
-        # tests that niters is set to an integer even if the user inputs
-        # a float
-        assert_equal(phot.niters, 1)
+def test_complete_photometry_one():
+    """
+    Tests in an image with a group of two overlapped stars and an
+    isolated one.
+    """
+    sigma_psf = 2.0
+    sources = Table()
+    sources['flux'] = [800, 1000, 1200]
+    sources['x_mean'] = [13, 18, 25]
+    sources['y_mean'] = [16, 16, 25]
+    sources['x_stddev'] = [sigma_psf, sigma_psf, sigma_psf]
+    sources['y_stddev'] = sources['x_stddev']
+    sources['theta'] = [0, 0, 0]
+    sources['id'] = [1, 2, 3]
+    sources['group_id'] = [1, 1, 2]
+    tshape = (32, 32)
 
-        # test that a ValueError is raised if niters <= 0
-        with pytest.raises(ValueError):
-            phot.niters = 0
 
-        # test that it's OK to set niters to None
-        phot.niters = None
+    # generate image with read-out noise (Gaussian) and
+    # background noise (Poisson)
+    image = (make_gaussian_sources(tshape, sources) +
+             make_noise_image(tshape, type='poisson', mean=6.,
+                              random_state=1) +
+             make_noise_image(tshape, type='gaussian', mean=0.,
+                              stddev=2., random_state=1))
 
-    def test_fitshape_exceptions(self):
-        daofind = DAOStarFinder(threshold=5.0,
-                                fwhm=gaussian_sigma_to_fwhm)
-        daogroup = DAOGroup(1.5*gaussian_sigma_to_fwhm)
-        median_bkg = MedianBackground(sigma=3.)
-        psf_model = IntegratedGaussianPRF(sigma=1.)
-        fitter = LevMarLSQFitter()
-        phot = DAOPhotPSFPhotometry(finder=daofind, group_maker=daogroup, bkg_estimator=median_bkg,
-                                    psf_model=psf_model, fitter=fitter, niters=1.1,
-                                    fitshape=(11, 11))
+    bkgrms = StdBackgroundRMS(sigma=3.)
+    std = bkgrms(image)
 
-        # first make sure setting to a scalar does the right thing (and makes
-        # no errors)
-        phot.fitshape = 11
-        assert np.all(phot.fitshape == (11, 11))
+    phot_obj = make_fiducial_phot_obj(std, sigma_psf)
 
-        # test that a ValuError is raised if fitshape has even components
-        with pytest.raises(ValueError):
-            phot.fitshape = (2, 2)
-        with pytest.raises(ValueError):
-            phot.fitshape = 2
+    result_tab, residual_image = phot_obj(image)
 
-        # test that a ValuError is raised if fitshape has non positive
-        # components
-        with pytest.raises(ValueError):
-            phot.fitshape = (-1, 0)
+    assert_allclose(result_tab['x_fit'], sources['x_mean'], rtol=1e-1)
+    assert_allclose(result_tab['y_fit'], sources['y_mean'], rtol=1e-1)
+    assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
+    assert_array_equal(result_tab['id'], sources['id'])
+    assert_array_equal(result_tab['group_id'], sources['group_id'])
+    assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
 
-        # test that a ValuError is raised if fitshape does not have two
-        # components
-        with pytest.raises(ValueError):
-            phot.fitshape = 2
+    # test fixed photometry
+    phot_obj.psf_model.x_0.fixed = True
+    phot_obj.psf_model.y_0.fixed = True
 
-    def test_aperture_radius_exceptions(self):
-        daofind = DAOStarFinder(threshold=5.0,
-                                fwhm=gaussian_sigma_to_fwhm)
-        daogroup = DAOGroup(1.5*gaussian_sigma_to_fwhm)
-        median_bkg = MedianBackground(sigma=3.)
-        psf_model = IntegratedGaussianPRF(sigma=1.)
-        fitter = LevMarLSQFitter()
-        phot = DAOPhotPSFPhotometry(finder=daofind, group_maker=daogroup, bkg_estimator=median_bkg,
-                                    psf_model=psf_model, fitter=fitter, niters=1.1,
-                                    fitshape=(11, 11))
-        # test that aperture_radius was set to None by default
-        assert_equal(phot.aperture_radius, None)
+    # setting the finder to None is not strictly needed, but is a good test to
+    # make sure fixed photometry doesn't try to use the star-finder
+    phot_obj.finder = None
 
-        # test that a ValuError is raised if aperture_radius is non positive
-        with pytest.raises(ValueError):
-            phot.aperture_radius = -3
+    pos = Table(names=['x_0', 'y_0'], data=[sources['x_mean'],
+                                            sources['y_mean']])
+    result_tab, residual_image = phot_obj(image, pos)
+
+    assert_array_equal(result_tab['x_fit'], sources['x_mean'])
+    assert_array_equal(result_tab['y_fit'], sources['y_mean'])
+    assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
+    assert_array_equal(result_tab['id'], sources['id'])
+    assert_array_equal(result_tab['group_id'], sources['group_id'])
+    assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
+
+
+@pytest.mark.xfail('not HAS_SCIPY or not HAS_MIN_ASTROPY')
+def test_complete_photometry_two():
+    """
+    Tests in an image with one single group with four stars.
+    """
+    sigma_psf = 2.0
+    sources = Table()
+    sources['flux'] = [700, 800, 700, 800]
+    sources['x_mean'] = [12, 17, 12, 17]
+    sources['y_mean'] = [15, 15, 20, 20]
+    sources['x_stddev'] = sigma_psf*np.ones(4)
+    sources['y_stddev'] = sources['x_stddev']
+    sources['theta'] = [0, 0, 0, 0]
+    sources['id'] = [1, 2, 3, 4]
+    sources['group_id'] = [1, 1, 1, 1]
+    tshape = (32, 32)
+
+    image = (make_gaussian_sources(tshape, sources) +
+             make_noise_image(tshape, type='poisson', mean=6.,
+                              random_state=1) +
+             make_noise_image(tshape, type='gaussian', mean=0.,
+                              stddev=2., random_state=1))
+
+    bkgrms = StdBackgroundRMS(sigma=3.)
+    std = bkgrms(image)
+
+    phot_obj = make_fiducial_phot_obj(std, sigma_psf)
+
+    result_tab, residual_image = phot_obj(image)
+
+    assert_allclose(result_tab['x_fit'], sources['x_mean'], rtol=1e-1)
+    assert_allclose(result_tab['y_fit'], sources['y_mean'], rtol=1e-1)
+    assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
+    assert_array_equal(result_tab['id'], sources['id'])
+    assert_array_equal(result_tab['group_id'], sources['group_id'])
+    assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
+
+    # test fixed photometry
+    phot_obj.psf_model.x_0.fixed = True
+    phot_obj.psf_model.y_0.fixed = True
+
+    # setting the finder to None is not strictly needed, but is a good test to
+    # make sure fixed photometry doesn't try to use the star-finder
+    phot_obj.finder = None
+
+    pos = Table(names=['x_0', 'y_0'], data=[sources['x_mean'],
+                                            sources['y_mean']])
+    result_tab, residual_image = phot_obj(image, pos)
+
+    assert_array_equal(result_tab['x_fit'], sources['x_mean'])
+    assert_array_equal(result_tab['y_fit'], sources['y_mean'])
+    assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
+    assert_array_equal(result_tab['id'], sources['id'])
+    assert_array_equal(result_tab['group_id'], sources['group_id'])
+    assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
+
+
+@pytest.mark.xfail('not HAS_SCIPY or not HAS_MIN_ASTROPY')
+def test_niters_exceptions():
+    phot_obj = make_fiducial_phot_obj()
+
+    # tests that niters is set to an integer even if the user inputs
+    # a float
+    phot_obj.niters = 1.1
+    assert_equal(phot_obj.niters, 1)
+
+    # test that a ValueError is raised if niters <= 0
+    with pytest.raises(ValueError):
+        phot_obj.niters = 0
+
+    # test that it's OK to set niters to None
+    phot_obj.niters = None
+
+
+@pytest.mark.xfail('not HAS_SCIPY or not HAS_MIN_ASTROPY')
+def test_fitshape_exceptions():
+    phot_obj = make_fiducial_phot_obj()
+
+    # first make sure setting to a scalar does the right thing (and makes
+    # no errors)
+    phot_obj.fitshape = 11
+    assert np.all(phot_obj.fitshape == (11, 11))
+
+    # test that a ValuError is raised if fitshape has even components
+    with pytest.raises(ValueError):
+        phot_obj.fitshape = (2, 2)
+    with pytest.raises(ValueError):
+        phot_obj.fitshape = 2
+
+    # test that a ValuError is raised if fitshape has non positive
+    # components
+    with pytest.raises(ValueError):
+        phot_obj.fitshape = (-1, 0)
+
+    # test that a ValuError is raised if fitshape does not have two
+    # components
+    with pytest.raises(ValueError):
+        phot_obj.fitshape = 2
+
+
+@pytest.mark.xfail('not HAS_SCIPY or not HAS_MIN_ASTROPY')
+def test_aperture_radius_exceptions():
+    phot_obj = make_fiducial_phot_obj()
+
+    # test that aperture_radius was set to None by default
+    assert_equal(phot_obj.aperture_radius, None)
+
+    # test that a ValuError is raised if aperture_radius is non positive
+    with pytest.raises(ValueError):
+        phot_obj.aperture_radius = -3


### PR DESCRIPTION
As I mentioned in https://github.com/astropy/photutils/pull/385#issuecomment-243602857, I had a few changes I wanted to suggest from #385 that seemed easier to just write up myself.  So this PR has those.  @mirca @hamogu @bsipocz, any thoughts you have on these are welcome:

* I changed `fitshape` so that it can be a lone int, meaning "a square with lengths of that shape".  I think that's one of the most common use cases so it seems sensible to have that shortcut.
* I did a bunch of renames of the attributes in `DAOPhotPSFPhotometry`.  Specifically, `group`->`grouper`, `bkg`->`bkg_estimator`, `psf`->`psf_model`, and `find`->`finder`.  I found the original names to be confusing because it's not clear it's the "thing that does that".  E.g., `group` would at first seem to be the actual list of groups, but of course it's actually the thing that *makes* the groups.  I can change these names again, of course, if anyone has other suggestions, but that set of names seems clearer to me.
* I made a change in `GroupPSF` that @mirca should probably have a look at (commit 478d98b6f82ab8ae304a7738f1789d25aa9a8637): that's a substantial change in how it's created, which I *think* is better because it allows a much more general set of models.  But @mirca will know if it might have unintended consequences I've missed.
*  `niters` can now be `None`, which means to keep going until no new sources are found.
* a few other minor bits here and there that I saw while doing the others
