### PR TITLE
fix see also section that was missing "also"

### DIFF
--- a/photutils/psf/groupstars.py
+++ b/photutils/psf/groupstars.py
@@ -60,9 +60,9 @@ class DAOGroup(GroupStarsBase):
     Assuming the psf fwhm to be known, ``crit_separation`` may be set to
     k*fwhm, for some positive real k.
 
-    See
-    ---
-    `~daofind`
+    See Also
+    --------
+    photutils.DAOStarFinder
 
     References
     ----------


### PR DESCRIPTION
This fixes a warning I've been seeing pop up about an improperly-named section.  (for some reason sphinx doesn't recognize this particular type of "warning" as a sphinx build warning... but it still appears in the logs.  Anyway, this fixes it.)