### PR TITLE
WIP: Data Noise Handling Future PSF Photometry API

### DIFF
--- a/docs/psf_spec/noise_data.rst
+++ b/docs/psf_spec/noise_data.rst
@@ -1,69 +1,10 @@
-NoiseModel
+NoiseData
 ==========
 
-EJT: No currently existing code in `photutils`.
-
-A single sentence summarizing this block.
-
-A longer descrption.  Can be multiple paragraphs.  You can link to other things
-like `photutils.background`.
-
-Parameters
-----------
-
-first_parameter_name : `~astropy.table.Table`
-    Description of first input
-
-second_parameter_name : SomeOtherType
-    Description of second input (if any)
-
-Returns
--------
-
-first_return : `~astropy.table.Table`
-    Description of the first thing this block outputs.
-
-second_return
-    Many blocks will only return one object, but if more things are returned
-    they can be described here (e.g., in python this is
-    ``first, second = some_function(...)``)
-
-
-Methods
--------
-
-Not all blocks will have these, but if desired some blocks can have methods that
-let you do something other than just running the block.  E.g::
-
-    some_block = BlockClassName()
-    output = some_block(input1, input2, ...)  # this is what is documented above
-    result = some_block.method_name(...)  #this is documented here
-
-method_name
-^^^^^^^^^^^
-
-Description of method
-
-Parameters
-""""""""""
-
-first_parameter : type
-    Description ...
-
-second_parameter : type
-    Description ...
-
-Returns
-"""""""
-
-first_return : type
-    Description ...
-
-
-Example Usage
--------------
-
-An example of *using* the block should be provided.  This needs to be after a
-``::`` in the rst and indented::
-
-    print("This is example code")
+NoiseData is currently handled as an additional input parameter for
+BasicPSFPhotometry, and by extension IterativelySubtractedPSFPhotometry.
+``Noise_calc`` should be provided as a callable function (or `None` in 
+which case it is ignored) returning the uncertainty (in standard deviations)
+of each pixel, the same shape as the input ``image`` array. The data and
+uncertainty arrays are then wrapped in an `~astropy.nddata.NDData` 
+instance.

--- a/docs/psf_spec/noise_data.rst
+++ b/docs/psf_spec/noise_data.rst
@@ -1,10 +1,90 @@
 NoiseData
 ==========
 
+NoiseData handles the determination and use of data uncertainty in the fitting
+of PSF models to image arrays, either by calculating the uncertainty of each
+image array value or by allowing the passing of a previously determined
+uncertainty array along with the array containing the image counts. This method
+may be subject to API changes and should not currently be considered the final
+API specification.
+
 NoiseData is currently handled as an additional input parameter for
-BasicPSFPhotometry, and by extension IterativelySubtractedPSFPhotometry.
-``Noise_calc`` should be provided as a callable function (or `None` in 
+`~photutils.psf.BasicPSFPhotometry`, and by extension more complex
+PSF fitting routines, such as 
+`~photutils.psf.IterativelySubtractedPSFPhotometry`. It is either a function
+that calculates the corresponding uncertainty value of a given data value,
+a value such that the uncertainty array is ignored and all data values
+effectively given unity weighting, or set to indicate that the uncertainties
+for the image array were pre-computed and passed into the routine.
+
+``noise_calc`` should therefore be provided as a ``callable`` function (or `None` in 
 which case it is ignored) returning the uncertainty (in standard deviations)
-of each pixel, the same shape as the input ``image`` array. The data and
-uncertainty arrays are then wrapped in an `~astropy.nddata.NDData` 
-instance.
+of each pixel, the same shape as the input ``image`` array.  The data and 
+uncertainty arrays are then wrapped in an `~astropy.nddata.NDData`
+instance. Alternatively, if ``image`` is provided as an 
+`~astropy.nddata.NDData` instance with both ``data`` and ``uncertainty``
+attributes then ``noise_calc`` is ignored and the provided uncertainty array
+in ``image`` is used directly when calling the chosen ``fitter`` in the PSF
+fitting routine.
+
+Parameters
+----------
+
+image : array-like
+    The input image for which the uncertainty of each pixel is to be calculated.
+
+Returns
+-------
+
+uncertainty : array-like
+    The uncertainties of the input ``image`` values, as determined by the callable
+    function ``noise_calc``. Must return an array of the same shape as ``image``.
+
+Example Usage
+-------------
+
+The simplest, and perhaps most common, uncertainty used in photometry is that
+derived from Poissonian statistics, where the standard deviation is the square
+root of the photon counts. We can then simply pass the `~numpy.sqrt` function
+as ``noise_calc``::
+
+    import numpy as np
+    from astropy.modeling.fitting import LevMarLSQFitter
+
+    from photutils.psf import (DAOGroup, IntegratedGaussianPRF,
+                               IterativelySubtractedPSFPhotometry)
+    from photutils.background import MMMBackground
+    from photutils.detection import IRAFStarFinder
+
+    daogroup = DAOGroup(crit_separation=8)
+    mmm_bkg = MMMBackground()
+    iraffind = IRAFStarFinder(threshold=2.5*self.mmm_bkg(image), fwhm=4.5)
+    fitter = LevMarLSQFitter()
+    psf_model = IntegratedGaussianPRF(sigma=2.05)
+    psf_model.sigma.fixed = False
+    iter_phot_psf = IterativelySubtractedPSFPhotometry(finder=iraffind,
+                                                       group_maker=daogroup,
+                                                       bkg_estimator=mmm_bkg,
+                                                       psf_model=psf_model,
+                                                       fitter=fitter,
+                                                       fitshape=(11, 11),
+                                                       niters=2,
+                                                       noise_calc=np.sqrt)
+
+However, if we wished, we could instead derive our own, more complex function
+to determine the corresponding uncertainty of a given pixel value. For instance,
+if -- for whatever reason -- the uncertainty of our data points was determined
+to be the logarithm of the absolute value of the counts, we could write such a
+function, remembering that the returned array must match in shape the input
+image::
+
+    def new_uncert_func(image):
+        return np.log10(np.abs(image) + 5)
+    iter_phot_psf = IterativelySubtractedPSFPhotometry(finder=iraffind,
+                                                       group_maker=daogroup,
+                                                       bkg_estimator=mmm_bkg,
+                                                       psf_model=psf_model,
+                                                       fitter=fitter,
+                                                       fitshape=(11, 11),
+                                                       niters=2,
+                                                       noise_calc=new_uncert_func)


### PR DESCRIPTION
This pull request is set up for the discussion of the forward-looking additions to PSF photometry and should not be merged until after the discussion is finished. In this case the issue is the 'data noise' (previously the 'noise_model'; the name of the block has been changed to avoid potential confusion with 'psf_model') aspect of the [block diagram](https://github.com/astropy/photutils/blob/master/docs/psf_spec/block_diagram.png). This API documentation complements that in #721 where the documentation for those blocks implemented, with solid APIs unlikely to change in future releases. Please see #766 for an overview of the fitting process and a revised block diagram.

The structure of the blocks input and output parameters is described in detail in the documentation, but the main issues are summarised below:

- [ ] NoiseData
  - [ ] Name
  - [ ] Formatting
  - [ ] Wording
  - [ ] Callable function vs more internal routine
  - [ ] Overload inputs keywords/function acceptable
  - [ ] Handling of conversion from uncertainty to ``weight`` keyword in ``fitter``
  - [ ] API workflow: requires ``data`` (array-like) and returns ``uncertainty`` (array-like)
  - [ ] Implications for ``aperture``

In particular discussion on 

- whether to revert the name back to 'noise_model', if this is too easily confused with 'psf_model', or if a third name is a better descriptor
- whether``noise_calc`` should be a simple ``callable`` function or a more internal routine of some kind 
- whether keyword overload (e.g., ``None`` allows for the simple effective unit-weighting of all data values and some secondary keyword, as yet unimplemented, to indicate that uncertainty values have been passed in with the data values and to ignore the computation of uncertainty values) is acceptable, and what such keywords should be
- the particular conversion of "uncertainty" to the ``weight`` keyword of ``fitter`` functions (i.e., is ``weight = 1/uncertainty``, are ``uncertainty`` values standard deviations or variance, etc)
- the implications of this API block -- primarily for PSF fitting -- on ``aperture`` fitting. Current implementation requires the update of ``aperture_photometry`` to accept the ``uncertainty`` argument (instead of its current ``error`` keyword) to correctly handle ``NDData`` arrays via ``@support_nddata``. Nominally a relatively minor and cosmetic keyword update, is it acceptable to force an API change on another part of `photutils` or must uncertainties be handled in a different way in the PSF fitting routines to avoid this conflict?

is appreciated to finalise the API call.

Please provide any feedback on the API for this PSF photometry fitting routine block you may have, such that the implementation meets all of the requirements of all users and is as clear as possible going forward. A simple example for this block, maintaining "do nothing" backwards-compatibility can be [found](https://github.com/Onoddil/photutils/blob/cfa21637ccdb1a71044c6b24da969186d527525e/photutils/psf/photometry.py) in ``IterativelySubtractedPSFPhotometry``. It should be noted that the code provided above does not include examples of keyword overloading for uncertainty passing, simply accepting the ``callable`` function to compute uncertainties based on data values. The changes made to support ``NDData`` in ``aperture_photometry`` can be seen [here](https://github.com/Onoddil/photutils/blob/cfa21637ccdb1a71044c6b24da969186d527525e/photutils/aperture/core.py). Please also provide simpler formatting or grammatical changes to improve the readability and professional look of the document. The function's primary goal is to allow for the inclusion of realistic uncertainty weights in the fitting routine within the PSF fitting process, allowing for the in-situ calculation of such uncertainties or the passing of pre-determined uncertainties.