### PR TITLE
Extended Centroid Functionality to Handle Oversampled Grids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,10 @@ New Features
 
   - Added ``NoDetectionsWarning`` class. [#836]
 
+- ``photutils.psf``
+
+  - Added new centroiding function ``centroid_epsf``. [#816]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -175,6 +175,8 @@ API changes
   - Removed ``pixel_scale`` keyword from ``EPSFStar``, ``EPSFBuilder``,
     and ``EPSFModel``. [#815]
 
+  - Added ``oversampling`` keyword to ``centroid_com``. [#816]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -496,7 +496,7 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
 def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     """
     Calculates centering shift of data using pixel symmetry, as described by Anderson
-    and King (2000; PASP 112, 1360).
+    and King (2000; PASP 112, 1360) in their ePSF-fitting algorithm.
 
     Calculate the shift of a 2-dimensional symmetric image based on the asymmetry between
     f(x, N) and f(x, -N), along with the differential df/dy(x, shift_val) and

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -19,7 +19,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ['GaussianConst2D', 'centroid_com', 'gaussian1d_moments',
            'fit_2dgaussian', 'centroid_1dg', 'centroid_2dg',
-           'centroid_sources']
+           'centroid_sources', 'centroid_epsf']
 
 
 class GaussianConst2D(Fittable2DModel):
@@ -71,7 +71,7 @@ class GaussianConst2D(Fittable2DModel):
 GaussianConst2D.__doc__ += CONSTRAINTS_DOC
 
 
-def centroid_com(data, mask=None):
+def centroid_com(data, mask=None, oversampling=1.):
     """
     Calculate the centroid of an n-dimensional array as its "center of
     mass" determined from moments.
@@ -113,7 +113,7 @@ def centroid_com(data, mask=None):
     indices = np.ogrid[[slice(0, i) for i in data.shape]]
 
     # note the output array is reversed to give (x, y) order
-    return np.array([np.sum(indices[axis] * data) / total
+    return np.array([np.sum(indices[axis] * data) / total / oversampling
                      for axis in range(data.ndim)])[::-1]
 
 
@@ -479,3 +479,91 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
         ycentroids.append(ycen + slices_large[0].start)
 
     return np.array(xcentroids), np.array(ycentroids)
+
+
+def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
+    """
+    Calculate the centroid shift of a 2-dimensional symmetric image by computing
+    the shift based on the asymmetry between f(x, N) and f(x, -N), along with the
+    differential df/dy(x, shift_val) and df/dy(x, -shift_val). Based on Anderson
+    and King (2000; PASP 112, 1360)
+    Invalid values (e.g. NaNs or infs) in the ``data`` array are
+    automatically masked.
+
+    Parameters
+    ----------
+    data : array_like
+        The input n-dimensional array.
+    mask : array_like (bool), optional
+        A boolean mask, with the same shape as ``data``, where a `True`
+        value indicates the corresponding element of ``data`` is masked.
+    oversampling : float, optional
+        The oversampling rate the image is evaluated at. Used to construct x and y
+        from data shape if x and y are not supplied.
+    shift_val : float, optional
+        The undersampled value at which to compute the shifts. Default is half a
+        pixel. If supplied, must be a strictly positive number.
+    Returns
+    -------
+    centroid : tuple of floats
+        The (x, y) coordinates of the centroid in pixel order.
+    """
+
+    data = data.astype(np.float)
+
+    if mask is not None and mask is not np.ma.nomask:
+        mask = np.asarray(mask, dtype=bool)
+        if data.shape != mask.shape:
+            raise ValueError('data and mask must have the same shape.')
+        data[mask] = 0.
+
+    if shift_val <= 0:
+        raise ValueError('shift_val must be a positive number.')
+
+    if oversampling is None:
+        raise ValueError('oversampling must be supplied.')
+
+    # Assume the center of the ePSF is the middle of an odd-sized grid.
+    xidx_0 = int((data.shape[1] - 1) / 2)
+    x_0 = np.arange(data.shape[1], dtype=float)[xidx_0] / oversampling
+    yidx_0 = int((data.shape[0] - 1) / 2)
+    y_0 = np.arange(data.shape[0], dtype=float)[yidx_0] / oversampling
+
+    x_shiftidx = np.around((shift_val * oversampling)).astype(int)
+    y_shiftidx = np.around((shift_val * oversampling)).astype(int)
+
+    badidx = ~np.isfinite([data[y, x] for x in [xidx_0, xidx_0+x_shiftidx, xidx_0+x_shiftidx-1, xidx_0+x_shiftidx+1] for y in [yidx_0, yidx_0+y_shiftidx, yidx_0+y_shiftidx-1, yidx_0+y_shiftidx+1]])
+    if np.any(badidx):
+        raise ValueError('One or more centroiding pixels is set to a bad value, '
+                         'e.g., NaN or inf.')
+
+    # In Anderson & King (2000) notation this is psi_E(0.5, 0.0) and values used to
+    # compute derivatives.
+    psi_pos_x = data[yidx_0, xidx_0 + x_shiftidx]
+    psi_pos_x_m1 = data[yidx_0, xidx_0 + x_shiftidx - 1]
+    psi_pos_x_p1 = data[yidx_0, xidx_0 + x_shiftidx + 1]
+    # Our derivatives are simple differences across two data points, but this must
+    # be in units of the undersampled grid, so 2 pixels becomes 2/oversampling pixels
+    dpsi_pos_x = np.abs(psi_pos_x_p1 - psi_pos_x_m1) / (2. / oversampling)
+    # psi_E(-0.5, 0.0) and derivative components.
+    psi_neg_x = data[yidx_0, xidx_0 - x_shiftidx]
+    psi_neg_x_m1 = data[yidx_0, xidx_0 - x_shiftidx - 1]
+    psi_neg_x_p1 = data[yidx_0, xidx_0 - x_shiftidx + 1]
+    dpsi_neg_x = np.abs(psi_neg_x_p1 - psi_neg_x_m1) / (2. / oversampling)
+
+    x_shift = (psi_pos_x - psi_neg_x) / (dpsi_pos_x + dpsi_neg_x)
+
+    # psi_E(0.0, 0.5) and derivatives.
+    psi_pos_y = data[yidx_0 + y_shiftidx, xidx_0]
+    psi_pos_y_m1 = data[yidx_0 + y_shiftidx - 1, xidx_0]
+    psi_pos_y_p1 = data[yidx_0 + y_shiftidx + 1, xidx_0]
+    dpsi_pos_y = np.abs(psi_pos_y_p1 - psi_pos_y_m1) / (2. / oversampling)
+    # psi_E(0.0, -0.5) and derivative components.
+    psi_neg_y = data[yidx_0 - y_shiftidx, xidx_0]
+    psi_neg_y_m1 = data[yidx_0 - y_shiftidx - 1, xidx_0]
+    psi_neg_y_p1 = data[yidx_0 - y_shiftidx + 1, xidx_0]
+    dpsi_neg_y = np.abs(psi_neg_y_p1 - psi_neg_y_m1) / (2. / oversampling)
+
+    y_shift = (psi_pos_y - psi_neg_y) / (dpsi_pos_y + dpsi_neg_y)
+
+    return x_0+x_shift, y_0+y_shift

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -88,6 +88,11 @@ def centroid_com(data, mask=None, oversampling=1.):
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
+    oversampling : float or tuple of two floats, optional
+        Oversampling factors of pixel indices. If ``oversampling`` is a scalar
+        this is treated as both x and y directions having the same oversampling
+        factor; otherwise it is treated as ``(x_oversamp, y_oversamp)``.
+
     Returns
     -------
     centroid : `~numpy.ndarray`
@@ -95,6 +100,13 @@ def centroid_com(data, mask=None, oversampling=1.):
         or ``(x, y, z)``), not numpy axis order.
     """
 
+    oversampling = np.atleast_1d(oversampling)
+    if len(oversampling) == 1:
+        oversampling = np.repeat(oversampling, 2)
+    # as these need to match data we reverse the order to (y, x)
+    oversampling = oversampling[::-1]
+    if np.any(oversampling <= 0):
+        raise ValueError('Oversampling factors must all be positive numbers.')
     data = data.astype(np.float)
 
     if mask is not None and mask is not np.ma.nomask:
@@ -113,7 +125,7 @@ def centroid_com(data, mask=None, oversampling=1.):
     indices = np.ogrid[[slice(0, i) for i in data.shape]]
 
     # note the output array is reversed to give (x, y) order
-    return np.array([np.sum(indices[axis] * data) / total / oversampling
+    return np.array([np.sum(indices[axis] * data) / total / oversampling[axis]
                      for axis in range(data.ndim)])[::-1]
 
 
@@ -483,11 +495,12 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
 
 def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     """
-    Calculate the centroid shift of a 2-dimensional symmetric image by computing
-    the shift based on the asymmetry between f(x, N) and f(x, -N), along with the
-    differential df/dy(x, shift_val) and df/dy(x, -shift_val). Based on Anderson
-    and King (2000; PASP 112, 1360)
-    Invalid values (e.g. NaNs or infs) in the ``data`` array are
+    Calculates centering shift of data using pixel symmetry, as described by Anderson
+    and King (2000; PASP 112, 1360).
+
+    Calculate the shift of a 2-dimensional symmetric image based on the asymmetry between
+    f(x, N) and f(x, -N), along with the differential df/dy(x, shift_val) and
+    df/dy(x, -shift_val). Invalid values (e.g. NaNs or infs) in the ``data`` array are
     automatically masked.
 
     Parameters
@@ -497,17 +510,25 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     mask : array_like (bool), optional
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
-    oversampling : float, optional
-        The oversampling rate the image is evaluated at. Used to construct x and y
-        from data shape if x and y are not supplied.
+    oversampling : float or tuple of two floats, optional
+        Oversampling factors of pixel indices. If ``oversampling`` is a scalar
+        this is treated as both x and y directions having the same oversampling
+        factor; otherwise it is treated as ``(x_oversamp, y_oversamp)``.
     shift_val : float, optional
         The undersampled value at which to compute the shifts. Default is half a
         pixel. If supplied, must be a strictly positive number.
+
     Returns
     -------
     centroid : tuple of floats
         The (x, y) coordinates of the centroid in pixel order.
     """
+
+    oversampling = np.atleast_1d(oversampling)
+    if len(oversampling) == 1:
+        oversampling = np.repeat(oversampling, 2)
+    if np.any(oversampling <= 0):
+        raise ValueError('Oversampling factors must all be positive numbers.')
 
     data = data.astype(np.float)
 
@@ -520,19 +541,19 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     if shift_val <= 0:
         raise ValueError('shift_val must be a positive number.')
 
-    if oversampling is None:
-        raise ValueError('oversampling must be supplied.')
-
     # Assume the center of the ePSF is the middle of an odd-sized grid.
     xidx_0 = int((data.shape[1] - 1) / 2)
-    x_0 = np.arange(data.shape[1], dtype=float)[xidx_0] / oversampling
+    x_0 = np.arange(data.shape[1], dtype=float)[xidx_0] / oversampling[0]
     yidx_0 = int((data.shape[0] - 1) / 2)
-    y_0 = np.arange(data.shape[0], dtype=float)[yidx_0] / oversampling
+    y_0 = np.arange(data.shape[0], dtype=float)[yidx_0] / oversampling[1]
 
-    x_shiftidx = np.around((shift_val * oversampling)).astype(int)
-    y_shiftidx = np.around((shift_val * oversampling)).astype(int)
+    x_shiftidx = np.around((shift_val * oversampling[0])).astype(int)
+    y_shiftidx = np.around((shift_val * oversampling[0])).astype(int)
 
-    badidx = ~np.isfinite([data[y, x] for x in [xidx_0, xidx_0+x_shiftidx, xidx_0+x_shiftidx-1, xidx_0+x_shiftidx+1] for y in [yidx_0, yidx_0+y_shiftidx, yidx_0+y_shiftidx-1, yidx_0+y_shiftidx+1]])
+    badidx = ~np.isfinite([data[y, x] for x in [xidx_0, xidx_0+x_shiftidx, xidx_0+x_shiftidx-1,
+                                                xidx_0+x_shiftidx+1]
+                           for y in [yidx_0, yidx_0+y_shiftidx, yidx_0+y_shiftidx-1,
+                                     yidx_0+y_shiftidx+1]])
     if np.any(badidx):
         raise ValueError('One or more centroiding pixels is set to a bad value, '
                          'e.g., NaN or inf.')
@@ -544,12 +565,12 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     psi_pos_x_p1 = data[yidx_0, xidx_0 + x_shiftidx + 1]
     # Our derivatives are simple differences across two data points, but this must
     # be in units of the undersampled grid, so 2 pixels becomes 2/oversampling pixels
-    dpsi_pos_x = np.abs(psi_pos_x_p1 - psi_pos_x_m1) / (2. / oversampling)
+    dpsi_pos_x = np.abs(psi_pos_x_p1 - psi_pos_x_m1) / (2. / oversampling[0])
     # psi_E(-0.5, 0.0) and derivative components.
     psi_neg_x = data[yidx_0, xidx_0 - x_shiftidx]
     psi_neg_x_m1 = data[yidx_0, xidx_0 - x_shiftidx - 1]
     psi_neg_x_p1 = data[yidx_0, xidx_0 - x_shiftidx + 1]
-    dpsi_neg_x = np.abs(psi_neg_x_p1 - psi_neg_x_m1) / (2. / oversampling)
+    dpsi_neg_x = np.abs(psi_neg_x_p1 - psi_neg_x_m1) / (2. / oversampling[0])
 
     x_shift = (psi_pos_x - psi_neg_x) / (dpsi_pos_x + dpsi_neg_x)
 
@@ -557,12 +578,12 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     psi_pos_y = data[yidx_0 + y_shiftidx, xidx_0]
     psi_pos_y_m1 = data[yidx_0 + y_shiftidx - 1, xidx_0]
     psi_pos_y_p1 = data[yidx_0 + y_shiftidx + 1, xidx_0]
-    dpsi_pos_y = np.abs(psi_pos_y_p1 - psi_pos_y_m1) / (2. / oversampling)
+    dpsi_pos_y = np.abs(psi_pos_y_p1 - psi_pos_y_m1) / (2. / oversampling[1])
     # psi_E(0.0, -0.5) and derivative components.
     psi_neg_y = data[yidx_0 - y_shiftidx, xidx_0]
     psi_neg_y_m1 = data[yidx_0 - y_shiftidx - 1, xidx_0]
     psi_neg_y_p1 = data[yidx_0 - y_shiftidx + 1, xidx_0]
-    dpsi_neg_y = np.abs(psi_neg_y_p1 - psi_neg_y_m1) / (2. / oversampling)
+    dpsi_neg_y = np.abs(psi_neg_y_p1 - psi_neg_y_m1) / (2. / oversampling[1])
 
     y_shift = (psi_pos_y - psi_neg_y) / (dpsi_pos_y + dpsi_neg_y)
 


### PR DESCRIPTION
This pull request allows ``centroid_com`` to be used on grids with oversampled pixel indices, returning a centre of mass on the original pixel scale (e.g., a 100x100 pixel grid with ``oversampling=4`` would have a centre of 12.5, not 50).

It also includes a new centroiding method, ``centroid_epsf``, based on the methodology laid out in Anderson & King (2000) for centroiding ePSFs based on their symmetries.



It is part of a larger PR refactor as part of #725 along with #815 and #817, and I leave the PR available for context and the discussions therein as to how these PRs relate to one another. In particular, this PR laids down the groundwork for #817 in which the ePSF framework changes the way it handles oversampled and undersampled grid pixel indices, with necessary changes to the centroiding methods used during ePSF creation in ``EPSFBuilder``.