### PR TITLE
Minor fix to the tests to test the input unit not kwarg

### DIFF
--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -509,8 +509,7 @@ def test_basic_circular_aperture_photometry_unit():
 
     table1 = aperture_photometry(data1, CircularAperture(position, radius),
                                  unit=unit)
-    table2 = aperture_photometry(data2, CircularAperture(position, radius),
-                                 unit=unit)
+    table2 = aperture_photometry(data2, CircularAperture(position, radius))
 
     assert_allclose(table1['aperture_sum'].value, true_flux)
     assert_allclose(table2['aperture_sum'].value, true_flux)


### PR DESCRIPTION
Maybe we also need to test the warning when there is both a unit for the input data and provided by kwarg?