### PR TITLE
Update numpy RandomState intersphinx link

### DIFF
--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -45,7 +45,7 @@ def apply_poisson_noise(data, random_state=None):
         The array on which to apply Poisson noise.  Every pixel in the
         array must have a positive value (i.e. counts).
 
-    random_state : int or `~numpy.random.RandomState`, optional
+    random_state : int or `~numpy.random.mtrand.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
 
     Returns
@@ -112,7 +112,7 @@ def make_noise_image(shape, distribution='gaussian', mean=None, stddev=None,
         Poisson noise (the variance of the Poisson distribution is equal
         to its mean).
 
-    random_state : int or `~numpy.random.RandomState`, optional
+    random_state : int or `~numpy.random.mtrand.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
         Separate function calls with the same noise parameters and
         ``random_state`` will generate the identical noise image.
@@ -187,7 +187,7 @@ def make_random_models_table(n_sources, param_ranges, random_state=None):
         as a `dict` mapping the parameter name to its ``(lower, upper)``
         bounds.
 
-    random_state : int or `~numpy.random.RandomState`, optional
+    random_state : int or `~numpy.random.mtrand.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
 
     Returns
@@ -277,7 +277,7 @@ def make_random_gaussians_table(n_sources, param_ranges, random_state=None):
         ignored.  Model parameters not defined in ``param_ranges`` will
         be set to the default value.
 
-    random_state : int or `~numpy.random.RandomState`, optional
+    random_state : int or `~numpy.random.mtrand.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
 
     Returns

--- a/photutils/isophote/tests/make_test_data.py
+++ b/photutils/isophote/tests/make_test_data.py
@@ -34,7 +34,7 @@ def make_test_image(nx=512, ny=512, x0=None, y0=None,
         The ellipticity of the reference isophote.
     pa : float, optional
         The position angle of the reference isophote.
-    random_state : int or `~numpy.random.RandomState`, optional
+    random_state : int or `~numpy.random.mtrand.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
         Separate function calls with the same ``random_state`` will
         generate the identical noise image.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -556,7 +556,7 @@ class SegmentationImage:
             background color (label = 0) when plotting the segmentation
             array.  The default is black ('#000000').
 
-        random_state : int or `~numpy.random.RandomState`, optional
+        random_state : int or `~numpy.random.mtrand.RandomState`, optional
             The pseudo-random number generator state used for random
             sampling.  Separate function calls with the same
             ``random_state`` will generate the same colormap.
@@ -580,7 +580,7 @@ class SegmentationImage:
             background color (label = 0) when plotting the segmentation
             array.  The default is black ('#000000').
 
-        random_state : int or `~numpy.random.RandomState`, optional
+        random_state : int or `~numpy.random.mtrand.RandomState`, optional
             The pseudo-random number generator state used for random
             sampling.  Separate function calls with the same
             ``random_state`` will generate the same colormap.

--- a/photutils/utils/check_random_state.py
+++ b/photutils/utils/check_random_state.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This module provides tools to seed a RandomState instance.
+This module provides tools to seed a numpy RandomState instance.
 """
 
 import numbers
@@ -12,20 +12,22 @@ __all__ = ['check_random_state']
 
 def check_random_state(seed):
     """
-    Turn seed into a `numpy.random.RandomState` instance.
+    Turn seed into a `numpy.random.mtrand.RandomState` instance.
 
     Parameters
     ----------
-    seed : `None`, int, or `numpy.random.RandomState`
-        If ``seed`` is `None`, return the `~numpy.random.RandomState`
-        singleton used by ``numpy.random``.  If ``seed`` is an `int`,
-        return a new `~numpy.random.RandomState` instance seeded with
-        ``seed``.  If ``seed`` is already a `~numpy.random.RandomState`,
-        return it.  Otherwise raise ``ValueError``.
+    seed : `None`, int, or `numpy.random.mtrand.RandomState`
+        If ``seed`` is `None`, return the
+        `~numpy.random.mtrand.RandomState` singleton used by
+        ``numpy.random``.  If ``seed`` is an `int`, return a new
+        `~numpy.random.mtrand.RandomState` instance seeded with
+        ``seed``.  If ``seed`` is already a
+        `~numpy.random.mtrand.RandomState`, return it.  Otherwise raise
+        ``ValueError``.
 
     Returns
     -------
-    random_state : `numpy.random.RandomState`
+    random_state : `numpy.random.mtrand.RandomState`
         RandomState object.
 
     Notes

--- a/photutils/utils/colormaps.py
+++ b/photutils/utils/colormaps.py
@@ -23,7 +23,7 @@ def random_cmap(ncolors=256, random_state=None):
     ncolors : int, optional
         The number of colors in the colormap.  The default is 256.
 
-    random_state : int or `~numpy.random.RandomState`, optional
+    random_state : int or `~numpy.random.mtrand.RandomState`, optional
         The pseudo-random number generator state used for random
         sampling.  Separate function calls with the same
         ``random_state`` will generate the same colormap.
@@ -48,7 +48,7 @@ def make_random_cmap(ncolors=256, random_state=None):
     ncolors : int, optional
         The number of colors in the colormap.  The default is 256.
 
-    random_state : int or `~numpy.random.RandomState`, optional
+    random_state : int or `~numpy.random.mtrand.RandomState`, optional
         The pseudo-random number generator state used for random
         sampling.  Separate function calls with the same
         ``random_state`` will generate the same colormap.


### PR DESCRIPTION
The numpy `RandomState` documentation is at `numpy.random.mtrand.RandomState`.