### PR TITLE
Allow a list of apertures to be input to aperture_photometry

### DIFF
--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -884,6 +884,13 @@ def aperture_photometry(data, apertures, error=None, pixelwise_error=True,
     thus supports `~astropy.nddata.NDData` objects as input.
     """
 
+    apertures = np.atleast_1d(apertures)
+    positions = apertures[0].positions
+    for aper in apertures[1:]:
+        if not np.array_equal(aper.positions, positions):
+            raise ValueError('Input apertures must all have identical '
+                             'positions.')
+
     data, error, pixelwise_error, mask, wcs = \
         _prepare_photometry_input(data, error, pixelwise_error, mask, wcs,
                                   unit)
@@ -892,7 +899,6 @@ def aperture_photometry(data, apertures, error=None, pixelwise_error=True,
         if (int(subpixels) != subpixels) or (subpixels <= 0):
             raise ValueError('subpixels must be a positive integer.')
 
-    apertures = np.atleast_1d(apertures)
 
     # convert sky to pixel apertures
     skyaper = False


### PR DESCRIPTION
This PR allows a list of aperture objects to be input to `aperture_photometry`.  All of the aperture inputs must have identical positions.  For multiple apertures, the output table column names are appended with the position index.

This also works for sky apertures, provided they have the same positions.

Examples:
```
from photutils import CircularAperture, aperture_photometry

pos = [(40, 40), (50, 50), (60, 60)]
radii = [3, 5, 7]
apers = [CircularAperture(pos, r=r) for r in radii]

data = np.ones((100, 100))
tbl = aperture_photometry(data, apers)
print(tbl)
id xcenter ycenter aperture_sum_0 aperture_sum_1 aperture_sum_2
      pix     pix                                               
--- ------- ------- -------------- -------------- --------------
  1    40.0    40.0  28.2743338823  78.5398163397  153.938040026
  2    50.0    50.0  28.2743338823  78.5398163397  153.938040026
  3    60.0    60.0  28.2743338823  78.5398163397  153.938040026
```

For a single aperture, the index is not appended to the column name(s):

```
tbl = aperture_photometry(data, apers[0])
print(tbl)
 id xcenter ycenter  aperture_sum
      pix     pix                
--- ------- ------- -------------
  1    40.0    40.0 28.2743338823
  2    50.0    50.0 28.2743338823
  3    60.0    60.0 28.2743338823
```