### PR TITLE
Fix to EPSFModel initial_norm, where flux failed to be returned

### DIFF
--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -546,11 +546,14 @@ class EPSFModel(FittableImageModel):
         if flux is None:
             if self._img_norm is None:
                 self._img_norm = self._compute_raw_image_norm()
+            flux = self._img_norm
 
         if normalize:
             self._compute_normalization()
         else:
             self._img_norm = self._compute_raw_image_norm()
+
+        return flux
 
     def _compute_raw_image_norm(self):
         """


### PR DESCRIPTION
A very small pull request to tweak a bugfix for a bug found and fixed in #937, where in `EPSFModel._initial_norm` the `flux` assignment incorrectly failed to be returned, rather than being an unused variable (cf. the equivalent function in `FittableImageModel` [here](https://github.com/astropy/photutils/blob/59a85c05dcf4735da7a13bdcefb95c154e0a3600/photutils/psf/models.py#L162-L171)), as was implemented in the above PR.