### PR TITLE
Soften API warning

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Photutils
 Photutils at a Glance
 =====================
 
-**Photutils** is an in-development `affiliated package
+**Photutils** is an  `affiliated package
 <http://www.astropy.org/affiliated/index.html>`_ of `Astropy`_ to
 provide tools for detecting and performing photometry of astronomical
 sources.  It is an open source (BSD licensed) Python package.  Bug

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,9 +39,11 @@ reports, comments, and help with development are very welcome.
 
 .. note::
 
-    Photutils is still under development and has not seen widespread
-    use yet.  We will change its API if we find that something can be
-    improved.
+    Like much astronomy software, Photutils is an evolving package.
+    The developers make an effort to maintain backwards compatibility,
+    but at times the API may change if there is a benefit to doing so.
+    If there are specific areas you think API stability is important,
+    please let us know as part of the development process!
 
 
 User Documentation


### PR DESCRIPTION
The current docs index page has a somewhat scary-sounding warning.  This PR updates it to be a bit softer, basically saying "we won't break the API unless there's a good reason."

Does this seem like reasonable wording (and something that's reasonable to keep), @larrybradley 