### PR TITLE
Used Polygon to implement  method for rectangular apertures

### DIFF
--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -31,8 +31,7 @@ class CircularMaskMixin(object):
         ----------
         method : {'exact', 'center', 'subpixel'}, optional
             The method used to determine the overlap of the aperture on
-            the pixel grid.  Not all options are available for all
-            aperture types.  Note that the more precise methods are
+            the pixel grid. Note that the more precise methods are
             generally slower.  The following methods are available:
 
                 * ``'exact'`` (default):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -33,8 +33,7 @@ class EllipticalMaskMixin(object):
         ----------
         method : {'exact', 'center', 'subpixel'}, optional
             The method used to determine the overlap of the aperture on
-            the pixel grid.  Not all options are available for all
-            aperture types.  Note that the more precise methods are
+            the pixel grid. Note that the more precise methods are
             generally slower.  The following methods are available:
 
                 * ``'exact'`` (default):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -34,8 +34,7 @@ class RectangularMaskMixin(object):
         ----------
         method : {'exact', 'center', 'subpixel'}, optional
             The method used to determine the overlap of the aperture on
-            the pixel grid.  Not all options are available for all
-            aperture types.  Note that the more precise methods are
+            the pixel grid. Note that the more precise methods are
             generally slower.  The following methods are available:
 
                 * ``'exact'`` (default):
@@ -87,13 +86,13 @@ class RectangularMaskMixin(object):
             ny, nx = bbox.shape
             mask = rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                             edges[3], nx, ny, w, h,
-                                            self.theta, 0, subpixels)
+                                            self.theta, use_exact, subpixels)
 
             # subtract the inner circle for an annulus
             if hasattr(self, 'w_in'):
                 mask -= rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                                  edges[3], nx, ny, self.w_in,
-                                                 h_in, self.theta, 0,
+                                                 h_in, self.theta, use_exact,
                                                  subpixels)
 
             masks.append(ApertureMask(mask, bbox))

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -66,16 +66,14 @@ def test_outside_array(aperture_class, params):
 def test_inside_array_simple(aperture_class, params):
     data = np.ones((40, 40), dtype=np.float)
     aperture = aperture_class((20., 20.), *params)
-    table1 = aperture_photometry(data, aperture, method='center', subpixels=10)
+    table1 = aperture_photometry(data, aperture, method='center', subpixels=25)
     table2 = aperture_photometry(data, aperture, method='subpixel',
-                                 subpixels=10)
-    table3 = aperture_photometry(data, aperture, method='exact', subpixels=10)
+                                 subpixels=25)
+    table3 = aperture_photometry(data, aperture, method='exact', subpixels=25)
     true_flux = aperture.area()
 
-    if not isinstance(aperture, (RectangularAperture, RectangularAnnulus)):
-        assert_allclose(table3['aperture_sum'], true_flux)
-        assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                        atol=0.1)
+    assert_allclose(table3['aperture_sum'], true_flux)
+    assert_allclose(table2['aperture_sum'], table3['aperture_sum'], atol=0.1)
     assert table1['aperture_sum'] < table3['aperture_sum']
 
 
@@ -123,24 +121,18 @@ class BaseTestAperturePhotometry(object):
                                      mask=mask, error=error)
         table2 = aperture_photometry(self.data,
                                      self.aperture,
-                                     method='subpixel', subpixels=12,
+                                     method='subpixel', subpixels=25,
                                      mask=mask, error=error)
         table3 = aperture_photometry(self.data,
                                      self.aperture, method='exact',
                                      mask=mask, error=error)
 
-        if not isinstance(self.aperture, (RectangularAperture,
-                                          RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum'], self.true_flux)
-            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                            atol=0.1)
+        assert_allclose(table3['aperture_sum'], self.true_flux)
+        assert_allclose(table2['aperture_sum'], table3['aperture_sum'], atol=0.1)
         assert np.all(table1['aperture_sum'] < table3['aperture_sum'])
 
-        if not isinstance(self.aperture, (RectangularAperture,
-                                          RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum_err'], true_error)
-            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                            atol=0.1)
+        assert_allclose(table3['aperture_sum_err'], true_error)
+        assert_allclose(table2['aperture_sum'], table3['aperture_sum'], atol=0.1)
         assert np.all(table1['aperture_sum_err'] < table3['aperture_sum_err'])
 
     def test_array_error(self):
@@ -159,24 +151,20 @@ class BaseTestAperturePhotometry(object):
                                      mask=mask, error=error)
         table2 = aperture_photometry(self.data,
                                      self.aperture,
-                                     method='subpixel', subpixels=12,
+                                     method='subpixel', subpixels=25,
                                      mask=mask, error=error)
         table3 = aperture_photometry(self.data,
                                      self.aperture, method='exact',
                                      mask=mask, error=error)
 
-        if not isinstance(self.aperture, (RectangularAperture,
-                                          RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum'], self.true_flux)
-            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                            atol=0.1)
+        assert_allclose(table3['aperture_sum'], self.true_flux)
+        assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
+                        atol=0.1)
         assert np.all(table1['aperture_sum'] < table3['aperture_sum'])
 
-        if not isinstance(self.aperture, (RectangularAperture,
-                                          RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum_err'], true_error)
-            assert_allclose(table2['aperture_sum_err'],
-                            table3['aperture_sum_err'], atol=0.1)
+        assert_allclose(table3['aperture_sum_err'], true_error)
+        assert_allclose(table2['aperture_sum_err'],
+                        table3['aperture_sum_err'], atol=0.1)
         assert np.all(table1['aperture_sum_err'] < table3['aperture_sum_err'])
 
 


### PR DESCRIPTION
I have implemented the exact method for the rectangles, using the python [Polygon](https://pypi.org/project/Polygon3/) bindings to the [GPC Library](http://www.cs.man.ac.uk/~toby/alan/software/). Polygon now becomes a necessary dependence.
No new testing has been added, but I have enabled the existing tests inside the aperture module, because before they singled out RectangularAperture and RectangularAnnulus .

Again, some testing will fail, but I think this is due to upstream problems in photutils rather than my edits (please correct me if I am wrong).

To prove my hypothesis about the tests, I attach a screenshot of the test summary for a test done on the branch exactrect (left), as well as a test done on the master (right).
![screenshot from 2018-06-28 13-20-42](https://user-images.githubusercontent.com/16090255/42031549-e3cb04a2-7ad6-11e8-9def-f87c3615bdbd.png)