### PR TITLE
Update isophote subpackage tests

### DIFF
--- a/photutils/isophote/tests/test_fitter.py
+++ b/photutils/isophote/tests/test_fitter.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 
 from astropy.io import fits
@@ -32,12 +33,11 @@ def test_gradient():
     sample = EllipseSample(DATA, 40.)
     sample.update()
 
-    assert sample.mean == pytest.approx(200.02, abs=0.01)
-    assert sample.gradient == pytest.approx(-4.222, abs=0.001)
-    assert sample.gradient_error == pytest.approx(0.0003, abs=0.0001)
-    assert sample.gradient_relative_error == pytest.approx(7.45e-05,
-                                                           abs=1.e-5)
-    assert sample.sector_area == pytest.approx(2.00, abs=0.01)
+    assert_allclose(sample.mean, 200.02, atol=0.01)
+    assert_allclose(sample.gradient, -4.222, atol=0.001)
+    assert_allclose(sample.gradient_error, 0.0003, atol=0.0001)
+    assert_allclose(sample.gradient_relative_error, 7.45e-05, atol=1.e-5)
+    assert_allclose(sample.sector_area, 2.00, atol=0.01)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -66,7 +66,7 @@ def test_fitting_raw():
     new_eps = sample.geometry.eps - correction
 
     # got closer to test data (eps=0.2)
-    assert new_eps == pytest.approx(0.21, abs=0.01)
+    assert_allclose(new_eps, 0.21, atol=0.01)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -191,7 +191,7 @@ class TestM51(object):
         isophote = fitter.fit()
 
         assert isophote.ndata == 119
-        assert isophote.intens == pytest.approx(685.4, abs=0.1)
+        assert_allclose(isophote.intens, 685.4, atol=0.1)
 
         # last sample taken by the original code, before turning inwards.
         sample = EllipseSample(self.data, 61.16, eps=0.219,
@@ -200,7 +200,7 @@ class TestM51(object):
         isophote = fitter.fit()
 
         assert isophote.ndata == 382
-        assert isophote.intens == pytest.approx(155.0, abs=0.1)
+        assert_allclose(isophote.intens, 155.0, atol=0.1)
 
     def test_m51_outer(self):
         # sample taken at the outskirts of the image, so many

--- a/photutils/isophote/tests/test_geometry.py
+++ b/photutils/isophote/tests/test_geometry.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 
 from ..geometry import EllipseGeometry
@@ -14,24 +15,15 @@ def test_geometry(astep, linear_growth):
                                linear_growth)
 
     sma1, sma2 = geometry.bounding_ellipses()
-    assert (sma1, sma2) == pytest.approx((90.0, 110.0), abs=0.01)
+    assert_allclose((sma1, sma2), (90.0, 110.0), atol=0.01)
 
     # using an arbitrary angle of 0.5 rad. This is to avoid a polar
     # vector that sits on top of one of the ellipse's axis.
     vertex_x, vertex_y = geometry.initialize_sector_geometry(0.6)
-
-    assert geometry.sector_angular_width == pytest.approx(0.0571, abs=0.01)
-    assert geometry.sector_area == pytest.approx(63.83, abs=0.01)
-
-    assert vertex_x[0] == pytest.approx(215.4, abs=0.1)
-    assert vertex_x[1] == pytest.approx(206.6, abs=0.1)
-    assert vertex_x[2] == pytest.approx(213.5, abs=0.1)
-    assert vertex_x[3] == pytest.approx(204.3, abs=0.1)
-
-    assert vertex_y[0] == pytest.approx(316.1, abs=0.1)
-    assert vertex_y[1] == pytest.approx(329.7, abs=0.1)
-    assert vertex_y[2] == pytest.approx(312.5, abs=0.1)
-    assert vertex_y[3] == pytest.approx(325.3, abs=0.1)
+    assert_allclose(geometry.sector_angular_width, 0.0571, atol=0.01)
+    assert_allclose(geometry.sector_area, 63.83, atol=0.01)
+    assert_allclose(vertex_x, [215.4, 206.6, 213.5, 204.3], atol=0.1)
+    assert_allclose(vertex_y, [316.1, 329.7, 312.5, 325.3], atol=0.1)
 
 
 def test_to_polar():
@@ -39,36 +31,33 @@ def test_to_polar():
     geometry = EllipseGeometry(0., 0., 100., 0.0, 0., 0.2, False)
 
     r, p = geometry.to_polar(100., 0.)
-    assert (r, p) == pytest.approx((100., 0.), abs=(0.1, 0.0001))
+    assert_allclose(r, 100., atol=0.1)
+    assert_allclose(p, 0., atol=0.0001)
 
     r, p = geometry.to_polar(0., 100.)
-    assert (r, p) == pytest.approx((100., np.pi/2.), abs=(0.1, 0.0001))
+    assert_allclose(r, 100., atol=0.1)
+    assert_allclose(p, np.pi/2., atol=0.0001)
 
     # vector with length 100. at 45 deg angle
     r, p = geometry.to_polar(70.71, 70.71)
-
-    # these have to be tested separately. For some unknown reason, using
-    # a combined assert statement as above raises an TypeError:
-    # unorderable types: tuple() < int()
-    # assert (r, p) == pytest.approx((100., np.pi/4.), abs=(0.1, 0.0001))
-    assert r == pytest.approx(100., abs=0.1)
-    assert p == pytest.approx(np.pi/4., abs=0.0001)
+    assert_allclose(r, 100., atol=0.1)
+    assert_allclose(p, np.pi/4., atol=0.0001)
 
     # position angle tilted 45 deg from X axis
     geometry = EllipseGeometry(0., 0., 100., 0.0, np.pi/4., 0.2, False)
 
     r, p = geometry.to_polar(100., 0.)
-    assert (r, p) == pytest.approx((100., np.pi*7./4), abs=(0.1, 0.0001))
+    assert_allclose(r, 100., atol=0.1)
+    assert_allclose(p, np.pi*7./4., atol=0.0001)
 
     r, p = geometry.to_polar(0., 100.)
-    assert (r, p) == pytest.approx((100., np.pi/4.), abs=(0.1, 0.0001))
+    assert_allclose(r, 100., atol=0.1)
+    assert_allclose(p, np.pi/4., atol=0.0001)
 
     # vector with length 100. at 45 deg angle
     r, p = geometry.to_polar(70.71, 70.71)
-    # same error as above
-    # assert (r, p) == pytest.approx((100., np.pi*2.), abs=(0.1, 0.0001))
-    assert r == pytest.approx(100., abs=0.1)
-    assert p == pytest.approx(np.pi*2., abs=0.0001)
+    assert_allclose(r, 100., atol=0.1)
+    assert_allclose(p, np.pi*2., atol=0.0001)
 
 
 def test_area():
@@ -77,29 +66,13 @@ def test_area():
 
     # sector at 45 deg on circle
     vertex_x, vertex_y = geometry.initialize_sector_geometry(45./180.*np.pi)
-
-    assert vertex_x[0] == pytest.approx(65.21, abs=0.01)
-    assert vertex_x[1] == pytest.approx(79.70, abs=0.01)
-    assert vertex_x[2] == pytest.approx(62.03, abs=0.01)
-    assert vertex_x[3] == pytest.approx(75.81, abs=0.01)
-
-    assert vertex_y[0] == pytest.approx(62.03, abs=0.01)
-    assert vertex_y[1] == pytest.approx(75.81, abs=0.01)
-    assert vertex_y[2] == pytest.approx(65.21, abs=0.01)
-    assert vertex_y[3] == pytest.approx(79.70, abs=0.01)
+    assert_allclose(vertex_x, [65.21, 79.70, 62.03, 75.81], atol=0.01)
+    assert_allclose(vertex_y, [62.03, 75.81, 65.21, 79.70], atol=0.01)
 
     # sector at 0 deg on circle
     vertex_x, vertex_y = geometry.initialize_sector_geometry(0)
-
-    assert vertex_x[0] == pytest.approx(89.97,  abs=0.01)
-    assert vertex_x[1] == pytest.approx(109.97, abs=0.01)
-    assert vertex_x[2] == pytest.approx(89.97,  abs=0.01)
-    assert vertex_x[3] == pytest.approx(109.96, abs=0.01)
-
-    assert vertex_y[0] == pytest.approx(-2.25, abs=0.01)
-    assert vertex_y[1] == pytest.approx(-2.75, abs=0.01)
-    assert vertex_y[2] == pytest.approx(2.25, abs=0.01)
-    assert vertex_y[3] == pytest.approx(2.75, abs=0.01)
+    assert_allclose(vertex_x, [89.97, 109.97, 89.97, 109.96], atol=0.01)
+    assert_allclose(vertex_y, [-2.25, -2.75, 2.25, 2.75], atol=0.01)
 
 
 def test_area2():
@@ -108,72 +81,55 @@ def test_area2():
 
     # sector at 45 deg on circle
     vertex_x, vertex_y = geometry.initialize_sector_geometry(45./180.*np.pi)
-
-    assert vertex_x[0] == pytest.approx(165.21, abs=0.01)
-    assert vertex_x[1] == pytest.approx(179.70, abs=0.01)
-    assert vertex_x[2] == pytest.approx(162.03, abs=0.01)
-    assert vertex_x[3] == pytest.approx(175.81, abs=0.01)
-
-    assert vertex_y[0] == pytest.approx(162.03, abs=0.01)
-    assert vertex_y[1] == pytest.approx(175.81, abs=0.01)
-    assert vertex_y[2] == pytest.approx(165.21, abs=0.01)
-    assert vertex_y[3] == pytest.approx(179.70, abs=0.01)
+    assert_allclose(vertex_x, [165.21, 179.70, 162.03, 175.81], atol=0.01)
+    assert_allclose(vertex_y, [162.03, 175.81, 165.21, 179.70], atol=0.01)
 
     # sector at 225 deg on circle
     vertex_x, vertex_y = geometry.initialize_sector_geometry(225./180.*np.pi)
-
-    assert vertex_x[0] == pytest.approx(34.791, abs=0.01)
-    assert vertex_x[1] == pytest.approx(20.30, abs=0.01)
-    assert vertex_x[2] == pytest.approx(37.97, abs=0.01)
-    assert vertex_x[3] == pytest.approx(24.19, abs=0.01)
-
-    assert vertex_y[0] == pytest.approx(37.97, abs=0.01)
-    assert vertex_y[1] == pytest.approx(24.19, abs=0.01)
-    assert vertex_y[2] == pytest.approx(34.79, abs=0.01)
-    assert vertex_y[3] == pytest.approx(20.30, abs=0.01)
+    assert_allclose(vertex_x, [34.79, 20.30, 37.97, 24.19], atol=0.01)
+    assert_allclose(vertex_y, [37.97, 24.19, 34.79, 20.30], atol=0.01)
 
 
 def test_reset_sma():
     geometry = EllipseGeometry(0., 0., 100., 0.0, 0., 0.2, False)
     sma, step = geometry.reset_sma(0.2)
-    assert sma == pytest.approx(83.33, abs=0.01)
-    assert step == pytest.approx(-0.1666, abs=0.001)
+    assert_allclose(sma, 83.33, atol=0.01)
+    assert_allclose(step, -0.1666, atol=0.001)
 
     geometry = EllipseGeometry(0., 0., 100., 0.0, 0., 20., True)
     sma, step = geometry.reset_sma(20.)
-    assert sma == pytest.approx(80.0, abs=0.01)
-    assert step == pytest.approx(-20.0, abs=0.01)
+    assert_allclose(sma, 80., atol=0.01)
+    assert_allclose(step, -20., atol=0.01)
 
 
 def test_update_sma():
     geometry = EllipseGeometry(0., 0., 100., 0.0, 0., 0.2, False)
     sma = geometry.update_sma(0.2)
-    assert sma == pytest.approx(120.0, abs=0.01)
+    assert_allclose(sma, 120., atol=0.01)
 
     geometry = EllipseGeometry(0., 0., 100., 0.0, 0., 20., True)
     sma = geometry.update_sma(20.)
-    assert sma == pytest.approx(120.0, abs=0.01)
+    assert_allclose(sma, 120., atol=0.01)
 
 
 def test_polar_angle_sector_limits():
     geometry = EllipseGeometry(0., 0., 100., 0.3, np.pi/4, 0.2, False)
     geometry.initialize_sector_geometry(np.pi/3)
     phi1, phi2 = geometry.polar_angle_sector_limits()
-
-    assert phi1 == pytest.approx(1.022198, abs=0.0001)
-    assert phi2 == pytest.approx(1.072198, abs=0.0001)
+    assert_allclose(phi1, 1.022198, atol=0.0001)
+    assert_allclose(phi2, 1.072198, atol=0.0001)
 
 
 def test_bounding_ellipses():
     geometry = EllipseGeometry(0., 0., 100., 0.3, np.pi/4, 0.2, False)
     sma1, sma2 = geometry.bounding_ellipses()
-    assert (sma1, sma2) == pytest.approx((90.0, 110.0), abs=0.01)
+    assert_allclose((sma1, sma2), (90.0, 110.0), atol=0.01)
 
 
 def test_radius():
     geometry = EllipseGeometry(0., 0., 100., 0.3, np.pi/4, 0.2, False)
     r = geometry.radius(0.0)
-    assert r == pytest.approx(100.0, abs=0.01)
+    assert_allclose(r, 100.0, atol=0.01)
 
     r = geometry.radius(np.pi/2)
-    assert r == pytest.approx(70.0, abs=0.01)
+    assert_allclose(r, 70.0, atol=0.01)

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 
 from .make_test_data import make_test_image
@@ -45,8 +46,8 @@ def test_harmonics_1():
     data_fit = est_std * np.sin(t + est_phase) + est_mean
     residual = data - data_fit
 
-    assert np.mean(residual) == pytest.approx(0.00, abs=0.001)
-    assert np.std(residual) == pytest.approx(0.01, abs=0.01)
+    assert_allclose(np.mean(residual), 0., atol=0.001)
+    assert_allclose(np.std(residual), 0.01, atol=0.01)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -69,8 +70,8 @@ def test_harmonics_2():
                 b2*np.cos(2*E) + 0.01*np.random.randn(N))
     residual = data - data_fit
 
-    assert np.mean(residual) == pytest.approx(0.00, abs=0.01)
-    assert np.std(residual) == pytest.approx(0.015, abs=0.01)
+    assert_allclose(np.mean(residual), 0., atol=0.01)
+    assert_allclose(np.std(residual), 0.015, atol=0.01)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -92,8 +93,8 @@ def test_harmonics_3():
                 0.01*np.random.randn(N))
     residual = data - data_fit
 
-    assert np.mean(residual) == pytest.approx(0.00, abs=0.01)
-    assert np.std(residual) == pytest.approx(0.015, abs=0.01)
+    assert_allclose(np.mean(residual), 0., atol=0.01)
+    assert_allclose(np.std(residual), 0.015, atol=0.01)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -112,19 +113,19 @@ class TestFitEllipseSamples(object):
         harmonics = fit_first_and_second_harmonics(s[0], s[2])
         y0, a1, b1, a2, b2 = harmonics[0]
 
-        assert np.mean(y0) == pytest.approx(200.019, abs=0.001)
-        assert np.mean(a1) == pytest.approx(-0.000138, abs=0.001)
-        assert np.mean(b1) == pytest.approx(0.000254, abs=0.001)
-        assert np.mean(a2) == pytest.approx(-5.658e-05, abs=0.001)
-        assert np.mean(b2) == pytest.approx(-0.00911, abs=0.001)
+        assert_allclose(np.mean(y0), 200.019, atol=0.001)
+        assert_allclose(np.mean(a1), -0.000138, atol=0.001)
+        assert_allclose(np.mean(b1), 0.000254, atol=0.001)
+        assert_allclose(np.mean(a2), -5.658e-05, atol=0.001)
+        assert_allclose(np.mean(b2), -0.00911, atol=0.001)
 
         # check that harmonics subtract nicely
         model = first_and_second_harmonic_function(
             s[0], np.array([y0, a1, b1, a2, b2]))
         residual = s[2] - model
 
-        assert np.mean(residual) == pytest.approx(0.00, abs=0.001)
-        assert np.std(residual) == pytest.approx(0.015, abs=0.01)
+        assert_allclose(np.mean(residual), 0., atol=0.001)
+        assert_allclose(np.std(residual), 0.015, atol=0.01)
 
     def test_fit_ellipsesample_2(self):
         # initial guess is rounder than actual image
@@ -134,11 +135,11 @@ class TestFitEllipseSamples(object):
         harmonics = fit_first_and_second_harmonics(s[0], s[2])
         y0, a1, b1, a2, b2 = harmonics[0]
 
-        assert np.mean(y0) == pytest.approx(188.686, abs=0.001)
-        assert np.mean(a1) == pytest.approx(0.000283, abs=0.001)
-        assert np.mean(b1) == pytest.approx(0.00692, abs=0.001)
-        assert np.mean(a2) == pytest.approx(-0.000215, abs=0.001)
-        assert np.mean(b2) == pytest.approx(10.153, abs=0.001)
+        assert_allclose(np.mean(y0), 188.686, atol=0.001)
+        assert_allclose(np.mean(a1), 0.000283, atol=0.001)
+        assert_allclose(np.mean(b1), 0.00692, atol=0.001)
+        assert_allclose(np.mean(a2), -0.000215, atol=0.001)
+        assert_allclose(np.mean(b2), 10.153, atol=0.001)
 
     def test_fit_ellipsesample_3(self):
         # initial guess for center is offset
@@ -148,11 +149,11 @@ class TestFitEllipseSamples(object):
         harmonics = fit_first_and_second_harmonics(s[0], s[2])
         y0, a1, b1, a2, b2 = harmonics[0]
 
-        assert np.mean(y0) == pytest.approx(152.660, abs=0.001)
-        assert np.mean(a1) == pytest.approx(55.338, abs=0.001)
-        assert np.mean(b1) == pytest.approx(33.091, abs=0.001)
-        assert np.mean(a2) == pytest.approx(33.036, abs=0.001)
-        assert np.mean(b2) == pytest.approx(-14.306, abs=0.001)
+        assert_allclose(np.mean(y0), 152.660, atol=0.001)
+        assert_allclose(np.mean(a1), 55.338, atol=0.001)
+        assert_allclose(np.mean(b1), 33.091, atol=0.001)
+        assert_allclose(np.mean(a2), 33.036, atol=0.001)
+        assert_allclose(np.mean(b2), -14.306, atol=0.001)
 
     def test_fit_ellipsesample_4(self):
         sample = EllipseSample(self.data2, 40., eps=0.4)
@@ -161,8 +162,8 @@ class TestFitEllipseSamples(object):
         harmonics = fit_first_and_second_harmonics(s[0], s[2])
         y0, a1, b1, a2, b2 = harmonics[0]
 
-        assert np.mean(y0) == pytest.approx(245.102, abs=0.001)
-        assert np.mean(a1) == pytest.approx(-0.003108, abs=0.001)
-        assert np.mean(b1) == pytest.approx(-0.0578, abs=0.001)
-        assert np.mean(a2) == pytest.approx(28.781, abs=0.001)
-        assert np.mean(b2) == pytest.approx(-63.184, abs=0.001)
+        assert_allclose(np.mean(y0), 245.102, atol=0.001)
+        assert_allclose(np.mean(a1), -0.003108, atol=0.001)
+        assert_allclose(np.mean(b1), -0.0578, atol=0.001)
+        assert_allclose(np.mean(a2), 28.781, atol=0.001)
+        assert_allclose(np.mean(b2), -63.184, atol=0.001)

--- a/photutils/isophote/tests/test_integrator.py
+++ b/photutils/isophote/tests/test_integrator.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 import numpy.ma as ma
-import pytest
+from numpy.testing import assert_allclose
 
 from astropy.io import fits
 from astropy.tests.helper import remote_data
@@ -47,11 +47,11 @@ class TestUnmasked(TestData):
 
         assert len(s[0]) == 225
         # intensities
-        assert np.mean(s[2]) == pytest.approx(200.76, abs=0.01)
-        assert np.std(s[2]) == pytest.approx(21.55, abs=0.01)
+        assert_allclose(np.mean(s[2]), 200.76, atol=0.01)
+        assert_allclose(np.std(s[2]), 21.55, atol=0.01)
         # radii
-        assert np.max(s[1]) == pytest.approx(40.0, abs=0.01)
-        assert np.min(s[1]) == pytest.approx(32.0, abs=0.01)
+        assert_allclose(np.max(s[1]), 40.0, atol=0.01)
+        assert_allclose(np.min(s[1]), 32.0, atol=0.01)
 
         assert sample.total_points == 225
         assert sample.actual_points == 225
@@ -61,11 +61,11 @@ class TestUnmasked(TestData):
         s, sample = self.make_sample(sma=10.)
 
         # intensities
-        assert np.mean(s[2]) == pytest.approx(1045.4, abs=0.1)
-        assert np.std(s[2]) == pytest.approx(143.0, abs=0.1)
+        assert_allclose(np.mean(s[2]), 1045.4, atol=0.1)
+        assert_allclose(np.std(s[2]), 143.0, atol=0.1)
         # radii
-        assert np.max(s[1]) == pytest.approx(10.0, abs=0.1)
-        assert np.min(s[1]) == pytest.approx(8.0, abs=0.1)
+        assert_allclose(np.max(s[1]), 10.0, atol=0.1)
+        assert_allclose(np.min(s[1]), 8.0, atol=0.1)
 
         assert sample.total_points == 57
         assert sample.actual_points == 57
@@ -75,11 +75,11 @@ class TestUnmasked(TestData):
 
         assert len(s[0]) == 225
         # intensities
-        assert np.mean(s[2]) == pytest.approx(201.1, abs=0.1)
-        assert np.std(s[2]) == pytest.approx(21.8, abs=0.1)
+        assert_allclose(np.mean(s[2]), 201.1, atol=0.1)
+        assert_allclose(np.std(s[2]), 21.8, atol=0.1)
         # radii
-        assert np.max(s[1]) == pytest.approx(40.0, abs=0.01)
-        assert np.min(s[1]) == pytest.approx(32.0, abs=0.01)
+        assert_allclose(np.max(s[1]), 40.0, atol=0.01)
+        assert_allclose(np.min(s[1]), 32.0, atol=0.01)
 
         assert sample.total_points == 225
         assert sample.actual_points == 225
@@ -89,13 +89,13 @@ class TestUnmasked(TestData):
 
         assert len(s[0]) == 64
         # intensities
-        assert np.mean(s[2]) == pytest.approx(199.9, abs=0.1)
-        assert np.std(s[2]) == pytest.approx(21.3, abs=0.1)
+        assert_allclose(np.mean(s[2]), 199.9, atol=0.1)
+        assert_allclose(np.std(s[2]), 21.3, atol=0.1)
         # radii
-        assert np.max(s[1]) == pytest.approx(40.0, abs=0.01)
-        assert np.min(s[1]) == pytest.approx(32.0, abs=0.01)
+        assert_allclose(np.max(s[1]), 40.0, atol=0.01)
+        assert_allclose(np.min(s[1]), 32.0, atol=0.01)
 
-        assert sample.sector_area == pytest.approx(12.4, abs=0.1)
+        assert_allclose(sample.sector_area, 12.4, atol=0.1)
         assert sample.total_points == 64
         assert sample.actual_points == 64
 
@@ -104,13 +104,13 @@ class TestUnmasked(TestData):
 
         assert len(s[0]) == 29
         # intensities
-        assert np.mean(s[2]) == pytest.approx(2339.0, abs=0.1)
-        assert np.std(s[2]) == pytest.approx(284.7, abs=0.1)
+        assert_allclose(np.mean(s[2]), 2339.0, atol=0.1)
+        assert_allclose(np.std(s[2]), 284.7, atol=0.1)
         # radii
-        assert np.max(s[1]) == pytest.approx(5.0, abs=0.01)
-        assert np.min(s[1]) == pytest.approx(4.0, abs=0.01)
+        assert_allclose(np.max(s[1]), 5.0, atol=0.01)
+        assert_allclose(np.min(s[1]), 4.0, atol=0.01)
 
-        assert sample.sector_area == pytest.approx(2.0, abs=0.1)
+        assert_allclose(sample.sector_area, 2.0, atol=0.1)
         assert sample.total_points == 29
         assert sample.actual_points == 29
 
@@ -119,13 +119,13 @@ class TestUnmasked(TestData):
 
         assert len(s[0]) == 64
         # intensities
-        assert np.mean(s[2]) == pytest.approx(199.9, abs=0.1)
-        assert np.std(s[2]) == pytest.approx(21.3, abs=0.1)
+        assert_allclose(np.mean(s[2]), 199.9, atol=0.1)
+        assert_allclose(np.std(s[2]), 21.3, atol=0.1)
         # radii
-        assert np.max(s[1]) == pytest.approx(40.0, abs=0.01)
-        assert np.min(s[1]) == pytest.approx(32.01, abs=0.01)
+        assert_allclose(np.max(s[1]), 40.0, atol=0.01)
+        assert_allclose(np.min(s[1]), 32.01, atol=0.01)
 
-        assert sample.sector_area == pytest.approx(12.4, abs=0.1)
+        assert_allclose(sample.sector_area, 12.4, atol=0.1)
         assert sample.total_points == 64
         assert sample.actual_points == 64
 
@@ -138,11 +138,11 @@ class TestMasked(TestData):
 
         assert len(s[0]) == 157
         # intensities
-        assert np.mean(s[2]) == pytest.approx(201.52, abs=0.01)
-        assert np.std(s[2]) == pytest.approx(25.21, abs=0.01)
+        assert_allclose(np.mean(s[2]), 201.52, atol=0.01)
+        assert_allclose(np.std(s[2]), 25.21, atol=0.01)
         # radii
-        assert np.max(s[1]) == pytest.approx(40.0, abs=0.01)
-        assert np.min(s[1]) == pytest.approx(32.0, abs=0.01)
+        assert_allclose(np.max(s[1]), 40.0, atol=0.01)
+        assert_allclose(np.min(s[1]), 32.0, atol=0.01)
 
         assert sample.total_points == 225
         assert sample.actual_points == 157
@@ -152,12 +152,12 @@ class TestMasked(TestData):
 
         assert len(s[0]) == 51
         # intensities
-        assert np.mean(s[2]) == pytest.approx(199.9, abs=0.1)
-        assert np.std(s[2]) == pytest.approx(24.12, abs=0.1)
+        assert_allclose(np.mean(s[2]), 199.9, atol=0.1)
+        assert_allclose(np.std(s[2]), 24.12, atol=0.1)
         # radii
-        assert np.max(s[1]) == pytest.approx(40.0, abs=0.01)
-        assert np.min(s[1]) == pytest.approx(32.0, abs=0.01)
+        assert_allclose(np.max(s[1]), 40.0, atol=0.01)
+        assert_allclose(np.min(s[1]), 32.0, atol=0.01)
 
-        assert sample.sector_area == pytest.approx(12.4, abs=0.1)
+        assert_allclose(sample.sector_area, 12.4, atol=0.1)
         assert sample.total_points == 64
         assert sample.actual_points == 51

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 
 from astropy.io import fits
@@ -84,11 +85,11 @@ class TestIsophote(object):
         assert g.pa <= (0.62 + 0.05)
 
         # fitted values
-        assert iso.intens == pytest.approx(682.9, abs=0.1)
-        assert iso.rms == pytest.approx(83.27, abs=0.01)
-        assert iso.int_err == pytest.approx(7.63, abs=0.01)
-        assert iso.pix_stddev == pytest.approx(117.8, abs=0.1)
-        assert iso.grad == pytest.approx(-36.08, abs=0.1)
+        assert_allclose(iso.intens, 682.9, atol=0.1)
+        assert_allclose(iso.rms, 83.27, atol=0.01)
+        assert_allclose(iso.int_err, 7.63, atol=0.01)
+        assert_allclose(iso.pix_stddev, 117.8, atol=0.1)
+        assert_allclose(iso.grad, -36.08, atol=0.1)
 
         # integrals
         assert iso.tflux_e <= 1.20e6
@@ -172,7 +173,7 @@ class TestIsophoteList(object):
 
         iso = result.get_closest(13.6)
         assert isinstance(iso, Isophote)
-        assert iso.sma == pytest.approx(14., abs=0.000001)
+        assert_allclose(iso.sma, 14., atol=1e-6)
 
     def test_extend(self):
         # the extend method shouldn't return anything,


### PR DESCRIPTION
I tracked down the newly-failing `Travis-CI` tests to a change somewhere in the `pytest.approx` function in the latest `pytest` release.  This PR replaces the use of `pytest.approx` with `numpy.testing.allclose`.  All of the tests now pass locally for me.