### PR TITLE
Deprecate unused interpolate_masked_data function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -152,6 +152,7 @@ API changes
   - The ``background_color`` keyword was removed from the
     ``random_cmap`` function. [#528]
 
+  - Deprecated unused ``interpolate_masked_data()``. [#526, #611]
 
 Bug Fixes
 ^^^^^^^^^

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 
 import numpy as np
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 
@@ -285,6 +286,7 @@ class ShepardIDWInterpolator(object):
             return interp_values
 
 
+@deprecated('0.4')
 def interpolate_masked_data(data, mask, error=None, background=None):
     """
     Interpolate over masked pixels in data and optional error or

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -2,9 +2,12 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import warnings
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .. import ShepardIDWInterpolator as idw
 from .. import interpolate_masked_data, mask_to_mirrored_num
@@ -111,6 +114,13 @@ class TestShepardIDWInterpolator(object):
 
 
 class TestInterpolateMaskedData(object):
+    def setup_class(cls):
+        """Ignore all deprecation warnings here."""
+        warnings.simplefilter('ignore', AstropyDeprecationWarning)
+
+    def teardown_class(cls):
+        warnings.resetwarnings()
+
     def test_mask_shape(self):
         with pytest.raises(ValueError):
             interpolate_masked_data(DATA, WRONG_SHAPE)


### PR DESCRIPTION
This PR replaces #526.  For some reason, github won't let me push to @pllim 's branch.