### PR TITLE
 Add show_progress keyword to datasets.get_path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ New Features
 
   - Added new ``make_wcs`` and ``make_imagehdu`` functions. [#527]
 
+  - Added new ``show_progress`` keyword to the ``load_*`` functions.
+    [#590]
+
 - ``photutils.segmentation``
 
   - Added a ``cmap`` method to ``SegmentationImage`` to generate a

--- a/docs/photutils/aperture.rst
+++ b/docs/photutils/aperture.rst
@@ -392,9 +392,7 @@ Galactic plane::
 
     >>> from photutils import datasets
     >>> hdu = datasets.load_spitzer_image()   # doctest: +REMOTE_DATA
-    Downloading http://data.astropy.org/photometry/spitzer_example_image.fits [Done]
     >>> catalog = datasets.load_spitzer_catalog()   # doctest: +REMOTE_DATA
-    Downloading http://data.astropy.org/photometry/spitzer_example_catalog.xml [Done]
 
 The catalog contains (among other things) the Galactic coordinates of
 the sources in the image as well as the PSF-fitted fluxes from the

--- a/docs/photutils/datasets.rst
+++ b/docs/photutils/datasets.rst
@@ -34,7 +34,6 @@ Let's load an example image of M67 with
 
     >>> from photutils import datasets
     >>> hdu = datasets.load_star_image()  # doctest: +REMOTE_DATA
-    Downloading http://data.astropy.org/photometry/M6707HH.fits [Done]
     >>> print(hdu.data.shape)  # doctest: +REMOTE_DATA
     (1059, 1059)
 

--- a/docs/photutils/detection.rst
+++ b/docs/photutils/detection.rst
@@ -46,7 +46,6 @@ background noise using sigma-clipped statistics::
     >>> from astropy.stats import sigma_clipped_stats
     >>> from photutils import datasets
     >>> hdu = datasets.load_star_image()    # doctest: +REMOTE_DATA
-    Downloading ...
     >>> data = hdu.data[0:400, 0:400]    # doctest: +REMOTE_DATA
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, iters=5)    # doctest: +REMOTE_DATA
     >>> print((mean, median, std))    # doctest: +REMOTE_DATA, +FLOAT_CMP

--- a/docs/photutils/getting_started.rst
+++ b/docs/photutils/getting_started.rst
@@ -11,7 +11,6 @@ background, calculated using the image median:
     >>> import numpy as np
     >>> from photutils import datasets
     >>> hdu = datasets.load_star_image()    # doctest: +REMOTE_DATA
-    Downloading ...
     >>> image = hdu.data[500:700, 500:700].astype(float)    # doctest: +REMOTE_DATA
     >>> image -= np.median(image)    # doctest: +REMOTE_DATA
 

--- a/docs/photutils/psf_matching.rst
+++ b/docs/photutils/psf_matching.rst
@@ -216,9 +216,7 @@ microns) PSF.  We load the PSFs using the
 
     >>> from photutils.datasets import load_irac_psf
     >>> ch1_hdu = load_irac_psf(channel=1)    # doctest: +REMOTE_DATA
-    Downloading http://data.astropy.org/photometry/irac_ch1_flight.fits [Done]
     >>> ch4_hdu = load_irac_psf(channel=4)    # doctest: +REMOTE_DATA
-    Downloading http://data.astropy.org/photometry/irac_ch4_flight.fits [Done]
     >>> ch1 = ch1_hdu.data    # doctest: +REMOTE_DATA
     >>> ch4 = ch4_hdu.data    # doctest: +REMOTE_DATA
 

--- a/photutils/datasets/load.py
+++ b/photutils/datasets/load.py
@@ -21,7 +21,7 @@ __all__ = ['get_path', 'load_spitzer_image', 'load_spitzer_catalog',
            'load_irac_psf', 'load_fermi_image', 'load_star_image']
 
 
-def get_path(filename, location='local', cache=True):
+def get_path(filename, location='local', cache=True, show_progress=False):
     """
     Get path (location on your disk) for a given file.
 
@@ -38,6 +38,9 @@ def get_path(filename, location='local', cache=True):
     cache : bool, optional
         Whether to cache the contents of remote URLs.  Default is
         `True`.
+    show_progress : bool, optional
+        Whether to display a progress bar during the download (default
+        is `False`).
 
     Returns
     -------
@@ -59,23 +62,32 @@ def get_path(filename, location='local', cache=True):
     elif location == 'remote':    # pragma: no cover
         try:
             url = 'https://data.astropy.org/photometry/{0}'.format(filename)
-            path = download_file(url, cache=cache)
+            path = download_file(url, cache=cache,
+                                 show_progress=show_progress)
         except (URLError, HTTPError):   # timeout or not found
-            path = download_file(datasets_url, cache=cache)
+            path = download_file(datasets_url, cache=cache,
+                                 show_progress=show_progress)
     elif location == 'photutils-datasets':    # pragma: no cover
-            path = download_file(datasets_url, cache=cache)
+            path = download_file(datasets_url, cache=cache,
+                                 show_progress=show_progress)
     else:
         raise ValueError('Invalid location: {0}'.format(location))
 
     return path
 
 
-def load_spitzer_image():    # pragma: no cover
+def load_spitzer_image(show_progress=False):    # pragma: no cover
     """
     Load a 4.5 micron Spitzer image.
 
     The catalog for this image is returned by
     :func:`load_spitzer_catalog`.
+
+    Parameters
+    ----------
+    show_progress : bool, optional
+        Whether to display a progress bar during the download (default
+        is `False`).
 
     Returns
     -------
@@ -96,18 +108,25 @@ def load_spitzer_image():    # pragma: no cover
         plt.imshow(hdu.data, origin='lower', vmax=50)
     """
 
-    path = get_path('spitzer_example_image.fits', location='remote')
+    path = get_path('spitzer_example_image.fits', location='remote',
+                    show_progress=show_progress)
     hdu = fits.open(path)[0]
 
     return hdu
 
 
-def load_spitzer_catalog():    # pragma: no cover
+def load_spitzer_catalog(show_progress=False):    # pragma: no cover
     """
     Load a 4.5 micron Spitzer catalog.
 
     The image from which this catalog was derived is returned by
     :func:`load_spitzer_image`.
+
+    Parameters
+    ----------
+    show_progress : bool, optional
+        Whether to display a progress bar during the download (default
+        is `False`).
 
     Returns
     -------
@@ -132,13 +151,14 @@ def load_spitzer_catalog():    # pragma: no cover
         plt.ylim(0.13, 0.30)
     """
 
-    path = get_path('spitzer_example_catalog.xml', location='remote')
+    path = get_path('spitzer_example_catalog.xml', location='remote',
+                    show_progress=show_progress)
     table = Table.read(path)
 
     return table
 
 
-def load_irac_psf(channel):    # pragma: no cover
+def load_irac_psf(channel, show_progress=False):    # pragma: no cover
     """
     Load a Spitzer IRAC PSF image.
 
@@ -151,6 +171,10 @@ def load_irac_psf(channel):    # pragma: no cover
           * Channel 2:  4.5 microns
           * Channel 3:  5.8 microns
           * Channel 4:  8.0 microns
+
+    show_progress : bool, optional
+        Whether to display a progress bar during the download (default
+        is `False`).
 
     Returns
     -------
@@ -193,15 +217,21 @@ def load_irac_psf(channel):    # pragma: no cover
         raise ValueError('channel must be 1, 2, 3, or 4')
 
     fn = 'irac_ch{0}_flight.fits'.format(channel)
-    path = get_path(fn, location='remote')
+    path = get_path(fn, location='remote', show_progress=show_progress)
     hdu = fits.open(path)[0]
 
     return hdu
 
 
-def load_fermi_image():
+def load_fermi_image(show_progress=False):
     """
     Load a Fermi counts image for the Galactic center region.
+
+    Parameters
+    ----------
+    show_progress : bool, optional
+        Whether to display a progress bar during the download (default
+        is `False`).
 
     Returns
     -------
@@ -218,13 +248,14 @@ def load_fermi_image():
         plt.imshow(hdu.data, vmax=10, origin='lower', interpolation='nearest')
     """
 
-    path = get_path('fermi_counts.fits.gz', location='local')
+    path = get_path('fermi_counts.fits.gz', location='local',
+                    show_progress=show_progress)
     hdu = fits.open(path)[1]
 
     return hdu
 
 
-def load_star_image():    # pragma: no cover
+def load_star_image(show_progress=False):    # pragma: no cover
     """
     Load an optical image of stars.
 
@@ -233,6 +264,12 @@ def load_star_image():    # pragma: no cover
     (NGS-POSS).  The image was digitized from the POSS-I Red plates as
     part of the Digitized Sky Survey produced at the Space Telescope
     Science Institute.
+
+    Parameters
+    ----------
+    show_progress : bool, optional
+        Whether to display a progress bar during the download (default
+        is `False`).
 
     Returns
     -------
@@ -249,7 +286,8 @@ def load_star_image():    # pragma: no cover
         plt.imshow(hdu.data, origin='lower', interpolation='nearest')
     """
 
-    path = get_path('M6707HH.fits', location='remote')
+    path = get_path('M6707HH.fits', location='remote',
+                    show_progress=show_progress)
     hdu = fits.open(path)[0]
 
     return hdu


### PR DESCRIPTION
Also sets `show_progress=False` by default so the local doctests will pass with `--remote-data` (even if the file has already been cached).