### PR TITLE
Fix to ePSF algorithm changes in v0.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,16 +86,8 @@ Bug Fixes
 
 - ``photutils.psf``
 
-  - Fix to algorithm in ``EPSFBuilder``, causing issues where ePSFs
-    failed to build. [#974]
-
-API changes
-^^^^^^^^^^^
-
-- ``photutils.psf``
-
-  - Added ``flux_residual_sigclip`` as an input parameter, allowing for
-    custom sigma clipping options in ``EPSFBuilder``. [#974]
+  - Fix to algorithm in ``EPSFBuilder``, addressing issues where ePSFs
+    failed to build (yielding striped ePSFs). [#974]
 
 
 0.7.1 (2019-10-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,26 @@ API changes
     ``assert_angle``, and ``pixel_to_icrs_coords``. [#953]
 
 
+0.7.2 (Unreleased)
+------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- ``photutils.psf``
+
+  - Fix to algorithm in ``EPSFBuilder``, causing issues where ePSFs
+    failed to build. [#974]
+
+API changes
+^^^^^^^^^^^
+
+- ``photutils.psf``
+
+  - Added ``flux_residual_sigclip`` as an input parameter, allowing for
+    custom sigma clipping options in ``EPSFBuilder``. [#974]
+
+
 0.7.1 (2019-10-09)
 ------------------
 

--- a/docs/epsf.rst
+++ b/docs/epsf.rst
@@ -21,9 +21,11 @@ Building an ePSF
 
 Photutils provides tools for building an ePSF following the
 prescription of `Anderson and King (2000; PASP 112, 1360)
-<http://adsabs.harvard.edu/abs/2000PASP..112.1360A>`_ The process
-involves iterating between the ePSF itself and the stars used to build
-it.
+<http://adsabs.harvard.edu/abs/2000PASP..112.1360A>`_ and subsequent
+enhancements detailed mainly in
+`Anderson (2016), ISR WFC3 2016-12 <www.stsci.edu/hst/wfc3/documents/ISRs/WFC3-2016-12.pdf>`_.
+The process involves iterating between the ePSF itself and the stars
+used to build it.
 
 To begin, we must first define a sample of stars used to build the
 ePSF.  Ideally these stars should be bright (high S/N) and isolated to

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -295,7 +295,8 @@ class EPSFBuilder:
     def __init__(self, oversampling=4., shape=None,
                  smoothing_kernel='quartic', recentering_func=centroid_epsf,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
-                 progress_bar=True, norm_radius=5.5, shift_val=0.5):
+                 progress_bar=True, norm_radius=5.5, shift_val=0.5,
+                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3):
 
         if oversampling is None:
             raise ValueError("'oversampling' must be specified.")
@@ -315,12 +316,18 @@ class EPSFBuilder:
 
         self.recentering_func = recentering_func
         self.recentering_maxiters = recentering_maxiters
+        self.recentering_boxsize = self._init_img_params(recentering_boxsize)
+        self.recentering_boxsize = self.recentering_boxsize.astype(int)
 
         self.smoothing_kernel = smoothing_kernel
 
         if not isinstance(fitter, EPSFFitter):
             raise TypeError('fitter must be an EPSFFitter instance.')
         self.fitter = fitter
+
+        if center_accuracy <= 0.0:
+            raise ValueError('center_accuracy must be a positive number.')
+        self.center_accuracy_sq = center_accuracy**2
 
         maxiters = int(maxiters)
         if maxiters <= 0:
@@ -440,29 +447,33 @@ class EPSFBuilder:
             image contains NaNs where there is no data.
         """
 
-        x = epsf.oversampling[0] * star._xidx_centered
-        y = epsf.oversampling[1] * star._yidx_centered
-        epsf_xcenter, epsf_ycenter = (int((epsf.data.shape[1] - 1) / 2),
-                                      int((epsf.data.shape[0] - 1) / 2))
-        xidx = _py2intround(x + epsf_xcenter)
-        yidx = _py2intround(y + epsf_ycenter)
-
-        mask = np.logical_and(np.logical_and(xidx >= 0, xidx < epsf.shape[1]),
-                              np.logical_and(yidx >= 0, yidx < epsf.shape[0]))
-        xidx = xidx[mask]
-        yidx = yidx[mask]
+        # Compute the normalized residual by subtracting the ePSF model
+        # from the normalized star at the location of the star in the
+        # undersampled grid.
 
         x = star._xidx_centered
         y = star._yidx_centered
 
-        # Compute the normalized residual by subtracting the ePSF model
-        # from the normalized star at the location of the star in the
-        # undersampled grid.
         stardata = (star._data_values_normalized -
                     epsf.evaluate(x=x, y=y, flux=1.0, x_0=0.0, y_0=0.0))
 
+        x = epsf.oversampling[0] * star._xidx_centered
+        y = epsf.oversampling[1] * star._yidx_centered
+        epsf_xcenter, epsf_ycenter = (int((epsf.data.shape[1] - 1) / 2),
+                                      int((epsf.data.shape[0] - 1) / 2))
+        _xidx = _py2intround(x + epsf_xcenter)
+        _yidx = _py2intround(y + epsf_ycenter)
+
         resampled_img = np.full(epsf.shape, np.nan)
-        resampled_img[yidx, xidx] = stardata[mask]
+
+        mask = np.logical_and(np.logical_and(xidx >= 0,
+                                             xidx < epsf.shape[1]),
+                              np.logical_and(yidx >= 0,
+                                             yidx < epsf.shape[0]))
+        xidx_ = xidx[mask]
+        yidx_ = yidx[mask]
+
+        resampled_img[yidx_, xidx_] = stardata[mask]
 
         return resampled_img
 
@@ -553,7 +564,8 @@ class EPSFBuilder:
 
         return convolve(epsf_data, kernel)
 
-    def _recenter_epsf(self, epsf, centroid_func=centroid_epsf):
+    def _recenter_epsf(self, epsf, centroid_func=centroid_epsf,
+                       box_size=(5, 5), maxiters=20, center_accuracy=1.0e-4):
         """
         Calculate the center of the ePSF data and shift the data so the
         ePSF center is at the center of the ePSF data array.
@@ -570,6 +582,20 @@ class EPSFBuilder:
             optionally an ``error`` keyword.  The callable object must
             return a tuple of two 1D `~numpy.ndarray` variables, representing
             the x and y centroids.
+        box_size : float or tuple of two floats, optional
+            The size (in pixels) of the box used to calculate the
+            centroid of the ePSF during each build iteration.  If a
+            single integer number is provided, then a square box will be
+            used.  If two values are provided, then they should be in
+            ``(ny, nx)`` order.  The default is 5.
+        maxiters : int, optional
+            The maximum number of recentering iterations to perform.
+            The default is 20.
+        center_accuracy : float, optional
+            The desired accuracy for the centers of stars.  The building
+            iterations will stop if the center of the ePSF changes by
+            less than ``center_accuracy`` pixels between iterations.
+            The default is 1.0e-4.
 
         Returns
         -------
@@ -577,41 +603,80 @@ class EPSFBuilder:
             The recentered ePSF data.
         """
 
+        epsf_data = epsf._data
+
+        epsf = EPSFModel(data=epsf._data, origin=epsf.origin,
+                         oversampling=epsf.oversampling,
+                         norm_radius=epsf._norm_radius,
+                         shift_val=epsf._shift_val, normalize=False)
+
         xcenter, ycenter = epsf.origin
 
         y, x = np.indices(epsf._data.shape, dtype=np.float)
         x /= epsf.oversampling[0]
         y /= epsf.oversampling[1]
 
-        mask = ~np.isfinite(epsf._data)
+        dx_total, dy_total = 0, 0
+        iter_num = 0
+        center_accuracy_sq = center_accuracy ** 2
+        center_dist_sq = center_accuracy_sq + 1.e6
+        center_dist_sq_prev = center_dist_sq + 1
+        while (iter_num < maxiters and
+               center_dist_sq >= center_accuracy_sq):
+            iter_num += 1
 
-        try:
-            # find a new center position
-            xcenter_new, ycenter_new = centroid_func(
-                epsf._data, mask=mask, oversampling=epsf.oversampling,
-                shift_val=epsf._shift_val)
-        except TypeError:
-            # centroid_func doesn't accept oversampling and/or shift_val
-            # keywords - try oversampling alone
+            # Anderson & King (2000) recentering function depends
+            # on specific pixels, and thus does not need a cutout
+            if self.recentering_func == centroid_epsf:
+                epsf_cutout = epsf_data
+            else:
+                slices_large, _ = overlap_slices(epsf_data.shape, box_size,
+                                                 (ycenter *
+                                                  self.oversampling[1],
+                                                  xcenter *
+                                                  self.oversampling[0]))
+                epsf_cutout = epsf_data[slices_large]
+            mask = ~np.isfinite(epsf_cutout)
+
             try:
+                # find a new center position
                 xcenter_new, ycenter_new = centroid_func(
-                    epsf._data, mask=mask, oversampling=epsf.oversampling)
+                    epsf_cutout, mask=mask, oversampling=epsf.oversampling,
+                    shift_val=epsf._shift_val)
             except TypeError:
-                # centroid_func doesn't accept oversampling and
-                # shift_val
-                xcenter_new, ycenter_new = centroid_func(epsf._data,
-                                                         mask=mask)
+                # centroid_func doesn't accept oversampling and/or shift_val
+                # keywords - try oversampling alone
+                try:
+                    xcenter_new, ycenter_new = centroid_func(
+                        epsf_cutout, mask=mask, oversampling=epsf.oversampling)
+                except TypeError:
+                    # centroid_func doesn't accept oversampling and
+                    # shift_val
+                    xcenter_new, ycenter_new = centroid_func(epsf_cutout,
+                                                             mask=mask)
 
-        # Calculate the shift; dx = i - x_star so if dx was positively
-        # incremented then x_star was negatively incremented for a given i.
-        # We will therefore actually subsequently subtract dx from xcenter
-        # (or x_star).
-        dx = xcenter_new - xcenter
-        dy = ycenter_new - ycenter
+            xcenter_new += slices_large[1].start/self.oversampling[0]
+            ycenter_new += slices_large[0].start/self.oversampling[1]
 
-        epsf_data = epsf.evaluate(x=x, y=y, flux=1.0,
-                                  x_0=xcenter - dx,  # subtract dx from x_0
-                                  y_0=ycenter - dy)  # even if positive
+            # Calculate the shift; dx = i - x_star so if dx was positively
+            # incremented then x_star was negatively incremented for a given i.
+            # We will therefore actually subsequently subtract dx from xcenter
+            # (or x_star).
+            dx = xcenter_new - xcenter
+            dy = ycenter_new - ycenter
+
+            center_dist_sq = dx**2 + dy**2
+
+            if center_dist_sq >= center_dist_sq_prev:  # don't shift
+                break
+            center_dist_sq_prev = center_dist_sq
+
+            dx_total += dx
+            dy_total += dy
+
+            epsf_data = epsf.evaluate(x=x, y=y, flux=1.0,
+                                      x_0=xcenter - dx_total,
+                                      y_0=ycenter - dy_total)
 
         return epsf_data
 
@@ -645,42 +710,43 @@ class EPSFBuilder:
             # improve the input ePSF
             epsf = copy.deepcopy(epsf)
 
-        for _ in range(self.recentering_maxiters):
-            # compute a 3D stack of 2D residual images
-            residuals = self._resample_residuals(stars, epsf)
+        # compute a 3D stack of 2D residual images
+        residuals = self._resample_residuals(stars, epsf)
 
-            # compute the sigma-clipped mean along the 3D stack
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', category=RuntimeWarning)
-                warnings.simplefilter('ignore', category=AstropyUserWarning)
-                residuals = self.sigclip(residuals, axis=0, masked=False,
-                                         return_bounds=False)
-                if HAS_BOTTLENECK:
-                    residuals = bottleneck.nanmean(residuals, axis=0)
-                else:
-                    residuals = np.nanmean(residuals, axis=0)
+        # compute the sigma-clipped mean along the 3D stack
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+            warnings.simplefilter('ignore', category=AstropyUserWarning)
+            residuals = self.sigclip(residuals, axis=0, masked=False,
+                                     return_bounds=False)
+            if HAS_BOTTLENECK:
+                residuals = bottleneck.nanmean(residuals, axis=0)
+            else:
+                residuals = np.nanmean(residuals, axis=0)
 
-            # interpolate any missing data (np.nan)
-            mask = ~np.isfinite(residuals)
-            if np.any(mask):
-                residuals = _interpolate_missing_data(residuals, mask,
-                                                      method='cubic')
+        # interpolate any missing data (np.nan)
+        mask = ~np.isfinite(residuals)
+        if np.any(mask):
+            residuals = _interpolate_missing_data(residuals, mask,
+                                                  method='cubic')
 
-                # fill any remaining nans (outer points) with zeros
-                residuals[~np.isfinite(residuals)] = 0.
+            # fill any remaining nans (outer points) with zeros
+            residuals[~np.isfinite(residuals)] = 0.
 
-            # add the residuals to the previous ePSF image
-            new_epsf = epsf._data + residuals
+        # add the residuals to the previous ePSF image
+        new_epsf = epsf._data + residuals
 
-            epsf = EPSFModel(data=new_epsf, origin=epsf.origin,
-                             oversampling=epsf.oversampling,
-                             norm_radius=epsf._norm_radius,
-                             shift_val=epsf._shift_val, normalize=False)
+        epsf = EPSFModel(data=new_epsf, origin=epsf.origin,
+                         oversampling=epsf.oversampling,
+                         norm_radius=epsf._norm_radius,
+                         shift_val=epsf._shift_val, normalize=False)
 
-            # smooth and recenter the ePSF
-            epsf._data = self._smooth_epsf(epsf._data)
-            epsf._data = self._recenter_epsf(
-                epsf, centroid_func=self.recentering_func)
+        # smooth and recenter the ePSF
+        epsf._data = self._smooth_epsf(epsf._data)
+        epsf._data = self._recenter_epsf(
+            epsf, centroid_func=self.recentering_func,
+            box_size=self.recentering_boxsize,
+            maxiters=self.recentering_maxiters)
 
         # return the new ePSF object, but with undersampled grid pixel
         # coordinates
@@ -720,8 +786,11 @@ class EPSFBuilder:
         fit_failed = np.zeros(n_stars, dtype=bool)
         epsf = init_epsf
         dt = 0.
+        center_dist_sq = self.center_accuracy_sq + 1.
+        centers = stars.cutout_center_flat
 
-        while (iter_num < self.maxiters and not np.all(fit_failed)):
+        while (iter_num < self.maxiters and not np.all(fit_failed) and
+               np.max(center_dist_sq) >= self.center_accuracy_sq):
 
             t_start = time.time()
             iter_num += 1
@@ -759,6 +828,13 @@ class EPSFBuilder:
                 idx = fit_failed.nonzero()[0]
                 for i in idx:
                     stars.all_stars[i]._excluded_from_fit = True
+
+            # if no star centers have moved by more than pixel accuracy,
+            # stop the iteration loop early
+            dx_dy = stars.cutout_center_flat - centers
+            dx_dy = dx_dy[np.logical_not(fit_failed)]
+            center_dist_sq = np.sum(dx_dy * dx_dy, axis=1, dtype=np.float64)
+            centers = stars.cutout_center_flat
 
             self._epsf.append(epsf)
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -603,15 +603,13 @@ class EPSFBuilder:
             centroid of the ePSF during each build iteration.  If a
             single integer number is provided, then a square box will be
             used.  If two values are provided, then they should be in
-            ``(ny, nx)`` order.  The default is 5.
+            ``(ny, nx)`` order.
         maxiters : int, optional
             The maximum number of recentering iterations to perform.
-            The default is 20.
         center_accuracy : float, optional
             The desired accuracy for the centers of stars.  The building
             iterations will stop if the center of the ePSF changes by
             less than ``center_accuracy`` pixels between iterations.
-            The default is 1.0e-4.
 
         Returns
         -------

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -311,9 +311,8 @@ class EPSFBuilder:
                  smoothing_kernel='quartic', recentering_func=centroid_epsf,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
                  progress_bar=True, norm_radius=5.5, shift_val=0.5,
-                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3,
-                 cenfunc='median', maxiters=10):
-        flux_residual_sigclip = SigmaClip(sigma=3  # TODO: replace with kwarg in 8.0
+                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3):
+        flux_residual_sigclip = SigmaClip(sigma=3, cenfunc='median', maxiters=10)  # TODO: replace with kwarg in 8.0
 
         if oversampling is None:
             raise ValueError("'oversampling' must be specified.")

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -290,13 +290,18 @@ class EPSFBuilder:
     shift_val : float, optional
         The undersampled value at which to compute the shifts.  It must
         be a strictly positive number.
+
+    sigclip : `~astropy.stats.SigmaClip` object, optional
+        A `~astropy.stats.SigmaClip` object used to compute the residual
+        of ePSF grid points based on star sampling residuals.
     """
 
     def __init__(self, oversampling=4., shape=None,
                  smoothing_kernel='quartic', recentering_func=centroid_epsf,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
                  progress_bar=True, norm_radius=5.5, shift_val=0.5,
-                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3):
+                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3,
+                 sigclip=SigmaClip(sigma=3, cenfunc='median', maxiters=10)):
 
         if oversampling is None:
             raise ValueError("'oversampling' must be specified.")
@@ -336,8 +341,7 @@ class EPSFBuilder:
 
         self.progress_bar = progress_bar
 
-        # TODO: allow custom SigmaClip object
-        self.sigclip = SigmaClip(sigma=2.5, cenfunc='mean', maxiters=10)
+        self.sigclip = sigclip
 
         # store each ePSF build iteration
         self._epsf = []

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -305,12 +305,6 @@ class EPSFBuilder:
             iterations will stop if the centers of all the stars change by
             less than ``center_accuracy`` pixels between iterations.  All
             stars must meet this condition for the loop to exit.
-
-    flux_residual_sigclip : `~astropy.stats.SigmaClip` object, optional
-        A `~astropy.stats.SigmaClip` object used to determine which pixels
-        are ignored based on the star sampling flux residuals, when
-        computing the average residual of ePSF grid points in each iteration
-        step.
     """
 
     def __init__(self, oversampling=4., shape=None,
@@ -318,8 +312,8 @@ class EPSFBuilder:
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
                  progress_bar=True, norm_radius=5.5, shift_val=0.5,
                  recentering_boxsize=(5, 5), center_accuracy=1.0e-3,
-                 flux_residual_sigclip=SigmaClip(sigma=3, cenfunc='median',
-                                                 maxiters=10)):
+                 cenfunc='median', maxiters=10):
+        flux_residual_sigclip = SigmaClip(sigma=3  # TODO: replace with kwarg in 8.0
 
         if oversampling is None:
             raise ValueError("'oversampling' must be specified.")

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This module provides tools to build and fit an effective PSF (ePSF)
-based on Anderson and King (2000; PASP 112, 1360).
+based on Anderson and King (2000; PASP 112, 1360) and Anderson (2016),
+ISR WFC3 2016-12.
 """
 
 import copy
@@ -233,7 +234,9 @@ class EPSFBuilder:
     Class to build an effective PSF (ePSF).
 
     See `Anderson and King (2000; PASP 112, 1360)
-    <http://adsabs.harvard.edu/abs/2000PASP..112.1360A>`_ for details.
+    <http://adsabs.harvard.edu/abs/2000PASP..112.1360A>`_ and
+    `Anderson (2016), ISR WFC3 2016-12
+    <www.stsci.edu/hst/wfc3/documents/ISRs/WFC3-2016-12.pdf>`_ for details.
 
     Parameters
     ----------

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -179,7 +179,7 @@ def test_epsfmodel_inputs():
 
 
 def test_epsf_build_with_noise():
-    oversampling  = 4
+    oversampling = 4
     size = 25
     sigma = 0.5
 

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -230,10 +230,9 @@ def test_epsf_build_with_noise():
     for star in stars:
         star.cutout_center = centroid_com(star.data)
 
-    epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=20,
+    epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=5,
                                progress_bar=False, norm_radius=7.5,
                                recentering_func=centroid_com,
                                shift_val=0.5)
     epsf, fitted_stars = epsf_builder(stars)
-    print(epsf.data, truth_epsf, np.amax(epsf.data), np.amax(truth_epsf))
     assert_allclose(epsf.data, truth_epsf, rtol=1e-1, atol=5e-2)

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -178,6 +178,7 @@ def test_epsfmodel_inputs():
             EPSFModel(data, origin=origin)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_epsf_build_with_noise():
     oversampling = 4
     size = 25

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -149,9 +149,6 @@ def test_epsfbuilder_inputs():
         EPSFBuilder(oversampling=[3, 6])
     with pytest.raises(ValueError):
         EPSFBuilder(oversampling=[-1, 4])
-    for sigclip in [None, [], 'a']:
-        with pytest.raises(ValueError):
-            EPSFBuilder(flux_residual_sigclip=sigclip)
 
 
 def test_epsfmodel_inputs():

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -151,7 +151,7 @@ def test_epsfbuilder_inputs():
         EPSFBuilder(oversampling=[-1, 4])
     for sigclip in [None, [], 'a']:
         with pytest.raises(ValueError):
-            EPSFBuilder(sigclip=sigclip)
+            EPSFBuilder(flux_residual_sigclip=sigclip)
 
 
 def test_epsfmodel_inputs():


### PR DESCRIPTION
This PR fixes the bug in `EPSFBuilder` in its v0.7 update. The bug, as best I pinned it down, is due to a subtle interaction between a "halfway" algorithm update to the original Anderson & King (2000) paper, from its form in v0.6 which was, as I understand it, implemented via discussions with Jay, unbeknownst to me at the time. I have subsequently found what I believe to be a citable version of the updates (and referenced them accordingly), and thus re-aligned the ePSF algorithm with its updated version. Ironically if I had made more code changes instead of fewer, and further aligned the code with the workflow of AK00 it would likely have been ok, but there we are...!

The main differences should therefore lie in the removal of the `residual smooth and recenter` loop of AK00, to follow [ISR WFC3 2016-12](http://www.stsci.edu/hst/wfc3/documents/ISRs/WFC3-2016-12.pdf); for continuity I simply reversed the recentering algorithm completely, keeping the original iteratively-find-the-center-via-centroiding function. There should hopefully be very few differences in the v0.6 and v0.7 results -- some preliminary testing on very poor datasets (16 randomly placed Gaussian stars with sigma of 0.5 pixels, noisy images and poor initial centroids for an oversampling factor of 4) gives results that are not complete gibberish as with the previous examples in issues raised, so hopefully this should successfully revert the bug.

This PR also implements the minor change to include a custom `SigmaClip`, allowing for custom sigma clip functions to be passed to `EPSFBuilder`.

This PR does _not_ include changes to one major difference between the v0.6 algorithm and both AK00 and ISR 2016-12: whether the residual sampling to grid point mapping is a nearest neighbour, "box of half a grid spacing length" function or, as is the case in the two cited works, residual samplings are placed in all grid points within a grid spacing (i.e., a box of a _full_ grid spacing length, 0.25 pixels of `oversampling=4`) for the purposes of sigma-clipping residuals for ePSF grid interpolation point updating. Given the current issue being one of non-obvious changes to cited works being made through offline, internal discussions I felt perhaps it was wise to hold off on this change before confirming whether this change was also a case of out-of-band 'unofficial' updates/suggestions. Is this the case, or should I make a separate PR to implement the swap from a one-to-one sampling:grid point mapping to a each-sampling-is-put-in-four-grid-points mapping? I can see arguments for reducing the distance a sampling point can be from any grid point, to reduce the effects of data points from 'extreme' distances affecting the sigma-clipped residual point.

Finally, this PR has come about through a fairly roundabout route, with several rebases a long the way, so it would be good to get a few pairs of eyes on the code to ensure no further bugs are introduced trying to fix the first bug. I believe the changes to at least be robust to _some_ level of my poking the code with a stick, but cc @eteq @larrybradley for some fresh perspective!

Fixes #969