### PR TITLE
 Simplify aperture property validation

### DIFF
--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -134,11 +134,11 @@ class BoundingBox:
             (self.iymax == other.iymax)
         )
 
-    def __or__(self, bbox):
-        return self.union(bbox)
+    def __or__(self, other):
+        return self.union(other)
 
-    def __and__(self, bbox):
-        return self.intersection(bbox)
+    def __and__(self, other):
+        return self.intersection(other)
 
     def __repr__(self):
         data = self.__dict__
@@ -283,57 +283,59 @@ class BoundingBox:
         aper = self.to_aperture()
         aper.plot(axes=axes, origin=origin, **kwargs)
 
-    def union(self, bbox):
+    def union(self, other):
         """
         Return a `BoundingBox` representing the union of this
         `BoundingBox` with another `BoundingBox`.
 
         Parameters
         ----------
-        bbox : `~photutils.BoundingBox`
+        other : `~photutils.BoundingBox`
             The `BoundingBox` to join with this one.
 
         Returns
         -------
         result : `~photutils.BoundingBox`
-            A `BoundingBox` representing the union of the input ``bbox``
-            with this one.
+            A `BoundingBox` representing the union of the input
+            `BoundingBox` with this one.
         """
 
-        if not isinstance(bbox, BoundingBox):
-            raise TypeError('bbox must be a BoundingBox instance')
+        if not isinstance(other, BoundingBox):
+            raise TypeError('BoundingBox can be joined only with another '
+                            'BoundingBox.')
 
-        ixmin = min((self.ixmin, bbox.ixmin))
-        ixmax = max((self.ixmax, bbox.ixmax))
-        iymin = min((self.iymin, bbox.iymin))
-        iymax = max((self.iymax, bbox.iymax))
+        ixmin = min((self.ixmin, other.ixmin))
+        ixmax = max((self.ixmax, other.ixmax))
+        iymin = min((self.iymin, other.iymin))
+        iymax = max((self.iymax, other.iymax))
 
         return BoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin, iymax=iymax)
 
-    def intersection(self, bbox):
+    def intersection(self, other):
         """
         Return a `BoundingBox` representing the intersection of this
         `BoundingBox` with another `BoundingBox`.
 
         Parameters
         ----------
-        bbox : `~photutils.BoundingBox`
+        other : `~photutils.BoundingBox`
             The `BoundingBox` to intersect with this one.
 
         Returns
         -------
         result : `~photutils.BoundingBox`
             A `BoundingBox` representing the intersection of the input
-            ``bbox`` with this one.
+            `BoundingBox` with this one.
         """
 
-        if not isinstance(bbox, BoundingBox):
-            raise TypeError('bbox must be a BoundingBox instance')
+        if not isinstance(other, BoundingBox):
+            raise TypeError('BoundingBox can be intersected only with '
+                            'another BoundingBox.')
 
-        ixmin = max(self.ixmin, bbox.ixmin)
-        ixmax = min(self.ixmax, bbox.ixmax)
-        iymin = max(self.iymin, bbox.iymin)
-        iymax = min(self.iymax, bbox.iymax)
+        ixmin = max(self.ixmin, other.ixmin)
+        ixmax = min(self.ixmax, other.ixmax)
+        iymin = max(self.iymin, other.iymin)
+        iymax = min(self.iymax, other.iymax)
         if ixmax < ixmin or iymax < iymin:
             return None
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -140,13 +140,13 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
     >>> aper = CircularAperture((pos1, pos2, pos3), 3.)
     """
 
+    _shape_params = ('r',)
     positions = PixelPositions('positions')
     r = PositiveScalar('r')
 
     def __init__(self, positions, r):
         self.positions = positions
         self.r = r
-        self._params = ['r']
 
     @property
     def bounding_boxes(self):
@@ -278,6 +278,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
     >>> aper = CircularAnnulus((pos1, pos2, pos3), 3., 5.)
     """
 
+    _shape_params = ('r_in', 'r_out')
     positions = PixelPositions('positions')
     r_in = PositiveScalar('r_in')
     r_out = PositiveScalar('r_out')
@@ -289,7 +290,6 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         self.positions = positions
         self.r_in = r_in
         self.r_out = r_out
-        self._params = ['r_in', 'r_out']
 
     @property
     def bounding_boxes(self):
@@ -403,13 +403,13 @@ class SkyCircularAperture(SkyAperture):
     >>> aper = SkyCircularAperture(positions, 0.5*u.arcsec)
     """
 
+    _shape_params = ('r',)
     positions = SkyCoordPositions('positions')
     r = AngleOrPixelScalarQuantity('r')
 
     def __init__(self, positions, r):
         self.positions = positions
         self.r = r
-        self._params = ['r']
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -466,6 +466,7 @@ class SkyCircularAnnulus(SkyAperture):
     >>> aper = SkyCircularAnnulus(positions, 0.5*u.arcsec, 1.0*u.arcsec)
     """
 
+    _shape_params = ('r_in', 'r_out')
     positions = SkyCoordPositions('positions')
     r_in = AngleOrPixelScalarQuantity('r_in')
     r_out = AngleOrPixelScalarQuantity('r_out')
@@ -478,7 +479,6 @@ class SkyCircularAnnulus(SkyAperture):
         self.positions = positions
         self.r_in = r_in
         self.r_out = r_out
-        self._params = ['r_in', 'r_out']
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -170,6 +170,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     >>> aper = EllipticalAperture((pos1, pos2, pos3), 5., 3., theta=np.pi)
     """
 
+    _shape_params = ('a', 'b', 'theta')
     positions = PixelPositions('positions')
     a = PositiveScalar('a')
     b = PositiveScalar('b')
@@ -180,7 +181,6 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         self.a = a
         self.b = b
         self.theta = theta
-        self._params = ['a', 'b', 'theta']
 
     @property
     def bounding_boxes(self):
@@ -333,6 +333,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     >>> aper = EllipticalAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=np.pi)
     """
 
+    _shape_params = ('a_in', 'a_out', 'b_out', 'theta')
     positions = PixelPositions('positions')
     a_in = PositiveScalar('a_in')
     a_out = PositiveScalar('a_out')
@@ -349,7 +350,6 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         self.b_out = b_out
         self.b_in = self.b_out * self.a_in / self.a_out
         self.theta = theta
-        self._params = ['a_in', 'a_out', 'b_out', 'theta']
 
     @property
     def bounding_boxes(self):
@@ -483,6 +483,7 @@ class SkyEllipticalAperture(SkyAperture):
     >>> aper = SkyEllipticalAperture(positions, 1.0*u.arcsec, 0.5*u.arcsec)
     """
 
+    _shape_params = ('a', 'b', 'theta')
     positions = SkyCoordPositions('positions')
     a = AngleOrPixelScalarQuantity('a')
     b = AngleOrPixelScalarQuantity('b')
@@ -497,7 +498,6 @@ class SkyEllipticalAperture(SkyAperture):
         self.a = a
         self.b = b
         self.theta = theta
-        self._params = ['a', 'b', 'theta']
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -566,6 +566,7 @@ class SkyEllipticalAnnulus(SkyAperture):
     ...                             1.0*u.arcsec)
     """
 
+    _shape_params = ('a_in', 'a_out', 'b_out', 'theta')
     positions = SkyCoordPositions('positions')
     a_in = AngleOrPixelScalarQuantity('a_in')
     a_out = AngleOrPixelScalarQuantity('a_out')
@@ -587,7 +588,6 @@ class SkyEllipticalAnnulus(SkyAperture):
         self.b_out = b_out
         self.b_in = self.b_out * self.a_in / self.a_out
         self.theta = theta
-        self._params = ['a_in', 'a_out', 'b_out', 'theta']
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -237,14 +237,14 @@ class ApertureMask:
             input ``data``.
         """
 
-        # make a copy to prevent changing the input data
-        cutout = self.cutout(data, fill_value=fill_value, copy=True)
-
+        cutout = self.cutout(data, fill_value=fill_value)
         if cutout is None:
             return None
         else:
-            # needed to zero out non-finite data values outside of the
-            # aperture mask but within the bounding box
-            cutout[self._mask] = 0.
+            weighted_cutout = cutout * self.data
 
-            return cutout * self.data
+            # needed to zero out non-finite data values outside of the
+            # mask but within the bounding box
+            weighted_cutout[self._mask] = 0.
+
+            return weighted_cutout

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -195,6 +195,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     >>> aper = RectangularAperture((pos1, pos2, pos3), 5., 3., theta=np.pi)
     """
 
+    _shape_params = ('w', 'h', 'theta')
     positions = PixelPositions('positions')
     w = PositiveScalar('w')
     h = PositiveScalar('h')
@@ -205,7 +206,6 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         self.w = w
         self.h = h
         self.theta = theta
-        self._params = ['w', 'h', 'theta']
 
     @property
     def bounding_boxes(self):
@@ -364,6 +364,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     >>> aper = RectangularAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=np.pi)
     """
 
+    _shape_params = ('w_in', 'w_out', 'h_out', 'theta')
     positions = PixelPositions('positions')
     w_in = PositiveScalar('w_in')
     w_out = PositiveScalar('w_out')
@@ -380,7 +381,6 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         self.h_out = h_out
         self.h_in = self.w_in * self.h_out / self.w_out
         self.theta = theta
-        self._params = ['w_in', 'w_out', 'h_out', 'theta']
 
     @property
     def bounding_boxes(self):
@@ -524,6 +524,7 @@ class SkyRectangularAperture(SkyAperture):
     >>> aper = SkyRectangularAperture(positions, 1.0*u.arcsec, 0.5*u.arcsec)
     """
 
+    _shape_params = ('w', 'h', 'theta')
     positions = SkyCoordPositions('positions')
     w = AngleOrPixelScalarQuantity('w')
     h = AngleOrPixelScalarQuantity('h')
@@ -538,7 +539,6 @@ class SkyRectangularAperture(SkyAperture):
         self.w = w
         self.h = h
         self.theta = theta
-        self._params = ['w', 'h', 'theta']
 
     def to_pixel(self, wcs, mode='all'):
         """
@@ -613,6 +613,7 @@ class SkyRectangularAnnulus(SkyAperture):
     ...                              5.0*u.arcsec)
     """
 
+    _shape_params = ('w_in', 'w_out', 'h_out', 'theta')
     positions = SkyCoordPositions('positions')
     w_in = AngleOrPixelScalarQuantity('w_in')
     w_out = AngleOrPixelScalarQuantity('w_out')
@@ -634,7 +635,6 @@ class SkyRectangularAnnulus(SkyAperture):
         self.h_out = h_out
         self.h_in = self.w_in * self.h_out / self.w_out
         self.theta = theta
-        self._params = ['w_in', 'w_out', 'h_out', 'theta']
 
     def to_pixel(self, wcs, mode='all'):
         """

--- a/photutils/aperture/tests/test_aperture_common.py
+++ b/photutils/aperture/tests/test_aperture_common.py
@@ -26,8 +26,9 @@ class BaseTestAperture(BaseTestApertureParams):
                                      expected_positions.dec)
         else:
             assert_array_equal(aper.positions, expected_positions)
-            for param in aper._params:
-                assert getattr(aper, param) == getattr(self.aperture, param)
+            for shape_param in aper._shape_params:
+                assert (getattr(aper, shape_param) ==
+                        getattr(self.aperture, shape_param))
 
     def test_slice(self):
         aper = self.aperture[self.slc]
@@ -41,5 +42,6 @@ class BaseTestAperture(BaseTestApertureParams):
                                      expected_positions.dec)
         else:
             assert_array_equal(aper.positions, expected_positions)
-            for param in aper._params:
-                assert getattr(aper, param) == getattr(self.aperture, param)
+            for shape_param in aper._shape_params:
+                assert (getattr(aper, shape_param) ==
+                        getattr(self.aperture, shape_param))


### PR DESCRIPTION
This PR mainly simplifies aperture property validation by changing the descriptor classes to use the `instance.__dict__`.  It also moves the aperture `_shape_params` to a class-level tuple instead of an instance-level tuple.  It also includes a few minor implementation changes.