### PR TITLE
Add remote tag for remote image in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Citing Photutils
 ----------------
 
 .. image:: https://zenodo.org/badge/2640766.svg
-   :target: https://zenodo.org/badge/latestdoi/2640766
+    :target: https://zenodo.org/badge/latestdoi/2640766
 
 If you use Photutils, please cite the package via its Zenodo record.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,7 +125,8 @@ If you just want the latest release, cite this (follow the link on the badge
 and then use one of the citation methods on the right):
 
 .. image:: https://zenodo.org/badge/2640766.svg
-   :target: https://zenodo.org/badge/latestdoi/2640766
+    :target: https://zenodo.org/badge/latestdoi/2640766
+    :remote:
 
 If you want to cite an earlier version, you can
 `search for photutils on Zenodo <https://zenodo.org/search?q=photutils>`_.  Then


### PR DESCRIPTION
This PR fixes an issue where the RTD builds are failing with the latest `docutils` release.  Remote images in the `Sphinx` docs must now have a `:remote:` tag 