### PR TITLE
Pinning pytest version to workaround 5.1 issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy astropy pytest pytest-astropy pytest-xdist Cython
+          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy astropy "pytest<5.1" pytest-astropy pytest-xdist Cython
       - run:
           name: Run tests
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4


### PR DESCRIPTION
… in the doctestplus plugin

Revert when pytest-doctestplus 0.4 is released.