### PR TITLE
Use Bezier curve for annulus plotting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ New Features
 
   - Apertures now have ``__repr__`` and ``__str__`` defined. [#493]
 
+  - Improved plotting of annulus apertures using Bezier curves. [#494]
+
 API changes
 ^^^^^^^^^^^
 


### PR DESCRIPTION
This PR improves the plotting annuli apertures.  When creating the annulus patch, it uses the bezier curve path instead of line segments between vertices.

Old:
![original](https://cloud.githubusercontent.com/assets/4992897/22162534/14537ce6-df1d-11e6-8b43-092e0bcdb095.png)

New:
![new](https://cloud.githubusercontent.com/assets/4992897/22162539/1a7f63d2-df1d-11e6-8154-cded162a10c8.png)
