### PR TITLE
Use pip to install scikit-image>0.14.1 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy astropy "pytest<3.7" pytest-astropy pytest-xdist Cython
+          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy astropy pytest pytest-astropy pytest-xdist Cython
       - run:
           name: Run tests
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - CONDA_CHANNELS='astropy-ci-extras astropy'
-        - CONDA_DEPENDENCIES='Cython scipy scikit-image scikit-learn matplotlib'
+        - CONDA_DEPENDENCIES='Cython scipy scikit-learn matplotlib'
+        - PIP_DEPENDENCIES='scikit-image>0.14.1'
         - CONDA_REQUIRED_DEPENDENCIES='Cython'
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
@@ -79,7 +80,7 @@ matrix:
 
         # Check for Sphinx doc build warnings
         - env: SETUP_CMD='build_docs -w'
-               PIP_DEPENDENCIES='sphinx-astropy'
+               PIP_DEPENDENCIES='sphinx-astropy scikit-image>0.14.1'
                EVENT_TYPE='push pull_request cron'
 
         # Test with optional dependencies disabled
@@ -96,15 +97,15 @@ matrix:
           env: PYTHON_VERSION=3.5
                NUMPY_VERSION=1.11
                ASTROPY_VERSION=lts
-               PIP_DEPENDENCIES='pytest<3.10'
+               PIP_DEPENDENCIES='pytest<3.10 scikit-image>0.14.1'
 
         - stage: Comprehensive tests
           env: NUMPY_VERSION=1.12 ASTROPY_VERSION=lts
-               PIP_DEPENDENCIES='pytest<3.10'
+               PIP_DEPENDENCIES='pytest<3.10 scikit-image>0.14.1'
 
         - stage: Comprehensive tests
           env: NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
-               PIP_DEPENDENCIES='pytest<3.10'
+               PIP_DEPENDENCIES='pytest<3.10 scikit-image>0.14.1'
                EVENT_TYPE='pull_request push cron'
 
         # Test with other Python and numpy versions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "Cython scipy matplotlib scikit-image"
+      CONDA_DEPENDENCIES: "Cython scipy matplotlib"
+      PIP_DEPENDENCIES: "scikit-image>0.14.1"
 
 
   matrix:


### PR DESCRIPTION
`scikit-image 0.14.1` is broken (`_validate_lengths` bug) with `numpy >= 1.16`.   `scikit-image 0.14.2` has been released with a fix, but unfortunately it's not yet available in conda.  The PR switches to use `pip` to install the latest `scikit-image`.

This PR also removes a `pytest` restriction in circleci.