### PR TITLE
Support NDData with StdDevUncertainty in aperture_photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ New Features
     aperture photometry, especially when using ``errors`` and
     ``Quantity`` inputs with many aperture positions. [#861]
 
+  - ``aperture_phometry`` now supports ``NDData`` with
+    ``StdDevUncertainty`` to input errors. [#866]
+
 - ``photutils.isophote``
 
   - Significantly improved the performance (~5 times faster) of
@@ -121,8 +124,8 @@ API changes
   - The Aperture plot keyword ``ax`` was deprecated and renamed to
     ``axes``. [#854]
 
-  - Deprecated the ``units`` keyword for the
-    ``PixelAperture.do_photometry`` method. [#861]
+  - Deprecated the ``units`` keyword in ``aperture_photometry``
+    and the ``PixelAperture.do_photometry`` method. [#866, #861]
 
 - ``photutils.background``
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from astropy.nddata import NDData
+from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable
 import astropy.units as u
 from astropy.utils import deprecated
@@ -882,16 +882,18 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
     Parameters
     ----------
-    data : array_like, `~astropy.units.Quantity`, `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.HDUList`
+    data : array_like, `~astropy.units.Quantity`, `~astropy.io.fits.ImageHDU`, `~astropy.io.fits.HDUList`, or `~astropy.nddata.NDData`
         The 2D array on which to perform photometry. ``data`` should be
         background-subtracted.  Units can be used during the photometry,
-        either provided with the data (i.e. a `~astropy.units.Quantity`
-        array) or the ``unit`` keyword.  If ``data`` is an
-        `~astropy.io.fits.ImageHDU` or `~astropy.io.fits.HDUList`, the
-        unit is determined from the ``'BUNIT'`` header keyword.
-        If ``data`` is a `~astropy.units.Quantity` array, then ``error``
-        (if input) must also be a `~astropy.units.Quantity` array with
-        the same units.
+        either provided with the data (e.g. `~astropy.units.Quantity` or
+        `~astropy.nddata.NDData` inputs) or the ``unit`` keyword.  If
+        ``data`` is an `~astropy.io.fits.ImageHDU` or
+        `~astropy.io.fits.HDUList`, the unit is determined from the
+        ``'BUNIT'`` header keyword.  If ``data`` is a
+        `~astropy.units.Quantity` array, then ``error`` (if input) must
+        also be a `~astropy.units.Quantity` array with the same units.
+        See the Notes section below for more information about
+        `~astropy.nddata.NDData` input.
 
     apertures : `~photutils.Aperture` or list of `~photutils.Aperture`
         The aperture(s) to use for the photometry.  If ``apertures`` is
@@ -989,15 +991,40 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
         The table metadata includes the Astropy and Photutils version
         numbers and the `aperture_photometry` calling arguments.
+
+    Notes
+    -----
+    If the input ``data`` is a `~astropy.nddata.NDData` instance, then
+    the ``error``, ``mask``, ``unit``, and ``wcs`` keyword inputs are
+    ignored.  Instead, these values should be defined as attributes in
+    the `~astropy.nddata.NDData` object.  In the case of ``error``, it
+    must be defined in the ``uncertainty`` attribute with a
+    `~astropy.nddata.StdDevUncertainty` instance.
     """
 
     if isinstance(data, NDData):
+        nddata_attr = {'error': error, 'mask': mask, 'unit': unit, 'wcs': wcs}
+        for key, value in nddata_attr.items():
+            if value is not None:
+                warnings.warn('The {0!r} keyword is be ignored.  Its value '
+                              'is obtained from the input NDData object.'
+                              .format(key), AstropyUserWarning)
+
         mask = data.mask
         wcs = data.wcs
+        if isinstance(data.uncertainty, StdDevUncertainty):
+            if data.uncertainty.unit is not None:
+                error = data.uncertainty.quantity
+            else:
+                error = data.uncertainty.array
         if data.unit is not None:
             data = u.Quantity(data.data, unit=data.unit)
         else:
             data = data.data
+
+        return aperture_photometry(data, apertures, error=error, mask=mask,
+                                   method=method, subpixels=subpixels,
+                                   wcs=wcs)
 
     # handle FITS HDU input data
     data, bunit, fits_wcs = _handle_hdu_input(data)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -874,6 +874,7 @@ def _prepare_photometry_data(data, error, mask):
     return data, variance
 
 
+@deprecated_renamed_argument('unit', None, '0.7')
 def aperture_photometry(data, apertures, error=None, mask=None,
                         method='exact', subpixels=5, unit=None, wcs=None):
     """
@@ -945,6 +946,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         ** 2`` subpixels.
 
     unit : `~astropy.units.UnitBase` object or str, optional
+        Deprecated in v0.7.
         An object that represents the unit associated with the input
         ``data`` and ``error`` arrays.  Must be a
         `~astropy.units.UnitBase` object or a string parseable by the

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from astropy.nddata import support_nddata
+from astropy.nddata import NDData
 from astropy.table import QTable
 import astropy.units as u
 from astropy.utils import deprecated
@@ -874,7 +874,6 @@ def _prepare_photometry_data(data, error, mask):
     return data, variance
 
 
-@support_nddata
 def aperture_photometry(data, apertures, error=None, mask=None,
                         method='exact', subpixels=5, unit=None, wcs=None):
     """
@@ -990,12 +989,15 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
         The table metadata includes the Astropy and Photutils version
         numbers and the `aperture_photometry` calling arguments.
-
-    Notes
-    -----
-    This function is decorated with `~astropy.nddata.support_nddata` and
-    thus supports `~astropy.nddata.NDData` objects as input.
     """
+
+    if isinstance(data, NDData):
+        mask = data.mask
+        wcs = data.wcs
+        if data.unit is not None:
+            data = u.Quantity(data.data, unit=data.unit)
+        else:
+            data = data.data
 
     # handle FITS HDU input data
     data, bunit, fits_wcs = _handle_hdu_input(data)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -1014,11 +1014,13 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
         mask = data.mask
         wcs = data.wcs
+
         if isinstance(data.uncertainty, StdDevUncertainty):
-            if data.uncertainty.unit is not None:
-                error = data.uncertainty.quantity
-            else:
+            if data.uncertainty.unit is None:
                 error = data.uncertainty.array
+            else:
+                error = data.uncertainty.array * data.uncertainty.unit
+
         if data.unit is not None:
             data = u.Quantity(data.data, unit=data.unit)
         else:

--- a/photutils/aperture/tests/test_aperture_photometry.py
+++ b/photutils/aperture/tests/test_aperture_photometry.py
@@ -263,7 +263,7 @@ class BaseTestDifferentData:
     def test_basic_circular_aperture_photometry(self):
         aperture = CircularAperture(self.position, self.radius)
         table = aperture_photometry(self.data, aperture,
-                                    method='exact', unit='adu')
+                                    method='exact')
 
         assert_allclose(table['aperture_sum'].value, self.true_flux)
         assert table['aperture_sum'].unit, self.fluxunit
@@ -277,7 +277,7 @@ class BaseTestDifferentData:
 class TestInputPrimaryHDU(BaseTestDifferentData):
 
     def setup_class(self):
-        data = np.ones((40, 40), dtype=np.float)
+        data = np.ones((40, 40), dtype=np.float) * u.adu
         self.data = fits.ImageHDU(data=data)
         self.data.header['BUNIT'] = 'adu'
         self.radius = 3
@@ -292,24 +292,13 @@ class TestInputHDUList(BaseTestDifferentData):
         data0 = np.ones((40, 40), dtype=np.float)
         data1 = np.empty((40, 40), dtype=np.float)
         data1.fill(2)
-        self.data = fits.HDUList([fits.ImageHDU(data=data0),
-                                  fits.ImageHDU(data=data1)])
+        hdu1 = fits.ImageHDU(data=data0)
+        hdu1.header['BUNIT'] = 'adu'
+        self.data = fits.HDUList([hdu1, fits.ImageHDU(data=data1)])
         self.radius = 3
         self.position = (20, 20)
         # It should stop at the first extension
         self.true_flux = np.pi * self.radius * self.radius
-
-
-class TestInputHDUDifferentBUNIT(BaseTestDifferentData):
-
-    def setup_class(self):
-        data = np.ones((40, 40), dtype=np.float)
-        self.data = fits.ImageHDU(data=data)
-        self.data.header['BUNIT'] = 'Jy'
-        self.radius = 3
-        self.position = (20, 20)
-        self.true_flux = np.pi * self.radius * self.radius
-        self.fluxunit = u.adu
 
 
 class TestInputNDData(BaseTestDifferentData):
@@ -465,20 +454,18 @@ def test_wcs_based_photometry():
 
 def test_basic_circular_aperture_photometry_unit():
     data1 = np.ones((40, 40), dtype=np.float)
-    data2 = u.Quantity(data1, unit=u.adu)
+    data2 = u.Quantity(data1*u.adu)
 
     radius = 3
     position = (20, 20)
     true_flux = np.pi * radius * radius
     unit = u.adu
 
-    table1 = aperture_photometry(data1, CircularAperture(position, radius),
-                                 unit=unit)
+    table1 = aperture_photometry(data1, CircularAperture(position, radius))
     table2 = aperture_photometry(data2, CircularAperture(position, radius))
 
-    assert_allclose(table1['aperture_sum'].value, true_flux)
+    assert_allclose(table1['aperture_sum'], true_flux)
     assert_allclose(table2['aperture_sum'].value, true_flux)
-    assert table1['aperture_sum'].unit == unit
     assert table2['aperture_sum'].unit == data2.unit == unit
 
 


### PR DESCRIPTION
This PR adds support for `NDData` input with its `uncertainty` attribute set to a `StdDevUncertainty` to input errors to `aperture_photometry`.  To accomplish this, the `@support_nddata` decorator was removed.  The `units` keyword in `aperture_photometry` was also deprecated because its primary purpose was to support the `@support_nddata` decorator.  Instead `Quantity` `data` and `error` objects should be explicitly input (with the same units) if one wants units.