### PR TITLE
remove double colon before doctest-requires

### DIFF
--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -341,7 +341,7 @@ array, which by design doesn't include increased noise on bright
 pixels.  To include Poisson noise from the sources, we can use the
 :func:`~photutils.utils.calc_total_error` function.
 
-Let's assume we we have a background-only image called ``bkg_error``.
+Let's assume we have a background-only image called ``bkg_error``.
 If our data are in units of electrons/s, we would use the exposure
 time as the effective gain::
 

--- a/docs/photutils/detection.rst
+++ b/docs/photutils/detection.rst
@@ -133,7 +133,7 @@ segmentation image or a specified footprint.  Please see the
 options.
 
 As simple example, let's find the local peaks in an image that are 10
-sigma above the background and a separated by a least 2 pixels:
+sigma above the background and a separated by at least 2 pixels:
 
 .. doctest-requires:: skimage
 

--- a/docs/photutils/grouping.rst
+++ b/docs/photutils/grouping.rst
@@ -19,7 +19,7 @@ powerful grouping algorithm to decide whether or not the profile
 of a given star extends into the fitting region around the centroid of any
 other star. This goal is achieved by means of a variable called "critical
 separation", which is defined as the distance such that any two stars
-separated by less than it would be overlapping. Stetson also gives intutive
+separated by less than it would be overlapping. Stetson also gives intuitive
 reasoning to suggest that the critical separation may be defined as the
 product of fwhm with some positive real number.
 

--- a/docs/photutils/morphology.rst
+++ b/docs/photutils/morphology.rst
@@ -34,7 +34,7 @@ First, we create the source image and subtract its background::
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, iters=5)
     >>> data -= median    # subtract background
 
-Then, calculate its properties::
+Then, calculate its properties:
 
 .. doctest-requires:: scipy, skimage
 

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -105,7 +105,7 @@ image, grouping overlapping sources into a single model, fitting the model to th
 sources, and subtracting the models from the image.  In DAOPHOT parlance, this
 is essentially running the "FIND, GROUP, NSTAR, SUBTRACT" once. Because it is
 only a single cycle of that sequence, this class should be used when the degree
-of crowdness of the field is not very high, for instance, when most stars are
+of crowdedness of the field is not very high, for instance, when most stars are
 separated by a distance no less than one FWHM and their brightness are
 relatively uniform.  It is critical to understand, though, that
 `~photutils.psf.BasicPSFPhotometry` does not actually contain the functionality
@@ -279,7 +279,7 @@ Let's then instantiate and use the objects:
     >>> residual_image = photometry.get_residual_image()
 
 Note that the parameters values for the finder class, i.e.,
-`~photutils.detection.IRAFStarFinder`, are completly chosen in an arbitrary
+`~photutils.detection.IRAFStarFinder`, are completely chosen in an arbitrary
 manner and optimum values do vary according to the data.
 
 As mentioned before, the way to actually do the photometry is by using
@@ -492,7 +492,7 @@ possible example of this feature. (For actual PSF photometry of stars you would
 *not* want to do this, because you the shape of the PSF should be set by bright
 stars or an optical model and held fixed when fitting.)
 
-First, let us instantiate a psf model object:
+First, let us instantiate a PSF model object:
 
 .. doctest-skip::
 
@@ -506,7 +506,7 @@ Let's first change this behavior:
 
     >>> gaussian_prf.sigma.fixed = False
 
-In addition, we need to indicate the inital guess which will be used in during
+In addition, we need to indicate the initial guess which will be used in during
 the fitting process. By the default, the initial guess is taken as the default
 value of ``sigma``, but we can change that by doing:
 
@@ -554,7 +554,7 @@ star as well. Also, note that both of the stars have ``sigma=2.0``.
     plt.imshow(image, cmap='viridis', aspect=1, interpolation='nearest',
                origin='lower', norm=LogNorm(vmin=vmin, vmax=vmax))
 
-Let's instantiate the necessary objetcs in order to use an
+Let's instantiate the necessary objects in order to use an
 `~photutils.psf.IterativelySubtractedPSFPhotometry` to perform photometry:
 
 .. doctest-requires:: scipy


### PR DESCRIPTION
  This prevents the `.. doctest-requires:: scipy, skimage` directive to appear as a code block in the HTML documentation.