### PR TITLE
Fix corner-case deblending bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,13 @@
 0.7 (unreleased)
 ----------------
 
-- No changes yet
+Bug Fixes
+^^^^^^^^^
+
+- ``photutils.segmentation``
+
+  - Fixed an issue where ``deblend_sources`` could fail for source label
+    512. [#806]
 
 
 0.6 (2018-12-11)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -281,5 +281,5 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
                 segm_tree[j - 1] = SegmentationImage(new_segm)
 
         return SegmentationImage(watershed(-data, segm_tree[0].data,
-                                           mask=segment_img.data,
+                                           mask=segment_img.data.astype(bool),
                                            connectivity=selem))

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -263,7 +263,7 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     if nbranch == 0:
         return segment_img
     else:
-        for j in np.arange(nbranch - 1, 0, -1):
+        for j in range(nbranch - 1, 0, -1):
             intersect_mask = (segm_tree[j].data *
                               segm_tree[j - 1].data).astype(bool)
             intersect_labels = np.unique(segm_tree[j].data[intersect_mask])

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -173,3 +173,17 @@ class TestDeblendSources:
         data[50, 50] = np.nan
         segm2 = deblend_sources(data, self.segm, 5)
         assert segm2.nlabels == 2
+
+    def test_watershed(self):
+        """
+        Regression test to ensure watershed input mask is bool array.
+
+        With scikit-image >= 0.13, the mask must be a bool array.  In
+        particular, if the mask array contains label 512, the watershed
+        algorithm fails.
+        """
+
+        segm = self.segm.copy()
+        segm.relabel(1, 512)
+        result = deblend_sources(self.data, segm, self.npixels)
+        assert result.nlabels == 2

--- a/photutils/utils/convolution.py
+++ b/photutils/utils/convolution.py
@@ -57,7 +57,10 @@ def filter_data(data, kernel, mode='constant', fill_value=0.0,
 
         # NOTE:  astropy.convolution.convolve fails with zero-sum
         # kernels (used in findstars) (cf. astropy #1647)
-        return ndimage.convolve(data, kernel_array, mode=mode,
+        # NOTE: if data is int and kernel is float, ndimage.convolve
+        # will return an int image - here we make the data float so
+        # that a float image is always returned
+        return ndimage.convolve(data.astype(float), kernel_array, mode=mode,
                                 cval=fill_value)
     else:
         return data

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -1,0 +1,68 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+from astropy.convolution import Gaussian2DKernel
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyUserWarning
+
+from ..convolution import filter_data
+from ...datasets import make_100gaussians_image
+
+try:
+    import scipy  # noqa
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+class TestFilterData:
+    def setup_class(self):
+        self.data = make_100gaussians_image()
+        self.kernel = Gaussian2DKernel(3., x_size=3, y_size=3)
+
+    def test_filter_data(self):
+        fdata1 = filter_data(self.data, self.kernel)
+        fdata2 = filter_data(self.data, self.kernel.array)
+        assert_allclose(fdata1, fdata2)
+
+    def test_filter_data_types(self):
+        """
+        Test to ensure output is a float array for integer input data.
+        """
+
+        fdata = filter_data(self.data.astype(int),
+                            self.kernel.array.astype(int))
+        assert fdata.dtype == np.float64
+
+        fdata = filter_data(self.data.astype(int),
+                            self.kernel.array.astype(float))
+        assert fdata.dtype == np.float64
+
+        fdata = filter_data(self.data.astype(float),
+                            self.kernel.array.astype(int))
+        assert fdata.dtype == np.float64
+
+        fdata = filter_data(self.data.astype(float),
+                            self.kernel.array.astype(float))
+        assert fdata.dtype == np.float64
+
+    def test_filter_data_kernel_none(self):
+        """
+        Test for kernel=None.
+        """
+
+        kernel = None
+        fdata = filter_data(self.data, kernel)
+        assert_allclose(fdata, self.data)
+
+    def test_filter_data_check_normalization(self):
+        """
+        Test kernel normalization check.
+        """
+
+        with catch_warnings(AstropyUserWarning) as w:
+            filter_data(self.data, self.kernel, check_normalization=True)
+            assert len(w) == 1


### PR DESCRIPTION
This PR fixes an issue with source deblending that occurs specifically for ~source id=512~ sources whose id number is greater than 255 and a power of 2 when using `scikit-image >= 0.13`.

Fixes #803.