### PR TITLE
Fix deblending with sources not in the segmentation mask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ New Features
 
   - Added a ``mask`` keyword to the ``detect_sources`` function. [#621]
 
+  - Fix ``deblend_sources`` when other sources are in the neighborhood. [#617]
+
 
 0.4 (2017-10-30)
 ----------------

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -224,8 +224,11 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
         raise ValueError('Invalid connectivity={0}.  '
                          'Options are 4 or 8'.format(connectivity))
 
+    # Work on a copy of the data to avoid modifying the input image
+    data = data.copy()
     segm_mask = (segment_img.data > 0)
     source_values = data[segm_mask]
+    data[~segm_mask] = 0
     source_min = np.min(source_values)
     source_max = np.max(source_values)
     if source_min == source_max:

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -224,11 +224,8 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
         raise ValueError('Invalid connectivity={0}.  '
                          'Options are 4 or 8'.format(connectivity))
 
-    # Work on a copy of the data to avoid modifying the input image
-    data = data.copy()
     segm_mask = (segment_img.data > 0)
     source_values = data[segm_mask]
-    data[~segm_mask] = 0
     source_min = np.min(source_values)
     source_max = np.max(source_values)
     if source_min == source_max:
@@ -255,9 +252,10 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
 
     # create top-down tree of local peaks
     segm_tree = []
+    mask = ~segm_mask
     for level in thresholds[::-1]:
         segm_tmp = detect_sources(data, level, npixels=npixels,
-                                  connectivity=connectivity)
+                                  connectivity=connectivity, mask=mask)
         if segm_tmp.nlabels >= 2:
             fluxes = []
             for i in segm_tmp.labels:

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -74,6 +74,18 @@ class TestDeblendSources(object):
         assert result.area(1) == result.area(5)
         assert result.area(1) == result.area(6)
 
+    def test_deblend_multiple_sources_with_neighbor(self):
+        g1 = models.Gaussian2D(100, 50, 50, 20, 5, theta=45)
+        g2 = models.Gaussian2D(100, 35, 50, 5, 5)
+        g3 = models.Gaussian2D(100, 60, 20, 5, 5)
+
+        x = self.x
+        y = self.y
+        data = (g1 + g2 + g3)(x, y)
+        segm = detect_sources(data, self.threshold, self.npixels)
+        result = deblend_sources(data, segm, self.npixels)
+        assert result.nlabels == 3
+
     @pytest.mark.parametrize('mode', ['exponential', 'linear'])
     def test_deblend_sources_norelabel(self, mode):
         result = deblend_sources(self.data, self.segm, self.npixels,


### PR DESCRIPTION
Fix #616.

To deblend a source a small stamp is created and can contain other
sources, depending on the shape of the source mask. These neighboring
sources are not masked so they are used in the deblending process. Given
that the data array is also used for flux computation before the
watershed, the most abvious solution is to put values outside the source
mask to zero. 

Maybe there is a better approach ? I will also try to make a test with a simulated image which reproduce the issue.