### PR TITLE
TST: Update flake8 setting for pep8speaks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,3 +1,6 @@
+scanner:
+    linter: flake8
+
 flake8:
   max-line-length: 120 # Default is 79 in PEP8
 


### PR DESCRIPTION
Attempt to fix #944 . Not sure how to test.

Looking at https://github.com/OrkoHunter/pep8speaks/blob/master/.pep8speaks.yml , I am not sure why `max-line-length` is not working, so I copy over the one thing that appears missing here compared to that one.