### PR TITLE
Minor travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,6 @@ matrix:
         # stable is also the LTS
         - stage: Test docs, astropy dev, and without optional dependencies
           env: ASTROPY_VERSION=development
-               PIP_DEPENDENCIES='pytest-astropy'
                EVENT_TYPE='pull_request push cron'
 
         #- stage: Test docs, astropy dev, and without optional dependencies


### PR DESCRIPTION
ci-helpers now takes care of installing pytest-astropy for astropy dev (and later for stable when 3.0 is out)