### PR TITLE
Add validation of parameters for all aperture classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Added parameter validation for all aperture classes. [#846]
+
 - ``photutils.isophote``
 
   - Significantly improved the performance (~5 times faster) of
@@ -113,6 +117,10 @@ API changes
   - Renamed ``random_cmap`` to ``make_random_cmap``. [#825]
 
   - Removed deprecated ``cutout_footprint`` function. [#835]
+
+  - Deprecated the ``wcs_helpers`` functions
+    ``pixel_scale_angle_at_skycoord``, ``assert_angle_or_pixel``,
+    ``assert_angle``, and ``pixel_to_icrs_coords``. [#846]
 
 - ``photutils.psf``
 

--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -51,7 +51,7 @@ coordinates using the :class:`~photutils.CircularAperture` class::
 
     >>> from photutils import CircularAperture
     >>> positions = [(30., 30.), (40., 40.)]
-    >>> apertures = CircularAperture(positions, r=3.)
+    >>> aperture = CircularAperture(positions, r=3.)
 
 The positions should be either a single tuple of ``(x, y)``, a list of
 ``(x, y)`` tuples, or an array with shape ``Nx2``, where ``N`` is the
@@ -70,7 +70,7 @@ object::
     >>> from photutils import SkyCircularAperture
     >>> positions = SkyCoord(l=[1.2, 2.3] * u.deg, b=[0.1, 0.2] * u.deg,
     ...                      frame='galactic')
-    >>> apertures = SkyCircularAperture(positions, r=4. * u.arcsec)
+    >>> aperture = SkyCircularAperture(positions, r=4. * u.arcsec)
 
 .. note::
     Sky apertures are not defined completely in celestial coordinates.
@@ -110,10 +110,11 @@ Performing Aperture Photometry
 
 After the aperture object is created, we can then perform the
 photometry using the :func:`~photutils.aperture_photometry` function.
-We start by defining the apertures as described above::
+We start by defining the aperture (at two positions) as described
+above::
 
     >>> positions = [(30., 30.), (40., 40.)]
-    >>> apertures = CircularAperture(positions, r=3.)
+    >>> aperture = CircularAperture(positions, r=3.)
 
 and then we call the :func:`~photutils.aperture_photometry` function
 with the data and the apertures::
@@ -121,7 +122,7 @@ with the data and the apertures::
     >>> import numpy as np
     >>> from photutils import aperture_photometry
     >>> data = np.ones((100, 100))
-    >>> phot_table = aperture_photometry(data, apertures)
+    >>> phot_table = aperture_photometry(data, aperture)
     >>> phot_table['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
      id xcenter ycenter aperture_sum
@@ -144,7 +145,7 @@ area of a circle with a radius of 3::
 Aperture and Pixel Overlap
 --------------------------
 
-The overlap of the apertures with the data pixels can be handled in
+The overlap of the aperture with the data pixels can be handled in
 different ways.  For the default method (``method='exact'``), the
 exact intersection of the aperture with each pixel is calculated.  The
 other options, ``'center'`` and ``'subpixel'``, are faster, but with
@@ -158,7 +159,7 @@ subpixels needs to be set with the ``subpixels`` keyword.
 This example uses the ``'subpixel'`` method where pixels are resampled
 by a factor of 5 (``subpixels=5``) in each dimension::
 
-    >>> phot_table = aperture_photometry(data, apertures, method='subpixel',
+    >>> phot_table = aperture_photometry(data, aperture, method='subpixel',
     ...                                  subpixels=5)
     >>> print(phot_table)  # doctest: +SKIP
      id xcenter ycenter aperture_sum
@@ -181,11 +182,12 @@ Multiple Apertures at Each Position
 -----------------------------------
 
 While the `~photutils.Aperture` objects support multiple positions,
-they must have a fixed shape, e.g. radius, size, and orientation.
+they must have a fixed size and shape, e.g. radius and orientation.
 
 To perform photometry in multiple apertures at each position, one may
 input a list of aperture objects to the
-:func:`~photutils.aperture_photometry` function.
+:func:`~photutils.aperture_photometry` function.  In this case, the
+apertures must all have identical position(s).
 
 Suppose that we wish to use three circular apertures, with radii of 3,
 4, and 5 pixels, on each source::
@@ -255,7 +257,7 @@ representing the background of the data (determined by
 `~photutils.background.Background2D` or an external function), simply
 subtract the background::
 
-    >>> phot_table = aperture_photometry(data - bkg, apertures)  # doctest: +SKIP
+    >>> phot_table = aperture_photometry(data - bkg, aperture)  # doctest: +SKIP
 
 
 Local Background Subtraction
@@ -280,12 +282,12 @@ radius 6 pixels and outer radius 8 pixels.  We start by defining the
 apertures::
 
     >>> from photutils import CircularAnnulus
-    >>> apertures = CircularAperture(positions, r=3)
-    >>> annulus_apertures = CircularAnnulus(positions, r_in=6., r_out=8.)
+    >>> aperture = CircularAperture(positions, r=3)
+    >>> annulus_aperture = CircularAnnulus(positions, r_in=6., r_out=8.)
 
 We then perform the photometry in both apertures::
 
-    >>> apers = [apertures, annulus_apertures]
+    >>> apers = [aperture, annulus_aperture]
     >>> phot_table = aperture_photometry(data, apers)
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
@@ -307,12 +309,12 @@ aperture, we need to divide its sum by its area.  The mean value can
 be calculated by using the :meth:`~photutils.CircularAnnulus.area`
 method::
 
-    >>> bkg_mean = phot_table['aperture_sum_1'] / annulus_apertures.area()
+    >>> bkg_mean = phot_table['aperture_sum_1'] / annulus_aperture.area()
 
 The total background within the circular aperture is then the mean local
 background times the circular aperture area::
 
-    >>> bkg_sum = bkg_mean * apertures.area()
+    >>> bkg_sum = bkg_mean * aperture.area()
     >>> final_sum = phot_table['aperture_sum_0'] - bkg_sum
     >>> phot_table['residual_aperture_sum'] = final_sum
     >>> phot_table['residual_aperture_sum'].info.format = '%.8g'  # for consistent table output
@@ -333,14 +335,14 @@ For this example we perform the photometry in a circular aperture with
 a radius of 5 pixels.  The local background level around each source
 is estimated as the sigma-clipped median value within a circular
 annulus of inner radius 10 pixels and outer radius 15 pixels.  We
-start by defining an example image and apertures for three sources::
+start by defining an example image and an aperture for three sources::
 
     >>> from photutils.datasets import make_100gaussians_image
     >>> from photutils import CircularAperture, CircularAnnulus
     >>> data = make_100gaussians_image()
     >>> positions = [(145.1, 168.3), (84.5, 224.1), (48.3, 200.3)]
-    >>> apertures = CircularAperture(positions, r=5)
-    >>> annulus_apertures = CircularAnnulus(positions, r_in=10, r_out=15)
+    >>> aperture = CircularAperture(positions, r=5)
+    >>> annulus_aperture = CircularAnnulus(positions, r_in=10, r_out=15)
 
 Let's plot the circular apertures (white) and circular annulus
 apertures (red) on the image:
@@ -353,20 +355,20 @@ apertures (red) on the image:
 
    data = make_100gaussians_image()
    positions = [(145.1, 168.3), (84.5, 224.1), (48.3, 200.3)]
-   apertures = CircularAperture(positions, r=5)
-   annulus_apertures = CircularAnnulus(positions, r_in=10, r_out=15)
+   aperture = CircularAperture(positions, r=5)
+   annulus_aperture = CircularAnnulus(positions, r_in=10, r_out=15)
 
    norm = simple_norm(data, 'sqrt', percent=99)
    plt.imshow(data, norm=norm)
-   apertures.plot(color='white', lw=2)
-   annulus_apertures.plot(color='red', lw=2)
+   aperture.plot(color='white', lw=2)
+   annulus_aperture.plot(color='red', lw=2)
    plt.xlim(0, 170)
    plt.ylim(130, 250)
 
 We can use aperture masks to directly access the pixel values in any
-aperture.  Let's do that for the annulus apertures::
+aperture.  Let's do that for the annulus aperture::
 
-   >>> annulus_masks = annulus_apertures.to_mask(method='center')
+   >>> annulus_masks = annulus_aperture.to_mask(method='center')
 
 The result is a list of `~photutils.aperture.ApertureMask` objects,
 one for each aperture position.  The values in these aperture masks
@@ -392,9 +394,9 @@ Let's focus on just the first annulus.  Let's plot its aperture mask:
     from photutils import CircularAperture, CircularAnnulus
     import matplotlib.pyplot as plt
     positions = [(145.1, 168.3), (84.5, 224.1), (48.3, 200.3)]
-    apertures = CircularAperture(positions, r=5)
-    annulus_apertures = CircularAnnulus(positions, r_in=10, r_out=15)
-    annulus_masks = annulus_apertures.to_mask(method='center')
+    aperture = CircularAperture(positions, r=5)
+    annulus_aperture = CircularAnnulus(positions, r_in=10, r_out=15)
+    annulus_masks = annulus_aperture.to_mask(method='center')
     plt.imshow(annulus_masks[0])
     plt.colorbar()
 
@@ -413,9 +415,9 @@ Let's plot the annulus data:
     from photutils.datasets import make_100gaussians_image
     import matplotlib.pyplot as plt
     positions = [(145.1, 168.3), (84.5, 224.1), (48.3, 200.3)]
-    apertures = CircularAperture(positions, r=5)
-    annulus_apertures = CircularAnnulus(positions, r_in=10, r_out=15)
-    annulus_masks = annulus_apertures.to_mask(method='center')
+    aperture = CircularAperture(positions, r=5)
+    annulus_aperture = CircularAnnulus(positions, r_in=10, r_out=15)
+    annulus_masks = annulus_aperture.to_mask(method='center')
     data = make_100gaussians_image()
     annulus_data = annulus_masks[0].multiply(data)
     plt.imshow(annulus_data)
@@ -442,7 +444,7 @@ median::
 The total background within the circular aperture is then the local background
 level times the circular aperture area::
 
-   >>> background = median_sigclip * apertures.area()
+   >>> background = median_sigclip * aperture.area()
    >>> print(background)  # doctest: +FLOAT_CMP
    380.7777584296913
 
@@ -460,9 +462,9 @@ each source::
     >>>
     >>> data = make_100gaussians_image()
     >>> positions = [(145.1, 168.3), (84.5, 224.1), (48.3, 200.3)]
-    >>> apertures = CircularAperture(positions, r=5)
-    >>> annulus_apertures = CircularAnnulus(positions, r_in=10, r_out=15)
-    >>> annulus_masks = annulus_apertures.to_mask(method='center')
+    >>> aperture = CircularAperture(positions, r=5)
+    >>> annulus_aperture = CircularAnnulus(positions, r_in=10, r_out=15)
+    >>> annulus_masks = annulus_aperture.to_mask(method='center')
     >>>
     >>> bkg_median = []
     >>> for mask in annulus_masks:
@@ -471,9 +473,9 @@ each source::
     ...     _, median_sigclip, _ = sigma_clipped_stats(annulus_data_1d)
     ...     bkg_median.append(median_sigclip)
     >>> bkg_median = np.array(bkg_median)
-    >>> phot = aperture_photometry(data, apertures)
+    >>> phot = aperture_photometry(data, aperture)
     >>> phot['annulus_median'] = bkg_median
-    >>> phot['aper_bkg'] = bkg_median * apertures.area()
+    >>> phot['aper_bkg'] = bkg_median * aperture.area()
     >>> phot['aper_sum_bkgsub'] = phot['aperture_sum'] - phot['aper_bkg']
     >>> for col in phot.colnames:
     ...     phot[col].info.format = '%.8g'  # for consistent table output
@@ -501,11 +503,11 @@ For example, suppose we have previously calculated the error on each
 pixel's value and saved it in the array ``error``::
 
     >>> positions = [(30., 30.), (40., 40.)]
-    >>> apertures = CircularAperture(positions, r=3.)
+    >>> aperture = CircularAperture(positions, r=3.)
     >>> data = np.ones((100, 100))
     >>> error = 0.1 * data
 
-    >>> phot_table = aperture_photometry(data, apertures, error=error)
+    >>> phot_table = aperture_photometry(data, aperture, error=error)
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
@@ -540,7 +542,7 @@ time as the effective gain::
     >>> from photutils.utils import calc_total_error
     >>> effective_gain = 500   # seconds
     >>> error = calc_total_error(data, bkg_error, effective_gain)    # doctest: +SKIP
-    >>> phot_table = aperture_photometry(data - bkg, apertures, error=error)    # doctest: +SKIP
+    >>> phot_table = aperture_photometry(data - bkg, aperture, error=error)    # doctest: +SKIP
 
 
 Pixel Masking
@@ -594,7 +596,7 @@ official Spitzer data reduction.  We define the apertures positions
 based on the existing catalog positions::
 
     >>> positions = SkyCoord(catalog['l'], catalog['b'], frame='galactic')   # doctest: +REMOTE_DATA
-    >>> apertures = SkyCircularAperture(positions, r=4.8 * u.arcsec)   # doctest: +REMOTE_DATA
+    >>> aperture = SkyCircularAperture(positions, r=4.8 * u.arcsec)   # doctest: +REMOTE_DATA
 
 Now perform the photometry in these apertures using the ``hdu``.  The
 ``hdu`` object is a FITS HDU that contains the data and a header
@@ -604,7 +606,7 @@ pixel coordinates.  The `~photutils.aperture_photometry` function uses
 the WCS information to automatically convert the apertures defined in
 celestial coordinates into pixel coordinates::
 
-    >>> phot_table = aperture_photometry(hdu, apertures)    # doctest: +REMOTE_DATA
+    >>> phot_table = aperture_photometry(hdu, aperture)    # doctest: +REMOTE_DATA
 
 The Spitzer catalog also contains the official fluxes for the sources,
 so we can compare to our fluxes.  Because the Spitzer catalog fluxes
@@ -640,8 +642,8 @@ Finally, we can plot the comparison of the photometry:
 
   # Set up apertures
   positions = SkyCoord(catalog['l'], catalog['b'], frame='galactic')
-  apertures = SkyCircularAperture(positions, r=4.8 * u.arcsec)
-  phot_table = aperture_photometry(hdu, apertures)
+  aperture = SkyCircularAperture(positions, r=4.8 * u.arcsec)
+  phot_table = aperture_photometry(hdu, aperture)
 
   # Convert to correct units
   factor = (1.2 * u.arcsec) ** 2 / u.pixel
@@ -684,7 +686,7 @@ Let's start by creating an aperture object::
 
     >>> from photutils import CircularAperture
     >>> positions = [(30., 30.), (40., 40.)]
-    >>> apertures = CircularAperture(positions, r=3.)
+    >>> aperture = CircularAperture(positions, r=3.)
 
 Now let's create a list of `~photutils.ApertureMask` objects using the
 :meth:`~photutils.PixelAperture.to_mask` method::

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Descriptor class(es) for aperture attribute validation.
+"""
+
+import weakref
+
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+import numpy as np
+
+
+class ApertureAttribute:
+    """
+    Base descriptor class for aperture attribute validation.
+    """
+
+    def __init__(self, name):
+        self.name = name
+        self.values = weakref.WeakKeyDictionary()
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return self.values.get(instance, None)
+
+    def __set__(self, instance, value):
+        self._validate(value)
+        if isinstance(value, (u.Quantity, SkyCoord)):
+            self.values[instance] = value
+        else:
+            self.values[instance] = float(value)
+
+    def _validate(self, value):
+        """
+        Validate the attribute value.
+
+        An exception is raised if the value is invalid.
+        """
+
+        raise NotImplementedError
+
+
+class Scalar(ApertureAttribute):
+    """
+    Check that value is a scalar.
+    """
+
+    def _validate(self, value):
+        if not np.isscalar(value):
+            raise ValueError(f'{self.name} must be a scalar')
+
+
+class PositiveScalar(ApertureAttribute):
+    """
+    Check that value is a stricly positive (>= 0) scalar.
+    """
+
+    def _validate(self, value):
+        if not np.isscalar(value) or value <= 0:
+            raise ValueError(f'{self.name} must be a positive scalar')

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Descriptor class(es) for aperture attribute validation.
+Descriptor classes for aperture attribute validation.
 """
 
 import weakref

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -59,7 +59,7 @@ class PixelPositions(ApertureAttribute):
         if isinstance(value, zip):
             value = tuple(value)
 
-        value = np.atleast_2d(value)  # np.ndarray
+        value = np.atleast_2d(value).astype(float)  # np.ndarray
         self._validate(value)
 
         if isinstance(value, u.Quantity):
@@ -77,6 +77,10 @@ class PixelPositions(ApertureAttribute):
         if (value.shape[1] != 2 and value.shape[0] != 2) or value.ndim > 2:
             raise TypeError(f'{self.name} must be an (x, y) pixel position '
                             'or a list or array of (x, y) pixel positions.')
+
+        if np.any(~np.isfinite(value)):
+            raise ValueError(f'{self.name} must not contain any non-finite '
+                             '(e.g. NaN or inf) positions')
 
 
 class SkyCoordPositions(ApertureAttribute):

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -72,15 +72,16 @@ class PixelPositions(ApertureAttribute):
 
     def _validate(self, value):
         if isinstance(value, u.Quantity) and value.unit != u.pixel:
-            raise u.UnitsError(f'{self.name} must be in pixel units')
+            raise u.UnitsError('{} must be in pixel units'.format(self.name))
 
         if (value.shape[1] != 2 and value.shape[0] != 2) or value.ndim > 2:
-            raise TypeError(f'{self.name} must be an (x, y) pixel position '
-                            'or a list or array of (x, y) pixel positions.')
+            raise TypeError('{} must be an (x, y) pixel position or a list '
+                            'or array of (x, y) pixel positions.'
+                            .format(self.name))
 
         if np.any(~np.isfinite(value)):
-            raise ValueError(f'{self.name} must not contain any non-finite '
-                             '(e.g. NaN or inf) positions')
+            raise ValueError('{} must not contain any non-finite (e.g. NaN '
+                             'or inf) positions'.format(self.name))
 
 
 class SkyCoordPositions(ApertureAttribute):
@@ -90,7 +91,8 @@ class SkyCoordPositions(ApertureAttribute):
 
     def _validate(self, value):
         if not isinstance(value, SkyCoord):
-            raise ValueError(f'{self.name} must be a SkyCoord instance')
+            raise ValueError('{} must be a SkyCoord instance'
+                             .format(self.name))
 
 
 class Scalar(ApertureAttribute):
@@ -100,7 +102,7 @@ class Scalar(ApertureAttribute):
 
     def _validate(self, value):
         if not np.isscalar(value):
-            raise ValueError(f'{self.name} must be a scalar')
+            raise ValueError('{} must be a scalar'.format(self.name))
 
 
 class PositiveScalar(ApertureAttribute):
@@ -110,7 +112,7 @@ class PositiveScalar(ApertureAttribute):
 
     def _validate(self, value):
         if not np.isscalar(value) or value <= 0:
-            raise ValueError(f'{self.name} must be a positive scalar')
+            raise ValueError('{} must be a positive scalar'.format(self.name))
 
 
 class AngleScalarQuantity(ApertureAttribute):
@@ -122,13 +124,14 @@ class AngleScalarQuantity(ApertureAttribute):
     def _validate(self, value):
         if isinstance(value, u.Quantity):
             if not value.isscalar:
-                raise ValueError(f'{self.name} must be a scalar')
+                raise ValueError('{} must be a scalar'.format(self.name))
 
             if not value.unit.physical_type == 'angle':
-                raise ValueError(f'{self.name} must have angular units')
+                raise ValueError('{} must have angular units'
+                                 .format(self.name))
         else:
-            raise TypeError(f'{self.name} must be an astropy Quantity '
-                            'instance')
+            raise TypeError('{} must be an astropy Quantity instance'.
+                            format(self.name))
 
 
 class AngleOrPixelScalarQuantity(ApertureAttribute):
@@ -140,12 +143,12 @@ class AngleOrPixelScalarQuantity(ApertureAttribute):
     def _validate(self, value):
         if isinstance(value, u.Quantity):
             if not value.isscalar:
-                raise ValueError(f'{self.name} must be a scalar')
+                raise ValueError('{} must be a scalar'.format(self.name))
 
             if not (value.unit.physical_type == 'angle' or
                     value.unit == u.pixel):
-                raise ValueError(f'{self.name} must have angular or pixel '
-                                 'units')
+                raise ValueError('{} must have angular or pixel units'
+                                 .format(self.name))
         else:
-            raise TypeError(f'{self.name} must be an astropy Quantity '
-                            'instance')
+            raise TypeError('{} must be an astropy Quantity instance'
+                            .format(self.name))

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -61,6 +61,16 @@ class PositiveScalar(ApertureAttribute):
             raise ValueError(f'{self.name} must be a positive scalar')
 
 
+class SkyCoordPosition(ApertureAttribute):
+    """
+    Check that value is a `~astropy.coordinates.SkyCoord`.
+    """
+
+    def _validate(self, value):
+        if not isinstance(value, SkyCoord):
+            raise ValueError(f'{self.name} must be a SkyCoord instance')
+
+
 class AngleOrPixelScalarQuantity(ApertureAttribute):
     """
     Check that value is either an angular or a pixel scalar

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -113,6 +113,24 @@ class PositiveScalar(ApertureAttribute):
             raise ValueError(f'{self.name} must be a positive scalar')
 
 
+class AngleScalarQuantity(ApertureAttribute):
+    """
+    Check that value is either an angular scalar
+    `~astropy.units.Quantity`.
+    """
+
+    def _validate(self, value):
+        if isinstance(value, u.Quantity):
+            if not value.isscalar:
+                raise ValueError(f'{self.name} must be a scalar')
+
+            if not value.unit.physical_type == 'angle':
+                raise ValueError(f'{self.name} must have angular units')
+        else:
+            raise TypeError(f'{self.name} must be an astropy Quantity '
+                            'instance')
+
+
 class AngleOrPixelScalarQuantity(ApertureAttribute):
     """
     Check that value is either an angular or a pixel scalar

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -59,3 +59,23 @@ class PositiveScalar(ApertureAttribute):
     def _validate(self, value):
         if not np.isscalar(value) or value <= 0:
             raise ValueError(f'{self.name} must be a positive scalar')
+
+
+class AngleOrPixelScalarQuantity(ApertureAttribute):
+    """
+    Check that value is either an angular or a pixel scalar
+    `~astropy.units.Quantity`.
+    """
+
+    def _validate(self, value):
+        if isinstance(value, u.Quantity):
+            if not value.isscalar:
+                raise ValueError(f'{self.name} must be a scalar')
+
+            if not (value.unit.physical_type == 'angle' or
+                    value.unit == u.pixel):
+                raise ValueError(f'{self.name} must have angular or pixel '
+                                 'units')
+        else:
+            raise TypeError(f'{self.name} must be an astropy Quantity '
+                            'instance')

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -94,12 +94,15 @@ class CircularMaskMixin:
 
 class CircularAperture(CircularMaskMixin, PixelAperture):
     """
-    Circular aperture(s), defined in pixel coordinates.
+    A circular aperture defined in pixel coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : array_like or `~astropy.units.Quantity`
-        Pixel coordinates of the aperture center(s) in one of the
+        The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` tuple
@@ -112,7 +115,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         rows of (x, y) coordinates.
 
     r : float
-        The radius of the aperture(s), in pixels.
+        The radius of the circle in pixels.
 
     Raises
     ------
@@ -181,12 +184,15 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
 class CircularAnnulus(CircularMaskMixin, PixelAperture):
     """
-    Circular annulus aperture(s), defined in pixel coordinates.
+    A circular annulus aperture defined in pixel coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : array_like or `~astropy.units.Quantity`
-        Pixel coordinates of the aperture center(s) in one of the
+        The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` tuple
@@ -199,10 +205,10 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         rows of (x, y) coordinates.
 
     r_in : float
-        The inner radius of the annulus.
+        The inner radius of the circular annulus in pixels.
 
     r_out : float
-        The outer radius of the annulus.
+        The outer radius of the circular annulus in pixels.
 
     Raises
     ------
@@ -278,16 +284,19 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
 
 class SkyCircularAperture(SkyAperture):
     """
-    Circular aperture(s), defined in sky coordinates.
+    A circular aperture defined in sky coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : `~astropy.coordinates.SkyCoord`
-        Celestial coordinates of the aperture center(s). This can be
+        The celestial coordinates of the aperture center(s). This can be
         either scalar coordinates or an array of coordinates.
 
-    r : `~astropy.units.Quantity`
-        The radius of the aperture(s), either in angular or pixel units.
+    r : scalar `~astropy.units.Quantity`
+        The radius of the circle, either in angular or pixel units.
     """
 
     def __init__(self, positions, r):
@@ -327,21 +336,24 @@ class SkyCircularAperture(SkyAperture):
 
 class SkyCircularAnnulus(SkyAperture):
     """
-    Circular annulus aperture(s), defined in sky coordinates.
+    A circular annulus aperture defined in sky coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : `~astropy.coordinates.SkyCoord`
-        Celestial coordinates of the aperture center(s). This can be
+        The celestial coordinates of the aperture center(s). This can be
         either scalar coordinates or an array of coordinates.
 
-    r_in : `~astropy.units.Quantity`
-        The inner radius of the annulus, either in angular or pixel
-        units.
+    r_in : scalar `~astropy.units.Quantity`
+        The inner radius of the circular annulus, either in angular or
+        pixel units.
 
-    r_out : `~astropy.units.Quantity`
-        The outer radius of the annulus, either in angular or pixel
-        units.
+    r_out : scalar `~astropy.units.Quantity`
+        The outer radius of the circular annulus, either in angular or
+        pixel units.
     """
 
     def __init__(self, positions, r_in, r_out):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -2,10 +2,8 @@
 
 import math
 
-from astropy.coordinates import SkyCoord
-
-from .attributes import (PositiveScalar, AngleOrPixelScalarQuantity,
-                         SkyCoordPosition)
+from .attributes import (PixelPositions, SkyCoordPositions, PositiveScalar,
+                         AngleOrPixelScalarQuantity)
 from .core import PixelAperture, SkyAperture
 from .bounding_box import BoundingBox
 from .mask import ApertureMask
@@ -124,14 +122,14 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         If the input radius, ``r``, is negative.
     """
 
+    positions = PixelPositions('positions')
     r = PositiveScalar('r')
 
     def __init__(self, positions, r):
-        self.positions = self._sanitize_positions(positions)
+        self.positions = positions
         self.r = r
         self._params = ['r']
 
-    # TODO: make lazyproperty?, but update if positions or radius change
     @property
     def bounding_boxes(self):
         xmin = self.positions[:, 0] - self.r
@@ -142,7 +140,6 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         return [BoundingBox._from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
 
-    # TODO: make lazyproperty?, but update if positions or radius change
     def area(self):
         return math.pi * self.r ** 2
 
@@ -219,6 +216,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         If inner radius (``r_in``) is negative.
     """
 
+    positions = PixelPositions('positions')
     r_in = PositiveScalar('r_in')
     r_out = PositiveScalar('r_out')
 
@@ -226,7 +224,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         if not (r_out > r_in):
             raise ValueError('r_out must be greater than r_in')
 
-        self.positions = self._sanitize_positions(positions)
+        self.positions = positions
         self.r_in = r_in
         self.r_out = r_out
         self._params = ['r_in', 'r_out']
@@ -300,7 +298,7 @@ class SkyCircularAperture(SkyAperture):
         The radius of the circle, either in angular or pixel units.
     """
 
-    positions = SkyCoordPosition('positions')
+    positions = SkyCoordPositions('positions')
     r = AngleOrPixelScalarQuantity('r')
 
     def __init__(self, positions, r):
@@ -355,7 +353,7 @@ class SkyCircularAnnulus(SkyAperture):
         pixel units.
     """
 
-    positions = SkyCoordPosition('positions')
+    positions = SkyCoordPositions('positions')
     r_in = AngleOrPixelScalarQuantity('r_in')
     r_out = AngleOrPixelScalarQuantity('r_out')
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -18,7 +18,7 @@ from astropy.wcs.utils import (skycoord_to_pixel, pixel_to_skycoord,
 
 from ..utils import get_version_info
 from ..utils.misc import _ABCMetaAndInheritDocstrings
-from ..utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from ..utils._wcs_helpers import _pixel_scale_angle_at_skycoord
 
 
 __all__ = ['Aperture', 'SkyAperture', 'PixelAperture', 'aperture_photometry']
@@ -524,7 +524,7 @@ class PixelAperture(Aperture):
         # Here, we define the scale at the WCS CRVAL position.
         crval = SkyCoord(*wcs.wcs.crval, frame=wcs_to_celestial_frame(wcs),
                          unit=wcs.wcs.cunit)
-        scale, angle = pixel_scale_angle_at_skycoord(crval, wcs)
+        scale, angle = _pixel_scale_angle_at_skycoord(crval, wcs)
 
         params = self._params[:]
         theta_key = 'theta'
@@ -599,7 +599,7 @@ class SkyAperture(Aperture):
         # Here, we define the scale at the WCS CRVAL position.
         crval = SkyCoord(*wcs.wcs.crval, frame=wcs_to_celestial_frame(wcs),
                          unit=wcs.wcs.cunit)
-        scale, angle = pixel_scale_angle_at_skycoord(crval, wcs)
+        scale, angle = _pixel_scale_angle_at_skycoord(crval, wcs)
 
         params = self._params[:]
         theta_key = 'theta'

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -72,36 +72,6 @@ class PixelAperture(Aperture):
     """
 
     @staticmethod
-    def _sanitize_positions(positions):
-        if isinstance(positions, u.Quantity):
-            if positions.unit == u.pixel:
-                positions = np.atleast_2d(positions.value)
-            else:
-                raise u.UnitsError('positions should be in pixel units')
-        elif isinstance(positions, (list, tuple, np.ndarray)):
-            positions = np.atleast_2d(positions)
-            if positions.shape[1] != 2:
-                if positions.shape[0] == 2:
-                    positions = np.transpose(positions)
-                else:
-                    raise TypeError('List or array of (x, y) pixel '
-                                    'coordinates is expected, got "{0}".'
-                                    .format(positions))
-        elif isinstance(positions, zip):
-            # This is needed for zip to work seamlessly in Python 3
-            # (e.g. positions = zip(xpos, ypos))
-            positions = np.atleast_2d(list(positions))
-        else:
-            raise TypeError('List or array of (x, y) pixel coordinates '
-                            'is expected, got "{0}".'.format(positions))
-
-        if positions.ndim > 2:
-            raise ValueError('{0}D position array is not supported. Only 2D '
-                             'arrays are supported.'.format(positions.ndim))
-
-        return positions
-
-    @staticmethod
     def _translate_mask_mode(mode, subpixels, rectangle=False):
         if mode not in ('center', 'subpixel', 'exact'):
             raise ValueError('Invalid mask mode: {0}'.format(mode))

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -552,7 +552,7 @@ class PixelAperture(Aperture):
         # The aperture object must have a single value for each shape
         # parameter so we must use a single pixel scale for all positions.
         # Here, we define the scale at the WCS CRVAL position.
-        crval = SkyCoord([wcs.wcs.crval], frame=wcs_to_celestial_frame(wcs),
+        crval = SkyCoord(*wcs.wcs.crval, frame=wcs_to_celestial_frame(wcs),
                          unit=wcs.wcs.cunit)
         scale, angle = pixel_scale_angle_at_skycoord(crval, wcs)
 
@@ -627,7 +627,7 @@ class SkyAperture(Aperture):
         # The aperture object must have a single value for each shape
         # parameter so we must use a single pixel scale for all positions.
         # Here, we define the scale at the WCS CRVAL position.
-        crval = SkyCoord([wcs.wcs.crval], frame=wcs_to_celestial_frame(wcs),
+        crval = SkyCoord(*wcs.wcs.crval, frame=wcs_to_celestial_frame(wcs),
                          unit=wcs.wcs.cunit)
         scale, angle = pixel_scale_angle_at_skycoord(crval, wcs)
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -173,7 +173,7 @@ class PixelAperture(Aperture):
 
     def mask_area(self, method='exact', subpixels=5):
         """
-        Return the area of the aperture(s) mask.
+        Return the area of the aperture masks (one per position).
 
         For ``method`` other than ``'exact'``, this area will be less
         than the exact analytical area (e.g. the ``area`` method).  Note
@@ -216,7 +216,7 @@ class PixelAperture(Aperture):
         Returns
         -------
         area : float
-            A list of the mask area of the aperture(s).
+            A list of the mask area (one per position) of the aperture.
         """
 
         mask = self.to_mask(method=method, subpixels=subpixels)
@@ -439,7 +439,7 @@ class PixelAperture(Aperture):
     def _prepare_plot(self, origin=(0, 0), indices=None, ax=None,
                       fill=False, **kwargs):
         """
-        Prepare to plot the aperture(s) on a matplotlib
+        Prepare to plot the aperture on a matplotlib
         `~matplotlib.axes.Axes` instance.
 
         Parameters
@@ -449,7 +449,7 @@ class PixelAperture(Aperture):
             image.
 
         indices : int or array of int, optional
-            The indices of the aperture(s) to plot.
+            The indices of the aperture position(s) to plot.
 
         ax : `matplotlib.axes.Axes` instance, optional
             If `None`, then the current `~matplotlib.axes.Axes` instance
@@ -465,8 +465,8 @@ class PixelAperture(Aperture):
         Returns
         -------
         plot_positions : `~numpy.ndarray`
-            The positions of the apertures to plot, after any
-            ``indices`` slicing and ``origin`` shift.
+            The aperture position(s) to plot, after any ``indices``
+            slicing and ``origin`` shift.
 
         ax : `matplotlib.axes.Axes` instance, optional
             The `~matplotlib.axes.Axes` on which to plot.
@@ -497,7 +497,7 @@ class PixelAperture(Aperture):
     def plot(self, origin=(0, 0), indices=None, ax=None, fill=False,
              **kwargs):
         """
-        Plot the aperture(s) on a matplotlib `~matplotlib.axes.Axes`
+        Plot the aperture on a matplotlib `~matplotlib.axes.Axes`
         instance.
 
         Parameters
@@ -506,8 +506,9 @@ class PixelAperture(Aperture):
             The ``(x, y)`` position of the origin of the displayed
             image.
 
-        indices : int or array of int, optional
-            The indices of the aperture(s) to plot.
+        indices : int, array of int, or `None`, optional
+            The indices of the aperture position(s) to plot.  If `None`
+            (default) then all aperture positions will be plotted.
 
         ax : `matplotlib.axes.Axes` instance, optional
             If `None`, then the current `~matplotlib.axes.Axes` instance
@@ -778,8 +779,10 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         `~astropy.io.fits.ImageHDU` or `~astropy.io.fits.HDUList`, the
         unit is determined from the ``'BUNIT'`` header keyword.
 
-    apertures : `~photutils.Aperture`
-        The aperture(s) to use for the photometry.
+    apertures : `~photutils.Aperture` or list of `~photutils.Aperture`
+        The aperture(s) to use for the photometry.  If ``apertures`` is
+        a list of `~photutils.Aperture` then they all must have the same
+        position(s).
 
     error : array_like or `~astropy.units.Quantity`, optional
         The pixel-wise Gaussian 1-sigma errors of the input ``data``.

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -100,12 +100,15 @@ class EllipticalMaskMixin:
 
 class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     """
-    Elliptical aperture(s), defined in pixel coordinates.
+    An elliptical aperture defined in pixel coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : array_like or `~astropy.units.Quantity`
-        Pixel coordinates of the aperture center(s) in one of the
+        The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` tuple
@@ -118,14 +121,14 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         rows of (x, y) coordinates.
 
     a : float
-        The semimajor axis.
+        The semimajor axis of the ellipse in pixels.
 
     b : float
-        The semiminor axis.
+        The semiminor axis of the ellipse in pixels.
 
     theta : float, optional
-        The rotation angle in radians of the semimajor axis from the
-        positive ``x`` axis.  The rotation angle increases
+        The rotation angle in radians of the ellipse semimajor axis from
+        the positive ``x`` axis.  The rotation angle increases
         counterclockwise.  The default is 0.
 
     Raises
@@ -211,12 +214,15 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
 
 class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     """
-    Elliptical annulus aperture(s), defined in pixel coordinates.
+    An elliptical annulus aperture defined in pixel coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : array_like or `~astropy.units.Quantity`
-        Pixel coordinates of the aperture center(s) in one of the
+        The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` tuple
@@ -229,21 +235,21 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         rows of (x, y) coordinates.
 
     a_in : float
-        The inner semimajor axis.
+        The inner semimajor axis of the elliptical annulus in pixels.
 
     a_out : float
-        The outer semimajor axis.
+        The outer semimajor axis of the elliptical annulus in pixels.
 
     b_out : float
-        The outer semiminor axis.  The inner semiminor axis is
-        calculated as:
+        The outer semiminor axis of the elliptical annulus in pixels.
+        The inner semiminor axis is calculated as:
 
             .. math:: b_{in} = b_{out}
                 \\left(\\frac{a_{in}}{a_{out}}\\right)
 
     theta : float, optional
-        The rotation angle in radians of the semimajor axis from the
-        positive ``x`` axis.  The rotation angle increases
+        The rotation angle in radians of the ellipse semimajor axis from
+        the positive ``x`` axis.  The rotation angle increases
         counterclockwise.  The default is 0.
 
     Raises
@@ -342,25 +348,30 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
 
 class SkyEllipticalAperture(SkyAperture):
     """
-    Elliptical aperture(s), defined in sky coordinates.
+    An elliptical aperture defined in sky coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : `~astropy.coordinates.SkyCoord`
-        Celestial coordinates of the aperture center(s). This can be
+        The celestial coordinates of the aperture center(s). This can be
         either scalar coordinates or an array of coordinates.
 
-    a : `~astropy.units.Quantity`
-        The semimajor axis, either in angular or pixel units.
+    a : scalar `~astropy.units.Quantity`
+        The semimajor axis of the ellipse, either in angular or pixel
+        units.
 
-    b : `~astropy.units.Quantity`
-        The semiminor axis, either in angular or pixel units.
+    b : scalar `~astropy.units.Quantity`
+        The semiminor axis of the ellipse, either in angular or pixel
+        units.
 
-    theta : `~astropy.units.Quantity`, optional
-        The position angle (in angular units) of the semimajor axis.
-        For a right-handed world coordinate system, the position angle
-        increases counterclockwise from North (PA=0).  The default is 0
-        degrees.
+    theta : scalar `~astropy.units.Quantity`, optional
+        The position angle (in angular units) of the ellipse semimajor
+        axis.  For a right-handed world coordinate system, the position
+        angle increases counterclockwise from North (PA=0).  The default
+        is 0 degrees.
     """
 
     def __init__(self, positions, a, b, theta=0.*u.deg):
@@ -409,32 +420,35 @@ class SkyEllipticalAperture(SkyAperture):
 
 class SkyEllipticalAnnulus(SkyAperture):
     """
-    Elliptical annulus aperture(s), defined in sky coordinates.
+    An elliptical annulus aperture defined in sky coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : `~astropy.coordinates.SkyCoord`
-        Celestial coordinates of the aperture center(s). This can be
+        The celestial coordinates of the aperture center(s). This can be
         either scalar coordinates or an array of coordinates.
 
-    a_in : `~astropy.units.Quantity`
+    a_in : scalar `~astropy.units.Quantity`
         The inner semimajor axis, either in angular or pixel units.
 
-    a_out : `~astropy.units.Quantity`
+    a_out : scalar `~astropy.units.Quantity`
         The outer semimajor axis, either in angular or pixel units.
 
-    b_out : `~astropy.units.Quantity`
+    b_out : scalar `~astropy.units.Quantity`
         The outer semiminor axis, either in angular or pixel units.  The
         inner semiminor axis is calculated as:
 
             .. math:: b_{in} = b_{out}
                 \\left(\\frac{a_{in}}{a_{out}}\\right)
 
-    theta : `~astropy.units.Quantity`, optional
-        The position angle (in angular units) of the semimajor axis.
-        For a right-handed world coordinate system, the position angle
-        increases counterclockwise from North (PA=0).  The default is 0
-        degrees.
+    theta : scalar `~astropy.units.Quantity`, optional
+        The position angle (in angular units) of the ellipse semimajor
+        axis.  For a right-handed world coordinate system, the position
+        angle increases counterclockwise from North (PA=0).  The default
+        is 0 degrees.
     """
 
     def __init__(self, positions, a_in, a_out, b_out, theta=0.*u.deg):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -102,12 +102,15 @@ class RectangularMaskMixin:
 
 class RectangularAperture(RectangularMaskMixin, PixelAperture):
     """
-    Rectangular aperture(s), defined in pixel coordinates.
+    A rectangular aperture defined in pixel coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : array_like or `~astropy.units.Quantity`
-        Pixel coordinates of the aperture center(s) in one of the
+        The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` tuple
@@ -120,16 +123,16 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         rows of (x, y) coordinates.
 
     w : float
-        The full width of the aperture.  For ``theta=0`` the width side
-        is along the ``x`` axis.
+        The full width of the rectangle in pixels.  For ``theta=0`` the
+        width side is along the ``x`` axis.
 
     h : float
-        The full height of the aperture.  For ``theta=0`` the height
-        side is along the ``y`` axis.
+        The full height of the rectangle in pixels.  For ``theta=0`` the
+        height side is along the ``y`` axis.
 
     theta : float, optional
-        The rotation angle in radians of the width (``w``) side from the
-        positive ``x`` axis.  The rotation angle increases
+        The rotation angle in radians of the rectangle "width" side from
+        the positive ``x`` axis.  The rotation angle increases
         counterclockwise.  The default is 0.
 
     Raises
@@ -224,12 +227,15 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
 
 class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     """
-    Rectangular annulus aperture(s), defined in pixel coordinates.
+    A rectangular annulus aperture defined in pixel coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : array_like or `~astropy.units.Quantity`
-        Pixel coordinates of the aperture center(s) in one of the
+        The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` tuple
@@ -242,16 +248,16 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         rows of (x, y) coordinates.
 
     w_in : float
-        The inner full width of the aperture.  For ``theta=0`` the width
-        side is along the ``x`` axis.
+        The inner full width of the rectangular annulus in pixels.  For
+        ``theta=0`` the width side is along the ``x`` axis.
 
     w_out : float
-        The outer full width of the aperture.  For ``theta=0`` the width
-        side is along the ``x`` axis.
+        The outer full width of the rectangular annulus in pixels.  For
+        ``theta=0`` the width side is along the ``x`` axis.
 
     h_out : float
-        The outer full height of the aperture.  The inner full height is
-        calculated as:
+        The outer full height of the rectangular annulus in pixels.  The
+        inner full height is calculated as:
 
             .. math:: h_{in} = h_{out}
                 \\left(\\frac{w_{in}}{w_{out}}\\right)
@@ -259,8 +265,8 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         For ``theta=0`` the height side is along the ``y`` axis.
 
     theta : float, optional
-        The rotation angle in radians of the width side from the
-        positive ``x`` axis.  The rotation angle increases
+        The rotation angle in radians of the rectangle "width" side from
+        the positive ``x`` axis.  The rotation angle increases
         counterclockwise.  The default is 0.
 
     Raises
@@ -378,29 +384,32 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
 class SkyRectangularAperture(SkyAperture):
     """
-    Rectangular aperture(s), defined in sky coordinates.
+    A rectangular aperture defined in sky coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : `~astropy.coordinates.SkyCoord`
-        Celestial coordinates of the aperture center(s). This can be
+        The celestial coordinates of the aperture center(s). This can be
         either scalar coordinates or an array of coordinates.
 
-    w : `~astropy.units.Quantity`
-        The full width of the aperture, either in angular or pixel
+    w : scalar `~astropy.units.Quantity`
+        The full width of the rectangle, either in angular or pixel
         units.  For ``theta=0`` the width side is along the North-South
         axis.
 
-    h :  `~astropy.units.Quantity`
-        The full height of the aperture, either in angular or pixel
+    h :  scalar `~astropy.units.Quantity`
+        The full height of the rectangle, either in angular or pixel
         units.  For ``theta=0`` the height side is along the East-West
         axis.
 
-    theta : `~astropy.units.Quantity`, optional
-        The position angle (in angular units) of the width side.  For a
-        right-handed world coordinate system, the position angle
-        increases counterclockwise from North (PA=0).  The default is 0
-        degrees.
+    theta : scalar `~astropy.units.Quantity`, optional
+        The position angle (in angular units) of the rectangle "width"
+        side.  For a right-handed world coordinate system, the position
+        angle increases counterclockwise from North (PA=0).  The default
+        is 0 degrees.
     """
 
     def __init__(self, positions, w, h, theta=0.*u.deg):
@@ -449,38 +458,41 @@ class SkyRectangularAperture(SkyAperture):
 
 class SkyRectangularAnnulus(SkyAperture):
     """
-    Rectangular annulus aperture(s), defined in sky coordinates.
+    A rectangular annulus aperture defined in sky coordinates.
+
+    The aperture has a single fixed size/shape, but it can have multiple
+    positions (see the ``positions`` input).
 
     Parameters
     ----------
     positions : `~astropy.coordinates.SkyCoord`
-        Celestial coordinates of the aperture center(s). This can be
+        The celestial coordinates of the aperture center(s). This can be
         either scalar coordinates or an array of coordinates.
 
-    w_in : `~astropy.units.Quantity`
-        The inner full width of the aperture, either in angular or pixel
-        units.  For ``theta=0`` the width side is along the North-South
-        axis.
+    w_in : scalar `~astropy.units.Quantity`
+        The inner full width of the rectangular annulus, either in
+        angular or pixel units.  For ``theta=0`` the width side is along
+        the North-South axis.
 
-    w_out : `~astropy.units.Quantity`
-        The outer full width of the aperture, either in angular or pixel
-        units.  For ``theta=0`` the width side is along the North-South
-        axis.
+    w_out : scalar `~astropy.units.Quantity`
+        The outer full width of the rectangular annulus, either in
+        angular or pixel units.  For ``theta=0`` the width side is along
+        the North-South axis.
 
-    h_out : `~astropy.units.Quantity`
-        The outer full height of the aperture, either in angular or
-        pixel units.  The inner full height is calculated as:
+    h_out : scalar `~astropy.units.Quantity`
+        The outer full height of the rectangular annulus, either in
+        angular or pixel units.  The inner full height is calculated as:
 
             .. math:: h_{in} = h_{out}
                 \\left(\\frac{w_{in}}{w_{out}}\\right)
 
         For ``theta=0`` the height side is along the East-West axis.
 
-    theta : `~astropy.units.Quantity`, optional
-        The position angle (in angular units) of the width side.  For a
-        right-handed world coordinate system, the position angle
-        increases counterclockwise from North (PA=0).  The default is 0
-        degrees.
+    theta : scalar `~astropy.units.Quantity`, optional
+        The position angle (in angular units) of the rectangle "width"
+        side.  For a right-handed world coordinate system, the position
+        angle increases counterclockwise from North (PA=0).  The default
+        is 0 degrees.
     """
 
     def __init__(self, positions, w_in, w_out, h_out, theta=0.*u.deg):

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -614,49 +614,30 @@ def test_aperture_partial_overlap():
 
 def test_pixel_aperture_repr():
     aper = CircularAperture((10, 20), r=3.0)
-    a_repr = '<CircularAperture([[10., 20.]], r=3.0)>'
-    a_str = 'Aperture: CircularAperture\npositions: [[10., 20.]]\nr: 3.0'
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    assert '<CircularAperture(' in repr(aper)
+    assert 'Aperture: CircularAperture' in str(aper)
 
     aper = CircularAnnulus((10, 20), r_in=3.0, r_out=5.0)
-    a_repr = '<CircularAnnulus([[10., 20.]], r_in=3.0, r_out=5.0)>'
-    a_str = ('Aperture: CircularAnnulus\npositions: [[10., 20.]]\nr_in: 3.0\n'
-             'r_out: 5.0')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    assert '<CircularAnnulus(' in repr(aper)
+    assert 'Aperture: CircularAnnulus' in str(aper)
 
     aper = EllipticalAperture((10, 20), a=5.0, b=3.0, theta=15.0)
-    a_repr = '<EllipticalAperture([[10., 20.]], a=5.0, b=3.0, theta=15.0)>'
-    a_str = ('Aperture: EllipticalAperture\npositions: [[10., 20.]]\n'
-             'a: 5.0\nb: 3.0\ntheta: 15.0')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    assert '<EllipticalAperture(' in repr(aper)
+    assert 'Aperture: EllipticalAperture' in str(aper)
 
     aper = EllipticalAnnulus((10, 20), a_in=4.0, a_out=8.0, b_out=4.0,
                              theta=15.0)
-    a_repr = ('<EllipticalAnnulus([[10., 20.]], a_in=4.0, a_out=8.0, b_out='
-              '4.0, theta=15.0)>')
-    a_str = ('Aperture: EllipticalAnnulus\npositions: [[10., 20.]]\na_in: '
-             '4.0\na_out: 8.0\nb_out: 4.0\ntheta: 15.0')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    assert '<EllipticalAnnulus(' in repr(aper)
+    assert 'Aperture: EllipticalAnnulus' in str(aper)
 
     aper = RectangularAperture((10, 20), w=5.0, h=3.0, theta=15.0)
-    a_repr = '<RectangularAperture([[10., 20.]], w=5.0, h=3.0, theta=15.0)>'
-    a_str = ('Aperture: RectangularAperture\npositions: [[10., 20.]]\n'
-             'w: 5.0\nh: 3.0\ntheta: 15.0')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    assert '<RectangularAperture(' in repr(aper)
+    assert 'Aperture: RectangularAperture' in str(aper)
 
     aper = RectangularAnnulus((10, 20), w_in=4.0, w_out=8.0, h_out=4.0,
                               theta=15.0)
-    a_repr = ('<RectangularAnnulus([[10., 20.]], w_in=4.0, w_out=8.0, '
-              'h_out=4.0, theta=15.0)>')
-    a_str = ('Aperture: RectangularAnnulus\npositions: [[10., 20.]]\n'
-             'w_in: 4.0\nw_out: 8.0\nh_out: 4.0\ntheta: 15.0')
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
+    assert '<RectangularAnnulus(' in repr(aper)
+    assert 'Aperture: RectangularAnnulus' in str(aper)
 
 
 def test_sky_aperture_repr():

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -614,46 +614,46 @@ def test_aperture_partial_overlap():
 
 def test_pixel_aperture_repr():
     aper = CircularAperture((10, 20), r=3.0)
-    a_repr = '<CircularAperture([[10, 20]], r=3.0)>'
-    a_str = 'Aperture: CircularAperture\npositions: [[10, 20]]\nr: 3.0'
+    a_repr = '<CircularAperture([[10., 20.]], r=3.0)>'
+    a_str = 'Aperture: CircularAperture\npositions: [[10., 20.]]\nr: 3.0'
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = CircularAnnulus((10, 20), r_in=3.0, r_out=5.0)
-    a_repr = '<CircularAnnulus([[10, 20]], r_in=3.0, r_out=5.0)>'
-    a_str = ('Aperture: CircularAnnulus\npositions: [[10, 20]]\nr_in: 3.0\n'
+    a_repr = '<CircularAnnulus([[10., 20.]], r_in=3.0, r_out=5.0)>'
+    a_str = ('Aperture: CircularAnnulus\npositions: [[10., 20.]]\nr_in: 3.0\n'
              'r_out: 5.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = EllipticalAperture((10, 20), a=5.0, b=3.0, theta=15.0)
-    a_repr = '<EllipticalAperture([[10, 20]], a=5.0, b=3.0, theta=15.0)>'
-    a_str = ('Aperture: EllipticalAperture\npositions: [[10, 20]]\n'
+    a_repr = '<EllipticalAperture([[10., 20.]], a=5.0, b=3.0, theta=15.0)>'
+    a_str = ('Aperture: EllipticalAperture\npositions: [[10., 20.]]\n'
              'a: 5.0\nb: 3.0\ntheta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = EllipticalAnnulus((10, 20), a_in=4.0, a_out=8.0, b_out=4.0,
                              theta=15.0)
-    a_repr = ('<EllipticalAnnulus([[10, 20]], a_in=4.0, a_out=8.0, b_out='
+    a_repr = ('<EllipticalAnnulus([[10., 20.]], a_in=4.0, a_out=8.0, b_out='
               '4.0, theta=15.0)>')
-    a_str = ('Aperture: EllipticalAnnulus\npositions: [[10, 20]]\na_in: '
+    a_str = ('Aperture: EllipticalAnnulus\npositions: [[10., 20.]]\na_in: '
              '4.0\na_out: 8.0\nb_out: 4.0\ntheta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = RectangularAperture((10, 20), w=5.0, h=3.0, theta=15.0)
-    a_repr = '<RectangularAperture([[10, 20]], w=5.0, h=3.0, theta=15.0)>'
-    a_str = ('Aperture: RectangularAperture\npositions: [[10, 20]]\n'
+    a_repr = '<RectangularAperture([[10., 20.]], w=5.0, h=3.0, theta=15.0)>'
+    a_str = ('Aperture: RectangularAperture\npositions: [[10., 20.]]\n'
              'w: 5.0\nh: 3.0\ntheta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = RectangularAnnulus((10, 20), w_in=4.0, w_out=8.0, h_out=4.0,
                               theta=15.0)
-    a_repr = ('<RectangularAnnulus([[10, 20]], w_in=4.0, w_out=8.0, '
+    a_repr = ('<RectangularAnnulus([[10., 20.]], w_in=4.0, w_out=8.0, '
               'h_out=4.0, theta=15.0)>')
-    a_str = ('Aperture: RectangularAnnulus\npositions: [[10, 20]]\n'
+    a_str = ('Aperture: RectangularAnnulus\npositions: [[10., 20.]]\n'
              'w_in: 4.0\nw_out: 8.0\nh_out: 4.0\ntheta: 15.0')
     assert repr(aper) == a_repr
     assert str(aper) == a_str

--- a/photutils/utils/_wcs_helpers.py
+++ b/photutils/utils/_wcs_helpers.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import UnitSphericalRepresentation
+from astropy.wcs.utils import skycoord_to_pixel
+
+
+def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
+    """
+    Calculate the pixel scale and WCS rotation angle at the position of
+    a SkyCoord coordinate.
+
+    Parameters
+    ----------
+    skycoord : `~astropy.coordinates.SkyCoord`
+        The SkyCoord coordinate.
+    wcs : `~astropy.wcs.WCS`
+        The world coordinate system (WCS) transformation to use.
+    offset : `~astropy.units.Quantity`
+        A small angular offset to use to compute the pixel scale and
+        position angle.
+
+    Returns
+    -------
+    scale : `~astropy.units.Quantity`
+        The pixel scale in arcsec/pixel.
+    angle : `~astropy.units.Quantity`
+        The angle (in degrees) measured counterclockwise from the
+        positive x axis to the "North" axis of the celestial coordinate
+        system.
+
+    Notes
+    -----
+    If distortions are present in the image, the x and y pixel scales
+    likely differ.  This function computes a single pixel scale along
+    the North/South axis.
+    """
+
+    # We take a point directly "above" (in latitude) the input position
+    # and convert it to pixel coordinates, then we use the pixel deltas
+    # between the input and offset point to calculate the pixel scale and
+    # angle.
+
+    # Find the coordinates as a representation object
+    coord = skycoord.represent_as('unitspherical')
+
+    # Add a a small perturbation in the latitude direction (since longitude
+    # is more difficult because it is not directly an angle)
+    coord_new = UnitSphericalRepresentation(coord.lon, coord.lat + offset)
+    coord_offset = skycoord.realize_frame(coord_new)
+
+    # Find pixel coordinates of offset coordinates and pixel deltas
+    x_offset, y_offset = skycoord_to_pixel(coord_offset, wcs, mode='all')
+    x, y = skycoord_to_pixel(skycoord, wcs, mode='all')
+    dx = x_offset - x
+    dy = y_offset - y
+
+    scale = offset.to(u.arcsec) / (np.hypot(dx, dy) * u.pixel)
+    angle = (np.arctan2(dy, dx) * u.radian).to(u.deg)
+
+    return scale, angle

--- a/photutils/utils/wcs_helpers.py
+++ b/photutils/utils/wcs_helpers.py
@@ -3,9 +3,12 @@
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import UnitSphericalRepresentation
+from astropy.utils import deprecated
 from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 
 
+@deprecated('0.7', 'The pixel_scale_angle_at_skycoord function is deprecated '
+            'and will be removed in v0.8')
 def pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
     """
     Calculate the pixel scale and WCS rotation angle at the position of
@@ -62,6 +65,8 @@ def pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
     return scale, angle
 
 
+@deprecated('0.7', 'The assert_angle_or_pixel function is deprecated and '
+            'will be removed in v0.8')
 def assert_angle_or_pixel(name, q):
     """
     Check that ``q`` is either an angular or a pixel
@@ -78,6 +83,8 @@ def assert_angle_or_pixel(name, q):
         raise TypeError("{0} should be a Quantity instance".format(name))
 
 
+@deprecated('0.7', 'The assert_angle function is deprecated and will be '
+            'removed in v0.8')
 def assert_angle(name, q):
     """
     Check that ``q`` is an angular :class:`~astropy.units.Quantity`.
@@ -92,6 +99,8 @@ def assert_angle(name, q):
         raise TypeError("{0} should be a Quantity instance".format(name))
 
 
+@deprecated('0.7', 'The pixel_to_icrs_coords function is deprecated and will '
+            'be removed in v0.8')
 def pixel_to_icrs_coords(x, y, wcs):
     """
     Convert pixel coordinates to ICRS Right Ascension and Declination.


### PR DESCRIPTION
This PR adds validation of the input parameters for all aperture classes using new descriptor classes.  Users will no longer get cryptic error messages for invalid parameter inputs.

The documentation for all apertures has also been updated to make it explicitly clear that apertures have a single fixed size/shape, but they can have multiple positions.

The descriptor classes made it possible to deprecate the `utils.wcs_helpers` functions, which will be removed in v0.8.

Closes #827.