### PR TITLE
Require numpy >= 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,25 +90,26 @@ matrix:
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
 
-        # Test with Astropy LTS version and the latest Python
+        # Test with Astropy LTS version and older numpy versions
+        # astropy >= 3.1 requires numpy >= 1.13
         - stage: Comprehensive tests
-          env: ASTROPY_VERSION=lts
-               EVENT_TYPE='pull_request push cron'
-               NUMPY_VERSION=1.13
+          env: PYTHON_VERSION=3.5
+               NUMPY_VERSION=1.11
+               ASTROPY_VERSION=lts
                PIP_DEPENDENCIES='pytest<3.10'
+
+        - stage: Comprehensive tests
+          env: NUMPY_VERSION=1.12 ASTROPY_VERSION=lts
+               PIP_DEPENDENCIES='pytest<3.10'
+
+        - stage: Comprehensive tests
+          env: NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
+               PIP_DEPENDENCIES='pytest<3.10'
+               EVENT_TYPE='pull_request push cron'
 
         # Test with other Python and numpy versions
         - stage: Comprehensive tests
           env: PYTHON_VERSION=3.7
-
-        - stage: Comprehensive tests
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
-
-        - stage: Comprehensive tests
-          env: NUMPY_VERSION=1.11
-
-        - stage: Comprehensive tests
-          env: NUMPY_VERSION=1.12
 
         # Test with numpy pre-release version
         - stage: Comprehensive tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.6 (unreleased)
 ----------------
 
+General
+^^^^^^^
+
+ - Versions of Numpy <1.11 are no longer supported. [#783]
+
 New Features
 ^^^^^^^^^^^^
 
@@ -18,12 +23,17 @@ New Features
 
 - ``photutils.psf``
 
+  - The ``Star``, ``Stars``, and ``LinkedStars`` classes are now
+    deprecated and have been renamed ``EPSFStar``, ``EPSFStars``, and
+    ``LinkedEPSFStars``, respectively. [#727]
+
   - Added a ``GriddedPSFModel`` class for spatially-dependent PSFs.
     [#772]
 
   - The ``pixel_scale`` keyword in ``EPSFStar``, ``EPSFBuilder`` and
     ``EPSFModel`` is now deprecated.  Use the ``oversampling`` keyword
     instead. [#780]
+
 
 API changes
 ^^^^^^^^^^^
@@ -42,10 +52,6 @@ API changes
     table with column names and types. [#758, #762]
 
 - ``photutils.psf``
-
-  - The ``Star``, ``Stars``, and ``LinkedStars`` classes are now
-    deprecated and have been renamed ``EPSFStar``, ``EPSFStars``, and
-    ``LinkedEPSFStars``, respectively. [#727]
 
   - The ``photutils.psf.funcs.py`` module was renamed
     ``photutils.psf.utils.py``. The ``prepare_psf_model`` and

--- a/photutils/__init__.py
+++ b/photutils/__init__.py
@@ -17,7 +17,7 @@ from ._astropy_init import *       # noqa
 import sys
 
 __minimum_python_version__ = '3.5'
-__minimum_numpy_version__ = '1.10'
+__minimum_numpy_version__ = '1.11'
 
 
 class UnsupportedPythonError(Exception):

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,6 @@ install_requires = astropy
 version = 0.6.dev
 # Note: these versions also need to be defined in the package __init__.py
 minimum_python_version = 3.5
-minimum_numpy_version = 1.10
+minimum_numpy_version = 1.11
 
 [entry_points]


### PR DESCRIPTION
`travis` started picking up `astropy 3.1` and `2.0.9`, which caused failures because these packages are not built in conda with `numpy 1.10`.  It doesn't seem that we can currently use conda to test `numpy 1.10`.  To solve conda environment issues, this PR bumps the minimum support numpy version to 1.11.