### PR TITLE
Adding python 3.6 to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.5
+        - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
@@ -42,6 +42,7 @@ env:
         - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
 matrix:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,10 +106,6 @@ matrix:
           env: NUMPY_VERSION=prerelease
                EVENT_TYPE='pull_request push cron'
 
-    allow_failures:
-      - env: NUMPY_VERSION=prerelease
-             EVENT_TYPE='pull_request push cron'
-
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 

--- a/photutils/extern/nddata_compat.py
+++ b/photutils/extern/nddata_compat.py
@@ -7,6 +7,7 @@ backwards-compatiblity with older versions of astropy
 import inspect
 
 import numpy as np
+from astropy.extern import six
 
 
 def extract_array(*args, **kwargs):
@@ -18,7 +19,8 @@ def extract_array(*args, **kwargs):
     from astropy.nddata.utils import extract_array
 
     # fill_value keyword is not in v1.0.x
-    if 'fill_value' in inspect.getfullargspec(extract_array)[0]:
+    if 'fill_value' in (inspect.getfullargspec(extract_array)[0] if not six.PY2
+                        else inspect.getargspec(extract_array)[0]):
         return extract_array(*args, **kwargs)
     else:
         return _extract_array_astropy1p1(*args, **kwargs)

--- a/photutils/extern/nddata_compat.py
+++ b/photutils/extern/nddata_compat.py
@@ -18,7 +18,7 @@ def extract_array(*args, **kwargs):
     from astropy.nddata.utils import extract_array
 
     # fill_value keyword is not in v1.0.x
-    if 'fill_value' in inspect.getargspec(extract_array)[0]:
+    if 'fill_value' in inspect.getfullargspec(extract_array)[0]:
         return extract_array(*args, **kwargs)
     else:
         return _extract_array_astropy1p1(*args, **kwargs)


### PR DESCRIPTION
Probably we need to wait a bit more until all the dependencies become available on python 3.6.