### PR TITLE
Added the ability to pass additional column names to PSFPhotometry classes to be returned to the user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ API changes
 
 - ``photutils.psf``
 
-  - Added ``output_cols`` as a parameter to ``BasicPSFPhotometry``,
+  - Added ``extra_output_cols`` as a parameter to ``BasicPSFPhotometry``,
     ``IterativelySubtractedPSFPhotometry`` and ``DAOPhotPSFPhotometry``. [#745]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bug Fixes
 API changes
 ^^^^^^^^^^^
 
+- ``photutils.psf``
+
+  - Added ``output_cols`` as a parameter to ``BasicPSFPhotometry``,
+    ``IterativelySubtractedPSFPhotometry`` and ``DAOPhotPSFPhotometry``. [#745]
+
 
 0.7 (2019-08-14)
 ----------------

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -97,8 +97,9 @@ class BasicPSFPhotometry:
         keyword.  For analytical PSF models, alternatively you may
         define a FWHM attribute on your input psf_model.
     extra_output_cols : list of str, optional
-        List of additional columns for parameters derived by any of the intermediate
-        fitting steps (e.g., ``finder``), such as roundness or sharpness.
+        List of additional columns for parameters derived by any of the
+        intermediate fitting steps (e.g., ``finder``), such as roundness or
+        sharpness.
 
     Notes
     -----
@@ -225,8 +226,8 @@ class BasicPSFPhotometry:
             the initial guess for any parameters of the ``psf_model``
             model that are not fixed. If ``init_guesses`` supplied with
             ``extra_output_cols`` the initial values are used; if the columns
-            specified in ``extra_output_cols`` are not given in ``init_guesses``
-            then NaNs will be returned.
+            specified in ``extra_output_cols`` are not given in
+            ``init_guesses`` then NaNs will be returned.
 
         Returns
         -------
@@ -293,13 +294,14 @@ class BasicPSFPhotometry:
                 init_guesses['flux_0'] = aperture_photometry(
                     image, apertures)['aperture_sum']
 
-            # if extra_output_cols have been given, check whether init_guesses was
-            # supplied with extra_output_cols pre-attached and populate columns not
-            # given with NaNs
+            # if extra_output_cols have been given, check whether init_guesses
+            # was supplied with extra_output_cols pre-attached and populate
+            # columns not given with NaNs
             if self._extra_output_cols is not None:
                 for col_name in self._extra_output_cols:
                     if col_name not in init_guesses.colnames:
-                        init_guesses[col_name] = np.full(len(init_guesses), np.nan)
+                        init_guesses[col_name] = np.full(len(init_guesses),
+                                                         np.nan)
         else:
             if self.finder is None:
                 raise ValueError('Finder cannot be None if init_guesses are '
@@ -322,8 +324,9 @@ class BasicPSFPhotometry:
                                            sources['ycentroid'],
                                            sources['aperture_flux']])
 
-                # Currently only needed for the finder, as group_maker and nstar
-                # return the original Table with new columns, unlike finder
+                # Currently only needed for the finder, as group_maker and
+                # nstar return the original Table with new columns, unlike
+                # finder
                 self._get_additional_columns(sources, init_guesses)
 
         self._define_fit_param_names()
@@ -525,7 +528,8 @@ class BasicPSFPhotometry:
                                                            '_' + str(i)).value
         else:
             for param_tab_name, param_name in self._pars_to_output.items():
-                param_tab[param_tab_name] = getattr(fit_model, param_name).value
+                param_tab[param_tab_name] = getattr(fit_model,
+                                                    param_name).value
 
         return param_tab
 
@@ -599,8 +603,9 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         loop will never end if the PSF has structure that causes
         subtraction to create new sources infinitely.
     extra_output_cols : list of str, optional
-        List of additional columns for parameters derived by any of the intermediate
-        fitting steps (e.g., ``finder``), such as roundness or sharpness.
+        List of additional columns for parameters derived by any of the
+        intermediate fitting steps (e.g., ``finder``), such as roundness or
+        sharpness.
 
     Notes
     -----
@@ -687,8 +692,8 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
             the initial guess for any parameters of the ``psf_model``
             model that are not fixed. If ``init_guesses`` supplied with
             ``extra_output_cols`` the initial values are used; if the columns
-            specified in ``extra_output_cols`` are not given in ``init_guesses``
-            then NaNs will be returned.
+            specified in ``extra_output_cols`` are not given in
+            ``init_guesses`` then NaNs will be returned.
 
         Returns
         -------
@@ -896,8 +901,9 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
         estimates for the fluxes of sources. If ``None``, one FWHM will
         be used if it can be determined from the ```psf_model``.
     extra_output_cols : list of str, optional
-        List of additional columns for parameters derived by any of the intermediate
-        fitting steps (e.g., ``finder``), such as roundness or sharpness.
+        List of additional columns for parameters derived by any of the
+        intermediate fitting steps (e.g., ``finder``), such as roundness or
+        sharpness.
 
     Notes
     -----

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -96,7 +96,7 @@ class BasicPSFPhotometry:
         (e.g. an `EPSFModel`), you must input the ``aperture_radius``
         keyword.  For analytical PSF models, alternatively you may
         define a FWHM attribute on your input psf_model.
-    output_cols : list of str, optional
+    extra_output_cols : list of str, optional
         List of additional columns for parameters derived by any of the intermediate
         fitting steps (e.g., ``finder``), such as roundness or sharpness.
 
@@ -123,7 +123,7 @@ class BasicPSFPhotometry:
 
     def __init__(self, group_maker, bkg_estimator, psf_model, fitshape,
                  finder=None, fitter=LevMarLSQFitter(), aperture_radius=None,
-                 output_cols=None):
+                 extra_output_cols=None):
         self.group_maker = group_maker
         self.bkg_estimator = bkg_estimator
         self.psf_model = psf_model
@@ -134,7 +134,7 @@ class BasicPSFPhotometry:
         self._pars_to_set = None
         self._pars_to_output = None
         self._residual_image = None
-        self._output_cols = output_cols
+        self._extra_output_cols = extra_output_cols
 
     @property
     def fitshape(self):
@@ -223,9 +223,10 @@ class BasicPSFPhotometry:
             used to estimate initial values for the fluxes. Additional
             columns of the form '<parametername>_0' will be used to set
             the initial guess for any parameters of the ``psf_model``
-            model that are not fixed. If ``init_guesses`` supplied with ``output_cols``
-            the initial values are used; if the columns specified in ``output_cols`` are
-            not given in ``init_guesses`` then NaNs will be returned.
+            model that are not fixed. If ``init_guesses`` supplied with
+            ``extra_output_cols`` the initial values are used; if the columns
+            specified in ``extra_output_cols`` are not given in ``init_guesses``
+            then NaNs will be returned.
 
         Returns
         -------
@@ -292,10 +293,11 @@ class BasicPSFPhotometry:
                 init_guesses['flux_0'] = aperture_photometry(
                     image, apertures)['aperture_sum']
 
-            # if output_cols have been given, check whether init_guesses was supplied with
-            # output_cols pre-attached and populate columns not given with NaNs
-            if self._output_cols is not None:
-                for col_name in self._output_cols:
+            # if extra_output_cols have been given, check whether init_guesses was
+            # supplied with extra_output_cols pre-attached and populate columns not
+            # given with NaNs
+            if self._extra_output_cols is not None:
+                for col_name in self._extra_output_cols:
                     if col_name not in init_guesses.colnames:
                         init_guesses[col_name] = np.full(len(init_guesses), np.nan)
         else:
@@ -424,8 +426,8 @@ class BasicPSFPhotometry:
 
         """
 
-        if self._output_cols is not None:
-            for col_name in self._output_cols:
+        if self._extra_output_cols is not None:
+            for col_name in self._extra_output_cols:
                 if col_name in in_table.colnames:
                     out_table[col_name] = in_table[col_name]
 
@@ -596,7 +598,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         stars remain.  Note that in this case it is *possible* that the
         loop will never end if the PSF has structure that causes
         subtraction to create new sources infinitely.
-    output_cols : list of str, optional
+    extra_output_cols : list of str, optional
         List of additional columns for parameters derived by any of the intermediate
         fitting steps (e.g., ``finder``), such as roundness or sharpness.
 
@@ -617,10 +619,10 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
 
     def __init__(self, group_maker, bkg_estimator, psf_model, fitshape,
                  finder, fitter=LevMarLSQFitter(), niters=3,
-                 aperture_radius=None, output_cols=None):
+                 aperture_radius=None, extra_output_cols=None):
 
         super().__init__(group_maker, bkg_estimator, psf_model, fitshape,
-                         finder, fitter, aperture_radius, output_cols)
+                         finder, fitter, aperture_radius, extra_output_cols)
         self.niters = niters
 
     @property
@@ -683,9 +685,10 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
             used to estimate initial values for the fluxes. Additional
             columns of the form '<parametername>_0' will be used to set
             the initial guess for any parameters of the ``psf_model``
-            model that are not fixed. If ``init_guesses`` supplied with ``output_cols``
-            the initial values are used; if the columns specified in ``output_cols`` are
-            not given in ``init_guesses`` then NaNs will be returned.
+            model that are not fixed. If ``init_guesses`` supplied with
+            ``extra_output_cols`` the initial values are used; if the columns
+            specified in ``extra_output_cols`` are not given in ``init_guesses``
+            then NaNs will be returned.
 
         Returns
         -------
@@ -892,7 +895,7 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
         The radius (in units of pixels) used to compute initial
         estimates for the fluxes of sources. If ``None``, one FWHM will
         be used if it can be determined from the ```psf_model``.
-    output_cols : list of str, optional
+    extra_output_cols : list of str, optional
         List of additional columns for parameters derived by any of the intermediate
         fitting steps (e.g., ``finder``), such as roundness or sharpness.
 
@@ -915,7 +918,7 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
                  sigma=3., ratio=1.0, theta=0.0, sigma_radius=1.5,
                  sharplo=0.2, sharphi=1.0, roundlo=-1.0, roundhi=1.0,
                  fitter=LevMarLSQFitter(),
-                 niters=3, aperture_radius=None, output_cols=None):
+                 niters=3, aperture_radius=None, extra_output_cols=None):
 
         self.crit_separation = crit_separation
         self.threshold = threshold
@@ -940,4 +943,5 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
         super().__init__(group_maker=group_maker, bkg_estimator=bkg_estimator,
                          psf_model=psf_model, fitshape=fitshape,
                          finder=finder, fitter=fitter, niters=niters,
-                         aperture_radius=aperture_radius, output_cols=output_cols)
+                         aperture_radius=aperture_radius,
+                         extra_output_cols=extra_output_cols)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -620,7 +620,8 @@ def test_psf_extra_output_cols(sigma_psf, sources):
                               stddev=2., random_state=1))
 
     init_guess1 = None
-    init_guess2 = Table(names=['x_0', 'y_0', 'sharpness', 'roundness1', 'roundness2'],
+    init_guess2 = Table(names=['x_0', 'y_0', 'sharpness', 'roundness1',
+                               'roundness2'],
                         data=[[17.4], [16], [0.4], [0], [0]])
     init_guess3 = Table(names=['x_0', 'y_0'],
                         data=[[17.4], [16]])
@@ -628,22 +629,25 @@ def test_psf_extra_output_cols(sigma_psf, sources):
                         data=[[17.4], [16], [0.4]])
     for init_guesses in [init_guess1, init_guess2, init_guess3]:
         dao_phot = DAOPhotPSFPhotometry(crit_separation=8, threshold=40,
-                                        fwhm=2*2*np.sqrt(2*np.log(2)), psf_model=psf_model,
-                                        fitshape=(11, 11),
-                                        extra_output_cols=['sharpness', 'roundness1',
+                                        fwhm=2*2*np.sqrt(2*np.log(2)),
+                                        psf_model=psf_model, fitshape=(11, 11),
+                                        extra_output_cols=['sharpness',
+                                                           'roundness1',
                                                            'roundness2'])
         phot_results = dao_phot(image, init_guesses=init_guesses)
         # test that the original required columns are also passed back, as well
         # as extra_output_cols
-        assert np.all([name in phot_results.colnames for name in ['x_0', 'y_0']])
-        assert np.all([name in phot_results.colnames for name in ['sharpness', 'roundness1',
-                                                                  'roundness2']])
+        assert np.all([name in phot_results.colnames for name in
+                       ['x_0', 'y_0']])
+        assert np.all([name in phot_results.colnames for name in
+                       ['sharpness', 'roundness1', 'roundness2']])
         assert len(phot_results) == 2
-        # checks to verify that half-passing init_guesses results in NaN output for
-        # extra_output_cols not passed as initial guesses
+        # checks to verify that half-passing init_guesses results in NaN output
+        # for extra_output_cols not passed as initial guesses
         if init_guesses == init_guess3:
-            assert(np.all(np.all(np.isnan(phot_results[o])) for o in ['sharpness', 'roundness1',
-                                                                      'roundness2']))
+            assert(np.all(np.all(np.isnan(phot_results[o])) for o in
+                   ['sharpness', 'roundness1', 'roundness2']))
         if init_guesses == init_guess4:
-            assert(np.all(np.all(np.isnan(phot_results[o])) for o in ['roundness1', 'roundness2']))
+            assert(np.all(np.all(np.isnan(phot_results[o])) for o in
+                   ['roundness1', 'roundness2']))
             assert(np.all(~np.isnan(phot_results['sharpness'])))


### PR DESCRIPTION
``output_cols`` is added as an additional input parameter to ``BasicPSFPhotometry``, ``IterativelySubtractedPSFPhotometry`` and ``DAOPhotPSFPhotometry`` allowing for the inclusion of a list of strings of parameters derived by the ``finder`` instance. If not ``None`` these additional columns are then passed back to the user in the output table. 

For example, if sharpness and roundness are parameters of interest from ``DAOStarFinder`` then ``output_cols = ['sharpness', 'roundness1', 'roundness2']`` would return the values calculated during the finder process, along with such values as ``x_fit``, etc.

Closes #680 