### PR TITLE
Added check for NDData.uncertainty being StdDevUncertainty array in construction of EPSFStar object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,9 @@ Other Changes and Additions
   to support both their ``iters`` (for astropy < 3.1) and ``maxiters``
   keywords. [#726]
 
+- Added the option for ``EPSFStar`` to have ``weights`` based on an
+  ``astropy.nddata.StdDevUncertainty`` object.
+
 
 0.5 (2018-08-06)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,7 +113,7 @@ Other Changes and Additions
   keywords. [#726]
 
 - Added the option for ``EPSFStar`` to have ``weights`` based on an
-  ``astropy.nddata.StdDevUncertainty`` object.
+  ``astropy.nddata.StdDevUncertainty`` object. [#739]
 
 
 0.5 (2018-08-06)

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -210,6 +210,10 @@ class EPSFFitter:
         # the factor to be different along the x and y axes.
         epsf._oversampling = 1.
 
+        # Weights should be pulled from ``EPSFStar`` instance, where the
+        # weights are determined from an NDData.uncertainty array if its
+        # uncertainty type is `weight`, or inverse uncertainty if type is
+        # `std`; otherwise unity weights are used.
         try:
             fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=scaled_data,
                                  weights=weights, **fitter_kwargs)

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -792,12 +792,12 @@ def _extract_stars(data, catalog, size=(11, 11), use_xy=True):
         # the data uncertainties we can take the inverse standard deviation as
         # the weight. Before assigning the weights we must ignore zero
         # variance data, however, setting the weights for these data points to
-        # zero.
-        else if data.uncertainty.uncertainty_type == 'std':
-            std_dev = data.uncertainty.array
+        # zero by forcing their standard deviations to a large value.
+        elif data.uncertainty.uncertainty_type == 'std':
+            std_dev = data.uncertainty.array.copy()
             zero_uncert = std_dev == 0.
-            weights = np.asanyarray(np.where(zero_uncert, 1/std_dev,
-                                             np.zeros_like(std_dev)), dtype=np.float)
+            std_dev[zero_uncert] = 1e9
+            weights = np.asanyarray(1/std_dev, dtype=np.float)
         else:
             warnings.warn('The data uncertainty attribute has an unsupported '
                           'type.  Only uncertainty_type="weights" can be '

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.nddata import NDData
+from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import Table
 
 from ..epsf import EPSFBuilder, EPSFFitter
@@ -77,6 +77,30 @@ class TestEPSFBuild:
         assert isinstance(stars, EPSFStars)
         assert isinstance(stars[0], EPSFStar)
         assert stars[0].data.shape == (size, size)
+
+    def test_extract_stars_stddev_weights(self):
+        size = 25
+        data = NDData(self.nddata.data,
+                      uncertainty=StdDevUncertainty(np.sqrt(self.nddata.data)))
+        stars = extract_stars(data, self.init_stars, size=size)
+
+        assert len(stars) == 41
+        assert isinstance(stars, EPSFStars)
+        assert isinstance(stars[0], EPSFStar)
+        assert stars[0].data.shape == (size, size)
+
+    def test_extract_stars_inputs(self):
+        with pytest.raises(ValueError):
+            extract_stars(np.ones(3), self.init_stars)
+
+        with pytest.raises(ValueError):
+            extract_stars(self.nddata, [(1, 1), (2, 2), (3, 3)])
+
+        with pytest.raises(ValueError):
+            extract_stars(self.nddata, [self.init_stars, self.init_stars])
+
+        with pytest.raises(ValueError):
+            extract_stars([self.nddata, self.nddata], self.init_stars)
 
     def test_epsf_build(self):
         """


### PR DESCRIPTION
Added the option for the weights in ``EPSFStar`` objects to be passed from ``StdDevUncertainty`` NDData arrays, extending from the original ``weights`` ``uncertainty_type`` option. Also added brief comment describing the origin of ``weights`` in EPSFFitter ``fitter``. Closes #734 