### PR TITLE
Fixes to ePSF Framework: Normalization Handling & ePSF Building

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,9 @@ Bug Fixes
   - A ValueError is raised if ``aperture_radius`` is not input and
     cannot be determined from the input ``psf_model``. [#903]
 
+  - Fixed normalization of ePSF model, now correctly normalizing on
+    undersampled pixel grid. [#817]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where ``deblend_sources`` could fail for sources

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -256,8 +256,7 @@ class EPSFBuilder:
         pixel.
 
     norm_radius : float, optional
-        The pixel radius over which the ePSF is normalized. If `None` or
-        not provided, defaults to 5.5 pixels.
+        The pixel radius over which the ePSF is normalized. Defaults to 5.5 pix.
 
     smoothing_kernel : {'quartic', 'quadratic'}, 2D `~numpy.ndarray`, or `None`
         The smoothing kernel to apply to the ePSF.  The predefined

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from .epsf_stars import EPSFStar, EPSFStars, LinkedEPSFStar
 from .models import EPSFModel
-from ..centroids import centroid_com
+from ..centroids import centroid_epsf
 from ..extern.sigma_clipping import SigmaClip
 
 try:
@@ -185,28 +185,24 @@ class EPSFFitter:
             x0 = 0
             y0 = 0
 
-        scaled_data = data / np.prod(epsf._oversampling)
-
-        # define positions in the ePSF oversampled grid
+        # Define positions in the undersampled grid. The fitter will
+        # evaluate on the defined interpolation grid, currently in the
+        # range [0, len(undersampled grid)].
         yy, xx = np.indices(data.shape, dtype=np.float)
-        xx = (xx - (star.cutout_center[0] - x0)) * epsf._oversampling[0]
-        yy = (yy - (star.cutout_center[1] - y0)) * epsf._oversampling[1]
+        xx = xx + x0 - star.cutout_center[0]
+        yy = yy + y0 - star.cutout_center[1]
 
         # define the initial guesses for fitted flux and shifts
         epsf.flux = star.flux
         epsf.x_0 = 0.0
         epsf.y_0 = 0.0
 
-        # create copy to avoid overwriting original oversampling factor
-        _epsf = epsf.copy()
-        _epsf._oversampling = np.array([1., 1.])
-
         try:
-            fitted_epsf = fitter(model=_epsf, x=xx, y=yy, z=scaled_data,
+            fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=data,
                                  weights=weights, **fitter_kwargs)
         except TypeError:
             # fitter doesn't support weights
-            fitted_epsf = fitter(model=_epsf, x=xx, y=yy, z=scaled_data,
+            fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=data,
                                  **fitter_kwargs)
 
         fit_error_status = 0
@@ -219,10 +215,8 @@ class EPSFFitter:
             fit_info = None
 
         # compute the star's fitted position
-        x_center = (star.cutout_center[0] +
-                    (fitted_epsf.x_0.value / epsf._oversampling[0]))
-        y_center = (star.cutout_center[1] +
-                    (fitted_epsf.y_0.value / epsf._oversampling[1]))
+        x_center = star.cutout_center[0] + fitted_epsf.x_0.value
+        y_center = star.cutout_center[1] + fitted_epsf.y_0.value
 
         star = copy.deepcopy(star)
         star.cutout_center = (x_center, y_center)
@@ -245,7 +239,7 @@ class EPSFBuilder:
 
     Parameters
     ----------
-    oversampling : float or tuple of two floats, optional
+    oversampling : int or tuple of two int, optional
         The oversampling factor(s) of the ePSF relative to the input
         ``stars`` along the x and y axes. The ``oversampling`` can
         either be a single float or a tuple of two floats of the form
@@ -261,6 +255,10 @@ class EPSFBuilder:
         have odd sizes along both axes to ensure a well-defined central
         pixel.
 
+    norm_radius : float, optional
+        The pixel radius over which the ePSF is normalized. If `None` or
+        not provided, defaults to 5.5 pixels.
+
     smoothing_kernel : {'quartic', 'quadratic'}, 2D `~numpy.ndarray`, or `None`
         The smoothing kernel to apply to the ePSF.  The predefined
         ``'quartic'`` and ``'quadratic'`` kernels are derived from
@@ -271,17 +269,10 @@ class EPSFBuilder:
     recentering_func : callable, optional
         A callable object (e.g. function or class) that is used to
         calculate the centroid of a 2D array.  The callable must accept
-        a 2D `~numpy.ndarray`, have a ``mask`` keyword and optionally an
-        ``error`` keyword.  The callable object must return a tuple of
-        two 1D `~numpy.ndarray`\\s, representing the x and y centroids.
-        The default is `~photutils.centroids.centroid_com`.
-
-    recentering_boxsize : float or tuple of two floats, optional
-        The size (in pixels) of the box used to calculate the centroid
-        of the ePSF during each build iteration.  If a single integer
-        number is provided, then a square box will be used.  If two
-        values are provided, then they should be in ``(ny, nx)`` order.
-        The default is 5.
+        a 2D `~numpy.ndarray`, have a ``mask`` keyword and optionally
+        ``error`` and ``oversampling`` keywords.  The callable object must return
+        a tuple of two 1D `~numpy.ndarray` variables, representing the x and y
+        centroids. The default is `~photutils.centroids.centroid_epsf`.
 
     recentering_maxiters : int, optional
         The maximum number of recentering iterations to perform during
@@ -293,41 +284,36 @@ class EPSFBuilder:
         `~astropy.modeling.fitting.LevMarLSQFitter`.  See the
         `EPSFFitter` documentation its options.
 
-    center_accuracy : float, optional
-        The desired accuracy for the centers of stars.  The building
-        iterations will stop if the centers of all the stars change by
-        less than ``center_accuracy`` pixels between iterations.  All
-        stars must meet this condition for the loop to exit.  The
-        default is 1.0e-3.
-
     maxiters : int, optional
-        The maximum number of iterations to perform.  If the
-        ``center_accuracy`` is met, then the iterations will stop prior
-        to ``maxiters``.  The default is 10.
+        The maximum number of iterations to perform. The default is 10.
 
     progress_bar : bool, option
         Whether to print the progress bar during the build iterations.
         The default is `True`.
     """
 
-    def __init__(self, oversampling=4., shape=None, smoothing_kernel='quartic',
-                 recentering_func=centroid_com, recentering_boxsize=(5, 5),
-                 recentering_maxiters=20, fitter=EPSFFitter(), center_accuracy=1.0e-3,
-                 maxiters=10, progress_bar=True):
+    def __init__(self, oversampling=4., shape=None,
+                 smoothing_kernel='quartic', norm_radius=5.5, shift_val=0.5,
+                 recentering_func=centroid_epsf, recentering_maxiters=20,
+                 fitter=EPSFFitter(), maxiters=10, progress_bar=True):
 
-        if oversampling <= 0.0:
-            raise ValueError('oversampling must be a positive number.')
-        oversampling = np.atleast_1d(oversampling).astype(float)
+        if oversampling is None:
+            raise ValueError("'oversampling' must be specified.")
+        oversampling = np.atleast_1d(oversampling).astype(int)
         if len(oversampling) == 1:
             oversampling = np.repeat(oversampling, 2)
+        if np.any(oversampling % 2 != 0):
+                raise ValueError('Oversampling factor must be a multiple of two')
+        if np.any(oversampling <= 0.0):
+            raise ValueError('oversampling must be a positive number.')
+        self._norm_radius = norm_radius
+        self._shift_val = shift_val
         self.oversampling = oversampling
         self.shape = self._init_img_params(shape)
         if self.shape is not None:
             self.shape = self.shape.astype(int)
 
         self.recentering_func = recentering_func
-        self.recentering_boxsize = self._init_img_params(recentering_boxsize)
-        self.recentering_boxsize = self.recentering_boxsize.astype(int)
         self.recentering_maxiters = recentering_maxiters
 
         self.smoothing_kernel = smoothing_kernel
@@ -336,20 +322,16 @@ class EPSFBuilder:
             raise TypeError('fitter must be an EPSFFitter instance.')
         self.fitter = fitter
 
-        if center_accuracy <= 0.0:
-            raise ValueError('center_accuracy must be a positive number.')
-        self.center_accuracy_sq = center_accuracy**2
-
         maxiters = int(maxiters)
         if maxiters <= 0:
-            raise ValueError('maxiters must be a positive number.')
+            raise ValueError("'maxiters' must be a positive number.")
         self.maxiters = maxiters
 
         self.progress_bar = progress_bar
 
         # TODO: allow custom SigmaClip object after faster SigmaClip
         # is available in astropy (>=3.1)
-        self.sigclip = SigmaClip(sigma=3., cenfunc='median', maxiters=10)
+        self.sigclip = SigmaClip(sigma=2.5, cenfunc='mean', maxiters=10)
 
         # store some data during each ePSF build iteration
         self._nfit_failed = []
@@ -400,6 +382,8 @@ class EPSFBuilder:
             The initial ePSF model.
         """
 
+        norm_radius = self._norm_radius
+        shift_val = self._shift_val
         oversampling = self.oversampling
         shape = self.shape
 
@@ -409,21 +393,27 @@ class EPSFBuilder:
             if len(shape) == 1:
                 shape = np.repeat(shape, 2)
         else:
-            x_shape = np.int(np.ceil(stars._max_shape[1] *
-                                     oversampling[0]))
-            y_shape = np.int(np.ceil(stars._max_shape[0] *
-                                     oversampling[1]))
+            # Stars class should have odd-sized dimensions, and thus we get the
+            # oversampled shape as oversampling * len + 1; if len=25, then
+            # newlen=101, for example.
+            x_shape = np.int(np.ceil(stars._max_shape[0]) * oversampling[0] + 1)
+            y_shape = np.int(np.ceil(stars._max_shape[1]) * oversampling[1] + 1)
             shape = np.array((y_shape, x_shape))
 
-        # ensure odd sizes
+        # verify odd sizes of shape
         shape = [(i + 1) if i % 2 == 0 else i for i in shape]
 
         data = np.zeros(shape, dtype=np.float)
-        xcenter = (shape[1] - 1) / 2.
-        ycenter = (shape[0] - 1) / 2.
+        # ePSF origin should be in the undersampled pixel units, not the oversampled
+        # grid units. The middle, fractional (as we wish for the center of the
+        # pixel, so the center should be at (v.5, w.5) detector pixels) value is
+        # simply the average of the two values at the extremes.
+        xcenter = stars._max_shape[0] / 2.
+        ycenter = stars._max_shape[1] / 2.
 
         epsf = EPSFModel(data=data, origin=(xcenter, ycenter),
-                         normalize=False, oversampling=oversampling)
+                         oversampling=oversampling, norm_radius=norm_radius,
+                         shift_val=shift_val)
 
         return epsf
 
@@ -453,11 +443,10 @@ class EPSFBuilder:
             image contains NaNs where there is no data.
         """
 
-        # find the integer index of EPSFStar pixels in the oversampled
-        # ePSF grid
-        x = epsf._oversampling[0] * star._xidx_centered
-        y = epsf._oversampling[1] * star._yidx_centered
-        epsf_xcenter, epsf_ycenter = epsf.origin
+        x = epsf.oversampling[0] * star._xidx_centered
+        y = epsf.oversampling[1] * star._yidx_centered
+        epsf_xcenter, epsf_ycenter = (int((epsf.data.shape[1] - 1) / 2),
+                                      int((epsf.data.shape[0] - 1) / 2))
         xidx = _py2intround(x + epsf_xcenter)
         yidx = _py2intround(y + epsf_ycenter)
 
@@ -466,15 +455,13 @@ class EPSFBuilder:
         xidx = xidx[mask]
         yidx = yidx[mask]
 
-        # Compute the normalized residual image by subtracting the
-        # normalized ePSF model from the normalized star at the location
-        # of the star in the undersampled grid.  Then, resample the
-        # normalized residual image in the oversampled ePSF grid.
-        # [(star - (epsf * xov * yov)) / (xov * yov)]
-        # --> [(star / (xov * yov)) - epsf]
-        stardata = ((star._data_values_normalized / np.prod(epsf._oversampling)) -
-                    epsf.evaluate(x=x, y=y, flux=1.0, x_0=0.0, y_0=0.0,
-                                  use_oversampling=False))
+        x = star._xidx_centered
+        y = star._yidx_centered
+
+        # Compute the normalized residual by subtracting the ePSF model from
+        # the normalized star at the location of the star in the undersampled grid.
+        stardata = (star._data_values_normalized -
+                    epsf.evaluate(x=x, y=y, flux=1.0, x_0=0.0, y_0=0.0))
 
         resampled_img = np.full(epsf.shape, np.nan)
         resampled_img[yidx, xidx] = stardata[mask]
@@ -495,16 +482,16 @@ class EPSFBuilder:
 
         Returns
         -------
-        star_imgs : 3D `~numpy.ndarray`
+        epsf_resid : 3D `~numpy.ndarray`
             A 3D cube containing the resampled residual images.
         """
 
         shape = (stars.n_good_stars, epsf.shape[0], epsf.shape[1])
-        star_imgs = np.zeros(shape)
+        epsf_resid = np.zeros(shape)
         for i, star in enumerate(stars.all_good_stars):
-            star_imgs[i, :, :] = self._resample_residual(star, epsf)
+            epsf_resid[i, :, :] = self._resample_residual(star, epsf)
 
-        return star_imgs
+        return epsf_resid
 
     def _smooth_epsf(self, epsf_data):
         """
@@ -568,17 +555,13 @@ class EPSFBuilder:
 
         return convolve(epsf_data, kernel)
 
-    def _recenter_epsf(self, epsf_data, epsf, centroid_func=centroid_com,
-                       box_size=5, maxiters=20, center_accuracy=1.0e-4):
+    def _recenter_epsf(self, epsf, centroid_func=centroid_epsf):
         """
         Calculate the center of the ePSF data and shift the data so the
         ePSF center is at the center of the ePSF data array.
 
         Parameters
         ----------
-        epsf_data : 2D `~numpy.ndarray`
-            A 2D array containing the ePSF image.
-
         epsf : `EPSFModel` object
             The ePSF model.
 
@@ -587,26 +570,9 @@ class EPSFBuilder:
             calculate the centroid of a 2D array.  The callable must
             accept a 2D `~numpy.ndarray`, have a ``mask`` keyword and
             optionally an ``error`` keyword.  The callable object must
-            return a tuple of two 1D `~numpy.ndarray`\\s, representing
+            return a tuple of two 1D `~numpy.ndarray` variables, representing
             the x and y centroids.  The default is
-            `~photutils.centroids.centroid_com`.
-
-        recentering_boxsize : float or tuple of two floats, optional
-            The size (in pixels) of the box used to calculate the
-            centroid of the ePSF during each build iteration.  If a
-            single integer number is provided, then a square box will be
-            used.  If two values are provided, then they should be in
-            ``(ny, nx)`` order.  The default is 5.
-
-        maxiters : int, optional
-            The maximum number of recentering iterations to perform.
-            The default is 20.
-
-        center_accuracy : float, optional
-            The desired accuracy for the centers of stars.  The building
-            iterations will stop if the center of the ePSF changes by
-            less than ``center_accuracy`` pixels between iterations.
-            The default is 1.0e-4.
+            `~photutils.centroids.centroid_epsf`.
 
         Returns
         -------
@@ -614,56 +580,39 @@ class EPSFBuilder:
             The recentered ePSF data.
         """
 
-        # Define an EPSFModel for the input data.  This EPSFModel will be
-        # used to evaluate the model on a shifted pixel grid to place the
-        # centroid at the array center.
-        epsf = EPSFModel(data=epsf_data, origin=epsf.origin, normalize=False,
-                         oversampling=epsf.oversampling)
-
-        epsf.fill_value = 0.0
         xcenter, ycenter = epsf.origin
 
-        dx_total = 0
-        dy_total = 0
-        y, x = np.indices(epsf_data.shape, dtype=np.float)
+        y, x = np.indices(epsf._data.shape, dtype=np.float)
+        x /= epsf.oversampling[0]
+        y /= epsf.oversampling[1]
 
-        iter_num = 0
-        center_accuracy_sq = center_accuracy ** 2
-        center_dist_sq = center_accuracy_sq + 1.e6
-        center_dist_sq_prev = center_dist_sq + 1
-        while (iter_num < maxiters and
-               center_dist_sq >= center_accuracy_sq):
+        mask = ~np.isfinite(epsf._data)
 
-            iter_num += 1
-
-            # extract a cutout from the ePSF
-            slices_large, _ = overlap_slices(epsf_data.shape, box_size,
-                                             (ycenter, xcenter))
-            epsf_cutout = epsf_data[slices_large]
-            mask = ~np.isfinite(epsf_cutout)
-
+        try:
             # find a new center position
-            xcenter_new, ycenter_new = centroid_func(epsf_cutout, mask=mask)
-            xcenter_new += slices_large[1].start
-            ycenter_new += slices_large[0].start
+            xcenter_new, ycenter_new = centroid_func(epsf._data, mask=mask,
+                                                     oversampling=epsf.oversampling,
+                                                     shift_val=epsf._shift_val)
+        except TypeError:
+            pass
+        try:
+            xcenter_new, ycenter_new = centroid_func(epsf._data, mask=mask,
+                                                     oversampling=epsf.oversampling)
+        # default centroid_epsf overloaded, or otherwise a function that does not accept
+        # oversampling or shift_val, in which case just pass data and mask
+        except TypeError:
+            xcenter_new, ycenter_new = centroid_func(epsf._data, mask=mask)
 
-            # calculate the shift
-            dx = xcenter - xcenter_new
-            dy = ycenter - ycenter_new
-            center_dist_sq = dx**2 + dy**2
-            if center_dist_sq >= center_dist_sq_prev:  # don't shift
-                break
-            center_dist_sq_prev = center_dist_sq
+        # Calculate the shift; dx = i - x_star so if dx was positively
+        # incremented then x_star was negatively incremented for a given i.
+        # We will therefore actually subsequently subtract dx from xcenter
+        # (or x_star).
+        dx = xcenter_new - xcenter
+        dy = ycenter_new - ycenter
 
-            # Resample the ePSF data to a shifted grid to place the
-            # centroid in the center of the central pixel.  The shift is
-            # always performed on the input epsf_data.
-            dx_total += dx  # accumulated shifts for the input epsf_data
-            dy_total += dy
-            epsf_data = epsf.evaluate(x=x, y=y, flux=1.0,
-                                      x_0=xcenter + dx_total,
-                                      y_0=ycenter + dy_total,
-                                      use_oversampling=False)
+        epsf_data = epsf.evaluate(x=x, y=y, flux=1.0,
+                                  x_0=xcenter - dx,  # subtract dx from x_0
+                                  y_0=ycenter - dy)  # even if positive
 
         return epsf_data
 
@@ -697,59 +646,55 @@ class EPSFBuilder:
             # improve the input ePSF
             epsf = copy.deepcopy(epsf)
 
-        # compute a 3D stack of 2D residual images
-        residuals = self._resample_residuals(stars, epsf)
+        for _ in range(self.recentering_maxiters):
+            # compute a 3D stack of 2D residual images
+            residuals = self._resample_residuals(stars, epsf)
+            self._residuals.append(residuals)
 
-        self._residuals.append(residuals)
+            # compute the sigma-clipped mean along the 3D stack
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', category=RuntimeWarning)
+                warnings.simplefilter('ignore', category=AstropyUserWarning)
+                residuals = self.sigclip(residuals, axis=0, masked=False,
+                                         return_bounds=False)
+                if HAS_BOTTLENECK:
+                    residuals = bottleneck.nanmean(residuals, axis=0)
+                else:
+                    residuals = np.nanmean(residuals, axis=0)
 
-        # compute the sigma-clipped median along the 3D stack
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-            warnings.simplefilter('ignore', category=AstropyUserWarning)
-            residuals = self.sigclip(residuals, axis=0, masked=False,
-                                     return_bounds=False)
-            if HAS_BOTTLENECK:
-                residuals = bottleneck.nanmedian(residuals, axis=0)
-            else:
-                residuals = np.nanmedian(residuals, axis=0)
+            self._residuals_sigclip.append(residuals)
 
-        self._residuals_sigclip.append(residuals)
+            # interpolate any missing data (np.nan)
+            mask = ~np.isfinite(residuals)
+            if np.any(mask):
+                residuals = _interpolate_missing_data(residuals, mask,
+                                                      method='cubic')
 
-        # interpolate any missing data (np.nan)
-        mask = ~np.isfinite(residuals)
-        if np.any(mask):
-            residuals = _interpolate_missing_data(residuals, mask,
-                                                  method='cubic')
+                # fill any remaining nans (outer points) with zeros
+                residuals[~np.isfinite(residuals)] = 0.
 
-            # fill any remaining nans (outer points) with zeros
-            residuals[~np.isfinite(residuals)] = 0.
+            self._residuals_interp.append(residuals)
 
-        self._residuals_interp.append(residuals)
+            # add the residuals to the previous ePSF image
+            new_epsf = epsf._data + residuals
 
-        # add the residuals to the previous ePSF image
-        new_epsf = epsf.normalized_data + residuals
+            epsf = EPSFModel(data=new_epsf, origin=epsf.origin,
+                             oversampling=epsf.oversampling,
+                             norm_radius=epsf._norm_radius,
+                             shift_val=epsf._shift_val, normalize=False)
 
-        # smooth the ePSF
-        new_epsf = self._smooth_epsf(new_epsf)
+            # smooth and recenter the ePSF
+            epsf._data = self._smooth_epsf(epsf._data)
+            epsf._data = self._recenter_epsf(epsf, centroid_func=self.recentering_func)
 
-        # recenter the ePSF
-        new_epsf = self._recenter_epsf(new_epsf, epsf,
-                                       centroid_func=self.recentering_func,
-                                       box_size=self.recentering_boxsize,
-                                       maxiters=self.recentering_maxiters,
-                                       center_accuracy=1.0e-4)
+        # return the new ePSF object, but with undersampled grid pixel coordinates
+        xcenter = (epsf._data.shape[1] - 1) / 2. / epsf.oversampling[0]
+        ycenter = (epsf._data.shape[0] - 1) / 2. / epsf.oversampling[1]
 
-        # normalize the ePSF data
-        new_epsf /= np.sum(new_epsf, dtype=np.float64)
-
-        # return the new ePSF object
-        xcenter = (new_epsf.shape[1] - 1) / 2.
-        ycenter = (new_epsf.shape[0] - 1) / 2.
-
-        epsf_new = EPSFModel(data=new_epsf, origin=(xcenter, ycenter),
-                             normalize=False, oversampling=epsf.oversampling)
-
-        return epsf_new
+        return EPSFModel(data=epsf._data, origin=(xcenter, ycenter),
+                         oversampling=epsf.oversampling,
+                         norm_radius=epsf._norm_radius,
+                         shift_val=epsf._shift_val)
 
     def build_epsf(self, stars, init_epsf=None):
         """
@@ -775,16 +720,13 @@ class EPSFBuilder:
         """
 
         iter_num = 0
-        center_dist_sq = self.center_accuracy_sq + 1.
         centers = stars.cutout_center_flat
         n_stars = stars.n_stars
         fit_failed = np.zeros(n_stars, dtype=bool)
         epsf = init_epsf
         dt = 0.
 
-        while (iter_num < self.maxiters and
-               np.max(center_dist_sq) >= self.center_accuracy_sq and
-               not np.all(fit_failed)):
+        while (iter_num < self.maxiters and not np.all(fit_failed)):
 
             t_start = time.time()
             iter_num += 1
@@ -890,10 +832,10 @@ def _interpolate_missing_data(data, mask, method='cubic'):
     data_interp = np.array(data, copy=True)
 
     if len(data_interp.shape) != 2:
-        raise ValueError('data must be a 2D array.')
+        raise ValueError("'data' must be a 2D array.")
 
     if mask.shape != data.shape:
-        raise ValueError('mask and data must have the same shape.')
+        raise ValueError("'mask' and 'data' must have the same shape.")
 
     y, x = np.indices(data_interp.shape)
     xy = np.dstack((x[~mask].ravel(), y[~mask].ravel()))[0]

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -91,6 +91,10 @@ class FittableImageModel(Fittable2DModel):
         data) to the flux of model's data.
         Then, best fitted value of the `flux` model
         parameter will represent an aperture-corrected flux of the target star.
+        In the case of aperture correction, ``normalization_correction`` should
+        be a value larger than one, as the total flux, including regions outside
+        of the aperture, should be larger than the flux inside the aperture,
+        and thus the correction is applied as an inversely multiplied factor.
 
     fill_value : float, optional
         The value to be returned by the `evaluate` or
@@ -149,6 +153,15 @@ class FittableImageModel(Fittable2DModel):
         # set the origin of the coordinate system in image's pixel grid:
         self.origin = origin
 
+        flux = self._initial_norm(flux, normalize)
+
+        super().__init__(flux, x_0, y_0)
+
+        # initialize interpolator:
+        self.compute_interpolator(ikwargs)
+
+    def _initial_norm(self, flux, normalize):
+
         if flux is None:
             if self._img_norm is None:
                 self._img_norm = self._compute_raw_image_norm(self._data)
@@ -156,10 +169,7 @@ class FittableImageModel(Fittable2DModel):
 
         self._compute_normalization(normalize)
 
-        super().__init__(flux, x_0, y_0)
-
-        # initialize interpolator:
-        self.compute_interpolator(ikwargs)
+        return flux
 
     def _compute_raw_image_norm(self, data):
         """
@@ -488,16 +498,234 @@ class FittableImageModel(Fittable2DModel):
 class EPSFModel(FittableImageModel):
     """
     A subclass of `FittableImageModel`. A fittable ePSF model.
+
+    oversampling : int or tuple of two int, optional
+        The oversampling factor(s) of the model in the ``x`` and ``y`` directions.
+        If ``oversampling`` is a scalar it will be treated as being the same in both
+        x and y; otherwise a tuple of two floats will be treated as
+        ``(x_oversamp, y_oversamp)``.
+    norm_radius : float, optional
+        The radius inside which the ePSF is normalized by the sum over
+        undersampled integer pixel values inside a circular aperture.
+    shift_val : float, optional
+        The fractional undersampled pixel amount (equivalent to an integer
+        oversampled pixel value) at which to evaluate the asymmetric
+        ePSF centroid corrections.
     """
 
-    def __init__(self, data, flux=1.0, x_0=0, y_0=0, normalize=True,
-                 normalization_correction=1.0, origin=None, oversampling=1.,
-                 fill_value=0., ikwargs={}):
+    flux = Parameter(description='Intensity scaling factor for image data.',
+                     default=1.0)
+    x_0 = Parameter(description='X-position of a feature in the image in '
+                    'the output coordinate grid on which the model is '
+                    'evaluated.', default=0.0)
+    y_0 = Parameter(description='Y-position of a feature in the image in '
+                    'the output coordinate grid on which the model is '
+                    'evaluated.', default=0.0)
 
-        super().__init__(
-            data=data, flux=flux, x_0=x_0, y_0=y_0, normalize=normalize,
-            normalization_correction=normalization_correction, origin=origin,
-            oversampling=oversampling, fill_value=fill_value, ikwargs=ikwargs)
+    def __init__(self, data, flux=flux.default, x_0=x_0.default, y_0=y_0.default,
+                 origin=None, oversampling=1, fill_value=0.0, norm_radius=5.5,
+                 shift_val=0.5, normalize=True, normalization_correction=1.0,
+                 ikwargs={}):
+        self._norm_radius = norm_radius
+        self._shift_val = shift_val
+
+        super().__init__(data=data, flux=flux, x_0=x_0, y_0=y_0, normalize=normalize,
+                         normalization_correction=normalization_correction,
+                         origin=origin, oversampling=oversampling, fill_value=fill_value,
+                         ikwargs=ikwargs)
+
+    def _initial_norm(self, flux, normalize):
+        if flux is None:
+            if self._img_norm is None:
+                self._img_norm = self._compute_raw_image_norm(self._data,
+                                                              self._norm_radius)
+            flux = self._img_norm
+
+        if normalize:
+            self._compute_normalization()
+        else:
+            self._img_norm = self._compute_raw_image_norm(self._data,
+                                                          self._norm_radius)
+
+    def _compute_raw_image_norm(self, data, radius):
+        """
+        Helper function that computes the normalization of input image data.
+        This quantity is computed as the sum of all undersampled integer pixel
+        values within radius pixels of the center of the ePSF.
+        """
+
+        # First need the indices of each axis at the oversampled resolution;
+        # if oversampling = 4 then x = [0, 0.25, 0.5, 0.75, ...]
+        x = np.arange(self._nx, dtype=np.float64) / self.oversampling[0]
+        y = np.arange(self._ny, dtype=np.float64) / self.oversampling[1]
+        # Take indices where the undersampled grid is an integer -- i.e., the
+        # actual undersampled grid -- and find the cut where
+        # sqrt(dx**2 + dy**2) <= radius
+        x_0, y_0 = int((self._nx - 1) / 2), int((self._ny - 1) / 2)
+        # However, as we are in units of the undersampled grid, we must convert
+        # to undersampled units by the same factor of oversampling
+        x_0 /= self.oversampling[0]
+        y_0 /= self.oversampling[1]
+        # When checking if the index is at the center of a pixel, we check such
+        # that the index number is half that of the oversampling -- if we
+        # oversample by a factor 4 then the middle pixel of the 0th large pixel
+        # is 2 ([0, 1, 2, 3, 4]). For this to work we require oversampling to be
+        # an even number; otherwise, the ``middle'' pixel will be halfway between
+        # two oversampled pixels.
+        over_index_middle = 1 / 2
+        cut = (((x.reshape(1, -1) - x_0)**2 + (y.reshape(-1, 1) - y_0)**2 <=
+                radius**2) & (x.reshape(1, -1) % 1.0 == over_index_middle) &
+               (y.reshape(-1, 1) % 1.0 == over_index_middle))
+        data = self._data
+
+        return np.sum(data[cut], dtype=np.float64)
+
+    def _compute_normalization(self):
+        """
+        Helper function that computes (corrected) normalization factor
+        of the original image data. For the ePSF this is defined as the
+        sum over the inner N (default=5.5) pixels of the non-oversampled
+        image. Will re-normalize the data to the value calculated.
+        """
+
+        if self._img_norm is None:
+            if np.sum(self._data) == 0:
+                self._img_norm = 1
+            else:
+                self._img_norm = self._compute_raw_image_norm(self._data,
+                                                              self._norm_radius)
+
+        if self._img_norm != 0.0 and np.isfinite(self._img_norm):
+            self._data /= (self._img_norm * self._normalization_correction)
+            self._normalization_status = 0
+        else:
+            self._normalization_status = 1
+            self._img_norm = 1
+            warnings.warn("Overflow encountered while computing "
+                          "normalization constant. Normalization "
+                          "constant will be set to 1.", NonNormalizable)
+
+    def _set_oversampling(self, value):
+        try:
+            value = np.atleast_1d(value).astype(int)
+            if len(value) == 1:
+                value = np.repeat(value, 2)
+            # We need oversampling to be a factor of 2 for ``middle of pixel''
+            # in the undersampled regime to have a pixel placed at it in the
+            # oversampled regime.
+            if np.any(value % 2 != 0) and np.logical_not(np.all(value == 1)):
+                raise ValueError('Oversampling factor must be a multiple of two')
+        except ValueError:
+            raise ValueError('Oversampling factor must be a scalar')
+        if np.any(value <= 0):
+            raise ValueError('Oversampling factor must be greater than 0')
+
+        self._oversampling = value
+
+    def normalized_data(self):
+        """
+        Overloaded dummy function that also returns self._data, as the
+        normalization occurs within _compute_normalization in EPSFModel,
+        and as such self._data will sum, accounting for under/oversampled
+        pixels, to 1/self._normalization_correction. """
+        return self._data
+
+    @FittableImageModel.origin.setter
+    def origin(self, origin):
+        if origin is None:
+            self._x_origin = (self._nx - 1) / 2.0 / self.oversampling[0]
+            self._y_origin = (self._ny - 1) / 2.0 / self.oversampling[1]
+        elif (hasattr(origin, '__iter__') and len(origin) == 2):
+            self._x_origin, self._y_origin = origin
+        else:
+            raise TypeError("Parameter 'origin' must be either None or an "
+                            "iterable with two elements.")
+
+    def compute_interpolator(self, ikwargs={}):
+        """
+        Compute/define the interpolating spline. This function can be overriden
+        in a subclass to define custom interpolators.
+
+        Parameters
+        ----------
+        ikwargs : dict, optional
+
+            Additional optional keyword arguments. Possible values are:
+
+            - **degree** : int, tuple, optional
+                Degree of the interpolating spline. A tuple can be used to
+                provide different degrees for the X- and Y-axes.
+                Default value is degree=3.
+
+            - **s** : float, optional
+                Non-negative smoothing factor. Default value s=0 corresponds to
+                interpolation.
+                See :py:class:`~scipy.interpolate.RectBivariateSpline` for more
+                details.
+
+        Notes
+        -----
+            * When subclassing :py:class:`FittableImageModel` for the
+              purpose of overriding :py:func:`compute_interpolator`,
+              the :py:func:`evaluate` may need to overriden as well depending
+              on the behavior of the new interpolator. In addition, for
+              improved future compatibility, make sure
+              that the overriding method stores keyword arguments ``ikwargs``
+              by calling ``_store_interpolator_kwargs`` method.
+            * Use caution when modifying interpolator's degree or smoothness in
+              a computationally intensive part of the code as it may decrease
+              code performance due to the need to recompute interpolator.
+        """
+        from scipy.interpolate import RectBivariateSpline
+
+        if 'degree' in ikwargs:
+            degree = ikwargs['degree']
+            if hasattr(degree, '__iter__') and len(degree) == 2:
+                degx = int(degree[0])
+                degy = int(degree[1])
+            else:
+                degx = int(degree)
+                degy = int(degree)
+            if degx < 0 or degy < 0:
+                raise ValueError("Interpolator degree must be a non-negative "
+                                 "integer")
+        else:
+            degx = 3
+            degy = 3
+
+        if 's' in ikwargs:
+            smoothness = ikwargs['s']
+        else:
+            smoothness = 0
+
+        # Interpolator must be set to interpolate on the undersampled pixel
+        # grid, going from 0 to len(undersampled_grid)
+        x = np.arange(self._nx, dtype=np.float) / self.oversampling[0]
+        y = np.arange(self._ny, dtype=np.float) / self.oversampling[1]
+        self.interpolator = RectBivariateSpline(
+            x, y, self._data.T, kx=degx, ky=degy, s=smoothness)
+
+        self._store_interpolator_kwargs(ikwargs)
+
+    def evaluate(self, x, y, flux, x_0, y_0):
+        """
+        Evaluate the model on some input variables and provided model
+        parameters.
+        """
+
+        xi = np.asarray(x) - x_0 + self._x_origin
+        yi = np.asarray(y) - y_0 + self._y_origin
+
+        evaluated_model = flux * self.interpolator.ev(xi, yi)
+
+        if self._fill_value is not None:
+            # find indices of pixels that are outside the input pixel grid and
+            # set these pixels to the 'fill_value':
+            invalid = (((xi < 0) | (xi > (self._nx - 1) / self.oversampling[0])) |
+                       ((yi < 0) | (yi > (self._ny - 1) / self.oversampling[1])))
+            evaluated_model[invalid] = self._fill_value
+
+        return evaluated_model
 
 
 class GriddedPSFModel(Fittable2DModel):

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -7,13 +7,13 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata import NDData
 from astropy.table import Table
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
 
 from ..epsf import EPSFBuilder, EPSFFitter
 from ..epsf_stars import extract_stars, EPSFStar, EPSFStars
-from ...centroids import gaussian1d_moments
-from ...datasets import make_gaussian_sources_image
+from ..models import IntegratedGaussianPRF, EPSFModel
+from ...datasets import make_gaussian_prf_sources_image
 
 try:
     import scipy  # noqa
@@ -31,10 +31,10 @@ class TestEPSFBuild:
 
         from scipy.spatial import cKDTree
 
-        shape = (500, 500)
+        shape = (750, 750)
 
         # define random star positions
-        nstars = 50
+        nstars = 100
         from astropy.utils.misc import NumpyRNGContext
         with NumpyRNGContext(12345):  # seed for repeatability
             xx = np.random.uniform(low=0, high=shape[1], size=nstars)
@@ -57,13 +57,12 @@ class TestEPSFBuild:
         self.stddev = 2.
         sources = Table()
         sources['amplitude'] = zz
-        sources['x_mean'] = xx
-        sources['y_mean'] = yy
-        sources['x_stddev'] = np.zeros(len(xx)) + self.stddev
-        sources['y_stddev'] = sources['x_stddev']
+        sources['x_0'] = xx
+        sources['y_0'] = yy
+        sources['sigma'] = np.zeros(len(xx)) + self.stddev
         sources['theta'] = 0.
 
-        self.data = make_gaussian_sources_image(shape, sources)
+        self.data = make_gaussian_prf_sources_image(shape, sources)
         self.nddata = NDData(self.data)
 
         init_stars = Table()
@@ -75,7 +74,7 @@ class TestEPSFBuild:
         size = 25
         stars = extract_stars(self.nddata, self.init_stars, size=size)
 
-        assert len(stars) == 41
+        assert len(stars) == 79
         assert isinstance(stars, EPSFStars)
         assert isinstance(stars[0], EPSFStar)
         assert stars[0].data.shape == (size, size)
@@ -88,19 +87,38 @@ class TestEPSFBuild:
         size = 25
         oversampling = 4.
         stars = extract_stars(self.nddata, self.init_stars, size=size)
-        epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=20,
-                                   progress_bar=False)
+        epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=8,
+                                   progress_bar=False, norm_radius=25,
+                                   recentering_maxiters=5)
         epsf, fitted_stars = epsf_builder(stars)
 
         ref_size = (size * oversampling) + 1
         assert epsf.data.shape == (ref_size, ref_size)
 
-        y0 = int((ref_size - 1) / 2)
-        z = epsf.data[y0, :]
-        ampl, peak, sigma = gaussian1d_moments(z)
-        assert_allclose(ampl, 0.002487, rtol=1e-4)
-        assert_allclose(peak, y0, rtol=1e-3)
-        assert_allclose(sigma, oversampling * self.stddev, rtol=1e-5)
+        y0 = (ref_size - 1) / 2 / oversampling
+        y = np.arange(ref_size, dtype=float) / oversampling
+
+        psf_model = IntegratedGaussianPRF(sigma=self.stddev)
+        z = epsf.data
+        x = psf_model.evaluate(y.reshape(-1, 1), y.reshape(1, -1), 1, y0, y0, self.stddev)
+        assert_allclose(z, x, rtol=1e-2, atol=1e-5)
+
+        resid_star = fitted_stars[0].compute_residual_image(epsf)
+        assert_almost_equal(np.sum(resid_star)/fitted_stars[0].flux, 0, decimal=3)
+
+    def test_epsf_fitting_bounds(self):
+        size = 25
+        oversampling = 4.
+        stars = extract_stars(self.nddata, self.init_stars, size=size)
+        epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=8,
+                                   progress_bar=True, norm_radius=25,
+                                   recentering_maxiters=5,
+                                   fitter=EPSFFitter(fit_boxsize=30),
+                                   smoothing_kernel='quadratic')
+        # With a boxsize larger than the cutout we expect the fitting to
+        # fail for all stars, due to star._fit_error_status
+        with pytest.raises(ValueError):
+            epsf, fitted_stars = epsf_builder(stars)
 
     def test_epsf_build_invalid_fitter(self):
         """
@@ -115,3 +133,38 @@ class TestEPSFBuild:
 
         with pytest.raises(TypeError):
             EPSFBuilder(fitter=LevMarLSQFitter, maxiters=3)
+
+
+def test_epsfbuilder_inputs():
+    with pytest.raises(ValueError):
+        epsf_builder = EPSFBuilder(oversampling=None)
+    with pytest.raises(ValueError):
+        epsf_builder = EPSFBuilder(oversampling=-1)
+    with pytest.raises(ValueError):
+        epsf_builder = EPSFBuilder(maxiters=-1)
+    with pytest.raises(ValueError):
+        epsf_builder = EPSFBuilder(oversampling=3)
+    with pytest.raises(ValueError):
+        epsf_builder = EPSFBuilder(oversampling=[3, 6])
+    with pytest.raises(ValueError):
+        epsf_builder = EPSFBuilder(oversampling=[-1, 4])
+
+
+def test_epsfmodel_inputs():
+    data = np.array([[], []])
+    with pytest.raises(ValueError):
+        epsf_model = EPSFModel(data)
+    data = np.ones((5, 5), dtype=float)
+    data[2, 2] = np.inf
+    with pytest.raises(ValueError):
+        epsf_model = EPSFModel(data)
+    data[2, 2] = np.finfo(np.float64).max * 2
+    with pytest.raises(ValueError):
+        epsf_model = EPSFModel(data, flux=None)
+    data[2, 2] = 1
+    for oversampling in [3, np.NaN, 'a', -1, [3, 4], [-2, 4]]:
+        with pytest.raises(ValueError):
+            epsf_model = EPSFModel(data, oversampling=oversampling)
+    for origin in ['a', (1, 2, 3)]:
+        with pytest.raises(TypeError):
+            epsf_model = EPSFModel(data, origin=origin)


### PR DESCRIPTION
This pull request, building upon the changes in #815 and #816, reworks the framework of the ``EPSFModel`` (and ``EPSFBuilder`` & ``EPSFStar``) to handle the oversampled pixel grid scale while correctly treating the ePSF pixels as being convolved with the original, undersampled pixel grid. This avoids the issue where flux is dependent on ``oversampling``, now properly handling the normalization of the grid by normalizing on every Nth ePSF pixel (for ``oversamping=N``).

There are also a few minor changes to ``EPSFBuilder``, changing the flow of ``_build_epsf_step`` to more closely match the algorithm detailed by Anderson & King (2000).


It is part of a larger PR refactor as part of #725 along with #815 and #816, and I leave the PR available for context and the discussions therein as to how these PRs relate to one another.

Please note that this PR is based off changes in #815 and #816, to ensure that those necessary changes are reflected in the codebase and to verify tests work, etc., so this PR will potentially require a rebase onto master once #815 and #816 are merged; please do not merge before the other two PRs have been reviewed and accepted.