### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -284,6 +284,72 @@ class ShepardIDWInterpolator:
             return interp_values
 
 
+def _mask_to_mirrored_num(image, mask_image, center_position, bbox=None):
+    """
+    Replace masked pixels with the value of the pixel mirrored across a
+    given ``center_position``.  If the mirror pixel is unavailable (i.e.
+    itself masked or outside of the image), then the masked pixel value
+    is set to zero.
+
+    Parameters
+    ----------
+    image : `numpy.ndarray`, 2D
+        The 2D array of the image.
+
+    mask_image : array-like, bool
+        A boolean mask with the same shape as ``image``, where a `True`
+        value indicates the corresponding element of ``image`` is
+        considered bad.
+
+    center_position : 2-tuple
+        (x, y) center coordinates around which masked pixels will be
+        mirrored.
+
+    bbox : list, tuple, `numpy.ndarray`, optional
+        The bounding box (x_min, x_max, y_min, y_max) over which to
+        replace masked pixels.
+
+    Returns
+    -------
+    result : `numpy.ndarray`, 2D
+        A 2D array with replaced masked pixels.
+    """
+
+    if bbox is None:
+        ny, nx = image.shape
+        bbox = [0, nx, 0, ny]
+    subdata = np.copy(image[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1])
+    submask = mask_image[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1]
+    y_masked, x_masked = np.nonzero(submask)
+    x_mirror = (2 * (center_position[0] - bbox[0]) -
+                x_masked + 0.5).astype('int32')
+    y_mirror = (2 * (center_position[1] - bbox[2]) -
+                y_masked + 0.5).astype('int32')
+
+    # Reset mirrored pixels that go out of the image.
+    outofimage = ((x_mirror < 0) | (y_mirror < 0) |
+                  (x_mirror >= subdata.shape[1]) |
+                  (y_mirror >= subdata.shape[0]))
+    if outofimage.any():
+        x_mirror[outofimage] = x_masked[outofimage].astype('int32')
+        y_mirror[outofimage] = y_masked[outofimage].astype('int32')
+
+    subdata[y_masked, x_masked] = subdata[y_mirror, x_mirror]
+
+    # Set pixels that mirrored to another masked pixel to zero.
+    # This will also set to zero any pixels that mirrored out of
+    # the image.
+    mirror_is_masked = submask[y_mirror, x_mirror]
+    x_bad = x_masked[mirror_is_masked]
+    y_bad = y_masked[mirror_is_masked]
+    subdata[y_bad, x_bad] = 0.0
+
+    outimage = np.copy(image)
+    outimage[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1] = subdata
+
+    return outimage
+
+
 @deprecated(0.7)
 def mask_to_mirrored_num(image, mask_image, center_position, bbox=None):
     """
@@ -330,36 +396,5 @@ def mask_to_mirrored_num(image, mask_image, center_position, bbox=None):
            [12, 13, 14, 15]])
     """
 
-    if bbox is None:
-        ny, nx = image.shape
-        bbox = [0, nx, 0, ny]
-    subdata = np.copy(image[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1])
-    submask = mask_image[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1]
-    y_masked, x_masked = np.nonzero(submask)
-    x_mirror = (2 * (center_position[0] - bbox[0]) -
-                x_masked + 0.5).astype('int32')
-    y_mirror = (2 * (center_position[1] - bbox[2]) -
-                y_masked + 0.5).astype('int32')
-
-    # Reset mirrored pixels that go out of the image.
-    outofimage = ((x_mirror < 0) | (y_mirror < 0) |
-                  (x_mirror >= subdata.shape[1]) |
-                  (y_mirror >= subdata.shape[0]))
-    if outofimage.any():
-        x_mirror[outofimage] = x_masked[outofimage].astype('int32')
-        y_mirror[outofimage] = y_masked[outofimage].astype('int32')
-
-    subdata[y_masked, x_masked] = subdata[y_mirror, x_mirror]
-
-    # Set pixels that mirrored to another masked pixel to zero.
-    # This will also set to zero any pixels that mirrored out of
-    # the image.
-    mirror_is_masked = submask[y_mirror, x_mirror]
-    x_bad = x_masked[mirror_is_masked]
-    y_bad = y_masked[mirror_is_masked]
-    subdata[y_bad, x_bad] = 0.0
-
-    outimage = np.copy(image)
-    outimage[bbox[2]:bbox[3]+1, bbox[0]:bbox[1]+1] = subdata
-
-    return outimage
+    return _mask_to_mirrored_num(image, mask_image, center_position,
+                                 bbox=bbox)

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from .. import ShepardIDWInterpolator as idw
-from .. import mask_to_mirrored_num
+from ..interpolation import _mask_to_mirrored_num
 
 try:
     import scipy  # noqa
@@ -131,7 +131,7 @@ class TestMaskToMirroredNum:
         data_ref = data.copy()
         data_ref[0, 0] = data[3, 3]
         data_ref[1, 1] = data[2, 2]
-        mirror_data = mask_to_mirrored_num(data, mask, center)
+        mirror_data = _mask_to_mirrored_num(data, mask, center)
         assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)
 
     def test_mask_to_mirrored_num_range(self):
@@ -147,7 +147,7 @@ class TestMaskToMirroredNum:
         data_ref = data.copy()
         data_ref[0, 0] = 0.
         data_ref[1, 1] = 0.
-        mirror_data = mask_to_mirrored_num(data, mask, center)
+        mirror_data = _mask_to_mirrored_num(data, mask, center)
         assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)
 
     def test_mask_to_mirrored_num_masked(self):
@@ -163,7 +163,7 @@ class TestMaskToMirroredNum:
         data_ref = data.copy()
         data_ref[0, 0] = 0.
         data_ref[1, 1] = 0.
-        mirror_data = mask_to_mirrored_num(data, mask, center)
+        mirror_data = _mask_to_mirrored_num(data, mask, center)
         assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)
 
     def test_mask_to_mirrored_num_bbox(self):
@@ -179,5 +179,5 @@ class TestMaskToMirroredNum:
         data_ref = data.copy()
         data_ref[1, 1] = data[2, 2]
         bbox = (1, 2, 1, 2)
-        mirror_data = mask_to_mirrored_num(data, mask, center, bbox=bbox)
+        mirror_data = _mask_to_mirrored_num(data, mask, center, bbox=bbox)
         assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)


### PR DESCRIPTION
Fix so that `AstropyDeprecationWarning` isn't raised in testing for this deprecated function.