### PR TITLE
Add fallback aperture_radius to psf photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,9 @@ Bug Fixes
   - Fixed a bug that caused photometry to fail on an ``EPSFmodel`` with
     multiple stars in a group. [#1135]
 
+  - Added a fallback ``aperture_radius`` for PSF models without a FWHM
+    or sigma attribute, raising a warning. [#740]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceProperties`` ``local_background`` to work with

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -256,6 +256,21 @@ class BasicPSFPhotometry:
             elif hasattr(self.psf_model, 'sigma'):
                 self.aperture_radius = (self.psf_model.sigma.value *
                                         gaussian_sigma_to_fwhm)
+            # If PSF model doesn't have FWHM or sigma value -- as it
+            # is not a Gaussian; most likely because it's an ePSF --
+            # then we fall back on fitting a circle of the average
+            # size of the fitting box. As ``fitshape`` is the width
+            # of the box, we need (width-1)/2 as the radius.
+            else:
+                self.aperture_radius = float(np.amin((np.asanyarray(
+                                             self.fitshape) - 1) / 2))
+                warnings.warn('aperture_radius is None and could not '
+                              'be determined by psf_model. Setting '
+                              'radius to the smallest fitshape size. '
+                              'If fitshape is significantly larger than '
+                              'the psf_model core lengthscale, consider '
+                              'supplying a specific aperture_radius.',
+                              AstropyUserWarning)
 
         if self.aperture_radius is None:
             if init_guesses is None:
@@ -741,6 +756,21 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
                 elif hasattr(self.psf_model, 'sigma'):
                     self.aperture_radius = (self.psf_model.sigma.value *
                                             gaussian_sigma_to_fwhm)
+                # If PSF model doesn't have FWHM or sigma value -- as it
+                # is not a Gaussian; most likely because it's an ePSF --
+                # then we fall back on fitting a circle of the average
+                # size of the fitting box. As ``fitshape`` is the width
+                # of the box, we need (width-1)/2 as the radius.
+                else:
+                    self.aperture_radius = float(np.amin((np.asanyarray(
+                                                 self.fitshape) - 1) / 2))
+                    warnings.warn('aperture_radius is None and could not '
+                                  'be determined by psf_model. Setting '
+                                  'radius to the smallest fitshape size. '
+                                  'If fitshape is significantly larger than '
+                                  'the psf_model core lengthscale, consider '
+                                  'supplying a specific aperture_radius.',
+                                  AstropyUserWarning)
 
             output_table = self._do_photometry()
         return output_table

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -258,14 +258,18 @@ class BasicPSFPhotometry:
                                         gaussian_sigma_to_fwhm)
             # If PSF model doesn't have FWHM or sigma value -- as it
             # is not a Gaussian; most likely because it's an ePSF --
-            # then we fall back on fitting a circle of the average
-            # size of the fitting box. As ``fitshape`` is the width
-            # of the box, we need (width-1)/2 as the radius.
-            else:
+            # and if fluxes were not supplied in ``init_guesses`` then we fall
+            # back on fitting a circle of the average size of the fitting box.
+            # As ``fitshape`` is the width of the box, we need (width-1)/2 as
+            # the radius.
+            elif (init_guesses is not None and
+                  'flux_0' not in init_guesses.colnames):
                 self.aperture_radius = float(np.amin((np.asanyarray(
                                              self.fitshape) - 1) / 2))
-                warnings.warn('aperture_radius is None and could not '
-                              'be determined by psf_model. Setting '
+                warnings.warn('init_guesses were input, but the flux_0 column '
+                              'was not provided. Initial fluxes cannot be '
+                              'calculated as aperture_radius is None and '
+                              'could not be determined by psf_model. Setting '
                               'radius to the smallest fitshape size. '
                               'If fitshape is significantly larger than '
                               'the psf_model core lengthscale, consider '
@@ -736,7 +740,10 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
                 # is not a Gaussian; most likely because it's an ePSF --
                 # then we fall back on fitting a circle of the average
                 # size of the fitting box. As ``fitshape`` is the width
-                # of the box, we need (width-1)/2 as the radius.
+                # of the box, we need (width-1)/2 as the radius. As opposed to
+                # ``BasicPSFPhotometry``, we have to fallback on this even if
+                # fluxes were given in ``init_guesses``, as this will be used
+                # in subsequent iterations.
                 else:
                     self.aperture_radius = float(np.amin((np.asanyarray(
                                                  self.fitshape) - 1) / 2))

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -272,30 +272,6 @@ class BasicPSFPhotometry:
                               'supplying a specific aperture_radius.',
                               AstropyUserWarning)
 
-        if self.aperture_radius is None:
-            if init_guesses is None:
-                raise ValueError('aperture_radius was not input and could '
-                                 'not be determined by the input psf_model '
-                                 '(e.g., an EPSFModel).  For tabular PSF '
-                                 'models, you must input the aperture_radius '
-                                 'keyword.  For analytical PSF models, you '
-                                 'must either input the aperture_radius '
-                                 'keyword or define a fwhm or sigma '
-                                 'attribute on your input psf_model.')
-
-            if (init_guesses is not None and
-                    'flux_0' not in init_guesses.colnames):
-                raise ValueError('init_guesses were input, but the "flux_0" '
-                                 'column was not present.  Initial fluxes '
-                                 'cannot be calculated because '
-                                 'aperture_radius must was not input and '
-                                 'could not be determined by the input '
-                                 'psf_model (e.g., an EPSFModel).  For '
-                                 'analytical PSF models, you must either '
-                                 'input the aperture_radius keyword or '
-                                 'define a fwhm or sigma attribute on your '
-                                 'input psf_model.')
-
         if init_guesses is not None:
             # make sure the code does not modify user's input
             init_guesses = init_guesses.copy()

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -485,41 +485,23 @@ def test_psf_boundary():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-def test_aperture_radius_value_error():
-    """
-    Test psf_photometry with discrete PRF model at the boundary of the data.
-    """
-
-    prf = DiscretePRF(test_psf, subsampling=1)
-
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=prf,
-                                    fitshape=7)
-
-    intab = Table(data=[[1], [1]], names=['x_0', 'y_0'])
-    with pytest.warns(AstropyUserWarning):
-        basic_phot(image=image, init_guesses=intab)
-
-
-def tophatfinder(image):
-    fluxes = np.unique(image[image > 0])
-    table = Table(names=['id', 'xcentroid', 'ycentroid', 'flux'],
-                  dtype=[int, float, float, float])
-    for n, f in enumerate(fluxes):
-        xs, ys = np.where(image == f)
-        x = np.mean(xs)
-        y = np.mean(ys)
-        table.add_row([int(n+1), x, y, f])
-
-    return table
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
 def test_default_aperture_radius():
     """
     Test psf_photometry with non-Gaussian model, such that it raises a
     warning about aperture_radius.
     """
+    def tophatfinder(image):
+        """ Simple top hat finder function for use with a top hat PRF"""
+        fluxes = np.unique(image[image > 0])
+        table = Table(names=['id', 'xcentroid', 'ycentroid', 'flux'],
+                      dtype=[int, float, float, float])
+        for n, f in enumerate(fluxes):
+            xs, ys = np.where(image == f)
+            x = np.mean(xs)
+            y = np.mean(ys)
+            table.add_row([int(n+1), x, y, f])
+
+        return table
 
     prf = np.zeros((7, 7), float)
     prf[2:5, 2:5] = 1/9
@@ -538,7 +520,8 @@ def test_default_aperture_radius():
 
     intab = Table(data=[[19.6, 34.9, 37], [4.5, 40.1, 19.6]],
                   names=['x_0', 'y_0'])
-    with pytest.warns(AstropyUserWarning):
+    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
+                                                'could not be determined'):
         basic_phot(image=img, init_guesses=intab)
 
     daofind = DAOStarFinder(threshold=5.0, fwhm=3)
@@ -548,7 +531,8 @@ def test_default_aperture_radius():
                                                    psf_model=prf,
                                                    fitshape=7)
 
-    with pytest.warns(AstropyUserWarning):
+    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
+                                                'could not be determined'):
         iter_phot(image=img, init_guesses=intab)
     # Have to reset the object or it saves any updates, and we wish to
     # re-verify the aperture_radius assignment
@@ -557,7 +541,8 @@ def test_default_aperture_radius():
                                                    bkg_estimator=None,
                                                    psf_model=prf,
                                                    fitshape=7, niters=2)
-    with pytest.warns(AstropyUserWarning):
+    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
+                                                'could not be determined'):
         iter_phot(image=img)
 
 


### PR DESCRIPTION
Added a fallback ``aperture_radius`` to BasicPSFPhotometry and IterativelySubtractedPSFPhotometry for non-Gaussian PSF models that do not have either a sigma or FWHM attribute. If neither are found, routines fall back to the smaller of the two ``fitshape`` lengths, using the available (e)PSF model pixels to compute an aperture radius flux. Closes #728 