### PR TITLE
 Simplify reseting lazy properties in SegmentationImage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,9 @@ New Features
   - Added the ``gini`` source property representing the Gini
     coefficient. [#864]
 
+  - Cached (lazy) properties can now be reset in ``SegmentationImage``
+    subclasses. [#916]
+
 - ``photutils.utils``
 
   - Added ``NoDetectionsWarning`` class. [#836]

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -204,13 +204,6 @@ class SegmentationImage:
 
         return self._data
 
-    def _reset_lazy_properties(self):
-        """Reset all lazy properties."""
-
-        for key, value in self.__class__.__dict__.items():
-            if isinstance(value, lazyproperty):
-                self.__dict__.pop(key, None)
-
     @lazyproperty
     def _cmap(self):
         """
@@ -300,7 +293,7 @@ class SegmentationImage:
 
         if '_data' in self.__dict__:
             # needed only when data is reassigned, not on init
-            self._reset_lazy_properties()
+            self.__dict__ = {}
 
         self._data = value  # pylint: disable=attribute-defined-outside-init
 


### PR DESCRIPTION
With this change, cached (lazy) properties can now be reset in `SegmentationImage` subclasses.