### PR TITLE
Update main doc pages

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -3,7 +3,9 @@ Citing Photutils
 
 If you use Photutils for a project that leads to a publication,
 whether directly or as a dependency of another package, please include
-the following acknowledgment::
+the following acknowledgment:
+
+.. code-block:: text
 
     This research made use of Photutils, an Astropy package for
     detection and photometry of astronomical sources (Bradley et al.
@@ -15,7 +17,9 @@ that was used.  We also encourage citations in the main text wherever
 appropriate.
 
 For example, for Photutils v0.6 one would cite Bradley et al. 2019
-with the BibTeX entry (https://zenodo.org/record/2533376/export/hx)::
+with the BibTeX entry (https://zenodo.org/record/2533376/export/hx):
+
+.. code-block:: text
 
   @misc{Bradley_2019_2533376,
      author = {Larry Bradley and Brigitta Sip{\H o}cz and Thomas Robitaille and

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,3 @@
+.. _photutils_citation:
+
+.. include:: ../CITATION.rst

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,39 @@
+Reporting Issues and Contributing
+=================================
+
+Reporting Issues
+----------------
+
+If you have found a bug in Photutils please report it by creating a
+new issue on the `Photutils GitHub issue tracker
+<https://github.com/astropy/photutils/issues>`_.  That requires
+creating a `free Github account <https://github.com/>`_ if you do not
+have one.
+
+Please include an example that demonstrates the issue and will allow
+the developers to reproduce and fix the problem.  You may be asked to
+also provide information about your operating system and a full Python
+stack trace.  The developers will walk you through obtaining a stack
+trace if it is necessary.
+
+
+Contributing
+------------
+
+Like the `Astropy`_ project, Photutils is made both by and for its
+users.  We accept contributions at all levels, spanning the gamut from
+fixing a typo in the documentation to developing a major new feature.
+We welcome contributors who will abide by the `Python Software
+Foundation Code of Conduct
+<https://www.python.org/psf/codeofconduct/>`_.
+
+Photutils follows the same workflow and coding guidelines as
+`Astropy`_.  The following pages will help you get started with
+contributing fixes, code, or documentation (no git or GitHub
+experience necessary):
+
+* `How to make a code contribution <https://astropy.readthedocs.io/en/stable/development/workflow/development_workflow.html>`_
+
+* `Coding Guidelines <https://docs.astropy.org/en/latest/development/codeguide.html>`_
+
+* `Developer Documentation <https://docs.astropy.org/en/latest/#developer-documentation>`_

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -2,16 +2,20 @@ Getting Started with Photutils
 ==============================
 
 The following example uses Photutils to find sources in an
-astronomical image and perform circular aperture photometry on them.
+astronomical image and then perform circular aperture photometry on
+them.
 
 We start by loading an image from the bundled datasets and selecting a
-subset of the image.  We then subtract a rough estimate of the
-background, calculated using the image median::
+subset of the image::
 
     >>> import numpy as np
     >>> from photutils import datasets
     >>> hdu = datasets.load_star_image()    # doctest: +REMOTE_DATA
     >>> image = hdu.data[500:700, 500:700].astype(float)    # doctest: +REMOTE_DATA
+
+We then subtract a rough estimate of the background, calculated using
+the image median::
+
     >>> image -= np.median(image)    # doctest: +REMOTE_DATA
 
 In the remainder of this example, we assume that the data is
@@ -50,11 +54,12 @@ detected sources are returned as an Astropy `~astropy.table.Table`:
     152 111.52575  195.73192 0.45827852 ...   0 8109 7.9278607    -2.24789
     Length = 152 rows
 
-Using the list of source locations (``xcentroid`` and ``ycentroid``),
-we now compute the sum of the pixel values in circular apertures with
-a radius of 4 pixels.  The :func:`~photutils.aperture_photometry`
-function returns an Astropy `~astropy.table.Table` with the results of
-the photometry:
+Using the source locations (i.e. the ``xcentroid`` and ``ycentroid``
+columns), we now define circular apertures centered at these positions
+with a radius of 4 pixels and compute the sum of the pixel values
+within the apertures.  The :func:`~photutils.aperture_photometry`
+function returns an Astropy `~astropy.table.QTable` with the results
+of the photometry:
 
 .. doctest-requires:: scipy
 
@@ -82,8 +87,9 @@ the photometry:
     Length = 152 rows
 
 The sum of the pixel values within the apertures are given in the
-column ``aperture_sum``.  We now plot the image and the defined
-apertures:
+``aperture_sum`` column.
+
+Finally, we plot the image and the defined apertures:
 
 .. doctest-skip::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,10 +21,15 @@ Photutils
 
 
 **Photutils** is an  `affiliated package
-<http://www.astropy.org/affiliated/index.html>`_ of `Astropy`_ to
-provide tools for detecting and performing photometry of astronomical
-sources.  It is an open source (BSD licensed) Python package.  Bug
-reports, comments, and help with development are very welcome.
+<https://www.astropy.org/affiliated/index.html>`_ of `Astropy`_ that
+primarily provides tools for detecting and performing photometry of
+astronomical sources.  It is an open source Python package and is
+licensed under a :ref:`3-clause BSD license <photutils_license>`.
+
+.. Important::
+    If you use Photutils for a project that leads to a publication,
+    whether directly or as a dependency of another package, please
+    include an :doc:`acknowledgment and/or citation <citation>`.
 
 
 Photutils at a glance
@@ -36,6 +41,8 @@ Photutils at a glance
     install.rst
     overview.rst
     getting_started.rst
+    citation.rst
+    license.rst
     changelog
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Photutils at a glance
     install.rst
     overview.rst
     getting_started.rst
+    contributing.rst
     citation.rst
     license.rst
     changelog
@@ -79,63 +80,3 @@ User Documentation
     but at times the API may change if there is a benefit to doing so.
     If there are specific areas you think API stability is important,
     please let us know as part of the development process!
-
-
-Reporting Issues
-================
-
-If you have found a bug in Photutils please report it by creating a
-new issue on the `Photutils GitHub issue tracker
-<https://github.com/astropy/photutils/issues>`_.
-
-Please include an example that demonstrates the issue that will allow
-the developers to reproduce and fix the problem. You may be asked to
-also provide information about your operating system and a full Python
-stack trace.  The developers will walk you through obtaining a stack
-trace if it is necessary.
-
-Photutils uses a package of utilities called `astropy-helpers
-<https://github.com/astropy/astropy-helpers>`_ during building and
-installation.  If you have any build or installation issue mentioning
-the ``astropy_helpers`` or ``ah_bootstrap`` modules please send a
-report to the `astropy-helpers issue tracker
-<https://github.com/astropy/astropy-helpers/issues>`_.  If you are
-unsure, then it's fine to report to the main Photutils issue tracker.
-
-
-Contributing
-============
-
-Like the `Astropy`_ project, Photutils is made both by and for its
-users.  We accept contributions at all levels, spanning the gamut from
-fixing a typo in the documentation to developing a major new feature.
-We welcome contributors who will abide by the `Python Software
-Foundation Code of Conduct
-<https://www.python.org/psf/codeofconduct/>`_.
-
-Photutils follows the same workflow and coding guidelines as
-`Astropy`_.  The following pages will help you get started with
-contributing fixes, code, or documentation (no git or GitHub
-experience necessary):
-
-* `How to make a code contribution <http://astropy.readthedocs.io/en/stable/development/workflow/development_workflow.html>`_
-
-* `Coding Guidelines <http://docs.astropy.org/en/latest/development/codeguide.html>`_
-
-* `Try the development version <http://astropy.readthedocs.io/en/stable/development/workflow/get_devel_version.html>`_
-
-* `Developer Documentation <http://docs.astropy.org/en/latest/#developer-documentation>`_
-
-Citing Photutils
-================
-
-If you use Photutils, please consider citing the package via its Zenodo record.
-If you just want the latest release, cite this (follow the link on the badge
-and then use one of the citation methods on the right):
-
-.. image:: https://zenodo.org/badge/2640766.svg
-    :target: https://zenodo.org/badge/latestdoi/2640766
-
-If you want to cite an earlier version, you can
-`search for photutils on Zenodo <https://zenodo.org/search?q=photutils>`_.  Then
-cite the Zenodo DOI for whatever version(s) of Photutils you are using.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,14 +32,15 @@ licensed under a :ref:`3-clause BSD license <photutils_license>`.
     include an :doc:`acknowledgment and/or citation <citation>`.
 
 
-Photutils at a glance
-=====================
+Getting Started
+===============
 
 .. toctree::
     :maxdepth: 1
 
     install.rst
     overview.rst
+    pixel_conventions.rst
     getting_started.rst
     contributing.rst
     citation.rst

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,112 +7,95 @@ Requirements
 
 Photutils has the following strict requirements:
 
-* `Python <http://www.python.org/>`_ |minimum_python_version| or later
+* `Python <https://www.python.org/>`_ |minimum_python_version| or later
 
-* `Numpy <http://www.numpy.org/>`_ |minimum_numpy_version| or later
+* `Numpy <https://www.numpy.org/>`_ |minimum_numpy_version| or later
 
 * `Astropy`_ 2.0 or later
 
-Photutils also depends on `pytest-astropy
+Photutils also optionally depends on other packages for some features:
+
+* `Scipy <https://www.scipy.org/>`_ 0.19 or later:  To power a variety of features in several
+  modules (strongly recommended).
+
+* `matplotlib <https://matplotlib.org/>`_ 2.2 or later:  To power a
+  variety of plotting features (e.g. plotting apertures).
+
+* `scikit-image <https://scikit-image.org/>`_ 0.13 or later:  Used in
+  `~photutils.segmentation.deblend_sources` for deblending segmented
+  sources.
+
+* `scikit-learn <https://scikit-learn.org/>`_ 0.19 or later:  Used in
+  `~photutils.psf.DBSCANGroup` to create star groups.
+
+Photutils depends on `pytest-astropy
 <https://github.com/astropy/pytest-astropy>`_ (0.4 or later) to run
 the test suite.
-
-Additionally, some functionality is available only if the following
-optional dependencies are installed:
-
-* `Scipy`_ 0.19 or later
-
-* `scikit-image`_ 0.13 or later
-
-* `scikit-learn <http://scikit-learn.org/>`_ 0.19 or later
-
-* `matplotlib <http://matplotlib.org/>`_ 2.2 or later
-
-.. warning::
-
-    While Photutils will import even if these optional dependencies
-    are not installed, the functionality will be severely limited.  It
-    is very strongly recommended that you install `Scipy`_ and
-    `scikit-image`_ to use Photutils.  Both are easily installed via
-    `conda`_ or `pip`_.
 
 
 Installing the latest released version
 ======================================
 
 The latest released (stable) version of Photutils can be installed
-either with `conda`_ or `pip`_.
-
-
-Using conda
------------
-
-Photutils can be installed with `conda`_ using the `astropy Anaconda
-channel <https://anaconda.org/astropy>`_::
-
-    conda install -c astropy photutils
-
+either with `pip`_ or `conda`_.
 
 Using pip
 ---------
 
-Before you can install Photutils using `pip`_, you will need to
-install a C compiler (e.g. ``gcc`` or ``clang``).  After you have
-installed a C compiler, simply run::
+To install ``photutils`` with `pip`_, run::
 
-    pip install --no-deps photutils
+    pip install photutils
 
-.. note::
+If you want to make sure that none of your existing dependencies get
+upgraded, instead you can do::
 
-    The ``--no-deps`` flag is optional, but highly recommended if you
-    already have Numpy and Astropy installed, since otherwise pip will
-    sometimes try to "help" you by upgrading your Numpy and Astropy
-    installations, which may not always be desired.
+    pip install astropy --no-deps
 
-.. note::
+Note that you will generally need a C compiler (e.g. ``gcc`` or
+``clang``) to be installed for the installation to succeed.
 
-    If you get a ``PermissionError`` this means that you do not have
-    the required administrative access to install new packages to your
-    Python installation.  In this case you may consider using the
-    ``--user`` option to install the package into your home directory.
-    You can read more about how to do this in the `pip documentation
-    <http://www.pip-installer.org/en/1.2.1/other-tools.html#using-pip-with-the-user-scheme>`_.
+If you get a ``PermissionError`` this means that you do not have the
+required administrative access to install new packages to your Python
+installation.  In this case you may consider using the ``--user``
+option to install the package into your home directory.  You can read
+more about how to do this in the `pip documentation
+<https://pip.pypa.io/en/stable/user_guide/#user-installs>`_.
 
-    Do **not** install Photutils or other third-party packages using
-    ``sudo`` unless you are fully aware of the risks.
+Do **not** install Photutils or other third-party packages using
+``sudo`` unless you are fully aware of the risks.
+
+Using conda
+-----------
+
+Photutils can be installed with `conda`_ if you have installed
+`Anaconda <https://www.anaconda.com/distribution/>`_ or `Miniconda
+<https://docs.conda.io/en/latest/miniconda.html>`_.  To install
+Photutils using the `astropy Anaconda channel
+<https://anaconda.org/astropy>`_, run::
+
+    conda install photutils -c astropy
 
 
-Installing the latest development version
-=========================================
-
+Installing the latest development version from Source
+=====================================================
 
 Prerequisites
 -------------
 
-You will need `Cython`_ (0.15 or later), a compiler suite, and the
-development headers for Python and Numpy in order to build Photutils
-from the source distribution.  On Linux, using the package manager for
-your distribution will usually be the easiest route, while on MacOS X
-you will need the XCode command line tools.
+You will need `Cython <https://cython.org/>`_ (0.28 or later), a
+compiler suite, and the development headers for Python and Numpy in
+order to build Photutils from the source distribution.  On Linux,
+using the package manager for your distribution will usually be the
+easiest route.
 
-The `instructions for building Numpy from source
-<http://docs.scipy.org/doc/numpy/user/install.html>`_ are also a good
-resource for setting up your environment to build Python packages.
+On MacOS X you will need the `XCode`_ command-line tools, which can be
+installed using::
 
-.. note::
+    xcode-select --install
 
-    If you are using MacOS X, you will need to the XCode command line
-    tools.  One way to get them is to install `XCode
-    <https://developer.apple.com/xcode/>`_. If you are using OS X 10.7
-    (Lion) or later, you must also explicitly install the command line
-    tools. You can do this by opening the XCode application, going to
-    **Preferences**, then **Downloads**, and then under
-    **Components**, click on the Install button to the right of
-    **Command Line Tools**.  Alternatively, on 10.7 (Lion) or later,
-    you do not need to install XCode, you can download just the
-    command line tools from
-    https://developer.apple.com/downloads/index.action (requires an
-    Apple developer account).
+Follow the onscreen instructions to install the command-line tools
+required.  Note that you do not need to install the full `XCode`_
+distribution (assuming you are using MacOS X 10.9 or later).
 
 
 Building and installing manually
@@ -123,8 +106,7 @@ version of the Photutils source code can be retrieved using git::
 
     git clone https://github.com/astropy/photutils.git
 
-Then, to build and install Photutils (from the root of the source
-tree)::
+Then to build and install Photutils, run::
 
     cd photutils
     python setup.py install
@@ -136,26 +118,12 @@ Building and installing using pip
 Alternatively, `pip`_ can be used to retrieve, build, and install the
 latest development version from `github`_::
 
-    pip install --no-deps git+https://github.com/astropy/photutils.git
+    pip install git+https://github.com/astropy/photutils.git
 
-.. note::
+Again, if you want to make sure that none of your existing
+dependencies get upgraded, instead you can do::
 
-    The ``--no-deps`` flag is optional, but highly recommended if you
-    already have Numpy and Astropy installed, since otherwise pip will
-    sometimes try to "help" you by upgrading your Numpy and Astropy
-    installations, which may not always be desired.
-
-.. note::
-
-    If you get a ``PermissionError`` this means that you do not have
-    the required administrative access to install new packages to your
-    Python installation.  In this case you may consider using the
-    ``--user`` option to install the package into your home directory.
-    You can read more about how to do this in the `pip documentation
-    <http://www.pip-installer.org/en/1.2.1/other-tools.html#using-pip-with-the-user-scheme>`_.
-
-    Do **not** install Photutils or other third-party packages using
-    ``sudo`` unless you are fully aware of the risks.
+    pip install git+https://github.com/astropy/photutils.git --no-deps
 
 
 Testing an installed Photutils
@@ -169,19 +137,15 @@ correctly is to use the :func:`photutils.test()` function:
     >>> import photutils
     >>> photutils.test()
 
+Note that this may not work if you start Python from within the
+Photutils source distribution directory.
+
 The tests should run and report any failures, which you can report to
 the `Photutils issue tracker
-<http://github.com/astropy/photutils/issues>`_.
-
-.. note::
-
-    This way of running the tests may not work if you start Python
-    from within the Photutils source distribution directory.
+<https://github.com/astropy/photutils/issues>`_.
 
 
-.. _Scipy: http://www.scipy.org/
-.. _scikit-image: http://scikit-image.org/
 .. _pip: https://pip.pypa.io/en/latest/
-.. _conda: http://conda.pydata.org/docs/
-.. _Cython: http://cython.org
+.. _conda: https://conda.pydata.org/docs/
 .. _github: https://github.com/astropy/photutils
+.. _Xcode: https://developer.apple.com/xcode/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,13 +20,13 @@ the test suite.
 Additionally, some functionality is available only if the following
 optional dependencies are installed:
 
-* `Scipy`_ 0.16 or later
+* `Scipy`_ 0.19 or later
 
-* `scikit-image`_ 0.11 or later
+* `scikit-image`_ 0.13 or later
 
-* `scikit-learn <http://scikit-learn.org/>`_ 0.18 or later
+* `scikit-learn <http://scikit-learn.org/>`_ 0.19 or later
 
-* `matplotlib <http://matplotlib.org/>`_ 1.3 or later
+* `matplotlib <http://matplotlib.org/>`_ 2.2 or later
 
 .. warning::
 

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,8 @@
+.. _photutils_license:
+
+License
+=======
+
+Photutils is licensed under a 3-clause BSD license:
+
+.. include:: ../LICENSE.rst

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -6,59 +6,30 @@ Introduction
 
 Photutils contains functions for:
 
-* estimating the background and background RMS in astronomical images
-* detecting sources in astronomical images
-* estimating morphological parameters of those sources (e.g., centroid
-  and shape parameters)
-* performing aperture and PSF photometry
+* performing aperture photometry
 
-The code and the documentation are available at the following links:
+* performing PSF-fitting photometry
+
+* detecting and extracting point-like sources (e.g. stars) in
+  astronomical images
+
+* detecting and extracting extended sources using image segmentation
+  in astronomical images
+
+* centroiding sources
+
+* estimating the background and background RMS in astronomical images
+
+* building an effective Point Spread Function (ePSF)
+
+* matching PSF kernels
+
+* estimating morphological parameters of detected sources
+
+The code and issue tracker are available at the following links:
 
 * Code: https://github.com/astropy/photutils
 * Issue Tracker: https://github.com/astropy/photutils/issues
-* Documentation: https://photutils.readthedocs.io/
-
-
-.. _coordinate-conventions:
-
-Coordinate Conventions
-----------------------
-
-In Photutils, pixel coordinates are zero-indexed, meaning that ``(x,
-y) = (0, 0)`` corresponds to the center of the lowest, leftmost array
-element.  This means that the value of ``data[0, 0]`` is taken as the
-value over the range ``-0.5 < x <= 0.5``, ``-0.5 < y <= 0.5``.  Note
-that this differs from the SourceExtractor_, IRAF_, FITS, and ds9_
-conventions, in which the center of the lowest, leftmost array element
-is ``(1, 1)``.
-
-The ``x`` (column) coordinate corresponds to the second (fast) array
-index and the ``y`` (row) coordinate corresponds to the first (slow)
-index.  ``data[y, x]`` gives the value at coordinates (x, y).  Along
-with zero-indexing, this means that an array is defined over the
-coordinate range ``-0.5 < x <= data.shape[1] - 0.5``, ``-0.5 < y <=
-data.shape[0] - 0.5``.
-
-.. _SourceExtractor: http://www.astromatic.net/software/sextractor
-.. _IRAF: http://iraf.noao.edu/
-.. _ds9: http://ds9.si.edu/
-
-
-Bundled Datasets
-----------------
-
-In this documentation, we use example `datasets <datasets.html>`_
-provided by calling functions such as
-:func:`~photutils.datasets.load_star_image`.  This function returns an
-Astropy :class:`~astropy.io.fits.ImageHDU` object, and is equivalent
-to doing:
-
-.. doctest-skip::
-
-    >>> from astropy.io import fits
-    >>> hdu = fits.open('dataset.fits')[0]
-
-where the ``[0]`` accesses the first HDU in the FITS file.
 
 
 Contributors

--- a/docs/pixel_conventions.rst
+++ b/docs/pixel_conventions.rst
@@ -1,0 +1,25 @@
+Pixel Coordinate Conventions
+----------------------------
+
+In Photutils, integer pixel coordinates fall at the center of pixels
+and they are 0-indexed, matching the Python 0-based indexing.  That
+means the first pixel is considered pixel ``0``, but pixel coordinate
+``0`` is the *center* of that pixel.  Hence, the first pixel spans
+pixel values ``-0.5`` to ``0.5``.
+
+For a 2-dimensional array, ``(x, y) = (0, 0)`` corresponds to the
+*center* of the bottom, leftmost array element.  That means the first
+pixel spans the ``x`` and ``y`` pixel values from ``-0.5`` to ``0.5``.
+Note that this differs from the `IRAF`_, `FITS WCS
+<https://fits.gsfc.nasa.gov/fits_wcs.html>`_ , `ds9`_, and
+`SourceExtractor`_ conventions, in which the center of the bottom,
+leftmost array element is ``(x, y) = (1, 1)``.
+
+Following Python indexing, the ``x`` (column) coordinate corresponds
+to the second (fast) array index and the ``y`` (row) coordinate
+corresponds to the first (slow) index.  ``image[y, x]`` gives the
+value at pixel coordinates ``(x, y)``.
+
+.. _SourceExtractor: https://www.astromatic.net/software/sextractor
+.. _IRAF: http://ast.noao.edu/data/software
+.. _ds9: http://ds9.si.edu/


### PR DESCRIPTION
This PR updates the main doc pages.  In particular there are new doc pages for reporting issues and contributing, pixel coordinate conventions, the license, and citing photutils.  The main page is much cleaner now.

This PR also bumps the minimum required version of some of the optional dependencies.