### PR TITLE
Making deprecations API consistent

### DIFF
--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -11,8 +11,7 @@ from astropy.nddata import NDData
 from astropy.nddata.utils import (overlap_slices, PartialOverlapError,
                                   NoOverlapError)
 from astropy.table import Table
-from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated
+from astropy.utils import lazyproperty, deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs.utils import skycoord_to_pixel
 
@@ -808,16 +807,16 @@ def _extract_stars(data, catalog, size=(11, 11), use_xy=True):
     return stars
 
 
-@deprecated(0.6, alternative='EPSFStar')
+@deprecated('0.6', alternative='EPSFStar')
 class Star(EPSFStar):
     pass
 
 
-@deprecated(0.6, alternative='EPSFStars')
+@deprecated('0.6', alternative='EPSFStars')
 class Stars(EPSFStars):
     pass
 
 
-@deprecated(0.6, alternative='LinkedEPSFStar')
+@deprecated('0.6', alternative='LinkedEPSFStar')
 class LinkedStar(LinkedEPSFStar):
     pass

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -197,7 +197,7 @@ class SegmentationImage:
         return self._data
 
     @lazyproperty
-    @deprecated(0.5, alternative='data_ma')
+    @deprecated('0.5', alternative='data_ma')
     def data_masked(self):
         return self.data_ma  # pragma: no cover
 
@@ -271,7 +271,7 @@ class SegmentationImage:
         return len(self.labels)
 
     @lazyproperty
-    @deprecated(0.5, alternative='max_label')
+    @deprecated('0.5', alternative='max_label')
     def max(self):
         return self.max_label  # pragma: no cover
 
@@ -311,7 +311,7 @@ class SegmentationImage:
 
         return np.bincount(self.data.ravel())[1:]
 
-    @deprecated(0.5, alternative='areas[labels-1]')
+    @deprecated('0.5', alternative='areas[labels-1]')
     def area(self, labels):  # pragma: no cover
         """
         The areas (in pixel**2) of the regions for the input labels.
@@ -333,7 +333,7 @@ class SegmentationImage:
         return self.areas[labels - 1]
 
     @lazyproperty
-    @deprecated(0.5, alternative='is_consecutive')
+    @deprecated('0.5', alternative='is_consecutive')
     def is_sequential(self):
         return self.is_consecutive  # pragma: no cover
 
@@ -398,7 +398,7 @@ class SegmentationImage:
         if len(bad_labels) > 0:
             raise ValueError('labels {} are invalid'.format(bad_labels))
 
-    @deprecated(0.5, alternative='check_labels')
+    @deprecated('0.5', alternative='check_labels')
     def check_label(self, label, allow_zero=False):  # pragma: no cover
         """
         Check for a valid label label number within the segmentation
@@ -550,7 +550,7 @@ class SegmentationImage:
             data[np.where(data == label)] = new_label
             self.data = data     # needed to call the data setter
 
-    @deprecated(0.5, alternative='relabel_consecutive()')
+    @deprecated('0.5', alternative='relabel_consecutive()')
     def relabel_sequential(self, start_label=1):
         return self.relabel_consecutive(start_label=start_label)  # pragma: no cover
 

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -10,7 +10,7 @@ from astropy.utils import deprecated
 __all__ = ['cutout_footprint']
 
 
-@deprecated(0.5)
+@deprecated('0.5')
 def cutout_footprint(data, position, box_size=3, footprint=None, mask=None,
                      error=None):
     """

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -3,7 +3,7 @@
 import warnings
 
 import numpy as np
-from astropy.utils.decorators import deprecated
+from astropy.utils import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 


### PR DESCRIPTION
Minor cleanup to use the API and namespace consistently throughout the package (everything worked here perfectly though, not using strings is only a problem when deprecating is happening in a bugfix version number).