### PR TITLE
Include setup_requires in package setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
         - SETUP_CMD='test'
         - EVENT_TYPE='push pull_request'
         - SETUP_XVFB=True
+        - MPLBACKEND=Agg
 
         # PEP8 errors/warnings:
         # E101 - mix of tabs and spaces

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,8 @@ edit_on_github = False
 github_project = astropy/photutils
 install_requires = astropy
 version = 0.6.dev
-# Note: you will also need to change this in your package's __init__.py
+# Note: these versions also need to be defined in the package __init__.py
 minimum_python_version = 3.5
+minimum_numpy_version = 1.10
 
 [entry_points]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,15 @@ AUTHOR = metadata.get('author', '')
 AUTHOR_EMAIL = metadata.get('author_email', '')
 LICENSE = metadata.get('license', 'unknown')
 URL = metadata.get('url', '')
-__minimum_python_version__ = metadata.get('minimum_python_version', '3.5')
+
+try:
+    __minimum_python_version__ = metadata['minimum_python_version']
+except KeyError:
+    raise KeyError('minimum_python_version must be defined in setup.cfg')
+try:
+    __minimum_numpy_version__ = metadata['minimum_numpy_version']
+except KeyError:
+    raise KeyError('minimum_numpy_version must be defined in setup.cfg')
 
 # Enforce Python version check - this is the same check as in __init__.py but
 # this one has to happen before importing ah_bootstrap.
@@ -127,6 +135,13 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 # ``setup``, since these are now deprecated. See this link for more details:
 # https://groups.google.com/forum/#!topic/astropy-dev/urYO8ckB2uM
 
+# Make sure to have the packages needed for building photutils, but do
+# not require them when installing from an sdist as the .c files are
+# included there.
+setup_requires = ['numpy>={}'.format(__minimum_numpy_version__)]
+if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
+    setup_requires.extend(['cython>=0.21'])
+
 install_requires = [s.strip() for s in metadata.get(
     'install_requires', 'astropy').split(',')]
 
@@ -134,6 +149,7 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
+      setup_requires=setup_requires,
       install_requires=install_requires,
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ builtins._ASTROPY_SETUP_ = True
 from astropy_helpers.setup_helpers import (register_commands,
                                            get_debug_option,
                                            get_package_info)
+from astropy_helpers.distutils_helpers import is_distutils_display_option
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
@@ -141,6 +142,11 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 setup_requires = ['numpy>={}'.format(__minimum_numpy_version__)]
 if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
     setup_requires.extend(['cython>=0.21'])
+
+# Avoid installing setup_requires dependencies if the user just
+# queries for information
+if is_distutils_display_option():
+    setup_requires = []
 
 install_requires = [s.strip() for s in metadata.get(
     'install_requires', 'astropy').split(',')]


### PR DESCRIPTION
This PR adds `numpy` and `Cython` to `setup_requires` for those building the package from source.