### PR TITLE
Rename BiweightMidvarianceBackgroundRMS to BiweightScaleBackgroundRMS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ API changes
     ``exclude_mesh_percentile`` were removed in favor of a single
     keyword called ``exclude_percentile``. [#544]
 
+  - Renamed ``BiweightMidvarianceBackgroundRMS`` to
+    ``BiweightScaleBackgroundRMS``. [#547]
+
 - ``photutils.datasets``
 
   - The ``make_poission_noise`` function was renamed to

--- a/docs/photutils/background.rst
+++ b/docs/photutils/background.rst
@@ -38,10 +38,9 @@ biased by the presence of real sources.
 
 A slightly better method involves using statistics that are robust
 against the presence of outliers, such as the biweight location for
-the background level and biweight midvariance or `median absolute
-deviation (MAD)
-<http://en.wikipedia.org/wiki/Median_absolute_deviation>`_ for the
-background noise estimation. However, for most astronomical scenes
+the background level and biweight scale or `median absolute deviation
+(MAD) <http://en.wikipedia.org/wiki/Median_absolute_deviation>`_ for
+the background noise estimation. However, for most astronomical scenes
 these methods will also be biased by the presence of astronomical
 sources in the image.
 
@@ -82,13 +81,11 @@ background level of 5::
     >>> print(biweight_location(data))
     5.1867597555
 
-Similarly, using the biweight midvariance and median absolute
-deviation to estimate the background noise level give values that are
-larger than the true value of 2::
+Similarly, using the median absolute deviation to estimate the
+background noise level gives a value that is larger than the true
+value of 2::
 
-    >>> from astropy.stats import biweight_midvariance, mad_std
-    >>> print(biweight_midvariance(data))
-    2.22011175104
+    >>> from astropy.stats import mad_std
     >>> print(mad_std(data))    # doctest: +FLOAT_CMP
     2.1443728009
 
@@ -195,7 +192,7 @@ keyword.  Photutils provides the following classes for this purpose:
 
 * `~photutils.background.StdBackgroundRMS`
 * `~photutils.background.MADStdBackgroundRMS`
-* `~photutils.background.BiweightMidvarianceBackgroundRMS`
+* `~photutils.background.BiweightScaleBackgroundRMS`
 
 For even more flexibility, users may input a custom function or
 callable object to the ``bkg_estimator`` and/or ``bkgrms_estimator``

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -12,17 +12,17 @@ import abc
 
 import numpy as np
 from astropy.extern import six
+from astropy.stats import sigma_clip, mad_std
 from astropy.utils.misc import InheritDocstrings
 
-from ..extern.sigma_clipping import sigma_clip
-from ..extern.stats import mad_std, biweight_location, biweight_midvariance
+from ..extern.biweight import biweight_location, biweight_scale
 
 
 __all__ = ['SigmaClip', 'BackgroundBase', 'BackgroundRMSBase',
            'MeanBackground', 'MedianBackground', 'ModeEstimatorBackground',
            'MMMBackground', 'SExtractorBackground',
            'BiweightLocationBackground', 'StdBackgroundRMS',
-           'MADStdBackgroundRMS', 'BiweightMidvarianceBackgroundRMS']
+           'MADStdBackgroundRMS', 'BiweightScaleBackgroundRMS']
 
 
 def _masked_median(data, axis=None):
@@ -615,10 +615,10 @@ class MADStdBackgroundRMS(BackgroundRMSBase):
         return mad_std(data, axis=axis)
 
 
-class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase):
+class BiweightScaleBackgroundRMS(BackgroundRMSBase):
     """
     Class to calculate the background RMS in an array as the
-    (sigma-clipped) biweight midvariance.
+    (sigma-clipped) biweight scale.
 
     Parameters
     ----------
@@ -635,10 +635,10 @@ class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase):
 
     Examples
     --------
-    >>> from photutils import SigmaClip, BiweightMidvarianceBackgroundRMS
+    >>> from photutils import SigmaClip, BiweightScaleBackgroundRMS
     >>> data = np.arange(100)
     >>> sigma_clip = SigmaClip(sigma=3.)
-    >>> bkgrms = BiweightMidvarianceBackgroundRMS(sigma_clip=sigma_clip)
+    >>> bkgrms = BiweightScaleBackgroundRMS(sigma_clip=sigma_clip)
 
     The background RMS value can be calculated by using the
     `calc_background_rms` method, e.g.:
@@ -656,7 +656,7 @@ class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase):
     """
 
     def __init__(self, c=9.0, M=None, **kwargs):
-        super(BiweightMidvarianceBackgroundRMS, self).__init__(**kwargs)
+        super(BiweightScaleBackgroundRMS, self).__init__(**kwargs)
         self.c = c
         self.M = M
 
@@ -664,4 +664,4 @@ class BiweightMidvarianceBackgroundRMS(BackgroundRMSBase):
         if self.sigma_clip is not None:
             data = self.sigma_clip(data, axis=axis)
 
-        return biweight_midvariance(data, c=self.c, M=self.M, axis=axis)
+        return biweight_scale(data, c=self.c, M=self.M, axis=axis)

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -12,10 +12,11 @@ import abc
 
 import numpy as np
 from astropy.extern import six
-from astropy.stats import sigma_clip, mad_std
+from astropy.stats import mad_std
 from astropy.utils.misc import InheritDocstrings
 
 from ..extern.biweight import biweight_location, biweight_scale
+from ..extern.sigma_clipping import sigma_clip
 
 
 __all__ = ['SigmaClip', 'BackgroundBase', 'BackgroundRMSBase',

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -12,10 +12,10 @@ import abc
 
 import numpy as np
 from astropy.extern import six
-from astropy.stats import mad_std
 from astropy.utils.misc import InheritDocstrings
 
 from ..extern.biweight import biweight_location, biweight_scale
+from ..extern.stats import mad_std
 from ..extern.sigma_clipping import sigma_clip
 
 

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -11,7 +11,7 @@ from ..core import (SigmaClip, MeanBackground, MedianBackground,
                     ModeEstimatorBackground, MMMBackground,
                     SExtractorBackground, BiweightLocationBackground,
                     StdBackgroundRMS, MADStdBackgroundRMS,
-                    BiweightMidvarianceBackgroundRMS)
+                    BiweightScaleBackgroundRMS)
 
 
 BKG = 0.0
@@ -26,7 +26,7 @@ BKG_CLASS0 = [MeanBackground, MedianBackground, ModeEstimatorBackground,
 BKG_CLASS = BKG_CLASS0 + [BiweightLocationBackground]
 
 RMS_CLASS = [StdBackgroundRMS, MADStdBackgroundRMS,
-             BiweightMidvarianceBackgroundRMS]
+             BiweightScaleBackgroundRMS]
 
 SIGMA_CLIP = SigmaClip(sigma=3.)
 

--- a/photutils/extern/biweight.py
+++ b/photutils/extern/biweight.py
@@ -1,0 +1,308 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module contains functions for computing robust statistics using
+Tukey's biweight function.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+from astropy.stats import median_absolute_deviation
+
+
+def biweight_location(data, c=6.0, M=None, axis=None):
+    r"""
+    Compute the biweight location.
+
+    The biweight location is a robust statistic for determining the
+    central location of a distribution.  It is given by:
+
+    .. math::
+
+        \zeta_{biloc}= M + \frac{\Sigma_{|u_i|<1} \ (x_i - M) (1 - u_i^2)^2}
+            {\Sigma_{|u_i|<1} \ (1 - u_i^2)^2}
+
+    where :math:`x` is the input data, :math:`M` is the sample median
+    (or the input initial location guess) and :math:`u_i` is given by:
+
+    .. math::
+
+        u_{i} = \frac{(x_i - M)}{c * MAD}
+
+    where :math:`c` is the tuning constant and :math:`MAD` is the
+    `median absolute deviation
+    <https://en.wikipedia.org/wiki/Median_absolute_deviation>`_.  The
+    biweight location tuning constant ``c`` is typically 6.0 (the
+    default).
+
+    Parameters
+    ----------
+    data : array-like
+        Input array or object that can be converted to an array.
+    c : float, optional
+        Tuning constant for the biweight estimator (default = 6.0).
+    M : float or array-like, optional
+        Initial guess for the location.  If ``M`` is a scalar value,
+        then its value will be used for the entire array (or along each
+        ``axis``, if specified).  If ``M`` is an array, then its must be
+        an array containing the initial location estimate along each
+        ``axis`` of the input array.  If `None` (default), then the
+        median of the input array will be used (or along each ``axis``,
+        if specified).
+    axis : int, optional
+        The axis along which the biweight locations are computed.  If
+        `None` (default), then the biweight location of the flattened
+        input array will be computed.
+
+    Returns
+    -------
+    biweight_location : float or `~numpy.ndarray`
+        The biweight location of the input data.  If ``axis`` is `None`
+        then a scalar will be returned, otherwise a `~numpy.ndarray`
+        will be returned.
+
+    References
+    ----------
+    .. [1] Beers, Flynn, and Gebhardt (1990; AJ 100, 32) (http://adsabs.harvard.edu/abs/1990AJ....100...32B)
+
+    .. [2] http://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/biwloc.htm
+    """
+
+    data = np.asanyarray(data)
+
+    if M is None:
+        M = np.median(data, axis=axis)
+    if axis is not None:
+        M = np.expand_dims(M, axis=axis)
+
+    # set up the differences
+    d = data - M
+
+    # set up the weighting
+    mad = median_absolute_deviation(data, axis=axis)
+    if axis is not None:
+        mad = np.expand_dims(mad, axis=axis)
+    u = d / (c * mad)
+
+    # now remove the outlier points
+    mask = (np.abs(u) >= 1)
+    u = (1 - u ** 2) ** 2
+    u[mask] = 0
+
+    return M.squeeze() + (d * u).sum(axis=axis) / u.sum(axis=axis)
+
+
+def biweight_scale(data, c=9.0, M=None, axis=None, modify_sample_size=False):
+    r"""
+    Compute the biweight scale.
+
+    The biweight scale is a robust statistic for determining the
+    standard deviation of a distribution.  It is the square root of the
+    `biweight midvariance
+    <https://en.wikipedia.org/wiki/Robust_measures_of_scale#The_biweight_midvariance>`_.
+    It is given by:
+
+    .. math::
+
+        \zeta_{biscl} = \sqrt{n} \ \frac{\sqrt{\Sigma_{|u_i| < 1} \
+            (x_i - M)^2 (1 - u_i^2)^4}} {|(\Sigma_{|u_i| < 1} \
+            (1 - u_i^2) (1 - 5u_i^2))|}
+
+    where :math:`x` is the input data, :math:`M` is the sample median
+    (or the input location) and :math:`u_i` is given by:
+
+    .. math::
+
+        u_{i} = \frac{(x_i - M)}{c * MAD}
+
+    where :math:`c` is the tuning constant and :math:`MAD` is the
+    `median absolute deviation
+    <https://en.wikipedia.org/wiki/Median_absolute_deviation>`_.  The
+    biweight midvariance tuning constant ``c`` is typically 9.0 (the
+    default).
+
+    For the standard definition of biweight scale, :math:`n` is the
+    total number of points in the array (or along the input ``axis``, if
+    specified).  That definition is used if ``modify_sample_size`` is
+    `False`, which is the default.
+
+    However, if ``modify_sample_size = True``, then :math:`n` is the
+    number of points for which :math:`|u_i| < 1` (i.e. the total number
+    of non-rejected values), i.e.
+
+    .. math::
+
+        n = \Sigma_{|u_i| < 1} \ 1
+
+    which results in a value closer to the true standard deviation for
+    small sample sizes or for a large number of rejected values.
+
+    Parameters
+    ----------
+    data : array-like
+        Input array or object that can be converted to an array.
+    c : float, optional
+        Tuning constant for the biweight estimator (default = 9.0).
+    M : float or array-like, optional
+        The location estimate.  If ``M`` is a scalar value, then its
+        value will be used for the entire array (or along each ``axis``,
+        if specified).  If ``M`` is an array, then its must be an array
+        containing the location estimate along each ``axis`` of the
+        input array.  If `None` (default), then the median of the input
+        array will be used (or along each ``axis``, if specified).
+    axis : int, optional
+        The axis along which the biweight scales are computed.  If
+        `None` (default), then the biweight scale of the flattened input
+        array will be computed.
+    modify_sample_size : bool, optional
+        If `False` (default), then the sample size used is the total
+        number of elements in the array (or along the input ``axis``, if
+        specified), which follows the standard definition of biweight
+        scale.  If `True`, then the sample size is reduced to correct
+        for any rejected values (i.e. the sample size used includes only
+        the non-rejected values), which results in a value closer to the
+        true standard deviation for small sample sizes or for a large
+        number of rejected values.
+
+    Returns
+    -------
+    biweight_scale : float or `~numpy.ndarray`
+        The biweight scale of the input data.  If ``axis`` is `None`
+        then a scalar will be returned, otherwise a `~numpy.ndarray`
+        will be returned.
+
+    References
+    ----------
+    .. [1] Beers, Flynn, and Gebhardt (1990; AJ 100, 32) (http://adsabs.harvard.edu/abs/1990AJ....100...32B)
+
+    .. [2] http://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/biwscale.htm
+    """
+
+    return np.sqrt(
+        biweight_midvariance(data, c=c, M=M, axis=axis,
+                             modify_sample_size=modify_sample_size))
+
+
+def biweight_midvariance(data, c=9.0, M=None, axis=None,
+                         modify_sample_size=False):
+    r"""
+    Compute the biweight midvariance.
+
+    The biweight midvariance is a robust statistic for determining the
+    variance of a distribution.  Its square root is a robust estimator
+    of scale (i.e. standard deviation).  It is given by:
+
+    .. math::
+
+        \zeta_{bivar} = n \ \frac{\Sigma_{|u_i| < 1} \
+            (x_i - M)^2 (1 - u_i^2)^4} {(\Sigma_{|u_i| < 1} \
+            (1 - u_i^2) (1 - 5u_i^2))^2}
+
+    where :math:`x` is the input data, :math:`M` is the sample median
+    (or the input location) and :math:`u_i` is given by:
+
+    .. math::
+
+        u_{i} = \frac{(x_i - M)}{c * MAD}
+
+    where :math:`c` is the tuning constant and :math:`MAD` is the
+    `median absolute deviation
+    <https://en.wikipedia.org/wiki/Median_absolute_deviation>`_.  The
+    biweight midvariance tuning constant ``c`` is typically 9.0 (the
+    default).
+
+    For the standard definition of `biweight midvariance
+    <https://en.wikipedia.org/wiki/Robust_measures_of_scale#The_biweight_midvariance>`_,
+    :math:`n` is the total number of points in the array (or along the
+    input ``axis``, if specified).  That definition is used if
+    ``modify_sample_size`` is `False`, which is the default.
+
+    However, if ``modify_sample_size = True``, then :math:`n` is the
+    number of points for which :math:`|u_i| < 1` (i.e. the total number
+    of non-rejected values), i.e.
+
+    .. math::
+
+        n = \Sigma_{|u_i| < 1} \ 1
+
+    which results in a value closer to the true variance for small
+    sample sizes or for a large number of rejected values.
+
+    Parameters
+    ----------
+    dat : array-like
+        Input array or object that can be converted to an array.
+    c : float, optional
+        Tuning constant for the biweight estimator (default = 9.0).
+    M : float or array-like, optional
+        The location estimate.  If ``M`` is a scalar value, then its
+        value will be used for the entire array (or along each ``axis``,
+        if specified).  If ``M`` is an array, then its must be an array
+        containing the location estimate along each ``axis`` of the
+        input array.  If `None` (default), then the median of the input
+        array will be used (or along each ``axis``, if specified).
+    axis : int, optional
+        The axis along which the biweight midvariances are computed.  If
+        `None` (default), then the biweight midvariance of the flattened
+        input array will be computed.
+    modify_sample_size : bool, optional
+        If `False` (default), then the sample size used is the total
+        number of elements in the array (or along the input ``axis``, if
+        specified), which follows the standard definition of biweight
+        midvariance.  If `True`, then the sample size is reduced to
+        correct for any rejected values (i.e. the sample size used
+        includes only the non-rejected values), which results in a value
+        closer to the true variance for small sample sizes or for a
+        large number of rejected values.
+
+    Returns
+    -------
+    biweight_midvariance : float or `~numpy.ndarray`
+        The biweight midvariance of the input data.  If ``axis`` is
+        `None` then a scalar will be returned, otherwise a
+        `~numpy.ndarray` will be returned.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Robust_measures_of_scale#The_biweight_midvariance
+
+    .. [2] Beers, Flynn, and Gebhardt (1990; AJ 100, 32) (http://adsabs.harvard.edu/abs/1990AJ....100...32B)
+    """
+
+    data = np.asanyarray(data)
+
+    if M is None:
+        M = np.median(data, axis=axis)
+    if axis is not None:
+        M = np.expand_dims(M, axis=axis)
+
+    # set up the differences
+    d = data - M
+
+    # set up the weighting
+    mad = median_absolute_deviation(data, axis=axis)
+    if axis is not None:
+        mad = np.expand_dims(mad, axis=axis)
+    u = d / (c * mad)
+
+    # now remove the outlier points
+    mask = np.abs(u) < 1
+    u = u ** 2
+
+    if modify_sample_size:
+        n = mask.sum(axis=axis)
+    else:
+        if axis is None:
+            n = data.size
+        else:
+            n = data.shape[axis]
+
+    f1 = d * d * (1. - u)**4
+    f1[~mask] = 0.
+    f1 = f1.sum(axis=axis)
+    f2 = (1. - u) * (1. - 5.*u)
+    f2[~mask] = 0.
+    f2 = np.abs(f2.sum(axis=axis))**2
+
+    return n * f1 / f2

--- a/photutils/extern/stats.py
+++ b/photutils/extern/stats.py
@@ -8,7 +8,10 @@ needed by the background classes.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from astropy.stats import median_absolute_deviation
+from distutils.version import LooseVersion
+from warnings import warn
+import numpy as np
+from astropy.utils import isiterable
 
 
 def mad_std(data, axis=None, func=None, ignore_nan=False):
@@ -56,3 +59,85 @@ def mad_std(data, axis=None, func=None, ignore_nan=False):
     MAD = median_absolute_deviation(data, axis=axis, func=func,
                                     ignore_nan=ignore_nan)
     return MAD * 1.482602218505602
+
+
+def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
+    """
+    Calculate the median absolute deviation (MAD).
+
+    The MAD is defined as ``median(abs(a - median(a)))``.
+
+    Parameters
+    ----------
+    data : array-like
+        Input array or object that can be converted to an array.
+    axis : {int, sequence of int, None}, optional
+        Axis along which the MADs are computed.  The default (`None`) is
+        to compute the MAD of the flattened array.
+    func : callable, optional
+        The function used to compute the median. Defaults to `numpy.ma.median`
+        for masked arrays, otherwise to `numpy.median`.
+    ignore_nan : bool
+        Ignore NaN values (treat them as if they are not in the array) when
+        computing the median.  This will use `numpy.ma.median` if ``axis`` is
+        specified, or `numpy.nanmedian` if ``axis==None`` and numpy's version
+        is >1.10 because nanmedian is slightly faster in this case.
+
+    Returns
+    -------
+    mad : float or `~numpy.ndarray`
+        The median absolute deviation of the input array.  If ``axis``
+        is `None` then a scalar will be returned, otherwise a
+        `~numpy.ndarray` will be returned.
+    """
+
+    if func is None:
+        # Check if the array has a mask and if so use np.ma.median
+        # See https://github.com/numpy/numpy/issues/7330 why using np.ma.median
+        # for normal arrays should not be done (summary: np.ma.median always
+        # returns an masked array even if the result should be scalar). (#4658)
+        if isinstance(data, np.ma.MaskedArray):
+            is_masked = True
+            func = np.ma.median
+            if ignore_nan:
+                data = np.ma.masked_invalid(data)
+        elif ignore_nan:
+            is_masked = False
+            func = np.nanmedian
+        else:
+            is_masked = False
+            func = np.median
+    else:
+        is_masked = None
+
+    if (not ignore_nan and
+            (LooseVersion(np.__version__) < LooseVersion('1.10'))
+            and np.any(np.isnan(data))):
+        warn("Numpy versions <1.10 will return a number rather than "
+             "NaN for the median of arrays containing NaNs.  This "
+             "behavior is unlikely to be what you expect.")
+
+    data = np.asanyarray(data)
+    # np.nanmedian has `keepdims`, which is a good option if we're not allowing
+    # user-passed functions here
+    data_median = func(data, axis=axis)
+
+    # broadcast the median array before subtraction
+    if axis is not None:
+        if isiterable(axis):
+            for ax in sorted(list(axis)):
+                data_median = np.expand_dims(data_median, axis=ax)
+        else:
+            data_median = np.expand_dims(data_median, axis=axis)
+
+    result = func(np.abs(data - data_median), axis=axis, overwrite_input=True)
+
+    if axis is None and np.ma.isMaskedArray(result):
+        # return scalar version
+        result = result.item()
+    elif np.ma.isMaskedArray(result) and not is_masked:
+        # if the input array was not a masked array, we don't want to return a
+        # masked array
+        result = result.filled(fill_value=np.nan)
+
+    return result

--- a/photutils/extern/stats.py
+++ b/photutils/extern/stats.py
@@ -1,22 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This module contains the updated versions of the ``mad_std``,
-``biweight_location``, and ``biweight_midvariance`` functions from
-astropy.stats.  These versions support the ``axis`` keyword, which is
+This module contains an updated version of ``mad_std`` from
+astropy.stats.  This version supports the ``axis`` keyword, which is
 needed by the background classes.
 """
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import numpy as np
+
 from astropy.stats import median_absolute_deviation
 
 
-__all__ = ['mad_std', 'biweight_location', 'biweight_midvariance']
-
-
-def mad_std(data, axis=None):
-    """
+def mad_std(data, axis=None, func=None, ignore_nan=False):
+    r"""
     Calculate a robust standard deviation using the `median absolute
     deviation (MAD)
     <http://en.wikipedia.org/wiki/Median_absolute_deviation>`_.
@@ -25,8 +21,8 @@ def mad_std(data, axis=None):
 
     .. math::
 
-        \\sigma \\approx \\frac{\\textrm{MAD}}{\Phi^{-1}(3/4)}
-            \\approx 1.4826 \ \\textrm{MAD}
+        \sigma \approx \frac{\textrm{MAD}}{\Phi^{-1}(3/4)}
+            \approx 1.4826 \ \textrm{MAD}
 
     where :math:`\Phi^{-1}(P)` is the normal inverse cumulative
     distribution function evaluated at probability :math:`P = 3/4`.
@@ -35,10 +31,18 @@ def mad_std(data, axis=None):
     ----------
     data : array-like
         Data array or object that can be converted to an array.
-    axis : int, optional
+    axis : {int, sequence of int, None}, optional
         Axis along which the robust standard deviations are computed.
         The default (`None`) is to compute the robust standard deviation
         of the flattened array.
+    func : callable, optional
+        The function used to compute the median. Defaults to `numpy.ma.median`
+        for masked arrays, otherwise to `numpy.median`.
+    ignore_nan : bool
+        Ignore NaN values (treat them as if they are not in the array) when
+        computing the median.  This will use `numpy.ma.median` if ``axis`` is
+        specified, or `numpy.nanmedian` if ``axis=None`` and numpy's version is
+        >1.10 because nanmedian is slightly faster in this case.
 
     Returns
     -------
@@ -46,201 +50,9 @@ def mad_std(data, axis=None):
         The robust standard deviation of the input data.  If ``axis`` is
         `None` then a scalar will be returned, otherwise a
         `~numpy.ndarray` will be returned.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from photutils.extern.stats import mad_std
-    >>> rand = np.random.RandomState(12345)
-    >>> madstd = mad_std(rand.normal(5, 2, (100, 100)))
-    >>> print(madstd)    # doctest: +FLOAT_CMP
-    2.0232764659422626
     """
 
     # NOTE: 1. / scipy.stats.norm.ppf(0.75) = 1.482602218505602
-    return median_absolute_deviation(data, axis=axis) * 1.482602218505602
-
-
-def biweight_location(a, c=6.0, M=None, axis=None):
-    """
-    Compute the biweight location.
-
-    The biweight location is a robust statistic for determining the
-    central location of a distribution.  It is given by:
-
-    .. math::
-
-        C_{bl}= M+\\frac{\Sigma_{\|u_i\|<1} (x_i-M)(1-u_i^2)^2}
-        {\Sigma_{\|u_i\|<1} (1-u_i^2)^2}
-
-    where :math:`M` is the sample median (or the input initial guess)
-    and :math:`u_i` is given by:
-
-    .. math::
-
-        u_{i} = \\frac{(x_i-M)}{c\ MAD}
-
-    where :math:`c` is the tuning constant and :math:`MAD` is the median
-    absolute deviation.
-
-    For more details, see `Beers, Flynn, and Gebhardt (1990); AJ 100, 32
-    <http://adsabs.harvard.edu/abs/1990AJ....100...32B>`_.
-
-    Parameters
-    ----------
-    a : array-like
-        Input array or object that can be converted to an array.
-    c : float, optional
-        Tuning constant for the biweight estimator.  Default value is 6.0.
-    M : float or array-like, optional
-        Initial guess for the biweight location.  An array can be input
-        when using the ``axis`` keyword.
-    axis : int, optional
-        Axis along which the biweight locations are computed.  The
-        default (`None`) is to compute the biweight location of the
-        flattened array.
-
-    Returns
-    -------
-    biweight_location : float or `~numpy.ndarray`
-        The biweight location of the input data.  If ``axis`` is `None`
-        then a scalar will be returned, otherwise a `~numpy.ndarray`
-        will be returned.
-
-    Examples
-    --------
-    Generate random variates from a Gaussian distribution and return the
-    biweight location of the distribution::
-
-        >>> import numpy as np
-        >>> from photutils.extern.stats import biweight_location
-        >>> rand = np.random.RandomState(12345)
-        >>> from numpy.random import randn
-        >>> loc = biweight_location(rand.randn(1000))
-        >>> print(loc)    # doctest: +FLOAT_CMP
-        -0.0175741540445
-    """
-
-    a = np.asanyarray(a)
-
-    if M is None:
-        M = np.median(a, axis=axis)
-    if axis is not None:
-        M = np.expand_dims(M, axis=axis)
-
-    # set up the differences
-    d = a - M
-
-    # set up the weighting
-    mad = median_absolute_deviation(a, axis=axis)
-    if axis is not None:
-        mad = np.expand_dims(mad, axis=axis)
-    u = d / (c * mad)
-
-    # now remove the outlier points
-    mask = (np.abs(u) >= 1)
-    u = (1 - u ** 2) ** 2
-    u[mask] = 0
-
-    return M.squeeze() + (d * u).sum(axis=axis) / u.sum(axis=axis)
-
-
-def biweight_midvariance(a, c=9.0, M=None, axis=None):
-    """
-    Compute the biweight midvariance.
-
-    The biweight midvariance is a robust statistic for determining the
-    midvariance (i.e. the standard deviation) of a distribution.  It is
-    given by:
-
-    .. math::
-
-      C_{bl}= (n')^{1/2} \\frac{[\Sigma_{|u_i|<1} (x_i-M)^2(1-u_i^2)^4]^{0.5}}
-      {|\Sigma_{|u_i|<1} (1-u_i^2)(1-5u_i^2)|}
-
-    where :math:`u_i` is given by
-
-    .. math::
-
-        u_{i} = \\frac{(x_i-M)}{c MAD}
-
-    where :math:`c` is the tuning constant and :math:`MAD` is the median
-    absolute deviation.  The midvariance tuning constant ``c`` is
-    typically 9.0.
-
-    :math:`n'` is the number of points for which :math:`|u_i| < 1`
-    holds, while the summations are over all :math:`i` up to :math:`n`:
-
-    .. math::
-
-        n' = \Sigma_{|u_i|<1}^n 1
-
-    This is slightly different than given in the reference below, but
-    results in a value closer to the true midvariance.
-    For more details, see `Beers, Flynn, and Gebhardt (1990); AJ 100, 32
-    <http://adsabs.harvard.edu/abs/1990AJ....100...32B>`_.
-
-    Parameters
-    ----------
-    a : array-like
-        Input array or object that can be converted to an array.
-    c : float, optional
-        Tuning constant for the biweight estimator.  Default value is 9.0.
-    M : float or array-like, optional
-        Initial guess for the biweight location.  An array can be input
-        when using the ``axis`` keyword.
-    axis : int, optional
-        Axis along which the biweight midvariances are computed.  The
-        default (`None`) is to compute the biweight midvariance of the
-        flattened array.
-
-    Returns
-    -------
-    biweight_midvariance : float or `~numpy.ndarray`
-        The biweight midvariance of the input data.  If ``axis`` is
-        `None` then a scalar will be returned, otherwise a
-        `~numpy.ndarray` will be returned.
-
-    Examples
-    --------
-    Generate random variates from a Gaussian distribution and return the
-    biweight midvariance of the distribution::
-
-        >>> import numpy as np
-        >>> from photutils.extern.stats import biweight_midvariance
-        >>> rand = np.random.RandomState(12345)
-        >>> from numpy.random import randn
-        >>> bmv = biweight_midvariance(rand.randn(1000))
-        >>> print(bmv)    # doctest: +FLOAT_CMP
-        0.986726249291
-    """
-
-    a = np.asanyarray(a)
-
-    if M is None:
-        M = np.median(a, axis=axis)
-    if axis is not None:
-        M = np.expand_dims(M, axis=axis)
-
-    # set up the differences
-    d = a - M
-
-    # set up the weighting
-    mad = median_absolute_deviation(a, axis=axis)
-    if axis is not None:
-        mad = np.expand_dims(mad, axis=axis)
-    u = d / (c * mad)
-
-    # now remove the outlier points
-    mask = np.abs(u) < 1
-    u = u ** 2
-    n = mask.sum(axis=axis)
-
-    f1 = d * d * (1. - u)**4
-    f1[~mask] = 0.
-    f1 = f1.sum(axis=axis) ** 0.5
-    f2 = (1. - u) * (1. - 5.*u)
-    f2[~mask] = 0.
-    f2 = np.abs(f2.sum(axis=axis))
-
-    return (n ** 0.5) * f1 / f2
+    MAD = median_absolute_deviation(data, axis=axis, func=func,
+                                    ignore_nan=ignore_nan)
+    return MAD * 1.482602218505602


### PR DESCRIPTION
`biweight_scale` is a standard deviation (RMS) estimator.  This change follows https://github.com/astropy/astropy/pull/5991.