### PR TITLE
Pin MPL to <3.1 for RTD builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,7 @@ python:
       path: .
       extra_requirements:
         - docs
+    - requirements: docs/rtd_requirements.txt
 
 submodules:
   include: all

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,0 +1,1 @@
+matplotlib<3.1


### PR DESCRIPTION
RTD builds started failing late last week due to excessive memory consumption.  @bsipocz suggested this possible fix.