### PR TITLE
Highlight docs as python 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,9 @@ sphinx.environment.BuildEnvironment.warn_node = _warn_node
 
 # -- General configuration ----------------------------------------------------
 
+# By default, highlight as Python 3.
+highlight_language = 'python3'
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.1'
 


### PR DESCRIPTION
Explicitly set docs `highlight_language` to `python3`.  This will fix the missing button to hide output in code blocks.

Related to https://github.com/astropy/astropy-helpers/pull/287