### PR TITLE
Deprecate util functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -299,6 +299,9 @@ API changes
 
   - Deprecated the ``mask_to_mirrored_num`` function. [#895]
 
+  - Deprecated the ``get_version_info``, ``filter_data``, and
+    ``std_blocksum`` functions. [#918]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -16,7 +16,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from .core import Aperture, SkyAperture
 from ._photometry_utils import (_handle_hdu_input, _handle_units,
                                 _prepare_photometry_data, _validate_inputs)
-from ..utils import get_version_info
+from ..utils.misc import _get_version_info
 
 __all__ = ['aperture_photometry']
 
@@ -229,7 +229,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     # define output table meta data
     meta = OrderedDict()
     meta['name'] = 'Aperture photometry results'
-    meta['version'] = get_version_info()
+    meta['version'] = _get_version_info()
     calling_args = "method='{0}', subpixels={1}".format(method, subpixels)
     meta['aperture_photometry_args'] = calling_args
 

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from .core import find_peaks
 from ..utils._moments import _moments, _moments_central
-from ..utils.convolution import filter_data
+from ..utils.convolution import _filter_data
 from ..utils.exceptions import NoDetectionsWarning
 
 __all__ = ['StarFinderBase', 'DAOStarFinder', 'IRAFStarFinder']
@@ -627,8 +627,8 @@ def _find_stars(data, kernel, threshold_eff, min_separation=None,
     .. _starfind: http://stsdas.stsci.edu/cgi-bin/gethelp.cgi?starfind
     """
 
-    convolved_data = filter_data(data, kernel.data, mode='constant',
-                                 fill_value=0.0, check_normalization=False)
+    convolved_data = _filter_data(data, kernel.data, mode='constant',
+                                  fill_value=0.0, check_normalization=False)
 
     # define a local footprint for the peak finder
     if min_separation is None:  # daofind

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .core import SegmentationImage
 from .detect import detect_sources
-from ..utils.convolution import filter_data
+from ..utils.convolution import _filter_data
 from ..utils.exceptions import NoDetectionsWarning
 
 __all__ = ['deblend_sources']
@@ -113,7 +113,7 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     labels = np.atleast_1d(labels)
     segment_img.check_labels(labels)
 
-    data = filter_data(data, filter_kernel, mode='constant', fill_value=0.0)
+    data = _filter_data(data, filter_kernel, mode='constant', fill_value=0.0)
 
     last_label = segment_img.max_label
     segm_deblended = deepcopy(segment_img)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .core import SegmentationImage
 from ..detection import detect_threshold
-from ..utils.convolution import filter_data
+from ..utils.convolution import _filter_data
 from ..utils.exceptions import NoDetectionsWarning
 
 __all__ = ['detect_sources', 'make_source_mask']
@@ -131,8 +131,8 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         raise ValueError('npixels must be a positive integer, got '
                          '"{0}"'.format(npixels))
 
-    image = filter_data(data, filter_kernel, mode='constant', fill_value=0.0,
-                        check_normalization=True)
+    image = _filter_data(data, filter_kernel, mode='constant', fill_value=0.0,
+                         check_normalization=True)
     # ignore RuntimeWarning caused by > when image contains NaNs
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', category=RuntimeWarning)

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -16,7 +16,7 @@ import numpy as np
 from .core import SegmentationImage
 from ..aperture import BoundingBox
 from ..utils._moments import _moments, _moments_central
-from ..utils.convolution import filter_data
+from ..utils.convolution import _filter_data
 from ..utils._wcs_helpers import _pixel_to_world
 
 __all__ = ['SourceProperties', 'source_properties', 'SourceCatalog']
@@ -1620,8 +1620,8 @@ def source_properties(data, segment_img, error=None, mask=None,
 
     # filter the data once, instead of repeating for each source
     if filter_kernel is not None:
-        filtered_data = filter_data(data, filter_kernel, mode='constant',
-                                    fill_value=0.0, check_normalization=True)
+        filtered_data = _filter_data(data, filter_kernel, mode='constant',
+                                     fill_value=0.0, check_normalization=True)
     else:
         filtered_data = None
 

--- a/photutils/utils/convolution.py
+++ b/photutils/utils/convolution.py
@@ -7,14 +7,52 @@ import warnings
 
 from astropy.convolution import Kernel2D
 from astropy.units import Quantity
+from astropy.utils import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
 __all__ = ['filter_data']
 
 
+@deprecated('0.7')
 def filter_data(data, kernel, mode='constant', fill_value=0.0,
                 check_normalization=False):
+    """
+    Convolve a 2D image with a 2D kernel.
+
+    The kernel may either be a 2D `~numpy.ndarray` or a
+    `~astropy.convolution.Kernel2D` object.
+
+    Parameters
+    ----------
+    data : array_like
+        The 2D array of the image.
+
+    kernel : array-like (2D) or `~astropy.convolution.Kernel2D`
+        The 2D kernel used to filter the input ``data``. Filtering the
+        ``data`` will smooth the noise and maximize detectability of
+        objects with a shape similar to the kernel.
+
+    mode : {'constant', 'reflect', 'nearest', 'mirror', 'wrap'}, optional
+        The ``mode`` determines how the array borders are handled.  For
+        the ``'constant'`` mode, values outside the array borders are
+        set to ``fill_value``.  The default is ``'constant'``.
+
+    fill_value : scalar, optional
+        Value to fill data values beyond the array borders if ``mode``
+        is ``'constant'``.  The default is ``0.0``.
+
+    check_normalization : bool, optional
+        If `True` then a warning will be issued if the kernel is not
+        normalized to 1.
+    """
+
+    return _filter_data(data, kernel, mode=mode, fill_value=fill_value,
+                        check_normalization=check_normalization)
+
+
+def _filter_data(data, kernel, mode='constant', fill_value=0.0,
+                 check_normalization=False):
     """
     Convolve a 2D image with a 2D kernel.
 

--- a/photutils/utils/misc.py
+++ b/photutils/utils/misc.py
@@ -4,10 +4,26 @@ This module provides tools to return the installed astropy and photutils
 versions.
 """
 
+from astropy.utils import deprecated
+
 __all__ = ['get_version_info']
 
 
+@deprecated('0.7')
 def get_version_info():
+    """
+    Return astropy and photutils versions.
+
+    Returns
+    -------
+    result : str
+        The astropy and photutils versions.
+    """
+
+    return _get_version_info()
+
+
+def _get_version_info():
     """
     Return astropy and photutils versions.
 

--- a/photutils/utils/stats.py
+++ b/photutils/utils/stats.py
@@ -3,6 +3,7 @@
 This module provides tools to calculate statistics.
 """
 
+from astropy.utils import deprecated
 import numpy as np
 
 __all__ = ['std_blocksum']
@@ -52,7 +53,40 @@ def _mesh_values(data, box_size):
     return data[idx]
 
 
+@deprecated('0.7')
 def std_blocksum(data, block_sizes, mask=None):
+    """
+    Calculate the standard deviation of block-summed data values at
+    sizes of ``block_sizes``.
+
+    Values from incomplete blocks, either because of the image edges or
+    masked pixels, are not included.
+
+    Parameters
+    ----------
+    data : array-like
+        The 2D array to block sum.
+
+    block_sizes : int, array-like of int
+        An array of integer (square) block sizes.
+
+    mask : array-like (bool), optional
+        A boolean mask, with the same shape as ``data``, where a `True`
+        value indicates the corresponding element of ``data`` is masked.
+        Blocks that contain *any* masked data are excluded from
+        calculations.
+
+    Returns
+    -------
+    result : `~numpy.ndarray`
+        An array of the standard deviations of the block-summed array
+        for the input ``block_sizes``.
+    """
+
+    return _std_blocksum(data, block_sizes, mask=mask)
+
+
+def _std_blocksum(data, block_sizes, mask=None):
     """
     Calculate the standard deviation of block-summed data values at
     sizes of ``block_sizes``.

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from ..convolution import filter_data
+from ..convolution import _filter_data
 from ...datasets import make_100gaussians_image
 
 try:
@@ -28,13 +28,13 @@ class TestFilterData:
         self.kernel = Gaussian2DKernel(3., x_size=3, y_size=3)
 
     def test_filter_data(self):
-        filt_data1 = filter_data(self.data, self.kernel)
-        filt_data2 = filter_data(self.data, self.kernel.array)
+        filt_data1 = _filter_data(self.data, self.kernel)
+        filt_data2 = _filter_data(self.data, self.kernel.array)
         assert_allclose(filt_data1, filt_data2)
 
     def test_filter_data_units(self):
         unit = u.electron
-        filt_data = filter_data(self.data * unit, self.kernel)
+        filt_data = _filter_data(self.data * unit, self.kernel)
         assert isinstance(filt_data, u.Quantity)
         assert filt_data.unit == unit
 
@@ -43,19 +43,19 @@ class TestFilterData:
         Test to ensure output is a float array for integer input data.
         """
 
-        filt_data = filter_data(self.data.astype(int),
+        filt_data = _filter_data(self.data.astype(int),
                                 self.kernel.array.astype(int))
         assert filt_data.dtype == np.float64
 
-        filt_data = filter_data(self.data.astype(int),
+        filt_data = _filter_data(self.data.astype(int),
                                 self.kernel.array.astype(float))
         assert filt_data.dtype == np.float64
 
-        filt_data = filter_data(self.data.astype(float),
+        filt_data = _filter_data(self.data.astype(float),
                                 self.kernel.array.astype(int))
         assert filt_data.dtype == np.float64
 
-        filt_data = filter_data(self.data.astype(float),
+        filt_data = _filter_data(self.data.astype(float),
                                 self.kernel.array.astype(float))
         assert filt_data.dtype == np.float64
 
@@ -65,7 +65,7 @@ class TestFilterData:
         """
 
         kernel = None
-        filt_data = filter_data(self.data, kernel)
+        filt_data = _filter_data(self.data, kernel)
         assert_allclose(filt_data, self.data)
 
     def test_filter_data_check_normalization(self):
@@ -74,5 +74,5 @@ class TestFilterData:
         """
 
         with catch_warnings(AstropyUserWarning) as w:
-            filter_data(self.data, self.kernel, check_normalization=True)
+            _filter_data(self.data, self.kernel, check_normalization=True)
             assert len(w) == 1

--- a/photutils/utils/tests/test_stats.py
+++ b/photutils/utils/tests/test_stats.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from ..stats import std_blocksum
+from ..stats import _std_blocksum
 from ...datasets import make_noise_image
 
 
@@ -16,13 +16,13 @@ def test_std_blocksum():
     data = make_noise_image((100, 100), mean=0, stddev=stddev,
                             random_state=12345)
     block_sizes = np.array([5, 7, 10])
-    stds = std_blocksum(data, block_sizes)
+    stds = _std_blocksum(data, block_sizes)
     expected = np.array([stddev, stddev, stddev])
     assert_allclose(stds / block_sizes, expected, atol=0.2)
 
     mask = np.zeros(data.shape, dtype=bool)
     mask[25:50, 25:50] = True
-    stds2 = std_blocksum(data, block_sizes, mask=mask)
+    stds2 = _std_blocksum(data, block_sizes, mask=mask)
     assert_allclose(stds2 / block_sizes, expected, atol=0.3)
 
 
@@ -30,4 +30,4 @@ def test_std_blocksum_mask_shape():
     with pytest.raises(ValueError):
         data = np.ones((10, 10))
         mask = np.ones((2, 2))
-        std_blocksum(data, 10, mask=mask)
+        _std_blocksum(data, 10, mask=mask)


### PR DESCRIPTION
The deprecated functions are used internally by `photutils`, but should not have been part of the public API.