### PR TITLE
Add a fittable FittableImageModel class

### DIFF
--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -43,7 +43,8 @@ class Discrete2DModel(Fittable2DModel):
         An array of weights for the corresponding data. [Currently not used]
 
     fillval : float, optional
-        The value to be returned by the `evaluate` or `__call__` methods
+        The value to be returned by the `evaluate` or
+        :py:func:`~astropy.modeling.Model.__call__` methods
         when evaluation is performed outside the definition domain of the
         model.
 

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -183,12 +183,20 @@ class FittableImageModel(Fittable2DModel):
 
     def _compute_normalization(self, normalize):
         """
-        Helper function that computes the inverse normalization factor of the
+        Helper function that computes (corrected) normalization factor of the
         original image data. This quantity is computed as the
-        sum of pixel values. Computation is performed only if this
-        sum has not been previously computed. Otherwise, the existing value is
-        not modified as :py:class:`FittableImageModel` does not allow image
-        data to be modified after the object is created.
+        inverse "raw image norm" (or total "flux" of model's image) corrected
+        by the ``normalization_correction``:
+
+        .. math::
+            N = 1/(\Phi * C),
+
+        where :math:`\Phi` is the "total flux" of model's image as computed
+        by `_compute_raw_image_norm` and *C* is the normalization correction
+        factor. :math:`\Phi` is computed only once if it has not been
+        previously computed. Otherwise, the existing (stored) value of
+        :math:`\Phi` is not modified as :py:class:`FittableImageModel`
+        does not allow image data to be modified after the object is created.
 
         .. note::
             Normally, this function should not be called by the end-user. It

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -15,10 +15,8 @@ from ..utils import mask_to_mirrored_num
 from ..extern.nddata_compat import extract_array
 
 __all__ = ['FittableImageModel2D', 'IntegratedGaussianPRF', 'PRFAdapter',
-           'prepare_psf_model']
+           'prepare_psf_model', 'get_grouped_psf_model']
 
-__all__ = ['IntegratedGaussianPRF', 'PRFAdapter', 'prepare_psf_model',
-           'get_grouped_psf_model']
 
 class FittableImageModel2D(Fittable2DModel):
     """

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -44,7 +44,7 @@ class Discrete2DModel(Fittable2DModel):
 
     fillval : float, optional
         The value to be returned by the `evaluate` or
-        :py:func:`~astropy.modeling.Model.__call__` methods
+        ``astropy.modeling.Model.__call__`` methods
         when evaluation is performed outside the definition domain of the
         model.
 

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -36,10 +36,10 @@ class FittableImageModel2D(Fittable2DModel):
         Array containing 2D image.
 
     origin : tuple, None, optional
-        A reference point in the input image `data` array.
+        A reference point in the input image ``data`` array.
 
         If `origin` represents the location of a feature (e.g., the position
-        of an intensity peak) in the input `data`, then model parameters
+        of an intensity peak) in the input ``data``, then model parameters
         `x_0` and `y_0` show the location of this peak in an another target
         image to which this model was fitted.
 
@@ -53,9 +53,9 @@ class FittableImageModel2D(Fittable2DModel):
         ``sum(normalization_const * data)`` is 1.
 
         Assuming model's data represent a PSF to be fitted to some star,
-        `normalization_const` could be used to account for aperture correction.
-        In this case, best fitted value of the `flux` model parameter will
-        represent an aperture-corrected flux of the star.
+        ``normalization_const`` could be used to account for aperture
+        correction. In this case, best fitted value of the `flux` model
+        parameter will represent an aperture-corrected flux of the star.
 
     fillval : float, optional
         The value to be returned by the `evaluate` or

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -13,7 +13,6 @@ __all__ = ['Discrete2DModel', 'IntegratedGaussianPRF', 'PRFAdapter',
 __all__ = ['IntegratedGaussianPRF', 'PRFAdapter', 'prepare_psf_model',
            'get_grouped_psf_model']
 
-@pytest.mark.skipif('not HAS_SCIPY')
 class Discrete2DModel(Fittable2DModel):
     """
     A discrete fittable 2D model of an image.
@@ -230,6 +229,8 @@ class Discrete2DModel(Fittable2DModel):
                 details.
 
         """
+        from scipy.interpolate import RectBivariateSpline
+
         if 'degree' in kwargs:
             degree = kwargs['degree']
             if hasattr(degree, '__iter__') and len(degree) == 2:

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -4,30 +4,31 @@ Models for doing PSF/PRF fitting photometry on image data.
 """
 
 from __future__ import division
+import warnings
 import numpy as np
 from astropy.modeling import models, Parameter, Fittable2DModel
 
-__all__ = ['Discrete2DModel', 'IntegratedGaussianPRF', 'PRFAdapter',
+__all__ = ['FittableImageModel2D', 'IntegratedGaussianPRF', 'PRFAdapter',
            'prepare_psf_model']
 
 __all__ = ['IntegratedGaussianPRF', 'PRFAdapter', 'prepare_psf_model',
            'get_grouped_psf_model']
 
-class Discrete2DModel(Fittable2DModel):
+class FittableImageModel2D(Fittable2DModel):
     """
-    A discrete fittable 2D model of an image.
+    A fittable 2D model of an image allowing for image intensity scaling
+    and image translations.
 
-    This class stores a discrete 2D image and computes the values at arbitrary
-    locations (including at intra-pixel, fractional positions) within this
-    image using spline interpolation provided by
-    :py:class:`~scipy.interpolate.RectBivariateSpline`. Even though this
-    particular spline interpolator does not support weighted smoothing,
-    :py:class:`Discrete2DModel` can be used to store image weights
-    so that these can be passed to the fitter.
+    This class stores normalized 2D image data and computes the values of
+    the model at arbitrary locations (including at intra-pixel,
+    fractional positions) within this image using spline interpolation
+    provided by :py:class:`~scipy.interpolate.RectBivariateSpline`.
 
     The fittable model provided by this class has three model parameters:
-    total flux of the underlying image, and two shifts along each axis of the
-    image.
+    an image intensity scaling factor (`flux`) which is applied to
+    normalized image, and two positional parameters (`x_0` and `y_0`)
+    indicating the location of a feature in the coordinate grid on which
+    the model is to be evaluated.
 
     Parameters
     ----------
@@ -35,12 +36,26 @@ class Discrete2DModel(Fittable2DModel):
         Array containing 2D image.
 
     origin : tuple, None, optional
-        Origin of the coordinate system in image pixels. Origin indicates where
-        in the image model coordinates ``x`` and ``y`` are zero. If `origin` is
-        `None`, then model's origin will be set to the center of the image.
+        A reference point in the input image `data` array.
 
-    weights : numpy.ndarray, None, optional
-        An array of weights for the corresponding data. [Currently not used]
+        If `origin` represents the location of a feature (e.g., the position
+        of an intensity peak) in the input `data`, then model parameters
+        `x_0` and `y_0` show the location of this peak in an another target
+        image to which this model was fitted.
+
+        Alternatively, when `origin` is set to ``(0,0)``, then model parameters
+        `x_0` and `y_0` are shifts by which model's image should be translated
+        in order to match a target image.
+
+    normalization_const : float, None, optional
+        Normalization constant by which to normalize input image data. If it is
+        `None`, then the normalization constant will be computed such that
+        ``sum(normalization_const * data)`` is 1.
+
+        Assuming model's data represent a PSF to be fitted to some star,
+        `normalization_const` could be used to account for aperture correction.
+        In this case, best fitted value of the `flux` model parameter will
+        represent an aperture-corrected flux of the star.
 
     fillval : float, optional
         The value to be returned by the `evaluate` or
@@ -51,78 +66,74 @@ class Discrete2DModel(Fittable2DModel):
     kwargs : dict, optional
 
         Additional optional keyword arguments to be passed directly to the
-        `compute_interpolator` method. Possible values are:
-
-        - **degree** : int, tuple, optional
-            Degree of the interpolating spline. A tuple can be used to provide
-            different degrees for the X- and Y-axes. Default value is degree=3.
-
-        - **s** : float, optional
-            Non-negative smoothing factor. Default value s=0 corresponds to
-            interpolation.
-            See :py:class:`~scipy.interpolate.RectBivariateSpline` for more
-            details.
+        `compute_interpolator` method. See `compute_interpolator` for more
+        details.
 
     """
-    flux = Parameter(description='Total flux of the image.', default=None)
-    x_0 = Parameter(description='Shift along the X-axis relative to the '
-                    'origin.', default=0.0)
-    y_0 = Parameter(description='Shift along the Y-axis relative to the '
-                    'origin.', default=0.0)
+    flux = Parameter(description='Intensity scaling factor of normalized '
+                     'image data.', default=1.0)
+    x_0 = Parameter(description='X-position of a feature in the image in '
+                    'the output coordinate grid on which the model is '
+                    'evaluated.', default=0.0)
+    y_0 = Parameter(description='Y-position of a feature in the image in '
+                    'the output coordinate grid on which the model is '
+                    'evaluated.', default=0.0)
 
     def __init__(self, data, flux=flux.default,
                  x_0=x_0.default, y_0=y_0.default,
-                 origin=None, weights=None, fillval=0.0, kwargs={}):
-        """
-        """
+                 origin=None, normalization_const=None,
+                 fillval=0.0, kwargs={}):
         self._fillval = fillval
-        self._weights = weights
 
-        # compute flux and normalize data so that sum(data) = 1:
-        tflux = np.sum(data, dtype=np.float64)
-        if tflux == 0.0 or not np.isfinite(tflux):
-            tflux = 1.0
-        if flux is None:
-            flux = tflux
-        self._ndata = data / tflux
+        data = np.asarray(data)
+
+        if not np.all(np.isfinite(data)):
+            raise ValueError("All elements of input 'data' must be finite.")
+
+        if normalization_const is None:
+            # compute normalizization constant so that
+            # sum(normalized_data) = 1:
+            tflux = np.sum(data, dtype=np.float64)
+            if tflux == 0.0 or not np.isfinite(tflux):
+                warnings.warn("Overflow encountered while computing "
+                              "normalization constant. Normalization constant "
+                              "will be set to 1.", RuntimeWarning)
+                tflux = 1.0
+
+            normalization_const = 1.0 / tflux
+
+        else:
+            if normalization_const == 0.0:
+                raise ValueError("'normalizing_constant' must be non-zero.")
+
+        self._normalized_data = normalization_const * data
 
         # set input image related parameters:
         self._ny, self._nx = data.shape
+        self._shape = data.shape
 
-        # find origin of the coordinate system in image's pixel grid:
+        # set the origin of the coordinate system in image's pixel grid:
         self.origin = origin
 
-        super(Discrete2DModel, self).__init__(flux, x_0, y_0)
+        super(FittableImageModel2D, self).__init__(flux, x_0, y_0)
 
         # define interpolating spline:
         self.compute_interpolator(kwargs)
 
     @property
-    def ndata(self):
-        """Normalized model data such that sum of all pixels is 1."""
-        return self._ndata
+    def normalized_data(self):
+        """ Normalized image data defined as ``normalization_const * data``."""
+        return self._normalized_data
 
     @property
-    def data(self):
-        """Model data such that sum of all pixels is equal to flux."""
-        return (self.flux.value * self._ndata)
-
-    @property
-    def weights(self):
-        """
-        Weights of image data. When setting weights, :py:class:`numpy.ndarray`
-        or `None` may be used.
-        """
-        return self._weights
-
-    @weights.setter
-    def weights(self, weights):
-        self._weights = weights
+    def intensity_scaled_data(self):
+        """ Intensity-scaled by a factor of `flux` normalized image data."""
+        return (self.flux.value * self._normalized_data)
 
     @property
     def shape(self):
         """A tuple of dimensions of the data array in numpy style (ny, nx)."""
-        return self._ndata.shape
+        return self._shape
 
     @property
     def nx(self):
@@ -149,28 +160,28 @@ class Discrete2DModel(Fittable2DModel):
             Modifying `origin` will not adjust (modify) model's parameters
             `x_0` and `y_0`.
         """
-        return (self._ox, self._oy)
+        return (self._x_origin, self._y_origin)
 
     @origin.setter
     def origin(self, origin):
         if origin is None:
-            self._ox = (self._nx - 1) / 2.0
-            self._oy = (self._ny - 1) / 2.0
+            self._x_origin = (self._nx - 1) / 2.0
+            self._y_origin = (self._ny - 1) / 2.0
         elif hasattr(origin, '__iter__') and len(origin) == 2:
-            self._ox, self._oy = origin
+            self._x_origin, self._y_origin = origin
         else:
             raise TypeError("Parameter 'origin' must be either None or an "
                             "iterable with two elements.")
 
     @property
-    def ox(self):
+    def x_origin(self):
         """X-coordinate of the origin of the coordinate system."""
-        return self._ox
+        return self._x_origin
 
     @property
-    def oy(self):
+    def y_origin(self):
         """Y-coordinate of the origin of the coordinate system."""
-        return self._oy
+        return self._y_origin
 
     @property
     def fillval(self):
@@ -184,25 +195,13 @@ class Discrete2DModel(Fittable2DModel):
     def fillval(self, fillval):
         self._fillval = fillval
 
-    def recenter(self):
-        """
-        Shift the origin of the coordinate system by amounts indicated by
-        the model parameters `x_0` and `y_0` and set model parameters
-        `x_0` and `y_0` to 0.0.
-
-        """
-        self._ox -= self.x_0.value
-        self._oy -= self.y_0.value
-        self.x_0 = 0.0
-        self.y_0 = 0.0
-
     def compute_interpolator(self, kwargs={}):
         """
         Compute/define the interpolating spline. This function can be overriden
         in a subclass to define custom interpolators.
 
         .. note::
-            When subclassing :py:class:`Discrete2DModel` for the purpose of
+            When subclassing :py:class:`FittableImageModel2D` for the purpose of
             overriding :py:func:`compute_interpolator`, the :py:func:`evaluate`
             may need to overriden as well depending on the behavior of the
             new interpolator.
@@ -255,7 +254,7 @@ class Discrete2DModel(Fittable2DModel):
         x = np.arange(self._nx, dtype=np.float)
         y = np.arange(self._ny, dtype=np.float)
         self.interpolator = RectBivariateSpline(
-            x, y, self._ndata.T, kx=degx, ky=degx, s=smoothness
+            x, y, self._normalized_data.T, kx=degx, ky=degx, s=smoothness
         )
 
     def evaluate(self, x, y, flux, x_0, y_0):
@@ -264,19 +263,19 @@ class Discrete2DModel(Fittable2DModel):
         parameters.
 
         """
-        xi = np.asarray(x, dtype=np.float) + (self._ox - x_0)
-        yi = np.asarray(y, dtype=np.float) + (self._oy - y_0)
+        xi = np.asarray(x, dtype=np.float) + (self._x_origin - x_0)
+        yi = np.asarray(y, dtype=np.float) + (self._y_origin - y_0)
 
-        ipsf = flux * self.interpolator.ev(xi, yi)
+        evaluated_model = flux * self.interpolator.ev(xi, yi)
 
         if self._fillval is not None:
             # find indices of pixels that are outside the input pixel grid and
             # set these pixels to the 'fillval':
             invalid = (((xi < 0) | (xi > self._nx - 1)) |
                        ((yi < 0) | (yi > self._ny - 1)))
-            ipsf[invalid] = self._fillval
+            evaluated_model[invalid] = self._fillval
 
-        return ipsf
+        return evaluated_model
 
 
 class IntegratedGaussianPRF(Fittable2DModel):

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -120,7 +120,7 @@ class FittableImageModel(Fittable2DModel):
 
     """
     flux = Parameter(description='Intensity scaling factor for image data.',
-                     default=None)
+                     default=1.0)
     x_0 = Parameter(description='X-position of a feature in the image in '
                     'the output coordinate grid on which the model is '
                     'evaluated.', default=0.0)

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -56,7 +56,7 @@ class FittableImageModel(Fittable2DModel):
     the model is to be evaluated.
 
     If this class is initialized with `flux` (intensity scaling factor)
-    set to `None`, then `flux` is be estimated as ``|sum(data)|``.
+    set to `None`, then `flux` is be estimated as ``sum(data)``.
 
     Parameters
     ----------
@@ -444,10 +444,15 @@ class FittableImageModel(Fittable2DModel):
 
         else:
             # Flatten x and y arguments in order to evaluate in SCIPY versions
-            # earlier than 0.14.0
+            # earlier than 0.14.0. This essentially replicates the code
+            # in 'RectBivariateSpline.ev()' method in versions >= 0.14.0.
+            if xi.shape != yi.shape:
+                xi, yi = np.broadcast_arrays(xi, yi)
             xi_flat = xi.ravel()
             yi_flat = yi.ravel()
+
             evaluated_model = f * self.interpolator.ev(xi_flat, yi_flat)
+
             # reshape evaluated_model to the original shape of x & y arguments:
             evaluated_model = evaluated_model.reshape(xi.shape)
 

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -13,6 +13,7 @@ __all__ = ['Discrete2DModel', 'IntegratedGaussianPRF', 'PRFAdapter',
 __all__ = ['IntegratedGaussianPRF', 'PRFAdapter', 'prepare_psf_model',
            'get_grouped_psf_model']
 
+@pytest.mark.skipif('not HAS_SCIPY')
 class Discrete2DModel(Fittable2DModel):
     """
     A discrete fittable 2D model of an image.
@@ -36,7 +37,7 @@ class Discrete2DModel(Fittable2DModel):
 
     origin : tuple, None, optional
         Origin of the coordinate system in image pixels. Origin indicates where
-        in the image model coordinates `x` and `y` are zero. If `origin` is
+        in the image model coordinates ``x`` and ``y`` are zero. If `origin` is
         `None`, then model's origin will be set to the center of the image.
 
     weights : numpy.ndarray, None, optional
@@ -136,7 +137,7 @@ class Discrete2DModel(Fittable2DModel):
     @property
     def origin(self):
         """
-        A tuple of `x` and `y` coordinates of the origin of the coordinate
+        A tuple of ``x`` and ``y`` coordinates of the origin of the coordinate
         system in terms of pixels of model's image.
 
         When setting the coordinate system origin, a tuple of two `int` or

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -56,7 +56,7 @@ class FittableImageModel(Fittable2DModel):
     the model is to be evaluated.
 
     If this class is initialized with `flux` (intensity scaling factor)
-    set to `None`, then `flux` is be estimated as ``sum(data)``.
+    set to `None`, then `flux` is going to be estimated as ``sum(data)``.
 
     Parameters
     ----------

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -3,6 +3,7 @@ from __future__ import division
 
 import numpy as np
 from astropy.modeling.models import Gaussian2D
+from astropy.tests.helper import pytest
 
 from .. import FittableImageModel
 

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -4,7 +4,7 @@ from __future__ import division
 import numpy as np
 from astropy.modeling.models import Gaussian2D
 
-from .. import FittableImageModel2D
+from .. import FittableImageModel
 
 try:
     import scipy
@@ -17,14 +17,14 @@ def test_image_model():
     gm = Gaussian2D(x_stddev=3, y_stddev=3)
     xg, yg = np.mgrid[-2:3, -2:3]
 
-    imod_nonorm = FittableImageModel2D(gm(xg, yg), flux=1)
+    imod_nonorm = FittableImageModel(gm(xg, yg), flux=1)
     assert np.allclose(imod_nonorm(0, 0), gm(0, 0))
 
-    imod_norm = FittableImageModel2D(gm(xg, yg), normalize=True, flux=1)
+    imod_norm = FittableImageModel(gm(xg, yg), normalize=True, flux=1)
     assert not np.allclose(imod_norm(0, 0), gm(0, 0))
     assert np.allclose(np.sum(imod_norm(xg, yg)), 1)
 
-    imod_norm2 = FittableImageModel2D(gm(xg, yg), normalize=True, normalization_correction=2, flux=1)
+    imod_norm2 = FittableImageModel(gm(xg, yg), normalize=True, normalization_correction=2, flux=1)
     assert not np.allclose(imod_norm2(0, 0), gm(0, 0))
     assert np.allclose(imod_norm(0, 0), imod_norm2(0, 0)*2)
     assert np.allclose(np.sum(imod_norm2(xg, yg)), 0.5)

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -17,14 +17,15 @@ def test_image_model():
     gm = Gaussian2D(x_stddev=3, y_stddev=3)
     xg, yg = np.mgrid[-2:3, -2:3]
 
-    imod_nonorm = FittableImageModel(gm(xg, yg), flux=1)
+    imod_nonorm = FittableImageModel(gm(xg, yg))
     assert np.allclose(imod_nonorm(0, 0), gm(0, 0))
 
-    imod_norm = FittableImageModel(gm(xg, yg), normalize=True, flux=1)
+    imod_norm = FittableImageModel(gm(xg, yg), normalize=True)
     assert not np.allclose(imod_norm(0, 0), gm(0, 0))
     assert np.allclose(np.sum(imod_norm(xg, yg)), 1)
 
-    imod_norm2 = FittableImageModel(gm(xg, yg), normalize=True, normalization_correction=2, flux=1)
+    imod_norm2 = FittableImageModel(gm(xg, yg), normalize=True,
+                                    normalization_correction=2)
     assert not np.allclose(imod_norm2(0, 0), gm(0, 0))
     assert np.allclose(imod_norm(0, 0), imod_norm2(0, 0)*2)
     assert np.allclose(np.sum(imod_norm2(xg, yg)), 0.5)

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -7,6 +7,7 @@ from astropy.modeling.models import Gaussian2D
 from .. import FittableImageModel2D
 
 try:
+    import scipy
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
@@ -23,7 +24,7 @@ def test_image_model():
     assert not np.allclose(imod_norm(0, 0), gm(0, 0))
     assert np.allclose(np.sum(imod_norm(xg, yg)), 1)
 
-    imod_norm2 = FittableImageModel2D(gm(xg, yg), normalize=True, correction_factor=2, flux=1)
+    imod_norm2 = FittableImageModel2D(gm(xg, yg), normalize=True, normalization_correction=2, flux=1)
     assert not np.allclose(imod_norm2(0, 0), gm(0, 0))
     assert np.allclose(imod_norm(0, 0), imod_norm2(0, 0)*2)
     assert np.allclose(np.sum(imod_norm2(xg, yg)), 0.5)

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -1,0 +1,29 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import division
+
+import numpy as np
+from astropy.modeling.models import Gaussian2D
+
+from .. import FittableImageModel2D
+
+try:
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
+def test_image_model():
+    gm = Gaussian2D(x_stddev=3, y_stddev=3)
+    xg, yg = np.mgrid[-2:3, -2:3]
+
+    imod_nonorm = FittableImageModel2D(gm(xg, yg), flux=1)
+    assert np.allclose(imod_nonorm(0, 0), gm(0, 0))
+
+    imod_norm = FittableImageModel2D(gm(xg, yg), normalize=True, flux=1)
+    assert not np.allclose(imod_norm(0, 0), gm(0, 0))
+    assert np.allclose(np.sum(imod_norm(xg, yg)), 1)
+
+    imod_norm2 = FittableImageModel2D(gm(xg, yg), normalize=True, correction_factor=2, flux=1)
+    assert not np.allclose(imod_norm2(0, 0), gm(0, 0))
+    assert np.allclose(imod_norm(0, 0), imod_norm2(0, 0)*2)
+    assert np.allclose(np.sum(imod_norm2(xg, yg)), 0.5)

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -13,6 +13,7 @@ except ImportError:
     HAS_SCIPY = False
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_image_model():
     gm = Gaussian2D(x_stddev=3, y_stddev=3)
     xg, yg = np.mgrid[-2:3, -2:3]


### PR DESCRIPTION
This PR adds a fittable 2D model that takes a 2D array and can evaluate the model at arbitrary (within the domain of definition) points. That is, it behaves like a continuous fittable model.
