### PR TITLE
Deprecate ESPF pixel scale

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ New Features
   - Added a ``GriddedPSFModel`` class for spatially-dependent PSFs.
     [#772]
 
+  - The ``pixel_scale`` keyword in ``EPSFStar``, ``EPSFBuilder`` and
+    ``EPSFModel`` is now deprecated.  Use the ``oversampling`` keyword
+    instead. [#780]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -12,7 +12,8 @@ import numpy as np
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import (overlap_slices, PartialOverlapError,
                                   NoOverlapError)
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyUserWarning,
+                                      AstropyDeprecationWarning)
 
 from .epsf_stars import EPSFStar, LinkedEPSFStar, EPSFStars
 from .models import EPSFModel
@@ -254,6 +255,12 @@ class EPSFBuilder:
     Parameters
     ----------
     pixel_scale : float or tuple of two floats, optional
+        .. warning::
+
+            The ``pixel_scale`` keyword is now deprecated (since v0.6)
+            and will likely be removed in v0.7.  Use the
+            ``oversampling`` keyword instead.
+
         The pixel scale (in arbitrary units) of the output ePSF.  The
         ``pixel_scale`` can either be a single float or tuple of two
         floats of the form ``(x_pixscale, y_pixscale)``.  If
@@ -343,6 +350,11 @@ class EPSFBuilder:
         if pixel_scale is None and oversampling is None:
             raise ValueError('Either pixel_scale or oversampling must be '
                              'input.')
+
+        if pixel_scale is not None:
+            warnings.warn('The pixel_scale keyword is deprecated and will '
+                          'likely be removed in v0.7.  Use the oversampling '
+                          'keyword instead.', AstropyDeprecationWarning)
 
         self.pixel_scale = self._init_img_params(pixel_scale)
         if oversampling <= 0.0:

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -487,9 +487,11 @@ class EPSFBuilder:
         # FittableImageModel requires a scalar oversampling factor
         oversampling = np.mean(oversampling)
 
-        return EPSFModel(data=data, origin=(xcenter, ycenter),
-                         normalize=False, oversampling=oversampling,
-                         pixel_scale=pixel_scale)
+        epsf = EPSFModel(data=data, origin=(xcenter, ycenter),
+                         normalize=False, oversampling=oversampling)
+        epsf._pixel_scale = pixel_scale
+
+        return epsf
 
     def _resample_residual(self, star, epsf):
         """
@@ -684,9 +686,11 @@ class EPSFBuilder:
         # Define an EPSFModel for the input data.  This EPSFModel will be
         # used to evaluate the model on a shifted pixel grid to place the
         # centroid at the array center.
+        pixel_scale = epsf.pixel_scale
         epsf = EPSFModel(data=epsf_data, origin=epsf.origin, normalize=False,
-                         oversampling=epsf.oversampling,
-                         pixel_scale=epsf.pixel_scale)
+                         oversampling=epsf.oversampling)
+        epsf._pixel_scale = pixel_scale
+
         epsf.fill_value = 0.0
         xcenter, ycenter = epsf.origin
 
@@ -814,9 +818,11 @@ class EPSFBuilder:
         xcenter = (new_epsf.shape[1] - 1) / 2.
         ycenter = (new_epsf.shape[0] - 1) / 2.
 
-        return EPSFModel(data=new_epsf, origin=(xcenter, ycenter),
-                         normalize=False, oversampling=epsf.oversampling,
-                         pixel_scale=epsf.pixel_scale)
+        epsf_new = EPSFModel(data=new_epsf, origin=(xcenter, ycenter),
+                             normalize=False, oversampling=epsf.oversampling)
+        epsf_new._pixel_scale = epsf.pixel_scale
+
+        return epsf_new
 
     def build_epsf(self, stars, init_epsf=None):
         """

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -12,7 +12,8 @@ from astropy.nddata.utils import (overlap_slices, PartialOverlapError,
                                   NoOverlapError)
 from astropy.table import Table
 from astropy.utils import lazyproperty, deprecated
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyUserWarning,
+                                      AstropyDeprecationWarning)
 from astropy.wcs.utils import skycoord_to_pixel
 
 from ..aperture import BoundingBox
@@ -59,6 +60,12 @@ class EPSFStar:
         An optional identification number or label for the star.
 
     pixel_scale : float or tuple of two floats, optional
+        .. warning::
+
+            The ``pixel_scale`` keyword is now deprecated (since v0.6)
+            and will likely be removed in v0.7.  Use the
+            ``oversampling`` keyword instead.
+
         The pixel scale (in arbitrary units) of the input ``data``.  The
         ``pixel_scale`` can either be a single float or tuple of two
         floats of the form ``(x_pixscale, y_pixscale)``.  If
@@ -98,6 +105,11 @@ class EPSFStar:
         self.origin = np.asarray(origin)
         self.wcs_large = wcs_large
         self.id_label = id_label
+
+        if pixel_scale != 1:
+            warnings.warn('The pixel_scale keyword is deprecated and will '
+                          'likely be removed in v0.7.  Use the oversampling '
+                          'keyword instead.', AstropyDeprecationWarning)
 
         pixel_scale = np.atleast_1d(pixel_scale)
         if len(pixel_scale) == 1:

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -10,7 +10,8 @@ import warnings
 import numpy as np
 from astropy.nddata import NDData
 from astropy.modeling import Parameter, Fittable2DModel
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import (AstropyWarning,
+                                      AstropyDeprecationWarning)
 
 
 __all__ = ['NonNormalizable', 'FittableImageModel', 'EPSFModel',
@@ -479,20 +480,17 @@ class FittableImageModel(Fittable2DModel):
 
 class EPSFModel(FittableImageModel):
     """
-    A subclass of `FittableImageModel` that adds a ``pixel_scale``
-    attribute.
-
-    The ``pixel_scale`` can be used in conjunction with the
-    `~photutils.psf.Star` pixel scale when fitting (and building) the
-    PSF.  This allows fitting (and building) a PSF using images of stars
-    with different pixel scales.
-
-    `EPSFModel` has the same parameters as `FittableImageModel` with the
-    addition of a single parameter listed below.
+    A subclass of `FittableImageModel`.
 
     Parameters
     ----------
     pixel_scale : float, tuple of two floats or `None`, optional
+        .. warning::
+
+            The ``pixel_scale`` keyword is now deprecated (since v0.6)
+            and will likely be removed in v0.7.  Use the
+            ``oversampling`` keyword instead.
+
         The pixel scale (in arbitrary units) of the ePSF.  The
         ``pixel_scale`` can either be a single float or tuple of two
         floats of the form ``(x_pixscale, y_pixscale)``.  If
@@ -520,6 +518,10 @@ class EPSFModel(FittableImageModel):
 
         if pixel_scale is None:
             pixel_scale = 1. / oversampling
+        else:
+            warnings.warn('The pixel_scale keyword is deprecated and will '
+                          'likely be removed in v0.7.  Use the oversampling '
+                          'keyword instead.', AstropyDeprecationWarning)
 
         super().__init__(
             data=data, flux=flux, x_0=x_0, y_0=y_0, normalize=normalize,


### PR DESCRIPTION
After discussion with Jay Anderson, the EPSF pixel scale is unnecessary.  This PR deprecates the `pixel_scale` keyword in `EPSModel`, `EPSFStar`, and `EPSFBuilder`.