### PR TITLE
Monkey patch Sphinx to suppress "nonlocal image URI found" warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,17 @@ conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 
+# Monkey patch to suppress "nonlocal image URI found" warnings
+# http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
+import sphinx.environment
+from docutils.utils import get_source_line
+
+def _warn_node(self, msg, node, **kwargs):
+    if not msg.startswith('nonlocal image URI found:'):
+        self._warnfunc(msg, '%s:%s' % get_source_line(node), **kwargs)
+
+sphinx.environment.BuildEnvironment.warn_node = _warn_node
+
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
The `travis-ci` `build_sphinx` tests are currently failing because of a "nonlocal image URI found" Sphinx warning.  This warning is caused by the external Zenodo badge image, which was added to the docs in https://github.com/astropy/photutils/pull/434.  This PR monkey patches Sphinx to suppress "nonlocal image URI found" warnings.

For reference, I first tried using the `suppress_warnings = ['image.nonlocal_uri']` configuration option introduced in Sphinx `1.4` (http://www.sphinx-doc.org/en/stable/config.html#confval-suppress_warnings), but that gave an `astropy_helpers` warning:

```
WARNING: while setting up extension astropy_helpers.sphinx.ext.autodoc_enhancements: directive 'autoattribute' is already registered, it will be overridden
```

@eteq Is this warning related to https://github.com/astropy/astropy-helpers/issues/227?