### PR TITLE
Improvements for source properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,13 @@ New Features
   - Added ``__repr__`` and ``__str__`` methods to ``SourceProperties``
     and ``SourceCatalog``. [#858]
 
+  - Significantly improved the performance of calculating the
+    ``background_at_centroid`` property in ``SourceCatalog``. [#863]
+
+  - The default output table columns (source properties) are defined
+    in a publicly-accessible variable called
+    ``photutils.segmentation.properties.DEFAULT_COLUMNS``. [#863]
+
 - ``photutils.utils``
 
   - Added ``NoDetectionsWarning`` class. [#836]
@@ -171,6 +178,16 @@ API changes
 
   - Deprecated the unused ``mask_value`` keyword in
     ``make_source_mask``. [#858]
+
+  - The ``bbox`` property now returns a ``BoundingBox`` instance.
+    [#863]
+
+  - The ``xmin/ymin`` and ``xmax/ymax`` properties have been
+    deprecated with the replacements having a ``bbox_`` prefix (e.g.
+    ``bbox_xmin``). [#863]
+
+  - The ``orientation`` property is now returned as a ``Quantity``
+    instance in units of degrees. [#863]
 
 - ``photutils.utils``
 

--- a/docs/morphology.rst
+++ b/docs/morphology.rst
@@ -48,10 +48,10 @@ Then, calculate its properties:
     >>> tbl['semiminor_axis_sigma'].info.format = '.10f'
     >>> tbl['orientation'].info.format = '.10f'
     >>> print(tbl)
-     id   xcentroid     ycentroid   ... semiminor_axis_sigma orientation
-             pix           pix      ...         pix              rad
-    --- ------------- ------------- ... -------------------- ------------
-      1 14.0225090502 16.9901801466 ...         3.6977761870 1.0494368937
+     id   xcentroid     ycentroid   ... semiminor_axis_sigma  orientation
+             pix           pix      ...         pix               deg
+    --- ------------- ------------- ... -------------------- -------------
+      1 14.0225090502 16.9901801466 ...         3.6977761870 60.1283048753
 
 Now let's use the measured morphological properties to define an
 approximate isophotal ellipse for the source:

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -425,7 +425,7 @@ class SourceProperties:
             Names of columns to exclude from the default columns in the
             output `~astropy.table.QTable`.  The default columns are
             defined in the
-            `photutils.segmentation.properties.DEFAULT_COLUMNS`
+            ``photutils.segmentation.properties.DEFAULT_COLUMNS``
             variable.
 
         Returns
@@ -1793,7 +1793,7 @@ class SourceCatalog:
             Names of columns to exclude from the default columns in the
             output `~astropy.table.QTable`.  The default columns are
             defined in the
-            `photutils.segmentation.properties.DEFAULT_COLUMNS`
+            ``photutils.segmentation.properties.DEFAULT_COLUMNS``
             variable.
 
         Returns
@@ -1854,7 +1854,7 @@ def _properties_table(obj, columns=None, exclude_columns=None):
     exclude_columns : str or list of str, optional
         Names of columns to exclude from the default columns in the
         output `~astropy.table.QTable`.  The default columns are defined
-        in the `photutils.segmentation.properties.DEFAULT_COLUMNS`
+        in the ``photutils.segmentation.properties.DEFAULT_COLUMNS``
         variable.
 
     Returns

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -23,6 +23,18 @@ __doctest_requires__ = {('SourceProperties', 'SourceProperties.*',
                          'source_properties', 'properties_table'):
                         ['scipy']}
 
+# default table columns for `to_table()` output
+DEFAULT_COLUMNS = ['id', 'xcentroid', 'ycentroid', 'sky_centroid',
+                   'sky_centroid_icrs', 'source_sum', 'source_sum_err',
+                   'background_sum', 'background_mean',
+                   'background_at_centroid', 'xmin', 'xmax', 'ymin', 'ymax',
+                   'min_value', 'max_value', 'minval_xpos', 'minval_ypos',
+                   'maxval_xpos', 'maxval_ypos', 'area', 'equivalent_radius',
+                   'perimeter', 'semimajor_axis_sigma',
+                   'semiminor_axis_sigma', 'orientation', 'eccentricity',
+                   'ellipticity', 'elongation', 'covar_sigx2', 'covar_sigxy',
+                   'covar_sigy2', 'cxx', 'cxy', 'cyy']
+
 
 class SourceProperties:
     """
@@ -408,8 +420,11 @@ class SourceProperties:
             of the attributes of `SourceProperties`.
 
         exclude_columns : str or list of str, optional
-            Names of columns to exclude from the default properties list
-            in the output `~astropy.table.QTable`.
+            Names of columns to exclude from the default columns in the
+            output `~astropy.table.QTable`.  The default columns are
+            defined in the
+            `photutils.segmentation.properties.DEFAULT_COLUMNS`
+            variable.
 
         Returns
         -------
@@ -1709,20 +1724,11 @@ class SourceCatalog:
             of the attributes of `SourceProperties`.
 
         exclude_columns : str or list of str, optional
-            Names of columns to exclude from the default properties list
-            in the output `~astropy.table.QTable`.  The default
-            properties are:
-
-            'id', 'xcentroid', 'ycentroid', 'sky_centroid',
-            'sky_centroid_icrs', 'source_sum', 'source_sum_err',
-            'background_sum', 'background_mean',
-            'background_at_centroid', 'xmin', 'xmax', 'ymin', 'ymax',
-            'min_value', 'max_value', 'minval_xpos', 'minval_ypos',
-            'maxval_xpos', 'maxval_ypos', 'area', 'equivalent_radius',
-            'perimeter', 'semimajor_axis_sigma', 'semiminor_axis_sigma',
-            'orientation', 'eccentricity', 'ellipticity', 'elongation',
-            'covar_sigx2', 'covar_sigxy', 'covar_sigy2', 'cxx', 'cxy',
-            'cyy'
+            Names of columns to exclude from the default columns in the
+            output `~astropy.table.QTable`.  The default columns are
+            defined in the
+            `photutils.segmentation.properties.DEFAULT_COLUMNS`
+            variable.
 
         Returns
         -------
@@ -1780,8 +1786,10 @@ def _properties_table(obj, columns=None, exclude_columns=None):
         of the attributes of `SourceProperties`.
 
     exclude_columns : str or list of str, optional
-        Names of columns to exclude from the default properties list
-        in the output `~astropy.table.QTable`.
+        Names of columns to exclude from the default columns in the
+        output `~astropy.table.QTable`.  The default columns are defined
+        in the `photutils.segmentation.properties.DEFAULT_COLUMNS`
+        variable.
 
     Returns
     -------
@@ -1789,18 +1797,8 @@ def _properties_table(obj, columns=None, exclude_columns=None):
         A table of source properties with one row per source.
     """
 
-    # default properties
-    columns_all = ['id', 'xcentroid', 'ycentroid', 'sky_centroid',
-                   'sky_centroid_icrs', 'source_sum', 'source_sum_err',
-                   'background_sum', 'background_mean',
-                   'background_at_centroid', 'xmin', 'xmax', 'ymin',
-                   'ymax', 'min_value', 'max_value', 'minval_xpos',
-                   'minval_ypos', 'maxval_xpos', 'maxval_ypos', 'area',
-                   'equivalent_radius', 'perimeter',
-                   'semimajor_axis_sigma', 'semiminor_axis_sigma',
-                   'orientation', 'eccentricity', 'ellipticity',
-                   'elongation', 'covar_sigx2', 'covar_sigxy',
-                   'covar_sigy2', 'cxx', 'cxy', 'cyy']
+    # start with the default columns
+    columns_all = DEFAULT_COLUMNS
 
     table_columns = None
     if exclude_columns is not None:

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -28,13 +28,14 @@ __doctest_requires__ = {('SourceProperties', 'SourceProperties.*',
 DEFAULT_COLUMNS = ['id', 'xcentroid', 'ycentroid', 'sky_centroid',
                    'sky_centroid_icrs', 'source_sum', 'source_sum_err',
                    'background_sum', 'background_mean',
-                   'background_at_centroid', 'xmin', 'xmax', 'ymin', 'ymax',
-                   'min_value', 'max_value', 'minval_xpos', 'minval_ypos',
-                   'maxval_xpos', 'maxval_ypos', 'area', 'equivalent_radius',
-                   'perimeter', 'semimajor_axis_sigma',
-                   'semiminor_axis_sigma', 'orientation', 'eccentricity',
-                   'ellipticity', 'elongation', 'covar_sigx2', 'covar_sigxy',
-                   'covar_sigy2', 'cxx', 'cxy', 'cyy']
+                   'background_at_centroid', 'bbox_xmin', 'bbox_xmax',
+                   'bbox_ymin', 'bbox_ymax', 'min_value', 'max_value',
+                   'minval_xpos', 'minval_ypos', 'maxval_xpos', 'maxval_ypos',
+                   'area', 'equivalent_radius', 'perimeter',
+                   'semimajor_axis_sigma', 'semiminor_axis_sigma',
+                   'orientation', 'eccentricity', 'ellipticity', 'elongation',
+                   'covar_sigx2', 'covar_sigxy', 'covar_sigy2', 'cxx', 'cxy',
+                   'cyy']
 
 
 class SourceProperties:
@@ -698,40 +699,88 @@ class SourceProperties:
                            self.slices[0].start, self.slices[0].stop)
 
     @lazyproperty
-    def xmin(self):
+    def bbox_xmin(self):
         """
-        The minimum ``x`` pixel location of the minimal bounding box
-        (`~photutils.SourceProperties.bbox`) of the source segment.
+        The minimum ``x`` pixel location within the minimal bounding box
+        containing the source segment.
         """
 
         return self.bbox.ixmin * u.pix
 
     @lazyproperty
-    def xmax(self):
+    def bbox_xmax(self):
         """
-        The maximum ``x`` pixel location of the minimal bounding box
-        (`~photutils.SourceProperties.bbox`) of the source segment.
+        The maximum ``x`` pixel location within the minimal bounding box
+        containing the source segment.
+
+        Note that this value is inclusive, unlike numpy slice indices.
         """
 
         return (self.bbox.ixmax - 1) * u.pix
 
     @lazyproperty
-    def ymin(self):
+    def bbox_ymin(self):
         """
-        The minimum ``y`` pixel location of the minimal bounding box
-        (`~photutils.SourceProperties.bbox`) of the source segment.
+        The minimum ``y`` pixel location within the minimal bounding box
+        containing the source segment.
         """
 
         return self.bbox.iymin * u.pix
 
     @lazyproperty
-    def ymax(self):
+    def bbox_ymax(self):
         """
-        The maximum ``y`` pixel location of the minimal bounding box
-        (`~photutils.SourceProperties.bbox`) of the source segment.
+        The maximum ``y`` pixel location within the minimal bounding box
+        containing the source segment.
+
+        Note that this value is inclusive, unlike numpy slice indices.
         """
 
         return (self.bbox.iymax - 1) * u.pix
+
+    @lazyproperty
+    @deprecated('0.7', 'bbox_xmin')
+    def xmin(self):
+        """
+        The minimum ``x`` pixel location within the minimal bounding box
+        containing the source segment.
+        """
+
+        return self.bbox_xmin  # pragma: no cover
+
+    @lazyproperty
+    @deprecated('0.7', 'bbox_xmax')
+    def xmax(self):
+        """
+        The maximum ``x`` pixel location within the minimal bounding box
+        containing the source segment.
+
+        Note that this value is inclusive, unlike numpy slice indices.
+        """
+
+        return self.bbox_xmax  # pragma: no cover
+
+    @lazyproperty
+    @deprecated('0.7', 'bbox_ymin')
+    def ymin(self):
+        """
+        The minimum ``y`` pixel location within the minimal bounding box
+        containing the source segment.
+        """
+
+        return self.bbox_ymin  # pragma: no cover
+
+    @lazyproperty
+    @deprecated('0.7', 'bbox_ymax')
+    def ymax(self):
+        """
+        The maximum``y`` pixel location within the minimal bounding box
+        containing the source segment.
+
+        Note that this value is inclusive, unlike numpy slice indices.
+        """
+
+        return self.bbox_ymax  # pragma: no cover
 
     @lazyproperty
     def sky_bbox_ll(self):
@@ -745,8 +794,8 @@ class SourceProperties:
         """
 
         if self._wcs is not None:
-            return pixel_to_skycoord(self.xmin.value - 0.5,
-                                     self.ymin.value - 0.5,
+            return pixel_to_skycoord(self.bbox_xmin.value - 0.5,
+                                     self.bbox_ymin.value - 0.5,
                                      self._wcs, origin=0)
         else:
             return None
@@ -763,8 +812,8 @@ class SourceProperties:
         """
 
         if self._wcs is not None:
-            return pixel_to_skycoord(self.xmin.value - 0.5,
-                                     self.ymax.value + 0.5,
+            return pixel_to_skycoord(self.bbox_xmin.value - 0.5,
+                                     self.bbox_ymax.value + 0.5,
                                      self._wcs, origin=0)
         else:
             return None
@@ -781,8 +830,8 @@ class SourceProperties:
         """
 
         if self._wcs is not None:
-            return pixel_to_skycoord(self.xmax.value + 0.5,
-                                     self.ymin.value - 0.5,
+            return pixel_to_skycoord(self.bbox_xmax.value + 0.5,
+                                     self.bbox_ymin.value - 0.5,
                                      self._wcs, origin=0)
         else:
             return None
@@ -799,8 +848,8 @@ class SourceProperties:
         """
 
         if self._wcs is not None:
-            return pixel_to_skycoord(self.xmax.value + 0.5,
-                                     self.ymax.value + 0.5,
+            return pixel_to_skycoord(self.bbox_xmax.value + 0.5,
+                                     self.bbox_ymax.value + 0.5,
                                      self._wcs, origin=0)
         else:
             return None
@@ -1685,8 +1734,8 @@ class SourceCatalog:
     @lazyproperty
     def sky_bbox_ll(self):
         if self.wcs is not None:
-            return pixel_to_skycoord(self.xmin.value - 0.5,
-                                     self.ymin.value - 0.5,
+            return pixel_to_skycoord(self.bbox_xmin.value - 0.5,
+                                     self.bbox_ymin.value - 0.5,
                                      self.wcs, origin=0)
         else:
             return self._none_list
@@ -1694,8 +1743,8 @@ class SourceCatalog:
     @lazyproperty
     def sky_bbox_ul(self):
         if self.wcs is not None:
-            return pixel_to_skycoord(self.xmin.value - 0.5,
-                                     self.ymax.value + 0.5,
+            return pixel_to_skycoord(self.bbox_xmin.value - 0.5,
+                                     self.bbox_ymax.value + 0.5,
                                      self.wcs, origin=0)
         else:
             return self._none_list
@@ -1703,8 +1752,8 @@ class SourceCatalog:
     @lazyproperty
     def sky_bbox_lr(self):
         if self.wcs is not None:
-            return pixel_to_skycoord(self.xmax.value + 0.5,
-                                     self.ymin.value - 0.5,
+            return pixel_to_skycoord(self.bbox_xmax.value + 0.5,
+                                     self.bbox_ymin.value - 0.5,
                                      self.wcs, origin=0)
         else:
             return self._none_list
@@ -1712,8 +1761,8 @@ class SourceCatalog:
     @lazyproperty
     def sky_bbox_ur(self):
         if self.wcs is not None:
-            return pixel_to_skycoord(self.xmax.value + 0.5,
-                                     self.ymax.value + 0.5,
+            return pixel_to_skycoord(self.bbox_xmax.value + 0.5,
+                                     self.bbox_ymax.value + 0.5,
                                      self.wcs, origin=0)
         else:
             return self._none_list

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1236,8 +1236,12 @@ class SourceProperties:
 
         covar_00, covar_01, _, covar_11 = self.covariance.flat
         if covar_00 < 0 or covar_11 < 0:    # negative variance
-            return np.nan * u.rad  # pragma: no cover
-        return 0.5 * np.arctan2(2. * covar_01, (covar_00 - covar_11))
+            return np.nan * u.deg  # pragma: no cover
+
+        # Quantity output in radians because inputs are Quantities
+        orient_radians = 0.5 * np.arctan2(2. * covar_01,
+                                          (covar_00 - covar_11))
+        return orient_radians.to(u.deg)
 
     @lazyproperty
     def elongation(self):
@@ -1523,7 +1527,7 @@ def source_properties(data, segment_img, error=None, mask=None,
     >>> props[1].perimeter    # doctest: +FLOAT_CMP
     <Quantity 5.41421356 pix>
     >>> props[1].orientation    # doctest: +FLOAT_CMP
-    <Quantity -0.74175931 rad>
+    <Quantity -42.4996777 deg>
     """
 
     if not isinstance(segment_img, SegmentationImage):
@@ -1716,7 +1720,7 @@ class SourceCatalog:
             'min_value', 'max_value', 'minval_xpos', 'minval_ypos',
             'maxval_xpos', 'maxval_ypos', 'area', 'equivalent_radius',
             'perimeter', 'semimajor_axis_sigma', 'semiminor_axis_sigma',
-            'eccentricity', 'orientation', 'ellipticity', 'elongation',
+            'orientation', 'eccentricity', 'ellipticity', 'elongation',
             'covar_sigx2', 'covar_sigxy', 'covar_sigy2', 'cxx', 'cxy',
             'cyy'
 
@@ -1794,7 +1798,7 @@ def _properties_table(obj, columns=None, exclude_columns=None):
                    'minval_ypos', 'maxval_xpos', 'maxval_ypos', 'area',
                    'equivalent_radius', 'perimeter',
                    'semimajor_axis_sigma', 'semiminor_axis_sigma',
-                   'eccentricity', 'orientation', 'ellipticity',
+                   'orientation', 'eccentricity', 'ellipticity',
                    'elongation', 'covar_sigx2', 'covar_sigxy',
                    'covar_sigy2', 'cxx', 'cxy', 'cyy']
 

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -12,6 +12,7 @@ from astropy.wcs.utils import pixel_to_skycoord
 
 
 from .core import SegmentationImage
+from ..aperture import BoundingBox
 from ..utils.convolution import filter_data
 from ..utils._moments import _moments, _moments_central
 
@@ -689,13 +690,12 @@ class SourceProperties:
     @lazyproperty
     def bbox(self):
         """
-        The bounding box ``(ymin, xmin, ymax, xmax)`` of the minimal
-        rectangular region containing the source segment.
+        The `~photutils.BoundingBox` of the minimal rectangular region
+        containing the source segment.
         """
 
-        # (stop - 1) to return the max pixel location, not the slice index
-        return (self.slices[0].start, self.slices[1].start,
-                self.slices[0].stop - 1, self.slices[1].stop - 1) * u.pix
+        return BoundingBox(self.slices[1].start, self.slices[1].stop,
+                           self.slices[0].start, self.slices[0].stop)
 
     @lazyproperty
     def xmin(self):
@@ -704,7 +704,7 @@ class SourceProperties:
         (`~photutils.SourceProperties.bbox`) of the source segment.
         """
 
-        return self.bbox[1]
+        return self.bbox.ixmin * u.pix
 
     @lazyproperty
     def xmax(self):
@@ -713,7 +713,7 @@ class SourceProperties:
         (`~photutils.SourceProperties.bbox`) of the source segment.
         """
 
-        return self.bbox[3]
+        return (self.bbox.ixmax - 1) * u.pix
 
     @lazyproperty
     def ymin(self):
@@ -722,7 +722,7 @@ class SourceProperties:
         (`~photutils.SourceProperties.bbox`) of the source segment.
         """
 
-        return self.bbox[0]
+        return self.bbox.iymin * u.pix
 
     @lazyproperty
     def ymax(self):
@@ -731,7 +731,7 @@ class SourceProperties:
         (`~photutils.SourceProperties.bbox`) of the source segment.
         """
 
-        return self.bbox[2]
+        return (self.bbox.iymax - 1) * u.pix
 
     @lazyproperty
     def sky_bbox_ll(self):

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -271,7 +271,11 @@ class TestSourcePropertiesFunction:
                                  MINOR_SIG*u.pix, rtol=1.e-2)
         assert_quantity_allclose(obj.orientation, THETA*u.rad,
                                  rtol=1.e-3)
-        assert_allclose(obj.bbox.value, [35, 25, 70, 77])
+        assert obj.xmin.value == 25
+        assert obj.xmax.value == 77
+        assert obj.ymin.value == 35
+        assert obj.ymax.value == 70
+
         assert_quantity_allclose(obj.area, 1058.0*u.pix**2)
         assert_allclose(len(obj.indices), 2)
         assert_allclose(len(obj.indices[0]), obj.area.value)
@@ -323,13 +327,12 @@ class TestSourcePropertiesFunction:
     def test_cutout_shapes(self):
         error = np.ones_like(IMAGE) * 1.
         props = source_properties(IMAGE, SEGM, error=error, background=1.)
-        bbox = props[0].bbox.value
-        true_shape = (bbox[2] - bbox[0] + 1, bbox[3] - bbox[1] + 1)
+        bbox = props[0].bbox
         properties = ['background_cutout_ma', 'data_cutout',
                       'data_cutout_ma', 'error_cutout_ma']
         shapes = [getattr(props[0], p).shape for p in properties]
         for shape in shapes:
-            assert shape == true_shape
+            assert shape == bbox.shape
 
     def test_make_cutout(self):
         props = source_properties(IMAGE, SEGM)
@@ -352,7 +355,11 @@ class TestSourcePropertiesFunction:
                                  MINOR_SIG*u.pix, rtol=1.e-2)
         assert_quantity_allclose(obj.orientation, THETA*u.rad,
                                  rtol=1.e-3)
-        assert_allclose(obj.bbox.value, [35, 25, 70, 77])
+        assert obj.xmin.value == 25
+        assert obj.xmax.value == 77
+        assert obj.ymin.value == 35
+        assert obj.ymax.value == 70
+
         area = obj.area.value
         assert_allclose(area, 1058.0)
 

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -271,10 +271,10 @@ class TestSourcePropertiesFunction:
                                  MINOR_SIG*u.pix, rtol=1.e-2)
         assert_quantity_allclose(obj.orientation, THETA*u.rad,
                                  rtol=1.e-3)
-        assert obj.xmin.value == 25
-        assert obj.xmax.value == 77
-        assert obj.ymin.value == 35
-        assert obj.ymax.value == 70
+        assert obj.bbox_xmin.value == 25
+        assert obj.bbox_xmax.value == 77
+        assert obj.bbox_ymin.value == 35
+        assert obj.bbox_ymax.value == 70
 
         assert_quantity_allclose(obj.area, 1058.0*u.pix**2)
         assert_allclose(len(obj.indices), 2)
@@ -285,8 +285,8 @@ class TestSourcePropertiesFunction:
                       'equivalent_radius', 'max_value', 'maxval_xpos',
                       'maxval_ypos', 'min_value', 'minval_xpos',
                       'minval_ypos', 'perimeter', 'cxx', 'cxy', 'cyy',
-                      'covar_sigx2', 'covar_sigxy', 'covar_sigy2', 'xmax',
-                      'xmin', 'ymax', 'ymin']
+                      'covar_sigx2', 'covar_sigxy', 'covar_sigy2',
+                      'bbox_xmin', 'bbox_xmax', 'bbox_ymin', 'bbox_ymax']
         for propname in properties:
             assert not isiterable(getattr(obj, propname))
 
@@ -355,10 +355,10 @@ class TestSourcePropertiesFunction:
                                  MINOR_SIG*u.pix, rtol=1.e-2)
         assert_quantity_allclose(obj.orientation, THETA*u.rad,
                                  rtol=1.e-3)
-        assert obj.xmin.value == 25
-        assert obj.xmax.value == 77
-        assert obj.ymin.value == 35
-        assert obj.ymax.value == 70
+        assert obj.bbox_xmin.value == 25
+        assert obj.bbox_xmax.value == 77
+        assert obj.bbox_ymin.value == 35
+        assert obj.bbox_ymax.value == 70
 
         area = obj.area.value
         assert_allclose(area, 1058.0)


### PR DESCRIPTION
This PR includes several improvements to source properties, including:

* Significantly improved the performance of `background_at_centroid` in `SourceCatalog`
* The default table output columns are now defined in a publicly-accessible variable (`photutils.segmentation.properties.DEFAULT_COLUMNS`)
* The `bbox` property now returns a `BoundingBox` instance
* The `xmin/ymin` and `xmax/ymax` properties are deprecated with the replacements having a `bbox_` prefix (e.g.`bbox_xmin`)
* The `orientation` property is now returned as a `Quantity` instance in units of degrees.