### PR TITLE
Define minimal bounding box for exact elliptical apertures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ New Features
 
   - Rectangular apertures now use the true minimal bounding box. [#507]
 
+  - Elliptical apertures now use the true minimal bounding box. [#508]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -150,12 +150,24 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
 
     @property
     def bounding_boxes(self):
-        # TODO:  use an actual minimal bounding box
-        radius = max(self.a, self.b)
-        xmin = self.positions[:, 0] - radius
-        xmax = self.positions[:, 0] + radius
-        ymin = self.positions[:, 1] - radius
-        ymax = self.positions[:, 1] + radius
+        """
+        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
+        for each position, enclosing the exact elliptical apertures.
+        """
+
+        cos_theta = np.cos(self.theta)
+        sin_theta = np.sin(self.theta)
+        ax = self.a * cos_theta
+        ay = self.a * sin_theta
+        bx = self.b * -sin_theta
+        by = self.b * cos_theta
+        dx = np.sqrt(ax*ax + bx*bx)
+        dy = np.sqrt(ay*ay + by*by)
+
+        xmin = self.positions[:, 0] - dx
+        xmax = self.positions[:, 0] + dx
+        ymin = self.positions[:, 1] - dy
+        ymax = self.positions[:, 1] + dy
 
         return [BoundingBox._from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
@@ -243,12 +255,24 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
 
     @property
     def bounding_boxes(self):
-        # TODO:  use an actual minimal bounding box
-        radius = max(self.a_out, self.b_out)
-        xmin = self.positions[:, 0] - radius
-        xmax = self.positions[:, 0] + radius
-        ymin = self.positions[:, 1] - radius
-        ymax = self.positions[:, 1] + radius
+        """
+        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
+        for each position, enclosing the exact elliptical apertures.
+        """
+
+        cos_theta = np.cos(self.theta)
+        sin_theta = np.sin(self.theta)
+        ax = self.a_out * cos_theta
+        ay = self.a_out * sin_theta
+        bx = self.b_out * -sin_theta
+        by = self.b_out * cos_theta
+        dx = np.sqrt(ax*ax + bx*bx)
+        dy = np.sqrt(ay*ay + by*by)
+
+        xmin = self.positions[:, 0] - dx
+        xmax = self.positions[:, 0] + dx
+        ymin = self.positions[:, 1] - dy
+        ymax = self.positions[:, 1] + dy
 
         return [BoundingBox._from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -156,8 +156,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     def bounding_boxes(self):
         """
         A list of minimal bounding boxes (`~photutils.BoundingBox`), one
-        for each position, enclosing the rectangular apertures for the
-        "exact" case.
+        for each position, enclosing the exact rectangular apertures.
         """
 
         w2 = self.w / 2.

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -810,3 +810,29 @@ def test_rectangular_bbox():
     a = RectangularAperture((50.5, 50.5), w=width, h=height,
                             theta=90.*np.pi/180.)
     assert a.bounding_boxes[0].shape == (width, height)
+
+
+def test_elliptical_bbox():
+    # integer axes
+    a = 7
+    b = 3
+    ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
+    assert ap.bounding_boxes[0].shape == (2*b + 1, 2*a + 1)
+
+    ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
+    assert ap.bounding_boxes[0].shape == (2*b, 2*a)
+
+    ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.*np.pi/180.)
+    assert ap.bounding_boxes[0].shape == (2*a + 1, 2*b + 1)
+
+    # fractional axes
+    a = 7.5
+    b = 4.5
+    ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
+    assert ap.bounding_boxes[0].shape == (2*b, 2*a)
+
+    ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
+    assert ap.bounding_boxes[0].shape == (2*b + 1, 2*a + 1)
+
+    ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.*np.pi/180.)
+    assert ap.bounding_boxes[0].shape == (2*a, 2*b)


### PR DESCRIPTION
The current bounding boxes are not optimized.