### PR TITLE
Fix failing tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ New Features
   - Added a ``centroid_sources`` function to calculate centroid of
     many sources in a single image. [#656]
 
+  - An n-dimensional array can now be input into the ``centroid_com``
+    function. [#685]
+
 - ``photutils.detection``
 
   - Added a ``centroid_func`` keyword to ``find_peaks``.  The

--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -34,8 +34,6 @@ subtract the background)::
     >>> from photutils import centroid_com, centroid_1dg, centroid_2dg
     >>> data = make_4gaussians_image()[43:79, 76:104]
 
-.. doctest-requires:: skimage
-
     >>> x1, y1 = centroid_com(data)
     >>> print((x1, y1))    # doctest: +FLOAT_CMP
     (13.93157998341213, 17.051234441067088)
@@ -46,7 +44,7 @@ subtract the background)::
     >>> print((x2, y2))    # doctest: +FLOAT_CMP
     (14.040352707371396, 16.962306463644801)
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: scipy
 
     >>> x3, y3 = centroid_2dg(data)
     >>> print((x3, y3))    # doctest: +FLOAT_CMP

--- a/docs/detection.rst
+++ b/docs/detection.rst
@@ -57,7 +57,7 @@ have FWHMs of around 3 pixels and have peaks approximately 5-sigma
 above the background. Running this class on the data yields an astropy
 `~astropy.table.Table` containing the results of the star finder:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: scipy
 
     >>> from photutils import DAOStarFinder
     >>> daofind = DAOStarFinder(fwhm=3.0, threshold=5.*std)    # doctest: +REMOTE_DATA
@@ -136,9 +136,7 @@ specified footprint.  Please see the
 options.
 
 As simple example, let's find the local peaks in an image that are 5
-sigma above the background and a separated by at least 5 pixels:
-
-.. doctest-requires:: skimage
+sigma above the background and a separated by at least 5 pixels::
 
     >>> from astropy.stats import sigma_clipped_stats
     >>> from photutils.datasets import make_100gaussians_image

--- a/docs/detection.rst
+++ b/docs/detection.rst
@@ -136,7 +136,9 @@ specified footprint.  Please see the
 options.
 
 As simple example, let's find the local peaks in an image that are 5
-sigma above the background and a separated by at least 5 pixels::
+sigma above the background and a separated by at least 5 pixels:
+
+.. doctest-requires:: scipy
 
     >>> from astropy.stats import sigma_clipped_stats
     >>> from photutils.datasets import make_100gaussians_image

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -24,7 +24,7 @@ noise level, estimated using the median absolute deviation
 (`~astropy.stats.mad_std`) of the image. The parameters of the
 detected sources are returned as an Astropy `~astropy.table.Table`:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: scipy
 
     >>> from photutils import DAOStarFinder
     >>> from astropy.stats import mad_std
@@ -56,7 +56,7 @@ a radius of 4 pixels.  The :func:`~photutils.aperture_photometry`
 function returns an Astropy `~astropy.table.Table` with the results of
 the photometry:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: scipy
 
     >>> from photutils import aperture_photometry, CircularAperture
     >>> positions = (sources['xcentroid'], sources['ycentroid'])    # doctest: +REMOTE_DATA

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -81,8 +81,8 @@ GaussianConst2D.__doc__ += CONSTRAINTS_DOC
 
 def centroid_com(data, mask=None):
     """
-    Calculate the centroid of a 2D array as its "center of mass"
-    determined from image moments.
+    Calculate the centroid of an n-dimensional array as its "center of
+    mass" determined from moments.
 
     Invalid values (e.g. NaNs or infs) in the ``data`` array are
     automatically masked.
@@ -90,7 +90,7 @@ def centroid_com(data, mask=None):
     Parameters
     ----------
     data : array_like
-        The 2D array of the image.
+        The input n-dimensional array.
 
     mask : array_like (bool), optional
         A boolean mask, with the same shape as ``data``, where a `True`
@@ -99,36 +99,30 @@ def centroid_com(data, mask=None):
     Returns
     -------
     centroid : `~numpy.ndarray`
-        The ``x, y`` coordinates of the centroid.
+        The coordinates of the centroid in pixel order (e.g. ``(x, y)``
+        or ``(x, y, z)``), not numpy axis order.
     """
 
-    from skimage.measure import moments
-
-    data = np.ma.asanyarray(data)
+    data = data.astype(np.float)
 
     if mask is not None and mask is not np.ma.nomask:
-        mask = np.asanyarray(mask)
+        mask = np.asarray(mask)
         if data.shape != mask.shape:
             raise ValueError('data and mask must have the same shape.')
-        data.mask |= mask
+        data[mask] = 0.
 
-    if np.any(~np.isfinite(data)):
-        data = np.ma.masked_invalid(data)
+    badidx = ~np.isfinite(data)
+    if np.any(badidx):
         warnings.warn('Input data contains input values (e.g. NaNs or infs), '
                       'which were automatically masked.', AstropyUserWarning)
+        data[badidx] = 0.
 
-    # Convert the data to a float64 (double) `numpy.ndarray`,
-    # which is required for input to `skimage.measure.moments`.
-    # Masked values are set to zero.
-    data = data.astype(np.float)
-    data.fill_value = 0.
-    data = data.filled()
+    total = np.sum(data)
+    indices = np.ogrid[[slice(0, i) for i in data.shape]]
 
-    m = moments(data, 1)
-    xcen = m[1, 0] / m[0, 0]
-    ycen = m[0, 1] / m[0, 0]
-
-    return np.array([xcen, ycen])
+    # note the output array is reversed to give (x, y) order
+    return np.array([np.sum(indices[axis] * data) / total
+                     for axis in range(data.ndim)])[::-1]
 
 
 def gaussian1d_moments(data, mask=None):

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -18,8 +18,6 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import overlap_slices
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ..morphology import data_properties
-
 
 __all__ = ['GaussianConst2D', 'centroid_com', 'gaussian1d_moments',
            'fit_2dgaussian', 'centroid_1dg', 'centroid_2dg',
@@ -197,6 +195,8 @@ def fit_2dgaussian(data, error=None, mask=None):
     result : A `GaussianConst2D` model instance.
         The best-fitting Gaussian 2D model.
     """
+
+    from ..morphology import data_properties  # prevent circular imports
 
     data = np.ma.asanyarray(data)
 

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -11,12 +11,6 @@ import pytest
 from ..core import (centroid_com, centroid_1dg, centroid_2dg,
                     gaussian1d_moments, fit_2dgaussian)
 
-try:
-    import skimage    # noqa
-    HAS_SKIMAGE = True
-except ImportError:
-    HAS_SKIMAGE = False
-
 
 XCS = [25.7]
 YCS = [26.2]
@@ -32,7 +26,6 @@ DATA[1, 1] = 2.
 @pytest.mark.parametrize(
     ('xc_ref', 'yc_ref', 'x_stddev', 'y_stddev', 'theta'),
     list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
-@pytest.mark.skipif('not HAS_SKIMAGE')
 def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
     model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
                        y_stddev=y_stddev, theta=theta)
@@ -52,7 +45,6 @@ def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
 @pytest.mark.parametrize(
     ('xc_ref', 'yc_ref', 'x_stddev', 'y_stddev', 'theta'),
     list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
-@pytest.mark.skipif('not HAS_SKIMAGE')
 def test_centroids_witherror(xc_ref, yc_ref, x_stddev, y_stddev, theta):
     model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
                        y_stddev=y_stddev, theta=theta)
@@ -67,7 +59,6 @@ def test_centroids_witherror(xc_ref, yc_ref, x_stddev, y_stddev, theta):
     assert_allclose([xc_ref, yc_ref], [xc3, yc3], rtol=0, atol=1.e-3)
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 def test_centroids_withmask():
     xc_ref, yc_ref = 24.7, 25.2
     model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=5.0, y_stddev=5.0)
@@ -87,7 +78,6 @@ def test_centroids_withmask():
     assert_allclose([xc3, yc3], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.parametrize('use_mask', [True, False])
 def test_centroids_nan_withmask(use_mask):
     xc_ref, yc_ref = 24.7, 25.2
@@ -112,7 +102,6 @@ def test_centroids_nan_withmask(use_mask):
     assert_allclose([xc3, yc3], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 def test_centroid_com_mask():
     """Test centroid_com with and without an image_mask."""
 
@@ -124,7 +113,6 @@ def test_centroid_com_mask():
     assert_allclose([0.5, 0.0], centroid_mask, rtol=0, atol=1.e-6)
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 def test_invalid_mask_shape():
     """
     Test if ValueError raises if mask shape doesn't match data
@@ -147,7 +135,6 @@ def test_invalid_mask_shape():
         gaussian1d_moments(data, mask=mask)
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 def test_invalid_error_shape():
     """
     Test if ValueError raises if error shape doesn't match data

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -12,6 +12,14 @@ from ..core import (centroid_com, centroid_1dg, centroid_2dg,
                     gaussian1d_moments, fit_2dgaussian)
 
 
+try:
+    # the fitting routines in astropy use scipy.optimize
+    import scipy    # noqa
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
 XCS = [25.7]
 YCS = [26.2]
 XSTDDEVS = [3.2, 4.0]
@@ -23,6 +31,7 @@ DATA[1, 0:2] = 1.
 DATA[1, 1] = 2.
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize(
     ('xc_ref', 'yc_ref', 'x_stddev', 'y_stddev', 'theta'),
     list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
@@ -42,6 +51,7 @@ def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
     assert_allclose([xc_ref, yc_ref], [xc3, yc3], rtol=0, atol=1.e-3)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize(
     ('xc_ref', 'yc_ref', 'x_stddev', 'y_stddev', 'theta'),
     list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
@@ -59,6 +69,7 @@ def test_centroids_witherror(xc_ref, yc_ref, x_stddev, y_stddev, theta):
     assert_allclose([xc_ref, yc_ref], [xc3, yc3], rtol=0, atol=1.e-3)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_centroids_withmask():
     xc_ref, yc_ref = 24.7, 25.2
     model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=5.0, y_stddev=5.0)
@@ -78,6 +89,7 @@ def test_centroids_withmask():
     assert_allclose([xc3, yc3], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize('use_mask', [True, False])
 def test_centroids_nan_withmask(use_mask):
     xc_ref, yc_ref = 24.7, 25.2
@@ -113,6 +125,7 @@ def test_centroid_com_mask():
     assert_allclose([0.5, 0.0], centroid_mask, rtol=0, atol=1.e-6)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_invalid_mask_shape():
     """
     Test if ValueError raises if mask shape doesn't match data
@@ -135,6 +148,7 @@ def test_invalid_mask_shape():
         gaussian1d_moments(data, mask=mask)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_invalid_error_shape():
     """
     Test if ValueError raises if error shape doesn't match data
@@ -170,6 +184,7 @@ def test_gaussian1d_moments():
     assert_allclose(result, desired, rtol=0, atol=1.e-6)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_fit2dgaussian_dof():
     data = np.ones((2, 2))
     with pytest.raises(ValueError):

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -16,13 +16,6 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-try:
-    import skimage    # noqa
-    HAS_SKIMAGE = True
-except ImportError:
-    HAS_SKIMAGE = False
-
-
 DATA = np.array([[0, 1, 0], [0, 2, 0], [0, 0, 0]]).astype(np.float)
 REF1 = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
 
@@ -122,7 +115,6 @@ class TestDetectThreshold(object):
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.skipif('not HAS_SKIMAGE')
 class TestFindPeaks(object):
     def test_box_size(self):
         """Test with box_size."""

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -21,12 +21,6 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-try:
-    import skimage    # noqa
-    HAS_SKIMAGE = True
-except ImportError:
-    HAS_SKIMAGE = False
-
 
 DATA = make_100gaussians_image()
 THRESHOLDS = [8.0, 10.0]
@@ -35,7 +29,6 @@ warnings.simplefilter('always', AstropyUserWarning)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.skipif('not HAS_SKIMAGE')
 class TestDAOStarFinder(object):
     @pytest.mark.parametrize(('threshold', 'fwhm'),
                              list(itertools.product(THRESHOLDS, FWHMS)))
@@ -103,7 +96,6 @@ class TestDAOStarFinder(object):
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.skipif('not HAS_SKIMAGE')
 class TestIRAFStarFinder(object):
     @pytest.mark.parametrize(('threshold', 'fwhm'),
                              list(itertools.product(THRESHOLDS, FWHMS)))

--- a/photutils/morphology/core.py
+++ b/photutils/morphology/core.py
@@ -9,8 +9,6 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 
-from ..segmentation import SourceProperties
-
 
 __all__ = ['data_properties']
 
@@ -44,6 +42,8 @@ def data_properties(data, mask=None, background=None):
     result : `~photutils.segmentation.SourceProperties` instance
         A `~photutils.segmentation.SourceProperties` object.
     """
+
+    from ..segmentation import SourceProperties  # prevent circular imports
 
     segment_image = np.ones(data.shape, dtype=np.int)
 

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -290,7 +290,7 @@ class SourceProperties(object):
         return self.make_cutout(self._data, masked_array=True)
 
     @lazyproperty
-    def _data_cutout_maskzeroed_double(self):
+    def _data_cutout_maskzeroed(self):
         """
         A 2D cutout from the (background-subtracted) (filtered) data,
         where pixels outside of the source segment and masked pixels are
@@ -299,9 +299,7 @@ class SourceProperties(object):
         Invalid values (e.g. NaNs or infs) are set to zero.  Negative
         data values are also set to zero because negative pixels
         (especially at large radii) can result in image moments that
-        result in negative variances.  The cutout image is double
-        precision, which is required for scikit-image's Cython-based
-        moment functions.
+        result in negative variances.
         """
 
         cutout = self.make_cutout(self._filtered_data, masked_array=False)
@@ -357,7 +355,7 @@ class SourceProperties(object):
     def moments(self):
         """Spatial moments up to 3rd order of the source."""
 
-        return _moments(self._data_cutout_maskzeroed_double, order=3)
+        return _moments(self._data_cutout_maskzeroed, order=3)
 
     @lazyproperty
     def moments_central(self):
@@ -367,7 +365,7 @@ class SourceProperties(object):
         """
 
         ycentroid, xcentroid = self.cutout_centroid.value
-        return _moments_central(self._data_cutout_maskzeroed_double,
+        return _moments_central(self._data_cutout_maskzeroed,
                                 center=(xcentroid, ycentroid), order=3)
 
     @lazyproperty

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -20,12 +20,6 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-try:
-    import skimage    # noqa
-    HAS_SKIMAGE = True
-except ImportError:
-    HAS_SKIMAGE = False
-
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestDetectSources(object):

--- a/photutils/utils/_moments.py
+++ b/photutils/utils/_moments.py
@@ -4,8 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 
-from ..centroids import centroid_com
-
 
 __all__ = ['_moments_central', '_moments']
 
@@ -38,6 +36,7 @@ def _moments_central(data, center=None, order=1):
         raise ValueError('data must be a 2D array.')
 
     if center is None:
+        from ..centroids import centroid_com
         center = centroid_com(data)
 
     indices = np.ogrid[[slice(0, i) for i in data.shape]]

--- a/photutils/utils/_moments.py
+++ b/photutils/utils/_moments.py
@@ -30,7 +30,7 @@ def _moments_central(data, center=None, order=1):
         The central image moments.
     """
 
-    data = np.asarray(data)
+    data = np.asarray(data).astype(float)
 
     if data.ndim != 2:
         raise ValueError('data must be a 2D array.')

--- a/photutils/utils/_moments.py
+++ b/photutils/utils/_moments.py
@@ -1,0 +1,68 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+from ..centroids import centroid_com
+
+
+__all__ = ['_moments_central', '_moments']
+
+
+def _moments_central(data, center=None, order=1):
+    """
+    Calculate the central image moments up to the specified order.
+
+    Parameters
+    ----------
+    data : 2D array-like
+        The input 2D array.
+
+    center : tuple of two floats or `None`, optional
+        The ``(x, y)`` center position.  If `None` it will calculated as
+        the "center of mass" of the input ``data``.
+
+    order : int, optional
+        The maximum order of the moments to calculate.
+
+    Returns
+    -------
+    moments : 2D `~numpy.ndarray`
+        The central image moments.
+    """
+
+    data = np.asarray(data)
+
+    if data.ndim != 2:
+        raise ValueError('data must be a 2D array.')
+
+    if center is None:
+        center = centroid_com(data)
+
+    indices = np.ogrid[[slice(0, i) for i in data.shape]]
+    ypowers = (indices[0] - center[1]) ** np.arange(order + 1)
+    xpowers = np.transpose(indices[1] - center[0]) ** np.arange(order + 1)
+
+    return np.dot(np.transpose(xpowers), np.dot(data, ypowers))
+
+
+def _moments(data, order=1):
+    """
+    Calculate the raw image moments up to the specified order.
+
+    Parameters
+    ----------
+    data : 2D array-like
+        The input 2D array.
+
+    order : int, optional
+        The maximum order of the moments to calculate.
+
+    Returns
+    -------
+    moments : 2D `~numpy.ndarray`
+        The raw image moments.
+    """
+
+    return _moments_central(data, center=(0, 0), order=order)

--- a/photutils/utils/_moments.py
+++ b/photutils/utils/_moments.py
@@ -44,7 +44,7 @@ def _moments_central(data, center=None, order=1):
     ypowers = (indices[0] - center[1]) ** np.arange(order + 1)
     xpowers = np.transpose(indices[1] - center[0]) ** np.arange(order + 1)
 
-    return np.dot(np.transpose(xpowers), np.dot(data, ypowers))
+    return np.dot(np.dot(np.transpose(ypowers), data), xpowers)
 
 
 def _moments(data, order=1):

--- a/photutils/utils/tests/test_moments.py
+++ b/photutils/utils/tests/test_moments.py
@@ -1,0 +1,39 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+from numpy.testing import assert_equal, assert_allclose
+import pytest
+
+from .._moments import _moments, _moments_central
+
+
+def test_moments():
+    data = np.array([[0, 1], [0, 1]])
+    moments = _moments(data, order=2)
+    result = np.array([[2, 2, 2], [1, 1, 1], [1, 1, 1]])
+
+    assert_equal(moments, result)
+    assert_allclose(moments[0, 1] / moments[0, 0], 1.0)
+    assert_allclose(moments[1, 0] / moments[0, 0], 0.5)
+
+
+def test_moments_central():
+    data = np.array([[0, 1], [0, 1]])
+    moments = _moments_central(data, order=2)
+    result = np.array([[2., 0., 0.], [0., 0., 0.], [0.5, 0., 0.]])
+    assert_allclose(moments, result)
+
+
+def test_moments_central_nonsquare():
+    data = np.array([[0, 1], [0, 1], [0, 1]])
+    moments = _moments_central(data, order=2)
+    result = np.array([[3., 0., 0.], [0., 0., 0.], [2., 0., 0.]])
+    assert_allclose(moments, result)
+
+
+def test_moments_central_invalid_dim():
+    data = np.arange(27).reshape(3, 3, 3)
+    with pytest.raises(ValueError):
+        _moments_central(data, order=3)


### PR DESCRIPTION
The tests are failing due to an upstream change in `scikit-image 0.14` where the row-column order was is swapped in the output of the moments function.  This PR implements a (private) moments function, removing the `sckit-image` moment dependencies.

As a result of the changes, the `centroid_com` function was generalized and can now accept an n-dimensional array as input.