### PR TITLE
Rename type keyword to distribution in make_noise_image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -163,6 +163,11 @@ API changes
   - The ``Background2D`` ``plot_meshes`` keyword ``ax`` was deprecated
     and renamed to ``axes``. [#854]
 
+- ``photutils.datasets``
+
+  - The ``make_noise_image`` ``type`` keyword was deprecated and
+    renamed to ``distribution``. [#877]
+
 - ``photutils.detection``
 
   - Removed deprecated ``subpixel`` keyword for ``find_peaks``. [#835]

--- a/docs/epsf.rst
+++ b/docs/epsf.rst
@@ -45,8 +45,8 @@ The simulated image does not contain any background or noise, so let's add
 those to the image::
 
     >>> from photutils.datasets import make_noise_image
-    >>> data +=  make_noise_image(data.shape, type='gaussian', mean=10.,
-    ...                           stddev=5., random_state=12345)  # doctest: +REMOTE_DATA
+    >>> data +=  make_noise_image(data.shape, distribution='gaussian',
+    ...                           mean=10., stddev=5., random_state=12345)  # doctest: +REMOTE_DATA
 
 Let's show the image:
 
@@ -60,7 +60,7 @@ Let's show the image:
 
     hdu = datasets.load_simulated_hst_star_image()
     data = hdu.data
-    data +=  make_noise_image(data.shape, type='gaussian', mean=10.,
+    data +=  make_noise_image(data.shape, distribution='gaussian', mean=10.,
                               stddev=5., random_state=12345)
     norm = simple_norm(data, 'sqrt', percent=99.)
     plt.imshow(data, norm=norm, origin='lower', cmap='viridis')
@@ -177,7 +177,7 @@ from which we'll build our ePSF.  Let's show the first 25 of them:
     hdu = datasets.load_simulated_hst_star_image()
     data = hdu.data
     from photutils.datasets import make_noise_image
-    data +=  make_noise_image(data.shape, type='gaussian', mean=10.,
+    data +=  make_noise_image(data.shape, distribution='gaussian', mean=10.,
                               stddev=5., random_state=12345)
 
     from photutils import find_peaks
@@ -253,7 +253,7 @@ Finally, let's show the constructed ePSF:
     hdu = datasets.load_simulated_hst_star_image()
     data = hdu.data
     from photutils.datasets import make_noise_image
-    data +=  make_noise_image(data.shape, type='gaussian', mean=10.,
+    data +=  make_noise_image(data.shape, distribution='gaussian', mean=10.,
                               stddev=5., random_state=12345)
 
     from photutils import find_peaks

--- a/docs/isophote.rst
+++ b/docs/isophote.rst
@@ -21,7 +21,7 @@ For this example, let's create a simple simulated galaxy image::
     >>> g = Gaussian2D(100., 75, 75, 20, 12, theta=40.*np.pi/180.)
     >>> ny = nx = 150
     >>> y, x = np.mgrid[0:ny, 0:nx]
-    >>> noise = make_noise_image((ny, nx), type='gaussian', mean=0.,
+    >>> noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
     ...                          stddev=2., random_state=12345)
     >>> data = g(x, y) + noise
 
@@ -34,7 +34,7 @@ For this example, let's create a simple simulated galaxy image::
     g = Gaussian2D(100., 75, 75, 20, 12, theta=40.*np.pi/180.)
     ny = nx = 150
     y, x = np.mgrid[0:ny, 0:nx]
-    noise = make_noise_image((ny, nx), type='gaussian', mean=0.,
+    noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
                              stddev=2., random_state=12345)
     data = g(x, y) + noise
     plt.imshow(data, origin='lower')
@@ -72,7 +72,7 @@ Let's show this initial ellipse guess:
     g = Gaussian2D(100., 75, 75, 20, 12, theta=40.*np.pi/180.)
     ny = nx = 150
     y, x = np.mgrid[0:ny, 0:nx]
-    noise = make_noise_image((ny, nx), type='gaussian', mean=0.,
+    noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
                              stddev=2., random_state=12345)
     data = g(x, y) + noise
 
@@ -151,7 +151,7 @@ position as a function of the semimajor axis length:
     g = Gaussian2D(100., 75, 75, 20, 12, theta=40.*np.pi/180.)
     ny = nx = 150
     y, x = np.mgrid[0:ny, 0:nx]
-    noise = make_noise_image((ny, nx), type='gaussian', mean=0.,
+    noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
                              stddev=2., random_state=12345)
     data = g(x, y) + noise
     geometry = EllipseGeometry(x0=75, y0=75, sma=20, eps=0.5,
@@ -211,7 +211,7 @@ isophotes, the elliptical model image, and the residual image:
     g = Gaussian2D(100., 75, 75, 20, 12, theta=40.*np.pi/180.)
     ny = nx = 150
     y, x = np.mgrid[0:ny, 0:nx]
-    noise = make_noise_image((ny, nx), type='gaussian', mean=0.,
+    noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
                              stddev=2., random_state=12345)
     data = g(x, y) + noise
     geometry = EllipseGeometry(x0=75, y0=75, sma=20, eps=0.5,

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -219,9 +219,9 @@ First let's create an image with four overlapping stars::
     >>> sources['id'] = [1, 2, 3, 4]
     >>> tshape = (32, 32)
     >>> image = (make_gaussian_sources_image(tshape, sources) +
-    ...          make_noise_image(tshape, type='poisson', mean=6.,
+    ...          make_noise_image(tshape, distribution='poisson', mean=6.,
     ...                           random_state=1) +
-    ...          make_noise_image(tshape, type='gaussian', mean=0.,
+    ...          make_noise_image(tshape, distribution='gaussian', mean=0.,
     ...                           stddev=2., random_state=1))
 
 .. doctest-requires:: matplotlib
@@ -253,9 +253,9 @@ First let's create an image with four overlapping stars::
     sources['id'] = [1, 2, 3, 4]
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
-             make_noise_image(tshape, type='poisson', mean=6.,
+             make_noise_image(tshape, distribution='poisson', mean=6.,
                               random_state=1) +
-             make_noise_image(tshape, type='gaussian', mean=0.,
+             make_noise_image(tshape, distribution='gaussian', mean=0.,
                               stddev=2., random_state=1))
 
     from matplotlib import rcParams
@@ -345,9 +345,9 @@ Now, let's compare the simulated and the residual images:
     sources['id'] = [1, 2, 3, 4]
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
-             make_noise_image(tshape, type='poisson', mean=6.,
+             make_noise_image(tshape, distribution='poisson', mean=6.,
                               random_state=1) +
-             make_noise_image(tshape, type='gaussian', mean=0.,
+             make_noise_image(tshape, distribution='gaussian', mean=0.,
                               stddev=2., random_state=1))
 
     from photutils.detection import IRAFStarFinder
@@ -454,9 +454,9 @@ Consider the previous example after the line
     sources['id'] = [1, 2, 3, 4]
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
-             make_noise_image(tshape, type='poisson', mean=6.,
+             make_noise_image(tshape, distribution='poisson', mean=6.,
                               random_state=1) +
-             make_noise_image(tshape, type='gaussian', mean=0.,
+             make_noise_image(tshape, distribution='gaussian', mean=0.,
                               stddev=2., random_state=1))
 
     from photutils.detection import IRAFStarFinder
@@ -572,9 +572,9 @@ star as well. Also, note that both of the stars have ``sigma=2.0``.
     sources['theta'] = [0] * 2
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
-             make_noise_image(tshape, type='poisson', mean=6.,
+             make_noise_image(tshape, distribution='poisson', mean=6.,
                               random_state=1) +
-             make_noise_image(tshape, type='gaussian', mean=0.,
+             make_noise_image(tshape, distribution='gaussian', mean=0.,
                               stddev=2., random_state=1))
 
     vmin, vmax = np.percentile(image, [5, 95])
@@ -649,9 +649,9 @@ Let's take a look at the residual image::
     sources['theta'] = [0] * 2
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
-             make_noise_image(tshape, type='poisson', mean=6.,
+             make_noise_image(tshape, distribution='poisson', mean=6.,
                               random_state=1) +
-             make_noise_image(tshape, type='gaussian', mean=0.,
+             make_noise_image(tshape, distribution='gaussian', mean=0.,
                               stddev=2., random_state=1))
 
     daogroup = DAOGroup(crit_separation=8)

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -16,7 +16,7 @@ from ...datasets.make import make_noise_image
 
 BKG = 0.0
 STD = 0.5
-DATA = make_noise_image((100, 100), type='gaussian', mean=BKG,
+DATA = make_noise_image((100, 100), distribution='gaussian', mean=BKG,
                         stddev=STD, random_state=12345)
 
 BKG_CLASS0 = [MeanBackground, MedianBackground, ModeEstimatorBackground,

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -12,6 +12,7 @@ from astropy.io import fits
 from astropy.modeling import models
 from astropy.table import Table
 import astropy.units as u
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.version import version as astropy_version
 from astropy.wcs import WCS
 import numpy as np
@@ -84,7 +85,8 @@ def apply_poisson_noise(data, random_state=None):
     return prng.poisson(data)
 
 
-def make_noise_image(shape, type='gaussian', mean=None, stddev=None,
+@deprecated_renamed_argument('type', 'distribution', 0.7)
+def make_noise_image(shape, distribution='gaussian', mean=None, stddev=None,
                      random_state=None):
     """
     Make a noise image containing Gaussian or Poisson noise.
@@ -94,7 +96,7 @@ def make_noise_image(shape, type='gaussian', mean=None, stddev=None,
     shape : 2-tuple of int
         The shape of the output 2D image.
 
-    type : {'gaussian', 'poisson'}
+    distribution : {'gaussian', 'poisson'}
         The distribution used to generate the random noise:
 
             * ``'gaussian'``: Gaussian distributed noise.
@@ -132,8 +134,9 @@ def make_noise_image(shape, type='gaussian', mean=None, stddev=None,
         # make Gaussian and Poisson noise images
         from photutils.datasets import make_noise_image
         shape = (100, 100)
-        image1 = make_noise_image(shape, type='gaussian', mean=0., stddev=5.)
-        image2 = make_noise_image(shape, type='poisson', mean=5.)
+        image1 = make_noise_image(shape, distribution='gaussian', mean=0.,
+                                  stddev=5.)
+        image2 = make_noise_image(shape, distribution='poisson', mean=5.)
 
         # plot the images
         import matplotlib.pyplot as plt
@@ -149,15 +152,15 @@ def make_noise_image(shape, type='gaussian', mean=None, stddev=None,
 
     prng = check_random_state(random_state)
 
-    if type == 'gaussian':
+    if distribution == 'gaussian':
         if stddev is None:
             raise ValueError('"stddev" must be input for Gaussian noise')
         image = prng.normal(loc=mean, scale=stddev, size=shape)
-    elif type == 'poisson':
+    elif distribution == 'poisson':
         image = prng.poisson(lam=mean, size=shape)
     else:
-        raise ValueError('Invalid type: {0}. Use either "gaussian" or '
-                         '"poisson".'.format(type))
+        raise ValueError('Invalid distribution: {0}. Use either "gaussian" '
+                         'or "poisson".'.format(distribution))
 
     return image
 
@@ -523,9 +526,10 @@ def make_gaussian_sources_image(shape, source_table, oversample=1):
         from photutils.datasets import make_noise_image
         shape = (100, 200)
         image1 = make_gaussian_sources_image(shape, table)
-        image2 = image1 + make_noise_image(shape, type='gaussian', mean=5.,
-                                           stddev=5.)
-        image3 = image1 + make_noise_image(shape, type='poisson', mean=5.)
+        image2 = image1 + make_noise_image(shape, distribution='gaussian',
+                                           mean=5., stddev=5.)
+        image3 = image1 + make_noise_image(shape, distribution='poisson',
+                                           mean=5.)
 
         # plot the images
         import matplotlib.pyplot as plt
@@ -607,9 +611,10 @@ def make_gaussian_prf_sources_image(shape, source_table):
         from photutils.datasets import make_noise_image
         shape = (100, 200)
         image1 = make_gaussian_prf_sources_image(shape, table)
-        image2 = image1 + make_noise_image(shape, type='gaussian', mean=5.,
-                                           stddev=5.)
-        image3 = image1 + make_noise_image(shape, type='poisson', mean=5.)
+        image2 = (image1 + make_noise_image(shape, distribution='gaussian',
+                                            mean=5., stddev=5.))
+        image3 =  (image1 + make_noise_image(shape, distribution='poisson',
+                                             mean=5.))
 
         # plot the images
         import matplotlib.pyplot as plt
@@ -687,7 +692,7 @@ def make_4gaussians_image(noise=True):
     data = make_gaussian_sources_image(shape, table) + 5.
 
     if noise:
-        data += make_noise_image(shape, type='gaussian', mean=0.,
+        data += make_noise_image(shape, distribution='gaussian', mean=0.,
                                  stddev=5., random_state=12345)
 
     return data
@@ -748,7 +753,7 @@ def make_100gaussians_image(noise=True):
     data = make_gaussian_sources_image(shape, sources) + 5.
 
     if noise:
-        data += make_noise_image(shape, type='gaussian', mean=0.,
+        data += make_noise_image(shape, distribution='gaussian', mean=0.,
                                  stddev=2., random_state=12345)
 
     return data

--- a/photutils/isophote/tests/make_test_data.py
+++ b/photutils/isophote/tests/make_test_data.py
@@ -67,7 +67,7 @@ def make_test_image(nx=512, ny=512, x0=None, y0=None,
                                    image[int(xcen), int(ycen - 1)] +
                                    image[int(xcen), int(ycen + 1)]) / 4.
 
-    image += make_noise_image(image.shape, type='gaussian', mean=0.,
+    image += make_noise_image(image.shape, distribution='gaussian', mean=0.,
                               stddev=noise, random_state=random_state)
 
     return image

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -118,7 +118,7 @@ class TestEllipse:
         nx = 150
         g = Gaussian2D(100., nx / 2., ny / 2., 20, 12, theta=40.*np.pi/180.)
         y, x = np.mgrid[0:ny, 0:nx]
-        noise = make_noise_image((ny, nx), type='gaussian', mean=0.,
+        noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
                                  stddev=2., random_state=12345)
         data = g(x, y) + noise
         ellipse = Ellipse(data)  # estimates initial center

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -121,9 +121,9 @@ def test_psf_photometry_niters(sigma_psf, sources):
     # generate image with read-out noise (Gaussian) and
     # background noise (Poisson)
     image = (make_gaussian_prf_sources_image(img_shape, sources) +
-             make_noise_image(img_shape, type='poisson', mean=6.,
+             make_noise_image(img_shape, distribution='poisson', mean=6.,
                               random_state=1) +
-             make_noise_image(img_shape, type='gaussian', mean=0.,
+             make_noise_image(img_shape, distribution='gaussian', mean=0.,
                               stddev=2., random_state=1))
     cp_image = image.copy()
     sigma_clip = SigmaClip(sigma=3.)
@@ -177,9 +177,9 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
     # generate image with read-out noise (Gaussian) and
     # background noise (Poisson)
     image = (make_gaussian_prf_sources_image(img_shape, sources) +
-             make_noise_image(img_shape, type='poisson', mean=6.,
+             make_noise_image(img_shape, distribution='poisson', mean=6.,
                               random_state=1) +
-             make_noise_image(img_shape, type='gaussian', mean=0.,
+             make_noise_image(img_shape, distribution='gaussian', mean=0.,
                               stddev=2., random_state=1))
     cp_image = image.copy()
 
@@ -313,7 +313,7 @@ def test_finder_positions_warning():
     positions['y_0'] = [15.7, 16.5, 25.1]
 
     image = (make_gaussian_prf_sources_image((32, 32), sources1) +
-             make_noise_image((32, 32), type='poisson', mean=6.,
+             make_noise_image((32, 32), distribution='poisson', mean=6.,
                               random_state=1))
 
     with catch_warnings(AstropyUserWarning):
@@ -335,9 +335,9 @@ def test_aperture_radius():
     # generate image with read-out noise (Gaussian) and
     # background noise (Poisson)
     image = (make_gaussian_prf_sources_image(img_shape, sources1) +
-             make_noise_image(img_shape, type='poisson', mean=6.,
+             make_noise_image(img_shape, distribution='poisson', mean=6.,
                               random_state=1) +
-             make_noise_image(img_shape, type='gaussian', mean=0.,
+             make_noise_image(img_shape, distribution='gaussian', mean=0.,
                               stddev=2., random_state=1))
 
     basic_phot_obj = make_psf_photometry_objs()[0]

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -104,7 +104,7 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         from photutils.datasets import make_noise_image
         shape = (100, 200)
         sources = make_gaussian_sources_image(shape, table)
-        noise = make_noise_image(shape, type='gaussian', mean=0.,
+        noise = make_noise_image(shape, distribution='gaussian', mean=0.,
                                  stddev=5., random_state=12345)
         image = sources + noise
 


### PR DESCRIPTION
This PR renames (and deprecates) the `type` keyword in `make_noise_image` to `distribution`.  `type` is a protected word in Python.