### PR TITLE
Add empty sections to changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,15 @@ Bug Fixes
   - Fixed an issue where ``deblend_sources`` could fail for sources
     with labels that are a power of 2 and greater than 255. [#806]
 
+API changes
+^^^^^^^^^^^
+
+-
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-
 
 0.6 (2018-12-11)
 ----------------


### PR DESCRIPTION
This makes a simple change to the changelog to put in the "empty" (i.e., don't have anything yet) sections to the changelog.

I think this is better because it makes it easier for new contributors to see where to put things.  I propose in the future the four sections get moved to whatever the new dev version is and then deleted if empty for the release version.  Am I right that there's not explicit release process docs for photutils, @larrybradley ? If I just missed it this could get added there, but I didn't see it...