### PR TITLE
Fix issue where aperture Quantity inputs would sometimes fail

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Fixed a bug where quantity inputs to the aperture classes would
+    sometimes fail. [#693]
+
 - ``photutils.detection``
 
   - Fixed an issue in ``detect_sources`` where in some cases sources

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -81,7 +81,7 @@ class PixelAperture(Aperture):
     @staticmethod
     def _sanitize_positions(positions):
         if isinstance(positions, u.Quantity):
-            if positions.unit is u.pixel:
+            if positions.unit == u.pixel:
                 positions = np.atleast_2d(positions.value)
             else:
                 raise u.UnitsError('positions should be in pixel units')

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -883,3 +883,21 @@ def test_to_sky_pixel():
     assert_allclose(ap.w_out, ap2.w_out)
     assert_allclose(ap.h_out, ap2.h_out)
     assert_allclose(ap.theta, ap2.theta)
+
+
+def test_position_units():
+    """Regression test for unit check."""
+    pos = (10, 10) * u.pix
+    pos = np.sqrt(pos**2)
+    ap = CircularAperture(pos, r=3.)
+    assert_allclose(ap.positions, np.array([[10, 10]]))
+
+
+def test_radius_units():
+    """Regression test for unit check."""
+    pos = SkyCoord(10, 10, unit='deg')
+    r = 3.*u.pix
+    r = np.sqrt(r**2)
+    ap = SkyCircularAperture(pos, r=r)
+    assert ap.r.value == 3.0
+    assert ap.r.unit == u.pix

--- a/photutils/utils/wcs_helpers.py
+++ b/photutils/utils/wcs_helpers.py
@@ -71,7 +71,7 @@ def assert_angle_or_pixel(name, q):
     """
 
     if isinstance(q, u.Quantity):
-        if q.unit.physical_type == 'angle' or q.unit is u.pixel:
+        if q.unit.physical_type == 'angle' or q.unit == u.pixel:
             pass
         else:
             raise ValueError("{0} should have angular or pixel "


### PR DESCRIPTION
This PR replaces the `is` operator with `==` for when checking input quantity units.  Thanks to @shiaki for reporting this issue.

Closes #692.