### PR TITLE
Update orientation units in narrative docs

### DIFF
--- a/docs/morphology.rst
+++ b/docs/morphology.rst
@@ -58,12 +58,13 @@ approximate isophotal ellipse for the source:
 
 .. doctest-skip::
 
+    >>> import astropy.units as u
     >>> from photutils import EllipticalAperture
     >>> position = (cat.xcentroid.value, cat.ycentroid.value)
     >>> r = 3.0  # approximate isophotal extent
     >>> a = cat.semimajor_axis_sigma.value * r
     >>> b = cat.semiminor_axis_sigma.value * r
-    >>> theta = cat.orientation.value
+    >>> theta = cat.orientation.to(u.rad).value
     >>> apertures = EllipticalAperture(position, a, b, theta=theta)
     >>> plt.imshow(data, origin='lower', cmap='viridis',
     ...            interpolation='nearest')
@@ -71,6 +72,7 @@ approximate isophotal ellipse for the source:
 
 .. plot::
 
+    import astropy.units as u
     import matplotlib.pyplot as plt
     from photutils import data_properties, EllipticalAperture
     from photutils.datasets import make_4gaussians_image
@@ -84,7 +86,7 @@ approximate isophotal ellipse for the source:
     position = (cat.xcentroid.value, cat.ycentroid.value)
     a = cat.semimajor_axis_sigma.value * r
     b = cat.semiminor_axis_sigma.value * r
-    theta = cat.orientation.value
+    theta = cat.orientation.to(u.rad).value
     apertures = EllipticalAperture(position, a, b, theta=theta)
     plt.imshow(data, origin='lower', cmap='viridis', interpolation='nearest')
     apertures.plot(color='#d62728')

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -382,6 +382,7 @@ orientation (`~photutils.segmentation.SourceProperties.orientation`):
 .. doctest-requires:: scipy, skimage
 
     >>> import numpy as np
+    >>> import astropy.units as u
     >>> from photutils import source_properties, EllipticalAperture
     >>> cat = source_properties(data, segm_deblend)
     >>> r = 3.  # approximate isophotal extent
@@ -390,7 +391,7 @@ orientation (`~photutils.segmentation.SourceProperties.orientation`):
     ...     position = np.transpose((obj.xcentroid.value, obj.ycentroid.value))
     ...     a = obj.semimajor_axis_sigma.value * r
     ...     b = obj.semiminor_axis_sigma.value * r
-    ...     theta = obj.orientation.value
+    ...     theta = obj.orientation.to(u.rad).value
     ...     apertures.append(EllipticalAperture(position, a, b, theta=theta))
 
 Now let's plot the derived elliptical apertures on the data:
@@ -418,6 +419,7 @@ Now let's plot the derived elliptical apertures on the data:
     import matplotlib.pyplot as plt
     from astropy.stats import gaussian_fwhm_to_sigma
     from astropy.convolution import Gaussian2DKernel
+    import astropy.units as u
     from astropy.visualization import SqrtStretch
     from astropy.visualization.mpl_normalize import ImageNormalize
     from photutils.datasets import make_100gaussians_image
@@ -446,7 +448,7 @@ Now let's plot the derived elliptical apertures on the data:
         position = np.transpose((obj.xcentroid.value, obj.ycentroid.value))
         a = obj.semimajor_axis_sigma.value * r
         b = obj.semiminor_axis_sigma.value * r
-        theta = obj.orientation.value
+        theta = obj.orientation.to(u.rad).value
         apertures.append(EllipticalAperture(position, a, b, theta=theta))
     norm = ImageNormalize(stretch=SqrtStretch())
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))


### PR DESCRIPTION
Minor fix to narrative docs to ensure correct units for source `orientation`.