### PR TITLE
Updates to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ language: c
 os:
     - linux
 
+stage: Initial tests
+
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
@@ -63,36 +65,23 @@ matrix:
     fast_finish: true
 
     include:
-        - stage: Initial tests
-          env: PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-
-        - stage: Initial tests
-          env: PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
-
-        - stage: Initial tests
-          env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-
-        - stage: Initial tests
-          env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        - env: PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
+        - env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
         # Do a PEP8/pyflakes test with flake8
-        - stage: Initial tests
-          os: linux
-          env: MAIN_CMD="flake8 photutils --count $FLAKE8_OPT" SETUP_CMD=''
+        - env: MAIN_CMD="flake8 photutils --count $FLAKE8_OPT" SETUP_CMD=''
 
-        - stage: Initial tests
-          os: linux
-          env: SETUP_CMD='test --coverage'
+        - env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - stage: Test docs, astropy dev, and without optional dependencies
-          os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter'
 
         - stage: Test docs, astropy dev, and without optional dependencies
-          os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter'
                EVENT_TYPE='pull_request push cron'
@@ -101,7 +90,6 @@ matrix:
         # We disable LTS testing until astropy 3.0 is out, as the current
         # stable is also the LTS
         - stage: Test docs, astropy dev, and without optional dependencies
-          os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
 
@@ -111,11 +99,9 @@ matrix:
 
         # Try with optional dependencies disabled
         - stage: Test docs, astropy dev, and without optional dependencies
-          os: linux
           env: PYTHON_VERSION=2.7 CONDA_DEPENDENCIES='Cython'
 
         - stage: Test docs, astropy dev, and without optional dependencies
-          os: linux
           env: CONDA_DEPENDENCIES='Cython'
 
         # Try older python and numpy versions. Since we can assume
@@ -123,25 +109,20 @@ matrix:
         # with different versions of Python, we can vary Python and
         # Numpy versions at the same time.
         - stage: Tests with other Python/Numpy versions
-          os: linux
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
                PIP_DEPENDENCIES='pytest>=3.1'
 
         - stage: Tests with other Python/Numpy versions
-          os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
 
         - stage: Tests with other Python/Numpy versions
-          os: linux
           env: NUMPY_VERSION=1.11
 
         - stage: Tests with other Python/Numpy versions
-          os: linux
           env: NUMPY_VERSION=1.12
 
         # Try numpy pre-release
         - stage: Tests with other Python/Numpy versions
-          os: linux
           env: NUMPY_VERSION=prerelease
                EVENT_TYPE='pull_request push cron'
 
@@ -151,8 +132,7 @@ matrix:
           env: SETUP_CMD='test' EVENT_TYPE='cron'
 
     allow_failures:
-        - os: linux
-          env: NUMPY_VERSION=prerelease
+        - env: NUMPY_VERSION=prerelease
                EVENT_TYPE='pull_request push cron'
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ language: c
 os:
     - linux
 
-stage: Comprehensive tests
-
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
@@ -55,7 +53,8 @@ env:
 
 stages:
    - name: Initial tests
-   - name: Comprehensive tests
+   - name: Test docs, astropy dev, and without optional dependencies
+   - name: Tests with other Python/Numpy versions
    - name: Cron tests
      if: type = cron
 
@@ -87,11 +86,13 @@ matrix:
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - os: linux
+        - stage: Test docs, astropy dev, and without optional dependencies
+          os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter'
 
-        - os: linux
+        - stage: Test docs, astropy dev, and without optional dependencies
+          os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter'
                EVENT_TYPE='pull_request push cron'
@@ -99,36 +100,48 @@ matrix:
         # Now try Astropy dev and LTS versions with the latest Python.
         # We disable LTS testing until astropy 3.0 is out, as the current
         # stable is also the LTS
-        - os: linux
+        - stage: Test docs, astropy dev, and without optional dependencies
+          os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
-        #- os: linux
-        #  env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts PYTEST_VERSION=2.7
-        #- os: linux
-        #  env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts PYTEST_VERSION=2.7
+
+        #- stage: Test docs, astropy dev, and without optional dependencies
+        #  os: linux
+        #  env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts
+
+        # Try with optional dependencies disabled
+        - stage: Test docs, astropy dev, and without optional dependencies
+          os: linux
+          env: PYTHON_VERSION=2.7 CONDA_DEPENDENCIES='Cython'
+
+        - stage: Test docs, astropy dev, and without optional dependencies
+          os: linux
+          env: CONDA_DEPENDENCIES='Cython'
 
         # Try older python and numpy versions. Since we can assume
         # that the Numpy developers have taken care of testing Numpy
         # with different versions of Python, we can vary Python and
         # Numpy versions at the same time.
-        - os: linux
+        - stage: Tests with other Python/Numpy versions
+          os: linux
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
                PIP_DEPENDENCIES='pytest>=3.1'
-        - os: linux
+
+        - stage: Tests with other Python/Numpy versions
+          os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
-        - os: linux
+
+        - stage: Tests with other Python/Numpy versions
+          os: linux
           env: NUMPY_VERSION=1.11
-        - os: linux
+
+        - stage: Tests with other Python/Numpy versions
+          os: linux
           env: NUMPY_VERSION=1.12
 
-        # Try with optional dependencies disabled
-        - os: linux
-          env: PYTHON_VERSION=2.7 CONDA_DEPENDENCIES='Cython'
-        - os: linux
-          env: CONDA_DEPENDENCIES='Cython'
-
         # Try numpy pre-release
-        - os: linux
+        - stage: Tests with other Python/Numpy versions
+          os: linux
           env: NUMPY_VERSION=prerelease
                EVENT_TYPE='pull_request push cron'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ language: c
 os:
     - linux
 
+stage: Comprehensive tests
+
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
@@ -35,23 +37,52 @@ env:
         - SETUP_XVFB=True
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
-    matrix:
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        # PEP8 errors/warnings:
+        # E101 - mix of tabs and spaces
+        # W191 - use of tabs
+        # W291 - trailing whitespace
+        # W292 - no newline at end of file
+        # W293 - trailing whitespace
+        # W391 - blank line at end of file
+        # E111 - 4 spaces per indentation level
+        # E112 - 4 spaces per indentation level
+        # E113 - 4 spaces per indentation level
+        # E502 - the backslash is redundant between brackets
+        # E722 - do not use bare except
+        # E901 - SyntaxError or IndentationError
+        # E902 - IOError
+        - FLAKE8_OPT="--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902"
+
+stages:
+   - name: Initial tests
+   - name: Comprehensive tests
+   - name: Cron tests
+     if: type = cron
 
 matrix:
     # Don't wait for allowed failures
     fast_finish: true
 
     include:
-        # Try MacOS X
-        - os: osx
-          env: SETUP_CMD='test'
+        - stage: Initial tests
+          env: PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
 
-        # Do a coverage test.
-        - os: linux
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
+
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+
+        # Do a PEP8/pyflakes test with flake8
+        - stage: Initial tests
+          os: linux
+          env: MAIN_CMD="flake8 photutils --count $FLAKE8_OPT" SETUP_CMD=''
+
+        - stage: Initial tests
+          os: linux
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
@@ -59,12 +90,11 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter'
-               SPHINX_VERSION='>1.6'
+
         - os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib jupyter'
                EVENT_TYPE='pull_request push cron'
-               SPHINX_VERSION='>1.6'
 
         # Now try Astropy dev and LTS versions with the latest Python.
         # We disable LTS testing until astropy 3.0 is out, as the current
@@ -77,10 +107,10 @@ matrix:
         #- os: linux
         #  env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts PYTEST_VERSION=2.7
 
-        # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different
-        # versions of Python, we can vary Python and Numpy versions at the same
-        # time.
+        # Try older python and numpy versions. Since we can assume
+        # that the Numpy developers have taken care of testing Numpy
+        # with different versions of Python, we can vary Python and
+        # Numpy versions at the same time.
         - os: linux
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
                PIP_DEPENDENCIES='pytest>=3.1'
@@ -102,9 +132,15 @@ matrix:
           env: NUMPY_VERSION=prerelease
                EVENT_TYPE='pull_request push cron'
 
-        # Do a PEP8 test with pycodestyle
+        # Try MacOS X
+        - stage: Cron tests
+          os: osx
+          env: SETUP_CMD='test' EVENT_TYPE='cron'
+
+    allow_failures:
         - os: linux
-          env: MAIN_CMD='pycodestyle photutils --count' SETUP_CMD=''
+          env: NUMPY_VERSION=prerelease
+               EVENT_TYPE='pull_request push cron'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
@@ -114,6 +150,6 @@ script:
    - $MAIN_CMD $SETUP_CMD
 
 after_success:
-    - if [[ $SETUP_CMD == *coverage* ]]; then
+    - if [[ $SETUP_CMD == *--coverage* ]]; then
           coveralls --rcfile='photutils/tests/coveragerc';
       fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,21 +17,6 @@ addopts = --pyargs -p no:warnings
 [ah_bootstrap]
 auto_use = True
 
-[pycodestyle]
-# E101 - mix of tabs and spaces
-# W191 - use of tabs
-# W291 - trailing whitespace
-# W292 - no newline at end of file
-# W293 - trailing whitespace
-# W391 - blank line at end of file
-# E111 - 4 spaces per indentation level
-# E112 - 4 spaces per indentation level
-# E113 - 4 spaces per indentation level
-# E901 - SyntaxError or IndentationError
-# E902 - IOError
-select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902
-exclude = extern,sphinx,*parsetab.py
-
 [metadata]
 package_name = photutils
 description = An Astropy package for photometry


### PR DESCRIPTION
This PR:

* moves the OSX test from regular testing to a cron test
* implements the new build stages
* adds a `flake8` test
* removes the pycodestyle from `setup.cfg`