### PR TITLE
Make SigmaClip a general class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ New Features
 
   - Added new ``std_blocksum`` function. [#355]
 
+  - Added new ``SigmaClip`` class. [#423]
+
 - ``photutils.datasets``
 
   - Added ``load_irac_psf`` function. [#403]

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -101,7 +101,7 @@ class SigmaClip(object):
         Defaults to the standard deviation (`numpy.std`).
     """
 
-    def __init__(self, sigma=3, sigma_lower=None, sigma_upper=None, iters=5,
+    def __init__(self, sigma=3., sigma_lower=None, sigma_upper=None, iters=5,
                  cenfunc=np.ma.median, stdfunc=np.std):
         self.sigma = sigma
         self.sigma_lower = sigma_lower
@@ -147,7 +147,17 @@ class SigmaClip(object):
 class BackgroundBase(object):
     """
     Base class for classes that estimate scalar background values.
+
+    Parameters
+    ----------
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
     """
+
+    def __init__(self, sigma_clip=SigmaClip(sigma=3., iters=5)):
+        self.sigma_clip = sigma_clip
 
     def __call__(self, data, axis=None):
         return self.calc_background(data, axis=axis)
@@ -178,7 +188,17 @@ class BackgroundBase(object):
 class BackgroundRMSBase(object):
     """
     Base class for classes that estimate scalar background rms values.
+
+    Parameters
+    ----------
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
     """
+
+    def __init__(self, sigma_clip=SigmaClip(sigma=3., iters=5)):
+        self.sigma_clip = sigma_clip
 
     def __call__(self, data, axis=None):
         return self.calc_background_rms(data, axis=axis)
@@ -205,38 +225,27 @@ class BackgroundRMSBase(object):
         """
 
 
-class MeanBackground(BackgroundBase, SigmaClip):
+class MeanBackground(BackgroundBase):
     """
     Class to calculate the background in an array as the (sigma-clipped)
     mean.
 
     Parameters
     ----------
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import MeanBackground
+    >>> from photutils import SigmaClip, MeanBackground
     >>> data = np.arange(100)
-    >>> bkg = MeanBackground(sigma=3.)
+    >>> sigma_clip = SigmaClip(sigma=3.)
+    >>> bkg = MeanBackground(sigma_clip)
 
     The background value can be calculated by using the
-    ``.calc_background()`` method, e.g.:
+    `calc_background` method, e.g.:
 
     >>> bkg_value = bkg.calc_background(data)
     >>> print(bkg_value)    # doctest: +FLOAT_CMP
@@ -251,42 +260,33 @@ class MeanBackground(BackgroundBase, SigmaClip):
     """
 
     def calc_background(self, data, axis=None):
+        if self.sigma_clip is not None:
+            data = self.sigma_clip(data, axis=axis)
 
-        return np.ma.mean(self.sigma_clip(data, axis=axis), axis=axis)
+        return np.ma.mean(data, axis=axis)
 
 
-class MedianBackground(BackgroundBase, SigmaClip):
+class MedianBackground(BackgroundBase):
     """
     Class to calculate the background in an array as the (sigma-clipped)
     median.
 
     Parameters
     ----------
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import MedianBackground
+    >>> from photutils import SigmaClip, MedianBackground
     >>> data = np.arange(100)
-    >>> bkg = MedianBackground(sigma=3.)
+    >>> sigma_clip = SigmaClip(sigma=3.)
+    >>> bkg = MedianBackground(sigma_clip)
 
     The background value can be calculated by using the
-    ``.calc_background()`` method, e.g.:
+    `calc_background` method, e.g.:
 
     >>> bkg_value = bkg.calc_background(data)
     >>> print(bkg_value)    # doctest: +FLOAT_CMP
@@ -301,11 +301,13 @@ class MedianBackground(BackgroundBase, SigmaClip):
     """
 
     def calc_background(self, data, axis=None):
+        if self.sigma_clip is not None:
+            data = self.sigma_clip(data, axis=axis)
 
-        return _masked_median(self.sigma_clip(data, axis=axis), axis=axis)
+        return _masked_median(data, axis=axis)
 
 
-class ModeEstimatorBackground(BackgroundBase, SigmaClip):
+class ModeEstimatorBackground(BackgroundBase):
     """
     Class to calculate the background in an array using a mode estimator
     of the form ``(median_factor * median) - (mean_factor * mean)``.
@@ -316,32 +318,21 @@ class ModeEstimatorBackground(BackgroundBase, SigmaClip):
         The multiplicative factor for the data median.  Defaults to 3.
     mean_factor : float, optional
         The multiplicative factor for the data mean.  Defaults to 2.
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import ModeEstimatorBackground
+    >>> from photutils import SigmaClip, ModeEstimatorBackground
     >>> data = np.arange(100)
+    >>> sigma_clip = SigmaClip(sigma=3.)
     >>> bkg = ModeEstimatorBackground(median_factor=3., mean_factor=2.,
-    ...                               sigma=3.)
+    ...                               sigma_clip=sigma_clip)
 
     The background value can be calculated by using the
-    ``.calc_background()`` method, e.g.:
+    `calc_background` method, e.g.:
 
     >>> bkg_value = bkg.calc_background(data)
     >>> print(bkg_value)    # doctest: +FLOAT_CMP
@@ -356,19 +347,18 @@ class ModeEstimatorBackground(BackgroundBase, SigmaClip):
     """
 
     def __init__(self, median_factor=3., mean_factor=2., **kwargs):
-
         super(ModeEstimatorBackground, self).__init__(**kwargs)
         self.median_factor = median_factor
         self.mean_factor = mean_factor
 
     def calc_background(self, data, axis=None):
-
-        data = self.sigma_clip(data, axis=axis)
+        if self.sigma_clip is not None:
+            data = self.sigma_clip(data, axis=axis)
         return ((self.median_factor * _masked_median(data, axis=axis)) -
                 (self.mean_factor * np.ma.mean(data, axis=axis)))
 
 
-class MMMBackground(ModeEstimatorBackground, SigmaClip):
+class MMMBackground(ModeEstimatorBackground):
     """
     Class to calculate the background in an array using the DAOPHOT MMM
     algorithm.
@@ -378,31 +368,21 @@ class MMMBackground(ModeEstimatorBackground, SigmaClip):
 
     Parameters
     ----------
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import MMMBackground
+    >>> from photutils import SigmaClip, MMMBackground
     >>> data = np.arange(100)
-    >>> bkg = MMMBackground(sigma=3.)
+    >>> sigma_clip = SigmaClip(sigma=3.)
+    >>> bkg = MMMBackground(sigma_clip=sigma_clip)
 
     The background value can be calculated by using the
-    ``.calc_background()`` method, e.g.:
+    `~photutils.background.core.ModeEstimatorBackground.calc_background`
+    method, e.g.:
 
     >>> bkg_value = bkg.calc_background(data)
     >>> print(bkg_value)    # doctest: +FLOAT_CMP
@@ -417,13 +397,12 @@ class MMMBackground(ModeEstimatorBackground, SigmaClip):
     """
 
     def __init__(self, **kwargs):
-
         kwargs['median_factor'] = 3.
         kwargs['mean_factor'] = 2.
         super(MMMBackground, self).__init__(**kwargs)
 
 
-class SExtractorBackground(BackgroundBase, SigmaClip):
+class SExtractorBackground(BackgroundBase):
     """
     Class to calculate the background in an array using the
     SExtractor algorithm.
@@ -439,31 +418,20 @@ class SExtractorBackground(BackgroundBase, SigmaClip):
 
     Parameters
     ----------
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import SExtractorBackground
+    >>> from photutils import SigmaClip, SExtractorBackground
     >>> data = np.arange(100)
-    >>> bkg = SExtractorBackground(sigma=3.)
+    >>> sigma_clip = SigmaClip(sigma=3.)
+    >>> bkg = SExtractorBackground(sigma_clip)
 
     The background value can be calculated by using the
-    ``.calc_background()`` method, e.g.:
+    `calc_background` method, e.g.:
 
     >>> bkg_value = bkg.calc_background(data)
     >>> print(bkg_value)    # doctest: +FLOAT_CMP
@@ -478,8 +446,9 @@ class SExtractorBackground(BackgroundBase, SigmaClip):
     """
 
     def calc_background(self, data, axis=None):
+        if self.sigma_clip is not None:
+            data = self.sigma_clip(data, axis=axis)
 
-        data = self.sigma_clip(data, axis=axis)
         _median = _masked_median(data, axis=axis)
         _mean = np.ma.mean(data, axis=axis)
         _std = np.ma.std(data, axis=axis)
@@ -497,7 +466,7 @@ class SExtractorBackground(BackgroundBase, SigmaClip):
         return bkg
 
 
-class BiweightLocationBackground(BackgroundBase, SigmaClip):
+class BiweightLocationBackground(BackgroundBase):
     """
     Class to calculate the background in an array using the biweight
     location.
@@ -510,31 +479,20 @@ class BiweightLocationBackground(BackgroundBase, SigmaClip):
     M : float, optional
         Initial guess for the biweight location.  Default value is
         `None`.
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import BiweightLocationBackground
+    >>> from photutils import SigmaClip, BiweightLocationBackground
     >>> data = np.arange(100)
-    >>> bkg = BiweightLocationBackground(sigma=3.)
+    >>> sigma_clip = SigmaClip(sigma=3.)
+    >>> bkg = BiweightLocationBackground(sigma_clip=sigma_clip)
 
     The background value can be calculated by using the
-    ``.calc_background()`` method, e.g.:
+    `calc_background` method, e.g.:
 
     >>> bkg_value = bkg.calc_background(data)
     >>> print(bkg_value)    # doctest: +FLOAT_CMP
@@ -549,49 +507,38 @@ class BiweightLocationBackground(BackgroundBase, SigmaClip):
     """
 
     def __init__(self, c=6, M=None, **kwargs):
-
         super(BiweightLocationBackground, self).__init__(**kwargs)
         self.c = c
         self.M = M
 
     def calc_background(self, data, axis=None):
+        if self.sigma_clip is not None:
+            data = self.sigma_clip(data, axis=axis)
 
-        return biweight_location(self.sigma_clip(data, axis=axis), c=self.c,
-                                 M=self.M, axis=axis)
+        return biweight_location(data, c=self.c, M=self.M, axis=axis)
 
 
-class StdBackgroundRMS(BackgroundRMSBase, SigmaClip):
+class StdBackgroundRMS(BackgroundRMSBase):
     """
     Class to calculate the background rms in an array as the
     (sigma-clipped) standard deviation.
 
     Parameters
     ----------
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import StdBackgroundRMS
+    >>> from photutils import SigmaClip, StdBackgroundRMS
     >>> data = np.arange(100)
-    >>> bkgrms = StdBackgroundRMS(sigma=3.)
+    >>> sigma_clip = SigmaClip(sigma=3.)
+    >>> bkgrms = StdBackgroundRMS(sigma_clip)
 
-    The background rms value can be calculated by using the
-    ``.calc_background_rms()`` method, e.g.:
+    The background value can be calculated by using the
+    `calc_background_rms` method, e.g.:
 
     >>> bkgrms_value = bkgrms.calc_background_rms(data)
     >>> print(bkgrms_value)    # doctest: +FLOAT_CMP
@@ -606,11 +553,13 @@ class StdBackgroundRMS(BackgroundRMSBase, SigmaClip):
     """
 
     def calc_background_rms(self, data, axis=None):
+        if self.sigma_clip is not None:
+            data = self.sigma_clip(data, axis=axis)
 
-        return np.ma.std(self.sigma_clip(data, axis=axis), axis=axis)
+        return np.ma.std(data, axis=axis)
 
 
-class MADStdBackgroundRMS(BackgroundRMSBase, SigmaClip):
+class MADStdBackgroundRMS(BackgroundRMSBase):
     """
     Class to calculate the background rms in an array as using the
     `median absolute deviation (MAD)
@@ -628,31 +577,20 @@ class MADStdBackgroundRMS(BackgroundRMSBase, SigmaClip):
 
     Parameters
     ----------
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import MADStdBackgroundRMS
+    >>> from photutils import SigmaClip, MADStdBackgroundRMS
     >>> data = np.arange(100)
-    >>> bkgrms = MADStdBackgroundRMS(sigma=3.)
+    >>> sigma_clip = SigmaClip(sigma=3.)
+    >>> bkgrms = MADStdBackgroundRMS(sigma_clip)
 
-    The background rms value can be calculated by using the
-    ``.calc_background_rms()`` method, e.g.:
+    The background value can be calculated by using the
+    `calc_background_rms` method, e.g.:
 
     >>> bkgrms_value = bkgrms.calc_background_rms(data)
     >>> print(bkgrms_value)    # doctest: +FLOAT_CMP
@@ -667,11 +605,13 @@ class MADStdBackgroundRMS(BackgroundRMSBase, SigmaClip):
     """
 
     def calc_background_rms(self, data, axis=None):
+        if self.sigma_clip is not None:
+            data = self.sigma_clip(data, axis=axis)
 
-        return mad_std(self.sigma_clip(data, axis=axis), axis=axis)
+        return mad_std(data, axis=axis)
 
 
-class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase, SigmaClip):
+class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase):
     """
     Class to calculate the background rms in an array as the
     (sigma-clipped) biweight midvariance.
@@ -684,31 +624,20 @@ class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase, SigmaClip):
     M : float, optional
         Initial guess for the biweight location.  Default value is
         `None`.
-    sigma : float, optional
-        The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
-    sigma_lower : float or `None`, optional
-        The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    sigma_upper : float or `None`, optional
-        The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
-    iters : int or `None`, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing). Defaults to 5.
+    sigma_clip : `SigmaClip` object, optional
+        A `SigmaClip` object that defines the sigma clipping parameters.
+        If `None` then no sigma clipping will be performed.  The default
+        is to perform sigma clipping with ``sigma=3.`` and ``iters=5``.
 
     Examples
     --------
-    >>> from photutils import BiweightMidvarianceBackgroundRMS
+    >>> from photutils import SigmaClip, BiweightMidvarianceBackgroundRMS
     >>> data = np.arange(100)
-    >>> bkgrms = BiweightMidvarianceBackgroundRMS(sigma=3.)
+    >>> sigma_clip = SigmaClip(sigma=3.)
+    >>> bkgrms = BiweightMidvarianceBackgroundRMS(sigma_clip=sigma_clip)
 
-    The background rms value can be calculated by using the
-    ``.calc_background_rms()`` method, e.g.:
+    The background value can be calculated by using the
+    `calc_background_rms` method, e.g.:
 
     >>> bkgrms_value = bkgrms.calc_background_rms(data)
     >>> print(bkgrms_value)    # doctest: +FLOAT_CMP
@@ -723,12 +652,12 @@ class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase, SigmaClip):
     """
 
     def __init__(self, c=9.0, M=None, **kwargs):
-
         super(BiweightMidvarianceBackgroundRMS, self).__init__(**kwargs)
         self.c = c
         self.M = M
 
     def calc_background_rms(self, data, axis=None):
+        if self.sigma_clip is not None:
+            data = self.sigma_clip(data, axis=axis)
 
-        return biweight_midvariance(self.sigma_clip(data, axis=axis),
-                                    c=self.c, M=self.M, axis=axis)
+        return biweight_midvariance(data, c=self.c, M=self.M, axis=axis)

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -5,10 +5,11 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from ...datasets.make import make_noise_image
-from ..core import (MeanBackground, MedianBackground, ModeEstimatorBackground,
-                    MMMBackground, SExtractorBackground,
-                    BiweightLocationBackground, StdBackgroundRMS,
-                    MADStdBackgroundRMS, BiweightMidvarianceBackgroundRMS)
+from ..core import (SigmaClip, MeanBackground, MedianBackground,
+                    ModeEstimatorBackground, MMMBackground,
+                    SExtractorBackground, BiweightLocationBackground,
+                    StdBackgroundRMS, MADStdBackgroundRMS,
+                    BiweightMidvarianceBackgroundRMS)
 
 
 BKG = 0.0
@@ -22,10 +23,12 @@ BKG_CLASS = [MeanBackground, MedianBackground, ModeEstimatorBackground,
 RMS_CLASS = [StdBackgroundRMS, MADStdBackgroundRMS,
              BiweightMidvarianceBackgroundRMS]
 
+SIGMA_CLIP = SigmaClip(sigma=3.)
+
 
 @pytest.mark.parametrize('bkg_class', BKG_CLASS)
 def test_background(bkg_class):
-    bkg = bkg_class(sigma=3.0)
+    bkg = bkg_class(sigma_clip=SIGMA_CLIP)
     bkgval = bkg.calc_background(DATA)
     assert not np.ma.isMaskedArray(bkgval)
     assert_allclose(bkgval, BKG, atol=1.e-2)
@@ -34,7 +37,7 @@ def test_background(bkg_class):
 
 @pytest.mark.parametrize('bkg_class', BKG_CLASS)
 def test_background_axis(bkg_class):
-    bkg = bkg_class(sigma=3.0)
+    bkg = bkg_class(sigma_clip=SIGMA_CLIP)
 
     bkg_arr = bkg.calc_background(DATA, axis=0)
     bkgi = []
@@ -53,19 +56,19 @@ def test_background_axis(bkg_class):
 
 def test_sextrator_background_zero_std():
     data = np.ones((100, 100))
-    bkg = SExtractorBackground(sigclip=False)
+    bkg = SExtractorBackground(sigma_clip=None)
     assert_allclose(bkg.calc_background(data), 1.0)
 
 
 def test_sextrator_background_skew():
     data = np.arange(100)
     data[70:] = 1.e7
-    bkg = SExtractorBackground(sigclip=False)
+    bkg = SExtractorBackground(sigma_clip=None)
     assert_allclose(bkg.calc_background(data), np.median(data))
 
 
 @pytest.mark.parametrize('rms_class', RMS_CLASS)
 def test_background_rms(rms_class):
-    bkgrms = rms_class(sigma=3.0)
+    bkgrms = rms_class(sigma_clip=SIGMA_CLIP)
     assert_allclose(bkgrms.calc_background_rms(DATA), STD, atol=1.e-2)
     assert_allclose(bkgrms(DATA), bkgrms.calc_background_rms(DATA))

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -13,8 +13,7 @@ from ...datasets import make_noise_image
 from ..groupstars import DAOGroup
 from ..photometry import DAOPhotPSFPhotometry
 from ...detection import DAOStarFinder
-from ...background import MedianBackground
-from ...background import StdBackgroundRMS
+from ...background import SigmaClip, MedianBackground, StdBackgroundRMS
 
 try:
     import scipy
@@ -37,7 +36,8 @@ def make_fiducial_phot_obj(std=1, sigma_psf=1):
     daofind = DAOStarFinder(threshold=5.0*std,
                             fwhm=sigma_psf*gaussian_sigma_to_fwhm)
     daogroup = DAOGroup(1.5*sigma_psf*gaussian_sigma_to_fwhm)
-    median_bkg = MedianBackground(sigma=3.)
+    sigma_clip = SigmaClip(sigma=3.)
+    median_bkg = MedianBackground(sigma_clip)
     psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
     fitter = LevMarLSQFitter()
     return DAOPhotPSFPhotometry(finder=daofind, group_maker=daogroup,
@@ -98,7 +98,8 @@ def test_complete_photometry_oneiter(sigma_psf, sources):
              make_noise_image(img_shape, type='gaussian', mean=0.,
                               stddev=2., random_state=1))
 
-    bkgrms = StdBackgroundRMS(sigma=3.)
+    sigma_clip = SigmaClip(sigma=3.)
+    bkgrms = StdBackgroundRMS(sigma_clip)
     std = bkgrms(image)
 
     phot_obj = make_fiducial_phot_obj(std, sigma_psf)


### PR DESCRIPTION
With this PR `SigmaClip` is no longer a mixin class.  Instead one must input a `SigmaClip` object to the background classes.

The `SigmaClip` class can be used in any function that performs sigma clipping as part of its functionality.  Instead of passing all of the many `sigma_clip` keywords to such a function, one can simply create a `SigmaClip` object and pass that to any function/class as needed.