### PR TITLE
PSF Photometry module refactoring

### DIFF
--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -448,6 +448,7 @@ passed using the keyword ``positions``:
                interpolation='nearest', origin='lower')
     plt.title('Residual Image')
     plt.colorbar(orientation='horizontal', fraction=0.046, pad=0.04)
+    plt.show()
 
 For more examples, also check the online notebook in the next section.
 

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -28,6 +28,7 @@ model-fitting analysis, regardless to exactly what kind of model is actually
 being fit.  We take this road, using "PSF photometry" as shorthand for the
 general approach.
 
+
 PSF Photometry in Crowded Fields
 --------------------------------
 
@@ -92,6 +93,7 @@ by the finding routine.
 Basic Usage
 ^^^^^^^^^^^
 
+<<<<<<< 9738851a6026e0026d0452370aaf933ef1f749a7
 `~photutils.psf.DAOPhotPSFPhotometry` is the core class that implements the
 DAOPHOT algorithm for performing PSF photometry in crowded fields.
 
@@ -113,6 +115,41 @@ implemented in such a way that they can be used callable functions.
 >>>>>>> update current docs
 
 The basic usage of `~photutils.psf.IterativelySubtractedPSFPhotometry` is as follows:
+=======
+Photutils provides three classes to perform PSF Photometry, i.e.,
+`~photutils.psf.BasicPSFPhotometry`, `~photutils.psf.IterativelySubtractedPSFPhotometry`,
+and `~photutils.psf.DAOPhotPSFPhotometry`.
+
+`~photutils.psf.BasicPSFPhotometry` implements the minimum tools for
+performing PSF photometry in crowded fields. Basically, it performs
+"FIND, GROUP, NSTAR, SUBTRACT" once. Because of that, this class should be
+used when the degree of crowdness of the field is not very high, for instance,
+when most stars are separated by a distance no less than one FWHM and their
+brightness are relatively uniform.
+
+`~photutils.psf.IterativelySubtractedPSFPhotometry` is similar to
+`~photutils.psf.BasicPSFPhotometry`, however it adds a parameter called
+``n_iters`` which is the number of iterations for which the loop
+"FIND, GROUP, NSTAR, SUBTRACT, FIND..." will be performed. This class enable
+photometry in a scenario where there exist significant overlap amongst
+brighter and fainter companions. For instance, the detection algorithm may not
+be able to detect fainter companions because of the presence of brighter stars,
+however, they will be detected in the next iteration after the brighter stars
+are fitted and subtracted.
+
+`~photutils.psf.DAOPhotPSFPhotometry` is a special case of `~photutils.psf.IterativelySubtractedPSFPhotometry`,
+in which ``finder``, ``group_maker``, ``bkg_estimator`` attributes are already
+set to `~photutils.detection.DAOStarFinder`, `~photutils.psf.DAOGroup`, and
+`~photutils.background.MMMBackground`, respectively. Therefore, users need to
+input the parameters of those classes to set up a `~photutils.psf.DAOPhotPSFPhotometry`
+object.
+
+Those classes and all of the classes they *use* for the steps in the
+photometry process are implemented in such a way that they can be used
+callable functions.
+
+The basic usage of, e.g., `~photutils.psf.IterativelySubtractedPSFPhotometry` is as follows:
+>>>>>>> Add narrative docs
 
 .. doctest-skip::
 
@@ -244,7 +281,7 @@ Note that the parameters values for the finder class, i.e.,
 manner and optimum values do vary according to the data.
 
 As mentioned before, the way to actually do the photometry is by using
-``daophot_photometry`` as a function-like call.
+``photometry`` as a function-like call.
 
 It's worth noting that ``image`` does not need to be background subtracted.
 The subtraction is done during the photometry process with the attribute
@@ -350,17 +387,13 @@ Consider the previous example after the line
     >>> pos = Table(names=['x_0', 'y_0'], data=[sources['x_mean'],
     ...                                         sources['y_mean']])
 
-Note that we do not need to set the ``finder`` and ``niters`` attributes in
-`~photutils.psf.IterativelySubtractedPSFPhotometry` and the positions are
-passed using the keyword ``positions``:
-
 .. doctest-skip::
 
-    >>> photometry = IterativelySubtractedPSFPhotometry(group_maker=daogroup,
-    ...                                                 bkg_estimator=mmm_bkg,
-    ...                                                 psf_model=psf_model,
-    ...                                                 fitter=LevMarLSQFitter(),
-    ...                                                 fitshape=(11,11))
+    >>> photometry = BasicPSFPhotometry(group_maker=daogroup,
+    ...                                 bkg_estimator=mmm_bkg,
+    ...                                 psf_model=psf_model,
+    ...                                 fitter=LevMarLSQFitter(),
+    ...                                 fitshape=(11,11))
     >>> result_tab = photometry(image=image, positions=pos)
     >>> residual_image = photometry.get_residual_image()
 
@@ -407,10 +440,6 @@ passed using the keyword ``positions``:
 
     bkgrms = MADStdBackgroundRMS()
     std = bkgrms(image)
-    iraffind = IRAFStarFinder(threshold=3.5*std,
-                              fwhm=sigma_psf*gaussian_sigma_to_fwhm,
-                              minsep_fwhm=0.01, roundhi=5.0, roundlo=-5.0,
-                              sharplo=0.0, sharphi=2.0)
     daogroup = DAOGroup(2.0*sigma_psf*gaussian_sigma_to_fwhm)
     mmm_bkg = MMMBackground()
     psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
@@ -423,13 +452,13 @@ passed using the keyword ``positions``:
 
     fitter = LevMarLSQFitter()
 
-    from photutils.psf import IterativelySubtractedPSFPhotometry
+    from photutils.psf import BasicPSFPhotometry
 
-    photometry = IterativelySubtractedPSFPhotometry(group_maker=daogroup,
-                                                    bkg_estimator=mmm_bkg,
-                                                    psf_model=psf_model,
-                                                    fitter=LevMarLSQFitter(),
-                                                    fitshape=(11,11))
+    photometry = BasicPSFPhotometry(group_maker=daogroup,
+                                    bkg_estimator=mmm_bkg,
+                                    psf_model=psf_model,
+                                    fitter=LevMarLSQFitter(),
+                                    fitshape=(11,11))
 
     result_tab = photometry(image=image, positions=pos)
     residual_image = photometry.get_residual_image()

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -94,11 +94,13 @@ Basic Usage
 
 `~photutils.psf.DAOPhotPSFPhotometry` is the core class that implements the
 DAOPHOT algorithm for performing PSF photometry in crowded fields.
-It basically encapsulates the loop "FIND, GROUP, NSTAR, SUBTRACT, FIND..." in
-one place so that one can easily perform PSF photometry just by setting up a
-`~photutils.psf.DAOPhotPSFPhotometry` object.
+
+The `~photutils.psf.IterativelySubtractedPSFPhotometry` basically encapsulates 
+the loop "FIND, GROUP, NSTAR, SUBTRACT, FIND..." in one place so that one can
+easily perform PSF photometry just by setting up a `~photutils.psf.IterativelySubtractedPSFPhotometry` object.
 
 This class and all of the classes it *uses* for the steps in the process are
+<<<<<<< 602c332796436c318110c45e016999d5f8c85b0c
 implemented in such a way that they can be used as callable functions. The actual
 implementation of the  ``__call__`` method for
 `~photutils.psf.DAOPhotPSFPhotometry` is identical to the ``do_photometry``
@@ -106,26 +108,31 @@ method (which is why the documentation for ``__call__`` is in
 ``do_photometry``). This allows subclasses of
 `~photutils.psf.DAOPhotPSFPhotometry` to override ``do_photometry`` if they want
 to change some behavior, making such code more maintainable.
+=======
+implemented in such a way that they can be used callable functions. 
+>>>>>>> update current docs
 
-The basic usage of `~photutils.psf.DAOPhotPSFPhotometry` is as follows:
+The basic usage of `~photutils.psf.IterativelySubtractedPSFPhotometry` is as follows:
 
 .. doctest-skip::
 
-    >>> # create a DAOPhotPSFPhotometry object
-    >>> from photutils.psf import DAOPhotPSFPhotometry
-    >>> my_photometry = DAOPhotPSFPhotometry(finder=my_finder,
-    ...                                      group_maker=my_group_maker,
-    ...                                      bkg_estimator=my_bkg_estimator,
-    ...                                      psf_model=my_psf_model,
-    ...                                      fitter=my_fitter, niters=1,
-    ...                                      fitshape=(7,7))
+    >>> # create a IterativelySubtractedPSFPhotometry object
+    >>> from photutils.psf import IterativelySubtractedPSFPhotometry
+    >>> my_photometry = IterativelySubtractedPSFPhotometry(finder=my_finder,
+    ...                                                    group_maker=my_group_maker,
+    ...                                                    bkg_estimator=my_bkg_estimator,
+    ...                                                    psf_model=my_psf_model,
+    ...                                                    fitter=my_fitter, niters=3,
+    ...                                                    fitshape=(7,7))
     >>> # get photometry results
-    >>> photometry_results, residual_image = my_photometry(image=my_image)
+    >>> photometry_results = my_photometry(image=my_image)
+    >>> # get residual image
+    >>> residual_image = my_photometry.get_residual_image()
 
 Where ``my_finder``, ``my_group_maker``, and ``my_bkg_estimator`` may be any
 suitable class or callable function. This approach allows one to customize every
 part of the photometry process provided that their input/output are compatible
-with the input/ouput expected by `~photutils.psf.DAOPhotPSFPhotometry`.
+with the input/ouput expected by `~photutils.psf.IterativelySubtractedPSFPhotometry`.
 `photutils.psf` provides all the necessary classes to reproduce the DAOPHOT
 algorithm, but any individual part of that algorithm can be swapped for a
 user-defined function.  See the API documentation for precise details on what
@@ -200,7 +207,7 @@ First let's create an image with four overlapping stars::
     plt.title('Simulated data')
     plt.colorbar(orientation='horizontal', fraction=0.046, pad=0.04)
 
-Then let's import the required classes to set up a `~photutils.psf.DAOPhotPSFPhotometry` object::
+Then let's import the required classes to set up a `~photutils.psf.IterativelySubtractedPSFPhotometry` object::
 
     >>> from photutils.detection import IRAFStarFinder
     >>> from photutils.psf import IntegratedGaussianPRF, DAOGroup
@@ -222,14 +229,15 @@ Let's then instantiate and use the objects:
     >>> mmm_bkg = MMMBackground()
     >>> fitter = LevMarLSQFitter()
     >>> psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
-    >>> from photutils.psf import DAOPhotPSFPhotometry
-    >>> daophot_photometry = DAOPhotPSFPhotometry(finder=iraffind,
-    ...                                           group_maker=daogroup,
-    ...                                           bkg_estimator=mmm_bkg,
-    ...                                           psf_model=psf_model,
-    ...                                           fitter=LevMarLSQFitter(),
-    ...                                           niters=1, fitshape=(11,11))
-    >>> result_tab, residual_image = daophot_photometry(image=image)
+    >>> from photutils.psf import IterativelySubtractedPSFPhotometry
+    >>> photometry = IterativelySubtractedPSFPhotometry(finder=iraffind,
+    ...                                                 group_maker=daogroup,
+    ...                                                 bkg_estimator=mmm_bkg,
+    ...                                                 psf_model=psf_model,
+    ...                                                 fitter=LevMarLSQFitter(),
+    ...                                                 niters=1, fitshape=(11,11))
+    >>> result_tab = photometry(image=image)
+    >>> residual_image = photometry.get_residual_image()
 
 Note that the parameters values for the finder class, i.e.,
 `~photutils.detection.IRAFStarFinder`, are completly chosen in an arbitrary
@@ -240,7 +248,7 @@ As mentioned before, the way to actually do the photometry is by using
 
 It's worth noting that ``image`` does not need to be background subtracted.
 The subtraction is done during the photometry process with the attribute
-``bkg`` that was used to set up ``daophot_photometry``.
+``bkg`` that was used to set up ``photometry``.
 
 Now, let's compare the simulated and the residual images:
 
@@ -297,15 +305,16 @@ Now, let's compare the simulated and the residual images:
     psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
     fitter = LevMarLSQFitter()
 
-    from photutils.psf import DAOPhotPSFPhotometry
+    from photutils.psf import IterativelySubtractedPSFPhotometry
 
-    daophot_photometry = DAOPhotPSFPhotometry(finder=iraffind,
-                                              group_maker=daogroup,
-                                              bkg_estimator=mmm_bkg,
-                                              psf_model=psf_model,
-                                              fitter=LevMarLSQFitter(),
-                                              niters=1, fitshape=(11,11))
-    result_tab, residual_image = daophot_photometry(image=image)
+    photometry = IterativelySubtractedPSFPhotometry(finder=iraffind,
+                                                    group_maker=daogroup,
+                                                    bkg_estimator=mmm_bkg,
+                                                    psf_model=psf_model,
+                                                    fitter=LevMarLSQFitter(),
+                                                    niters=1, fitshape=(11,11))
+    result_tab = photometry(image=image)
+    residual_image = photometry.get_residual_image()
 
     from matplotlib import rcParams
     rcParams['font.size'] = 13
@@ -342,18 +351,18 @@ Consider the previous example after the line
     ...                                         sources['y_mean']])
 
 Note that we do not need to set the ``finder`` and ``niters`` attributes in
-`~photutils.psf.DAOPhotPSFPhotometry` and the positions are passed using the
-keyword ``positions``:
+`~photutils.psf.IterativelySubtractedPSFPhotometry` and the positions are
+passed using the keyword ``positions``:
 
 .. doctest-skip::
 
-    >>> daophot_photometry = DAOPhotPSFPhotometry(group_maker=daogroup,
-    ...                                           bkg_estimator=mmm_bkg,
-    ...                                           psf_model=psf_model,
-    ...                                           fitter=LevMarLSQFitter(),
-    ...                                           fitshape=(11,11))
-    >>> result_tab, residual_image = daophot_photometry(image=image,
-    ...                                                 positions=pos)
+    >>> photometry = IterativelySubtractedPSFPhotometry(group_maker=daogroup,
+    ...                                                 bkg_estimator=mmm_bkg,
+    ...                                                 psf_model=psf_model,
+    ...                                                 fitter=LevMarLSQFitter(),
+    ...                                                 fitshape=(11,11))
+    >>> result_tab = photometry(image=image, positions=pos)
+    >>> residual_image = photometry.get_residual_image()
 
 .. doctest-skip::
 
@@ -414,16 +423,16 @@ keyword ``positions``:
 
     fitter = LevMarLSQFitter()
 
-    from photutils.psf import DAOPhotPSFPhotometry
+    from photutils.psf import IterativelySubtractedPSFPhotometry
 
-    daophot_photometry = DAOPhotPSFPhotometry(group_maker=daogroup,
-                                              bkg_estimator=mmm_bkg,
-                                              psf_model=psf_model,
-                                              fitter=LevMarLSQFitter(),
-                                              fitshape=(11,11))
+    photometry = IterativelySubtractedPSFPhotometry(group_maker=daogroup,
+                                                    bkg_estimator=mmm_bkg,
+                                                    psf_model=psf_model,
+                                                    fitter=LevMarLSQFitter(),
+                                                    fitshape=(11,11))
 
-    result_tab, residual_image = daophot_photometry(image=image,
-                                                    positions=pos)
+    result_tab = photometry(image=image, positions=pos)
+    residual_image = photometry.get_residual_image()
 
     from matplotlib import rcParams
     import matplotlib.pyplot as plt

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -90,8 +90,8 @@ by the finding routine.
     keep track and easily differentiate where input/outputs came from.
 
 
-Basic Usage
-^^^^^^^^^^^
+High-Level Structure
+^^^^^^^^^^^^^^^^^^^^
 
 <<<<<<< 9191a3211154cbf2dfdd6a11fccb13beb3ec5763
 <<<<<<< 9738851a6026e0026d0452370aaf933ef1f749a7
@@ -171,20 +171,27 @@ do these stages (which is what the other classes require).
 Those classes and all of the classes they *use* for the steps in the
 photometry process can always be replaced by user-supplied functions if you wish
 to customize any stage of the photometry process.  This makes the machinery very
-flexible, while still providing a ``batteries included'' approach with a default
+flexible, while still providing a "batteries included" approach with a default
 implementation that's suitable for many use cases.
 
+<<<<<<< ac156ea6615b6f86dbf4339fc06eefdfd9c2e907
 <<<<<<< 9191a3211154cbf2dfdd6a11fccb13beb3ec5763
 The basic usage of, e.g., `~photutils.psf.IterativelySubtractedPSFPhotometry` is as follows:
 >>>>>>> Add narrative docs
 =======
+=======
+
+Basic Usage
+^^^^^^^^^^^
+
+>>>>>>> more doc updates
 The basic usage of, e.g., `~photutils.psf.IterativelySubtractedPSFPhotometry` is
 as follows:
 >>>>>>> update the explanation for the new scheme
 
 .. doctest-skip::
 
-    >>> # create a IterativelySubtractedPSFPhotometry object
+    >>> # create an IterativelySubtractedPSFPhotometry object
     >>> from photutils.psf import IterativelySubtractedPSFPhotometry
     >>> my_photometry = IterativelySubtractedPSFPhotometry(finder=my_finder,
     ...                                                    group_maker=my_group_maker,

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -93,34 +93,7 @@ by the finding routine.
 High-Level Structure
 ^^^^^^^^^^^^^^^^^^^^
 
-<<<<<<< 9191a3211154cbf2dfdd6a11fccb13beb3ec5763
-<<<<<<< 9738851a6026e0026d0452370aaf933ef1f749a7
-`~photutils.psf.DAOPhotPSFPhotometry` is the core class that implements the
-DAOPHOT algorithm for performing PSF photometry in crowded fields.
-
-The `~photutils.psf.IterativelySubtractedPSFPhotometry` basically encapsulates 
-the loop "FIND, GROUP, NSTAR, SUBTRACT, FIND..." in one place so that one can
-easily perform PSF photometry just by setting up a `~photutils.psf.IterativelySubtractedPSFPhotometry` object.
-
-This class and all of the classes it *uses* for the steps in the process are
-<<<<<<< 602c332796436c318110c45e016999d5f8c85b0c
-implemented in such a way that they can be used as callable functions. The actual
-implementation of the  ``__call__`` method for
-`~photutils.psf.DAOPhotPSFPhotometry` is identical to the ``do_photometry``
-method (which is why the documentation for ``__call__`` is in
-``do_photometry``). This allows subclasses of
-`~photutils.psf.DAOPhotPSFPhotometry` to override ``do_photometry`` if they want
-to change some behavior, making such code more maintainable.
-=======
-implemented in such a way that they can be used callable functions. 
->>>>>>> update current docs
-
-The basic usage of `~photutils.psf.IterativelySubtractedPSFPhotometry` is as follows:
-=======
-Photutils provides three classes to perform PSF Photometry, i.e.,
-=======
 Photutils provides three classes to perform PSF Photometry:
->>>>>>> update the explanation for the new scheme
 `~photutils.psf.BasicPSFPhotometry`, `~photutils.psf.IterativelySubtractedPSFPhotometry`,
 and `~photutils.psf.DAOPhotPSFPhotometry`.  Together these provide the core
 workflow to make photometric measurements given an appropriate PSF (or other)
@@ -174,20 +147,11 @@ to customize any stage of the photometry process.  This makes the machinery very
 flexible, while still providing a "batteries included" approach with a default
 implementation that's suitable for many use cases.
 
-<<<<<<< ac156ea6615b6f86dbf4339fc06eefdfd9c2e907
-<<<<<<< 9191a3211154cbf2dfdd6a11fccb13beb3ec5763
-The basic usage of, e.g., `~photutils.psf.IterativelySubtractedPSFPhotometry` is as follows:
->>>>>>> Add narrative docs
-=======
-=======
-
 Basic Usage
 ^^^^^^^^^^^
 
->>>>>>> more doc updates
 The basic usage of, e.g., `~photutils.psf.IterativelySubtractedPSFPhotometry` is
 as follows:
->>>>>>> update the explanation for the new scheme
 
 .. doctest-skip::
 

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -128,7 +128,7 @@ model.
 
 `~photutils.psf.BasicPSFPhotometry` implements the minimum tools for
 model-fitting photometry. At its core, this involves finding sources in an
-image, groupingoverlapping sources into a single model, fitting the model to the
+image, grouping overlapping sources into a single model, fitting the model to the
 sources, and subtracting the models from the image.  In DAOPHOT parlance, this
 is essentially running the "FIND, GROUP, NSTAR, SUBTRACT" once. Because it is
 only a single cycle of that sequence, this class should be used when the degree
@@ -153,7 +153,7 @@ may not be able to detect a faint and bright star very close together in the
 first iteration, but they will be detected in the next iteration after the
 brighter stars have been fit and subtracted.  Like
 `~photutils.psf.BasicPSFPhotometry`, it does not include implementations of the
-stages of this process, but it provides t
+stages of this process, but it provides the structure in which those stages run.
 
 `~photutils.psf.DAOPhotPSFPhotometry` is a special case of
 `~photutils.psf.IterativelySubtractedPSFPhotometry`. Unlike

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -29,8 +29,8 @@ being fit.  We take this road, using "PSF photometry" as shorthand for the
 general approach.
 
 
-PSF Photometry in Crowded Fields
---------------------------------
+PSF Photometry
+--------------
 
 Photutils provides a modular set of tools to perform PSF photometry for
 different science cases. These are implemented as separate classes to do
@@ -93,6 +93,7 @@ by the finding routine.
 Basic Usage
 ^^^^^^^^^^^
 
+<<<<<<< 9191a3211154cbf2dfdd6a11fccb13beb3ec5763
 <<<<<<< 9738851a6026e0026d0452370aaf933ef1f749a7
 `~photutils.psf.DAOPhotPSFPhotometry` is the core class that implements the
 DAOPHOT algorithm for performing PSF photometry in crowded fields.
@@ -117,39 +118,69 @@ implemented in such a way that they can be used callable functions.
 The basic usage of `~photutils.psf.IterativelySubtractedPSFPhotometry` is as follows:
 =======
 Photutils provides three classes to perform PSF Photometry, i.e.,
+=======
+Photutils provides three classes to perform PSF Photometry:
+>>>>>>> update the explanation for the new scheme
 `~photutils.psf.BasicPSFPhotometry`, `~photutils.psf.IterativelySubtractedPSFPhotometry`,
-and `~photutils.psf.DAOPhotPSFPhotometry`.
+and `~photutils.psf.DAOPhotPSFPhotometry`.  Together these provide the core
+workflow to make photometric measurements given an appropriate PSF (or other)
+model.
 
 `~photutils.psf.BasicPSFPhotometry` implements the minimum tools for
-performing PSF photometry in crowded fields. Basically, it performs
-"FIND, GROUP, NSTAR, SUBTRACT" once. Because of that, this class should be
-used when the degree of crowdness of the field is not very high, for instance,
-when most stars are separated by a distance no less than one FWHM and their
-brightness are relatively uniform.
+model-fitting photometry. At its core, this involves finding sources in an
+image, groupingoverlapping sources into a single model, fitting the model to the
+sources, and subtracting the models from the image.  In DAOPHOT parlance, this
+is essentially running the "FIND, GROUP, NSTAR, SUBTRACT" once. Because it is
+only a single cycle of that sequence, this class should be used when the degree
+of crowdness of the field is not very high, for instance, when most stars are
+separated by a distance no less than one FWHM and their brightness are
+relatively uniform.  It is critical to understand, though, that
+`~photutils.psf.BasicPSFPhotometry` does not actually contain the functionality
+to *do* all these steps - that is provided by other objects (or can be
+user-written) functions.  Rather it provides the framework and data structures
+in which these operations run.  Because of this,
+`~photutils.psf.BasicPSFPhotometry` is particularly useful for build more
+complex workflows, as all of the stages can be turned on or off or
+replaced with different implementations as the user desires.
 
 `~photutils.psf.IterativelySubtractedPSFPhotometry` is similar to
-`~photutils.psf.BasicPSFPhotometry`, however it adds a parameter called
+`~photutils.psf.BasicPSFPhotometry`, but it adds a parameter called
 ``n_iters`` which is the number of iterations for which the loop
-"FIND, GROUP, NSTAR, SUBTRACT, FIND..." will be performed. This class enable
-photometry in a scenario where there exist significant overlap amongst
-brighter and fainter companions. For instance, the detection algorithm may not
-be able to detect fainter companions because of the presence of brighter stars,
-however, they will be detected in the next iteration after the brighter stars
-are fitted and subtracted.
+"FIND, GROUP, NSTAR, SUBTRACT, FIND..." will be performed. This class enables
+photometry in a scenario where there exists significant overlap between stars
+that are of quite different brightness. For instance, the detection algorithm
+may not be able to detect a faint and bright star very close together in the
+first iteration, but they will be detected in the next iteration after the
+brighter stars have been fit and subtracted.  Like
+`~photutils.psf.BasicPSFPhotometry`, it does not include implementations of the
+stages of this process, but it provides t
 
-`~photutils.psf.DAOPhotPSFPhotometry` is a special case of `~photutils.psf.IterativelySubtractedPSFPhotometry`,
-in which ``finder``, ``group_maker``, ``bkg_estimator`` attributes are already
-set to `~photutils.detection.DAOStarFinder`, `~photutils.psf.DAOGroup`, and
+`~photutils.psf.DAOPhotPSFPhotometry` is a special case of
+`~photutils.psf.IterativelySubtractedPSFPhotometry`. Unlike
+`~photutils.psf.IterativelySubtractedPSFPhotometry` and
+`~photutils.psf.BasicPSFPhotometry`, the class includes specific implementations
+of the stages of the photometric measurements, tuned to reproduce the algorithms
+used for the DAOPHOT code. Specifically, the ``finder``,
+``group_maker``, ``bkg_estimator`` attributes are set to the
+`~photutils.detection.DAOStarFinder`, `~photutils.psf.DAOGroup`, and
 `~photutils.background.MMMBackground`, respectively. Therefore, users need to
-input the parameters of those classes to set up a `~photutils.psf.DAOPhotPSFPhotometry`
-object.
+input the parameters of those classes to set up a
+`~photutils.psf.DAOPhotPSFPhotometry` object, rather than providing objects to
+do these stages (which is what the other classes require).
 
 Those classes and all of the classes they *use* for the steps in the
-photometry process are implemented in such a way that they can be used
-callable functions.
+photometry process can always be replaced by user-supplied functions if you wish
+to customize any stage of the photometry process.  This makes the machinery very
+flexible, while still providing a ``batteries included'' approach with a default
+implementation that's suitable for many use cases.
 
+<<<<<<< 9191a3211154cbf2dfdd6a11fccb13beb3ec5763
 The basic usage of, e.g., `~photutils.psf.IterativelySubtractedPSFPhotometry` is as follows:
 >>>>>>> Add narrative docs
+=======
+The basic usage of, e.g., `~photutils.psf.IterativelySubtractedPSFPhotometry` is
+as follows:
+>>>>>>> update the explanation for the new scheme
 
 .. doctest-skip::
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -604,10 +604,13 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
     groups, and then repeat until no more stars are detected or a given
     number of iterations is reached.
 
-    In order to make groups of sources, this class uses
-    `~photutils.psf.DAOGroup`. To find sources, this class uses
-    `~photutils.detection.DAOStarFinder`. To do background estimation,
-    it uses `~photutils.background.MMMBackground`.
+    Basically, this classes uses `~IterativelySubstractedPSFPhotometry`, but
+    with grouping, finding, and background estimation routines defined a
+    priori. More precisely, this class uses `~photutils.psf.DAOGroup` for
+    grouping, `~photutils.detection.DAOStarFinder` for finding sources, and
+    `~photutils.background.MMMBackground` for background estimation. Those
+    classes are based on GROUP, FIND, and SKY routines used in DAOPHOT,
+    respectively.
 
     The parameter ``crit_separation`` is associated with `~photutils.psf.DAOGroup`.
     ``sigma_clip`` is associated with `~photutils.background.MMMBackground`.

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -416,16 +416,16 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         Fitter object used to compute the optimized centroid positions
         and/or flux of the identified sources. See
         `~astropy.modeling.fitting` for more details on fitters.
+    aperture_radius : float
+        The radius (in units of pixels) used to compute initial
+        estimates for the fluxes of sources. If ``None``, one FWHM will
+        be used if it can be determined from the ```psf_model``.
     niters : int or None
         Number of iterations to perform of the loop FIND, GROUP,
         SUBTRACT, NSTAR. If None, iterations will proceed until no more
         stars remain.  Note that in this case it is *possible* that the
         loop will never end if the PSF has structure that causes
         subtraction to create new sources infinitely.
-    aperture_radius : float
-        The radius (in units of pixels) used to compute initial
-        estimates for the fluxes of sources. If ``None``, one FWHM will
-        be used if it can be determined from the ```psf_model``.
 
     Notes
     -----

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -472,6 +472,18 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
                 raise ValueError('niters must be None or an integer or '
                                  'convertable into an integer.')
 
+    @property
+    def finder(self):
+        return self._finder
+
+    @finder.setter
+    def finder(self, value):
+        if value is None:
+            raise ValueError("finder cannot be None. Please see the Detection, "
+                             "section on photutils docs.")
+        else:
+            self._finder = value
+
     def do_photometry(self, image, positions=None):
         """
         Perform PSF photometry in ``image``.

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -193,6 +193,19 @@ class BasicPSFPhotometry(object):
             if self.finder is None:
                 raise ValueError('Finder cannot be None if positions are '
                                  'not given.')
+            sources = self.finder(image)
+            if len(sources) > 0:
+                apertures = CircularAperture((sources['xcentroid'],
+                                              sources['ycentroid']),
+                                             r=self.aperture_radius)
+                
+                sources['aperture_flux'] = aperture_photometry(image,
+                        apertures)['aperture_sum']
+                
+                positions = Table(names=['x_0', 'y_0', 'flux_0'],
+                                  data=[sources['xcentroid'],
+                                  sources['ycentroid'],
+                                  sources['aperture_flux']])
 
         return self.do_photometry(image, positions)
 
@@ -232,23 +245,6 @@ class BasicPSFPhotometry(object):
             None is returned if no sources are found in ``image``.
         """
 
-        if positions is None:
-            sources = self.finder(image)
-            if len(sources) > 0:
-                apertures = CircularAperture((sources['xcentroid'],
-                                              sources['ycentroid']),
-                                             r=self.aperture_radius)
-                
-                sources['aperture_flux'] = aperture_photometry(image,
-                        apertures)['aperture_sum']
-                
-                positions = Table(names=['x_0', 'y_0', 'flux_0'],
-                                  data=[sources['xcentroid'],
-                                  sources['ycentroid'],
-                                  sources['aperture_flux']])
-            else:
-                return None
-        
         star_groups = self.group_maker(positions)
         output_tab, self._residual_image = self.nstar(image, star_groups)
         output_tab = hstack([positions, output_tab])

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -411,9 +411,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         ``id`` is an integer-valued column starting from ``1``,
         ``xcentroid`` and ``ycentroid`` are center position estimates of
         the sources and ``flux`` contains flux estimates of the sources.
-        See, e.g., `~photutils.detection.DAOStarFinder`.  If ``finder``
-        is ``None``, initial guesses for positions of objects must be
-        provided.
+        See, e.g., `~photutils.detection.DAOStarFinder` or `~photutils.detection.IRAFStarFinder`.
     fitter : `~astropy.modeling.fitting.Fitter` instance
         Fitter object used to compute the optimized centroid positions
         and/or flux of the identified sources. See

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -447,9 +447,6 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
     def __init__(self, group_maker, bkg_estimator, psf_model, fitshape,
                  finder, fitter=LevMarLSQFitter(), niters=3,
                  aperture_radius=None):
-        if finder is None:
-            raise ValueError("finder cannot be None. Please see the Detection, "
-                             "section on photutils docs.")
 
         super(IterativelySubtractedPSFPhotometry, self).__init__(group_maker,
                 bkg_estimator, psf_model, fitshape, finder, fitter, aperture_radius)
@@ -481,8 +478,10 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
     @finder.setter
     def finder(self, value):
         if value is None:
-            raise ValueError("finder cannot be None. Please see the Detection, "
-                             "section on photutils docs.")
+            raise ValueError("finder cannot be None for "
+                             "IterativelySubtractedPSFPhotometry - you may "
+                             "want to use BasicPSFPhotometry. Please see the "
+                             "Detection section on photutils documentation.")
         else:
             self._finder = value
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -504,12 +504,13 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
 
         Returns
         -------
-        output_tab : `~astropy.table.Table` or None
+        output_table : `~astropy.table.Table` or None
             Table with the photometry results, i.e., centroids and
             fluxes estimations and the initial estimates used to start
             the fitting process.
             None is returned if no sources are found in ``image``.
         """
+
         self._residual_image = image
         
         if positions is not None:
@@ -526,6 +527,24 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         return output_table
 
     def _do_photometry(self, n_start=1):
+        """
+        Helper function which performs the iterations of the photometry process.
+
+        Parameters
+        ----------
+        n_start : int
+            Integer representing the start index of the iteration.
+            It is 1 if positions are None, and 2 otherwise.
+
+        Returns
+        -------
+        output_table : `~astropy.table.Table` or None
+            Table with the photometry results, i.e., centroids and
+            fluxes estimations and the initial estimates used to start
+            the fitting process.
+            None is returned if no sources are found in ``image``.
+        """
+
         output_table = Table([[], [], [], [], [], [], [], [], []],
                 names=('x_0', 'y_0', 'flux_0', 'id', 'group_id',
                        'iter_detected', 'x_fit', 'y_fit',

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -93,6 +93,12 @@ class BasicPSFPhotometry(object):
 
     Notes
     -----
+    Note that an ambiguity arises whenever ``finder`` and ``positions``
+    (keyword argument for ``do_photometry`)` are both not ``None``. In this
+    case, ``finder`` is ignored and initial guesses are taken from
+    ``positions``. In addition, an warning is raised to remaind the user about
+    this behavior.
+
     If there are problems with fitting large groups, change the
     parameters of the grouping algorithm to reduce the number of sources
     in each group or input a ``star_groups`` table that only includes

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -688,16 +688,28 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
                  fitshape, sigma=3., ratio=1.0, theta=0.0, sigma_radius=1.5, sharplo=0.2,
                  sharphi=1.0, roundlo=-1.0, roundhi=1.0, fitter=LevMarLSQFitter(), 
                  niters=3, aperture_radius=None):
-        
-        self.group_maker = DAOGroup(crit_separation=crit_separation)
-        self.bkg_estimator = MMMBackground(sigma_clip=SigmaClip(sigma=sigma))
-        self.finder = DAOStarFinder(threshold=threshold, fwhm=fwhm, ratio=ratio,
-                                    theta=theta, sigma_radius=sigma_radius,
-                                    sharplo=sharplo, sharphi=sharphi,
-                                    roundlo=roundlo, roundhi=roundhi)
+       
+        self.crit_separation = crit_separation
+        self.threshold = threshold
+        self.fwhm = fwhm
+        self.sigma = sigma
+        self.ratio = ratio
+        self.theta = theta
+        self.sigma_radius = sigma_radius
+        self.sharplo = sharplo
+        self.sharphi = sharphi
+        self.roundlo = roundlo
+        self.roundhi = roundhi
 
-        super(DAOPhotPSFPhotometry, self).__init__(group_maker=self.group_maker,
-                                                   bkg_estimator=self.bkg_estimator,
+        group_maker = DAOGroup(crit_separation=self.crit_separation)
+        bkg_estimator = MMMBackground(sigma_clip=SigmaClip(sigma=self.sigma))
+        finder = DAOStarFinder(threshold=self.threshold, fwhm=self.fwhm, ratio=self.ratio,
+                               theta=self.theta, sigma_radius=self.sigma_radius,
+                               sharplo=self.sharplo, sharphi=self.sharphi,
+                               roundlo=self.roundlo, roundhi=self.roundhi)
+
+        super(DAOPhotPSFPhotometry, self).__init__(group_maker=group_maker,
+                                                   bkg_estimator=bkg_estimator,
                                                    psf_model=psf_model, fitshape=fitshape,
-                                                   finder=self.finder, fitter=fitter, niters=niters,
+                                                   finder=finder, fitter=fitter, niters=niters,
                                                    aperture_radius=aperture_radius)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -7,7 +7,6 @@ import warnings
 
 from astropy.table import Table, vstack, hstack
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.nddata.utils import overlap_slices
 from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.utils.exceptions import AstropyUserWarning
 from .funcs import subtract_psf
@@ -18,6 +17,13 @@ from ..background import MMMBackground, SigmaClip
 from ..detection import DAOStarFinder
 from . import DAOGroup
 
+from astropy.utils import minversion
+ASTROPY_LT_1_1 = not minversion('astropy', '1.1')
+
+if ASTROPY_LT_1_1:
+    from ..extern.nddata_compat import _overlap_slices_astropy1p1 as overlap_slices
+else:
+    from astropy.nddata.utils import overlap_slices
 
 __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
            'DAOPhotPSFPhotometry']

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -604,8 +604,8 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
     groups, and then repeat until no more stars are detected or a given
     number of iterations is reached.
 
-    Basically, this classes uses `~IterativelySubstractedPSFPhotometry`, but
-    with grouping, finding, and background estimation routines defined a
+    Basically, this classes uses `~photutils.psf.IterativelySubstractedPSFPhotometry`,
+    but with grouping, finding, and background estimation routines defined a
     priori. More precisely, this class uses `~photutils.psf.DAOGroup` for
     grouping, `~photutils.detection.DAOStarFinder` for finding sources, and
     `~photutils.background.MMMBackground` for background estimation. Those

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -26,9 +26,9 @@ class BasicPSFPhotometry(object):
     the DAOPHOT routines FIND, GROUP, NSTAR, and SUBTRACT once.
     This implementation allows a flexible and customizable interface to
     perform photometry. For instance, one is able to use different
-    implementations for grouping and finding sources by passing them using
-    ``group_maker`` and ``finder`` respectivelly. In addition, sky background
-    estimation is performed by ``bkg_estimator``.
+    implementations for grouping and finding sources by using ``group_maker``
+    and ``finder`` respectivelly. In addition, sky background estimation is
+    performed by ``bkg_estimator``.
 
     Parameters
     ----------
@@ -363,11 +363,11 @@ class BasicPSFPhotometry(object):
 
 class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
     """
-    This class implements the an iterative algorithm to perform point
-    spread function photometry in crowded fields. This consists of
-    applying a loop of find sources, make groups, fit groups, subtract
-    groups, and then repeat until no more stars are detected or a given
-    number of iterations is reached.
+    This class implements an iterative algorithm to perform point spread
+    function photometry in crowded fields. This consists of applying a
+    loop of find sources, make groups, fit groups, subtract groups, and then
+    repeat until no more stars are detected or a given number of iterations is
+    reached.
 
     Parameters
     ----------
@@ -586,14 +586,14 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
     
     In order to make groups of sources, this class uses
     `~photutils.psf.DAOGroup`. To find sources, this class uses
-    `~photutitls.detection.DAOStarFinder`. To do background estimation,
+    `~photutils.detection.DAOStarFinder`. To do background estimation,
     it uses `~photutils.background.MMMBackground`.
     
     The parameter ``crit_separation`` is associated with `~photutils.psf.DAOGroup`.
     ``sigma_clip`` is associated with `~photutils.background.MMMBackground`.
-    ``threshold`` and ``fwhm`` are associated with `~photutitls.detection.DAOStarFinder`.
+    ``threshold`` and ``fwhm`` are associated with `~photutils.detection.DAOStarFinder`.
     Parameters from ``ratio`` to ``roundhi`` are also associated with
-    `~photutitls.detection.DAOStarFinder`.
+    `~photutils.detection.DAOStarFinder`.
 
     Parameters
     ----------
@@ -624,7 +624,7 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
         number.
     sigma : float, optional
         Number of standard deviations used to perform sigma clip with a
-        `SigmaClip` object.
+        `~photutils.SigmaClip` object.
     ratio : float, optional
         The ratio of the minor to major axis standard deviations of the
         Gaussian kernel.  ``ratio`` must be strictly positive and less

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -326,8 +326,8 @@ class BasicPSFPhotometry(object):
             try:
                 from astropy.nddata.utils import NoOverlapError
             except ImportError:
-                raise ImportError("astropy 1.2.1 is required in order to use"
-                                  "this class.")
+                raise ImportError("astropy 1.1 or greater is required in "
+                                  "order to use this class.")
             # do not subtract if the fitting did not go well
             try:
                 image = subtract_psf(image, self.psf_model, param_table,

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -22,8 +22,10 @@ __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
 
 class BasicPSFPhotometry(object):
     """
-    This class implements a PSF photometry algorithm that basically performs
-    the DAOPHOT routines FIND, GROUP, NSTAR, and SUBTRACT once.
+    This class implements a PSF photometry algorithm that can find sources in an
+    image, group overlapping sources into a single model, fit the model to the
+    sources, and subtracting the models from the image. This is roughly
+    equivalent to the DAOPHOT routines FIND, GROUP, NSTAR, and SUBTRACT.
     This implementation allows a flexible and customizable interface to
     perform photometry. For instance, one is able to use different
     implementations for grouping and finding sources by using ``group_maker``

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -3,10 +3,13 @@
 
 from __future__ import division
 import numpy as np
+import warnings
+
 from astropy.table import Table, vstack, hstack
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import overlap_slices
 from astropy.stats import gaussian_sigma_to_fwhm
+from astropy.utils.exceptions import AstropyUserWarning
 from .funcs import subtract_psf
 from .models import get_grouped_psf_model
 from ..aperture import CircularAperture, aperture_photometry
@@ -222,6 +225,11 @@ class BasicPSFPhotometry(object):
                                         gaussian_sigma_to_fwhm)
 
         if positions is not None:
+            if self.finder is not None:
+                warnings.warn('Both positions and finder are different than '
+                              'None, which is ambiguous. finder is going to '
+                              'be ignored.', AstropyUserWarning)
+
             if 'flux_0' not in positions.colnames:
                 apertures = CircularAperture((positions['x_0'],
                                               positions['y_0']),

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -11,17 +11,24 @@ from .funcs import subtract_psf
 from .models import get_grouped_psf_model
 from ..aperture import CircularAperture, aperture_photometry
 
+from ..background import MMMBackground, SigmaClip
+from ..detection import DAOStarFinder
+from . import DAOGroup
 
-__all__ = ['DAOPhotPSFPhotometry']
+
+__all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
+           'DAOPhotPSFPhotometry']
 
 
-class DAOPhotPSFPhotometry(object):
+class BasicPSFPhotometry(object):
     """
-    This class implements the DAOPHOT algorithm proposed by Stetson
-    (1987) to perform point spread function photometry in crowded
-    fields. This consists of applying the loop FIND, GROUP, NSTAR,
-    SUBTRACT, FIND until no more stars are detected or a given number of
-    iterations is reached.
+    This class implements a PSF photometry algorithm that basically performs
+    the DAOPHOT routines FIND, GROUP, NSTAR, and SUBTRACT once.
+    This implementation allows a flexible and customizable interface to
+    perform photometry. For instance, one is able to use different
+    implementations for grouping and finding sources by passing them using
+    ``group_maker`` and ``finder`` respectivelly. In addition, sky background
+    estimation is performed by ``bkg_estimator``.
 
     Parameters
     ----------
@@ -39,8 +46,8 @@ class DAOPhotPSFPhotometry(object):
     bkg_estimator : callable, instance of any `~photutils.BackgroundBase` subclass, or None
         ``bkg_estimator`` should be able to compute either a scalar
         background or a 2D background of a given 2D image. See, e.g.,
-        `~photutils.background.MedianBackground`.  Can be None to do no
-        background subtraction.
+        `~photutils.background.MedianBackground`.  If None, no
+        background subtraction is performed.
     psf_model : `astropy.modeling.Fittable2DModel` instance
         PSF or PRF model to fit the data. Could be one of the models in
         this package like `~photutils.psf.sandbox.DiscretePRF`,
@@ -74,12 +81,6 @@ class DAOPhotPSFPhotometry(object):
         Fitter object used to compute the optimized centroid positions
         and/or flux of the identified sources. See
         `~astropy.modeling.fitting` for more details on fitters.
-    niters : int or None
-        Number of iterations to perform of the loop FIND, GROUP,
-        SUBTRACT, NSTAR. If None, iterations will proceed until no more
-        stars remain.  Note that in this case it is *possible* that the
-        loop will never end if the PSF has structure that causes
-        subtraction to create new sources infinitely.
     aperture_radius : float
         The radius (in units of pixels) used to compute initial
         estimates for the fluxes of sources. If ``None``, one FWHM will
@@ -101,34 +102,15 @@ class DAOPhotPSFPhotometry(object):
     """
 
     def __init__(self, group_maker, bkg_estimator, psf_model, fitshape,
-                 finder=None, fitter=LevMarLSQFitter(), niters=3,
-                 aperture_radius=None):
+                 finder=None, fitter=LevMarLSQFitter(), aperture_radius=None):
         self.finder = finder
         self.group_maker = group_maker
         self.bkg_estimator = bkg_estimator
         self.psf_model = psf_model
         self.fitter = fitter
-        self.niters = niters
         self.fitshape = fitshape
         self.aperture_radius = aperture_radius
-
-    @property
-    def niters(self):
-        return self._niters
-
-    @niters.setter
-    def niters(self, value):
-        if value is None:
-            self._niters = None
-        else:
-            try:
-                if value <= 0:
-                    raise ValueError('niters must be positive.')
-                else:
-                    self._niters = int(value)
-            except:
-                raise ValueError('niters must be None or an integer or '
-                                 'convertable into an integer.')
+        self._residual_image = None
 
     @property
     def fitshape(self):
@@ -171,14 +153,49 @@ class DAOPhotPSFPhotometry(object):
                              'number, received aperture_radius = {}'
                              .format(value))
 
-    def __call__(self, image, positions=None):
+    def get_residual_image(self):
         """
-        Performs PSF photometry using the DAOPHOT algorithm. See
-        `do_photometry` for more details including the `__call__`
-        signature.
+        Returns an image that is the result of the subtraction between
+        the original image and the fitted sources.
+
+        Returns
+        -------
+        residual_image : 2D array-like, `~astropy.io.fits.ImageHDU`, `~astropy.io.fits.HDUList`
         """
 
+        return self._residual_image
+
+    def __call__(self, image, positions=None):
+        """
+        Performs PSF photometry. See `do_photometry` for more details
+        including the `__call__` signature.
+        """
+
+        if self.bkg_estimator is not None:
+            image = image - self.bkg_estimator(image)
+
+        if self.aperture_radius is None:
+            if hasattr(self.psf_model, 'fwhm'):
+                self.aperture_radius = self.psf_model.fwhm.value
+            elif hasattr(self.psf_model, 'sigma'):
+                self.aperture_radius = (self.psf_model.sigma.value *
+                                        gaussian_sigma_to_fwhm)
+        
+        if positions is not None:
+            if 'flux_0' not in positions.colnames:
+                apertures = CircularAperture((positions['x_0'],
+                                              positions['y_0']),
+                                             r=self.aperture_radius)
+
+                positions['flux_0'] = aperture_photometry(
+                    image, apertures)['aperture_sum']
+        else:
+            if self.finder is None:
+                raise ValueError('Finder cannot be None if positions are '
+                                 'not given.')
+
         return self.do_photometry(image, positions)
+
 
     def do_photometry(self, image, positions=None):
         """
@@ -189,13 +206,11 @@ class DAOPhotPSFPhotometry(object):
         ``image``. A compound model, in fact a sum of ``psf_model``,
         will be fitted to groups of stars automatically identified by
         ``group_maker``. Also, ``image`` is not assumed to be background
-        subtracted.  If positions are not ``None`` then this method
-        performs forced PSF photometry, i.e., the positions are assumed
-        to be known with high accuracy and only fluxes are fitted. If
+        subtracted.  If ``positions`` are not ``None`` then this method uses
+        ``positions`` as initial guesses for the centroids. If
         the centroid positions are set as ``fixed`` in the PSF model
         ``psf_model``, then the optimizer will only consider the flux as
-        a variable. Otherwise, ``positions`` will be used as initial
-        guesses for the centroids.
+        a variable.
 
         Parameters
         ----------
@@ -205,104 +220,41 @@ class DAOPhotPSFPhotometry(object):
             Positions (in pixel coordinates) at which to *start* the fit
             for each object. Columns 'x_0' and 'y_0' must be present.
             'flux_0' can also be provided to set initial fluxes.
+            If 'flux_0' is not provided, aperture photometry is used to
+            estimate initial values for the fluxes.
 
         Returns
         -------
-        outtab : `~astropy.table.Table`
+        output_tab : `~astropy.table.Table` or None
             Table with the photometry results, i.e., centroids and
             fluxes estimations and the initial estimates used to start
             the fitting process.
-        residual_image : array-like, `~astropy.io.fits.ImageHDU`, `~astropy.io.fits.HDUList`
-            Residual image calculated by subtracting the fitted sources
-            and the original image.
+            None is returned if no sources are found in ``image``.
         """
-
-        if self.bkg_estimator is None:
-            residual_image = image.copy()
-        else:
-            residual_image = image - self.bkg_estimator(image)
-
-        if self.aperture_radius is None:
-            if hasattr(self.psf_model, 'fwhm'):
-                self.aperture_radius = self.psf_model.fwhm.value
-            elif hasattr(self.psf_model, 'sigma'):
-                self.aperture_radius = (self.psf_model.sigma.value *
-                                        gaussian_sigma_to_fwhm)
 
         if positions is None:
-            if self.finder is None:
-                raise ValueError('Finder cannot be None if positions are '
-                                 'not given.')
-
-            outtab = Table([[], [], [], [], [], []],
-                           names=('id', 'group_id', 'iter_detected', 'x_fit',
-                                  'y_fit', 'flux_fit'),
-                           dtype=('i4', 'i4', 'i4', 'f8', 'f8', 'f8'))
-
-            intab = Table([[], [], []],
-                          names=('x_0', 'y_0', 'flux_0'),
-                          dtype=('f8', 'f8', 'f8'))
-
-            sources = self.finder(residual_image)
-
-            apertures = CircularAperture((sources['xcentroid'],
-                                          sources['ycentroid']),
-                                         r=self.aperture_radius)
-
-            sources['aperture_flux'] = aperture_photometry(
-                residual_image, apertures)['aperture_sum']
-            n = 1
-            while(len(sources) > 0 and
-                  (self.niters is None or n <= self.niters)):
-                init_guess_tab = Table(names=['x_0', 'y_0', 'flux_0'],
-                                       data=[sources['xcentroid'],
-                                             sources['ycentroid'],
-                                             sources['aperture_flux']])
-                intab = vstack([intab, init_guess_tab])
-                star_groups = self.group_maker(init_guess_tab)
-                result_tab, residual_image = self.nstar(residual_image,
-                                                        star_groups)
-                result_tab['iter_detected'] = \
-                    n*np.ones(result_tab['x_fit'].shape, dtype=np.int)
-
-                outtab = vstack([outtab, result_tab])
-                sources = self.finder(residual_image)
-
-                if len(sources) > 0:
-                    apertures = CircularAperture((sources['xcentroid'],
-                                                  sources['ycentroid']),
-                                                 r=self.aperture_radius)
-                    sources['aperture_flux'] = \
-                        aperture_photometry(residual_image,
-                                            apertures)['aperture_sum']
-                n += 1
-
-            outtab = hstack([intab, outtab])
-        else:
-            if 'flux_0' not in positions.colnames:
-                apertures = CircularAperture((positions['x_0'],
-                                              positions['y_0']),
+            sources = self.finder(image)
+            if len(sources) > 0:
+                apertures = CircularAperture((sources['xcentroid'],
+                                              sources['ycentroid']),
                                              r=self.aperture_radius)
+                
+                sources['aperture_flux'] = aperture_photometry(image,
+                        apertures)['aperture_sum']
+                
+                positions = Table(names=['x_0', 'y_0', 'flux_0'],
+                                  data=[sources['xcentroid'],
+                                  sources['ycentroid'],
+                                  sources['aperture_flux']])
+            else:
+                return None
+        
+        star_groups = self.group_maker(positions)
+        output_tab, self._residual_image = self.nstar(image, star_groups)
+        output_tab = hstack([positions, output_tab])
 
-                positions['flux_0'] = aperture_photometry(
-                    residual_image, apertures)['aperture_sum']
+        return output_tab
 
-            intab = Table(names=['x_0', 'y_0', 'flux_0'],
-                          data=[positions['x_0'], positions['y_0'],
-                          positions['flux_0']])
-
-            star_groups = self.group_maker(intab)
-            outtab, residual_image = self.nstar(residual_image, star_groups)
-            outtab = hstack([intab, outtab])
-
-        return outtab, residual_image
-
-    def get_uncertainties(self):
-        """
-        Return the uncertainties on the fitted parameters
-        """
-
-        raise NotImplementedError
 
     def nstar(self, image, star_groups):
         """
@@ -407,3 +359,318 @@ class DAOPhotPSFPhotometry(object):
                                [getattr(fit_model, 'flux').value]])
 
         return param_tab
+
+
+class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
+    """
+    This class implements the an iterative algorithm to perform point
+    spread function photometry in crowded fields. This consists of
+    applying a loop of find sources, make groups, fit groups, subtract
+    groups, and then repeat until no more stars are detected or a given
+    number of iterations is reached.
+
+    Parameters
+    ----------
+    group_maker : callable or `~photutils.psf.GroupStarsBase`
+        ``group_maker`` should be able to decide whether a given star
+        overlaps with any other and label them as beloging to the same
+        group.  ``group_maker`` receives as input an
+        `~astropy.table.Table` object with columns named as ``id``,
+        ``x_0``, ``y_0``, in which ``x_0`` and ``y_0`` have the same
+        meaning of ``xcentroid`` and ``ycentroid``.  This callable must
+        return an `~astropy.table.Table` with columns ``id``, ``x_0``,
+        ``y_0``, and ``group_id``. The column ``group_id`` should cotain
+        integers starting from ``1`` that indicate which group a given
+        source belongs to. See, e.g., `~photutils.psf.DAOGroup`.
+    bkg_estimator : callable, instance of any `~photutils.BackgroundBase` subclass, or None
+        ``bkg_estimator`` should be able to compute either a scalar
+        background or a 2D background of a given 2D image. See, e.g.,
+        `~photutils.background.MedianBackground`.  If None, no
+        background subtraction is performed.
+    psf_model : `astropy.modeling.Fittable2DModel` instance
+        PSF or PRF model to fit the data. Could be one of the models in
+        this package like `~photutils.psf.sandbox.DiscretePRF`,
+        `~photutils.psf.IntegratedGaussianPRF`, or any other suitable 2D
+        model.  This object needs to identify three parameters (position
+        of center in x and y coordinates and the flux) in order to set
+        them to suitable starting values for each fit. The names of
+        these parameters should be given as ``x_0``, ``y_0`` and
+        ``flux``.  `~photutils.psf.prepare_psf_model` can be used to
+        prepare any 2D model to match this assumption.
+    fitshape : int or length-2 array-like
+        Rectangular shape around the center of a star which will be used
+        to collect the data to do the fitting. Can be an integer to be
+        the same along both axes. E.g., 5 is the same as (5, 5), which
+        means to fit only at the following relative pixel positions:
+        [-2, -1, 0, 1, 2].  Each element of ``fitshape`` must be an odd
+        number.
+    finder : callable or instance of any `~photutils.detection.StarFinderBase` subclasses
+        ``finder`` should be able to identify stars, i.e. compute a
+        rough estimate of the centroids, in a given 2D image.
+        ``finder`` receives as input a 2D image and returns an
+        `~astropy.table.Table` object which contains columns with names:
+        ``id``, ``xcentroid``, ``ycentroid``, and ``flux``. In which
+        ``id`` is an integer-valued column starting from ``1``,
+        ``xcentroid`` and ``ycentroid`` are center position estimates of
+        the sources and ``flux`` contains flux estimates of the sources.
+        See, e.g., `~photutils.detection.DAOStarFinder`.  If ``finder``
+        is ``None``, initial guesses for positions of objects must be
+        provided.
+    fitter : `~astropy.modeling.fitting.Fitter` instance
+        Fitter object used to compute the optimized centroid positions
+        and/or flux of the identified sources. See
+        `~astropy.modeling.fitting` for more details on fitters.
+    niters : int or None
+        Number of iterations to perform of the loop FIND, GROUP,
+        SUBTRACT, NSTAR. If None, iterations will proceed until no more
+        stars remain.  Note that in this case it is *possible* that the
+        loop will never end if the PSF has structure that causes
+        subtraction to create new sources infinitely.
+    aperture_radius : float
+        The radius (in units of pixels) used to compute initial
+        estimates for the fluxes of sources. If ``None``, one FWHM will
+        be used if it can be determined from the ```psf_model``.
+
+    Notes
+    -----
+    If there are problems with fitting large groups, change the
+    parameters of the grouping algorithm to reduce the number of sources
+    in each group or input a ``star_groups`` table that only includes
+    the groups that are relevant (e.g. manually remove all entries that
+    coincide with artifacts).
+
+    References
+    ----------
+    [1] Stetson, Astronomical Society of the Pacific, Publications,
+        (ISSN 0004-6280), vol. 99, March 1987, p. 191-222.
+        Available at: http://adsabs.harvard.edu/abs/1987PASP...99..191S
+    """
+
+    def __init__(self, group_maker, bkg_estimator, psf_model, fitshape,
+                 finder, fitter=LevMarLSQFitter(), niters=3,
+                 aperture_radius=None):
+        if finder is None:
+            raise ValueError("finder cannot be None. Please see the Detection, "
+                             "section on photutils docs.")
+
+        super(IterativelySubtractedPSFPhotometry, self).__init__(group_maker,
+                bkg_estimator, psf_model, fitshape, finder, fitter, aperture_radius)
+        self.niters = niters
+
+
+    @property
+    def niters(self):
+        return self._niters
+
+    @niters.setter
+    def niters(self, value):
+        if value is None:
+            self._niters = None
+        else:
+            try:
+                if value <= 0:
+                    raise ValueError('niters must be positive.')
+                else:
+                    self._niters = int(value)
+            except:
+                raise ValueError('niters must be None or an integer or '
+                                 'convertable into an integer.')
+
+    def do_photometry(self, image, positions=None):
+        """
+        Perform PSF photometry in ``image``.
+
+        This method assumes that ``psf_model`` has centroids and flux
+        parameters which will be fitted to the data provided in
+        ``image``. A compound model, in fact a sum of ``psf_model``,
+        will be fitted to groups of stars automatically identified by
+        ``group_maker``. Also, ``image`` is not assumed to be background
+        subtracted.  If ``positions`` are not ``None`` then this method uses
+        ``positions`` as initial guesses for the centroids. If
+        the centroid positions are set as ``fixed`` in the PSF model
+        ``psf_model``, then the optimizer will only consider the flux as
+        a variable.
+
+        Parameters
+        ----------
+        image : 2D array-like, `~astropy.io.fits.ImageHDU`, `~astropy.io.fits.HDUList`
+            Image to perform photometry.
+        positions: `~astropy.table.Table`
+            Positions (in pixel coordinates) at which to *start* the fit
+            for each object. Columns 'x_0' and 'y_0' must be present.
+            'flux_0' can also be provided to set initial fluxes.
+            If 'flux_0' is not provided, aperture photometry is used to
+            estimate initial values for the fluxes.
+
+        Returns
+        -------
+        output_tab : `~astropy.table.Table` or None
+            Table with the photometry results, i.e., centroids and
+            fluxes estimations and the initial estimates used to start
+            the fitting process.
+            None is returned if no sources are found in ``image``.
+        """
+        self._residual_image = image
+        
+        if positions is not None:
+            table = super(IterativelySubtractedPSFPhotometry,
+                self).do_photometry(self._residual_image, positions)
+            table['iter_detected'] = np.ones(table['x_fit'].shape, dtype=np.int)
+            
+            # n_start = 2 because it starts in the second iteration
+            # since the first iteration is above
+            output_table = self._do_photometry(n_start=2)
+            output_table = vstack([table, output_table])
+        else:
+            output_table = self._do_photometry()
+        return output_table
+
+    def _do_photometry(self, n_start=1):
+        output_table = Table([[], [], [], [], [], [], [], [], []],
+                names=('x_0', 'y_0', 'flux_0', 'id', 'group_id',
+                       'iter_detected', 'x_fit', 'y_fit',
+                       'flux_fit'),
+                dtype=('f8', 'f8', 'f8', 'i4', 'i4', 'i4', 'f8', 'f8',
+                       'f8'))
+        sources = self.finder(self._residual_image)
+
+        n = n_start
+        while(len(sources) > 0 and
+              (self.niters is None or n <= self.niters)):
+            apertures = CircularAperture((sources['xcentroid'],
+                                          sources['ycentroid']),
+                                          r=self.aperture_radius)
+            sources['aperture_flux'] = aperture_photometry(self._residual_image,
+                    apertures)['aperture_sum']
+            init_guess_tab = Table(names=['x_0', 'y_0', 'flux_0'],
+                               data=[sources['xcentroid'],
+                               sources['ycentroid'],
+                               sources['aperture_flux']])
+            table = super(IterativelySubtractedPSFPhotometry,
+                    self).do_photometry(self._residual_image, init_guess_tab)
+            table['iter_detected'] = n*np.ones(table['x_fit'].shape, dtype=np.int)
+            output_table = vstack([output_table, table])
+            sources = self.finder(self._residual_image)
+            n += 1
+
+        return output_table
+
+
+class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
+    """
+    This class implements  an iterative algorithm based on the
+    DAOPHOT algorithm presented by Stetson (1987) to perform point
+    spread function photometry in crowded fields. This consists of
+    applying a loop of find sources, make groups, fit groups, subtract
+    groups, and then repeat until no more stars are detected or a given
+    number of iterations is reached.
+    
+    In order to make groups of sources, this class uses
+    `~photutils.psf.DAOGroup`. To find sources, this class uses
+    `~photutitls.detection.DAOStarFinder`. To do background estimation,
+    it uses `~photutils.background.MMMBackground`.
+    
+    The parameter ``crit_separation`` is associated with `~photutils.psf.DAOGroup`.
+    ``sigma_clip`` is associated with `~photutils.background.MMMBackground`.
+    ``threshold`` and ``fwhm`` are associated with `~photutitls.detection.DAOStarFinder`.
+    Parameters from ``ratio`` to ``roundhi`` are also associated with
+    `~photutitls.detection.DAOStarFinder`.
+
+    Parameters
+    ----------
+    crit_separation : float or int
+        Distance, in units of pixels, such that any two stars separated by
+        less than this distance will be placed in the same group.
+    threshold : float
+        The absolute image value above which to select sources.
+    fwhm : float
+        The full-width half-maximum (FWHM) of the major axis of the
+        Gaussian kernel in units of pixels.
+    psf_model : `astropy.modeling.Fittable2DModel` instance
+        PSF or PRF model to fit the data. Could be one of the models in
+        this package like `~photutils.psf.sandbox.DiscretePRF`,
+        `~photutils.psf.IntegratedGaussianPRF`, or any other suitable 2D
+        model.  This object needs to identify three parameters (position
+        of center in x and y coordinates and the flux) in order to set
+        them to suitable starting values for each fit. The names of
+        these parameters should be given as ``x_0``, ``y_0`` and
+        ``flux``.  `~photutils.psf.prepare_psf_model` can be used to
+        prepare any 2D model to match this assumption.
+    fitshape : int or length-2 array-like
+        Rectangular shape around the center of a star which will be used
+        to collect the data to do the fitting. Can be an integer to be
+        the same along both axes. E.g., 5 is the same as (5, 5), which
+        means to fit only at the following relative pixel positions:
+        [-2, -1, 0, 1, 2].  Each element of ``fitshape`` must be an odd
+        number.
+    sigma : float, optional
+        Number of standard deviations used to perform sigma clip with a
+        `SigmaClip` object.
+    ratio : float, optional
+        The ratio of the minor to major axis standard deviations of the
+        Gaussian kernel.  ``ratio`` must be strictly positive and less
+        than or equal to 1.0.  The default is 1.0 (i.e., a circular
+        Gaussian kernel).
+    theta : float, optional
+        The position angle (in degrees) of the major axis of the
+        Gaussian kernel measured counter-clockwise from the positive x
+        axis.
+    sigma_radius : float, optional
+        The truncation radius of the Gaussian kernel in units of sigma
+        (standard deviation) [``1 sigma = FWHM /
+        (2.0*sqrt(2.0*log(2.0)))``].
+    sharplo : float, optional
+        The lower bound on sharpness for object detection.
+    sharphi : float, optional
+        The upper bound on sharpness for object detection.
+    roundlo : float, optional
+        The lower bound on roundess for object detection.
+    roundhi : float, optional
+        The upper bound on roundess for object detection.
+    fitter : `~astropy.modeling.fitting.Fitter` instance
+        Fitter object used to compute the optimized centroid positions
+        and/or flux of the identified sources. See
+        `~astropy.modeling.fitting` for more details on fitters.
+    niters : int or None
+        Number of iterations to perform of the loop FIND, GROUP,
+        SUBTRACT, NSTAR. If None, iterations will proceed until no more
+        stars remain.  Note that in this case it is *possible* that the
+        loop will never end if the PSF has structure that causes
+        subtraction to create new sources infinitely.
+    aperture_radius : float
+        The radius (in units of pixels) used to compute initial
+        estimates for the fluxes of sources. If ``None``, one FWHM will
+        be used if it can be determined from the ```psf_model``.
+
+    Notes
+    -----
+    If there are problems with fitting large groups, change the
+    parameters of the grouping algorithm to reduce the number of sources
+    in each group or input a ``star_groups`` table that only includes
+    the groups that are relevant (e.g. manually remove all entries that
+    coincide with artifacts).
+
+    References
+    ----------
+    [1] Stetson, Astronomical Society of the Pacific, Publications,
+        (ISSN 0004-6280), vol. 99, March 1987, p. 191-222.
+        Available at: http://adsabs.harvard.edu/abs/1987PASP...99..191S
+    """
+
+    def __init__(self, crit_separation, threshold, fwhm, psf_model,
+                 fitshape, sigma=3., ratio=1.0, theta=0.0, sigma_radius=1.5, sharplo=0.2,
+                 sharphi=1.0, roundlo=-1.0, roundhi=1.0, fitter=LevMarLSQFitter(), 
+                 niters=3, aperture_radius=None):
+        
+        self.group_maker = DAOGroup(crit_separation=crit_separation)
+        self.bkg_estimator = MMMBackground(sigma_clip=SigmaClip(sigma=sigma))
+        self.finder = DAOStarFinder(threshold=threshold, fwhm=fwhm, ratio=ratio,
+                                    theta=theta, sigma_radius=sigma_radius,
+                                    sharplo=sharplo, sharphi=sharphi,
+                                    roundlo=roundlo, roundhi=roundhi)
+
+        super(DAOPhotPSFPhotometry, self).__init__(group_maker=self.group_maker,
+                                                   bkg_estimator=self.bkg_estimator,
+                                                   psf_model=psf_model, fitshape=fitshape,
+                                                   finder=self.finder, fitter=fitter, niters=niters,
+                                                   aperture_radius=aperture_radius)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -618,7 +618,7 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
     groups, and then repeat until no more stars are detected or a given
     number of iterations is reached.
 
-    Basically, this classes uses `~photutils.psf.IterativelySubstractedPSFPhotometry`,
+    Basically, this classes uses `~photutils.psf.IterativelySubtractedPSFPhotometry`,
     but with grouping, finding, and background estimation routines defined a
     priori. More precisely, this class uses `~photutils.psf.DAOGroup` for
     grouping, `~photutils.detection.DAOStarFinder` for finding sources, and

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -48,7 +48,7 @@ def make_psf_photometry_objs(std=1, sigma_psf=1):
     mode_bkg = MMMBackground()
     psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
     fitter = LevMarLSQFitter()
-    
+
     basic_phot_obj = BasicPSFPhotometry(finder=daofind,
                                         group_maker=daogroup,
                                         bkg_estimator=mode_bkg,
@@ -56,7 +56,7 @@ def make_psf_photometry_objs(std=1, sigma_psf=1):
                                         fitter=fitter,
                                         fitshape=(11, 11))
 
-    
+
     iter_phot_obj = IterativelySubtractedPSFPhotometry(finder=daofind,
                                                        group_maker=daogroup,
                                                        bkg_estimator=mode_bkg,
@@ -128,7 +128,6 @@ def test_psf_photometry_niters(sigma_psf, sources):
              make_noise_image(img_shape, type='gaussian', mean=0.,
                               stddev=2., random_state=1))
     cp_image = image.copy()
-
     sigma_clip = SigmaClip(sigma=3.)
     bkgrms = StdBackgroundRMS(sigma_clip)
     std = bkgrms(image)
@@ -173,8 +172,8 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
              make_noise_image(img_shape, type='gaussian', mean=0.,
                               stddev=2., random_state=1))
     cp_image = image.copy()
-    
-    sigma_clip = SigmaClip(sigma=3.) 
+
+    sigma_clip = SigmaClip(sigma=3.)
     bkgrms = StdBackgroundRMS(sigma_clip)
     std = bkgrms(image)
     phot_objs = make_psf_photometry_objs(std, sigma_psf)
@@ -188,7 +187,7 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
         assert_array_equal(result_tab['id'], sources['id'])
         assert_array_equal(result_tab['group_id'], sources['group_id'])
         assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
-    
+
         # test fixed photometry
         phot_proc.psf_model.x_0.fixed = True
         phot_proc.psf_model.y_0.fixed = True
@@ -214,7 +213,7 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
 
 
 @pytest.mark.xfail('not HAS_SCIPY')
-def test_niters_exceptions():
+def test_niters_errors():
     iter_phot_obj = make_psf_photometry_objs()[1]
 
     # tests that niters is set to an integer even if the user inputs
@@ -231,7 +230,7 @@ def test_niters_exceptions():
 
 
 @pytest.mark.xfail('not HAS_SCIPY')
-def test_fitshape_exceptions():
+def test_fitshape_erros():
     basic_phot_obj = make_psf_photometry_objs()[0]
 
     # first make sure setting to a scalar does the right thing (and makes
@@ -256,7 +255,7 @@ def test_fitshape_exceptions():
         basic_phot_obj.fitshape = (3, 3, 3)
 
 @pytest.mark.xfail('not HAS_SCIPY')
-def test_aperture_radius_exceptions():
+def test_aperture_radius_errors():
     basic_phot_obj = make_psf_photometry_objs()[0]
 
     # test that aperture_radius was set to None by default
@@ -265,6 +264,17 @@ def test_aperture_radius_exceptions():
     # test that a ValuError is raised if aperture_radius is non positive
     with pytest.raises(ValueError):
         basic_phot_obj.aperture_radius = -3
+
+@pytest.mark.xfail('not HAS_SCIPY')
+def test_finder_erros():
+    iter_phot_obj = make_psf_photometry_objs()[1]
+    with pytest.raises(ValueError):
+        iter_phot_obj.finder = None
+
+    with pytest.raises(ValueError):
+        iter_phot_obj = IterativelySubtractedPSFPhotometry(finder=None,
+                group_maker=DAOGroup(1), bkg_estimator=MMMBackground(),
+                psf_model=IntegratedGaussianPRF(1), fitshape=(11, 11))
 
 @pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1_2')
 def test_aperture_radius():

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -8,7 +8,7 @@ from astropy.table import Table
 from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling import Parameter, Fittable2DModel
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, catch_warnings
 from astropy.utils import minversion
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -291,7 +291,7 @@ def test_finder_positions_warning():
              make_noise_image((32, 32), type='poisson', mean=6.,
                               random_state=1))
 
-    with pytest.warns(AstropyUserWarning):
+    with catch_warnings(AstropyUserWarning):
         result_tab = basic_phot_obj(image=image, positions=positions)
         assert_array_equal(result_tab['x_0'], positions['x_0'])
         assert_array_equal(result_tab['y_0'], positions['y_0'])

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -5,6 +5,7 @@ import astropy
 from astropy.table import Table
 from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling import Parameter, Fittable2DModel
 from astropy.tests.helper import pytest
 from astropy.utils import minversion
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
@@ -98,6 +99,56 @@ sources2['theta'] = [0] * 4
 sources2['id'] = [1, 2, 3, 4]
 sources2['group_id'] = [1, 1, 1, 1]
 
+# one faint star and one brither companion
+# although they are in the same group, the detection algorithm
+# is not able to detect the fainter star, hence photometry should
+# be performed with niters > 1 or niters=None
+sigma_psfs.append(2)
+sources3 = Table()
+sources3['flux'] = [10000, 1000]
+sources3['x_mean'] = [18, 13]
+sources3['y_mean'] = [17, 19]
+sources3['x_stddev'] = [sigma_psfs[-1]] * 2
+sources3['y_stddev'] = sources3['x_stddev']
+sources3['theta'] = [0] * 2
+sources3['id'] = [1] * 2
+sources3['group_id'] = [1] * 2
+sources3['iter_detected'] = [1, 2]
+
+
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1_2')
+@pytest.mark.parametrize("sigma_psf, sources", [(sigma_psfs[2], sources3)])
+def test_psf_photometry_niters(sigma_psf, sources):
+    img_shape = (32, 32)
+    # generate image with read-out noise (Gaussian) and
+    # background noise (Poisson)
+    image = (make_gaussian_sources(img_shape, sources) +
+             make_noise_image(img_shape, type='poisson', mean=6.,
+                              random_state=1) +
+             make_noise_image(img_shape, type='gaussian', mean=0.,
+                              stddev=2., random_state=1))
+    cp_image = image.copy()
+
+    sigma_clip = SigmaClip(sigma=3.)
+    bkgrms = StdBackgroundRMS(sigma_clip)
+    std = bkgrms(image)
+
+    iter_phot_obj = make_psf_photometry_objs(std, sigma_psf)[1]
+    iter_phot_obj.niters = None
+    result_tab = iter_phot_obj(image)
+    residual_image = iter_phot_obj.get_residual_image()
+
+    assert_allclose(result_tab['x_fit'], sources['x_mean'], rtol=1e-1)
+    assert_allclose(result_tab['y_fit'], sources['y_mean'], rtol=1e-1)
+    assert_allclose(result_tab['flux_fit'], sources['flux'], rtol=1e-1)
+    assert_array_equal(result_tab['id'], sources['id'])
+    assert_array_equal(result_tab['group_id'], sources['group_id'])
+    assert_array_equal(result_tab['iter_detected'], sources['iter_detected'])
+    assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
+
+    # make sure image is note overwritten
+    assert_array_equal(cp_image, image)
+
 
 @pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1_2')
 @pytest.mark.parametrize("sigma_psf, sources",
@@ -114,7 +165,6 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
     """
 
     img_shape = (32, 32)
-
     # generate image with read-out noise (Gaussian) and
     # background noise (Poisson)
     image = (make_gaussian_sources(img_shape, sources) +
@@ -195,16 +245,15 @@ def test_fitshape_exceptions():
     with pytest.raises(ValueError):
         basic_phot_obj.fitshape = 2
 
-    # test that a ValuError is raised if fitshape has non positive
+    # test that a ValueError is raised if fitshape has non positive
     # components
     with pytest.raises(ValueError):
         basic_phot_obj.fitshape = (-1, 0)
 
-    # test that a ValuError is raised if fitshape does not have two
-    # components
+    # test that a ValueError is raised if fitshape has more than two
+    # dimensions
     with pytest.raises(ValueError):
-        basic_phot_obj.fitshape = 2
-
+        basic_phot_obj.fitshape = (3, 3, 3)
 
 @pytest.mark.xfail('not HAS_SCIPY')
 def test_aperture_radius_exceptions():
@@ -216,3 +265,36 @@ def test_aperture_radius_exceptions():
     # test that a ValuError is raised if aperture_radius is non positive
     with pytest.raises(ValueError):
         basic_phot_obj.aperture_radius = -3
+
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1_2')
+def test_aperture_radius():
+    img_shape = (32, 32)
+
+    # generate image with read-out noise (Gaussian) and
+    # background noise (Poisson)
+    image = (make_gaussian_sources(img_shape, sources1) +
+             make_noise_image(img_shape, type='poisson', mean=6.,
+                              random_state=1) +
+             make_noise_image(img_shape, type='gaussian', mean=0.,
+                              stddev=2., random_state=1))
+
+    basic_phot_obj = make_psf_photometry_objs()[0]
+    # test that aperture radius is properly set whenever the PSF model has
+    # a `fwhm` attribute
+    class PSFModelWithFWHM(Fittable2DModel):
+        x_0 = Parameter(default=1)
+        y_0 = Parameter(default=1)
+        flux = Parameter(default=1)
+        fwhm = Parameter(default=5)
+
+        def __init__(self, fwhm=fwhm.default):
+            super(PSFModelWithFWHM, self).__init__(fwhm=fwhm)
+
+        def evaluate(self, x, y, x_0, y_0, flux, fwhm):
+            return flux / (fwhm * (x - x_0)**2 * (y - y_0)**2)
+
+    psf_model = PSFModelWithFWHM()
+    basic_phot_obj.psf_model = psf_model
+    result_tab = basic_phot_obj(image)
+
+    assert_equal(basic_phot_obj.aperture_radius, psf_model.fwhm.value)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -25,6 +25,9 @@ from ...background import SigmaClip, MedianBackground, StdBackgroundRMS
 from ...background import MedianBackground, MMMBackground, SigmaClip
 from ...background import StdBackgroundRMS
 
+
+ASTROPY_GT_1_1 = minversion('astropy', '1.1')
+
 try:
     import scipy
     HAS_SCIPY = True
@@ -119,7 +122,7 @@ sources3['group_id'] = [1] * 2
 sources3['iter_detected'] = [1, 2]
 
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
 @pytest.mark.parametrize("sigma_psf, sources", [(sigma_psfs[2], sources3)])
 def test_psf_photometry_niters(sigma_psf, sources):
     img_shape = (32, 32)
@@ -152,7 +155,7 @@ def test_psf_photometry_niters(sigma_psf, sources):
     assert_array_equal(cp_image, image)
 
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
 @pytest.mark.parametrize("sigma_psf, sources",
                          [(sigma_psfs[0], sources1),
                           (sigma_psfs[1], sources2),
@@ -279,7 +282,7 @@ def test_finder_erros():
                 group_maker=DAOGroup(1), bkg_estimator=MMMBackground(),
                 psf_model=IntegratedGaussianPRF(1), fitshape=(11, 11))
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
 def test_finder_positions_warning():
     basic_phot_obj = make_psf_photometry_objs(sigma_psf=2)[0]
     positions = Table()
@@ -297,7 +300,7 @@ def test_finder_positions_warning():
         assert_allclose(result_tab['x_fit'], positions['x_0'], rtol=1e-1)
         assert_allclose(result_tab['y_fit'], positions['y_0'], rtol=1e-1)
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
 def test_aperture_radius():
     img_shape = (32, 32)
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -6,6 +6,7 @@ from astropy.table import Table
 from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.tests.helper import pytest
+from astropy.utils import minversion
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 from ..models import IntegratedGaussianPRF
 from ...datasets import make_gaussian_sources
@@ -16,6 +17,8 @@ from ...detection import DAOStarFinder
 from ...background import SigmaClip, MedianBackground, StdBackgroundRMS
 from ...background import MedianBackground, MMMBackground, SigmaClip
 from ...background import StdBackgroundRMS
+
+ASTROPY_GT_1_1_2 = minversion('astropy', '1.1.2') 
 
 try:
     import scipy
@@ -96,7 +99,7 @@ sources2['id'] = [1, 2, 3, 4]
 sources2['group_id'] = [1, 1, 1, 1]
 
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1_2')
 @pytest.mark.parametrize("sigma_psf, sources",
                          [(sigma_psfs[0], sources1),
                           (sigma_psfs[1], sources2),

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -3,7 +3,6 @@ from __future__ import division
 
 import numpy as np
 import astropy
-import warnings
 
 from astropy.table import Table
 from astropy.stats import gaussian_sigma_to_fwhm

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -18,13 +18,12 @@ from ..models import IntegratedGaussianPRF
 from ...datasets import make_gaussian_sources
 from ...datasets import make_noise_image
 from ..groupstars import DAOGroup
-from ..photometry import DAOPhotPSFPhotometry, IterativelySubtractedPSFPhotometry, BasicPSFPhotometry
+from ..photometry import DAOPhotPSFPhotometry, IterativelySubtractedPSFPhotometry
+from ..photometry import BasicPSFPhotometry
 from ...detection import DAOStarFinder
 from ...background import SigmaClip, MedianBackground, StdBackgroundRMS
 from ...background import MedianBackground, MMMBackground, SigmaClip
 from ...background import StdBackgroundRMS
-
-ASTROPY_GT_1_1_2 = minversion('astropy', '1.1.2')
 
 try:
     import scipy
@@ -120,7 +119,7 @@ sources3['group_id'] = [1] * 2
 sources3['iter_detected'] = [1, 2]
 
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1_2')
+@pytest.mark.xfail('not HAS_SCIPY')
 @pytest.mark.parametrize("sigma_psf, sources", [(sigma_psfs[2], sources3)])
 def test_psf_photometry_niters(sigma_psf, sources):
     img_shape = (32, 32)
@@ -153,7 +152,7 @@ def test_psf_photometry_niters(sigma_psf, sources):
     assert_array_equal(cp_image, image)
 
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1_2')
+@pytest.mark.xfail('not HAS_SCIPY')
 @pytest.mark.parametrize("sigma_psf, sources",
                          [(sigma_psfs[0], sources1),
                           (sigma_psfs[1], sources2),
@@ -298,7 +297,7 @@ def test_finder_positions_warning():
         assert_allclose(result_tab['x_fit'], positions['x_0'], rtol=1e-1)
         assert_allclose(result_tab['y_fit'], positions['y_0'], rtol=1e-1)
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1_2')
+@pytest.mark.xfail('not HAS_SCIPY')
 def test_aperture_radius():
     img_shape = (32, 32)
 


### PR DESCRIPTION
This is a rework of #421.

The actual plan as stated by @eteq is the following:
- [x] Write a new class called something generic like `BasicPSFPhotometry`.  It would take all the same arguments as the current `DAOPhotPSFPhotometry` except `niters`, and it would mostly be a straight copy-and-paste of most of `DAOPhotPSFPhotometry` without the loop.  `do_photometry` for that would return just the table, _not_ the subtracted image (although the users is of course free to do their own subtraction). `finder` can be None, which means just use the positions if they are given as an argument to `do_photometry` (or if both are None raise an error)
- [x] Replace the existing `DAOPhotPSFPhotometry` with a class called something like `IterativelySubtractedPSFPhotometry`.  This would look just like the current `DAOPhotPSFPhotometry`, but the internal implementation would just basically use `BasicPSFPhotometry` so it would end up a lot simpler than the current `DAOPhotPSFPhotometry`.  `do_photometry` would also just return the table, unlike the current one, which also returns the residual image, but it would do something like `self.residual_image = residual_image` at the very end so that the user can access it if they want it.  For this class `finder` _cannot_ be None - attempting to do so should raise an error  
- [x] Add a _subclass_ of `IterativelySubtractedPSFPhotometry` called `DAOPhotPSFPhotometry`.  This would take all of the parameters that all of the _sub-objects_ used in `DAOPhotPSFPhotometry` require, rather than explicitly setting e.g. the grouper, finder, etc.  Its implementation would be just an `__init__` which creates the relevant objects to reproduce the “daophot-style algorithm”
