### PR TITLE
Consistent handling of cases when there are no source/peak detections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,10 @@ New Features
   - Added ``__repr__`` and ``__str__`` methods to
     ``SegmentationImage``. [#825]
 
+- ``photutils.utils``
+
+  - Added ``NoDetectionsWarning`` class. [#836]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -61,6 +65,10 @@ API changes
 
   - Removed deprecated ``subpixel`` keyword for ``find_peaks``. [#835]
 
+  - ``DAOStarFinder``, ``IRAFStarFinder``, and ``find_peaks`` now return
+    ``None`` if no source/peaks are found.  Also, for this case a
+    ``NoDetectionsWarning`` is issued. [#836]
+
 - ``photutils.segmentation``
 
   - Removed deprecated ``SegmentationImage`` attributes
@@ -75,6 +83,17 @@ API changes
   - The ``SegmentationImage`` ``segments`` and ``slices`` attributes
     now have the same length as ``labels`` (no ``None`` placeholders).
     [#825]
+
+  - ``detect_sources`` now returns ``None`` is no sources are found.
+    Also, for this case a ``NoDetectionsWarning`` is issued. [#836]
+
+  - The ``SegmentationImage`` input ``data`` array must contain at
+    least one non-zero pixel and must not contain any non-finite values.
+    [#836]
+
+  - A ``ValueError`` is raised if an empty list is input into
+    ``SourceCatalog`` or no valid sources are defined in
+    ``source_properties``. [#836]
 
 - ``photutils.utils``
 

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -662,7 +662,7 @@ def _find_stars(data, kernel, threshold_eff, min_separation=None,
     tbl = find_peaks(convolved_data, threshold_eff, footprint=footprint,
                      mask=mask)
     if len(tbl) == 0:
-        return []
+        return None
 
     coords = np.transpose([tbl['y_peak'], tbl['x_peak']])
 
@@ -907,7 +907,7 @@ class DAOStarFinder(StarFinderBase):
 
         Returns
         -------
-        table : `~astropy.table.Table`
+        table : `~astropy.table.Table` or `None`
             A table of found stars with the following parameters:
 
             * ``id``: unique object identification number.
@@ -927,24 +927,19 @@ class DAOStarFinder(StarFinderBase):
               ``-2.5 * log10(flux)``.  The derivation matches that of
               `DAOFIND`_ if ``sky`` is 0.0.
 
-            If no stars are found then an empty table is returned.
+            `None` is returned if no stars are found.
 
         """
 
         star_cutouts = _find_stars(data, self.kernel, self.threshold_eff,
                                    mask=mask,
                                    exclude_border=self.exclude_border)
-        self._star_cutouts = star_cutouts
 
-        columns = ('id', 'xcentroid', 'ycentroid', 'sharpness', 'roundness1',
-                   'roundness2', 'npix', 'sky', 'peak', 'flux', 'mag')
-        coltypes = (np.int_, np.float_, np.float_, np.float_, np.float_,
-                    np.float_, np.int_, np.float_, np.float_, np.float_,
-                    np.float_)
-
-        if len(star_cutouts) == 0:
+        if star_cutouts is None:
             warnings.warn('No sources were found.', NoDetectionsWarning)
-            return Table(names=columns, dtype=coltypes)
+            return None
+
+        self._star_cutouts = star_cutouts
 
         star_props = []
         for star_cutout in star_cutouts:
@@ -974,7 +969,7 @@ class DAOStarFinder(StarFinderBase):
         if nstars == 0:
             warnings.warn('Sources were found, but none pass the sharpness '
                           'and roundness criteria.', NoDetectionsWarning)
-            return Table(names=columns, dtype=coltypes)
+            return None
 
         if self.brightest is not None:
             fluxes = [props.flux for props in star_props]
@@ -984,7 +979,9 @@ class DAOStarFinder(StarFinderBase):
 
         table = Table()
         table['id'] = np.arange(nstars) + 1
-        for column in columns[1:]:
+        columns = ('xcentroid', 'ycentroid', 'sharpness', 'roundness1',
+                   'roundness2', 'npix', 'sky', 'peak', 'flux', 'mag')
+        for column in columns:
             table[column] = [getattr(props, column) for props in star_props]
 
         return table
@@ -1138,7 +1135,7 @@ class IRAFStarFinder(StarFinderBase):
 
         Returns
         -------
-        table : `~astropy.table.Table`
+        table : `~astropy.table.Table` or `None`
             A table of found objects with the following parameters:
 
             * ``id``: unique object identification number.
@@ -1155,7 +1152,7 @@ class IRAFStarFinder(StarFinderBase):
             * ``mag``: the object instrumental magnitude calculated as
               ``-2.5 * log10(flux)``.
 
-            If no stars are found then an empty table is returned.
+            `None` is returned if no stars are found.
 
         """
 
@@ -1163,17 +1160,12 @@ class IRAFStarFinder(StarFinderBase):
                                    min_separation=self.min_separation,
                                    mask=mask,
                                    exclude_border=self.exclude_border)
-        self._star_cutouts = star_cutouts
 
-        columns = ('id', 'xcentroid', 'ycentroid', 'fwhm', 'sharpness',
-                   'roundness', 'pa', 'npix', 'sky', 'peak', 'flux', 'mag')
-        coltypes = (np.int_, np.float_, np.float_, np.float_, np.float_,
-                    np.float_, np.float_, np.int_, np.float_, np.float_,
-                    np.float_, np.float_)
-
-        if len(star_cutouts) == 0:
+        if star_cutouts is None:
             warnings.warn('No sources were found.', NoDetectionsWarning)
-            return Table(names=columns, dtype=coltypes)
+            return None
+
+        self._star_cutouts = star_cutouts
 
         star_props = []
         for star_cutout in star_cutouts:
@@ -1201,7 +1193,7 @@ class IRAFStarFinder(StarFinderBase):
         if nstars == 0:
             warnings.warn('Sources were found, but none pass the sharpness '
                           'and roundness criteria.', NoDetectionsWarning)
-            return Table(names=columns, dtype=coltypes)
+            return None
 
         if self.brightest is not None:
             fluxes = [props.flux for props in star_props]
@@ -1211,7 +1203,9 @@ class IRAFStarFinder(StarFinderBase):
 
         table = Table()
         table['id'] = np.arange(nstars) + 1
-        for column in columns[1:]:
+        columns = ('xcentroid', 'ycentroid', 'fwhm', 'sharpness', 'roundness',
+                   'pa', 'npix', 'sky', 'peak', 'flux', 'mag')
+        for column in columns:
             table[column] = [getattr(props, column) for props in star_props]
 
         return table

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -14,12 +14,12 @@ import warnings
 import numpy as np
 from astropy.stats import gaussian_fwhm_to_sigma
 from astropy.table import Table
-from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import lazyproperty
 
 from .core import find_peaks
 from ..utils._moments import _moments, _moments_central
 from ..utils.convolution import filter_data
+from ..utils.exceptions import NoDetectionsWarning
 from ..utils.misc import _ABCMetaAndInheritDocstrings
 
 
@@ -943,7 +943,7 @@ class DAOStarFinder(StarFinderBase):
                     np.float_)
 
         if len(star_cutouts) == 0:
-            warnings.warn('No sources were found.', AstropyUserWarning)
+            warnings.warn('No sources were found.', NoDetectionsWarning)
             return Table(names=columns, dtype=coltypes)
 
         star_props = []
@@ -973,7 +973,7 @@ class DAOStarFinder(StarFinderBase):
         nstars = len(star_props)
         if nstars == 0:
             warnings.warn('Sources were found, but none pass the sharpness '
-                          'and roundness criteria.', AstropyUserWarning)
+                          'and roundness criteria.', NoDetectionsWarning)
             return Table(names=columns, dtype=coltypes)
 
         if self.brightest is not None:
@@ -1172,7 +1172,7 @@ class IRAFStarFinder(StarFinderBase):
                     np.float_, np.float_)
 
         if len(star_cutouts) == 0:
-            warnings.warn('No sources were found.', AstropyUserWarning)
+            warnings.warn('No sources were found.', NoDetectionsWarning)
             return Table(names=columns, dtype=coltypes)
 
         star_props = []
@@ -1200,7 +1200,7 @@ class IRAFStarFinder(StarFinderBase):
         nstars = len(star_props)
         if nstars == 0:
             warnings.warn('Sources were found, but none pass the sharpness '
-                          'and roundness criteria.', AstropyUserWarning)
+                          'and roundness criteria.', NoDetectionsWarning)
             return Table(names=columns, dtype=coltypes)
 
         if self.brightest is not None:

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -659,9 +659,13 @@ def _find_stars(data, kernel, threshold_eff, min_separation=None,
                                 constant_values=[0.])
 
     # find local peaks in the convolved data
-    tbl = find_peaks(convolved_data, threshold_eff, footprint=footprint,
-                     mask=mask)
-    if len(tbl) == 0:
+    with warnings.catch_warnings():
+        # suppress any NoDetectionsWarning from find_peaks
+        warnings.filterwarnings('ignore', category=NoDetectionsWarning)
+        tbl = find_peaks(convolved_data, threshold_eff, footprint=footprint,
+                         mask=mask)
+
+    if tbl is None:
         return None
 
     coords = np.transpose([tbl['y_peak'], tbl['x_peak']])

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -9,10 +9,11 @@ from numpy.testing import assert_allclose
 import pytest
 
 from astropy.table import Table
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.tests.helper import catch_warnings
 
 from ..findstars import DAOStarFinder, IRAFStarFinder
 from ...datasets import make_100gaussians_image
+from ...utils.exceptions import NoDetectionsWarning
 
 try:
     import scipy    # noqa
@@ -24,7 +25,6 @@ except ImportError:
 DATA = make_100gaussians_image()
 THRESHOLDS = [8.0, 10.0]
 FWHMS = [1.0, 1.5, 2.0]
-warnings.simplefilter('always', AstropyUserWarning)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -64,21 +64,35 @@ class TestDAOStarFinder:
 
     def test_daofind_nosources(self):
         data = np.ones((3, 3))
-        starfinder = DAOStarFinder(threshold=10, fwhm=1)
-        t = starfinder(data)
-        assert len(t) == 0
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
+            starfinder = DAOStarFinder(threshold=10, fwhm=1)
+            t = starfinder(data)
+            assert len(t) == 0
+
+            assert warning_lines[0].category == NoDetectionsWarning
+            assert ('No sources were found.' in str(warning_lines[0].message))
 
     def test_daofind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        starfinder = DAOStarFinder(threshold=50, fwhm=1.0, sharplo=1.)
-        t = starfinder(DATA)
-        assert len(t) == 0
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
+            starfinder = DAOStarFinder(threshold=50, fwhm=1.0, sharplo=1.)
+            t = starfinder(DATA)
+            assert len(t) == 0
+
+            assert warning_lines[0].category == NoDetectionsWarning
+            assert ('Sources were found, but none pass the sharpness and '
+                    'roundness criteria.' in str(warning_lines[0].message))
 
     def test_daofind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        starfinder = DAOStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
-        t = starfinder(DATA)
-        assert len(t) == 0
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
+            starfinder = DAOStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
+            t = starfinder(DATA)
+            assert len(t) == 0
+
+            assert warning_lines[0].category == NoDetectionsWarning
+            assert ('Sources were found, but none pass the sharpness and '
+                    'roundness criteria.' in str(warning_lines[0].message))
 
     def test_daofind_flux_negative(self):
         """Test handling of negative flux (here created by large sky)."""
@@ -171,21 +185,35 @@ class TestIRAFStarFinder:
 
     def test_irafstarfind_nosources(self):
         data = np.ones((3, 3))
-        starfinder = IRAFStarFinder(threshold=10, fwhm=1)
-        t = starfinder(data)
-        assert len(t) == 0
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
+            starfinder = IRAFStarFinder(threshold=10, fwhm=1)
+            t = starfinder(data)
+            assert len(t) == 0
+
+            assert warning_lines[0].category == NoDetectionsWarning
+            assert ('No sources were found.' in str(warning_lines[0].message))
 
     def test_irafstarfind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, sharplo=2.)
-        t = starfinder(DATA)
-        assert len(t) == 0
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
+            starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, sharplo=2.)
+            t = starfinder(DATA)
+            assert len(t) == 0
+
+            assert warning_lines[0].category == NoDetectionsWarning
+            assert ('Sources were found, but none pass the sharpness and '
+                    'roundness criteria.' in str(warning_lines[0].message))
 
     def test_irafstarfind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
-        t = starfinder(DATA)
-        assert len(t) == 0
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
+            starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
+            t = starfinder(DATA)
+            assert len(t) == 0
+
+            assert warning_lines[0].category == NoDetectionsWarning
+            assert ('Sources were found, but none pass the sharpness and '
+                    'roundness criteria.' in str(warning_lines[0].message))
 
     def test_irafstarfind_sky(self):
         starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=10.)
@@ -193,9 +221,14 @@ class TestIRAFStarFinder:
         assert len(t) == 4
 
     def test_irafstarfind_largesky(self):
-        starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
-        t = starfinder(DATA)
-        assert len(t) == 0
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
+            starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
+            t = starfinder(DATA)
+            assert len(t) == 0
+
+            assert warning_lines[0].category == NoDetectionsWarning
+            assert ('Sources were found, but none pass the sharpness and '
+                    'roundness criteria.' in str(warning_lines[0].message))
 
     def test_irafstarfind_peakmax_filtering(self):
         """

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -2,7 +2,6 @@
 
 import os.path as op
 import itertools
-import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose

--- a/photutils/detection/tests/test_findstars.py
+++ b/photutils/detection/tests/test_findstars.py
@@ -67,7 +67,7 @@ class TestDAOStarFinder:
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             starfinder = DAOStarFinder(threshold=10, fwhm=1)
             t = starfinder(data)
-            assert len(t) == 0
+            assert t is None
 
             assert warning_lines[0].category == NoDetectionsWarning
             assert ('No sources were found.' in str(warning_lines[0].message))
@@ -77,7 +77,7 @@ class TestDAOStarFinder:
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             starfinder = DAOStarFinder(threshold=50, fwhm=1.0, sharplo=1.)
             t = starfinder(DATA)
-            assert len(t) == 0
+            assert t is None
 
             assert warning_lines[0].category == NoDetectionsWarning
             assert ('Sources were found, but none pass the sharpness and '
@@ -88,7 +88,7 @@ class TestDAOStarFinder:
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             starfinder = DAOStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
             t = starfinder(DATA)
-            assert len(t) == 0
+            assert t is None
 
             assert warning_lines[0].category == NoDetectionsWarning
             assert ('Sources were found, but none pass the sharpness and '
@@ -188,7 +188,7 @@ class TestIRAFStarFinder:
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             starfinder = IRAFStarFinder(threshold=10, fwhm=1)
             t = starfinder(data)
-            assert len(t) == 0
+            assert t is None
 
             assert warning_lines[0].category == NoDetectionsWarning
             assert ('No sources were found.' in str(warning_lines[0].message))
@@ -198,7 +198,7 @@ class TestIRAFStarFinder:
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, sharplo=2.)
             t = starfinder(DATA)
-            assert len(t) == 0
+            assert t is None
 
             assert warning_lines[0].category == NoDetectionsWarning
             assert ('Sources were found, but none pass the sharpness and '
@@ -209,7 +209,7 @@ class TestIRAFStarFinder:
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
             t = starfinder(DATA)
-            assert len(t) == 0
+            assert t is None
 
             assert warning_lines[0].category == NoDetectionsWarning
             assert ('Sources were found, but none pass the sharpness and '
@@ -224,7 +224,7 @@ class TestIRAFStarFinder:
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
             t = starfinder(DATA)
-            assert len(t) == 0
+            assert t is None
 
             assert warning_lines[0].category == NoDetectionsWarning
             assert ('Sources were found, but none pass the sharpness and '

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -16,6 +16,7 @@ from .utils import (get_grouped_psf_model, subtract_psf,
 from ..aperture import CircularAperture, aperture_photometry
 from ..background import MMMBackground
 from ..detection import DAOStarFinder
+from ..utils.exceptions import NoDetectionsWarning
 
 
 __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
@@ -696,7 +697,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         sources = self.finder(self._residual_image)
 
         n = n_start
-        while(len(sources) > 0 and
+        while(sources is not None and
               (self.niters is None or n <= self.niters)):
             apertures = CircularAperture((sources['xcentroid'],
                                           sources['ycentroid']),
@@ -731,7 +732,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
 
             # do not warn if no sources are found beyond the first iteration
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore', AstropyUserWarning)
+                warnings.simplefilter('ignore', NoDetectionsWarning)
                 sources = self.finder(self._residual_image)
 
             n += 1

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -159,11 +159,13 @@ class SegmentationImage:
     data : array_like (int)
         A 2D segmentation image where source regions are labeled by
         different positive integer values.  A value of zero is reserved
-        for the background.
+        for the background.  The segmentation image must contain at
+        least one non-zero pixel and must not contain any non-finite
+        values (e.g. NaN, inf).
     """
 
     def __init__(self, data):
-        self.data = np.asanyarray(data, dtype=np.int)
+        self.data = data
 
     def __getitem__(self, index):
         return self.segments[index]
@@ -276,6 +278,15 @@ class SegmentationImage:
 
     @data.setter
     def data(self, value):
+        if np.any(~np.isfinite(value)):
+            raise ValueError('data must not contain any non-finite values '
+                             '(e.g. NaN, inf)')
+
+        value = np.asanyarray(value, dtype=np.int)
+        if not np.any(value):
+            raise ValueError('The segmentation image must contain at least '
+                             'one non-zero pixel.')
+
         if np.min(value) < 0:
             raise ValueError('The segmentation image cannot contain '
                              'negative integers.')

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -249,8 +249,17 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     segm_tree = []
     mask = ~segm_mask
     for level in thresholds[::-1]:
-        segm_tmp = detect_sources(data, level, npixels=npixels,
-                                  connectivity=connectivity, mask=mask)
+        # suppress warnings for no detections during deblending
+        with warnings.catch_warnings():
+            message = 'No sources were found'
+            warnings.filterwarnings('ignore', message=message,
+                                    category=AstropyUserWarning)
+            segm_tmp = detect_sources(data, level, npixels=npixels,
+                                      connectivity=connectivity, mask=mask)
+
+        if segm_tmp is None:  # no sources found at this threshold level
+            continue
+
         if segm_tmp.nlabels >= 2:
             fluxes = []
             for i in segm_tmp.labels:

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -9,6 +9,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from .core import SegmentationImage
 from .detect import detect_sources
 from ..utils.convolution import filter_data
+from ..utils.exceptions import NoDetectionsWarning
 
 
 __all__ = ['deblend_sources']
@@ -245,28 +246,25 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
         raise ValueError('"{0}" is an invalid mode; mode must be '
                          '"exponential" or "linear"')
 
+    # suppress NoDetectionsWarning during deblending
+    warnings.filterwarnings('ignore', category=NoDetectionsWarning)
+
     # create top-down tree of local peaks
     segm_tree = []
     mask = ~segm_mask
     for level in thresholds[::-1]:
-        # suppress warnings for no detections during deblending
-        with warnings.catch_warnings():
-            message = 'No sources were found'
-            warnings.filterwarnings('ignore', message=message,
-                                    category=AstropyUserWarning)
-            segm_tmp = detect_sources(data, level, npixels=npixels,
-                                      connectivity=connectivity, mask=mask)
+        segm_tmp = detect_sources(data, level, npixels=npixels,
+                                  connectivity=connectivity, mask=mask)
 
-        if segm_tmp is None:  # no sources found at this threshold level
+        if segm_tmp is None or segm_tmp.nlabels < 2:
             continue
 
-        if segm_tmp.nlabels >= 2:
-            fluxes = []
-            for i in segm_tmp.labels:
-                fluxes.append(np.nansum(data[segm_tmp == i]))
-            idx = np.where((np.array(fluxes) / source_sum) >= contrast)[0]
-            if len(idx >= 2):
-                segm_tree.append(segm_tmp)
+        fluxes = []
+        for i in segm_tmp.labels:
+            fluxes.append(np.nansum(data[segm_tmp == i]))
+        idx = np.where((np.array(fluxes) / source_sum) >= contrast)[0]
+        if len(idx >= 2):
+            segm_tree.append(segm_tmp)
 
     nbranch = len(segm_tree)
     if nbranch == 0:

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -1,8 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
+
 import numpy as np
-from astropy.stats import gaussian_fwhm_to_sigma
 from astropy.convolution import Gaussian2DKernel
+from astropy.stats import gaussian_fwhm_to_sigma
+from astropy.utils.exceptions import AstropyUserWarning
 
 from .core import SegmentationImage
 from ..detection import detect_threshold
@@ -64,10 +67,11 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
 
     Returns
     -------
-    segment_image : `~photutils.segmentation.SegmentationImage`
+    segment_image : `~photutils.segmentation.SegmentationImage` or `None`
         A 2D segmentation image, with the same shape as ``data``, where
         sources are marked by different positive integer values.  A
-        value of zero is reserved for the background.
+        value of zero is reserved for the background.  If no sources
+        are found then `None` is returned.
 
     See Also
     --------
@@ -156,7 +160,11 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
     # now relabel to make consecutive label indices
     segm_img, nobj = ndimage.label(segm_img, structure=selem)
 
-    return SegmentationImage(segm_img)
+    if nobj == 0:
+        warnings.warn('No sources were found.', AstropyUserWarning)
+        return None
+    else:
+        return SegmentationImage(segm_img)
 
 
 def make_source_mask(data, snr, npixels, mask=None, mask_value=None,

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -5,11 +5,11 @@ import warnings
 import numpy as np
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
-from astropy.utils.exceptions import AstropyUserWarning
 
 from .core import SegmentationImage
 from ..detection import detect_threshold
 from ..utils.convolution import filter_data
+from ..utils.exceptions import NoDetectionsWarning
 
 
 __all__ = ['detect_sources', 'make_source_mask']
@@ -161,7 +161,7 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
     segm_img, nobj = ndimage.label(segm_img, structure=selem)
 
     if nobj == 0:
-        warnings.warn('No sources were found.', AstropyUserWarning)
+        warnings.warn('No sources were found.', NoDetectionsWarning)
         return None
     else:
         return SegmentationImage(segm_img)

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1418,6 +1418,8 @@ class SourceCatalog:
         if isinstance(properties_list, SourceProperties):
             self._data = [properties_list]
         elif isinstance(properties_list, list):
+            if len(properties_list) == 0:
+                raise ValueError('properties_list must not be an empty list.')
             self._data = properties_list
         else:
             raise ValueError('invalid input.')

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1406,6 +1406,9 @@ def source_properties(data, segment_img, error=None, mask=None,
             data, segment_img, label, filtered_data=filtered_data,
             error=error, mask=mask, background=background, wcs=wcs))
 
+    if len(sources_props) == 0:
+        raise ValueError('No sources are defined.')
+
     return SourceCatalog(sources_props, wcs=wcs)
 
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
+
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSegmentationImage:
     def setup_class(self):
@@ -40,7 +41,26 @@ class TestSegmentationImage:
         segm.data[0, 0] = 100.
         assert segm.data[0, 0] != segm2.data[0, 0]
 
-    def test_negative_data(self):
+    def test_invalid_data(self):
+        # contains all zeros
+        data = np.zeros((3, 3))
+        with pytest.raises(ValueError):
+            SegmentationImage(data)
+
+        # contains a NaN
+        data = np.zeros((5, 5))
+        data[2, 2] = np.nan
+        with pytest.raises(ValueError):
+            SegmentationImage(data)
+
+        # contains an inf
+        data = np.zeros((5, 5))
+        data[2, 2] = np.inf
+        data[0, 0] = -np.inf
+        with pytest.raises(ValueError):
+            SegmentationImage(data)
+
+        # contains a negative value
         data = np.arange(-1, 8).reshape(3, 3)
         with pytest.raises(ValueError):
             SegmentationImage(data)

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -187,3 +187,21 @@ class TestDeblendSources:
         segm.reassign_label(1, 512)
         result = deblend_sources(self.data, segm, self.npixels)
         assert result.nlabels == 2
+
+    def test_nondetection(self):
+        """
+        Test for case where no sources are detected at one of the
+        threshold levels.
+
+        For this case, no warnings should be raised when deblending
+        sources.
+        """
+
+        data = np.copy(self.data3)
+        data[50, 50] = 1000.
+        data[50, 70] = 500.
+        self.segm = detect_sources(data, self.threshold, self.npixels)
+
+        with catch_warnings(AstropyUserWarning) as warning_lines:
+            deblend_sources(data, self.segm, self.npixels)
+            assert len(warning_lines) == 0

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -105,7 +105,7 @@ class TestDeblendSources:
         assert result.nlabels == 2
 
     def test_segment_img_badshape(self):
-        segm_wrong = np.zeros((2, 2))
+        segm_wrong = np.ones((2, 2))
         with pytest.raises(ValueError):
             deblend_sources(self.data, segm_wrong, self.npixels)
 

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -11,6 +11,7 @@ from astropy.modeling import models
 from ..core import SegmentationImage
 from ..deblend import deblend_sources
 from ..detect import detect_sources
+from ...utils.exceptions import NoDetectionsWarning
 
 try:
     import scipy    # noqa
@@ -193,8 +194,8 @@ class TestDeblendSources:
         Test for case where no sources are detected at one of the
         threshold levels.
 
-        For this case, no warnings should be raised when deblending
-        sources.
+        For this case, a `NoDetectionsWarning` should not be raised when
+        deblending sources.
         """
 
         data = np.copy(self.data3)
@@ -202,6 +203,6 @@ class TestDeblendSources:
         data[50, 70] = 500.
         self.segm = detect_sources(data, self.threshold, self.npixels)
 
-        with catch_warnings(AstropyUserWarning) as warning_lines:
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
             deblend_sources(data, self.segm, self.npixels)
             assert len(warning_lines) == 0

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -11,6 +11,7 @@ from astropy.stats import gaussian_fwhm_to_sigma
 
 from ..detect import detect_sources, make_source_mask
 from ...datasets import make_4gaussians_image
+from ...utils.exceptions import NoDetectionsWarning
 
 try:
     import scipy    # noqa
@@ -40,10 +41,9 @@ class TestDetectSources:
     def test_small_sources(self):
         """Test detection where sources are smaller than npixels size."""
 
-        with catch_warnings(AstropyUserWarning) as warning_lines:
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
             detect_sources(self.data, threshold=0.9, npixels=5)
-
-            assert warning_lines[0].category == AstropyUserWarning
+            assert warning_lines[0].category == NoDetectionsWarning
             assert ('No sources were found.' in str(warning_lines[0].message))
 
     def test_npixels(self):
@@ -76,9 +76,9 @@ class TestDetectSources:
             assert(segm.nlabels == 1)
             assert(segm.areas[0] == 13)
 
-        with catch_warnings(AstropyUserWarning) as warning_lines:
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
             detect_sources(data, 0, npixels=14)
-            assert warning_lines[0].category == AstropyUserWarning
+            assert warning_lines[0].category == NoDetectionsWarning
             assert ('No sources were found.' in str(warning_lines[0].message))
 
     def test_zerothresh(self):
@@ -90,9 +90,9 @@ class TestDetectSources:
     def test_zerodet(self):
         """Test detection with large snr_threshold giving no detections."""
 
-        with catch_warnings(AstropyUserWarning) as warning_lines:
+        with catch_warnings(NoDetectionsWarning) as warning_lines:
             detect_sources(self.data, threshold=7, npixels=2)
-            assert warning_lines[0].category == AstropyUserWarning
+            assert warning_lines[0].category == NoDetectionsWarning
             assert ('No sources were found.' in str(warning_lines[0].message))
 
     def test_8connectivity(self):

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -49,7 +49,7 @@ BACKGRD_VALS = [None, 0., 1., 3.5]
 class TestSourceProperties:
     def test_segment_shape(self):
         with pytest.raises(ValueError):
-            SourceProperties(IMAGE, np.zeros((2, 2)), label=1)
+            SourceProperties(IMAGE, np.eye(3, dtype=int), label=1)
 
     @pytest.mark.parametrize('label', (0, -1))
     def test_label_invalid(self, label):
@@ -177,22 +177,22 @@ class TestSourceProperties:
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSourcePropertiesFunctionInputs:
     def test_segment_shape(self):
-        wrong_shape = np.zeros((2, 2))
+        wrong_shape = np.eye(3, dtype=int)
         with pytest.raises(ValueError):
             source_properties(IMAGE, wrong_shape)
 
     def test_error_shape(self):
-        wrong_shape = np.zeros((2, 2))
+        wrong_shape = np.ones((2, 2))
         with pytest.raises(ValueError):
             source_properties(IMAGE, SEGM, error=wrong_shape)
 
     def test_background_shape(self):
-        wrong_shape = np.zeros((2, 2))
+        wrong_shape = np.ones((2, 2))
         with pytest.raises(ValueError):
             source_properties(IMAGE, SEGM, background=wrong_shape)
 
     def test_mask_shape(self):
-        wrong_shape = np.zeros((2, 2))
+        wrong_shape = np.zeros((2, 2)).astype(bool)
         with pytest.raises(ValueError):
             source_properties(IMAGE, SEGM, mask=wrong_shape)
 

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -77,6 +77,9 @@ class TestSourceProperties:
         assert props.sky_bbox_lr is not None
         assert props.sky_bbox_ur is not None
 
+        tbl = props.to_table()
+        assert len(tbl) == 1
+
     def test_nowcs(self):
         props = SourceProperties(IMAGE, SEGM, wcs=None, label=1)
         assert props.sky_centroid_icrs is None
@@ -201,8 +204,8 @@ class TestSourcePropertiesFunctionInputs:
         assert props[0].id == 1
 
     def test_invalidlabels(self):
-        props = source_properties(IMAGE, SEGM, labels=-1)
-        assert len(props) == 0
+        with pytest.raises(ValueError):
+            props = source_properties(IMAGE, SEGM, labels=-1)
 
 
 @pytest.mark.skipif('not HAS_SKIMAGE')
@@ -460,11 +463,6 @@ class TestSourceCatalog:
         assert len(t) == 1
         with pytest.raises(KeyError):
             t['id']
-
-    def test_table_empty_props(self):
-        cat = source_properties(IMAGE, SEGM, labels=-1)
-        with pytest.raises(ValueError):
-            cat.to_table()
 
     def test_table_wcs(self):
         mywcs = WCS.WCS(naxis=2)

--- a/photutils/utils/__init__.py
+++ b/photutils/utils/__init__.py
@@ -7,6 +7,7 @@ from .check_random_state import *    # noqa
 from .colormaps import *             # noqa
 from .convolution import *           # noqa
 from .errors import *                # noqa
+from .exceptions import *            # noqa
 from .interpolation import *         # noqa
 from .misc import *                  # noqa
 from .stats import *                 # noqa

--- a/photutils/utils/exceptions.py
+++ b/photutils/utils/exceptions.py
@@ -1,0 +1,12 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.utils.exceptions import AstropyWarning
+
+
+__all__ = ['NoDetectionsWarning']
+
+
+class NoDetectionsWarning(AstropyWarning):
+    """
+    A warning class to indicate no sources were detected.
+    """


### PR DESCRIPTION
This PR makes the handling of cases when there are no source/peak detection consistent across the various `photutils` detection functions (i.e. star finders, local peak finder, and segmentation).  In all cases a new `NoDetectionsWarning` is issued and `None` is returned from the function.  This is an API change because previously some functions returned an empty `QTable/Table`.  Non-detections should now be checked using e.g. `if result is None: ...`.

If desired, the `NoDetectionsWarning` can be suppressed using the `warnings` package, e.g.:

```python
import warnings
from photutils import detect_sources
from photutils.utils import NoDetectionsWarning

with warnings.catch_warnings():
    warnings.simplefilter('ignore', NoDetectionsWarning)
    cat = detect_sources(data, ...)    # any photutils detection/peak finder function
```

Relatedly, the `SegmentationImage` input `data` array must now contain at least one non-zero pixel and must not contain any non-finite values.  Also, a `ValueError` is now raised if an empty list is input into `SourceCatalog` or no valid sources are defined in `source_properties`.

    