### PR TITLE
Add option to make_wcs to produce WCS in Galactic coordinates

### DIFF
--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -664,15 +664,21 @@ def make_100gaussians_image(noise=True):
     return data
 
 
-def make_wcs(shape):
+def make_wcs(shape, galactic=False):
     """
-    Create a simple celestial WCS object.
+    Create a simple celestial WCS object in either the ICRS or Galactic
+    coordinate frame.
 
     Parameters
     ----------
     shape : 2-tuple of int
         The shape of the 2D array to be used with the output
         `~astropy.wcs.WCS` object.
+
+    galactic : bool, optional
+        If `True`, then the output WCS will be in the Galactic
+        coordinate frame.  If `False` (default), then the output WCS
+        will be in the ICRS coordinate frame.
 
     Returns
     -------
@@ -702,10 +708,13 @@ def make_wcs(shape):
     wcs.wcs.crpix = [shape[1] / 2, shape[0] / 2]     # 1-indexed (x, y)
     wcs.wcs.crval = [197.8925, -1.36555556]
     wcs.wcs.cunit = ['deg', 'deg']
-    wcs.wcs.radesys = 'ICRS'
     wcs.wcs.cd = [[-scale * np.cos(rho), scale * np.sin(rho)],
                   [scale * np.sin(rho), scale * np.cos(rho)]]
-    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    if not galactic:
+        wcs.wcs.radesys = 'ICRS'
+        wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    else:
+        wcs.wcs.ctype = ['GLON-CAR', 'GLAT-CAR']
 
     return wcs
 

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -12,7 +12,8 @@ from astropy.modeling.models import Moffat2D
 from .. import (make_noise_image, apply_poisson_noise,
                 make_gaussian_sources_image, make_random_gaussians_table,
                 make_4gaussians_image, make_100gaussians_image,
-                make_random_models_table, make_model_sources_image)
+                make_random_models_table, make_model_sources_image,
+                make_wcs)
 
 
 TABLE = Table()
@@ -144,3 +145,15 @@ def test_make_random_models_table():
     # make_gaussian_sources_image tests
     image = make_model_sources_image((300, 500), model, source_table)
     assert image.sum() > 1
+
+
+def test_make_wcs():
+    shape = (100, 200)
+    wcs = make_wcs(shape)
+    assert wcs._naxis1 == shape[1]
+    assert wcs._naxis2 == shape[0]
+    assert wcs.wcs.radesys == 'ICRS'
+
+    wcs = make_wcs(shape, galactic=True)
+    assert wcs.wcs.ctype[0] == 'GLON-CAR'
+    assert wcs.wcs.ctype[1] == 'GLAT-CAR'


### PR DESCRIPTION
Useful for testing....

`make_wcs` hasn't been released yet, so I don't think this needs a changelog entry.