### PR TITLE
Remove jupyter from RTD environment

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -7,11 +7,10 @@ dependencies:
     - python>=3
     - astropy
     - Cython
-    - jupyter
     - matplotlib
     - numpy
+    - scipy
     - scikit-image
     - scikit-learn
-    - scipy
     - docutils
     - Sphinx


### PR DESCRIPTION
I don't think we need `jupyter` any longer in the RTD environment.  This should speed up the RTD builds some.

CC:  @bsipocz 