### PR TITLE
Add filtering/selection by peakmax and brightest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ API changes
   - The ``find_peaks`` function will no longer issue a RuntimeWarning
     if the input data contains NaNs. [#712]
 
+  - ``DAOStarFinder`` and ``IRAFStarFinder`` gain two new parameters:
+    ``brightest`` to keep the top ``brightest`` (based on the flux) objects
+    in the returned catalog *after all other filtering has been applied* and
+    ``peakmax`` to exclude sources with peak pixel values larger or equal to
+    ``peakmax``. [#750]
+
 - ``photutils.epsf``
 
   - The ``Star``, ``Stars``, and ``LinkedStars`` classes are now

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -102,7 +102,7 @@ class TestDAOStarFinder:
 
     def test_daofind_peakmax_filtering(self):
         """
-        Regression test that objects with ``peak`` < ``peakmax`` are
+        Regression test that objects with ``peak`` >= ``peakmax`` are
         filtered out.
         """
         peakmax = 20
@@ -186,7 +186,7 @@ class TestIRAFStarFinder:
 
     def test_irafstarfind_peakmax_filtering(self):
         """
-        Regression test that objects with ``peak`` < ``peakmax`` are
+        Regression test that objects with ``peak`` >= ``peakmax`` are
         filtered out.
         """
         peakmax = 20

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -100,6 +100,38 @@ class TestDAOStarFinder:
         t = starfinder(DATA)
         assert len(t) == 102
 
+    def test_daofind_peakmax_filtering(self):
+        """
+        Regression test that objects with ``peak`` < ``peakmax`` are
+        filtered out.
+        """
+        peakmax = 20
+        starfinder = DAOStarFinder(threshold=7., fwhm=1.5, roundlo=-np.inf,
+                                   roundhi=np.inf, sharplo=-np.inf,
+                                   sharphi=np.inf, peakmax=peakmax)
+        t = starfinder(DATA)
+        assert len(t) == 37
+        assert all(t['peak'] < peakmax)
+
+    def test_daofind_brightest_filtering(self):
+        """
+        Regression test that only top ``brightest`` objects are selected.
+        """
+        brightest = 40
+        peakmax = 20
+        starfinder = DAOStarFinder(threshold=7., fwhm=1.5, roundlo=-np.inf,
+                                   roundhi=np.inf, sharplo=-np.inf,
+                                   sharphi=np.inf, brightest=brightest)
+        t = starfinder(DATA)
+        # combined with peakmax
+        assert len(t) == brightest
+        starfinder = DAOStarFinder(threshold=7., fwhm=1.5, roundlo=-np.inf,
+                                   roundhi=np.inf, sharplo=-np.inf,
+                                   sharphi=np.inf, brightest=brightest,
+                                   peakmax=peakmax)
+        t = starfinder(DATA)
+        assert len(t) == 37
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestIRAFStarFinder:
@@ -151,3 +183,27 @@ class TestIRAFStarFinder:
         starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
         t = starfinder(DATA)
         assert len(t) == 0
+
+    def test_irafstarfind_peakmax_filtering(self):
+        """
+        Regression test that objects with ``peak`` < ``peakmax`` are
+        filtered out.
+        """
+        peakmax = 20
+        starfinder = IRAFStarFinder(threshold=7., fwhm=2, roundlo=-np.inf,
+                                    roundhi=np.inf, sharplo=-np.inf,
+                                    sharphi=np.inf, peakmax=peakmax)
+        t = starfinder(DATA)
+        assert len(t) == 117
+        assert all(t['peak'] < peakmax)
+
+    def test_irafstarfind_brightest_filtering(self):
+        """
+        Regression test that only top ``brightest`` objects are selected.
+        """
+        brightest = 40
+        starfinder = IRAFStarFinder(threshold=7., fwhm=2, roundlo=-np.inf,
+                                    roundhi=np.inf, sharplo=-np.inf,
+                                    sharphi=np.inf, brightest=brightest)
+        t = starfinder(DATA)
+        assert len(t) == brightest


### PR DESCRIPTION
This PR adds two new parameters to `IRAFStarFind` and `DAOStarFind` star detection classes to allow source selection/filtering by:

1. `peakmax` - maximum peak pixel value for selecting stars.
2. `brightest` - number of brightest objects to keep.

The rationale for these parameters is that `peakmax` could allow automatic exclusion of sources that reach a known saturation level of the detector and `brightest` would keep top `brightest` stars eliminating the faintest objects that could be false detections.

CC: @larrybradley 