### PR TITLE
Deprecate inputting aperture pixel positions shaped as 2xN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,11 @@ Bug Fixes
 API changes
 ^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Deprecated inputting aperture pixel positions shaped as 2xN.
+    [#847]
+
 - ``photutils.detection``
 
   - Removed deprecated ``subpixel`` keyword for ``find_peaks``. [#835]

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -3,10 +3,12 @@
 Descriptor classes for aperture attribute validation.
 """
 
+import warnings
 import weakref
 
 from astropy.coordinates import SkyCoord
 import astropy.units as u
+from astropy.utils.exceptions import AstropyDeprecationWarning
 import numpy as np
 
 
@@ -66,6 +68,11 @@ class PixelPositions(ApertureAttribute):
             value = value.value
 
         if value.shape[1] != 2 and value.shape[0] == 2:
+            warnings.warn('Inputing positions shaped as 2xN is deprecated '
+                          'and will be removed in v0.8.  Positions should be '
+                          'a (x, y) pixel position or a list or array of '
+                          '(x, y) pixel positions, e.g. [(x1, y1), '
+                          '(x2, y2), (x3, y3)].', AstropyDeprecationWarning)
             value = np.transpose(value)
 
         self.values[instance] = value

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -104,14 +104,10 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
-            * single ``(x, y)`` tuple
-            * list of ``(x, y)`` tuples
-            * ``Nx2`` or ``2xN`` `~numpy.ndarray`
-            * ``Nx2`` or ``2xN`` `~astropy.units.Quantity` in pixel units
-
-        Note that a ``2x2`` `~numpy.ndarray` or
-        `~astropy.units.Quantity` is interpreted as ``Nx2``, i.e. two
-        rows of (x, y) coordinates.
+            * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
+            * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
+            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
+              pixel units
 
     r : float
         The radius of the circle in pixels.
@@ -120,6 +116,18 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
     ------
     ValueError : `ValueError`
         If the input radius, ``r``, is negative.
+
+    Examples
+    --------
+    >>> from photutils import CircularAperture
+    >>> aper = CircularAperture([10., 20.], 3.)
+    >>> aper = CircularAperture((10., 20.), 3.)
+
+    >>> pos1 = (10., 20.)  # (x, y)
+    >>> pos2 = (30., 40.)
+    >>> pos3 = (50., 60.)
+    >>> aper = CircularAperture([pos1, pos2, pos3], 3.)
+    >>> aper = CircularAperture((pos1, pos2, pos3), 3.)
     """
 
     positions = PixelPositions('positions')
@@ -192,14 +200,10 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
-            * single ``(x, y)`` tuple
-            * list of ``(x, y)`` tuples
-            * ``Nx2`` or ``2xN`` `~numpy.ndarray`
-            * ``Nx2`` or ``2xN`` `~astropy.units.Quantity` in pixel units
-
-        Note that a ``2x2`` `~numpy.ndarray` or
-        `~astropy.units.Quantity` is interpreted as ``Nx2``, i.e. two
-        rows of (x, y) coordinates.
+            * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
+            * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
+            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
+              pixel units
 
     r_in : float
         The inner radius of the circular annulus in pixels.
@@ -214,6 +218,18 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
 
     ValueError : `ValueError`
         If inner radius (``r_in``) is negative.
+
+    Examples
+    --------
+    >>> from photutils import CircularAnnulus
+    >>> aper = CircularAnnulus([10., 20.], 3., 5.)
+    >>> aper = CircularAnnulus((10., 20.), 3., 5.)
+
+    >>> pos1 = (10., 20.)  # (x, y)
+    >>> pos2 = (30., 40.)
+    >>> pos3 = (50., 60.)
+    >>> aper = CircularAnnulus([pos1, pos2, pos3], 3., 5.)
+    >>> aper = CircularAnnulus((pos1, pos2, pos3), 3., 5.)
     """
 
     positions = PixelPositions('positions')
@@ -221,7 +237,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
     r_out = PositiveScalar('r_out')
 
     def __init__(self, positions, r_in, r_out):
-        if not (r_out > r_in):
+        if not r_out > r_in:
             raise ValueError('r_out must be greater than r_in')
 
         self.positions = positions
@@ -296,6 +312,14 @@ class SkyCircularAperture(SkyAperture):
 
     r : scalar `~astropy.units.Quantity`
         The radius of the circle, either in angular or pixel units.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>> from photutils import SkyCircularAperture
+    >>> positions = SkyCoord(ra=[10., 20.], dec=[30., 40.], unit='deg')
+    >>> aper = SkyCircularAperture(positions, 0.5*u.arcsec)
     """
 
     positions = SkyCoordPositions('positions')
@@ -351,6 +375,14 @@ class SkyCircularAnnulus(SkyAperture):
     r_out : scalar `~astropy.units.Quantity`
         The outer radius of the circular annulus, either in angular or
         pixel units.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>> from photutils import SkyCircularAnnulus
+    >>> positions = SkyCoord(ra=[10., 20.], dec=[30., 40.], unit='deg')
+    >>> aper = SkyCircularAnnulus(positions, 0.5*u.arcsec, 1.0*u.arcsec)
     """
 
     positions = SkyCoordPositions('positions')

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -111,14 +111,10 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
-            * single ``(x, y)`` tuple
-            * list of ``(x, y)`` tuples
-            * ``Nx2`` or ``2xN`` `~numpy.ndarray`
-            * ``Nx2`` or ``2xN`` `~astropy.units.Quantity` in pixel units
-
-        Note that a ``2x2`` `~numpy.ndarray` or
-        `~astropy.units.Quantity` is interpreted as ``Nx2``, i.e. two
-        rows of (x, y) coordinates.
+            * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
+            * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
+            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
+              pixel units
 
     a : float
         The semimajor axis of the ellipse in pixels.
@@ -135,6 +131,18 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     ------
     ValueError : `ValueError`
         If either axis (``a`` or ``b``) is negative.
+
+    Examples
+    --------
+    >>> from photutils import EllipticalAperture
+    >>> aper = EllipticalAperture([10., 20.], 5., 3.)
+    >>> aper = EllipticalAperture((10., 20.), 5., 3., theta=np.pi)
+
+    >>> pos1 = (10., 20.)  # (x, y)
+    >>> pos2 = (30., 40.)
+    >>> pos3 = (50., 60.)
+    >>> aper = EllipticalAperture([pos1, pos2, pos3], 5., 3.)
+    >>> aper = EllipticalAperture((pos1, pos2, pos3), 5., 3., theta=np.pi)
     """
 
     positions = PixelPositions('positions')
@@ -227,14 +235,10 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
-            * single ``(x, y)`` tuple
-            * list of ``(x, y)`` tuples
-            * ``Nx2`` or ``2xN`` `~numpy.ndarray`
-            * ``Nx2`` or ``2xN`` `~astropy.units.Quantity` in pixel units
-
-        Note that a ``2x2`` `~numpy.ndarray` or
-        `~astropy.units.Quantity` is interpreted as ``Nx2``, i.e. two
-        rows of (x, y) coordinates.
+            * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
+            * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
+            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
+              pixel units
 
     a_in : float
         The inner semimajor axis of the elliptical annulus in pixels.
@@ -263,6 +267,18 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     ValueError : `ValueError`
         If either the inner semimajor axis (``a_in``) or the outer semiminor
         axis (``b_out``) is negative.
+
+    Examples
+    --------
+    >>> from photutils import EllipticalAnnulus
+    >>> aper = EllipticalAnnulus([10., 20.], 3., 8., 5.)
+    >>> aper = EllipticalAnnulus((10., 20.), 3., 8., 5., theta=np.pi)
+
+    >>> pos1 = (10., 20.)  # (x, y)
+    >>> pos2 = (30., 40.)
+    >>> pos3 = (50., 60.)
+    >>> aper = EllipticalAnnulus([pos1, pos2, pos3], 3., 8., 5.)
+    >>> aper = EllipticalAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=np.pi)
     """
 
     positions = PixelPositions('positions')
@@ -378,6 +394,14 @@ class SkyEllipticalAperture(SkyAperture):
         axis.  For a right-handed world coordinate system, the position
         angle increases counterclockwise from North (PA=0).  The default
         is 0 degrees.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>> from photutils import SkyEllipticalAperture
+    >>> positions = SkyCoord(ra=[10., 20.], dec=[30., 40.], unit='deg')
+    >>> aper = SkyEllipticalAperture(positions, 1.0*u.arcsec, 0.5*u.arcsec)
     """
 
     positions = SkyCoordPositions('positions')
@@ -452,6 +476,15 @@ class SkyEllipticalAnnulus(SkyAperture):
         axis.  For a right-handed world coordinate system, the position
         angle increases counterclockwise from North (PA=0).  The default
         is 0 degrees.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>> from photutils import SkyEllipticalAnnulus
+    >>> positions = SkyCoord(ra=[10., 20.], dec=[30., 40.], unit='deg')
+    >>> aper = SkyEllipticalAnnulus(positions, 0.5*u.arcsec, 2.0*u.arcsec,
+    ...                             1.0*u.arcsec)
     """
 
     positions = SkyCoordPositions('positions')

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -69,8 +69,8 @@ class RectangularMaskMixin:
             A list of aperture mask objects.
         """
 
-        use_exact, subpixels = self._translate_mask_mode(method, subpixels,
-                                                         rectangle=True)
+        _, subpixels = self._translate_mask_mode(method, subpixels,
+                                                 rectangle=True)
 
         if hasattr(self, 'w'):
             w = self.w
@@ -114,14 +114,10 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
-            * single ``(x, y)`` tuple
-            * list of ``(x, y)`` tuples
-            * ``Nx2`` or ``2xN`` `~numpy.ndarray`
-            * ``Nx2`` or ``2xN`` `~astropy.units.Quantity` in pixel units
-
-        Note that a ``2x2`` `~numpy.ndarray` or
-        `~astropy.units.Quantity` is interpreted as ``Nx2``, i.e. two
-        rows of (x, y) coordinates.
+            * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
+            * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
+            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
+              pixel units
 
     w : float
         The full width of the rectangle in pixels.  For ``theta=0`` the
@@ -140,6 +136,18 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     ------
     ValueError : `ValueError`
         If either width (``w``) or height (``h``) is negative.
+
+    Examples
+    --------
+    >>> from photutils import RectangularAperture
+    >>> aper = RectangularAperture([10., 20.], 5., 3.)
+    >>> aper = RectangularAperture((10., 20.), 5., 3., theta=np.pi)
+
+    >>> pos1 = (10., 20.)  # (x, y)
+    >>> pos2 = (30., 40.)
+    >>> pos3 = (50., 60.)
+    >>> aper = RectangularAperture([pos1, pos2, pos3], 5., 3.)
+    >>> aper = RectangularAperture((pos1, pos2, pos3), 5., 3., theta=np.pi)
     """
 
     positions = PixelPositions('positions')
@@ -241,14 +249,10 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
-            * single ``(x, y)`` tuple
-            * list of ``(x, y)`` tuples
-            * ``Nx2`` or ``2xN`` `~numpy.ndarray`
-            * ``Nx2`` or ``2xN`` `~astropy.units.Quantity` in pixel units
-
-        Note that a ``2x2`` `~numpy.ndarray` or
-        `~astropy.units.Quantity` is interpreted as ``Nx2``, i.e. two
-        rows of (x, y) coordinates.
+            * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
+            * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
+            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
+              pixel units
 
     w_in : float
         The inner full width of the rectangular annulus in pixels.  For
@@ -281,6 +285,18 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     ValueError : `ValueError`
         If either the inner width (``w_in``) or the outer height
         (``h_out``) is negative.
+
+    Examples
+    --------
+    >>> from photutils import RectangularAnnulus
+    >>> aper = RectangularAnnulus([10., 20.], 3., 8., 5.)
+    >>> aper = RectangularAnnulus((10., 20.), 3., 8., 5., theta=np.pi)
+
+    >>> pos1 = (10., 20.)  # (x, y)
+    >>> pos2 = (30., 40.)
+    >>> pos3 = (50., 60.)
+    >>> aper = RectangularAnnulus([pos1, pos2, pos3], 3., 8., 5.)
+    >>> aper = RectangularAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=np.pi)
     """
 
     positions = PixelPositions('positions')
@@ -417,6 +433,14 @@ class SkyRectangularAperture(SkyAperture):
         side.  For a right-handed world coordinate system, the position
         angle increases counterclockwise from North (PA=0).  The default
         is 0 degrees.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>> from photutils import SkyRectangularAperture
+    >>> positions = SkyCoord(ra=[10., 20.], dec=[30., 40.], unit='deg')
+    >>> aper = SkyRectangularAperture(positions, 1.0*u.arcsec, 0.5*u.arcsec)
     """
 
     positions = SkyCoordPositions('positions')
@@ -497,6 +521,15 @@ class SkyRectangularAnnulus(SkyAperture):
         side.  For a right-handed world coordinate system, the position
         angle increases counterclockwise from North (PA=0).  The default
         is 0 degrees.
+
+    Examples
+    --------
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>> from photutils import SkyRectangularAnnulus
+    >>> positions = SkyCoord(ra=[10., 20.], dec=[30., 40.], unit='deg')
+    >>> aper = SkyRectangularAnnulus(positions, 3.0*u.arcsec, 8.0*u.arcsec,
+    ...                              5.0*u.arcsec)
     """
 
     positions = SkyCoordPositions('positions')

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -87,18 +87,16 @@ def test_aperture_plots(aperture_class, params):
 
 def test_aperture_pixel_positions():
     pos1 = (10, 20)
-    pos2 = u.Quantity((10, 20), unit=u.pixel)
-    pos3 = ((10, 20, 30), (10, 20, 30))
-    pos3_pairs = ((10, 10), (20, 20), (30, 30))
+    pos2 = [(10, 20)]
+    pos3 = u.Quantity((10, 20), unit=u.pixel)
 
     r = 3
     ap1 = CircularAperture(pos1, r)
     ap2 = CircularAperture(pos2, r)
     ap3 = CircularAperture(pos3, r)
 
-    assert_allclose(np.atleast_2d(pos1), ap1.positions)
-    assert_allclose(np.atleast_2d(pos2.value), ap2.positions)
-    assert_allclose(pos3_pairs, ap3.positions)
+    assert_allclose(ap1.positions, ap2.positions)
+    assert_allclose(ap1.positions, ap3.positions)
 
 
 class BaseTestAperturePhotometry:

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -257,8 +257,9 @@ class BasicPSFPhotometry:
                               'going to be ignored.', AstropyUserWarning)
 
             if 'flux_0' not in init_guesses.colnames:
-                apertures = CircularAperture((init_guesses['x_0'],
-                                              init_guesses['y_0']),
+                positions = np.transpose((init_guesses['x_0'],
+                                          init_guesses['y_0']))
+                apertures = CircularAperture(positions,
                                              r=self.aperture_radius)
 
                 init_guesses['flux_0'] = aperture_photometry(
@@ -269,8 +270,9 @@ class BasicPSFPhotometry:
                                  'not given.')
             sources = self.finder(image)
             if len(sources) > 0:
-                apertures = CircularAperture((sources['xcentroid'],
-                                              sources['ycentroid']),
+                positions = np.transpose((sources['xcentroid'],
+                                          sources['ycentroid']))
+                apertures = CircularAperture(positions,
                                              r=self.aperture_radius)
 
                 sources['aperture_flux'] = aperture_photometry(
@@ -699,8 +701,9 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         n = n_start
         while(sources is not None and
               (self.niters is None or n <= self.niters)):
-            apertures = CircularAperture((sources['xcentroid'],
-                                          sources['ycentroid']),
+            positions = np.transpose((sources['xcentroid'],
+                                      sources['ycentroid']))
+            apertures = CircularAperture(positions,
                                          r=self.aperture_radius)
             sources['aperture_flux'] = aperture_photometry(
                 self._residual_image, apertures)['aperture_sum']


### PR DESCRIPTION
This PR deprecates inputting aperture pixels positions shaped a `2xN`.  This "feature" led to some confusion, especially for the `2x2` case where positions were interpreted as Nx2 (i.e. two rows of (x, y)).  Pixel positions now should be input as a `(x, y)` pixel position or a list or array of `(x, y)` pixel positions, e.g. `[(x1, y1), (x2, y2), (x3, y3)]`.  

This PR also adds "Examples" sections to the aperture docstrings.  Closes #790.