### PR TITLE
add request to cite photutils via Zenodo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,8 @@ Tests:
 Citing Photutils
 ----------------
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.155353.svg
-    :target: https://doi.org/10.5281/zenodo.155353
+.. image:: https://zenodo.org/badge/2640766.svg
+   :target: https://zenodo.org/badge/latestdoi/2640766
 
 If you use Photutils, please cite the package via its Zenodo record.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,6 +114,12 @@ Citing Photutils
 ================
 
 If you use Photutils, please consider citing the package via its Zenodo record.
-To find all versions (including the latest), you can
+If you just want the latest release, cite this (follow the link on the badge
+and then use one of the citation methods on the right):
+
+.. image:: https://zenodo.org/badge/2640766.svg
+   :target: https://zenodo.org/badge/latestdoi/2640766
+
+If you want to cite an earlier version, you can
 `search for photutils on Zenodo <https://zenodo.org/search?q=photutils>`_.  Then
 cite the Zenodo DOI for whatever version(s) of Photutils you are using.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,7 +113,7 @@ experience necessary):
 Citing Photutils
 ================
 
-If you use Photutils, please consider citing the package via it's Zenodo record.
+If you use Photutils, please consider citing the package via its Zenodo record.
 To find all versions (including the latest), you can
 `search for photutils on Zenodo <https://zenodo.org/search?q=photutils>`_.  Then
 cite the Zenodo DOI for whatever version(s) of Photutils you are using.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,3 +109,11 @@ experience necessary):
 * `Try the development version <http://astropy.readthedocs.io/en/stable/development/workflow/get_devel_version.html>`_
 
 * `Developer Documentation <http://docs.astropy.org/en/latest/#developer-documentation>`_
+
+Citing Photutils
+================
+
+If you use Photutils, please consider citing the package via it's Zenodo record.
+To find all versions (including the latest), you can
+`search for photutils on Zenodo <https://zenodo.org/search?q=photutils>`_.  Then
+cite the Zenodo DOI for whatever version(s) of Photutils you are using.


### PR DESCRIPTION
This adds a section to the index page of the docs on citing photutils, pointing to zenodo (a la the discussion in #422).

One complication I realized: it's not possible to actually provide the DOI link in the docs themselves, because the DOI doesn't get minted.  So my workaround here is to just say "search for photutils on zenodo".  Formally speaking that's the write answer anyway because in principal they should cite the specific version they use.  But I'm open to any ideas on how best to address this...? (@astrofrog @larrybradley @bsipocz, or maybe @arfon has an idea of how this is supposed to work with the github integration?)

If merged, I'd say this closes #422.