### PR TITLE
Fix scalar SkyCoord column in aperture_photometry table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,10 @@ Bug Fixes
     NaN for non-finite data values outside the aperture but within the
     aperture bounding box. [#843]
 
+  - Fixed an issue where the ``celestial_center`` column (for sky
+    apertures) would be a length-1 array containing a ``SkyCoord``
+    object instead of a length-1 ``SkyCoord`` object. [#844]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where ``deblend_sources`` could fail for sources

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -282,7 +282,7 @@ class PixelAperture(Aperture):
                 unit = None
 
         if isinstance(_list[0], u.Quantity):
-            # list of Quantity -> Quantity array
+            # turn list of Quantities into a Quantity array
             output = u.Quantity(_list)
 
             if unit is not None:
@@ -922,7 +922,8 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
     if skyaper:
         if skycoord_pos.isscalar:
-            tbl['celestial_center'] = (skycoord_pos,)
+            # create length-1 SkyCoord array
+            tbl['celestial_center'] = skycoord_pos.reshape((-1,))
         else:
             tbl['celestial_center'] = skycoord_pos
 

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -924,6 +924,7 @@ def test_scalar_aperture():
                           'aperture_sum_err_0', 'aperture_sum_1',
                           'aperture_sum_err_1'])
 
+
 def test_nan_in_bbox():
     """
     Regression test that non-finite data values outside of the aperture
@@ -949,5 +950,19 @@ def test_nan_in_bbox():
 
     tbl3 = aperture_photometry(data1, aper2, error=error)
     tbl4 = aperture_photometry(data2, aper2, error=error)
-    assert_allclose(tbl1['aperture_sum'], tbl2['aperture_sum'])
-    assert_allclose(tbl1['aperture_sum_err'], tbl2['aperture_sum_err'])
+    assert_allclose(tbl3['aperture_sum'], tbl4['aperture_sum'])
+    assert_allclose(tbl3['aperture_sum_err'], tbl4['aperture_sum_err'])
+
+
+def test_scalar_skycoord():
+    """
+    Regression test to check that scalar SkyCoords are added to the table
+    as a length-1 SkyCoord array.
+    """
+
+    data = make_4gaussians_image()
+    wcs = make_wcs(data.shape)
+    skycoord = pixel_to_skycoord(90, 60, wcs)
+    aper = SkyCircularAperture(skycoord, r=0.1*u.arcsec)
+    tbl = aperture_photometry(data, aper, wcs=wcs)
+    assert isinstance(tbl['celestial_center'], SkyCoord)


### PR DESCRIPTION
This PR fixes a corner-case issue where the `celestial_center` column (for sky apertures) would be a length-1 array containing a `SkyCoord` object instead of a length-1 `SkyCoord` object.