### PR TITLE
Update aperture subpackage to use BoundingBox class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,17 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Added ``BoundingBox`` class, used when defining apertures. [#481]
+
 API changes
 ^^^^^^^^^^^
+
+- ``photutils.aperture``
+
+  - The ``ApertureMask`` ``apply()`` method has been renamed to
+    ``multiply()``. [#481].
 
 - ``photutils.datasets``
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -126,7 +126,6 @@ and then use one of the citation methods on the right):
 
 .. image:: https://zenodo.org/badge/2640766.svg
     :target: https://zenodo.org/badge/latestdoi/2640766
-    :remote:
 
 If you want to cite an earlier version, you can
 `search for photutils on Zenodo <https://zenodo.org/search?q=photutils>`_.  Then

--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -470,8 +470,8 @@ All `~photutils.PixelAperture` objects have a
 :meth:`~photutils.PixelAperture.to_mask` method that returns a list of
 `~photutils.ApertureMask` objects, one for each aperture position.
 The `~photutils.ApertureMask` object contains a cutout of the aperture
-mask and a slices object that provides the locations where the mask is
-to be applied.  It also provides a
+mask and a `~photutils.BoundingBox` object that provides the bounding
+box where the mask is to be applied.  It also provides a
 :meth:`~photutils.ApertureMask.to_image` method to obtain an image of
 the mask in a 2D array of the given shape, a
 :meth:`~photutils.ApertureMask.cutout` method to create a cutout from

--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -476,10 +476,10 @@ to be applied.  It also provides a
 the mask in a 2D array of the given shape, a
 :meth:`~photutils.ApertureMask.cutout` method to create a cutout from
 the input data over the mask bounding box, and an
-:meth:`~photutils.ApertureMask.apply` method to apply the aperture
-mask to the input data to create a mask-weighted data cutout.   All of
-these methods properly handle the cases of partial or no overlap of
-the aperture mask with the data.
+:meth:`~photutils.ApertureMask.multiply` method to multiply the
+aperture mask with the input data to create a mask-weighted data
+cutout.   All of these methods properly handle the cases of partial or
+no overlap of the aperture mask with the data.
 
 Let's start by creating an aperture object::
 
@@ -503,9 +503,9 @@ We can also create a cutout from a data image over the mask domain::
     >>> data_cutout = mask.cutout(data)
 
 We can also create a mask-weighted cutout from the data.  Here the
-circular aperture mask has been applied to the data::
+circular aperture mask has been multiplied with the data::
 
-    >>> data_cutout_aper = mask.apply(data)
+    >>> data_cutout_aper = mask.multiply(data)
 
 
 .. _custom-apertures:

--- a/photutils/aperture/__init__.py
+++ b/photutils/aperture/__init__.py
@@ -4,6 +4,7 @@ This subpackage contains modules and packages for identifying sources in
 an astronomical image.
 """
 
+from .bounding_box import *
 from .circle import *
 from .core import *
 from .ellipse import *

--- a/photutils/aperture/__init__.py
+++ b/photutils/aperture/__init__.py
@@ -7,4 +7,5 @@ an astronomical image.
 from .circle import *
 from .core import *
 from .ellipse import *
+from .mask import *
 from .rectangle import *

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -48,8 +48,6 @@ class BoundingBox(object):
     >>> # "extent" is useful when plotting the BoundingBox with matplotlib
     >>> bbox.extent  # matplotlib order: (x, y)
     (0.5, 9.5, 1.5, 19.5)
-    >>> print(bbox.as_patch())
-    Rectangle(0.5,1.5;9x18)
     """
 
     def __init__(self, ixmin, ixmax, iymin, iymax):

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -198,8 +198,10 @@ class BoundingBox(object):
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
             np.random.seed(12345)
-            ax.imshow(np.random.random((10, 10)), interpolation='nearest', cmap='viridis')
-            ax.add_patch(bbox.as_patch(facecolor='none', edgecolor='white', lw=2.))
+            ax.imshow(np.random.random((10, 10)), interpolation='nearest',
+                      cmap='viridis')
+            ax.add_patch(bbox.as_patch(facecolor='none', edgecolor='white',
+                         lw=2.))
         """
 
         from matplotlib.patches import Rectangle

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -1,0 +1,208 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+
+__all__ = ['BoundingBox']
+
+
+class BoundingBox(object):
+    """
+    A rectangular bounding box in integer (not float) pixel indices.
+
+    Parameters
+    ----------
+    ixmin, ixmax, iymin, iymax : int
+        The bounding box pixel indices.  Note that the upper values
+        (``iymax`` and ``ixmax``) are exclusive as for normal slices in
+        Python.  The lower values (``ixmin`` and ``iymin``) must not be
+        greater than the respective upper values (``ixmax`` and
+        ``iymax``).
+
+    Examples
+    --------
+    >>> from photutils import BoundingBox
+
+    >>> # constructing a BoundingBox like this is cryptic:
+    >>> bbox = BoundingBox(1, 10, 2, 20)
+
+    >>> # it's better to use keyword arguments for readability:
+    >>> bbox = BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
+    >>> bbox  # nice repr, useful for interactive work
+    BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
+
+    >>> # sometimes it's useful to check if two bounding boxes are the same
+    >>> bbox == BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
+    True
+    >>> bbox == BoundingBox(ixmin=7, ixmax=10, iymin=2, iymax=20)
+    False
+
+    >>> # "shape" and "slices" can be useful when working with numpy arrays
+    >>> bbox.shape  # numpy order: (y, x)
+    (18, 9)
+    >>> bbox.slices  # numpy order: (y, x)
+    (slice(2, 20, None), slice(1, 10, None))
+
+    >>> # "extent" is useful when plotting the BoundingBox with matplotlib
+    >>> bbox.extent  # matplotlib order: (x, y)
+    (0.5, 9.5, 1.5, 19.5)
+    >>> print(bbox.as_patch())
+    Rectangle(0.5,1.5;9x18)
+    """
+
+    def __init__(self, ixmin, ixmax, iymin, iymax):
+        if ixmin > ixmax:
+            raise ValueError('ixmin must be <= ixmax')
+        if iymin > iymax:
+            raise ValueError('iymin must be <= iymax')
+
+        self.ixmin = ixmin
+        self.ixmax = ixmax
+        self.iymin = iymin
+        self.iymax = iymax
+
+    @classmethod
+    def _from_float(cls, xmin, xmax, ymin, ymax):
+        """
+        Return the smallest bounding box that fully contains a given
+        rectangle defined by float coordinate values.
+
+        Following the pixel index convention, an integer index
+        corresponds to the center of a pixel and the pixel edges span
+        from (index - 0.5) to (index + 0.5).  For example, the pixel
+        edge spans of the following pixels are:
+
+        - pixel 0: from -0.5 to 0.5
+        - pixel 1: from 0.5 to 1.5
+        - pixel 2: from 1.5 to 2.5
+
+        In addition, because `BoundingBox` upper limits are exclusive
+        (by definition), 1 is added to the upper pixel edges.  See
+        examples below.
+
+        Parameters
+        ----------
+        xmin, xmax, ymin, ymax : float
+            Float coordinates defining a rectangle.  The lower values
+            (``xmin`` and ``ymin``) must not be greater than the
+            respective upper values (``xmax`` and ``ymax``).
+
+        Returns
+        -------
+        bbox : `BoundingBox` object
+            The minimal ``BoundingBox`` object fully containing the
+            input rectangle coordinates.
+
+        Examples
+        --------
+        >>> from photutils import BoundingBox
+        >>> BoundingBox._from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
+        BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
+
+        >>> BoundingBox._from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
+        BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
+        """
+
+        ixmin = np.floor(xmin + 0.5).astype(int)
+        ixmax = np.floor(xmax + 1.5).astype(int)
+        iymin = np.floor(ymin + 0.5).astype(int)
+        iymax = np.floor(ymax + 1.5).astype(int)
+
+        return cls(ixmin, ixmax, iymin, iymax)
+
+    def __eq__(self, other):
+        if not isinstance(other, BoundingBox):
+            raise TypeError('Can compare BoundingBox only to another '
+                            'BoundingBox.')
+
+        return (
+            (self.ixmin == other.ixmin) and
+            (self.ixmax == other.ixmax) and
+            (self.iymin == other.iymin) and
+            (self.iymax == other.iymax)
+        )
+
+    def __repr__(self):
+        data = self.__dict__
+        data['name'] = self.__class__.__name__
+        fmt = ('{name}(ixmin={ixmin}, ixmax={ixmax}, iymin={iymin}, '
+               'iymax={iymax})')
+        return fmt.format(**data)
+
+    @property
+    def shape(self):
+        """
+        The ``(ny, nx)`` shape of the bounding box.
+        """
+
+        return self.iymax - self.iymin, self.ixmax - self.ixmin
+
+    @property
+    def slices(self):
+        """
+        The bounding box as a tuple of `slice` objects.
+
+        The slice tuple is in numpy axis order (i.e. ``(y, x)``) and
+        therefore can be used to slice numpy arrays.
+        """
+
+        return (slice(self.iymin, self.iymax), slice(self.ixmin, self.ixmax))
+
+    @property
+    def extent(self):
+        """
+        The extent of the mask, defined as the ``(xmin, xmax, ymin,
+        ymax)`` bounding box from the bottom-left corner of the
+        lower-left pixel to the upper-right corner of the upper-right
+        pixel.
+
+        The upper edges here are the actual pixel positions of the
+        edges, i.e. they are not "exclusive" indices used for python
+        indexing.  This is useful for plotting the bounding box using
+        Matplotlib.
+        """
+
+        return (
+            self.ixmin - 0.5,
+            self.ixmax - 0.5,
+            self.iymin - 0.5,
+            self.iymax - 0.5,
+        )
+
+    def as_patch(self, **kwargs):
+        """
+        Return a `matplotlib.patches.Rectangle` that represents the
+        bounding box.
+
+        Parameters
+        ----------
+        kwargs
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        result : `matplotlib.patches.Rectangle`
+            A matplotlib rectangular patch.
+
+        Examples
+        --------
+        .. plot::
+            :include-source:
+
+            import matplotlib.pyplot as plt
+            from photutils import BoundingBox
+            bbox = BoundingBox(2, 7, 3, 8)
+            fig = plt.figure()
+            ax = fig.add_subplot(1, 1, 1)
+            np.random.seed(12345)
+            ax.imshow(np.random.random((10, 10)), interpolation='nearest', cmap='viridis')
+            ax.add_patch(bbox.as_patch(facecolor='none', edgecolor='white', lw=2.))
+        """
+
+        from matplotlib.patches import Rectangle
+
+        return Rectangle(xy=(self.extent[0], self.extent[2]),
+                         width=self.shape[1], height=self.shape[0], **kwargs)

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -82,12 +82,14 @@ class CircularMaskMixin(object):
         masks = []
         for bbox, edges in zip(self.bounding_boxes, self._centered_edges):
             ny, nx = bbox.shape
-            mask = circular_overlap_grid(*edges, nx, ny, radius, use_exact,
+            mask = circular_overlap_grid(edges[0], edges[1], edges[2],
+                                         edges[3], nx, ny, radius, use_exact,
                                          subpixels)
 
             # subtract the inner circle for an annulus
             if hasattr(self, 'r_in'):
-                mask -= circular_overlap_grid(*edges, nx, ny, self.r_in,
+                mask -= circular_overlap_grid(edges[0], edges[1], edges[2],
+                                              edges[3], nx, ny, self.r_in,
                                               use_exact, subpixels)
 
             masks.append(ApertureMask(mask, bbox))

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -8,9 +8,9 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
-from .core import (PixelAperture, SkyAperture, ApertureMask,
-                   _sanitize_pixel_positions, _translate_mask_method,
-                   _make_annulus_path)
+from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
+                   _translate_mask_method, _make_annulus_path)
+from .mask import ApertureMask
 from ..geometry import circular_overlap_grid
 from ..utils.wcs_helpers import (skycoord_to_pixel_scale_angle,
                                  assert_angle_or_pixel)
@@ -28,8 +28,8 @@ class CircularMaskMixin(object):
 
     def to_mask(self, method='exact', subpixels=5):
         """
-        Return a list of `ApertureMask` objects, one for each aperture
-        position.
+        Return a list of `~photutils.ApertureMask` objects, one for each
+        aperture position.
 
         Parameters
         ----------

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -9,7 +9,7 @@ import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
 from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
-                   _translate_mask_method, _make_annulus_path)
+                   _make_annulus_path)
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import circular_overlap_grid
@@ -71,11 +71,7 @@ class CircularMaskMixin(object):
             A list of aperture mask objects.
         """
 
-        if method not in ('center', 'subpixel', 'exact'):
-            raise ValueError('"{0}" method is not available for this '
-                             'aperture.'.format(method))
-
-        use_exact, subpixels = _translate_mask_method(method, subpixels)
+        use_exact, subpixels = self._translate_mask_mode(method, subpixels)
 
         if hasattr(self, 'r'):
             radius = self.r

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -124,15 +124,11 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
     """
 
     def __init__(self, positions, r):
-        try:
-            self.r = float(r)
-        except TypeError:
-            raise TypeError('r must be numeric, received {0}'.format(type(r)))
-
         if r < 0:
             raise ValueError('r must be non-negative')
 
         self.positions = self._sanitize_positions(positions)
+        self.r = float(r)
 
     # TODO: make lazyproperty?, but update if positions or radius change
     @property
@@ -196,19 +192,14 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
     """
 
     def __init__(self, positions, r_in, r_out):
-        try:
-            self.r_in = r_in
-            self.r_out = r_out
-        except TypeError:
-            raise TypeError("'r_in' and 'r_out' must be numeric, received "
-                            "{0} and {1}".format((type(r_in), type(r_out))))
-
         if not (r_out > r_in):
             raise ValueError('r_out must be greater than r_in')
         if r_in < 0:
             raise ValueError('r_in must be non-negative')
 
         self.positions = self._sanitize_positions(positions)
+        self.r_in = float(r_in)
+        self.r_out = float(r_out)
 
     @property
     def bounding_boxes(self):
@@ -259,7 +250,7 @@ class SkyCircularAperture(SkyAperture):
         if isinstance(positions, SkyCoord):
             self.positions = positions
         else:
-            raise TypeError('positions must be a SkyCoord object.')
+            raise TypeError('positions must be a SkyCoord object')
 
         assert_angle_or_pixel('r', r)
         self.r = r
@@ -324,14 +315,14 @@ class SkyCircularAnnulus(SkyAperture):
         if isinstance(positions, SkyCoord):
             self.positions = positions
         else:
-            raise TypeError("positions should be a SkyCoord instance")
+            raise TypeError('positions must be a SkyCoord object')
 
         assert_angle_or_pixel('r_in', r_in)
         assert_angle_or_pixel('r_out', r_out)
 
         if r_in.unit.physical_type != r_out.unit.physical_type:
             raise ValueError("r_in and r_out should either both be angles "
-                             "or in pixels")
+                             "or in pixels.")
 
         self.r_in = r_in
         self.r_out = r_out

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -8,7 +8,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
-from .core import PixelAperture, SkyAperture, _make_annulus_path
+from .core import PixelAperture, SkyAperture
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import circular_overlap_grid
@@ -227,7 +227,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
                                                  resolution=resolution)
             patch_outer = mpatches.CirclePolygon(position, self.r_out,
                                                  resolution=resolution)
-            path = _make_annulus_path(patch_inner, patch_outer)
+            path = self._make_annulus_path(patch_inner, patch_outer)
             patch = mpatches.PathPatch(path, **kwargs)
             ax.add_patch(patch)
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -8,8 +8,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
-from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
-                   _make_annulus_path)
+from .core import PixelAperture, SkyAperture, _make_annulus_path
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import circular_overlap_grid
@@ -133,7 +132,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         if r < 0:
             raise ValueError('r must be non-negative')
 
-        self.positions = _sanitize_pixel_positions(positions)
+        self.positions = self._sanitize_positions(positions)
 
     # TODO: make lazyproperty?, but update if positions or radius change
     @property
@@ -209,7 +208,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         if r_in < 0:
             raise ValueError('r_in must be non-negative')
 
-        self.positions = _sanitize_pixel_positions(positions)
+        self.positions = self._sanitize_positions(positions)
 
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -31,34 +31,6 @@ def _get_version_info():
                                                  photutils_version)
 
 
-def _sanitize_pixel_positions(positions):
-    if isinstance(positions, u.Quantity):
-        if positions.unit is u.pixel:
-            positions = np.atleast_2d(positions.value)
-        else:
-            raise u.UnitsError("positions should be in pixel units")
-    elif isinstance(positions, (list, tuple, np.ndarray)):
-        positions = np.atleast_2d(positions)
-        if positions.shape[1] != 2:
-            if positions.shape[0] == 2:
-                positions = np.transpose(positions)
-            else:
-                raise TypeError("List or array of (x, y) pixel coordinates "
-                                "is expected got '{0}'.".format(positions))
-    elif isinstance(positions, zip):
-        # This is needed for zip to work seamlessly in Python 3
-        positions = np.atleast_2d(list(positions))
-    else:
-        raise TypeError("List or array of (x, y) pixel coordinates "
-                        "is expected got '{0}'.".format(positions))
-
-    if positions.ndim > 2:
-        raise ValueError('{0}D position array not supported. Only 2D '
-                         'arrays supported.'.format(positions.ndim))
-
-    return positions
-
-
 def _make_annulus_path(patch_inner, patch_outer):
     import matplotlib.path as mpath
 
@@ -96,6 +68,35 @@ class PixelAperture(Aperture):
     """
     Abstract base class for apertures defined in pixel coordinates.
     """
+
+    @staticmethod
+    def _sanitize_positions(positions):
+        if isinstance(positions, u.Quantity):
+            if positions.unit is u.pixel:
+                positions = np.atleast_2d(positions.value)
+            else:
+                raise u.UnitsError('positions should be in pixel units')
+        elif isinstance(positions, (list, tuple, np.ndarray)):
+            positions = np.atleast_2d(positions)
+            if positions.shape[1] != 2:
+                if positions.shape[0] == 2:
+                    positions = np.transpose(positions)
+                else:
+                    raise TypeError('List or array of (x, y) pixel '
+                                    'coordinates is expected, got "{0}".'
+                                    .format(positions))
+        elif isinstance(positions, zip):
+            # This is needed for zip to work seamlessly in Python 3
+            positions = np.atleast_2d(list(positions))
+        else:
+            raise TypeError('List or array of (x, y) pixel coordinates '
+                            'is expected, got "{0}".'.format(positions))
+
+        if positions.ndim > 2:
+            raise ValueError('{0}D position array is not supported. Only 2D '
+                             'arrays are supported.'.format(positions.ndim))
+
+        return positions
 
     @staticmethod
     def _translate_mask_mode(mode, subpixels, rectangle=False):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -113,28 +113,35 @@ class PixelAperture(Aperture):
     """
 
     @abc.abstractproperty
-    def _slices(self):
-        """The minimal bounding box slices for the aperture(s)."""
+    def bounding_boxes(self):
+        """
+        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
+        for each position, for the aperture.
+        """
 
         raise NotImplementedError('Needs to be implemented in a '
                                   'PixelAperture subclass.')
 
     @property
-    def _geom_slices(self):
+    def _centered_edges(self):
         """
-        A tuple of slices to be used by the low-level
-        `photutils.geometry` functions.
+        A list of ``(xmin, xmax, ymin, ymax)`` tuples, one for each
+        position, of the pixel edges after recentering the aperture at
+        the origin.
+
+        These pixel edges are used by the low-level `photutils.geometry`
+        functions.
         """
 
-        geom_slices = []
-        for _slice, position in zip(self._slices, self.positions):
-            x_min = _slice[1].start - position[0] - 0.5
-            x_max = _slice[1].stop - position[0] - 0.5
-            y_min = _slice[0].start - position[1] - 0.5
-            y_max = _slice[0].stop - position[1] - 0.5
-            geom_slices.append((slice(y_min, y_max), slice(x_min, x_max)))
+        edges = []
+        for position, bbox in zip(self.positions, self.bounding_boxes):
+            xmin = bbox.ixmin - 0.5 - position[0]
+            xmax = bbox.ixmax - 0.5 - position[0]
+            ymin = bbox.iymin - 0.5 - position[1]
+            ymax = bbox.iymax - 0.5 - position[1]
+            edges.append((xmin, xmax, ymin, ymax))
 
-        return geom_slices
+        return edges
 
     def area(self):
         """

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -108,37 +108,6 @@ class Aperture(object):
         return len(self.positions)
 
 
-class SkyAperture(Aperture):
-    """
-    Abstract base class for 2D apertures defined in celestial coordinates.
-    """
-
-    @abc.abstractmethod
-    def to_pixel(self, wcs, mode='all'):
-        """
-        Convert the aperture to a `PixelAperture` object in pixel
-        coordinates.
-
-        Parameters
-        ----------
-        wcs : `~astropy.wcs.WCS`
-            The WCS transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
-
-        Returns
-        -------
-        aperture : `PixelAperture` object
-            A `PixelAperture` object.
-        """
-
-        raise NotImplementedError('Needs to be implemented in a '
-                                  'SkyAperture subclass.')
-
-
 class PixelAperture(Aperture):
     """
     Abstract base class for 2D apertures defined in pixel coordinates.
@@ -526,6 +495,41 @@ class PixelAperture(Aperture):
         kwargs
             Any keyword arguments accepted by `matplotlib.patches.Patch`.
         """
+
+        raise NotImplementedError('Needs to be implemented in a '
+                                  'PixelAperture subclass.')
+
+
+class SkyAperture(Aperture):
+    """
+    Abstract base class for all apertures defined in celestial
+    coordinates.
+    """
+
+    @abc.abstractmethod
+    def to_pixel(self, wcs, mode='all'):
+        """
+        Convert the aperture to a `PixelAperture` object in pixel
+        coordinates.
+
+        Parameters
+        ----------
+        wcs : `~astropy.wcs.WCS` object
+            The world coordinate system (WCS) transformation to use.
+
+        mode : {'all', 'wcs'}, optional
+            Whether to do the transformation including distortions
+            (``'all'``; default) or including only the core WCS
+            transformation (``'wcs'``).
+
+        Returns
+        -------
+        aperture : `PixelAperture` object
+            A `PixelAperture` object.
+        """
+
+        raise NotImplementedError('Needs to be implemented in a '
+                                  'SkyAperture subclass.')
 
 
 class ApertureMask(object):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -16,19 +16,10 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import InheritDocstrings
 from astropy.wcs import WCS
 
+from ..utils import get_version_info
+
 
 __all__ = ['Aperture', 'SkyAperture', 'PixelAperture', 'aperture_photometry']
-
-
-def _get_version_info():
-    from astropy import __version__
-    astropy_version = __version__
-
-    from photutils import __version__
-    photutils_version = __version__
-
-    return 'astropy: {0}, photutils: {1}'.format(astropy_version,
-                                                 photutils_version)
 
 
 class _ABCMetaAndInheritDocstrings(InheritDocstrings, abc.ABCMeta):
@@ -801,7 +792,7 @@ def aperture_photometry(data, apertures, error=None, pixelwise_error=True,
                     .format(method, subpixels, pixelwise_error))
     meta = OrderedDict()
     meta['name'] = 'Aperture photometry results'
-    meta['version'] = _get_version_info()
+    meta['version'] = get_version_info()
     meta['aperture_photometry_args'] = calling_args
 
     tbl = QTable(meta=meta)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -110,10 +110,7 @@ class Aperture(object):
 
 class PixelAperture(Aperture):
     """
-    Abstract base class for 2D apertures defined in pixel coordinates.
-
-    Derived classes must define a ``_slices`` property, ``to_mask`` and
-    ``plot`` methods, and optionally an ``area`` method.
+    Abstract base class for apertures defined in pixel coordinates.
     """
 
     @abc.abstractproperty

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -31,23 +31,6 @@ def _get_version_info():
                                                  photutils_version)
 
 
-def _make_annulus_path(patch_inner, patch_outer):
-    import matplotlib.path as mpath
-
-    verts_inner = patch_inner.get_verts()
-    verts_outer = patch_outer.get_verts()
-    codes_inner = (np.ones(len(verts_inner), dtype=mpath.Path.code_type) *
-                   mpath.Path.LINETO)
-    codes_inner[0] = mpath.Path.MOVETO
-    codes_outer = (np.ones(len(verts_outer), dtype=mpath.Path.code_type) *
-                   mpath.Path.LINETO)
-    codes_outer[0] = mpath.Path.MOVETO
-    codes = np.concatenate((codes_inner, codes_outer))
-    verts = np.concatenate((verts_inner, verts_outer[::-1]))
-
-    return mpath.Path(verts, codes)
-
-
 class _ABCMetaAndInheritDocstrings(InheritDocstrings, abc.ABCMeta):
     pass
 
@@ -427,6 +410,23 @@ class PixelAperture(Aperture):
                                                             unit=unit)
 
         return aperture_sums, aperture_sum_errs
+
+    @staticmethod
+    def _make_annulus_path(patch_inner, patch_outer):
+        import matplotlib.path as mpath
+
+        verts_inner = patch_inner.get_verts()
+        verts_outer = patch_outer.get_verts()
+        codes_inner = (np.ones(len(verts_inner), dtype=mpath.Path.code_type) *
+                       mpath.Path.LINETO)
+        codes_inner[0] = mpath.Path.MOVETO
+        codes_outer = (np.ones(len(verts_outer), dtype=mpath.Path.code_type) *
+                       mpath.Path.LINETO)
+        codes_outer[0] = mpath.Path.MOVETO
+        codes = np.concatenate((codes_inner, codes_outer))
+        verts = np.concatenate((verts_inner, verts_outer[::-1]))
+
+        return mpath.Path(verts, codes)
 
     def _prepare_plot(self, origin=(0, 0), indices=None, ax=None,
                       fill=False, **kwargs):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -17,8 +17,7 @@ from astropy.utils.misc import InheritDocstrings
 from astropy.wcs import WCS
 
 
-__all__ = ['Aperture', 'SkyAperture', 'PixelAperture', 'ApertureMask',
-           'aperture_photometry']
+__all__ = ['Aperture', 'SkyAperture', 'PixelAperture', 'aperture_photometry']
 
 
 def _get_version_info():
@@ -204,8 +203,8 @@ class PixelAperture(Aperture):
     @abc.abstractmethod
     def to_mask(self, method='exact', subpixels=5):
         """
-        Return a list of `ApertureMask` objects, one for each aperture
-        position.
+        Return a list of `~photutils.ApertureMask` objects, one for each
+        aperture position.
 
         Parameters
         ----------
@@ -527,199 +526,6 @@ class SkyAperture(Aperture):
 
         raise NotImplementedError('Needs to be implemented in a '
                                   'SkyAperture subclass.')
-
-
-class ApertureMask(object):
-    """
-    Class for an aperture mask.
-
-    Parameters
-    ----------
-    mask : array_like
-        A 2D array of an aperture mask representing the fractional
-        overlap of the aperture on the pixel grid.  This should be the
-        full-sized (i.e. not truncated) array that is the direct output
-        of one of the low-level `photutils.geometry` functions.
-
-    bbox_slice : tuple of slice objects
-        A tuple of ``(y, x)`` numpy slice objects defining the aperture
-        minimal bounding box.
-    """
-
-    def __init__(self, mask, bbox_slice):
-        self.data = np.asanyarray(mask)
-        self.shape = mask.shape
-        self.slices = bbox_slice
-
-        dy = bbox_slice[0].stop - bbox_slice[0].start
-        dx = bbox_slice[1].stop - bbox_slice[1].start
-        if self.data.shape != (dy, dx):
-            raise ValueError('mask shape and bbox_slice do not agree.')
-
-    @property
-    def array(self):
-        """The 2D mask array."""
-
-        return self.data
-
-    def __array__(self):
-        """
-        Array representation of the mask array (e.g., for matplotlib).
-        """
-
-        return self.data
-
-    def _overlap_slices(self, shape):
-        """
-        Calculate the slices for the overlapping part of ``self.slices``
-        and an array of the given shape.
-
-        Parameters
-        ----------
-        shape : tuple of int
-            The ``(ny, nx)`` shape of array where the slices are to be
-            applied.
-
-        Returns
-        -------
-        slices_large : tuple of slices
-            A tuple of slice objects for each axis of the large array,
-            such that ``large_array[slices_large]`` extracts the region
-            of the large array that overlaps with the small array.
-
-        slices_small : slice
-            A tuple of slice objects for each axis of the small array,
-            such that ``small_array[slices_small]`` extracts the region
-            of the small array that is inside the large array.
-        """
-
-        if len(shape) != 2:
-            raise ValueError('input shape must have 2 elements.')
-
-        ymin = self.slices[0].start
-        ymax = self.slices[0].stop
-        xmin = self.slices[1].start
-        xmax = self.slices[1].stop
-
-        if (xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0):
-            # no overlap of the aperture with the data
-            return None, None
-
-        slices_large = (slice(max(ymin, 0), min(ymax, shape[0])),
-                        slice(max(xmin, 0), min(xmax, shape[1])))
-
-        slices_small = (slice(max(-ymin, 0),
-                              min(ymax - ymin, shape[0] - ymin)),
-                        slice(max(-xmin, 0),
-                              min(xmax - xmin, shape[1] - xmin)))
-
-        return slices_large, slices_small
-
-    def to_image(self, shape):
-        """
-        Return an image of the mask in a 2D array of the given shape,
-        taking any edge effects into account.
-
-        Parameters
-        ----------
-        shape : tuple of int
-            The ``(ny, nx)`` shape of the output array.
-
-        Returns
-        -------
-        result : `~numpy.ndarray`
-            A 2D array of the mask.
-        """
-
-        if len(shape) != 2:
-            raise ValueError('input shape must have 2 elements.')
-
-        mask = np.zeros(shape)
-
-        try:
-            mask[self.slices] = self.data
-        except ValueError:    # partial or no overlap
-            slices_large, slices_small = self._overlap_slices(shape)
-
-            if slices_small is None:
-                return None    # no overlap
-
-            mask = np.zeros(shape)
-            mask[slices_large] = self.data[slices_small]
-
-        return mask
-
-    def cutout(self, data, fill_value=0.):
-        """
-        Create a cutout from the input data over the mask bounding box,
-        taking any edge effects into account.
-
-        Parameters
-        ----------
-        data : array_like or `~astropy.units.Quantity`
-            A 2D array on which to apply the aperture mask.
-
-        fill_value : float, optional
-            The value is used to fill pixels where the aperture mask
-            does not overlap with the input ``data``.  The default is 0.
-
-        Returns
-        -------
-        result : `~numpy.ndarray`
-            A 2D array cut out from the input ``data`` representing the
-            same cutout region as the aperture mask.  If there is a
-            partial overlap of the aperture mask with the input data,
-            pixels outside of the data will be assigned to
-            ``fill_value``.  `None` is returned if there is no overlap
-            of the aperture with the input ``data``.
-        """
-
-        data = np.asanyarray(data)
-        cutout = data[self.slices]
-
-        if cutout.shape != self.shape:
-            slices_large, slices_small = self._overlap_slices(data.shape)
-
-            if slices_small is None:
-                return None    # no overlap
-
-            cutout = np.zeros(self.shape, dtype=data.dtype)
-            cutout[:] = fill_value
-            cutout[slices_small] = data[slices_large]
-
-            if isinstance(data, u.Quantity):
-                cutout = u.Quantity(cutout, unit=data.unit)
-
-        return cutout
-
-    def apply(self, data, fill_value=0.):
-        """
-        Apply the aperture mask to the input data, taking any edge
-        effects into account.
-
-        The result is a mask-weighted cutout from the data.
-
-        Parameters
-        ----------
-        data : array_like or `~astropy.units.Quantity`
-            A 2D array on which to apply the aperture mask.
-
-        fill_value : float, optional
-            The value is used to fill pixels where the aperture mask
-            does not overlap with the input ``data``.  The default is 0.
-
-        Returns
-        -------
-        result : `~numpy.ndarray`
-            A 2D mask-weighted cutout from the input ``data``.  If there
-            is a partial overlap of the aperture mask with the input
-            data, pixels outside of the data will be assigned to
-            ``fill_value`` before being multipled with the mask.  `None`
-            is returned if there is no overlap of the aperture with the
-            input ``data``.
-        """
-
-        return self.cutout(data, fill_value=fill_value) * self.data
 
 
 def _prepare_photometry_input(data, error, pixelwise_error, mask, wcs, unit):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -59,21 +59,6 @@ def _sanitize_pixel_positions(positions):
     return positions
 
 
-def _translate_mask_method(method, subpixels):
-    if method == 'center':
-        use_exact = 0
-        subpixels = 1
-    elif method == 'subpixel':
-        use_exact = 0
-    elif method == 'exact':
-        use_exact = 1
-        subpixels = 1
-    else:
-        raise ValueError('"{0}" is not a valid method.'.format(method))
-
-    return use_exact, subpixels
-
-
 def _make_annulus_path(patch_inner, patch_outer):
     import matplotlib.path as mpath
 
@@ -111,6 +96,34 @@ class PixelAperture(Aperture):
     """
     Abstract base class for apertures defined in pixel coordinates.
     """
+
+    @staticmethod
+    def _translate_mask_mode(mode, subpixels, rectangle=False):
+        if mode not in ('center', 'subpixel', 'exact'):
+            raise ValueError('Invalid mask mode: {0}'.format(mode))
+
+        if rectangle and mode == 'exact':
+            warnings.warn('The "exact" method is not yet implemented for '
+                          'rectangular apertures -- using "subpixel" method '
+                          'with "subpixels=32"', AstropyUserWarning)
+            mode = 'subpixel'
+            subpixels = 32
+
+        if mode == 'subpixels':
+            if not isinstance(subpixels, int) or subpixels <= 0:
+                raise ValueError('subpixels must be a strictly positive '
+                                 'integer'.format(subpixels))
+
+        if mode == 'center':
+            use_exact = 0
+            subpixels = 1
+        elif mode == 'subpixel':
+            use_exact = 0
+        elif mode == 'exact':
+            use_exact = 1
+            subpixels = 1
+
+        return use_exact, subpixels
 
     @abc.abstractproperty
     def bounding_boxes(self):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -136,19 +136,13 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     """
 
     def __init__(self, positions, a, b, theta):
-        try:
-            self.a = float(a)
-            self.b = float(b)
-            self.theta = float(theta)
-        except TypeError:
-            raise TypeError("'a' and 'b' and 'theta' must be numeric, "
-                            "received {0} and {1} and {2}."
-                            .format((type(a), type(b), type(theta))))
-
         if a < 0 or b < 0:
             raise ValueError("'a' and 'b' must be non-negative.")
 
         self.positions = self._sanitize_positions(positions)
+        self.a = float(a)
+        self.b = float(b)
+        self.theta = float(theta)
 
     @property
     def bounding_boxes(self):
@@ -228,25 +222,17 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     """
 
     def __init__(self, positions, a_in, a_out, b_out, theta):
-        try:
-            self.a_in = float(a_in)
-            self.a_out = float(a_out)
-            self.b_out = float(b_out)
-            self.theta = float(theta)
-        except TypeError:
-            raise TypeError("'a_in' and 'a_out' and 'b_out' and 'theta' must "
-                            "be numeric, received {0} and {1} and {2} and "
-                            "{3}.".format((type(a_in), type(a_out),
-                                           type(b_out), type(theta))))
-
         if not (a_out > a_in):
-            raise ValueError("'a_out' must be greater than 'a_in'")
+            raise ValueError('"a_out" must be greater than "a_in".')
         if a_in < 0 or b_out < 0:
-            raise ValueError("'a_in' and 'b_out' must be non-negative")
-
-        self.b_in = b_out * a_in / a_out
+            raise ValueError('"a_in" and "b_out" must be non-negative.')
 
         self.positions = self._sanitize_positions(positions)
+        self.a_in = float(a_in)
+        self.a_out = float(a_out)
+        self.b_out = float(b_out)
+        self.b_in = self.b_out * self.a_in / self.a_out
+        self.theta = float(theta)
 
     @property
     def bounding_boxes(self):
@@ -307,7 +293,7 @@ class SkyEllipticalAperture(SkyAperture):
         if isinstance(positions, SkyCoord):
             self.positions = positions
         else:
-            raise TypeError("positions should be a SkyCoord instance")
+            raise TypeError('positions must be a SkyCoord instance')
 
         assert_angle_or_pixel('a', a)
         assert_angle_or_pixel('b', b)
@@ -394,7 +380,7 @@ class SkyEllipticalAnnulus(SkyAperture):
         if isinstance(positions, SkyCoord):
             self.positions = positions
         else:
-            raise TypeError("positions should be a SkyCoord instance")
+            raise TypeError('positions must be a SkyCoord instance')
 
         assert_angle_or_pixel('a_in', a_in)
         assert_angle_or_pixel('a_out', a_out)

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -8,9 +8,9 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
-from .core import (PixelAperture, SkyAperture, ApertureMask,
-                   _sanitize_pixel_positions, _translate_mask_method,
-                   _make_annulus_path)
+from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
+                   _translate_mask_method, _make_annulus_path)
+from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
 from ..utils.wcs_helpers import (skycoord_to_pixel_scale_angle, assert_angle,
                                  assert_angle_or_pixel)
@@ -28,8 +28,8 @@ class EllipticalMaskMixin(object):
 
     def to_mask(self, method='exact', subpixels=5):
         """
-        Return a list of `ApertureMask` objects, one for each aperture
-        position.
+        Return a list of `~photutils.ApertureMask` objects, one for each
+        aperture position.
 
         Parameters
         ----------

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -9,7 +9,7 @@ import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
 from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
-                   _translate_mask_method, _make_annulus_path)
+                   _make_annulus_path)
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
@@ -71,11 +71,7 @@ class EllipticalMaskMixin(object):
             A list of aperture mask objects.
         """
 
-        if method not in ('center', 'subpixel', 'exact'):
-            raise ValueError('"{0}" method is not available for this '
-                             'aperture.'.format(method))
-
-        use_exact, subpixels = _translate_mask_method(method, subpixels)
+        use_exact, subpixels = self._translate_mask_mode(method, subpixels)
 
         if hasattr(self, 'a'):
             a = self.a

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -85,12 +85,14 @@ class EllipticalMaskMixin(object):
         masks = []
         for bbox, edges in zip(self.bounding_boxes, self._centered_edges):
             ny, nx = bbox.shape
-            mask = elliptical_overlap_grid(*edges, nx, ny, a, b, self.theta,
+            mask = elliptical_overlap_grid(edges[0], edges[1], edges[2],
+                                           edges[3], nx, ny, a, b, self.theta,
                                            use_exact, subpixels)
 
             # subtract the inner ellipse for an annulus
             if hasattr(self, 'a_in'):
-                mask -= elliptical_overlap_grid(*edges, nx, ny, self.a_in,
+                mask -= elliptical_overlap_grid(edges[0], edges[1], edges[2],
+                                                edges[3], nx, ny, self.a_in,
                                                 b_in, self.theta, use_exact,
                                                 subpixels)
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -8,8 +8,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
-from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
-                   _make_annulus_path)
+from .core import PixelAperture, SkyAperture, _make_annulus_path
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
@@ -149,7 +148,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         if a < 0 or b < 0:
             raise ValueError("'a' and 'b' must be non-negative.")
 
-        self.positions = _sanitize_pixel_positions(positions)
+        self.positions = self._sanitize_positions(positions)
 
     @property
     def bounding_boxes(self):
@@ -247,7 +246,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
 
         self.b_in = b_out * a_in / a_out
 
-        self.positions = _sanitize_pixel_positions(positions)
+        self.positions = self._sanitize_positions(positions)
 
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -8,7 +8,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
-from .core import PixelAperture, SkyAperture, _make_annulus_path
+from .core import PixelAperture, SkyAperture
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
@@ -262,7 +262,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
                                            2.*self.b_in, theta_deg, **kwargs)
             patch_outer = mpatches.Ellipse(position, 2.*self.a_out,
                                            2.*self.b_out, theta_deg, **kwargs)
-            path = _make_annulus_path(patch_inner, patch_outer)
+            path = self._make_annulus_path(patch_inner, patch_outer)
             patch = mpatches.PathPatch(path, **kwargs)
             ax.add_patch(patch)
 

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -172,9 +172,9 @@ class ApertureMask(object):
 
         return cutout
 
-    def apply(self, data, fill_value=0.):
+    def multiply(self, data, fill_value=0.):
         """
-        Apply the aperture mask to the input data, taking any edge
+        Multiply the aperture mask with the input data, taking any edge
         effects into account.
 
         The result is a mask-weighted cutout from the data.
@@ -182,7 +182,7 @@ class ApertureMask(object):
         Parameters
         ----------
         data : array_like or `~astropy.units.Quantity`
-            A 2D array on which to apply the aperture mask.
+            The 2D array to multiply with the aperture mask.
 
         fill_value : float, optional
             The value is used to fill pixels where the aperture mask

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -1,0 +1,202 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+import astropy.units as u
+
+
+__all__ = ['ApertureMask']
+
+
+class ApertureMask(object):
+    """
+    Class for an aperture mask.
+
+    Parameters
+    ----------
+    mask : array_like
+        A 2D array of an aperture mask representing the fractional
+        overlap of the aperture on the pixel grid.  This should be the
+        full-sized (i.e. not truncated) array that is the direct output
+        of one of the low-level `photutils.geometry` functions.
+
+    bbox_slice : tuple of slice objects
+        A tuple of ``(y, x)`` numpy slice objects defining the aperture
+        minimal bounding box.
+    """
+
+    def __init__(self, mask, bbox_slice):
+        self.data = np.asanyarray(mask)
+        self.shape = mask.shape
+        self.slices = bbox_slice
+
+        dy = bbox_slice[0].stop - bbox_slice[0].start
+        dx = bbox_slice[1].stop - bbox_slice[1].start
+        if self.data.shape != (dy, dx):
+            raise ValueError('mask shape and bbox_slice do not agree.')
+
+    @property
+    def array(self):
+        """The 2D mask array."""
+
+        return self.data
+
+    def __array__(self):
+        """
+        Array representation of the mask array (e.g., for matplotlib).
+        """
+
+        return self.data
+
+    def _overlap_slices(self, shape):
+        """
+        Calculate the slices for the overlapping part of ``self.slices``
+        and an array of the given shape.
+
+        Parameters
+        ----------
+        shape : tuple of int
+            The ``(ny, nx)`` shape of array where the slices are to be
+            applied.
+
+        Returns
+        -------
+        slices_large : tuple of slices
+            A tuple of slice objects for each axis of the large array,
+            such that ``large_array[slices_large]`` extracts the region
+            of the large array that overlaps with the small array.
+
+        slices_small : slice
+            A tuple of slice objects for each axis of the small array,
+            such that ``small_array[slices_small]`` extracts the region
+            of the small array that is inside the large array.
+        """
+
+        if len(shape) != 2:
+            raise ValueError('input shape must have 2 elements.')
+
+        ymin = self.slices[0].start
+        ymax = self.slices[0].stop
+        xmin = self.slices[1].start
+        xmax = self.slices[1].stop
+
+        if (xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0):
+            # no overlap of the aperture with the data
+            return None, None
+
+        slices_large = (slice(max(ymin, 0), min(ymax, shape[0])),
+                        slice(max(xmin, 0), min(xmax, shape[1])))
+
+        slices_small = (slice(max(-ymin, 0),
+                              min(ymax - ymin, shape[0] - ymin)),
+                        slice(max(-xmin, 0),
+                              min(xmax - xmin, shape[1] - xmin)))
+
+        return slices_large, slices_small
+
+    def to_image(self, shape):
+        """
+        Return an image of the mask in a 2D array of the given shape,
+        taking any edge effects into account.
+
+        Parameters
+        ----------
+        shape : tuple of int
+            The ``(ny, nx)`` shape of the output array.
+
+        Returns
+        -------
+        result : `~numpy.ndarray`
+            A 2D array of the mask.
+        """
+
+        if len(shape) != 2:
+            raise ValueError('input shape must have 2 elements.')
+
+        mask = np.zeros(shape)
+
+        try:
+            mask[self.slices] = self.data
+        except ValueError:    # partial or no overlap
+            slices_large, slices_small = self._overlap_slices(shape)
+
+            if slices_small is None:
+                return None    # no overlap
+
+            mask = np.zeros(shape)
+            mask[slices_large] = self.data[slices_small]
+
+        return mask
+
+    def cutout(self, data, fill_value=0.):
+        """
+        Create a cutout from the input data over the mask bounding box,
+        taking any edge effects into account.
+
+        Parameters
+        ----------
+        data : array_like or `~astropy.units.Quantity`
+            A 2D array on which to apply the aperture mask.
+
+        fill_value : float, optional
+            The value is used to fill pixels where the aperture mask
+            does not overlap with the input ``data``.  The default is 0.
+
+        Returns
+        -------
+        result : `~numpy.ndarray`
+            A 2D array cut out from the input ``data`` representing the
+            same cutout region as the aperture mask.  If there is a
+            partial overlap of the aperture mask with the input data,
+            pixels outside of the data will be assigned to
+            ``fill_value``.  `None` is returned if there is no overlap
+            of the aperture with the input ``data``.
+        """
+
+        data = np.asanyarray(data)
+        cutout = data[self.slices]
+
+        if cutout.shape != self.shape:
+            slices_large, slices_small = self._overlap_slices(data.shape)
+
+            if slices_small is None:
+                return None    # no overlap
+
+            cutout = np.zeros(self.shape, dtype=data.dtype)
+            cutout[:] = fill_value
+            cutout[slices_small] = data[slices_large]
+
+            if isinstance(data, u.Quantity):
+                cutout = u.Quantity(cutout, unit=data.unit)
+
+        return cutout
+
+    def apply(self, data, fill_value=0.):
+        """
+        Apply the aperture mask to the input data, taking any edge
+        effects into account.
+
+        The result is a mask-weighted cutout from the data.
+
+        Parameters
+        ----------
+        data : array_like or `~astropy.units.Quantity`
+            A 2D array on which to apply the aperture mask.
+
+        fill_value : float, optional
+            The value is used to fill pixels where the aperture mask
+            does not overlap with the input ``data``.  The default is 0.
+
+        Returns
+        -------
+        result : `~numpy.ndarray`
+            A 2D mask-weighted cutout from the input ``data``.  If there
+            is a partial overlap of the aperture mask with the input
+            data, pixels outside of the data will be assigned to
+            ``fill_value`` before being multipled with the mask.  `None`
+            is returned if there is no overlap of the aperture with the
+            input ``data``.
+        """
+
+        return self.cutout(data, fill_value=fill_value) * self.data

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -2,16 +2,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import math
-import warnings
 
 import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
-from astropy.utils.exceptions import AstropyUserWarning
 
 from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
-                   _translate_mask_method, _make_annulus_path)
+                   _make_annulus_path)
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
@@ -74,17 +72,8 @@ class RectangularMaskMixin(object):
             A list of aperture mask objects.
         """
 
-        if method == 'exact':
-            warnings.warn("'exact' method is not implemented for rectangular "
-                          "apertures -- instead using 'subpixel' method with "
-                          "subpixels=32", AstropyUserWarning)
-            method = 'subpixel'
-            subpixels = 32
-        elif method not in ('center', 'subpixel'):
-            raise ValueError('"{0}" method is not available for this '
-                             'aperture.'.format(method))
-
-        use_exact, subpixels = _translate_mask_method(method, subpixels)
+        use_exact, subpixels = self._translate_mask_mode(method, subpixels,
+                                                         rectangle=True)
 
         if hasattr(self, 'w'):
             w = self.w

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -87,12 +87,14 @@ class RectangularMaskMixin(object):
         masks = []
         for bbox, edges in zip(self.bounding_boxes, self._centered_edges):
             ny, nx = bbox.shape
-            mask = rectangular_overlap_grid(*edges, nx, ny, w, h, self.theta,
-                                            0, subpixels)
+            mask = rectangular_overlap_grid(edges[0], edges[1], edges[2],
+                                            edges[3], nx, ny, w, h,
+                                            self.theta, 0, subpixels)
 
             # subtract the inner circle for an annulus
             if hasattr(self, 'w_in'):
-                mask -= rectangular_overlap_grid(*edges, nx, ny, self.w_in,
+                mask -= rectangular_overlap_grid(edges[0], edges[1], edges[2],
+                                                 edges[3], nx, ny, self.w_in,
                                                  h_in, self.theta, 0,
                                                  subpixels)
 

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -140,18 +140,13 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     """
 
     def __init__(self, positions, w, h, theta):
-        try:
-            self.w = float(w)
-            self.h = float(h)
-            self.theta = float(theta)
-        except TypeError:
-            raise TypeError("'w' and 'h' and 'theta' must "
-                            "be numeric, received {0} and {1} and {2}."
-                            .format((type(w), type(h), type(theta))))
         if w < 0 or h < 0:
             raise ValueError("'w' and 'h' must be nonnegative.")
 
         self.positions = self._sanitize_positions(positions)
+        self.w = float(w)
+        self.h = float(h)
+        self.theta = float(theta)
 
     @property
     def bounding_boxes(self):
@@ -242,25 +237,17 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     """
 
     def __init__(self, positions, w_in, w_out, h_out, theta):
-        try:
-            self.w_in = float(w_in)
-            self.w_out = float(w_out)
-            self.h_out = float(h_out)
-            self.theta = float(theta)
-        except TypeError:
-            raise TypeError("'w_in' and 'w_out' and 'h_out' and 'theta' must "
-                            "be numeric, received {0} and {1} and {2} and "
-                            "{3}.".format((type(w_in), type(w_out),
-                                           type(h_out), type(theta))))
-
         if not (w_out > w_in):
             raise ValueError("'w_out' must be greater than 'w_in'")
         if w_in < 0 or h_out < 0:
             raise ValueError("'w_in' and 'h_out' must be non-negative")
 
-        self.h_in = w_in * h_out / w_out
-
         self.positions = self._sanitize_positions(positions)
+        self.w_in = float(w_in)
+        self.w_out = float(w_out)
+        self.h_out = float(h_out)
+        self.h_in = self.w_in * self.h_out / self.w_out
+        self.theta = float(theta)
 
     @property
     def bounding_boxes(self):
@@ -341,7 +328,7 @@ class SkyRectangularAperture(SkyAperture):
         if isinstance(positions, SkyCoord):
             self.positions = positions
         else:
-            raise TypeError("positions should be a SkyCoord instance")
+            raise TypeError('positions must be a SkyCoord instance')
 
         assert_angle_or_pixel('w', w)
         assert_angle_or_pixel('h', h)
@@ -435,7 +422,8 @@ class SkyRectangularAnnulus(SkyAperture):
         if isinstance(positions, SkyCoord):
             self.positions = positions
         else:
-            raise TypeError("positions should be a SkyCoord instance")
+            raise TypeError('positions must be a SkyCoord instance')
+
         assert_angle_or_pixel('w_in', w_in)
         assert_angle_or_pixel('w_out', w_out)
         assert_angle_or_pixel('h_out', h_out)

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -8,8 +8,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
-from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
-                   _make_annulus_path)
+from .core import PixelAperture, SkyAperture, _make_annulus_path
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
@@ -152,7 +151,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         if w < 0 or h < 0:
             raise ValueError("'w' and 'h' must be nonnegative.")
 
-        self.positions = _sanitize_pixel_positions(positions)
+        self.positions = self._sanitize_positions(positions)
 
     @property
     def bounding_boxes(self):
@@ -261,7 +260,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
         self.h_in = w_in * h_out / w_out
 
-        self.positions = _sanitize_pixel_positions(positions)
+        self.positions = self._sanitize_positions(positions)
 
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -8,7 +8,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 
-from .core import PixelAperture, SkyAperture, _make_annulus_path
+from .core import PixelAperture, SkyAperture
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
@@ -293,7 +293,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
             patch_outer = mpatches.Rectangle(positions_outer[i],
                                              self.w_out, self.h_out,
                                              theta_deg, **kwargs)
-            path = _make_annulus_path(patch_inner, patch_outer)
+            path = self._make_annulus_path(patch_inner, patch_outer)
             patch = mpatches.PathPatch(path, **kwargs)
             ax.add_patch(patch)
 

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -10,9 +10,9 @@ import astropy.units as u
 from astropy.wcs.utils import skycoord_to_pixel
 from astropy.utils.exceptions import AstropyUserWarning
 
-from .core import (PixelAperture, SkyAperture, ApertureMask,
-                   _sanitize_pixel_positions, _translate_mask_method,
-                   _make_annulus_path)
+from .core import (PixelAperture, SkyAperture, _sanitize_pixel_positions,
+                   _translate_mask_method, _make_annulus_path)
+from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
 from ..utils.wcs_helpers import (skycoord_to_pixel_scale_angle, assert_angle,
                                  assert_angle_or_pixel)
@@ -31,8 +31,8 @@ class RectangularMaskMixin(object):
 
     def to_mask(self, method='exact', subpixels=5):
         """
-        Return a list of `ApertureMask` objects, one for each aperture
-        position.
+        Return a list of `~photutils.ApertureMask` objects, one for each
+        aperture position.
 
         Parameters
         ----------

--- a/photutils/utils/__init__.py
+++ b/photutils/utils/__init__.py
@@ -9,4 +9,5 @@ from .convolution import *
 from .cutouts import *
 from .errors import *
 from .interpolation import *
+from .misc import *
 from .stats import *

--- a/photutils/utils/misc.py
+++ b/photutils/utils/misc.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+
+__all__ = ['get_version_info']
+
+
+def get_version_info():
+    """
+    Return astropy and photutils versions.
+
+    Returns
+    -------
+    result : str
+        The astropy and photutils versions.
+    """
+
+    from astropy import __version__
+    astropy_version = __version__
+
+    from photutils import __version__
+    photutils_version = __version__
+
+    return 'astropy: {0}, photutils: {1}'.format(astropy_version,
+                                                 photutils_version)


### PR DESCRIPTION
This `BoundingBox` class was introduced in the `regions` package.  This PR makes `photutils.aperture` similar to region masking in the `regions` package.

Also the `ApertureMask` `apply()` method was renamed to `multiply()`, which matches the `regions` package.