### PR TITLE
BoundingBox improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ New Features
 
   - Added parameter validation for all aperture classes. [#846]
 
+  - Added ``from_float``, ``as_artist``, ``union`` and
+    ``intersection`` methods to ``BoundingBox`` class. [#851]
+
 - ``photutils.isophote``
 
   - Significantly improved the performance (~5 times faster) of
@@ -93,6 +96,9 @@ API changes
   - ``DAOStarFinder``, ``IRAFStarFinder``, and ``find_peaks`` now return
     ``None`` if no source/peaks are found.  Also, for this case a
     ``NoDetectionsWarning`` is issued. [#836]
+
+  - Deprecated the ``BoundingBox`` ``as_patch`` method (instead use
+    ``as_artist``). [#851]
 
 - ``photutils.segmentation``
 

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -134,6 +134,9 @@ class BoundingBox:
     def __or__(self, bbox):
         return self.union(bbox)
 
+    def __and__(self, bbox):
+        return self.intersection(bbox)
+
     def __repr__(self):
         data = self.__dict__
         data['name'] = self.__class__.__name__
@@ -304,5 +307,34 @@ class BoundingBox:
         ixmax = max((self.ixmax, bbox.ixmax))
         iymin = min((self.iymin, bbox.iymin))
         iymax = max((self.iymax, bbox.iymax))
+
+        return BoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin, iymax=iymax)
+
+    def intersection(self, bbox):
+        """
+        Return a `BoundingBox` representing the intersection of this
+        `BoundingBox` with another `BoundingBox`.
+
+        Parameters
+        ----------
+        bbox : `~photutils.BoundingBox`
+            The `BoundingBox` to intersect with this one.
+
+        Returns
+        -------
+        result : `~photutils.BoundingBox`
+            A `BoundingBox` representing the intersection of the input
+            ``bbox`` with this one.
+        """
+
+        if not isinstance(bbox, BoundingBox):
+            raise TypeError('bbox must be a BoundingBox instance')
+
+        ixmin = max(self.ixmin, bbox.ixmin)
+        ixmax = min(self.ixmax, bbox.ixmax)
+        iymin = max(self.iymin, bbox.iymin)
+        iymax = min(self.iymax, bbox.iymax)
+        if ixmax < ixmin or iymax < iymin:
+            return None
 
         return BoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin, iymax=iymax)

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -131,6 +131,9 @@ class BoundingBox:
             (self.iymax == other.iymax)
         )
 
+    def __or__(self, bbox):
+        return self.union(bbox)
+
     def __repr__(self):
         data = self.__dict__
         data['name'] = self.__class__.__name__
@@ -276,3 +279,30 @@ class BoundingBox:
 
         aper = self.to_aperture()
         aper.plot(origin=origin, ax=ax, fill=fill, **kwargs)
+
+    def union(self, bbox):
+        """
+        Return a `BoundingBox` representing the union of this
+        `BoundingBox` with another `BoundingBox`.
+
+        Parameters
+        ----------
+        bbox : `~photutils.BoundingBox`
+            The `BoundingBox` to join with this one.
+
+        Returns
+        -------
+        result : `~photutils.BoundingBox`
+            A `BoundingBox` representing the union of the input ``bbox``
+            with this one.
+        """
+
+        if not isinstance(bbox, BoundingBox):
+            raise TypeError('bbox must be a BoundingBox instance')
+
+        ixmin = min((self.ixmin, bbox.ixmin))
+        ixmax = max((self.ixmax, bbox.ixmax))
+        iymin = min((self.iymin, bbox.iymin))
+        iymax = max((self.iymax, bbox.iymax))
+
+        return BoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin, iymax=iymax)

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -70,7 +70,7 @@ class BoundingBox:
         self.iymax = iymax
 
     @classmethod
-    def _from_float(cls, xmin, xmax, ymin, ymax):
+    def from_float(cls, xmin, xmax, ymin, ymax):
         """
         Return the smallest bounding box that fully contains a given
         rectangle defined by float coordinate values.
@@ -104,10 +104,10 @@ class BoundingBox:
         Examples
         --------
         >>> from photutils import BoundingBox
-        >>> BoundingBox._from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
+        >>> BoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
         BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
 
-        >>> BoundingBox._from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
+        >>> BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
         BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
         """
 

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from astropy.io.fits.util import _is_int
+from astropy.utils import deprecated
 
 
 __all__ = ['BoundingBox']
@@ -177,14 +178,34 @@ class BoundingBox:
             self.iymax - 0.5,
         )
 
-    def as_patch(self, **kwargs):
+    @deprecated('0.7', alternative='as_artist')
+    def as_patch(self, **kwargs):  # pragma: no cover
         """
         Return a `matplotlib.patches.Rectangle` that represents the
         bounding box.
 
         Parameters
         ----------
-        kwargs
+        kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        result : `matplotlib.patches.Rectangle`
+            A matplotlib rectangular patch.
+        """
+
+        return self.as_artist(**kwargs)
+
+    def as_artist(self, **kwargs):
+        """
+        Return a `matplotlib.patches.Rectangle` that represents the
+        bounding box.
+
+        Parameters
+        ----------
+        kwargs : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
 
@@ -206,7 +227,7 @@ class BoundingBox:
             np.random.seed(12345)
             ax.imshow(np.random.random((10, 10)), interpolation='nearest',
                       cmap='viridis')
-            ax.add_patch(bbox.as_patch(facecolor='none', edgecolor='white',
+            ax.add_patch(bbox.as_artist(facecolor='none', edgecolor='white',
                          lw=2.))
         """
 
@@ -226,9 +247,9 @@ class BoundingBox:
         xpos = (self.extent[1] + self.extent[0]) / 2.
         ypos = (self.extent[3] + self.extent[2]) / 2.
         xypos = (xpos, ypos)
-        h, w = self.shape
+        height, width = self.shape
 
-        return RectangularAperture(xypos, w=w, h=h, theta=0.)
+        return RectangularAperture(xypos, w=width, h=height, theta=0.)
 
     def plot(self, origin=(0, 0), ax=None, fill=False, **kwargs):
         """
@@ -249,7 +270,7 @@ class BoundingBox:
             Set whether to fill the aperture patch.  The default is
             `False`.
 
-        kwargs
+        kwargs : `dict`
             Any keyword arguments accepted by `matplotlib.patches.Patch`.
         """
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -145,7 +145,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         ymin = self.positions[:, 1] - self.r
         ymax = self.positions[:, 1] + self.r
 
-        return [BoundingBox._from_float(x0, x1, y0, y1)
+        return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
 
     def area(self):
@@ -252,7 +252,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         ymin = self.positions[:, 1] - self.r_out
         ymax = self.positions[:, 1] + self.r_out
 
-        return [BoundingBox._from_float(x0, x1, y0, y1)
+        return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
 
     def area(self):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -178,7 +178,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         ymin = self.positions[:, 1] - dy
         ymax = self.positions[:, 1] + dy
 
-        return [BoundingBox._from_float(x0, x1, y0, y1)
+        return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
 
     def area(self):
@@ -320,7 +320,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         ymin = self.positions[:, 1] - dy
         ymax = self.positions[:, 1] + dy
 
-        return [BoundingBox._from_float(x0, x1, y0, y1)
+        return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
 
     def area(self):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -185,7 +185,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         ymin = self.positions[:, 1] - dy
         ymax = self.positions[:, 1] + dy
 
-        return [BoundingBox._from_float(x0, x1, y0, y1)
+        return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
 
     def area(self):
@@ -341,7 +341,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         ymin = self.positions[:, 1] - dy
         ymax = self.positions[:, 1] + dy
 
-        return [BoundingBox._from_float(x0, x1, y0, y1)
+        return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
 
     def area(self):

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -90,10 +90,10 @@ def test_bounding_box_extent():
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
-def test_bounding_box_as_patch():
+def test_bounding_box_as_artist():
     bbox = BoundingBox(1, 10, 2, 20)
 
-    patch = bbox.as_patch()
+    patch = bbox.as_artist()
     assert_allclose(patch.get_xy(), (0.5, 1.5))
     assert_allclose(patch.get_width(), 9)
     assert_allclose(patch.get_height(), 18)

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ..bounding_box import BoundingBox
+from ..rectangle import RectangularAperture
 
 try:
     import matplotlib    # noqa
@@ -14,7 +15,6 @@ except ImportError:
 
 def test_bounding_box_init():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert bbox.ixmin == 1
     assert bbox.ixmax == 10
     assert bbox.iymin == 2
@@ -56,50 +56,63 @@ def test_bounding_box_from_float():
 
 def test_bounding_box_eq():
     bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox == bbox
-
+    assert bbox == BoundingBox(1, 10, 2, 20)
     assert bbox != BoundingBox(9, 10, 2, 20)
     assert bbox != BoundingBox(1, 99, 2, 20)
     assert bbox != BoundingBox(1, 10, 9, 20)
     assert bbox != BoundingBox(1, 10, 2, 99)
 
     with pytest.raises(TypeError):
-        bbox == (1, 10, 2, 20)
+        assert bbox == (1, 10, 2, 20)
 
 
 def test_bounding_box_repr():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert repr(bbox) == 'BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)'
-    assert eval(repr(bbox)) == bbox
 
 
 def test_bounding_box_shape():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert bbox.shape == (18, 9)
 
 
 def test_bounding_box_slices():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert bbox.slices == (slice(2, 20), slice(1, 10))
 
 
 def test_bounding_box_extent():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert_allclose(bbox.extent, (0.5, 9.5, 1.5, 19.5))
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_bounding_box_as_artist():
     bbox = BoundingBox(1, 10, 2, 20)
-
     patch = bbox.as_artist()
+
     assert_allclose(patch.get_xy(), (0.5, 1.5))
     assert_allclose(patch.get_width(), 9)
     assert_allclose(patch.get_height(), 18)
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_bounding_box_to_aperture():
+    bbox = BoundingBox(1, 10, 2, 20)
+    aper = RectangularAperture((5, 10.5), w=9., h=18., theta=0.)
+    bbox_aper = bbox.to_aperture()
+    assert_allclose(bbox_aper.positions, aper.positions)
+
+    assert bbox_aper.w == aper.w
+    assert bbox_aper.h == aper.h
+    assert bbox_aper.theta == aper.theta
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_bounding_box_plot():
+    # TODO: check the content of the plot
+    bbox = BoundingBox(1, 10, 2, 20)
+    bbox.plot()
 
 
 def test_bounding_box_union():
@@ -114,6 +127,7 @@ def test_bounding_box_union():
 
     with pytest.raises(TypeError):
         bbox1.union((5, 21, 7, 32))
+
 
 def test_bounding_box_intersect():
     bbox1 = BoundingBox(1, 10, 2, 20)

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -47,10 +47,10 @@ def test_bounding_box_inputs():
 
 def test_bounding_box_from_float():
     # This is the example from the method docstring
-    bbox = BoundingBox._from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
+    bbox = BoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
     assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
 
-    bbox = BoundingBox._from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
+    bbox = BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
     assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
 
 

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -63,6 +63,9 @@ def test_bounding_box_eq():
     assert bbox != BoundingBox(1, 10, 9, 20)
     assert bbox != BoundingBox(1, 10, 2, 99)
 
+    with pytest.raises(TypeError):
+        bbox == (1, 10, 2, 20)
+
 
 def test_bounding_box_repr():
     bbox = BoundingBox(1, 10, 2, 20)
@@ -97,3 +100,32 @@ def test_bounding_box_as_artist():
     assert_allclose(patch.get_xy(), (0.5, 1.5))
     assert_allclose(patch.get_width(), 9)
     assert_allclose(patch.get_height(), 18)
+
+
+def test_bounding_box_union():
+    bbox1 = BoundingBox(1, 10, 2, 20)
+    bbox2 = BoundingBox(5, 21, 7, 32)
+    bbox_union_expected = BoundingBox(1, 21, 2, 32)
+    bbox_union1 = bbox1 | bbox2
+    bbox_union2 = bbox1.union(bbox2)
+
+    assert bbox_union1 == bbox_union_expected
+    assert bbox_union1 == bbox_union2
+
+    with pytest.raises(TypeError):
+        bbox1.union((5, 21, 7, 32))
+
+def test_bounding_box_intersect():
+    bbox1 = BoundingBox(1, 10, 2, 20)
+    bbox2 = BoundingBox(5, 21, 7, 32)
+    bbox_intersect_expected = BoundingBox(5, 10, 7, 20)
+    bbox_intersect1 = bbox1 & bbox2
+    bbox_intersect2 = bbox1.intersection(bbox2)
+
+    assert bbox_intersect1 == bbox_intersect_expected
+    assert bbox_intersect1 == bbox_intersect2
+
+    with pytest.raises(TypeError):
+        bbox1.intersection((5, 21, 7, 32))
+
+    assert bbox1.intersection(BoundingBox(30, 40, 50, 60)) is None


### PR DESCRIPTION
This PR adds several improvements to the `BoundingBox` class:

* Adds a `from_float` method (previously private)
* Adds `union` and `intersection` methods
* Enables unions and intersections via the `|` and `&` operators, respectively
* Renames the `as_patch` method to `as_artist` (for consistency with the `regions` package); deprecates the `as_patch` method

Examples:
```python
>>> from photutils import BoundingBox

>>> bbox1 = BoundingBox(1, 10, 2, 20)
>>> bbox2 = BoundingBox(5, 21, 7, 32)

>>> bbox1.union(bbox2)
BoundingBox(ixmin=1, ixmax=21, iymin=2, iymax=32)

>>> bbox1 | bbox2
BoundingBox(ixmin=1, ixmax=21, iymin=2, iymax=32)

>>> bbox1.intersection(bbox2)
BoundingBox(ixmin=5, ixmax=10, iymin=7, iymax=20)

>>> bbox1 & bbox2
BoundingBox(ixmin=5, ixmax=10, iymin=7, iymax=20)
```
