### PR TITLE
Background2D improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,11 @@ New Features
 
   - Added a ``to_sky`` method for pixel apertures. [#512]
 
+- ``photutils.background``
+
+  - Mesh rejection now also applies to pixels that are masked during
+    sigma clipping. [#544]
+
 - ``photutils.datasets``
 
   - Added new ``make_wcs`` and ``make_imagehdu`` functions. [#527]
@@ -46,6 +51,12 @@ API changes
 
   - Removed the ``pixelwise_errors`` keyword from
     ``aperture_photometry``. [#489]
+
+- ``photutils.background``
+
+  - The ``Background2D`` keywords ``exclude_mesh_method`` and
+    ``exclude_mesh_percentile`` were removed in favor of a single
+    keyword called ``exclude_percentile``. [#544]
 
 - ``photutils.datasets``
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -194,28 +194,21 @@ class Background2D(object):
         value indicates the corresponding element of ``data`` is masked.
         Masked data are excluded from calculations.
 
-    exclude_mesh_method : {'threshold', 'any', 'all'}, optional
-        The method used to determine whether to exclude a particular
-        mesh based on the number of masked pixels it contains in the
-        input (e.g. source) ``mask`` or padding mask (if
-        ``edge_method='pad'``):
-
-            * ``'threshold'``:  exclude meshes that contain greater than
-              ``exclude_mesh_percentile`` percent masked pixels.  This is
-              the default.
-            * ``'any'``:  exclude meshes that contain any masked pixels.
-            * ``'all'``:  exclude meshes that are completely masked.
-
-    exclude_mesh_percentile : float in the range of [0, 100], optional
-        The percentile of masked pixels in a mesh used as a threshold
-        for determining if the mesh is excluded.  If
-        ``exclude_mesh_method='threshold'``, then meshes that contain
-        greater than ``exclude_mesh_percentile`` percent masked pixels
-        are excluded.  This parameter is used only if
-        ``exclude_mesh_method='threshold'``.  The default is 10.  For
-        best results, ``exclude_mesh_percentile`` should be kept as low
-        as possible (i.e, as long as there are sufficient pixels for
-        reasonable statistical estimates).
+    exclude_percentile : float in the range of [0, 100], optional
+        The percentage of masked pixels in a mesh, used as a threshold
+        for determining if the mesh is excluded.  If a mesh has more
+        than ``exclude_percentile`` percent of its pixels masked then it
+        will be excluded from the low-resolution map.  Masked pixels
+        include those from the input ``mask``, those resulting from the
+        data padding (i.e. if ``edge_method='pad'``), and those
+        resulting from any sigma clipping (i.e. if ``sigma_clip`` is
+        used).  Setting ``exclude_percentile=0`` will exclude meshes
+        that have any masked pixels.  Setting ``exclude_percentile=100``
+        will only exclude meshes that are completely masked.  Note that
+        completely masked meshes are *always* excluded.  For best
+        results, ``exclude_percentile`` should be kept as low as
+        possible (as long as there are sufficient pixels for reasonable
+        statistical estimates).  The default is 10.
 
     filter_size : int or array_like (int), optional
         The window size of the 2D median filter to apply to the
@@ -288,9 +281,9 @@ class Background2D(object):
     """
 
     def __init__(self, data, box_size, mask=None,
-                 exclude_mesh_method='threshold', exclude_mesh_percentile=10.,
-                 filter_size=(3, 3), filter_threshold=None,
-                 edge_method='pad', sigma_clip=SigmaClip(sigma=3., iters=10),
+                 exclude_percentile=10., filter_size=(3, 3),
+                 filter_threshold=None, edge_method='pad',
+                 sigma_clip=SigmaClip(sigma=3., iters=10),
                  bkg_estimator=SExtractorBackground(sigma_clip=None),
                  bkgrms_estimator=StdBackgroundRMS(sigma_clip=None),
                  interpolator=BkgZoomInterpolator()):
@@ -309,14 +302,13 @@ class Background2D(object):
             if mask.shape != data.shape:
                 raise ValueError('mask and data must have the same shape')
 
-        if exclude_mesh_percentile < 0 or exclude_mesh_percentile > 100:
-            raise ValueError('exclude_mesh_percentile must be between 0 and '
-                             '100 (inclusive).')
+        if exclude_percentile < 0 or exclude_percentile > 100:
+            raise ValueError('exclude_percentile must be between 0 and 100 '
+                             '(inclusive).')
 
         self.data = data
         self.mask = mask
-        self.exclude_mesh_method = exclude_mesh_method
-        self.exclude_mesh_percentile = exclude_mesh_percentile
+        self.exclude_percentile = exclude_percentile
 
         filter_size = np.atleast_1d(filter_size)
         if len(filter_size) == 1:
@@ -417,9 +409,8 @@ class Background2D(object):
         mesh image of the meshes to use for the background
         interpolation.
 
-        The ``exclude_mesh_method`` and ``exclude_mesh_percentile``
-        keywords determine which meshes are not used for the background
-        interpolation.
+        The ``exclude_percentile`` keyword determines which meshes are
+        not used for the background interpolation.
 
         Parameters
         ----------
@@ -436,39 +427,22 @@ class Background2D(object):
         # the number of masked pixels in each mesh
         nmasked = np.ma.count_masked(data, axis=1)
 
-        if self.exclude_mesh_method == 'any':
-            # keep meshes that do not have any masked pixels
-            mesh_idx = np.where(nmasked == 0)[0]
-            if len(mesh_idx) == 0:
-                raise ValueError('All meshes contain at least one masked '
-                                 'pixel.  Please check your data or try '
-                                 'an alternate exclude_mesh_method option.')
+        # meshes that contain more than ``exclude_percentile`` percent
+        # masked pixels are excluded:
+        #   - for exclude_percentile=0, good meshes will be only where
+        #     nmasked=0
+        #   - meshes where nmasked=self.box_npixels are *always* excluded
+        #     (second conditional needed for exclude_percentile=100)
+        threshold_npixels = self.exclude_percentile / 100. * self.box_npixels
+        mesh_idx = np.where((nmasked <= threshold_npixels) &
+                            (nmasked != self.box_npixels))[0]    # good meshes
 
-        elif self.exclude_mesh_method == 'all':
-            # keep meshes that are not completely masked
-            mesh_idx = np.where((self.box_npixels - nmasked) != 0)[0]
-            if len(mesh_idx) == 0:
-                raise ValueError('All meshes are completely masked.  '
-                                 'Please check your data or try an '
-                                 'alternate exclude_mesh_method option.')
-
-        elif self.exclude_mesh_method == 'threshold':
-            # keep meshes only with at least ``exclude_mesh_percentile``
-            # unmasked pixels
-            threshold_npixels = (self.exclude_mesh_percentile / 100. *
-                                 self.box_npixels)
-            mesh_idx = np.where((self.box_npixels - nmasked) >=
-                                threshold_npixels)[0]
-            if len(mesh_idx) == 0:
-                raise ValueError('All meshes contain < {0} ({1} percent per '
-                                 'mesh) unmasked pixels.  Please check your '
-                                 'data or decrease "exclude_mesh_percentile".'
-                                 .format(threshold_npixels,
-                                         self.exclude_mesh_percentile))
-
-        else:
-            raise ValueError('exclude_mesh_method must be "any", "all", or '
-                             '"threshold".')
+        if len(mesh_idx) == 0:
+            raise ValueError('All meshes contain > {0} ({1} percent per '
+                             'mesh) masked pixels.  Please check your data '
+                             'or decrease "exclude_percentile".'
+                             .format(threshold_npixels,
+                                     self.exclude_percentile))
 
         return mesh_idx
 
@@ -538,7 +512,7 @@ class Background2D(object):
         if data.shape != self.mesh_idx.shape:
             raise ValueError('data and mesh_idx must have the same shape')
 
-        data2d = np.zeros(self._mesh_shape)
+        data2d = np.zeros(self._mesh_shape).astype(data.dtype)
         mask2d = np.ones(data2d.shape).astype(np.bool)
         data2d[self.mesh_yidx, self.mesh_xidx] = data
         mask2d[self.mesh_yidx, self.mesh_xidx] = False
@@ -687,21 +661,26 @@ class Background2D(object):
         self.mesh_yidx, self.mesh_xidx = np.unravel_index(self.mesh_idx,
                                                           self._mesh_shape)
 
-        # needed for background_mesh_ma and background_rms_mesh_ma
-        # properties
+        # These properties are needed later to calculate
+        # background_mesh_ma and background_rms_mesh_ma.  Note that bkg1d
+        # and bkgrms1d are masked arrays, but the mask should always be
+        # False.
         self.bkg1d = self.bkg_estimator(self._data_sigclip, axis=1)
         self.bkgrms1d = self.bkgrms_estimator(self._data_sigclip, axis=1)
 
-        # make the 2D mesh arrays
+        # make the unfiltered 2D mesh arrays
         if len(self.bkg1d) == self.nboxes:
+            # these are 2D masked arrays
             bkg = self._make_2d_array(self.bkg1d)
             bkgrms = self._make_2d_array(self.bkgrms1d)
         else:
+            # these are 2D ndarrays (not masked; masked regions were
+            # interpolated)
             bkg = self._interpolate_meshes(self.bkg1d)
             bkgrms = self._interpolate_meshes(self.bkgrms1d)
 
-        self.background_mesh_prefiltered = bkg
-        self.background_rms_mesh_prefiltered = bkgrms
+        self.background_mesh_unfiltered = bkg
+        self.background_rms_mesh_unfiltered = bkgrms
         self.background_mesh = bkg
         self.background_rms_mesh = bkgrms
 
@@ -736,13 +715,13 @@ class Background2D(object):
     @lazyproperty
     def mesh_nmasked(self):
         """
-        A 2D (masked) array of the number of masked pixels in each mesh.
+        A 2D masked array of the number of masked pixels in each mesh.
         Only meshes included in the background estimation are included.
         Excluded meshes will be masked in the image.
         """
 
-        return self._make_2d_array(np.ma.count_masked(self._data_sigclip,
-                                                      axis=1))
+        return self._make_2d_array(
+            np.ma.count_masked(self._data_sigclip, axis=1))
 
     @lazyproperty
     def background_mesh_ma(self):

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -505,6 +505,8 @@ class Background2D(object):
             else:
                 raise ValueError('edge_method must be "pad" or "crop"')
 
+        self.nboxes = self.nxboxes * self.nyboxes
+
         # a reshaped 2D array with mesh data along the x axis
         mesh_data = np.ma.swapaxes(data_ma.reshape(
             self.nyboxes, self.box_size[0], self.nxboxes, self.box_size[1]),
@@ -685,7 +687,7 @@ class Background2D(object):
         self.bkgrms1d = self.bkgrms_estimator(data_sigclip, axis=1)
 
         # make the 2D mesh arrays
-        if len(self.bkg1d) == (self.nxboxes * self.nyboxes):
+        if len(self.bkg1d) == self.nboxes:
             bkg = self._make_2d_array(self.bkg1d)
             bkgrms = self._make_2d_array(self.bkgrms1d)
         else:
@@ -740,7 +742,7 @@ class Background2D(object):
         The background 2D (masked) array mesh prior to any interpolation.
         """
 
-        if len(self.bkg1d) == (self.nxboxes * self.nyboxes):
+        if len(self.bkg1d) == self.nboxes:
             return self.background_mesh
         else:
             return self._make_2d_array(self.bkg1d)
@@ -751,7 +753,7 @@ class Background2D(object):
         The background RMS 2D (masked) array mesh prior to any interpolation.
         """
 
-        if len(self.bkg1d) == (self.nxboxes * self.nyboxes):
+        if len(self.bkg1d) == self.nboxes:
             return self.background_rms_mesh
         else:
             return self._make_2d_array(self.bkgrms1d)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -507,7 +507,7 @@ class Background2D(object):
 
         self.nboxes = self.nxboxes * self.nyboxes
 
-        # a reshaped 2D array with mesh data along the x axis
+        # a reshaped 2D masked array with mesh data along the x axis
         mesh_data = np.ma.swapaxes(data_ma.reshape(
             self.nyboxes, self.box_size[0], self.nxboxes, self.box_size[1]),
             1, 2).reshape(self.nyboxes * self.nxboxes, self.box_npixels)
@@ -675,7 +675,7 @@ class Background2D(object):
             data_sigclip = self.sigma_clip(self.mesh_data, axis=1)
         else:
             data_sigclip = self.mesh_data
-        self._data_sigclip = data_sigclip
+        self._data_sigclip = data_sigclip     # always 2D masked array
 
         self._mesh_shape = (self.nyboxes, self.nxboxes)
         self.mesh_yidx, self.mesh_xidx = np.unravel_index(self.mesh_idx,
@@ -694,6 +694,8 @@ class Background2D(object):
             bkg = self._interpolate_meshes(self.bkg1d)
             bkgrms = self._interpolate_meshes(self.bkgrms1d)
 
+        self.background_mesh_prefiltered = bkg
+        self.background_rms_mesh_prefiltered = bkgrms
         self.background_mesh = bkg
         self.background_rms_mesh = bkgrms
 


### PR DESCRIPTION
Prompted by #543, this PR improves the mesh rejection algorithm such that it now also applies to any pixels rejected from sigma clipping.  Previously the mesh rejection applied only to the input `mask` array.  This PR also simplifies the API by combining the functionality of the `exclude_mesh_method` and`exclude_mesh_percentile` keywords into a single `exclude_percentile` keyword.  A few tests were also added to increase test coverage.