### PR TITLE
Fix isophote fitting when initial centers are not specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,12 @@ Bug Fixes
   - Fixed an issue in ``DAOStarFinder`` where in some cases a few too
     many sources could be returned. [#671]
 
+- ``photutils.isophote``
+
+  - Fixed a bug where isophote fitting would fail when the initial
+    center was not specified for an image with an elongated aspect
+    ratio. [#673]
+
 - ``photutils.segmentation``
 
   - Fixed ``deblend_sources`` when other sources are in the

--- a/photutils/isophote/ellipse.py
+++ b/photutils/isophote/ellipse.py
@@ -180,8 +180,8 @@ class Ellipse(object):
         if geometry is not None:
             self._geometry = geometry
         else:
-            _x0 = image.shape[0] / 2
-            _y0 = image.shape[1] / 2
+            _x0 = image.shape[1] / 2
+            _y0 = image.shape[0] / 2
             self._geometry = EllipseGeometry(_x0, _y0, 10., eps=0.2,
                                              pa=np.pi/2)
 

--- a/photutils/isophote/fitter.py
+++ b/photutils/isophote/fitter.py
@@ -246,9 +246,9 @@ class EllipseFitter(object):
         if abs(sample.geometry.eps > MAX_EPS):
             proceed = False
         if (sample.geometry.x0 < 1. or
-                sample.geometry.x0 > sample.image.shape[0] or
+                sample.geometry.x0 > sample.image.shape[1] or
                 sample.geometry.y0 < 1. or
-                sample.geometry.y0 > sample.image.shape[1]):
+                sample.geometry.y0 > sample.image.shape[0]):
             proceed = False
 
         # See if eps == 0 (round isophote) was crossed.

--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -200,10 +200,10 @@ class EllipseGeometry(object):
         shape = image.shape
         _x0 = self.x0
         _y0 = self.y0
-        if (_x0 is None or _x0 < 0 or _x0 >= shape[0] or _y0 is None or
-                _y0 < 0 or _y0 >= shape[1]):
-            _x0 = shape[0] / 2
-            _y0 = shape[1] / 2
+        if (_x0 is None or _x0 < 0 or _x0 >= shape[1] or _y0 is None or
+                _y0 < 0 or _y0 >= shape[0]):
+            _x0 = shape[1] / 2
+            _y0 = shape[0] / 2
 
         max_fom = 0.
         max_i = 0
@@ -219,8 +219,8 @@ class EllipseGeometry(object):
                 # ensure that it stays inside image frame
                 i1 = int(max(0, i - self._centerer_mask_half_size))
                 j1 = int(max(0, j - self._centerer_mask_half_size))
-                i2 = int(min(shape[0] - 1, i + self._centerer_mask_half_size))
-                j2 = int(min(shape[1] - 1, j + self._centerer_mask_half_size))
+                i2 = int(min(shape[1] - 1, i + self._centerer_mask_half_size))
+                j2 = int(min(shape[0] - 1, j + self._centerer_mask_half_size))
 
                 window = image[j1:j2, i1:i2]
 

--- a/photutils/isophote/integrator.py
+++ b/photutils/isophote/integrator.py
@@ -44,8 +44,8 @@ class _Integrator(object):
         self._intensities = intensities
 
         # for bounds checking
-        self._i_range = range(0, self._image.shape[0] - 1)
-        self._j_range = range(0, self._image.shape[1] - 1)
+        self._i_range = range(0, self._image.shape[1] - 1)
+        self._j_range = range(0, self._image.shape[0] - 1)
 
     def integrate(self, radius, phi):
         """

--- a/photutils/isophote/model.py
+++ b/photutils/isophote/model.py
@@ -127,7 +127,7 @@ def build_ellipse_model(shape, isolist, fill=0., high_harmonics=False):
             j = int(y)
 
             # if outside image boundaries, ignore.
-            if (i > 0 and i < shape[0]-1 and j > 0 and j < shape[1] - 1):
+            if (i > 0 and i < shape[1] - 1 and j > 0 and j < shape[0] - 1):
                 # get fractional deviations relative to target array
                 fx = x - float(i)
                 fy = y - float(j)

--- a/photutils/isophote/sample.py
+++ b/photutils/isophote/sample.py
@@ -106,8 +106,8 @@ class EllipseSample(object):
             _x0 = x0
             _y0 = y0
             if not _x0 or not _y0:
-                _x0 = image.shape[0] / 2
-                _y0 = image.shape[1] / 2
+                _x0 = image.shape[1] / 2
+                _y0 = image.shape[0] / 2
 
             self.geometry = EllipseGeometry(_x0, _y0, sma, eps,
                                             position_angle, astep,


### PR DESCRIPTION
This PR fixes an issue in isophote fitting where the fitting could fail when the input image is elongated and the initial object center is not specified.  The fitting could also fail for elongated images if the source was close to the image edge.

Fixes #670.  Thanks to @hujh08 for reporting this!