### PR TITLE
Update find_peaks to return empty table with column names if no peaks are found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ API changes
   - The ``find_peaks`` function will no longer issue a RuntimeWarning
     if the input data contains NaNs. [#712]
 
+  - If no sources/peaks are found, ``DAOStarFinder``,
+    ``IRAFStarFinder``, and ``find_peaks`` now will return an empty
+    table with column names and types. [#758, #762]
+
 - ``photutils.epsf``
 
   - The ``Star``, ``Stars``, and ``LinkedStars`` classes are now

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -937,13 +937,11 @@ class DAOStarFinder(StarFinderBase):
                                    exclude_border=self.exclude_border)
         self._star_cutouts = star_cutouts
 
-        columns = ['id', 'xcentroid', 'ycentroid', 'sharpness', 'roundness1',
-                   'roundness2', 'npix', 'sky', 'peak', 'flux', 'mag']
-
-        coltypes = (
-            np.int_, np.float_, np.float_, np.float_, np.float_, np.float_,
-            np.int_, np.float_, np.float_, np.float_, np.float_
-        )
+        columns = ('id', 'xcentroid', 'ycentroid', 'sharpness', 'roundness1',
+                   'roundness2', 'npix', 'sky', 'peak', 'flux', 'mag')
+        coltypes = (np.int_, np.float_, np.float_, np.float_, np.float_,
+                    np.float_, np.int_, np.float_, np.float_, np.float_,
+                    np.float_)
 
         if len(star_cutouts) == 0:
             warnings.warn('No sources were found.', AstropyUserWarning)
@@ -987,7 +985,6 @@ class DAOStarFinder(StarFinderBase):
 
         table = Table()
         table['id'] = np.arange(nstars) + 1
-
         for column in columns[1:]:
             table[column] = [getattr(props, column) for props in star_props]
 
@@ -1170,13 +1167,11 @@ class IRAFStarFinder(StarFinderBase):
                                    exclude_border=self.exclude_border)
         self._star_cutouts = star_cutouts
 
-        columns = ['id', 'xcentroid', 'ycentroid', 'fwhm', 'sharpness',
-                   'roundness', 'pa', 'npix', 'sky', 'peak', 'flux', 'mag']
-
-        coltypes = (
-            np.int_, np.float_, np.float_, np.float_, np.float_, np.float_,
-            np.float_, np.int_, np.float_, np.float_, np.float_, np.float_
-        )
+        columns = ('id', 'xcentroid', 'ycentroid', 'fwhm', 'sharpness',
+                   'roundness', 'pa', 'npix', 'sky', 'peak', 'flux', 'mag')
+        coltypes = (np.int_, np.float_, np.float_, np.float_, np.float_,
+                    np.float_, np.float_, np.int_, np.float_, np.float_,
+                    np.float_, np.float_)
 
         if len(star_cutouts) == 0:
             warnings.warn('No sources were found.', AstropyUserWarning)
@@ -1218,7 +1213,6 @@ class IRAFStarFinder(StarFinderBase):
 
         table = Table()
         table['id'] = np.arange(nstars) + 1
-
         for column in columns[1:]:
             table[column] = [getattr(props, column) for props in star_props]
 

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -132,6 +132,11 @@ class TestFindPeaks:
         assert_array_equal(tbl['y_peak'], PEAKREF1[:, 0])
         assert_array_equal(tbl['peak_value'], [1., 1.])
 
+    def test_centroid_func_and_subpixel(self):
+        with pytest.raises(ValueError):
+            find_peaks(PEAKDATA, 0.1, centroid_func=centroid_com,
+                       subpixel=True)
+
     def test_subpixel_regionsize(self):
         """Test that data cutout has at least 6 values."""
 

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -5,8 +5,6 @@ from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 import warnings
 
-from astropy.table import Table
-
 from ..core import detect_threshold, find_peaks
 from ...centroids import centroid_com
 from ...datasets import make_4gaussians_image, make_wcs
@@ -174,19 +172,7 @@ class TestFindPeaks:
         """Test border exclusion."""
 
         tbl = find_peaks(PEAKDATA, 0.1, box_size=3, border_width=3)
-        assert_array_equal(len(tbl), 0)
-
-    def test_zerodet(self):
-        """Test with large threshold giving no sources."""
-
-        tbl = find_peaks(PEAKDATA, 5., box_size=3, border_width=3)
-        assert_array_equal(len(tbl), 0)
-
-    def test_constant_data(self):
-        """Test constant data."""
-
-        tbl = find_peaks(np.ones((5, 5)), 0.1, box_size=3.)
-        assert_array_equal(len(tbl), 0)
+        assert len(tbl) == 0
 
     def test_box_size_int(self):
         """Test non-integer box_size."""
@@ -221,31 +207,41 @@ class TestFindPeaks:
 
         data = np.ones((10, 10))
         tbl = find_peaks(data, 0.)
-        assert tbl == Table()
+        assert len(tbl) == 0
+        assert set(tbl.colnames) == {'x_peak', 'y_peak', 'peak_value'}
 
     def test_no_peaks(self):
-        """Test for empty output table when no peaks are found."""
+        """
+        Test for an empty output table with the expected column names
+        when no peaks are found.
+        """
 
         data = make_4gaussians_image()
         wcs = make_wcs(data.shape)
 
-        tbl = find_peaks(data, 100000)
-        assert tbl == Table()
+        tbl1 = find_peaks(data, 100)
+        tbl2 = find_peaks(data, 10000)
+        assert set(tbl1.colnames) == set(tbl2.colnames)
 
-        tbl = find_peaks(data, 100000, centroid_func=centroid_com)
-        assert tbl == Table()
+        tbl1 = find_peaks(data, 100, centroid_func=centroid_com)
+        tbl2 = find_peaks(data, 100000, centroid_func=centroid_com)
+        assert set(tbl1.colnames) == set(tbl2.colnames)
 
-        tbl = find_peaks(data, 100000, subpixel=True)
-        assert tbl == Table()
+        tbl1 = find_peaks(data, 100, subpixel=True)
+        tbl2 = find_peaks(data, 100000, subpixel=True)
+        assert set(tbl1.colnames) == set(tbl2.colnames)
 
-        tbl = find_peaks(data, 100000, wcs=wcs)
-        assert tbl == Table()
+        tbl1 = find_peaks(data, 100, wcs=wcs)
+        tbl2 = find_peaks(data, 100000, wcs=wcs)
+        assert set(tbl1.colnames) == set(tbl2.colnames)
 
-        tbl = find_peaks(data, 100000, wcs=wcs, centroid_func=centroid_com)
-        assert tbl == Table()
+        tbl1 = find_peaks(data, 100, wcs=wcs, centroid_func=centroid_com)
+        tbl2 = find_peaks(data, 100000, wcs=wcs, centroid_func=centroid_com)
+        assert set(tbl1.colnames) == set(tbl2.colnames)
 
-        tbl = find_peaks(data, 100000, wcs=wcs, subpixel=True)
-        assert tbl == Table()
+        tbl1 = find_peaks(data, 100, wcs=wcs, subpixel=True)
+        tbl2 = find_peaks(data, 100000, wcs=wcs, subpixel=True)
+        assert set(tbl1.colnames) == set(tbl2.colnames)
 
     def test_data_nans(self):
         """Test that data with NaNs does not issue Runtime warning."""


### PR DESCRIPTION
This PR adds column names and types to `find_peaks` output empty tables if no peaks are found.