### PR TITLE
Make table output of DAOStarFinder and IRAFStarFinder consistent

### DIFF
--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -913,9 +913,17 @@ class DAOStarFinder(StarFinderBase):
                                    exclude_border=self.exclude_border)
         self.star_cutouts = star_cutouts
 
+        columns = ['id', 'xcentroid', 'ycentroid', 'sharpness', 'roundness1',
+                   'roundness2', 'npix', 'sky', 'peak', 'flux', 'mag']
+
+        coltypes = (
+            np.int_, np.float_, np.float_, np.float_, np.float_, np.float_,
+            np.int_, np.float_, np.float_, np.float_, np.float_
+        )
+
         if len(star_cutouts) == 0:
             warnings.warn('No sources were found.', AstropyUserWarning)
-            return Table()
+            return Table(names=columns, dtype=coltypes)
 
         star_props = []
         for star_cutout in star_cutouts:
@@ -945,7 +953,7 @@ class DAOStarFinder(StarFinderBase):
         if nstars == 0:
             warnings.warn('Sources were found, but none pass the sharpness '
                           'and roundness criteria.', AstropyUserWarning)
-            return Table()
+            return Table(names=columns, dtype=coltypes)
 
         if self.brightest is not None:
             fluxes = [props.flux for props in star_props]
@@ -956,9 +964,7 @@ class DAOStarFinder(StarFinderBase):
         table = Table()
         table['id'] = np.arange(nstars) + 1
 
-        columns = ['xcentroid', 'ycentroid', 'sharpness', 'roundness1',
-                   'roundness2', 'npix', 'sky', 'peak', 'flux', 'mag']
-        for column in columns:
+        for column in columns[1:]:
             table[column] = [getattr(props, column) for props in star_props]
 
         return table
@@ -1130,9 +1136,17 @@ class IRAFStarFinder(StarFinderBase):
                                    min_separation=self.min_separation,
                                    exclude_border=self.exclude_border)
 
+        columns = ['id', 'xcentroid', 'ycentroid', 'fwhm', 'sharpness',
+                   'roundness', 'pa', 'npix', 'sky', 'peak', 'flux', 'mag']
+
+        coltypes = (
+            np.int_, np.float_, np.float_, np.float_, np.float_, np.float_,
+            np.float_, np.int_, np.float_, np.float_, np.float_, np.float_
+        )
+
         if len(star_cutouts) == 0:
             warnings.warn('No sources were found.', AstropyUserWarning)
-            return Table()
+            return Table(names=columns, dtype=coltypes)
 
         star_props = []
         for star_cutout in star_cutouts:
@@ -1160,7 +1174,7 @@ class IRAFStarFinder(StarFinderBase):
         if nstars == 0:
             warnings.warn('Sources were found, but none pass the sharpness '
                           'and roundness criteria.', AstropyUserWarning)
-            return Table()
+            return Table(names=columns, dtype=coltypes)
 
         if self.brightest is not None:
             fluxes = [props.flux for props in star_props]
@@ -1171,9 +1185,7 @@ class IRAFStarFinder(StarFinderBase):
         table = Table()
         table['id'] = np.arange(nstars) + 1
 
-        columns = ['xcentroid', 'ycentroid', 'fwhm', 'sharpness', 'roundness',
-                   'pa', 'npix', 'sky', 'peak', 'flux', 'mag']
-        for column in columns:
+        for column in columns[1:]:
             table[column] = [getattr(props, column) for props in star_props]
 
         return table


### PR DESCRIPTION
This PR make output of `DAOStarFinder` and `IRAFStarFinder` consistent regardless of whether any stars have been found. This addresses the issue https://github.com/astropy/photutils/issues/757

CC: @larrybradley 