### PR TITLE
Removing astropy dev testing using python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,12 +66,9 @@ matrix:
                EVENT_TYPE='pull_request push cron'
                SPHINX_VERSION='>1.6'
 
-        # Now try Astropy dev and LTS versions with the latest 3.x and 2.7.
+        # Now try Astropy dev and LTS versions with the latest Python.
         # We disable LTS testing until astropy 3.0 is out, as the current
         # stable is also the LTS
-        - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
         - os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'


### PR DESCRIPTION
As astropy doesn't support python2 any more, this test is expected to always fail from now on.