### PR TITLE
Raise ValueError in PSF fitting if aperture_radius is not set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,6 +105,9 @@ Bug Fixes
   - Fixed a bug in the ``EPSFStar`` ``register_epsf`` and
     ``compute_residual_image`` computations. [#885]
 
+  - A ValueError is raised if ``aperture_radius`` is not input and
+    cannot be determined from the input ``psf_model``. [#903]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where ``deblend_sources`` could fail for sources

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -164,9 +164,7 @@ class BasicPSFPhotometry:
         elif value is None:
             self._aperture_radius = value
         else:
-            raise ValueError('aperture_radius must be a real-valued '
-                             'number, received aperture_radius = {}'
-                             .format(value))
+            raise ValueError('aperture_radius must be a positive number')
 
     def get_residual_image(self):
         """
@@ -241,16 +239,33 @@ class BasicPSFPhotometry:
                 self.aperture_radius = (self.psf_model.sigma.value *
                                         gaussian_sigma_to_fwhm)
 
+        if self.aperture_radius is None:
+            if init_guesses is None:
+                raise ValueError('aperture_radius was not input and could '
+                                 'not be determined by the input psf_model '
+                                 '(e.g. an EPSFModel).  For tabular PSF '
+                                 'models, you must input the aperture_radius '
+                                 'keyword.  For analytical PSF models, you '
+                                 'must either input the aperture_radius '
+                                 'keyword or define a fwhm or sigma '
+                                 'attribute on your input psf_model.')
+
+            if (init_guesses is not None and
+                    'flux_0' not in init_guesses.colnames):
+                raise ValueError('init_guesses were input, but the "flux_0" '
+                                 'column was not present.  Initial fluxes '
+                                 'cannot be calculated because '
+                                 'aperture_radius must was not input and '
+                                 'could not be determined by the input '
+                                 'psf_model (e.g. an EPSFModel).  For '
+                                 'analytical PSF models, you must either '
+                                 'input the aperture_radius keyword or '
+                                 'define a fwhm or sigma attribute on your '
+                                 'input psf_model.')
+
         if init_guesses is not None:
             # make sure the code does not modify user's input
             init_guesses = init_guesses.copy()
-            if self.aperture_radius is None:
-                if 'flux_0' not in init_guesses.colnames:
-                    raise ValueError('aperture_radius is None and could not '
-                                     'be determined by psf_model. Please, '
-                                     'either provided a value for '
-                                     'aperture_radius or define fwhm/sigma '
-                                     'at psf_model.')
 
             if self.finder is not None:
                 warnings.warn('Both init_guesses and finder are different '

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -88,10 +88,14 @@ class BasicPSFPhotometry:
         Fitter object used to compute the optimized centroid positions
         and/or flux of the identified sources. See
         `~astropy.modeling.fitting` for more details on fitters.
-    aperture_radius : float or None
+    aperture_radius : `None` or float
         The radius (in units of pixels) used to compute initial
-        estimates for the fluxes of sources. If ``None``, one FWHM will
-        be used if it can be determined from the ``psf_model``.
+        estimates for the fluxes of sources.  ``aperture_radius`` must
+        be set if initial flux guesses are not input to the photometry
+        class via the ``init_guesses`` keyword.  For tabular PSF models
+        (e.g. an `EPSFModel`), you must input the ``aperture_radius``
+        keyword.  For analytical PSF models, alternatively you may
+        define a FWHM attribute on your input psf_model.
 
     Notes
     -----

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -487,7 +487,8 @@ def test_psf_boundary():
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_aperture_radius_value_error():
     """
-    Test psf_photometry with discrete PRF model at the boundary of the data.
+    Test that a ValueError is raised for tabular PSF models when
+    aperture_radius is not defined.
     """
 
     prf = DiscretePRF(test_psf, subsampling=1)
@@ -496,11 +497,13 @@ def test_aperture_radius_value_error():
                                     bkg_estimator=None, psf_model=prf,
                                     fitshape=7)
 
-    intab = Table(data=[[1], [1]], names=['x_0', 'y_0'])
-    with pytest.raises(ValueError) as err:
-        basic_phot(image=image, init_guesses=intab)
+    with pytest.raises(ValueError):
+        basic_phot(image=image)
 
-    assert 'aperture_radius is None' in str(err.value)
+    # with initial guesses, but without a "flux_0" column
+    intab = Table(data=[[1], [1]], names=['x_0', 'y_0'])
+    with pytest.raises(ValueError):
+        basic_phot(image=image, init_guesses=intab)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION
`aperture_radius` is used to compute initial estimates for the fluxes of sources.  If initial flux guesses are not input to the photometry class via the ``init_guesses`` keyword, then `aperture_radius` must be set.  Currently, a cryptic error is raised if that's not the case.  This PR raises a `ValueError` with a helpful message if `aperture_radius` is needed and it is not set or cannot be determined from the input `psf_model`.

This issue was reported in #728, #804, and #849 (and via other channels).
Closes #728.