### PR TITLE
Add mask keyword to detect_sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 0.5 (unreleased)
 ----------------
 
-- No changes yet
+New Features
+^^^^^^^^^^^^
+
+- ``photutils.segmentation``
+
+  - Added a ``mask`` keyword to the ``detect_sources`` function. [#621]
 
 
 0.4 (2017-10-30)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -15,7 +15,7 @@ __all__ = ['detect_sources', 'make_source_mask']
 
 
 def detect_sources(data, threshold, npixels, filter_kernel=None,
-                   connectivity=8):
+                   connectivity=8, mask=None):
     """
     Detect sources above a specified threshold value in an image and
     return a `~photutils.segmentation.SegmentationImage` object.
@@ -23,6 +23,8 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
     Detected sources must have ``npixels`` connected pixels that are
     each greater than the ``threshold`` value.  If the filtering option
     is used, then the ``threshold`` is applied to the filtered image.
+    The input ``mask`` can be used to mask pixels in the input data.
+    Masked pixels will not be included in any source.
 
     This function does not deblend overlapping sources.  First use this
     function to detect sources followed by
@@ -56,6 +58,11 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         (default).  4-connected pixels touch along their edges.
         8-connected pixels touch along their edges or corners.  For
         reference, SExtractor uses 8-connected pixels.
+
+    mask : array_like (bool)
+        A boolean mask, with the same shape as the input ``data``, where
+        `True` values indicate masked pixels.  Masked pixels will not be
+        included in any source.
 
     Returns
     -------
@@ -121,6 +128,12 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
 
     image = (filter_data(data, filter_kernel, mode='constant', fill_value=0.0,
                          check_normalization=True) > threshold)
+
+    if mask is not None:
+        if mask.shape != image.shape:
+            raise ValueError('mask must have the same shape as the input '
+                             'image.')
+        image &= ~mask
 
     if connectivity == 4:
         selem = ndimage.generate_binary_structure(2, 1)

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -126,6 +126,15 @@ class TestDetectSources(object):
             assert ('The kernel is not normalized.'
                     in str(warning_lines[0].message))
 
+    def test_mask(self):
+        data = np.zeros((11, 11))
+        data[3:8, 3:8] = 5.
+        mask = np.zeros_like(data, dtype=bool)
+        mask[4:6, 4:6] = True
+        segm1 = detect_sources(data, 1., 1.)
+        segm2 = detect_sources(data, 1., 1., mask=mask)
+        assert segm2.areas[1] == segm1.areas[1] - mask.sum()
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestMakeSourceMask(object):

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -135,6 +135,10 @@ class TestDetectSources(object):
         segm2 = detect_sources(data, 1., 1., mask=mask)
         assert segm2.areas[1] == segm1.areas[1] - mask.sum()
 
+    def test_mask_shape(self):
+        with pytest.raises(ValueError):
+            detect_sources(self.data, 1., 1., mask=np.ones((5, 5)))
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestMakeSourceMask(object):


### PR DESCRIPTION
This is useful for excluding pixels/regions from source detection.

This will also be used to fix the deblending bug reported in #616.