### PR TITLE
Enhancements to source segmentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Added ``plot`` and ``to_aperture`` methods to ``BoundingBox``. [#662]
+
 - ``photutils.centroid``
 
   - Added a ``centroid_sources`` function to calculate centroid of
@@ -20,6 +24,31 @@ New Features
 - ``photutils.segmentation``
 
   - Added a ``mask`` keyword to the ``detect_sources`` function. [#621]
+
+  - Renamed ``SegmentationImage`` ``max`` attribute to ``max_label``.
+    ``max`` is deprecated. [#662]
+
+  - Added a ``Segment`` class to hold the cutout image and properties
+    of single labeled region (source segment). [#662]
+
+  - Deprecated the ``SegmentationImage`` ``area`` method.  Instead use
+    the ``areas`` attribute. [#662]
+
+  - Renamed ``SegmentationImage`` ``data_masked`` attribute to
+    ``data_ma``.  ``data_masked`` is deprecated. [#662]
+
+  - Renamed ``SegmentationImage`` ``is_sequential`` attribute to
+    ``is_consecutive``.  ``is_sequential`` is deprecated. [#662]
+
+  - Renamed ``SegmentationImage`` ``relabel_sequential`` attribute to
+    ``relabel_consecutive``.  ``relabel_sequential`` is deprecated.
+    [#662]
+
+  - Added a ``missing_labels`` property to ``SegmentationImage``.
+    [#662]
+
+  - Added a ``check_labels`` method to ``SegmentationImage``.  The
+    ``check_label`` method is deprecated. [#662]
 
 - ``photutils.utils``
 
@@ -44,6 +73,8 @@ Bug Fixes
   - Fixed an issue with ``deblend_sources`` where sources were not
     deblended where the data contain one or more NaNs. [#658]
 
+  - Fixed the ``SegmentationImage`` ``areas`` attribute to not include
+    the zero (background) label. [#662]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -216,3 +216,18 @@ class BoundingBox(object):
 
         return Rectangle(xy=(self.extent[0], self.extent[2]),
                          width=self.shape[1], height=self.shape[0], **kwargs)
+
+    def to_aperture(self):
+        """
+        Return a `~photutils.aperture.RectangularAperture` that
+        represents the bounding box.
+        """
+
+        from .rectangle import RectangularAperture
+
+        xpos = (self.extent[1] + self.extent[0]) / 2.
+        ypos = (self.extent[3] + self.extent[2]) / 2.
+        xypos = (xpos, ypos)
+        h, w = self.shape
+
+        return RectangularAperture(xypos, w=w, h=h, theta=0.)

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -231,3 +231,29 @@ class BoundingBox(object):
         h, w = self.shape
 
         return RectangularAperture(xypos, w=w, h=h, theta=0.)
+
+    def plot(self, origin=(0, 0), ax=None, fill=False, **kwargs):
+        """
+        Plot the `BoundingBox` on a matplotlib `~matplotlib.axes.Axes`
+        instance.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        ax : `matplotlib.axes.Axes` instance, optional
+            If `None`, then the current `~matplotlib.axes.Axes` instance
+            is used.
+
+        fill : bool, optional
+            Set whether to fill the aperture patch.  The default is
+            `False`.
+
+        kwargs
+            Any keyword arguments accepted by `matplotlib.patches.Patch`.
+        """
+
+        aper = self.to_aperture()
+        aper.plot(origin=origin, ax=ax, fill=fill, **kwargs)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -164,14 +164,6 @@ class SegmentationImage(object):
             if isinstance(value, lazyproperty):
                 self.__dict__.pop(key, None)
 
-    @property
-    def array(self):
-        """
-        The 2D segmentation image.
-        """
-
-        return self._data
-
     def __array__(self):
         """
         Array representation of the segmentation image (e.g., for

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -28,7 +28,6 @@ class SegmentationImage(object):
     """
 
     def __init__(self, data):
-
         self.data = np.asanyarray(data, dtype=np.int)
 
     @property
@@ -44,10 +43,18 @@ class SegmentationImage(object):
         if np.min(value) < 0:
             raise ValueError('The segmentation image cannot contain '
                              'negative integers.')
+
+        if '_data' in self.__dict__:
+            # needed only when data is reassigned, not on init
+            self._reset_lazy_properties()
+
         self._data = value
-        # be sure to delete any lazy properties to reset their values.
-        del (self.data_masked, self.shape, self.labels, self.nlabels,
-             self.max, self.slices, self.areas, self.is_sequential)
+
+    def _reset_lazy_properties(self):
+        """Reset all lazy properties."""
+        for key, value in self.__class__.__dict__.items():
+            if isinstance(value, lazyproperty):
+                self.__dict__.pop(key, None)
 
     @property
     def array(self):
@@ -111,6 +118,7 @@ class SegmentationImage(object):
         array([1, 3, 4, 5, 7])
         """
 
+        # np.unique also sorts elements
         return np.unique(data[data != 0])
 
     @lazyproperty

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -386,7 +386,7 @@ class SegmentationImage(object):
             raise ValueError('labels {} are invalid'.format(bad_labels))
 
     @deprecated(0.5, alternative='check_labels')
-    def check_label(self, label, allow_zero=False):
+    def check_label(self, label, allow_zero=False):  # pragma: no cover
         """
         Check for a valid label label number within the segmentation
         image.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -139,7 +139,12 @@ class SegmentationImage(object):
         return self._data
 
     @lazyproperty
+    @deprecated(0.5, alternative='data_ma')
     def data_masked(self):
+        return self.data_ma  # pragma: no cover
+
+    @lazyproperty
+    def data_ma(self):
         """
         A `~numpy.ma.MaskedArray` version of the segmentation image
         where the background (label = 0) has been masked.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -225,9 +225,18 @@ class SegmentationImage(object):
 
     @lazyproperty
     def slices(self):
-        """The minimal bounding box slices for each labeled region."""
+        """
+        A list of tuples, where each tuple contains two slices
+        representing the minimal box that contains the labeled region.
+
+        The list starts with the *non-zero* label.  The returned list
+        has a length equal to the maximum label number.  If a label
+        number is missing, then `None` is returned for that list element
+        instead of a slice.
+        """
 
         from scipy.ndimage import find_objects
+
         return find_objects(self._data)
 
     @lazyproperty

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from copy import deepcopy
 
 import numpy as np
-from astropy.utils import lazyproperty
+from astropy.utils import lazyproperty, deprecated
 
 from ..utils.colormaps import random_cmap
 
@@ -142,10 +142,15 @@ class SegmentationImage(object):
         return len(self.labels)
 
     @lazyproperty
+    @deprecated(0.5, alternative='max_label')
     def max(self):
+        return self.max_label  # pragma: no cover
+
+    @lazyproperty
+    def max_label(self):
         """The maximum non-zero label in the segmentation image."""
 
-        return np.max(self.data)
+        return np.max(self.labels)
 
     @lazyproperty
     def slices(self):
@@ -256,7 +261,7 @@ class SegmentationImage(object):
 
         from matplotlib import colors
 
-        cmap = random_cmap(self.max + 1, random_state=random_state)
+        cmap = random_cmap(self.max_label + 1, random_state=random_state)
 
         if background_color is not None:
             cmap.colors[0] = colors.hex2color(background_color)
@@ -388,7 +393,7 @@ class SegmentationImage(object):
         if self.is_sequential and (self.labels[0] == start_label):
             return
 
-        forward_map = np.zeros(self.max + 1, dtype=np.int)
+        forward_map = np.zeros(self.max_label + 1, dtype=np.int)
         forward_map[self.labels] = np.arange(self.nlabels) + start_label
         self.data = forward_map[self.data]
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -82,17 +82,12 @@ class SegmentationImage(object):
     def _create_source_segments(self):
         """Create a list of `SourceSegment` objects."""
 
-        # zero label (for the background)
-        slc0 = 0
-        source_segms = [SourceSegment(0, slc0, self.areas[0])]
-
+        source_segms = []
         for i, slc in enumerate(self.slices):
-            label = i + 1
             if slc is None:
                 source_segms.append(None)
             else:
-                source_segms.append(SourceSegment(label, slc,
-                                                  self.areas[label]))
+                source_segms.append(SourceSegment(i+1, slc, self.areas[i]))
 
         self._source_segments = source_segms
 
@@ -241,11 +236,19 @@ class SegmentationImage(object):
 
     @lazyproperty
     def areas(self):
-        """The areas (in pixel**2) of all labeled regions."""
+        """
+        A 1D array of areas (in pixel**2) of the non-zero labeled
+        regions.
 
-        return np.bincount(self.data.ravel())
+        The `~numpy.ndarray` starts with the *non-zero* label The
+        returned array has a length equal to the maximum label number.
+        If a label number is missing, then 0 is returned for that array
+        element.
+        """
 
-    @deprecated(0.5, alternative='areas[labels]')
+        return np.bincount(self.data.ravel())[1:]
+
+    @deprecated(0.5, alternative='areas[labels-1]')
     def area(self, labels):  # pragma: no cover
         """
         The areas (in pixel**2) of the regions for the input labels.
@@ -264,7 +267,7 @@ class SegmentationImage(object):
         labels = np.atleast_1d(labels)
         for label in labels:
             self.check_label(label, allow_zero=True)
-        return self.areas[labels]
+        return self.areas[labels - 1]
 
     @lazyproperty
     @deprecated(0.5, alternative='is_consecutive')

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -258,10 +258,15 @@ class SegmentationImage(object):
         return self.areas[labels]
 
     @lazyproperty
+    @deprecated(0.5, alternative='is_consecutive')
     def is_sequential(self):
+        return self.is_consecutive  # pragma: no cover
+
+    @lazyproperty
+    def is_consecutive(self):
         """
         Determine whether or not the non-zero labels in the segmenation
-        image are sequential (with no missing values).
+        image are consecutive (i.e. no missing values).
         """
 
         if (self.labels[-1] - self.labels[0] + 1) == self.nlabels:
@@ -272,8 +277,6 @@ class SegmentationImage(object):
     def copy(self):
         """
         Return a deep copy of this class instance.
-
-        Deep copy is used so that all attributes and values are copied.
         """
 
         return deepcopy(self)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -109,21 +109,6 @@ class SegmentationImage(object):
     def __init__(self, data):
         self.data = np.asanyarray(data, dtype=np.int)
 
-    @lazyproperty
-    def source_segments(self):
-        """
-        A list of `SourceSegment` objects.
-
-        The returned list has a length equal to 1 plus the maximum label
-        number.  If a label number is missing from the segmentation
-        image, then `None` is returned instead of a `SourceSegment`
-        object.
-        """
-
-        if not hasattr(self, '_source_segments'):
-            self._create_source_segments()
-        return self._source_segments
-
     def __getitem__(self, index):
         return self.source_segments[index]
 
@@ -135,8 +120,16 @@ class SegmentationImage(object):
         for i in self.source_segments:
             yield i
 
-    def _create_source_segments(self):
-        """Create a list of `SourceSegment` objects."""
+    @lazyproperty
+    def source_segments(self):
+        """
+        A list of `SourceSegment` objects.
+
+        The list starts with the *non-zero* label.  The returned list
+        has a length equal to the maximum label number.  If a label
+        number is missing from the segmentation image, then `None` is
+        returned instead of a `SourceSegment` object.
+        """
 
         source_segms = []
         for i, slc in enumerate(self.slices):
@@ -146,7 +139,7 @@ class SegmentationImage(object):
                 source_segms.append(
                     SourceSegment(self.data, i+1, slc, self.areas[i]))
 
-        self._source_segments = source_segms
+        return source_segms
 
     @property
     def data(self):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -261,7 +261,7 @@ class SegmentationImage(object):
 
         Parameters
         ----------
-        labels : int, array-like (1D, int)
+        labels : int, 1D array-like (int)
             The label(s) for which to return areas.
 
         Returns
@@ -271,8 +271,8 @@ class SegmentationImage(object):
         """
 
         labels = np.atleast_1d(labels)
-        for label in labels:
-            self.check_label(label, allow_zero=True)
+        self.check_labels(labels)
+
         return self.areas[labels - 1]
 
     @lazyproperty
@@ -310,6 +310,38 @@ class SegmentationImage(object):
 
         return deepcopy(self)
 
+    def check_labels(self, labels):
+        """
+        Check that the input label(s) are valid label numbers within the
+        segmentation image.
+
+        Parameters
+        ----------
+        labels : int, 1D array-like (int)
+            The label(s) to check.
+
+        Raises
+        ------
+        ValueError
+            If any input ``labels`` are invalid.
+        """
+
+        labels = np.atleast_1d(labels)
+        bad_labels = set()
+
+        # check for positive label numbers
+        idx = np.where(labels <= 0)[0]
+        if len(idx) > 0:
+            bad_labels.update(labels[idx])
+
+        # check if label is in the segmentation image
+        bad_labels.update(np.setdiff1d(labels, self.labels))
+
+        bad_labels = tuple(bad_labels)
+        if len(bad_labels) > 0:
+            raise ValueError('labels {} are invalid'.format(bad_labels))
+
+    @deprecated(0.5, alternative='check_labels')
     def check_label(self, label, allow_zero=False):
         """
         Check for a valid label label number within the segmentation

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -286,6 +286,17 @@ class SegmentationImage(object):
         else:
             return False
 
+    @lazyproperty
+    def missing_labels(self):
+        """
+        A 1D `~numpy.ndarray` of the sorted non-zero labels that are
+        missing in the consecutive sequence from zero to the maximum
+        label number.
+        """
+
+        return np.array(sorted(set(range(0, self.max_label + 1)).
+                               difference(np.insert(self.labels, 0, 0))))
+
     def copy(self):
         """
         Return a deep copy of this class instance.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -432,9 +432,13 @@ class SegmentationImage(object):
             data[np.where(data == label)] = new_label
             self.data = data     # needed to call the data setter
 
+    @deprecated(0.5, alternative='relabel_consecutive()')
     def relabel_sequential(self, start_label=1):
+        return self.relabel_consecutive(start_label=start_label)  # pragma: no cover
+
+    def relabel_consecutive(self, start_label=1):
         """
-        Relabel the label numbers sequentially, such that there are no
+        Relabel the label numbers consecutively, such that there are no
         missing label numbers (up to the maximum label number).
 
         Parameters
@@ -452,7 +456,7 @@ class SegmentationImage(object):
         ...                           [7, 0, 0, 0, 0, 5],
         ...                           [7, 7, 0, 5, 5, 5],
         ...                           [7, 7, 0, 0, 5, 5]])
-        >>> segm.relabel_sequential()
+        >>> segm.relabel_consecutive()
         >>> segm.data
         array([[1, 1, 0, 0, 3, 3],
                [0, 0, 0, 0, 0, 3],
@@ -465,7 +469,7 @@ class SegmentationImage(object):
         if start_label <= 0:
             raise ValueError('start_label must be > 0.')
 
-        if self.is_sequential and (self.labels[0] == start_label):
+        if self.is_consecutive and (self.labels[0] == start_label):
             return
 
         forward_map = np.zeros(self.max_label + 1, dtype=np.int)
@@ -484,7 +488,7 @@ class SegmentationImage(object):
 
         relabel : bool, optional
             If `True`, then the segmentation image will be relabeled
-            such that the labels are in sequential order starting from
+            such that the labels are in consecutive order starting from
             1.
 
         Examples
@@ -537,7 +541,7 @@ class SegmentationImage(object):
 
         relabel : bool, optional
             If `True`, then the segmentation image will be relabeled
-            such that the labels are in sequential order starting from
+            such that the labels are in consecutive order starting from
             1.
 
         Examples
@@ -576,7 +580,7 @@ class SegmentationImage(object):
 
         self.relabel(labels, new_label=0)
         if relabel:
-            self.relabel_sequential()
+            self.relabel_consecutive()
 
     def remove_border_labels(self, border_width, partial_overlap=True,
                              relabel=False):
@@ -598,7 +602,7 @@ class SegmentationImage(object):
 
         relabel : bool, optional
             If `True`, then the segmentation image will be relabeled
-            such that the labels are in sequential order starting from
+            such that the labels are in consecutive order starting from
             1.
 
         Examples
@@ -667,7 +671,7 @@ class SegmentationImage(object):
 
         relabel : bool, optional
             If `True`, then the segmentation image will be relabeled
-            such that the labels are in sequential order starting from
+            such that the labels are in consecutive order starting from
             1.
 
         Examples

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -81,18 +81,15 @@ class Segment(object):
 
     @lazyproperty
     def cutout(self):
-        """Cutout image of the segment."""
-
-        return self.make_cutout(self._data, masked_array=False)
-
-    @lazyproperty
-    def cutout_ma(self):
         """
-        Cutout masked array image of the segment, where pixels outside
-        of the labeled region are masked.
+        Cutout image of the segment, where pixels in other segments are
+        set to zero.
         """
 
-        return self.make_cutout(self._data, masked_array=True)
+        cutout = np.copy(self._data[self.slices])
+        cutout[cutout != self.label] = 0
+
+        return cutout
 
 
 class SegmentationImage(object):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import numpy as np
 from astropy.utils import lazyproperty, deprecated
 
+from ..aperture import BoundingBox
 from ..utils.colormaps import random_cmap
 
 
@@ -36,6 +37,11 @@ class SourceSegment(object):
         self.label = label
         self.slices = slices
         self.area = area
+
+    @lazyproperty
+    def bbox(self):
+        return BoundingBox(self.slices[1].start, self.slices[1].stop,
+                           self.slices[0].start, self.slices[0].stop)
 
 
 class SegmentationImage(object):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -45,6 +45,21 @@ class Segment(object):
         self.slices = slices
         self.area = area
 
+    def __str__(self):
+        cls_name = '<{0}.{1}>'.format(self.__class__.__module__,
+                                      self.__class__.__name__)
+
+        cls_info = []
+        params = ['label', 'slices', 'bbox', 'area']
+        for param in params:
+            cls_info.append((param, getattr(self, param)))
+        fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
+
+        return '{}\n'.format(cls_name) + '\n'.join(fmt)
+
+    def __repr__(self):
+        return self.__str__()
+
     @lazyproperty
     def data(self):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -231,7 +231,8 @@ class SegmentationImage(object):
 
         return np.bincount(self.data.ravel())
 
-    def area(self, labels):
+    @deprecated(0.5, alternative='areas[labels]')
+    def area(self, labels):  # pragma: no cover
         """
         The areas (in pixel**2) of the regions for the input labels.
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -112,13 +112,13 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     if labels is None:
         labels = segment_img.labels
     labels = np.atleast_1d(labels)
+    segment_img.check_labels(labels)
 
     data = filter_data(data, filter_kernel, mode='constant', fill_value=0.0)
 
     last_label = segment_img.max_label
     segm_deblended = deepcopy(segment_img)
     for label in labels:
-        segment_img.check_label(label)
         source_slice = segment_img.slices[label - 1]
         source_data = data[source_slice]
         source_segm = SegmentationImage(np.copy(

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -66,19 +66,20 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
         ``contrast`` must be between 0 and 1, inclusive.  If ``contrast
         = 0`` then every local peak will be made a separate object
         (maximum deblending).  If ``contrast = 1`` then no deblending
-        will occur.  The default is 0.001, which will deblend sources with
-        a magnitude differences of about 7.5.
+        will occur.  The default is 0.001, which will deblend sources
+        with a magnitude difference of about 7.5.
 
     mode : {'exponential', 'linear'}, optional
         The mode used in defining the spacing between the
-        multi-thresholding levels (see the ``nlevels`` keyword).
+        multi-thresholding levels (see the ``nlevels`` keyword).  The
+        default is 'exponential'.
 
-    connectivity : {4, 8}, optional
+    connectivity : {8, 4}, optional
         The type of pixel connectivity used in determining how pixels
-        are grouped into a detected source.  The options are 4 or 8
-        (default).  4-connected pixels touch along their edges.
-        8-connected pixels touch along their edges or corners.  For
-        reference, SExtractor uses 8-connected pixels.
+        are grouped into a detected source.  The options are 8 (default)
+        or 4.  8-connected pixels touch along their edges or corners.
+        4-connected pixels touch along their edges.  For reference,
+        SExtractor uses 8-connected pixels.
 
     relabel : bool
         If `True` (default), then the segmentation image will be

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -87,7 +87,7 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
 
     relabel : bool
         If `True` (default), then the segmentation image will be
-        relabeled such that the labels are in sequential order starting
+        relabeled such that the labels are in consecutive order starting
         from 1.
 
     Returns
@@ -146,7 +146,7 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
             last_label += source_deblended.nlabels
 
     if relabel:
-        segm_deblended.relabel_sequential()
+        segm_deblended.relabel_consecutive()
 
     return segm_deblended
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -27,11 +27,6 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     order to deblend sources, they must be separated enough such that
     there is a saddle between them.
 
-    .. note::
-        This function is experimental.  Please report any issues on the
-        `Photutils GitHub issue tracker
-        <https://github.com/astropy/photutils/issues>`_
-
     Parameters
     ----------
     data : array_like

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -115,7 +115,7 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
 
     data = filter_data(data, filter_kernel, mode='constant', fill_value=0.0)
 
-    last_label = segment_img.max
+    last_label = segment_img.max_label
     segm_deblended = deepcopy(segment_img)
     for label in labels:
         segment_img.check_label(label)

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1052,6 +1052,9 @@ class SourceProperties(object):
             value = map_coordinates(self._background,
                                     [[self.ycentroid.value],
                                      [self.xcentroid.value]])[0]
+
+            # map_coordinates works if self._background is a Quantity, but
+            # the returned value is a numpy array (without units)
             if isinstance(self._background, u.Quantity):
                 value *= self._background.unit
 

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -8,7 +8,8 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import QTable
 from astropy.utils import deprecated, lazyproperty
-from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import (AstropyUserWarning,
+                                      AstropyDeprecationWarning)
 from astropy.wcs.utils import pixel_to_skycoord
 
 
@@ -1223,7 +1224,10 @@ def source_properties(data, segment_img, error=None, mask=None,
     sources_props = []
     for label in labels:
         if label not in segment_img.labels:
-            continue      # skip invalid labels (without warnings)
+            warnings.warn('label {} is not in the segmentation image.'
+                          .format(label), AstropyUserWarning)
+            continue  # skip invalid labels
+
         sources_props.append(SourceProperties(
             data, segment_img, label, filtered_data=filtered_data,
             error=error, mask=mask, background=background, wcs=wcs))

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -20,8 +20,9 @@ __all__ = ['SourceProperties', 'source_properties', 'SourceCatalog',
            'properties_table']
 
 __doctest_requires__ = {('SourceProperties', 'SourceProperties.*',
-                         'SourceCatalog', 'SourceCatalog.*', 'source_properties',
-                         'properties_table'): ['scipy', 'skimage']}
+                         'SourceCatalog', 'SourceCatalog.*',
+                         'source_properties', 'properties_table'):
+                        ['scipy', 'skimage']}
 
 
 class SourceProperties(object):
@@ -167,7 +168,7 @@ class SourceProperties(object):
         self._error = error    # total error; 2D array
         self._background = background    # 2D array
 
-        segment_img.check_label(label)
+        segment_img.check_labels(label)
         self.label = label
         self._slice = segment_img.slices[label - 1]
         self._segment_img = segment_img

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -630,6 +630,7 @@ class SourceProperties(object):
         minimum pixel value of the (background-subtracted) data.
         """
 
+        # NOTE:  Quantity converts this to float
         return np.argwhere(self.data_cutout_ma == self.min_value)[0] * u.pix
 
     @lazyproperty
@@ -639,6 +640,7 @@ class SourceProperties(object):
         maximum pixel value of the (background-subtracted) data.
         """
 
+        # NOTE:  Quantity converts this to float
         return np.argwhere(self.data_cutout_ma == self.max_value)[0] * u.pix
 
     @lazyproperty

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -453,7 +453,7 @@ class SourceProperties(object):
 
     @lazyproperty
     @deprecated(0.4, alternative='sky_centroid_icrs')
-    def icrs_centroid(self):
+    def icrs_centroid(self):  # pragma: no cover
         """
         The sky coordinates, in the International Celestial Reference
         System (ICRS) frame, of the centroid within the source segment,
@@ -464,7 +464,7 @@ class SourceProperties(object):
 
     @lazyproperty
     @deprecated(0.4, alternative='sky_centroid_icrs.ra')
-    def ra_icrs_centroid(self):
+    def ra_icrs_centroid(self):  # pragma: no cover
         """
         The ICRS Right Ascension coordinate (in degrees) of the centroid
         within the source segment.
@@ -477,7 +477,7 @@ class SourceProperties(object):
 
     @lazyproperty
     @deprecated(0.4, alternative='sky_centroid_icrs.dec')
-    def dec_icrs_centroid(self):
+    def dec_icrs_centroid(self):  # pragma: no cover
         """
         The ICRS Declination coordinate (in degrees) of the centroid
         within the source segment.
@@ -1311,7 +1311,7 @@ class SourceCatalog(object):
 
     @lazyproperty
     @deprecated(0.4, alternative='sky_centroid_icrs')
-    def icrs_centroid(self):
+    def icrs_centroid(self):  # pragma: no cover
         if self.wcs is not None:
             return self.sky_centroid_icrs
         else:
@@ -1319,7 +1319,7 @@ class SourceCatalog(object):
 
     @lazyproperty
     @deprecated(0.4, alternative='sky_centroid_icrs.ra')
-    def ra_icrs_centroid(self):
+    def ra_icrs_centroid(self):  # pragma: no cover
         if self.wcs is not None:
             return self.sky_centroid_icrs.ra.deg * u.deg
         else:
@@ -1327,7 +1327,7 @@ class SourceCatalog(object):
 
     @lazyproperty
     @deprecated(0.4, alternative='sky_centroid_icrs.dec')
-    def dec_icrs_centroid(self):
+    def dec_icrs_centroid(self):  # pragma: no cover
         if self.wcs is not None:
             return self.sky_centroid_icrs.dec.deg * u.deg
         else:
@@ -1493,7 +1493,7 @@ def _properties_table(obj, columns=None, exclude_columns=None):
 
 
 @deprecated(0.4, alternative='SourceCatalog.to_table()')
-def properties_table(source_props, columns=None, exclude_columns=None):
+def properties_table(source_props, columns=None, exclude_columns=None):  # pragma: no cover
     """
     Construct a `~astropy.table.QTable` of properties from a list of
     `SourceProperties` objects.

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -78,10 +78,18 @@ class TestSegmentationImage(object):
             if segment is not None:
                 assert segment.label == (i + 1)
 
-    def test_segment_cutouts(self):
+    def test_segment_cutout(self):
         assert_allclose(self.segm[4].cutout.shape, (3, 3))
-        assert_allclose(self.segm[4].cutout_ma.shape, (3, 3))
-        assert np.ma.is_masked(self.segm[4].cutout_ma)
+        assert_allclose(np.unique(self.segm[4].cutout), [0, 5])
+
+    def test_segment_mask_cutout(self):
+        cutout = self.segm[4].make_cutout(self.data, masked_array=False)
+        assert not np.ma.is_masked(cutout)
+        assert_allclose(cutout.shape, (3, 3))
+
+        cutout = self.segm[4].make_cutout(self.data, masked_array=True)
+        assert np.ma.is_masked(cutout)
+        assert_allclose(cutout.shape, (3, 3))
 
     def test_segment_make_cutout_input(self):
         with pytest.raises(ValueError):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -126,7 +126,7 @@ class TestSegmentationImage(object):
         assert segm.nlabels == len(segm.slices) - segm.slices.count(None)
 
     @pytest.mark.parametrize('start_label', [1, 5])
-    def test_relabel_sequential(self, start_label):
+    def test_relabel_consecutive(self, start_label):
         segm = SegmentationImage(self.data)
         ref_data = np.array([[1, 1, 0, 0, 3, 3],
                              [0, 0, 0, 0, 0, 3],
@@ -135,19 +135,19 @@ class TestSegmentationImage(object):
                              [5, 5, 0, 4, 4, 4],
                              [5, 5, 0, 0, 4, 4]])
         ref_data[ref_data != 0] += (start_label - 1)
-        segm.relabel_sequential(start_label=start_label)
+        segm.relabel_consecutive(start_label=start_label)
         assert_allclose(segm.data, ref_data)
 
-        # relabel_sequential should do nothing if already sequential
-        segm.relabel_sequential(start_label=start_label)
+        # relabel_consecutive should do nothing if already consecutive
+        segm.relabel_consecutive(start_label=start_label)
         assert_allclose(segm.data, ref_data)
         assert segm.nlabels == len(segm.slices) - segm.slices.count(None)
 
     @pytest.mark.parametrize('start_label', [0, -1])
-    def test_relabel_sequential_start_invalid(self, start_label):
+    def test_relabel_consecutive_start_invalid(self, start_label):
         with pytest.raises(ValueError):
             segm = SegmentationImage(self.data)
-            segm.relabel_sequential(start_label=start_label)
+            segm.relabel_consecutive(start_label=start_label)
 
     def test_keep_labels(self):
         ref_data = np.array([[0, 0, 0, 0, 0, 0],

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -73,8 +73,8 @@ class TestSegmentationImage(object):
     def test_nlabels(self):
         assert self.segm.nlabels == 5
 
-    def test_max(self):
-        assert self.segm.max == 7
+    def test_max_label(self):
+        assert self.segm.max_label == 7
 
     def test_areas(self):
         expected = np.array([18, 2, 0, 2, 3, 6, 0, 5])

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -86,6 +86,11 @@ class TestSegmentationImage(object):
         idx = np.array(labels) - 1
         assert_allclose(self.segm.areas[idx], expected[idx])
 
+    def test_cmap(self):
+        cmap = self.segm.cmap()
+        assert len(cmap.colors) == (self.segm.max_label + 1)
+        assert_allclose(cmap.colors[0], [0, 0, 0])
+
     def test_outline_segments(self):
         segm_array = np.zeros((5, 5)).astype(int)
         segm_array[1:4, 1:4] = 2

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -76,6 +76,9 @@ class TestSegmentationImage(object):
     def test_max_label(self):
         assert self.segm.max_label == 7
 
+    def test_missing_labels(self):
+        assert_allclose(self.segm.missing_labels, [2, 6])
+
     def test_areas(self):
         expected = np.array([2, 0, 2, 3, 6, 0, 5])
         assert_allclose(self.segm.areas, expected)

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -50,17 +50,16 @@ class TestSegmentationImage(object):
         with pytest.raises(ValueError):
             SegmentationImage(data)
 
-    def test_zero_label(self):
+    @pytest.mark.parametrize('label', [0, -1, 2])
+    def test_invalid_label(self, label):
+        # test with scalar labels
         with pytest.raises(ValueError):
-            self.segm.check_label(0)
+            self.segm.check_labels(label)
 
-    def test_negative_label(self):
+    def test_invalid_label_array(self):
+        # test with array of labels
         with pytest.raises(ValueError):
-            self.segm.check_label(-1)
-
-    def test_invalid_label(self):
-        with pytest.raises(ValueError):
-            self.segm.check_label(2)
+            self.segm.check_labels([0, -1, 2])
 
     def test_data_ma(self):
         assert isinstance(self.segm.data_ma, np.ma.MaskedArray)

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -34,7 +34,6 @@ class TestSegmentationImage(object):
         self.segm = SegmentationImage(self.data)
 
     def test_array(self):
-        assert_allclose(self.segm.data, self.segm.array)
         assert_allclose(self.segm.data, self.segm.__array__())
 
     def test_copy(self):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -62,10 +62,10 @@ class TestSegmentationImage(object):
         with pytest.raises(ValueError):
             self.segm.check_label(2)
 
-    def test_data_masked(self):
-        assert isinstance(self.segm.data_masked, np.ma.MaskedArray)
-        assert np.ma.count(self.segm.data_masked) == 18
-        assert np.ma.count_masked(self.segm.data_masked) == 18
+    def test_data_ma(self):
+        assert isinstance(self.segm.data_ma, np.ma.MaskedArray)
+        assert np.ma.count(self.segm.data_ma) == 18
+        assert np.ma.count_masked(self.segm.data_ma) == 18
 
     def test_labels(self):
         assert_allclose(self.segm.labels, [1, 3, 4, 5, 7])

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -78,11 +78,18 @@ class TestSegmentationImage(object):
             if segment is not None:
                 assert segment.label == (i + 1)
 
+    def test_segment_repr_str(self):
+        assert repr(self.segm[0]) == str(self.segm[0])
+
+        props = ['label', 'slices', 'bbox', 'area']
+        for prop in props:
+            assert '{}:'.format(prop) in repr(self.segm[0])
+
     def test_segment_data(self):
         assert_allclose(self.segm[4].data.shape, (3, 3))
         assert_allclose(np.unique(self.segm[4].data), [0, 5])
 
-    def test_segment_mask_cutout(self):
+    def test_segment_make_cutout(self):
         cutout = self.segm[4].make_cutout(self.data, masked_array=False)
         assert not np.ma.is_masked(cutout)
         assert_allclose(cutout.shape, (3, 3))

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -67,6 +67,7 @@ class TestSegmentationImage(object):
 
     def test_segments(self):
         assert isinstance(self.segm[0], Segment)
+        assert_allclose(self.segm[0].data, self.segm[0].__array__())
         assert self.segm[4].area == self.segm.areas[4]
         assert self.segm[4].slices == self.segm.slices[4]
         assert self.segm[3].bbox.slices == self.segm[3].slices
@@ -77,9 +78,9 @@ class TestSegmentationImage(object):
             if segment is not None:
                 assert segment.label == (i + 1)
 
-    def test_segment_cutout(self):
-        assert_allclose(self.segm[4].cutout.shape, (3, 3))
-        assert_allclose(np.unique(self.segm[4].cutout), [0, 5])
+    def test_segment_data(self):
+        assert_allclose(self.segm[4].data.shape, (3, 3))
+        assert_allclose(np.unique(self.segm[4].data), [0, 5])
 
     def test_segment_mask_cutout(self):
         cutout = self.segm[4].make_cutout(self.data, masked_array=False)

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -77,14 +77,14 @@ class TestSegmentationImage(object):
         assert self.segm.max_label == 7
 
     def test_areas(self):
-        expected = np.array([18, 2, 0, 2, 3, 6, 0, 5])
+        expected = np.array([2, 0, 2, 3, 6, 0, 5])
         assert_allclose(self.segm.areas, expected)
 
     def test_area(self):
-        expected = np.array([18, 2, 0, 2, 3, 6, 0, 5])
-        assert self.segm.area(0) == expected[0]
+        expected = np.array([2, 0, 2, 3, 6, 0, 5])
         labels = [3, 1, 4]
-        assert_allclose(self.segm.area(labels), expected[labels])
+        idx = np.array(labels) - 1
+        assert_allclose(self.segm.areas[idx], expected[idx])
 
     def test_outline_segments(self):
         segm_array = np.zeros((5, 5)).astype(int)

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -68,11 +68,11 @@ class TestDeblendSources(object):
         result = deblend_sources(data, segm, self.npixels)
         assert result.nlabels == 6
         assert result.nlabels == len(result.slices)
-        assert result.area(1) == result.area(2)
-        assert result.area(1) == result.area(3)
-        assert result.area(1) == result.area(4)
-        assert result.area(1) == result.area(5)
-        assert result.area(1) == result.area(6)
+        assert result.areas[0] == result.areas[1]
+        assert result.areas[0] == result.areas[2]
+        assert result.areas[0] == result.areas[3]
+        assert result.areas[0] == result.areas[4]
+        assert result.areas[0] == result.areas[5]
 
     def test_deblend_multiple_sources_with_neighbor(self):
         g1 = models.Gaussian2D(100, 50, 50, 20, 5, theta=45)

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -91,7 +91,7 @@ class TestDeblendSources(object):
         result = deblend_sources(self.data, self.segm, self.npixels,
                                  mode=mode, relabel=False)
         assert result.nlabels == 2
-        assert len(result.slices) <= result.max
+        assert len(result.slices) <= result.max_label
         assert len(result.slices) == 3   # label 1 is None
         assert_allclose(np.nonzero(self.segm), np.nonzero(result))
 

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -166,7 +166,7 @@ class TestDetectSources(object):
         mask[4:6, 4:6] = True
         segm1 = detect_sources(data, 1., 1.)
         segm2 = detect_sources(data, 1., 1., mask=mask)
-        assert segm2.areas[1] == segm1.areas[1] - mask.sum()
+        assert segm2.areas[0] == segm1.areas[0] - mask.sum()
 
     def test_mask_shape(self):
         with pytest.raises(ValueError):

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -80,7 +80,7 @@ class TestDetectSources(object):
         for npixels in np.arange(9, 14):
             segm = detect_sources(data, 0, npixels=npixels)
             assert(segm.nlabels == 1)
-            assert(segm.areas[1] == 13)
+            assert(segm.areas[0] == 13)
 
         segm = detect_sources(data, 0, npixels=14)
         assert(segm.nlabels == 0)


### PR DESCRIPTION
This PR adds several enhancements to the segmentation subpackage, mostly within the `SegmentationImage` class.  This class now has a property which can be used to generate a list of `Segment` objects, one for each labeled region.  The `Segment` object holds the cutout image and properties (e.g. slices, `BoundingBox`, area) of a single source segment.  There is also new ``check_labels`` method and ``missing_labels`` property.  Some `SegmentationImage` attributes were also renamed (with the old names deprecated).  The segmentation subpackage narrative docs were also improved, particularly additions to the source deblending section.

This PR also includes a fix to not include the zero (background) label in the `areas` attribute.

Finally, ``plot`` and ``to_aperture`` methods were added to the `BoundingBox` class for easy visualization.

I realize I put too much in a single PR, but I couldn't stop.... 😄 