### PR TITLE
Fix aperture photometry corner case for non-finite data values within the bounding box

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,10 @@ Bug Fixes
   - Fixed an issue where the ``ApertureMask.cutout`` method would drop
     the data units when ``copy=True``. [#842]
 
+  - Fixed a corner-case issue where aperture photometry would return
+    NaN for non-finite data values outside the aperture but within the
+    aperture bounding box. [#843]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where ``deblend_sources`` could fail for sources

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -116,7 +116,7 @@ class PixelAperture(Aperture):
         if mode == 'subpixels':
             if not isinstance(subpixels, int) or subpixels <= 0:
                 raise ValueError('subpixels must be a strictly positive '
-                                 'integer'.format(subpixels))
+                                 'integer')
 
         if mode == 'center':
             use_exact = 0
@@ -271,7 +271,7 @@ class PixelAperture(Aperture):
 
     @staticmethod
     def _prepare_photometry_output(_list, unit=None):
-        if len(_list) == 0:   # if error is not input
+        if not _list:  # if error is not input
             return _list
 
         if unit is not None:
@@ -384,8 +384,8 @@ class PixelAperture(Aperture):
 
         aperture_sums = []
         aperture_sum_errs = []
-        for mask in self.to_mask(method=method, subpixels=subpixels):
-            data_weighted = mask.multiply(data)
+        for apermask in self.to_mask(method=method, subpixels=subpixels):
+            data_weighted = apermask.multiply(data)
 
             if data_weighted is None:
                 aperture_sums.append(np.nan)
@@ -393,7 +393,7 @@ class PixelAperture(Aperture):
                 aperture_sums.append(np.sum(data_weighted))
 
             if error is not None:
-                variance_weighted = mask.multiply(error**2)
+                variance_weighted = apermask.multiply(error**2)
 
                 if variance_weighted is None:
                     aperture_sum_errs.append(np.nan)
@@ -684,12 +684,12 @@ def _prepare_photometry_input(data, error, mask, wcs, unit):
     """
 
     if isinstance(data, fits.HDUList):
-        for i in range(len(data)):
-            if data[i].data is not None:
+        for i, hdu in enumerate(data):
+            if hdu.data is not None:
                 warnings.warn("Input data is a HDUList object, photometry is "
                               "run only for the {0} HDU."
                               .format(i), AstropyUserWarning)
-                data = data[i]
+                data = hdu
                 break
 
     if isinstance(data, (fits.PrimaryHDU, fits.ImageHDU)):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -385,21 +385,21 @@ class PixelAperture(Aperture):
         aperture_sums = []
         aperture_sum_errs = []
         for mask in self.to_mask(method=method, subpixels=subpixels):
-            data_cutout = mask.cutout(data)
+            data_weighted = mask.multiply(data)
 
-            if data_cutout is None:
+            if data_weighted is None:
                 aperture_sums.append(np.nan)
             else:
-                aperture_sums.append(np.sum(data_cutout * mask.data))
+                aperture_sums.append(np.sum(data_weighted))
 
             if error is not None:
-                error_cutout = mask.cutout(error)
+                variance_weighted = mask.multiply(error**2)
 
-                if error_cutout is None:
+                if variance_weighted is None:
                     aperture_sum_errs.append(np.nan)
                 else:
-                    aperture_var = np.sum(error_cutout ** 2 * mask.data)
-                    aperture_sum_errs.append(np.sqrt(aperture_var))
+                    aperture_sum_errs.append(
+                        np.sqrt(np.sum(variance_weighted)))
 
         # handle Quantity objects and input units
         aperture_sums = self._prepare_photometry_output(aperture_sums,

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -151,8 +151,8 @@ class ApertureMask:
             A 2D array on which to apply the aperture mask.
 
         fill_value : float, optional
-            The value is used to fill pixels where the aperture mask
-            does not overlap with the input ``data``.  The default is 0.
+            The value used to fill pixels where the aperture mask does
+            not overlap with the input ``data``.  The default is 0.
 
         copy : bool, optional
             If `True` then the returned cutout array will always be hold

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -923,3 +923,31 @@ def test_scalar_aperture():
     assert (colnames3 == ['id', 'xcenter', 'ycenter', 'aperture_sum_0',
                           'aperture_sum_err_0', 'aperture_sum_1',
                           'aperture_sum_err_1'])
+
+def test_nan_in_bbox():
+    """
+    Regression test that non-finite data values outside of the aperture
+    mask but within the bounding box do not affect the photometry.
+    """
+
+    data1 = np.ones((101, 101))
+    data2 = data1.copy()
+    data1[33, 33] = np.nan
+    data1[67, 67] = np.inf
+    data1[33, 67] = -np.inf
+    data1[22, 22] = np.nan
+    data1[22, 23] = np.inf
+    error = data1.copy()
+
+    aper1 = CircularAperture((50, 50), r=20.)
+    aper2 = CircularAperture((5, 5), r=20.)
+
+    tbl1 = aperture_photometry(data1, aper1, error=error)
+    tbl2 = aperture_photometry(data2, aper1, error=error)
+    assert_allclose(tbl1['aperture_sum'], tbl2['aperture_sum'])
+    assert_allclose(tbl1['aperture_sum_err'], tbl2['aperture_sum_err'])
+
+    tbl3 = aperture_photometry(data1, aper2, error=error)
+    tbl4 = aperture_photometry(data2, aper2, error=error)
+    assert_allclose(tbl1['aperture_sum'], tbl2['aperture_sum'])
+    assert_allclose(tbl1['aperture_sum_err'], tbl2['aperture_sum_err'])


### PR DESCRIPTION
This PR fixes a corner-case issue where aperture photometry would return NaN for non-finite data values outside the aperture but within the aperture bounding box.