### PR TITLE
Add numpy 1.13 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,9 @@ matrix:
         - stage: Tests with other Python/Numpy versions
           env: NUMPY_VERSION=1.12
 
+        - stage: Tests with other Python/Numpy versions
+          env: NUMPY_VERSION=1.13
+
         # Try numpy pre-release
         - stage: Tests with other Python/Numpy versions
           env: NUMPY_VERSION=prerelease


### PR DESCRIPTION
Numpy stable is now v1.14, so v1.13 wasn't being tested.