### PR TITLE
Catch warning about no detected sources in IterativelySubtractedPSFPhotometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,12 @@ API changes
   - The ``unit``, ``hdu``, ``wcs``, and ``wcsheader`` keywords in
     ``photutils.datasets`` functions were removed. [#527]
 
+- ``photutils.psf``
+
+  - ``IterativelySubtractedPSFPhotometry`` issues a "no sources
+    detected" warning only on the first iteration, if applicable.
+    [#566]
+
 - ``photutils.utils``
 
   - The ``background_color`` keyword was removed from the

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -729,7 +729,12 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
             table['iter_detected'] = n*np.ones(table['x_fit'].shape, dtype=np.int32)
 
             output_table = vstack([output_table, table])
-            sources = self.finder(self._residual_image)
+
+            # do not warn if no sources are found beyond the first iteration
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', AstropyUserWarning)
+                sources = self.finder(self._residual_image)
+
             n += 1
 
         return output_table


### PR DESCRIPTION
`IterativelySubtractedPSFPhotometry` iterates until the star finders detect no more sources.  The star finders issue a warning when no sources are detected.  Thus, `IterativelySubtractedPSFPhotometry` will always raise this warning, even when everything worked perfectly fine.

This PR catches this warning after the first iteration of `IterativelySubtractedPSFPhotometry`.  In other words, if no stars are detected on the first iteration, the warning is still issued.  After that, the warning is suppressed.

Also, this warning is the reason why the Sphinx builds are failing for #562.