### PR TITLE
Print astropy_helpers used here rather than in astropy

### DIFF
--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -49,12 +49,13 @@ import os
 # This is to figure out the package version, rather than
 # using Astropy's
 try:
-    from .version import version
+    from .version import version, astropy_helpers_version
 except ImportError:
     version = 'dev'
 
 try:
     packagename = os.path.basename(os.path.dirname(__file__))
     TESTED_VERSIONS[packagename] = version
+    TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version
 except NameError:   # Needed to support Astropy <= 1.0.0
     pass


### PR DESCRIPTION
 to the test header

This is the guinea pig counterpart from the packages side to make use of https://github.com/astropy/astropy/pull/8201

ps: @pllim - if you're happy with this I can add it to the template (with a bit more care to add a the `astropy_helpers_version` in a try/except given that packages may not yet caught up with astropy-helpers 2.0.6/3.0.1 that introduced it)