### PR TITLE
Updated test_photometry to correctly use IntegratedGaussianPRF

### DIFF
--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -13,13 +13,14 @@ from astropy.version import version as astropy_version
 from astropy.wcs import WCS
 
 from ..utils import check_random_state
+from ..psf import IntegratedGaussianPRF
 
 
 __all__ = ['apply_poisson_noise', 'make_noise_image',
            'make_random_models_table', 'make_random_gaussians_table',
            'make_model_sources_image', 'make_gaussian_sources_image',
            'make_4gaussians_image', 'make_100gaussians_image',
-           'make_wcs', 'make_imagehdu']
+           'make_wcs', 'make_imagehdu', 'make_gaussian_prf_sources_image']
 
 
 def apply_poisson_noise(data, random_state=None):
@@ -552,6 +553,86 @@ def make_gaussian_sources_image(shape, source_table, oversample=1):
 
     return make_model_sources_image(shape, model, source_table,
                                     oversample=oversample)
+
+
+def make_gaussian_prf_sources_image(shape, source_table):
+    """
+    Make an image containing 2D Gaussian sources.
+
+    Parameters
+    ----------
+    shape : 2-tuple of int
+        The shape of the output 2D image.
+
+    source_table : `~astropy.table.Table`
+        Table of parameters for the Gaussian sources.  Each row of the
+        table corresponds to a Gaussian source whose parameters are
+        defined by the column names.  With the exception of ``'flux'``,
+        column names that do not match model parameters will be ignored
+        (flux will be converted to amplitude).  If both ``'flux'`` and
+        ``'amplitude'`` are present, then ``'flux'`` will be ignored.
+        Model parameters not defined in the table will be set to the
+        default value.
+
+    Returns
+    -------
+    image : 2D `~numpy.ndarray`
+        Image containing 2D Gaussian sources.
+
+    See Also
+    --------
+    make_model_sources_image, make_random_gaussians_table
+
+    Examples
+    --------
+    .. plot::
+        :include-source:
+
+        # make a table of Gaussian sources
+        from astropy.table import Table
+        table = Table()
+        table['amplitude'] = [50, 70, 150, 210]
+        table['x_0'] = [160, 25, 150, 90]
+        table['y_0'] = [70, 40, 25, 60]
+        table['sigma'] = [15.2, 5.1, 3., 8.1]
+
+        # make an image of the sources without noise, with Gaussian
+        # noise, and with Poisson noise
+        from photutils.datasets import make_gaussian_sources_image
+        from photutils.datasets import make_noise_image
+        shape = (100, 200)
+        image1 = make_gaussian_prf_sources_image(shape, table)
+        image2 = image1 + make_noise_image(shape, type='gaussian', mean=5.,
+                                           stddev=5.)
+        image3 = image1 + make_noise_image(shape, type='poisson', mean=5.)
+
+        # plot the images
+        import matplotlib.pyplot as plt
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(8, 12))
+        ax1.imshow(image1, origin='lower', interpolation='nearest')
+        ax1.set_title('Original image')
+        ax2.imshow(image2, origin='lower', interpolation='nearest')
+        ax2.set_title('Original image with added Gaussian noise'
+                      ' ($\\mu = 5, \\sigma = 5$)')
+        ax3.imshow(image3, origin='lower', interpolation='nearest')
+        ax3.set_title('Original image with added Poisson noise ($\\mu = 5$)')
+    """
+
+    model = IntegratedGaussianPRF(sigma=1)
+
+    if 'sigma' in source_table.colnames:
+        sigma = source_table['sigma']
+    else:
+        sigma = model.sigma.value    # default
+
+    colnames = source_table.colnames
+    if 'flux' not in colnames and 'amplitude' in colnames:
+        source_table = source_table.copy()
+        source_table['flux'] = (source_table['amplitude'] *
+                                (2. * np.pi * sigma * sigma))
+
+    return make_model_sources_image(shape, model, source_table,
+                                    oversample=1)
 
 
 def make_4gaussians_image(noise=True):

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -598,7 +598,7 @@ def make_gaussian_prf_sources_image(shape, source_table):
 
         # make an image of the sources without noise, with Gaussian
         # noise, and with Poisson noise
-        from photutils.datasets import make_gaussian_sources_image
+        from photutils.datasets import make_gaussian_prf_sources_image
         from photutils.datasets import make_noise_image
         shape = (100, 200)
         image1 = make_gaussian_prf_sources_image(shape, table)

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -20,20 +20,20 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-TABLE = Table()
-TABLE['flux'] = [1, 2, 3]
-TABLE['x_mean'] = [30, 50, 70.5]
-TABLE['y_mean'] = [50, 50, 50.5]
-TABLE['x_stddev'] = [1, 2, 3.5]
-TABLE['y_stddev'] = [2, 1, 3.5]
-TABLE['theta'] = np.array([0., 30, 50]) * np.pi / 180.
+SOURCE_TABLE = Table()
+SOURCE_TABLE['flux'] = [1, 2, 3]
+SOURCE_TABLE['x_mean'] = [30, 50, 70.5]
+SOURCE_TABLE['y_mean'] = [50, 50, 50.5]
+SOURCE_TABLE['x_stddev'] = [1, 2, 3.5]
+SOURCE_TABLE['y_stddev'] = [2, 1, 3.5]
+SOURCE_TABLE['theta'] = np.array([0., 30, 50]) * np.pi / 180.
 
-TABLE2 = Table()
-TABLE2['x_0'] = [30, 50, 70.5]
-TABLE2['y_0'] = [50, 50, 50.5]
+SOURCE_TABLE_PRF = Table()
+SOURCE_TABLE_PRF['x_0'] = [30, 50, 70.5]
+SOURCE_TABLE_PRF['y_0'] = [50, 50, 50.5]
 # Without sigma, make_gaussian_prf_sources_image will default to sigma = 1
 # so we can ignore it when converting to amplitude
-TABLE2['amplitude'] = np.array([1, 2, 3]) / (2 * np.pi)
+SOURCE_TABLE_PRF['amplitude'] = np.array([1, 2, 3]) / (2 * np.pi)
 
 
 def test_make_noise_image():
@@ -87,23 +87,23 @@ def test_apply_poisson_noise_negative():
 
 def test_make_gaussian_sources_image():
     shape = (100, 100)
-    image = make_gaussian_sources_image(shape, TABLE)
+    image = make_gaussian_sources_image(shape, SOURCE_TABLE)
     assert image.shape == shape
-    assert_allclose(image.sum(), TABLE['flux'].sum())
+    assert_allclose(image.sum(), SOURCE_TABLE['flux'].sum())
 
 
 @pytest.mark.xfail('not HAS_SCIPY')
 def test_make_gaussian_prf_sources_image():
     shape = (100, 100)
-    image = make_gaussian_prf_sources_image(shape, TABLE2)
+    image = make_gaussian_prf_sources_image(shape, SOURCE_TABLE_PRF)
     assert image.shape == shape
     # Without sigma in table, image assumes sigma = 1
-    flux = TABLE2['amplitude'] * (2 * np.pi)
+    flux = SOURCE_TABLE_PRF['amplitude'] * (2 * np.pi)
     assert_allclose(image.sum(), flux.sum())
 
 
 def test_make_gaussian_sources_image_amplitude():
-    table = TABLE.copy()
+    table = SOURCE_TABLE.copy()
     table.remove_column('flux')
     table['amplitude'] = [1, 2, 3]
     shape = (100, 100)
@@ -113,9 +113,9 @@ def test_make_gaussian_sources_image_amplitude():
 
 def test_make_gaussian_sources_image_oversample():
     shape = (100, 100)
-    image = make_gaussian_sources_image(shape, TABLE, oversample=10)
+    image = make_gaussian_sources_image(shape, SOURCE_TABLE, oversample=10)
     assert image.shape == shape
-    assert_allclose(image.sum(), TABLE['flux'].sum())
+    assert_allclose(image.sum(), SOURCE_TABLE['flux'].sum())
 
 
 def test_make_random_gaussians_table():


### PR DESCRIPTION
Changed test image creation in ``test_photometry`` to correctly create discrete pixel images, instead of evaluating the Gaussian PDF at the pixel centre. The PR adds a new function, ``make_gaussian_prf_sources_image`` which is analogous to the original ``make_gaussian_sources_image`` except it calls ``IntegratedGaussianPRF`` instead of ``Gaussian2D`` as the input model. Minor changes were made to the various tests as ``IntegratedGaussianPRF`` takes differing inputs -- ``x_mean`` becomes ``x_0``, etc.

This fixes the issue seen where fit and input fluxes were incompatible, as two differing models were being fit and producing differing results. Thus the accuracy of several ``assert_allclose`` statements could be improved with the conflict resolved.