### PR TITLE
Iterative PSF fitting routine where all newly found sources are re-fit along with previously detected sources.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ New Features
     segmentation images (e.g.  ``remove_labels``, ``keep_labels``).
     [#810]
 
+- ``photutils.psf``
+  
+  - New iterative PSF photometry fitting algorithm,
+    ``IterativeGroupPSFPhotometry``, re-fitting previously detected sources
+    in a given group with sources detected in the current iteration. [#732]
+
 Bug Fixes
 ^^^^^^^^^
 


### PR DESCRIPTION
An initial inclusion of a more robust PSF fitting algorithm, similar in scope to ``IterativelySubtractedPSFPhotometry``. However, instead of fitting sources, subtracting them and fitting sources found in the residual image, ``IterativeGroupPSFPhotometry`` looks at the residual image for new sources, and then re-fits all sources in the subsequent loop. 

The loop then becomes 
0) [find or provide initial sources] 
1a) group sources 
1b) fit sources in main image 
1c) compute residual 
1d) find new sources in residual 
1e) [stop if no new sources] 
2a) re-group sources
2b) re-fit sources in main image 
2c) compute new residual 
2d) find further sources in residual
...

This allows for the case where individual fitting of one PSF model to two overlapping sources would give unphysical parameters for the brightest source, providing a "second chance" to correct the derived parameters of the first source with the knowledge that there is a second source, previously hidden in the image. Because the fitting always occurs on the image, rather than the previous iteration's residuals, we do not propagate any poor fits from any prior loops forward.