### PR TITLE
Selecting jobs to run with travis cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
         - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - CONDA_CHANNELS='astropy-ci-extras'
         - SETUP_XVFB=True
+        - EVENT_TYPE='pull_request push'
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
@@ -65,6 +66,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib jupyter'
+               EVENT_TYPE='pull_request push cron'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
@@ -83,8 +85,10 @@ matrix:
         # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
+               EVENT_TYPE='pull_request push cron'
         - os: linux
           env: ASTROPY_VERSION=development
+               EVENT_TYPE='pull_request push cron'
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
         - os: linux
@@ -99,9 +103,11 @@ matrix:
         # Try numpy pre-release
         - os: linux
           env: NUMPY_VERSION=prerelease
+               EVENT_TYPE='pull_request push cron'
 
     allow_failures:
       - env: NUMPY_VERSION=prerelease
+             EVENT_TYPE='pull_request push cron'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git


### PR DESCRIPTION
I've switched on travis to run once a week from cron on master, unless there has been a build in the previous 24 hours. 
However I think it's no use to run it on the whole matrix, we don't expect any changes and failure with old versions of dependencies that were tested and passed when the last build was run.