### PR TITLE
Remove pixelwise_errors keyword from aperture_photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ API changes
   - The ``ApertureMask`` ``apply()`` method has been renamed to
     ``multiply()``. [#481].
 
+  - Removed the ``pixelwise_errors`` keyword from
+    ``aperture_photometry``. [#489]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -328,21 +328,6 @@ time as the effective gain::
     >>> error = calc_total_error(data, bkg_error, effective_gain)    # doctest: +SKIP
     >>> phot_table = aperture_photometry(data - bkg, apertures, error=error)    # doctest: +SKIP
 
-.. note::
-
-    In cases where the ``error`` array is slowly varying across the
-    image, it is not necessary to sum the error from every pixel in
-    the aperture individually.  Instead, we can approximate the error
-    as being roughly constant across the aperture and simply take the
-    value of :math:`\sigma` at the center of the aperture.  This can
-    be done by setting the keyword ``pixelwise_errors=False``.  In
-    this case the flux error is
-
-    .. math:: \Delta F = \sigma \sqrt{A}
-
-    where :math:`\sigma` is the ``error`` at the center of the
-    aperture and :math:`A` is the area of the aperture.
-
 
 Pixel Masking
 -------------

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -104,8 +104,11 @@ class BaseTestAperturePhotometry(object):
         error = 1.
         if not hasattr(self, 'mask'):
             mask = None
+            true_error = np.sqrt(self.area)
         else:
             mask = self.mask
+            # 1 masked pixel
+            true_error = np.sqrt(self.area - 1)
 
         table1 = aperture_photometry(self.data,
                                      self.aperture, method='center',
@@ -125,7 +128,6 @@ class BaseTestAperturePhotometry(object):
                             atol=0.1)
         assert np.all(table1['aperture_sum'] < table3['aperture_sum'])
 
-        true_error = np.sqrt(self.area)
         if not isinstance(self.aperture, (RectangularAperture,
                                           RectangularAnnulus)):
             assert_allclose(table3['aperture_sum_err'], true_error)
@@ -280,7 +282,7 @@ class TestMaskedSkipCircular(BaseTestAperturePhotometry):
     def setup_class(self):
         self.data = np.ones((40, 40), dtype=np.float)
         self.mask = np.zeros((40, 40), dtype=bool)
-        self.mask[19, 19] = True
+        self.mask[20, 20] = True
         position = (20., 20.)
         r = 10.
         self.aperture = CircularAperture(position, r)


### PR DESCRIPTION
This PR removes the `pixelwise_errors` keyword from `aperture_photometry`.  With the recent refactoring of the aperture subpackage to use mask objects, using pixelwise errors is actually slightly *faster* than using the approximation.  When refactoring, I also discovered a long-standing bug when not using pixelwise errors and the central aperture pixel happened to be masked -- in that case the resulting aperture sum error was always 0 (there is not an easy fix for that issue -- it likely requires using masked arrays).

I discussed this issue with @astrofrog at the JWST data analysis workshop and he agreed with removing the `pixelwise_errors` keyword.