### PR TITLE
Refactored 2D Background class to use object-oriented interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,15 +21,15 @@ New Features
 
   - Added ``axis`` keyword to new background classes. [#392]
 
-  - Added new ``BackgroundBase2D`` and ``BackgroundIDW2D`` classes.
-    [#355, #370]
-
   - Added new ``removed_masked``, ``meshpix_threshold``, and
     ``edge_method`` keywords for the 2D background classes. [#355]
 
   - Added new ``std_blocksum`` function. [#355]
 
   - Added new ``SigmaClip`` class. [#423]
+
+  - Added new ``BkgZoomInterpolator`` and ``BkgIDWInterpolator``
+    classes. [#437]
 
 - ``photutils.datasets``
 
@@ -58,7 +58,7 @@ New Features
 
 - ``photutils.segmentation``
 
-  - Added ``copy`` and ``area`` methods and a ``areas`` property to
+  - Added ``copy`` and ``area`` methods and an ``areas`` property to
     ``SegmentationImage``. [#331]
 
 - ``photutils.psf``
@@ -76,17 +76,25 @@ API changes
 
   - Removed the ``effective_gain`` keyword from
     ``aperture_photometry``.  Users must now input the total error,
-    which can be calculating using the ``calc_total_error`` function.
+    which can be calculated using the ``calc_total_error`` function.
     [#368]
 
 - ``photutils.background``
 
   - For the background classes, the ``filter_shape`` keyword was
-    renamed to ``filter_size``.  The ``mode_estimate`` keyword was
-    renamed to ``mode_estimator``.  The ``background_low_res`` and
+    renamed to ``filter_size``.  The ``background_low_res`` and
     ``background_rms_low_res`` class attributes were renamed to
-    ``background_mesh2d`` and ``background_rms_mesh2d``, respectively.
-    [#355]
+    ``background_mesh`` and ``background_rms_mesh``, respectively.
+    [#355, #437]
+
+  - The ``Background2D`` ``method`` and ``backfunc`` keywords have
+    been removed.  In its place one can input callable objects via the
+    ``sigma_clip``, ``bkg_estimator``, and ``bkgrms_estimator``
+    keywords. [#437]
+
+  - The interpolator to be used by the ``Background2D`` class can be
+    input as a callable object via the new ``interpolator`` keyword.
+    [#437]
 
 - ``photutils.centroids``
 
@@ -97,9 +105,9 @@ API changes
 
 - ``photutils.detection``
 
-  - Changed finding algorithm implementations (daofind and IRAF's star
-    find) from functional to object-oriented style. Deprecated old
-    style. [#379]
+  - Changed finding algorithm implementations (``daofind`` and
+    ``starfind``) from functional to object-oriented style. Deprecated
+    old style. [#379]
 
 - ``photutils.morphology``
 
@@ -113,14 +121,14 @@ API changes
 - ``photutils.psf``
 
   - Removed the ``effective_gain`` keyword from ``psf_photometry``.
-    Users must now input the total error, which can be calculating using
-    the ``calc_total_error`` function. [#368]
+    Users must now input the total error, which can be calculated
+    using the ``calc_total_error`` function. [#368]
 
 - ``photutils.segmentation``
 
   - Removed the ``effective_gain`` keyword from ``SourceProperties``
     and ``source_properties``.  Users must now input the total error,
-    which can be calculating using the ``calc_total_error`` function.
+    which can be calculated using the ``calc_total_error`` function.
     [#368]
 
 - ``photutils.utils``
@@ -143,7 +151,8 @@ Bug Fixes
 General
 ^^^^^^^
 
-- Drop numpy 1.6 support, minimal required version is now numpy 1.7. [#327]
+- Dropped numpy 1.6 support. Minimal required version is now numpy
+  1.7. [#327]
 
 - Fixed configparser for Python 3.5. [#366, #384]
 

--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -301,7 +301,7 @@ array, which by design doesn't include increased noise on bright
 pixels.  To include Poisson noise from the sources, we can use the
 :func:`~photutils.utils.calc_total_error` function.  For example,
 suppose we have a function ``background()`` that calculates the
-position-dependent background level and rms of our data::
+position-dependent background level and RMS of our data::
 
     >>> from photutils.utils import calc_total_error
     >>> effective_gain = 1.5

--- a/docs/photutils/background.rst
+++ b/docs/photutils/background.rst
@@ -441,6 +441,44 @@ the background subtraction can be improved by masking the sources
 and/or through further iterations.
 
 
+Plotting Meshes
+^^^^^^^^^^^^^^^
+
+Finally, the meshes that were used in generating the 2D background can
+be plotted on the original image using the
+:meth:`~photutils.background.Background2D.plot_meshes` method:
+
+.. doctest-skip::
+
+    >>> plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm)
+    >>> bkg3.plot_meshes(outlines=True, color='#1f77b4')
+
+.. plot::
+
+    from photutils.datasets import make_100gaussians_image
+    from photutils.background import Background2D
+    from scipy.ndimage.interpolation import rotate
+    import matplotlib.pylab as plt
+    from astropy.visualization import SqrtStretch
+    from astropy.visualization.mpl_normalize import ImageNormalize
+    data = make_100gaussians_image()
+    ny, nx = data.shape
+    y, x = np.mgrid[:ny, :nx]
+    gradient =  x * y / 5000.
+    data2 = data + gradient
+    data3 = rotate(data2, -45.)
+    mask = (data3 == 0)
+    bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
+    back3 = bkg3.background * ~mask
+    norm = ImageNormalize(stretch=SqrtStretch())
+    plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm)
+    bkg3.plot_meshes(outlines=True, color='#17becf')
+
+The meshes extended beyond the original image on the top and right
+because :class:`~photutils.background.Background2D`'s default
+``edge_method`` is ``'pad'``.
+
+
 Reference/API
 -------------
 

--- a/docs/photutils/background.rst
+++ b/docs/photutils/background.rst
@@ -1,5 +1,5 @@
-Background and Background Noise Estimation
-==========================================
+Background Estimation (`photutils.background`)
+==============================================
 
 Introduction
 ------------
@@ -7,34 +7,34 @@ Introduction
 To accurately measure the photometry and morphological properties of
 astronomical sources, one requires an accurate estimate of the
 background, which can be from both the sky and the detector.
-Similarly, having an accurate estimate of the background rms noise is
+Similarly, having an accurate estimate of the background noise is
 important for determining the significance of source detections and
 for estimating photometric errors.
 
 Unfortunately, accurate background and background noise estimation is
 a difficult task.  Further, because astronomical images can cover a
 wide variety of scenes, there is not a single background estimation
-method that will always be applicable.  Photutils provides some tools
-for estimating the background and background noise in your data, but
-ultimately you have the flexibility of determining the background most
-appropriate for your data.
+method that will always be applicable.  Photutils provides tools for
+estimating the background and background noise in your data, but they
+will likely require some tweaking to optimize the background estimate
+for your data.
 
 
-Scalar Background Level and Noise Estimation
---------------------------------------------
+Scalar Background and Noise Estimation
+--------------------------------------
 
 Simple Statistics
 ^^^^^^^^^^^^^^^^^
 
 If the background level and noise are relatively constant across an
 image, the simplest way to estimate these values is to derive scalar
-values for these quantities using simple approximations.  Of course,
-when computing the image statistics one must take into account the
-astronomical sources present in the images, which add a positive tail
-to the distribution of pixel intensities.  For example, one may
-consider using the image median as the background level and the image
-standard deviation as the 1-sigma background noise, but the resulting
-values are obviously biased by the presence of real sources.
+quantities using simple approximations.  Of course, when computing the
+image statistics one must take into account the astronomical sources
+present in the images, which add a positive tail to the distribution
+of pixel intensities.  For example, one may consider using the image
+median as the background level and the image standard deviation as the
+1-sigma background noise, but the resulting values are obviously
+biased by the presence of real sources.
 
 A slightly better method involves using statistics that are robust
 against the presence of outliers, such as the biweight location for
@@ -93,8 +93,8 @@ larger than the true value of 2::
     2.1443728009
 
 
-Sigma-Clipped Statistics
-^^^^^^^^^^^^^^^^^^^^^^^^
+Sigma Clipping Sources
+^^^^^^^^^^^^^^^^^^^^^^
 
 The most widely used technique to remove the sources from the image
 statistics is called sigma clipping.  Briefly, pixels that are above
@@ -117,7 +117,7 @@ An even better procedure is to exclude the sources in the image by
 masking them.  Of course, this technique requires one to `identify the
 sources in the data <detection.html>`_, which in turn depends on the
 background and background noise.  Therefore, this method for
-estimating the background and background rms requires an iterative
+estimating the background and background RMS requires an iterative
 procedure.
 
 Photutils provides a convenience function,
@@ -125,8 +125,7 @@ Photutils provides a convenience function,
 masks.  It uses sigma-clipped statistics as the first estimate of the
 background and noise levels for the source detection.  Sources are
 then identified using image segmentation.  Finally, the source masks
-are dilated to ensure that the extended regions of detected sources
-are completely masked.
+are dilated to mask more extended regions around the detected sources.
 
 Here we use a aggressive 2-sigma detection threshold to maximize the
 source detections and dilate using a 11x11 box:
@@ -141,59 +140,93 @@ source detections and dilate using a 11x11 box:
 
 Of course, the source detection and masking procedure can be iterated
 further.  Even with one iteration we are within 0.02% of the true
-background and 1.5% of the true background rms.
+background and 1.5% of the true background RMS.
 
 .. _scipy: http://www.scipy.org/
 
 
-2D Background Level and Noise Estimation
----------------------------------------------
+2D Background and Noise Estimation
+----------------------------------
 
 If the background or the background noise varies across the image,
 then you will generally want to generate a 2D image of the background
-and background rms (or compute these values locally).  This can be
+and background RMS (or compute these values locally).  This can be
 accomplished by applying the above techniques to subregions of the
 image.  A common procedure is to use sigma-clipped statistics in each
 mesh of a grid that covers the input data to create a low-resolution
-background map.  The final background or background rms map can then
-be generated by interpolating the low-resolution map.
+background image.  The final background or background RMS image can
+then be generated by interpolating the low-resolution image.
 
-Photutils provides the :class:`~photutils.background.Background2D` and
-:class:`~photutils.background.BackgroundIDW2D` classes to estimate the
-2D background and background rms noise in an astronomical image.  To
-resize the low-resolution maps,
-:class:`~photutils.background.Background2D` uses bicublic spline
-interpolation, while :class:`~photutils.background.BackgroundIDW2D`
-uses inverse-distance weighted interpolation (see
-`~photutils.utils.ShepardIDWInterpolator`).
+Photutils provides the :class:`~photutils.background.Background2D`
+class to estimate the 2D background and background noise in an
+astronomical image. :class:`~photutils.background.Background2D`
+requires the size of the box (``box_size``) in which to estimate the
+background.  Selecting the box size requires some care by the user.
+The box size should generally be larger than the typical size of
+sources in the image, but small enough to encapsulate any background
+variations.  For best results, the box size should also be chosen so
+that the data are covered by an integer number of boxes in both
+dimensions.  If that is not the case, the ``edge_method`` keyword
+determines whether to pad or crop the image such that there is an
+integer multiple of the ``box_size`` in both dimensions.
 
-Both classes require the size of the box (``box_size``) in which to
-estimate the background.  Selecting the box size requires some care by
-the user.  The box size should generally be larger than the typical
-size of sources in the image, but small enough to encapsulate any
-background variations.  For best results, the box size should also be
-chosen so that the data are covered by an integer number of boxes in
-both dimensions.  The ``edge_method`` keyword is used to determine how
-to handle the case where the image size is not an integer multiple of
-the ``box_size`` in either dimension.
+The background level in each of the meshes is calculated using the
+function or callable object (e.g. class instance) input via
+``bkg_estimator`` keyword.  Photutils provides a several background
+classes that can be used:
 
-The background level in each of the meshes is based on sigma-clipped
-statistics, where the sigma-clipping is controlled controlled by the
-``sigmaclip_sigma`` and the ``sigclip_iters`` input parameters.  The
-background level in each mesh is estimated using one of several
-defined methods or by using a custom method (see
-:ref:`background_methods` below).  The background rms in each mesh is
-estimated by the sigma-clipped standard deviation.
+* `~photutils.background.MeanBackground`
+* `~photutils.background.MedianBackground`
+* `~photutils.background.ModeEstimatorBackground`
+* `~photutils.background.MMMBackground`
+* `~photutils.background.SExtractorBackground`
+* `~photutils.background.BiweightLocationBackground`
 
-After the background has been determined in each of the boxes, the
-low-resolution background can be median filtered in a box of size
-``filter_size`` to suppress local under- or overestimations (e.g., due
-to bright galaxies in a particular box).  Likewise, the median filter
-can be applied only to those boxes which are above a specified
-threshold (``filter_threshold``).
+The default is a `~photutils.background.SExtractorBackground`
+instance.  For this method, the background in each mesh is calculated
+as ``(2.5 * median) - (1.5 * mean)``.  However, if ``(mean - median) /
+std > 0.3`` then the ``median`` is used instead (despite what the
+`SExtractor <http://www.astromatic.net/software/sextractor>`_ User's
+Manual says, this is the method it always uses).
 
-For this example, we will add a strong background gradient to the
-image::
+Likewise, the background RMS level is each mesh is calculated using
+the function or callable object input via the ``bkgrms_estimator``
+keyword.  Photutils provides the following classes for this purpose:
+
+* `~photutils.background.StdBackgroundRMS`
+* `~photutils.background.MADStdBackgroundRMS`
+* `~photutils.background.BiweightMidvarianceBackgroundRMS`
+
+For even more flexibility, users may input a custom function or
+callable object to the ``bkg_estimator`` and/or ``bkgrms_estimator``
+keywords.
+
+By default the ``bkg_estimator`` and ``bkgrms_estimator`` are applied
+to sigma clipped data.  Sigma clipping is defined by inputting a
+:class:`~photutils.background.SigmaClip` object to the ``sigma_clip``
+keyword.  The default is to perform sigma clipping with ``sigma=3``
+and ``iters=10``.  Sigma clipping can be turned off by setting
+``sigma_clip=None``.
+
+After the background level has been determined in each of the boxes,
+the low-resolution background image can be median filtered, with a
+window of size of ``filter_size``, to suppress local under- or
+overestimations (e.g., due to bright galaxies in a particular box).
+Likewise, the median filter can be applied only to those boxes where
+the background level is above a specified threshold
+(``filter_threshold``).
+
+The low-resolution background and background RMS images are resized to
+the original data size using the using the function or callable object
+input via the ``interpolator`` keyword.  Photutils provides two
+interpolator classes:
+:class:`~photutils.background.BkgZoomInterpolator` (default), which
+performs spline interpolation, and
+:class:`~photutils.background.BkgIDWInterpolator`, which uses
+inverse-distance weighted (IDW) interpolation.
+
+For this example, we will create a test image by adding a strong
+background gradient to the image defined above::
 
     >>> ny, nx = data.shape
     >>> y, x = np.mgrid[:ny, :nx]
@@ -216,21 +249,25 @@ image::
     plt.imshow(data2, norm=norm, origin='lower', cmap='Greys_r')
 
 We start by creating a `~photutils.background.Background2D` object
-using a box size of 50x50, a 3x3 median filter, and the "median"
-background method, which estimates the background using the
-sigma-clipped median in each box:
+using a box size of 50x50 and a 3x3 median filter.  We will estimate
+the background level in each mesh as the sigma-clipped median using an
+instance of :class:`~photutils.background.MedianBackground`.
 
 .. doctest-requires:: scipy
 
-    >>> from photutils.background import Background2D
+    >>> from photutils import Background2D, SigmaClip, MedianBackground
+    >>> sigma_clip = SigmaClip(sigma=3., iters=10)
+    >>> bkg_estimator = MedianBackground()
     >>> bkg = Background2D(data2, (50, 50), filter_size=(3, 3),
-    ...                    method='median')
+    ...                    sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
 
-The 2D background map and background rms maps are retrieved using the
-``background`` and ``background_rms`` attributes, respectively.  The
-low-resolution versions of these maps are the ``bkg_mesh2d`` and
-``bkgrms_mesh2d`` attributes, respectively.   The global median value
-of the low-resolution background and background rms maps is provided
+
+The 2D background and background RMS images are retrieved using the
+``background`` and ``background_rms`` attributes, respectively, on the
+returned object.  The low-resolution versions of these images are
+stored in the ``background_mesh`` and ``background_rms_mesh``
+attributes, respectively.   The global median value of the
+low-resolution background and background RMS image can be accessed
 with the ``background_median`` and ``background_rms_median``
 attributes, respectively:
 
@@ -251,13 +288,16 @@ Let's plot the background image:
 
     import matplotlib.pylab as plt
     from photutils.datasets import make_100gaussians_image
-    from photutils.background import Background2D
+    from photutils import Background2D, SigmaClip, MedianBackground
     data = make_100gaussians_image()
     ny, nx = data.shape
     y, x = np.mgrid[:ny, :nx]
     gradient =  x * y / 5000.
     data2 = data + gradient
-    bkg = Background2D(data2, (50, 50), filter_size=(3, 3), method='median')
+    sigma_clip = SigmaClip(sigma=3., iters=10)
+    bkg_estimator = MedianBackground()
+    bkg = Background2D(data2, (50, 50), filter_size=(3, 3),
+                       sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
     plt.imshow(bkg.background, origin='lower', cmap='Greys_r')
 
 and the background-subtracted image:
@@ -273,75 +313,36 @@ and the background-subtracted image:
     from astropy.visualization import SqrtStretch
     from astropy.visualization.mpl_normalize import ImageNormalize
     from photutils.datasets import make_100gaussians_image
-    from photutils.background import Background2D
+    from photutils import Background2D, SigmaClip, MedianBackground
     data = make_100gaussians_image()
     ny, nx = data.shape
     y, x = np.mgrid[:ny, :nx]
     gradient =  x * y / 5000.
     data2 = data + gradient
-    bkg = Background2D(data2, (50, 50), filter_size=(3, 3), method='median')
+    sigma_clip = SigmaClip(sigma=3., iters=10)
+    bkg_estimator = MedianBackground()
+    bkg = Background2D(data2, (50, 50), filter_size=(3, 3),
+                       sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data2 - bkg.background, norm=norm, origin='lower', cmap='Greys_r')
-
-
-.. _background_methods:
-
-Background Methods
-^^^^^^^^^^^^^^^^^^
-
-The background level in each of the background meshes can by estimated
-using one of several defined methods or by using a custom method.  For
-all methods, the statistics are calculated from the sigma-clipped data
-values in each mesh.  The defined methods are ``'mean'``,
-``'median'``, ``'sextractor'``, and ``'mode_estimator'``.  ``'mean'``
-and ``'median'`` are simply the sigma-clipped mean and median,
-respectively, in each background mesh.  For ``'sextractor'``, the
-background in each mesh is ``(2.5 * median) - (1.5 * mean)``.
-However, if ``(mean - median) / std > 0.3`` then the ``median`` is
-used instead (despite what the `SExtractor
-<http://www.astromatic.net/software/sextractor>`_ User's Manual says,
-this is the method it always uses).  For ``'mode_estimator'``, the
-background is ``(3 * median) - (2 * mean)``.
-
-A custom calculation can also be defined for the background level by
-setting ``method='custom'`` and inputing a custom function to the
-``backfunc`` parameter.  The custom function must must take in a 2D
-`~numpy.ma.MaskedArray` of size ``NxZ``, where the ``Z`` axis (axis=1)
-contains the sigma-clipped pixels in each background mesh, and outputs
-a 1D `~numpy.ndarray` low-resolution background map of length ``N``.
-
-We demonstrate this capability using a custom function that is simply
-the median of the sigma-clipped data in each mesh (this is the same
-calculation used by ``method='median'``).  We start by defining the
-custom function::
-
-    >>> def backfunc(data):
-    ...    return np.ma.median(data, axis=1)
-
-Now we can pass the function to the
-`~photutils.background.Background2D` class:
-
-.. doctest-requires:: scipy
-
-    >>> b = Background2D(data, (50, 50), filter_size=(3, 3),
-    ...                  method='custom', backfunc=backfunc)
-    >>> bkg = b.background
+    plt.imshow(data2 - bkg.background, norm=norm, origin='lower',
+               cmap='Greys_r')
 
 
 Masking
 ^^^^^^^
 
 Masks can also be input into `~photutils.background.Background2D`.  As
-described above, this can be employed to mask sources in the image to
-estimate the background with an iterative procedure.
+described above, this can be employed to mask sources in the image
+prior to estimating the background levels.
 
 Additionally, input masks are often necessary if your data array
 includes regions without data coverage (e.g., from a rotated image or
 an image from a mosaic).  Otherwise the data values in the regions
-without coverage (e.g., usually zeros) will adversely contribute to
+without coverage (usually zeros or NaNs) will adversely contribute to
 the background statistics.
 
-Let's create such an image (this requires `scipy`_) and plot it:
+Let's create such an image and plot it (NOTE: this example requires
+`scipy`_):
 
 .. doctest-requires:: scipy
 
@@ -369,7 +370,7 @@ Let's create such an image (this requires `scipy`_) and plot it:
 Now we create a coverage mask and input it into
 `~photutils.background.Background2D` to exclude the regions where we
 have no data.  For real data, one can usually create a coverage mask
-from a weight or rms image.  For this example we also use a smaller
+from a weight or noise image.  In this example we also use a smaller
 box size to help capture the strong gradient in the background:
 
 .. doctest-requires:: scipy
@@ -377,10 +378,10 @@ box size to help capture the strong gradient in the background:
     >>> mask = (data3 == 0)
     >>> bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
 
-Masks are never applied to the returned background map because the
-input ``mask`` can represent either a coverage mask or a source mask,
-or a combination of both.  We need to manually apply the coverage mask
-to the returned background map:
+The input masks are never applied to the returned background image
+because the input ``mask`` can represent either a coverage mask or a
+source mask, or a combination of both.  Therefore, we need to manually
+apply the coverage mask to the returned background image:
 
 .. doctest-requires:: scipy
 
@@ -435,9 +436,9 @@ Finally, let's subtract the background from the image and plot it:
     norm = ImageNormalize(stretch=SqrtStretch())
     plt.imshow(data3 - back3, origin='lower', cmap='Greys_r', norm=norm)
 
-Some small residual background is still present in the image, but the
-background subtraction can be improved through further interations and
-by masking the sources.
+If there is any small residual background still present in the image,
+the background subtraction can be improved by masking the sources
+and/or through further iterations.
 
 
 Reference/API

--- a/docs/photutils/detection.rst
+++ b/docs/photutils/detection.rst
@@ -135,7 +135,7 @@ In Photutils, source extraction is performed using the
 :func:`~photutils.detection.detect_threshold` tool is a convenience
 function to generate a 2D detection threshold image using simple
 sigma-clipped statistics to estimate the background and background
-rms.
+RMS.
 
 For this example, let's detect sources in a synthetic image provided
 by the `datasets <datasets.html>`_ module::
@@ -146,7 +146,7 @@ by the `datasets <datasets.html>`_ module::
 We will use :func:`~photutils.detection.detect_threshold` to produce a
 detection threshold image.
 :func:`~photutils.detection.detect_threshold` will estimate the
-background and background rms using sigma-clipped statistics if they
+background and background RMS using sigma-clipped statistics if they
 are not input.  The threshold level is calculated using the ``snr``
 input as the sigma level above the background.  Here we generate a
 simple pixel-wise threshold at 3 sigma above the background::

--- a/docs/photutils/overview.rst
+++ b/docs/photutils/overview.rst
@@ -6,7 +6,7 @@ Introduction
 
 Photutils contains functions for:
 
-* estimating the background and background rms in astronomical images
+* estimating the background and background RMS in astronomical images
 * detecting sources in astronomical images
 * estimating morphological parameters of those sources (e.g., centroid
   and shape parameters)

--- a/docs/photutils/segmentation.rst
+++ b/docs/photutils/segmentation.rst
@@ -37,16 +37,19 @@ Let's detect sources and measure their properties in a synthetic
 image.  For this example, we will use the
 :class:`~photutils.background.Background2D` class to produce a
 background and background noise image.  We define a 2D detection
-threshold image using the background and background rms maps.  We set
+threshold image using the background and background RMS maps.  We set
 the threshold at 3 sigma above the background:
 
 .. doctest-requires:: scipy
 
     >>> from photutils.datasets import make_100gaussians_image
-    >>> from photutils import Background2D, detect_threshold, detect_sources
+    >>> from photutils import Background2D, MedianBackground
+    >>> from photutils import detect_threshold, detect_sources
     >>> from astropy.convolution import Gaussian2DKernel
     >>> data = make_100gaussians_image()
-    >>> bkg = Background2D(data, (50, 50), filter_size=(3, 3), method='median')
+    >>> bkg_estimator = MedianBackground()
+    >>> bkg = Background2D(data, (50, 50), filter_size=(3, 3),
+    ...                    bkg_estimator=bkg_estimator)
     >>> threshold = bkg.background + (3. * bkg.background_rms)
 
 Now we find sources that have 5 connected pixels that are each greater
@@ -136,12 +139,15 @@ Now let's plot the results:
     from astropy.visualization import SqrtStretch
     from astropy.visualization.mpl_normalize import ImageNormalize
     from photutils.datasets import make_100gaussians_image
-    from photutils import Background2D, detect_threshold, detect_sources
+    from photutils import Background2D, MedianBackground
+    from photutils import detect_threshold, detect_sources
     from photutils import source_properties, properties_table
     from photutils.utils import random_cmap
     from photutils import EllipticalAperture
     data = make_100gaussians_image()
-    bkg = Background2D(data, (50, 50), filter_size=(3, 3), method='median')
+    bkg_estimator = MedianBackground()
+    bkg = Background2D(data, (50, 50), filter_size=(3, 3),
+                       bkg_estimator=bkg_estimator)
     threshold = bkg.background + (3. * bkg.background_rms)
     sigma = 2.0 * gaussian_fwhm_to_sigma    # FWHM = 2.
     kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -579,7 +579,10 @@ class Background2D(object):
         "MINIBACK_RMS" background maps in SExtractor, respectively.
         """
 
-        data_sigclip = self.sigma_clip(self.mesh_data, axis=1)
+        if self.sigma_clip is not None:
+            data_sigclip = self.sigma_clip(self.mesh_data, axis=1)
+        else:
+            data_sigclip = self.mesh_data
 
         self._mesh_shape = (self.nyboxes, self.nxboxes)
         self.mesh_yidx, self.mesh_xidx = np.unravel_index(self.mesh_idx,

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -670,6 +670,7 @@ class Background2D(object):
             data_sigclip = self.sigma_clip(self.mesh_data, axis=1)
         else:
             data_sigclip = self.mesh_data
+        self._data_sigclip = data_sigclip
 
         self._mesh_shape = (self.nyboxes, self.nxboxes)
         self.mesh_yidx, self.mesh_xidx = np.unravel_index(self.mesh_idx,
@@ -718,6 +719,17 @@ class Background2D(object):
         # the position coordinates used when calling an interpolator
         nx, ny = self.data.shape
         self.data_coords = np.array(list(product(range(ny), range(nx))))
+
+    @lazyproperty
+    def mesh_nmasked(self):
+        """
+        A 2D (masked) array of the number of masked pixels in each mesh.
+        Only meshes included in the background estimation are included.
+        Excluded meshes will be masked in the image.
+        """
+
+        return self._make_2d_array(np.ma.count_masked(self._data_sigclip,
+                                                      axis=1))
 
     @lazyproperty
     def background_mesh_ma(self):

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -6,21 +6,13 @@ background rms in a 2D image.
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from distutils.version import LooseVersion
 from itertools import product
-import warnings
 import numpy as np
 from numpy.lib.index_tricks import index_exp
-from astropy.stats import sigma_clip
 from astropy.utils import lazyproperty
 from .core import SExtractorBackground
 from ..utils import ShepardIDWInterpolator
-
-import astropy
-if LooseVersion(astropy.__version__) < LooseVersion('1.1'):
-    ASTROPY_LT_1P1 = True
-else:
-    ASTROPY_LT_1P1 = False
+from ..extern.sigma_clipping import sigma_clip
 
 
 __all__ = ['BackgroundBase2D', 'Background2D', 'BackgroundIDW2D',
@@ -402,18 +394,10 @@ class BackgroundBase2D(object):
         ``box_size``.
         """
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            if ASTROPY_LT_1P1:
-                self.data_sigclip = sigma_clip(
-                    data2d, sig=self.sigclip_sigma, axis=1,
-                    iters=self.sigclip_iters, cenfunc=np.ma.median,
-                    varfunc=np.ma.var)
-            else:
-                self.data_sigclip = sigma_clip(
-                    data2d, sigma=self.sigclip_sigma, axis=1,
-                    iters=self.sigclip_iters, cenfunc=np.ma.median,
-                    stdfunc=np.std)
+        self.data_sigclip = sigma_clip(
+            data2d, sigma=self.sigclip_sigma, axis=1,
+            iters=self.sigclip_iters, cenfunc=np.ma.median,
+            stdfunc=np.std)
 
         # the number of masked and unmasked pixels in each mesh
         # including *both* the input (and padding) mask and pixels masked

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -35,6 +35,7 @@ class BkgZoomInterpolator(object):
         self.pad_crop = pad_crop
 
     def __call__(self, mesh, bkgbase_obj):
+        mesh = np.asanyarray(mesh)
         if np.ptp(mesh) == 0:
             return np.zeros_like(bkgbase_obj.data) + np.min(mesh)
 
@@ -74,6 +75,7 @@ class BkgIDWInterpolator(object):
         self.leafsize = leafsize
 
     def __call__(self, mesh, bkgbase_obj):
+        mesh = np.asanyarray(mesh)
         if np.ptp(mesh) == 0:
             return np.zeros_like(bkgbase_obj.data) + np.min(mesh)
 
@@ -214,6 +216,8 @@ class Background2D(object):
                  bkgrms_estimator=StdBackgroundRMS(sigma_clip=None),
                  interpolator=BkgZoomInterpolator()):
 
+        data = np.asanyarray(data)
+
         box_size = np.atleast_1d(box_size)
         if len(box_size) == 1:
             box_size = (box_size, box_size)
@@ -222,6 +226,7 @@ class Background2D(object):
         self.box_npixels = self.box_size[0] * self.box_size[1]
 
         if mask is not None:
+            mask = np.asanyarray(mask)
             if mask.shape != data.shape:
                 raise ValueError('mask and data must have the same shape')
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -24,8 +24,8 @@ __doctest_requires__ = {('BkgZoomInterpolator', 'Background2D'): ['scipy']}
 class BkgZoomInterpolator(object):
     """
     This class generates full-sized background and background RMS images
-    from lower-resolution mesh images using the
-    `~scipy.ndimage.interpolation.zoom` (spline) interpolator.
+    from lower-resolution mesh images using the `~scipy.ndimage.zoom`
+    (spline) interpolator.
 
     This class must be used in concert with the `Background2D` class.
 
@@ -719,7 +719,7 @@ class Background2D(object):
         """
         The median value of the 2D low-resolution background map.
 
-        This is equivalent to the value `SExtractor`_ prints to stdout
+        This is equivalent to the value SExtractor prints to stdout
         (i.e., "(M+D) Background: <value>").
         """
 
@@ -730,7 +730,7 @@ class Background2D(object):
         """
         The median value of the low-resolution background RMS map.
 
-        This is equivalent to the value `SExtractor`_ prints to stdout
+        This is equivalent to the value SExtractor prints to stdout
         (i.e., "(M+D) RMS: <value>").
         """
 

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This module defines background classes to estimate a scalar background
-and background rms from an array (which may be masked) of any dimension.
+and background RMS from an array (which may be masked) of any dimension.
 These classes were designed as part of an object-oriented interface for
 the tools in the PSF subpackage.
 """
@@ -189,7 +189,7 @@ class BackgroundBase(object):
 @six.add_metaclass(_ABCMetaAndInheritDocstrings)
 class BackgroundRMSBase(object):
     """
-    Base class for classes that estimate scalar background rms values.
+    Base class for classes that estimate scalar background RMS values.
 
     Parameters
     ----------
@@ -208,20 +208,20 @@ class BackgroundRMSBase(object):
     @abc.abstractmethod
     def calc_background_rms(self, data, axis=None):
         """
-        Calculate the background rms value.
+        Calculate the background RMS value.
 
         Parameters
         ----------
         data : array_like or `~numpy.ma.MaskedArray`
-            The array for which to calculate the background rms value.
+            The array for which to calculate the background RMS value.
         axis : int or `None`, optional
-            The array axis along which the background rms is calculated.
+            The array axis along which the background RMS is calculated.
             If `None`, then the entire array is used.
 
         Returns
         -------
         result : float or `~numpy.ma.MaskedArray`
-            The calculated background rms value.  If ``axis`` is `None`
+            The calculated background RMS value.  If ``axis`` is `None`
             then a scalar will be returned, otherwise a
             `~numpy.ma.MaskedArray` will be returned.
         """
@@ -523,7 +523,7 @@ class BiweightLocationBackground(BackgroundBase):
 
 class StdBackgroundRMS(BackgroundRMSBase):
     """
-    Class to calculate the background rms in an array as the
+    Class to calculate the background RMS in an array as the
     (sigma-clipped) standard deviation.
 
     Parameters
@@ -540,14 +540,14 @@ class StdBackgroundRMS(BackgroundRMSBase):
     >>> sigma_clip = SigmaClip(sigma=3.)
     >>> bkgrms = StdBackgroundRMS(sigma_clip)
 
-    The background value can be calculated by using the
+    The background RMS value can be calculated by using the
     `calc_background_rms` method, e.g.:
 
     >>> bkgrms_value = bkgrms.calc_background_rms(data)
     >>> print(bkgrms_value)    # doctest: +FLOAT_CMP
     28.866070047722118
 
-    Alternatively, the background rms value can be calculated by calling
+    Alternatively, the background RMS value can be calculated by calling
     the class instance as a function, e.g.:
 
     >>> bkgrms_value = bkgrms(data)
@@ -564,7 +564,7 @@ class StdBackgroundRMS(BackgroundRMSBase):
 
 class MADStdBackgroundRMS(BackgroundRMSBase):
     """
-    Class to calculate the background rms in an array as using the
+    Class to calculate the background RMS in an array as using the
     `median absolute deviation (MAD)
     <http://en.wikipedia.org/wiki/Median_absolute_deviation>`_.
 
@@ -592,14 +592,14 @@ class MADStdBackgroundRMS(BackgroundRMSBase):
     >>> sigma_clip = SigmaClip(sigma=3.)
     >>> bkgrms = MADStdBackgroundRMS(sigma_clip)
 
-    The background value can be calculated by using the
+    The background RMS value can be calculated by using the
     `calc_background_rms` method, e.g.:
 
     >>> bkgrms_value = bkgrms.calc_background_rms(data)
     >>> print(bkgrms_value)    # doctest: +FLOAT_CMP
     37.065055462640053
 
-    Alternatively, the background rms value can be calculated by calling
+    Alternatively, the background RMS value can be calculated by calling
     the class instance as a function, e.g.:
 
     >>> bkgrms_value = bkgrms(data)
@@ -616,7 +616,7 @@ class MADStdBackgroundRMS(BackgroundRMSBase):
 
 class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase):
     """
-    Class to calculate the background rms in an array as the
+    Class to calculate the background RMS in an array as the
     (sigma-clipped) biweight midvariance.
 
     Parameters
@@ -639,14 +639,14 @@ class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase):
     >>> sigma_clip = SigmaClip(sigma=3.)
     >>> bkgrms = BiweightMidvarianceBackgroundRMS(sigma_clip=sigma_clip)
 
-    The background value can be calculated by using the
+    The background RMS value can be calculated by using the
     `calc_background_rms` method, e.g.:
 
     >>> bkgrms_value = bkgrms.calc_background_rms(data)
     >>> print(bkgrms_value)    # doctest: +FLOAT_CMP
     30.094338485893392
 
-    Alternatively, the background rms value can be calculated by calling
+    Alternatively, the background RMS value can be calculated by calling
     the class instance as a function, e.g.:
 
     >>> bkgrms_value = bkgrms(data)

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -72,7 +72,6 @@ class TestBackground2D(object):
 
     @pytest.mark.parametrize('filter_size', FILTER_SIZES)
     def test_resizing(self, filter_size):
-        # SExtractorBackground cannot be used here
         b1 = Background2D(DATA, (22, 22), filter_size=filter_size,
                           bkg_estimator=MeanBackground(), edge_method='crop')
         b2 = Background2D(DATA, (22, 22), filter_size=filter_size,

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -1,11 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import itertools
+
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
-import itertools
-from ..background_2d import Background2D, BackgroundIDW2D, std_blocksum
+
+from ..core import MeanBackground
+from ..background_2d import (BkgZoomInterpolator, BkgIDWInterpolator,
+                             Background2D, std_blocksum)
 from ...datasets import make_noise_image
 
 try:
@@ -22,49 +26,57 @@ BKG_RMS_MESH = np.zeros((4, 4))
 PADBKG_MESH = np.ones((5, 5))
 PADBKG_RMS_MESH = np.zeros((5, 5))
 FILTER_SIZES = [(1, 1), (3, 3)]
-METHODS = ['mean', 'median', 'sextractor', 'mode_estimator']
 EDGE_METHODS = ['pad', 'crop']
-
-
-def custom_backfunc(data):
-    """Same as method='mean'."""
-    return np.ma.mean(data, axis=1)
+INTERPOLATORS = [BkgZoomInterpolator(), BkgIDWInterpolator()]
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestBackground2D(object):
-    @pytest.mark.parametrize(('filter_size', 'method'),
-                             list(itertools.product(FILTER_SIZES, METHODS)))
-    def test_background(self, filter_size, method):
+    @pytest.mark.parametrize(('filter_size', 'interpolator'),
+                             list(itertools.product(FILTER_SIZES,
+                                                    INTERPOLATORS)))
+    def test_background(self, filter_size, interpolator):
         b = Background2D(DATA, (25, 25), filter_size=filter_size,
-                         method=method)
+                         interpolator=interpolator)
         assert_allclose(b.background, DATA)
         assert_allclose(b.background_rms, BKG_RMS)
-        assert_allclose(b.background_mesh2d, BKG_MESH)
-        assert_allclose(b.background_rms_mesh2d, BKG_RMS_MESH)
+        assert_allclose(b.background_mesh, BKG_MESH)
+        assert_allclose(b.background_rms_mesh, BKG_RMS_MESH)
         assert b.background_median == 1.0
         assert b.background_rms_median == 0.0
 
-    def test_background_nonconstant(self):
+    @pytest.mark.parametrize('interpolator', INTERPOLATORS)
+    def test_background_nonconstant(self, interpolator):
         data = np.copy(DATA)
         data[25:50, 50:75] = 10.
         bkg_low_res = np.copy(BKG_MESH)
         bkg_low_res[1, 2] = 10.
-        b1 = Background2D(data, (25, 25), filter_size=(1, 1), method='mean')
-        assert_allclose(b1.background_mesh2d, bkg_low_res)
+        b1 = Background2D(data, (25, 25), filter_size=(1, 1),
+                          interpolator=interpolator)
+        assert_allclose(b1.background_mesh, bkg_low_res)
         assert b1.background.shape == data.shape
-        b2 = Background2D(data, (25, 25), filter_size=(1, 1), method='mean',
-                          edge_method='pad')
-        assert_allclose(b2.background_mesh2d, bkg_low_res)
+        b2 = Background2D(data, (25, 25), filter_size=(1, 1),
+                          edge_method='pad', interpolator=interpolator)
+        assert_allclose(b2.background_mesh, bkg_low_res)
         assert b2.background.shape == data.shape
 
-    @pytest.mark.parametrize(('filter_size', 'method'),
-                             list(itertools.product(FILTER_SIZES, METHODS)))
-    def test_resizing(self, filter_size, method):
+    def test_no_sigma_clipping(self):
+        data = np.copy(DATA)
+        data[10, 10] = 100.
+        b1 = Background2D(data, (25, 25), filter_size=(1, 1),
+                          bkg_estimator=MeanBackground())
+        b2 = Background2D(data, (25, 25), filter_size=(1, 1), sigma_clip=None,
+                          bkg_estimator=MeanBackground())
+
+        assert b2.background_mesh[0, 0] > b1.background_mesh[0, 0]
+
+    @pytest.mark.parametrize('filter_size', FILTER_SIZES)
+    def test_resizing(self, filter_size):
+        # SExtractorBackground cannot be used here
         b1 = Background2D(DATA, (22, 22), filter_size=filter_size,
-                          edge_method='crop', method=method)
+                          bkg_estimator=MeanBackground(), edge_method='crop')
         b2 = Background2D(DATA, (22, 22), filter_size=filter_size,
-                          edge_method='pad', method=method)
+                          bkg_estimator=MeanBackground(), edge_method='pad')
         assert_allclose(b1.background, b2.background)
         assert_allclose(b1.background_rms, b2.background_rms)
 
@@ -79,118 +91,94 @@ class TestBackground2D(object):
         data[25:50, 25:50] = 100.
         mask = np.zeros_like(DATA, dtype=np.bool)
         mask[25:50, 25:50] = True
-        b = Background2D(data, box_size, filter_size=(1, 1), mask=mask)
+        b = Background2D(data, box_size, filter_size=(1, 1), mask=mask,
+                         bkg_estimator=MeanBackground())
         assert_allclose(b.background, DATA)
         assert_allclose(b.background_rms, BKG_RMS)
 
         # test mask padding
-        b2 = Background2D(data, (22, 22), filter_size=(1, 1), mask=mask,
-                          edge_method='pad')
+        b2 = Background2D(data, box_size, filter_size=(1, 1), mask=mask,
+                          bkg_estimator=MeanBackground(), edge_method='pad')
         assert_allclose(b2.background, DATA)
 
-    @pytest.mark.parametrize('remove_masked', (['any', 'all', 'threshold']))
-    def test_remove_masked(self, remove_masked):
-        b = Background2D(DATA, (25, 25), remove_masked=remove_masked)
+    @pytest.mark.parametrize('exclude_mesh_method',
+                             (['any', 'all', 'threshold']))
+    def test_exclude_mesh(self, exclude_mesh_method):
+        b = Background2D(DATA, (25, 25),
+                         exclude_mesh_method=exclude_mesh_method)
         assert_allclose(b.background, DATA)
-        b2 = Background2D(DATA, (25, 25), remove_masked='_none')
-        assert_allclose(b2.background, DATA)
 
         # test if data is completely masked
         with pytest.raises(ValueError):
             mask = np.ones_like(DATA, dtype=np.bool)
             Background2D(DATA, (25, 25), mask=mask,
-                         remove_masked=remove_masked)
+                         exclude_mesh_method=exclude_mesh_method)
 
     def test_filter_threshold(self):
         """Only meshes greater than filter_threshold are filtered."""
+
         data = np.copy(DATA)
         data[25:50, 50:75] = 10.
         b = Background2D(data, (25, 25), filter_size=(3, 3),
                          filter_threshold=9.)
         assert_allclose(b.background, DATA)
-        assert_allclose(b.background_mesh2d, BKG_MESH)
+        assert_allclose(b.background_mesh, BKG_MESH)
         b2 = Background2D(data, (25, 25), filter_size=(3, 3),
                           filter_threshold=11.)   # no filtering
-        assert b2.background_mesh2d[1, 2] == 10
+        assert b2.background_mesh[1, 2] == 10
 
     def test_filter_threshold_high(self):
         """No filtering because filter_threshold is too large."""
+
         data = np.copy(DATA)
         data[25:50, 50:75] = 10.
         ref_data = np.copy(BKG_MESH)
         ref_data[1, 2] = 10.
         b = Background2D(data, (25, 25), filter_size=(3, 3),
                          filter_threshold=100.)
-        assert_allclose(b.background_mesh2d, ref_data)
+        assert_allclose(b.background_mesh, ref_data)
 
     def test_filter_threshold_nofilter(self):
         """No filtering because filter_size is (1, 1)."""
+
         data = np.copy(DATA)
         data[25:50, 50:75] = 10.
         ref_data = np.copy(BKG_MESH)
         ref_data[1, 2] = 10.
         b = Background2D(data, (25, 25), filter_size=(1, 1),
                          filter_threshold=1.)
-        assert_allclose(b.background_mesh2d, ref_data)
+        assert_allclose(b.background_mesh, ref_data)
 
     def test_scalar_sizes(self):
-        b1 = Background2D(DATA, (25, 25), filter_size=(3, 3), method='mean')
-        b2 = Background2D(DATA, 25, filter_size=3, method='mean')
+        b1 = Background2D(DATA, (25, 25), filter_size=(3, 3))
+        b2 = Background2D(DATA, 25, filter_size=3)
         assert_allclose(b1.background, b2.background)
         assert_allclose(b1.background_rms, b2.background_rms)
 
-    def test_meshpix_threshold(self):
+    def test_exclude_mesh_percentile(self):
         with pytest.raises(ValueError):
-            Background2D(DATA, (5, 5), remove_masked='threshold',
-                         meshpix_threshold=26)
-
-    def test_custom_method(self):
-        b0 = Background2D(DATA, (25, 25), filter_size=(3, 3), method='mean')
-        b1 = Background2D(DATA, (25, 25), filter_size=(3, 3), method='custom',
-                          backfunc=custom_backfunc)
-        assert_allclose(b0.background, b1.background)
-        assert_allclose(b0.background_rms, b1.background_rms)
+            Background2D(DATA, (5, 5), exclude_mesh_method='threshold',
+                         exclude_mesh_percentile=101)
 
     def test_mask_badshape(self):
         with pytest.raises(ValueError):
             Background2D(DATA, (25, 25), filter_size=(1, 1),
                          mask=np.zeros((2, 2)))
 
-    def test_invalid_method(self):
-        with pytest.raises(ValueError):
-            Background2D(DATA, (25, 25), filter_size=(1, 1),
-                         method='not_valid')
-
     def test_invalid_edge_method(self):
         with pytest.raises(ValueError):
             Background2D(DATA, (22, 22), filter_size=(1, 1),
                          edge_method='not_valid')
 
-    def test_invalid_remove_masked(self):
+    def test_invalid_exclude_mesh_method(self):
         with pytest.raises(ValueError):
             Background2D(DATA, (22, 22), filter_size=(1, 1),
-                         remove_masked='not_valid')
+                         exclude_mesh_method='not_valid')
 
-    def test_custom_return_nonarray(self):
-        def backfunc(data):
-            return 1
+    def test_invalid_mesh_idx_len(self):
         with pytest.raises(ValueError):
-            Background2D(DATA, (25, 25), filter_size=(3, 3),
-                         method='custom', backfunc=backfunc)
-
-    def test_custom_return_masked_array(self):
-        def backfunc(data):
-            return np.ma.masked_array([1], mask=False)
-        with pytest.raises(ValueError):
-            Background2D(DATA, (25, 25), filter_size=(3, 3),
-                         method='custom', backfunc=backfunc)
-
-    def test_custom_return_badshape(self):
-        def backfunc(data):
-            return np.ones((2, 2))
-        with pytest.raises(ValueError):
-            Background2D(DATA, (25, 25), filter_size=(3, 3),
-                         method='custom', backfunc=backfunc)
+            bkg = Background2D(DATA, (25, 25), filter_size=(1, 1))
+            bkg._make_2d_array(np.arange(3))
 
     def test_plot_meshes(self):
         """
@@ -200,27 +188,6 @@ class TestBackground2D(object):
 
         b = Background2D(DATA, (25, 25))
         b.plot_meshes(outlines=True)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
-class TestBackgroundIDW2D(object):
-    def test_background_idw(self):
-        b = BackgroundIDW2D(DATA, (25, 25), filter_size=(1, 1), method='mean')
-        assert_allclose(b.background, DATA)
-        assert_allclose(b.background_rms, BKG_RMS)
-        assert_allclose(b.background_mesh2d, BKG_MESH)
-        assert_allclose(b.background_rms_mesh2d, BKG_RMS_MESH)
-        assert b.background_median == 1.0
-        assert b.background_rms_median == 0.0
-
-    def test_background_idw_nonconstant(self):
-        data = np.copy(DATA)
-        data[25:50, 50:75] = 10.
-        bkg_low_res = np.copy(BKG_MESH)
-        bkg_low_res[1, 2] = 10.
-        b = BackgroundIDW2D(data, (25, 25), filter_size=(1, 1), method='mean')
-        assert_allclose(b.background_mesh2d, bkg_low_res)
-        assert b.background.shape == data.shape
 
 
 class TestStdBlocksum(object):

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -9,8 +9,7 @@ from astropy.tests.helper import pytest
 
 from ..core import MeanBackground
 from ..background_2d import (BkgZoomInterpolator, BkgIDWInterpolator,
-                             Background2D, std_blocksum)
-from ...datasets import make_noise_image
+                             Background2D)
 
 try:
     import scipy
@@ -187,18 +186,3 @@ class TestBackground2D(object):
 
         b = Background2D(DATA, (25, 25))
         b.plot_meshes(outlines=True)
-
-
-class TestStdBlocksum(object):
-    stddev = 5
-    data = make_noise_image((100, 100), mean=0, stddev=stddev,
-                            random_state=12345)
-    block_sizes = np.array([5, 7, 10])
-    stds = std_blocksum(data, block_sizes)
-    expected = np.array([stddev, stddev, stddev])
-    assert_allclose(stds / block_sizes, expected, atol=0.2)
-
-    mask = np.zeros_like(data, dtype=np.bool)
-    mask[25:50, 25:50] = True
-    stds2 = std_blocksum(data, block_sizes, mask=mask)
-    assert_allclose(stds2 / block_sizes, expected, atol=0.3)

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -19,13 +19,26 @@ STD = 0.5
 DATA = make_noise_image((100, 100), type='gaussian', mean=BKG, stddev=STD,
                         random_state=12345)
 
-BKG_CLASS = [MeanBackground, MedianBackground, ModeEstimatorBackground,
-             MMMBackground, SExtractorBackground, BiweightLocationBackground]
+BKG_CLASS0 = [MeanBackground, MedianBackground, ModeEstimatorBackground,
+              MMMBackground, SExtractorBackground]
+# BiweightLocationBackground cannot handle a constant background
+# (astropy.stats.biweight_location needs to be fixed)
+BKG_CLASS = BKG_CLASS0 + [BiweightLocationBackground]
 
 RMS_CLASS = [StdBackgroundRMS, MADStdBackgroundRMS,
              BiweightMidvarianceBackgroundRMS]
 
 SIGMA_CLIP = SigmaClip(sigma=3.)
+
+
+@pytest.mark.parametrize('bkg_class', BKG_CLASS0)
+def test_constant_background(bkg_class):
+    data = np.ones((100, 100))
+    bkg = bkg_class(sigma_clip=SIGMA_CLIP)
+    bkgval = bkg.calc_background(data)
+    assert not np.ma.isMaskedArray(bkgval)
+    assert_allclose(bkgval, 1.0)
+    assert_allclose(bkg(data), bkg.calc_background(data))
 
 
 @pytest.mark.parametrize('bkg_class', BKG_CLASS)

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -1,9 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
+
 from ...datasets.make import make_noise_image
 from ..core import (SigmaClip, MeanBackground, MedianBackground,
                     ModeEstimatorBackground, MMMBackground,

--- a/photutils/utils/__init__.py
+++ b/photutils/utils/__init__.py
@@ -9,3 +9,4 @@ from .convolution import *
 from .cutouts import *
 from .interpolation import *
 from .prepare_data import *
+from .stats import *

--- a/photutils/utils/stats.py
+++ b/photutils/utils/stats.py
@@ -1,0 +1,99 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+
+__all__ = ['std_blocksum']
+
+
+def _mesh_values(data, box_size):
+    """
+    Extract all the data values in boxes of size ``box_size``.
+
+    Values from incomplete boxes, either because of the image edges or
+    masked pixels, are not returned.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ma.MaskedArray`
+        The input masked array.
+
+    box_size : int
+        The box size.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        A 2D array containing the data values in the boxes (along the x
+        axis).
+    """
+
+    data = np.ma.asanyarray(data)
+
+    ny, nx = data.shape
+    nyboxes = ny // box_size
+    nxboxes = nx // box_size
+
+    # include only complete boxes
+    ny_crop = nyboxes * box_size
+    nx_crop = nxboxes * box_size
+    data = data[0:ny_crop, 0:nx_crop]
+
+    # a reshaped 2D masked array with mesh data along the x axis
+    data = np.ma.swapaxes(data.reshape(
+        nyboxes, box_size, nxboxes, box_size), 1, 2).reshape(
+            nyboxes * nxboxes, box_size * box_size)
+
+    # include only boxes without any masked pixels
+    idx = np.where(np.ma.count_masked(data, axis=1) == 0)
+
+    return data[idx]
+
+
+def std_blocksum(data, block_sizes, mask=None):
+    """
+    Calculate the standard deviation of block-summed data values at
+    sizes of ``block_sizes``.
+
+    Values from incomplete blocks, either because of the image edges or
+    masked pixels, are not included.
+
+    Parameters
+    ----------
+    data : array-like
+        The 2D array to block sum.
+
+    block_sizes : int, array-like of int
+        An array of integer (square) block sizes.
+
+    mask : array-like (bool), optional
+        A boolean mask, with the same shape as ``data``, where a `True`
+        value indicates the corresponding element of ``data`` is masked.
+        Blocks that contain *any* masked data are excluded from
+        calculations.
+
+    Returns
+    -------
+    result : `~numpy.ndarray`
+        An array of the standard deviations of the block-summed array
+        for the input ``block_sizes``.
+    """
+
+    data = np.ma.asanyarray(data)
+
+    if mask is not None and mask is not np.ma.nomask:
+        mask = np.asanyarray(mask)
+        if data.shape != mask.shape:
+            raise ValueError('data and mask must have the same shape.')
+        data.mask |= mask
+
+    stds = []
+    block_sizes = np.atleast_1d(block_sizes)
+    for block_size in block_sizes:
+        mesh_values = _mesh_values(data, block_size)
+        block_sums = np.sum(mesh_values, axis=1)
+        stds.append(np.std(block_sums))
+
+    return np.array(stds)

--- a/photutils/utils/tests/test_stats.py
+++ b/photutils/utils/tests/test_stats.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
+
+from ..stats import std_blocksum
+from ...datasets import make_noise_image
+
+
+def test_std_blocksum():
+    stddev = 5
+    data = make_noise_image((100, 100), mean=0, stddev=stddev,
+                            random_state=12345)
+    block_sizes = np.array([5, 7, 10])
+    stds = std_blocksum(data, block_sizes)
+    expected = np.array([stddev, stddev, stddev])
+    assert_allclose(stds / block_sizes, expected, atol=0.2)
+
+    mask = np.zeros_like(data, dtype=np.bool)
+    mask[25:50, 25:50] = True
+    stds2 = std_blocksum(data, block_sizes, mask=mask)
+    assert_allclose(stds2 / block_sizes, expected, atol=0.3)
+
+
+def test_std_blocksum_mask_shape():
+    with pytest.raises(ValueError):
+        data = np.ones((10, 10))
+        mask = np.ones((2, 2))
+        std_blocksum(data, 10, mask=mask)


### PR DESCRIPTION
This PR is a refactor/rewrite of the 2D Background class (`Background2D`) to use an object-oriented interface (using the background and background RMS classes).  Here's a simple example:

```
from photutils import SigmaClip, MedianBackground, StdBackgroundRMS, Background2D

sigma_clip = SigmaClip(sigma=3., iters=10)
bkg_estimator = MedianBackground()
bkgrms_estimator = StdBackgroundRMS()
bkg = Background2D(data, (50, 50), sigma_clip=sigma_clip, bkg_estimator=bkg_estimator, bkgrms_estimator=bkgrms_estimator)
```