### PR TITLE
Fix aperture_photometry output for a length-1 list of apetures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,14 @@ API changes
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - If a single aperture is input as a list into the
+    ``aperture_photometry`` function, then the output columns will be
+    called ``aperture_sum_0`` and ``aperture_sum_err_0`` (if errors
+    are used).  Previously these column names did not have the
+    trailing "_0". [#779]
+
 - ``photutils.segmentation``
 
   - Fixed a bug in the computation of ``sky_bbox_ul``,

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -880,6 +880,10 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         if (int(subpixels) != subpixels) or (subpixels <= 0):
             raise ValueError('subpixels must be a positive integer.')
 
+    scalar_aperture = False
+    if isinstance(apertures, Aperture):
+        scalar_aperture = True
+
     apertures = np.atleast_1d(apertures)
 
     # convert sky to pixel apertures
@@ -929,7 +933,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
         sum_key = 'aperture_sum'
         sum_err_key = 'aperture_sum_err'
-        if len(apertures) > 1:
+        if not scalar_aperture:
             sum_key += '_{}'.format(i)
             sum_err_key += '_{}'.format(i)
 

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -898,3 +898,26 @@ def test_radius_units():
     ap = SkyCircularAperture(pos, r=r)
     assert ap.r.value == 3.0
     assert ap.r.unit == u.pix
+
+
+def test_scalar_aperture():
+    """
+    Regression test to check that length-1 aperture list appends a "_0"
+    on the column names to be consistent with list inputs.
+    """
+
+    data = np.ones((20, 20), dtype=np.float)
+
+    ap = CircularAperture((10, 10), r=3.)
+    colnames1 = aperture_photometry(data, ap, error=data).colnames
+    assert (colnames1 == ['id', 'xcenter', 'ycenter', 'aperture_sum',
+                          'aperture_sum_err'])
+
+    colnames2 = aperture_photometry(data, [ap], error=data).colnames
+    assert (colnames2 == ['id', 'xcenter', 'ycenter', 'aperture_sum_0',
+                          'aperture_sum_err_0'])
+
+    colnames3 = aperture_photometry(data, [ap, ap], error=data).colnames
+    assert (colnames3 == ['id', 'xcenter', 'ycenter', 'aperture_sum_0',
+                          'aperture_sum_err_0', 'aperture_sum_1',
+                          'aperture_sum_err_1'])


### PR DESCRIPTION
If a single aperture is input as a list into the ``aperture_photometry`` function, then the output columns will be called ``aperture_sum_0`` and ``aperture_sum_err_0`` (if errors are used).  Previously these column names did not have the trailing `_0`.

Fixes #705.