### PR TITLE
Fix Background2D for unequal array padding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,12 @@ General
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.background``
+
+  - Fixed issue with ``Background2D`` with ``edge_method='pad'`` that
+    occurred when unequal padding needed to be applied to each axis.
+    [#498]
+
 - ``photutils.geometry``
 
   - Fixed a bug in ``circular_overlap_grid`` affecting 32-bit machines

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -336,7 +336,7 @@ class Background2D(object):
         self._calc_bkg_bkgrms()
         self._calc_coordinates()
 
-    def _pad_data(self, xextra, yextra):
+    def _pad_data(self, yextra, xextra):
         """
         Pad the ``data`` and ``mask`` to have an integer number of
         background meshes of size ``box_size`` in both dimensions.  The
@@ -345,11 +345,11 @@ class Background2D(object):
 
         Parameters
         ----------
-        xextra, yextra : int
+        yextra, xextra : int
             The modulus of the data size and the box size in both the
-            ``x`` and ``y`` dimensions.  This is the number of extra
-            pixels beyond a multiple of the box size in the ``x`` and
-            ``y`` dimensions.
+            ``y`` and ``x`` dimensions.  This is the number of extra
+            pixels beyond a multiple of the box size in the ``y`` and
+            ``x`` dimensions.
 
         Returns
         -------

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -71,17 +71,17 @@ class TestBackground2D(object):
 
     @pytest.mark.parametrize('filter_size', FILTER_SIZES)
     def test_resizing(self, filter_size):
-        b1 = Background2D(DATA, (22, 22), filter_size=filter_size,
+        b1 = Background2D(DATA, (23, 22), filter_size=filter_size,
                           bkg_estimator=MeanBackground(), edge_method='crop')
-        b2 = Background2D(DATA, (22, 22), filter_size=filter_size,
+        b2 = Background2D(DATA, (23, 22), filter_size=filter_size,
                           bkg_estimator=MeanBackground(), edge_method='pad')
         assert_allclose(b1.background, b2.background)
         assert_allclose(b1.background_rms, b2.background_rms)
 
-    @pytest.mark.parametrize('box_size', ([(25, 25), (22, 22)]))
+    @pytest.mark.parametrize('box_size', ([(25, 25), (23, 22)]))
     def test_background_mask(self, box_size):
         """
-        Test with an input mask.  Note that box_size=(22, 22) tests the
+        Test with an input mask.  Note that box_size=(23, 22) tests the
         resizing of the image and mask.
         """
 
@@ -165,12 +165,12 @@ class TestBackground2D(object):
 
     def test_invalid_edge_method(self):
         with pytest.raises(ValueError):
-            Background2D(DATA, (22, 22), filter_size=(1, 1),
+            Background2D(DATA, (23, 22), filter_size=(1, 1),
                          edge_method='not_valid')
 
     def test_invalid_exclude_mesh_method(self):
         with pytest.raises(ValueError):
-            Background2D(DATA, (22, 22), filter_size=(1, 1),
+            Background2D(DATA, (23, 22), filter_size=(1, 1),
                          exclude_mesh_method='not_valid')
 
     def test_invalid_mesh_idx_len(self):


### PR DESCRIPTION
This PR fixes https://github.com/astropy/photutils/issues/496.  The x and y array padding widths were swapped (sigh), so this bug affected input arrays that required unequal padding along each axis.  The tests were also updated to catch this case now.