### PR TITLE
Fix corner-case aperture photometry bug

### DIFF
--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -178,6 +178,8 @@ class ApertureMask(object):
         """
 
         data = np.asanyarray(data)
+        if data.ndim != 2:
+            raise ValueError('data must be a 2D array.')
 
         partial_overlap = False
         if self.bbox.ixmin < 0 or self.bbox.iymin < 0:

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -234,4 +234,8 @@ class ApertureMask(object):
             input ``data``.
         """
 
-        return self.cutout(data, fill_value=fill_value) * self.data
+        cutout = self.cutout(data, fill_value=fill_value)
+        if cutout is None:
+            return None
+        else:
+            return cutout * self.data

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -154,9 +154,17 @@ class ApertureMask(object):
         """
 
         data = np.asanyarray(data)
-        cutout = data[self.bbox.slices]
 
-        if cutout.shape != self.shape:
+        partial_overlap = False
+        if self.bbox.ixmin < 0 or self.bbox.iymin < 0:
+            partial_overlap = True
+
+        if not partial_overlap:
+            # try this for speed -- the result may still be a partial
+            # overlap, in which case the next block will be triggered
+            cutout = data[self.bbox.slices]
+
+        if partial_overlap or (cutout.shape != self.shape):
             slices_large, slices_small = self._overlap_slices(data.shape)
 
             if slices_small is None:

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -3,9 +3,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 
+from ..bounding_box import BoundingBox
 from ..circle import CircularAperture
+from ..mask import ApertureMask
 
 try:
     import matplotlib    # noqa
@@ -14,7 +17,46 @@ except ImportError:
     HAS_MATPLOTLIB = False
 
 
-POSITIONS = [(-20, -20), (-20, 20), (20, -20)]
+POSITIONS = [(-20, -20), (-20, 20), (20, -20), (60, 60)]
+
+
+def test_mask_input_shapes():
+    with pytest.raises(ValueError):
+        mask_data = np.ones((10, 10))
+        bbox = BoundingBox(5, 10, 5, 10)
+        ApertureMask(mask_data, bbox)
+
+
+def test_mask_array():
+    mask_data = np.ones((10, 10))
+    bbox = BoundingBox(5, 15, 5, 15)
+    mask = ApertureMask(mask_data, bbox)
+    data = np.array(mask)
+    assert_allclose(data, mask.data)
+
+
+def test_mask_cutout_shape():
+    mask_data = np.ones((10, 10))
+    bbox = BoundingBox(5, 15, 5, 15)
+    mask = ApertureMask(mask_data, bbox)
+
+    with pytest.raises(ValueError):
+        mask.cutout(np.arange(10))
+
+    with pytest.raises(ValueError):
+        mask._overlap_slices((10,))
+
+    with pytest.raises(ValueError):
+        mask.to_image((10,))
+
+
+def test_mask_cutout_copy():
+    data = np.ones((50, 50))
+    aper = CircularAperture((25, 25), r=10.)
+    mask = aper.to_mask()[0]
+    cutout = mask.cutout(data, copy=True)
+    data[25, 25] = 100.
+    assert cutout[10, 10] == 1.
 
 
 @pytest.mark.parametrize('position', POSITIONS)

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -1,0 +1,49 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+import pytest
+
+from ..circle import CircularAperture
+
+try:
+    import matplotlib    # noqa
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
+
+
+POSITIONS = [(-20, -20), (-20, 20), (20, -20)]
+
+
+@pytest.mark.parametrize('position', POSITIONS)
+def test_mask_cutout_no_overlap(position):
+    data = np.ones((50, 50))
+    aper = CircularAperture(position, r=10.)
+    mask = aper.to_mask()[0]
+
+    cutout = mask.cutout(data)
+    assert cutout is None
+
+    weighted_data = mask.multiply(data)
+    assert weighted_data is None
+
+    image = mask.to_image(data.shape)
+    assert image is None
+
+
+@pytest.mark.parametrize('position', POSITIONS)
+def test_mask_cutout_partial_overlap(position):
+    data = np.ones((50, 50))
+    aper = CircularAperture(position, r=30.)
+    mask = aper.to_mask()[0]
+
+    cutout = mask.cutout(data)
+    assert cutout.shape == mask.shape
+
+    weighted_data = mask.multiply(data)
+    assert weighted_data.shape == mask.shape
+
+    image = mask.to_image(data.shape)
+    assert image.shape == data.shape


### PR DESCRIPTION
This PR fixes an aperture photometry bug that was triggered when the aperture `x` and `y` positions were both negative *and* the aperture had no overlap with the data.  Instead of returning `nan`, it would incorrectly return a value.

This PR also adds a `copy` keyword to the `ApertureMask.cutout()` method and `ApertureMask` unit tests.

Fixes #637.