### PR TITLE
Allow failures for travis-ci test with numpy pre-release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,9 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=prerelease
 
+    allow_failures:
+      - env: NUMPY_VERSION=prerelease
+
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh


### PR DESCRIPTION
This PR changes the `travis-ci` test with the numpy pre-release version to be an allowed failure.
@bsipocz, you changed this in #396 from an allowed failure.  Was that intentional?

It appears that while this "test" has been passing, looking in the `travis-ci` logs, it appears that the tests haven't actually been running.  This test is now failing in the middle of the tests without any indication why it's failing:

https://travis-ci.org/astropy/photutils/jobs/159388076

Any objections to making this test an allowed failure again?