### PR TITLE
Remove background_color keyword from random_cmap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,11 @@ API changes
   - The ``unit``, ``hdu``, ``wcs``, and ``wcsheader`` keywords in
     ``photutils.datasets`` functions were removed. [#527]
 
+- ``photutils.utils``
+
+  - The ``background_color`` keyword was removed from the
+    ``random_cmap`` function. [#528]
+
 
 Bug Fixes
 ^^^^^^^^^

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -230,7 +230,7 @@ class SegmentationImage(object):
             raise ValueError('label "{0}" is not in the segmentation '
                              'image'.format(label))
 
-    def cmap(self, background_color='black', random_state=None):
+    def cmap(self, background_color='#000000', random_state=None):
         """
         A matplotlib colormap consisting of random (muted) colors.
 
@@ -238,10 +238,11 @@ class SegmentationImage(object):
 
         Parameters
         ----------
-        background_color : str, optional
-            The name of the background (first) color in the colormap.
-            Valid colors names are defined by
-            ``matplotlib.colors.cnames``.  The default is ``'black'``.
+        background_color : str or `None`, optional
+            A hex string in the "#rrggbb" format defining the first
+            color in the colormap.  This color will be used as the
+            background color (label = 0) when plotting the segmentation
+            image.  The default is black.
 
         random_state : int or `~numpy.random.RandomState`, optional
             The pseudo-random number generator state used for random
@@ -249,8 +250,14 @@ class SegmentationImage(object):
             ``random_state`` will generate the same colormap.
         """
 
-        return random_cmap(self.max + 1, background_color=background_color,
-                           random_state=random_state)
+        from matplotlib import colors
+
+        cmap = random_cmap(self.max + 1, random_state=random_state)
+
+        if background_color is not None:
+            cmap.colors[0] = colors.hex2color(background_color)
+
+        return cmap
 
     def outline_segments(self, mask_background=False):
         """

--- a/photutils/utils/colormaps.py
+++ b/photutils/utils/colormaps.py
@@ -10,7 +10,7 @@ from .check_random_state import check_random_state
 __all__ = ['random_cmap']
 
 
-def random_cmap(ncolors=256, background_color='black', random_state=None):
+def random_cmap(ncolors=256, random_state=None):
     """
     Generate a matplotlib colormap consisting of random (muted) colors.
 
@@ -19,14 +19,7 @@ def random_cmap(ncolors=256, background_color='black', random_state=None):
     Parameters
     ----------
     ncolors : int, optional
-        The number of colors in the colormap.  For use with segmentation
-        images, ``ncolors`` should be set to the number of labels.  The
-        default is 256.
-
-    background_color : str, optional
-        The name of the background (first) color in the colormap.  Valid
-        colors names are defined by ``matplotlib.colors.cnames``.  The
-        default is ``'black'``.
+        The number of colors in the colormap.  The default is 256.
 
     random_state : int or `~numpy.random.RandomState`, optional
         The pseudo-random number generator state used for random
@@ -47,11 +40,5 @@ def random_cmap(ncolors=256, background_color='black', random_state=None):
     v = prng.uniform(low=0.5, high=1.0, size=ncolors)
     hsv = np.dstack((h, s, v))
     rgb = np.squeeze(colors.hsv_to_rgb(hsv))
-
-    if background_color is not None:
-        if background_color not in colors.cnames:
-            raise ValueError('"{0}" is not a valid background color '
-                             'name'.format(background_color))
-        rgb[0] = colors.hex2color(colors.cnames[background_color])
 
     return colors.ListedColormap(rgb)

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 
 from ..colormaps import random_cmap
@@ -15,17 +16,7 @@ except ImportError:
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_colormap():
-    cmap = random_cmap(100, random_state=12345)
-    assert cmap(0) == (0., 0., 0., 1.0)
-
-
-@pytest.mark.skipif('not HAS_MATPLOTLIB')
-def test_colormap_background():
-    cmap = random_cmap(100, background_color='white', random_state=12345)
-    assert cmap(0) == (1., 1., 1., 1.0)
-
-
-@pytest.mark.skipif('not HAS_MATPLOTLIB')
-def test_invalid_background():
-    with pytest.raises(ValueError):
-        random_cmap(100, background_color='invalid', random_state=12345)
+    ncolors = 100
+    cmap = random_cmap(ncolors, random_state=12345)
+    assert len(cmap.colors) == ncolors
+    assert_allclose(cmap.colors[0], [0.9234715, 0.64837165, 0.76454726])


### PR DESCRIPTION
`random_cmap` can now be used more generally, while the `background_color` option is reserved for the `SegmentationImage.cmap()` method.