### PR TITLE
Pin pytest<3.10 for astropy LTS travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ matrix:
           env: ASTROPY_VERSION=lts
                EVENT_TYPE='pull_request push cron'
                NUMPY_VERSION=1.13
+               PIP_DEPENDENCIES='pytest<3.10'
 
         # Test with other Python and numpy versions
         - stage: Comprehensive tests


### PR DESCRIPTION
The `astropy` LTS `travis` test started failing because it started using `pytest 3.10.1`.  Apparently something in `astropy` or `astropy_helpers` LTS is not compatible with `pytest 3.10`.  This pins the `pytest < v3.10`, which will pick up `v3.6.4`.