### PR TITLE
Allow WCS objects that support the shared WCS interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 0.7 (unreleased)
 ----------------
 
+General
+^^^^^^^
+
+ - Any WCS object that supports the `astropy shared interface for WCS
+   <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ is now
+   supported. [#899]
+
 New Features
 ^^^^^^^^^^^^
 
@@ -20,6 +27,10 @@ New Features
 
   - ``aperture_phometry`` now supports ``NDData`` with
     ``StdDevUncertainty`` to input errors. [#866]
+
+  - The ``mode`` keyword in the ``to_sky`` and ``to_pixel`` aperture
+    methods was removed to implement the shared WCS interface.  All
+    WCS transforms now include distortions (if present). [#899]
 
 - ``photutils.datasets``
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -195,20 +195,18 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         else:
             return patches
 
-    def to_sky(self, wcs, mode='all'):
+    def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyCircularAperture` object defined
         in celestial coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -216,8 +214,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
             A `SkyCircularAperture` object.
         """
 
-        sky_params = self._to_sky_params(wcs, mode=mode)
-        return SkyCircularAperture(**sky_params)
+        return SkyCircularAperture(**self._to_sky_params(wcs))
 
 
 class CircularAnnulus(CircularMaskMixin, PixelAperture):
@@ -328,20 +325,18 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         else:
             return patches
 
-    def to_sky(self, wcs, mode='all'):
+    def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyCircularAnnulus` object defined
         in celestial coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -349,8 +344,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
             A `SkyCircularAnnulus` object.
         """
 
-        sky_params = self._to_sky_params(wcs, mode=mode)
-        return SkyCircularAnnulus(**sky_params)
+        return SkyCircularAnnulus(**self._to_sky_params(wcs))
 
 
 class SkyCircularAperture(SkyAperture):
@@ -386,20 +380,18 @@ class SkyCircularAperture(SkyAperture):
         self.positions = positions
         self.r = r
 
-    def to_pixel(self, wcs, mode='all'):
+    def to_pixel(self, wcs):
         """
         Convert the aperture to a `CircularAperture` object defined in
         pixel coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -407,8 +399,7 @@ class SkyCircularAperture(SkyAperture):
             A `CircularAperture` object.
         """
 
-        pixel_params = self._to_pixel_params(wcs, mode=mode)
-        return CircularAperture(**pixel_params)
+        return CircularAperture(**self._to_pixel_params(wcs))
 
 
 class SkyCircularAnnulus(SkyAperture):
@@ -455,20 +446,18 @@ class SkyCircularAnnulus(SkyAperture):
         self.r_in = r_in
         self.r_out = r_out
 
-    def to_pixel(self, wcs, mode='all'):
+    def to_pixel(self, wcs):
         """
         Convert the aperture to a `CircularAnnulus` object defined in
         pixel coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -476,5 +465,4 @@ class SkyCircularAnnulus(SkyAperture):
             A `CircularAnnulus` object.
         """
 
-        pixel_params = self._to_pixel_params(wcs, mode=mode)
-        return CircularAnnulus(**pixel_params)
+        return CircularAnnulus(**self._to_pixel_params(wcs))

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -230,20 +230,18 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         else:
             return patches
 
-    def to_sky(self, wcs, mode='all'):
+    def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyEllipticalAperture` object defined
         in celestial coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -251,8 +249,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
             A `SkyEllipticalAperture` object.
         """
 
-        sky_params = self._to_sky_params(wcs, mode=mode)
-        return SkyEllipticalAperture(**sky_params)
+        return SkyEllipticalAperture(**self._to_sky_params(wcs))
 
 
 class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
@@ -385,20 +382,18 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         else:
             return patches
 
-    def to_sky(self, wcs, mode='all'):
+    def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyEllipticalAnnulus` object defined
         in celestial coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -406,8 +401,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
             A `SkyEllipticalAnnulus` object.
         """
 
-        sky_params = self._to_sky_params(wcs, mode=mode)
-        return SkyEllipticalAnnulus(**sky_params)
+        return SkyEllipticalAnnulus(**self._to_sky_params(wcs))
 
 
 class SkyEllipticalAperture(SkyAperture):
@@ -462,20 +456,18 @@ class SkyEllipticalAperture(SkyAperture):
         self.b = b
         self.theta = theta
 
-    def to_pixel(self, wcs, mode='all'):
+    def to_pixel(self, wcs):
         """
         Convert the aperture to an `EllipticalAperture` object defined
         in pixel coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -483,8 +475,7 @@ class SkyEllipticalAperture(SkyAperture):
             An `EllipticalAperture` object.
         """
 
-        pixel_params = self._to_pixel_params(wcs, mode=mode)
-        return EllipticalAperture(**pixel_params)
+        return EllipticalAperture(**self._to_pixel_params(wcs))
 
 
 class SkyEllipticalAnnulus(SkyAperture):
@@ -552,20 +543,18 @@ class SkyEllipticalAnnulus(SkyAperture):
         self.b_in = self.b_out * self.a_in / self.a_out
         self.theta = theta
 
-    def to_pixel(self, wcs, mode='all'):
+    def to_pixel(self, wcs):
         """
         Convert the aperture to an `EllipticalAnnulus` object defined in
         pixel coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -573,5 +562,4 @@ class SkyEllipticalAnnulus(SkyAperture):
             An `EllipticalAnnulus` object.
         """
 
-        pixel_params = self._to_pixel_params(wcs, mode=mode)
-        return EllipticalAnnulus(**pixel_params)
+        return EllipticalAnnulus(**self._to_pixel_params(wcs))

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -108,10 +108,13 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         the ``data`` (and optional ``error``) as
         `~astropy.units.Quantity` objects.
 
-    wcs : `~astropy.wcs.WCS`, optional
-        The WCS transformation to use if the input ``apertures`` is a
-        `SkyAperture` object.  If ``data`` is an
-        `~astropy.io.fits.ImageHDU` or `~astropy.io.fits.HDUList`,
+    wcs : WCS object, optional
+        A world coordinate system (WCS) transformation that supports the
+        `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).  Used only if the input
+        ``apertures`` contains a `SkyAperture` object.  If ``data`` is
+        an `~astropy.io.fits.ImageHDU` or `~astropy.io.fits.HDUList`,
         ``wcs`` overrides any WCS transformation present in the header.
 
     Returns

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -257,20 +257,18 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         else:
             return patches
 
-    def to_sky(self, wcs, mode='all'):
+    def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyRectangularAperture` object
         defined in celestial coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -278,8 +276,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
             A `SkyRectangularAperture` object.
         """
 
-        sky_params = self._to_sky_params(wcs, mode=mode)
-        return SkyRectangularAperture(**sky_params)
+        return SkyRectangularAperture(**self._to_sky_params(wcs))
 
 
 class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
@@ -423,20 +420,18 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         else:
             return patches
 
-    def to_sky(self, wcs, mode='all'):
+    def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyRectangularAnnulus` object
         defined in celestial coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -444,8 +439,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
             A `SkyRectangularAnnulus` object.
         """
 
-        sky_params = self._to_sky_params(wcs, mode=mode)
-        return SkyRectangularAnnulus(**sky_params)
+        return SkyRectangularAnnulus(**self._to_sky_params(wcs))
 
 
 class SkyRectangularAperture(SkyAperture):
@@ -502,20 +496,18 @@ class SkyRectangularAperture(SkyAperture):
         self.h = h
         self.theta = theta
 
-    def to_pixel(self, wcs, mode='all'):
+    def to_pixel(self, wcs):
         """
         Convert the aperture to a `RectangularAperture` object defined
         in pixel coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -523,8 +515,7 @@ class SkyRectangularAperture(SkyAperture):
             A `RectangularAperture` object.
         """
 
-        pixel_params = self._to_pixel_params(wcs, mode=mode)
-        return RectangularAperture(**pixel_params)
+        return RectangularAperture(**self._to_pixel_params(wcs))
 
 
 class SkyRectangularAnnulus(SkyAperture):
@@ -598,20 +589,18 @@ class SkyRectangularAnnulus(SkyAperture):
         self.h_in = self.w_in * self.h_out / self.w_out
         self.theta = theta
 
-    def to_pixel(self, wcs, mode='all'):
+    def to_pixel(self, wcs):
         """
         Convert the aperture to a `RectangularAnnulus` object defined in
         pixel coordinates.
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS`
-            The world coordinate system (WCS) transformation to use.
-
-        mode : {'all', 'wcs'}, optional
-            Whether to do the transformation including distortions
-            (``'all'``; default) or only including only the core WCS
-            transformation (``'wcs'``).
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that supports
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
@@ -619,5 +608,4 @@ class SkyRectangularAnnulus(SkyAperture):
             A `RectangularAnnulus` object.
         """
 
-        pixel_params = self._to_pixel_params(wcs, mode=mode)
-        return RectangularAnnulus(**pixel_params)
+        return RectangularAnnulus(**self._to_pixel_params(wcs))

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -332,7 +332,13 @@ def test_wcs_based_photometry():
     pos_orig_pixel = u.Quantity(([160., 25., 150., 90.],
                                  [70., 40., 25., 60.]), unit=u.pixel)
 
-    pos_skycoord = pixel_to_skycoord(pos_orig_pixel[0], pos_orig_pixel[1], wcs)
+    try:
+        pos_skycoord = wcs.pixel_to_world(pos_orig_pixel[0],
+                                          pos_orig_pixel[1])
+    except AttributeError:
+        # for Astropy < 3.1
+        pos_skycoord = pixel_to_skycoord(pos_orig_pixel[0],
+                                         pos_orig_pixel[1], wcs)
 
     pos_skycoord_s = pos_skycoord[2]
 
@@ -870,7 +876,13 @@ def test_scalar_skycoord():
 
     data = make_4gaussians_image()
     wcs = make_wcs(data.shape)
-    skycoord = pixel_to_skycoord(90, 60, wcs)
+
+    try:
+        skycoord = wcs.pixel_to_world(90, 60)
+    except AttributeError:
+        # for Astropy < 3.1
+        skycoord = pixel_to_skycoord(90, 60, wcs)
+
     aper = SkyCircularAperture(skycoord, r=0.1*u.arcsec)
     tbl = aperture_photometry(data, aper, wcs=wcs)
     assert isinstance(tbl['sky_center'], SkyCoord)
@@ -883,7 +895,12 @@ def test_nddata_input():
     mask[8:13, 8:13] = True
     unit = 'adu'
     wcs = make_wcs(data.shape)
-    skycoord = pixel_to_skycoord(10, 10, wcs)
+    try:
+        skycoord = wcs.pixel_to_world(10, 10)
+    except AttributeError:
+        # for Astropy < 3.1
+        skycoord = pixel_to_skycoord(10, 10, wcs)
+
     aper = SkyCircularAperture(skycoord, r=0.7*u.arcsec)
 
     tbl1 = aperture_photometry(data*u.adu, aper, error=error*u.adu, mask=mask,

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -787,7 +787,7 @@ def make_wcs(shape, galactic=False):
     Notes
     -----
     The `make_gwcs` function returns an equivalent WCS transformation to
-    this one, but in a `gwcs.wcs.WCS` object.
+    this one, but as a `gwcs.wcs.WCS` object.
 
     Examples
     --------
@@ -835,7 +835,7 @@ def make_gwcs(shape, galactic=False):
     ----------
     shape : 2-tuple of int
         The shape of the 2D array to be used with the output
-        `~astropy.wcs.WCS` object.
+        `~gwcs.wcs.WCS` object.
 
     galactic : bool, optional
         If `True`, then the output WCS will be in the Galactic
@@ -854,7 +854,7 @@ def make_gwcs(shape, galactic=False):
     Notes
     -----
     The `make_wcs` function returns an equivalent WCS transformation to
-    this one, but in an `astropy.wcs.WCS` object.
+    this one, but as an `astropy.wcs.WCS` object.
 
     Examples
     --------
@@ -916,7 +916,7 @@ def make_imagehdu(data, wcs=None):
     data : 2D array-like
         The input 2D data.
 
-    wcs : `~astropy.wcs.WCS`, optional
+    wcs : `None` or `~astropy.wcs.WCS`, optional
         The world coordinate system (WCS) transformation to include in
         the output FITS header.
 

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -312,54 +312,31 @@ class Reproject:
         self.wcs_rectified = wcs_rectified
 
     @staticmethod
-    def _reproject(wcs1, wcs2):
+    def _reproject(wcs1, wcs2, x, y):
         """
         Perform the forward transformation of ``wcs1`` followed by the
         inverse transformation of ``wcs2``.
 
         Parameters
         ----------
-        wcs1, wcs2 : `~astropy.wcs.WCS` or `~gwcs.wcs.WCS`
-            The WCS objects.
+        wcs1, wcs2 : WCS objects
+            World coordinate system (WCS) transformations that support
+            the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+            `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
         Returns
         -------
-        result : func
-            Function to compute the transformations.  It takes x, y
-            positions in ``wcs1`` and returns x, y positions in
-            ``wcs2``.  The input and output x, y positions are zero
-            indexed.
+        x, y:  float or array-like of float
+            The pixel coordinates.
         """
 
-        import gwcs
-
-        forward_origin = []
-        if isinstance(wcs1, fitswcs.WCS):
-            forward = wcs1.all_pix2world
-            forward_origin = [0]
-        elif isinstance(wcs2, gwcs.wcs.WCS):
-            forward = wcs1.forward_transform
-        else:
-            raise ValueError('wcs1 must be an astropy.wcs.WCS or '
-                             'gwcs.wcs.WCS object.')
-
-        inverse_origin = []
-        if isinstance(wcs2, fitswcs.WCS):
-            inverse = wcs2.all_world2pix
-            inverse_origin = [0]
-        elif isinstance(wcs2, gwcs.wcs.WCS):
-            inverse = wcs2.forward_transform.inverse
-        else:
-            raise ValueError('wcs2 must be an astropy.wcs.WCS or '
-                             'gwcs.wcs.WCS object.')
-
-        def _reproject_func(x, y):
-            forward_args = [x, y] + forward_origin
-            sky = forward(*forward_args)
-            inverse_args = sky + inverse_origin
-            return inverse(*inverse_args)
-
-        return _reproject_func
+        try:
+            skycoord = wcs1.pixel_to_world(x, y)
+            return wcs2.world_to_pixel(skycoord)
+        except AttributeError:
+            raise ValueError('Input wcs objects do not support the shared '
+                             'WCS interface.')
 
     def to_rectified(self, x, y):
         """
@@ -378,8 +355,7 @@ class Reproject:
             The zero-index pixel coordinates in the rectified image.
         """
 
-        return self._reproject(self.wcs_original,
-                               self.wcs_rectified)(x, y)
+        return self._reproject(self.wcs_original, self.wcs_rectified, x, y)
 
     def to_original(self, x, y):
         """
@@ -398,5 +374,4 @@ class Reproject:
             (unrectified) image.
         """
 
-        return self._reproject(self.wcs_rectified,
-                               self.wcs_original)(x, y)
+        return self._reproject(self.wcs_rectified, self.wcs_original, x, y)

--- a/photutils/utils/_wcs_helpers.py
+++ b/photutils/utils/_wcs_helpers.py
@@ -5,11 +5,82 @@ This module provides WCS helper tools.
 
 from astropy import units as u
 from astropy.coordinates import UnitSphericalRepresentation
-from astropy.wcs.utils import skycoord_to_pixel
+from astropy.wcs import WCS
+from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
 
-def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
+def _pixel_to_world(xpos, ypos, wcs):
+    """
+    Calculate the sky coordinates at the input pixel positions.
+
+    Parameters
+    ----------
+    xpos, ypos : float or array-like
+        The x and y pixel position(s).
+
+    wcs : WCS object or `None`
+        A world coordinate system (WCS) transformation that supports the
+        `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
+    Returns
+    -------
+    skycoord : `~astropy.coordinates.SkyCoord`
+        The sky coordinate(s) at the input position(s).
+    """
+
+    if wcs is None:
+        return None
+
+    try:
+        return wcs.pixel_to_world(xpos, ypos)
+    except AttributeError:
+        if isinstance(wcs, WCS):
+            # for Astropy < 3.1 WCS support
+            return pixel_to_skycoord(xpos, ypos, wcs, origin=0)
+        else:
+            raise ValueError('Input wcs does not support the shared WCS '
+                             'interface.')
+
+
+def _world_to_pixel(skycoord, wcs):
+    """
+    Calculate the sky coordinates at the input pixel positions.
+
+    Parameters
+    ----------
+    skycoord : `~astropy.coordinates.SkyCoord`
+        The sky coordinate(s).
+
+    wcs : WCS object or `None`
+        A world coordinate system (WCS) transformation that supports the
+        `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
+    Returns
+    -------
+    xpos, ypos : float or array-like
+        The x and y pixel position(s) at the input sky coordinate(s).
+    """
+
+    if wcs is None:
+        return None
+
+    try:
+        return wcs.world_to_pixel(skycoord)
+    except AttributeError:
+        if isinstance(wcs, WCS):
+            # for Astropy < 3.1 WCS support
+            return skycoord_to_pixel(skycoord, wcs, origin=0)
+        else:
+            raise ValueError('Input wcs does not support the shared WCS '
+                             'interface.')
+
+
+def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1.0*u.arcsec):
     """
     Calculate the pixel scale and WCS rotation angle at the position of
     a SkyCoord coordinate.
@@ -18,8 +89,13 @@ def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
     ----------
     skycoord : `~astropy.coordinates.SkyCoord`
         The SkyCoord coordinate.
-    wcs : `~astropy.wcs.WCS`
-        The world coordinate system (WCS) transformation to use.
+
+    wcs : WCS object
+        A world coordinate system (WCS) transformation that supports the
+        `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
     offset : `~astropy.units.Quantity`
         A small angular offset to use to compute the pixel scale and
         position angle.
@@ -28,6 +104,7 @@ def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
     -------
     scale : `~astropy.units.Quantity`
         The pixel scale in arcsec/pixel.
+
     angle : `~astropy.units.Quantity`
         The angle (in degrees) measured counterclockwise from the
         positive x axis to the "North" axis of the celestial coordinate
@@ -40,25 +117,25 @@ def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
     the North/South axis.
     """
 
-    # We take a point directly "above" (in latitude) the input position
-    # and convert it to pixel coordinates, then we use the pixel deltas
-    # between the input and offset point to calculate the pixel scale and
-    # angle.
+    try:
+        x, y = wcs.world_to_pixel(skycoord)
 
-    # Find the coordinates as a representation object
-    coord = skycoord.represent_as('unitspherical')
+        # We take a point directly North (i.e. latitude offset) the input
+        # sky coordinate and convert it to pixel coordinates, then we use the
+        # pixel deltas between the input and offset sky coordinate to
+        # calculate the pixel scale and angle.
+        skycoord_offset = skycoord.directional_offset_by(0.0, offset)
+        x_offset, y_offset = wcs.world_to_pixel(skycoord_offset)
+    except AttributeError:
+        # for Astropy < 3.1 WCS support
+        x, y = skycoord_to_pixel(skycoord, wcs)
+        coord = skycoord.represent_as('unitspherical')
+        coord_new = UnitSphericalRepresentation(coord.lon, coord.lat + offset)
+        coord_offset = skycoord.realize_frame(coord_new)
+        x_offset, y_offset = skycoord_to_pixel(coord_offset, wcs)
 
-    # Add a a small perturbation in the latitude direction (since longitude
-    # is more difficult because it is not directly an angle)
-    coord_new = UnitSphericalRepresentation(coord.lon, coord.lat + offset)
-    coord_offset = skycoord.realize_frame(coord_new)
-
-    # Find pixel coordinates of offset coordinates and pixel deltas
-    x_offset, y_offset = skycoord_to_pixel(coord_offset, wcs, mode='all')
-    x, y = skycoord_to_pixel(skycoord, wcs, mode='all')
     dx = x_offset - x
     dy = y_offset - y
-
     scale = offset.to(u.arcsec) / (np.hypot(dx, dy) * u.pixel)
     angle = (np.arctan2(dy, dx) * u.radian).to(u.deg)
 

--- a/photutils/utils/wcs_helpers.py
+++ b/photutils/utils/wcs_helpers.py
@@ -4,10 +4,9 @@ This module provides WCS helper tools.
 """
 
 from astropy import units as u
-from astropy.coordinates import UnitSphericalRepresentation
 from astropy.utils import deprecated
-from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
-import numpy as np
+
+from ._wcs_helpers import _pixel_to_world, _pixel_scale_angle_at_skycoord
 
 
 @deprecated('0.7', 'The pixel_scale_angle_at_skycoord function is deprecated '
@@ -21,8 +20,13 @@ def pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
     ----------
     skycoord : `~astropy.coordinates.SkyCoord`
         The SkyCoord coordinate.
-    wcs : `~astropy.wcs.WCS`
-        The world coordinate system (WCS) transformation to use.
+
+    wcs : WCS object
+        A world coordinate system (WCS) transformation that supports the
+        `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
     offset : `~astropy.units.Quantity`
         A small angular offset to use to compute the pixel scale and
         position angle.
@@ -31,6 +35,7 @@ def pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
     -------
     scale : `~astropy.units.Quantity`
         The pixel scale in arcsec/pixel.
+
     angle : `~astropy.units.Quantity`
         The angle (in degrees) measured counterclockwise from the
         positive x axis to the "North" axis of the celestial coordinate
@@ -43,29 +48,7 @@ def pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1. * u.arcsec):
     the North/South axis.
     """
 
-    # We take a point directly "above" (in latitude) the input position
-    # and convert it to pixel coordinates, then we use the pixel deltas
-    # between the input and offset point to calculate the pixel scale and
-    # angle.
-
-    # Find the coordinates as a representation object
-    coord = skycoord.represent_as('unitspherical')
-
-    # Add a a small perturbation in the latitude direction (since longitude
-    # is more difficult because it is not directly an angle)
-    coord_new = UnitSphericalRepresentation(coord.lon, coord.lat + offset)
-    coord_offset = skycoord.realize_frame(coord_new)
-
-    # Find pixel coordinates of offset coordinates and pixel deltas
-    x_offset, y_offset = skycoord_to_pixel(coord_offset, wcs, mode='all')
-    x, y = skycoord_to_pixel(skycoord, wcs, mode='all')
-    dx = x_offset - x
-    dy = y_offset - y
-
-    scale = offset.to(u.arcsec) / (np.hypot(dx, dy) * u.pixel)
-    angle = (np.arctan2(dy, dx) * u.radian).to(u.deg)
-
-    return scale, angle
+    return _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=offset)
 
 
 @deprecated('0.7', 'The assert_angle_or_pixel function is deprecated and '
@@ -120,10 +103,11 @@ def pixel_to_icrs_coords(x, y, wcs):
     y : float or array-like
         The y pixel coordinate.
 
-    wcs : `~astropy.wcs.WCS`
-        The WCS transformation to use to convert from pixel coordinates
-        to ICRS world coordinates.
-        `~astropy.table.Table`.
+    wcs : WCS object
+        A world coordinate system (WCS) transformation that supports the
+        `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
 
     Returns
     -------
@@ -134,7 +118,7 @@ def pixel_to_icrs_coords(x, y, wcs):
         The ICRS Declination in degrees.
     """
 
-    icrs_coords = pixel_to_skycoord(x, y, wcs).icrs
+    icrs_coords = (_pixel_to_world(x, y, wcs)).icrs
     icrs_ra = icrs_coords.ra.degree * u.deg
     icrs_dec = icrs_coords.dec.degree * u.deg
 


### PR DESCRIPTION
This PR implements support for the [Astropy unified WCS APE](http://docs.astropy.org/en/stable/wcs/wcsapi.html).

This required removing the `mode` keyword in the ``to_sky`` and ``to_pixel`` aperture methods.  All WCS transforms now include distortions (if present).