### PR TITLE
Time optimization in do_photometry

### DIFF
--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -384,12 +384,12 @@ class PixelAperture(Aperture):
             mask = np.asanyarray(mask)
 
             data = copy.deepcopy(data)    # do not modify input data
-            data[mask] = 0
+            data[np.where(mask)] = 0
 
             if error is not None:
                 # do not modify input data
                 error = copy.deepcopy(np.asanyarray(error))
-                error[mask] = 0.
+                error[np.where(mask)] = 0.
 
         aperture_sums = []
         aperture_sum_errs = []


### PR DESCRIPTION
Unless there is some design concept behind using "data[mask] = value" instead of "data[np.where(mask)] = value", the former is 10x slower than the latter (see below). As it is "do_photometry" can become a significant bottleneck for large arrays. Note that this is independent of my previous pull request.

data = np.empty((100, 100))
mask = np.zeros((100, 100), dtype=np.int)
%timeit data[mask] = 22
**562 µs ± 76.9 µs** per loop (mean ± std. dev. of 7 runs, 1000 loops each)
%timeit data[np.where(mask)] = 22
**63.2 µs ± 4.82 µs** per loop (mean ± std. dev. of 7 runs, 10000 loops each)

data = np.empty((2000, 100, 100))
mask = np.zeros((2000, 100, 100), dtype=np.int)

%timeit data[np.where(mask)] = 22
**151 ms ± 23.7 ms** per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit data[mask] = 22
**1min 8s ± 1.59 s** per loop (mean ± std. dev. of 7 runs, 1 loop each)
