### PR TITLE
Improvements for segmentation-based properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ New Features
 - ``photutils.segmentation``
 
   - Significantly improved the performance of relabeling in
-    segmentation images (e.g.  ``remove_labels``, ``keep_labels``).
+    segmentation images (e.g. ``remove_labels``, ``keep_labels``).
     [#810]
 
   - Added new ``background_area`` attribute to ``SegmentationImage``.
@@ -36,6 +36,12 @@ New Features
 
   - Added ``__repr__`` and ``__str__`` methods to
     ``SegmentationImage``. [#825]
+
+  - Added ``slices``, ``indices``, and ``filtered_data_cutout_ma``
+    attributes to ``SourceProperties``. [#858]
+
+  - Added ``__repr__`` and ``__str__`` methods to ``SourceProperties``
+    and ``SourceCatalog``. [#858]
 
 - ``photutils.utils``
 
@@ -152,6 +158,12 @@ API changes
   - A ``ValueError`` is raised if an empty list is input into
     ``SourceCatalog`` or no valid sources are defined in
     ``source_properties``. [#836]
+
+  - Deprecated the ``values`` and ``coords`` attributes in
+    ``SourceProperties``. [#858]
+
+  - Deprecated the unused ``mask_value`` keyword in
+    ``make_source_mask``. [#858]
 
 - ``photutils.utils``
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -295,7 +295,7 @@ class SegmentationImage:
             # needed only when data is reassigned, not on init
             self._reset_lazy_properties()
 
-        self._data = value
+        self._data = value  # pylint: disable=attribute-defined-outside-init
 
     @lazyproperty
     def data_ma(self):
@@ -457,10 +457,7 @@ class SegmentationImage:
         image are consecutive (i.e. no missing values).
         """
 
-        if (self.labels[-1] - self.labels[0] + 1) == self.nlabels:
-            return True
-        else:
-            return False
+        return (self.labels[-1] - self.labels[0] + 1) == self.nlabels
 
     @lazyproperty
     def missing_labels(self):
@@ -470,8 +467,8 @@ class SegmentationImage:
         label number.
         """
 
-        return np.array(sorted(set(range(0, self.max_label + 1)).
-                               difference(np.insert(self.labels, 0, 0))))
+        return np.array(sorted(set(range(0, self.max_label + 1))
+                               .difference(np.insert(self.labels, 0, 0))))
 
     def copy(self):
         """Return a deep copy of this class instance."""
@@ -523,7 +520,7 @@ class SegmentationImage:
         # check if label is in the segmentation image
         bad_labels.update(np.setdiff1d(labels, self.labels))
 
-        if len(bad_labels) > 0:
+        if bad_labels:
             if len(bad_labels) == 1:
                 raise ValueError('label {} is invalid'.format(bad_labels))
             else:

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -284,7 +284,7 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
                 # higher level, and relabel.
                 segm_tree[j].remove_labels(intersect_labels)
                 new_segments = segm_tree[j].data + segm_tree[j - 1].data
-                new_segm, nsegm = ndimage.label(new_segments)
+                new_segm, _ = ndimage.label(new_segments)
                 segm_tree[j - 1] = SegmentationImage(new_segm)
 
         return SegmentationImage(watershed(-data, segm_tree[0].data,

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from .core import SegmentationImage
 from ..detection import detect_threshold
@@ -167,6 +168,7 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         return SegmentationImage(segm_img)
 
 
+@deprecated_renamed_argument('mask_value', None, 0.7)
 def make_source_mask(data, snr, npixels, mask=None, mask_value=None,
                      filter_fwhm=None, filter_size=3, filter_kernel=None,
                      sigclip_sigma=3.0, sigclip_iters=5, dilate_size=11):
@@ -194,6 +196,7 @@ def make_source_mask(data, snr, npixels, mask=None, mask_value=None,
         statistics.
 
     mask_value : float, optional
+        Deprecated.
         An image data value (e.g., ``0.0``) that is ignored when
         computing the image background statistics.  ``mask_value`` will
         be ignored if ``mask`` is input.

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -198,10 +198,11 @@ class SourceProperties:
 
         segment_img.check_labels(label)
         self.label = label
-        self._slice = segment_img.slices[segment_img.get_index(label)]
         self._segment_img = segment_img
         self._mask = mask
         self._wcs = wcs
+        self.segment = segment_img[segment_img.get_index(label)]
+        self.slices = self.segment.slices
 
     @lazyproperty
     def _segment_mask(self):
@@ -213,7 +214,7 @@ class SourceProperties:
         within the rectangular cutout are `True`.
         """
 
-        return self._segment_img.data[self._slice] != self.label
+        return self._segment_img.data[self.slices] != self.label
 
     @lazyproperty
     def _input_mask(self):
@@ -222,7 +223,7 @@ class SourceProperties:
         """
 
         if self._mask is not None:
-            return self._mask[self._slice]
+            return self._mask[self.slices]
         else:
             return None
 
@@ -299,7 +300,7 @@ class SourceProperties:
         This array is used for moment-based properties.
         """
 
-        filt_data = self._filtered_data[self._slice]
+        filt_data = self._filtered_data[self.slices]
         filt_data = np.where(self._total_mask, 0., filt_data)  # copy
         filt_data[filt_data < 0] = 0.
         return filt_data.astype(np.float64)
@@ -348,10 +349,10 @@ class SourceProperties:
                              'segmentation image input to SourceProperties')
 
         if masked_array:
-            return np.ma.masked_array(data[self._slice],
+            return np.ma.masked_array(data[self.slices],
                                       mask=self._total_mask)
         else:
-            return data[self._slice]
+            return data[self.slices]
 
     def to_table(self, columns=None, exclude_columns=None):
         """
@@ -388,7 +389,7 @@ class SourceProperties:
         bounding box of the source segment.
         """
 
-        return self._data[self._slice]
+        return self._data[self.slices]
 
     @lazyproperty
     def data_cutout_ma(self):
@@ -400,7 +401,7 @@ class SourceProperties:
         input, or any non-finite ``data`` values (NaN and +/- inf).
         """
 
-        return np.ma.masked_array(self._data[self._slice],
+        return np.ma.masked_array(self._data[self.slices],
                                   mask=self._total_mask)
 
     @lazyproperty
@@ -416,7 +417,7 @@ class SourceProperties:
         input, or any non-finite ``data`` values (NaN and +/- inf).
         """
 
-        return np.ma.masked_array(self._filtered_data[self._slice],
+        return np.ma.masked_array(self._filtered_data[self.slices],
                                   mask=self._total_mask)
 
     @lazyproperty
@@ -435,7 +436,7 @@ class SourceProperties:
         if self._error is None:
             return None
         else:
-            return np.ma.masked_array(self._error[self._slice],
+            return np.ma.masked_array(self._error[self.slices],
                                       mask=self._total_mask)
 
     @lazyproperty
@@ -455,7 +456,7 @@ class SourceProperties:
         if self._background is None:
             return None
         else:
-            return np.ma.masked_array(self._background[self._slice],
+            return np.ma.masked_array(self._background[self.slices],
                                       mask=self._total_mask)
 
     @lazyproperty
@@ -516,7 +517,7 @@ class SourceProperties:
         """
 
         yy, xx = np.nonzero(self.data_cutout_ma)
-        return (yy + self._slice[0].start, xx + self._slice[1].start)
+        return (yy + self.slices[0].start, xx + self.slices[1].start)
 
     @lazyproperty
     @deprecated('0.7', 'indices')
@@ -583,8 +584,8 @@ class SourceProperties:
         """
 
         ycen, xcen = self.cutout_centroid.value
-        return (ycen + self._slice[0].start,
-                xcen + self._slice[1].start) * u.pix
+        return (ycen + self.slices[0].start,
+                xcen + self.slices[1].start) * u.pix
 
     @lazyproperty
     def xcentroid(self):
@@ -639,8 +640,8 @@ class SourceProperties:
         """
 
         # (stop - 1) to return the max pixel location, not the slice index
-        return (self._slice[0].start, self._slice[1].start,
-                self._slice[0].stop - 1, self._slice[1].stop - 1) * u.pix
+        return (self.slices[0].start, self.slices[1].start,
+                self.slices[0].stop - 1, self.slices[1].stop - 1) * u.pix
 
     @lazyproperty
     def xmin(self):
@@ -826,8 +827,8 @@ class SourceProperties:
             return (np.nan, np.nan) * u.pix
         else:
             yp, xp = self.minval_cutout_pos.value
-            return (yp + self._slice[0].start,
-                    xp + self._slice[1].start) * u.pix
+            return (yp + self.slices[0].start,
+                    xp + self.slices[1].start) * u.pix
 
     @lazyproperty
     def maxval_pos(self):
@@ -843,8 +844,8 @@ class SourceProperties:
             return (np.nan, np.nan) * u.pix
         else:
             yp, xp = self.maxval_cutout_pos.value
-            return (yp + self._slice[0].start,
-                    xp + self._slice[1].start) * u.pix
+            return (yp + self.slices[0].start,
+                    xp + self.slices[1].start) * u.pix
 
     @lazyproperty
     def minval_xpos(self):

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -454,20 +454,36 @@ class SourceProperties:
         return self.background_cutout_ma.compressed()
 
     @lazyproperty
-    def coords(self):
+    def indices(self):
         """
         A tuple of two `~numpy.ndarray` containing the ``y`` and ``x``
-        pixel coordinates of unmasked pixels within the source segment.
+        pixel indices, respectively, of unmasked pixels within the
+        source segment.
 
-        Non-finite pixel values (e.g. NaN, infs) are excluded
-        (automatically masked).
+        Non-finite ``data`` values (e.g. NaN, infs) are excluded.
 
-        If all pixels are masked, ``coords`` will be a tuple of
-        two empty arrays.
+        If all ``data`` pixels are masked, a tuple of two empty arrays
+        will be returned.
         """
 
         yy, xx = np.nonzero(self.data_cutout_ma)
         return (yy + self._slice[0].start, xx + self._slice[1].start)
+
+    @lazyproperty
+    @deprecated('0.7', 'indices')
+    def coords(self):
+        """
+        A tuple of two `~numpy.ndarray` containing the ``y`` and ``x``
+        pixel indices, respectively, of unmasked pixels within the
+        source segment.
+
+        Non-finite ``data`` values (e.g. NaN, infs) are excluded.
+
+        If all ``data`` pixels are masked, a tuple of two empty arrays
+        will be returned.
+        """
+
+        return self.indices  # pragma: no cover
 
     @lazyproperty
     def moments(self):

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1601,8 +1601,7 @@ class SourceCatalog:
         return self.__str__()
 
     def __getattr__(self, attr):
-        exclude = ['sky_centroid', 'sky_centroid_icrs', 'icrs_centroid',
-                   'ra_icrs_centroid', 'dec_icrs_centroid', 'sky_bbox_ll',
+        exclude = ['sky_centroid', 'sky_centroid_icrs', 'sky_bbox_ll',
                    'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
         if attr not in exclude:
             if attr not in self._cache:
@@ -1612,7 +1611,7 @@ class SourceCatalog:
                     # turn list of Quantities into a Quantity array
                     values = u.Quantity(values)
                 if isinstance(values[0], SkyCoord):  # pragma: no cover
-                    # turn list of SkyCoord into a SkyCoord array
+                    # failsafe: turn list of SkyCoord into a SkyCoord array
                     values = SkyCoord(values)
 
                 self._cache[attr] = values

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1153,13 +1153,13 @@ class SourceProperties:
         order.
         """
 
-        if not np.isnan(np.sum(self.covariance)):
+        if np.any(~np.isfinite(self.covariance)):
+            return (np.nan, np.nan) * u.pix**2
+        else:
             eigvals = np.linalg.eigvals(self.covariance)
-            if np.any(eigvals < 0):    # negative variance
+            if np.any(eigvals < 0):  # negative variance
                 return (np.nan, np.nan) * u.pix**2  # pragma: no cover
             return (np.max(eigvals), np.min(eigvals)) * u.pix**2
-        else:
-            return (np.nan, np.nan) * u.pix**2
 
     @lazyproperty
     def semimajor_axis_sigma(self):

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -6,7 +6,7 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import QTable
-from astropy.utils import lazyproperty
+from astropy.utils import lazyproperty, deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs.utils import pixel_to_skycoord
 
@@ -417,9 +417,24 @@ class SourceProperties:
                                       mask=self._total_mask)
 
     @lazyproperty
+    @deprecated('0.7')
     def values(self):
         """
-        A 1D `~numpy.ndarray` of the unmasked pixel values within the
+        A 1D `~numpy.ndarray` of the unmasked ``data`` values within the
+        source segment.
+
+        Non-finite pixel values (e.g. NaN, infs) are excluded
+        (automatically masked).
+
+        If all pixels are masked, ``values`` will be an empty array.
+        """
+
+        return self._data_values  # pragma: no cover
+
+    @lazyproperty
+    def _data_values(self):
+        """
+        A 1D `~numpy.ndarray` of the unmasked ``data`` values within the
         source segment.
 
         Non-finite pixel values (e.g. NaN, infs) are excluded
@@ -680,7 +695,7 @@ class SourceProperties:
         if self._is_completely_masked:
             return np.nan * self._data_unit
         else:
-            return np.min(self.values)
+            return np.min(self._data_values)
 
     @lazyproperty
     def max_value(self):
@@ -692,7 +707,7 @@ class SourceProperties:
         if self._is_completely_masked:
             return np.nan * self._data_unit
         else:
-            return np.max(self.values)
+            return np.max(self._data_values)
 
     @lazyproperty
     def minval_cutout_pos(self):
@@ -832,7 +847,7 @@ class SourceProperties:
         if self._is_completely_masked:
             return np.nan * self._data_unit  # table output needs unit
         else:
-            return np.sum(self.values)
+            return np.sum(self._data_values)
 
     @lazyproperty
     def source_sum_err(self):
@@ -942,7 +957,7 @@ class SourceProperties:
         if self._is_completely_masked:
             return np.nan * u.pix**2
         else:
-            return len(self.values) * u.pix**2
+            return len(self._data_values) * u.pix**2
 
     @lazyproperty
     def equivalent_radius(self):

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -204,6 +204,23 @@ class SourceProperties:
         self.segment = segment_img[segment_img.get_index(label)]
         self.slices = self.segment.slices
 
+    def __str__(self):
+        cls_name = '<{0}.{1}>'.format(self.__class__.__module__,
+                                      self.__class__.__name__)
+
+        cls_info = []
+        params = ['label', 'sky_centroid']
+        for param in params:
+            cls_info.append((param, getattr(self, param)))
+        fmt = (['{0}: {1}'.format(key, val) for key, val in cls_info])
+        fmt.insert(1, 'centroid (x, y): ({0:0.4f}, {1:0.4f})'
+                   .format(self.xcentroid.value, self.ycentroid.value))
+
+        return '{}\n'.format(cls_name) + '\n'.join(fmt)
+
+    def __repr__(self):
+        return self.__str__()
+
     @lazyproperty
     def _segment_mask(self):
         """
@@ -1523,6 +1540,16 @@ class SourceCatalog:
     def __iter__(self):
         for i in self._data:
             yield i
+
+    def __str__(self):
+        cls_name = '<{0}.{1}>'.format(self.__class__.__module__,
+                                      self.__class__.__name__)
+        fmt = ['Catalog length: {0}'.format(len(self))]
+
+        return '{}\n'.format(cls_name) + '\n'.join(fmt)
+
+    def __repr__(self):
+        return self.__str__()
 
     def __getattr__(self, attr):
         exclude = ['sky_centroid', 'sky_centroid_icrs', 'icrs_centroid',

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -153,7 +153,7 @@ class TestSegmentationImage:
         assert self.segm.background_area == 18
 
     def test_is_consecutive(self):
-        assert self.segm.is_consecutive is False
+        assert not self.segm.is_consecutive
 
     def test_missing_labels(self):
         assert_allclose(self.segm.missing_labels, [2, 6])

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -206,3 +206,9 @@ class TestDeblendSources:
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             deblend_sources(data, self.segm, self.npixels)
             assert len(warning_lines) == 0
+
+    def test_nonconsecutive_labels(self):
+        segm = self.segm.copy()
+        segm.reassign_label(1, 1000)
+        result = deblend_sources(self.data, segm, self.npixels)
+        assert result.nlabels == 2

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -121,9 +121,13 @@ class TestSourceProperties:
         # ensure mask is identical for data, error, and background
         assert props.data_cutout_ma.compressed().size == 677
         assert (props.data_cutout_ma.compressed().size ==
+                props.filtered_data_cutout_ma.compressed().size)
+        assert (props.data_cutout_ma.compressed().size ==
                 props.error_cutout_ma.compressed().size)
         assert (props.data_cutout_ma.compressed().size ==
                 props.background_cutout_ma.compressed().size)
+        assert (len(props._filtered_data_values) ==
+                props.filtered_data_cutout_ma.compressed().size)
 
         # test for non-finite values in error and/or background outside
         # of the data mask

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -522,11 +522,11 @@ class TestSourceCatalog:
         mywcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
 
         cat = source_properties(IMAGE, SEGM, wcs=mywcs)
-        columns = ['sky_centroid', 'sky_centroid_icrs', 'icrs_centroid',
-                   'ra_icrs_centroid', 'dec_icrs_centroid', 'sky_bbox_ll',
+        columns = ['sky_centroid', 'sky_centroid_icrs', 'sky_bbox_ll',
                    'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
         t = cat.to_table(columns=columns)
-        assert t[0]['sky_centroid'] is not None
+        for column in columns:
+            assert t[0][column] is not None
         assert t.colnames == columns
 
         obj = cat[0]
@@ -545,11 +545,11 @@ class TestSourceCatalog:
 
     def test_table_no_wcs(self):
         cat = source_properties(IMAGE, SEGM)
-        columns = ['sky_centroid', 'sky_centroid_icrs', 'icrs_centroid',
-                   'ra_icrs_centroid', 'dec_icrs_centroid', 'sky_bbox_ll',
+        columns = ['sky_centroid', 'sky_centroid_icrs', 'sky_bbox_ll',
                    'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
         t = cat.to_table(columns=columns)
-        assert t[0]['sky_centroid'] is None
+        for column in columns:
+            assert t[0][column] is None
         assert t.colnames == columns
 
     def test_repr_str(self):

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -24,13 +24,6 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-try:
-    import skimage    # noqa
-    HAS_SKIMAGE = True
-except ImportError:
-    HAS_SKIMAGE = False
-
-
 XCEN = 51.
 YCEN = 52.7
 MAJOR_SIG = 8.
@@ -48,7 +41,6 @@ ERR_VALS = [0., 2.5]
 BACKGRD_VALS = [None, 0., 1., 3.5]
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSourceProperties:
     def test_segment_shape(self):
@@ -193,7 +185,6 @@ class TestSourceProperties:
             assert '{}:'.format(attr) in repr(props)
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSourcePropertiesFunctionInputs:
     def test_segment_shape(self):
@@ -233,7 +224,6 @@ class TestSourcePropertiesFunctionInputs:
             source_properties(IMAGE, SEGM, labels=-1)
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSourcePropertiesFunction:
     def test_properties(self):
@@ -441,7 +431,6 @@ class TestSourcePropertiesFunction:
         assert cat[segm.get_index(label=1000)].id == 1000
 
 
-@pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSourceCatalog:
     def test_basic(self):

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -180,6 +180,14 @@ class TestSourceProperties:
         assert np.all(np.isnan(obj.minval_cutout_pos.value))
         assert np.all(np.isnan(obj.maxval_cutout_pos.value))
 
+    def test_repr_str(self):
+        props = SourceProperties(IMAGE, SEGM, label=1)
+        assert repr(props) == str(props)
+
+        attrs = ['label', 'centroid', 'sky_centroid']
+        for attr in attrs:
+            assert '{}:'.format(attr) in repr(props)
+
 
 @pytest.mark.skipif('not HAS_SKIMAGE')
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -516,3 +524,12 @@ class TestSourceCatalog:
         t = cat.to_table(columns=columns)
         assert t[0]['sky_centroid'] is None
         assert t.colnames == columns
+
+    def test_repr_str(self):
+        segm = np.zeros(IMAGE.shape)
+        x = y = np.arange(0, 100, 10)
+        segm[y, x] = np.arange(10)
+        cat = source_properties(IMAGE, segm)
+
+        assert repr(cat) == str(cat)
+        assert 'Catalog length:' in repr(cat)

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -236,7 +236,6 @@ class TestSourcePropertiesFunction:
                                  rtol=1.e-3)
         assert_allclose(props[0].bbox.value, [35, 25, 70, 77])
         assert_quantity_allclose(props[0].area, 1058.0*u.pix**2)
-        assert_allclose(len(props[0].values), props[0].area.value)
         assert_allclose(len(props[0].coords), 2)
         assert_allclose(len(props[0].coords[0]), props[0].area.value)
 

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -236,8 +236,8 @@ class TestSourcePropertiesFunction:
                                  rtol=1.e-3)
         assert_allclose(props[0].bbox.value, [35, 25, 70, 77])
         assert_quantity_allclose(props[0].area, 1058.0*u.pix**2)
-        assert_allclose(len(props[0].coords), 2)
-        assert_allclose(len(props[0].coords[0]), props[0].area.value)
+        assert_allclose(len(props[0].indices), 2)
+        assert_allclose(len(props[0].indices[0]), props[0].area.value)
 
         properties = ['background_at_centroid', 'background_mean',
                       'eccentricity', 'ellipticity', 'elongation',


### PR DESCRIPTION
This PR makes several improvements in the segmentation subpackage related to source properties, including:

* Adds `__repr__` and `__str__` methods to `SourceProperties` and `SourceCatalog`
* Adds `slices`, `indices`, and `filtered_data_cutout_ma` attributes to `SourceProperties`
* Deprecates the `values` and `coords` attributes in `SourceProperties`
* Deprecates the (unused) `mask_value` keyword in `make_source_mask`

A new perimeter algorithm also replaces the previous one, which depended on `scikit-image`.

This PR also adds more robust validation of `SourceProperties` inputs and improves the test coverage of the segmentation subpackage.