### PR TITLE
Allow for masking regions in star finders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,21 @@
 0.6 (unreleased)
 ----------------
 
+New Features
+^^^^^^^^^^^^
+
+- ``photutils.detection``
+
+  - ``DAOStarFinder`` and ``IRAFStarFinder`` gain two new parameters:
+    ``brightest`` to keep the top ``brightest`` (based on the flux)
+    objects in the returned catalog (after all other filtering has
+    been applied) and ``peakmax`` to exclude sources with peak pixel
+    values larger or equal to ``peakmax``. [#750]
+
+  - Added a ``mask`` keyword to ``DAOStarFinder`` and
+    ``IRAFStarFinder`` that can be used to mask regions of the input
+    image.  [#759]
+
 API changes
 ^^^^^^^^^^^
 
@@ -13,18 +28,11 @@ API changes
   - The ``find_peaks`` function will no longer issue a RuntimeWarning
     if the input data contains NaNs. [#712]
 
-  - ``DAOStarFinder`` and ``IRAFStarFinder`` gain two new parameters:
-    ``brightest`` to keep the top ``brightest`` (based on the flux) objects
-    in the returned catalog *after all other filtering has been applied* and
-    ``peakmax`` to exclude sources with peak pixel values larger or equal to
-    ``peakmax``. [#750]
-
 - ``photutils.epsf``
 
   - The ``Star``, ``Stars``, and ``LinkedStars`` classes are now
     deprecated and have been renamed ``EPSFStar``, ``EPSFStars``, and
     ``LinkedEPSFStars``, respectively. [#727]
-
 
 Bug Fixes
 ^^^^^^^^^

--- a/docs/detection.rst
+++ b/docs/detection.rst
@@ -47,9 +47,9 @@ background noise using sigma-clipped statistics::
     >>> from photutils import datasets
     >>> hdu = datasets.load_star_image()    # doctest: +REMOTE_DATA
     >>> data = hdu.data[0:401, 0:401]    # doctest: +REMOTE_DATA
-    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, iters=5)    # doctest: +REMOTE_DATA
+    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)    # doctest: +REMOTE_DATA
     >>> print((mean, median, std))    # doctest: +REMOTE_DATA, +FLOAT_CMP
-    (3667.7792400186008, 3649.0, 204.27923665845705)
+    (3668.09661145823, 3649.0, 204.41388592022315)
 
 Now we will subtract the background and use an instance of
 :class:`~photutils.DAOStarFinder` to find the stars in the image that
@@ -122,7 +122,9 @@ Regions of the input image can be masked by using the ``mask`` keyword
 with the :class:`~photutils.DAOStarFinder` or
 :class:`~photutils.IRAFStarFinder` instance.  This simple examples
 uses :class:`~photutils.DAOStarFinder` and masks two rectangular
-regions.  No sources will be detected in the masked regions::
+regions.  No sources will be detected in the masked regions:
+
+.. doctest-skip::
 
    >>> from photutils import DAOStarFinder
    >>> daofind = DAOStarFinder(fwhm=3.0, threshold=5.*std)

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -105,6 +105,7 @@ class TestDAOStarFinder:
         Regression test that objects with ``peak`` >= ``peakmax`` are
         filtered out.
         """
+
         peakmax = 20
         starfinder = DAOStarFinder(threshold=7., fwhm=1.5, roundlo=-np.inf,
                                    roundhi=np.inf, sharplo=-np.inf,
@@ -115,8 +116,10 @@ class TestDAOStarFinder:
 
     def test_daofind_brightest_filtering(self):
         """
-        Regression test that only top ``brightest`` objects are selected.
+        Regression test that only top ``brightest`` objects are
+        selected.
         """
+
         brightest = 40
         peakmax = 20
         starfinder = DAOStarFinder(threshold=7., fwhm=1.5, roundlo=-np.inf,
@@ -131,6 +134,16 @@ class TestDAOStarFinder:
                                    peakmax=peakmax)
         t = starfinder(DATA)
         assert len(t) == 37
+
+    def test_daofind_mask(self):
+        """Test DAOStarFinder with a mask."""
+
+        starfinder = DAOStarFinder(threshold=10, fwhm=1.5)
+        mask = np.zeros_like(DATA, dtype=bool)
+        mask[100:200] = True
+        tbl1 = starfinder(DATA)
+        tbl2 = starfinder(DATA, mask=mask)
+        assert len(tbl1) > len(tbl2)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -207,3 +220,13 @@ class TestIRAFStarFinder:
                                     sharphi=np.inf, brightest=brightest)
         t = starfinder(DATA)
         assert len(t) == brightest
+
+    def test_irafstarfind_mask(self):
+        """Test IRAFStarFinder with a mask."""
+
+        starfinder = IRAFStarFinder(threshold=10, fwhm=1.5)
+        mask = np.zeros_like(DATA, dtype=bool)
+        mask[100:200] = True
+        tbl1 = starfinder(DATA)
+        tbl2 = starfinder(DATA, mask=mask)
+        assert len(tbl1) > len(tbl2)


### PR DESCRIPTION
This PR adds a  `mask` keyword to `DAOStarFinder` and     `IRAFStarFinder` that can be used to mask regions of the input image. 