### PR TITLE
Add scikit-learn as optional dependency

### DIFF
--- a/docs/photutils/install.rst
+++ b/docs/photutils/install.rst
@@ -20,6 +20,8 @@ optional dependencies are installed:
 
 * `scikit-image`_ 0.11 or later
 
+* `scikit-learn <http://scikit-learn.org/>`_ 0.18 or later
+
 * `matplotlib <http://matplotlib.org/>`_ 1.3 or later
 
 .. warning::


### PR DESCRIPTION
`DBSCANGroup` requires `scikit-learn` as an optional dependency, which is now noted in the installation docs.