### PR TITLE
Rename celestial_center to sky_center

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,11 @@ Bug Fixes
 API changes
 ^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Renamed the ``celestial_center`` column to ``sky_center`` in the
+    ``aperture_photometry`` output table. [#848]
+
 - ``photutils.detection``
 
   - Removed deprecated ``subpixel`` keyword for ``find_peaks``. [#835]

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -824,8 +824,8 @@ def aperture_photometry(data, apertures, error=None, mask=None,
               The ``x`` and ``y`` pixel coordinates of the input
               aperture center(s).
 
-            * ``'celestial_center'``:
-              The celestial coordinates of the input aperture center(s).
+            * ``'sky_center'``:
+              The sky coordinates of the input aperture center(s).
               Returned only if the input ``apertures`` is a
               `SkyAperture` object.
 
@@ -896,9 +896,9 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     if skyaper:
         if skycoord_pos.isscalar:
             # create length-1 SkyCoord array
-            tbl['celestial_center'] = skycoord_pos.reshape((-1,))
+            tbl['sky_center'] = skycoord_pos.reshape((-1,))
         else:
-            tbl['celestial_center'] = skycoord_pos
+            tbl['sky_center'] = skycoord_pos
 
     for i, aper in enumerate(apertures):
         aper_sum, aper_sum_err = aper.do_photometry(data, error=error,

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -946,4 +946,4 @@ def test_scalar_skycoord():
     skycoord = pixel_to_skycoord(90, 60, wcs)
     aper = SkyCircularAperture(skycoord, r=0.1*u.arcsec)
     tbl = aperture_photometry(data, aper, wcs=wcs)
-    assert isinstance(tbl['celestial_center'], SkyCoord)
+    assert isinstance(tbl['sky_center'], SkyCoord)


### PR DESCRIPTION
For naming consistency and consistency with segmentation-based properties, this PR renames the `celestial_center` column in the aperture photometry table (when using `Sky` apertures) to `sky_center`.