### PR TITLE
Remove high level API doc page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ import photutils
 
 rst_epilog = """
 .. _Astropy: https://www.astropy.org/
-.. _Photutils: high-level_API.html
+.. _Photutils: index.html
 """
 
 # -- Project information ------------------------------------------------------

--- a/docs/high-level_API.rst
+++ b/docs/high-level_API.rst
@@ -1,9 +1,0 @@
-API Reference
-=============
-
-These are the functions and classes available in the top-level
-``photutils`` namespace.  Other functionality is available by
-importing specific sub-packages (e.g. `photutils.utils`).
-
-.. automodapi:: photutils
-    :no-heading:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,11 @@ User Documentation
     datasets.rst
     utils.rst
 
+.. toctree::
+    :hidden:
+
+    test_function.rst
+
 .. note::
 
     Like much astronomy software, Photutils is an evolving package.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,11 +69,6 @@ User Documentation
     datasets.rst
     utils.rst
 
-.. toctree::
-    :maxdepth: 1
-
-    high-level_API.rst
-
 .. note::
 
     Like much astronomy software, Photutils is an evolving package.

--- a/docs/test_function.rst
+++ b/docs/test_function.rst
@@ -1,0 +1,4 @@
+Photutils Test Function
+=======================
+
+.. autofunction:: photutils.test

--- a/photutils/__init__.py
+++ b/photutils/__init__.py
@@ -24,8 +24,6 @@ if not _ASTROPY_SETUP_:  # noqa
     from .psf import *  # noqa
     from .segmentation import *  # noqa
 
-__all__ = ['test']  # the test runner is defined in _astropy_init
-
 
 # Set the bibtex entry to the article referenced in CITATION.
 def _get_bibtex():


### PR DESCRIPTION
The `high-level_API` doc page relies on *not* having `__all__` defined in the package init.  Here I remove that page, since it's not really necessary.