### PR TITLE
Remove code for outdated dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ General
 - Dropped support for astropy 1.x versions.  Minimal required version
   is now astropy 2.0. [#575]
 
+- Dropped scipy 0.15 support.  Minimal required version is now scipy
+  0.16. [#576]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/photutils/install.rst
+++ b/docs/photutils/install.rst
@@ -11,12 +11,12 @@ Photutils has the following strict requirements:
 
 * `Numpy <http://www.numpy.org/>`_ 1.9 or later
 
-* `Astropy`_ 1.0 or later
+* `Astropy`_ 2.0 or later
 
 Additionally, some functionality is available only if the following
 optional dependencies are installed:
 
-* `Scipy`_ 0.15 or later
+* `Scipy`_ 0.16 or later
 
 * `scikit-image`_ 0.11 or later
 

--- a/docs/photutils/psf.rst
+++ b/docs/photutils/psf.rst
@@ -257,7 +257,7 @@ Then let's import the required classes to set up a `~photutils.psf.IterativelySu
 
 Let's then instantiate and use the objects:
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
     >>> bkgrms = MADStdBackgroundRMS()
     >>> std = bkgrms(image)
@@ -564,7 +564,7 @@ star as well. Also, note that both of the stars have ``sigma=2.0``.
 Let's instantiate the necessary objects in order to use an
 `~photutils.psf.IterativelySubtractedPSFPhotometry` to perform photometry:
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
     >>> daogroup = DAOGroup(crit_separation=8)
     >>> mmm_bkg = MMMBackground()
@@ -582,7 +582,7 @@ Let's instantiate the necessary objects in order to use an
 
 Now, let's use the callable ``itr_phot_obj`` to perform photometry:
 
-.. doctest-requires:: scipy
+.. doctest-requires:: scipy, skimage
 
     >>> phot_results = itr_phot_obj(image)
     >>> phot_results['id', 'group_id', 'iter_detected', 'x_0', 'y_0', 'flux_0'] #doctest: +SKIP

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -8,11 +8,10 @@ algorithms in aperture_photometry, not in the wrappers.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from distutils.version import LooseVersion
+import pytest
 import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_less)
-import pytest
 
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
@@ -22,16 +21,12 @@ from astropy.tests.helper import remote_data
 import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 
-import astropy
-ASTROPY_LT_13 = LooseVersion(astropy.__version__) < LooseVersion('1.3')
-NUMPY_LT_12 = LooseVersion(np.__version__) < LooseVersion('1.12')
-
-from ...datasets import (get_path, make_4gaussians_image, make_wcs,
-                         make_imagehdu)
 from ..core import *
 from ..circle import *
 from ..ellipse import *
 from ..rectangle import *
+from ...datasets import (get_path, make_4gaussians_image, make_wcs,
+                         make_imagehdu)
 
 try:
     import matplotlib
@@ -666,114 +661,64 @@ def test_sky_aperture_repr():
     s = SkyCoord([1, 2], [3, 4], unit='deg')
 
     aper = SkyCircularAperture(s, r=3*u.pix)
-    if ASTROPY_LT_13 and NUMPY_LT_12:
-        a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                  '    [(1.0, 3.0), (2.0, 4.0)]>, r=3.0 pix)>')
-        a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
-                 'r: 3.0 pix')
-    else:
-        a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                  '    [( 1.,  3.), ( 2.,  4.)]>, r=3.0 pix)>')
-        a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'r: 3.0 pix')
+    a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
+              '    [( 1.,  3.), ( 2.,  4.)]>, r=3.0 pix)>')
+    a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
+             '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+             'r: 3.0 pix')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyCircularAnnulus(s, r_in=3.*u.pix, r_out=5*u.pix)
-    if ASTROPY_LT_13 and NUMPY_LT_12:
-        a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                  '    [(1.0, 3.0), (2.0, 4.0)]>, r_in=3.0 pix, r_out=5.0 '
-                  'pix)>')
-        a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
-                 'r_in: 3.0 pix\nr_out: 5.0 pix')
-    else:
-        a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                  '    [( 1.,  3.), ( 2.,  4.)]>, r_in=3.0 pix, r_out=5.0 '
-                  'pix)>')
-        a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'r_in: 3.0 pix\nr_out: 5.0 pix')
+    a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
+              '    [( 1.,  3.), ( 2.,  4.)]>, r_in=3.0 pix, r_out=5.0 pix)>')
+    a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
+             '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+             'r_in: 3.0 pix\nr_out: 5.0 pix')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyEllipticalAperture(s, a=3*u.pix, b=5*u.pix, theta=15*u.deg)
-    if ASTROPY_LT_13 and NUMPY_LT_12:
-        a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [(1.0, 3.0), (2.0, 4.0)]>, a=3.0 pix, b=5.0 pix,'
-                  ' theta=15.0 deg)>')
-        a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
-                 'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
-    else:
-        a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, a=3.0 pix, b=5.0 pix,'
-                  ' theta=15.0 deg)>')
-        a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
+    a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
+              'deg\n    [( 1.,  3.), ( 2.,  4.)]>, a=3.0 pix, b=5.0 pix,'
+              ' theta=15.0 deg)>')
+    a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
+             '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+             'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyEllipticalAnnulus(s, a_in=3*u.pix, a_out=5*u.pix, b_out=3*u.pix,
                                 theta=15*u.deg)
-    if ASTROPY_LT_13 and NUMPY_LT_12:
-        a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [(1.0, 3.0), (2.0, 4.0)]>, a_in=3.0 pix, '
-                  'a_out=5.0 pix, b_out=3.0 pix, theta=15.0 deg)>')
-        a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
-                 'a_in: 3.0 pix\na_out: 5.0 pix\nb_out: 3.0 pix\n'
-                 'theta: 15.0 deg')
-    else:
-        a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, a_in=3.0 pix, '
-                  'a_out=5.0 pix, b_out=3.0 pix, theta=15.0 deg)>')
-        a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'a_in: 3.0 pix\na_out: 5.0 pix\nb_out: 3.0 pix\n'
-                 'theta: 15.0 deg')
+    a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
+              'deg\n    [( 1.,  3.), ( 2.,  4.)]>, a_in=3.0 pix, '
+              'a_out=5.0 pix, b_out=3.0 pix, theta=15.0 deg)>')
+    a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
+             '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+             'a_in: 3.0 pix\na_out: 5.0 pix\nb_out: 3.0 pix\n'
+             'theta: 15.0 deg')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyRectangularAperture(s, w=3*u.pix, h=5*u.pix, theta=15*u.deg)
-    if ASTROPY_LT_13 and NUMPY_LT_12:
-        a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [(1.0, 3.0), (2.0, 4.0)]>, w=3.0 pix, h=5.0 pix'
-                  ', theta=15.0 deg)>')
-        a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
-                 'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
-    else:
-        a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, w=3.0 pix, h=5.0 pix'
-                  ', theta=15.0 deg)>')
-        a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
+    a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
+              'deg\n    [( 1.,  3.), ( 2.,  4.)]>, w=3.0 pix, h=5.0 pix'
+              ', theta=15.0 deg)>')
+    a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
+             '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+             'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyRectangularAnnulus(s, w_in=3*u.pix, w_out=3.4*u.pix,
                                  h_out=5*u.pix, theta=15*u.deg)
-    if ASTROPY_LT_13 and NUMPY_LT_12:
-        a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-                  '\n    [(1.0, 3.0), (2.0, 4.0)]>, w_in=3.0 pix, '
-                  'w_out=3.4 pix, h_out=5.0 pix, theta=15.0 deg)>')
-        a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1.0, 3.0), (2.0, 4.0)]>\n'
-                 'w_in: 3.0 pix\nw_out: 3.4 pix\nh_out: 5.0 pix\n'
-                 'theta: 15.0 deg')
-    else:
-        a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-                  '\n    [( 1.,  3.), ( 2.,  4.)]>, w_in=3.0 pix, '
-                  'w_out=3.4 pix, h_out=5.0 pix, theta=15.0 deg)>')
-        a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'w_in: 3.0 pix\nw_out: 3.4 pix\nh_out: 5.0 pix\n'
-                 'theta: 15.0 deg')
+    a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
+              '\n    [( 1.,  3.), ( 2.,  4.)]>, w_in=3.0 pix, '
+              'w_out=3.4 pix, h_out=5.0 pix, theta=15.0 deg)>')
+    a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
+             '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
+             'w_in: 3.0 pix\nw_out: 3.4 pix\nh_out: 5.0 pix\n'
+             'theta: 15.0 deg')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -17,6 +17,13 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
+try:
+    import matplotlib
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
+
+
 
 DATA = np.ones((100, 100))
 BKG_RMS = np.zeros((100, 100))
@@ -194,6 +201,7 @@ class TestBackground2D(object):
             bkg = Background2D(DATA, (25, 25), filter_size=(1, 1))
             bkg._make_2d_array(np.arange(3))
 
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_plot_meshes(self):
         """
         This test should run without any errors, but there is no return

--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -1,20 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from distutils.version import LooseVersion
+
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+
 from ..windows import (HanningWindow, TukeyWindow, CosineBellWindow,
                        SplitCosineBellWindow, TopHatWindow)
 
 try:
     import scipy    # noqa
     HAS_SCIPY = True
-    if LooseVersion(scipy.__version__) < LooseVersion('0.16'):
-        SKIMAGE_LT_0P16 = True
-    else:
-        SKIMAGE_LT_0P16 = False
 except ImportError:
     HAS_SCIPY = False
 
@@ -48,9 +45,6 @@ def test_tukey():
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_tukey_scipy():
     """Test Tukey window against 1D scipy version."""
-
-    if SKIMAGE_LT_0P16:
-        return    # skip this test
 
     # scipy.signal.tukey was introduced in Scipy v0.16.0
     from scipy.signal import tukey

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -22,16 +22,6 @@ __all__ = ['FittableImageModel', 'NonNormalizable',
            'prepare_psf_model', 'get_grouped_psf_model']
 
 
-try:
-    import scipy
-    HAS_SCIPY = True
-    from distutils.version import LooseVersion
-    SCIPY_VER_GE_014 = (LooseVersion(scipy.version.full_version) >=
-                        LooseVersion('0.14'))
-except ImportError:
-    HAS_SCIPY = False
-
-
 class NonNormalizable(AstropyWarning):
     """
     Used to indicate that a :py:class:`FittableImageModel` model is
@@ -466,23 +456,7 @@ class FittableImageModel(Fittable2DModel):
         yi = self._oversampling * (np.asarray(y) - y_0) + self._y_origin
 
         f = flux * self._normalization_constant
-
-        if SCIPY_VER_GE_014:
-            evaluated_model = f * self.interpolator.ev(xi, yi)
-
-        else:
-            # Flatten x and y arguments in order to evaluate in SCIPY versions
-            # earlier than 0.14.0. This essentially replicates the code
-            # in 'RectBivariateSpline.ev()' method in versions >= 0.14.0.
-            if xi.shape != yi.shape:
-                xi, yi = np.broadcast_arrays(xi, yi)
-            xi_flat = xi.ravel()
-            yi_flat = yi.ravel()
-
-            evaluated_model = f * self.interpolator.ev(xi_flat, yi_flat)
-
-            # reshape evaluated_model to the original shape of x & y arguments:
-            evaluated_model = evaluated_model.reshape(xi.shape)
+        evaluated_model = f * self.interpolator.ev(xi, yi)
 
         if self._fill_value is not None:
             # find indices of pixels that are outside the input pixel grid and

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -11,9 +11,6 @@ from ..utils.colormaps import random_cmap
 
 __all__ = ['SegmentationImage']
 
-# outline_segments requires scikit-image >= 0.11
-__doctest_skip__ = {'SegmentationImage.outline_segments'}
-
 __doctest_requires__ = {('SegmentationImage', 'SegmentationImage.*'):
                         ['scipy', 'skimage']}
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from copy import deepcopy
-from distutils.version import LooseVersion
 
 import numpy as np
 from astropy.utils import lazyproperty
@@ -301,10 +300,7 @@ class SegmentationImage(object):
                [0, 0, 0, 0, 0, 0]])
         """
 
-        import skimage
-        if LooseVersion(skimage.__version__) < LooseVersion('0.11'):
-            raise ImportError('The outline_segments() function requires '
-                              'scikit-image >= 0.11')
+        # requires scikit-image >= 0.11
         from skimage.segmentation import find_boundaries
 
         outlines = self.data * find_boundaries(self.data, mode='inner')

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -18,10 +17,6 @@ except ImportError:
 try:
     import skimage
     HAS_SKIMAGE = True
-    if LooseVersion(skimage.__version__) < LooseVersion('0.11'):
-        SKIMAGE_LT_0P11 = True
-    else:
-        SKIMAGE_LT_0P11 = False
 except ImportError:
     HAS_SKIMAGE = False
 
@@ -92,8 +87,6 @@ class TestSegmentationImage(object):
         assert_allclose(self.segm.area(labels), expected[labels])
 
     def test_outline_segments(self):
-        if SKIMAGE_LT_0P11:
-            return    # skip this test
         segm_array = np.zeros((5, 5)).astype(int)
         segm_array[1:4, 1:4] = 2
         segm = SegmentationImage(segm_array)
@@ -102,8 +95,6 @@ class TestSegmentationImage(object):
         assert_allclose(segm.outline_segments(), segm_array_ref)
 
     def test_outline_segments_masked_background(self):
-        if SKIMAGE_LT_0P11:
-            return    # skip this test
         segm_array = np.zeros((5, 5)).astype(int)
         segm_array[1:4, 1:4] = 2
         segm = SegmentationImage(segm_array)

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from distutils.version import LooseVersion
 import itertools
 
 import numpy as np
@@ -26,10 +25,6 @@ except ImportError:
 try:
     import skimage
     HAS_SKIMAGE = True
-    if LooseVersion(skimage.__version__) < LooseVersion('0.11'):
-        SKIMAGE_LT_0P11 = True
-    else:
-        SKIMAGE_LT_0P11 = False
 except ImportError:
     HAS_SKIMAGE = False
 


### PR DESCRIPTION
This PR also bumps the minimum required version of `scipy` from `0.15` to `0.16`.