### PR TITLE
Make setup.py be python 2 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,10 @@
 import glob
 import os
 import sys
-
-from configparser import ConfigParser
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
 
 # Get some values from the setup.cfg
 conf = ConfigParser()


### PR DESCRIPTION
Fixes an issue where an `ImportError` is raised before the warning about the package requiring python 3.5+.  Fixes #793.
