### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,25 +10,18 @@ __pycache__
 *.c
 
 # Other generated files
+MANIFEST
 */version.py
 */cython_version.py
 htmlcov
 .coverage
-MANIFEST
 .ipynb_checkpoints
 benchmarks/_results
 
 # Sphinx
+_build
+_generated
 docs/api
-docs/_build
-
-# Eclipse editor project files
-.project
-.pydevproject
-.settings
-
-# Pycharm editor project files
-.idea
 
 # Packages/installer info
 *.egg
@@ -36,6 +29,7 @@ docs/_build
 dist
 build
 eggs
+.eggs
 parts
 bin
 var
@@ -49,6 +43,10 @@ distribute-*.tar.gz
 .tox
 .*.sw[op]
 *~
+.idea
+.project
+.pydevproject
+.settings
 
 # Mac OSX
 .DS_Store


### PR DESCRIPTION
This PR changes the `docs/_build` entry to simply `_build` to ignore the `Sphinx 1.8+` output directory (cf. https://github.com/astropy/sphinx-astropy/issues/12).  I also made a few minor changes.