### PR TITLE
MNT: Set Cython language level for PY3

### DIFF
--- a/photutils/geometry/circular_overlap.pyx
+++ b/photutils/geometry/circular_overlap.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+#cython: language_level=3
 """
 The functions defined here allow one to determine the exact area of
 overlap of a rectangle and a circle (written by Thomas Robitaille).

--- a/photutils/geometry/core.pxd
+++ b/photutils/geometry/core.pxd
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+#cython: language_level=3
 
 # This file is needed in order to be able to cimport functions into other Cython files
 

--- a/photutils/geometry/core.pyx
+++ b/photutils/geometry/core.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+#cython: language_level=3
 """
 The functions here are the core geometry functions.
 """

--- a/photutils/geometry/elliptical_overlap.pyx
+++ b/photutils/geometry/elliptical_overlap.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+#cython: language_level=3
 """
 The functions defined here allow one to determine the exact area of
 overlap of an ellipse and a triangle (written by Thomas Robitaille).

--- a/photutils/geometry/rectangular_overlap.pyx
+++ b/photutils/geometry/rectangular_overlap.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+#cython: language_level=3
 
 import numpy as np
 cimport numpy as np


### PR DESCRIPTION
Fix #786

I am no Cython expert, so please think about whether this is what you need. At least I don't see any PY2 jobs in your CI, so I don't have to worry about PY2. This patch does get rid of all the language level warnings on my local installation.

p.s. While testing this patch locally, I encountered #787 failures. If the CI here pass, then they are unrelated. ~~If CI here shows the same failures, then they are indeed a side effect of setting Cython language level somehow. Only time will tell...~~ UPDATE: CI passed for this PR.