### PR TITLE
Add __repr__ and __str__ for aperture classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ New Features
 
   - Added ``BoundingBox`` class, used when defining apertures. [#481]
 
+  - Apertures now have ``__repr__`` and ``__str__`` defined. [#493]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -132,6 +132,25 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         self.positions = self._sanitize_positions(positions)
         self.r = float(r)
 
+    def _positions_str(self, prefix=None):
+        return np.array2string(self.positions, separator=',', prefix=prefix)
+
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, r={2})>'.format(prefix, self._positions_str(prefix),
+                                        self.r)
+
+    def __str__(self):
+        prefix = 'positions'
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            (prefix, self._positions_str(prefix + ': ')),
+            ('r', self.r)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
+
     # TODO: make lazyproperty?, but update if positions or radius change
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -131,14 +131,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
         self.positions = self._sanitize_positions(positions)
         self.r = float(r)
-
-    def __repr__(self):
-        shape_info = 'r={0}'.format(self.r)
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('r', self.r)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('r', self.r)]
 
     # TODO: make lazyproperty?, but update if positions or radius change
     @property
@@ -210,14 +203,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         self.positions = self._sanitize_positions(positions)
         self.r_in = float(r_in)
         self.r_out = float(r_out)
-
-    def __repr__(self):
-        shape_info = 'r_in={0}, r_out={1}'.format(self.r_in, self.r_out)
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('r_in', self.r_in), ('r_out', self.r_out)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('r_in', self.r_in), ('r_out', self.r_out)]
 
     @property
     def bounding_boxes(self):
@@ -272,14 +258,7 @@ class SkyCircularAperture(SkyAperture):
 
         assert_angle_or_pixel('r', r)
         self.r = r
-
-    def __repr__(self):
-        shape_info = 'r={0}'.format(self.r)
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('r', self.r)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('r', self.r)]
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -352,14 +331,7 @@ class SkyCircularAnnulus(SkyAperture):
 
         self.r_in = r_in
         self.r_out = r_out
-
-    def __repr__(self):
-        shape_info = 'r_in={0}, r_out={1}'.format(self.r_in, self.r_out)
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('r_in', self.r_in), ('r_out', self.r_out)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('r_in', self.r_in), ('r_out', self.r_out)]
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -132,9 +132,6 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         self.positions = self._sanitize_positions(positions)
         self.r = float(r)
 
-    def _positions_str(self, prefix=None):
-        return np.array2string(self.positions, separator=',', prefix=prefix)
-
     def __repr__(self):
         prefix = '<{0}('.format(self.__class__.__name__)
         return '{0}{1}, r={2})>'.format(prefix, self._positions_str(prefix),

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -274,18 +274,12 @@ class SkyCircularAperture(SkyAperture):
         self.r = r
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, r={2})>'.format(prefix, self.positions, self.r)
+        shape_info = 'r={0}'.format(self.r)
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            ('positions', self.positions),
-            ('r', self.r)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('r', self.r)]
+        return self._cls_str(shape_info)
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -360,20 +354,12 @@ class SkyCircularAnnulus(SkyAperture):
         self.r_out = r_out
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, r_in={2}, r_out={3})>'.format(prefix, self.positions,
-                                                      self.r_in, self.r_out)
+        shape_info = 'r_in={0}, r_out={1}'.format(self.r_in, self.r_out)
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            ('positions', self.positions),
-            ('r_in', self.r_in),
-            ('r_out', self.r_out)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('r_in', self.r_in), ('r_out', self.r_out)]
+        return self._cls_str(shape_info)
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -219,6 +219,23 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         self.r_in = float(r_in)
         self.r_out = float(r_out)
 
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, r_in={2}, r_out={3})>'.format(
+            prefix, self._positions_str(prefix), self.r_in, self.r_out)
+
+    def __str__(self):
+        prefix = 'positions'
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            (prefix, self._positions_str(prefix + ': ')),
+            ('r_in', self.r_in),
+            ('r_out', self.r_out)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
+
     @property
     def bounding_boxes(self):
         xmin = self.positions[:, 0] - self.r_out

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -133,20 +133,12 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         self.r = float(r)
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, r={2})>'.format(prefix, self._positions_str(prefix),
-                                        self.r)
+        shape_info = 'r={0}'.format(self.r)
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        prefix = 'positions'
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            (prefix, self._positions_str(prefix + ': ')),
-            ('r', self.r)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('r', self.r)]
+        return self._cls_str(shape_info)
 
     # TODO: make lazyproperty?, but update if positions or radius change
     @property
@@ -220,21 +212,12 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         self.r_out = float(r_out)
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, r_in={2}, r_out={3})>'.format(
-            prefix, self._positions_str(prefix), self.r_in, self.r_out)
+        shape_info = 'r_in={0}, r_out={1}'.format(self.r_in, self.r_out)
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        prefix = 'positions'
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            (prefix, self._positions_str(prefix + ': ')),
-            ('r_in', self.r_in),
-            ('r_out', self.r_out)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('r_in', self.r_in), ('r_out', self.r_out)]
+        return self._cls_str(shape_info)
 
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -290,6 +290,20 @@ class SkyCircularAperture(SkyAperture):
         assert_angle_or_pixel('r', r)
         self.r = r
 
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, r={2})>'.format(prefix, self.positions, self.r)
+
+    def __str__(self):
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            ('positions', self.positions),
+            ('r', self.r)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
+
     def to_pixel(self, wcs, mode='all'):
         """
         Convert the aperture to a `CircularAperture` instance in pixel
@@ -361,6 +375,22 @@ class SkyCircularAnnulus(SkyAperture):
 
         self.r_in = r_in
         self.r_out = r_out
+
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, r_in={2}, r_out={3})>'.format(prefix, self.positions,
+                                                      self.r_in, self.r_out)
+
+    def __str__(self):
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            ('positions', self.positions),
+            ('r_in', self.r_in),
+            ('r_out', self.r_out)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -37,6 +37,31 @@ class Aperture(object):
             return 1
         return len(self.positions)
 
+    def _positions_str(self, prefix=None):
+        if isinstance(self, PixelAperture):
+            return np.array2string(self.positions, separator=', ',
+                                   prefix=prefix)
+        elif isinstance(self, SkyAperture):
+            return self.positions
+        else:
+            raise TypeError('Aperture must be a subclass of PixelAperture '
+                            'or SkyAperture')
+
+    def _cls_repr(self, shape_info):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, {2})>'.format(prefix, self._positions_str(prefix),
+                                      shape_info)
+
+    def _cls_str(self, shape_info):
+        prefix = 'positions'
+        cls_info = [
+            ('Aperture', self.__class__.__name__),
+            (prefix, self._positions_str(prefix + ': '))]
+        cls_info += shape_info
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
+        return '\n'.join(fmt)
+
 
 class PixelAperture(Aperture):
     """
@@ -71,24 +96,6 @@ class PixelAperture(Aperture):
                              'arrays are supported.'.format(positions.ndim))
 
         return positions
-
-    def _positions_str(self, prefix=None):
-        return np.array2string(self.positions, separator=', ', prefix=prefix)
-
-    def _cls_repr(self, shape_info):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, {2})>'.format(prefix, self._positions_str(prefix),
-                                      shape_info)
-
-    def _cls_str(self, shape_info):
-        prefix = 'positions'
-        cls_info = [
-            ('Aperture', self.__class__.__name__),
-            (prefix, self._positions_str(prefix + ': '))]
-        cls_info += shape_info
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
-        return '\n'.join(fmt)
 
     @staticmethod
     def _translate_mask_mode(mode, subpixels, rectangle=False):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -72,6 +72,9 @@ class PixelAperture(Aperture):
 
         return positions
 
+    def _positions_str(self, prefix=None):
+        return np.array2string(self.positions, separator=', ', prefix=prefix)
+
     @staticmethod
     def _translate_mask_mode(mode, subpixels, rectangle=False):
         if mode not in ('center', 'subpixel', 'exact'):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -75,6 +75,21 @@ class PixelAperture(Aperture):
     def _positions_str(self, prefix=None):
         return np.array2string(self.positions, separator=', ', prefix=prefix)
 
+    def _cls_repr(self, shape_info):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, {2})>'.format(prefix, self._positions_str(prefix),
+                                      shape_info)
+
+    def _cls_str(self, shape_info):
+        prefix = 'positions'
+        cls_info = [
+            ('Aperture', self.__class__.__name__),
+            (prefix, self._positions_str(prefix + ': '))]
+        cls_info += shape_info
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
+        return '\n'.join(fmt)
+
     @staticmethod
     def _translate_mask_mode(mode, subpixels, rectangle=False):
         if mode not in ('center', 'subpixel', 'exact'):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -42,24 +42,30 @@ class Aperture(object):
             return np.array2string(self.positions, separator=', ',
                                    prefix=prefix)
         elif isinstance(self, SkyAperture):
-            return self.positions
+            return repr(self.positions)
         else:
             raise TypeError('Aperture must be a subclass of PixelAperture '
                             'or SkyAperture')
 
-    def _cls_repr(self, shape_info):
+    def __repr__(self):
         prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, {2})>'.format(prefix, self._positions_str(prefix),
-                                      shape_info)
+        params = [self._positions_str(prefix)]
+        for key, val in self._repr_params:
+            if key not in ['b_in', 'h_in']:   # not aperture parameters
+                params.append('{0}={1}'.format(key, val))
+        params = ', '.join(params)
 
-    def _cls_str(self, shape_info):
+        return '{0}{1})>'.format(prefix, params)
+
+    def __str__(self):
         prefix = 'positions'
         cls_info = [
             ('Aperture', self.__class__.__name__),
             (prefix, self._positions_str(prefix + ': '))]
-        cls_info += shape_info
-
+        if self._repr_params is not None:
+            cls_info += self._repr_params
         fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
+
         return '\n'.join(fmt)
 
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -330,21 +330,13 @@ class SkyEllipticalAperture(SkyAperture):
         self.theta = theta
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, a={2}, b={3}, theta={4})>'.format(
-            prefix, self.positions, self.a, self.b, self.theta)
+        shape_info = 'a={0}, b={1}, theta={2}'.format(self.a, self.b,
+                                                      self.theta)
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            ('positions', self.positions),
-            ('a', self.a),
-            ('b', self.b),
-            ('theta', self.theta)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('a', self.a), ('b', self.b), ('theta', self.theta)]
+        return self._cls_str(shape_info)
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -440,23 +432,14 @@ class SkyEllipticalAnnulus(SkyAperture):
         self.theta = theta
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, a_in={2}, a_out={3}, b_out={4}, theta={5})>'.format(
-            prefix, self.positions, self.a_in, self.a_out, self.b_out,
-            self.theta)
+        shape_info = ('a_in={0}, a_out={1}, b_out={2}, theta={3}'
+                      .format(self.a_in, self.a_out, self.b_out, self.theta))
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            ('positions', self.positions),
-            ('a_in', self.a_in),
-            ('a_out', self.a_out),
-            ('b_out', self.b_out),
-            ('theta', self.theta)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('a_in', self.a_in), ('a_out', self.a_out),
+                      ('b_out', self.b_out), ('theta', self.theta)]
+        return self._cls_str(shape_info)
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -145,15 +145,8 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         self.a = float(a)
         self.b = float(b)
         self.theta = float(theta)
-
-    def __repr__(self):
-        shape_info = 'a={0}, b={1}, theta={2}'.format(self.a, self.b,
-                                                      self.theta)
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('a', self.a), ('b', self.b), ('theta', self.theta)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('a', self.a), ('b', self.b),
+                             ('theta', self.theta)]
 
     @property
     def bounding_boxes(self):
@@ -244,17 +237,9 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         self.b_out = float(b_out)
         self.b_in = self.b_out * self.a_in / self.a_out
         self.theta = float(theta)
-
-    def __repr__(self):
-        shape_info = ('a_in={0}, a_out={1}, b_out={2}, theta={3}'
-                      .format(self.a_in, self.a_out, self.b_out, self.theta))
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('a_in', self.a_in), ('a_out', self.a_out),
-                      ('b_in', self.b_in), ('b_out', self.b_out),
-                      ('theta', self.theta)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('a_in', self.a_in), ('a_out', self.a_out),
+                             ('b_in', self.b_in), ('b_out', self.b_out),
+                             ('theta', self.theta)]
 
     @property
     def bounding_boxes(self):
@@ -328,15 +313,8 @@ class SkyEllipticalAperture(SkyAperture):
         self.a = a
         self.b = b
         self.theta = theta
-
-    def __repr__(self):
-        shape_info = 'a={0}, b={1}, theta={2}'.format(self.a, self.b,
-                                                      self.theta)
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('a', self.a), ('b', self.b), ('theta', self.theta)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('a', self.a), ('b', self.b),
+                             ('theta', self.theta)]
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -430,16 +408,8 @@ class SkyEllipticalAnnulus(SkyAperture):
         self.a_out = a_out
         self.b_out = b_out
         self.theta = theta
-
-    def __repr__(self):
-        shape_info = ('a_in={0}, a_out={1}, b_out={2}, theta={3}'
-                      .format(self.a_in, self.a_out, self.b_out, self.theta))
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('a_in', self.a_in), ('a_out', self.a_out),
-                      ('b_out', self.b_out), ('theta', self.theta)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('a_in', self.a_in), ('a_out', self.a_out),
+                             ('b_out', self.b_out), ('theta', self.theta)]
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -147,22 +147,13 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         self.theta = float(theta)
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, a={2}, b={3}, theta={4})>'.format(
-            prefix, self._positions_str(prefix), self.a, self.b, self.theta)
+        shape_info = 'a={0}, b={1}, theta={2}'.format(self.a, self.b,
+                                                      self.theta)
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        prefix = 'positions'
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            (prefix, self._positions_str(prefix + ': ')),
-            ('a', self.a),
-            ('b', self.b),
-            ('theta', self.theta)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('a', self.a), ('b', self.b), ('theta', self.theta)]
+        return self._cls_str(shape_info)
 
     @property
     def bounding_boxes(self):
@@ -255,25 +246,15 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         self.theta = float(theta)
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, a_in={2}, a_out={3}, b_out={4}, theta={5})>'.format(
-            prefix, self._positions_str(prefix), self.a_in, self.a_out,
-            self.b_out, self.theta)
+        shape_info = ('a_in={0}, a_out={1}, b_out={2}, theta={3}'
+                      .format(self.a_in, self.a_out, self.b_out, self.theta))
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        prefix = 'positions'
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            (prefix, self._positions_str(prefix + ': ')),
-            ('a_in', self.a_in),
-            ('a_out', self.a_out),
-            ('b_in', self.b_in),
-            ('b_out', self.b_out),
-            ('theta', self.theta)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('a_in', self.a_in), ('a_out', self.a_out),
+                      ('b_in', self.b_in), ('b_out', self.b_out),
+                      ('theta', self.theta)]
+        return self._cls_str(shape_info)
 
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -348,6 +348,23 @@ class SkyEllipticalAperture(SkyAperture):
         self.b = b
         self.theta = theta
 
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, a={2}, b={3}, theta={4})>'.format(
+            prefix, self.positions, self.a, self.b, self.theta)
+
+    def __str__(self):
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            ('positions', self.positions),
+            ('a', self.a),
+            ('b', self.b),
+            ('theta', self.theta)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
+
     def to_pixel(self, wcs, mode='all'):
         """
         Convert the aperture to an `EllipticalAperture` instance in
@@ -440,6 +457,25 @@ class SkyEllipticalAnnulus(SkyAperture):
         self.a_out = a_out
         self.b_out = b_out
         self.theta = theta
+
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, a_in={2}, a_out={3}, b_out={4}, theta={5})>'.format(
+            prefix, self.positions, self.a_in, self.a_out, self.b_out,
+            self.theta)
+
+    def __str__(self):
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            ('positions', self.positions),
+            ('a_in', self.a_in),
+            ('a_out', self.a_out),
+            ('b_out', self.b_out),
+            ('theta', self.theta)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -146,6 +146,24 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         self.b = float(b)
         self.theta = float(theta)
 
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, a={2}, b={3}, theta={4})>'.format(
+            prefix, self._positions_str(prefix), self.a, self.b, self.theta)
+
+    def __str__(self):
+        prefix = 'positions'
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            (prefix, self._positions_str(prefix + ': ')),
+            ('a', self.a),
+            ('b', self.b),
+            ('theta', self.theta)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
+
     @property
     def bounding_boxes(self):
         # TODO:  use an actual minimal bounding box
@@ -235,6 +253,27 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         self.b_out = float(b_out)
         self.b_in = self.b_out * self.a_in / self.a_out
         self.theta = float(theta)
+
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, a_in={2}, a_out={3}, b_out={4}, theta={5})>'.format(
+            prefix, self._positions_str(prefix), self.a_in, self.a_out,
+            self.b_out, self.theta)
+
+    def __str__(self):
+        prefix = 'positions'
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            (prefix, self._positions_str(prefix + ': ')),
+            ('a_in', self.a_in),
+            ('a_out', self.a_out),
+            ('b_in', self.b_in),
+            ('b_out', self.b_out),
+            ('theta', self.theta)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
 
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -149,15 +149,8 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         self.w = float(w)
         self.h = float(h)
         self.theta = float(theta)
-
-    def __repr__(self):
-        shape_info = 'w={0}, h={1}, theta={2}'.format(self.w, self.h,
-                                                      self.theta)
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('w', self.w), ('h', self.h), ('theta', self.theta)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('w', self.w), ('h', self.h),
+                             ('theta', self.theta)]
 
     @property
     def bounding_boxes(self):
@@ -259,17 +252,9 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         self.h_out = float(h_out)
         self.h_in = self.w_in * self.h_out / self.w_out
         self.theta = float(theta)
-
-    def __repr__(self):
-        shape_info = ('w_in={0}, w_out={1}, h_out={2}, theta={3}'
-                      .format(self.w_in, self.w_out, self.h_out, self.theta))
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('w_in', self.w_in), ('w_out', self.w_out),
-                      ('h_in', self.h_in), ('h_out', self.h_out),
-                      ('theta', self.theta)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('w_in', self.w_in), ('w_out', self.w_out),
+                             ('h_in', self.h_in), ('h_out', self.h_out),
+                             ('theta', self.theta)]
 
     @property
     def bounding_boxes(self):
@@ -363,15 +348,8 @@ class SkyRectangularAperture(SkyAperture):
         self.w = w
         self.h = h
         self.theta = theta
-
-    def __repr__(self):
-        shape_info = 'w={0}, h={1}, theta={2}'.format(self.w, self.h,
-                                                      self.theta)
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('w', self.w), ('h', self.h), ('theta', self.theta)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('w', self.w), ('h', self.h),
+                             ('theta', self.theta)]
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -472,16 +450,8 @@ class SkyRectangularAnnulus(SkyAperture):
         self.w_out = w_out
         self.h_out = h_out
         self.theta = theta
-
-    def __repr__(self):
-        shape_info = ('w_in={0}, w_out={1}, h_out={2}, theta={3}'
-                      .format(self.w_in, self.w_out, self.h_out, self.theta))
-        return self._cls_repr(shape_info)
-
-    def __str__(self):
-        shape_info = [('w_in', self.w_in), ('w_out', self.w_out),
-                      ('h_out', self.h_out), ('theta', self.theta)]
-        return self._cls_str(shape_info)
+        self._repr_params = [('w_in', self.w_in), ('w_out', self.w_out),
+                             ('h_out', self.h_out), ('theta', self.theta)]
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -383,6 +383,23 @@ class SkyRectangularAperture(SkyAperture):
         self.h = h
         self.theta = theta
 
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, w={2}, h={3}, theta={4})>'.format(
+            prefix, self.positions, self.w, self.h, self.theta)
+
+    def __str__(self):
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            ('positions', self.positions),
+            ('w', self.w),
+            ('h', self.h),
+            ('theta', self.theta)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
+
     def to_pixel(self, wcs, mode='all'):
         """
         Convert the aperture to a `RectangularAperture` instance in
@@ -482,6 +499,25 @@ class SkyRectangularAnnulus(SkyAperture):
         self.w_out = w_out
         self.h_out = h_out
         self.theta = theta
+
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, w_in={2}, w_out={3}, h_out={4}, theta={5})>'.format(
+            prefix, self.positions, self.w_in, self.w_out, self.h_out,
+            self.theta)
+
+    def __str__(self):
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            ('positions', self.positions),
+            ('w_in', self.w_in),
+            ('w_out', self.w_out),
+            ('h_out', self.h_out),
+            ('theta', self.theta)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -150,6 +150,24 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         self.h = float(h)
         self.theta = float(theta)
 
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, w={2}, h={3}, theta={4})>'.format(
+            prefix, self._positions_str(prefix), self.w, self.h, self.theta)
+
+    def __str__(self):
+        prefix = 'positions'
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            (prefix, self._positions_str(prefix + ': ')),
+            ('w', self.w),
+            ('h', self.h),
+            ('theta', self.theta)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
+
     @property
     def bounding_boxes(self):
         # TODO:  use an actual minimal bounding box
@@ -250,6 +268,27 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         self.h_out = float(h_out)
         self.h_in = self.w_in * self.h_out / self.w_out
         self.theta = float(theta)
+
+    def __repr__(self):
+        prefix = '<{0}('.format(self.__class__.__name__)
+        return '{0}{1}, w_in={2}, w_out={3}, h_out={4}, theta={5})>'.format(
+            prefix, self._positions_str(prefix), self.w_in, self.w_out,
+            self.h_out, self.theta)
+
+    def __str__(self):
+        prefix = 'positions'
+        clsinfo = [
+            ('Aperture', self.__class__.__name__),
+            (prefix, self._positions_str(prefix + ': ')),
+            ('w_in', self.w_in),
+            ('w_out', self.w_out),
+            ('h_in', self.h_in),
+            ('h_out', self.h_out),
+            ('theta', self.theta)
+        ]
+
+        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
+        return '\n'.join(fmt)
 
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -151,22 +151,13 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         self.theta = float(theta)
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, w={2}, h={3}, theta={4})>'.format(
-            prefix, self._positions_str(prefix), self.w, self.h, self.theta)
+        shape_info = 'w={0}, h={1}, theta={2}'.format(self.w, self.h,
+                                                      self.theta)
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        prefix = 'positions'
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            (prefix, self._positions_str(prefix + ': ')),
-            ('w', self.w),
-            ('h', self.h),
-            ('theta', self.theta)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('w', self.w), ('h', self.h), ('theta', self.theta)]
+        return self._cls_str(shape_info)
 
     @property
     def bounding_boxes(self):
@@ -270,25 +261,15 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         self.theta = float(theta)
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, w_in={2}, w_out={3}, h_out={4}, theta={5})>'.format(
-            prefix, self._positions_str(prefix), self.w_in, self.w_out,
-            self.h_out, self.theta)
+        shape_info = ('w_in={0}, w_out={1}, h_out={2}, theta={3}'
+                      .format(self.w_in, self.w_out, self.h_out, self.theta))
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        prefix = 'positions'
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            (prefix, self._positions_str(prefix + ': ')),
-            ('w_in', self.w_in),
-            ('w_out', self.w_out),
-            ('h_in', self.h_in),
-            ('h_out', self.h_out),
-            ('theta', self.theta)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('w_in', self.w_in), ('w_out', self.w_out),
+                      ('h_in', self.h_in), ('h_out', self.h_out),
+                      ('theta', self.theta)]
+        return self._cls_str(shape_info)
 
     @property
     def bounding_boxes(self):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -365,21 +365,13 @@ class SkyRectangularAperture(SkyAperture):
         self.theta = theta
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, w={2}, h={3}, theta={4})>'.format(
-            prefix, self.positions, self.w, self.h, self.theta)
+        shape_info = 'w={0}, h={1}, theta={2}'.format(self.w, self.h,
+                                                      self.theta)
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            ('positions', self.positions),
-            ('w', self.w),
-            ('h', self.h),
-            ('theta', self.theta)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('w', self.w), ('h', self.h), ('theta', self.theta)]
+        return self._cls_str(shape_info)
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -482,23 +474,14 @@ class SkyRectangularAnnulus(SkyAperture):
         self.theta = theta
 
     def __repr__(self):
-        prefix = '<{0}('.format(self.__class__.__name__)
-        return '{0}{1}, w_in={2}, w_out={3}, h_out={4}, theta={5})>'.format(
-            prefix, self.positions, self.w_in, self.w_out, self.h_out,
-            self.theta)
+        shape_info = ('w_in={0}, w_out={1}, h_out={2}, theta={3}'
+                      .format(self.w_in, self.w_out, self.h_out, self.theta))
+        return self._cls_repr(shape_info)
 
     def __str__(self):
-        clsinfo = [
-            ('Aperture', self.__class__.__name__),
-            ('positions', self.positions),
-            ('w_in', self.w_in),
-            ('w_out', self.w_out),
-            ('h_out', self.h_out),
-            ('theta', self.theta)
-        ]
-
-        fmt = ['{0}: {1}'.format(key, val) for key, val in clsinfo]
-        return '\n'.join(fmt)
+        shape_info = [('w_in', self.w_in), ('w_out', self.w_out),
+                      ('h_out', self.h_out), ('theta', self.theta)]
+        return self._cls_str(shape_info)
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -636,13 +636,12 @@ def test_pixel_aperture_repr():
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
-    aper = EllipticalAnnulus((10, 20), a_in=5.0, a_out=7.0, b_out=3.0,
+    aper = EllipticalAnnulus((10, 20), a_in=4.0, a_out=8.0, b_out=4.0,
                              theta=15.0)
-    a_repr = ('<EllipticalAnnulus([[10, 20]], a_in=5.0, a_out=7.0, b_out='
-              '3.0, theta=15.0)>')
+    a_repr = ('<EllipticalAnnulus([[10, 20]], a_in=4.0, a_out=8.0, b_out='
+              '4.0, theta=15.0)>')
     a_str = ('Aperture: EllipticalAnnulus\npositions: [[10, 20]]\na_in: '
-             '5.0\na_out: 7.0\nb_in: 2.142857142857143\nb_out: 3.0\n'
-             'theta: 15.0')
+             '4.0\na_out: 8.0\nb_in: 2.0\nb_out: 4.0\ntheta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
@@ -653,13 +652,12 @@ def test_pixel_aperture_repr():
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
-    aper = RectangularAnnulus((10, 20), w_in=5.0, w_out=7.0, h_out=3.0,
+    aper = RectangularAnnulus((10, 20), w_in=4.0, w_out=8.0, h_out=4.0,
                               theta=15.0)
-    a_repr = ('<RectangularAnnulus([[10, 20]], w_in=5.0, w_out=7.0, '
-              'h_out=3.0, theta=15.0)>')
+    a_repr = ('<RectangularAnnulus([[10, 20]], w_in=4.0, w_out=8.0, '
+              'h_out=4.0, theta=15.0)>')
     a_str = ('Aperture: RectangularAnnulus\npositions: [[10, 20]]\n'
-             'w_in: 5.0\nw_out: 7.0\nh_in: 2.142857142857143\nh_out: 3.0\n'
-             'theta: 15.0')
+             'w_in: 4.0\nw_out: 8.0\nh_in: 2.0\nh_out: 4.0\ntheta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
@@ -669,61 +667,69 @@ def test_sky_aperture_repr():
 
     s = SkyCoord([1, 2], [3, 4], unit='deg')
     aper = SkyCircularAperture(s, r=3*u.pix)
-    a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-              '    [( 1.,  3.), ( 2.,  4.)]>, r=3.0 pix)>')
-    a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-             'r: 3.0 pix')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    a_repr0 = '<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg'
+    a_repr1 = 'r=3.0 pix)>'
+    a_str0 = ('Aperture: SkyCircularAperture\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg\n')
+    a_str1 = 'r: 3.0 pix'
+    assert repr(aper).startswith(a_repr0)
+    assert repr(aper).endswith(a_repr1)
+    assert str(aper).startswith(a_str0)
+    assert str(aper).endswith(a_str1)
 
     aper = SkyCircularAnnulus(s, r_in=3.*u.pix, r_out=5*u.pix)
-    a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n    '
-              '[( 1.,  3.), ( 2.,  4.)]>, r_in=3.0 pix, r_out=5.0 pix)>')
-    a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\nr_in: 3.0 '
-             'pix\nr_out: 5.0 pix')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    a_repr0 = '<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
+    a_repr1 = 'r_in=3.0 pix, r_out=5.0 pix)>'
+    a_str0 = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg\n')
+    a_str1 = 'r_in: 3.0 pix\nr_out: 5.0 pix'
+    assert repr(aper).startswith(a_repr0)
+    assert repr(aper).endswith(a_repr1)
+    assert str(aper).startswith(a_str0)
+    assert str(aper).endswith(a_str1)
 
     aper = SkyEllipticalAperture(s, a=3*u.pix, b=5*u.pix, theta=15*u.deg)
-    a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-              '    [( 1.,  3.), ( 2.,  4.)]>, a=3.0 pix, b=5.0 pix, theta='
-              '15.0 deg)>')
-    a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\na: 3.0 pix\n'
-             'b: 5.0 pix\ntheta: 15.0 deg')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    a_repr0 = '<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in deg'
+    a_repr1 = 'a=3.0 pix, b=5.0 pix, theta=15.0 deg)>'
+    a_str0 = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg')
+    a_str1 = 'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg'
+    assert repr(aper).startswith(a_repr0)
+    assert repr(aper).endswith(a_repr1)
+    assert str(aper).startswith(a_str0)
+    assert str(aper).endswith(a_str1)
 
     aper = SkyEllipticalAnnulus(s, a_in=3*u.pix, a_out=5*u.pix, b_out=3*u.pix,
                                 theta=15*u.deg)
-    a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n    '
-              '[( 1.,  3.), ( 2.,  4.)]>, a_in=3.0 pix, a_out=5.0 pix, b_out='
-              '3.0 pix, theta=15.0 deg)>')
-    a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\na_in: 3.0 pix'
-             '\na_out: 5.0 pix\nb_out: 3.0 pix\ntheta: 15.0 deg')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    a_repr0 = '<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
+    a_repr1 = 'a_in=3.0 pix, a_out=5.0 pix, b_out=3.0 pix, theta=15.0 deg)>'
+    a_str0 = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord (ICRS): '
+              '(ra, dec) in deg')
+    a_str1 = 'a_in: 3.0 pix\na_out: 5.0 pix\nb_out: 3.0 pix\ntheta: 15.0 deg'
+    assert repr(aper).startswith(a_repr0)
+    assert repr(aper).endswith(a_repr1)
+    assert str(aper).startswith(a_str0)
+    assert str(aper).endswith(a_str1)
 
     aper = SkyRectangularAperture(s, w=3*u.pix, h=5*u.pix, theta=15*u.deg)
-    a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-              '    [( 1.,  3.), ( 2.,  4.)]>, w=3.0 pix, h=5.0 pix, theta='
-              '15.0 deg)>')
-    a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord (ICRS):'
-             ' (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\nw: 3.0 pix\n'
-             'h: 5.0 pix\ntheta: 15.0 deg')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    a_repr0 = '<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in deg'
+    a_repr1 = 'w=3.0 pix, h=5.0 pix, theta=15.0 deg)>'
+    a_str0 = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord (ICRS):'
+             ' (ra, dec) in deg')
+    a_str1 = 'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg'
+    assert repr(aper).startswith(a_repr0)
+    assert repr(aper).endswith(a_repr1)
+    assert str(aper).startswith(a_str0)
+    assert str(aper).endswith(a_str1)
 
     aper = SkyRectangularAnnulus(s, w_in=3*u.pix, w_out=3.4*u.pix,
                                  h_out=5*u.pix, theta=15*u.deg)
-    a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
-              '    [( 1.,  3.), ( 2.,  4.)]>, w_in=3.0 pix, w_out=3.4 pix, '
-              'h_out=5.0 pix, theta=15.0 deg)>')
-    a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\nw_in: 3.0 pix'
-             '\nw_out: 3.4 pix\nh_out: 5.0 pix\ntheta: 15.0 deg')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    a_repr0 = '<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
+    a_repr1 = 'w_in=3.0 pix, w_out=3.4 pix, h_out=5.0 pix, theta=15.0 deg)>'
+    a_str0 = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg')
+    a_str1 = 'w_in: 3.0 pix\nw_out: 3.4 pix\nh_out: 5.0 pix\ntheta: 15.0 deg'
+    assert repr(aper).startswith(a_repr0)
+    assert repr(aper).endswith(a_repr1)
+    assert str(aper).startswith(a_str0)
+    assert str(aper).endswith(a_str1)

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -662,3 +662,68 @@ def test_pixel_aperture_repr():
              'theta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
+
+
+def test_sky_aperture_repr():
+    from astropy.coordinates import SkyCoord
+
+    s = SkyCoord([1, 2], [3, 4], unit='deg')
+    aper = SkyCircularAperture(s, r=3*u.pix)
+    a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
+              '    [( 1.,  3.), ( 2.,  4.)]>, r=3.0 pix)>')
+    a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+             'r: 3.0 pix')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = SkyCircularAnnulus(s, r_in=3.*u.pix, r_out=5*u.pix)
+    a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n    '
+              '[( 1.,  3.), ( 2.,  4.)]>, r_in=3.0 pix, r_out=5.0 pix)>')
+    a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\nr_in: 3.0 '
+             'pix\nr_out: 5.0 pix')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = SkyEllipticalAperture(s, a=3*u.pix, b=5*u.pix, theta=15*u.deg)
+    a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
+              '    [( 1.,  3.), ( 2.,  4.)]>, a=3.0 pix, b=5.0 pix, theta='
+              '15.0 deg)>')
+    a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\na: 3.0 pix\n'
+             'b: 5.0 pix\ntheta: 15.0 deg')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = SkyEllipticalAnnulus(s, a_in=3*u.pix, a_out=5*u.pix, b_out=3*u.pix,
+                                theta=15*u.deg)
+    a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n    '
+              '[( 1.,  3.), ( 2.,  4.)]>, a_in=3.0 pix, a_out=5.0 pix, b_out='
+              '3.0 pix, theta=15.0 deg)>')
+    a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\na_in: 3.0 pix'
+             '\na_out: 5.0 pix\nb_out: 3.0 pix\ntheta: 15.0 deg')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = SkyRectangularAperture(s, w=3*u.pix, h=5*u.pix, theta=15*u.deg)
+    a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
+              '    [( 1.,  3.), ( 2.,  4.)]>, w=3.0 pix, h=5.0 pix, theta='
+              '15.0 deg)>')
+    a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord (ICRS):'
+             ' (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\nw: 3.0 pix\n'
+             'h: 5.0 pix\ntheta: 15.0 deg')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = SkyRectangularAnnulus(s, w_in=3*u.pix, w_out=3.4*u.pix,
+                                 h_out=5*u.pix, theta=15*u.deg)
+    a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
+              '    [( 1.,  3.), ( 2.,  4.)]>, w_in=3.0 pix, w_out=3.4 pix, '
+              'h_out=5.0 pix, theta=15.0 deg)>')
+    a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord (ICRS): '
+             '(ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\nw_in: 3.0 pix'
+             '\nw_out: 3.4 pix\nh_out: 5.0 pix\ntheta: 15.0 deg')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -613,3 +613,52 @@ def test_aperture_partial_overlap():
     assert_array_less(tbl['aperture_sum_err'][1:].value, np.pi * r **2)
     assert tbl['aperture_sum'].unit == unit
     assert tbl['aperture_sum_err'].unit == unit
+
+
+def test_pixel_aperture_repr():
+    aper = CircularAperture((10, 20), r=3.0)
+    a_repr = '<CircularAperture([[10, 20]], r=3.0)>'
+    a_str = 'Aperture: CircularAperture\npositions: [[10, 20]]\nr: 3.0'
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = CircularAnnulus((10, 20), r_in=3.0, r_out=5.0)
+    a_repr = '<CircularAnnulus([[10, 20]], r_in=3.0, r_out=5.0)>'
+    a_str = ('Aperture: CircularAnnulus\npositions: [[10, 20]]\nr_in: 3.0\n'
+             'r_out: 5.0')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = EllipticalAperture((10, 20), a=5.0, b=3.0, theta=15.0)
+    a_repr = '<EllipticalAperture([[10, 20]], a=5.0, b=3.0, theta=15.0)>'
+    a_str = ('Aperture: EllipticalAperture\npositions: [[10, 20]]\n'
+             'a: 5.0\nb: 3.0\ntheta: 15.0')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = EllipticalAnnulus((10, 20), a_in=5.0, a_out=7.0, b_out=3.0,
+                             theta=15.0)
+    a_repr = ('<EllipticalAnnulus([[10, 20]], a_in=5.0, a_out=7.0, b_out='
+              '3.0, theta=15.0)>')
+    a_str = ('Aperture: EllipticalAnnulus\npositions: [[10, 20]]\na_in: '
+             '5.0\na_out: 7.0\nb_in: 2.142857142857143\nb_out: 3.0\n'
+             'theta: 15.0')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = RectangularAperture((10, 20), w=5.0, h=3.0, theta=15.0)
+    a_repr = '<RectangularAperture([[10, 20]], w=5.0, h=3.0, theta=15.0)>'
+    a_str = ('Aperture: RectangularAperture\npositions: [[10, 20]]\n'
+             'w: 5.0\nh: 3.0\ntheta: 15.0')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
+    aper = RectangularAnnulus((10, 20), w_in=5.0, w_out=7.0, h_out=3.0,
+                              theta=15.0)
+    a_repr = ('<RectangularAnnulus([[10, 20]], w_in=5.0, w_out=7.0, '
+              'h_out=3.0, theta=15.0)>')
+    a_str = ('Aperture: RectangularAnnulus\npositions: [[10, 20]]\n'
+             'w_in: 5.0\nw_out: 7.0\nh_in: 2.142857142857143\nh_out: 3.0\n'
+             'theta: 15.0')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -8,6 +8,7 @@ algorithms in aperture_photometry, not in the wrappers.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from distutils.version import LooseVersion
 import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_less)
@@ -16,6 +17,9 @@ from astropy.nddata import NDData
 import astropy.units as u
 from astropy.tests.helper import pytest, remote_data
 from astropy.tests.helper import assert_quantity_allclose
+
+import astropy
+ASTROPY_LT_13 = LooseVersion(astropy.__version__) < LooseVersion('1.3')
 
 from ..core import *
 from ..circle import *
@@ -666,70 +670,116 @@ def test_sky_aperture_repr():
     from astropy.coordinates import SkyCoord
 
     s = SkyCoord([1, 2], [3, 4], unit='deg')
+
     aper = SkyCircularAperture(s, r=3*u.pix)
-    a_repr0 = '<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg'
-    a_repr1 = 'r=3.0 pix)>'
-    a_str0 = ('Aperture: SkyCircularAperture\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg\n')
-    a_str1 = 'r: 3.0 pix'
-    assert repr(aper).startswith(a_repr0)
-    assert repr(aper).endswith(a_repr1)
-    assert str(aper).startswith(a_str0)
-    assert str(aper).endswith(a_str1)
+    if ASTROPY_LT_13:
+        a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                  '    [(1.0, 3.0), (2.0, 4.0)]>, r=3.0 pix)>')
+        a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
+                 'r: 3.0 pix')
+    else:
+        a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                  '    [( 1.,  3.), ( 2.,  4.)]>, r=3.0 pix)>')
+        a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+                 'r: 3.0 pix')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
 
     aper = SkyCircularAnnulus(s, r_in=3.*u.pix, r_out=5*u.pix)
-    a_repr0 = '<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-    a_repr1 = 'r_in=3.0 pix, r_out=5.0 pix)>'
-    a_str0 = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg\n')
-    a_str1 = 'r_in: 3.0 pix\nr_out: 5.0 pix'
-    assert repr(aper).startswith(a_repr0)
-    assert repr(aper).endswith(a_repr1)
-    assert str(aper).startswith(a_str0)
-    assert str(aper).endswith(a_str1)
+    if ASTROPY_LT_13:
+        a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                  '    [(1.0, 3.0), (2.0, 4.0)]>, r_in=3.0 pix, r_out=5.0 '
+                  'pix)>')
+        a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
+                 'r_in: 3.0 pix\nr_out: 5.0 pix')
+    else:
+        a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                  '    [( 1.,  3.), ( 2.,  4.)]>, r_in=3.0 pix, r_out=5.0 '
+                  'pix)>')
+        a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+                 'r_in: 3.0 pix\nr_out: 5.0 pix')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
 
     aper = SkyEllipticalAperture(s, a=3*u.pix, b=5*u.pix, theta=15*u.deg)
-    a_repr0 = '<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in deg'
-    a_repr1 = 'a=3.0 pix, b=5.0 pix, theta=15.0 deg)>'
-    a_str0 = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg')
-    a_str1 = 'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg'
-    assert repr(aper).startswith(a_repr0)
-    assert repr(aper).endswith(a_repr1)
-    assert str(aper).startswith(a_str0)
-    assert str(aper).endswith(a_str1)
+    if ASTROPY_LT_13:
+        a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [(1.0, 3.0), (2.0, 4.0)]>, a=3.0 pix, b=5.0 pix,'
+                  ' theta=15.0 deg)>')
+        a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
+                 'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
+    else:
+        a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, a=3.0 pix, b=5.0 pix,'
+                  ' theta=15.0 deg)>')
+        a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+                 'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
 
     aper = SkyEllipticalAnnulus(s, a_in=3*u.pix, a_out=5*u.pix, b_out=3*u.pix,
                                 theta=15*u.deg)
-    a_repr0 = '<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-    a_repr1 = 'a_in=3.0 pix, a_out=5.0 pix, b_out=3.0 pix, theta=15.0 deg)>'
-    a_str0 = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord (ICRS): '
-              '(ra, dec) in deg')
-    a_str1 = 'a_in: 3.0 pix\na_out: 5.0 pix\nb_out: 3.0 pix\ntheta: 15.0 deg'
-    assert repr(aper).startswith(a_repr0)
-    assert repr(aper).endswith(a_repr1)
-    assert str(aper).startswith(a_str0)
-    assert str(aper).endswith(a_str1)
+    if ASTROPY_LT_13:
+        a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [(1.0, 3.0), (2.0, 4.0)]>, a_in=3.0 pix, '
+                  'a_out=5.0 pix, b_out=3.0 pix, theta=15.0 deg)>')
+        a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
+                 'a_in: 3.0 pix\na_out: 5.0 pix\nb_out: 3.0 pix\n'
+                 'theta: 15.0 deg')
+    else:
+        a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, a_in=3.0 pix, '
+                  'a_out=5.0 pix, b_out=3.0 pix, theta=15.0 deg)>')
+        a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+                 'a_in: 3.0 pix\na_out: 5.0 pix\nb_out: 3.0 pix\n'
+                 'theta: 15.0 deg')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
 
     aper = SkyRectangularAperture(s, w=3*u.pix, h=5*u.pix, theta=15*u.deg)
-    a_repr0 = '<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in deg'
-    a_repr1 = 'w=3.0 pix, h=5.0 pix, theta=15.0 deg)>'
-    a_str0 = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord (ICRS):'
-             ' (ra, dec) in deg')
-    a_str1 = 'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg'
-    assert repr(aper).startswith(a_repr0)
-    assert repr(aper).endswith(a_repr1)
-    assert str(aper).startswith(a_str0)
-    assert str(aper).endswith(a_str1)
+    if ASTROPY_LT_13:
+        a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [(1.0, 3.0), (2.0, 4.0)]>, w=3.0 pix, h=5.0 pix'
+                  ', theta=15.0 deg)>')
+        a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
+                 'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
+    else:
+        a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, w=3.0 pix, h=5.0 pix'
+                  ', theta=15.0 deg)>')
+        a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+                 'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str
+
 
     aper = SkyRectangularAnnulus(s, w_in=3*u.pix, w_out=3.4*u.pix,
                                  h_out=5*u.pix, theta=15*u.deg)
-    a_repr0 = '<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-    a_repr1 = 'w_in=3.0 pix, w_out=3.4 pix, h_out=5.0 pix, theta=15.0 deg)>'
-    a_str0 = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord (ICRS): '
-             '(ra, dec) in deg')
-    a_str1 = 'w_in: 3.0 pix\nw_out: 3.4 pix\nh_out: 5.0 pix\ntheta: 15.0 deg'
-    assert repr(aper).startswith(a_repr0)
-    assert repr(aper).endswith(a_repr1)
-    assert str(aper).startswith(a_str0)
-    assert str(aper).endswith(a_str1)
+    if ASTROPY_LT_13:
+        a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
+                  '\n    [(1.0, 3.0), (2.0, 4.0)]>, w_in=3.0 pix, '
+                  'w_out=3.4 pix, h_out=5.0 pix, theta=15.0 deg)>')
+        a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
+                 'w_in: 3.0 pix\nw_out: 3.4 pix\nh_out: 5.0 pix\n'
+                 'theta: 15.0 deg')
+    else:
+        a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
+                  '\n    [( 1.,  3.), ( 2.,  4.)]>, w_in=3.0 pix, '
+                  'w_out=3.4 pix, h_out=5.0 pix, theta=15.0 deg)>')
+        a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+                 'w_in: 3.0 pix\nw_out: 3.4 pix\nh_out: 5.0 pix\n'
+                 'theta: 15.0 deg')
+    assert repr(aper) == a_repr
+    assert str(aper) == a_str


### PR DESCRIPTION
Example:
```python
>>> from photutils import CircularAperture
>>> a = CircularAperture((10, 20), r=3)
>>> a
<CircularAperture([[10, 20]], r=3.0)>

>>> print(a)
Aperture: CircularAperture
positions: [[10, 20]]
r: 3.0
```