### PR TITLE
Fix ellipse fitting test for new gradient computation

### DIFF
--- a/photutils/isophote/tests/test_fitter.py
+++ b/photutils/isophote/tests/test_fitter.py
@@ -201,7 +201,7 @@ class TestM51:
         isophote = fitter.fit()
 
         assert isophote.ndata == 382
-        assert_allclose(isophote.intens, 155.0, atol=0.1)
+        assert_allclose(isophote.intens, 156.3, atol=0.1)
 
     def test_m51_outer(self):
         # sample taken at the outskirts of the image, so many


### PR DESCRIPTION
This test (with the remote M51 data) started failing after the new gradient computation was added in #934.