### PR TITLE
Cleanup for scalar aperture

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,8 @@ API changes
     an ``ApertureMask`` object instead of a length-1 list containing
     an ``ApertureMask``. [#852]
 
+  - Deprecated the Aperture ``mask_area`` method. [#853]
+
 - ``photutils.detection``
 
   - Removed deprecated ``subpixel`` keyword for ``find_peaks``. [#835]

--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -726,12 +726,14 @@ All `~photutils.PixelAperture` subclasses must define a
 optionally an ``area()`` method.  All `~photutils.SkyAperture`
 subclasses must implement only a ``to_pixel()`` method.
 
-    * ``bounding_boxes``:  A property defining a list of minimal
-      `~photutils.BoundingBox` objects for the aperture, one at each
-      aperture position.
+    * ``bounding_boxes``:  The minimal bounding box for the aperture.
+      If the aperture is scalar then a single `~photutils.BoundingBox`
+      is returned, otherwise a list of `~photutils.BoundingBox` is
+      returned.
 
-    * ``to_mask()``: A method to return a list of
-      `~photutils.ApertureMask` objects, one for each aperture position.
+    * ``to_mask()``: Return a mask for the aperture.  If the aperture
+      is scalar then a single `~photutils.ApertureMask` is returned,
+      otherwise a list of `~photutils.ApertureMask` is returned.
 
     * ``area()``: A method to return the exact analytical area (in
       pixels**2) of the aperture.

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -11,6 +11,7 @@ from astropy.io import fits
 from astropy.nddata import support_nddata
 from astropy.table import QTable
 import astropy.units as u
+from astropy.utils import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 from astropy.wcs.utils import (skycoord_to_pixel, pixel_to_skycoord,
@@ -167,9 +168,11 @@ class PixelAperture(Aperture):
 
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
+    @deprecated('0.7', alternative=('e.g. np.sum(aper.to_mask().data) for a '
+                                    'scalar aperture'))
     def mask_area(self, method='exact', subpixels=5):
         """
-        Return the area of the aperture masks (one per position).
+        Return the area of the aperture mask.
 
         For ``method`` other than ``'exact'``, this area will be less
         than the exact analytical area (e.g. the ``area`` method).  Note
@@ -215,8 +218,10 @@ class PixelAperture(Aperture):
             A list of the mask area (one per position) of the aperture.
         """
 
-        mask = self.to_mask(method=method, subpixels=subpixels)
-        return [np.sum(m.data) for m in mask]
+        masks = self.to_mask(method=method, subpixels=subpixels)
+        if self.isscalar:
+            masks = (masks,)
+        return [np.sum(mask.data) for mask in masks]
 
     @abc.abstractmethod
     def to_mask(self, method='exact', subpixels=5):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -124,8 +124,11 @@ class PixelAperture(Aperture):
     @abc.abstractproperty
     def bounding_boxes(self):
         """
-        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
-        for each position, for the aperture.
+        The minimal bounding box for the aperture.
+
+        If the aperture is scalar then a single `~photutils.BoundingBox`
+        is returned, otherwise a list of `~photutils.BoundingBox` is
+        returned.
         """
 
         raise NotImplementedError('Needs to be implemented in a subclass.')

--- a/photutils/aperture/tests/test_aperture_common.py
+++ b/photutils/aperture/tests/test_aperture_common.py
@@ -2,8 +2,6 @@
 
 from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
-import astropy.units as u
-import numpy as np
 from numpy.testing import assert_array_equal
 
 


### PR DESCRIPTION
This PR is a followup to #852 to fix some docstrings, unused imports, and the `mask_area` method for scalar aperture objects.  The `mask_area` is now deprecated as the `ApertureMask` objects should be directly used.
