### PR TITLE
Fix to IterativelySubtractedPSFPhotometry where residual_image was not set for non-background subtracted images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.psf``
+
+  - Fix to ``IterativelySubtractedPSFPhotometry`` where the residual
+    image was not initialized when ``bkg_estimator`` was not
+    supplied. [#942]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -674,6 +674,8 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         else:
             if self.bkg_estimator is not None:
                 self._residual_image = image - self.bkg_estimator(image)
+            else:
+                self._residual_image = image
 
             if self.aperture_radius is None:
                 if hasattr(self.psf_model, 'fwhm'):


### PR DESCRIPTION
Very small pull request to fix the case where `self._residual_image` is never initialised for the case where `bkg_estimator=None` in `IterativelySubtractedPSFPhotometry`.