### PR TITLE
Fix radial gradient computation in `ellipse`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,7 @@ Bug Fixes
 
   - Fixed an issue where the linear fitting mode was not working.
     [#912]
+  - Fixed radial gradient computation []
 
 - ``photutils.psf``
 
@@ -239,6 +240,10 @@ API changes
 
   - Isophote central values and intensity gradients are now returned
     in the output table. [#892]
+
+  - Sample ``update`` method now needs to know the fix/fit state of
+    each individual parameter. This can be passed to it via a
+    Geometry instance, as in ``update(geometry.fix)`` []
 
 - ``photutils.psf``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,7 +118,8 @@ Bug Fixes
 
   - Fixed an issue where the linear fitting mode was not working.
     [#912]
-  - Fixed radial gradient computation []
+
+  - Fixed the radial gradient computation [#934].
 
 - ``photutils.psf``
 
@@ -241,9 +242,10 @@ API changes
   - Isophote central values and intensity gradients are now returned
     in the output table. [#892]
 
-  - Sample ``update`` method now needs to know the fix/fit state of
-    each individual parameter. This can be passed to it via a
-    Geometry instance, as in ``update(geometry.fix)`` []
+  - The ``EllipseSample`` ``update`` method now needs to know the
+    fix/fit state of each individual parameter.  This can be passed to
+    it via a ``Geometry`` instance, e.g. ``update(geometry.fix)``.
+    [#922]
 
 - ``photutils.psf``
 

--- a/photutils/isophote/sample.py
+++ b/photutils/isophote/sample.py
@@ -304,10 +304,14 @@ class EllipseSample:
         # another sample, this time using larger radius. Meaningful
         # gradient means something  shallower, but still close to within
         # a factor 3 from previous gradient estimate. If no previous
-        # estimate is available, guess it.
+        # estimate is available, guess it by adding the error to the
+        # current gradient.
         previous_gradient = self.gradient
         if not previous_gradient:
-            previous_gradient = -0.05  # good enough, based on usage
+            previous_gradient = gradient + gradient_error
+
+            # solution adopted before 08/12/2019
+            # previous_gradient = -0.05  # good enough, based on usage
 
         if gradient >= (previous_gradient / 3.):  # gradient is negative!
             gradient, gradient_error = self._get_gradient(2 * step)

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -64,9 +64,9 @@ class TestEllipse:
         # verify that the list is properly sorted in sem-major axis length
         assert isophote_list[-1] > isophote_list[0]
 
-        # the fit should stop where gradient looses reliability.
-        assert len(isophote_list) == 67
-        assert isophote_list[-1].stop_code == 5
+        # the fit should stop where gradient loses reliability.
+        assert len(isophote_list) == 69
+        assert isophote_list[-1].stop_code == 1
 
     def test_linear(self):
         ellipse = Ellipse(self.data)
@@ -158,7 +158,7 @@ class TestEllipseOnRealData:
         ellipse = Ellipse(data, geometry=g)
         isophote_list = ellipse.fit_image()
 
-        assert len(isophote_list) == 57
+        assert len(isophote_list) == 64
 
         # check that isophote at about sma=70 got an uneventful fit
         assert isophote_list.get_closest(70.).stop_code == 0

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -44,10 +44,11 @@ def test_model():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_model_simulated_data():
-    data = make_test_image(eps=0.5, pa=np.pi/3., noise=1.e-2,
+    data = make_test_image(nx=200, ny=200, i0=10., sma=5.,
+                           eps=0.5, pa=np.pi/3., noise=0.05,
                            random_state=123)
 
-    g = EllipseGeometry(256., 256., 10., 0.5, np.pi/3.)
+    g = EllipseGeometry(100., 100., 5., 0.5, np.pi/3.)
     ellipse = Ellipse(data, geometry=g, threshold=1.e5)
     isophote_list = ellipse.fit_image()
     model = build_ellipse_model(data.shape, isophote_list,


### PR DESCRIPTION
This was uncovered when fixing issue #920 . 

The fix may generate slightly different results in a few cases, but mostly it increases stability in low SNR areas on the image, typically at the outskirts of galaxies. The algorithm is able to keep iterating on wider ellipses than before.

Tests were verified and modified accordingly The fix was also verified on the notebooks in `photutils-datasets`, for which there is also PR #17
