### PR TITLE
Fix BoundingBox from_float() upper bounds

### DIFF
--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -114,9 +114,9 @@ class BoundingBox(object):
         """
 
         ixmin = int(np.floor(xmin + 0.5))
-        ixmax = int(np.floor(xmax + 1.5))
+        ixmax = int(np.ceil(xmax + 0.5))
         iymin = int(np.floor(ymin + 0.5))
-        iymax = int(np.floor(ymax + 1.5))
+        iymax = int(np.ceil(ymax + 0.5))
 
         return cls(ixmin, ixmax, iymin, iymax)
 


### PR DESCRIPTION
This is yet another fix for BoundingBox.from_float(). In the case where the upper bound is at the pixel edge (e.g. xmax=2.5), the code was effectively rounding up and then adding 1. In those cases, the bounding box upper bound is too large by one pixel.

Note that this "fix" affects only aperture masks, not photometry.