### PR TITLE
Remove numpy 1.8 and python 3.3 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ env:
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
@@ -83,8 +82,6 @@ matrix:
         # the Numpy developers have taken care of testing Numpy with different
         # versions of Python, we can vary Python and Numpy versions at the same
         # time.
-        - os: linux
-          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
         - os: linux
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 General
 ^^^^^^^
 
+- Dropped python 3.3 support. [#542]
+
+- Dropped numpy 1.8 support. Minimal required version is now numpy
+  1.9. [#542]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/photutils/install.rst
+++ b/docs/photutils/install.rst
@@ -7,9 +7,9 @@ Requirements
 
 Photutils has the following strict requirements:
 
-* `Python <http://www.python.org/>`_ 2.7, 3.3, 3.4, 3.5 or 3.6
+* `Python <http://www.python.org/>`_ 2.7, 3.4, 3.5 or 3.6
 
-* `Numpy <http://www.numpy.org/>`_ 1.8 or later
+* `Numpy <http://www.numpy.org/>`_ 1.9 or later
 
 * `Astropy`_ 1.0 or later
 


### PR DESCRIPTION
I still have check whether we have any workaround, but opening this nevertheless to keep this in out mind.