### PR TITLE
Allow centroid_com mask to be non-boolean

### DIFF
--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -104,7 +104,7 @@ def centroid_com(data, mask=None):
     data = data.astype(np.float)
 
     if mask is not None and mask is not np.ma.nomask:
-        mask = np.asarray(mask)
+        mask = np.asarray(mask, dtype=bool)
         if data.shape != mask.shape:
             raise ValueError('data and mask must have the same shape.')
         data[mask] = 0.

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -90,6 +90,18 @@ def test_centroids_withmask():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
+def test_centroids_withmask_nonbool():
+    data = np.arange(16).reshape(4, 4)
+    mask = np.zeros(data.shape)
+    mask[0:2, :] = 1
+    mask2 = np.array(mask, dtype=bool)
+
+    xc1, yc1 = centroid_com(data, mask=mask)
+    xc2, yc2 = centroid_com(data, mask=mask2)
+    assert_allclose([xc1, yc1], [xc2, yc2])
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize('use_mask', [True, False])
 def test_centroids_nan_withmask(use_mask):
     xc_ref, yc_ref = 24.7, 25.2


### PR DESCRIPTION
This PR allows the `centroid_com` `mask` keyword to be a non-boolean array.  Previously, if an integer mask array was input, it could give a wrong result (instead of raising an error).

Thanks to @ysBach for reporting this.