### PR TITLE
Do not use deprecated _naxis1/2 for astropy<3.1

### DIFF
--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -9,6 +9,7 @@ from astropy.convolution import discretize_model
 from astropy.io import fits
 from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
+from astropy.version import version as astropy_version
 from astropy.wcs import WCS
 
 from ..utils import check_random_state
@@ -706,8 +707,13 @@ def make_wcs(shape, galactic=False):
     wcs = WCS(naxis=2)
     rho = np.pi / 3.
     scale = 0.1 / 3600.
-    wcs._naxis1 = shape[1]     # nx
-    wcs._naxis2 = shape[0]     # ny
+
+    if astropy_version < '3.1':
+        wcs._naxis1 = shape[1]     # nx
+        wcs._naxis2 = shape[0]     # ny
+    else:
+        wcs.pixel_shape = shape
+
     wcs.wcs.crpix = [shape[1] / 2, shape[0] / 2]     # 1-indexed (x, y)
     wcs.wcs.crval = [197.8925, -1.36555556]
     wcs.wcs.cunit = ['deg', 'deg']

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -6,6 +6,7 @@ import pytest
 
 from astropy.table import Table
 from astropy.modeling.models import Moffat2D
+from astropy.version import version as astropy_version
 
 from .. import (make_noise_image, apply_poisson_noise,
                 make_gaussian_sources_image, make_random_gaussians_table,
@@ -148,8 +149,13 @@ def test_make_random_models_table():
 def test_make_wcs():
     shape = (100, 200)
     wcs = make_wcs(shape)
-    assert wcs._naxis1 == shape[1]
-    assert wcs._naxis2 == shape[0]
+
+    if astropy_version < '3.1':
+        assert wcs._naxis1 == shape[1]
+        assert wcs._naxis2 == shape[0]
+    else:
+        assert wcs.pixel_shape == shape
+
     assert wcs.wcs.radesys == 'ICRS'
 
     wcs = make_wcs(shape, galactic=True)


### PR DESCRIPTION
For `astropy >= 3.1` use the new `pixel_shape` attribute instead of the deprecated private `_naxis[1/2]` attributes.