### PR TITLE
Add to_sky method for pixel apertures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ New Features
 
   - Elliptical apertures now use the true minimal bounding box. [#508]
 
+  - Added a ``to_sky`` method for pixel apertures. [#512]
+
+
 API changes
 ^^^^^^^^^^^
 

--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -83,6 +83,28 @@ object::
     coordinates.
 
 
+Converting Between Pixel and Sky Apertures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The pixel apertures can be converted to sky apertures, and visa versa.
+To accomplish this, use the :meth:`~photutils.PixelAperture.to_sky`
+method for pixel apertures, e.g.:
+
+.. doctest-skip::
+
+    >>> aperture = CircularAperture((10, 20), r=4.)
+    >>> sky_aperture = aperture.to_sky(wcs)
+
+and the :meth:`~photutils.SkyAperture.to_pixel` method for sky
+apertures, e.g.:
+
+.. doctest-skip::
+
+    >>> position = SkyCoord(1.2, 0.1, unit='deg', frame='icrs')
+    >>> aperture = SkyCircularAperture(position, r=4. * u.arcsec)
+    >>> pix_aperture = aperture.to_pixel(wcs)
+
+
 Performing Aperture Photometry
 ------------------------------
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -306,8 +306,8 @@ class SkyCircularAperture(SkyAperture):
 
     def to_pixel(self, wcs, mode='all'):
         """
-        Convert the aperture to a `CircularAperture` instance in pixel
-        coordinates.
+        Convert the aperture to a `CircularAperture` object defined in
+        pixel coordinates.
 
         Parameters
         ----------
@@ -367,8 +367,8 @@ class SkyCircularAnnulus(SkyAperture):
 
     def to_pixel(self, wcs, mode='all'):
         """
-        Convert the aperture to a `CircularAnnulus` instance in pixel
-        coordinates.
+        Convert the aperture to a `CircularAnnulus` object defined in
+        pixel coordinates.
 
         Parameters
         ----------

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -127,7 +127,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
         self.positions = self._sanitize_positions(positions)
         self.r = float(r)
-        self._repr_params = [('r', self.r)]
+        self._params = ['r']
 
     # TODO: make lazyproperty?, but update if positions or radius change
     @property
@@ -199,7 +199,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         self.positions = self._sanitize_positions(positions)
         self.r_in = float(r_in)
         self.r_out = float(r_out)
-        self._repr_params = [('r_in', self.r_in), ('r_out', self.r_out)]
+        self._params = ['r_in', 'r_out']
 
     @property
     def bounding_boxes(self):
@@ -254,7 +254,6 @@ class SkyCircularAperture(SkyAperture):
 
         assert_angle_or_pixel('r', r)
         self.r = r
-        self._repr_params = [('r', self.r)]
         self._params = ['r']
 
     def to_pixel(self, wcs, mode='all'):
@@ -316,7 +315,6 @@ class SkyCircularAnnulus(SkyAperture):
 
         self.r_in = r_in
         self.r_out = r_out
-        self._repr_params = [('r_in', self.r_in), ('r_out', self.r_out)]
         self._params = ['r_in', 'r_out']
 
     def to_pixel(self, wcs, mode='all'):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -155,6 +155,30 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
             patch = mpatches.Circle(position, self.r, **kwargs)
             ax.add_patch(patch)
 
+    def to_sky(self, wcs, mode='all'):
+        """
+        Convert the aperture to a `SkyCircularAperture` object defined
+        in celestial coordinates.
+
+        Parameters
+        ----------
+        wcs : `~astropy.wcs.WCS`
+            The world coordinate system (WCS) transformation to use.
+
+        mode : {'all', 'wcs'}, optional
+            Whether to do the transformation including distortions
+            (``'all'``; default) or only including only the core WCS
+            transformation (``'wcs'``).
+
+        Returns
+        -------
+        aperture : `SkyCircularAperture` object
+            A `SkyCircularAperture` object.
+        """
+
+        sky_params = self._to_sky_params(wcs, mode=mode)
+        return SkyCircularAperture(**sky_params)
+
 
 class CircularAnnulus(CircularMaskMixin, PixelAperture):
     """
@@ -230,6 +254,30 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
             path = self._make_annulus_path(patch_inner, patch_outer)
             patch = mpatches.PathPatch(path, **kwargs)
             ax.add_patch(patch)
+
+    def to_sky(self, wcs, mode='all'):
+        """
+        Convert the aperture to a `SkyCircularAnnulus` object defined
+        in celestial coordinates.
+
+        Parameters
+        ----------
+        wcs : `~astropy.wcs.WCS`
+            The world coordinate system (WCS) transformation to use.
+
+        mode : {'all', 'wcs'}, optional
+            Whether to do the transformation including distortions
+            (``'all'``; default) or only including only the core WCS
+            transformation (``'wcs'``).
+
+        Returns
+        -------
+        aperture : `SkyCircularAnnulus` object
+            A `SkyCircularAnnulus` object.
+        """
+
+        sky_params = self._to_sky_params(wcs, mode=mode)
+        return SkyCircularAnnulus(**sky_params)
 
 
 class SkyCircularAperture(SkyAperture):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -12,7 +12,7 @@ from .core import PixelAperture, SkyAperture
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import circular_overlap_grid
-from ..utils.wcs_helpers import (skycoord_to_pixel_scale_angle,
+from ..utils.wcs_helpers import (pixel_scale_angle_at_skycoord,
                                  assert_angle_or_pixel)
 
 
@@ -286,9 +286,8 @@ class SkyCircularAperture(SkyAperture):
         if self.r.unit.physical_type == 'angle':
             central_pos = SkyCoord([wcs.wcs.crval], frame=self.positions.name,
                                    unit=wcs.wcs.cunit)
-            xc, yc, scale, angle = skycoord_to_pixel_scale_angle(central_pos,
-                                                                 wcs)
-            r = (scale * self.r).to(u.pixel).value
+            scale, _ = pixel_scale_angle_at_skycoord(central_pos, wcs)
+            r = (self.r / scale).to(u.pixel).value
         else:    # pixels
             r = self.r.value
 
@@ -358,10 +357,9 @@ class SkyCircularAnnulus(SkyAperture):
         if self.r_in.unit.physical_type == 'angle':
             central_pos = SkyCoord([wcs.wcs.crval], frame=self.positions.name,
                                    unit=wcs.wcs.cunit)
-            xc, yc, scale, angle = skycoord_to_pixel_scale_angle(central_pos,
-                                                                 wcs)
-            r_in = (scale * self.r_in).to(u.pixel).value
-            r_out = (scale * self.r_out).to(u.pixel).value
+            scale, _ = pixel_scale_angle_at_skycoord(central_pos, wcs)
+            r_in = (self.r_in / scale).to(u.pixel).value
+            r_out = (self.r_out / scale).to(u.pixel).value
         else:    # pixels
             r_in = self.r_in.value
             r_out = self.r_out.value

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -577,6 +577,31 @@ class PixelAperture(Aperture):
 
         return sky_params
 
+    @abc.abstractmethod
+    def to_sky(self, wcs, mode='all'):
+        """
+        Convert the aperture to a `SkyAperture` object defined in
+        celestial coordinates.
+
+        Parameters
+        ----------
+        wcs : `~astropy.wcs.WCS` object
+            The world coordinate system (WCS) transformation to use.
+
+        mode : {'all', 'wcs'}, optional
+            Whether to do the transformation including distortions
+            (``'all'``; default) or including only the core WCS
+            transformation (``'wcs'``).
+
+        Returns
+        -------
+        aperture : `SkyAperture` object
+            A `SkyAperture` object.
+        """
+
+        raise NotImplementedError('Needs to be implemented in a '
+                                  'PixelAperture subclass.')
+
 
 class SkyAperture(Aperture):
     """
@@ -635,8 +660,8 @@ class SkyAperture(Aperture):
     @abc.abstractmethod
     def to_pixel(self, wcs, mode='all'):
         """
-        Convert the aperture to a `PixelAperture` object in pixel
-        coordinates.
+        Convert the aperture to a `PixelAperture` object defined in
+        pixel coordinates.
 
         Parameters
         ----------

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -586,7 +586,7 @@ class SkyAperture(Aperture):
 
     def _to_pixel_params(self, wcs, mode='all'):
         """
-        Convert the sky aperture parameters to those for a pixel-based
+        Convert the sky aperture parameters to those for a pixel
         aperture.
 
         Parameters

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -53,9 +53,8 @@ class Aperture(object):
     def __repr__(self):
         prefix = '<{0}('.format(self.__class__.__name__)
         params = [self._positions_str(prefix)]
-        for key, val in self._repr_params:
-            if key not in ['b_in', 'h_in']:   # not aperture parameters
-                params.append('{0}={1}'.format(key, val))
+        for param in self._params:
+            params.append('{0}={1}'.format(param, getattr(self, param)))
         params = ', '.join(params)
 
         return '{0}{1})>'.format(prefix, params)
@@ -65,8 +64,9 @@ class Aperture(object):
         cls_info = [
             ('Aperture', self.__class__.__name__),
             (prefix, self._positions_str(prefix + ': '))]
-        if self._repr_params is not None:
-            cls_info += self._repr_params
+        if self._params is not None:
+            for param in self._params:
+                cls_info.append((param, getattr(self, param)))
         fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
 
         return '\n'.join(fmt)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -568,7 +568,7 @@ class PixelAperture(Aperture):
         params = self._params[:]
         theta_key = 'theta'
         if theta_key in self._params:
-            sky_params[theta_key] = (self.theta - angle).to(u.radian).value
+            sky_params[theta_key] = (self.theta * u.rad) - angle.to(u.rad)
             params.remove(theta_key)
 
         param_vals = [getattr(self, param) for param in params]
@@ -619,7 +619,7 @@ class SkyAperture(Aperture):
         params = self._params[:]
         theta_key = 'theta'
         if theta_key in self._params:
-            pixel_params[theta_key] = (angle + self.theta).to(u.radian).value
+            pixel_params[theta_key] = (self.theta + angle).to(u.radian).value
             params.remove(theta_key)
 
         param_vals = [getattr(self, param) for param in params]

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -142,8 +142,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         self.a = float(a)
         self.b = float(b)
         self.theta = float(theta)
-        self._repr_params = [('a', self.a), ('b', self.b),
-                             ('theta', self.theta)]
+        self._params = ['a', 'b', 'theta']
 
     @property
     def bounding_boxes(self):
@@ -246,9 +245,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         self.b_out = float(b_out)
         self.b_in = self.b_out * self.a_in / self.a_out
         self.theta = float(theta)
-        self._repr_params = [('a_in', self.a_in), ('a_out', self.a_out),
-                             ('b_in', self.b_in), ('b_out', self.b_out),
-                             ('theta', self.theta)]
+        self._params = ['a_in', 'a_out', 'b_out', 'theta']
 
     @property
     def bounding_boxes(self):
@@ -334,8 +331,6 @@ class SkyEllipticalAperture(SkyAperture):
         self.a = a
         self.b = b
         self.theta = theta
-        self._repr_params = [('a', self.a), ('b', self.b),
-                             ('theta', self.theta)]
         self._params = ['a', 'b', 'theta']
 
     def to_pixel(self, wcs, mode='all'):
@@ -415,8 +410,6 @@ class SkyEllipticalAnnulus(SkyAperture):
         self.a_out = a_out
         self.b_out = b_out
         self.theta = theta
-        self._repr_params = [('a_in', self.a_in), ('a_out', self.a_out),
-                             ('b_out', self.b_out), ('theta', self.theta)]
         self._params = ['a_in', 'a_out', 'b_out', 'theta']
 
     def to_pixel(self, wcs, mode='all'):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -383,8 +383,8 @@ class SkyEllipticalAperture(SkyAperture):
 
     def to_pixel(self, wcs, mode='all'):
         """
-        Convert the aperture to an `EllipticalAperture` instance in
-        pixel coordinates.
+        Convert the aperture to an `EllipticalAperture` object defined
+        in pixel coordinates.
 
         Parameters
         ----------
@@ -462,8 +462,8 @@ class SkyEllipticalAnnulus(SkyAperture):
 
     def to_pixel(self, wcs, mode='all'):
         """
-        Convert the aperture to an `EllipticalAnnulus` instance in pixel
-        coordinates.
+        Convert the aperture to an `EllipticalAnnulus` object defined in
+        pixel coordinates.
 
         Parameters
         ----------

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -184,6 +184,30 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
                                      theta_deg, **kwargs)
             ax.add_patch(patch)
 
+    def to_sky(self, wcs, mode='all'):
+        """
+        Convert the aperture to a `SkyEllipticalAperture` object defined
+        in celestial coordinates.
+
+        Parameters
+        ----------
+        wcs : `~astropy.wcs.WCS`
+            The world coordinate system (WCS) transformation to use.
+
+        mode : {'all', 'wcs'}, optional
+            Whether to do the transformation including distortions
+            (``'all'``; default) or only including only the core WCS
+            transformation (``'wcs'``).
+
+        Returns
+        -------
+        aperture : `SkyEllipticalAperture` object
+            A `SkyEllipticalAperture` object.
+        """
+
+        sky_params = self._to_sky_params(wcs, mode=mode)
+        return SkyEllipticalAperture(**sky_params)
+
 
 class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     """
@@ -290,6 +314,30 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
             path = self._make_annulus_path(patch_inner, patch_outer)
             patch = mpatches.PathPatch(path, **kwargs)
             ax.add_patch(patch)
+
+    def to_sky(self, wcs, mode='all'):
+        """
+        Convert the aperture to a `SkyEllipticalAnnulus` object defined
+        in celestial coordinates.
+
+        Parameters
+        ----------
+        wcs : `~astropy.wcs.WCS`
+            The world coordinate system (WCS) transformation to use.
+
+        mode : {'all', 'wcs'}, optional
+            Whether to do the transformation including distortions
+            (``'all'``; default) or only including only the core WCS
+            transformation (``'wcs'``).
+
+        Returns
+        -------
+        aperture : `SkyEllipticalAnnulus` object
+            A `SkyEllipticalAnnulus` object.
+        """
+
+        sky_params = self._to_sky_params(wcs, mode=mode)
+        return SkyEllipticalAnnulus(**sky_params)
 
 
 class SkyEllipticalAperture(SkyAperture):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -12,7 +12,7 @@ from .core import PixelAperture, SkyAperture
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
-from ..utils.wcs_helpers import (skycoord_to_pixel_scale_angle, assert_angle,
+from ..utils.wcs_helpers import (pixel_scale_angle_at_skycoord, assert_angle,
                                  assert_angle_or_pixel)
 
 
@@ -364,11 +364,11 @@ class SkyEllipticalAperture(SkyAperture):
         x, y = skycoord_to_pixel(self.positions, wcs, mode=mode)
         central_pos = SkyCoord([wcs.wcs.crval], frame=self.positions.name,
                                unit=wcs.wcs.cunit)
-        xc, yc, scale, angle = skycoord_to_pixel_scale_angle(central_pos, wcs)
+        scale, angle = pixel_scale_angle_at_skycoord(central_pos, wcs)
 
         if self.a.unit.physical_type == 'angle':
-            a = (scale * self.a).to(u.pixel).value
-            b = (scale * self.b).to(u.pixel).value
+            a = (self.a / scale).to(u.pixel).value
+            b = (self.b / scale).to(u.pixel).value
         else:  # pixel
             a = self.a.value
             b = self.b.value
@@ -459,12 +459,12 @@ class SkyEllipticalAnnulus(SkyAperture):
         x, y = skycoord_to_pixel(self.positions, wcs, mode=mode)
         central_pos = SkyCoord([wcs.wcs.crval], frame=self.positions.name,
                                unit=wcs.wcs.cunit)
-        xc, yc, scale, angle = skycoord_to_pixel_scale_angle(central_pos, wcs)
+        scale, angle = pixel_scale_angle_at_skycoord(central_pos, wcs)
 
         if self.a_in.unit.physical_type == 'angle':
-            a_in = (scale * self.a_in).to(u.pixel).value
-            a_out = (scale * self.a_out).to(u.pixel).value
-            b_out = (scale * self.b_out).to(u.pixel).value
+            a_in = (self.a_in / scale).to(u.pixel).value
+            a_out = (self.a_out / scale).to(u.pixel).value
+            b_out = (self.b_out / scale).to(u.pixel).value
         else:
             a_in = self.a_in.value
             a_out = self.a_out.value

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -197,6 +197,30 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
                                        **kwargs)
             ax.add_patch(patch)
 
+    def to_sky(self, wcs, mode='all'):
+        """
+        Convert the aperture to a `SkyRectangularAperture` object
+        defined in celestial coordinates.
+
+        Parameters
+        ----------
+        wcs : `~astropy.wcs.WCS`
+            The world coordinate system (WCS) transformation to use.
+
+        mode : {'all', 'wcs'}, optional
+            Whether to do the transformation including distortions
+            (``'all'``; default) or only including only the core WCS
+            transformation (``'wcs'``).
+
+        Returns
+        -------
+        aperture : `SkyRectangularAperture` object
+            A `SkyRectangularAperture` object.
+        """
+
+        sky_params = self._to_sky_params(wcs, mode=mode)
+        return SkyRectangularAperture(**sky_params)
+
 
 class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     """
@@ -326,6 +350,30 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
             path = self._make_annulus_path(patch_inner, patch_outer)
             patch = mpatches.PathPatch(path, **kwargs)
             ax.add_patch(patch)
+
+    def to_sky(self, wcs, mode='all'):
+        """
+        Convert the aperture to a `SkyRectangularAnnulus` object
+        defined in celestial coordinates.
+
+        Parameters
+        ----------
+        wcs : `~astropy.wcs.WCS`
+            The world coordinate system (WCS) transformation to use.
+
+        mode : {'all', 'wcs'}, optional
+            Whether to do the transformation including distortions
+            (``'all'``; default) or only including only the core WCS
+            transformation (``'wcs'``).
+
+        Returns
+        -------
+        aperture : `SkyRectangularAnnulus` object
+            A `SkyRectangularAnnulus` object.
+        """
+
+        sky_params = self._to_sky_params(wcs, mode=mode)
+        return SkyRectangularAnnulus(**sky_params)
 
 
 class SkyRectangularAperture(SkyAperture):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -146,8 +146,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         self.w = float(w)
         self.h = float(h)
         self.theta = float(theta)
-        self._repr_params = [('w', self.w), ('h', self.h),
-                             ('theta', self.theta)]
+        self._params = ['w', 'h', 'theta']
 
     @property
     def bounding_boxes(self):
@@ -263,9 +262,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         self.h_out = float(h_out)
         self.h_in = self.w_in * self.h_out / self.w_out
         self.theta = float(theta)
-        self._repr_params = [('w_in', self.w_in), ('w_out', self.w_out),
-                             ('h_in', self.h_in), ('h_out', self.h_out),
-                             ('theta', self.theta)]
+        self._params = ['w_in', 'w_out', 'h_out', 'theta']
 
     @property
     def bounding_boxes(self):
@@ -374,8 +371,6 @@ class SkyRectangularAperture(SkyAperture):
         self.w = w
         self.h = h
         self.theta = theta
-        self._repr_params = [('w', self.w), ('h', self.h),
-                             ('theta', self.theta)]
         self._params = ['w', 'h', 'theta']
 
     def to_pixel(self, wcs, mode='all'):
@@ -461,8 +456,6 @@ class SkyRectangularAnnulus(SkyAperture):
         self.w_out = w_out
         self.h_out = h_out
         self.theta = theta
-        self._repr_params = [('w_in', self.w_in), ('w_out', self.w_out),
-                             ('h_out', self.h_out), ('theta', self.theta)]
         self._params = ['w_in', 'w_out', 'h_out', 'theta']
 
     def to_pixel(self, wcs, mode='all'):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -12,7 +12,7 @@ from .core import PixelAperture, SkyAperture
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
-from ..utils.wcs_helpers import (skycoord_to_pixel_scale_angle, assert_angle,
+from ..utils.wcs_helpers import (pixel_scale_angle_at_skycoord, assert_angle,
                                  assert_angle_or_pixel)
 
 
@@ -404,11 +404,11 @@ class SkyRectangularAperture(SkyAperture):
         x, y = skycoord_to_pixel(self.positions, wcs, mode=mode)
         central_pos = SkyCoord([wcs.wcs.crval], frame=self.positions.name,
                                unit=wcs.wcs.cunit)
-        xc, yc, scale, angle = skycoord_to_pixel_scale_angle(central_pos, wcs)
+        scale, angle = pixel_scale_angle_at_skycoord(central_pos, wcs)
 
         if self.w.unit.physical_type == 'angle':
-            w = (scale * self.w).to(u.pixel).value
-            h = (scale * self.h).to(u.pixel).value
+            w = (self.w / scale).to(u.pixel).value
+            h = (self.h / scale).to(u.pixel).value
         else:
             # pixels
             w = self.w.value
@@ -506,12 +506,12 @@ class SkyRectangularAnnulus(SkyAperture):
         x, y = skycoord_to_pixel(self.positions, wcs, mode=mode)
         central_pos = SkyCoord([wcs.wcs.crval], frame=self.positions.name,
                                unit=wcs.wcs.cunit)
-        xc, yc, scale, angle = skycoord_to_pixel_scale_angle(central_pos, wcs)
+        scale, angle = pixel_scale_angle_at_skycoord(central_pos, wcs)
 
         if self.w_in.unit.physical_type == 'angle':
-            w_in = (scale * self.w_in).to(u.pixel).value
-            w_out = (scale * self.w_out).to(u.pixel).value
-            h_out = (scale * self.h_out).to(u.pixel).value
+            w_in = (self.w_in / scale).to(u.pixel).value
+            w_out = (self.w_out / scale).to(u.pixel).value
+            h_out = (self.h_out / scale).to(u.pixel).value
         else:
             # pixels
             w_in = self.w_in.value

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -423,8 +423,8 @@ class SkyRectangularAperture(SkyAperture):
 
     def to_pixel(self, wcs, mode='all'):
         """
-        Convert the aperture to a `RectangularAperture` instance in
-        pixel coordinates.
+        Convert the aperture to a `RectangularAperture` object defined
+        in pixel coordinates.
 
         Parameters
         ----------
@@ -508,8 +508,8 @@ class SkyRectangularAnnulus(SkyAperture):
 
     def to_pixel(self, wcs, mode='all'):
         """
-        Convert the aperture to a `RectangularAnnulus` instance in pixel
-        coordinates.
+        Convert the aperture to a `RectangularAnnulus` object defined in
+        pixel coordinates.
 
         Parameters
         ----------

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -861,6 +861,19 @@ def test_to_sky_pixel():
     assert_allclose(ap.b_out, ap2.b_out)
     assert_allclose(ap.theta, ap2.theta)
 
+    ap = RectangularAperture(((12.3, 15.7), (48.19, 98.14)), w=3.14, h=5.32,
+                             theta=103.*np.pi/180.)
+    ap2 = ap.to_sky(wcs).to_pixel(wcs)
+    assert_allclose(ap.positions, ap2.positions)
+    assert_allclose(ap.w, ap2.w)
+    assert_allclose(ap.h, ap2.h)
+    assert_allclose(ap.theta, ap2.theta)
 
-
-
+    ap = RectangularAnnulus(((12.3, 15.7), (48.19, 98.14)), w_in=3.14,
+                            w_out=15.32, h_out=4.89, theta=103.*np.pi/180.)
+    ap2 = ap.to_sky(wcs).to_pixel(wcs)
+    assert_allclose(ap.positions, ap2.positions)
+    assert_allclose(ap.w_in, ap2.w_in)
+    assert_allclose(ap.w_out, ap2.w_out)
+    assert_allclose(ap.h_out, ap2.h_out)
+    assert_allclose(ap.theta, ap2.theta)

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -826,3 +826,41 @@ def test_elliptical_bbox():
 
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.*np.pi/180.)
     assert ap.bounding_boxes[0].shape == (2*a, 2*b)
+
+
+def test_to_sky_pixel():
+    hdu = make_4gaussians_image(hdu=True, wcs=True)
+    wcs = WCS(header=hdu.header)
+
+    ap = CircularAperture(((12.3, 15.7), (48.19, 98.14)), r=3.14)
+    ap2 = ap.to_sky(wcs).to_pixel(wcs)
+    assert_allclose(ap.positions, ap2.positions)
+    assert_allclose(ap.r, ap2.r)
+
+    ap = CircularAnnulus(((12.3, 15.7), (48.19, 98.14)), r_in=3.14,
+                         r_out=5.32)
+    ap2 = ap.to_sky(wcs).to_pixel(wcs)
+    assert_allclose(ap.positions, ap2.positions)
+    assert_allclose(ap.r_in, ap2.r_in)
+    assert_allclose(ap.r_out, ap2.r_out)
+
+    ap = EllipticalAperture(((12.3, 15.7), (48.19, 98.14)), a=3.14, b=5.32,
+                            theta=103.*np.pi/180.)
+    ap2 = ap.to_sky(wcs).to_pixel(wcs)
+    assert_allclose(ap.positions, ap2.positions)
+    assert_allclose(ap.a, ap2.a)
+    assert_allclose(ap.b, ap2.b)
+    assert_allclose(ap.theta, ap2.theta)
+
+    ap = EllipticalAnnulus(((12.3, 15.7), (48.19, 98.14)), a_in=3.14,
+                           a_out=15.32, b_out=4.89, theta=103.*np.pi/180.)
+    ap2 = ap.to_sky(wcs).to_pixel(wcs)
+    assert_allclose(ap.positions, ap2.positions)
+    assert_allclose(ap.a_in, ap2.a_in)
+    assert_allclose(ap.a_out, ap2.a_out)
+    assert_allclose(ap.b_out, ap2.b_out)
+    assert_allclose(ap.theta, ap2.theta)
+
+
+
+

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -645,7 +645,7 @@ def test_pixel_aperture_repr():
     a_repr = ('<EllipticalAnnulus([[10, 20]], a_in=4.0, a_out=8.0, b_out='
               '4.0, theta=15.0)>')
     a_str = ('Aperture: EllipticalAnnulus\npositions: [[10, 20]]\na_in: '
-             '4.0\na_out: 8.0\nb_in: 2.0\nb_out: 4.0\ntheta: 15.0')
+             '4.0\na_out: 8.0\nb_out: 4.0\ntheta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
@@ -661,7 +661,7 @@ def test_pixel_aperture_repr():
     a_repr = ('<RectangularAnnulus([[10, 20]], w_in=4.0, w_out=8.0, '
               'h_out=4.0, theta=15.0)>')
     a_str = ('Aperture: RectangularAnnulus\npositions: [[10, 20]]\n'
-             'w_in: 4.0\nw_out: 8.0\nh_in: 2.0\nh_out: 4.0\ntheta: 15.0')
+             'w_in: 4.0\nw_out: 8.0\nh_out: 4.0\ntheta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 


### PR DESCRIPTION
This PR also centralizes the `to_pixel` calculations in the core `SkyAperture` class.