### PR TITLE
Expanded FittableImageModel's oversampling factor to allow differing oversampling in x and y

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,8 +78,8 @@ API changes
 
 - ``photutils.psf``
 
-  - ``FittableImageModel`` and subclasses now allow for two-dimensional
-    ``oversampling`` factors, specifying both oversampling in x and y. [#834]
+  - ``FittableImageModel`` and subclasses now allow for different ``oversampling``
+    factors to be specified in x and y directions. [#834]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,11 @@ API changes
 
   - Renamed ``random_cmap`` to ``make_random_cmap``. [#825]
 
+- ``photutils.psf``
+
+  - ``FittableImageModel`` and subclasses now allow for two-dimensional
+    ``oversampling`` factors, specifying both oversampling in x and y. [#834]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -208,7 +208,7 @@ class EPSFFitter:
         # of the ePSF and EPSFStar pixel scales.  This allows for
         # oversampling factors that differ between stars and also for
         # the factor to be different along the x and y axes.
-        epsf._oversampling = 1.
+        epsf._oversampling = np.array([1., 1.])
 
         try:
             fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=scaled_data,

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -99,6 +99,20 @@ class TestFittableImageModel:
         assert_allclose(val36, model_oversampled(2.5 + 0.66, -3.5 + 0.66),
                         rtol=1.e-6)
 
+    def test_oversampling_inputs(self):
+        data = np.arange(30).reshape(5, 6)
+        for oversampling in [4, (3, 3), (3, 4), '1', ('1', '2')]:
+            fim = FittableImageModel(data, oversampling=oversampling)
+            if not hasattr(oversampling, '__len__'):
+                _oversamp = float(oversampling)
+            else:
+                _oversamp = tuple(float(o) for o in oversampling)
+            assert np.all(fim._oversampling == _oversamp)
+
+        for oversampling in ['a', ('b', 2), (-1, 3), -1]:
+            with pytest.raises(ValueError):
+                fim = FittableImageModel(data, oversampling=oversampling)
+
 
 class TestGriddedPSFModel:
     def setup_class(self):


### PR DESCRIPTION
This PR gives ``FittableImageModel`` the option to accept ``oversampling`` factors that give differing values in the x and y direction, as a tuple of ``(x_oversamp, y_oversamp)``. It maintains backwards compatibility by accepting a scalar, interpreted as providing the same oversampling factors for both x and y (i.e., treating it as ``(oversampling, oversampling)``).

cc @eteq @larrybradley for comments. Forms part of a wider branch change with #815, #816 and #817 (see [here](https://github.com/astropy/photutils/pull/815#issuecomment-486709606) for more details).