### PR TITLE
Fix ApertureMask.cutout to preserve units when copy=True

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Fixed an issue where the ``ApertureMask.cutout`` method would drop
+    the data units when ``copy=True``. [#842]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where ``deblend_sources`` could fail for sources

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -187,7 +187,7 @@ class ApertureMask:
             # try this for speed -- the result may still be a partial
             # overlap, in which case the next block will be triggered
             if copy:
-                cutout = np.copy(data[self.bbox.slices])
+                cutout = data[self.bbox.slices].copy()  # preserves Quantity
             else:
                 cutout = data[self.bbox.slices]
 


### PR DESCRIPTION
This PR fixes an issue where the `ApertureMask.cutout` method would drop the data units when `copy=True`:

```python
>>> import astropy.units as u
>>> from photutils import CircularAperture
>>> data = np.ones((11, 11))
>>> aper = CircularAperture((5, 5), r=1.)
>>> mask = aper.to_mask()[0]
>>> cutout = mask.cutout(data*u.adu, copy=True)
>>> cutout
array([[1., 1., 1.],
       [1., 1., 1.],
       [1., 1., 1.]])
```