### PR TITLE
Reduce max line length in pep8speak

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,7 +2,7 @@ scanner:
     linter: flake8
 
 flake8:
-  max-line-length: 100  # Default is 79 in PEP8
+  max-line-length: 79  # Using the default of 79 in PEP8
 
   ignore:
     - E741  # l and b are valid variable names for the galactic frame

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,7 +2,7 @@ scanner:
     linter: flake8
 
 flake8:
-  max-line-length: 120 # Default is 79 in PEP8
+  max-line-length: 100  # Default is 79 in PEP8
 
   ignore:
     - E741  # l and b are valid variable names for the galactic frame


### PR DESCRIPTION
In a way that will not make @eteq unhappy. :wink: 

(I would go with the default 79 if I can have my way though!)