### PR TITLE
add area_overlap method for apertures

### DIFF
--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -340,7 +340,7 @@ class PixelAperture(Aperture):
 
         Returns
         -------
-        areas : array_like
+        areas : float or array_like
             The overlapping areas between the aperture masks and the data.
         """
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -347,8 +347,7 @@ class PixelAperture(Aperture):
         masks = self.to_mask(method=method, subpixels=subpixels)
         if self.isscalar:
             masks = (masks,)
-        masks_overlap = [mask.multiply(np.ones_like(data)) for mask in masks]
-        areas = [mask_overlap.sum() for mask_overlap in masks_overlap]
+        areas = [mask.multiply(np.ones_like(data)).sum() for mask in masks]
         if self.isscalar:
             return areas[0]
         else:

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -297,6 +297,63 @@ class PixelAperture(Aperture):
 
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
+    def area_overlap(self, data, method='exact', subpixels=5):
+        """
+        Return the areas of the aperture masks that overlap with the data,
+        i.e., how many pixels are actually used to calculate each sum
+
+        Parameters
+        ----------
+        data : array_like or `~astropy.units.Quantity`
+            The 2D array to multiply with the aperture mask.
+
+        method : {'exact', 'center', 'subpixel'}, optional
+            The method used to determine the overlap of the aperture on
+            the pixel grid.  Not all options are available for all
+            aperture types.  Note that the more precise methods are
+            generally slower.  The following methods are available:
+
+                * ``'exact'`` (default):
+                  The the exact fractional overlap of the aperture and
+                  each pixel is calculated.  The returned mask will
+                  contain values between 0 and 1.
+
+                * ``'center'``:
+                  A pixel is considered to be entirely in or out of the
+                  aperture depending on whether its center is in or out
+                  of the aperture.  The returned mask will contain
+                  values only of 0 (out) and 1 (in).
+
+                * ``'subpixel'``:
+                  A pixel is divided into subpixels (see the
+                  ``subpixels`` keyword), each of which are considered
+                  to be entirely in or out of the aperture depending on
+                  whether its center is in or out of the aperture.  If
+                  ``subpixels=1``, this method is equivalent to
+                  ``'center'``.  The returned mask will contain values
+                  between 0 and 1.
+
+        subpixels : int, optional
+            For the ``'subpixel'`` method, resample pixels by this factor
+            in each dimension.  That is, each pixel is divided into
+            ``subpixels ** 2`` subpixels.
+
+        Returns
+        -------
+        areas : array_like
+            The overlapping areas between the aperture masks and the data.
+        """
+
+        masks = self.to_mask(method=method, subpixels=subpixels)
+        if self.isscalar:
+            masks = (masks,)
+        masks_overlap = [mask.multiply(np.ones_like(data)) for mask in masks]
+        areas = [mask_overlap.sum() for mask_overlap in masks_overlap]
+        if self.isscalar:
+            return areas[0]
+        else:
+            return areas
+
     def _do_photometry(self, data, variance, method='exact', subpixels=5,
                        unit=None):
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -347,7 +347,8 @@ class PixelAperture(Aperture):
         masks = self.to_mask(method=method, subpixels=subpixels)
         if self.isscalar:
             masks = (masks,)
-        areas = [mask.multiply(np.ones_like(data)).sum() for mask in masks]
+        data = np.ones_like(data)
+        areas = [mask.multiply(data).sum() for mask in masks]
         if self.isscalar:
             return areas[0]
         else:


### PR DESCRIPTION
Apertures have a method `area` that gives the exact area of the aperture. This can be used, e.g., to calculate the [local background](https://photutils.readthedocs.io/en/stable/aperture.html#local-background-subtraction) for aperture photometry. However this is the wrong number to use if the aperture is on the edge of the image. We need a method that returns the *overlapping* area between the aperture mask and the data. I have attempted to implement that in `area_overlap`. I wasn't sure if this was the right place to put it, so feedback is welcome.