### PR TITLE
Fix to ePSF normalisation treatment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,23 @@ Other Changes and Additions
   keywords. [#726]
 
 
+Bug Fixes
+^^^^^^^^^
+
+- ``photutils.psf``
+
+  - Fixed normalization of ePSF model, now correctly normalizing on
+    undersampled pixel grid.
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Updated background and detection functions that call
+  ``astropy.stats.SigmaClip`` or ``astropy.stats.sigma_clipped_stats``
+  to support both their ``iters`` (for astropy < 3.1) and ``maxiters``
+  keywords. [#726]
+
+
 0.5 (2018-08-06)
 ----------------
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -557,27 +557,26 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     psi_pos_x = data[y_0, x_0 + x_shiftidx]
     psi_pos_x_m1 = data[y_0, x_0 + x_shiftidx - 1]
     psi_pos_x_p1 = data[y_0, x_0 + x_shiftidx + 1]
-    dpsi_pos_x = (psi_pos_x_p1 - psi_pos_x_m1) / 2.
+    dpsi_pos_x = np.abs(psi_pos_x_p1 - psi_pos_x_m1) / 2.
     # psi_E(-0.5, 0.0) and derivative components.
     psi_neg_x = data[y_0, x_0 - x_shiftidx]
     psi_neg_x_m1 = data[y_0, x_0 - x_shiftidx - 1]
     psi_neg_x_p1 = data[y_0, x_0 - x_shiftidx + 1]
-    dpsi_neg_x = (psi_neg_x_p1 - psi_neg_x_m1) / 2.
+    dpsi_neg_x = np.abs(psi_neg_x_p1 - psi_neg_x_m1) / 2.
 
-    x_shift = (psi_pos_x - psi_neg_x) / (dpsi_pos_x - dpsi_neg_x)
+    x_shift = (psi_pos_x - psi_neg_x) / (dpsi_pos_x + dpsi_neg_x)
 
     # psi_E(0.0, 0.5) and derivatives.
     psi_pos_y = data[y_0 + y_shiftidx, x_0]
     psi_pos_y_m1 = data[y_0 + y_shiftidx - 1, x_0]
     psi_pos_y_p1 = data[y_0 + y_shiftidx + 1, x_0]
-    dpsi_pos_y = (psi_pos_y_p1 - psi_pos_y_m1) / 2.
+    dpsi_pos_y = np.abs(psi_pos_y_p1 - psi_pos_y_m1) / 2.
     # psi_E(0.0, -0.5) and derivative components.
     psi_neg_y = data[y_0 - y_shiftidx, x_0]
     psi_neg_y_m1 = data[y_0 - y_shiftidx - 1, x_0]
     psi_neg_y_p1 = data[y_0 - y_shiftidx + 1, x_0]
-    dpsi_neg_y = (psi_neg_y_p1 - psi_neg_y_m1) / 2.
+    dpsi_neg_y = np.abs(psi_neg_y_p1 - psi_neg_y_m1) / 2.
 
-    y_shift = (psi_pos_y - psi_neg_y) / (dpsi_pos_y - dpsi_neg_y)
-
+    y_shift = (psi_pos_y - psi_neg_y) / (dpsi_pos_y + dpsi_neg_y)
 
     return x_0+x_shift, y_0+y_shift

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -8,8 +8,8 @@ from astropy.modeling.models import Gaussian1D, Gaussian2D
 import pytest
 
 from ..core import (centroid_com, centroid_1dg, centroid_2dg,
-                    gaussian1d_moments, fit_2dgaussian)
-
+                    gaussian1d_moments, fit_2dgaussian,
+                    centroid_epsf)
 
 try:
     # the fitting routines in astropy use scipy.optimize
@@ -200,3 +200,24 @@ def test_fit2dgaussian_dof():
     data = np.ones((2, 2))
     with pytest.raises(ValueError):
         fit_2dgaussian(data)
+
+
+def test_centroid_epsf():
+    data = np.ones((5, 5), dtype=float)
+    mask = np.zeros((4, 5), dtype=int)
+    mask[2, 2] = 1
+
+    # Test data and mask having the same shape
+    with pytest.raises(ValueError):
+        centroid_epsf(data, mask)
+
+    with pytest.raises(ValueError):
+        centroid_epsf(data, shift_val=-1)
+
+    with pytest.raises(ValueError):
+        centroid_epsf(data, oversampling=None)
+
+    data = np.ones((21, 21), dtype=float)
+    data[10, 10] = np.inf
+    with pytest.raises(ValueError):
+        centroid_epsf(data)

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -12,13 +12,14 @@ from astropy.table import Table
 from astropy.wcs import WCS
 
 from ..utils import check_random_state
+from ..psf import IntegratedGaussianPRF
 
 
 __all__ = ['apply_poisson_noise', 'make_noise_image',
            'make_random_models_table', 'make_random_gaussians_table',
            'make_model_sources_image', 'make_gaussian_sources_image',
            'make_4gaussians_image', 'make_100gaussians_image',
-           'make_wcs', 'make_imagehdu']
+           'make_wcs', 'make_imagehdu', 'make_gaussian_prf_sources_image']
 
 
 def apply_poisson_noise(data, random_state=None):
@@ -548,6 +549,100 @@ def make_gaussian_sources_image(shape, source_table, oversample=1):
         source_table = source_table.copy()
         source_table['amplitude'] = (source_table['flux'] /
                                      (2. * np.pi * xstd * ystd))
+
+    return make_model_sources_image(shape, model, source_table,
+                                    oversample=oversample)
+
+
+def make_gaussian_prf_sources_image(shape, source_table, oversample=1):
+    """
+    Make an image containing 2D Gaussian sources.
+
+    Parameters
+    ----------
+    shape : 2-tuple of int
+        The shape of the output 2D image.
+
+    source_table : `~astropy.table.Table`
+        Table of parameters for the Gaussian sources.  Each row of the
+        table corresponds to a Gaussian source whose parameters are
+        defined by the column names.  With the exception of ``'flux'``,
+        column names that do not match model parameters will be ignored
+        (flux will be converted to amplitude).  If both ``'flux'`` and
+        ``'amplitude'`` are present, then ``'flux'`` will be ignored.
+        Model parameters not defined in the table will be set to the
+        default value.
+
+    oversample : float, optional
+        The sampling factor used to discretize the models on a pixel
+        grid.  If the value is 1.0 (the default), then the models will
+        be discretized by taking the value at the center of the pixel
+        bin.  Note that this method will not preserve the total flux of
+        very small sources.  Otherwise, the models will be discretized
+        by taking the average over an oversampled grid.  The pixels will
+        be oversampled by the ``oversample`` factor.
+
+    Returns
+    -------
+    image : 2D `~numpy.ndarray`
+        Image containing 2D Gaussian sources.
+
+    See Also
+    --------
+    make_model_sources_image, make_random_gaussians_table
+
+    Examples
+    --------
+    .. plot::
+        :include-source:
+
+        # make a table of Gaussian sources
+        from astropy.table import Table
+        table = Table()
+        table['amplitude'] = [50, 70, 150, 210]
+        table['x_0'] = [160, 25, 150, 90]
+        table['y_0'] = [70, 40, 25, 60]
+        table['sigma'] = [15.2, 5.1, 3., 8.1]
+        table['theta'] = np.array([145., 20., 0., 60.]) * np.pi / 180.
+
+        # make an image of the sources without noise, with Gaussian
+        # noise, and with Poisson noise
+        from photutils.datasets import make_gaussian_prf_sources_image
+        from photutils.datasets import make_noise_image
+        shape = (100, 200)
+        image1 = make_gaussian_prf_sources_image(shape, table)
+        image2 = image1 + make_noise_image(shape, type='gaussian', mean=5.,
+                                           stddev=5.)
+        image3 = image1 + make_noise_image(shape, type='poisson', mean=5.)
+
+        # plot the images
+        import matplotlib.pyplot as plt
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(8, 12))
+        ax1.imshow(image1, origin='lower', interpolation='nearest')
+        ax1.set_title('Original image')
+        ax2.imshow(image2, origin='lower', interpolation='nearest')
+        ax2.set_title('Original image with added Gaussian noise'
+                      ' ($\\mu = 5, \\sigma = 5$)')
+        ax3.imshow(image3, origin='lower', interpolation='nearest')
+        ax3.set_title('Original image with added Poisson noise ($\\mu = 5$)')
+    """
+
+    model = IntegratedGaussianPRF()
+
+    if 'sigma' in source_table.colnames:
+        std = source_table['sigma']
+    else:
+        std = model.sigma.value    # default
+
+    colnames = source_table.colnames
+    if 'flux' in colnames and 'amplitude' not in colnames:
+        source_table = source_table.copy()
+        source_table['amplitude'] = (source_table['flux'] /
+                                     (2. * np.pi * std * std))
+    if 'amplitude' in colnames and 'flux' not in colnames:
+        source_table = source_table.copy()
+        source_table['flux'] = (source_table['amplitude'] *
+                                (2. * np.pi * std * std))
 
     return make_model_sources_image(shape, model, source_table,
                                     oversample=oversample)

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
 
 from astropy.table import Table
@@ -11,8 +11,13 @@ from .. import (make_noise_image, apply_poisson_noise,
                 make_gaussian_sources_image, make_random_gaussians_table,
                 make_4gaussians_image, make_100gaussians_image,
                 make_random_models_table, make_model_sources_image,
-                make_wcs)
+                make_wcs, make_gaussian_prf_sources_image)
 
+try:
+    import scipy    # noqa
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
 
 TABLE = Table()
 TABLE['flux'] = [1, 2, 3]
@@ -155,3 +160,15 @@ def test_make_wcs():
     wcs = make_wcs(shape, galactic=True)
     assert wcs.wcs.ctype[0] == 'GLON-CAR'
     assert wcs.wcs.ctype[1] == 'GLAT-CAR'
+
+
+@pytest.mark.xfail('not HAS_SCIPY')
+def test_gaussian_prf():
+    table = Table()
+    table['flux'] = [50]
+    table['x_0'] = [5]
+    table['y_0'] = [5]
+
+    shape = (10, 10)
+    image1 = make_gaussian_prf_sources_image(shape, table)
+    assert_almost_equal(np.sum(image1), table['flux'][0], decimal=3)

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -676,7 +676,6 @@ class EPSFBuilder:
                                       x_0=xcenter + dx_total, # add dx to x_0
                                       y_0=ycenter + dy_total, # even if negative
                                       use_oversampling=False)
-
         return epsf_data
 
     def _build_epsf_step(self, stars, epsf=None):

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -252,7 +252,7 @@ class EPSFBuilder:
         pixel.
 
     norm_radius : float, optional
-        The pixel radius over which the ePSF is normalized. If ``None'' or
+        The pixel radius over which the ePSF is normalized. If `None` or
         not provided, defaults to 5.5 pixels.
 
     smoothing_kernel : {'quartic', 'quadratic'}, 2D `~numpy.ndarray`, or `None`
@@ -267,8 +267,8 @@ class EPSFBuilder:
         calculate the centroid of a 2D array.  The callable must accept
         a 2D `~numpy.ndarray`, have a ``mask`` keyword and optionally an
         ``error`` keyword.  The callable object must return a tuple of
-        two 1D `~numpy.ndarray`s, representing the x and y centroids.
-        The default is `~photutils.centroids.centroid_epsf`.
+        two 1D `~numpy.ndarray` variables, representing the x and y
+        centroids. The default is `~photutils.centroids.centroid_epsf`.
 
     recentering_maxiters : int, optional
         The maximum number of recentering iterations to perform during

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -13,9 +13,8 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import (overlap_slices, PartialOverlapError,
                                   NoOverlapError)
 from astropy.utils.exceptions import AstropyUserWarning
-
 from .epsf_stars import EPSFStar, LinkedEPSFStar, EPSFStars
-from .models import EPSFModel
+from .models import EPSFModel, EPSFModel2
 from ..centroids import centroid_com
 from ..extern import SigmaClip
 
@@ -187,14 +186,10 @@ class EPSFFitter:
             x0 = 0
             y0 = 0
 
-        x_oversamp = star.pixel_scale[0] / epsf.pixel_scale[0]
-        y_oversamp = star.pixel_scale[1] / epsf.pixel_scale[1]
-        scaled_data = data / (x_oversamp * y_oversamp)
-
         # define positions in the ePSF oversampled grid
         yy, xx = np.indices(data.shape, dtype=np.float)
-        xx = (xx - (star.cutout_center[0] - x0)) * x_oversamp
-        yy = (yy - (star.cutout_center[1] - y0)) * y_oversamp
+        xx = (xx - (star.cutout_center[0] - x0))
+        yy = (yy - (star.cutout_center[1] - y0))
 
         # define the initial guesses for fitted flux and shifts
         epsf.flux = star.flux
@@ -210,11 +205,11 @@ class EPSFFitter:
         epsf._oversampling = 1.
 
         try:
-            fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=scaled_data,
+            fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=data,
                                  weights=weights, **fitter_kwargs)
         except TypeError:
             # fitter doesn't support weights
-            fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=scaled_data,
+            fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=data,
                                  **fitter_kwargs)
 
         fit_error_status = 0
@@ -228,9 +223,9 @@ class EPSFFitter:
 
         # compute the star's fitted position
         x_center = (star.cutout_center[0] +
-                    (fitted_epsf.x_0.value / x_oversamp))
+                    (fitted_epsf.x_0.value * epsf.oversampling))
         y_center = (star.cutout_center[1] +
-                    (fitted_epsf.y_0.value / y_oversamp))
+                    (fitted_epsf.y_0.value * epsf.oversampling))
 
         star = copy.deepcopy(star)
         star.cutout_center = (x_center, y_center)
@@ -253,29 +248,9 @@ class EPSFBuilder:
 
     Parameters
     ----------
-    pixel_scale : float or tuple of two floats, optional
-        The pixel scale (in arbitrary units) of the output ePSF.  The
-        ``pixel_scale`` can either be a single float or tuple of two
-        floats of the form ``(x_pixscale, y_pixscale)``.  If
-        ``pixel_scale`` is a scalar then the pixel scale will be the
-        same for both the x and y axes.  The ePSF ``pixel_scale`` is
-        used in conjunction with the star pixel scale when building and
-        fitting the ePSF.  This allows for building (and fitting) a ePSF
-        using images of stars with different pixel scales (e.g. velocity
-        aberrations).  Either ``oversampling`` or ``pixel_scale`` must
-        be input.  If both are input, ``pixel_scale`` will override the
-        input ``oversampling``.
-
-    oversampling : float or tuple of two floats, optional
+    oversampling : float, optional
         The oversampling factor(s) of the ePSF relative to the input
-        ``stars`` along the x and y axes.  The ``oversampling`` can
-        either be a single float or a tuple of two floats of the form
-        ``(x_oversamp, y_oversamp)``.  If ``oversampling`` is a scalar
-        then the oversampling will be the same for both the x and y
-        axes.  The ``oversampling`` factor will be used with the minimum
-        pixel scale of all input stars to calculate the ePSF pixel
-        scale.  Either ``oversampling`` or ``pixel_scale`` must be
-        input.  If both are input, ``oversampling`` will be ignored.
+        ``stars`` along the x and y axes.
 
     shape : float, tuple of two floats, or `None`, optional
         The shape of the output ePSF.  If the ``shape`` is not `None`,
@@ -334,19 +309,17 @@ class EPSFBuilder:
         The default is `True`.
     """
 
-    def __init__(self, pixel_scale=None, oversampling=4., shape=None,
+    def __init__(self, oversampling=4., shape=None,
                  smoothing_kernel='quartic', recentering_func=centroid_com,
                  recentering_boxsize=(5, 5), recentering_maxiters=20,
                  fitter=EPSFFitter(), center_accuracy=1.0e-3, maxiters=10,
                  progress_bar=True):
 
-        if pixel_scale is None and oversampling is None:
-            raise ValueError('Either pixel_scale or oversampling must be '
-                             'input.')
+        if oversampling is None:
+            raise ValueError('Oversampling must be specified.')
 
-        self.pixel_scale = self._init_img_params(pixel_scale)
         if oversampling <= 0.0:
-            raise ValueError('oversampling must be a positive number.')
+            raise ValueError('Oversampling must be a positive number.')
         self.oversampling = oversampling
         self.shape = self._init_img_params(shape)
         if self.shape is not None:
@@ -361,19 +334,19 @@ class EPSFBuilder:
         self.fitter = fitter
 
         if center_accuracy <= 0.0:
-            raise ValueError('center_accuracy must be a positive number.')
+            raise ValueError('Center_accuracy must be a positive number.')
         self.center_accuracy_sq = center_accuracy**2
 
         maxiters = int(maxiters)
         if maxiters <= 0:
-            raise ValueError('maxiters must be a positive number.')
+            raise ValueError('Maxiters must be a positive number.')
         self.maxiters = maxiters
 
         self.progress_bar = progress_bar
 
         # TODO: allow custom SigmaClip object after faster SigmaClip
         # is available in astropy (>=3.1)
-        self.sigclip = SigmaClip(sigma=3., cenfunc='median', maxiters=10)
+        self.sigclip = SigmaClip(sigma=2.5, cenfunc='mean', maxiters=10)
 
         # store some data during each ePSF build iteration
         self._nfit_failed = []
@@ -405,10 +378,6 @@ class EPSFBuilder:
         """
         Create an initial `EPSFModel` object.
 
-        The initial ePSF data are all zeros.  The ePSF pixel scale is
-        determined either from the ``pixel_scale`` or ``oversampling``
-        values.
-
         If ``shape`` is not specified, the shape of the ePSF data array
         is determined from the shape of the input ``stars`` and the
         oversampling factor.  If the size is even along any axis, it
@@ -426,29 +395,11 @@ class EPSFBuilder:
             The initial ePSF model.
         """
 
-        pixel_scale = self.pixel_scale
         oversampling = self.oversampling
         shape = self.shape
 
-        if pixel_scale is None and oversampling is None:
-            raise ValueError('Either pixel_scale or oversampling must be '
-                             'input.')
-
-        # define the ePSF pixel scale
-        if pixel_scale is not None:
-            pixel_scale = np.atleast_1d(pixel_scale).astype(float)
-            if len(pixel_scale) == 1:
-                pixel_scale = np.repeat(pixel_scale, 2)
-
-            oversampling = (stars._min_pixel_scale[0] / pixel_scale[0],
-                            stars._min_pixel_scale[1] / pixel_scale[1])
-        else:
-            oversampling = np.atleast_1d(oversampling).astype(float)
-            if len(oversampling) == 1:
-                oversampling = np.repeat(oversampling, 2)
-
-            pixel_scale = (stars._min_pixel_scale[0] / oversampling[0],
-                           stars._min_pixel_scale[1] / oversampling[1])
+        if oversampling is None:
+            raise ValueError('Oversampling must be specified.')
 
         # define the ePSF shape
         if shape is not None:
@@ -456,10 +407,8 @@ class EPSFBuilder:
             if len(shape) == 1:
                 shape = np.repeat(shape, 2)
         else:
-            x_shape = np.int(np.ceil(stars._max_shape[0] *
-                                     oversampling[1]))
-            y_shape = np.int(np.ceil(stars._max_shape[1] *
-                                     oversampling[0]))
+            x_shape = np.int(np.ceil(stars._max_shape[0] * oversampling))
+            y_shape = np.int(np.ceil(stars._max_shape[1] * oversampling))
             shape = np.array((y_shape, x_shape))
 
         # ensure odd sizes
@@ -469,12 +418,8 @@ class EPSFBuilder:
         xcenter = (shape[1] - 1) / 2.
         ycenter = (shape[0] - 1) / 2.
 
-        # FittableImageModel requires a scalar oversampling factor
-        oversampling = np.mean(oversampling)
-
-        return EPSFModel(data=data, origin=(xcenter, ycenter),
-                         normalize=False, oversampling=oversampling,
-                         pixel_scale=pixel_scale)
+        return EPSFModel2(data=data, origin=(xcenter, ycenter),
+                         normalize=False, oversampling=oversampling)
 
     def _resample_residual(self, star, epsf):
         """
@@ -504,10 +449,8 @@ class EPSFBuilder:
 
         # find the integer index of EPSFStar pixels in the oversampled
         # ePSF grid
-        x_oversamp = star.pixel_scale[0] / epsf.pixel_scale[0]
-        y_oversamp = star.pixel_scale[1] / epsf.pixel_scale[1]
-        x = x_oversamp * star._xidx_centered
-        y = y_oversamp * star._yidx_centered
+        x = epsf.oversampling * star._xidx_centered
+        y = epsf.oversampling * star._yidx_centered
         epsf_xcenter, epsf_ycenter = epsf.origin
         xidx = _py2intround(x + epsf_xcenter)
         yidx = _py2intround(y + epsf_ycenter)
@@ -524,7 +467,7 @@ class EPSFBuilder:
         # [(star - (epsf * xov * yov)) / (xov * yov)]
         # --> [(star / (xov * yov)) - epsf]
         stardata = ((star._data_values_normalized /
-                     (x_oversamp * y_oversamp)) -
+                     (epsf.oversampling * epsf.oversampling)) -
                     epsf.evaluate(x=x, y=y, flux=1.0, x_0=0.0, y_0=0.0,
                                   use_oversampling=False))
 
@@ -687,9 +630,8 @@ class EPSFBuilder:
         # Define an EPSFModel for the input data.  This EPSFModel will be
         # used to evaluate the model on a shifted pixel grid to place the
         # centroid at the array center.
-        epsf = EPSFModel(data=epsf_data, origin=epsf.origin, normalize=False,
-                         oversampling=epsf.oversampling,
-                         pixel_scale=epsf.pixel_scale)
+        epsf = EPSFModel2(data=epsf_data, origin=epsf.origin, normalize=False,
+                         oversampling=epsf.oversampling)
         epsf.fill_value = 0.0
         xcenter, ycenter = epsf.origin
 
@@ -817,9 +759,8 @@ class EPSFBuilder:
         xcenter = (new_epsf.shape[1] - 1) / 2.
         ycenter = (new_epsf.shape[0] - 1) / 2.
 
-        return EPSFModel(data=new_epsf, origin=(xcenter, ycenter),
-                         normalize=False, oversampling=epsf.oversampling,
-                         pixel_scale=epsf.pixel_scale)
+        return EPSFModel2(data=new_epsf, origin=(xcenter, ycenter),
+                         normalize=False, oversampling=epsf.oversampling)
 
     def build_epsf(self, stars, init_epsf=None):
         """
@@ -852,6 +793,12 @@ class EPSFBuilder:
         dx_dy = np.zeros((n_stars, 2), dtype=np.float)
         epsf = init_epsf
         dt = 0.
+
+        counter = 1
+        import matplotlib.pyplot as plt
+        from astropy.visualization import simple_norm
+        import matplotlib
+        matplotlib.rcParams['font.size'] = 10
 
         while (iter_num < self.maxiters and
                 np.max(center_dist_sq) >= self.center_accuracy_sq and
@@ -905,6 +852,15 @@ class EPSFBuilder:
             self._epsf.append(epsf)
 
             dt = time.time() - t_start
+
+
+            norm = simple_norm(epsf.data, 'log', percent=99.)
+            plt.imshow(epsf.data, norm=norm, origin='lower', cmap='viridis')
+            plt.colorbar()
+            plt.savefig('epsf_{}.pdf'.format(counter))
+            plt.close()
+            counter += 1
+            print(np.sum(epsf.data), epsf._normalization_correction)
 
         return epsf, stars
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -213,10 +213,8 @@ class EPSFFitter:
             fit_info = None
 
         # compute the star's fitted position
-        x_center = (star.cutout_center[0] +
-                    (fitted_epsf.x_0.value * epsf.oversampling))
-        y_center = (star.cutout_center[1] +
-                    (fitted_epsf.y_0.value * epsf.oversampling))
+        x_center = star.cutout_center[0] + fitted_epsf.x_0.value 
+        y_center = star.cutout_center[1] + fitted_epsf.y_0.value
 
         star = copy.deepcopy(star)
         star.cutout_center = (x_center, y_center)
@@ -790,12 +788,6 @@ class EPSFBuilder:
         epsf = init_epsf
         dt = 0.
 
-        counter = 1
-        import matplotlib.pyplot as plt
-        from astropy.visualization import simple_norm
-        import matplotlib
-        matplotlib.rcParams['font.size'] = 10
-
         while (iter_num < self.maxiters and
                 np.max(center_dist_sq) >= self.center_accuracy_sq and
                 not np.all(fit_failed)):
@@ -848,15 +840,6 @@ class EPSFBuilder:
             self._epsf.append(epsf)
 
             dt = time.time() - t_start
-
-
-            norm = simple_norm(epsf.data, 'log', percent=99.)
-            plt.imshow(epsf.data, norm=norm, origin='lower', cmap='viridis')
-            plt.colorbar()
-            plt.savefig('epsf_{}.pdf'.format(counter))
-            plt.close()
-            counter += 1
-            print(np.sum(epsf.data))
 
         return epsf, stars
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -14,7 +14,7 @@ from astropy.nddata.utils import (overlap_slices, PartialOverlapError,
                                   NoOverlapError)
 from astropy.utils.exceptions import AstropyUserWarning
 from .epsf_stars import EPSFStar, LinkedEPSFStar, EPSFStars
-from .models import EPSFModel, EPSFModel2
+from .models import EPSFModel
 from ..centroids import centroid_com
 from ..extern import SigmaClip
 
@@ -418,7 +418,7 @@ class EPSFBuilder:
         xcenter = (shape[1] - 1) / 2.
         ycenter = (shape[0] - 1) / 2.
 
-        return EPSFModel2(data=data, origin=(xcenter, ycenter),
+        return EPSFModel(data=data, origin=(xcenter, ycenter),
                          normalize=False, oversampling=oversampling)
 
     def _resample_residual(self, star, epsf):

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -451,7 +451,6 @@ class EPSFStars:
         count.
         """
 
-        # return np.count_nonzero(~self._excluded_from_fit.ravel())
         return len(self.all_good_stars)
 
     @lazyproperty

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -65,11 +65,9 @@ class EPSFStar:
         floats of the form ``(x_pixscale, y_pixscale)``.  If
         ``pixel_scale`` is a scalar then the pixel scale will be the
         same for both the x and y axes.  The star ``pixel_scale`` is
-        used in conjunction with the ePSF pixel scale or oversampling
-        factor when building and fitting the ePSF.  The ratio of the
-        star-to-ePSF pixel scales represents the ePSF oversampling
-        factor.  ``pixel_scale`` allows for building (and fitting) an
-        ePSF using images of stars with different pixel scales (e.g.
+        used in conjunction with the ePSF oversampling factor when building 
+        and fitting the ePSF. ``pixel_scale`` allows for building (and fitting) 
+        an ePSF using images of stars with different pixel scales (e.g.
         velocity aberrations).
     """
 
@@ -214,13 +212,12 @@ class EPSFStar:
 
         x_oversamp = self.pixel_scale[0] / epsf.pixel_scale[0]
         y_oversamp = self.pixel_scale[1] / epsf.pixel_scale[1]
-        # TODO: check ePSF evaluation.
+
         yy, xx = np.indices(self.shape, dtype=np.float)
         xx = x_oversamp * (xx - self.cutout_center[0])
         yy = y_oversamp * (yy - self.cutout_center[1])
 
-        return (self.flux * x_oversamp * y_oversamp *
-                epsf.evaluate(xx, yy, flux=1.0, x_0=0.0, y_0=0.0))
+        return (self.flux * epsf.evaluate(xx, yy, flux=1.0, x_0=0.0, y_0=0.0))
 
     def compute_residual_image(self, epsf):
         """

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -65,8 +65,8 @@ class EPSFStar:
         floats of the form ``(x_pixscale, y_pixscale)``.  If
         ``pixel_scale`` is a scalar then the pixel scale will be the
         same for both the x and y axes.  The star ``pixel_scale`` is
-        used in conjunction with the ePSF oversampling factor when building 
-        and fitting the ePSF. ``pixel_scale`` allows for building (and fitting) 
+        used in conjunction with the ePSF oversampling factor when building
+        and fitting the ePSF. ``pixel_scale`` allows for building (and fitting)
         an ePSF using images of stars with different pixel scales (e.g.
         velocity aberrations).
     """
@@ -210,12 +210,9 @@ class EPSFStar:
             A 2D array of the registered/scaled ePSF.
         """
 
-        x_oversamp = self.pixel_scale[0] / epsf.pixel_scale[0]
-        y_oversamp = self.pixel_scale[1] / epsf.pixel_scale[1]
-
         yy, xx = np.indices(self.shape, dtype=np.float)
-        xx = x_oversamp * (xx - self.cutout_center[0])
-        yy = y_oversamp * (yy - self.cutout_center[1])
+        xx = xx - self.cutout_center[0]
+        yy = yy - self.cutout_center[1]
 
         return (self.flux * epsf.evaluate(xx, yy, flux=1.0, x_0=0.0, y_0=0.0))
 
@@ -744,7 +741,7 @@ def _extract_stars(data, catalog, size=(11, 11), use_xy=True):
         The extraction box size along each axis.  If ``size`` is a
         scalar then a square box of size ``size`` will be used.  If
         ``size`` has two elements, they should be in ``(ny, nx)`` order.
-        The size must be greater than or equal to 3 pixel for both axes. 
+        The size must be greater than or equal to 3 pixel for both axes.
         Size must be odd in both axes; if either is even, it is padded
         by one to force oddness.
 

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -502,15 +502,8 @@ class EPSFModel(Fittable2DModel):
         details.
 
     """
-    x_0 = Parameter(description='X-position of a feature in the image in '
-                    'the output coordinate grid on which the model is '
-                    'evaluated.', default=0.0)
-    y_0 = Parameter(description='Y-position of a feature in the image in '
-                    'the output coordinate grid on which the model is '
-                    'evaluated.', default=0.0)
-
-    def __init__(self, data, x_0=x_0.default, y_0=y_0.default,
-                 origin=None, oversampling=1, fill_value=0.0, norm_radius=5.5, ikwargs={}):
+    def __init__(self, data, origin=None, oversampling=1, fill_value=0.0, 
+                 norm_radius=5.5, ikwargs={}):
         self._fill_value = fill_value
         self._img_norm = None
         self._normalization_status = 0
@@ -534,6 +527,7 @@ class EPSFModel(Fittable2DModel):
 
         self._compute_normalization()
 
+        x_0, y_0 = self.origin
         super().__init__(x_0, y_0)
 
         # initialize interpolator:
@@ -653,8 +647,6 @@ class EPSFModel(Fittable2DModel):
         if origin is None:
             self._x_origin = (self._nx - 1) / 2.0
             self._y_origin = (self._ny - 1) / 2.0
-        elif hasattr(origin, '__iter__') and len(origin) == 2:
-            self._x_origin, self._y_origin = origin
         else:
             raise TypeError("Parameter 'origin' must be either None or an "
                             "iterable with two elements.")

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -11,7 +11,7 @@ from astropy.modeling import models, Parameter, Fittable2DModel
 from astropy.utils.exceptions import AstropyWarning
 
 
-__all__ = ['NonNormalizable', 'FittableImageModel', 'EPSFModel',
+__all__ = ['NonNormalizable', 'FittableImageModel', 'EPSFModel', 'EPSFModel2',
            'IntegratedGaussianPRF', 'PRFAdapter', 'prepare_psf_model',
            'get_grouped_psf_model']
 
@@ -475,77 +475,419 @@ class FittableImageModel(Fittable2DModel):
 
         return evaluated_model
 
-
-class EPSFModel(FittableImageModel):
+class EPSFModel(Fittable2DModel):
     """
-    A subclass of `FittableImageModel` that adds a ``pixel_scale``
-    attribute.
-
-    The ``pixel_scale`` can be used in conjunction with the
-    `~photutils.psf.Star` pixel scale when fitting (and building) the
-    PSF.  This allows fitting (and building) a PSF using images of stars
-    with different pixel scales.
-
-    `EPSFModel` has the same parameters as `FittableImageModel` with the
-    addition of a single parameter listed below.
+    A fittable ePSF model.
 
     Parameters
     ----------
-    pixel_scale : float, tuple of two floats or `None`, optional
-        The pixel scale (in arbitrary units) of the ePSF.  The
-        ``pixel_scale`` can either be a single float or tuple of two
-        floats of the form ``(x_pixscale, y_pixscale)``.  If
-        ``pixel_scale`` is a scalar then the pixel scale will be the
-        same for both the x and y axes.  The default is `None`, which
-        means it will be set to the inverse of the ``oversampling``
-        factor.
+    data : numpy.ndarray
+        Array containing oePSF pixel values on a regularly oversampled pixel
+        grid.
 
-        The ePSF ``pixel_scale`` is used only when building the ePSF and
-        when fitting the ePSF to `Star` objects with `EPSFFitter`.  In
-        those cases, the ``pixel_scale`` is used in conjunction with the
-        `Star` pixel scale when building and fitting the ePSF.  This
-        allows for building (and fitting) a ePSF using images of stars
-        with different pixel scales (e.g. velocity aberrations).  The
-        ``oversampling`` factor is ignored in these cases.
+    origin : tuple, None, optional
+        A reference point in the input image ``data`` array. When origin is
+        `None`, origin will be set at the middle of the image array.
 
-        If you are not using `EPSFBuilder` or `EPSFFitter`, then you
-        must set the ``oversampling`` factor.  The ``pixel_scale`` will
-        be ignored.
+
+    normalize : bool, optional
+        Indicates whether or not the model should be build on normalized
+        input image data. If true, then the normalization constant (*N*) is
+        computed so that
+
+        .. math::
+            N \\cdot C \\cdot \\Sigma_{i,j}D_{i,j} = 1,
+
+        where *N* is the normalization constant, *C* is correction factor
+        given by the parameter ``normalization_correction``, and
+        :math:`D_{i,j}` are the elements of the input image ``data`` array.
+
+    normalization_correction : float, optional
+        A strictly positive number that represents correction that needs to
+        be applied to model's data normalization (see *C* in the equation
+        in the comments to ``normalize`` for more details).
+
+        A possible application for this parameter is to account for aperture
+        correction. Assuming model's data represent a PSF to be fitted to
+        some target star, we set ``normalization_correction`` to the aperture
+        correction that needs to be applied to the model. That is,
+        ``normalization_correction`` in this case should be set to the
+        ratio between the total flux of the PSF (including flux outside model's
+        data) to the flux of model's data.
+        Then, best fitted value of the `flux` model
+        parameter will represent an aperture-corrected flux of the target star.
+
+    fill_value : float, optional
+        The value to be returned by the `evaluate` or
+        ``astropy.modeling.Model.__call__`` methods
+        when evaluation is performed outside the definition domain of the
+        model.
+
+    ikwargs : dict, optional
+
+        Additional optional keyword arguments to be passed directly to the
+        `compute_interpolator` method. See `compute_interpolator` for more
+        details.
+
     """
+    x_0 = Parameter(description='X-position of a feature in the image in '
+                    'the output coordinate grid on which the model is '
+                    'evaluated.', default=0.0)
+    y_0 = Parameter(description='Y-position of a feature in the image in '
+                    'the output coordinate grid on which the model is '
+                    'evaluated.', default=0.0)
 
-    def __init__(self, data, flux=1.0, x_0=0, y_0=0, normalize=True,
-                 normalization_correction=1.0, origin=None, oversampling=1.,
-                 pixel_scale=None, fill_value=0., ikwargs={}):
+    def __init__(self, data, x_0=x_0.default, y_0=y_0.default,
+                 normalize=False, normalization_correction=1.0,
+                 origin=None, oversampling=1, fill_value=0.0, ikwargs={}):
+        self._fill_value = fill_value
+        self._img_norm = None
+        self._normalization_status = 0 if normalize else 2
+        self._store_interpolator_kwargs(ikwargs)
+        self._set_oversampling(oversampling)
 
-        if pixel_scale is None:
-            pixel_scale = 1. / oversampling
+        if normalization_correction <= 0:
+            raise ValueError("'normalization_correction' must be strictly "
+                             "positive.")
+        self._normalization_correction = normalization_correction
 
-        super().__init__(
-            data=data, flux=flux, x_0=x_0, y_0=y_0, normalize=normalize,
-            normalization_correction=normalization_correction, origin=origin,
-            oversampling=oversampling, fill_value=fill_value, ikwargs=ikwargs)
+        self._data = np.array(data, copy=True, dtype=np.float64)
 
-        self._pixel_scale = pixel_scale
+        if not np.all(np.isfinite(self._data)):
+            raise ValueError("All elements of input 'data' must be finite.")
+
+        # set input image related parameters:
+        self._ny, self._nx = self._data.shape
+        self._shape = self._data.shape
+        if self._data.size < 1:
+            raise ValueError("Image data array cannot be zero-sized.")
+
+        # set the origin of the coordinate system in image's pixel grid:
+        self.origin = origin
+
+        self._compute_normalization(normalize)
+
+        super().__init__(x_0, y_0)
+
+        # initialize interpolator:
+        self.compute_interpolator(ikwargs)
+
+    def _compute_raw_image_norm(self, data):
+        """
+        Helper function that computes the uncorrected inverse normalization
+        factor of input image data. This quantity is computed as the
+        *sum of all pixel values*.
+
+        .. note::
+            This function is intended to be overriden in a subclass if one
+            desires to change the way the normalization factor is computed.
+
+        """
+        return np.sum(self._data, dtype=np.float64)
+
+    def _compute_normalization(self, normalize):
+        """
+        Helper function that computes (corrected) normalization factor
+        of the original image data. This quantity is computed as the
+        inverse "raw image norm" (or total "flux" of model's image)
+        corrected by the ``normalization_correction``:
+
+        .. math::
+            N = 1/(\\Phi * C),
+
+        where :math:`\\Phi` is the "total flux" of model's image as
+        computed by `_compute_raw_image_norm` and *C* is the
+        normalization correction factor. :math:`\\Phi` is computed only
+        once if it has not been previously computed. Otherwise, the
+        existing (stored) value of :math:`\\Phi` is not modified as
+        :py:class:`FittableImageModel` does not allow image data to be
+        modified after the object is created.
+
+        .. note::
+            Normally, this function should not be called by the
+            end-user. It is intended to be overriden in a subclass if
+            one desires to change the way the normalization factor is
+            computed.
+        """
+
+        self._normalization_constant = 1.0 / self._normalization_correction
+
+        if normalize:
+            # compute normalization constant so that
+            # N*C*sum(data) = 1:
+            if self._img_norm is None:
+                self._img_norm = self._compute_raw_image_norm(self._data)
+
+            if self._img_norm != 0.0 and np.isfinite(self._img_norm):
+                self._normalization_constant /= self._img_norm
+                self._normalization_status = 0
+
+            else:
+                self._normalization_constant = 1.0
+                self._normalization_status = 1
+                warnings.warn("Overflow encountered while computing "
+                              "normalization constant. Normalization "
+                              "constant will be set to 1.", NonNormalizable)
+
+        else:
+            self._normalization_status = 2
 
     @property
-    def pixel_scale(self):
+    def oversampling(self):
         """
-        The ``(x, y)`` pixel scale (in arbitrary units) of the PSF.
+        The factor by which the stored image is oversampled.  I.e., an input
+        to this model is multipled by this factor to yield the index into the
+        stored image.
+        """
+        return self._oversampling
+
+    def _set_oversampling(self, value):
+        try:
+            value = float(value)
+        except ValueError:
+            raise ValueError('Oversampling factor must be a scalar')
+        if value <= 0:
+            raise ValueError('Oversampling factor must be greater than 0')
+
+        self._oversampling = value
+
+    @property
+    def data(self):
+        """ Get ePSF oversampled grid values. """
+        return self._data
+
+    @property
+    def normalized_data(self):
+        """ Get normalized and/or intensity-corrected image data. """
+        return (self._normalization_constant * self._data)
+
+    @property
+    def normalization_constant(self):
+        """ Get normalization constant. """
+        return self._normalization_constant
+
+    @property
+    def normalization_status(self):
+        """
+        Get normalization status. Possible status values are:
+
+        - 0: **Performed**. Model has been successfuly normalized at
+          user's request.
+        - 1: **Failed**. Attempt to normalize has failed.
+        - 2: **NotRequested**. User did not request model to be normalized.
+
+        """
+        return self._normalization_status
+
+    @property
+    def normalization_correction(self):
+        """
+        Set/Get flux correction factor.
+
+        .. note::
+            When setting correction factor, model's flux will be adjusted
+            accordingly such that if this model was a good fit to some target
+            image before, then it will remain a good fit after correction
+            factor change.
+
+        """
+        return self._normalization_correction
+
+    @normalization_correction.setter
+    def normalization_correction(self, normalization_correction):
+        old_cf = self._normalization_correction
+        self._normalization_correction = normalization_correction
+        self._compute_normalization(normalize=self._normalization_status != 2)
+
+        # adjust model's flux so that if this model was a good fit to some
+        # target image, then it will remain a good fit after correction factor
+        # change:
+        self.flux *= normalization_correction / old_cf
+
+    @property
+    def shape(self):
+        """A tuple of dimensions of the data array in numpy style (ny, nx)."""
+        return self._shape
+
+    @property
+    def nx(self):
+        """Number of columns in the data array."""
+        return self._nx
+
+    @property
+    def ny(self):
+        """Number of rows in the data array."""
+        return self._ny
+
+    @property
+    def origin(self):
+        """
+        A tuple of ``x`` and ``y`` coordinates of the origin of the coordinate
+        system in terms of pixels of model's image.
+
+        When setting the coordinate system origin, a tuple of two `int` or
+        `float` may be used. If origin is set to `None`, the origin of the
+        coordinate system will be set to the middle of the data array
+        (``(npix-1)/2.0``).
+
+        .. warning::
+            Modifying `origin` will not adjust (modify) model's parameters
+            `x_0` and `y_0`.
+        """
+        return (self._x_origin, self._y_origin)
+
+    @origin.setter
+    def origin(self, origin):
+        if origin is None:
+            self._x_origin = (self._nx - 1) / 2.0
+            self._y_origin = (self._ny - 1) / 2.0
+        elif hasattr(origin, '__iter__') and len(origin) == 2:
+            self._x_origin, self._y_origin = origin
+        else:
+            raise TypeError("Parameter 'origin' must be either None or an "
+                            "iterable with two elements.")
+
+    @property
+    def x_origin(self):
+        """X-coordinate of the origin of the coordinate system."""
+        return self._x_origin
+
+    @property
+    def y_origin(self):
+        """Y-coordinate of the origin of the coordinate system."""
+        return self._y_origin
+
+    @property
+    def fill_value(self):
+        """Fill value to be returned for coordinates outside of the domain of
+        definition of the interpolator. If ``fill_value`` is `None`, then
+        values outside of the domain of definition are the ones returned
+        by the interpolator.
+
+        """
+        return self._fill_value
+
+    @fill_value.setter
+    def fill_value(self, fill_value):
+        self._fill_value = fill_value
+
+    def _store_interpolator_kwargs(self, ikwargs):
+        """
+        This function should be called in a subclass whenever model's
+        interpolator is (re-)computed.
+        """
+        self._interpolator_kwargs = copy.deepcopy(ikwargs)
+
+    @property
+    def interpolator_kwargs(self):
+        """
+        Get current interpolator's arguments used when interpolator was
+        created.
+        """
+        return self._interpolator_kwargs
+
+    def compute_interpolator(self, ikwargs={}):
+        """
+        Compute/define the interpolating spline. This function can be overriden
+        in a subclass to define custom interpolators.
+
+        Parameters
+        ----------
+        ikwargs : dict, optional
+
+            Additional optional keyword arguments. Possible values are:
+
+            - **degree** : int, tuple, optional
+                Degree of the interpolating spline. A tuple can be used to
+                provide different degrees for the X- and Y-axes.
+                Default value is degree=3.
+
+            - **s** : float, optional
+                Non-negative smoothing factor. Default value s=0 corresponds to
+                interpolation.
+                See :py:class:`~scipy.interpolate.RectBivariateSpline` for more
+                details.
+
+        Notes
+        -----
+            * When subclassing :py:class:`FittableImageModel` for the
+              purpose of overriding :py:func:`compute_interpolator`,
+              the :py:func:`evaluate` may need to overriden as well depending
+              on the behavior of the new interpolator. In addition, for
+              improved future compatibility, make sure
+              that the overriding method stores keyword arguments ``ikwargs``
+              by calling ``_store_interpolator_kwargs`` method.
+
+            * Use caution when modifying interpolator's degree or smoothness in
+              a computationally intensive part of the code as it may decrease
+              code performance due to the need to recompute interpolator.
+
+        """
+        from scipy.interpolate import RectBivariateSpline
+
+        if 'degree' in ikwargs:
+            degree = ikwargs['degree']
+            if hasattr(degree, '__iter__') and len(degree) == 2:
+                degx = int(degree[0])
+                degy = int(degree[1])
+            else:
+                degx = int(degree)
+                degy = int(degree)
+            if degx < 0 or degy < 0:
+                raise ValueError("Interpolator degree must be a non-negative "
+                                 "integer")
+        else:
+            degx = 3
+            degy = 3
+
+        if 's' in ikwargs:
+            smoothness = ikwargs['s']
+        else:
+            smoothness = 0
+
+        x = np.arange(self._nx, dtype=np.float)
+        y = np.arange(self._ny, dtype=np.float)
+        self.interpolator = RectBivariateSpline(
+            x, y, self._data.T, kx=degx, ky=degy, s=smoothness
+        )
+
+        self._store_interpolator_kwargs(ikwargs)
+
+    def evaluate(self, x, y, flux, x_0, y_0, use_oversampling=True):
+        """
+        Evaluate the model on some input variables and provided model
+        parameters.
+
+        Parameters
+        ----------
+        use_oversampling : bool, optional
+            Whether to use the oversampling factor to calculate the
+            model pixel indices.  The default is `True`, which means the
+            input indices will be multipled by this factor.
         """
 
-        return self._pixel_scale
+        if use_oversampling:
+            xi = self._oversampling * (np.asarray(x) - x_0)
+            yi = self._oversampling * (np.asarray(y) - y_0)
+        else:
+            xi = np.asarray(x) - x_0
+            yi = np.asarray(y) - y_0
 
-    @pixel_scale.setter
-    def pixel_scale(self, pixel_scale):
-        if pixel_scale is not None:
-            pixel_scale = np.atleast_1d(pixel_scale)
-            if len(pixel_scale) == 1:
-                pixel_scale = np.repeat(pixel_scale, 2).astype(float)
-            elif len(pixel_scale) > 2:
-                raise ValueError('pixel_scale must be a scalar or tuple '
-                                 'of two floats.')
+        xi += self._x_origin
+        yi += self._y_origin
 
-        self._pixel_scale = pixel_scale
+        f = flux * self._normalization_constant
+        evaluated_model = f * self.interpolator.ev(xi, yi)
+
+        if self._fill_value is not None:
+            # find indices of pixels that are outside the input pixel grid and
+            # set these pixels to the 'fill_value':
+            invalid = (((xi < 0) | (xi > self._nx - 1)) |
+                       ((yi < 0) | (yi > self._ny - 1)))
+            evaluated_model[invalid] = self._fill_value
+
+        return evaluated_model
+
 
 
 class IntegratedGaussianPRF(Fittable2DModel):

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -132,8 +132,6 @@ def test_epsfbuilder_inputs():
     with pytest.raises(ValueError):
         epsf_builder = EPSFBuilder(oversampling=-1)
     with pytest.raises(ValueError):
-        epsf_builder = EPSFBuilder(shape=5, center_accuracy=-1)
-    with pytest.raises(ValueError):
         epsf_builder = EPSFBuilder(maxiters=-1)
 
 
@@ -145,7 +143,7 @@ def test_epsfmodel_inputs():
     data[2, 2] = np.inf
     with pytest.raises(ValueError):
         epsf_model = EPSFModel(data)
-    data[2, 2] = np.finfo(np.float64).max + 1
+    data[2, 2] = np.finfo(np.float64).max * 2
     with pytest.raises(ValueError):
         epsf_model = EPSFModel(data, flux=None)
     data[2, 2] = 1


### PR DESCRIPTION
Pull request to handle the fitting of effective PSFs in a manner consistent with that of the original Anderson & King (2000, PASP, 112, 1360) paper. Oversampled ePSF grid is no longer assumed to be a normalised image, but properly handles the normalisation in the original, undersampled grid. Currently the flux evaluation of ``EPSFModel`` is a simple ``np.sum(data)``, but the ePSF grid is an oversampling of data points where each point represents the fraction of light falling within a "normal" (i.e., undersampled) pixel centered at its x, y location relative to a point source. Thus the flux evaluation is currently overestimated by a factor of approximately oversampling^2. 

The main fix in this PR is then a change to ``EPSFModel``'s ``_compute_raw_image_norm`` function, in which only integer pixel values are picked to compute the normalization integral (or sum, in this case). Most of the subsequent changes are consistency fixes for whether pixel indices should be referenced by their undersampled (i.e., 0 to 25 for a 25x25 cutout of a star from an observation) or oversampled (i.e., 0 to 101 for a 4x oversampled ePSF grid) values. For example, ``EPSFBuilder`` now has  ``_resample_residual`` first use the oversampled ``x`` and ``y`` indices to compute the (e.g.) 0.25x0.25 pixel bin the sample falls into, and then uses the undersampled ``x`` and ``y`` values for evaluating the ePSF at the finer sample offsets.

``EPSFModel`` is no longer a subclass of ``FittableImageModel`` but itself an additional subclass of ``Fittable2DModel``, as ``EPSFModel`` overloads a significant number of ``FittableImageModel`` functions so it felt less confusing to simply define it as its own additional subclass. 

This PR also removes the factor of ``oversampling`` required in the star fitting routines -- such as ``register_epsf`` in ``EPSFStar`` -- to correct for their fluxes, which allows for the two routines to be used separately from one another. This then gives consistent results between the fitting done in ``EPSFFitter`` and the fluxes derived from using the ePSF model in, for example, ``BasicPSFPhotometry``.

Also included is the treatment of grid centroiding as ``centroid_epsf``, as detailed by Anderson & King (2000) using the asymmetry of the grid at maximum gradient. Finally, ``pixel_scale`` is removed as a parameter accepted by ``EPSFModel``, with ``oversampling`` defined by its input rather than allowing for the inclusion of two pixel scales and calculating the ratio between them, streamlining the setup process and reducing confusion from a user point of view.