### PR TITLE
Clean up of interpolation utils

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -246,6 +246,10 @@ API changes
     ``pixel_scale_angle_at_skycoord``, ``assert_angle_or_pixel``,
     ``assert_angle``, and ``pixel_to_icrs_coords``. [#846]
 
+  - Removed deprecated ``interpolate_masked_data`` function. [#895]
+
+  - Deprecated the ``mask_to_mirrored_num`` function. [#895]
+
 - ``photutils.psf``
 
   - ``FittableImageModel`` and subclasses now allow for different

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -3,6 +3,7 @@
 This module provides tools for interpolating data.
 """
 
+from astropy.utils import deprecated
 import numpy as np
 
 __all__ = ['ShepardIDWInterpolator', 'mask_to_mirrored_num']
@@ -282,6 +283,7 @@ class ShepardIDWInterpolator:
             return interp_values
 
 
+@deprecated(0.7)
 def mask_to_mirrored_num(image, mask_image, center_position, bbox=None):
     """
     Replace masked pixels with the value of the pixel mirrored across a

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -9,6 +9,7 @@ import numpy as np
 __all__ = ['ShepardIDWInterpolator', 'mask_to_mirrored_num']
 
 __doctest_requires__ = {('ShepardIDWInterpolator'): ['scipy']}
+__doctest_skip__ = ['mask_to_mirrored_num']
 
 
 class ShepardIDWInterpolator:

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from .. import ShepardIDWInterpolator as idw
-from .. import interpolate_masked_data, mask_to_mirrored_num
+from .. import mask_to_mirrored_num
 
 try:
     import scipy  # noqa
@@ -112,55 +112,6 @@ class TestShepardIDWInterpolator:
     def test_positions_3d(self):
         with pytest.raises(ValueError):
             self.f(np.ones((3, 3, 3)))
-
-
-class TestInterpolateMaskedData:
-    def setup_class(cls):
-        """Ignore all deprecation warnings here."""
-        warnings.simplefilter('ignore', AstropyDeprecationWarning)
-
-    def teardown_class(cls):
-        warnings.resetwarnings()
-
-    def test_mask_shape(self):
-        with pytest.raises(ValueError):
-            interpolate_masked_data(DATA, WRONG_SHAPE)
-
-    def test_error_shape(self):
-        with pytest.raises(ValueError):
-            interpolate_masked_data(DATA, MASK, error=WRONG_SHAPE)
-
-    def test_background_shape(self):
-        with pytest.raises(ValueError):
-            interpolate_masked_data(DATA, MASK, background=WRONG_SHAPE)
-
-    def test_interpolation(self):
-        data2 = DATA.copy()
-        data2[2, 2] = 100.
-        error2 = ERROR.copy()
-        error2[2, 2] = 100.
-        background2 = BACKGROUND.copy()
-        background2[2, 2] = 100.
-        data, error, background = interpolate_masked_data(
-            data2, MASK, error=error2, background=background2)
-        assert_allclose(data, DATA)
-        assert_allclose(error, ERROR)
-        assert_allclose(background, BACKGROUND)
-
-    def test_interpolation_larger_mask(self):
-        data2 = DATA.copy()
-        data2[2, 2] = 100.
-        error2 = ERROR.copy()
-        error2[2, 2] = 100.
-        background2 = BACKGROUND.copy()
-        background2[2, 2] = 100.
-        mask2 = MASK.copy()
-        mask2[1:4, 1:4] = True
-        data, error, background = interpolate_masked_data(
-            data2, MASK, error=error2, background=background2)
-        assert_allclose(data, DATA)
-        assert_allclose(error, ERROR)
-        assert_allclose(background, BACKGROUND)
 
 
 class TestMaskToMirroredNum:

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -115,6 +115,10 @@ class TestShepardIDWInterpolator:
 
 
 class TestMaskToMirroredNum:
+    def setup_class(cls):
+        """Ignore all deprecation warnings here."""
+        warnings.simplefilter('ignore', AstropyDeprecationWarning)
+
     def test_mask_to_mirrored_num(self):
         """
         Test mask_to_mirrored_num.


### PR DESCRIPTION
This PR removes the long-deprecated `interpolate_masked_data` function and deprecates `mask_to_mirrored_num`.