### PR TITLE
Fix make_source_mask for no detections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -218,6 +218,9 @@ API changes
   - Deprecated the ``BoundingBox`` ``as_patch`` method (instead use
     ``as_artist``). [#851]
 
+  - Renamed the ``snr`` (deprecated) keyword to ``nsigma`` in
+    ``detect_threshold``. [#917]
+
 - ``photutils.isophote``
 
   - Isophote central values and intensity gradients are now returned
@@ -278,6 +281,9 @@ API changes
 
   - The ``orientation`` property is now returned as a ``Quantity``
     instance in units of degrees. [#863]
+
+  - Renamed the ``snr`` (deprecated) keyword to ``nsigma`` in
+    ``make_source_mask``. [#917]
 
 - ``photutils.utils``
 

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -130,7 +130,7 @@ source detections and dilate using a 11x11 box:
 .. doctest-requires:: scipy
 
     >>> from photutils import make_source_mask
-    >>> mask = make_source_mask(data, snr=2, npixels=5, dilate_size=11)
+    >>> mask = make_source_mask(data, nsigma=2, npixels=5, dilate_size=11)
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, mask=mask)
     >>> print((mean, median, std))  # doctest: +FLOAT_CMP
     (5.001013475475569, 5.000584905604376, 1.970887100626572)

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -43,12 +43,13 @@ a convenience function called
 detection threshold image using simple sigma-clipped statistics to
 estimate the background level and RMS.
 
-The threshold level is calculated using the ``snr`` input as the sigma
-level above the background.  Here we generate a simple threshold at 2
-sigma (per pixel) above the background::
+The threshold level is calculated using the ``nsigma`` input as the
+number of standard deviations (per pixel) above the background.  Here
+we generate a simple threshold at 2 sigma (per pixel) above the
+background::
 
     >>> from photutils import detect_threshold
-    >>> threshold = detect_threshold(data, snr=2.)
+    >>> threshold = detect_threshold(data, nsigma=2.)
 
 For more sophisticated analyses, one should generate a 2D background
 and background-only error image (e.g., from your data reduction or by
@@ -117,7 +118,7 @@ segmentation image showing the detected sources:
     from photutils.datasets import make_100gaussians_image
     from photutils import detect_threshold, detect_sources
     data = make_100gaussians_image()
-    threshold = detect_threshold(data, snr=2.)
+    threshold = detect_threshold(data, nsigma=2.)
     sigma = 3.0 * gaussian_fwhm_to_sigma  # FWHM = 3.
     kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
     kernel.normalize()
@@ -186,7 +187,7 @@ the deblended segmentation image:
     from photutils import detect_threshold, detect_sources, deblend_sources
 
     data = make_100gaussians_image()
-    threshold = detect_threshold(data, snr=2.)
+    threshold = detect_threshold(data, nsigma=2.)
     sigma = 3.0 * gaussian_fwhm_to_sigma  # FWHM = 3.
     kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
     kernel.normalize()
@@ -214,7 +215,7 @@ Let's plot one of the deblended sources:
     from photutils import detect_threshold, detect_sources, deblend_sources
 
     data = make_100gaussians_image()
-    threshold = detect_threshold(data, snr=2.)
+    threshold = detect_threshold(data, nsigma=2.)
     sigma = 3.0 * gaussian_fwhm_to_sigma  # FWHM = 3.
     kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
     kernel.normalize()

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -8,6 +8,7 @@ import warnings
 
 from astropy.stats import sigma_clipped_stats
 from astropy.table import Table
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.version import version as astropy_version
 import numpy as np
 
@@ -17,7 +18,8 @@ from ..utils._wcs_helpers import _pixel_to_world
 __all__ = ['detect_threshold', 'find_peaks']
 
 
-def detect_threshold(data, snr, background=None, error=None, mask=None,
+@deprecated_renamed_argument('snr', 'nsigma', 0.7)
+def detect_threshold(data, nsigma, background=None, error=None, mask=None,
                      mask_value=None, sigclip_sigma=3.0, sigclip_iters=None):
     """
     Calculate a pixel-wise threshold image that can be used to detect
@@ -28,9 +30,10 @@ def detect_threshold(data, snr, background=None, error=None, mask=None,
     data : array_like
         The 2D array of the image.
 
-    snr : float
-        The signal-to-noise ratio per pixel above the ``background`` for
-        which to consider a pixel as possibly being part of a source.
+    nsigma : float
+        The number of standard deviations per pixel above the
+        ``background`` for which to consider a pixel as possibly being
+        part of a source.
 
     background : float or array_like, optional
         The background value(s) of the input ``data``.  ``background``
@@ -125,7 +128,7 @@ def detect_threshold(data, snr, background=None, error=None, mask=None,
                                  'must have the same shape as the input '
                                  'data.')
 
-    return background + (error * snr)
+    return background + (error * nsigma)
 
 
 def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -40,61 +40,61 @@ FITSWCS = make_wcs(IMAGE.shape)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestDetectThreshold:
-    def test_snr(self):
-        """Test basic snr."""
+    def test_nsigma(self):
+        """Test basic nsigma."""
 
-        threshold = detect_threshold(DATA, snr=0.1)
+        threshold = detect_threshold(DATA, nsigma=0.1)
         ref = 0.4 * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
-    def test_snr_zero(self):
-        """Test snr=0."""
+    def test_nsigma_zero(self):
+        """Test nsigma=0."""
 
-        threshold = detect_threshold(DATA, snr=0.0)
+        threshold = detect_threshold(DATA, nsigma=0.0)
         ref = (1. / 3.) * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
     def test_background(self):
-        threshold = detect_threshold(DATA, snr=1.0, background=1)
+        threshold = detect_threshold(DATA, nsigma=1.0, background=1)
         ref = (5. / 3.) * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
     def test_background_image(self):
         background = np.ones((3, 3))
-        threshold = detect_threshold(DATA, snr=1.0, background=background)
+        threshold = detect_threshold(DATA, nsigma=1.0, background=background)
         ref = (5. / 3.) * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
     def test_background_badshape(self):
         wrong_shape = np.zeros((2, 2))
         with pytest.raises(ValueError):
-            detect_threshold(DATA, snr=2., background=wrong_shape)
+            detect_threshold(DATA, nsigma=2., background=wrong_shape)
 
     def test_error(self):
-        threshold = detect_threshold(DATA, snr=1.0, error=1)
+        threshold = detect_threshold(DATA, nsigma=1.0, error=1)
         ref = (4. / 3.) * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
     def test_error_image(self):
         error = np.ones((3, 3))
-        threshold = detect_threshold(DATA, snr=1.0, error=error)
+        threshold = detect_threshold(DATA, nsigma=1.0, error=error)
         ref = (4. / 3.) * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
     def test_error_badshape(self):
         wrong_shape = np.zeros((2, 2))
         with pytest.raises(ValueError):
-            detect_threshold(DATA, snr=2., error=wrong_shape)
+            detect_threshold(DATA, nsigma=2., error=wrong_shape)
 
     def test_background_error(self):
-        threshold = detect_threshold(DATA, snr=2.0, background=10., error=1.)
+        threshold = detect_threshold(DATA, nsigma=2.0, background=10., error=1.)
         ref = 12. * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
     def test_background_error_images(self):
         background = np.ones((3, 3)) * 10.
         error = np.ones((3, 3))
-        threshold = detect_threshold(DATA, snr=2.0, background=background,
+        threshold = detect_threshold(DATA, nsigma=2.0, background=background,
                                      error=error)
         ref = 12. * np.ones((3, 3))
         assert_allclose(threshold, ref)
@@ -102,7 +102,7 @@ class TestDetectThreshold:
     def test_mask_value(self):
         """Test detection with mask_value."""
 
-        threshold = detect_threshold(DATA, snr=1.0, mask_value=0.0)
+        threshold = detect_threshold(DATA, nsigma=1.0, mask_value=0.0)
         ref = 2. * np.ones((3, 3))
         assert_array_equal(threshold, ref)
 
@@ -114,7 +114,7 @@ class TestDetectThreshold:
         """
 
         mask = REF1.astype(np.bool)
-        threshold = detect_threshold(DATA, snr=1., error=0, mask=mask,
+        threshold = detect_threshold(DATA, nsigma=1., error=0, mask=mask,
                                      sigclip_sigma=10, sigclip_iters=1)
         ref = (1. / 8.) * np.ones((3, 3))
         assert_array_equal(threshold, ref)
@@ -123,7 +123,7 @@ class TestDetectThreshold:
         """Test that image_mask overrides mask_value."""
 
         mask = REF1.astype(np.bool)
-        threshold = detect_threshold(DATA, snr=0.1, error=0, mask_value=0.0,
+        threshold = detect_threshold(DATA, nsigma=0.1, error=0, mask_value=0.0,
                                      mask=mask, sigclip_sigma=10,
                                      sigclip_iters=1)
         ref = np.ones((3, 3))

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -243,7 +243,7 @@ def make_source_mask(data, snr, npixels, mask=None, mask_value=None,
 
     Returns
     -------
-    mask : 2D `~numpy.ndarray`, bool
+    mask : 2D bool `~numpy.ndarray`
         A 2D boolean image containing the source mask.
     """
 
@@ -265,6 +265,8 @@ def make_source_mask(data, snr, npixels, mask=None, mask_value=None,
         kernel.normalize()
 
     segm = detect_sources(data, threshold, npixels, filter_kernel=kernel)
+    if segm is None:
+        return np.zeros(data.shape, dtype=bool)
 
     selem = np.ones((dilate_size, dilate_size))
-    return ndimage.binary_dilation(segm.data.astype(np.bool), selem)
+    return ndimage.binary_dilation(segm.data.astype(bool), selem)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -110,10 +110,10 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
 
         # detect the sources
         from photutils import detect_threshold, detect_sources
-        threshold = detect_threshold(image, snr=3)
+        threshold = detect_threshold(image, nsigma=3)
         from astropy.convolution import Gaussian2DKernel
-        sigma = 3.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))  # FWHM = 3
-        kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
+        kernel_sigma = 3.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))  # FWHM = 3
+        kernel = Gaussian2DKernel(kernel_sigma, x_size=3, y_size=3)
         kernel.normalize()
         segm = detect_sources(image, threshold, npixels=5,
                               filter_kernel=kernel)
@@ -177,8 +177,9 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         return segm
 
 
+@deprecated_renamed_argument('snr', 'nsigma', 0.7)
 @deprecated_renamed_argument('mask_value', None, 0.7)
-def make_source_mask(data, snr, npixels, mask=None, mask_value=None,
+def make_source_mask(data, nsigma, npixels, mask=None, mask_value=None,
                      filter_fwhm=None, filter_size=3, filter_kernel=None,
                      sigclip_sigma=3.0, sigclip_iters=5, dilate_size=11):
     """
@@ -189,9 +190,10 @@ def make_source_mask(data, snr, npixels, mask=None, mask_value=None,
     data : array_like
         The 2D array of the image.
 
-    snr : float
-        The signal-to-noise ratio per pixel above the ``background`` for
-        which to consider a pixel as possibly being part of a source.
+    nsigma : float
+        The number of standard deviations per pixel above the
+        ``background`` for which to consider a pixel as possibly being
+        part of a source.
 
     npixels : int
         The number of connected pixels, each greater than ``threshold``,
@@ -249,7 +251,7 @@ def make_source_mask(data, snr, npixels, mask=None, mask_value=None,
 
     from scipy import ndimage
 
-    threshold = detect_threshold(data, snr, background=None, error=None,
+    threshold = detect_threshold(data, nsigma, background=None, error=None,
                                  mask=mask, mask_value=None,
                                  sigclip_sigma=sigclip_sigma,
                                  sigclip_iters=sigclip_iters)
@@ -258,8 +260,8 @@ def make_source_mask(data, snr, npixels, mask=None, mask_value=None,
     if filter_kernel is not None:
         kernel = filter_kernel
     if filter_fwhm is not None:
-        sigma = filter_fwhm * gaussian_fwhm_to_sigma
-        kernel = Gaussian2DKernel(sigma, x_size=filter_size,
+        kernel_sigma = filter_fwhm * gaussian_fwhm_to_sigma
+        kernel = Gaussian2DKernel(kernel_sigma, x_size=filter_size,
                                   y_size=filter_size)
     if kernel is not None:
         kernel.normalize()

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -90,7 +90,7 @@ class TestDetectSources:
         assert_array_equal(segm.data, self.refdata)
 
     def test_zerodet(self):
-        """Test detection with large snr_threshold giving no detections."""
+        """Test detection with large threshold giving no detections."""
 
         with catch_warnings(NoDetectionsWarning) as warning_lines:
             detect_sources(self.data, threshold=7, npixels=2)

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -190,3 +190,7 @@ class TestMakeSourceMask:
         kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
         mask2 = make_source_mask(self.data, 5, 10, filter_kernel=kernel)
         assert_allclose(mask1, mask2)
+
+    def test_no_detections(self):
+        mask = make_source_mask(self.data, 100, 100)
+        assert np.count_nonzero(mask) == 0


### PR DESCRIPTION
`make_source_mask` returns a bool array of all `False` if there are no detections.
Fixes https://github.com/astropy/photutils/issues/904.

This PR also renames the `snr` (deprecated) keyword to `nsigma` is `make_source_mask` and `detect_threshold`.