### PR TITLE
Removal of pixel_scale from ePSF framework

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,9 @@ API changes
   - ``FittableImageModel`` and subclasses now allow for different ``oversampling``
     factors to be specified in x and y directions. [#834]
 
+  - Removed ``pixel_scale`` keyword from ``EPSFStar``, ``EPSFBuilder``,
+    and ``EPSFModel``. [#815]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -188,34 +188,28 @@ class EPSFFitter:
             x0 = 0
             y0 = 0
 
-        x_oversamp = star.pixel_scale[0] / epsf.pixel_scale[0]
-        y_oversamp = star.pixel_scale[1] / epsf.pixel_scale[1]
-        scaled_data = data / (x_oversamp * y_oversamp)
+        scaled_data = data / epsf._oversampling**2
 
         # define positions in the ePSF oversampled grid
         yy, xx = np.indices(data.shape, dtype=np.float)
-        xx = (xx - (star.cutout_center[0] - x0)) * x_oversamp
-        yy = (yy - (star.cutout_center[1] - y0)) * y_oversamp
+        xx = (xx - (star.cutout_center[0] - x0)) * epsf._oversampling
+        yy = (yy - (star.cutout_center[1] - y0)) * epsf._oversampling
 
         # define the initial guesses for fitted flux and shifts
         epsf.flux = star.flux
         epsf.x_0 = 0.0
         epsf.y_0 = 0.0
 
-        # The oversampling factor is used in the FittableImageModel
-        # evaluate method (which is use when fitting).  We do not want
-        # to use oversampling here because it has been set by the ratio
-        # of the ePSF and EPSFStar pixel scales.  This allows for
-        # oversampling factors that differ between stars and also for
-        # the factor to be different along the x and y axes.
-        epsf._oversampling = np.array([1., 1.])
+        # create copy to avoid overwriting original oversampling factor
+        _epsf = epsf.copy()
+        _epsf._oversampling = np.array([1., 1.])
 
         try:
-            fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=scaled_data,
+            fitted_epsf = fitter(model=_epsf, x=xx, y=yy, z=scaled_data,
                                  weights=weights, **fitter_kwargs)
         except TypeError:
             # fitter doesn't support weights
-            fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=scaled_data,
+            fitted_epsf = fitter(model=_epsf, x=xx, y=yy, z=scaled_data,
                                  **fitter_kwargs)
 
         fit_error_status = 0
@@ -229,9 +223,9 @@ class EPSFFitter:
 
         # compute the star's fitted position
         x_center = (star.cutout_center[0] +
-                    (fitted_epsf.x_0.value / x_oversamp))
+                    (fitted_epsf.x_0.value / epsf._oversampling))
         y_center = (star.cutout_center[1] +
-                    (fitted_epsf.y_0.value / y_oversamp))
+                    (fitted_epsf.y_0.value / epsf._oversampling))
 
         star = copy.deepcopy(star)
         star.cutout_center = (x_center, y_center)
@@ -254,35 +248,9 @@ class EPSFBuilder:
 
     Parameters
     ----------
-    pixel_scale : float or tuple of two floats, optional
-        .. warning::
-
-            The ``pixel_scale`` keyword is now deprecated (since v0.6)
-            and will likely be removed in v0.7.  Use the
-            ``oversampling`` keyword instead.
-
-        The pixel scale (in arbitrary units) of the output ePSF.  The
-        ``pixel_scale`` can either be a single float or tuple of two
-        floats of the form ``(x_pixscale, y_pixscale)``.  If
-        ``pixel_scale`` is a scalar then the pixel scale will be the
-        same for both the x and y axes.  The ePSF ``pixel_scale`` is
-        used in conjunction with the star pixel scale when building and
-        fitting the ePSF.  This allows for building (and fitting) a ePSF
-        using images of stars with different pixel scales (e.g. velocity
-        aberrations).  Either ``oversampling`` or ``pixel_scale`` must
-        be input.  If both are input, ``pixel_scale`` will override the
-        input ``oversampling``.
-
-    oversampling : float or tuple of two floats, optional
-        The oversampling factor(s) of the ePSF relative to the input
-        ``stars`` along the x and y axes.  The ``oversampling`` can
-        either be a single float or a tuple of two floats of the form
-        ``(x_oversamp, y_oversamp)``.  If ``oversampling`` is a scalar
-        then the oversampling will be the same for both the x and y
-        axes.  The ``oversampling`` factor will be used with the minimum
-        pixel scale of all input stars to calculate the ePSF pixel
-        scale.  Either ``oversampling`` or ``pixel_scale`` must be
-        input.  If both are input, ``oversampling`` will be ignored.
+    oversampling : float, optional
+        The oversampling factor of the ePSF relative to the input
+        ``stars`` along the x and y axes.
 
     shape : float, tuple of two floats, or `None`, optional
         The shape of the output ePSF.  If the ``shape`` is not `None`,
@@ -341,22 +309,11 @@ class EPSFBuilder:
         The default is `True`.
     """
 
-    def __init__(self, pixel_scale=None, oversampling=4., shape=None,
-                 smoothing_kernel='quartic', recentering_func=centroid_com,
-                 recentering_boxsize=(5, 5), recentering_maxiters=20,
-                 fitter=EPSFFitter(), center_accuracy=1.0e-3, maxiters=10,
-                 progress_bar=True):
+    def __init__(self, oversampling=4., shape=None, smoothing_kernel='quartic',
+                 recentering_func=centroid_com, recentering_boxsize=(5, 5),
+                 recentering_maxiters=20, fitter=EPSFFitter(), center_accuracy=1.0e-3,
+                 maxiters=10, progress_bar=True):
 
-        if pixel_scale is None and oversampling is None:
-            raise ValueError('Either pixel_scale or oversampling must be '
-                             'input.')
-
-        if pixel_scale is not None:
-            warnings.warn('The pixel_scale keyword is deprecated and will '
-                          'likely be removed in v0.7.  Use the oversampling '
-                          'keyword instead.', AstropyDeprecationWarning)
-
-        self.pixel_scale = self._init_img_params(pixel_scale)
         if oversampling <= 0.0:
             raise ValueError('oversampling must be a positive number.')
         self.oversampling = oversampling
@@ -420,9 +377,7 @@ class EPSFBuilder:
         """
         Create an initial `EPSFModel` object.
 
-        The initial ePSF data are all zeros.  The ePSF pixel scale is
-        determined either from the ``pixel_scale`` or ``oversampling``
-        values.
+        The initial ePSF data are all zeros.
 
         If ``shape`` is not specified, the shape of the ePSF data array
         is determined from the shape of the input ``stars`` and the
@@ -441,29 +396,11 @@ class EPSFBuilder:
             The initial ePSF model.
         """
 
-        pixel_scale = self.pixel_scale
         oversampling = self.oversampling
         shape = self.shape
 
-        if pixel_scale is None and oversampling is None:
-            raise ValueError('Either pixel_scale or oversampling must be '
-                             'input.')
-
-        # define the ePSF pixel scale
-        if pixel_scale is not None:
-            pixel_scale = np.atleast_1d(pixel_scale).astype(float)
-            if len(pixel_scale) == 1:
-                pixel_scale = np.repeat(pixel_scale, 2)
-
-            oversampling = (stars._min_pixel_scale[0] / pixel_scale[0],
-                            stars._min_pixel_scale[1] / pixel_scale[1])
-        else:
-            oversampling = np.atleast_1d(oversampling).astype(float)
-            if len(oversampling) == 1:
-                oversampling = np.repeat(oversampling, 2)
-
-            pixel_scale = (stars._min_pixel_scale[0] / oversampling[0],
-                           stars._min_pixel_scale[1] / oversampling[1])
+        if oversampling is None:
+            raise ValueError('Oversampling must be input.')
 
         # define the ePSF shape
         if shape is not None:
@@ -472,9 +409,9 @@ class EPSFBuilder:
                 shape = np.repeat(shape, 2)
         else:
             x_shape = np.int(np.ceil(stars._max_shape[0] *
-                                     oversampling[1]))
+                                     oversampling))
             y_shape = np.int(np.ceil(stars._max_shape[1] *
-                                     oversampling[0]))
+                                     oversampling))
             shape = np.array((y_shape, x_shape))
 
         # ensure odd sizes
@@ -484,12 +421,8 @@ class EPSFBuilder:
         xcenter = (shape[1] - 1) / 2.
         ycenter = (shape[0] - 1) / 2.
 
-        # FittableImageModel requires a scalar oversampling factor
-        oversampling = np.mean(oversampling)
-
         epsf = EPSFModel(data=data, origin=(xcenter, ycenter),
                          normalize=False, oversampling=oversampling)
-        epsf._pixel_scale = pixel_scale
 
         return epsf
 
@@ -521,10 +454,8 @@ class EPSFBuilder:
 
         # find the integer index of EPSFStar pixels in the oversampled
         # ePSF grid
-        x_oversamp = star.pixel_scale[0] / epsf.pixel_scale[0]
-        y_oversamp = star.pixel_scale[1] / epsf.pixel_scale[1]
-        x = x_oversamp * star._xidx_centered
-        y = y_oversamp * star._yidx_centered
+        x = epsf._oversampling * star._xidx_centered
+        y = epsf._oversampling * star._yidx_centered
         epsf_xcenter, epsf_ycenter = epsf.origin
         xidx = _py2intround(x + epsf_xcenter)
         yidx = _py2intround(y + epsf_ycenter)
@@ -540,8 +471,7 @@ class EPSFBuilder:
         # normalized residual image in the oversampled ePSF grid.
         # [(star - (epsf * xov * yov)) / (xov * yov)]
         # --> [(star / (xov * yov)) - epsf]
-        stardata = ((star._data_values_normalized /
-                     (x_oversamp * y_oversamp)) -
+        stardata = ((star._data_values_normalized / epsf._oversampling**2) -
                     epsf.evaluate(x=x, y=y, flux=1.0, x_0=0.0, y_0=0.0,
                                   use_oversampling=False))
 
@@ -686,10 +616,8 @@ class EPSFBuilder:
         # Define an EPSFModel for the input data.  This EPSFModel will be
         # used to evaluate the model on a shifted pixel grid to place the
         # centroid at the array center.
-        pixel_scale = epsf.pixel_scale
         epsf = EPSFModel(data=epsf_data, origin=epsf.origin, normalize=False,
                          oversampling=epsf.oversampling)
-        epsf._pixel_scale = pixel_scale
 
         epsf.fill_value = 0.0
         xcenter, ycenter = epsf.origin
@@ -820,7 +748,6 @@ class EPSFBuilder:
 
         epsf_new = EPSFModel(data=new_epsf, origin=(xcenter, ycenter),
                              normalize=False, oversampling=epsf.oversampling)
-        epsf_new._pixel_scale = epsf.pixel_scale
 
         return epsf_new
 

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -196,10 +196,10 @@ class EPSFStar:
         """
 
         yy, xx = np.indices(self.shape, dtype=np.float)
-        xx = epsf._oversampling * (xx - self.cutout_center[0])
-        yy = epsf._oversampling * (yy - self.cutout_center[1])
+        xx = epsf._oversampling[0] * (xx - self.cutout_center[0])
+        yy = epsf._oversampling[1] * (yy - self.cutout_center[1])
 
-        return (self.flux * epsf._oversampling**2 *
+        return (self.flux * np.prod(epsf._oversampling) *
                 epsf.evaluate(xx, yy, flux=1.0, x_0=0.0, y_0=0.0))
 
     def compute_residual_image(self, epsf):

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -489,75 +489,17 @@ class FittableImageModel(Fittable2DModel):
 
 class EPSFModel(FittableImageModel):
     """
-    A subclass of `FittableImageModel`.
-
-    Parameters
-    ----------
-    pixel_scale : float, tuple of two floats or `None`, optional
-        .. warning::
-
-            The ``pixel_scale`` keyword is now deprecated (since v0.6)
-            and will likely be removed in v0.7.  Use the
-            ``oversampling`` keyword instead.
-
-        The pixel scale (in arbitrary units) of the ePSF.  The
-        ``pixel_scale`` can either be a single float or tuple of two
-        floats of the form ``(x_pixscale, y_pixscale)``.  If
-        ``pixel_scale`` is a scalar then the pixel scale will be the
-        same for both the x and y axes.  The default is `None`, which
-        means it will be set to the inverse of the ``oversampling``
-        factor.
-
-        The ePSF ``pixel_scale`` is used only when building the ePSF and
-        when fitting the ePSF to `Star` objects with `EPSFFitter`.  In
-        those cases, the ``pixel_scale`` is used in conjunction with the
-        `Star` pixel scale when building and fitting the ePSF.  This
-        allows for building (and fitting) a ePSF using images of stars
-        with different pixel scales (e.g. velocity aberrations).  The
-        ``oversampling`` factor is ignored in these cases.
-
-        If you are not using `EPSFBuilder` or `EPSFFitter`, then you
-        must set the ``oversampling`` factor.  The ``pixel_scale`` will
-        be ignored.
+    A subclass of `FittableImageModel`. A fittable ePSF model.
     """
 
     def __init__(self, data, flux=1.0, x_0=0, y_0=0, normalize=True,
                  normalization_correction=1.0, origin=None, oversampling=1.,
-                 pixel_scale=None, fill_value=0., ikwargs={}):
-
-        if pixel_scale is None:
-            pixel_scale = 1. / oversampling
-        else:
-            warnings.warn('The pixel_scale keyword is deprecated and will '
-                          'likely be removed in v0.7.  Use the oversampling '
-                          'keyword instead.', AstropyDeprecationWarning)
+                 fill_value=0., ikwargs={}):
 
         super().__init__(
             data=data, flux=flux, x_0=x_0, y_0=y_0, normalize=normalize,
             normalization_correction=normalization_correction, origin=origin,
             oversampling=oversampling, fill_value=fill_value, ikwargs=ikwargs)
-
-        self._pixel_scale = pixel_scale
-
-    @property
-    def pixel_scale(self):
-        """
-        The ``(x, y)`` pixel scale (in arbitrary units) of the PSF.
-        """
-
-        return self._pixel_scale
-
-    @pixel_scale.setter
-    def pixel_scale(self, pixel_scale):
-        if pixel_scale is not None:
-            pixel_scale = np.atleast_1d(pixel_scale)
-            if len(pixel_scale) == 1:
-                pixel_scale = np.repeat(pixel_scale, 2).astype(float)
-            elif len(pixel_scale) > 2:
-                raise ValueError('pixel_scale must be a scalar or tuple '
-                                 'of two floats.')
-
-        self._pixel_scale = pixel_scale
 
 
 class GriddedPSFModel(Fittable2DModel):


### PR DESCRIPTION
This pull request removes any reference to ``pixel_scale`` from ``EPSFModel``, ``EPSFBuilder``, and ``EPSFStar``, instead only using ``oversampling`` to define the relative grid sizes and ePSF pixel scale.

It is part of a larger PR refactor as part of #725 along with #816 and #817, and I leave the PR available for context and the discussions therein as to how these PRs relate to one another.

cc: @larrybradley @eteq 