### PR TITLE
Add quadratic centroid estimator

### DIFF
--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -17,6 +17,9 @@ centroid of a single source.  The centroid methods are:
 * :func:`~photutils.centroids.centroid_2dg`: Calculates the centroid
   by fitting a 2D Gaussian to the 2D distribution of the data.
 
+* :func:`~photutils.centroids.centroid_quadratic_2d`: Calculates the centroid
+  by fitting a 2D quadratic function to the 2D distribution of the data.
+
 Masks can be input into each of these functions to mask bad pixels.
 Error arrays can be input into the two fitting methods to weight the
 fits.
@@ -31,7 +34,7 @@ not subtract the background from the data (but in practice, one should
 subtract the background)::
 
     >>> from photutils.datasets import make_4gaussians_image
-    >>> from photutils import centroid_com, centroid_1dg, centroid_2dg
+    >>> from photutils import centroid_com, centroid_1dg, centroid_2dg, centroid_quadratic_2d
     >>> data = make_4gaussians_image()[43:79, 76:104]
 
     >>> x1, y1 = centroid_com(data)
@@ -50,6 +53,10 @@ subtract the background)::
     >>> print((x3, y3))    # doctest: +FLOAT_CMP
     (14.002212073733611, 16.996134592982017)
 
+    >>> x4, y4 = centroid_quadratic_2d(data)
+    >>> print((x4, y4))    # doctest: +FLOAT_CMP
+    (14.32314970320474, 16.919720562376941)
+
 Now let's plot the results.  Because the centroids are all very
 similar, we also include an inset plot zoomed in near the centroid:
 
@@ -57,13 +64,14 @@ similar, we also include an inset plot zoomed in near the centroid:
     :include-source:
 
     from photutils.datasets import make_4gaussians_image
-    from photutils import centroid_com, centroid_1dg, centroid_2dg
+    from photutils import centroid_com, centroid_1dg, centroid_2dg, centroid_quadratic_2d
     import matplotlib.pyplot as plt
 
     data = make_4gaussians_image()[43:79, 76:104]    # extract single object
     x1, y1 = centroid_com(data)
     x2, y2 = centroid_1dg(data)
     x3, y3 = centroid_2dg(data)
+    x4, y4 = centroid_quadratic_2d(data)
     fig, ax = plt.subplots(1, 1)
     ax.imshow(data, origin='lower', interpolation='nearest', cmap='viridis')
     marker = '+'
@@ -71,6 +79,7 @@ similar, we also include an inset plot zoomed in near the centroid:
     plt.plot(x1, y1, color='#1f77b4', marker=marker, ms=ms, mew=mew)
     plt.plot(x2, y2, color='#17becf', marker=marker, ms=ms, mew=mew)
     plt.plot(x3, y3, color='#d62728', marker=marker, ms=ms, mew=mew)
+    plt.plot(x4, y4, color='#ffb6c1', marker=marker, ms=ms, mew=mew)
 
     from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
     from mpl_toolkits.axes_grid1.inset_locator import mark_inset
@@ -80,6 +89,7 @@ similar, we also include an inset plot zoomed in near the centroid:
     ax2.plot(x1, y1, color='#1f77b4', marker=marker, ms=ms, mew=mew)
     ax2.plot(x2, y2, color='#17becf', marker=marker, ms=ms, mew=mew)
     ax2.plot(x3, y3, color='#d62728', marker=marker, ms=ms, mew=mew)
+    plt.plot(x4, y4, color='#ffb6c1', marker=marker, ms=ms, mew=mew)
     ax2.set_xlim(13, 15)
     ax2.set_ylim(16, 18)
     mark_inset(ax, ax2, loc1=3, loc2=4, fc='none', ec='0.5')

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -8,7 +8,7 @@ from astropy.modeling.models import Gaussian1D, Gaussian2D
 import pytest
 
 from ..core import (centroid_com, centroid_1dg, centroid_2dg,
-                    gaussian1d_moments, fit_2dgaussian)
+                    gaussian1d_moments, fit_2dgaussian, centroid_quadratic_2d)
 
 
 try:
@@ -48,6 +48,9 @@ def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
 
     xc3, yc3 = centroid_2dg(data)
     assert_allclose([xc_ref, yc_ref], [xc3, yc3], rtol=0, atol=1.e-3)
+
+    xc4, yc4 = centroid_quadratic_2d(data)
+    assert_allclose([xc_ref, yc_ref], [xc4, yc4], rtol=0, atol=1.e-2)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION
This code implements a quadratic estimator for centroids in 2D arrays based on the work of [Vakili & Hogg (2016) ](https://arxiv.org/abs/1610.05873).

The fundamental idea is that most of the information to infer the centroids of a blob are located in the center pixels, and fitting a quadratic function would capture most of that information. In practice, [Vakili & Hogg (2016) ](https://arxiv.org/abs/1610.05873) showed that the information loss resulted by ignoring the values of other pixels is negligible in various scenarios of signal-to-noise ratio.

This method has been implemented for one dimensional data in https://github.com/richteague/bettermoments.

This implementation is a collaboration with @dfm, @nksaunders, @rodluger, @christinahedges, @afeinstein20, @megbedell, and @benmontet.