### PR TITLE
Raise errors for invalid inputs to star or peak finders

### DIFF
--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -244,6 +244,13 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
                       AstropyUserWarning)
         return Table()  # empty table
 
+    if not np.isscalar(threshold):
+        threshold = np.asanyarray(threshold)
+
+        if data.shape != threshold.shape:
+            raise ValueError('A threshold array must have the same shape as '
+                             'the input data.')
+
     # remove NaN values to avoid runtime warnings
     nan_mask = np.isnan(data)
     if np.any(nan_mask):

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -835,8 +835,14 @@ class DAOStarFinder(StarFinderBase):
                  sigma_radius=1.5, sharplo=0.2, sharphi=1.0, roundlo=-1.0,
                  roundhi=1.0, sky=0.0, exclude_border=False):
 
+        if not np.isscalar(threshold):
+            raise TypeError('threshold must be a scalar value.')
         self.threshold = threshold
+
+        if not np.isscalar(fwhm):
+            raise TypeError('fwhm must be a scalar value.')
         self.fwhm = fwhm
+
         self.ratio = ratio
         self.theta = theta
         self.sigma_radius = sigma_radius
@@ -1023,8 +1029,14 @@ class IRAFStarFinder(StarFinderBase):
                  sharplo=0.5, sharphi=2.0, roundlo=0.0, roundhi=0.2, sky=None,
                  exclude_border=False):
 
+        if not np.isscalar(threshold):
+            raise TypeError('threshold must be a scalar value.')
         self.threshold = threshold
+
+        if not np.isscalar(fwhm):
+            raise TypeError('fwhm must be a scalar value.')
         self.fwhm = fwhm
+
         self.sigma_radius = sigma_radius
         self.minsep_fwhm = minsep_fwhm
         self.sharplo = sharplo

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -157,6 +157,12 @@ class TestFindPeaks:
         with pytest.raises(ValueError):
             find_peaks(PEAKDATA, 0.1, mask=np.ones((5, 5)))
 
+    def test_thresholdshape(self):
+        """Test if threshold shape doesn't match data shape."""
+
+        with pytest.raises(ValueError):
+            find_peaks(PEAKDATA, np.ones((2, 2)))
+
     def test_npeaks(self):
         """Test npeaks."""
 

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -43,6 +43,13 @@ class TestDAOStarFinder:
         for col in t.colnames:
             assert_allclose(t[col], t_ref[col])
 
+    def test_daofind_threshold_fwhm_inputs(self):
+        with pytest.raises(TypeError):
+            DAOStarFinder(threshold=np.ones((2, 2)), fwhm=3.)
+
+        with pytest.raises(TypeError):
+            DAOStarFinder(threshold=3., fwhm=np.ones((2, 2)))
+
     def test_daofind_include_border(self):
         starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
                                    exclude_border=False)
@@ -109,6 +116,13 @@ class TestIRAFStarFinder:
         assert t.colnames == t_ref.colnames
         for col in t.colnames:
             assert_allclose(t[col], t_ref[col])
+
+    def test_irafstarfind_threshold_fwhm_inputs(self):
+        with pytest.raises(TypeError):
+            IRAFStarFinder(threshold=np.ones((2, 2)), fwhm=3.)
+
+        with pytest.raises(TypeError):
+            IRAFStarFinder(threshold=3., fwhm=np.ones((2, 2)))
 
     def test_irafstarfind_nosources(self):
         data = np.ones((3, 3))


### PR DESCRIPTION
This gives the user helpful messages for invalid input shapes or types.