### PR TITLE
Aperture plotting improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,6 +106,16 @@ API changes
 
   - Deprecated the Aperture ``mask_area`` method. [#853]
 
+  - Aperture ``area`` is now an attribute instead of a method. [#854]
+
+  - The Aperture plot keyword ``ax`` was deprecated and renamed to
+    ``axes``. [#854]
+
+- ``photutils.background``
+
+  - The ``Background2D`` ``plot_meshes`` keyword ``ax`` was deprecated
+    and renamed to ``axes``. [#854]
+
 - ``photutils.detection``
 
   - Removed deprecated ``subpixel`` keyword for ``find_peaks``. [#835]

--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -309,12 +309,12 @@ aperture, we need to divide its sum by its area.  The mean value can
 be calculated by using the :meth:`~photutils.CircularAnnulus.area`
 method::
 
-    >>> bkg_mean = phot_table['aperture_sum_1'] / annulus_aperture.area()
+    >>> bkg_mean = phot_table['aperture_sum_1'] / annulus_aperture.area
 
 The total background within the circular aperture is then the mean local
 background times the circular aperture area::
 
-    >>> bkg_sum = bkg_mean * aperture.area()
+    >>> bkg_sum = bkg_mean * aperture.area
     >>> final_sum = phot_table['aperture_sum_0'] - bkg_sum
     >>> phot_table['residual_aperture_sum'] = final_sum
     >>> phot_table['residual_aperture_sum'].info.format = '%.8g'  # for consistent table output
@@ -444,7 +444,7 @@ median::
 The total background within the circular aperture is then the local background
 level times the circular aperture area::
 
-   >>> background = median_sigclip * aperture.area()
+   >>> background = median_sigclip * aperture.area
    >>> print(background)  # doctest: +FLOAT_CMP
    380.7777584296913
 
@@ -475,7 +475,7 @@ each source::
     >>> bkg_median = np.array(bkg_median)
     >>> phot = aperture_photometry(data, aperture)
     >>> phot['annulus_median'] = bkg_median
-    >>> phot['aper_bkg'] = bkg_median * aperture.area()
+    >>> phot['aper_bkg'] = bkg_median * aperture.area
     >>> phot['aper_sum_bkgsub'] = phot['aperture_sum'] - phot['aper_bkg']
     >>> for col in phot.colnames:
     ...     phot[col].info.format = '%.8g'  # for consistent table output
@@ -722,21 +722,22 @@ functionality: a new type of aperture photometry simply requires the
 definition of a new `~photutils.Aperture` subclass.
 
 All `~photutils.PixelAperture` subclasses must define a
-``bounding_boxes`` property, ``to_mask()`` and ``plot()`` methods, and
-optionally an ``area()`` method.  All `~photutils.SkyAperture`
-subclasses must implement only a ``to_pixel()`` method.
+``bounding_boxes`` property and ``to_mask()`` and ``plot()`` methods.
+They may also optionally define an ``area`` property.  All
+`~photutils.SkyAperture` subclasses must only implement a
+``to_pixel()`` method.
 
     * ``bounding_boxes``:  The minimal bounding box for the aperture.
       If the aperture is scalar then a single `~photutils.BoundingBox`
       is returned, otherwise a list of `~photutils.BoundingBox` is
       returned.
 
+    * ``area``: An optional property defining the exact analytical
+      area (in pixels**2) of the aperture.
+
     * ``to_mask()``: Return a mask for the aperture.  If the aperture
       is scalar then a single `~photutils.ApertureMask` is returned,
       otherwise a list of `~photutils.ApertureMask` is returned.
-
-    * ``area()``: A method to return the exact analytical area (in
-      pixels**2) of the aperture.
 
     * ``plot()``: A method to plot the aperture on a
       `matplotlib.axes.Axes` instance.

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -257,7 +257,7 @@ class BoundingBox:
 
         return RectangularAperture(xypos, w=width, h=height, theta=0.)
 
-    def plot(self, origin=(0, 0), ax=None, fill=False, **kwargs):
+    def plot(self, origin=(0, 0), ax=None, **kwargs):
         """
         Plot the `BoundingBox` on a matplotlib `~matplotlib.axes.Axes`
         instance.
@@ -272,16 +272,12 @@ class BoundingBox:
             If `None`, then the current `~matplotlib.axes.Axes` instance
             is used.
 
-        fill : bool, optional
-            Set whether to fill the aperture patch.  The default is
-            `False`.
-
         kwargs : `dict`
             Any keyword arguments accepted by `matplotlib.patches.Patch`.
         """
 
         aper = self.to_aperture()
-        aper.plot(origin=origin, ax=ax, fill=fill, **kwargs)
+        aper.plot(origin=origin, ax=ax, **kwargs)
 
     def union(self, bbox):
         """

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -3,6 +3,7 @@
 import numpy as np
 from astropy.io.fits.util import _is_int
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 
 
 __all__ = ['BoundingBox']
@@ -257,27 +258,28 @@ class BoundingBox:
 
         return RectangularAperture(xypos, w=width, h=height, theta=0.)
 
-    def plot(self, origin=(0, 0), ax=None, **kwargs):
+    @deprecated_renamed_argument('ax', 'axes', '0.7')
+    def plot(self, axes=None, origin=(0, 0), **kwargs):
         """
         Plot the `BoundingBox` on a matplotlib `~matplotlib.axes.Axes`
         instance.
 
         Parameters
         ----------
+        axes : `matplotlib.axes.Axes` or `None`, optional
+            The matplotlib axes on which to plot.  If `None`, then the
+            current `~matplotlib.axes.Axes` instance is used.
+
         origin : array_like, optional
             The ``(x, y)`` position of the origin of the displayed
             image.
-
-        ax : `matplotlib.axes.Axes` instance, optional
-            If `None`, then the current `~matplotlib.axes.Axes` instance
-            is used.
 
         kwargs : `dict`
             Any keyword arguments accepted by `matplotlib.patches.Patch`.
         """
 
         aper = self.to_aperture()
-        aper.plot(origin=origin, ax=ax, **kwargs)
+        aper.plot(axes=axes, origin=origin, **kwargs)
 
     def union(self, bbox):
         """

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -177,7 +177,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         indices : int or array of int, optional
             The indices of the aperture positions to plot.
 
-        kwargs : dict
+        kwargs : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
 
@@ -203,19 +203,6 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
             return patches[0]
         else:
             return patches
-
-    def plot(self, origin=(0, 0), indices=None, ax=None, **kwargs):
-        import matplotlib.pyplot as plt
-
-        if ax is None:
-            ax = plt.gca()
-
-        patches = self._to_patch(origin=origin, indices=indices, **kwargs)
-        if self.isscalar:
-            patches = (patches,)
-
-        for patch in patches:
-            ax.add_patch(patch)
 
     def to_sky(self, wcs, mode='all'):
         """

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -164,6 +164,45 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
     def area(self):
         return math.pi * self.r ** 2
 
+    def _to_patch(self, origin=(0, 0), indices=None, **kwargs):
+        """
+        Return a `~matplotlib.patches.patch` for the aperture.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        indices : int or array of int, optional
+            The indices of the aperture positions to plot.
+
+        kwargs : dict
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+            A patch for the aperture.  If the aperture is scalar then a
+            single `~matplotlib.patches.patch` is returned, otherwise a
+            list of `~matplotlib.patches.patch` is returned.
+        """
+
+        import matplotlib.patches as mpatches
+
+        xy_positions, patch_params = self._define_patch_params(
+            origin=origin, indices=indices, **kwargs)
+
+        patches = []
+        for xy_position in xy_positions:
+            patches.append(mpatches.Circle(xy_position, self.r, **kwargs))
+
+        if self.isscalar:
+            return patches[0]
+        else:
+            return patches
+
     def plot(self, origin=(0, 0), indices=None, ax=None, fill=False,
              **kwargs):
         import matplotlib.patches as mpatches

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -306,19 +306,47 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
     def area(self):
         return math.pi * (self.r_out ** 2 - self.r_in ** 2)
 
-    def plot(self, origin=(0, 0), indices=None, ax=None, fill=False,
-             **kwargs):
+    def _to_patch(self, origin=(0, 0), indices=None, **kwargs):
+        """
+        Return a `~matplotlib.patches.patch` for the aperture.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        indices : int or array of int, optional
+            The indices of the aperture positions to plot.
+
+        kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+            A patch for the aperture.  If the aperture is scalar then a
+            single `~matplotlib.patches.patch` is returned, otherwise a
+            list of `~matplotlib.patches.patch` is returned.
+        """
+
         import matplotlib.patches as mpatches
 
-        plot_positions, ax, kwargs = self._prepare_plot(
-            origin, indices, ax, fill, **kwargs)
+        xy_positions, patch_kwargs = self._define_patch_params(
+            origin=origin, indices=indices, **kwargs)
 
-        for position in plot_positions:
-            patch_inner = mpatches.Circle(position, self.r_in)
-            patch_outer = mpatches.Circle(position, self.r_out)
+        patches = []
+        for xy_position in xy_positions:
+            patch_inner = mpatches.Circle(xy_position, self.r_in)
+            patch_outer = mpatches.Circle(xy_position, self.r_out)
             path = self._make_annulus_path(patch_inner, patch_outer)
-            patch = mpatches.PathPatch(path, **kwargs)
-            ax.add_patch(patch)
+            patches.append(mpatches.PathPatch(path, **patch_kwargs))
+
+        if self.isscalar:
+            return patches[0]
+        else:
+            return patches
 
     def to_sky(self, wcs, mode='all'):
         """

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -161,6 +161,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         else:
             return bboxes
 
+    @property
     def area(self):
         return math.pi * self.r ** 2
 
@@ -303,6 +304,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         else:
             return bboxes
 
+    @property
     def area(self):
         return math.pi * (self.r_out ** 2 - self.r_in ** 2)
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -191,27 +191,30 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
         import matplotlib.patches as mpatches
 
-        xy_positions, patch_params = self._define_patch_params(
+        xy_positions, patch_kwargs = self._define_patch_params(
             origin=origin, indices=indices, **kwargs)
 
         patches = []
         for xy_position in xy_positions:
-            patches.append(mpatches.Circle(xy_position, self.r, **kwargs))
+            patches.append(mpatches.Circle(xy_position, self.r,
+                                           **patch_kwargs))
 
         if self.isscalar:
             return patches[0]
         else:
             return patches
 
-    def plot(self, origin=(0, 0), indices=None, ax=None, fill=False,
-             **kwargs):
-        import matplotlib.patches as mpatches
+    def plot(self, origin=(0, 0), indices=None, ax=None, **kwargs):
+        import matplotlib.pyplot as plt
 
-        plot_positions, ax, kwargs = self._prepare_plot(
-            origin, indices, ax, fill, **kwargs)
+        if ax is None:
+            ax = plt.gca()
 
-        for position in plot_positions:
-            patch = mpatches.Circle(position, self.r, **kwargs)
+        patches = self._to_patch(origin=origin, indices=indices, **kwargs)
+        if self.isscalar:
+            patches = (patches,)
+
+        for patch in patches:
             ax.add_patch(patch)
 
     def to_sky(self, wcs, mode='all'):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -88,6 +88,15 @@ class Aperture(metaclass=_ABCMetaAndInheritDocstrings):
     def isscalar(self):
         return self.shape == ()
 
+    @property
+    @abc.abstractmethod
+    def positions(self):
+        """
+        The aperture positions.
+        """
+
+        raise NotImplementedError('Needs to be implemented in a subclass.')
+
 
 class PixelAperture(Aperture):
     """
@@ -135,7 +144,8 @@ class PixelAperture(Aperture):
 
         return use_exact, subpixels
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def bounding_boxes(self):
         """
         The minimal bounding box for the aperture.

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -180,6 +180,7 @@ class PixelAperture(Aperture):
 
         return edges
 
+    @property
     def area(self):
         """
         Return the exact area of the aperture shape.

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -12,6 +12,7 @@ from astropy.nddata import support_nddata
 from astropy.table import QTable
 import astropy.units as u
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 from astropy.wcs.utils import (skycoord_to_pixel, pixel_to_skycoord,
@@ -534,6 +535,10 @@ class PixelAperture(Aperture):
 
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
+    @deprecated_renamed_argument('indices', None, '0.7',
+                                 alternative=('indices directly on the '
+                                              'aperture object '
+                                              '(e.g. aper[idx].plot())'))
     def plot(self, origin=(0, 0), indices=None, ax=None, **kwargs):
         """
         Plot the aperture on a matplotlib `~matplotlib.axes.Axes`

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -535,17 +535,22 @@ class PixelAperture(Aperture):
 
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
+    @deprecated_renamed_argument('ax', 'axes', '0.7')
     @deprecated_renamed_argument('indices', None, '0.7',
                                  alternative=('indices directly on the '
                                               'aperture object '
                                               '(e.g. aper[idx].plot())'))
-    def plot(self, origin=(0, 0), indices=None, ax=None, **kwargs):
+    def plot(self, axes=None, origin=(0, 0), indices=None, **kwargs):
         """
         Plot the aperture on a matplotlib `~matplotlib.axes.Axes`
         instance.
 
         Parameters
         ----------
+        axes : `matplotlib.axes.Axes` or `None`, optional
+            The matplotlib axes on which to plot.  If `None`, then the
+            current `~matplotlib.axes.Axes` instance is used.
+
         origin : array_like, optional
             The ``(x, y)`` position of the origin of the displayed
             image.
@@ -554,10 +559,6 @@ class PixelAperture(Aperture):
             The indices of the aperture position(s) to plot.  If `None`
             (default) then all aperture positions will be plotted.
 
-        ax : `matplotlib.axes.Axes` instance, optional
-            If `None`, then the current `~matplotlib.axes.Axes` instance
-            is used.
-
         kwargs : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
@@ -565,15 +566,15 @@ class PixelAperture(Aperture):
 
         import matplotlib.pyplot as plt
 
-        if ax is None:
-            ax = plt.gca()
+        if axes is None:
+            axes = plt.gca()
 
         patches = self._to_patch(origin=origin, indices=indices, **kwargs)
         if self.isscalar:
             patches = (patches,)
 
         for patch in patches:
-            ax.add_patch(patch)
+            axes.add_patch(patch)
 
     def _to_sky_params(self, wcs, mode='all'):
         """

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -470,7 +470,7 @@ class PixelAperture(Aperture):
         indices : int or array of int, optional
             The indices of the aperture positions to plot.
 
-        kwargs : dict
+        kwargs : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
 
@@ -479,7 +479,7 @@ class PixelAperture(Aperture):
         xy_positions : `~numpy.ndarray`
             The aperture patch positions.
 
-        patch_params : dict
+        patch_params : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
         """
@@ -497,8 +497,34 @@ class PixelAperture(Aperture):
         return xy_positions, patch_params
 
     @abc.abstractmethod
-    def plot(self, origin=(0, 0), indices=None, ax=None, fill=False,
-             **kwargs):
+    def _to_patch(self, origin=(0, 0), indices=None, **kwargs):
+        """
+        Return a `~matplotlib.patches.patch` for the aperture.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        indices : int or array of int, optional
+            The indices of the aperture positions to plot.
+
+        kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+            A patch for the aperture.  If the aperture is scalar then a
+            single `~matplotlib.patches.patch` is returned, otherwise a
+            list of `~matplotlib.patches.patch` is returned.
+        """
+
+        raise NotImplementedError('Needs to be implemented in a subclass.')
+
+    def plot(self, origin=(0, 0), indices=None, ax=None, **kwargs):
         """
         Plot the aperture on a matplotlib `~matplotlib.axes.Axes`
         instance.
@@ -517,15 +543,22 @@ class PixelAperture(Aperture):
             If `None`, then the current `~matplotlib.axes.Axes` instance
             is used.
 
-        fill : bool, optional
-            Set whether to fill the aperture patch.  The default is
-            `False`.
-
-        kwargs
-            Any keyword arguments accepted by `matplotlib.patches.Patch`.
+        kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
         """
 
-        raise NotImplementedError('Needs to be implemented in a subclass.')
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            ax = plt.gca()
+
+        patches = self._to_patch(origin=origin, indices=indices, **kwargs)
+        if self.isscalar:
+            patches = (patches,)
+
+        for patch in patches:
+            ax.add_patch(patch)
 
     def _to_sky_params(self, wcs, mode='all'):
         """
@@ -544,7 +577,7 @@ class PixelAperture(Aperture):
 
         Returns
         -------
-        sky_params : dict
+        sky_params : `dict`
             A dictionary of parameters for an equivalent sky aperture.
         """
 
@@ -619,7 +652,7 @@ class SkyAperture(Aperture):
 
         Returns
         -------
-        pixel_params : dict
+        pixel_params : `dict`
             A dictionary of parameters for an equivalent pixel aperture.
         """
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -195,18 +195,46 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     def area(self):
         return math.pi * self.a * self.b
 
-    def plot(self, origin=(0, 0), indices=None, ax=None, fill=False,
-             **kwargs):
+    def _to_patch(self, origin=(0, 0), indices=None, **kwargs):
+        """
+        Return a `~matplotlib.patches.patch` for the aperture.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        indices : int or array of int, optional
+            The indices of the aperture positions to plot.
+
+        kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+            A patch for the aperture.  If the aperture is scalar then a
+            single `~matplotlib.patches.patch` is returned, otherwise a
+            list of `~matplotlib.patches.patch` is returned.
+        """
+
         import matplotlib.patches as mpatches
 
-        plot_positions, ax, kwargs = self._prepare_plot(
-            origin, indices, ax, fill, **kwargs)
+        xy_positions, patch_kwargs = self._define_patch_params(
+            origin=origin, indices=indices, **kwargs)
 
+        patches = []
         theta_deg = self.theta * 180. / np.pi
-        for position in plot_positions:
-            patch = mpatches.Ellipse(position, 2.*self.a, 2.*self.b,
-                                     theta_deg, **kwargs)
-            ax.add_patch(patch)
+        for xy_position in xy_positions:
+            patches.append(mpatches.Ellipse(xy_position, 2.*self.a, 2.*self.b,
+                                            theta_deg, **patch_kwargs))
+
+        if self.isscalar:
+            return patches[0]
+        else:
+            return patches
 
     def to_sky(self, wcs, mode='all'):
         """
@@ -343,22 +371,50 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     def area(self):
         return math.pi * (self.a_out * self.b_out - self.a_in * self.b_in)
 
-    def plot(self, origin=(0, 0), indices=None, ax=None, fill=False,
-             **kwargs):
+    def _to_patch(self, origin=(0, 0), indices=None, **kwargs):
+        """
+        Return a `~matplotlib.patches.patch` for the aperture.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        indices : int or array of int, optional
+            The indices of the aperture positions to plot.
+
+        kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+            A patch for the aperture.  If the aperture is scalar then a
+            single `~matplotlib.patches.patch` is returned, otherwise a
+            list of `~matplotlib.patches.patch` is returned.
+        """
+
         import matplotlib.patches as mpatches
 
-        plot_positions, ax, kwargs = self._prepare_plot(
-            origin, indices, ax, fill, **kwargs)
+        xy_positions, patch_kwargs = self._define_patch_params(
+            origin=origin, indices=indices, **kwargs)
 
+        patches = []
         theta_deg = self.theta * 180. / np.pi
-        for position in plot_positions:
-            patch_inner = mpatches.Ellipse(position, 2.*self.a_in,
-                                           2.*self.b_in, theta_deg, **kwargs)
-            patch_outer = mpatches.Ellipse(position, 2.*self.a_out,
-                                           2.*self.b_out, theta_deg, **kwargs)
+        for xy_position in xy_positions:
+            patch_inner = mpatches.Ellipse(xy_position, 2.*self.a_in,
+                                           2.*self.b_in, theta_deg)
+            patch_outer = mpatches.Ellipse(xy_position, 2.*self.a_out,
+                                           2.*self.b_out, theta_deg)
             path = self._make_annulus_path(patch_inner, patch_outer)
-            patch = mpatches.PathPatch(path, **kwargs)
-            ax.add_patch(patch)
+            patches.append(mpatches.PathPatch(path, **patch_kwargs))
+
+        if self.isscalar:
+            return patches[0]
+        else:
+            return patches
 
     def to_sky(self, wcs, mode='all'):
         """

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -201,6 +201,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         else:
             return bboxes
 
+    @property
     def area(self):
         return math.pi * self.a * self.b
 
@@ -369,6 +370,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         else:
             return bboxes
 
+    @property
     def area(self):
         return math.pi * (self.a_out * self.b_out - self.a_in * self.b_in)
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -102,6 +102,23 @@ class EllipticalMaskMixin:
         else:
             return masks
 
+    @staticmethod
+    def _extents(semimajor_axis, semiminor_axis, theta):
+        """
+        Calculate half of the bounding box extents of an ellipse.
+        """
+
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        semimajor_x = semimajor_axis * cos_theta
+        semimajor_y = semimajor_axis * sin_theta
+        semiminor_x = semiminor_axis * -sin_theta
+        semiminor_y = semiminor_axis * cos_theta
+        x_extent = np.sqrt(semimajor_x**2 + semiminor_x**2)
+        y_extent = np.sqrt(semimajor_y**2 + semiminor_y**2)
+
+        return x_extent, y_extent
+
 
 class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     """
@@ -169,20 +186,12 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         for each position, enclosing the exact elliptical apertures.
         """
 
-        cos_theta = np.cos(self.theta)
-        sin_theta = np.sin(self.theta)
-        ax = self.a * cos_theta
-        ay = self.a * sin_theta
-        bx = self.b * -sin_theta
-        by = self.b * cos_theta
-        dx = np.sqrt(ax*ax + bx*bx)
-        dy = np.sqrt(ay*ay + by*by)
-
         positions = np.atleast_2d(self.positions)
-        xmin = positions[:, 0] - dx
-        xmax = positions[:, 0] + dx
-        ymin = positions[:, 1] - dy
-        ymax = positions[:, 1] + dy
+        x_delta, y_delta = self._extents(self.a, self.b, self.theta)
+        xmin = positions[:, 0] - x_delta
+        xmax = positions[:, 0] + x_delta
+        ymin = positions[:, 1] - y_delta
+        ymax = positions[:, 1] + y_delta
 
         bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
                   for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
@@ -345,20 +354,12 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         for each position, enclosing the exact elliptical apertures.
         """
 
-        cos_theta = np.cos(self.theta)
-        sin_theta = np.sin(self.theta)
-        ax = self.a_out * cos_theta
-        ay = self.a_out * sin_theta
-        bx = self.b_out * -sin_theta
-        by = self.b_out * cos_theta
-        dx = np.sqrt(ax*ax + bx*bx)
-        dy = np.sqrt(ay*ay + by*by)
-
         positions = np.atleast_2d(self.positions)
-        xmin = positions[:, 0] - dx
-        xmax = positions[:, 0] + dx
-        ymin = positions[:, 1] - dy
-        ymax = positions[:, 1] + dy
+        x_delta, y_delta = self._extents(self.a_out, self.b_out, self.theta)
+        xmin = positions[:, 0] - x_delta
+        xmax = positions[:, 0] + x_delta
+        ymin = positions[:, 1] - y_delta
+        ymax = positions[:, 1] + y_delta
 
         bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
                   for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -106,6 +106,25 @@ class RectangularMaskMixin:
             return masks
 
     @staticmethod
+    def _extents(width, height, theta):
+        """
+        Calculate half of the bounding box extents of an ellipse.
+        """
+
+        half_width = width / 2.
+        half_height = height / 2.
+        sin_theta = math.sin(theta)
+        cos_theta = math.cos(theta)
+        x_extent1 = abs((half_width * cos_theta) - (half_height * sin_theta))
+        x_extent2 = abs((half_width * cos_theta) + (half_height * sin_theta))
+        y_extent1 = abs((half_width * sin_theta) + (half_height * cos_theta))
+        y_extent2 = abs((half_width * sin_theta) - (half_height * cos_theta))
+        x_extent = max(x_extent1, x_extent2)
+        y_extent = max(y_extent1, y_extent2)
+
+        return x_extent, y_extent
+
+    @staticmethod
     def _lower_left_positions(positions, width, height, theta):
         """
         Calculate lower-left positions from the input center positions.
@@ -192,22 +211,12 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         for each position, enclosing the exact rectangular apertures.
         """
 
-        half_width = self.w / 2.
-        half_height = self.h / 2.
-        cos_theta = math.cos(self.theta)
-        sin_theta = math.sin(self.theta)
-        dx1 = abs(half_width * cos_theta - half_height * sin_theta)
-        dy1 = abs(half_width * sin_theta + half_height * cos_theta)
-        dx2 = abs(half_width * cos_theta + half_height * sin_theta)
-        dy2 = abs(half_width * sin_theta - half_height * cos_theta)
-        dx = max(dx1, dx2)
-        dy = max(dy1, dy2)
-
         positions = np.atleast_2d(self.positions)
-        xmin = positions[:, 0] - dx
-        xmax = positions[:, 0] + dx
-        ymin = positions[:, 1] - dy
-        ymax = positions[:, 1] + dy
+        x_delta, y_delta = self._extents(self.w, self.h, self.theta)
+        xmin = positions[:, 0] - x_delta
+        xmax = positions[:, 0] + x_delta
+        ymin = positions[:, 1] - y_delta
+        ymax = positions[:, 1] + y_delta
 
         bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
                   for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
@@ -377,22 +386,12 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         "exact" case.
         """
 
-        half_width = self.w_out / 2.
-        half_height = self.h_out / 2.
-        cos_theta = math.cos(self.theta)
-        sin_theta = math.sin(self.theta)
-        dx1 = abs(half_width * cos_theta - half_height * sin_theta)
-        dy1 = abs(half_width * sin_theta + half_height * cos_theta)
-        dx2 = abs(half_width * cos_theta + half_height * sin_theta)
-        dy2 = abs(half_width * sin_theta - half_height * cos_theta)
-        dx = max(dx1, dx2)
-        dy = max(dy1, dy2)
-
         positions = np.atleast_2d(self.positions)
-        xmin = positions[:, 0] - dx
-        xmax = positions[:, 0] + dx
-        ymin = positions[:, 1] - dy
-        ymax = positions[:, 1] + dy
+        x_delta, y_delta = self._extents(self.w_out, self.h_out, self.theta)
+        xmin = positions[:, 0] - x_delta
+        xmax = positions[:, 0] + x_delta
+        ymin = positions[:, 1] - y_delta
+        ymax = positions[:, 1] + y_delta
 
         bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
                   for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -226,6 +226,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         else:
             return bboxes
 
+    @property
     def area(self):
         return self.w * self.h
 
@@ -401,6 +402,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         else:
             return bboxes
 
+    @property
     def area(self):
         return self.w_out * self.h_out - self.w_in * self.h_in
 

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -66,7 +66,7 @@ def test_inside_array_simple(aperture_class, params):
     table2 = aperture_photometry(data, aperture, method='subpixel',
                                  subpixels=10)
     table3 = aperture_photometry(data, aperture, method='exact', subpixels=10)
-    true_flux = aperture.area()
+    true_flux = aperture.area
 
     if not isinstance(aperture, (RectangularAperture, RectangularAnnulus)):
         assert_allclose(table3['aperture_sum'], true_flux)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -9,6 +9,7 @@ from itertools import product
 import numpy as np
 from numpy.lib.index_tricks import index_exp
 from astropy.utils import lazyproperty
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from .core import SExtractorBackground, StdBackgroundRMS
 from ..utils import ShepardIDWInterpolator
@@ -795,7 +796,8 @@ class Background2D:
 
         return self.interpolator(self.background_rms_mesh, self)
 
-    def plot_meshes(self, ax=None, marker='+', color='blue', outlines=False,
+    @deprecated_renamed_argument('ax', 'axes', '0.7')
+    def plot_meshes(self, axes=None, marker='+', color='blue', outlines=False,
                     **kwargs):
         """
         Plot the low-resolution mesh boxes on a matplotlib Axes
@@ -803,8 +805,9 @@ class Background2D:
 
         Parameters
         ----------
-        ax : `matplotlib.axes.Axes` instance, optional
-            If `None`, then the current ``Axes`` instance is used.
+        axes : `matplotlib.axes.Axes` or `None`, optional
+            The matplotlib axes on which to plot.  If `None`, then the
+            current `~matplotlib.axes.Axes` instance is used.
 
         marker : str, optional
             The marker to use to mark the center of the boxes.  Default
@@ -818,7 +821,7 @@ class Background2D:
             Whether or not to plot the box outlines in addition to the
             box centers.
 
-        kwargs
+        kwargs : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.  Used only if ``outlines`` is
             True.
@@ -827,13 +830,13 @@ class Background2D:
         import matplotlib.pyplot as plt
 
         kwargs['color'] = color
-        if ax is None:
-            ax = plt.gca()
-        ax.scatter(self.x, self.y, marker=marker, color=color)
+        if axes is None:
+            axes = plt.gca()
+        axes.scatter(self.x, self.y, marker=marker, color=color)
         if outlines:
             from ..aperture import RectangularAperture
             xy = np.column_stack([self.x, self.y])
             apers = RectangularAperture(xy, self.box_size[1],
                                         self.box_size[0], 0.)
-            apers.plot(ax=ax, **kwargs)
+            apers.plot(axes=axes, **kwargs)
         return


### PR DESCRIPTION
The focus of this PR is mainly to simplify some aspects of the aperture implementation, mainly in the area of plotting apertures.  The Aperture `plot` method is now simplified and defined only in the `PixelAperture` base class.

This PR includes also two API changes.  The `plot` `ax` keyword is deprecated and renamed to `axes` for both the Aperture `plot` methods and the `Background2D.plot_meshes()` method.  Also Aperture `area` is now an attribute instead of a method (this is arguably a bug fix).