### PR TITLE
Added flag to BasicPSFPhotometry to preserve ID order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,11 @@ Bug Fixes
 API changes
 ^^^^^^^^^^^
 
--
+- ``photutils.psf``
+
+  - Added ``preserve_id_order`` as input parameter to ``BasicPSFPhotometry``,
+    allowing for the return of source table in ``id`` rather than ``group_id``
+    order. [#746]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -90,6 +90,11 @@ class BasicPSFPhotometry:
         The radius (in units of pixels) used to compute initial
         estimates for the fluxes of sources. If ``None``, one FWHM will
         be used if it can be determined from the ``psf_model``.
+    preserve_id_order : bool, optional
+        Flag indicating whether to present final output table in ascending
+        ID order. Default is ``False``, and thus sources may be presented
+        in differing order to any input as ``init_guesses``, with output
+        being arranged by ``group_id``.
 
     Notes
     -----
@@ -113,7 +118,8 @@ class BasicPSFPhotometry:
     """
 
     def __init__(self, group_maker, bkg_estimator, psf_model, fitshape,
-                 finder=None, fitter=LevMarLSQFitter(), aperture_radius=None):
+                 finder=None, fitter=LevMarLSQFitter(), aperture_radius=None,
+                 preserve_id_order=False):
         self.group_maker = group_maker
         self.bkg_estimator = bkg_estimator
         self.psf_model = psf_model
@@ -124,6 +130,7 @@ class BasicPSFPhotometry:
         self._pars_to_set = None
         self._pars_to_output = None
         self._residual_image = None
+        self._preserve_id_order = preserve_id_order
 
     @property
     def fitshape(self):
@@ -291,6 +298,9 @@ class BasicPSFPhotometry:
 
         star_groups = star_groups.group_by('group_id')
         output_tab = hstack([star_groups, output_tab])
+
+        if self._preserve_id_order:
+            output_tab = output_tab.group_by('id')
 
         return output_tab
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -538,7 +538,7 @@ def test_psf_preserve_order(sigma_psf, sources):
     img_shape = (32, 32)
     # generate image with read-out noise (Gaussian) and
     # background noise (Poisson)
-    image = (make_gaussian_sources_image(img_shape, sources) +
+    image = (make_gaussian_prf_sources_image(img_shape, sources) +
              make_noise_image(img_shape, type='poisson', mean=6.,
                               random_state=1) +
              make_noise_image(img_shape, type='gaussian', mean=0.,
@@ -548,7 +548,7 @@ def test_psf_preserve_order(sigma_psf, sources):
     mmm_bkg = MMMBackground()
     daogroup = DAOGroup(crit_separation=8)
     basic_phot = BasicPSFPhotometry(group_maker=daogroup, bkg_estimator=mmm_bkg,
-                                  psf_model=psf_model, fitshape=(11, 11))
+                                    psf_model=psf_model, fitshape=(11, 11))
     phot_results = basic_phot(image, init_guesses=Table(names=['x_0', 'y_0', 'flux_0'],
                                                         data=[[7.8, 20.5, 13.1],
                                                               [19.4, 8.8, 21.4],
@@ -558,8 +558,8 @@ def test_psf_preserve_order(sigma_psf, sources):
     assert np.all(phot_results['id'] == [1, 3, 2])
 
     basic_phot = BasicPSFPhotometry(group_maker=daogroup, bkg_estimator=mmm_bkg,
-                                  psf_model=psf_model, fitshape=(11, 11),
-                                  preserve_id_order=True)
+                                    psf_model=psf_model, fitshape=(11, 11),
+                                    preserve_id_order=True)
     phot_results = basic_phot(image, init_guesses=Table(names=['x_0', 'y_0', 'flux_0'],
                                                         data=[[7.8, 20.5, 13.1],
                                                               [19.4, 8.8, 21.4],


### PR DESCRIPTION
Flag ``preserve_id_order`` added to ``BasicPSFPhotometry``, allowing for the re-sorting of ``output_table`` by source ID, overloading the default case where sources are returned in ascending ``group_id``. This would allow for sources to be returned in the same order as an input ``init_guesses``. Closes #645 