### PR TITLE
Unpin qt=4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ matrix:
         # time.
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
+               CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib qt=4'
         - os: linux
           env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib qt=4'
+        - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - CONDA_CHANNELS='astropy-ci-extras'
         - SETUP_XVFB=True
 
@@ -61,10 +61,10 @@ matrix:
         # may run for a long time
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib jupyter qt=4'
+               CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib jupyter'
         - os: linux
           env: SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib jupyter qt=4'
+               CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib jupyter'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib qt=4"
+      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib"
 
   matrix:
       - PYTHON_VERSION: "2.7"


### PR DESCRIPTION
The upstream issues have been fixed (e.g. https://github.com/ContinuumIO/anaconda-issues/issues/1090).

Fixes https://github.com/astropy/photutils/issues/429.