### PR TITLE
Use true minimal bounding box for rectangular apertures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ New Features
 
   - Improved plotting of annulus apertures using Bezier curves. [#494]
 
+  - Rectangular apertures now use the true minimal bounding box. [#507]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -154,12 +154,27 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
 
     @property
     def bounding_boxes(self):
-        # TODO:  use an actual minimal bounding box
-        radius = max(self.h, self.w) * (2. ** -0.5)
-        xmin = self.positions[:, 0] - radius
-        xmax = self.positions[:, 0] + radius
-        ymin = self.positions[:, 1] - radius
-        ymax = self.positions[:, 1] + radius
+        """
+        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
+        for each position, enclosing the rectangular apertures for the
+        "exact" case.
+        """
+
+        w2 = self.w / 2.
+        h2 = self.h / 2.
+        cos_theta = math.cos(self.theta)
+        sin_theta = math.sin(self.theta)
+        dx1 = abs(w2 * cos_theta - h2 * sin_theta)
+        dy1 = abs(w2 * sin_theta + h2 * cos_theta)
+        dx2 = abs(w2 * cos_theta + h2 * sin_theta)
+        dy2 = abs(w2 * sin_theta - h2 * cos_theta)
+        dx = max(dx1, dx2)
+        dy = max(dy1, dy2)
+
+        xmin = self.positions[:, 0] - dx
+        xmax = self.positions[:, 0] + dx
+        ymin = self.positions[:, 1] - dy
+        ymax = self.positions[:, 1] + dy
 
         return [BoundingBox._from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
@@ -258,12 +273,27 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
     @property
     def bounding_boxes(self):
-        # TODO:  use an actual minimal bounding box
-        radius = max(self.h_out, self.w_out) * (2. ** -0.5)
-        xmin = self.positions[:, 0] - radius
-        xmax = self.positions[:, 0] + radius
-        ymin = self.positions[:, 1] - radius
-        ymax = self.positions[:, 1] + radius
+        """
+        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
+        for each position, enclosing the rectangular apertures for the
+        "exact" case.
+        """
+
+        w2 = self.w_out / 2.
+        h2 = self.h_out / 2.
+        cos_theta = math.cos(self.theta)
+        sin_theta = math.sin(self.theta)
+        dx1 = abs(w2 * cos_theta - h2 * sin_theta)
+        dy1 = abs(w2 * sin_theta + h2 * cos_theta)
+        dx2 = abs(w2 * cos_theta + h2 * sin_theta)
+        dy2 = abs(w2 * sin_theta - h2 * cos_theta)
+        dx = max(dx1, dx2)
+        dy = max(dy1, dy2)
+
+        xmin = self.positions[:, 0] - dx
+        xmax = self.positions[:, 0] + dx
+        ymin = self.positions[:, 1] - dy
+        ymax = self.positions[:, 1] + dy
 
         return [BoundingBox._from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -783,3 +783,30 @@ def test_sky_aperture_repr():
                  'theta: 15.0 deg')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
+
+
+def test_rectangular_bbox():
+    # odd sizes
+    width = 7
+    height = 3
+    a = RectangularAperture((50, 50), w=width, h=height, theta=0)
+    assert a.bounding_boxes[0].shape == (height, width)
+
+    a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
+    assert a.bounding_boxes[0].shape == (height + 1, width + 1)
+
+    a = RectangularAperture((50, 50), w=width, h=height, theta=90.*np.pi/180.)
+    assert a.bounding_boxes[0].shape == (width, height)
+
+    # even sizes
+    width = 8
+    height = 4
+    a = RectangularAperture((50, 50), w=width, h=height, theta=0)
+    assert a.bounding_boxes[0].shape == (height + 1, width + 1)
+
+    a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
+    assert a.bounding_boxes[0].shape == (height, width)
+
+    a = RectangularAperture((50.5, 50.5), w=width, h=height,
+                            theta=90.*np.pi/180.)
+    assert a.bounding_boxes[0].shape == (width, height)


### PR DESCRIPTION
The current bounding box for rectangular apertures is defined as the smallest square that will contain the rectangle at all rotation angles.

Note that the minimal bounding box here is defined for the "exact" rectangle.  For `method="center"` the bounding box could have an extra pixel of padding on each side.

Addresses #499.