### PR TITLE
Remove NaNs to avoid RuntimeWarnings in find_peaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,10 @@ API changes
 
   - The ``find_peaks`` function now returns an empty
     ``astropy.table.Table`` instead of an empty list if the input data
-    is an array of constant values.  [#709]
+    is an array of constant values. [#709]
+
+  - The ``find_peaks`` function will no longer issue a RuntimeWarning
+    if the input data contains NaNs. [#712]
 
 
 0.5 (2018-08-06)

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -230,6 +230,8 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
 
     from scipy.ndimage import maximum_filter
 
+    data = np.asanyarray(data)
+
     if np.all(data == data.flat[0]):
         warnings.warn('Input data is constant. No local peaks can be found.',
                       AstropyUserWarning)

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -228,19 +228,25 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         empty table is returned.
     """
 
-    from scipy import ndimage
+    from scipy.ndimage import maximum_filter
 
     if np.all(data == data.flat[0]):
         warnings.warn('Input data is constant. No local peaks can be found.',
                       AstropyUserWarning)
         return Table()  # empty table
 
+    # remove NaN values to avoid runtime warnings
+    nan_mask = np.isnan(data)
+    if np.any(nan_mask):
+        data = np.copy(data)  # ndarray
+        data[nan_mask] = np.nanmin(data)
+
     if footprint is not None:
-        data_max = ndimage.maximum_filter(data, footprint=footprint,
-                                          mode='constant', cval=0.0)
+        data_max = maximum_filter(data, footprint=footprint, mode='constant',
+                                  cval=0.0)
     else:
-        data_max = ndimage.maximum_filter(data, size=box_size,
-                                          mode='constant', cval=0.0)
+        data_max = maximum_filter(data, size=box_size, mode='constant',
+                                  cval=0.0)
 
     peak_goodmask = (data == data_max)    # good pixels are True
 

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -3,6 +3,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 import pytest
+import warnings
 
 from astropy.table import Table
 
@@ -238,3 +239,13 @@ class TestFindPeaks:
 
         tbl = find_peaks(data, 100000, wcs=wcs, subpixel=True)
         assert tbl == Table()
+
+    def test_data_nans(self):
+        """Test that data with NaNs does not issue Runtime warning."""
+
+        data = np.copy(PEAKDATA)
+        data[1, 1] = np.nan
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            find_peaks(data, 0.)


### PR DESCRIPTION
Followup to #709.
