### PR TITLE
Improve performance of source deblending

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,10 @@ New Features
   - Cached (lazy) properties can now be reset in ``SegmentationImage``
     subclasses. [#916]
 
+  - Significantly improved the performance of ``deblend_sources``.  It
+    is ~40-50% faster for large images (e.g. 4k x 4k) with a few
+    thousand of sources. [#924]
+
 - ``photutils.utils``
 
   - Added ``NoDetectionsWarning`` class. [#836]

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -764,8 +764,9 @@ class SegmentationImage:
         idx[self.labels] = self.labels
         idx[labels] = new_label
 
-        # calling the data setter resets all cached properties
-        self.data = idx[self.data]
+        data_new = idx[self.data]
+        self.__dict__ = {}  # reset all cached properties
+        self._data = data_new  # use _data to avoid validation
 
         if relabel:
             self.relabel_consecutive()
@@ -809,7 +810,10 @@ class SegmentationImage:
 
         new_labels = np.zeros(self.max_label + 1, dtype=np.int)
         new_labels[self.labels] = np.arange(self.nlabels) + start_label
-        self.data = new_labels[self.data]
+
+        data_new = new_labels[self.data]
+        self.__dict__ = {}  # reset all cached properties
+        self._data = data_new  # use _data to avoid validation
 
     def keep_label(self, label, relabel=False):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -762,14 +762,17 @@ class SegmentationImage:
 
         idx = np.zeros(self.max_label + 1, dtype=int)
         idx[self.labels] = self.labels
-        idx[labels] = new_label
+        idx[labels] = new_label  # reassign labels
+
+        if relabel:
+            labels = np.unique(idx[idx != 0])
+            idx2 = np.zeros(max(labels) + 1, dtype=np.int)
+            idx2[labels] = np.arange(len(labels)) + 1
+            idx = idx2[idx]
 
         data_new = idx[self.data]
         self.__dict__ = {}  # reset all cached properties
         self._data = data_new  # use _data to avoid validation
-
-        if relabel:
-            self.relabel_consecutive()
 
     def relabel_consecutive(self, start_label=1):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -282,7 +282,7 @@ class SegmentationImage:
             raise ValueError('data must not contain any non-finite values '
                              '(e.g. NaN, inf)')
 
-        value = np.asanyarray(value, dtype=np.int)
+        value = np.asarray(value, dtype=int)
         if not np.any(value):
             raise ValueError('The segmentation image must contain at least '
                              'one non-zero pixel.')

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -803,8 +803,8 @@ class SegmentationImage:
         if start_label <= 0:
             raise ValueError('start_label must be > 0.')
 
-        if ((self.labels[-1] - self.labels[0] + 1) == self.nlabels and
-                (self.labels[0] == start_label)):
+        if ((self.labels[0] == start_label) and
+                (self.labels[-1] - self.labels[0] + 1) == self.nlabels):
             return
 
         new_labels = np.zeros(self.max_label + 1, dtype=np.int)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1025,10 +1025,7 @@ class SegmentationImage:
         """
 
         self.check_labels(labels)
-
-        self.reassign_label(labels, new_label=0)
-        if relabel:
-            self.relabel_consecutive()
+        self.reassign_labels(labels, new_label=0, relabel=relabel)
 
     def remove_border_labels(self, border_width, partial_overlap=True,
                              relabel=False):

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -4,7 +4,6 @@ This module provides tools for deblending overlapping sources labeled in
 a segmentation image.
 """
 
-from copy import deepcopy
 import warnings
 
 from astropy.utils.exceptions import AstropyUserWarning
@@ -116,7 +115,8 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     data = _filter_data(data, filter_kernel, mode='constant', fill_value=0.0)
 
     last_label = segment_img.max_label
-    segm_deblended = deepcopy(segment_img)
+    segm_deblended = object.__new__(SegmentationImage)
+    segm_deblended._data = np.copy(segment_img.data)
     for label in labels:
         source_slice = segment_img.slices[segment_img.get_index(label)]
         source_data = data[source_slice]

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -112,7 +112,9 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     labels = np.atleast_1d(labels)
     segment_img.check_labels(labels)
 
-    data = _filter_data(data, filter_kernel, mode='constant', fill_value=0.0)
+    if filter_kernel is not None:
+        data = _filter_data(data, filter_kernel, mode='constant',
+                            fill_value=0.0)
 
     last_label = segment_img.max_label
     segm_deblended = object.__new__(SegmentationImage)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -10,7 +10,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
 from .core import SegmentationImage
-from .detect import _make_binary_structure, detect_sources
+from .detect import _make_binary_structure, _detect_sources
 from ..utils.convolution import _filter_data
 from ..utils.exceptions import NoDetectionsWarning
 
@@ -254,18 +254,10 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     # suppress NoDetectionsWarning during deblending
     warnings.filterwarnings('ignore', category=NoDetectionsWarning)
 
-    segments = []
     mask = ~segm_mask
-    for level in thresholds:
-        segm_tmp = detect_sources(data, level, npixels=npixels,
-                                  connectivity=connectivity, mask=mask)
-
-        # NOTE: higher threshold levels may not meet 'npixels' criterion
-        # resulting in no detections
-        if segm_tmp is None or segm_tmp.nlabels == 1:
-            continue
-
-        segments.append(segm_tmp)
+    segments = _detect_sources(data, thresholds, npixels=npixels,
+                               connectivity=connectivity, mask=mask,
+                               deblend_skip=True)
 
     selem = _make_binary_structure(data.ndim, connectivity)
 

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -144,6 +144,11 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
                              'image.')
         image &= ~mask
 
+    # return if threshold was too high to detect any sources
+    if np.count_nonzero(image) == 0:
+        warnings.warn('No sources were found.', NoDetectionsWarning)
+        return None
+
     ndim = image.ndim
     if ndim == 1:
         selem = ndimage.generate_binary_structure(ndim, 1)
@@ -168,13 +173,15 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         if np.count_nonzero(segment_mask) < npixels:
             cutout[segment_mask] = 0
 
-    if np.sum(segm_img) == 0:
+    if np.count_nonzero(segm_img) == 0:
         warnings.warn('No sources were found.', NoDetectionsWarning)
         return None
-    else:
-        segm = SegmentationImage(segm_img)
-        segm.relabel_consecutive()
-        return segm
+
+    segm = object.__new__(SegmentationImage)
+    segm._data = segm_img
+    segm.relabel_consecutive()
+
+    return segm
 
 
 @deprecated_renamed_argument('snr', 'nsigma', 0.7)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -59,6 +59,141 @@ def _make_binary_structure(ndim, connectivity):
     return selem
 
 
+def _detect_sources(data, thresholds, npixels, filter_kernel=None,
+                    connectivity=8, mask=None, deblend_skip=False):
+    """
+    Detect sources above a specified threshold value in an image and
+    return a `~photutils.segmentation.SegmentationImage` object.
+
+    Detected sources must have ``npixels`` connected pixels that are
+    each greater than the ``threshold`` value.  If the filtering option
+    is used, then the ``threshold`` is applied to the filtered image.
+    The input ``mask`` can be used to mask pixels in the input data.
+    Masked pixels will not be included in any source.
+
+    This function does not deblend overlapping sources.  First use this
+    function to detect sources followed by
+    :func:`~photutils.segmentation.deblend_sources` to deblend sources.
+
+    Parameters
+    ----------
+    data : array_like
+        The 2D array of the image.
+
+    thresholds : array-like of floats or arrays
+        The data value or pixel-wise data values to be used for the
+        detection thresholds.  A 2D ``threshold`` must have the same
+        shape as ``data``.  See `~photutils.detection.detect_threshold`
+        for one way to create a ``threshold`` image.
+
+    npixels : int
+        The number of connected pixels, each greater than ``threshold``,
+        that an object must have to be detected.  ``npixels`` must be a
+        positive integer.
+
+    filter_kernel : array-like (2D) or `~astropy.convolution.Kernel2D`, optional
+        The 2D array of the kernel used to filter the image before
+        thresholding.  Filtering the image will smooth the noise and
+        maximize detectability of objects with a shape similar to the
+        kernel.
+
+    connectivity : {4, 8}, optional
+        The type of pixel connectivity used in determining how pixels
+        are grouped into a detected source.  The options are 4 or 8
+        (default).  4-connected pixels touch along their edges.
+        8-connected pixels touch along their edges or corners.  For
+        reference, SExtractor uses 8-connected pixels.
+
+    mask : array_like of bool, optional
+        A boolean mask, with the same shape as the input ``data``, where
+        `True` values indicate masked pixels.  Masked pixels will not be
+        included in any source.
+
+    deblend_skip : bool, optional
+        If `True` do not include the segmentation image in the output
+        list for any threshold level where the number of detected
+        sources is less than 2.  This is useful for source deblending
+        and improves its performance.
+
+    Returns
+    -------
+    segment_image : list of `~photutils.segmentation.SegmentationImage`
+        A list of 2D segmentation images, with the same shape as
+        ``data``, where sources are marked by different positive integer
+        values.  A value of zero is reserved for the background.  If no
+        sources are found for a given threshold, then the output list
+        will contain `None` for that threshold.  Also see the
+        ``deblend_skip`` keyword.
+    """
+
+    from scipy import ndimage
+
+    if (npixels <= 0) or (int(npixels) != npixels):
+        raise ValueError('npixels must be a positive integer, got '
+                         '"{0}"'.format(npixels))
+
+    if mask is not None:
+        if mask.shape != data.shape:
+            raise ValueError('mask must have the same shape as the input '
+                             'image.')
+
+    if filter_kernel is not None:
+        data = _filter_data(data, filter_kernel, mode='constant',
+                            fill_value=0.0, check_normalization=True)
+
+    # ignore RuntimeWarning caused by > comparison when data contains NaNs
+    warnings.simplefilter('ignore', category=RuntimeWarning)
+
+    selem = _make_binary_structure(data.ndim, connectivity)
+
+    segms = []
+    for threshold in thresholds:
+        data2 = data > threshold
+
+        if mask is not None:
+            data2 &= ~mask
+
+        # return if threshold was too high to detect any sources
+        if np.count_nonzero(data2) == 0:
+            warnings.warn('No sources were found.', NoDetectionsWarning)
+            if deblend_skip:
+                continue
+            else:
+                segms.append(None)
+                continue
+
+        segm_img, _ = ndimage.label(data2, structure=selem)
+
+        # remove objects with less than npixels
+        # NOTE:  for typical data, making the cutout images is ~10x faster
+        # than using segm_img directly
+        segm_slices = ndimage.find_objects(segm_img)
+        for i, slices in enumerate(segm_slices):
+            cutout = segm_img[slices]
+            segment_mask = (cutout == (i+1))
+            if np.count_nonzero(segment_mask) < npixels:
+                cutout[segment_mask] = 0
+
+        if np.count_nonzero(segm_img) == 0:
+            warnings.warn('No sources were found.', NoDetectionsWarning)
+            if deblend_skip:
+                continue
+            else:
+                segms.append(None)
+                continue
+
+        segm = object.__new__(SegmentationImage)
+        segm._data = segm_img
+
+        if deblend_skip and segm.nlabels == 1:
+            continue
+        else:
+            segm.relabel_consecutive()
+            segms.append(segm)
+
+    return segms
+
+
 def detect_sources(data, threshold, npixels, filter_kernel=None,
                    connectivity=8, mask=None):
     """
@@ -104,7 +239,7 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         8-connected pixels touch along their edges or corners.  For
         reference, SExtractor uses 8-connected pixels.
 
-    mask : array_like (bool)
+    mask : array_like of bool, optional
         A boolean mask, with the same shape as the input ``data``, where
         `True` values indicate masked pixels.  Masked pixels will not be
         included in any source.
@@ -166,54 +301,9 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         ax2.imshow(segm.data, origin='lower', interpolation='nearest')
     """
 
-    from scipy import ndimage
-
-    if (npixels <= 0) or (int(npixels) != npixels):
-        raise ValueError('npixels must be a positive integer, got '
-                         '"{0}"'.format(npixels))
-
-    if filter_kernel is not None:
-        data = _filter_data(data, filter_kernel, mode='constant',
-                            fill_value=0.0, check_normalization=True)
-
-    # ignore RuntimeWarning caused by > comparison when data contains NaNs
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', category=RuntimeWarning)
-        data = data > threshold
-
-    if mask is not None:
-        if mask.shape != data.shape:
-            raise ValueError('mask must have the same shape as the input '
-                             'image.')
-        data &= ~mask
-
-    # return if threshold was too high to detect any sources
-    if np.count_nonzero(data) == 0:
-        warnings.warn('No sources were found.', NoDetectionsWarning)
-        return None
-
-    selem = _make_binary_structure(data.ndim, connectivity)
-    segm_img, _ = ndimage.label(data, structure=selem)
-
-    # remove objects with less than npixels
-    # NOTE:  for typical data, making the cutout images is ~10x faster
-    # than using segm_img directly
-    segm_slices = ndimage.find_objects(segm_img)
-    for i, slices in enumerate(segm_slices):
-        cutout = segm_img[slices]
-        segment_mask = (cutout == (i+1))
-        if np.count_nonzero(segment_mask) < npixels:
-            cutout[segment_mask] = 0
-
-    if np.count_nonzero(segm_img) == 0:
-        warnings.warn('No sources were found.', NoDetectionsWarning)
-        return None
-
-    segm = object.__new__(SegmentationImage)
-    segm._data = segm_img
-    segm.relabel_consecutive()
-
-    return segm
+    return _detect_sources(data, (threshold,), npixels,
+                           filter_kernel=filter_kernel,
+                           connectivity=connectivity, mask=mask)[0]
 
 
 @deprecated_renamed_argument('snr', 'nsigma', 0.7)


### PR DESCRIPTION
This PR improves the performance of source deblending.  For large (e.g. ~4k x 4k) images with a few thousand sources, it's about ~40-50% faster.   For several hundred sources in smaller images (~1k x 1k), it's about 25% faster.  More performance improvements will come in a later PR.