### PR TITLE
Fix deblend_sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,13 @@ Bug Fixes
   - Fixed a bug in ``filter_data`` where units were dropped for data
     ``Quantity`` objects. [#872]
 
+  - Fixed a bug in ``deblend_sources`` where sources could be
+    deblended too much when ``connectivity=8``. [#890]
+
+  - Fixed a bug in ``deblend_sources`` where the ``contrast``
+    parameter had little effect if the original segment contained
+    three or more sources. [#890]
+
 
 API changes
 ^^^^^^^^^^^

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -27,16 +27,15 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     Sources are deblended using a combination of multi-thresholding and
     `watershed segmentation
     <https://en.wikipedia.org/wiki/Watershed_(image_processing)>`_.  In
-    order to deblend sources, they must be separated enough such that
-    there is a saddle between them.
+    order to deblend sources, there must be a saddle between them.
 
     Parameters
     ----------
     data : array_like
-        The 2D array of the image.
+        The data array.
 
     segment_img : `~photutils.segmentation.SegmentationImage` or array_like (int)
-        A 2D segmentation image, either as a
+        A segmentation image, either as a
         `~photutils.segmentation.SegmentationImage` object or an
         `~numpy.ndarray`, with the same shape as ``data`` where sources
         are labeled by different positive integer values.  A value of
@@ -47,8 +46,8 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
         that an object must have to be detected.  ``npixels`` must be a
         positive integer.
 
-    filter_kernel : array-like (2D) or `~astropy.convolution.Kernel2D`, optional
-        The 2D array of the kernel used to filter the image before
+    filter_kernel : array-like or `~astropy.convolution.Kernel2D`, optional
+        The array of the kernel used to filter the image before
         thresholding.  Filtering the image will smooth the noise and
         maximize detectability of objects with a shape similar to the
         kernel.
@@ -59,18 +58,19 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
 
     nlevels : int, optional
         The number of multi-thresholding levels to use.  Each source
-        will be re-thresholded at ``nlevels``, spaced exponentially or
-        linearly (see the ``mode`` keyword), between its minimum and
-        maximum values within the source segment.
+        will be re-thresholded at ``nlevels`` levels spaced
+        exponentially or linearly (see the ``mode`` keyword) between its
+        minimum and maximum values within the source segment.
 
     contrast : float, optional
         The fraction of the total (blended) source flux that a local
-        peak must have to be considered as a separate object.
-        ``contrast`` must be between 0 and 1, inclusive.  If ``contrast
-        = 0`` then every local peak will be made a separate object
-        (maximum deblending).  If ``contrast = 1`` then no deblending
-        will occur.  The default is 0.001, which will deblend sources
-        with a magnitude difference of about 7.5.
+        peak must have (at any one of the multi-thresholds) to be
+        considered as a separate object.  ``contrast`` must be between 0
+        and 1, inclusive.  If ``contrast = 0`` then every local peak
+        will be made a separate object (maximum deblending).  If
+        ``contrast = 1`` then no deblending will occur.  The default is
+        0.001, which will deblend sources with a 7.5 magnitude
+        difference.
 
     mode : {'exponential', 'linear'}, optional
         The mode used in defining the spacing between the
@@ -92,7 +92,7 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     Returns
     -------
     segment_image : `~photutils.segmentation.SegmentationImage`
-        A 2D segmentation image, with the same shape as ``data``, where
+        A segmentation image, with the same shape as ``data``, where
         sources are marked by different positive integer values.  A
         value of zero is reserved for the background.
 
@@ -158,9 +158,9 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     Parameters
     ----------
     data : array_like
-        The 2D array of the image.  The should be a cutout for a single
-        source.  ``data`` should already be smoothed by the same filter
-        used in :func:`~photutils.detect_sources`, if applicable.
+        The cutout data array for a single source.  ``data`` should also
+        already be smoothed by the same filter used in
+        :func:`~photutils.detect_sources`, if applicable.
 
     segment_img : `~photutils.segmentation.SegmentationImage`
         A cutout `~photutils.segmentation.SegmentationImage` object with
@@ -174,34 +174,36 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
 
     nlevels : int, optional
         The number of multi-thresholding levels to use.  Each source
-        will be re-thresholded at ``nlevels``, spaced exponentially or
-        linearly (see the ``mode`` keyword), between its minimum and
-        maximum values within the source segment.
+        will be re-thresholded at ``nlevels`` levels spaced
+        exponentially or linearly (see the ``mode`` keyword) between its
+        minimum and maximum values within the source segment.
 
     contrast : float, optional
         The fraction of the total (blended) source flux that a local
-        peak must have to be considered as a separate object.
-        ``contrast`` must be between 0 and 1, inclusive.  If ``contrast
-        = 0`` then every local peak will be made a separate object
-        (maximum deblending).  If ``contrast = 1`` then no deblending
-        will occur.  The default is 0.001, which will deblend sources with
-        a magnitude differences of about 7.5.
+        peak must have (at any one of the multi-thresholds) to be
+        considered as a separate object.  ``contrast`` must be between 0
+        and 1, inclusive.  If ``contrast = 0`` then every local peak
+        will be made a separate object (maximum deblending).  If
+        ``contrast = 1`` then no deblending will occur.  The default is
+        0.001, which will deblend sources with a 7.5 magnitude
+        difference.
 
     mode : {'exponential', 'linear'}, optional
         The mode used in defining the spacing between the
-        multi-thresholding levels (see the ``nlevels`` keyword).
+        multi-thresholding levels (see the ``nlevels`` keyword).  The
+        default is 'exponential'.
 
-    connectivity : {4, 8}, optional
+    connectivity : {8, 4}, optional
         The type of pixel connectivity used in determining how pixels
-        are grouped into a detected source.  The options are 4 or 8
-        (default).  4-connected pixels touch along their edges.
-        8-connected pixels touch along their edges or corners.  For
-        reference, SExtractor uses 8-connected pixels.
+        are grouped into a detected source.  The options are 8 (default)
+        or 4.  8-connected pixels touch along their edges or corners.
+        4-connected pixels touch along their edges.  For reference,
+        SExtractor uses 8-connected pixels.
 
     Returns
     -------
     segment_image : `~photutils.segmentation.SegmentationImage`
-        A 2D segmentation image, with the same shape as ``data``, where
+        A segmentation image, with the same shape as ``data``, where
         sources are marked by different positive integer values.  A
         value of zero is reserved for the background.
     """
@@ -212,7 +214,7 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     if nlevels < 1:
         raise ValueError('nlevels must be >= 1, got "{0}"'.format(nlevels))
     if contrast < 0 or contrast > 1:
-        raise ValueError('contrast must be >= 0 or <= 1, got '
+        raise ValueError('contrast must be >= 0 and <= 1, got '
                          '"{0}"'.format(contrast))
 
     ndim = data.ndim
@@ -229,16 +231,17 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
 
     segm_mask = (segment_img.data > 0)
     source_values = data[segm_mask]
+    source_sum = float(np.nansum(source_values))
     source_min = np.nanmin(source_values)
     source_max = np.nanmax(source_values)
     if source_min == source_max:
         return segment_img  # no deblending
+
     if mode == 'exponential' and source_min < 0:
         warnings.warn('Source "{0}" contains negative values, setting '
                       'deblending mode to "linear"'.format(
                           segment_img.labels[0]), AstropyUserWarning)
         mode = 'linear'
-    source_sum = float(np.nansum(source_values))
 
     steps = np.arange(1., nlevels + 1)
     if mode == 'exponential':
@@ -251,53 +254,57 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
                                    (nlevels + 1)) * steps
     else:
         raise ValueError('"{0}" is an invalid mode; mode must be '
-                         '"exponential" or "linear"')
+                         '"exponential" or "linear"'.format(mode))
 
     # suppress NoDetectionsWarning during deblending
     warnings.filterwarnings('ignore', category=NoDetectionsWarning)
 
-    # create top-down tree of local peaks
-    segm_tree = []
+    level_segms = []
     mask = ~segm_mask
-    for level in thresholds[::-1]:
+    for level in thresholds:
         segm_tmp = detect_sources(data, level, npixels=npixels,
                                   connectivity=connectivity, mask=mask)
 
-        if segm_tmp is None or segm_tmp.nlabels < 2:
+        # NOTE: higher threshold levels may not meet 'npixels' criterion
+        # resulting in no detections
+        if segm_tmp is None or segm_tmp.nlabels == 1:
             continue
 
-        fluxes = []
-        for i in segm_tmp.labels:
-            fluxes.append(np.nansum(data[segm_tmp == i]))
-        idx = np.where((np.array(fluxes) / source_sum) >= contrast)[0]
-        if idx.size >= 2:
-            segm_tree.append(segm_tmp)
+        fluxes = np.array([np.nansum(data[segm_tmp == i])
+                           for i in segm_tmp.labels])
+        idx = np.where((fluxes / source_sum) >= contrast)[0]
 
-    nbranch = len(segm_tree)
-    if nbranch == 0:
+        # at least 2 segment meet the contrast requirement
+        if idx.size >= 2:
+            level_segms.append(segm_tmp)
+
+    nlevels = len(level_segms)
+    if nlevels == 0:  # no deblending
         return segment_img
     else:
-        for j in range(nbranch - 1, 0, -1):
-            intersect_mask = (segm_tree[j].data *
-                              segm_tree[j - 1].data).astype(bool)
-            intersect_labels = np.unique(segm_tree[j].data[intersect_mask])
+        for i in range(nlevels - 1):
+            segm_lower = level_segms[i].data
+            segm_upper = level_segms[i + 1].data
+            relabel = False
+            # if the are more sources at the upper level, then
+            # remove the parent source(s) from the lower level,
+            # but keep any sources in the lower level that do not have
+            # multiple children in the upper level
+            for label in level_segms[i].labels:
+                mask = (segm_lower == label)
+                # checks for 1-to-1 label mapping n -> m (where m >= 0)
+                upper_labels = segm_upper[mask]
+                upper_labels = np.unique(upper_labels[upper_labels != 0])
+                if upper_labels.size >= 2:
+                    relabel = True
+                    segm_lower[mask] = segm_upper[mask]
 
-            if segm_tree[j - 1].nlabels <= len(intersect_labels):
-                segm_tree[j - 1] = segm_tree[j]
+            if relabel:
+                level_segms[i + 1] = SegmentationImage(
+                    ndimage.label(segm_lower, structure=selem)[0])
             else:
-                # If a higher tree level has more peaks than in the
-                # intersected label(s) with the level below, then remove
-                # the intersected label(s) in the lower level, add the
-                # higher level, and relabel.
-                if len(set(segm_tree[j].labels)
-                       .difference(set(intersect_labels))) > 0:
-                    segm_tree[j].remove_labels(intersect_labels)
-                    new_segments = segm_tree[j].data + segm_tree[j - 1].data
-                else:
-                    new_segments = segm_tree[j - 1].data
-                new_segm, _ = ndimage.label(new_segments, structure=selem)
-                segm_tree[j - 1] = SegmentationImage(new_segm)
+                level_segms[i + 1] = level_segms[i]
 
-        return SegmentationImage(watershed(-data, segm_tree[0].data,
+        return SegmentationImage(watershed(-data, level_segms[-1].data,
                                            mask=segment_img.data.astype(bool),
                                            connectivity=selem))

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -215,13 +215,17 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
         raise ValueError('contrast must be >= 0 or <= 1, got '
                          '"{0}"'.format(contrast))
 
-    if connectivity == 4:
-        selem = ndimage.generate_binary_structure(2, 1)
-    elif connectivity == 8:
-        selem = ndimage.generate_binary_structure(2, 2)
+    ndim = data.ndim
+    if ndim == 1:
+        selem = ndimage.generate_binary_structure(ndim, 1)
     else:
-        raise ValueError('Invalid connectivity={0}.  '
-                         'Options are 4 or 8'.format(connectivity))
+        if connectivity == 4:
+            selem = ndimage.generate_binary_structure(ndim, 1)
+        elif connectivity == 8:
+            selem = ndimage.generate_binary_structure(ndim, 2)
+        else:
+            raise ValueError('Invalid connectivity={0}.  '
+                             'Options are 4 or 8'.format(connectivity))
 
     segm_mask = (segment_img.data > 0)
     source_values = data[segm_mask]

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -289,8 +289,12 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
                 # intersected label(s) with the level below, then remove
                 # the intersected label(s) in the lower level, add the
                 # higher level, and relabel.
-                segm_tree[j].remove_labels(intersect_labels)
-                new_segments = segm_tree[j].data + segm_tree[j - 1].data
+                if len(set(segm_tree[j].labels)
+                       .difference(set(intersect_labels))) > 0:
+                    segm_tree[j].remove_labels(intersect_labels)
+                    new_segments = segm_tree[j].data + segm_tree[j - 1].data
+                else:
+                    new_segments = segm_tree[j - 1].data
                 new_segm, _ = ndimage.label(new_segments)
                 segm_tree[j - 1] = SegmentationImage(new_segm)
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -276,6 +276,8 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
 
         # at least 2 segment meet the contrast requirement
         if idx.size >= 2:
+            # keep only the labels that meet the contrast criterion
+            segm_tmp.keep_labels(segm_tmp.labels[idx])
             level_segms.append(segm_tmp)
 
     nlevels = len(level_segms)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -295,7 +295,7 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
                     new_segments = segm_tree[j].data + segm_tree[j - 1].data
                 else:
                     new_segments = segm_tree[j - 1].data
-                new_segm, _ = ndimage.label(new_segments)
+                new_segm, _ = ndimage.label(new_segments, structure=selem)
                 segm_tree[j - 1] = SegmentationImage(new_segm)
 
         return SegmentationImage(watershed(-data, segm_tree[0].data,

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -131,8 +131,12 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         raise ValueError('npixels must be a positive integer, got '
                          '"{0}"'.format(npixels))
 
-    image = (filter_data(data, filter_kernel, mode='constant', fill_value=0.0,
-                         check_normalization=True) > threshold)
+    image = filter_data(data, filter_kernel, mode='constant', fill_value=0.0,
+                        check_normalization=True)
+    # ignore RuntimeWarning caused by > when image contains NaNs
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        image = image > threshold
 
     if mask is not None:
         if mask.shape != image.shape:

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -152,7 +152,7 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
             raise ValueError('Invalid connectivity={0}.  '
                              'Options are 4 or 8'.format(connectivity))
 
-    segm_img, nobj = ndimage.label(image, structure=selem)
+    segm_img, _ = ndimage.label(image, structure=selem)
 
     # remove objects with less than npixels
     # NOTE:  for typical data, making the cutout images is ~10x faster
@@ -164,14 +164,13 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         if np.count_nonzero(segment_mask) < npixels:
             cutout[segment_mask] = 0
 
-    # now relabel to make consecutive label indices
-    segm_img, nobj = ndimage.label(segm_img, structure=selem)
-
-    if nobj == 0:
+    if np.sum(segm_img) == 0:
         warnings.warn('No sources were found.', NoDetectionsWarning)
         return None
     else:
-        return SegmentationImage(segm_img)
+        segm = SegmentationImage(segm_img)
+        segm.relabel_consecutive()
+        return segm
 
 
 @deprecated_renamed_argument('mask_value', None, 0.7)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -140,13 +140,17 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
                              'image.')
         image &= ~mask
 
-    if connectivity == 4:
-        selem = ndimage.generate_binary_structure(2, 1)
-    elif connectivity == 8:
-        selem = ndimage.generate_binary_structure(2, 2)
+    ndim = image.ndim
+    if ndim == 1:
+        selem = ndimage.generate_binary_structure(ndim, 1)
     else:
-        raise ValueError('Invalid connectivity={0}.  '
-                         'Options are 4 or 8'.format(connectivity))
+        if connectivity == 4:
+            selem = ndimage.generate_binary_structure(ndim, 1)
+        elif connectivity == 8:
+            selem = ndimage.generate_binary_structure(ndim, 2)
+        else:
+            raise ValueError('Invalid connectivity={0}.  '
+                             'Options are 4 or 8'.format(connectivity))
 
     segm_img, nobj = ndimage.label(image, structure=selem)
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -113,7 +113,7 @@ class TestSegmentationImage:
     def test_segment_repr_str(self):
         assert repr(self.segm[0]) == str(self.segm[0])
 
-        props = ['label', 'slices', 'bbox', 'area']
+        props = ['label', 'slices', 'area']
         for prop in props:
             assert '{}:'.format(prop) in repr(self.segm[0])
 

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -3,7 +3,7 @@
 Tests for the deblend module.
 """
 
-from astropy.modeling import models
+from astropy.modeling.models import Gaussian2D
 from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
@@ -32,9 +32,9 @@ except ImportError:
 @pytest.mark.skipif('not HAS_SKIMAGE')
 class TestDeblendSources:
     def setup_class(self):
-        g1 = models.Gaussian2D(100, 50, 50, 5, 5)
-        g2 = models.Gaussian2D(100, 35, 50, 5, 5)
-        g3 = models.Gaussian2D(30, 70, 50, 5, 5)
+        g1 = Gaussian2D(100, 50, 50, 5, 5)
+        g2 = Gaussian2D(100, 35, 50, 5, 5)
+        g3 = Gaussian2D(30, 70, 50, 5, 5)
         y, x = np.mgrid[0:100, 0:100]
         self.x = x
         self.y = y
@@ -58,10 +58,10 @@ class TestDeblendSources:
         assert_allclose(np.nonzero(self.segm), np.nonzero(result))
 
     def test_deblend_multiple_sources(self):
-        g4 = models.Gaussian2D(100, 50, 15, 5, 5)
-        g5 = models.Gaussian2D(100, 35, 15, 5, 5)
-        g6 = models.Gaussian2D(100, 50, 85, 5, 5)
-        g7 = models.Gaussian2D(100, 35, 85, 5, 5)
+        g4 = Gaussian2D(100, 50, 15, 5, 5)
+        g5 = Gaussian2D(100, 35, 15, 5, 5)
+        g6 = Gaussian2D(100, 50, 85, 5, 5)
+        g7 = Gaussian2D(100, 35, 85, 5, 5)
         x = self.x
         y = self.y
         data = self.data + g4(x, y) + g5(x, y) + g6(x, y) + g7(x, y)
@@ -76,9 +76,9 @@ class TestDeblendSources:
         assert result.areas[0] == result.areas[5]
 
     def test_deblend_multiple_sources_with_neighbor(self):
-        g1 = models.Gaussian2D(100, 50, 50, 20, 5, theta=45)
-        g2 = models.Gaussian2D(100, 35, 50, 5, 5)
-        g3 = models.Gaussian2D(100, 60, 20, 5, 5)
+        g1 = Gaussian2D(100, 50, 50, 20, 5, theta=45)
+        g2 = Gaussian2D(100, 35, 50, 5, 5)
+        g3 = Gaussian2D(100, 60, 20, 5, 5)
 
         x = self.x
         y = self.y
@@ -86,6 +86,25 @@ class TestDeblendSources:
         segm = detect_sources(data, self.threshold, self.npixels)
         result = deblend_sources(data, segm, self.npixels)
         assert result.nlabels == 3
+
+    @pytest.mark.parametrize('contrast, nlabels',
+                             ((0.001, 6), (0.017, 5), (0.06, 4), (0.1, 3),
+                              (0.15, 2), (0.45, 1)))
+    def test_deblend_contrast(self, contrast, nlabels):
+        y, x = np.mgrid[0:51, 0:151]
+        y0 = 25
+        data = (Gaussian2D(9.5, 16, y0, 5, 5)(x, y) +
+                Gaussian2D(51, 30, y0, 3, 3)(x, y) +
+                Gaussian2D(30, 42, y0, 5, 5)(x, y) +
+                Gaussian2D(80, 66, y0, 8, 8)(x, y) +
+                Gaussian2D(71, 88, y0, 8, 8)(x, y) +
+                Gaussian2D(18, 119, y0, 7, 7)(x, y))
+
+        npixels = 5
+        segm = detect_sources(data, 1.0, npixels)
+        segm2 = deblend_sources(data, segm, npixels, mode='linear',
+                                nlevels=32, contrast=contrast)
+        assert segm2.nlabels == nlabels
 
     @pytest.mark.parametrize('mode', ['exponential', 'linear'])
     def test_deblend_sources_norelabel(self, mode):

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -106,6 +106,31 @@ class TestDeblendSources:
                                 nlevels=32, contrast=contrast)
         assert segm2.nlabels == nlabels
 
+    def test_deblend_connectivity(self):
+        data = np.zeros((51, 51))
+        data[15:36, 15:36] = 10.
+        data[14, 36] = 1.
+        data[13, 37] = 10
+        data[14, 14] = 5.
+        data[13, 13] = 10.
+        data[36, 14] = 10.
+        data[37, 13] = 10.
+        data[36, 36] = 10.
+        data[37, 37] = 10.
+
+        segm = detect_sources(data, 0.1, 1, connectivity=4)
+        assert segm.nlabels == 9
+        segm2 = deblend_sources(data, segm, 1, mode='linear', connectivity=4)
+        assert segm2.nlabels == 9
+
+        segm = detect_sources(data, 0.1, 1, connectivity=8)
+        assert segm.nlabels == 1
+        segm2 = deblend_sources(data, segm, 1, mode='linear', connectivity=8)
+        assert segm2.nlabels == 3
+
+        with pytest.raises(ValueError):
+            deblend_sources(data, segm, 1, mode='linear', connectivity=4)
+
     @pytest.mark.parametrize('mode', ['exponential', 'linear'])
     def test_deblend_sources_norelabel(self, mode):
         result = deblend_sources(self.data, self.segm, self.npixels,


### PR DESCRIPTION
This PR fixes the bug in the dev version of `deblend_sources` reported by @stephenmwilkins in #880.

While investigating and testing this bug, I discovered two other bugs that could be triggered:

* Sources could be deblended too much when `connectivity=8`.
* The `contrast` parameter had little effect if the original segment contained three or more sources.

Both are also fixed in this PR.

Closes #880 .

A separate PR will be forthcoming that improves the performance of source deblending.