### PR TITLE
Fix travis test with optional dependencies disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ matrix:
 
         # Test with optional dependencies disabled
         - env: CONDA_DEPENDENCIES=$CONDA_REQUIRED_DEPENDENCIES
+               PIP_DEPENDENCIES=''
 
         # Test with Astropy dev version and the latest Python
         - stage: Comprehensive tests


### PR DESCRIPTION
The travis tests with optional dependencies disabled was actually installing some optional dependencies via `PIP_DEPENDENCIES`.  I expect that travis test to now fail due to a bug in a test that requires scipy.  Once I see that indeed this test fails, then I'll add a commit here to fix the bad test.