### PR TITLE
add <param>_0 and <param>_fit machinery back

### DIFF
--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -519,6 +519,7 @@ able to identify it, and hence we should use
 star as well. Also, note that both of the stars have ``sigma=2.0``.
 
 .. plot::
+    :include-source:
 
     import matplotlib.pyplot as plt
     from photutils.datasets import make_random_gaussians, make_noise_image
@@ -565,7 +566,7 @@ Let's instantiate the necessary objetcs in order to use an
     ...                                                   psf_model=psf_model,
     ...                                                   fitter=fitter,
     ...                                                   fitshape=(11, 11),
-    ...                                                   niters=None)
+    ...                                                   niters=2)
 
 Now, let's use the callable ``itr_phot_obj`` to perform photometry:
 

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -547,16 +547,16 @@ Also, note that both of the stars have ``sigma=2.0``.
                interpolation='nearest', origin='lower')
 
 Let's instantiate the necessary objetcs in order to use an
-`~photutils.psf.IterativelySubtractedPSFPhotometry` to perform photometry::
+`~photutils.psf.IterativelySubtractedPSFPhotometry` to perform photometry:
+
+.. doctest-requires:: scipy
 
     >>> daogroup = DAOGroup(crit_separation=8)
     >>> mmm_bkg = MMMBackground()
     >>> iraffind = IRAFStarFinder(threshold=2.5*mmm_bkg(image), fwhm=4.5)
     >>> fitter = LevMarLSQFitter()
-
     >>> gaussian_prf = IntegratedGaussianPRF(sigma=2.05)
     >>> gaussian_prf.sigma.fixed = False
-
     >>> itr_phot_obj = IterativelySubtractedPSFPhotometry(finder=iraffind,
     ...                                                   group_maker=daogroup,
     ...                                                   bkg_estimator=mmm_bkg,
@@ -565,7 +565,9 @@ Let's instantiate the necessary objetcs in order to use an
     ...                                                   fitshape=(11, 11),
     ...                                                   niters=None)
 
-Now, let's use the callable ``itr_phot_obj`` to perform photometry::
+Now, let's use the callable ``itr_phot_obj`` to perform photometry:
+
+.. doctest-requires:: scipy
 
     >>> phot_results = itr_phot_obj(image)
     >>> phot_results_itr['id', 'group_id', 'iter_detected', 'x_0', 'y_0', 'flux_0'] #doctest: +SKIP

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -484,11 +484,13 @@ Consider the previous example after the line
 Fitting additional parameters
 -----------------------------
 
-The PSF photometry classes can also be used to fit additional parameters
-simultaneously, for instance, the PSF width and the sky background.
+The PSF photometry classes can also be used to fit more model parameters than
+just the flux and center positions. While a more realistic use case might be
+fitting sky backgrounds, or shape parameters of galaxies, here we use the
+``sigma`` parameter in `~photutils.psf.IntegratedGaussianPRF` as the simplest
+possible example of this feature.
 
-Consider the case in which one would like to fit the ``sigma`` parameter in
-``IntegratedGaussianPRF``. First, let us instantiate a psf model object:
+First, let us instantiate a psf model object:
 
 .. doctest-skip::
 
@@ -510,11 +512,11 @@ value of ``sigma``, but we can change that by doing:
 
     >>> gaussian_prf.sigma.value = 2.05
 
-Now, let's create an artificial image which has a brighter star and one
-overlapping companion at a distance close enough so that the detection
-algorithms won't be able to identify it, and hence we should use
-``IterativelySubtractedPSFPhotometry`` to reduce the fainter star as well.
-Also, note that both of the stars have ``sigma=2.0``.
+Now, let's create a simulated image which has a brighter star and one
+overlapping fainter companion so that the detection algorithm won't be
+able to identify it, and hence we should use
+`~photutils.psf.IterativelySubtractedPSFPhotometry` to measure the fainter
+star as well. Also, note that both of the stars have ``sigma=2.0``.
 
 .. plot::
 
@@ -531,8 +533,8 @@ Also, note that both of the stars have ``sigma=2.0``.
 
     sources = Table()
     sources['flux'] = [10000, 1000]
-    sources['x_mean'] = [18, 13]
-    sources['y_mean'] = [17, 19]
+    sources['x_mean'] = [18, 9]
+    sources['y_mean'] = [17, 21]
     sources['x_stddev'] = [2] * 2
     sources['y_stddev'] = sources['x_stddev']
     sources['theta'] = [0] * 2
@@ -570,16 +572,16 @@ Now, let's use the callable ``itr_phot_obj`` to perform photometry:
 .. doctest-requires:: scipy
 
     >>> phot_results = itr_phot_obj(image)
-    >>> phot_results_itr['id', 'group_id', 'iter_detected', 'x_0', 'y_0', 'flux_0'] #doctest: +SKIP
-        id group_id iter_detected      x_0           y_0          flux_0
+    >>> phot_results['id', 'group_id', 'iter_detected', 'x_0', 'y_0', 'flux_0']
+         id group_id iter_detected      x_0           y_0          flux_0
         --- -------- ------------- ------------- ------------- -------------
-          1        1             1 17.9830836988  17.014907321 9753.12898388
-          1        1             2 12.6296930472 19.6647630336 722.116920665
-    >>> phot_results_itr['sigma_0', 'sigma_fit', 'x_fit', 'y_fit', 'flux_fit'] #doctest: +SKIP
+          1        1             1 18.0045935148 17.0060558543 9437.07321281
+          1        1             2 9.06141447183 21.0680052846 977.163727416
+    >>> phot_results['sigma_0', 'sigma_fit', 'x_fit', 'y_fit', 'flux_fit']
         sigma_0   sigma_fit       x_fit         y_fit        flux_fit
         ------- ------------- ------------- ------------- -------------
-           2.05 2.03898434182 17.9155310586 17.0377322599 10478.1845716
-           2.05 1.77365765325 12.2809666868 19.2416219146 772.882624378
+           2.05 1.98092026939 17.9995106906 17.0039419384 10016.4470148
+           2.05 1.98516037471 9.12116345703 21.0599164498 1036.79115883
 
 We can see that ``sigma_0`` (the initial guess for ``sigma``) was assigned
 to the value we used when creating the PSF model.
@@ -605,8 +607,8 @@ Let's take a look at the residual image::
 
     sources = Table()
     sources['flux'] = [10000, 1000]
-    sources['x_mean'] = [18, 13]
-    sources['y_mean'] = [17, 19]
+    sources['x_mean'] = [18, 9]
+    sources['y_mean'] = [17, 21]
     sources['x_stddev'] = [2] * 2
     sources['y_stddev'] = sources['x_stddev']
     sources['theta'] = [0] * 2
@@ -634,10 +636,8 @@ Let's take a look at the residual image::
             interpolation='nearest', origin='lower')
 
 
-For more examples, also check the online notebook in the next section.
-
-Example Notebooks (online)
---------------------------
+Additional Example Notebooks (online)
+-------------------------------------
 
 * `PSF photometry on artificial Gaussian stars in crowded fields <https://github.com/astropy/photutils-datasets/blob/master/notebooks/ArtificialCrowdedFieldPSFPhotometry.ipynb>`_
 * `PSF photometry on artificial Gaussian stars <https://github.com/astropy/photutils-datasets/blob/master/notebooks/GaussianPSFPhot.ipynb>`_

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -521,7 +521,9 @@ star as well. Also, note that both of the stars have ``sigma=2.0``.
 .. plot::
     :include-source:
 
+    import numpy as np
     import matplotlib.pyplot as plt
+    from matplotlib.colors import LogNorm
     from photutils.datasets import make_random_gaussians, make_noise_image
     from photutils.datasets import make_gaussian_sources
     from photutils.psf import IterativelySubtractedPSFPhotometry, BasicPSFPhotometry
@@ -546,8 +548,9 @@ star as well. Also, note that both of the stars have ``sigma=2.0``.
              make_noise_image(tshape, type='gaussian', mean=0.,
                               stddev=2., random_state=1))
 
-    plt.imshow(image, cmap='viridis', aspect=1,
-               interpolation='nearest', origin='lower')
+    vmin, vmax = np.percentile(image, [5, 95])
+    plt.imshow(image, cmap='viridis', aspect=1, interpolation='nearest',
+               origin='lower', norm=LogNorm(vmin=vmin, vmax=vmax))
 
 Let's instantiate the necessary objetcs in order to use an
 `~photutils.psf.IterativelySubtractedPSFPhotometry` to perform photometry:
@@ -573,12 +576,12 @@ Now, let's use the callable ``itr_phot_obj`` to perform photometry:
 .. doctest-requires:: scipy
 
     >>> phot_results = itr_phot_obj(image)
-    >>> phot_results['id', 'group_id', 'iter_detected', 'x_0', 'y_0', 'flux_0']
+    >>> phot_results['id', 'group_id', 'iter_detected', 'x_0', 'y_0', 'flux_0'] #doctest: +SKIP
          id group_id iter_detected      x_0           y_0          flux_0
         --- -------- ------------- ------------- ------------- -------------
           1        1             1 18.0045935148 17.0060558543 9437.07321281
           1        1             2 9.06141447183 21.0680052846 977.163727416
-    >>> phot_results['sigma_0', 'sigma_fit', 'x_fit', 'y_fit', 'flux_fit']
+    >>> phot_results['sigma_0', 'sigma_fit', 'x_fit', 'y_fit', 'flux_fit'] #doctest: +SKIP
         sigma_0   sigma_fit       x_fit         y_fit        flux_fit
         ------- ------------- ------------- ------------- -------------
            2.05 1.98092026939 17.9995106906 17.0039419384 10016.4470148

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -396,7 +396,7 @@ Consider the previous example after the line
     ...                                 psf_model=psf_model,
     ...                                 fitter=LevMarLSQFitter(),
     ...                                 fitshape=(11,11))
-    >>> result_tab = photometry(image=image, positions=pos)
+    >>> result_tab = photometry(image=image, init_guesses=pos)
     >>> residual_image = photometry.get_residual_image()
 
 .. doctest-skip::
@@ -462,7 +462,7 @@ Consider the previous example after the line
                                     fitter=LevMarLSQFitter(),
                                     fitshape=(11,11))
 
-    result_tab = photometry(image=image, positions=pos)
+    result_tab = photometry(image=image, init_guesses=pos)
     residual_image = photometry.get_residual_image()
 
     from matplotlib import rcParams

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -488,7 +488,9 @@ The PSF photometry classes can also be used to fit more model parameters than
 just the flux and center positions. While a more realistic use case might be
 fitting sky backgrounds, or shape parameters of galaxies, here we use the
 ``sigma`` parameter in `~photutils.psf.IntegratedGaussianPRF` as the simplest
-possible example of this feature.
+possible example of this feature. (For actual PSF photometry of stars you would
+*not* want to do this, because you the shape of the PSF should be set by bright
+stars or an optical model and held fixed when fitting.)
 
 First, let us instantiate a psf model object:
 

--- a/photutils/extern/decorators.py
+++ b/photutils/extern/decorators.py
@@ -10,6 +10,7 @@ import inspect
 
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
+from astropy.utils import minversion
 
 ASTROPY_LT_1_3 = not minversion('astropy', '1.3')
 

--- a/photutils/extern/decorators.py
+++ b/photutils/extern/decorators.py
@@ -11,169 +11,176 @@ import inspect
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 
+ASTROPY_LT_1_3 = not minversion('astropy', '1.3')
+
+
 __all__ = ['deprecated_renamed_argument']
 
-def deprecated_renamed_argument(old_name, new_name, since,
-                                arg_in_kwargs=False, relax=False):
-    """Deprecate a _renamed_ function argument.
 
-    The decorator assumes that the argument with the ``old_name`` was removed
-    from the function signature and the ``new_name`` replaced it at the
-    **same position** in the signature.  If the ``old_name`` argument is
-    given when calling the decorated function the decorator will catch it and
-    issue a deprecation warning and pass it on as ``new_name`` argument.
+if not ASTROPY_LT_1_3:
+    from astropy.utils.decorators import deprecated_renamed_argument
+else:
+    def deprecated_renamed_argument(old_name, new_name, since,
+                                    arg_in_kwargs=False, relax=False):
+        """Deprecate a _renamed_ function argument.
 
-    Parameters
-    ----------
-    old_name : str or list/tuple thereof
-        The old name of the argument.
+        The decorator assumes that the argument with the ``old_name`` was removed
+        from the function signature and the ``new_name`` replaced it at the
+        **same position** in the signature.  If the ``old_name`` argument is
+        given when calling the decorated function the decorator will catch it and
+        issue a deprecation warning and pass it on as ``new_name`` argument.
 
-    new_name : str or list/tuple thereof
-        The new name of the argument.
+        Parameters
+        ----------
+        old_name : str or list/tuple thereof
+            The old name of the argument.
 
-    since : str or number or list/tuple thereof
-        The release at which the old argument became deprecated.
+        new_name : str or list/tuple thereof
+            The new name of the argument.
 
-    arg_in_kwargs : bool or list/tuple thereof, optional
-        If the argument is not a named argument (for example it
-        was meant to be consumed by ``**kwargs``) set this to
-        ``True``.  Otherwise the decorator will throw an Exception
-        if the ``new_name`` cannot be found in the signature of
-        the decorated function.
-        Default is ``False``.
+        since : str or number or list/tuple thereof
+            The release at which the old argument became deprecated.
 
-    relax : bool or list/tuple thereof, optional
-        If ``False`` a ``TypeError`` is raised if both ``new_name`` and
-        ``old_name`` are given.  If ``True`` the value for ``new_name`` is used
-        and a Warning is issued.
-        Default is ``False``.
+        arg_in_kwargs : bool or list/tuple thereof, optional
+            If the argument is not a named argument (for example it
+            was meant to be consumed by ``**kwargs``) set this to
+            ``True``.  Otherwise the decorator will throw an Exception
+            if the ``new_name`` cannot be found in the signature of
+            the decorated function.
+            Default is ``False``.
 
-    Raises
-    ------
-    TypeError
-        If the new argument name cannot be found in the function
-        signature and arg_in_kwargs was False or if it is used to
-        deprecate the name of the ``*args``-, ``**kwargs``-like arguments.
-        At runtime such an Error is raised if both the new_name
-        and old_name were specified when calling the function and
-        "relax=False".
+        relax : bool or list/tuple thereof, optional
+            If ``False`` a ``TypeError`` is raised if both ``new_name`` and
+            ``old_name`` are given.  If ``True`` the value for ``new_name`` is used
+            and a Warning is issued.
+            Default is ``False``.
 
-    Notes
-    -----
-    The decorator should be applied to a function where the **name**
-    of an argument was changed but it applies the same logic.
+        Raises
+        ------
+        TypeError
+            If the new argument name cannot be found in the function
+            signature and arg_in_kwargs was False or if it is used to
+            deprecate the name of the ``*args``-, ``**kwargs``-like arguments.
+            At runtime such an Error is raised if both the new_name
+            and old_name were specified when calling the function and
+            "relax=False".
 
-    .. warning::
-        If ``old_name`` is a list or tuple the ``new_name`` and ``since`` must
-        also be a list or tuple with the same number of entries. ``relax`` and
-        ``arg_in_kwarg`` can be a single bool (applied to all) or also a
-        list/tuple with the same number of entries like ``new_name``, etc.
+        Notes
+        -----
+        The decorator should be applied to a function where the **name**
+        of an argument was changed but it applies the same logic.
 
-    .. warning::
-        This decorator needs to access the original signature of the decorated
-        function. Therefore this decorator must be the **first** decorator on
-        any function if it needs to work for Python before version 3.4.
-    """
-    cls_iter = (list, tuple)
-    if isinstance(old_name, cls_iter):
-        n = len(old_name)
-        # Assume that new_name and since are correct (tuple/list with the
-        # appropriate length) in the spirit of the "consenting adults". But the
-        # optional parameters may not be set, so if these are not iterables
-        # wrap them.
-        if not isinstance(arg_in_kwargs, cls_iter):
-            arg_in_kwargs = [arg_in_kwargs] * n
-        if not isinstance(relax, cls_iter):
-            relax = [relax] * n
-    else:
-        # To allow a uniform approach later on, wrap all arguments in lists.
-        n = 1
-        old_name = [old_name]
-        new_name = [new_name]
-        since = [since]
-        arg_in_kwargs = [arg_in_kwargs]
-        relax = [relax]
+        .. warning::
+            If ``old_name`` is a list or tuple the ``new_name`` and ``since`` must
+            also be a list or tuple with the same number of entries. ``relax`` and
+            ``arg_in_kwarg`` can be a single bool (applied to all) or also a
+            list/tuple with the same number of entries like ``new_name``, etc.
 
-    def decorator(function):
-        # Lazy import to avoid cyclic imports
-        from astropy.utils.compat.funcsigs import signature
+        .. warning::
+            This decorator needs to access the original signature of the decorated
+            function. Therefore this decorator must be the **first** decorator on
+            any function if it needs to work for Python before version 3.4.
+        """
+        cls_iter = (list, tuple)
+        if isinstance(old_name, cls_iter):
+            n = len(old_name)
+            # Assume that new_name and since are correct (tuple/list with the
+            # appropriate length) in the spirit of the "consenting adults". But the
+            # optional parameters may not be set, so if these are not iterables
+            # wrap them.
+            if not isinstance(arg_in_kwargs, cls_iter):
+                arg_in_kwargs = [arg_in_kwargs] * n
+            if not isinstance(relax, cls_iter):
+                relax = [relax] * n
+        else:
+            # To allow a uniform approach later on, wrap all arguments in lists.
+            n = 1
+            old_name = [old_name]
+            new_name = [new_name]
+            since = [since]
+            arg_in_kwargs = [arg_in_kwargs]
+            relax = [relax]
 
-        # The named arguments of the function.
-        arguments = signature(function).parameters
-        keys = list(arguments.keys())
-        position = [None] * n
+        def decorator(function):
+            # Lazy import to avoid cyclic imports
+            from astropy.utils.compat.funcsigs import signature
 
-        for i in range(n):
-            # Determine the position of the argument.
-            if new_name[i] in arguments:
-                param = arguments[new_name[i]]
-                # There are several possibilities now:
+            # The named arguments of the function.
+            arguments = signature(function).parameters
+            keys = list(arguments.keys())
+            position = [None] * n
 
-                # 1.) Positional or keyword argument:
-                if param.kind == param.POSITIONAL_OR_KEYWORD:
-                    position[i] = keys.index(new_name[i])
-
-                # 2.) Keyword only argument (Python 3 only):
-                elif param.kind == param.KEYWORD_ONLY:
-                    # These cannot be specified by position.
-                    position[i] = None
-
-                # 3.) positional-only argument, varargs, varkwargs or some
-                #     unknown type:
-                else:
-                    raise TypeError('cannot replace argument "{0}" of kind {1}'
-                                    '.'.format(new_name[i], repr(param.kind)))
-
-            # In case the argument is not found in the list of arguments
-            # the only remaining possibility is that it should be catched
-            # by some kind of **kwargs argument.
-            # This case has to be explicitly specified, otherwise throw
-            # an exception!
-            elif arg_in_kwargs[i]:
-                position[i] = None
-            else:
-                raise TypeError('"{}" was not specified in the function '
-                                'signature. If it was meant to be part of '
-                                '"**kwargs" then set "arg_in_kwargs" to "True"'
-                                '.'.format(new_name[i]))
-
-        @functools.wraps(function)
-        def wrapper(*args, **kwargs):
             for i in range(n):
-                # The only way to have oldkeyword inside the function is
-                # that it is passed as kwarg because the oldkeyword
-                # parameter was renamed to newkeyword.
-                if old_name[i] in kwargs:
-                    value = kwargs.pop(old_name[i])
-                    warnings.warn('"{0}" was deprecated in version {1} '
-                                  'and will be removed in a future version. '
-                                  'Use argument "{2}" instead.'
-                                  ''.format(old_name[i], since[i],
-                                            new_name[i]),
-                                  AstropyDeprecationWarning)
+                # Determine the position of the argument.
+                if new_name[i] in arguments:
+                    param = arguments[new_name[i]]
+                    # There are several possibilities now:
 
-                    # Check if the newkeyword was given as well.
-                    newarg_in_args = (position[i] is not None and
-                                      len(args) > position[i])
-                    newarg_in_kwargs = new_name[i] in kwargs
+                    # 1.) Positional or keyword argument:
+                    if param.kind == param.POSITIONAL_OR_KEYWORD:
+                        position[i] = keys.index(new_name[i])
 
-                    if newarg_in_args or newarg_in_kwargs:
-                        # If both are given print a Warning if relax is True or
-                        # raise an Exception is relax is False.
-                        if relax[i]:
-                            warnings.warn('"{0}" and "{1}" keywords were set. '
-                                          'Using the value of "{1}".'
-                                          ''.format(old_name[i], new_name[i]),
-                                          AstropyUserWarning)
-                        else:
-                            raise TypeError('cannot specify both "{}" and "{}"'
-                                            '.'.format(old_name[i],
-                                                       new_name[i]))
+                    # 2.) Keyword only argument (Python 3 only):
+                    elif param.kind == param.KEYWORD_ONLY:
+                        # These cannot be specified by position.
+                        position[i] = None
+
+                    # 3.) positional-only argument, varargs, varkwargs or some
+                    #     unknown type:
                     else:
-                        # If the new argument isn't specified just pass the old
-                        # one with the name of the new argument to the function
-                        kwargs[new_name[i]] = value
-            return function(*args, **kwargs)
+                        raise TypeError('cannot replace argument "{0}" of kind {1}'
+                                        '.'.format(new_name[i], repr(param.kind)))
 
-        return wrapper
-    return decorator
+                # In case the argument is not found in the list of arguments
+                # the only remaining possibility is that it should be catched
+                # by some kind of **kwargs argument.
+                # This case has to be explicitly specified, otherwise throw
+                # an exception!
+                elif arg_in_kwargs[i]:
+                    position[i] = None
+                else:
+                    raise TypeError('"{}" was not specified in the function '
+                                    'signature. If it was meant to be part of '
+                                    '"**kwargs" then set "arg_in_kwargs" to "True"'
+                                    '.'.format(new_name[i]))
+
+            @functools.wraps(function)
+            def wrapper(*args, **kwargs):
+                for i in range(n):
+                    # The only way to have oldkeyword inside the function is
+                    # that it is passed as kwarg because the oldkeyword
+                    # parameter was renamed to newkeyword.
+                    if old_name[i] in kwargs:
+                        value = kwargs.pop(old_name[i])
+                        warnings.warn('"{0}" was deprecated in version {1} '
+                                      'and will be removed in a future version. '
+                                      'Use argument "{2}" instead.'
+                                      ''.format(old_name[i], since[i],
+                                                new_name[i]),
+                                      AstropyDeprecationWarning)
+
+                        # Check if the newkeyword was given as well.
+                        newarg_in_args = (position[i] is not None and
+                                          len(args) > position[i])
+                        newarg_in_kwargs = new_name[i] in kwargs
+
+                        if newarg_in_args or newarg_in_kwargs:
+                            # If both are given print a Warning if relax is True or
+                            # raise an Exception is relax is False.
+                            if relax[i]:
+                                warnings.warn('"{0}" and "{1}" keywords were set. '
+                                              'Using the value of "{1}".'
+                                              ''.format(old_name[i], new_name[i]),
+                                              AstropyUserWarning)
+                            else:
+                                raise TypeError('cannot specify both "{}" and "{}"'
+                                                '.'.format(old_name[i],
+                                                           new_name[i]))
+                        else:
+                            # If the new argument isn't specified just pass the old
+                            # one with the name of the new argument to the function
+                            kwargs[new_name[i]] = value
+                return function(*args, **kwargs)
+
+            return wrapper
+        return decorator

--- a/photutils/extern/decorators.py
+++ b/photutils/extern/decorators.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import functools
 import warnings
+import inspect
 
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
@@ -67,63 +68,6 @@ def deprecated_renamed_argument(old_name, new_name, since,
         also be a list or tuple with the same number of entries. ``relax`` and
         ``arg_in_kwarg`` can be a single bool (applied to all) or also a
         list/tuple with the same number of entries like ``new_name``, etc.
-
-    Examples
-    --------
-    The deprecation warnings are not shown in the following examples.
-
-    To deprecate a positional or keyword argument::
-
-        >>> from photutils.extern.decorators import deprecated_renamed_argument
-        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0')
-        ... def test(sigma):
-        ...     return sigma
-
-        >>> test(2)
-        2
-        >>> test(sigma=2)
-        2
-        >>> test(sig=2)
-        2
-
-    To deprecate an argument catched inside the ``**kwargs`` the
-    ``arg_in_kwargs`` has to be set::
-
-        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0',
-        ...                             arg_in_kwargs=True)
-        ... def test(**kwargs):
-        ...     return kwargs['sigma']
-
-        >>> test(sigma=2)
-        2
-        >>> test(sig=2)
-        2
-
-    By default providing the new and old keyword will lead to an Exception. If
-    a Warning is desired set the ``relax`` argument::
-
-        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0', relax=True)
-        ... def test(sigma):
-        ...     return sigma
-
-        >>> test(sig=2)
-        2
-
-    It is also possible to replace multiple arguments. The ``old_name``,
-    ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
-    same number of entries::
-
-        >>> @deprecated_renamed_argument(['a', 'b'], ['alpha', 'beta'],
-        ...                              ['1.0', 1.2])
-        ... def test(alpha, beta):
-        ...     return alpha, beta
-
-        >>> test(a=2, b=3)
-        (2, 3)
-
-    In this case ``arg_in_kwargs`` and ``relax`` can be a single value (which
-    is applied to all renamed arguments) or must also be a `tuple` or `list`
-    with values for each of the arguments.
 
     .. warning::
         This decorator needs to access the original signature of the decorated

--- a/photutils/extern/decorators.py
+++ b/photutils/extern/decorators.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Sundry function and class decorators."""
+
+from __future__ import print_function
+
+import functools
+import warnings
+
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
+
+__all__ = ['deprecated_renamed_argument']
+
+def deprecated_renamed_argument(old_name, new_name, since,
+                                arg_in_kwargs=False, relax=False):
+    """Deprecate a _renamed_ function argument.
+
+    The decorator assumes that the argument with the ``old_name`` was removed
+    from the function signature and the ``new_name`` replaced it at the
+    **same position** in the signature.  If the ``old_name`` argument is
+    given when calling the decorated function the decorator will catch it and
+    issue a deprecation warning and pass it on as ``new_name`` argument.
+
+    Parameters
+    ----------
+    old_name : str or list/tuple thereof
+        The old name of the argument.
+
+    new_name : str or list/tuple thereof
+        The new name of the argument.
+
+    since : str or number or list/tuple thereof
+        The release at which the old argument became deprecated.
+
+    arg_in_kwargs : bool or list/tuple thereof, optional
+        If the argument is not a named argument (for example it
+        was meant to be consumed by ``**kwargs``) set this to
+        ``True``.  Otherwise the decorator will throw an Exception
+        if the ``new_name`` cannot be found in the signature of
+        the decorated function.
+        Default is ``False``.
+
+    relax : bool or list/tuple thereof, optional
+        If ``False`` a ``TypeError`` is raised if both ``new_name`` and
+        ``old_name`` are given.  If ``True`` the value for ``new_name`` is used
+        and a Warning is issued.
+        Default is ``False``.
+
+    Raises
+    ------
+    TypeError
+        If the new argument name cannot be found in the function
+        signature and arg_in_kwargs was False or if it is used to
+        deprecate the name of the ``*args``-, ``**kwargs``-like arguments.
+        At runtime such an Error is raised if both the new_name
+        and old_name were specified when calling the function and
+        "relax=False".
+
+    Notes
+    -----
+    The decorator should be applied to a function where the **name**
+    of an argument was changed but it applies the same logic.
+
+    .. warning::
+        If ``old_name`` is a list or tuple the ``new_name`` and ``since`` must
+        also be a list or tuple with the same number of entries. ``relax`` and
+        ``arg_in_kwarg`` can be a single bool (applied to all) or also a
+        list/tuple with the same number of entries like ``new_name``, etc.
+
+    Examples
+    --------
+    The deprecation warnings are not shown in the following examples.
+
+    To deprecate a positional or keyword argument::
+
+        >>> from photutils.extern.decorators import deprecated_renamed_argument
+        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0')
+        ... def test(sigma):
+        ...     return sigma
+
+        >>> test(2)
+        2
+        >>> test(sigma=2)
+        2
+        >>> test(sig=2)
+        2
+
+    To deprecate an argument catched inside the ``**kwargs`` the
+    ``arg_in_kwargs`` has to be set::
+
+        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0',
+        ...                             arg_in_kwargs=True)
+        ... def test(**kwargs):
+        ...     return kwargs['sigma']
+
+        >>> test(sigma=2)
+        2
+        >>> test(sig=2)
+        2
+
+    By default providing the new and old keyword will lead to an Exception. If
+    a Warning is desired set the ``relax`` argument::
+
+        >>> @deprecated_renamed_argument('sig', 'sigma', '1.0', relax=True)
+        ... def test(sigma):
+        ...     return sigma
+
+        >>> test(sig=2)
+        2
+
+    It is also possible to replace multiple arguments. The ``old_name``,
+    ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
+    same number of entries::
+
+        >>> @deprecated_renamed_argument(['a', 'b'], ['alpha', 'beta'],
+        ...                              ['1.0', 1.2])
+        ... def test(alpha, beta):
+        ...     return alpha, beta
+
+        >>> test(a=2, b=3)
+        (2, 3)
+
+    In this case ``arg_in_kwargs`` and ``relax`` can be a single value (which
+    is applied to all renamed arguments) or must also be a `tuple` or `list`
+    with values for each of the arguments.
+
+    .. warning::
+        This decorator needs to access the original signature of the decorated
+        function. Therefore this decorator must be the **first** decorator on
+        any function if it needs to work for Python before version 3.4.
+    """
+    cls_iter = (list, tuple)
+    if isinstance(old_name, cls_iter):
+        n = len(old_name)
+        # Assume that new_name and since are correct (tuple/list with the
+        # appropriate length) in the spirit of the "consenting adults". But the
+        # optional parameters may not be set, so if these are not iterables
+        # wrap them.
+        if not isinstance(arg_in_kwargs, cls_iter):
+            arg_in_kwargs = [arg_in_kwargs] * n
+        if not isinstance(relax, cls_iter):
+            relax = [relax] * n
+    else:
+        # To allow a uniform approach later on, wrap all arguments in lists.
+        n = 1
+        old_name = [old_name]
+        new_name = [new_name]
+        since = [since]
+        arg_in_kwargs = [arg_in_kwargs]
+        relax = [relax]
+
+    def decorator(function):
+        # Lazy import to avoid cyclic imports
+        from astropy.utils.compat.funcsigs import signature
+
+        # The named arguments of the function.
+        arguments = signature(function).parameters
+        keys = list(arguments.keys())
+        position = [None] * n
+
+        for i in range(n):
+            # Determine the position of the argument.
+            if new_name[i] in arguments:
+                param = arguments[new_name[i]]
+                # There are several possibilities now:
+
+                # 1.) Positional or keyword argument:
+                if param.kind == param.POSITIONAL_OR_KEYWORD:
+                    position[i] = keys.index(new_name[i])
+
+                # 2.) Keyword only argument (Python 3 only):
+                elif param.kind == param.KEYWORD_ONLY:
+                    # These cannot be specified by position.
+                    position[i] = None
+
+                # 3.) positional-only argument, varargs, varkwargs or some
+                #     unknown type:
+                else:
+                    raise TypeError('cannot replace argument "{0}" of kind {1}'
+                                    '.'.format(new_name[i], repr(param.kind)))
+
+            # In case the argument is not found in the list of arguments
+            # the only remaining possibility is that it should be catched
+            # by some kind of **kwargs argument.
+            # This case has to be explicitly specified, otherwise throw
+            # an exception!
+            elif arg_in_kwargs[i]:
+                position[i] = None
+            else:
+                raise TypeError('"{}" was not specified in the function '
+                                'signature. If it was meant to be part of '
+                                '"**kwargs" then set "arg_in_kwargs" to "True"'
+                                '.'.format(new_name[i]))
+
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            for i in range(n):
+                # The only way to have oldkeyword inside the function is
+                # that it is passed as kwarg because the oldkeyword
+                # parameter was renamed to newkeyword.
+                if old_name[i] in kwargs:
+                    value = kwargs.pop(old_name[i])
+                    warnings.warn('"{0}" was deprecated in version {1} '
+                                  'and will be removed in a future version. '
+                                  'Use argument "{2}" instead.'
+                                  ''.format(old_name[i], since[i],
+                                            new_name[i]),
+                                  AstropyDeprecationWarning)
+
+                    # Check if the newkeyword was given as well.
+                    newarg_in_args = (position[i] is not None and
+                                      len(args) > position[i])
+                    newarg_in_kwargs = new_name[i] in kwargs
+
+                    if newarg_in_args or newarg_in_kwargs:
+                        # If both are given print a Warning if relax is True or
+                        # raise an Exception is relax is False.
+                        if relax[i]:
+                            warnings.warn('"{0}" and "{1}" keywords were set. '
+                                          'Using the value of "{1}".'
+                                          ''.format(old_name[i], new_name[i]),
+                                          AstropyUserWarning)
+                        else:
+                            raise TypeError('cannot specify both "{}" and "{}"'
+                                            '.'.format(old_name[i],
+                                                       new_name[i]))
+                    else:
+                        # If the new argument isn't specified just pass the old
+                        # one with the name of the new argument to the function
+                        kwargs[new_name[i]] = value
+            return function(*args, **kwargs)
+
+        return wrapper
+    return decorator

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -773,7 +773,7 @@ def prepare_psf_model(psfmodel, xname=None, yname=None, fluxname=None,
     return outmod
 
 
-def get_grouped_psf_model(template_psf_model, star_group):
+def get_grouped_psf_model(template_psf_model, star_group, pars_to_set):
     """
     Construct a joint PSF model which consists of a sum of PSF's templated on
     a specific model, but whose parameters are given by a table of objects.
@@ -795,11 +795,11 @@ def get_grouped_psf_model(template_psf_model, star_group):
     """
 
     group_psf = None
-    for i in range(len(star_group)):
+
+    for star in star_group:
         psf_to_add = template_psf_model.copy()
-        psf_to_add.flux = star_group['flux_0'][i]
-        psf_to_add.x_0 = star_group['x_0'][i]
-        psf_to_add.y_0 = star_group['y_0'][i]
+        for param_tab_name, param_name in pars_to_set.items():
+            setattr(psf_to_add, param_name, star[param_tab_name])
 
         if group_psf is None:
             # this is the first one only

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -217,7 +217,9 @@ class BasicPSFPhotometry(object):
             for each object. Columns 'x_0' and 'y_0' must be present.
             'flux_0' can also be provided to set initial fluxes.
             If 'flux_0' is not provided, aperture photometry is used to
-            estimate initial values for the fluxes.
+            estimate initial values for the fluxes. Additional columns of the
+            form '<parametername>_0' will be used to set the initial guess for
+            any parameters of the ``psf_model`` model that are not fixed.
 
         Returns
         -------
@@ -580,7 +582,9 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
             for each object. Columns 'x_0' and 'y_0' must be present.
             'flux_0' can also be provided to set initial fluxes.
             If 'flux_0' is not provided, aperture photometry is used to
-            estimate initial values for the fluxes.
+            estimate initial values for the fluxes. Additional columns of the
+            form '<parametername>_0' will be used to set the initial guess for
+            any parameters of the ``psf_model`` model that are not fixed.
 
         Returns
         -------

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -15,8 +15,9 @@ from .models import get_grouped_psf_model
 from ..aperture import CircularAperture, aperture_photometry
 from ..background import MMMBackground, SigmaClip
 from ..detection import DAOStarFinder
-
+from ..extern.decorators import deprecated_renamed_argument
 from astropy.utils import minversion
+
 ASTROPY_LT_1_1 = not minversion('astropy', '1.1')
 
 if ASTROPY_LT_1_1:

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -594,7 +594,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         if positions is not None:
             table = super(IterativelySubtractedPSFPhotometry,
                 self).do_photometry(image, positions)
-            table['iter_detected'] = np.ones(table['x_fit'].shape, dtype=np.int)
+            table['iter_detected'] = np.ones(table['x_fit'].shape, dtype=np.int32)
 
             # n_start = 2 because it starts in the second iteration
             # since the first iteration is above
@@ -674,7 +674,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
                     self).nstar(self._residual_image, star_groups)
             table = hstack([init_guess_tab, table])
 
-            table['iter_detected'] = n*np.ones(table['x_fit'].shape, dtype=np.int)
+            table['iter_detected'] = n*np.ones(table['x_fit'].shape, dtype=np.int32)
 
             output_table = vstack([output_table, table])
             sources = self.finder(self._residual_image)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -27,7 +27,8 @@ else:
 
 if not ASTROPY_LT_1_3:
     from astropy.utils.decorators import deprecated_renamed_argument
-
+else:
+    from ..extern.decorators import deprecated_renamed_argument
 
 __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
            'DAOPhotPSFPhotometry']

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -15,15 +15,18 @@ from .models import get_grouped_psf_model
 from ..aperture import CircularAperture, aperture_photometry
 from ..background import MMMBackground, SigmaClip
 from ..detection import DAOStarFinder
-from ...utils.decorators import deprecated_renamed_argument
 
 from astropy.utils import minversion
 ASTROPY_LT_1_1 = not minversion('astropy', '1.1')
+ASTROPY_LT_1_3 = not minversion('astropy', '1.3')
 
 if ASTROPY_LT_1_1:
     from ..extern.nddata_compat import _overlap_slices_astropy1p1 as overlap_slices
 else:
     from astropy.nddata.utils import overlap_slices
+
+if not ASTROPY_LT_1_3:
+    from astropy.utils.decorators import deprecated_renamed_argument
 
 
 __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -18,17 +18,12 @@ from ..detection import DAOStarFinder
 
 from astropy.utils import minversion
 ASTROPY_LT_1_1 = not minversion('astropy', '1.1')
-ASTROPY_LT_1_3 = not minversion('astropy', '1.3')
 
 if ASTROPY_LT_1_1:
     from ..extern.nddata_compat import _overlap_slices_astropy1p1 as overlap_slices
 else:
     from astropy.nddata.utils import overlap_slices
 
-if not ASTROPY_LT_1_3:
-    from astropy.utils.decorators import deprecated_renamed_argument
-else:
-    from ..extern.decorators import deprecated_renamed_argument
 
 __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
            'DAOPhotPSFPhotometry']

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -374,15 +374,12 @@ class BasicPSFPhotometry(object):
         Convenience function to define mappings between the names of the
         columns in the initial guess table (and the name of the fitted
         parameters) and the actual name of the parameters in the model.
-
-        Returns
-        -------
-        pars_to_set : dict
-            Dict which maps the names of the parameters initial guesses to the
-            actual name of the parameter in the model.
-        pars_to_output : dict
-            Dict which maps the names of the fitted parameters to the
-            actual name of the parameter in the model.
+        
+        This method sets the following parameters on the ``self`` object:
+        * ``pars_to_set`` : Dict which maps the names of the parameters 
+          initial guesses to the actual name of the parameter in the model.
+        * ``pars_to_output`` : Dict which maps the names of the fitted 
+          parameters to the actual name of the parameter in the model.
         """
 
         xname, yname, fluxname = _extract_psf_fitting_names(self.psf_model)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -319,8 +319,9 @@ class BasicPSFPhotometry(object):
             ``group_id``, ``x_0``, ``y_0``, ``flux_0``.  ``x_0`` and
             ``y_0`` are initial estimates of the centroids and
             ``flux_0`` is an initial estimate of the flux. Additionally,
-            columns named as ``<param_name>_0`` are required to fit any other
-            free (non fixed) parameter.
+            columns named as ``<param_name>_0`` are required if any other
+            parameter in the psf model is free (i.e., the ``fixed``
+            attribute of that parameter is ``False``).
 
         Returns
         -------
@@ -374,11 +375,11 @@ class BasicPSFPhotometry(object):
         Convenience function to define mappings between the names of the
         columns in the initial guess table (and the name of the fitted
         parameters) and the actual name of the parameters in the model.
-        
+
         This method sets the following parameters on the ``self`` object:
-        * ``pars_to_set`` : Dict which maps the names of the parameters 
+        * ``pars_to_set`` : Dict which maps the names of the parameters
           initial guesses to the actual name of the parameter in the model.
-        * ``pars_to_output`` : Dict which maps the names of the fitted 
+        * ``pars_to_output`` : Dict which maps the names of the fitted
           parameters to the actual name of the parameter in the model.
         """
 

--- a/photutils/psf/tests/test_misc.py
+++ b/photutils/psf/tests/test_misc.py
@@ -147,8 +147,9 @@ def test_psf_adapter(moffimg, prepkwargs, tols):
 def test_get_grouped_psf_model():
     igp = IntegratedGaussianPRF(sigma=1.2)
     tab = Table(names=['x_0', 'y_0', 'flux_0'], data=[[1, 2], [3, 4], [0.5, 1]])
+    pars_to_set = {'x_0':'x_0', 'y_0':'y_0', 'flux_0':'flux'}
 
-    gpsf = get_grouped_psf_model(igp, tab)
+    gpsf = get_grouped_psf_model(igp, tab, pars_to_set)
 
     assert gpsf.x_0_0 == 1
     assert gpsf.y_0_1 == 4

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -29,7 +29,8 @@ from ...datasets import make_noise_image
 from ...detection import DAOStarFinder
 
 
-ASTROPY_GT_1_3 = minversion('astropy', '1.3')
+# greather or equal than
+ASTROPY_GET_1_3 = minversion('astropy', '1.3')
 
 
 try:
@@ -126,7 +127,7 @@ sources3['group_id'] = [1] * 2
 sources3['iter_detected'] = [1, 2]
 
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GET_1_3')
 @pytest.mark.parametrize("sigma_psf, sources", [(sigma_psfs[2], sources3)])
 def test_psf_photometry_niters(sigma_psf, sources):
     img_shape = (32, 32)
@@ -160,7 +161,7 @@ def test_psf_photometry_niters(sigma_psf, sources):
     assert_array_equal(cp_image, image)
 
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GET_1_3')
 @pytest.mark.parametrize("sigma_psf, sources",
                          [(sigma_psfs[0], sources1),
                           (sigma_psfs[1], sources2),
@@ -228,7 +229,7 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
         phot_proc.psf_model.y_0.fixed = False
 
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_niters_errors():
     iter_phot_obj = make_psf_photometry_objs()[1]
 
@@ -245,7 +246,7 @@ def test_niters_errors():
     iter_phot_obj.niters = None
 
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_fitshape_erros():
     basic_phot_obj = make_psf_photometry_objs()[0]
 
@@ -270,7 +271,7 @@ def test_fitshape_erros():
     with pytest.raises(ValueError):
         basic_phot_obj.fitshape = (3, 3, 3)
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_aperture_radius_errors():
     basic_phot_obj = make_psf_photometry_objs()[0]
 
@@ -281,7 +282,7 @@ def test_aperture_radius_errors():
     with pytest.raises(ValueError):
         basic_phot_obj.aperture_radius = -3
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_finder_erros():
     basic_phot_obj = make_psf_photometry_objs()[0]
     iter_phot_obj = make_psf_photometry_objs()[1]
@@ -294,7 +295,7 @@ def test_finder_erros():
                 group_maker=DAOGroup(1), bkg_estimator=MMMBackground(),
                 psf_model=IntegratedGaussianPRF(1), fitshape=(11, 11))
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_finder_positions_warning():
     basic_phot_obj = make_psf_photometry_objs(sigma_psf=2)[0]
     positions = Table()
@@ -316,7 +317,7 @@ def test_finder_positions_warning():
         basic_phot_obj.finder = None
         result_tab = basic_phot_obj(image=image)
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_aperture_radius():
     img_shape = (32, 32)
 
@@ -415,7 +416,7 @@ for x, y, flux in WIDE_INTAB:
     wide_image += discretize_model(model, (0, IMAGE_SIZE), (0, IMAGE_SIZE),
                                    mode='oversample')
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_psf_photometry_discrete():
     """ Test psf_photometry with discrete PRF model. """
 
@@ -428,7 +429,7 @@ def test_psf_photometry_discrete():
     for n in ['x', 'y', 'flux']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-6)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_tune_coordinates():
     """
     Test psf_photometry with discrete PRF model and coordinates that need
@@ -446,11 +447,11 @@ def test_tune_coordinates():
                                 bkg_estimator=None, psf_model=prf,
                                 fitshape=7)
 
-    f = basic_phot(image=image, positions=intab)
+    f = basic_phot(image=image, init_guesses=intab)
     for n in ['x', 'y', 'flux']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_psf_boundary():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
@@ -466,7 +467,7 @@ def test_psf_boundary():
     f = basic_phot(image=image, init_guesses=intab)
     assert_allclose(f['flux_fit'], 0, atol=1e-8)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_aperture_radius_value_error():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
@@ -484,7 +485,7 @@ def test_aperture_radius_value_error():
 
     assert 'aperture_radius is None' in str(err.value)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_psf_boundary_gaussian():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
@@ -500,7 +501,7 @@ def test_psf_boundary_gaussian():
     f = basic_phot(image=image, init_guesses=intab)
     assert_allclose(f['flux_fit'], 0, atol=1e-8)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_psf_photometry_gaussian():
     """
     Test psf_photometry with Gaussian PSF model.
@@ -515,7 +516,7 @@ def test_psf_photometry_gaussian():
     for n in ['x', 'y', 'flux']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GET_1_3')
 def test_psf_fitting_data_on_edge():
     """
     No mask is input explicitly here, but source 2 is so close to the

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -349,19 +349,31 @@ def test_aperture_radius():
 
     assert_equal(basic_phot_obj.aperture_radius, psf_model.fwhm.value)
 
+
+PARS_TO_SET_0 = {'x_0': 'x_0', 'y_0': 'y_0', 'flux_0': 'flux'}
+PARS_TO_OUTPUT_0 = {'x_fit': 'x_0', 'y_fit': 'y_0', 'flux_fit': 'flux'}
+PARS_TO_SET_1 = PARS_TO_SET_0.copy()
+PARS_TO_SET_1['sigma_0'] = 'sigma'
+PARS_TO_OUTPUT_1 = PARS_TO_OUTPUT_0.copy()
+PARS_TO_OUTPUT_1['sigma_fit'] = 'sigma'
+@pytest.mark.parametrize("actual_pars_to_set, actual_pars_to_output,"
+                         "is_sigma_fixed",[(PARS_TO_SET_0, PARS_TO_OUTPUT_0,
+                                            True),
+                                           (PARS_TO_SET_1, PARS_TO_OUTPUT_1,
+                                            False)])
 @pytest.mark.skipif('not HAS_SCIPY')
-def test_define_fit_param_names():
+def test_define_fit_param_names(actual_pars_to_set, actual_pars_to_output,
+                                is_sigma_fixed):
     psf_model = IntegratedGaussianPRF()
-    psf_model.sigma.fixed = False
+    psf_model.sigma.fixed = is_sigma_fixed
 
     basic_phot_obj = make_psf_photometry_objs()[0]
     basic_phot_obj.psf_model = psf_model
 
     pars_to_set, pars_to_output = basic_phot_obj._define_fit_param_names()
-    assert_equal(pars_to_set, {'x_0': 'x_0', 'y_0': 'y_0', 'flux_0': 'flux',
-                               'sigma_0': 'sigma'})
-    assert_equal(pars_to_output, {'x_fit': 'x_0', 'y_fit': 'y_0',
-                                  'flux_fit': 'flux', 'sigma_fit': 'sigma'})
+    assert_equal(pars_to_set, actual_pars_to_set)
+    assert_equal(pars_to_output, actual_pars_to_output)
+
 
 # tests previously written to psf_photometry
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -357,7 +357,7 @@ def test_define_fit_param_names():
     basic_phot_obj = make_psf_photometry_objs()[0]
     basic_phot_obj.psf_model = psf_model
 
-    pars_to_set, pars_to_output = basic_phot_obj._define_fit_param_names(['x_0', 'y_0', 'flux_0', 'sigma_0'])
+    pars_to_set, pars_to_output = basic_phot_obj._define_fit_param_names()
     assert_equal(pars_to_set, {'x_0': 'x_0', 'y_0': 'y_0', 'flux_0': 'flux',
                                'sigma_0': 'sigma'})
     assert_equal(pars_to_output, {'x_fit': 'x_0', 'y_fit': 'y_0',

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -217,7 +217,7 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
         assert_array_equal(result_tab['group_id'], sources['group_id'])
         assert_allclose(np.mean(residual_image), 0.0, atol=1e1)
 
-        # make sure image is note overwritten
+        # make sure image is not overwritten
         assert_array_equal(cp_image, image)
 
         # make sure initial guess table is not modified
@@ -283,7 +283,9 @@ def test_aperture_radius_errors():
 
 @pytest.mark.xfail('not HAS_SCIPY')
 def test_finder_erros():
+    basic_phot_obj = make_psf_photometry_objs()[0]
     iter_phot_obj = make_psf_photometry_objs()[1]
+
     with pytest.raises(ValueError):
         iter_phot_obj.finder = None
 
@@ -309,6 +311,10 @@ def test_finder_positions_warning():
         assert_array_equal(result_tab['y_0'], positions['y_0'])
         assert_allclose(result_tab['x_fit'], positions['x_0'], rtol=1e-1)
         assert_allclose(result_tab['y_fit'], positions['y_0'], rtol=1e-1)
+
+    with pytest.raises(ValueError):
+        basic_phot_obj.finder = None
+        result_tab = basic_phot_obj(image=image)
 
 @pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
 def test_aperture_radius():

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -144,6 +144,7 @@ def test_psf_photometry_niters(sigma_psf, sources):
 
     iter_phot_obj = make_psf_photometry_objs(std, sigma_psf)[1]
     iter_phot_obj.niters = None
+
     result_tab = iter_phot_obj(image)
     residual_image = iter_phot_obj.get_residual_image()
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -343,6 +343,19 @@ def test_aperture_radius():
 
     assert_equal(basic_phot_obj.aperture_radius, psf_model.fwhm.value)
 
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_define_fit_param_names():
+    psf_model = IntegratedGaussianPRF()
+    psf_model.sigma.fixed = False
+
+    basic_phot_obj = make_psf_photometry_objs()[0]
+    basic_phot_obj.psf_model = psf_model
+
+    pars_to_set, pars_to_output = basic_phot_obj._define_fit_param_names(['x_0', 'y_0', 'flux_0', 'sigma_0'])
+    assert_equal(pars_to_set, {'x_0': 'x_0', 'y_0': 'y_0', 'flux_0': 'flux',
+                               'sigma_0': 'sigma'})
+    assert_equal(pars_to_output, {'x_fit': 'x_0', 'y_fit': 'y_0',
+                                  'flux_fit': 'flux', 'sigma_fit': 'sigma'})
 
 # tests previously written to psf_photometry
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -29,7 +29,7 @@ from ...datasets import make_noise_image
 from ...detection import DAOStarFinder
 
 
-ASTROPY_GT_1_1 = minversion('astropy', '1.1')
+ASTROPY_GT_1_3 = minversion('astropy', '1.3')
 
 
 try:
@@ -126,7 +126,7 @@ sources3['group_id'] = [1] * 2
 sources3['iter_detected'] = [1, 2]
 
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_3')
 @pytest.mark.parametrize("sigma_psf, sources", [(sigma_psfs[2], sources3)])
 def test_psf_photometry_niters(sigma_psf, sources):
     img_shape = (32, 32)
@@ -160,7 +160,7 @@ def test_psf_photometry_niters(sigma_psf, sources):
     assert_array_equal(cp_image, image)
 
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_3')
 @pytest.mark.parametrize("sigma_psf, sources",
                          [(sigma_psfs[0], sources1),
                           (sigma_psfs[1], sources2),
@@ -294,7 +294,7 @@ def test_finder_erros():
                 group_maker=DAOGroup(1), bkg_estimator=MMMBackground(),
                 psf_model=IntegratedGaussianPRF(1), fitshape=(11, 11))
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_finder_positions_warning():
     basic_phot_obj = make_psf_photometry_objs(sigma_psf=2)[0]
     positions = Table()
@@ -306,7 +306,7 @@ def test_finder_positions_warning():
                               random_state=1))
 
     with catch_warnings(AstropyUserWarning):
-        result_tab = basic_phot_obj(image=image, positions=positions)
+        result_tab = basic_phot_obj(image=image, init_guesses=positions)
         assert_array_equal(result_tab['x_0'], positions['x_0'])
         assert_array_equal(result_tab['y_0'], positions['y_0'])
         assert_allclose(result_tab['x_fit'], positions['x_0'], rtol=1e-1)
@@ -316,7 +316,7 @@ def test_finder_positions_warning():
         basic_phot_obj.finder = None
         result_tab = basic_phot_obj(image=image)
 
-@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.xfail('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_aperture_radius():
     img_shape = (32, 32)
 
@@ -415,7 +415,7 @@ for x, y, flux in WIDE_INTAB:
     wide_image += discretize_model(model, (0, IMAGE_SIZE), (0, IMAGE_SIZE),
                                    mode='oversample')
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_psf_photometry_discrete():
     """ Test psf_photometry with discrete PRF model. """
 
@@ -423,12 +423,12 @@ def test_psf_photometry_discrete():
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
                                     bkg_estimator=None, psf_model=prf,
                                     fitshape=7)
-    f = basic_phot(image=image, positions=INTAB)
+    f = basic_phot(image=image, init_guesses=INTAB)
 
     for n in ['x', 'y', 'flux']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-6)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_tune_coordinates():
     """
     Test psf_photometry with discrete PRF model and coordinates that need
@@ -450,7 +450,7 @@ def test_tune_coordinates():
     for n in ['x', 'y', 'flux']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_psf_boundary():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
@@ -463,10 +463,10 @@ def test_psf_boundary():
                             fitshape=7, aperture_radius=5.5)
 
     intab = Table(data=[[1], [1]], names=['x_0', 'y_0'])
-    f = basic_phot(image=image, positions=intab)
+    f = basic_phot(image=image, init_guesses=intab)
     assert_allclose(f['flux_fit'], 0, atol=1e-8)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_aperture_radius_value_error():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
@@ -480,11 +480,11 @@ def test_aperture_radius_value_error():
 
     intab = Table(data=[[1], [1]], names=['x_0', 'y_0'])
     with pytest.raises(ValueError) as err:
-        f = basic_phot(image=image, positions=intab)
+        f = basic_phot(image=image, init_guesses=intab)
 
     assert 'aperture_radius is None' in str(err.value)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_psf_boundary_gaussian():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
@@ -497,10 +497,10 @@ def test_psf_boundary_gaussian():
                             fitshape=7)
 
     intab = Table(data=[[1], [1]], names=['x_0', 'y_0'])
-    f = basic_phot(image=image, positions=intab)
+    f = basic_phot(image=image, init_guesses=intab)
     assert_allclose(f['flux_fit'], 0, atol=1e-8)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_psf_photometry_gaussian():
     """
     Test psf_photometry with Gaussian PSF model.
@@ -511,11 +511,11 @@ def test_psf_photometry_gaussian():
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
                             bkg_estimator=None, psf_model=psf,
                             fitshape=7)
-    f = basic_phot(image=image, positions=INTAB)
+    f = basic_phot(image=image, init_guesses=INTAB)
     for n in ['x', 'y', 'flux']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
 
-@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_1')
+@pytest.mark.skipif('not HAS_SCIPY or not ASTROPY_GT_1_3')
 def test_psf_fitting_data_on_edge():
     """
     No mask is input explicitly here, but source 2 is so close to the
@@ -528,7 +528,7 @@ def test_psf_fitting_data_on_edge():
                             bkg_estimator=None, psf_model=psf_guess,
                             fitshape=7)
 
-    outtab = basic_phot(image=wide_image, positions=WIDE_INTAB)
+    outtab = basic_phot(image=wide_image, init_guesses=WIDE_INTAB)
 
     for n in ['x', 'y', 'flux']:
         assert_allclose(outtab[n + '_0'], outtab[n + '_fit'],

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -370,9 +370,9 @@ def test_define_fit_param_names(actual_pars_to_set, actual_pars_to_output,
     basic_phot_obj = make_psf_photometry_objs()[0]
     basic_phot_obj.psf_model = psf_model
 
-    pars_to_set, pars_to_output = basic_phot_obj._define_fit_param_names()
-    assert_equal(pars_to_set, actual_pars_to_set)
-    assert_equal(pars_to_output, actual_pars_to_output)
+    basic_phot_obj._define_fit_param_names()
+    assert_equal(basic_phot_obj._pars_to_set, actual_pars_to_set)
+    assert_equal(basic_phot_obj._pars_to_output, actual_pars_to_output)
 
 
 # tests previously written to psf_photometry


### PR DESCRIPTION
Fixes #464 and #478. 

This works fine for ``BasicPSFPhotometry``. However, we should be careful for ``IterativelySubstractedPSFPhotometry``, for instance, in case where ``positions`` is not ``None`` and ``niters > 1``,  there is no way to get initial guesses for additional parameters in the next iterations. For now, the code uses the default value of the parameter in the PSF model.

cc @eteq 

@Gabriel-p do you have time to review this? :)