### PR TITLE
move SigmaClip parameter iters to maxiters for AstropyDeprecation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ Bug Fixes
   - Fixed a bug in the computation of ``sky_bbox_ul``,
     ``sky_bbox_lr``, ``sky_bbox_ur`` in the ``SourceCatalog``. [#716]
 
+Other Changes
+^^^^^^^^^^^^^
+
+- Parameter update for ``astropy.stats.SigmaClip`` call moving iters to maxiters
+
 
 0.5 (2018-08-06)
 ----------------

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -282,7 +282,7 @@ class Background2D:
     def __init__(self, data, box_size, mask=None,
                  exclude_percentile=10., filter_size=(3, 3),
                  filter_threshold=None, edge_method='pad',
-                 sigma_clip=SigmaClip(sigma=3., iters=10),
+                 sigma_clip=SigmaClip(sigma=3., maxiters=10),
                  bkg_estimator=SExtractorBackground(sigma_clip=None),
                  bkgrms_estimator=StdBackgroundRMS(sigma_clip=None),
                  interpolator=BkgZoomInterpolator()):

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -68,7 +68,7 @@ class BackgroundBase(metaclass=_ABCMetaAndInheritDocstrings):
         ``sigma=3.`` and ``iters=5``.
     """
 
-    def __init__(self, sigma_clip=SigmaClip(sigma=3., iters=5)):
+    def __init__(self, sigma_clip=SigmaClip(sigma=3., maxiters=5)):
         self.sigma_clip = sigma_clip
 
     def __call__(self, data, axis=None):
@@ -111,7 +111,7 @@ class BackgroundRMSBase(metaclass=_ABCMetaAndInheritDocstrings):
         ``sigma=3.`` and ``iters=5``.
     """
 
-    def __init__(self, sigma_clip=SigmaClip(sigma=3., iters=5)):
+    def __init__(self, sigma_clip=SigmaClip(sigma=3., maxiters=5)):
         self.sigma_clip = sigma_clip
 
     def __call__(self, data, axis=None):

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -92,7 +92,7 @@ def detect_threshold(data, snr, background=None, error=None, mask=None,
     if background is None or error is None:
         data_mean, data_median, data_std = sigma_clipped_stats(
             data, mask=mask, mask_value=mask_value, sigma=sigclip_sigma,
-            iters=sigclip_iters)
+            maxiters=sigclip_iters)
         bkgrd_image = np.zeros_like(data) + data_mean
         bkgrdrms_image = np.zeros_like(data) + data_std
 


### PR DESCRIPTION
This may already be planned, but I keep getting deprecation warnings for the SigmaClip routine, this updates `iters` to `maxiters`:

```
AstropyDeprecationWarning: "iters" was deprecated in version 3.1 and will be removed in a future version.
Use argument "maxiters" instead. def __init__(self, sigma_clip=SigmaClip(sigma=3., iters=5))
```