### PR TITLE
Allow aperture radii to be vector quantities instead of scalars

### DIFF
--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -114,7 +114,8 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         rows of (x, y) coordinates.
 
     r : float
-        The radius of the aperture(s), in pixels.
+        The radii of the aperture(s), in pixels.  This can be a scalar
+        (same radius for all apertures) or an array of radii.
 
     Raises
     ------
@@ -296,7 +297,9 @@ class SkyCircularAperture(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     r : `~astropy.units.Quantity`
-        The radius of the aperture(s), either in angular or pixel units.
+        The radii of the aperture(s), either in angular or pixel units.
+        This can be a scalar (same radius for all apertures) or an array
+        of radii.
     """
 
     def __init__(self, positions, r):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -304,7 +304,6 @@ class SkyCircularAperture(SkyAperture):
             self.positions = positions
         else:
             raise TypeError('positions must be a SkyCoord object')
-        assert_angle_or_pixel('r', r)
         if self.positions.shape == ():
             self.r = r
         else:
@@ -316,7 +315,7 @@ class SkyCircularAperture(SkyAperture):
                 self.r=np.ones(len(self.positions))*r[0]
         if self.r.shape != self.positions.shape:
             raise TypeError('Length of radius vector must match length of positions')
-
+        assert_angle_or_pixel('r', r)
         self._params = ['r']
 
     def to_pixel(self, wcs, mode='all'):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -209,10 +209,12 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         rows of (x, y) coordinates.
 
     r_in : float
-        The inner radius of the annulus.
+        The inner radius of the annulus.  This can be a scalar
+        (same radius for all apertures) or an array of radii.
 
     r_out : float
-        The outer radius of the annulus.
+        The outer radius of the annulus.  This can be a scalar
+        (same radius for all apertures) or an array of radii.
 
     Raises
     ------
@@ -374,11 +376,13 @@ class SkyCircularAnnulus(SkyAperture):
 
     r_in : `~astropy.units.Quantity`
         The inner radius of the annulus, either in angular or pixel
-        units.
+        units.  This can be a scalar (same radius for all apertures)
+        or an array of radii.
 
     r_out : `~astropy.units.Quantity`
         The outer radius of the annulus, either in angular or pixel
-        units.
+        units.  This can be a scalar (same radius for all apertures)
+        or an array of radii.
     """
 
     def __init__(self, positions, r_in, r_out):


### PR DESCRIPTION
This works for `CircularAperture`, `CircularAnnulus`, `SkyCircularAperture`, `SkyCircularAnnulus`.  I haven't looked yet at other aperture types.  Aperture radii are stored internally as `np.ndarray`/`Quantity`.  Input types can be scalars or vectors, with scalars promoted as needed.  

I haven't done proper test development, but simple tests like:
```
import numpy as np
from astropy.coordinates import SkyCoord
from astropy import units as u, constants as c

from astropy.io import fits
from astropy.wcs import WCS
import photutils.aperture
import photutils

c1=photutils.aperture.CircularAperture((236.5,194.5),2)
c2=photutils.aperture.CircularAperture([(236.5,194.5),(255.75,185.25)],2)
c3=photutils.aperture.CircularAperture([(236.5,194.5,),(255.75,185.25)],[2,3])

s1=photutils.aperture.SkyCircularAperture(SkyCoord('10:11:31.957','+19:48:07.79',unit=('hour','deg')),2*u.arcsec)
s2=photutils.aperture.SkyCircularAperture(SkyCoord(['10:11:31.957','10:11:30.578'],['+19:48:07.79','+19:47:58.423'],unit=('hour','deg')),2*u.arcsec)
s3=photutils.aperture.SkyCircularAperture(SkyCoord(['10:11:31.957','10:11:30.578'],['+19:48:07.79','+19:47:58.423'],unit=('hour','deg')),np.array([2,3])*u.arcsec)


a1=photutils.aperture.CircularAnnulus((236.5,194.5),2,4)
a2=photutils.aperture.CircularAnnulus([(236.5,194.5),(255.75,185.25)],2,4)
a3=photutils.aperture.CircularAnnulus([(236.5,194.5,),(255.75,185.25)],[2,3],[4,6])

sa1=photutils.aperture.SkyCircularAnnulus(SkyCoord('10:11:31.957','+19:48:07.79',unit=('hour','deg')),2*u.arcsec,4*u.arcsec)
sa2=photutils.aperture.SkyCircularAnnulus(SkyCoord(['10:11:31.957','10:11:30.578'],['+19:48:07.79','+19:47:58.423'],unit=('hour','deg')),2*u.arcsec,4*u.arcsec)
sa3=photutils.aperture.SkyCircularAnnulus(SkyCoord(['10:11:31.957','10:11:30.578'],['+19:48:07.79','+19:47:58.423'],unit=('hour','deg')),np.array([2,3])*u.arcsec,np.array([4,6])*u.arcsec)


f=fits.open('/Users/dlk/Halpha/stacking/GP/p3569_f11_152.909_19.7892_5m.fits')
w=WCS(f[0].header)

oc1=photutils.aperture_photometry(f[0].data,c1,wcs=w)
oc2=photutils.aperture_photometry(f[0].data,c2,wcs=w)
oc3=photutils.aperture_photometry(f[0].data,c3,wcs=w)
os1=photutils.aperture_photometry(f[0].data,s1,wcs=w)
os2=photutils.aperture_photometry(f[0].data,s2,wcs=w)
os3=photutils.aperture_photometry(f[0].data,s3,wcs=w)
oa1=photutils.aperture_photometry(f[0].data,a1,wcs=w)
oa2=photutils.aperture_photometry(f[0].data,a2,wcs=w)
oa3=photutils.aperture_photometry(f[0].data,a3,wcs=w)
osa1=photutils.aperture_photometry(f[0].data,sa1,wcs=w)
osa2=photutils.aperture_photometry(f[0].data,sa2,wcs=w)
osa3=photutils.aperture_photometry(f[0].data,sa3,wcs=w)
```
Work (the FITS file is just an arbitrary file I had lying around).  