### PR TITLE
Use system six rather than the deprecated astropy bundled one

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -20,6 +20,8 @@ python -c 'import sys; print(sys.maxsize)'
 # is resolved
 easy_install "pytest<3.2"
 
+pip install six
+
 python setup.py test -V -a "-s"
 
 EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
+        - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib six'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
         - SETUP_XVFB=True
         - ASTROPY_USE_SYSTEM_PYTEST=1
@@ -99,10 +99,10 @@ matrix:
 
         # Try with optional dependencies disabled
         - stage: Test docs, astropy dev, and without optional dependencies
-          env: PYTHON_VERSION=2.7 CONDA_DEPENDENCIES='Cython'
+          env: PYTHON_VERSION=2.7 CONDA_DEPENDENCIES='Cython six'
 
         - stage: Test docs, astropy dev, and without optional dependencies
-          env: CONDA_DEPENDENCIES='Cython'
+          env: CONDA_DEPENDENCIES='Cython six'
 
         # Try older python and numpy versions. Since we can assume
         # that the Numpy developers have taken care of testing Numpy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ General
 - Dropped scipy 0.15 support.  Minimal required version is now scipy
   0.16. [#576]
 
+- Explicitly require six as dependency. [#601]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib"
+      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib six"
 
 
   matrix:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@
 
 import datetime
 import os
+import six
 import sys
 
 try:
@@ -40,7 +41,6 @@ except ImportError:
 
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
-from astropy.extern import six
 
 # Get configuration information from setup.cfg
 try:

--- a/docs/photutils/install.rst
+++ b/docs/photutils/install.rst
@@ -13,6 +13,8 @@ Photutils has the following strict requirements:
 
 * `Astropy`_ 2.0 or later
 
+* `six <https://pythonhosted.org/six/>`_
+
 Additionally, some functionality is available only if the following
 optional dependencies are installed:
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -6,9 +6,9 @@ import copy
 import warnings
 from collections import OrderedDict
 
+import six
 import numpy as np
 from astropy.coordinates import SkyCoord
-from astropy.extern import six
 from astropy.io import fits
 from astropy.nddata import support_nddata
 from astropy.table import QTable

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -10,8 +10,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import abc
 
+import six
 import numpy as np
-from astropy.extern import six
 from astropy.stats import (SigmaClip, biweight_location, biweight_scale,
                            mad_std)
 from astropy.utils.misc import InheritDocstrings

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -14,8 +14,8 @@ import warnings
 import math
 import abc
 
+import six
 import numpy as np
-from astropy.extern import six
 from astropy.table import Column, Table
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import InheritDocstrings

--- a/photutils/psf/groupstars.py
+++ b/photutils/psf/groupstars.py
@@ -3,8 +3,9 @@
 
 from __future__ import division
 import abc
+
+import six
 import numpy as np
-from astropy.extern import six
 from astropy.table import Column
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,6 @@ license = BSD
 url = http://photutils.readthedocs.io/
 edit_on_github = False
 github_project = astropy/photutils
-install_requires = astropy
+install_requires = astropy six
 
 [entry_points]


### PR DESCRIPTION
This may need a changelog entry, as now six becomes formally a dependency?