### PR TITLE
Fix bug in EPSFStar residual image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,11 @@ Bug Fixes
     apertures) would be a length-1 array containing a ``SkyCoord``
     object instead of a length-1 ``SkyCoord`` object. [#844]
 
+- ``photutils.psf``
+
+  - Fixed a bug in the ``EPSFStar`` ``register_epsf`` and
+    ``compute_residual_image`` computations. [#885]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where ``deblend_sources`` could fail for sources

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -198,7 +198,8 @@ class EPSFStar:
         yy = epsf._oversampling[1] * (yy - self.cutout_center[1])
 
         return (self.flux * np.prod(epsf._oversampling) *
-                epsf.evaluate(xx, yy, flux=1.0, x_0=0.0, y_0=0.0))
+                epsf.evaluate(xx, yy, flux=1.0, x_0=0.0, y_0=0.0,
+                              use_oversampling=False))
 
     def compute_residual_image(self, epsf):
         """

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -61,6 +61,7 @@ class TestExtractStars:
             extract_stars([self.nddata, self.nddata], self.stars_tbl)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_epsf_star_residual_image():
     """
     Test to ensure ``compute_residual_image`` gives correct residuals.


### PR DESCRIPTION
This PR fixes a bug in the `EPSFStar` `register_epsf` and `compute_residual_image` computations.

Many thanks to @SunilSimha and @mattabern for reporting this issue.

Fixes #805.