### PR TITLE
Update `CircularAperture.plot()` to return patches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,13 @@
 1.1.0 (unreleased)
 ------------------
 
-- No changes yet
+New Features
+^^^^^^^^^^^^
+
+- ``photutils.aperture``
+
+  - The ``PixelAperture.plot()`` method now returns a list of
+    ``matplotlib.patches.Patch`` objects. [#923]
 
 
 1.0.1 (2020-09-24)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -492,6 +492,12 @@ class PixelAperture(Aperture):
         kwargs : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : list of `~matplotlib.patches.Patch`
+            A list of matplotlib patches for the plotted aperture. The
+            patches can be used, for example, when adding a plot legend.
         """
 
         import matplotlib.pyplot as plt
@@ -505,6 +511,8 @@ class PixelAperture(Aperture):
 
         for patch in patches:
             axes.add_patch(patch)
+
+        return patches
 
     def _to_sky_params(self, wcs):
         """

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -6,11 +6,17 @@ Tests for the circle module.
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 import numpy as np
+import pytest
 
 from .test_aperture_common import BaseTestAperture
 from ..circle import (CircularAperture, CircularAnnulus, SkyCircularAperture,
                       SkyCircularAnnulus)
 
+try:
+    import matplotlib  # noqa
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
@@ -21,9 +27,43 @@ UNIT = u.arcsec
 class TestCircularAperture(BaseTestAperture):
     aperture = CircularAperture(POSITIONS, r=3.)
 
+    @pytest.mark.skipif("not HAS_MATPLOTLIB")
+    def test_plot(self):
+        self.aperture.plot()
+
+    @pytest.mark.skipif("not HAS_MATPLOTLIB")
+    def test_plot_returns_patches(self):
+        from matplotlib import pyplot as plt
+
+        my_patches = self.aperture.plot()
+        assert isinstance(my_patches, list)
+        for patch in my_patches:
+            assert isinstance(patch, matplotlib.patches.Patch)
+
+        # test creating a legend with these patches
+        plt.legend(my_patches, list(range(len(my_patches))))
+
 
 class TestCircularAnnulus(BaseTestAperture):
     aperture = CircularAnnulus(POSITIONS, r_in=3., r_out=7.)
+
+    @pytest.mark.skipif("not HAS_MATPLOTLIB")
+    def test_plot(self):
+        self.aperture.plot()
+
+    @pytest.mark.skipif("not HAS_MATPLOTLIB")
+    def test_plot_returns_patches(self):
+        from matplotlib import pyplot as plt
+
+        my_patches = self.aperture.plot()
+        assert isinstance(my_patches, list)
+
+        for p in my_patches:
+            assert isinstance(p, matplotlib.patches.Patch)
+
+        # make sure I can create a legend with these patches
+        labels = list(range(len(my_patches)))
+        plt.legend(my_patches, labels)
 
 
 class TestSkyCircularAperture(BaseTestAperture):


### PR DESCRIPTION
I updated the `photutils.aperture.core.PixelAperture.plot` method so it returns the Patches to be used later. For example, I wanted to compare the apertures found with `DAOStarFind` and `IRAFStarFind` and add a legend. Having the patches allows me to create a legend to identify the apertures. 

Here is an example of what I wanted to do:
![dao_vs_iraf](https://user-images.githubusercontent.com/4368088/62795361-8dec7e80-baa4-11e9-9c38-9f91b9bfb6a0.png)

And here is the code that generated the code:
```python
...
iraf_patches = iraf_apertures.plot(color='blue', lw=1.5, alpha=0.5, axes=ax)
dao_patches = dao_apertures.plot(color='red', lw='1.5', alpha=0.5, axes=ax)

ax.legend([iraf_patches[0], dao_patches[0]], ['IRAFStarFind', 'DAOStarFind'],
         framealpha=1)
...
```

I added some tests to `photutils.aperture.tests/test_circle.py` and updated the docstring of the updated function. Please, let me know if you need anything else here. 