### PR TITLE
Fixed issues with deblend_sources and source_properties when NaNs are present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,14 @@ Bug Fixes
 
 - ``photutils.segmentation``
 
-  - Fix ``deblend_sources`` when other sources are in the neighborhood. [#617]
+  - Fixed ``deblend_sources`` when other sources are in the
+    neighborhood. [#617]
+
+  - Fixed ``source_properties`` to handle the case where the data
+    contain one or more NaNs. [#658]
+
+  - Fixed an issue with ``deblend_sources`` where sources were not
+    deblended where the data contain one or more NaNs. [#658]
 
 
 Other Changes and Additions

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -226,8 +226,8 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
 
     segm_mask = (segment_img.data > 0)
     source_values = data[segm_mask]
-    source_min = np.min(source_values)
-    source_max = np.max(source_values)
+    source_min = np.nanmin(source_values)
+    source_max = np.nanmax(source_values)
     if source_min == source_max:
         return segment_img     # no deblending
     if source_min < 0:
@@ -235,7 +235,7 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
                       'deblending mode to "linear"'.format(
                           segment_img.labels[0]), AstropyUserWarning)
         mode = 'linear'
-    source_sum = float(np.sum(source_values))
+    source_sum = float(np.nansum(source_values))
 
     steps = np.arange(1., nlevels + 1)
     if mode == 'exponential':
@@ -259,7 +259,7 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
         if segm_tmp.nlabels >= 2:
             fluxes = []
             for i in segm_tmp.labels:
-                fluxes.append(np.sum(data[segm_tmp == i]))
+                fluxes.append(np.nansum(data[segm_tmp == i]))
             idx = np.where((np.array(fluxes) / source_sum) >= contrast)[0]
             if len(idx >= 2):
                 segm_tree.append(segm_tmp)

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -612,7 +612,7 @@ class SourceProperties(object):
         within the source segment.
         """
 
-        return np.min(self.values)
+        return np.nanmin(self.values)
 
     @lazyproperty
     def max_value(self):
@@ -621,7 +621,7 @@ class SourceProperties(object):
         within the source segment.
         """
 
-        return np.max(self.values)
+        return np.nanmax(self.values)
 
     @lazyproperty
     def minval_cutout_pos(self):
@@ -984,8 +984,8 @@ class SourceProperties(object):
         non-masked pixels in the source segment.
         """
 
-        return np.sum(np.ma.masked_array(self._data[self._slice],
-                                         mask=self._cutout_total_mask))
+        return np.nansum(np.ma.masked_array(self._data[self._slice],
+                                            mask=self._cutout_total_mask))
 
     @lazyproperty
     def source_sum_err(self):
@@ -1008,7 +1008,7 @@ class SourceProperties(object):
         if self._error is not None:
             # power doesn't work here, see astropy #2968
             # return np.sqrt(np.sum(self.error_cutout_ma**2))
-            return np.sqrt(np.sum(
+            return np.sqrt(np.nansum(
                 np.ma.masked_array(self.error_cutout_ma.data**2,
                                    mask=self.error_cutout_ma.mask)))
         else:

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -164,3 +164,14 @@ class TestDeblendSources(object):
         assert segm_deblend.nlabels == 1
         with pytest.raises(ValueError):
             deblend_sources(data, segm, npixels=1, connectivity=4)
+
+    def test_data_nan(self):
+        """
+        Test that deblending occurs even if the data within a segment
+        contains one or more NaNs.  Regression test for #658.
+        """
+
+        data = self.data.copy()
+        data[50, 50] = np.nan
+        segm2 = deblend_sources(data, self.segm, 5)
+        assert segm2.nlabels == 2

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -14,8 +14,8 @@ import astropy.units as u
 from astropy.utils.misc import isiterable
 import astropy.wcs as WCS
 
-from ..properties import (SourceProperties, source_properties,
-                          SourceCatalog, properties_table)
+from ..properties import (SegmentationImage, SourceProperties,
+                          source_properties, SourceCatalog, properties_table)
 
 try:
     import scipy    # noqa
@@ -289,6 +289,18 @@ class TestSourcePropertiesFunction(object):
         keys = ['semimajor_axis_sigma', 'semiminor_axis_sigma']
         for key in keys:
             assert p1[key] != p2[key]
+
+    def test_data_nan(self):
+        """Test case when data contains NaNs within a segment."""
+
+        data = np.ones((20, 20))
+        data[2, 2] = np.nan
+        segm = np.zeros((20, 20)).astype(int)
+        segm[1:5, 1:5] = 1
+        segm[7:15, 7:15] = 2
+        segm = SegmentationImage(segm)
+        props = source_properties(data, segm)
+        assert_quantity_allclose(props.minval_xpos, [1, 7]*u.pix)
 
 
 @pytest.mark.skipif('not HAS_SKIMAGE')


### PR DESCRIPTION
This PR fixes two issues in the `segmentation` subpackage.  `deblend_sources` will now properly deblend sources when the data within the segment contain one or more NaNs.  The `source_properties` function will now also properly handle any NaNs in the data (instead of raising an error).  In both cases, the NaN values are ignored.