### PR TITLE
Remove unused imports

### DIFF
--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -12,8 +12,7 @@ import numpy as np
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import (overlap_slices, PartialOverlapError,
                                   NoOverlapError)
-from astropy.utils.exceptions import (AstropyUserWarning,
-                                      AstropyDeprecationWarning)
+from astropy.utils.exceptions import AstropyUserWarning
 
 from .epsf_stars import EPSFStar, LinkedEPSFStar, EPSFStars
 from .models import EPSFModel

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -12,8 +12,7 @@ from astropy.nddata.utils import (overlap_slices, PartialOverlapError,
                                   NoOverlapError)
 from astropy.table import Table
 from astropy.utils import lazyproperty, deprecated
-from astropy.utils.exceptions import (AstropyUserWarning,
-                                      AstropyDeprecationWarning)
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs.utils import skycoord_to_pixel
 
 from ..aperture import BoundingBox

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -10,8 +10,7 @@ import warnings
 import numpy as np
 from astropy.nddata import NDData
 from astropy.modeling import Parameter, Fittable2DModel
-from astropy.utils.exceptions import (AstropyWarning,
-                                      AstropyDeprecationWarning)
+from astropy.utils.exceptions import AstropyWarning
 
 
 __all__ = ['NonNormalizable', 'FittableImageModel', 'EPSFModel',


### PR DESCRIPTION
Removed unused `AstropyDeprecationWarning` s following the removal of the ePSF `pixel_scale` in #815.

CC: @Onoddil 