### PR TITLE
Added doctest skip to matplotlib import line in aperture.rst

### DIFF
--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -379,11 +379,13 @@ the aperture is simply being used to estimate the local background.
 Whole pixels are fine, assuming you have a sufficient number of them
 on which to apply your statistical estimator.
 
-Let's focus on just the first annulus.  Let's plot its aperture mask::
+Let's focus on just the first annulus.  Let's plot its aperture mask:
+
+.. doctest-skip::
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.imshow(annulus_masks[0])  # doctest: +SKIP
-    >>> plt.colorbar()  # doctest: +SKIP
+    >>> plt.imshow(annulus_masks[0])
+    >>> plt.colorbar()
 
 .. plot::
 


### PR DESCRIPTION
This PR adds ``# doctest: +SKIP`` to the ``matplotlib`` import line in ``aperture.rst``, avoiding the issue where CircleCI builds fail in testing due to parsing the import statement without previously installing the module in the test suite.