### PR TITLE
Return an empty Table instead of an empty list for consistency in find_peaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,14 @@
 0.6 (unreleased)
 ----------------
 
-- No changes yet
+API changes
+^^^^^^^^^^^
+
+- ``photutils.detection``
+
+  - The ``find_peaks`` function now returns an empty
+    ``astropy.table.Table`` instead of an empty list if the input data
+    is an array of constant values.  [#709]
 
 
 0.5 (2018-08-06)

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -223,13 +223,16 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         their values.  If ``centroid_func`` is input, then the table
         will also contain the centroid position.  If ``subpixel=True``
         (deprecated), then the table will also contain the local
-        centroid and fitted peak value.
+        centroid and fitted peak value.  If no peaks are found then an
+        empty table is returned.
     """
 
     from scipy import ndimage
 
     if np.all(data == data.flat[0]):
-        return []
+        warnings.warn('Input data is constant. No local peaks can be found.',
+                      AstropyUserWarning)
+        return Table()  # empty table
 
     if footprint is not None:
         data_max = ndimage.maximum_filter(data, footprint=footprint,

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -222,19 +222,19 @@ class TestFindPeaks:
         wcs = make_wcs(data.shape)
 
         tbl = find_peaks(data, 100000)
-        assert len(tbl) == 0
+        assert tbl == Table()
 
         tbl = find_peaks(data, 100000, centroid_func=centroid_com)
-        assert len(tbl) == 0
+        assert tbl == Table()
 
         tbl = find_peaks(data, 100000, subpixel=True)
-        assert len(tbl) == 0
+        assert tbl == Table()
 
         tbl = find_peaks(data, 100000, wcs=wcs)
-        assert len(tbl) == 0
+        assert tbl == Table()
 
         tbl = find_peaks(data, 100000, wcs=wcs, centroid_func=centroid_com)
-        assert len(tbl) == 0
+        assert tbl == Table()
 
         tbl = find_peaks(data, 100000, wcs=wcs, subpixel=True)
-        assert len(tbl) == 0
+        assert tbl == Table()

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -4,6 +4,8 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 
+from astropy.table import Table
+
 from ..core import detect_threshold, find_peaks
 from ...centroids import centroid_com
 from ...datasets import make_4gaussians_image, make_wcs
@@ -205,6 +207,13 @@ class TestFindPeaks:
         tbl = find_peaks(data, 100, wcs=wcs, subpixel=True)
         for col in cols:
             assert col in tbl.colnames
+
+    def test_constant_array(self):
+        """Test for empty output table when data is constant."""
+
+        data = np.ones((10, 10))
+        tbl = find_peaks(data, 0.)
+        assert tbl == Table()
 
     def test_no_peaks(self):
         """Test for empty output table when no peaks are found."""


### PR DESCRIPTION
If the input data is an array of constant values, an empty `Table` is now returned instead of an empty list for consistency when no local peaks are found.

CC: @cdeil 