### PR TITLE
Remove gwcs optional dep from travis and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib gwcs'
+        - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
         - SETUP_XVFB=True
         - ASTROPY_USE_SYSTEM_PYTEST=1
@@ -58,11 +58,11 @@ matrix:
         # may run for a long time
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
-               CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter gwcs'
+               CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter'
                SPHINX_VERSION='>1.6'
         - os: linux
           env: SETUP_CMD='build_docs -w'
-               CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter gwcs'
+               CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter'
                EVENT_TYPE='pull_request push cron'
                SPHINX_VERSION='>1.6'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib gwcs"
+      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib"
 
 
   matrix:


### PR DESCRIPTION
This PR removes `gwcs` from the optional dependencies in `travis` and `AppVeyor`.  I don't see any tests that use `gwcs`.

Also, the `AppVeyor` build failures appear to be due to not being able to install `gwcs`.  Hopefully this change resolves that issue as well.

