### PR TITLE
 Update minimum python and astropy dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.6
+        - PYTHON_VERSION=3.7
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - CONDA_CHANNELS='astropy-ci-extras astropy'
@@ -67,7 +67,7 @@ matrix:
     fast_finish: true
 
     include:
-        - env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+        - env: SETUP_CMD='egg_info'
 
         # PEP8/pyflakes test with flake8
         - env: MAIN_CMD="flake8 photutils --count $FLAKE8_OPT" SETUP_CMD=''
@@ -76,7 +76,6 @@ matrix:
         # latest Python version.  The duration of the slowest 50 tests
         # will also be listed.
         - env: SETUP_CMD='test --coverage --remote-data -a "--durations=50"'
-               NUMPY_VERSION=1.14
 
         # Check for Sphinx doc build warnings
         - env: SETUP_CMD='build_docs -w'
@@ -93,29 +92,21 @@ matrix:
           env: CONDA_DEPENDENCIES=''
                PIP_DEPENDENCIES='Cython scipy scikit-learn matplotlib scikit-image>0.14.1'
 
-        # Test with other Python versions
+        # Test with the oldest-supported Python and numpy versions
         - stage: Comprehensive tests
-          env: PYTHON_VERSION=3.7
-
-        # Test with Astropy LTS version and older numpy versions
-        - stage: Comprehensive tests
-          env: PYTHON_VERSION=3.5
+          env: PYTHON_VERSION=3.6
                NUMPY_VERSION=1.13
-               ASTROPY_VERSION=lts
-               PIP_DEPENDENCIES='pytest<3.10 scikit-image>0.14.1'
-               EVENT_TYPE='pull_request push cron'
 
-        # Test with other numpy versions
+        # Test with an older numpy version
         - stage: Comprehensive tests
-          env: PYTHON_VERSION=3.7
-               NUMPY_VERSION=1.15
+          env: NUMPY_VERSION=1.15
 
-        # Test with Astropy dev version
+        # Test with the Astropy development version
         - stage: Comprehensive tests
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
 
-        # Test with numpy pre-release version
+        # Test with the numpy pre-release version
         - stage: Comprehensive tests
           env: NUMPY_VERSION=dev
                EVENT_TYPE='push pull_request cron'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 General
 ^^^^^^^
 
+- The minimum required python version is >= 3.6. [#952]
+
+- The minimum required astropy version is >= 3.2. [#952]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,11 +7,11 @@ Requirements
 
 Photutils has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.5 or later
+* `Python <https://www.python.org/>`_ 3.6 or later
 
 * `Numpy <https://www.numpy.org/>`_ 1.13 or later
 
-* `Astropy`_ 2.0 or later
+* `Astropy`_ 3.2 or later
 
 Photutils also optionally depends on other packages for some features:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,20 +21,19 @@ classifiers =
     Programming Language :: Cython
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Astronomy
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 packages = find:
 setup_requires =
     numpy>=1.13
 install_requires =
     numpy>=1.13
-    astropy>=2.0
+    astropy>=3.2
 tests_require =
     pytest
     pytest-remotedata


### PR DESCRIPTION
The next version of `photutils` will require `python >= 3.6` and `astropy >= 3.2`.  Updating the astropy dependency allows us to take advantage of significant performance improvements (starting with v3.1) and the latest version (i.e fixes) of the shared interface for WCS (APE14).  `astropy 4.0` will be released in the fall.