### PR TITLE
WIP: Culler and Ender Future PSF Photometry API

### DIFF
--- a/docs/psf_spec/culler_and_ender.rst
+++ b/docs/psf_spec/culler_and_ender.rst
@@ -1,12 +1,42 @@
 CullerAndEnder
 ==============
 
-CullerAndEnder determines the fit quality of IterativelySubtractedPSFPhotometry 
-sources, removing any sources from the input `~astropy.table.Table` below a 
+CullerAndEnder determines the fit quality of any sources found in PSF fitting
+routines that build off `~photutils.psf.BasicPSFPhotometry` to include an 
+iterative element, such as `~photutils.psf.IterativelySubtractedPSFPhotometry`. It
+removes any sources from the input `~astropy.table.Table` below a 
 minimum fit criterion, and subsequently determines whether the loop can be ended 
 prematurely, most likely when all found sources are of good quality and no 
 additional sources have been found. This method may be subject to API changes in
 future versions and should not be considered final.
+
+This block is an extra step at the end of each iterative PSF fitting loop, set up
+to consider whether the fitting process is complete, or if any sources can have
+their fits improved or be added to the output table. As such it requires three
+inputs: ``data``, the `~astropy.table.Table` of sources found in the N-1 previous
+iterations of the routine with their corresponding positions, fluxes, etc.;
+``psf_model``, the `~astropy.modeling.Fittable2DModel` describing the PSF; and
+``new_sources``, a `~astropy.table.Table` list of those sources found in the
+residual image once the ``data`` sources are removed (i.e., additional sources
+with no previously derived parameters).
+
+The two halves of the block are further split into "cull" and "end": one function
+determining whether any sources in ``data`` are sufficiently poorly explained by
+``psf_model`` that they should not be considered sources at all (e.g., they are
+cosmic ray hits picked up as being above some local background); and a second
+function, which considers whether we have reached the end of the finding of new 
+sources prematurely (whether finding all sources before the loop counter reaches
+``niters`` or simply because there are no new sources if ``niters = None``). These
+functions (``cull_data`` and ``end_loop``) return a ``new_data`` table, with culled
+sources (those whose goodness-of-fit criteria are sufficiently low to be deemed
+non-stellar, e.g.), and ``end_flag``, a boolean for whether the iterations can be
+ceased (prematurely or not), respectively.
+
+Each subclass of ``CullerAndEnderBase`` can then provide its own definitions of
+``cull_data`` and ``end_loop`` depending on the specific user cases. For example,
+``end_loop`` could simply be ``return len(new_sources) == 0``, while ``cull_data``
+would likely involve the removal of sources with a chi-squared fit to ``psf_model``
+above some threshold, or equivalent.
 
 Parameters
 ----------
@@ -32,8 +62,8 @@ Example Usage
 -------------
 
 In the simplest example, a list of sources ``found_sources`` with parameters ``x_0``, ``y_0``
-and ``flux`` are compared to the expected PSF model (a FittableImageModel such as 
-`photutils.psf.IntegratedGaussianPRF`) and any fits above some minimum goodness-of-fit
+and ``flux`` are compared to the expected PSF model (a `~astropy.modeling.Fittable2DModel`
+such as `photutils.psf.IntegratedGaussianPRF`) and any fits above some minimum goodness-of-fit
 criterion are removed. If len(new_sources) == 0 then end_flag would return True, otherwise
 it will be set to False.::
 

--- a/docs/psf_spec/culler_and_ender.rst
+++ b/docs/psf_spec/culler_and_ender.rst
@@ -1,69 +1,42 @@
 CullerAndEnder
 ==============
 
-EJT: No currently existing code in `photutils`.
-
-A single sentence summarizing this block.
-
-A longer descrption.  Can be multiple paragraphs.  You can link to other things
-like `photutils.background`.
+CullerAndEnder determines the fit quality of IterativelySubtractedPSFPhotometry 
+sources, removing any sources from the input `~astropy.table.Table` below a 
+minimum fit criterion, and subsequently determines whether the loop can be ended 
+prematurely, most likely when all found sources are of good quality and no 
+additional sources have been found. This method may be subject to API changes in
+future versions and should not be considered final.
 
 Parameters
 ----------
 
-first_parameter_name : `~astropy.table.Table`
-    Description of first input
-
-second_parameter_name : SomeOtherType
-    Description of second input (if any)
+data : `~astropy.table.Table`
+    Table containing the sources.
+psf_model : `astropy.modeling.Fittable2DModel` instance
+    PSF/PRF model to which the data are being fit.
+new_sources : `~astropy.table.Table`
+    Newly found list of sources to compare with the sources
+    in ``data``, when deciding whether to end iteration.
 
 Returns
 -------
 
-first_return : `~astropy.table.Table`
-    Description of the first thing this block outputs.
-
-second_return
-    Many blocks will only return one object, but if more things are returned
-    they can be described here (e.g., in python this is
-    ``first, second = some_function(...)``)
-
-
-Methods
--------
-
-Not all blocks will have these, but if desired some blocks can have methods that
-let you do something other than just running the block.  E.g::
-
-    some_block = BlockClassName()
-    output = some_block(input1, input2, ...)  # this is what is documented above
-    result = some_block.method_name(...)  #this is documented here
-
-method_name
-^^^^^^^^^^^
-
-Description of method
-
-Parameters
-""""""""""
-
-first_parameter : type
-    Description ...
-
-second_parameter : type
-    Description ...
-
-Returns
-"""""""
-
-first_return : type
-    Description ...
-
+culled_data : `~astropy.table.Table`
+        ``data`` with poor fits removed.
+end_flag : boolean
+    Flag indicating whether to end iterative PSF fitting
+    before the maximum number of loops.
 
 Example Usage
 -------------
 
-An example of *using* the block should be provided.  This needs to be after a
-``::`` in the rst and indented::
+In the simplest example, a list of sources ``found_sources`` with parameters ``x_0``, ``y_0``
+and ``flux`` are compared to the expected PSF model (a FittableImageModel such as 
+`photutils.psf.IntegratedGaussianPRF`) and any fits above some minimum goodness-of-fit
+criterion are removed. If len(new_sources) == 0 then end_flag would return True, otherwise
+it will be set to False.::
 
-    print("This is example code")
+    from photutils.psf import CullerAndEnder
+    culler_and_ender = CullerAndEnder()
+    good_sources, end_flag = culler_and_ender(found_sources, psf_model, new_sources)


### PR DESCRIPTION
This pull request is set up for the discussion of the forward-looking additions to PSF photometry and should not be merged until after the discussion is finished. In this case the issue is the 'culler and ender' aspect of the [block diagram](https://github.com/astropy/photutils/blob/master/docs/psf_spec/block_diagram.png). This API documentation complements that in #721 where the documentation for those blocks implemented, with solid APIs unlikely to change in future releases. Please see #766 for an overview of the fitting process and a revised block diagram.

The structure of the blocks input and output parameters is described in detail in the documentation, but the main three stages are summarised below:

- [ ] ``CullerAndEnder`` 
  - [ ] Formatting
  - [ ] Wording
  - [ ] API workflow: requires ``data`` (`~astropy.table.Table`), ``psf_model`` (`~astropy.modeling.Fittable2DModel`), and ``new_sources`` (`~astropy.table.Table`) and returns ``new_data`` (`~astropy.table.Table`) and ``end_flag`` (boolean).
- [ ] ``cull_data``
  - [ ] Formatting
  - [ ] Wording
  - [ ] API workflow: requires ``data`` and ``psf_model`` and returns ``new_data`` (`~astropy.table.Table`)
- [ ] ``end_loop``
  - [ ] Formatting
  - [ ] Wording
  - [ ] API workflow: requires ``new_data``, ``data`` and ``new_sources``, returning ``end_flag`` (boolean)

Please provide any feedback on the API for this PSF photometry fitting routine block you may have, such that the implementation meets all of the requirements of all users and is as clear as possible going forward. A simple example for this block, maintaining "do nothing" backwards-compatibility can be found [here](https://github.com/Onoddil/photutils/blob/culler_ender_spec/photutils/psf/funcs.py), with [example](https://github.com/Onoddil/photutils/blob/culler_ender_spec/photutils/psf/photometry.py) implementation in ``IterativelySubtractedPSFPhotometry``. Please also provide simpler formatting or grammatical changes to improve the readability and professional look of the document. The function's primary goals are to remove poor quality fits from the list of sources returned to the user, and break the iterative process if certain criteria are met.
