### PR TITLE
Disable pytest-warnings during testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
+addopts = -p no:warnings
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
pytest 3.1.0 included pytest-warnings in its core [0] and now lists all warning that occurred during testing at the end of the build, which can way too verbose. This PR sets it back to previous behaviour.

Obviously, long term we can aim to write tests that don't emit warnings.

[0] https://docs.pytest.org/en/latest/changelog.html#changelog-history