### PR TITLE
Ignore pytest last failed cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ distribute-*.tar.gz
 
 # Mac OSX
 .DS_Store
+
+# Pytest
+v/


### PR DESCRIPTION
This `v` directory started appearing on failed tests when running `pytest`.