### PR TITLE
Enable raising deprecations

### DIFF
--- a/docs/morphology.rst
+++ b/docs/morphology.rst
@@ -31,7 +31,7 @@ First, we create the source image and subtract its background::
     >>> from photutils.datasets import make_4gaussians_image
     >>> from astropy.stats import sigma_clipped_stats
     >>> data = make_4gaussians_image()[43:79, 76:104]
-    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, iters=5)
+    >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)
     >>> data -= median    # subtract background
 
 Then, calculate its properties:

--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -25,7 +25,7 @@ from astropy.tests.helper import enable_deprecations_as_exceptions
 ## To ignore some specific deprecation warning messages for Python version
 ## MAJOR.MINOR or later, add:
 ##     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
-# enable_deprecations_as_exceptions()
+enable_deprecations_as_exceptions()
 
 # Uncomment and customize the following lines to add/remove entries from
 # the list of packages for which version numbers are displayed when running

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -236,6 +236,12 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         empty table is returned.
     """
 
+    if subpixel:
+        warnings.warn('The subpixel keyword is deprecated and will be '
+                      'removed in a future version.  The centroid_func '
+                      'keyword can be used to calculate centroid positions.',
+                      AstropyDeprecationWarning)
+
     if centroid_func is not None and subpixel:
         raise ValueError('centroid_func and subpixel (deprecated) cannot '
                          'both be used.')
@@ -349,11 +355,6 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         table['x_centroid'] = x_centroids
         table['y_centroid'] = y_centroids
     elif subpixel:
-        warnings.warn('The subpixel keyword is deprecated and will be '
-                      'removed in a future version.  The centroid_func '
-                      'keyword can be used to calculate centroid positions.',
-                      AstropyDeprecationWarning)
-
         from ..centroids import fit_2dgaussian  # prevents circular import
 
         x_centroids, y_centroids = [], []

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -137,8 +137,9 @@ class TestFindPeaks:
 
     def test_centroid_func_and_subpixel(self):
         with pytest.raises(ValueError):
-            find_peaks(PEAKDATA, 0.1, centroid_func=centroid_com,
-                       subpixel=True)
+            with catch_warnings(AstropyDeprecationWarning):
+                find_peaks(PEAKDATA, 0.1, centroid_func=centroid_com,
+                           subpixel=True)
 
     def test_subpixel_regionsize(self):
         """Test that data cutout has at least 6 values."""
@@ -240,11 +241,13 @@ class TestFindPeaks:
 
         with catch_warnings(AstropyDeprecationWarning) as w:
             tbl1 = find_peaks(data, 100, subpixel=True)
-        tbl2 = find_peaks(data, 100000, subpixel=True)
 
         # find_peaks with subpixels uses deprecated cutout_footprint, thus
         # 4 warnings are expected here
         assert len(w) == 4
+
+        with catch_warnings(AstropyDeprecationWarning):
+            tbl2 = find_peaks(data, 100000, subpixel=True)
 
         assert set(tbl1.colnames) == set(tbl2.colnames)
 
@@ -258,7 +261,7 @@ class TestFindPeaks:
 
         with catch_warnings(AstropyDeprecationWarning):
             tbl1 = find_peaks(data, 100, wcs=wcs, subpixel=True)
-        tbl2 = find_peaks(data, 100000, wcs=wcs, subpixel=True)
+            tbl2 = find_peaks(data, 100000, wcs=wcs, subpixel=True)
         assert set(tbl1.colnames) == set(tbl2.colnames)
 
     def test_data_nans(self):

--- a/photutils/utils/tests/test_cutouts.py
+++ b/photutils/utils/tests/test_cutouts.py
@@ -4,6 +4,9 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
 from ..cutouts import cutout_footprint
 
 
@@ -22,12 +25,15 @@ class TestCutoutFootprint:
     def test_dataonly(self):
         data = np.ones((5, 5))
         position = (2, 2)
-        result1 = cutout_footprint(data, position, 3)
-        result2 = cutout_footprint(data, position, footprint=np.ones((3, 3)))
+        with catch_warnings(AstropyDeprecationWarning) as w:
+            result1 = cutout_footprint(data, position, 3)
+            result2 = cutout_footprint(data, position,
+                                       footprint=np.ones((3, 3)))
         assert_allclose(result1[:-2], result2[:-2])
         assert result1[-2] is None
         assert result2[-2] is None
         assert result1[-1] == result2[-1]
+        assert len(w) == 2
 
     def test_mask_error(self):
         data = error = np.ones((5, 5))
@@ -36,26 +42,31 @@ class TestCutoutFootprint:
         box_size1 = 3
         box_size2 = (3, 3)
         footprint = np.ones((3, 3))
-        result1 = cutout_footprint(data, position, box_size1, mask=mask,
-                                   error=error)
-        result2 = cutout_footprint(data, position, box_size2, mask=mask,
-                                   error=error)
-        result3 = cutout_footprint(data, position, box_size1,
-                                   footprint=footprint, mask=mask,
-                                   error=error)
+        with catch_warnings(AstropyDeprecationWarning) as w:
+            result1 = cutout_footprint(data, position, box_size1, mask=mask,
+                                       error=error)
+            result2 = cutout_footprint(data, position, box_size2, mask=mask,
+                                       error=error)
+            result3 = cutout_footprint(data, position, box_size1,
+                                       footprint=footprint, mask=mask,
+                                       error=error)
         assert_allclose(result1[:-1], result2[:-1])
         assert_allclose(result1[:-1], result3[:-1])
         assert result1[-1] == result2[-1]
+        assert len(w) == 3
 
     def test_position_len(self):
         with pytest.raises(ValueError):
-            cutout_footprint(np.ones((3, 3)), [1])
+            with catch_warnings(AstropyDeprecationWarning):
+                cutout_footprint(np.ones((3, 3)), [1])
 
     def test_nofootprint(self):
         with pytest.raises(ValueError):
-            cutout_footprint(np.ones((3, 3)), (1, 1), box_size=None,
-                             footprint=None)
+            with catch_warnings(AstropyDeprecationWarning):
+                cutout_footprint(np.ones((3, 3)), (1, 1), box_size=None,
+                                 footprint=None)
 
     def test_wrongboxsize(self):
         with pytest.raises(ValueError):
-            cutout_footprint(np.ones((3, 3)), (1, 1), box_size=(1, 2, 3))
+            with catch_warnings(AstropyDeprecationWarning):
+                cutout_footprint(np.ones((3, 3)), (1, 1), box_size=(1, 2, 3))


### PR DESCRIPTION
This has been switched off in #608. Instead of disabling it, we can catch the warnings coming from out test suite.

Astropy currently doesn't offer infrastructure to deprecate a keyword, but ideally it should as currently we don't always issue the deprecation warning for e.g.  the usage of `subpixel`. As a workaround, I suggest to move the warning to the top of the function.