### PR TITLE
Halved computational time of photutils.background.background_2d.data_coords

### DIFF
--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -720,8 +720,11 @@ class Background2D:
 
         # the position coordinates used when calling an interpolator
         nx, ny = self.data.shape
+        # Create an array consisting of all combinations of pixels up to max(nx, ny)
+        # then filter based on if nx and ny are not equal to each other.
         self.data_coords = np.array(list(itertools.combinations(range(max(nx, ny)), 2)))
-        self.data_coords[np.logical_and(self.data_coords[:, 0] < ny, self.data_coords[:, 1] < nx)]
+        if nx != ny:
+            self.data_coords[np.logical_and(self.data_coords[:, 0] < ny, self.data_coords[:, 1] < nx)]
         
     @lazyproperty
     def mesh_nmasked(self):

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -4,7 +4,7 @@ This module defines classes to estimate the 2D background and background
 RMS in an image.
 """
 
-from itertools import product
+from itertools import product, combinations
 
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
@@ -720,8 +720,9 @@ class Background2D:
 
         # the position coordinates used when calling an interpolator
         nx, ny = self.data.shape
-        self.data_coords = np.array(list(product(range(ny), range(nx))))
-
+        self.data_coords = np.array(list(itertools.combinations(range(max(nx, ny)), 2)))
+        self.data_coords[np.logical_and(self.data_coords[:, 0] < ny, self.data_coords[:, 1] < nx)]
+        
     @lazyproperty
     def mesh_nmasked(self):
         """


### PR DESCRIPTION
Halved computational time of photutils.background.background_2d.data_coords. in background_2d._calc_coordinates() by using itertools.combinations instead of itertools.product and then filtering for values exceeding the smallest pixel axis (if x_max != y_max).

background_2d._calc_coordinates() is costly, and not a useful function. I would suggest deprecating it.