### PR TITLE
Improve performance of ellipse fitting

### DIFF
--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -415,12 +415,13 @@ class EllipseGeometry:
         # that is incurred when using vectorized code.
         #
         # The split in two separate functions helps in
-        # the profiling analysis.
+        # the profiling analysis: most of the time is
+        # spent in the scalar function.
 
         if type(x) == type(1) or type(x) == type(1.0):
-            self._to_polar_scalar(x, y)
+            return self._to_polar_scalar(x, y)
         else:
-            self._to_polar_vectorized(x, y)
+            return self._to_polar_vectorized(x,y)
 
     def _to_polar_scalar(self, x, y):
 

--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -409,77 +409,77 @@ class EllipseGeometry:
         radius, angle : float
             The ellipse radius and polar angle.
         """
-        # We split in between a scalar version and a 
+        # We split in between a scalar version and a
         # vectorized version. This is necessary for
         # now so we don't pay a heavy speed penalty
         # that is incurred when using vectorized code.
-        #
+
         # The split in two separate functions helps in
         # the profiling analysis: most of the time is
         # spent in the scalar function.
 
-        if type(x) == type(1) or type(x) == type(1.0):
+        if isinstance(x, int) or isinstance(x, float):
             return self._to_polar_scalar(x, y)
         else:
-            return self._to_polar_vectorized(x,y)
+            return self._to_polar_vectorized(x, y)
 
     def _to_polar_scalar(self, x, y):
 
-            x1 = x - self.x0
-            y1 = y - self.y0
+        x1 = x - self.x0
+        y1 = y - self.y0
 
-            radius = x1**2 + y1**2
-            if radius > 0.0:
-                radius = math.sqrt(radius)
-                angle = math.asin(abs(y1) / radius)
-            else:
-                radius = 0.
-                angle = 1.
+        radius = x1**2 + y1**2
+        if radius > 0.0:
+            radius = math.sqrt(radius)
+            angle = math.asin(abs(y1) / radius)
+        else:
+            radius = 0.
+            angle = 1.
 
-            if x1 >= 0. and y1 < 0.:
-                angle = 2*np.pi - angle
-            elif x1 < 0. and y1 >= 0.:
-                angle = np.pi - angle
-            elif x1 < 0. and y1 < 0.:
-                angle = np.pi + angle
+        if x1 >= 0. and y1 < 0.:
+            angle = 2*np.pi - angle
+        elif x1 < 0. and y1 >= 0.:
+            angle = np.pi - angle
+        elif x1 < 0. and y1 < 0.:
+            angle = np.pi + angle
 
-            pa1 = self.pa
-            if self.pa < 0.:
-                pa1 = self.pa + 2*np.pi
-            angle = angle - pa1
-            if angle < 0.:
-                angle = angle + 2*np.pi
+        pa1 = self.pa
+        if self.pa < 0.:
+            pa1 = self.pa + 2*np.pi
+        angle = angle - pa1
+        if angle < 0.:
+            angle = angle + 2*np.pi
 
-            return radius, angle
+        return radius, angle
 
     def _to_polar_vectorized(self, x, y):
 
-            x1 = np.atleast_2d(x) - self.x0
-            y1 = np.atleast_2d(y) - self.y0
+        x1 = np.atleast_2d(x) - self.x0
+        y1 = np.atleast_2d(y) - self.y0
 
-            radius = x1**2 + y1**2
-            angle = np.ones(radius.shape)
+        radius = x1**2 + y1**2
+        angle = np.ones(radius.shape)
 
-            imask = (radius > 0.0)
-            radius[imask] = np.sqrt(radius[imask])
-            angle[imask] = np.arcsin(np.abs(y1[imask]) / radius[imask])
-            radius[~imask] = 0.
-            angle[~imask] = 1.
+        imask = (radius > 0.0)
+        radius[imask] = np.sqrt(radius[imask])
+        angle[imask] = np.arcsin(np.abs(y1[imask]) / radius[imask])
+        radius[~imask] = 0.
+        angle[~imask] = 1.
 
-            idx = (x1 >= 0.) & (y1 < 0)
-            angle[idx] = 2*np.pi - angle[idx]
-            idx = (x1 < 0.) & (y1 >= 0.)
-            angle[idx] = np.pi - angle[idx]
-            idx = (x1 < 0.) & (y1 < 0.)
-            angle[idx] = np.pi + angle[idx]
+        idx = (x1 >= 0.) & (y1 < 0)
+        angle[idx] = 2*np.pi - angle[idx]
+        idx = (x1 < 0.) & (y1 >= 0.)
+        angle[idx] = np.pi - angle[idx]
+        idx = (x1 < 0.) & (y1 < 0.)
+        angle[idx] = np.pi + angle[idx]
 
-            pa1 = self.pa
-            if self.pa < 0.:
-                pa1 = self.pa + 2*np.pi
-            angle = angle - pa1
-            angle[angle < 0] += 2*np.pi
+        pa1 = self.pa
+        if self.pa < 0.:
+            pa1 = self.pa + 2*np.pi
+        angle = angle - pa1
+        angle[angle < 0] += 2*np.pi
 
-            return radius, angle
+        return radius, angle
 
     def update_sma(self, step):
         """

--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -413,7 +413,16 @@ class EllipseGeometry:
         # vectorized version. This is necessary for
         # now so we don't pay a heavy speed penalty
         # that is incurred when using vectorized code.
+        #
+        # The split in two separate functions helps in
+        # the profiling analysis.
+
         if type(x) == type(1) or type(x) == type(1.0):
+            self._to_polar_scalar(x, y)
+        else:
+            self._to_polar_vectorized(x, y)
+
+    def _to_polar_scalar(self, x, y):
 
             x1 = x - self.x0
             y1 = y - self.y0
@@ -442,7 +451,7 @@ class EllipseGeometry:
 
             return radius, angle
 
-        else:
+    def _to_polar_vectorized(self, x, y):
 
             x1 = np.atleast_2d(x) - self.x0
             y1 = np.atleast_2d(y) - self.y0

--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -410,32 +410,68 @@ class EllipseGeometry:
             The ellipse radius and polar angle.
         """
 
-        x1 = np.atleast_2d(x) - self.x0
-        y1 = np.atleast_2d(y) - self.y0
+        if type(x) == type(1) or type(x) == type(1.0):
 
-        radius = x1**2 + y1**2
-        angle = np.ones(radius.shape)
+            x1 = x - self.x0
+            y1 = y - self.y0
 
-        imask = (radius > 0.0)
-        radius[imask] = np.sqrt(radius[imask])
-        angle[imask] = np.arcsin(np.abs(y1[imask]) / radius[imask])
-        radius[~imask] = 0.
-        angle[~imask] = 1.
+            radius = x1**2 + y1**2
+            if radius > 0.0:
+                radius = math.sqrt(radius)
+                angle = math.asin(abs(y1) / radius)
+            else:
+                radius = 0.
+                angle = 1.
 
-        idx = (x1 >= 0.) & (y1 < 0)
-        angle[idx] = 2*np.pi - angle[idx]
-        idx = (x1 < 0.) & (y1 >= 0.)
-        angle[idx] = np.pi - angle[idx]
-        idx = (x1 < 0.) & (y1 < 0.)
-        angle[idx] = np.pi + angle[idx]
+            if x1 >= 0. and y1 < 0.:
+                angle = 2*np.pi - angle
+            elif x1 < 0. and y1 >= 0.:
+                angle = np.pi - angle
+            elif x1 < 0. and y1 < 0.:
+                angle = np.pi + angle
 
-        pa1 = self.pa
-        if self.pa < 0.:
-            pa1 = self.pa + 2*np.pi
-        angle = angle - pa1
-        angle[angle < 0] += 2*np.pi
+            pa1 = self.pa
+            if self.pa < 0.:
+                pa1 = self.pa + 2*np.pi
+            angle = angle - pa1
+            if angle < 0.:
+                angle = angle + 2*np.pi
 
-        return radius, angle
+            return radius, angle
+
+        else:
+
+
+            x1 = np.atleast_2d(x) - self.x0
+            y1 = np.atleast_2d(y) - self.y0
+
+            radius = x1**2 + y1**2
+            angle = np.ones(radius.shape)
+
+            imask = (radius > 0.0)
+            radius[imask] = np.sqrt(radius[imask])
+            angle[imask] = np.arcsin(np.abs(y1[imask]) / radius[imask])
+            radius[~imask] = 0.
+            angle[~imask] = 1.
+
+            idx = (x1 >= 0.) & (y1 < 0)
+            angle[idx] = 2*np.pi - angle[idx]
+            idx = (x1 < 0.) & (y1 >= 0.)
+            angle[idx] = np.pi - angle[idx]
+            idx = (x1 < 0.) & (y1 < 0.)
+            angle[idx] = np.pi + angle[idx]
+
+            pa1 = self.pa
+            if self.pa < 0.:
+                pa1 = self.pa + 2*np.pi
+            angle = angle - pa1
+            angle[angle < 0] += 2*np.pi
+
+            return radius, angle
+
+
+
+
 
     def update_sma(self, step):
         """

--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -413,7 +413,6 @@ class EllipseGeometry:
         # vectorized version. This is necessary for
         # now so we don't pay a heavy speed penalty
         # that is incurred when using vectorized code.
-
         if type(x) == type(1) or type(x) == type(1.0):
 
             x1 = x - self.x0

--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -409,6 +409,10 @@ class EllipseGeometry:
         radius, angle : float
             The ellipse radius and polar angle.
         """
+        # We split in between a scalar version and a 
+        # vectorized version. This is necessary for
+        # now so we don't pay a heavy speed penalty
+        # that is incurred when using vectorized code.
 
         if type(x) == type(1) or type(x) == type(1.0):
 
@@ -441,7 +445,6 @@ class EllipseGeometry:
 
         else:
 
-
             x1 = np.atleast_2d(x) - self.x0
             y1 = np.atleast_2d(y) - self.y0
 
@@ -468,10 +471,6 @@ class EllipseGeometry:
             angle[angle < 0] += 2*np.pi
 
             return radius, angle
-
-
-
-
 
     def update_sma(self, step):
         """

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -251,7 +251,7 @@ class Isophote:
             a_err = abs(a) * np.sqrt((ce[1] / c[1])**2 + gre**2)
             b_err = abs(b) * np.sqrt((ce[2] / c[2])**2 + gre**2)
 
-        except Exception as e:    # we want to catch everything
+        except Exception:    # we want to catch everything
             a = b = a_err = b_err = None
 
         return a, b, a_err, b_err
@@ -291,7 +291,7 @@ class Isophote:
                                    self.grad / (1. - (1. - eps)**2)))
             else:
                 self.pa_err = 0.
-        except Exception as e:    # we want to catch everything
+        except Exception:    # we want to catch everything
             self.x0_err = self.y0_err = self.pa_err = self.ellip_err = 0.
 
     def fix_geometry(self, isophote):


### PR DESCRIPTION
This comes from work discussed in issue #802. 

In a nutshell, when profiling the code, we found  that vectorization of the `geometry.to_polar` method caused a significant performance degradation. In this PR we modify `to_polar` so it can handle scalar input quantities using scalar code, but still keeping its vectorized habilities. 

Profiling analysis indicates that the code returned to its overal performance level, similar to we had before.

Due to its own nature, the ellipse fitting algorithm as originally coded is slow. We are still investigating other approaches that involve a more in-depth vectorization of the entire algorithm, or caching of intermediate data (or both). This PR is to be taken as a stopgap solution to a pressing problem.

We tested this using both the test code provided in #802, as well as the notebook tutorials in `photutils-datasets`.