### PR TITLE
Additions and improvements to SegmentationImage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,18 @@ New Features
     segmentation images (e.g.  ``remove_labels``, ``keep_labels``).
     [#810]
 
+  - Added new ``background_area`` attribute to ``SegmentationImage``.
+    [#825]
+
+  - Added new ``data_ma`` attribute to ``Segment``. [#825]
+
+  - Added new ``SegmentationImage`` methods:  ``find_index``,
+    ``find_indices``, ``find_areas``, ``check_label``, ``keep_label``,
+    ``remove_label``, and ``reassign_labels``. [#825]
+
+  - Added ``__repr__`` and ``__str__`` methods to
+    ``SegmentationImage``. [#825]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -34,15 +46,36 @@ Bug Fixes
   - Fixed the ``background_at_centroid`` source property to use
     bilinear interpolation. [#822]
 
+  - Fixed ``SegmentationImage`` ``outline_segments`` to include
+    outlines along the image boundaries. [#825]
+
 API changes
 ^^^^^^^^^^^
 
--
+- ``photutils.segmentation``
+
+  - Removed deprecated ``SegmentationImage`` attributes
+    ``data_masked``, ``max``, and ``is_sequential``  and methods
+    ``area`` and ``relabel_sequential``. [#825]
+
+  - Renamed ``SegmentationImage`` methods ``cmap`` (deprecated) to
+    ``make_cmap`` and ``relabel`` (deprecated) to ``reassign_label``.
+    The new ``reassign_label`` method gains a ``relabel`` keyword.
+    [#825]
+
+  - The ``SegmentationImage`` ``segments`` and ``slices`` attributes
+    now have the same length as ``labels`` (no ``None`` placeholders).
+    [#825]
+
+- ``photutils.utils``
+
+  - Renamed ``random_cmap`` to ``make_random_cmap``. [#825]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -
+
 
 0.6 (2018-12-11)
 ----------------

--- a/docs/grouping.rst
+++ b/docs/grouping.rst
@@ -145,10 +145,10 @@ in the same group have the same aperture color:
 .. doctest-skip::
 
     >>> from photutils import CircularAperture
-    >>> from photutils.utils import random_cmap
+    >>> from photutils.utils import make_random_cmap
     >>> plt.imshow(sim_image, origin='lower', interpolation='nearest',
     ...            cmap='Greys_r')
-    >>> cmap = random_cmap(random_state=12345)
+    >>> cmap = make_random_cmap(random_state=12345)
     >>> for i, group in enumerate(star_groups.groups):
     >>>     xypos = np.transpose([group['x_0'], group['y_0']])
     >>>     ap = CircularAperture(xypos, r=fwhm)
@@ -165,7 +165,7 @@ in the same group have the same aperture color:
                                     make_gaussian_sources_image)
     from photutils.psf.groupstars import DAOGroup
     from photutils import CircularAperture
-    from photutils.utils import random_cmap
+    from photutils.utils import make_random_cmap
     import matplotlib.pyplot as plt
     from matplotlib import rcParams
 
@@ -199,7 +199,7 @@ in the same group have the same aperture color:
     plt.imshow(sim_image, origin='lower', interpolation='nearest',
                cmap='Greys_r')
 
-    cmap = random_cmap(random_state=12345)
+    cmap = make_random_cmap(random_state=12345)
     for i, group in enumerate(star_groups.groups):
         xypos = np.transpose([group['x_0'], group['y_0']])
         ap = CircularAperture(xypos, r=fwhm)
@@ -232,7 +232,7 @@ to use :class:`~photutils.psf.DBSCANGroup`.
                                     make_gaussian_sources_image)
     from photutils.psf.groupstars import DBSCANGroup
     from photutils import CircularAperture
-    from photutils.utils import random_cmap
+    from photutils.utils import make_random_cmap
     import matplotlib.pyplot as plt
     from matplotlib import rcParams
 
@@ -266,7 +266,7 @@ to use :class:`~photutils.psf.DBSCANGroup`.
     plt.imshow(sim_image, origin='lower', interpolation='nearest',
                cmap='Greys_r')
 
-    cmap = random_cmap(random_state=12345)
+    cmap = make_random_cmap(random_state=12345)
     for i, group in enumerate(star_groups.groups):
         xypos = np.transpose([group['x_0'], group['y_0']])
         ap = CircularAperture(xypos, r=fwhm)

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -228,7 +228,7 @@ Let's plot one of the deblended sources:
     cmap1 = segm.make_cmap(random_state=123)
     ax2.imshow(segm.data[slc], origin='lower', cmap=cmap1)
     ax2.set_title('Original Segment')
-    cmap2 = segm_deblend.cmap(random_state=123)
+    cmap2 = segm_deblend.make_cmap(random_state=123)
     ax3.imshow(segm_deblend.data[slc], origin='lower', cmap=cmap2)
     ax3.set_title('Deblended Segments')
     plt.tight_layout()
@@ -403,7 +403,7 @@ Now let's plot the derived elliptical apertures on the data:
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     >>> ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     >>> ax1.set_title('Data')
-    >>> cmap = segm_deblend.cmap(random_state=12345)
+    >>> cmap = segm_deblend.make_cmap(random_state=12345)
     >>> ax2.imshow(segm_deblend, origin='lower', cmap=cmap)
     >>> ax2.set_title('Segmentation Image')
     >>> for aperture in apertures:
@@ -450,7 +450,7 @@ Now let's plot the derived elliptical apertures on the data:
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     ax1.set_title('Data')
-    cmap = segm_deblend.cmap(random_state=12345)
+    cmap = segm_deblend.make_cmap(random_state=12345)
     ax2.imshow(segm_deblend, origin='lower', cmap=cmap)
     ax2.set_title('Segmentation Image')
     for aperture in apertures:

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -102,7 +102,8 @@ segmentation image showing the detected sources:
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     >>> ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     >>> ax1.set_title('Data')
-    >>> ax2.imshow(segm, origin='lower', cmap=segm.cmap(random_state=12345))
+    >>> cmap = segm.make_cmap(random_state=12345)
+    >>> ax2.imshow(segm, origin='lower', cmap=cmap)
     >>> ax2.set_title('Segmentation Image')
 
 .. plot::
@@ -125,7 +126,8 @@ segmentation image showing the detected sources:
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     ax1.set_title('Data')
-    ax2.imshow(segm, origin='lower', cmap=segm.cmap(random_state=12345))
+    cmap = segm.make_cmap(random_state=12345)
+    ax2.imshow(segm, origin='lower', cmap=cmap)
     ax2.set_title('Segmentation Image')
     plt.tight_layout()
 
@@ -193,8 +195,8 @@ the deblended segmentation image:
 
     norm = ImageNormalize(stretch=SqrtStretch())
     fig, ax = plt.subplots(1, 1, figsize=(10, 6.5))
-    ax.imshow(segm_deblend, origin='lower',
-              cmap=segm_deblend.cmap(random_state=12345))
+    cmap = segm_deblend.make_cmap(random_state=12345)
+    ax.imshow(segm_deblend, origin='lower', cmap=cmap)
     ax.set_title('Deblended Segmentation Image')
     plt.tight_layout()
 
@@ -223,11 +225,11 @@ Let's plot one of the deblended sources:
     slc = (slice(273, 297), slice(425, 444))
     ax1.imshow(data[slc], origin='lower')
     ax1.set_title('Data')
-    ax2.imshow(segm.data[slc], origin='lower',
-               cmap=segm.cmap(random_state=123))
+    cmap1 = segm.make_cmap(random_state=123)
+    ax2.imshow(segm.data[slc], origin='lower', cmap=cmap1)
     ax2.set_title('Original Segment')
-    ax3.imshow(segm_deblend.data[slc], origin='lower',
-               cmap=segm_deblend.cmap(random_state=123))
+    cmap2 = segm_deblend.cmap(random_state=123)
+    ax3.imshow(segm_deblend.data[slc], origin='lower', cmap=cmap2)
     ax3.set_title('Deblended Segments')
     plt.tight_layout()
 
@@ -240,17 +242,18 @@ several methods that can be used to visualize or modify itself (e.g.,
 combining labels, removing labels, removing border segments) prior to
 measuring source photometry and other source properties, including:
 
-  * :meth:`~photutils.segmentation.SegmentationImage.relabel`:
-    Relabel one or more label numbers.
+  * :meth:`~photutils.segmentation.SegmentationImage.reassign_label`:
+    Reassign one or more label numbers.
 
-  * :meth:`~photutils.segmentation.SegmentationImage.relabel_sequential`:
-    Relable the label numbers sequentially.
+  * :meth:`~photutils.segmentation.SegmentationImage.relabel_consecutive`:
+    Reassign the label numbers consecutively, such that there are no
+    missing label numbers (up to the maximum label number).
 
   * :meth:`~photutils.segmentation.SegmentationImage.keep_labels`:
-    Keep only certain label numbers.
+    Keep only the specified labels.
 
   * :meth:`~photutils.segmentation.SegmentationImage.remove_labels`:
-    Remove one or more label numbers.
+    Remove one or more labels.
 
   * :meth:`~photutils.segmentation.SegmentationImage.remove_border_labels`:
     Remove labeled segments near the image border.
@@ -400,8 +403,8 @@ Now let's plot the derived elliptical apertures on the data:
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     >>> ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     >>> ax1.set_title('Data')
-    >>> ax2.imshow(segm_deblend, origin='lower',
-    ...            cmap=segm_deblend.cmap(random_state=12345))
+    >>> cmap = segm_deblend.cmap(random_state=12345)
+    >>> ax2.imshow(segm_deblend, origin='lower', cmap=cmap)
     >>> ax2.set_title('Segmentation Image')
     >>> for aperture in apertures:
     ...     aperture.plot(color='white', lw=1.5, ax=ax1)
@@ -447,8 +450,8 @@ Now let's plot the derived elliptical apertures on the data:
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     ax1.set_title('Data')
-    ax2.imshow(segm_deblend, origin='lower',
-               cmap=segm_deblend.cmap(random_state=12345))
+    cmap = segm_deblend.cmap(random_state=12345)
+    ax2.imshow(segm_deblend, origin='lower', cmap=cmap)
     ax2.set_title('Segmentation Image')
     for aperture in apertures:
         aperture.plot(color='white', lw=1.5, ax=ax1)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 
 import numpy as np
-from astropy.utils import lazyproperty, deprecated
+from astropy.utils import lazyproperty
 
 from ..aperture import BoundingBox
 from ..utils.colormaps import random_cmap
@@ -207,11 +207,6 @@ class SegmentationImage:
         return self._data
 
     @lazyproperty
-    @deprecated('0.5', alternative='data_ma')
-    def data_masked(self):
-        return self.data_ma  # pragma: no cover
-
-    @lazyproperty
     def data_ma(self):
         """
         A `~numpy.ma.MaskedArray` version of the segmentation image
@@ -281,11 +276,6 @@ class SegmentationImage:
         return len(self.labels)
 
     @lazyproperty
-    @deprecated('0.5', alternative='max_label')
-    def max(self):
-        return self.max_label  # pragma: no cover
-
-    @lazyproperty
     def max_label(self):
         """The maximum non-zero label in the segmentation image."""
 
@@ -321,8 +311,7 @@ class SegmentationImage:
 
         return np.bincount(self.data.ravel())[1:]
 
-    @deprecated('0.5', alternative='areas[labels-1]')
-    def area(self, labels):  # pragma: no cover
+    def get_areas(self, labels):
         """
         The areas (in pixel**2) of the regions for the input labels.
 
@@ -343,14 +332,9 @@ class SegmentationImage:
         return self.areas[labels - 1]
 
     @lazyproperty
-    @deprecated('0.5', alternative='is_consecutive')
-    def is_sequential(self):
-        return self.is_consecutive  # pragma: no cover
-
-    @lazyproperty
     def is_consecutive(self):
         """
-        Determine whether or not the non-zero labels in the segmenation
+        Determine whether or not the non-zero labels in the segmentation
         image are consecutive (i.e. no missing values).
         """
 
@@ -407,40 +391,6 @@ class SegmentationImage:
         bad_labels = tuple(bad_labels)
         if len(bad_labels) > 0:
             raise ValueError('labels {} are invalid'.format(bad_labels))
-
-    @deprecated('0.5', alternative='check_labels')
-    def check_label(self, label, allow_zero=False):  # pragma: no cover
-        """
-        Check for a valid label label number within the segmentation
-        image.
-
-        Parameters
-        ----------
-        label : int
-            The label number to check.
-
-        allow_zero : bool
-            If `True` then a label of 0 is valid, otherwise 0 is
-            invalid.
-
-        Raises
-        ------
-        ValueError
-            If the input ``label`` is invalid.
-        """
-
-        if label == 0:
-            if allow_zero:
-                return
-            else:
-                raise ValueError('label "0" is reserved for the background')
-
-        if label < 0:
-            raise ValueError('label must be a positive integer, got '
-                             '"{0}"'.format(label))
-        if label not in self.labels:
-            raise ValueError('label "{0}" is not in the segmentation '
-                             'image'.format(label))
 
     def cmap(self, background_color='#000000', random_state=None):
         """
@@ -564,10 +514,6 @@ class SegmentationImage:
 
         # calling the data setter resets all cached properties
         self.data = idx[self.data]
-
-    @deprecated('0.5', alternative='relabel_consecutive()')
-    def relabel_sequential(self, start_label=1):
-        return self.relabel_consecutive(start_label=start_label)  # pragma: no cover
 
     def relabel_consecutive(self, start_label=1):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -657,20 +657,18 @@ class SegmentationImage:
         new_labels[self.labels] = np.arange(self.nlabels) + start_label
         self.data = new_labels[self.data]
 
-    def keep_labels(self, labels, relabel=False):
+    def keep_label(self, label, relabel=False):
         """
-        Keep only the specified labels.
+        Keep only the specified label.
 
         Parameters
         ----------
-        labels : int, array-like (1D, int)
-            The label number(s) to keep.  Labels of zero and those not
-            in the segmentation image will be ignored.
+        label : int
+            The label number to keep.
 
         relabel : bool, optional
-            If `True`, then the segmentation image will be relabeled
-            such that the labels are in consecutive order starting from
-            1.
+            If `True`, then the single segment will be assigned a label
+            value of 1.
 
         Examples
         --------
@@ -681,7 +679,7 @@ class SegmentationImage:
         ...                           [7, 0, 0, 0, 0, 5],
         ...                           [7, 7, 0, 5, 5, 5],
         ...                           [7, 7, 0, 0, 5, 5]])
-        >>> segm.keep_labels(labels=3)
+        >>> segm.keep_label(label=3)
         >>> segm.data
         array([[0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0],
@@ -696,31 +694,26 @@ class SegmentationImage:
         ...                           [7, 0, 0, 0, 0, 5],
         ...                           [7, 7, 0, 5, 5, 5],
         ...                           [7, 7, 0, 0, 5, 5]])
-        >>> segm.keep_labels(labels=[5, 3])
+        >>> segm.keep_label(label=3, relabel=True)
         >>> segm.data
         array([[0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0],
-               [0, 0, 3, 3, 0, 0],
-               [0, 0, 0, 0, 0, 5],
-               [0, 0, 0, 5, 5, 5],
-               [0, 0, 0, 0, 5, 5]])
+               [0, 0, 1, 1, 0, 0],
+               [0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0]])
         """
 
-        labels = np.atleast_1d(labels)
-        labels_tmp = list(set(self.labels) - set(labels))
-        self.remove_labels(labels_tmp, relabel=relabel)
+        self.keep_labels(label, relabel=relabel)
 
-    def remove_labels(self, labels, relabel=False):
+    def keep_labels(self, labels, relabel=False):
         """
-        Remove one or more labels.
-
-        Removed labels are assigned a value of zero (i.e., background).
+        Keep only the specified labels.
 
         Parameters
         ----------
         labels : int, array-like (1D, int)
-            The label number(s) to remove.  Labels of zero and those not
-            in the segmentation image will be ignored.
+            The label number(s) to keep.
 
         relabel : bool, optional
             If `True`, then the segmentation image will be relabeled
@@ -736,7 +729,64 @@ class SegmentationImage:
         ...                           [7, 0, 0, 0, 0, 5],
         ...                           [7, 7, 0, 5, 5, 5],
         ...                           [7, 7, 0, 0, 5, 5]])
-        >>> segm.remove_labels(labels=5)
+        >>> segm.keep_labels(labels=[5, 3])
+        >>> segm.data
+        array([[0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0],
+               [0, 0, 3, 3, 0, 0],
+               [0, 0, 0, 0, 0, 5],
+               [0, 0, 0, 5, 5, 5],
+               [0, 0, 0, 0, 5, 5]])
+
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.keep_labels(labels=[5, 3], relabel=True)
+        >>> segm.data
+        array([[0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0],
+               [0, 0, 1, 1, 0, 0],
+               [0, 0, 0, 0, 0, 2],
+               [0, 0, 0, 2, 2, 2],
+               [0, 0, 0, 0, 2, 2]])
+        """
+
+        self.check_labels(labels)
+
+        labels = np.atleast_1d(labels)
+        labels_tmp = list(set(self.labels) - set(labels))
+        self.remove_labels(labels_tmp, relabel=relabel)
+
+    def remove_label(self, label, relabel=False):
+        """
+        Remove the label number.
+
+        The removed label is assigned a value of zero (i.e., background)
+        in the segmentation image.
+
+        Parameters
+        ----------
+        label : int
+            The label number to remove.
+
+        relabel : bool, optional
+            If `True`, then the segmentation image will be relabeled
+            such that the labels are in consecutive order starting from
+            1.
+
+        Examples
+        --------
+        >>> from photutils import SegmentationImage
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.remove_label(label=5)
         >>> segm.data
         array([[1, 1, 0, 0, 4, 4],
                [0, 0, 0, 0, 0, 4],
@@ -751,6 +801,44 @@ class SegmentationImage:
         ...                           [7, 0, 0, 0, 0, 5],
         ...                           [7, 7, 0, 5, 5, 5],
         ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.remove_label(label=5, relabel=True)
+        >>> segm.data
+        array([[1, 1, 0, 0, 3, 3],
+               [0, 0, 0, 0, 0, 3],
+               [0, 0, 2, 2, 0, 0],
+               [4, 0, 0, 0, 0, 0],
+               [4, 4, 0, 0, 0, 0],
+               [4, 4, 0, 0, 0, 0]])
+        """
+
+        self.remove_labels(label, relabel=relabel)
+
+    def remove_labels(self, labels, relabel=False):
+        """
+        Remove one or more labels.
+
+        Removed labels are assigned a value of zero (i.e., background)
+        in the segmentation image.
+
+        Parameters
+        ----------
+        labels : int, array-like (1D, int)
+            The label number(s) to remove.
+
+        relabel : bool, optional
+            If `True`, then the segmentation image will be relabeled
+            such that the labels are in consecutive order starting from
+            1.
+
+        Examples
+        --------
+        >>> from photutils import SegmentationImage
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
         >>> segm.remove_labels(labels=[5, 3])
         >>> segm.data
         array([[1, 1, 0, 0, 4, 4],
@@ -759,7 +847,24 @@ class SegmentationImage:
                [7, 0, 0, 0, 0, 0],
                [7, 7, 0, 0, 0, 0],
                [7, 7, 0, 0, 0, 0]])
+
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.remove_labels(labels=[5, 3], relabel=True)
+        >>> segm.data
+        array([[1, 1, 0, 0, 2, 2],
+               [0, 0, 0, 0, 0, 2],
+               [0, 0, 0, 0, 0, 0],
+               [3, 0, 0, 0, 0, 0],
+               [3, 3, 0, 0, 0, 0],
+               [3, 3, 0, 0, 0, 0]])
         """
+
+        self.check_labels(labels)
 
         self.reassign_label(labels, new_label=0)
         if relabel:

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -6,7 +6,7 @@ import numpy as np
 from astropy.utils import lazyproperty, deprecated
 
 from ..aperture import BoundingBox
-from ..utils.colormaps import random_cmap
+from ..utils.colormaps import make_random_cmap
 
 
 __all__ = ['Segment', 'SegmentationImage']
@@ -470,7 +470,7 @@ class SegmentationImage:
 
         from matplotlib import colors
 
-        cmap = random_cmap(self.max_label + 1, random_state=random_state)
+        cmap = make_random_cmap(self.max_label + 1, random_state=random_state)
 
         if background_color is not None:
             cmap.colors[0] = colors.hex2color(background_color)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -417,9 +417,11 @@ class SegmentationImage:
         if len(bad_labels) > 0:
             raise ValueError('labels {} are invalid'.format(bad_labels))
 
+    @deprecated('0.7', alternative='make_cmap')
     def cmap(self, background_color='#000000', random_state=None):
         """
-        A matplotlib colormap consisting of random (muted) colors.
+        Define a matplotlib colormap consisting of (random) muted
+        colors.
 
         This is very useful for plotting the segmentation image.
 
@@ -429,12 +431,41 @@ class SegmentationImage:
             A hex string in the "#rrggbb" format defining the first
             color in the colormap.  This color will be used as the
             background color (label = 0) when plotting the segmentation
-            image.  The default is black.
+            image.  The default is black ('#000000').
 
         random_state : int or `~numpy.random.RandomState`, optional
             The pseudo-random number generator state used for random
             sampling.  Separate function calls with the same
             ``random_state`` will generate the same colormap.
+        """
+
+        return self.make_cmap(background_color=background_color,
+                              random_state=random_state)
+
+    def make_cmap(self, background_color='#000000', random_state=None):
+        """
+        Define a matplotlib colormap consisting of (random) muted
+        colors.
+
+        This is very useful for plotting the segmentation image.
+
+        Parameters
+        ----------
+        background_color : str or `None`, optional
+            A hex string in the "#rrggbb" format defining the first
+            color in the colormap.  This color will be used as the
+            background color (label = 0) when plotting the segmentation
+            image.  The default is black ('#000000').
+
+        random_state : int or `~numpy.random.RandomState`, optional
+            The pseudo-random number generator state used for random
+            sampling.  Separate function calls with the same
+            ``random_state`` will generate the same colormap.
+
+        Returns
+        -------
+        cmap : `matplotlib.colors.ListedColormap`
+            The matplotlib colormap.
         """
 
         from matplotlib import colors

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -182,6 +182,16 @@ class SegmentationImage:
             if isinstance(value, lazyproperty):
                 self.__dict__.pop(key, None)
 
+    @lazyproperty
+    def _cmap(self):
+        """
+        A matplotlib colormap consisting of (random) muted colors.
+
+        This is very useful for plotting the segmentation image.
+        """
+
+        return self.make_cmap(background_color='#000000', random_state=1234)
+
     @staticmethod
     def _get_labels(data):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -70,15 +70,30 @@ class Segment:
     @lazyproperty
     def data(self):
         """
-        Cutout image of the segment, where pixels outside of the labeled
-        region are set to zero (i.e. neighboring segments within the
-        rectangular cutout image are not shown).
+        A 2D cutout image of the segment using the minimal bounding box,
+        where pixels outside of the labeled region are set to zero (i.e.
+        neighboring segments within the rectangular cutout image are not
+        shown).
         """
 
         cutout = np.copy(self._segment_img[self.slices])
         cutout[cutout != self.label] = 0
 
         return cutout
+
+    @lazyproperty
+    def data_ma(self):
+        """
+        A 2D `~numpy.ma.MaskedArray` cutout image of the segment using
+        the minimal bounding box.
+
+        The mask is `True` for pixels outside of the source segment
+        (i.e. neighboring segments within the rectangular cutout image
+        are masked).
+        """
+
+        mask = (self._segment_img[self.slices] != self.label)
+        return np.ma.masked_array(self._segment_img[self.slices], mask=mask)
 
     @lazyproperty
     def bbox(self):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -152,6 +152,22 @@ class SegmentationImage:
         for i in self.segments:
             yield i
 
+    def __str__(self):
+        cls_name = '<{0}.{1}>'.format(self.__class__.__module__,
+                                      self.__class__.__name__)
+
+        cls_info = []
+        params = ['shape', 'nlabels', 'max_label']
+        for param in params:
+            cls_info.append((param, getattr(self, param)))
+        fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
+
+        return '{}\n'.format(cls_name) + '\n'.join(fmt)
+
+    def __repr__(self):
+        return self.__str__()
+
+
     @lazyproperty
     def segments(self):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -98,8 +98,8 @@ class Segment:
     @lazyproperty
     def bbox(self):
         """
-        The `BoundingBox` of the minimal rectangular region containing
-        the source segment.
+        The `~photutils.BoundingBox` of the minimal rectangular region
+        containing the source segment.
         """
 
         return BoundingBox(self.slices[1].start, self.slices[1].stop,

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -553,7 +553,7 @@ class SegmentationImage:
 
         return cmap
 
-    @deprecated('0.7', alternative='reassign_label')
+    @deprecated('0.7', alternative='reassign_labels')
     def relabel(self, labels, new_label):
         """
         Reassign one or more label numbers.
@@ -572,20 +572,25 @@ class SegmentationImage:
 
         self.reassign_label(labels, new_label)
 
-    def reassign_label(self, labels, new_label):
+    def reassign_label(self, label, new_label, relabel=False):
         """
-        Reassign one or more label numbers.
+        Reassign a label number to a new number.
 
-        Multiple input ``labels`` will all be reassigned to the same
-        ``new_label`` number.
+        If ``new_label`` is already present in the segmentation image,
+        then it will be combined with the input ``label`` number.
 
         Parameters
         ----------
-        labels : int, array-like (1D, int)
-            The label numbers(s) to reassign.
+        labels : int
+            The label number to reassign.
 
         new_label : int
-            The reassigned label number.
+            The newly assigned label number.
+
+        relabel : bool, optional
+            If `True`, then the segmentation image will be relabeled
+            such that the labels are in consecutive order starting from
+            1.
 
         Examples
         --------
@@ -596,7 +601,80 @@ class SegmentationImage:
         ...                           [7, 0, 0, 0, 0, 5],
         ...                           [7, 7, 0, 5, 5, 5],
         ...                           [7, 7, 0, 0, 5, 5]])
-        >>> segm.reassign_label(labels=[1, 7], new_label=2)
+        >>> segm.reassign_label(label=1, new_label=2)
+        >>> segm.data
+        array([[2, 2, 0, 0, 4, 4],
+               [0, 0, 0, 0, 0, 4],
+               [0, 0, 3, 3, 0, 0],
+               [7, 0, 0, 0, 0, 5],
+               [7, 7, 0, 5, 5, 5],
+               [7, 7, 0, 0, 5, 5]])
+
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.reassign_label(label=1, new_label=4)
+        >>> segm.data
+        array([[4, 4, 0, 0, 4, 4],
+               [0, 0, 0, 0, 0, 4],
+               [0, 0, 3, 3, 0, 0],
+               [7, 0, 0, 0, 0, 5],
+               [7, 7, 0, 5, 5, 5],
+               [7, 7, 0, 0, 5, 5]])
+
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.reassign_label(label=1, new_label=4, relabel=True)
+        >>> segm.data
+        array([[2, 2, 0, 0, 2, 2],
+               [0, 0, 0, 0, 0, 2],
+               [0, 0, 1, 1, 0, 0],
+               [4, 0, 0, 0, 0, 3],
+               [4, 4, 0, 3, 3, 3],
+               [4, 4, 0, 0, 3, 3]])
+        """
+
+        self.reassign_labels(label, new_label, relabel=relabel)
+
+    def reassign_labels(self, labels, new_label, relabel=False):
+        """
+        Reassign one or more label numbers.
+
+        Multiple input ``labels`` will all be reassigned to the same
+        ``new_label`` number.  If ``new_label`` is already present in
+        the segmentation image, then it will be combined with the input
+        ``labels``.
+
+        Parameters
+        ----------
+        labels : int, array-like (1D, int)
+            The label numbers(s) to reassign.
+
+        new_label : int
+            The reassigned label number.
+
+        relabel : bool, optional
+            If `True`, then the segmentation image will be relabeled
+            such that the labels are in consecutive order starting from
+            1.
+
+        Examples
+        --------
+        >>> from photutils import SegmentationImage
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.reassign_labels(labels=[1, 7], new_label=2)
         >>> segm.data
         array([[2, 2, 0, 0, 4, 4],
                [0, 0, 0, 0, 0, 4],
@@ -604,7 +682,39 @@ class SegmentationImage:
                [2, 0, 0, 0, 0, 5],
                [2, 2, 0, 5, 5, 5],
                [2, 2, 0, 0, 5, 5]])
+
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.reassign_labels(labels=[1, 7], new_label=4)
+        >>> segm.data
+        array([[4, 4, 0, 0, 4, 4],
+               [0, 0, 0, 0, 0, 4],
+               [0, 0, 3, 3, 0, 0],
+               [4, 0, 0, 0, 0, 5],
+               [4, 4, 0, 5, 5, 5],
+               [4, 4, 0, 0, 5, 5]])
+
+        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
+        ...                           [0, 0, 0, 0, 0, 4],
+        ...                           [0, 0, 3, 3, 0, 0],
+        ...                           [7, 0, 0, 0, 0, 5],
+        ...                           [7, 7, 0, 5, 5, 5],
+        ...                           [7, 7, 0, 0, 5, 5]])
+        >>> segm.reassign_labels(labels=[1, 7], new_label=2, relabel=True)
+        >>> segm.data
+        array([[1, 1, 0, 0, 3, 3],
+               [0, 0, 0, 0, 0, 3],
+               [0, 0, 2, 2, 0, 0],
+               [1, 0, 0, 0, 0, 4],
+               [1, 1, 0, 4, 4, 4],
+               [1, 1, 0, 0, 4, 4]])
         """
+
+        self.check_labels(labels)
 
         labels = np.atleast_1d(labels)
         if len(labels) == 0:
@@ -617,10 +727,13 @@ class SegmentationImage:
         # calling the data setter resets all cached properties
         self.data = idx[self.data]
 
+        if relabel:
+            self.relabel_consecutive()
+
     def relabel_consecutive(self, start_label=1):
         """
         Reassign the label numbers consecutively, such that there are no
-        missing label numbers (up to the maximum label number).
+        missing label numbers.
 
         Parameters
         ----------
@@ -764,8 +877,8 @@ class SegmentationImage:
         """
         Remove the label number.
 
-        The removed label is assigned a value of zero (i.e., background)
-        in the segmentation image.
+        The removed label is assigned a value of zero (i.e.,
+        background).
 
         Parameters
         ----------
@@ -817,8 +930,7 @@ class SegmentationImage:
         """
         Remove one or more labels.
 
-        Removed labels are assigned a value of zero (i.e., background)
-        in the segmentation image.
+        Removed labels are assigned a value of zero (i.e., background).
 
         Parameters
         ----------

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -298,6 +298,14 @@ class SegmentationImage:
         return find_objects(self._data)
 
     @lazyproperty
+    def background_area(self):
+        """
+        The area (in pixel**2) of the background (label=0) region.
+        """
+
+        return len(self.data[self.data == 0])
+
+    @lazyproperty
     def areas(self):
         """
         A 1D array of areas (in pixel**2) of the non-zero labeled
@@ -318,7 +326,8 @@ class SegmentationImage:
         Parameters
         ----------
         labels : int, 1D array-like (int)
-            The label(s) for which to return areas.
+            The label(s) for which to return areas.  Label must be
+            non-zero.
 
         Returns
         -------

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -442,6 +442,24 @@ class SegmentationImage:
 
         return deepcopy(self)
 
+    def check_label(self, label):
+        """
+        Check that the input label is a valid label number within the
+        segmentation image.
+
+        Parameters
+        ----------
+        label : int
+            The label number to check.
+
+        Raises
+        ------
+        ValueError
+            If the input ``label`` is invalid.
+        """
+
+        self.check_labels(label)
+
     def check_labels(self, labels):
         """
         Check that the input label(s) are valid label numbers within the
@@ -469,9 +487,11 @@ class SegmentationImage:
         # check if label is in the segmentation image
         bad_labels.update(np.setdiff1d(labels, self.labels))
 
-        bad_labels = tuple(bad_labels)
         if len(bad_labels) > 0:
-            raise ValueError('labels {} are invalid'.format(bad_labels))
+            if len(bad_labels) == 1:
+                raise ValueError('label {} is invalid'.format(bad_labels))
+            else:
+                raise ValueError('labels {} are invalid'.format(bad_labels))
 
     @deprecated('0.7', alternative='make_cmap')
     def cmap(self, background_color='#000000', random_state=None):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -221,7 +221,7 @@ class SegmentationImage:
         return np.ma.masked_where(self.data == 0, self.data)
 
     @staticmethod
-    def _labels(data):
+    def _get_labels(data):
         """
         Return a sorted array of the non-zero labels in the segmentation
         image.
@@ -240,7 +240,7 @@ class SegmentationImage:
 
         Notes
         -----
-        This is a separate static method so it can be used in
+        This is a static method so it can be used in
         :meth:`remove_masked_labels` on a masked version of the
         segmentation image.
 
@@ -253,7 +253,7 @@ class SegmentationImage:
         ...                           [7, 0, 0, 0, 0, 5],
         ...                           [7, 7, 0, 5, 5, 5],
         ...                           [7, 7, 0, 0, 5, 5]])
-        >>> segm._labels(segm.data)
+        >>> segm._get_labels(segm.data)
         array([1, 3, 4, 5, 7])
         """
 
@@ -272,7 +272,7 @@ class SegmentationImage:
     def labels(self):
         """The sorted non-zero labels in the segmentation image."""
 
-        return self._labels(self.data)
+        return self._get_labels(self.data)
 
     @lazyproperty
     def nlabels(self):
@@ -846,8 +846,8 @@ class SegmentationImage:
         if mask.shape != self.shape:
             raise ValueError('mask must have the same shape as the '
                              'segmentation image')
-        remove_labels = self._labels(self.data[mask])
+        remove_labels = self._get_labels(self.data[mask])
         if not partial_overlap:
-            interior_labels = self._labels(self.data[~mask])
+            interior_labels = self._get_labels(self.data[~mask])
             remove_labels = list(set(remove_labels) - set(interior_labels))
         self.remove_labels(remove_labels, relabel=relabel)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -97,6 +97,11 @@ class Segment:
 
     @lazyproperty
     def bbox(self):
+        """
+        The `BoundingBox` of the minimal rectangular region containing
+        the source segment.
+        """
+
         return BoundingBox(self.slices[1].start, self.slices[1].stop,
                            self.slices[0].start, self.slices[0].stop)
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -843,7 +843,7 @@ class SegmentationImage:
         Returns
         -------
         boundaries : 2D `~numpy.ndarray` or `~numpy.ma.MaskedArray`
-            An image with the same shape of the segmenation image
+            An image with the same shape of the segmentation image
             containing only the outlines of the labeled segments.  The
             pixel values in the outlines correspond to the labels in the
             segmentation image.  If ``mask_background`` is `True`, then

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -446,56 +446,6 @@ class SegmentationImage:
 
         return cmap
 
-    def outline_segments(self, mask_background=False):
-        """
-        Outline the labeled segments.
-
-        The "outlines" represent the pixels *just inside* the segments,
-        leaving the background pixels unmodified.  This corresponds to
-        the ``mode='inner'`` in `skimage.segmentation.find_boundaries`.
-
-        Parameters
-        ----------
-        mask_background : bool, optional
-            Set to `True` to mask the background pixels (labels = 0) in
-            the returned image.  This is useful for overplotting the
-            segment outlines on an image.  The default is `False`.
-
-        Returns
-        -------
-        boundaries : 2D `~numpy.ndarray` or `~numpy.ma.MaskedArray`
-            An image with the same shape of the segmenation image
-            containing only the outlines of the labeled segments.  The
-            pixel values in the outlines correspond to the labels in the
-            segmentation image.  If ``mask_background`` is `True`, then
-            a `~numpy.ma.MaskedArray` is returned.
-
-        Examples
-        --------
-        >>> from photutils import SegmentationImage
-        >>> segm = SegmentationImage([[0, 0, 0, 0, 0, 0],
-        ...                           [0, 2, 2, 2, 2, 0],
-        ...                           [0, 2, 2, 2, 2, 0],
-        ...                           [0, 2, 2, 2, 2, 0],
-        ...                           [0, 2, 2, 2, 2, 0],
-        ...                           [0, 0, 0, 0, 0, 0]])
-        >>> segm.outline_segments()
-        array([[0, 0, 0, 0, 0, 0],
-               [0, 2, 2, 2, 2, 0],
-               [0, 2, 0, 0, 2, 0],
-               [0, 2, 0, 0, 2, 0],
-               [0, 2, 2, 2, 2, 0],
-               [0, 0, 0, 0, 0, 0]])
-        """
-
-        # requires scikit-image >= 0.11
-        from skimage.segmentation import find_boundaries
-
-        outlines = self.data * find_boundaries(self.data, mode='inner')
-        if mask_background:
-            outlines = np.ma.masked_where(outlines == 0, outlines)
-        return outlines
-
     @deprecated('0.7', alternative='reassign_label')
     def relabel(self, labels, new_label):
         """
@@ -843,3 +793,53 @@ class SegmentationImage:
             interior_labels = self._get_labels(self.data[~mask])
             remove_labels = list(set(remove_labels) - set(interior_labels))
         self.remove_labels(remove_labels, relabel=relabel)
+
+    def outline_segments(self, mask_background=False):
+        """
+        Outline the labeled segments.
+
+        The "outlines" represent the pixels *just inside* the segments,
+        leaving the background pixels unmodified.  This corresponds to
+        the ``mode='inner'`` in `skimage.segmentation.find_boundaries`.
+
+        Parameters
+        ----------
+        mask_background : bool, optional
+            Set to `True` to mask the background pixels (labels = 0) in
+            the returned image.  This is useful for overplotting the
+            segment outlines on an image.  The default is `False`.
+
+        Returns
+        -------
+        boundaries : 2D `~numpy.ndarray` or `~numpy.ma.MaskedArray`
+            An image with the same shape of the segmenation image
+            containing only the outlines of the labeled segments.  The
+            pixel values in the outlines correspond to the labels in the
+            segmentation image.  If ``mask_background`` is `True`, then
+            a `~numpy.ma.MaskedArray` is returned.
+
+        Examples
+        --------
+        >>> from photutils import SegmentationImage
+        >>> segm = SegmentationImage([[0, 0, 0, 0, 0, 0],
+        ...                           [0, 2, 2, 2, 2, 0],
+        ...                           [0, 2, 2, 2, 2, 0],
+        ...                           [0, 2, 2, 2, 2, 0],
+        ...                           [0, 2, 2, 2, 2, 0],
+        ...                           [0, 0, 0, 0, 0, 0]])
+        >>> segm.outline_segments()
+        array([[0, 0, 0, 0, 0, 0],
+               [0, 2, 2, 2, 2, 0],
+               [0, 2, 0, 0, 2, 0],
+               [0, 2, 0, 0, 2, 0],
+               [0, 2, 2, 2, 2, 0],
+               [0, 0, 0, 0, 0, 0]])
+        """
+
+        # requires scikit-image >= 0.11
+        from skimage.segmentation import find_boundaries
+
+        outlines = self.data * find_boundaries(self.data, mode='inner')
+        if mask_background:
+            outlines = np.ma.masked_where(outlines == 0, outlines)
+        return outlines

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -541,7 +541,7 @@ class SegmentationImage:
         """
 
         return self.make_cmap(background_color=background_color,
-                              random_state=random_state)
+                              random_state=random_state)  # pragma: no cover
 
     def make_cmap(self, background_color='#000000', random_state=None):
         """
@@ -595,7 +595,7 @@ class SegmentationImage:
             The reassigned label number.
         """
 
-        self.reassign_label(labels, new_label)
+        self.reassign_label(labels, new_label)  # pragma: no cover
 
     def reassign_label(self, label, new_label, relabel=False):
         """

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -114,7 +114,7 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     last_label = segment_img.max_label
     segm_deblended = deepcopy(segment_img)
     for label in labels:
-        source_slice = segment_img.slices[label - 1]
+        source_slice = segment_img.slices[segment_img.get_index(label)]
         source_data = data[source_slice]
         source_segm = SegmentationImage(np.copy(
             segment_img.data[source_slice]))

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -66,7 +66,7 @@ class TestSegmentationImage:
     def test_segments(self):
         assert isinstance(self.segm[0], Segment)
         assert_allclose(self.segm[0].data, self.segm[0].__array__())
-        assert self.segm[4].area == self.segm.areas[4]
+        assert self.segm[4].area == self.segm.get_area(self.segm[4].label)
         assert self.segm[4].slices == self.segm.slices[4]
         assert self.segm[3].bbox.slices == self.segm[3].slices
         assert self.segm[1] is None
@@ -110,7 +110,7 @@ class TestSegmentationImage:
         assert self.segm.max_label == 7
 
     def test_areas(self):
-        expected = np.array([2, 0, 2, 3, 6, 0, 5])
+        expected = np.array([2, 2, 3, 6, 5])
         assert_allclose(self.segm.areas, expected)
 
     def test_is_consecutive(self):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -7,6 +7,12 @@ import pytest
 from ..core import Segment, SegmentationImage
 
 try:
+    import matplotlib    # noqa
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
+
+try:
     import scipy    # noqa
     HAS_SCIPY = True
 except ImportError:
@@ -140,6 +146,7 @@ class TestSegmentationImage:
         with pytest.raises(ValueError):
             self.segm.check_labels([2, 6])
 
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_make_cmap(self):
         cmap = self.segm.make_cmap()
         assert len(cmap.colors) == (self.segm.max_label + 1)

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -150,9 +150,9 @@ class TestSegmentationImage:
         assert np.ma.count(segm_outlines) == 8
         assert np.ma.count_masked(segm_outlines) == 17
 
-    def test_relabel(self):
+    def test_reassign_label(self):
         segm = SegmentationImage(self.data)
-        segm.relabel(labels=[1, 7], new_label=2)
+        segm.reassign_label(labels=[1, 7], new_label=2)
         ref_data = np.array([[2, 2, 0, 0, 4, 4],
                              [0, 0, 0, 0, 0, 4],
                              [0, 0, 3, 3, 0, 0],

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -131,25 +131,6 @@ class TestSegmentationImage:
         assert len(cmap.colors) == (self.segm.max_label + 1)
         assert_allclose(cmap.colors[0], [0, 0, 0])
 
-    def test_outline_segments(self):
-        segm_array = np.zeros((5, 5)).astype(int)
-        segm_array[1:4, 1:4] = 2
-        segm = SegmentationImage(segm_array)
-        segm_array_ref = np.copy(segm_array)
-        segm_array_ref[2, 2] = 0
-        assert_allclose(segm.outline_segments(), segm_array_ref)
-
-    def test_outline_segments_masked_background(self):
-        segm_array = np.zeros((5, 5)).astype(int)
-        segm_array[1:4, 1:4] = 2
-        segm = SegmentationImage(segm_array)
-        segm_array_ref = np.copy(segm_array)
-        segm_array_ref[2, 2] = 0
-        segm_outlines = segm.outline_segments(mask_background=True)
-        assert isinstance(segm_outlines, np.ma.MaskedArray)
-        assert np.ma.count(segm_outlines) == 8
-        assert np.ma.count_masked(segm_outlines) == 17
-
     def test_reassign_label(self):
         segm = SegmentationImage(self.data)
         segm.reassign_label(labels=[1, 7], new_label=2)
@@ -277,3 +258,22 @@ class TestSegmentationImage:
         mask = np.zeros((3, 3), dtype=np.bool)
         with pytest.raises(ValueError):
             segm.remove_masked_labels(mask)
+
+    def test_outline_segments(self):
+        segm_array = np.zeros((5, 5)).astype(int)
+        segm_array[1:4, 1:4] = 2
+        segm = SegmentationImage(segm_array)
+        segm_array_ref = np.copy(segm_array)
+        segm_array_ref[2, 2] = 0
+        assert_allclose(segm.outline_segments(), segm_array_ref)
+
+    def test_outline_segments_masked_background(self):
+        segm_array = np.zeros((5, 5)).astype(int)
+        segm_array[1:4, 1:4] = 2
+        segm = SegmentationImage(segm_array)
+        segm_array_ref = np.copy(segm_array)
+        segm_array_ref[2, 2] = 0
+        segm_outlines = segm.outline_segments(mask_background=True)
+        assert isinstance(segm_outlines, np.ma.MaskedArray)
+        assert np.ma.count(segm_outlines) == 8
+        assert np.ma.count_masked(segm_outlines) == 17

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -66,15 +66,16 @@ class TestSegmentationImage:
     def test_segments(self):
         assert isinstance(self.segm[0], Segment)
         assert_allclose(self.segm[0].data, self.segm[0].__array__())
-        assert self.segm[4].area == self.segm.get_area(self.segm[4].label)
-        assert self.segm[4].slices == self.segm.slices[4]
-        assert self.segm[3].bbox.slices == self.segm[3].slices
-        assert self.segm[1] is None
-        assert self.segm[5] is None
+
+        label = 4
+        idx = self.segm.get_index(label)
+        assert self.segm[idx].label == label
+        assert self.segm[idx].area == self.segm.get_area(label)
+        assert self.segm[idx].slices == self.segm.slices[idx]
+        assert self.segm[idx].bbox.slices == self.segm[idx].slices
 
         for i, segment in enumerate(self.segm):
-            if segment is not None:
-                assert segment.label == (i + 1)
+            assert segment.label == self.segm.labels[i]
 
     def test_segment_repr_str(self):
         assert repr(self.segm[0]) == str(self.segm[0])
@@ -84,15 +85,15 @@ class TestSegmentationImage:
             assert '{}:'.format(prop) in repr(self.segm[0])
 
     def test_segment_data(self):
-        assert_allclose(self.segm[4].data.shape, (3, 3))
-        assert_allclose(np.unique(self.segm[4].data), [0, 5])
+        assert_allclose(self.segm[3].data.shape, (3, 3))
+        assert_allclose(np.unique(self.segm[3].data), [0, 5])
 
     def test_segment_make_cutout(self):
-        cutout = self.segm[4].make_cutout(self.data, masked_array=False)
+        cutout = self.segm[3].make_cutout(self.data, masked_array=False)
         assert not np.ma.is_masked(cutout)
         assert_allclose(cutout.shape, (3, 3))
 
-        cutout = self.segm[4].make_cutout(self.data, masked_array=True)
+        cutout = self.segm[3].make_cutout(self.data, masked_array=True)
         assert np.ma.is_masked(cutout)
         assert_allclose(cutout.shape, (3, 3))
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -12,14 +12,6 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-try:
-    import skimage    # noqa
-    HAS_SKIMAGE = True
-except ImportError:
-    HAS_SKIMAGE = False
-
-
-@pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSegmentationImage:
     def setup_class(self):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -126,8 +126,8 @@ class TestSegmentationImage:
         with pytest.raises(ValueError):
             self.segm.check_labels([2, 6])
 
-    def test_cmap(self):
-        cmap = self.segm.cmap()
+    def test_make_cmap(self):
+        cmap = self.segm.make_cmap()
         assert len(cmap.colors) == (self.segm.max_label + 1)
         assert_allclose(cmap.colors[0], [0, 0, 0])
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -131,9 +131,9 @@ class TestSegmentationImage:
         assert len(cmap.colors) == (self.segm.max_label + 1)
         assert_allclose(cmap.colors[0], [0, 0, 0])
 
-    def test_reassign_label(self):
+    def test_reassign_labels(self):
         segm = SegmentationImage(self.data)
-        segm.reassign_label(labels=[1, 7], new_label=2)
+        segm.reassign_labels(labels=[1, 7], new_label=2)
         ref_data = np.array([[2, 2, 0, 0, 4, 4],
                              [0, 0, 0, 0, 0, 4],
                              [0, 0, 3, 3, 0, 0],

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -184,6 +184,6 @@ class TestDeblendSources:
         """
 
         segm = self.segm.copy()
-        segm.relabel(1, 512)
+        segm.reassign_label(1, 512)
         result = deblend_sources(self.data, segm, self.npixels)
         assert result.nlabels == 2

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -90,7 +90,7 @@ class TestDeblendSources:
                                  mode=mode, relabel=False)
         assert result.nlabels == 2
         assert len(result.slices) <= result.max_label
-        assert len(result.slices) == 3   # label 1 is None
+        assert len(result.slices) == result.nlabels
         assert_allclose(np.nonzero(self.segm), np.nonzero(result))
 
     @pytest.mark.parametrize('mode', ['exponential', 'linear'])

--- a/photutils/utils/colormaps.py
+++ b/photutils/utils/colormaps.py
@@ -1,16 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
+from astropy.utils import deprecated
 
 from .check_random_state import check_random_state
 
 
-__all__ = ['random_cmap']
+__all__ = ['make_random_cmap']
 
 
+@deprecated('0.7', alternative='make_random_cmap')
 def random_cmap(ncolors=256, random_state=None):
     """
-    Generate a matplotlib colormap consisting of random (muted) colors.
+    Make a matplotlib colormap consisting of (random) muted colors.
 
     A random colormap is very useful for plotting segmentation images.
 
@@ -26,7 +28,32 @@ def random_cmap(ncolors=256, random_state=None):
 
     Returns
     -------
-    cmap : `matplotlib.colors.Colormap`
+    cmap : `matplotlib.colors.ListedColormap`
+        The matplotlib colormap with random colors.
+    """
+
+    return make_random_cmap(ncolors=ncolors, random_state=random_state)
+
+
+def make_random_cmap(ncolors=256, random_state=None):
+    """
+    Make a matplotlib colormap consisting of (random) muted colors.
+
+    A random colormap is very useful for plotting segmentation images.
+
+    Parameters
+    ----------
+    ncolors : int, optional
+        The number of colors in the colormap.  The default is 256.
+
+    random_state : int or `~numpy.random.RandomState`, optional
+        The pseudo-random number generator state used for random
+        sampling.  Separate function calls with the same
+        ``random_state`` will generate the same colormap.
+
+    Returns
+    -------
+    cmap : `matplotlib.colors.ListedColormap`
         The matplotlib colormap with random colors.
     """
 

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -3,7 +3,7 @@
 from numpy.testing import assert_allclose
 import pytest
 
-from ..colormaps import random_cmap
+from ..colormaps import make_random_cmap
 
 try:
     import matplotlib    # noqa
@@ -15,6 +15,6 @@ except ImportError:
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_colormap():
     ncolors = 100
-    cmap = random_cmap(ncolors, random_state=12345)
+    cmap = make_random_cmap(ncolors, random_state=12345)
     assert len(cmap.colors) == ncolors
     assert_allclose(cmap.colors[0], [0.9234715, 0.64837165, 0.76454726])


### PR DESCRIPTION
This PR makes several improvements to `SegmentationImage` (and `Segment`):

* Adds new `background_area` attribute.

* Add new `find_index`, `find_indices`, `find_areas`, `check_label`, `keep_label`, `remove_label`, and `reassign_labels` methods.

* Adds `__repr__` and `__str__` methods.

* Fixed `outline_segments` to include segment outlines along the image boundaries.

* Renamed methods `cmap` (deprecated) to `make_cmap` and `relabel` (deprecated) to `reassign_label`.  The `reassign_label` gains a `relabel` keyword.

* The `segments` and `slices` attributes now have the same length as `labels` (i.e. no `None` placeholders for non-consecutive labels).

* Remove all old deprecated attributes and methods.

* Adds new `data_ma` attribute to `Segment` class.

Relatedly, the ``random_cmap`` (deprecated) utility function was renamed ``make_random_cmap``.
