### PR TITLE
Deprecate unused interpolate_masked_data function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,10 @@ API changes
   - Removed the ``pixelwise_errors`` keyword from
     ``aperture_photometry``. [#489]
 
+- ``photutils.utils``
+
+  - Deprecated unused ``interpolate_masked_data()``. [#526]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/extern/decorators.py
+++ b/photutils/extern/decorators.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 
 import functools
 import warnings
-import inspect
 
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -2,23 +2,18 @@
 """
 Models for doing PSF/PRF fitting photometry on image data.
 """
-
 from __future__ import division
+
 import warnings
-import numpy as np
 import copy
-from astropy.table import Table
+
+import numpy as np
 from astropy.modeling import models, Parameter, Fittable2DModel
-from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.nddata.utils import subpixel_indices
 from astropy.utils.exceptions import AstropyWarning
-from ..utils import mask_to_mirrored_num
-from ..extern.nddata_compat import extract_array
 
 __all__ = ['FittableImageModel', 'NonNormalizable',
            'IntegratedGaussianPRF', 'PRFAdapter',
            'prepare_psf_model', 'get_grouped_psf_model']
-
 
 try:
     import scipy

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -132,7 +132,6 @@ class BasicPSFPhotometry(object):
         self._pars_to_output = None
         self._residual_image = None
 
-
     @property
     def fitshape(self):
         return self._fitshape
@@ -382,7 +381,7 @@ class BasicPSFPhotometry(object):
         xname, yname, fluxname = _extract_psf_fitting_names(self.psf_model)
         self._pars_to_set = {'x_0': xname, 'y_0': yname, 'flux_0': fluxname}
         self._pars_to_output = {'x_fit': xname, 'y_fit': yname,
-                'flux_fit': fluxname}
+                                'flux_fit': fluxname}
 
         for p, isfixed in self.psf_model.fixed.items():
             p0 = p + '_0'
@@ -520,7 +519,6 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
                 bkg_estimator, psf_model, fitshape, finder, fitter, aperture_radius)
         self.niters = niters
 
-
     @property
     def niters(self):
         return self._niters
@@ -594,7 +592,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
 
         if init_guesses is not None:
             table = super(IterativelySubtractedPSFPhotometry,
-                self).do_photometry(image, init_guesses)
+                          self).do_photometry(image, init_guesses)
             table['iter_detected'] = np.ones(table['x_fit'].shape,
                                              dtype=np.int32)
 

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -312,7 +312,6 @@ class Reproject(object):
         Whether to use 0- or 1-based pixel coordinates.
     """
 
-
     def __init__(self, wcs_original, wcs_rectified):
         self.wcs_original = wcs_original
         self.wcs_rectified = wcs_rectified

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -22,8 +22,7 @@ from ..photometry import DAOPhotPSFPhotometry, IterativelySubtractedPSFPhotometr
 from ..photometry import BasicPSFPhotometry
 from ..sandbox import DiscretePRF
 from ...background import SigmaClip, MedianBackground, StdBackgroundRMS
-from ...background import MedianBackground, MMMBackground, SigmaClip
-from ...background import StdBackgroundRMS
+from ...background import MMMBackground
 from ...datasets import make_gaussian_sources
 from ...datasets import make_noise_image
 from ...detection import DAOStarFinder

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 
 import numpy as np
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 
@@ -285,6 +286,7 @@ class ShepardIDWInterpolator(object):
             return interp_values
 
 
+@deprecated('0.4')
 def interpolate_masked_data(data, mask, error=None, background=None):
     """
     Interpolate over masked pixels in data and optional error or

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -2,9 +2,12 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import warnings
+
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .. import ShepardIDWInterpolator as idw
 from .. import interpolate_masked_data, mask_to_mirrored_num
@@ -111,6 +114,13 @@ class TestShepardIDWInterpolator(object):
 
 
 class TestInterpolateMaskedData(object):
+    def setup_class(cls):
+        """Ignore all deprecation warnings here."""
+        warnings.simplefilter('ignore', AstropyDeprecationWarning)
+
+    def teardown_class(cls):
+        warnings.resetwarnings()
+
     def test_mask_shape(self):
         with pytest.raises(ValueError):
             interpolate_masked_data(DATA, WRONG_SHAPE)


### PR DESCRIPTION
Deprecate `interpolate_masked_data()`. Minor PEP8 fixes for the rest.

See https://github.com/astropy/photutils/pull/525#discussion_r108764307