### PR TITLE
WIP: PSF Photometry API documentation for established functionality

### DIFF
--- a/docs/psf_spec/background_estimator.rst
+++ b/docs/psf_spec/background_estimator.rst
@@ -3,10 +3,10 @@ BackgroundEstimator
 
 Existing code documented at
 https://photutils.readthedocs.io/en/stable/api/photutils.background.BackgroundBase.html
-- while the ``__call__`` function has no docstring, the ``calc_background``
+-- while the ``__call__`` function has no docstring, the ``calc_background``
 function is the actual block API. This function is used significantly through `photutils`
-and should therefore be relatively stable to call changes; documentation is therefore 
-unlikely to change.
+and is heavily used within the PSF fitting process, so the documentation is summarized
+again here.
 
 Routine to estimate the background level of images and provide background subtraction. 
 Can either be applied across an entire image or applied in a two-dimensional grid, at

--- a/docs/psf_spec/background_estimator.rst
+++ b/docs/psf_spec/background_estimator.rst
@@ -1,8 +1,8 @@
 BackgroundEstimator
 ===================
 
-Existing code documented at
-https://photutils.readthedocs.io/en/stable/api/photutils.background.BackgroundBase.html
+Existing code documented `here 
+<https://photutils.readthedocs.io/en/stable/api/photutils.background.BackgroundBase.html>`_
 -- while the ``__call__`` function has no docstring, the ``calc_background``
 function is the actual block API. This function is used significantly through `photutils`
 and is heavily used within the PSF fitting process, so the documentation is summarized

--- a/docs/psf_spec/background_estimator.rst
+++ b/docs/psf_spec/background_estimator.rst
@@ -1,28 +1,33 @@
 BackgroundEstimator
 ===================
 
-EJT: Existing code documented at
+Existing code documented at
 https://photutils.readthedocs.io/en/stable/api/photutils.background.BackgroundBase.html
 - while the ``__call__`` function has no docstring, the ``calc_background``
-function is the actual block API.  I'm providing this as an *example* block
-because it is heavily used in other parts of `photutils` and therefore probably
-should not be changed much unless absolutely necessary.
+function is the actual block API. The documentation is therefore unlikely to change.
 
-A single sentence summarizing this block.
+Routine to estimate the background level of images and provide background subtraction. 
+Can either be applied across an entire image or applied in a two-dimensional grid, at
+which point background estimation is applied at each grid location locally.
 
-A longer descrption.  Can be multiple paragraphs.  You can link to other things
-like `photutils.background`.
-
+Base class from which all background estimators are defined. Further parameters may be
+specified by subclass estimators, such as the ``ModeEstimatorBackground`` in ``photutils``
+which takes ``median_factor`` and ``mean_factor`` as additional variables.
 
 Parameters
 ----------
 
+sigma_clip : `~astropy.stats.SigmaClip` object or None
+    The object which defines the level of sigma clipping applied to the data. If `None`
+    then no clipping is performed. Passed when creating the class in ``__init__``.
+
 data : array_like or `~numpy.ma.MaskedArray`
-    The array for which to calculate the background value.
+    The array for which to calculate the background value. Passed to the ``__call__`` 
+    function.
 
 axis : int or `None`, optional
     The array axis along which the background is calculated.  If
-    `None`, then the entire array is used.
+    `None`, then the entire array is used. Passed to the ``__call__`` function.
 
 Returns
 -------
@@ -36,14 +41,14 @@ result : float or `~numpy.ma.MaskedArray`
 Methods
 -------
 
-This block requires no methods beyond ``__call__()``.
+This block requires no methods beyond first initialisation, and ``__call__()``.
 
 
 Example Usage
 -------------
 
 A variety of implementations of this block already exist in ``photutils``. A
-canononical example is the mode estimation algorithm ``3 * median - 2 * mean``.
+canonical example is the mode estimation algorithm ``3 * median - 2 * mean``.
 This can be done on an array called  ``image_data`` by using the block like so::
 
     from photutils.background import ModeEstimatorBackground

--- a/docs/psf_spec/background_estimator.rst
+++ b/docs/psf_spec/background_estimator.rst
@@ -4,7 +4,9 @@ BackgroundEstimator
 Existing code documented at
 https://photutils.readthedocs.io/en/stable/api/photutils.background.BackgroundBase.html
 - while the ``__call__`` function has no docstring, the ``calc_background``
-function is the actual block API. The documentation is therefore unlikely to change.
+function is the actual block API. This function is used significantly through `photutils`
+and should therefore be relatively stable to call changes; documentation is therefore 
+unlikely to change.
 
 Routine to estimate the background level of images and provide background subtraction. 
 Can either be applied across an entire image or applied in a two-dimensional grid, at

--- a/docs/psf_spec/finder.rst
+++ b/docs/psf_spec/finder.rst
@@ -3,10 +3,21 @@ ObjectFinder
 
 Existing code documented at
 https://photutils.readthedocs.io/en/stable/api/photutils.detection.StarFinderBase.html
-- see the ``find_stars`` function for the basic API.
+- see the ``find_stars`` function for the basic API. ``Finder`` is a relatively
+independent routine in the PSF fitting process, and as such it is documented within its
+own documentation blocks, based on ``StarFinderBase``; it is documented here for
+completeness.
 
 The object which defines the detection of objects in an image. Subclass finders
-may require additional parameters -- see below for the example of ``DAOStarFinder``.
+may require additional parameters -- see below for the example of ``DAOStarFinder``. The
+class is defined entirely by its ``find_stars`` function, with some initialization,
+depending on the individual subclass.
+
+``find_stars`` accepts ``data``, the two-dimensional image in which sources should be
+found, and returns ``table``, an `~astropy.table.Table` list of sources which passed
+the given detection criteria. For example, in `~photutils.detection.DAOStarFinder`
+a source must have given ``sharpness`` and ``roundness`` within specified ranges for
+acceptance as a detected source.
 
 Parameters
 ----------

--- a/docs/psf_spec/finder.rst
+++ b/docs/psf_spec/finder.rst
@@ -27,8 +27,8 @@ Example Usage
 
 StarFinder currently implements two methods: DAOFind and IRAFFind. For example, daofind
 can be run to find objects with FWHM of approximately 3 pixels with a peak 5-sigma above
-the background:
-::
+the background::
+
     from photutils import DAOStarFinder
     daofind = DAOStarFinder(fwhm=3.0, threshold=5.*std)
     sources = daofind(data)

--- a/docs/psf_spec/finder.rst
+++ b/docs/psf_spec/finder.rst
@@ -1,71 +1,35 @@
 ObjectFinder
 ============
 
-EJT: Existing code documented at
+Existing code documented at
 https://photutils.readthedocs.io/en/stable/api/photutils.detection.StarFinderBase.html
 - see the ``find_stars`` function for the basic API.
 
-A single sentence summarizing this block.
-
-A longer descrption.  Can be multiple paragraphs.  You can link to other things
-like `photutils.background`.
+The object which defines the detection of objects in an image. Subclass finders
+may require additional parameters -- see below for the example of ``DAOStarFinder``.
 
 Parameters
 ----------
 
-first_parameter_name : `~astropy.table.Table`
-    Description of first input
+data : array_like
+    The 2D image array in which the finder should detection sources.
 
-second_parameter_name : SomeOtherType
-    Description of second input (if any)
 
 Returns
 -------
 
-first_return : `~astropy.table.Table`
-    Description of the first thing this block outputs.
-
-second_return
-    Many blocks will only return one object, but if more things are returned
-    they can be described here (e.g., in python this is
-    ``first, second = some_function(...)``)
-
-
-Methods
--------
-
-Not all blocks will have these, but if desired some blocks can have methods that
-let you do something other than just running the block.  E.g::
-
-    some_block = BlockClassName()
-    output = some_block(input1, input2, ...)  # this is what is documented above
-    result = some_block.method_name(...)  #this is documented here
-
-method_name
-^^^^^^^^^^^
-
-Description of method
-
-Parameters
-""""""""""
-
-first_parameter : type
-    Description ...
-
-second_parameter : type
-    Description ...
-
-Returns
-"""""""
-
-first_return : type
-    Description ...
+table : `~astropy.table.Table`
+    The table of detected sources.
 
 
 Example Usage
 -------------
 
-An example of *using* the block should be provided.  This needs to be after a
-``::`` in the rst and indented::
-
-    print("This is example code")
+StarFinder currently implements two methods: DAOFind and IRAFFind. For example, daofind
+can be run to find objects with FWHM of approximately 3 pixels with a peak 5-sigma above
+the background:
+::
+    from photutils import DAOStarFinder
+    daofind = DAOStarFinder(fwhm=3.0, threshold=5.*std)
+    sources = daofind(data)
+    

--- a/docs/psf_spec/finder.rst
+++ b/docs/psf_spec/finder.rst
@@ -1,9 +1,9 @@
 ObjectFinder
 ============
 
-Existing code documented at
-https://photutils.readthedocs.io/en/stable/api/photutils.detection.StarFinderBase.html
-- see the ``find_stars`` function for the basic API. ``Finder`` is a relatively
+Existing code documented `here 
+<https://photutils.readthedocs.io/en/stable/api/photutils.detection.StarFinderBase.html>`_
+-- see the ``find_stars`` function for the basic API. ``Finder`` is a relatively
 independent routine in the PSF fitting process, and as such it is documented within its
 own documentation blocks, based on ``StarFinderBase``; it is documented here for
 completeness.

--- a/docs/psf_spec/group_maker.rst
+++ b/docs/psf_spec/group_maker.rst
@@ -2,17 +2,24 @@ GroupMaker
 ==========
 
 Documented as the ``__call__`` method of ``GroupStarsBase`` - see
-https://photutils.readthedocs.io/en/stable/api/photutils.psf.groupstars.GroupStarsBase.html
-API may potentially change if group_stars is updated to scene_maker extending PSF fitting to
-non-point source objects; however, it is likely that the fundamental inputs and outputs
-remain at least functionally similar to those shown here. Large changes to the GroupMaker
-call may require significant changes to the PSF Photometry fitting routines (e.g.,
-``IterativelySubtractedPSFPhotometry``).
+https://photutils.readthedocs.io/en/stable/api/photutils.psf.groupstars.GroupStarsBase.html.
+The API for the group maker may be subject to change if ``group_stars`` requires changes
+to accommodate future revisions to the PSF fitting process -- primarily it would require
+updates if the PSF fitting is extended to include non-point sources and "scene maker"
+functionality. These large changes would subsequently require significant changes to the
+PSF fitting routines (e.g., ``IterativelySubtractedPSFPhotometry``) as a whole.
 
 A function which groups stars within some critical separation, returning potentially
 overlapping sources with an additonal column indicating their common group members.
 Subclasses of ``GroupStarsBase`` may require further input parameters, such as 
 ``crit_separation`` required for ``DAOGroup``.
+
+The main functionality of this routine is within ``group_stars``, which accepts
+``starlist``, a `~astropy.table.Table` of sources with centroid positions, and returns
+``group_starlist``, the same `~astropy.table.Table` passed to the routine but with an
+additional column indicating the group number of the sources. These sources are grouped
+by the individual criteria specified within the ``group_stars`` function defined by the
+``GroupStarsBase`` subclass in question.
 
 Parameters
 ----------

--- a/docs/psf_spec/group_maker.rst
+++ b/docs/psf_spec/group_maker.rst
@@ -1,13 +1,15 @@
 GroupMaker
 ==========
 
-Documented as the `__call__` method of ``GroupStarsBase`` - see
+Documented as the ``__call__`` method of ``GroupStarsBase`` - see
 https://photutils.readthedocs.io/en/stable/api/photutils.psf.groupstars.GroupStarsBase.html
-It'll be substantial work to re-design the photometry loops if this is changed
-in a backwards-incompatible manner, but of course that's possible if there's a
-good reason for it.
+API may potentially change if group_stars is updated to scene_maker extending PSF fitting to
+non-point source objects; however, it is likely that the fundamental inputs and outputs
+remain at least functionally similar to those shown here. Large changes to the GroupMaker
+call may require significant changes to the PSF Photometry fitting routines (e.g.,
+``IterativelySubtractedPSFPhotometry``).
 
-An object which groups stars within some critical separation, returning potentially
+A function which groups stars within some critical separation, returning potentially
 overlapping sources with an additonal column indicating their common group members.
 Subclasses of ``GroupStarsBase`` may require further input parameters, such as 
 ``crit_separation`` required for ``DAOGroup``.
@@ -48,15 +50,15 @@ starlist : `~astropy.table.Table`
 Returns
 """""""
 
-`~np.array` with the IDs of all stars with distance less than ``crit_separation`` to ``star``.
+`~numpy.array` with the IDs of all stars with distance less than ``crit_separation`` to ``star``.
 
 
 Example Usage
 -------------
 
 Here we create a ``DAOGroup`` list of overlapping sources, then find all sources within 3 pixels
-of the first source in the list.
-::
+of the first source in the list.::
+
     from photutils.psf.groupstars import DAOGroup
     group = DAOGroup(starlist, crit_separation=3)
     stargroups = group.group_stars(starlist)

--- a/docs/psf_spec/group_maker.rst
+++ b/docs/psf_spec/group_maker.rst
@@ -1,73 +1,63 @@
 GroupMaker
 ==========
 
-EJT: Documented as the ``__call__`` method of ``GroupStarsBase`` - see
+Documented as the `__call__` method of ``GroupStarsBase`` - see
 https://photutils.readthedocs.io/en/stable/api/photutils.psf.groupstars.GroupStarsBase.html
 It'll be substantial work to re-design the photometry loops if this is changed
 in a backwards-incompatible manner, but of course that's possible if there's a
 good reason for it.
 
-A single sentence summarizing this block.
-
-A longer descrption.  Can be multiple paragraphs.  You can link to other things
-like `photutils.background`.
+An object which groups stars within some critical separation, returning potentially
+overlapping sources with an additonal column indicating their common group members.
+Subclasses of ``GroupStarsBase`` may require further input parameters, such as 
+``crit_separation`` required for ``DAOGroup``.
 
 Parameters
 ----------
 
-first_parameter_name : `~astropy.table.Table`
-    Description of first input
-
-second_parameter_name : SomeOtherType
-    Description of second input (if any)
+starlist : `~astropy.table.Table`
+    List of star positions; ``x_0`` and ``y_0``, the centroids of the sources, must be
+    provided.
 
 Returns
 -------
 
-first_return : `~astropy.table.Table`
-    Description of the first thing this block outputs.
-
-second_return
-    Many blocks will only return one object, but if more things are returned
-    they can be described here (e.g., in python this is
-    ``first, second = some_function(...)``)
+group_starlist : `~astropy.table.Table`
+    ``starlist`` with an additional column appended -- ``group_id`` gives unique
+    group number of mutually overlapping sources.
 
 
 Methods
 -------
 
-Not all blocks will have these, but if desired some blocks can have methods that
-let you do something other than just running the block.  E.g::
-
-    some_block = BlockClassName()
-    output = some_block(input1, input2, ...)  # this is what is documented above
-    result = some_block.method_name(...)  #this is documented here
-
-method_name
+find_group
 ^^^^^^^^^^^
 
-Description of method
+Convenience function provided by ``DAOGroup`` returning all objects within
+``crit_separation`` from a given star from ``starlist``.
 
 Parameters
 """"""""""
 
-first_parameter : type
-    Description ...
-
-second_parameter : type
-    Description ...
+star : `~astropy.table.Row`
+    Single star from ``starlist`` whose mutual group members are required.
+starlist : `~astropy.table.Table`
+    List of star positions; ``x_0`` and ``y_0``, the centroids of the sources, must be
+    provided.
 
 Returns
 """""""
 
-first_return : type
-    Description ...
+`~np.array` with the IDs of all stars with distance less than ``crit_separation`` to ``star``.
 
 
 Example Usage
 -------------
 
-An example of *using* the block should be provided.  This needs to be after a
-``::`` in the rst and indented::
-
-    print("This is example code")
+Here we create a ``DAOGroup`` list of overlapping sources, then find all sources within 3 pixels
+of the first source in the list.
+::
+    from photutils.psf.groupstars import DAOGroup
+    group = DAOGroup(starlist, crit_separation=3)
+    stargroups = group.group_stars(starlist)
+    id_overlap = group.find_stars(starlist[0], starlist)

--- a/docs/psf_spec/group_maker.rst
+++ b/docs/psf_spec/group_maker.rst
@@ -1,13 +1,14 @@
 GroupMaker
 ==========
 
-Documented as the ``__call__`` method of ``GroupStarsBase`` - see
-https://photutils.readthedocs.io/en/stable/api/photutils.psf.groupstars.GroupStarsBase.html.
-The API for the group maker may be subject to change if ``group_stars`` requires changes
-to accommodate future revisions to the PSF fitting process -- primarily it would require
-updates if the PSF fitting is extended to include non-point sources and "scene maker"
-functionality. These large changes would subsequently require significant changes to the
-PSF fitting routines (e.g., ``IterativelySubtractedPSFPhotometry``) as a whole.
+Documented as the ``__call__`` method of ``GroupStarsBase`` -- see `here 
+<https://photutils.readthedocs.io/en/stable/api/photutils.psf.groupstars.GroupStarsBase.html>`_
+for more information. The API for the group maker may be subject to change if ``group_stars``
+requires changes to accommodate future revisions to the PSF fitting process -- primarily it
+would require updates if the PSF fitting is extended to include non-point sources and
+"scene maker" functionality. These large changes would subsequently require significant
+changes to the PSF fitting routines (e.g., `~photutils.psf.IterativelySubtractedPSFPhotometry`)
+as a whole.
 
 A function which groups stars within some critical separation, returning potentially
 overlapping sources with an additonal column indicating their common group members.
@@ -64,7 +65,7 @@ Example Usage
 -------------
 
 Here we create a ``DAOGroup`` list of overlapping sources, then find all sources within 3 pixels
-of the first source in the list.::
+of the first source in the list. ::
 
     from photutils.psf.groupstars import DAOGroup
     group = DAOGroup(starlist, crit_separation=3)

--- a/docs/psf_spec/index.rst
+++ b/docs/psf_spec/index.rst
@@ -14,6 +14,7 @@ Blocks
 .. toctree::
     :maxdepth: 1
 
+    block_template
     background_estimator
     block_template
     culler_and_ender
@@ -24,3 +25,4 @@ Blocks
     psf_model
     scene_maker
     single_object_model
+

--- a/docs/psf_spec/psf_model.rst
+++ b/docs/psf_spec/psf_model.rst
@@ -1,7 +1,7 @@
 PsfModel
 ========
 
-EJT: the PSF models in the current ``photutils.psf`` are not explicitly
+The PSF models in the current ``photutils.psf`` are not explicitly
 defined as a specific class, but any 2D model (inputs: x,y, output: flux) can
 be considered a PSF Model.  The `~photutils.psf.PRFAdapter` class is the
 clearest application specific example, however, and demonstrates the required
@@ -9,30 +9,30 @@ convention for *names* of the PSF model's parameters.  Hopefully that class can
 be used *directly* as this block, as it is meant to wrap any arbitrary other
 models to make it compatible with the machinery.
 
-A single sentence summarizing this block.
-
-A longer descrption.  Can be multiple paragraphs.  You can link to other things
-like `photutils.background`.
+The model for the PSF -- integrated over discrete pixels (see `discussion 
+<https://github.com/astropy/photutils/blob/master/docs/psf.rst#terminology>'_ 
+on terminology for more details) -- on which we should evaluate the parameters
+of the source. The main input is a 2D image, with the model being represented
+by a ``FittableImageModel``, returning ``flux``, ``x_0``, and ``y_0``, the
+overall source flux and centroid position. Individual models will require 
+additional parameters, such as the ``IntegratedGaussianPRF`` which additionally
+requiring ``sigma`` as a parameter that describes the underlying Gaussian PSF.
 
 Parameters
 ----------
 
-first_parameter_name : `~astropy.table.Table`
-    Description of first input
-
-second_parameter_name : SomeOtherType
-    Description of second input (if any)
+data : np.ndarray
+    Array containing the 2D image representing the source(s) that should be
+    evaluated for centroiding and flux.
 
 Returns
 -------
 
-first_return : `~astropy.table.Table`
-    Description of the first thing this block outputs.
-
-second_return
-    Many blocks will only return one object, but if more things are returned
-    they can be described here (e.g., in python this is
-    ``first, second = some_function(...)``)
+flux : float
+    The flux of the source; if any normalization has been applied then ``flux``
+    will be set to 1.
+x_0 : float
+    The position of the source in the x axis, to sub-pixel resolution.
 
 
 Methods
@@ -45,31 +45,38 @@ let you do something other than just running the block.  E.g::
     output = some_block(input1, input2, ...)  # this is what is documented above
     result = some_block.method_name(...)  #this is documented here
 
-method_name
+evaluate
 ^^^^^^^^^^^
 
-Description of method
+Function that returns the values of the pixels of a model with ``flux``, ``x_0`` and
+``y_0`` as parameters.
 
 Parameters
 """"""""""
 
-first_parameter : type
-    Description ...
-
-second_parameter : type
-    Description ...
+x : float
+    Central values of the pixels in the x axis at which to evaluate the PSF.
+y : float
+    Central values of the pixels in the y axis at which to evaluate the PSF.
+flux : float
+    Overall flux level of source, setting the scaling of each pixel.
+x_0 : float
+    The centroid position of the source in the x axis.
+y_0 : float
+    The centroid position of the source in the y axis.
 
 Returns
 """""""
 
-first_return : type
-    Description ...
+The evaluation of the PSF, integrated over discrete pixels, at the centroid position
+and with the flux level specified.
 
 
 Example Usage
 -------------
-
-An example of *using* the block should be provided.  This needs to be after a
-``::`` in the rst and indented::
-
-    print("This is example code")
+Here we create a discrete Gaussian PSF with standard deviation of 2 pixels, and 
+fit for centroid and overall flux level of a source.
+::
+    from photutils.psf import IntegratedGaussianPRF
+    psf_model = IntegratedGaussianPRF(sigma=2)
+    model_image = psf_model.evaluate(x, y, flux, x_0, y_0, sigma=2)

--- a/docs/psf_spec/psf_model.rst
+++ b/docs/psf_spec/psf_model.rst
@@ -9,6 +9,14 @@ of the source. The main input is a 2D image, with the model returning ``flux``,
 in the current ``photutils.psf`` are not explicitly defined as a specific class,
 but any 2D model (inputs: x,y, output: flux) can be considered a PSF Model.
 
+This block is primarily an external block, defined as a
+`~astropy.modeling.Fittable2DModel`, and should have a well documented subclass.
+The requirements for use within the PSF model block are that the
+`~astropy.modeling.Fittable2DModel` have parameters ``flux``, ``x_0``, and ``y_0``,
+as well as the ``evaluate`` function. When the model is combined with a minimization
+routine the best fitting flux and position for the input ``data`` image array
+containing the source are returned.
+
 The `~photutils.psf.PRFAdapter` class allows for the wrapping of any arbitrary 
 other models to make it compatible with the machinery. Some individual models 
 will require additional parameters, such as the ``IntegratedGaussianPRF`` which 
@@ -30,17 +38,12 @@ flux : float
     will be set to 1.
 x_0 : float
     The position of the source in the x axis, to sub-pixel resolution.
+y_0 : float
+    The position of the source in the y axis, to sub-pixel resolution.
 
 
 Methods
 -------
-
-Not all blocks will have these, but if desired some blocks can have methods that
-let you do something other than just running the block.  E.g::
-
-    some_block = BlockClassName()
-    output = some_block(input1, input2, ...)  # this is what is documented above
-    result = some_block.method_name(...)  #this is documented here
 
 evaluate
 ^^^^^^^^^^^

--- a/docs/psf_spec/psf_model.rst
+++ b/docs/psf_spec/psf_model.rst
@@ -1,4 +1,4 @@
-PsfModel
+PSFModel
 ========
 
 The model for the PSF -- integrated over discrete pixels (see `discussion 

--- a/docs/psf_spec/psf_model.rst
+++ b/docs/psf_spec/psf_model.rst
@@ -1,22 +1,19 @@
 PsfModel
 ========
 
-The PSF models in the current ``photutils.psf`` are not explicitly
-defined as a specific class, but any 2D model (inputs: x,y, output: flux) can
-be considered a PSF Model.  The `~photutils.psf.PRFAdapter` class is the
-clearest application specific example, however, and demonstrates the required
-convention for *names* of the PSF model's parameters.  Hopefully that class can
-be used *directly* as this block, as it is meant to wrap any arbitrary other
-models to make it compatible with the machinery.
-
 The model for the PSF -- integrated over discrete pixels (see `discussion 
-<https://github.com/astropy/photutils/blob/master/docs/psf.rst#terminology>'_ 
+<https://github.com/astropy/photutils/blob/master/docs/psf.rst#terminology>`_ 
 on terminology for more details) -- on which we should evaluate the parameters
-of the source. The main input is a 2D image, with the model being represented
-by a ``FittableImageModel``, returning ``flux``, ``x_0``, and ``y_0``, the
-overall source flux and centroid position. Individual models will require 
-additional parameters, such as the ``IntegratedGaussianPRF`` which additionally
-requiring ``sigma`` as a parameter that describes the underlying Gaussian PSF.
+of the source. The main input is a 2D image, with the model returning ``flux``,
+``x_0``, and ``y_0``, the overall source flux and centroid position. PSF models
+in the current ``photutils.psf`` are not explicitly defined as a specific class,
+but any 2D model (inputs: x,y, output: flux) can be considered a PSF Model.
+
+The `~photutils.psf.PRFAdapter` class allows for the wrapping of any arbitrary 
+other models to make it compatible with the machinery. Some individual models 
+will require additional parameters, such as the ``IntegratedGaussianPRF`` which 
+additionally requiring ``sigma`` as a parameter that describes the underlying 
+Gaussian PSF.
 
 Parameters
 ----------
@@ -75,8 +72,8 @@ and with the flux level specified.
 Example Usage
 -------------
 Here we create a discrete Gaussian PSF with standard deviation of 2 pixels, and 
-fit for centroid and overall flux level of a source.
-::
+fit for centroid and overall flux level of a source.::
+
     from photutils.psf import IntegratedGaussianPRF
     psf_model = IntegratedGaussianPRF(sigma=2)
     model_image = psf_model.evaluate(x, y, flux, x_0, y_0, sigma=2)


### PR DESCRIPTION
This PR is part of the process for establishing the block API for PSF photometry. The documentation in this PR is unlikely to change as the four blocks here -- background estimation, source finder, source grouper, and PSF model -- are either independently used within `photutils` and thus well tested, matured and established pieces of code, or are relatively straightforward and thus leave little room for API changes. Please see #766 for an overview of the fitting process.

The documentation for ``background_estimator`` and ``finder`` should be very stable to changes, as these are the external function calls to routines used significantly throughout `photutils`. For these the primary issues are wording and formatting.

``group_maker`` however is slightly less stable, and thus in addition to checking for clarity and formatting this block description must succinctly and clearly explain the dependency of the group maker on the scene maker (developed in parallel with the extension of PSF fitting to non-point sources, in which "groups" can include the merging of several point sources into an extended object and vice versa).

``psf_model`` is a relatively minor documentation block, as it is primarily an external astropy class for which the PSF model must be a subclass, with specific input parameters. Thus this documentation must also explain this dependency.

The issues to be discussed in this PR are therefore:
- [ ] Background estimator
  - [ ] Formatting
  - [ ] Wording
- [ ] Finder
  - [ ] Formatting
  - [ ] Wording
- [ ] Group Maker
  - [ ] Formatting
  - [ ] Wording
  - [ ] Scene maker dependency
- [ ] PSF Model
  - [ ] Formatting
  - [ ] Wording
  - [ ] Fittable2DModel dependency

Please provide comments on any clarifications, inconsistencies, formatting changes or documentation flow changes here.