### PR TITLE
Update SigmaClip and sigma_clipped_stats calls for deprecated keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,14 @@ Bug Fixes
   - Fixed a bug in the computation of ``sky_bbox_ul``,
     ``sky_bbox_lr``, ``sky_bbox_ur`` in the ``SourceCatalog``. [#716]
 
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Updated background and detection functions that call
+  ``astropy.stats.SigmaClip`` or ``astropy.stats.sigma_clipped_stats``
+  to support both their ``iters`` (for astropy < 3.1) and ``maxiters``
+  keywords. [#726]
+
 
 0.5 (2018-08-06)
 ----------------

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -102,7 +102,7 @@ provides a better estimate of the background and background noise
 levels::
 
     >>> from astropy.stats import sigma_clipped_stats
-    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, iters=5)
+    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)
     >>> print((mean, median, std))  # doctest: +FLOAT_CMP
     (5.199138651621793, 5.155587433358291, 2.094275212132969)
 
@@ -202,7 +202,7 @@ By default the ``bkg_estimator`` and ``bkgrms_estimator`` are applied
 to sigma clipped data.  Sigma clipping is defined by inputting a
 :class:`astropy.stats.SigmaClip` object to the ``sigma_clip`` keyword.
 The default is to perform sigma clipping with ``sigma=3`` and
-``iters=10``.  Sigma clipping can be turned off by setting
+``maxiters=10``.  Sigma clipping can be turned off by setting
 ``sigma_clip=None``.
 
 After the background level has been determined in each of the boxes,
@@ -254,7 +254,7 @@ instance of :class:`~photutils.background.MedianBackground`.
 
     >>> from astropy.stats import SigmaClip
     >>> from photutils import Background2D, MedianBackground
-    >>> sigma_clip = SigmaClip(sigma=3., iters=10)
+    >>> sigma_clip = SigmaClip(sigma=3.)
     >>> bkg_estimator = MedianBackground()
     >>> bkg = Background2D(data2, (50, 50), filter_size=(3, 3),
     ...                    sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
@@ -293,7 +293,7 @@ Let's plot the background image:
     y, x = np.mgrid[:ny, :nx]
     gradient =  x * y / 5000.
     data2 = data + gradient
-    sigma_clip = SigmaClip(sigma=3., iters=10)
+    sigma_clip = SigmaClip(sigma=3.)
     bkg_estimator = MedianBackground()
     bkg = Background2D(data2, (50, 50), filter_size=(3, 3),
                        sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
@@ -319,7 +319,7 @@ and the background-subtracted image:
     y, x = np.mgrid[:ny, :nx]
     gradient =  x * y / 5000.
     data2 = data + gradient
-    sigma_clip = SigmaClip(sigma=3., iters=10)
+    sigma_clip = SigmaClip(sigma=3.)
     bkg_estimator = MedianBackground()
     bkg = Background2D(data2, (50, 50), filter_size=(3, 3),
                        sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -8,11 +8,18 @@ from itertools import product
 
 import numpy as np
 from numpy.lib.index_tricks import index_exp
-from astropy.stats import SigmaClip
 from astropy.utils import lazyproperty
 
 from .core import SExtractorBackground, StdBackgroundRMS
 from ..utils import ShepardIDWInterpolator
+
+from astropy.version import version as astropy_version
+if astropy_version < '3.1':
+    from astropy.stats import SigmaClip
+    SIGMA_CLIP = SigmaClip(sigma=3., iters=10)
+else:
+    from ..extern import SigmaClip
+    SIGMA_CLIP = SigmaClip(sigma=3., maxiters=10)
 
 
 __all__ = ['BkgZoomInterpolator', 'BkgIDWInterpolator', 'Background2D']
@@ -238,7 +245,7 @@ class Background2D:
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=10``.
+        ``sigma=3.`` and ``maxiters=10``.
 
     bkg_estimator : callable, optional
         A callable object (a function or e.g., an instance of any
@@ -282,7 +289,7 @@ class Background2D:
     def __init__(self, data, box_size, mask=None,
                  exclude_percentile=10., filter_size=(3, 3),
                  filter_threshold=None, edge_method='pad',
-                 sigma_clip=SigmaClip(sigma=3., iters=10),
+                 sigma_clip=SIGMA_CLIP,
                  bkg_estimator=SExtractorBackground(sigma_clip=None),
                  bkgrms_estimator=StdBackgroundRMS(sigma_clip=None),
                  interpolator=BkgZoomInterpolator()):

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -9,10 +9,17 @@ the tools in the PSF subpackage.
 import abc
 
 import numpy as np
-from astropy.stats import (SigmaClip, biweight_location, biweight_scale,
-                           mad_std)
+from astropy.stats import biweight_location, biweight_scale, mad_std
 
 from ..utils.misc import _ABCMetaAndInheritDocstrings
+
+from astropy.version import version as astropy_version
+if astropy_version < '3.1':
+    from astropy.stats import SigmaClip
+    SIGMA_CLIP = SigmaClip(sigma=3., iters=10)
+else:
+    from ..extern import SigmaClip
+    SIGMA_CLIP = SigmaClip(sigma=3., maxiters=10)
 
 
 __all__ = ['BackgroundBase', 'BackgroundRMSBase', 'MeanBackground',
@@ -65,10 +72,10 @@ class BackgroundBase(metaclass=_ABCMetaAndInheritDocstrings):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
     """
 
-    def __init__(self, sigma_clip=SigmaClip(sigma=3., iters=5)):
+    def __init__(self, sigma_clip=SIGMA_CLIP):
         self.sigma_clip = sigma_clip
 
     def __call__(self, data, axis=None):
@@ -108,10 +115,10 @@ class BackgroundRMSBase(metaclass=_ABCMetaAndInheritDocstrings):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
     """
 
-    def __init__(self, sigma_clip=SigmaClip(sigma=3., iters=5)):
+    def __init__(self, sigma_clip=SIGMA_CLIP):
         self.sigma_clip = sigma_clip
 
     def __call__(self, data, axis=None):
@@ -152,7 +159,7 @@ class MeanBackground(BackgroundBase):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------
@@ -195,7 +202,7 @@ class MedianBackground(BackgroundBase):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------
@@ -242,7 +249,7 @@ class ModeEstimatorBackground(BackgroundBase):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------
@@ -294,7 +301,7 @@ class MMMBackground(ModeEstimatorBackground):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------
@@ -346,7 +353,7 @@ class SExtractorBackground(BackgroundBase):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------
@@ -410,7 +417,7 @@ class BiweightLocationBackground(BackgroundBase):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------
@@ -458,7 +465,7 @@ class StdBackgroundRMS(BackgroundRMSBase):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------
@@ -512,7 +519,7 @@ class MADStdBackgroundRMS(BackgroundRMSBase):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------
@@ -561,7 +568,7 @@ class BiweightScaleBackgroundRMS(BackgroundRMSBase):
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters.  If `None` then no sigma clipping will be
         performed.  The default is to perform sigma clipping with
-        ``sigma=3.`` and ``iters=5``.
+        ``sigma=3.`` and ``maxiters=5``.
 
     Examples
     --------

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -8,6 +8,7 @@ from astropy.stats import sigma_clipped_stats
 from astropy.table import Table
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
+from astropy.version import version as astropy_version
 from astropy.wcs.utils import pixel_to_skycoord
 
 from ..utils.cutouts import cutout_footprint
@@ -90,9 +91,15 @@ def detect_threshold(data, snr, background=None, error=None, mask=None,
     """
 
     if background is None or error is None:
-        data_mean, data_median, data_std = sigma_clipped_stats(
-            data, mask=mask, mask_value=mask_value, sigma=sigclip_sigma,
-            iters=sigclip_iters)
+        if astropy_version < '3.1':
+            data_mean, data_median, data_std = sigma_clipped_stats(
+                data, mask=mask, mask_value=mask_value, sigma=sigclip_sigma,
+                iters=sigclip_iters)
+        else:
+            data_mean, data_median, data_std = sigma_clipped_stats(
+                data, mask=mask, mask_value=mask_value, sigma=sigclip_sigma,
+                maxiters=sigclip_iters)
+
         bkgrd_image = np.zeros_like(data) + data_mean
         bkgrdrms_image = np.zeros_like(data) + data_std
 
@@ -189,7 +196,7 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         calculate the centroid of a 2D array.  The ``centroid_func``
         must accept a 2D `~numpy.ndarray`, have a ``mask`` keyword, and
         optionally an ``error`` keyword.  The callable object must
-        return a tuple of two 1D `~numpy.ndarray`\s, representing the x
+        return a tuple of two 1D `~numpy.ndarray`\\s, representing the x
         and y centroids, respectively.
 
     subpixel : bool, optional

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -95,7 +95,8 @@ class TestDetectThreshold:
     def test_image_mask(self):
         """
         Test detection with image_mask.
-        sig=10 and iters=1 to prevent sigma clipping after applying the mask.
+        Set sigma=10 and iters=1 to prevent sigma clipping after
+        applying the mask.
         """
 
         mask = REF1.astype(np.bool)


### PR DESCRIPTION
In `astropy.stats.SigmaClip` and `astropy.stats.sigma_clipped_stats`, the `iters` keyword was recently deprecated and renamed to `maxiters`.  This PR updates photutils function to support both the `iters` (for astropy < 3.1) and `maxiters` (for astropy >= 3.1) keywords, eliminating the deprecation warnings.

This PR replaces #718.