### PR TITLE
Simplify aperture bounding box calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -172,6 +172,9 @@ API changes
   - The ``aperture_photometry`` function moved to a new
     ``photutils.aperture.photometry`` module. [#876]
 
+  - Renamed the ``bounding_boxes`` attribute for pixel-based apertures
+    to ``bbox`` for consistency. [#896]
+
 - ``photutils.background``
 
   - The ``Background2D`` ``plot_meshes`` keyword ``ax`` was deprecated

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from .attributes import (AngleOrPixelScalarQuantity, PixelPositions,
                          PositiveScalar, SkyCoordPositions)
-from .bounding_box import BoundingBox
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import circular_overlap_grid
@@ -149,20 +148,8 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         self.r = r
 
     @property
-    def bounding_boxes(self):
-        positions = np.atleast_2d(self.positions)
-        xmin = positions[:, 0] - self.r
-        xmax = positions[:, 0] + self.r
-        ymin = positions[:, 1] - self.r
-        ymax = positions[:, 1] + self.r
-
-        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
-                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
-
-        if self.isscalar:
-            return bboxes[0]
-        else:
-            return bboxes
+    def _xy_extents(self):
+        return self.r, self.r
 
     @property
     def area(self):
@@ -292,20 +279,8 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         self.r_out = r_out
 
     @property
-    def bounding_boxes(self):
-        positions = np.atleast_2d(self.positions)
-        xmin = positions[:, 0] - self.r_out
-        xmax = positions[:, 0] + self.r_out
-        ymin = positions[:, 1] - self.r_out
-        ymax = positions[:, 1] + self.r_out
-
-        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
-                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
-
-        if self.isscalar:
-            return bboxes[0]
-        else:
-            return bboxes
+    def _xy_extents(self):
+        return self.r_out, self.r_out
 
     @property
     def area(self):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -79,7 +79,7 @@ class CircularMaskMixin:
             raise ValueError('Cannot determine the aperture radius.')
 
         masks = []
-        for bbox, edges in zip(np.atleast_1d(self.bounding_boxes),
+        for bbox, edges in zip(np.atleast_1d(self.bbox),
                                self._centered_edges):
             ny, nx = bbox.shape
             mask = circular_overlap_grid(edges[0], edges[1], edges[2],

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -162,7 +162,12 @@ class PixelAperture(Aperture):
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
     @property
+    @deprecated('0.7', alternative='bbox')
     def bounding_boxes(self):
+        return self.bbox
+
+    @property
+    def bbox(self):
         """
         The minimal bounding box for the aperture.
 
@@ -199,7 +204,7 @@ class PixelAperture(Aperture):
 
         edges = []
         for position, bbox in zip(np.atleast_2d(self.positions),
-                                  np.atleast_1d(self.bounding_boxes)):
+                                  np.atleast_1d(self.bbox)):
             xmin = bbox.ixmin - 0.5 - position[0]
             xmax = bbox.ixmax - 0.5 - position[0]
             ymin = bbox.iymin - 0.5 - position[1]

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -16,6 +16,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs.utils import (skycoord_to_pixel, pixel_to_skycoord,
                                wcs_to_celestial_frame)
 
+from .bounding_box import BoundingBox
 from ._photometry_utils import (_handle_units, _prepare_photometry_data,
                                 _validate_inputs)
 from ..utils.misc import _ABCMetaAndInheritDocstrings
@@ -149,6 +150,18 @@ class PixelAperture(Aperture):
 
     @property
     @abc.abstractmethod
+    def _xy_extents(self):
+        """
+        The (x, y) extents of the aperture measured from the center
+        position.
+
+        In other words, the (x, y) extents are half of the aperture
+        minimal bounding box size in each dimension.
+        """
+
+        raise NotImplementedError('Needs to be implemented in a subclass.')
+
+    @property
     def bounding_boxes(self):
         """
         The minimal bounding box for the aperture.
@@ -158,7 +171,20 @@ class PixelAperture(Aperture):
         returned.
         """
 
-        raise NotImplementedError('Needs to be implemented in a subclass.')
+        positions = np.atleast_2d(self.positions)
+        x_delta, y_delta = self._xy_extents
+        xmin = positions[:, 0] - x_delta
+        xmax = positions[:, 0] + x_delta
+        ymin = positions[:, 1] - y_delta
+        ymax = positions[:, 1] + y_delta
+
+        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
+                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
+
+        if self.isscalar:
+            return bboxes[0]
+        else:
+            return bboxes
 
     @property
     def _centered_edges(self):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -12,7 +12,6 @@ import numpy as np
 from .attributes import (AngleOrPixelScalarQuantity, AngleScalarQuantity,
                          PixelPositions, PositiveScalar, Scalar,
                          SkyCoordPositions)
-from .bounding_box import BoundingBox
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
@@ -106,7 +105,7 @@ class EllipticalMaskMixin:
             return masks
 
     @staticmethod
-    def _extents(semimajor_axis, semiminor_axis, theta):
+    def _calc_extents(semimajor_axis, semiminor_axis, theta):
         """
         Calculate half of the bounding box extents of an ellipse.
         """
@@ -183,26 +182,8 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         self.theta = theta
 
     @property
-    def bounding_boxes(self):
-        """
-        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
-        for each position, enclosing the exact elliptical apertures.
-        """
-
-        positions = np.atleast_2d(self.positions)
-        x_delta, y_delta = self._extents(self.a, self.b, self.theta)
-        xmin = positions[:, 0] - x_delta
-        xmax = positions[:, 0] + x_delta
-        ymin = positions[:, 1] - y_delta
-        ymax = positions[:, 1] + y_delta
-
-        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
-                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
-
-        if self.isscalar:
-            return bboxes[0]
-        else:
-            return bboxes
+    def _xy_extents(self):
+        return self._calc_extents(self.a, self.b, self.theta)
 
     @property
     def area(self):
@@ -352,26 +333,8 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         self.theta = theta
 
     @property
-    def bounding_boxes(self):
-        """
-        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
-        for each position, enclosing the exact elliptical apertures.
-        """
-
-        positions = np.atleast_2d(self.positions)
-        x_delta, y_delta = self._extents(self.a_out, self.b_out, self.theta)
-        xmin = positions[:, 0] - x_delta
-        xmax = positions[:, 0] + x_delta
-        ymin = positions[:, 1] - y_delta
-        ymax = positions[:, 1] + y_delta
-
-        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
-                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
-
-        if self.isscalar:
-            return bboxes[0]
-        else:
-            return bboxes
+    def _xy_extents(self):
+        return self._calc_extents(self.a_out, self.b_out, self.theta)
 
     @property
     def area(self):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -83,7 +83,7 @@ class EllipticalMaskMixin:
             raise ValueError('Cannot determine the aperture shape.')
 
         masks = []
-        for bbox, edges in zip(np.atleast_1d(self.bounding_boxes),
+        for bbox, edges in zip(np.atleast_1d(self.bbox),
                                self._centered_edges):
             ny, nx = bbox.shape
             mask = elliptical_overlap_grid(edges[0], edges[1], edges[2],

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -12,7 +12,6 @@ import numpy as np
 from .attributes import (AngleOrPixelScalarQuantity, AngleScalarQuantity,
                          PixelPositions, PositiveScalar, Scalar,
                          SkyCoordPositions)
-from .bounding_box import BoundingBox
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
@@ -109,7 +108,7 @@ class RectangularMaskMixin:
             return masks
 
     @staticmethod
-    def _extents(width, height, theta):
+    def _calc_extents(width, height, theta):
         """
         Calculate half of the bounding box extents of an ellipse.
         """
@@ -208,26 +207,8 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         self.theta = theta
 
     @property
-    def bounding_boxes(self):
-        """
-        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
-        for each position, enclosing the exact rectangular apertures.
-        """
-
-        positions = np.atleast_2d(self.positions)
-        x_delta, y_delta = self._extents(self.w, self.h, self.theta)
-        xmin = positions[:, 0] - x_delta
-        xmax = positions[:, 0] + x_delta
-        ymin = positions[:, 1] - y_delta
-        ymax = positions[:, 1] + y_delta
-
-        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
-                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
-
-        if self.isscalar:
-            return bboxes[0]
-        else:
-            return bboxes
+    def _xy_extents(self):
+        return self._calc_extents(self.w, self.h, self.theta)
 
     @property
     def area(self):
@@ -383,27 +364,8 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         self.theta = theta
 
     @property
-    def bounding_boxes(self):
-        """
-        A list of minimal bounding boxes (`~photutils.BoundingBox`), one
-        for each position, enclosing the rectangular apertures for the
-        "exact" case.
-        """
-
-        positions = np.atleast_2d(self.positions)
-        x_delta, y_delta = self._extents(self.w_out, self.h_out, self.theta)
-        xmin = positions[:, 0] - x_delta
-        xmax = positions[:, 0] + x_delta
-        ymin = positions[:, 1] - y_delta
-        ymax = positions[:, 1] + y_delta
-
-        bboxes = [BoundingBox.from_float(x0, x1, y0, y1)
-                  for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
-
-        if self.isscalar:
-            return bboxes[0]
-        else:
-            return bboxes
+    def _xy_extents(self):
+        return self._calc_extents(self.w_out, self.h_out, self.theta)
 
     @property
     def area(self):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -86,7 +86,7 @@ class RectangularMaskMixin:
             raise ValueError('Cannot determine the aperture radius.')
 
         masks = []
-        for bbox, edges in zip(np.atleast_1d(self.bounding_boxes),
+        for bbox, edges in zip(np.atleast_1d(self.bbox),
                                self._centered_edges):
             ny, nx = bbox.shape
             mask = rectangular_overlap_grid(edges[0], edges[1], edges[2],

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -693,26 +693,26 @@ def test_rectangular_bbox():
     width = 7
     height = 3
     a = RectangularAperture((50, 50), w=width, h=height, theta=0)
-    assert a.bounding_boxes.shape == (height, width)
+    assert a.bbox.shape == (height, width)
 
     a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
-    assert a.bounding_boxes.shape == (height + 1, width + 1)
+    assert a.bbox.shape == (height + 1, width + 1)
 
     a = RectangularAperture((50, 50), w=width, h=height, theta=90.*np.pi/180.)
-    assert a.bounding_boxes.shape == (width, height)
+    assert a.bbox.shape == (width, height)
 
     # even sizes
     width = 8
     height = 4
     a = RectangularAperture((50, 50), w=width, h=height, theta=0)
-    assert a.bounding_boxes.shape == (height + 1, width + 1)
+    assert a.bbox.shape == (height + 1, width + 1)
 
     a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
-    assert a.bounding_boxes.shape == (height, width)
+    assert a.bbox.shape == (height, width)
 
     a = RectangularAperture((50.5, 50.5), w=width, h=height,
                             theta=90.*np.pi/180.)
-    assert a.bounding_boxes.shape == (width, height)
+    assert a.bbox.shape == (width, height)
 
 
 def test_elliptical_bbox():
@@ -720,25 +720,25 @@ def test_elliptical_bbox():
     a = 7
     b = 3
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
-    assert ap.bounding_boxes.shape == (2*b + 1, 2*a + 1)
+    assert ap.bbox.shape == (2*b + 1, 2*a + 1)
 
     ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
-    assert ap.bounding_boxes.shape == (2*b, 2*a)
+    assert ap.bbox.shape == (2*b, 2*a)
 
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.*np.pi/180.)
-    assert ap.bounding_boxes.shape == (2*a + 1, 2*b + 1)
+    assert ap.bbox.shape == (2*a + 1, 2*b + 1)
 
     # fractional axes
     a = 7.5
     b = 4.5
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
-    assert ap.bounding_boxes.shape == (2*b, 2*a)
+    assert ap.bbox.shape == (2*b, 2*a)
 
     ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
-    assert ap.bounding_boxes.shape == (2*b + 1, 2*a + 1)
+    assert ap.bbox.shape == (2*b + 1, 2*a + 1)
 
     ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.*np.pi/180.)
-    assert ap.bounding_boxes.shape == (2*a, 2*b)
+    assert ap.bbox.shape == (2*a, 2*b)
 
 
 def test_to_sky_pixel():


### PR DESCRIPTION
This PR simplifies the aperture bounding box calculations by consolidating the code in the `PixelAperture` base class.  The `bounding_boxes` attribute for pixel-based apertures is now deprecated and has been renamed `bbox` for consistency across the `photutils` package.