### PR TITLE
Fix a labeling bug in deblend_sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,15 @@ API changes
     ``assert_angle``, and ``pixel_to_icrs_coords``. [#953]
 
 
+0.7.1 (unreleased)
+------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- Fixed a labeling bug in ``deblend_sources``. [#961]
+
+
 0.7 (2019-08-14)
 ----------------
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -140,6 +140,8 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
                              'developers.'.format(label))
 
         if source_deblended.nlabels > 1:
+            source_deblended.relabel_consecutive(start_label=1)
+
             # replace the original source with the deblended source
             source_mask = (source_deblended.data > 0)
             segm_tmp = segm_deblended.data
@@ -212,7 +214,8 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     segment_image : `~photutils.segmentation.SegmentationImage`
         A segmentation image, with the same shape as ``data``, where
         sources are marked by different positive integer values.  A
-        value of zero is reserved for the background.
+        value of zero is reserved for the background.  Note that the
+        returned `SegmentationImage` may *not* have consecutive labels.
     """
 
     from scipy.ndimage import label as ndilabel

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -131,6 +131,32 @@ class TestDeblendSources:
         with pytest.raises(ValueError):
             deblend_sources(data, segm, 1, mode='linear', connectivity=4)
 
+    def test_deblend_label_assignment(self):
+        """
+        Regression test to ensure newly-deblended labels are unique.
+        """
+
+        y, x = np.mgrid[0:201, 0:101]
+        y0a = 35
+        y1a = 60
+        yshift = 100
+        y0b = y0a + yshift
+        y1b = y1a + yshift
+        data = (Gaussian2D(80, 36, y0a, 8, 8)(x, y) +
+                Gaussian2D(71, 58, y1a, 8, 8)(x, y) +
+                Gaussian2D(30, 36, y1a, 7, 7)(x, y) +
+                Gaussian2D(30, 58, y0a, 7, 7)(x, y) +
+                Gaussian2D(80, 36, y0b, 8, 8)(x, y) +
+                Gaussian2D(71, 58, y1b, 8, 8)(x, y) +
+                Gaussian2D(30, 36, y1b, 7, 7)(x, y) +
+                Gaussian2D(30, 58, y0b, 7, 7)(x, y))
+
+        npixels = 5
+        segm1 = detect_sources(data, 5.0, npixels)
+        segm2 = deblend_sources(data, segm1, npixels, mode='linear',
+                                nlevels=32, contrast=0.3)
+        assert segm2.nlabels == 4
+
     @pytest.mark.parametrize('mode', ['exponential', 'linear'])
     def test_deblend_sources_norelabel(self, mode):
         result = deblend_sources(self.data, self.segm, self.npixels,


### PR DESCRIPTION
This PR fixes #959, which was caused by a re-labeling bug introduced in v0.7 in `deblend_sources`.

Many thanks to @thriveth for reporting the original bug and providing the data and a MWE that enabled me to debug this issue!