### PR TITLE
Add SourceCatalog class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,12 @@ New Features
     the bounding box corner vertices (``sky_bbox_ll``, ``sky_bbox_ul``
     ``sky_bbox_lr``, and ``sky_bbox_ur``). [#592]
 
+  - Added new ``SourceCatalog`` class to hold the list of
+    ``SourceProperties``. [#608]
+
+  - The ``properties_table`` function is now deprecated.  Use the
+    ``SourceCatalog.to_table()`` method instead. [#608]
+
 - ``phtotutils.psf``
 
   - Uncertainties on fitted parameters are added to the final table. [#516]

--- a/docs/photutils/morphology.rst
+++ b/docs/photutils/morphology.rst
@@ -38,11 +38,11 @@ Then, calculate its properties:
 
 .. doctest-requires:: scipy, skimage
 
-    >>> from photutils import data_properties, properties_table
-    >>> props = data_properties(data)
+    >>> from photutils import data_properties
+    >>> cat = data_properties(data)
     >>> columns = ['id', 'xcentroid', 'ycentroid', 'semimajor_axis_sigma',
     ...            'semiminor_axis_sigma', 'orientation']
-    >>> tbl = properties_table(props, columns=columns)
+    >>> tbl = cat.to_table(columns=columns)
     >>> tbl['xcentroid'].info.format = '.10f'  # optional format
     >>> tbl['ycentroid'].info.format = '.10f'
     >>> tbl['semiminor_axis_sigma'].info.format = '.10f'
@@ -58,12 +58,12 @@ approximate isophotal ellipse for the source:
 
 .. doctest-skip::
 
-    >>> from photutils import properties_table, EllipticalAperture
-    >>> position = (props.xcentroid.value, props.ycentroid.value)
+    >>> from photutils import EllipticalAperture
+    >>> position = (cat.xcentroid.value, cat.ycentroid.value)
     >>> r = 3.0    # approximate isophotal extent
-    >>> a = props.semimajor_axis_sigma.value * r
-    >>> b = props.semiminor_axis_sigma.value * r
-    >>> theta = props.orientation.value
+    >>> a = cat.semimajor_axis_sigma.value * r
+    >>> b = cat.semiminor_axis_sigma.value * r
+    >>> theta = cat.orientation.value
     >>> apertures = EllipticalAperture(position, a, b, theta=theta)
     >>> plt.imshow(data, origin='lower', cmap='viridis',
     ...            interpolation='nearest')
@@ -72,19 +72,19 @@ approximate isophotal ellipse for the source:
 .. plot::
 
     import matplotlib.pyplot as plt
-    from photutils import data_properties, properties_table, EllipticalAperture
+    from photutils import data_properties, EllipticalAperture
     from photutils.datasets import make_4gaussians_image
 
     data = make_4gaussians_image()[43:79, 76:104]    # extract single object
-    props = data_properties(data)
+    cat = data_properties(data)
     columns = ['id', 'xcentroid', 'ycentroid', 'semimajor_axis_sigma',
                'semiminor_axis_sigma', 'orientation']
-    tbl = properties_table(props, columns=columns)
+    tbl = cat.to_table(columns=columns)
     r = 2.5    # approximate isophotal extent
-    position = (props.xcentroid.value, props.ycentroid.value)
-    a = props.semimajor_axis_sigma.value * r
-    b = props.semiminor_axis_sigma.value * r
-    theta = props.orientation.value
+    position = (cat.xcentroid.value, cat.ycentroid.value)
+    a = cat.semimajor_axis_sigma.value * r
+    b = cat.semiminor_axis_sigma.value * r
+    theta = cat.orientation.value
     apertures = EllipticalAperture(position, a, b, theta=theta)
     plt.imshow(data, origin='lower', cmap='viridis', interpolation='nearest')
     apertures.plot(color='#d62728')

--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -6,7 +6,7 @@ from astropy.tests.pytest_plugins import *    # noqa
 
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
-enable_deprecations_as_exceptions()    # noqa
+# enable_deprecations_as_exceptions()    # noqa
 
 # Uncomment and customize the following lines to add/remove entries from
 # the list of packages for which version numbers are displayed when running

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1525,9 +1525,9 @@ def properties_table(source_props, columns=None, exclude_columns=None):
     """
 
     if ((isinstance(source_props, list) or
-             isinstance(source_props, SourceCatalog)) and
-            len(source_props) == 0):
-        raise ValueError('source_props is an empty list')
+         isinstance(source_props, SourceCatalog)) and len(source_props) == 0):
+            raise ValueError('source_props is an empty list')
+
     source_props = np.atleast_1d(source_props)
 
     # all scalar-valued properties

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -20,7 +20,7 @@ __all__ = ['SourceProperties', 'source_properties', 'SourceCatalog',
            'properties_table']
 
 __doctest_requires__ = {('SourceProperties', 'SourceProperties.*',
-                         'SourceCatalog', 'source_properties',
+                         'SourceCatalog', 'SourceCatalog.*', 'source_properties',
                          'properties_table'): ['scipy', 'skimage']}
 
 

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1234,9 +1234,7 @@ class SourceCatalog(object):
     """
 
     def __init__(self, properties_list, wcs=None):
-        if properties_list is None:
-            self._data = []
-        elif isinstance(properties_list, SourceProperties):
+        if isinstance(properties_list, SourceProperties):
             self._data = [properties_list]
         elif isinstance(properties_list, list):
             self._data = properties_list
@@ -1252,6 +1250,7 @@ class SourceCatalog(object):
     def __getitem__(self, index):
         return self._data[index]
 
+    # python 2 only
     def __getslice__(self, i, j):
         return self.__getitem__(slice(i, j))
 
@@ -1273,7 +1272,7 @@ class SourceCatalog(object):
                 if isinstance(values[0], u.Quantity):
                     # turn list of Quantities into a Quantity array
                     values = u.Quantity(values)
-                if isinstance(values[0], SkyCoord):   # failsafe
+                if isinstance(values[0], SkyCoord):   # pragma: no cover
                     # turn list of SkyCoord into a SkyCoord array
                     values = SkyCoord(values)
 
@@ -1474,9 +1473,12 @@ def _properties_table(obj, columns=None, exclude_columns=None):
             if isinstance(values[0], u.Quantity):
                 # turn list of Quantities into a Quantity array
                 values = u.Quantity(values)
-            if isinstance(values[0], SkyCoord):   # failsafe
+            if isinstance(values[0], SkyCoord):   # pragma: no cover
                 # turn list of SkyCoord into a SkyCoord array
                 values = SkyCoord(values)
+
+        if isinstance(obj, SourceCatalog) and values is None:
+            values = [None] * len(obj)
 
         tbl[column] = values
 
@@ -1639,7 +1641,7 @@ def properties_table(source_props, columns=None, exclude_columns=None):
             if isinstance(values[0], u.Quantity):
                 # turn list of Quantities into a Quantity array
                 values = u.Quantity(values)
-            if isinstance(values[0], SkyCoord):   # failsafe
+            if isinstance(values[0], SkyCoord):   # pragma: no cover
                 # turn list of SkyCoord into a SkyCoord array
                 values = SkyCoord(values)
 

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -14,8 +14,8 @@ import astropy.units as u
 from astropy.utils.misc import isiterable
 import astropy.wcs as WCS
 
-from ..properties import (SourceProperties, source_properties, properties_table,
-                          SourceCatalog)
+from ..properties import (SourceProperties, source_properties,
+                          SourceCatalog, properties_table)
 
 try:
     import scipy    # noqa
@@ -310,6 +310,7 @@ class TestSourceCatalog(object):
         cat = source_properties(IMAGE, SEGM)
         cat2 = SourceCatalog(cat[0])
         assert len(cat) == 1
+        assert len(cat2) == 1
 
         with pytest.raises(ValueError):
             SourceCatalog('a')
@@ -332,7 +333,7 @@ class TestSourceCatalog(object):
         cat = source_properties(IMAGE, SEGM)
         columns = ['idzz', 'xcentroidzz']
         with pytest.raises(AttributeError):
-           cat.to_table(columns=columns)
+            cat.to_table(columns=columns)
 
     def test_table_exclude(self):
         cat = source_properties(IMAGE, SEGM)
@@ -371,6 +372,7 @@ class TestSourceCatalog(object):
         t = cat.to_table(columns=columns)
         assert t[0]['sky_centroid'] is None
         assert t.colnames == columns
+
 
 @pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -14,7 +14,8 @@ import astropy.units as u
 from astropy.utils.misc import isiterable
 import astropy.wcs as WCS
 
-from ..properties import SourceProperties, source_properties, properties_table
+from ..properties import (SourceProperties, source_properties, properties_table,
+                          SourceCatalog)
 
 try:
     import scipy    # noqa
@@ -292,6 +293,87 @@ class TestSourcePropertiesFunction(object):
 
 @pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.skipif('not HAS_SCIPY')
+class TestSourceCatalog(object):
+    def test_basic(self):
+        segm = np.zeros(IMAGE.shape)
+        x = y = np.arange(0, 100, 10)
+        segm[y, x] = np.arange(10)
+        cat = source_properties(IMAGE, segm)
+        assert len(cat) == 9
+        cat2 = cat[0:5]
+        assert len(cat2) == 5
+        cat3 = SourceCatalog(cat2)
+        del cat3[4]
+        assert len(cat3) == 4
+
+    def test_inputs(self):
+        cat = source_properties(IMAGE, SEGM)
+        cat2 = SourceCatalog(cat[0])
+        assert len(cat) == 1
+
+        with pytest.raises(ValueError):
+            SourceCatalog('a')
+
+    def test_table(self):
+        cat = source_properties(IMAGE, SEGM)
+        t = cat.to_table()
+        assert isinstance(t, QTable)
+        assert len(t) == 1
+
+    def test_table_include(self):
+        cat = source_properties(IMAGE, SEGM)
+        columns = ['id', 'xcentroid']
+        t = cat.to_table(columns=columns)
+        assert isinstance(t, QTable)
+        assert len(t) == 1
+        assert t.colnames == columns
+
+    def test_table_include_invalidname(self):
+        cat = source_properties(IMAGE, SEGM)
+        columns = ['idzz', 'xcentroidzz']
+        with pytest.raises(AttributeError):
+           cat.to_table(columns=columns)
+
+    def test_table_exclude(self):
+        cat = source_properties(IMAGE, SEGM)
+        exclude = ['id', 'xcentroid']
+        t = cat.to_table(exclude_columns=exclude)
+        assert isinstance(t, QTable)
+        assert len(t) == 1
+        with pytest.raises(KeyError):
+            t['id']
+
+    def test_table_empty_props(self):
+        cat = source_properties(IMAGE, SEGM, labels=-1)
+        with pytest.raises(ValueError):
+            cat.to_table()
+
+    def test_table_wcs(self):
+        mywcs = WCS.WCS(naxis=2)
+        rho = np.pi / 3.
+        scale = 0.1 / 3600.
+        mywcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
+                        [scale*np.sin(rho), scale*np.cos(rho)]]
+        mywcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+
+        cat = source_properties(IMAGE, SEGM, wcs=mywcs)
+        columns = ['sky_centroid', 'sky_centroid_icrs', 'icrs_centroid',
+                   'ra_icrs_centroid', 'dec_icrs_centroid', 'sky_bbox_ll',
+                   'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
+        t = cat.to_table(columns=columns)
+        assert t[0]['sky_centroid'] is not None
+        assert t.colnames == columns
+
+        cat = source_properties(IMAGE, SEGM)
+        columns = ['sky_centroid', 'sky_centroid_icrs', 'icrs_centroid',
+                   'ra_icrs_centroid', 'dec_icrs_centroid', 'sky_bbox_ll',
+                   'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
+        t = cat.to_table(columns=columns)
+        assert t[0]['sky_centroid'] is None
+        assert t.colnames == columns
+
+@pytest.mark.skipif('not HAS_SKIMAGE')
+@pytest.mark.skipif('not HAS_SCIPY')
 class TestPropertiesTable(object):
     def test_properties_table(self):
         props = source_properties(IMAGE, SEGM)
@@ -340,6 +422,9 @@ class TestPropertiesTable(object):
         mywcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
 
         props = source_properties(IMAGE, SEGM, wcs=mywcs)
-        columns = ['sky_centroid_icrs']
+        columns = ['sky_centroid', 'sky_centroid_icrs', 'icrs_centroid',
+                   'ra_icrs_centroid', 'dec_icrs_centroid', 'sky_bbox_ll',
+                   'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
         t = properties_table(props, columns=columns)
+        assert t.colnames == columns
         assert t[0]['sky_centroid_icrs'] is not None


### PR DESCRIPTION
The `SourceCatalog` class holds the list of `SourceProperties` instances and is returned by the `source_properties` function.  This simplifies the API (and the underlying code).

This PR also deprecates the `properties_table` function.  Instead, the `SourceCatalog` has a `to_table()` method to create an astropy `QTable` of the catalog.  