### PR TITLE
Add indexing, slicing, and iteration to non-scalar Aperture objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New Features
   - Added ``from_float``, ``as_artist``, ``union`` and
     ``intersection`` methods to ``BoundingBox`` class. [#851]
 
+  - Added ``shape`` and ``isscalar`` properties to Aperture objects.
+    [#852]
+
 - ``photutils.isophote``
 
   - Significantly improved the performance (~5 times faster) of
@@ -88,6 +91,18 @@ API changes
 
   - Renamed the ``celestial_center`` column to ``sky_center`` in the
     ``aperture_photometry`` output table. [#848]
+
+  - Aperture objects defined with a single (x, y) position (input as
+    1D) are now considered scalar objects, which can be checked with
+    the new ``isscalar`` Aperture property. [#852]
+
+  - Non-scalar Aperture objects can now be index, sliced, and
+    iterated. [#852]
+
+  - Scalar Aperture objects now return scalar ``positions`` and
+    ``bounding_boxes`` properties and its ``to_mask`` method returns
+    an ``ApertureMask`` object instead of a length-1 list containing
+    an ``ApertureMask``. [#852]
 
 - ``photutils.detection``
 

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -61,13 +61,13 @@ class PixelPositions(ApertureAttribute):
         if isinstance(value, zip):
             value = tuple(value)
 
-        value = np.atleast_2d(value).astype(float)  # np.ndarray
+        value = np.asanyarray(value).astype(float)  # np.ndarray
         self._validate(value)
 
         if isinstance(value, u.Quantity):
             value = value.value
 
-        if value.shape[1] != 2 and value.shape[0] == 2:
+        if value.ndim == 2 and value.shape[1] != 2 and value.shape[0] == 2:
             warnings.warn('Inputing positions shaped as 2xN is deprecated '
                           'and will be removed in v0.8.  Positions should be '
                           'a (x, y) pixel position or a list or array of '
@@ -81,14 +81,15 @@ class PixelPositions(ApertureAttribute):
         if isinstance(value, u.Quantity) and value.unit != u.pixel:
             raise u.UnitsError('{} must be in pixel units'.format(self.name))
 
+        if np.any(~np.isfinite(value)):
+            raise ValueError('{} must not contain any non-finite (e.g. NaN '
+                             'or inf) positions'.format(self.name))
+
+        value = np.atleast_2d(value)
         if (value.shape[1] != 2 and value.shape[0] != 2) or value.ndim > 2:
             raise TypeError('{} must be an (x, y) pixel position or a list '
                             'or array of (x, y) pixel positions.'
                             .format(self.name))
-
-        if np.any(~np.isfinite(value)):
-            raise ValueError('{} must not contain any non-finite (e.g. NaN '
-                             'or inf) positions'.format(self.name))
 
 
 class SkyCoordPositions(ApertureAttribute):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -90,7 +90,10 @@ class CircularMaskMixin:
 
             masks.append(ApertureMask(mask, bbox))
 
-        return masks
+        if self.isscalar:
+            return masks[0]
+        else:
+            return masks
 
 
 class CircularAperture(CircularMaskMixin, PixelAperture):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -76,7 +76,8 @@ class CircularMaskMixin:
             raise ValueError('Cannot determine the aperture radius.')
 
         masks = []
-        for bbox, edges in zip(self.bounding_boxes, self._centered_edges):
+        for bbox, edges in zip(np.atleast_1d(self.bounding_boxes),
+                               self._centered_edges):
             ny, nx = bbox.shape
             mask = circular_overlap_grid(edges[0], edges[1], edges[2],
                                          edges[3], nx, ny, radius, use_exact,
@@ -151,8 +152,13 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         ymin = positions[:, 1] - self.r
         ymax = positions[:, 1] + self.r
 
-        return [BoundingBox.from_float(x0, x1, y0, y1)
-                for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
+                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+
+        if self.isscalar:
+            return bboxes[0]
+        else:
+            return bboxes
 
     def area(self):
         return math.pi * self.r ** 2
@@ -259,8 +265,13 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         ymin = positions[:, 1] - self.r_out
         ymax = positions[:, 1] + self.r_out
 
-        return [BoundingBox.from_float(x0, x1, y0, y1)
-                for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
+                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+
+        if self.isscalar:
+            return bboxes[0]
+        else:
+            return bboxes
 
     def area(self):
         return math.pi * (self.r_out ** 2 - self.r_in ** 2)

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -2,6 +2,8 @@
 
 import math
 
+import numpy as np
+
 from .attributes import (PixelPositions, SkyCoordPositions, PositiveScalar,
                          AngleOrPixelScalarQuantity)
 from .core import PixelAperture, SkyAperture
@@ -140,10 +142,11 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
     @property
     def bounding_boxes(self):
-        xmin = self.positions[:, 0] - self.r
-        xmax = self.positions[:, 0] + self.r
-        ymin = self.positions[:, 1] - self.r
-        ymax = self.positions[:, 1] + self.r
+        positions = np.atleast_2d(self.positions)
+        xmin = positions[:, 0] - self.r
+        xmax = positions[:, 0] + self.r
+        ymin = positions[:, 1] - self.r
+        ymax = positions[:, 1] + self.r
 
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
@@ -247,10 +250,11 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
 
     @property
     def bounding_boxes(self):
-        xmin = self.positions[:, 0] - self.r_out
-        xmax = self.positions[:, 0] + self.r_out
-        ymin = self.positions[:, 1] - self.r_out
-        ymax = self.positions[:, 1] + self.r_out
+        positions = np.atleast_2d(self.positions)
+        xmin = positions[:, 0] - self.r_out
+        xmax = positions[:, 0] + self.r_out
+        ymin = positions[:, 1] - self.r_out
+        ymax = positions[:, 1] + self.r_out
 
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -140,7 +140,7 @@ class PixelAperture(Aperture):
 
         edges = []
         for position, bbox in zip(np.atleast_2d(self.positions),
-                                  self.bounding_boxes):
+                                  np.atleast_1d(self.bounding_boxes)):
             xmin = bbox.ixmin - 0.5 - position[0]
             xmax = bbox.ixmax - 0.5 - position[0]
             ymin = bbox.iymin - 0.5 - position[1]

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -139,7 +139,8 @@ class PixelAperture(Aperture):
         """
 
         edges = []
-        for position, bbox in zip(self.positions, self.bounding_boxes):
+        for position, bbox in zip(np.atleast_2d(self.positions),
+                                  self.bounding_boxes):
             xmin = bbox.ixmin - 0.5 - position[0]
             xmax = bbox.ixmax - 0.5 - position[0]
             ymin = bbox.iymin - 0.5 - position[1]
@@ -473,7 +474,7 @@ class PixelAperture(Aperture):
         # is ``fill=True``.  Here we make the default ``fill=False``.
         kwargs['fill'] = fill
 
-        plot_positions = copy.deepcopy(self.positions)
+        plot_positions = copy.deepcopy(np.atleast_2d(self.positions))
         if indices is not None:
             plot_positions = plot_positions[np.atleast_1d(indices)]
 
@@ -905,9 +906,11 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     meta['aperture_photometry_args'] = calling_args
 
     tbl = QTable(meta=meta)
-    tbl['id'] = np.arange(len(apertures[0]), dtype=int) + 1
 
-    xypos_pixel = np.transpose(apertures[0].positions) * u.pixel
+    positions = np.atleast_2d(apertures[0].positions)
+    tbl['id'] = np.arange(positions.shape[0], dtype=int) + 1
+
+    xypos_pixel = np.transpose(positions) * u.pixel
     tbl['xcenter'] = xypos_pixel[0]
     tbl['ycenter'] = xypos_pixel[1]
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -78,7 +78,10 @@ class Aperture(metaclass=_ABCMetaAndInheritDocstrings):
 
     @property
     def shape(self):
-        return self.positions.shape[:-1]
+        if isinstance(self.positions, SkyCoord):
+            return self.positions.shape
+        else:
+            return self.positions.shape[:-1]
 
     @property
     def isscalar(self):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -374,7 +374,12 @@ class PixelAperture(Aperture):
 
         aperture_sums = []
         aperture_sum_errs = []
-        for apermask in self.to_mask(method=method, subpixels=subpixels):
+
+        masks = self.to_mask(method=method, subpixels=subpixels)
+        if self.isscalar:
+            masks = (masks,)
+
+        for apermask in masks:
             data_weighted = apermask.multiply(data)
 
             if data_weighted is None:

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -30,13 +30,10 @@ class Aperture(metaclass=_ABCMetaAndInheritDocstrings):
     """
 
     def __len__(self):
-        if isinstance(self, SkyAperture) and self.positions.isscalar:
-            return 1
-        else:
-            if self.positions.shape[0] == 1:
-                raise TypeError('Scalar {0!r} object has no len()'
-                                .format(self.__class__.__name__))
-            return self.positions.shape[0]
+        if self.isscalar:
+            raise TypeError('Scalar {0!r} object has no len()'
+                            .format(self.__class__.__name__))
+        return self.shape[0]
 
     def __getitem__(self, index):
         kwargs = dict()
@@ -78,6 +75,14 @@ class Aperture(metaclass=_ABCMetaAndInheritDocstrings):
         fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
 
         return '\n'.join(fmt)
+
+    @property
+    def shape(self):
+        return self.positions.shape[:-1]
+
+    @property
+    def isscalar(self):
+        return self.shape == ()
 
 
 class PixelAperture(Aperture):
@@ -867,9 +872,9 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         if (int(subpixels) != subpixels) or (subpixels <= 0):
             raise ValueError('subpixels must be a positive integer.')
 
-    scalar_aperture = False
+    single_aperture = False
     if isinstance(apertures, Aperture):
-        scalar_aperture = True
+        single_aperture = True
         apertures = (apertures,)
 
     # convert sky to pixel apertures
@@ -920,7 +925,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
         sum_key = 'aperture_sum'
         sum_err_key = 'aperture_sum_err'
-        if not scalar_aperture:
+        if not single_aperture:
             sum_key += '_{}'.format(i)
             sum_err_key += '_{}'.format(i)
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -173,10 +173,11 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         dx = np.sqrt(ax*ax + bx*bx)
         dy = np.sqrt(ay*ay + by*by)
 
-        xmin = self.positions[:, 0] - dx
-        xmax = self.positions[:, 0] + dx
-        ymin = self.positions[:, 1] - dy
-        ymax = self.positions[:, 1] + dy
+        positions = np.atleast_2d(self.positions)
+        xmin = positions[:, 0] - dx
+        xmax = positions[:, 0] + dx
+        ymin = positions[:, 1] - dy
+        ymax = positions[:, 1] + dy
 
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
@@ -315,10 +316,11 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         dx = np.sqrt(ax*ax + bx*bx)
         dy = np.sqrt(ay*ay + by*by)
 
-        xmin = self.positions[:, 0] - dx
-        xmax = self.positions[:, 0] + dx
-        ymin = self.positions[:, 1] - dy
-        ymax = self.positions[:, 1] + dy
+        positions = np.atleast_2d(self.positions)
+        xmin = positions[:, 0] - dx
+        xmax = positions[:, 0] + dx
+        ymin = positions[:, 1] - dy
+        ymax = positions[:, 1] + dy
 
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -95,7 +95,10 @@ class EllipticalMaskMixin:
 
             masks.append(ApertureMask(mask, bbox))
 
-        return masks
+        if self.isscalar:
+            return masks[0]
+        else:
+            return masks
 
 
 class EllipticalAperture(EllipticalMaskMixin, PixelAperture):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -80,7 +80,8 @@ class EllipticalMaskMixin:
             raise ValueError('Cannot determine the aperture shape.')
 
         masks = []
-        for bbox, edges in zip(self.bounding_boxes, self._centered_edges):
+        for bbox, edges in zip(np.atleast_1d(self.bounding_boxes),
+                               self._centered_edges):
             ny, nx = bbox.shape
             mask = elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                            edges[3], nx, ny, a, b, self.theta,
@@ -182,8 +183,13 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         ymin = positions[:, 1] - dy
         ymax = positions[:, 1] + dy
 
-        return [BoundingBox.from_float(x0, x1, y0, y1)
-                for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
+                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+
+        if self.isscalar:
+            return bboxes[0]
+        else:
+            return bboxes
 
     def area(self):
         return math.pi * self.a * self.b
@@ -325,8 +331,13 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         ymin = positions[:, 1] - dy
         ymax = positions[:, 1] + dy
 
-        return [BoundingBox.from_float(x0, x1, y0, y1)
-                for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
+                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+
+        if self.isscalar:
+            return bboxes[0]
+        else:
+            return bboxes
 
     def area(self):
         return math.pi * (self.a_out * self.b_out - self.a_in * self.b_in)

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -180,10 +180,11 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         dx = max(dx1, dx2)
         dy = max(dy1, dy2)
 
-        xmin = self.positions[:, 0] - dx
-        xmax = self.positions[:, 0] + dx
-        ymin = self.positions[:, 1] - dy
-        ymax = self.positions[:, 1] + dy
+        positions = np.atleast_2d(self.positions)
+        xmin = positions[:, 0] - dx
+        xmax = positions[:, 0] + dx
+        ymin = positions[:, 1] - dy
+        ymax = positions[:, 1] + dy
 
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
@@ -336,10 +337,11 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         dx = max(dx1, dx2)
         dy = max(dy1, dy2)
 
-        xmin = self.positions[:, 0] - dx
-        xmax = self.positions[:, 0] + dx
-        ymin = self.positions[:, 1] - dy
-        ymax = self.positions[:, 1] + dy
+        positions = np.atleast_2d(self.positions)
+        xmin = positions[:, 0] - dx
+        xmax = positions[:, 0] + dx
+        ymin = positions[:, 1] - dy
+        ymax = positions[:, 1] + dy
 
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -83,7 +83,8 @@ class RectangularMaskMixin:
             raise ValueError('Cannot determine the aperture radius.')
 
         masks = []
-        for bbox, edges in zip(self.bounding_boxes, self._centered_edges):
+        for bbox, edges in zip(np.atleast_1d(self.bounding_boxes),
+                               self._centered_edges):
             ny, nx = bbox.shape
             mask = rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                             edges[3], nx, ny, w, h,
@@ -189,8 +190,13 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         ymin = positions[:, 1] - dy
         ymax = positions[:, 1] + dy
 
-        return [BoundingBox.from_float(x0, x1, y0, y1)
-                for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
+                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+
+        if self.isscalar:
+            return bboxes[0]
+        else:
+            return bboxes
 
     def area(self):
         return self.w * self.h
@@ -346,8 +352,13 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         ymin = positions[:, 1] - dy
         ymax = positions[:, 1] + dy
 
-        return [BoundingBox.from_float(x0, x1, y0, y1)
-                for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
+                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+
+        if self.isscalar:
+            return bboxes[0]
+        else:
+            return bboxes
 
     def area(self):
         return self.w_out * self.h_out - self.w_in * self.h_in

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -98,7 +98,10 @@ class RectangularMaskMixin:
 
             masks.append(ApertureMask(mask, bbox))
 
-        return masks
+        if self.isscalar:
+            return masks[0]
+        else:
+            return masks
 
 
 class RectangularAperture(RectangularMaskMixin, PixelAperture):

--- a/photutils/aperture/tests/test_aperture_common.py
+++ b/photutils/aperture/tests/test_aperture_common.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.coordinates import SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
 import astropy.units as u
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -19,8 +20,9 @@ class BaseTestAperture(BaseTestApertureParams):
         assert aper.isscalar
         expected_positions = self.aperture.positions[self.index]
         if isinstance(expected_positions, SkyCoord):
-            assert u.allclose(aper.positions.ra, expected_positions.ra)
-            assert u.allclose(aper.positions.dec, expected_positions.dec)
+            assert_quantity_allclose(aper.positions.ra, expected_positions.ra)
+            assert_quantity_allclose(aper.positions.dec,
+                                     expected_positions.dec)
         else:
             assert_array_equal(aper.positions, expected_positions)
             for param in aper._params:
@@ -33,8 +35,9 @@ class BaseTestAperture(BaseTestApertureParams):
 
         expected_positions = self.aperture.positions[self.slc]
         if isinstance(self.aperture.positions, SkyCoord):
-            assert u.allclose(aper.positions.ra, expected_positions.ra)
-            assert u.allclose(aper.positions.dec, expected_positions.dec)
+            assert_quantity_allclose(aper.positions.ra, expected_positions.ra)
+            assert_quantity_allclose(aper.positions.dec,
+                                     expected_positions.dec)
         else:
             assert_array_equal(aper.positions, expected_positions)
             for param in aper._params:

--- a/photutils/aperture/tests/test_aperture_common.py
+++ b/photutils/aperture/tests/test_aperture_common.py
@@ -1,0 +1,41 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+import numpy as np
+from numpy.testing import assert_array_equal
+
+
+class BaseTestApertureParams:
+    index = 2
+    slc = slice(0, 2)
+    expected_slc_len = 2
+
+
+class BaseTestAperture(BaseTestApertureParams):
+    def test_index(self):
+        aper = self.aperture[self.index]
+        assert isinstance(aper, self.aperture.__class__)
+        assert aper.isscalar
+        expected_positions = self.aperture.positions[self.index]
+        if isinstance(expected_positions, SkyCoord):
+            assert u.allclose(aper.positions.ra, expected_positions.ra)
+            assert u.allclose(aper.positions.dec, expected_positions.dec)
+        else:
+            assert_array_equal(aper.positions, expected_positions)
+            for param in aper._params:
+                assert getattr(aper, param) == getattr(self.aperture, param)
+
+    def test_slice(self):
+        aper = self.aperture[self.slc]
+        assert isinstance(aper, self.aperture.__class__)
+        assert len(aper) == self.expected_slc_len
+
+        expected_positions = self.aperture.positions[self.slc]
+        if isinstance(self.aperture.positions, SkyCoord):
+            assert u.allclose(aper.positions.ra, expected_positions.ra)
+            assert u.allclose(aper.positions.dec, expected_positions.dec)
+        else:
+            assert_array_equal(aper.positions, expected_positions)
+            for param in aper._params:
+                assert getattr(aper, param) == getattr(self.aperture, param)

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -89,14 +89,17 @@ def test_aperture_pixel_positions():
     pos1 = (10, 20)
     pos2 = [(10, 20)]
     pos3 = u.Quantity((10, 20), unit=u.pixel)
+    pos4 = u.Quantity([(10, 20)], unit=u.pixel)
 
     r = 3
     ap1 = CircularAperture(pos1, r)
     ap2 = CircularAperture(pos2, r)
     ap3 = CircularAperture(pos3, r)
+    ap4 = CircularAperture(pos4, r)
 
-    assert_allclose(ap1.positions, ap2.positions)
+    assert not np.array_equal(ap1.positions, ap2.positions)
     assert_allclose(ap1.positions, ap3.positions)
+    assert_allclose(ap2.positions, ap4.positions)
 
 
 class BaseTestAperturePhotometry:
@@ -868,7 +871,7 @@ def test_position_units():
     pos = (10, 10) * u.pix
     pos = np.sqrt(pos**2)
     ap = CircularAperture(pos, r=3.)
-    assert_allclose(ap.positions, np.array([[10, 10]]))
+    assert_allclose(ap.positions, np.array([10, 10]))
 
 
 def test_radius_units():

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -767,26 +767,26 @@ def test_rectangular_bbox():
     width = 7
     height = 3
     a = RectangularAperture((50, 50), w=width, h=height, theta=0)
-    assert a.bounding_boxes[0].shape == (height, width)
+    assert a.bounding_boxes.shape == (height, width)
 
     a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
-    assert a.bounding_boxes[0].shape == (height + 1, width + 1)
+    assert a.bounding_boxes.shape == (height + 1, width + 1)
 
     a = RectangularAperture((50, 50), w=width, h=height, theta=90.*np.pi/180.)
-    assert a.bounding_boxes[0].shape == (width, height)
+    assert a.bounding_boxes.shape == (width, height)
 
     # even sizes
     width = 8
     height = 4
     a = RectangularAperture((50, 50), w=width, h=height, theta=0)
-    assert a.bounding_boxes[0].shape == (height + 1, width + 1)
+    assert a.bounding_boxes.shape == (height + 1, width + 1)
 
     a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
-    assert a.bounding_boxes[0].shape == (height, width)
+    assert a.bounding_boxes.shape == (height, width)
 
     a = RectangularAperture((50.5, 50.5), w=width, h=height,
                             theta=90.*np.pi/180.)
-    assert a.bounding_boxes[0].shape == (width, height)
+    assert a.bounding_boxes.shape == (width, height)
 
 
 def test_elliptical_bbox():
@@ -794,25 +794,25 @@ def test_elliptical_bbox():
     a = 7
     b = 3
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
-    assert ap.bounding_boxes[0].shape == (2*b + 1, 2*a + 1)
+    assert ap.bounding_boxes.shape == (2*b + 1, 2*a + 1)
 
     ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
-    assert ap.bounding_boxes[0].shape == (2*b, 2*a)
+    assert ap.bounding_boxes.shape == (2*b, 2*a)
 
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.*np.pi/180.)
-    assert ap.bounding_boxes[0].shape == (2*a + 1, 2*b + 1)
+    assert ap.bounding_boxes.shape == (2*a + 1, 2*b + 1)
 
     # fractional axes
     a = 7.5
     b = 4.5
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
-    assert ap.bounding_boxes[0].shape == (2*b, 2*a)
+    assert ap.bounding_boxes.shape == (2*b, 2*a)
 
     ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
-    assert ap.bounding_boxes[0].shape == (2*b + 1, 2*a + 1)
+    assert ap.bounding_boxes.shape == (2*b + 1, 2*a + 1)
 
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.*np.pi/180.)
-    assert ap.bounding_boxes[0].shape == (2*a, 2*b)
+    assert ap.bounding_boxes.shape == (2*a, 2*b)
 
 
 def test_to_sky_pixel():

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+import numpy as np
+
+from .test_aperture_common import BaseTestAperture
+from ..circle import (CircularAperture, CircularAnnulus, SkyCircularAperture,
+                      SkyCircularAnnulus)
+
+
+POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
+ra, dec = np.transpose(POSITIONS)
+SKYCOORD = SkyCoord(ra=ra, dec=dec, unit='deg')
+UNIT = u.arcsec
+
+
+class TestCircularAperture(BaseTestAperture):
+    aperture = CircularAperture(POSITIONS, r=3.)
+
+
+class TestCircularAnnulus(BaseTestAperture):
+    aperture = CircularAnnulus(POSITIONS, r_in=3., r_out=7.)
+
+
+class TestSkyCircularAperture(BaseTestAperture):
+    aperture = SkyCircularAperture(SKYCOORD, r=3.*UNIT)
+
+
+class TestSkyCircularAnnulus(BaseTestAperture):
+    aperture = SkyCircularAnnulus(SKYCOORD, r_in=3.*UNIT, r_out=7.*UNIT)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+import numpy as np
+
+from .test_aperture_common import BaseTestAperture
+from ..ellipse import (EllipticalAperture, EllipticalAnnulus,
+                       SkyEllipticalAperture, SkyEllipticalAnnulus)
+
+
+POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
+ra, dec = np.transpose(POSITIONS)
+SKYCOORD = SkyCoord(ra=ra, dec=dec, unit='deg')
+UNIT = u.arcsec
+
+
+class TestEllipticalAperture(BaseTestAperture):
+    aperture = EllipticalAperture(POSITIONS, a=10., b=5., theta=np.pi/2.)
+
+
+class TestEllipticalAnnulus(BaseTestAperture):
+    aperture = EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=17,
+                                 theta=np.pi/3)
+
+
+class TestSkyEllipticalAperture(BaseTestAperture):
+    aperture = SkyEllipticalAperture(SKYCOORD, a=10.*UNIT, b=5.*UNIT,
+                                     theta=30*u.deg)
+
+
+class TestSkyEllipticalAnnulus(BaseTestAperture):
+    aperture = SkyEllipticalAnnulus(SKYCOORD, a_in=10.*UNIT, a_out=20.*UNIT,
+                                    b_out=17.*UNIT, theta=60*u.deg)

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -52,7 +52,7 @@ def test_mask_cutout_shape():
 def test_mask_cutout_copy():
     data = np.ones((50, 50))
     aper = CircularAperture((25, 25), r=10.)
-    mask = aper.to_mask()[0]
+    mask = aper.to_mask()
     cutout = mask.cutout(data, copy=True)
     data[25, 25] = 100.
     assert cutout[10, 10] == 1.
@@ -61,7 +61,7 @@ def test_mask_cutout_copy():
 def test_mask_cutout_copy_quantity():
     data = np.ones((50, 50)) * u.adu
     aper = CircularAperture((25, 25), r=10.)
-    mask = aper.to_mask()[0]
+    mask = aper.to_mask()
     cutout = mask.cutout(data, copy=True)
     assert cutout.unit == data.unit
 
@@ -73,7 +73,7 @@ def test_mask_cutout_copy_quantity():
 def test_mask_cutout_no_overlap(position):
     data = np.ones((50, 50))
     aper = CircularAperture(position, r=10.)
-    mask = aper.to_mask()[0]
+    mask = aper.to_mask()
 
     cutout = mask.cutout(data)
     assert cutout is None
@@ -89,7 +89,7 @@ def test_mask_cutout_no_overlap(position):
 def test_mask_cutout_partial_overlap(position):
     data = np.ones((50, 50))
     aper = CircularAperture(position, r=30.)
-    mask = aper.to_mask()[0]
+    mask = aper.to_mask()
 
     cutout = mask.cutout(data)
     assert cutout.shape == mask.shape
@@ -105,7 +105,7 @@ def test_mask_multiply():
     radius = 10.
     data = np.ones((50, 50))
     aper = CircularAperture((25, 25), r=radius)
-    mask = aper.to_mask()[0]
+    mask = aper.to_mask()
     data_weighted = mask.multiply(data)
     assert np.sum(data_weighted) == radius**2 * np.pi
 
@@ -118,7 +118,7 @@ def test_mask_multiply_quantity():
     radius = 10.
     data = np.ones((50, 50)) * u.adu
     aper = CircularAperture((25, 25), r=radius)
-    mask = aper.to_mask()[0]
+    mask = aper.to_mask()
 
     data_weighted = mask.multiply(data)
     assert data_weighted.unit == u.adu

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -1,0 +1,35 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+import numpy as np
+
+from .test_aperture_common import BaseTestAperture
+
+from ..rectangle import (RectangularAperture, RectangularAnnulus,
+                         SkyRectangularAperture, SkyRectangularAnnulus)
+
+
+POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
+ra, dec = np.transpose(POSITIONS)
+SKYCOORD = SkyCoord(ra=ra, dec=dec, unit='deg')
+UNIT = u.arcsec
+
+
+class TestRectangularAperture(BaseTestAperture):
+    aperture = RectangularAperture(POSITIONS, w=10., h=5., theta=np.pi/2.)
+
+
+class TestRectangularAnnulus(BaseTestAperture):
+    aperture = RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=17,
+                                  theta=np.pi/3)
+
+
+class TestSkyRectangularAperture(BaseTestAperture):
+    aperture = SkyRectangularAperture(SKYCOORD, w=10.*UNIT, h=5.*UNIT,
+                                      theta=30*u.deg)
+
+
+class TestSkyRectangularAnnulus(BaseTestAperture):
+    aperture = SkyRectangularAnnulus(SKYCOORD, w_in=10.*UNIT, w_out=20.*UNIT,
+                                     h_out=17.*UNIT, theta=60*u.deg)


### PR DESCRIPTION
The PR adds indexing, slicing, and iteration to non-scalar Aperture objects.  This change required the definition of "scalar" Apertures as those initialized with a single `(x, y)` position (input as a 1D, shape (2,)).  Scalar Apertures can be checked using the new `isscalar` property.

Aperture objects also now have a `shape` property.

Scalar Aperture objects now return scalar `positions` and `bounding_boxes` properties and its `to_mask` method now returns an `ApertureMask` object instead of a length-1 list containing an `ApertureMask`.  This is an API change that affects only scalar apertures.

Examples:
```python
>>> from photutils import CircularAperture
>>> pos = [(10, 10), (20, 20), (30, 30), (40, 40)]
>>> aper = CircularAperture(pos, r=3)
>>> aper
<CircularAperture([[10., 10.],
                   [20., 20.],
                   [30., 30.],
                   [40., 40.]], r=3.0)>
>>> aper[1]
<CircularAperture([20., 20.], r=3.0)>
>>> aper[0:2]
<CircularAperture([[10., 10.],
                   [20., 20.]], r=3.0)>
>>> aper.isscalar
False
>>> aper.shape
(4,)
```

Closes #838.