### PR TITLE
Change GroupPSF class to a generator function

### DIFF
--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -574,10 +574,12 @@ def get_grouped_psf_model(template_psf_model, star_group):
 
     Parameters
     ----------
+    template_psf_model : `astropy.modeling.Fittable2DModel` instance
+        The model to use for *individual* objects.  Must have parameters named
+        `x_0`, `y_0`, and `flux`.
     star_group : `~astropy.table.Table`
         Table of stars for which the compound PSF will be constructed.  It
         must have columns named `x_0`, `y_0`, and `flux_0`.
-    template_psf_model : `astropy.modeling.Fittable2DModel` instance
 
     Returns
     -------

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -576,16 +576,16 @@ def get_grouped_psf_model(template_psf_model, star_group):
     ----------
     template_psf_model : `astropy.modeling.Fittable2DModel` instance
         The model to use for *individual* objects.  Must have parameters named
-        `x_0`, `y_0`, and `flux`.
+        ``x_0``, ``y_0``, and ``flux``.
     star_group : `~astropy.table.Table`
         Table of stars for which the compound PSF will be constructed.  It
-        must have columns named `x_0`, `y_0`, and `flux_0`.
+        must have columns named ``x_0``, ``y_0``, and ``flux_0``.
 
     Returns
     -------
-    group_psf : CompoundModel
-        `CompoundModel` instance which is a sum of the given PSF
-        models.
+    group_psf
+        An `astropy.modeling` ``CompoundModel`` instance which is a sum of the
+        given PSF models.
     """
 
     group_psf = None

--- a/photutils/psf/tests/test_misc.py
+++ b/photutils/psf/tests/test_misc.py
@@ -143,6 +143,7 @@ def test_psf_adapter(moffimg, prepkwargs, tols):
         assert fit_psfmod.psfmodel.amplitude == guess_moffat.amplitude
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_get_grouped_psf_model():
     igp = IntegratedGaussianPRF(sigma=1.2)
     tab = Table(names=['x_0', 'y_0', 'flux_0'], data=[[1, 2], [3, 4], [0.5, 1]])

--- a/photutils/psf/tests/test_misc.py
+++ b/photutils/psf/tests/test_misc.py
@@ -8,7 +8,8 @@ from __future__ import division
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
-from .. import IntegratedGaussianPRF, prepare_psf_model
+from astropy.table import Table
+from .. import IntegratedGaussianPRF, prepare_psf_model, get_grouped_psf_model
 
 try:
     import scipy
@@ -140,3 +141,16 @@ def test_psf_adapter(moffimg, prepkwargs, tols):
     assert fit_psfmod.psfmodel.alpha == guess_moffat.alpha
     if prepkwargs['fluxname'] is None:
         assert fit_psfmod.psfmodel.amplitude == guess_moffat.amplitude
+
+
+def test_get_grouped_psf_model():
+    igp = IntegratedGaussianPRF(sigma=1.2)
+    tab = Table(names=['x_0', 'y_0', 'flux_0'], data=[[1, 2], [3, 4], [0.5, 1]])
+
+    gpsf = get_grouped_psf_model(igp, tab)
+
+    assert gpsf.x_0_0 == 1
+    assert gpsf.y_0_1 == 4
+    assert gpsf.flux_0 == 0.5
+    assert gpsf.flux_1 == 1
+    assert gpsf.sigma_0 == gpsf.sigma_1 == 1.2


### PR DESCRIPTION
This follows some of the discussion from #417 (that was about whether or not `GroupPSF` should be inside `DAOPhotPSFPhotometry`).  After looking at that I realized not only does it make sense for `GroupPSF` to not be only available from `DAOPhotPSFPhotometry`, but it probably also should be a generator function.

My reasoning is that the `GroupPSF` class is a bit surprising: it *sounds* like it's a model, but it's actually a class with a method that *generates* a model.  I think it's cleaner (and more likely to be re-usable by others) to just change this to a function which returns the new model.  That way there's not confusion between the class that *is* the model and the class that *makes* the model (because after this PR the latter is not a class at all).

This also closes #417 by moving the functionality to the `psf/models.py` module.

cc @larrybradley @mirca 