### PR TITLE
Using system pytest rather than astropy bundled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,9 @@ matrix:
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts PYTEST_VERSION=2.8
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts PYTEST_VERSION=2.7
         - os: linux
-          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts PYTEST_VERSION=2.8
+          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts PYTEST_VERSION=2.7
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ matrix:
     include:
         # Try MacOS X
         - os: osx
-          env: SETUP_CMD='test'
+          env: SETUP_CMD='test' ASTROPY_USE_SYSTEM_PYTEST=1
 
         # Do a coverage test.
         - os: linux
-          env: SETUP_CMD='test --coverage'
+          env: SETUP_CMD='test --coverage' ASTROPY_USE_SYSTEM_PYTEST=1
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
@@ -71,12 +71,12 @@ matrix:
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
-          env: ASTROPY_VERSION=development
+          env: ASTROPY_VERSION=development ASTROPY_USE_SYSTEM_PYTEST=1
                EVENT_TYPE='pull_request push cron'
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
         - os: linux
-          env: ASTROPY_VERSION=lts
+          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
@@ -87,7 +87,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
         - os: linux
-          env: NUMPY_VERSION=1.11
+          env: NUMPY_VERSION=1.11 ASTROPY_USE_SYSTEM_PYTEST=1
 
         # Try with optional dependencies disabled
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
         - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - CONDA_CHANNELS='astropy-ci-extras'
         - SETUP_XVFB=True
+        - ASTROPY_USE_SYSTEM_PYTEST=1
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
@@ -48,11 +49,11 @@ matrix:
     include:
         # Try MacOS X
         - os: osx
-          env: SETUP_CMD='test' ASTROPY_USE_SYSTEM_PYTEST=1
+          env: SETUP_CMD='test'
 
         # Do a coverage test.
         - os: linux
-          env: SETUP_CMD='test --coverage' ASTROPY_USE_SYSTEM_PYTEST=1
+          env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
@@ -71,12 +72,12 @@ matrix:
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
-          env: ASTROPY_VERSION=development ASTROPY_USE_SYSTEM_PYTEST=1
+          env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts PYTEST_VERSION=2.8
         - os: linux
-          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts
+          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts PYTEST_VERSION=2.8
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
@@ -87,7 +88,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
         - os: linux
-          env: NUMPY_VERSION=1.11 ASTROPY_USE_SYSTEM_PYTEST=1
+          env: NUMPY_VERSION=1.11
 
         # Try with optional dependencies disabled
         - os: linux

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -12,11 +12,13 @@ from distutils.version import LooseVersion
 import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_less)
+import pytest
+
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.nddata import NDData
 from astropy.table import Table
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from ..bounding_box import BoundingBox
 

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -5,7 +5,7 @@ import itertools
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from astropy.tests.helper import pytest
+import pytest
 
 from ..core import MeanBackground
 from ..background_2d import (BkgZoomInterpolator, BkgIDWInterpolator,

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from ...datasets.make import make_noise_image
 from ..core import (SigmaClip, MeanBackground, MedianBackground,

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -6,7 +6,7 @@ import itertools
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.modeling.models import Gaussian1D, Gaussian2D
-from astropy.tests.helper import pytest
+import pytest
 
 from ..core import (centroid_com, centroid_1dg, centroid_2dg,
                     gaussian1d_moments, fit_2dgaussian)

--- a/photutils/datasets/tests/test_load.py
+++ b/photutils/datasets/tests/test_load.py
@@ -2,7 +2,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from astropy.tests.helper import pytest, remote_data
+import pytest
+from astropy.tests.helper import remote_data
 
 from .. import load, get_path
 

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -4,7 +4,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
+
 from astropy.table import Table
 from astropy.modeling.models import Moffat2D
 

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from ..core import detect_threshold, find_peaks
 from ...datasets import make_4gaussians_image, make_wcs

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -7,7 +7,9 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest, catch_warnings
+import pytest
+
+from astropy.tests.helper import catch_warnings
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.exceptions import AstropyDeprecationWarning

--- a/photutils/geometry/tests/test_circular_overlap_grid.py
+++ b/photutils/geometry/tests/test_circular_overlap_grid.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import itertools
 
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import circular_overlap_grid
 

--- a/photutils/geometry/tests/test_elliptical_overlap_grid.py
+++ b/photutils/geometry/tests/test_elliptical_overlap_grid.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import itertools
 
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import elliptical_overlap_grid
 

--- a/photutils/geometry/tests/test_rectangular_overlap_grid.py
+++ b/photutils/geometry/tests/test_rectangular_overlap_grid.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import itertools
 
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import rectangular_overlap_grid
 

--- a/photutils/morphology/tests/test_core.py
+++ b/photutils/morphology/tests/test_core.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from ..core import data_properties
 

--- a/photutils/psf/matching/tests/test_fourier.py
+++ b/photutils/psf/matching/tests/test_fourier.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from astropy.tests.helper import pytest
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.modeling.models import Gaussian2D

--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from distutils.version import LooseVersion
-from astropy.tests.helper import pytest
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from ..windows import (HanningWindow, TukeyWindow, CosineBellWindow,

--- a/photutils/psf/tests/test_funcs.py
+++ b/photutils/psf/tests/test_funcs.py
@@ -2,7 +2,7 @@
 from __future__ import division
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.convolution.utils import discretize_model
 from astropy.table import Table

--- a/photutils/psf/tests/test_groupstars.py
+++ b/photutils/psf/tests/test_groupstars.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import division
 import numpy as np
-from astropy.tests.helper import pytest
+import pytest
 from numpy.testing import assert_array_equal
 from astropy.table import Table, vstack
 from ..groupstars import DAOGroup, DBSCANGroup

--- a/photutils/psf/tests/test_imagemodel.py
+++ b/photutils/psf/tests/test_imagemodel.py
@@ -3,7 +3,7 @@ from __future__ import division
 
 import numpy as np
 from astropy.modeling.models import Gaussian2D
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import FittableImageModel
 

--- a/photutils/psf/tests/test_misc.py
+++ b/photutils/psf/tests/test_misc.py
@@ -7,7 +7,7 @@ place to go
 from __future__ import division
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 from astropy.table import Table
 from .. import IntegratedGaussianPRF, prepare_psf_model, get_grouped_psf_model
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -2,9 +2,8 @@
 from __future__ import division
 
 import numpy as np
-import astropy
-
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
+import pytest
 
 from astropy.table import Table
 from astropy.stats import gaussian_sigma_to_fwhm
@@ -13,17 +12,16 @@ from astropy.modeling import Parameter, Fittable2DModel
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import Gaussian2D
 from astropy.convolution.utils import discretize_model
-from astropy.tests.helper import pytest, catch_warnings
+from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 
 from ..groupstars import DAOGroup
 from ..models import IntegratedGaussianPRF
-from ..photometry import DAOPhotPSFPhotometry, IterativelySubtractedPSFPhotometry
-from ..photometry import BasicPSFPhotometry
+from ..photometry import (DAOPhotPSFPhotometry, BasicPSFPhotometry,
+                          IterativelySubtractedPSFPhotometry)
 from ..sandbox import DiscretePRF
-from ...background import SigmaClip, MedianBackground, StdBackgroundRMS
-from ...background import MedianBackground, MMMBackground, SigmaClip
-from ...background import StdBackgroundRMS
+from ...background import (SigmaClip, MedianBackground, StdBackgroundRMS,
+                           MMMBackground)
 from ...datasets import make_gaussian_sources_image, make_noise_image
 from ...detection import DAOStarFinder
 

--- a/photutils/psf/tests/test_prf_adapter.py
+++ b/photutils/psf/tests/test_prf_adapter.py
@@ -3,7 +3,7 @@ from __future__ import division
 import numpy as np
 from numpy.testing import assert_allclose
 from .. import PRFAdapter
-from astropy.tests.helper import pytest
+import pytest
 from astropy.modeling.models import Moffat2D
 
 

--- a/photutils/psf/tests/test_sandbox.py
+++ b/photutils/psf/tests/test_sandbox.py
@@ -6,7 +6,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.modeling.models import Gaussian2D
 from astropy.convolution.utils import discretize_model
 from astropy.table import Table
-from astropy.tests.helper import pytest
+import pytest
 from ..sandbox import DiscretePRF
 
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from ..core import SegmentationImage
 

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -4,7 +4,9 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest, catch_warnings
+import pytest
+
+from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.modeling import models
 

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -4,7 +4,9 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
-from astropy.tests.helper import pytest, catch_warnings
+import pytest
+
+from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -6,7 +6,9 @@ import itertools
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest, assert_quantity_allclose
+import pytest
+
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.modeling import models
 from astropy.table import Table
 import astropy.units as u

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from ..colormaps import random_cmap
 

--- a/photutils/utils/tests/test_cutouts.py
+++ b/photutils/utils/tests/test_cutouts.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from ..cutouts import cutout_footprint
 

--- a/photutils/utils/tests/test_errors.py
+++ b/photutils/utils/tests/test_errors.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 import astropy.units as u
 
 from ..errors import calc_total_error

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import ShepardIDWInterpolator as idw
 from .. import interpolate_masked_data, mask_to_mirrored_num

--- a/photutils/utils/tests/test_random_state.py
+++ b/photutils/utils/tests/test_random_state.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import check_random_state
 

--- a/photutils/utils/tests/test_stats.py
+++ b/photutils/utils/tests/test_stats.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+import pytest
 
 from ..stats import std_blocksum
 from ...datasets import make_noise_image


### PR DESCRIPTION
astropy core is considering removing the bundled pytest (see https://github.com/astropy/astropy/issues/5509), so I use photutils to see how badly this idea affect affiliates (e.g. we may see pytest 3.0.x related failures).