### PR TITLE
Add a generic model-based image generator

### DIFF
--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -362,7 +362,7 @@ def make_model_sources(image_shape, model, source_table, oversample=1,
     # use this to store the *initial* values so we can set them back when done
     # with the loop.  Best not to copy a model, because some PSF models may have
     # substantial amounts of data in them
-    params_to_set = {pnm: getattr(model, pnm) for pnm in params_to_set}
+    init_params = {pnm: getattr(model, pnm) for pnm in params_to_set}
 
     try:
         for i, source in enumerate(source_table):
@@ -375,7 +375,7 @@ def make_model_sources(image_shape, model, source_table, oversample=1,
                                           (0, image_shape[0]), mode='oversample',
                                           factor=oversample)
     finally:
-        for pnm, val in params_to_set.items():
+        for pnm, val in init_params.items():
             setattr(model, paramnm, val)
 
     if unit is not None:

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -304,9 +304,11 @@ def make_model_sources(image_shape, model, source_table, oversample=1,
         `photutils.psf.models` model.
 
     source_table : `~astropy.table.Table`
-        Table of parameters for the sources.  The column names must have names
-        that match the parameters of the `model`. Any parameter that is *not* in
-        the table will be left at whatever value it has for ``model``.
+        Table of parameters for the sources.  The column names must
+        match the model parameter names.  Column names that do not match
+        model parameters will be ignored.  Any model parameter that is
+        *not* in the table will be left at whatever value it has for
+        ``model``.
 
     oversample : float, optional
         The sampling factor used to discretize the models on a
@@ -355,9 +357,6 @@ def make_model_sources(image_shape, model, source_table, oversample=1,
     for colnm in source_table.colnames:
         if colnm in model.param_names:
             params_to_set.append(colnm)
-        else:
-            raise ValueError('Table column {} is not a parameter in model '
-                             '{}'.format(colnm, model))
 
     # use this to store the *initial* values so we can set them back when done
     # with the loop.  Best not to copy a model, because some PSF models may have

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -300,8 +300,7 @@ def make_model_sources(image_shape, model, source_table, oversample=1,
         will be *added* to that array.
 
     model : 2D astropy.modeling.models object
-        The model to be used for rendering the sources.  Usually would be a
-        `photutils.psf.models` model.
+        The model to be used for rendering the sources.
 
     source_table : `~astropy.table.Table`
         Table of parameters for the sources.  The column names must
@@ -639,8 +638,7 @@ def make_random_models(model, n_sources, param_ranges=None, random_state=None):
     Parameters
     ----------
     model : 2D astropy.modeling.models object
-        The model to be used for the sources.  Usually would be a
-        `photutils.psf.models` model.
+        The model to be used for the sources.
 
     n_sources : int
         The number of random Gaussian sources to generate

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -168,13 +168,9 @@ def test_make_random_models():
     model = Moffat2D(amplitude=1)
     param_ranges = {'x_0': (0, 300), 'y_0': (0, 500),
                     'gamma': (1, 3), 'alpha': (1.5, 3)}
-
     source_table = make_random_models(model, 10, param_ranges)
 
-    # most of the make_model_sources options are exercised in the make_gaussian_sources tests
-    imshape = (300, 500)
-
-    image = make_model_sources(imshape, model, source_table)
-
+    # most of the make_model_sources options are exercised in the
+    # make_gaussian_sources tests
+    image = make_model_sources((300, 500), model, source_table)
     assert image.sum() > 1
-    assert image.sum() < 100

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -7,10 +7,12 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.table import Table
 import astropy.units as u
+from astropy.modeling.models import Moffat2D
 
 from .. import (make_noise_image, make_poisson_noise, make_gaussian_sources,
                 make_random_gaussians, make_4gaussians_image,
-                make_100gaussians_image)
+                make_100gaussians_image,
+                make_random_models, make_model_sources)
 
 
 TABLE = Table()
@@ -160,3 +162,19 @@ def test_make_100gaussians_image():
     image = make_100gaussians_image()
     assert image.shape == shape
     assert_allclose(image.sum(), data_sum, rtol=1.e-6)
+
+
+def test_make_random_models():
+    model = Moffat2D(amplitude=1)
+    param_ranges = {'x_0': (0, 300), 'y_0': (0, 500),
+                    'gamma': (1, 3), 'alpha': (1.5, 3)}
+
+    source_table = make_random_models(model, 10, param_ranges)
+
+    # most of the make_model_sources options are exercised in the make_gaussian_sources tests
+    imshape = (300, 500)
+
+    image = make_model_sources(imshape, model, source_table)
+
+    assert image.sum() > 1
+    assert image.sum() < 100


### PR DESCRIPTION
This PR slightly generalizes the machinery in `photutils.datsets` to support generic models rather than just gaussian models.

The proximate use case is for code I regularly re-do in some of the notebooks to mock up PSF-photometry.  More generally, this is going to be useful down the line for doing artificial star tests.  

A couple questions for @larrybradley : I followed the naming scheme of `make_random_gaussians` and `make_gaussian_sources`, but I find that a bit confusing - it's not clear from the names which makes the table, and which makes the "image".  Is there some reason I'm missing for this naming scheme?  And do you think we can change it even if it's a subtle backwards-compatibility break? (Or should we deprecate?)

And a related question: does it make more sense to instead move all of the wcs-ing and such to the `make_noise_image` function?  That way the flow would be something like:
`make_random_*`->`make_*_sources` _>[`make_*_sources` for other models] -> `make_noise_image`, with the WCS options only being added at the end.