### PR TITLE
Add Reproject class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - PIP_DEPENDENCIES=''
+        - PIP_DEPENDENCIES='gwcs'
         - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - CONDA_CHANNELS='astropy-ci-extras'
         - SETUP_XVFB=True
@@ -59,9 +59,11 @@ matrix:
         # may run for a long time
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
+               PIP_DEPENDENCIES='gwcs'
                CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib jupyter'
         - os: linux
           env: SETUP_CMD='build_docs -w'
+               PIP_DEPENDENCIES='gwcs'
                CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib jupyter'
                EVENT_TYPE='pull_request push cron'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib"
+      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib gwcs"
 
 
   matrix:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ intersphinx_mapping['astropy'] = ('http://docs.astropy.org/en/latest/', None)
 
 # Extend astropy intersphinx_mapping with packages we use here
 intersphinx_mapping['skimage'] = ('http://scikit-image.org/docs/stable/', None)
-
+intersphinx_mapping['gwcs'] = ('http://gwcs.readthedocs.io/en/latest/', None)
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -14,13 +14,14 @@ from astropy.modeling import Parameter, Fittable2DModel
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import subpixel_indices
 from astropy import wcs as fitswcs
-from gwcs import wcs
 
 from ..utils import mask_to_mirrored_num
 from ..extern.nddata_compat import extract_array
 
 
 __all__ = ['DiscretePRF', 'Reproject']
+
+__doctest_requires__ = {('Reproject'): ['gwcs']}
 
 
 class DiscretePRF(Fittable2DModel):
@@ -311,6 +312,7 @@ class Reproject(object):
         Whether to use 0- or 1-based pixel coordinates.
     """
 
+
     def __init__(self, wcs_original, wcs_rectified):
         self.wcs_original = wcs_original
         self.wcs_rectified = wcs_rectified
@@ -335,25 +337,27 @@ class Reproject(object):
             indexed.
         """
 
+        import gwcs
+
         forward_origin = []
         if isinstance(wcs1, fitswcs.WCS):
             forward = wcs1.all_pix2world
             forward_origin = [0]
-        elif isinstance(wcs2, wcs.WCS):
+        elif isinstance(wcs2, gwcs.wcs.WCS):
             forward = wcs1.forward_transform
         else:
             raise ValueError('wcs1 must be an astropy.wcs.WCS or '
-                             'gwcs.WCS object.')
+                             'gwcs.wcs.WCS object.')
 
         inverse_origin = []
         if isinstance(wcs2, fitswcs.WCS):
             inverse = wcs2.all_world2pix
             inverse_origin = [0]
-        elif isinstance(wcs2, wcs.WCS):
+        elif isinstance(wcs2, gwcs.wcs.WCS):
             inverse = wcs2.forward_transform.inverse
         else:
             raise ValueError('wcs2 must be an astropy.wcs.WCS or '
-                             'gwcs.WCS object.')
+                             'gwcs.wcs.WCS object.')
 
         def _reproject_func(x, y):
             forward_args = [x, y] + forward_origin

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -5,7 +5,9 @@ for prime-time (i.e., is not considered a stable public API), but is
 included either for experimentation or as legacy code.
 """
 
-from __future__ import division
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
 import numpy as np
 from astropy.table import Table
 from astropy.modeling import Parameter, Fittable2DModel
@@ -13,6 +15,7 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import subpixel_indices
 from astropy import wcs as fitswcs
 from gwcs import wcs
+
 from ..utils import mask_to_mirrored_num
 from ..extern.nddata_compat import extract_array
 
@@ -252,9 +255,9 @@ class DiscretePRF(Fittable2DModel):
                 sub_prf_indices = np.all(positions_subpixel_indices == [j, i],
                                          axis=1)
                 if not sub_prf_indices.any():
-                    raise ValueError('The source coordinates do not sample all '
-                                     'sub-pixel positions. Reduce the value '
-                                     'of the subsampling parameter.')
+                    raise ValueError('The source coordinates do not sample '
+                                     'all sub-pixel positions. Reduce the '
+                                     'value of the subsampling parameter.')
 
                 positions_sub_prfs = positions[sub_prf_indices]
                 for k, position in enumerate(positions_sub_prfs):

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -11,11 +11,13 @@ from astropy.table import Table
 from astropy.modeling import Parameter, Fittable2DModel
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import subpixel_indices
+from astropy import wcs as fitswcs
+from gwcs import wcs
 from ..utils import mask_to_mirrored_num
 from ..extern.nddata_compat import extract_array
 
 
-__all__ = ['DiscretePRF']
+__all__ = ['DiscretePRF', 'Reproject']
 
 
 class DiscretePRF(Fittable2DModel):
@@ -289,3 +291,111 @@ class DiscretePRF(Fittable2DModel):
                 prf_model[i, j] = np.ma.getdata(
                     combine(np.ma.dstack(extracted_sub_prfs), axis=2))
         return cls(prf_model, subsampling=subsampling)
+
+
+class Reproject(object):
+    """
+    Class to reproject pixel coordinates between unrectified and
+    rectified images.
+
+    Parameters
+    ----------
+    wcs_original, wcs_rectified : `~astropy.wcs.WCS` or `~gwcs.wcs.WCS`
+        The WCS objects for the original (unrectified) and rectified
+        images.
+
+    origin : {0, 1}
+        Whether to use 0- or 1-based pixel coordinates.
+    """
+
+    def __init__(self, wcs_original, wcs_rectified):
+        self.wcs_original = wcs_original
+        self.wcs_rectified = wcs_rectified
+
+    @staticmethod
+    def _reproject(wcs1, wcs2):
+        """
+        Perform the forward transformation of ``wcs1`` followed by the
+        inverse transformation of ``wcs2``.
+
+        Parameters
+        ----------
+        wcs1, wcs2 : `~astropy.wcs.WCS` or `~gwcs.wcs.WCS`
+            The WCS objects.
+
+        Returns
+        -------
+        result : func
+            Function to compute the transformations.  It takes x, y
+            positions in ``wcs1`` and returns x, y positions in
+            ``wcs2``.  The input and output x, y positions are zero
+            indexed.
+        """
+
+        forward_origin = []
+        if isinstance(wcs1, fitswcs.WCS):
+            forward = wcs1.all_pix2world
+            forward_origin = [0]
+        elif isinstance(wcs2, wcs.WCS):
+            forward = wcs1.forward_transform
+        else:
+            raise ValueError('wcs1 must be an astropy.wcs.WCS or '
+                             'gwcs.WCS object.')
+
+        inverse_origin = []
+        if isinstance(wcs2, fitswcs.WCS):
+            inverse = wcs2.all_world2pix
+            inverse_origin = [0]
+        elif isinstance(wcs2, wcs.WCS):
+            inverse = wcs2.forward_transform.inverse
+        else:
+            raise ValueError('wcs2 must be an astropy.wcs.WCS or '
+                             'gwcs.WCS object.')
+
+        def _reproject_func(x, y):
+            forward_args = [x, y] + forward_origin
+            sky = forward(*forward_args)
+            inverse_args = sky + inverse_origin
+            return inverse(*inverse_args)
+
+        return _reproject_func
+
+    def to_rectified(self, x, y):
+        """
+        Convert the input (x, y) positions from the original
+        (unrectified) image to the rectified image.
+
+        Parameters
+        ----------
+        x, y:  float or array-like of float
+            The zero-index pixel coordinates in the original
+            (unrectified) image.
+
+        Returns
+        -------
+        x, y:  float or array-like
+            The zero-index pixel coordinates in the rectified image.
+        """
+
+        return self._reproject(self.wcs_original,
+                               self.wcs_rectified)(x, y)
+
+    def to_original(self, x, y):
+        """
+        Convert the input (x, y) positions from the rectified image to
+        the original (unrectified) image.
+
+        Parameters
+        ----------
+        x, y:  float or array-like of float
+            The zero-index pixel coordinates in the rectified image.
+
+        Returns
+        -------
+        x, y:  float or array-like
+            The zero-index pixel coordinates in the original
+            (unrectified) image.
+        """
+
+        return self._reproject(self.wcs_rectified,
+                               self.wcs_original)(x, y)


### PR DESCRIPTION
Adds a `Reproject` class to the PSF sandbox for reprojecting pixel coordinates between unrectified and rectified images.