### PR TITLE
Replace numpy dtypes with Python versions

### DIFF
--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -49,7 +49,7 @@ TEST_APERTURES = list(zip(APERTURE_CL, ((3.,), (3., 5.),
 
 @pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
 def test_outside_array(aperture_class, params):
-    data = np.ones((10, 10), dtype=np.float)
+    data = np.ones((10, 10), dtype=float)
     aperture = aperture_class((-60, 60), *params)
     fluxtable = aperture_photometry(data, aperture)
     # aperture is fully outside array:
@@ -58,7 +58,7 @@ def test_outside_array(aperture_class, params):
 
 @pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
 def test_inside_array_simple(aperture_class, params):
-    data = np.ones((40, 40), dtype=np.float)
+    data = np.ones((40, 40), dtype=float)
     aperture = aperture_class((20., 20.), *params)
     table1 = aperture_photometry(data, aperture, method='center', subpixels=10)
     table2 = aperture_photometry(data, aperture, method='subpixel',
@@ -104,7 +104,7 @@ class BaseTestAperturePhotometry:
 
     def test_array_error(self):
         # Array error
-        error = np.ones(self.data.shape, dtype=np.float)
+        error = np.ones(self.data.shape, dtype=float)
         if not hasattr(self, 'mask'):
             mask = None
             true_error = np.sqrt(self.area)
@@ -142,7 +142,7 @@ class BaseTestAperturePhotometry:
 class TestCircular(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         position = (20., 20.)
         r = 10.
         self.aperture = CircularAperture(position, r)
@@ -153,7 +153,7 @@ class TestCircular(BaseTestAperturePhotometry):
 class TestCircularArray(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         position = ((20., 20.), (25., 25.))
         r = 10.
         self.aperture = CircularAperture(position, r)
@@ -165,7 +165,7 @@ class TestCircularArray(BaseTestAperturePhotometry):
 class TestCircularAnnulus(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         position = (20., 20.)
         r_in = 8.
         r_out = 10.
@@ -177,7 +177,7 @@ class TestCircularAnnulus(BaseTestAperturePhotometry):
 class TestCircularAnnulusArray(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         position = ((20., 20.), (25., 25.))
         r_in = 8.
         r_out = 10.
@@ -190,7 +190,7 @@ class TestCircularAnnulusArray(BaseTestAperturePhotometry):
 class TestElliptical(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         position = (20., 20.)
         a = 10.
         b = 5.
@@ -203,7 +203,7 @@ class TestElliptical(BaseTestAperturePhotometry):
 class TestEllipticalAnnulus(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         position = (20., 20.)
         a_in = 5.
         a_out = 8.
@@ -218,7 +218,7 @@ class TestEllipticalAnnulus(BaseTestAperturePhotometry):
 class TestRectangularAperture(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         position = (20., 20.)
         h = 5.
         w = 8.
@@ -231,7 +231,7 @@ class TestRectangularAperture(BaseTestAperturePhotometry):
 class TestRectangularAnnulus(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         position = (20., 20.)
         h_out = 8.
         w_in = 8.
@@ -246,7 +246,7 @@ class TestRectangularAnnulus(BaseTestAperturePhotometry):
 class TestMaskedSkipCircular(BaseTestAperturePhotometry):
 
     def setup_class(self):
-        self.data = np.ones((40, 40), dtype=np.float)
+        self.data = np.ones((40, 40), dtype=float)
         self.mask = np.zeros((40, 40), dtype=bool)
         self.mask[20, 20] = True
         position = (20., 20.)
@@ -275,7 +275,7 @@ class BaseTestDifferentData:
 class TestInputNDData(BaseTestDifferentData):
 
     def setup_class(self):
-        data = np.ones((40, 40), dtype=np.float)
+        data = np.ones((40, 40), dtype=float)
         self.data = NDData(data, unit=u.adu)
         self.radius = 3
         self.position = [(20, 20), (30, 30)]
@@ -434,7 +434,7 @@ def test_wcs_based_photometry():
 
 
 def test_basic_circular_aperture_photometry_unit():
-    data1 = np.ones((40, 40), dtype=np.float)
+    data1 = np.ones((40, 40), dtype=float)
     data2 = u.Quantity(data1*u.adu)
 
     radius = 3
@@ -453,7 +453,7 @@ def test_basic_circular_aperture_photometry_unit():
 def test_aperture_photometry_with_error_units():
     """Test aperture_photometry when error has units (see #176)."""
 
-    data1 = np.ones((40, 40), dtype=np.float)
+    data1 = np.ones((40, 40), dtype=float)
     data2 = u.Quantity(data1, unit=u.adu)
     error = u.Quantity(data1, unit=u.adu)
     radius = 3
@@ -822,7 +822,7 @@ def test_scalar_aperture():
     on the column names to be consistent with list inputs.
     """
 
-    data = np.ones((20, 20), dtype=np.float)
+    data = np.ones((20, 20), dtype=float)
 
     ap = CircularAperture((10, 10), r=3.)
     colnames1 = aperture_photometry(data, ap, error=data).colnames

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -528,7 +528,7 @@ class Background2D:
             return data2d
         else:
             # some meshes were masked
-            mask2d = np.ones(data2d.shape).astype(np.bool)
+            mask2d = np.ones(data2d.shape).astype(bool)
             mask2d[self.mesh_yidx, self.mesh_xidx] = False
 
             return np.ma.masked_array(data2d, mask=mask2d)

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -110,7 +110,7 @@ def centroid_com(data, mask=None, oversampling=1.):
     oversampling = oversampling[::-1]
     if np.any(oversampling <= 0):
         raise ValueError('Oversampling factors must all be positive numbers.')
-    data = data.astype(np.float)
+    data = data.astype(float)
 
     if mask is not None and mask is not np.ma.nomask:
         mask = np.asarray(mask, dtype=bool)
@@ -536,7 +536,7 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     if np.any(oversampling <= 0):
         raise ValueError('Oversampling factors must all be positive numbers.')
 
-    data = data.astype(np.float)
+    data = data.astype(float)
 
     if mask is not None and mask is not np.ma.nomask:
         mask = np.asarray(mask, dtype=bool)

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -153,7 +153,7 @@ def test_centroids_nan_withmask(use_mask):
 def test_centroid_com_mask():
     """Test centroid_com with and without an image_mask."""
 
-    data = np.ones((2, 2)).astype(np.float)
+    data = np.ones((2, 2)).astype(float)
     mask = [[False, False], [True, True]]
     centroid = centroid_com(data, mask=None)
     centroid_mask = centroid_com(data, mask=mask)
@@ -246,7 +246,7 @@ def test_centroid_epsf():
         data = psf.evaluate(x=x.reshape(1, -1), y=y.reshape(-1, 1), flux=1, x_0=offsets[0],
                             y_0=offsets[1], sigma=sigma)
 
-        mask = np.zeros(data.shape, np.bool)
+        mask = np.zeros(data.shape, dtype=bool)
         mask[0, 0] = 1
         centers = centroid_epsf(data, mask=mask, oversampling=oversampling)
         assert_allclose(centers, offsets+x0, rtol=1e-3, atol=1e-2)

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -433,7 +433,7 @@ def make_model_sources_image(shape, model, source_table, oversample=1):
         plt.imshow(data)
     """
 
-    image = np.zeros(shape, dtype=np.float64)
+    image = np.zeros(shape, dtype=float)
     yidx, xidx = np.indices(shape)
 
     params_to_set = []

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -128,7 +128,7 @@ class _StarFinderKernel:
 
         self.mask = np.where(
             (self.elliptical_radius <= self.f) |
-            (self.circular_radius <= 2.0), 1, 0).astype(np.int)
+            (self.circular_radius <= 2.0), 1, 0).astype(int)
         self.npixels = self.mask.sum()
 
         # NOTE: the central (peak) pixel of gaussian_kernel has a value of 1.
@@ -492,7 +492,7 @@ class _IRAFStarFindProperties:
         self.kernel = kernel
 
         if sky is None:
-            skymask = ~self.kernel.mask.astype(np.bool)  # 1=sky, 0=obj
+            skymask = ~self.kernel.mask.astype(bool)  # 1=sky, 0=obj
             nsky = np.count_nonzero(skymask)
             if nsky == 0:
                 mean_sky = (np.max(self.cutout.data) -
@@ -632,7 +632,7 @@ def _find_stars(data, kernel, threshold_eff, min_separation=None,
 
     # define a local footprint for the peak finder
     if min_separation is None:  # daofind
-        footprint = kernel.mask.astype(np.bool)
+        footprint = kernel.mask.astype(bool)
     else:
         # define a circular footprint
         idx = np.arange(-min_separation, min_separation + 1)

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -28,10 +28,10 @@ try:
 except ImportError:
     HAS_GWCS = False
 
-DATA = np.array([[0, 1, 0], [0, 2, 0], [0, 0, 0]]).astype(np.float)
+DATA = np.array([[0, 1, 0], [0, 2, 0], [0, 0, 0]]).astype(float)
 REF1 = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
 
-PEAKDATA = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1]]).astype(np.float)
+PEAKDATA = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1]]).astype(float)
 PEAKREF1 = np.array([[0, 0], [2, 2]])
 
 IMAGE = make_4gaussians_image()
@@ -113,7 +113,7 @@ class TestDetectThreshold:
         applying the mask.
         """
 
-        mask = REF1.astype(np.bool)
+        mask = REF1.astype(bool)
         threshold = detect_threshold(DATA, nsigma=1., error=0, mask=mask,
                                      sigclip_sigma=10, sigclip_iters=1)
         ref = (1. / 8.) * np.ones((3, 3))
@@ -122,7 +122,7 @@ class TestDetectThreshold:
     def test_image_mask_override(self):
         """Test that image_mask overrides mask_value."""
 
-        mask = REF1.astype(np.bool)
+        mask = REF1.astype(bool)
         threshold = detect_threshold(DATA, nsigma=0.1, error=0, mask_value=0.0,
                                      mask=mask, sigclip_sigma=10,
                                      sigclip_iters=1)

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -487,7 +487,7 @@ class IsophoteList:
         return self._list[index]
 
     def _collect_as_array(self, attr_name):
-        return np.array(self._collect_as_list(attr_name), dtype=np.float64)
+        return np.array(self._collect_as_list(attr_name), dtype=float)
 
     def _collect_as_list(self, attr_name):
         return [getattr(iso, attr_name) for iso in self._list]

--- a/photutils/morphology/core.py
+++ b/photutils/morphology/core.py
@@ -41,7 +41,7 @@ def data_properties(data, mask=None, background=None):
 
     from ..segmentation import SourceProperties  # prevent circular imports
 
-    segment_image = np.ones(data.shape, dtype=np.int)
+    segment_image = np.ones(data.shape, dtype=int)
 
     return SourceProperties(data, segment_image, label=1, mask=mask,
                             background=background)

--- a/photutils/morphology/tests/test_core.py
+++ b/photutils/morphology/tests/test_core.py
@@ -29,7 +29,7 @@ DATA[1, 1] = 2.
 
 @pytest.mark.skipif('not HAS_SKIMAGE')
 def test_data_properties():
-    data = np.ones((2, 2)).astype(np.float)
+    data = np.ones((2, 2)).astype(float)
     mask = np.array([[False, False], [True, True]])
     props = data_properties(data, mask=None)
     props2 = data_properties(data, mask=mask)

--- a/photutils/psf/groupstars.py
+++ b/photutils/psf/groupstars.py
@@ -120,7 +120,7 @@ class DAOGroup(GroupStarsBase):
                                         data=np.arange(len(cstarlist)) + 1))
         cstarlist.add_column(Column(name='group_id',
                                     data=np.zeros(len(cstarlist),
-                                                  dtype=np.int)))
+                                                  dtype=int)))
 
         if not np.array_equal(cstarlist['id'], np.arange(len(cstarlist)) + 1):
             raise ValueError('id colum must be an integer-valued ' +
@@ -241,5 +241,5 @@ class DBSCANGroup(GroupStarsBase):
                         min_samples=self.min_samples, metric=self.metric,
                         algorithm=self.algorithm, leaf_size=self.leaf_size)
         cstarlist['group_id'] = (dbscan.fit(pos_stars).labels_ +
-                                 np.ones(len(cstarlist), dtype=np.int))
+                                 np.ones(len(cstarlist), dtype=int))
         return cstarlist

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -387,7 +387,7 @@ class BasicPSFPhotometry:
             group_psf = get_grouped_psf_model(self.psf_model,
                                               star_groups.groups[n],
                                               self._pars_to_set)
-            usepixel = np.zeros_like(image, dtype=np.bool)
+            usepixel = np.zeros_like(image, dtype=bool)
 
             for row in star_groups.groups[n]:
                 usepixel[overlap_slices(large_array_shape=image.shape,

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -242,7 +242,7 @@ class DiscretePRF(Fittable2DModel):
         prf_model = np.ndarray(shape=(subsampling, subsampling, size, size))
         positions_subpixel_indices = \
             np.array([subpixel_indices(_, subsampling) for _ in positions],
-                     dtype=np.int)
+                     dtype=int)
 
         for i in range(subsampling):
             for j in range(subsampling):

--- a/photutils/psf/tests/test_groupstars.py
+++ b/photutils/psf/tests/test_groupstars.py
@@ -54,10 +54,10 @@ class TestDAOGROUP:
                         -np.sqrt(2)/4])
         x_1 = x_0 + 2.0
         first_group = Table([x_0, y_0, np.arange(len(x_0)) + 1,
-                            np.ones(len(x_0), dtype=np.int)],
+                            np.ones(len(x_0), dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         second_group = Table([x_1, y_0, len(x_0) + np.arange(len(x_0)) + 1,
-                              2*np.ones(len(x_0), dtype=np.int)],
+                              2*np.ones(len(x_0), dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         starlist = vstack([first_group, second_group])
         daogroup = DAOGroup(crit_separation=0.6)
@@ -85,10 +85,10 @@ class TestDAOGROUP:
         """
 
         first_group = Table([np.zeros(5), np.linspace(0, 1, 5),
-                             np.arange(5) + 1, np.ones(5, dtype=np.int)],
+                             np.arange(5) + 1, np.ones(5, dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         second_group = Table([np.zeros(5), np.linspace(2, 3, 5),
-                              6 + np.arange(5), 2*np.ones(5, dtype=np.int)],
+                              6 + np.arange(5), 2*np.ones(5, dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         starlist = vstack([first_group, second_group])
         daogroup = DAOGroup(crit_separation=0.3)
@@ -116,10 +116,10 @@ class TestDAOGROUP:
         """
 
         first_group = Table([np.linspace(0, 1, 5), np.zeros(5),
-                             np.arange(5) + 1, np.ones(5, dtype=np.int)],
+                             np.arange(5) + 1, np.ones(5, dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         second_group = Table([np.linspace(2, 3, 5), np.zeros(5),
-                              6 + np.arange(5), 2*np.ones(5, dtype=np.int)],
+                              6 + np.arange(5), 2*np.ones(5, dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         starlist = vstack([first_group, second_group])
         daogroup = DAOGroup(crit_separation=0.3)
@@ -154,7 +154,7 @@ class TestDAOGROUP:
         xx = np.hstack((x, x))
         yy = np.hstack((y, -y))
         starlist = Table([xx, yy, np.arange(10) + 1,
-                          np.ones(10, dtype=np.int)],
+                          np.ones(10, dtype=int)],
                          names=('x_0', 'y_0', 'id', 'group_id'))
         daogroup = DAOGroup(crit_separation=2.5)
         test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
@@ -181,16 +181,16 @@ class TestDAOGROUP:
         """
 
         first_group = Table([1.5*np.ones(5), np.linspace(0, 1, 5),
-                             np.arange(5) + 1, np.ones(5, dtype=np.int)],
+                             np.arange(5) + 1, np.ones(5, dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         second_group = Table([1.5*np.ones(5), np.linspace(2, 3, 5),
-                              6 + np.arange(5), 2*np.ones(5, dtype=np.int)],
+                              6 + np.arange(5), 2*np.ones(5, dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         third_group = Table([np.linspace(0, 1, 5), 1.5*np.ones(5),
-                             11 + np.arange(5), 3*np.ones(5, dtype=np.int)],
+                             11 + np.arange(5), 3*np.ones(5, dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         fourth_group = Table([np.linspace(2, 3, 5), 1.5*np.ones(5),
-                              16 + np.arange(5), 4*np.ones(5, dtype=np.int)],
+                              16 + np.arange(5), 4*np.ones(5, dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         starlist = vstack([first_group, second_group, third_group,
                            fourth_group])
@@ -225,13 +225,13 @@ class TestDAOGROUP:
         x_1 = x_0 + 2.0
         x_2 = x_0 + 4.0
         first_group = Table([x_0, y_0, np.arange(5) + 1,
-                             np.ones(5, dtype=np.int)],
+                             np.ones(5, dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         second_group = Table([x_1, y_0, 6 + np.arange(5),
-                              2*np.ones(5, dtype=np.int)],
+                              2*np.ones(5, dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         third_group = Table([x_2, y_0, 11 + np.arange(5),
-                             3*np.ones(5, dtype=np.int)],
+                             3*np.ones(5, dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         starlist = vstack([first_group, second_group, third_group])
         daogroup = DAOGroup(crit_separation=0.6)
@@ -287,10 +287,10 @@ class TestDBSCANGroup:
                         -np.sqrt(2)/4])
         x_1 = x_0 + 2.0
         first_group = Table([x_0, y_0, np.arange(len(x_0)) + 1,
-                            np.ones(len(x_0), dtype=np.int)],
+                            np.ones(len(x_0), dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         second_group = Table([x_1, y_0, len(x_0) + np.arange(len(x_0)) + 1,
-                              2*np.ones(len(x_0), dtype=np.int)],
+                              2*np.ones(len(x_0), dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         starlist = vstack([first_group, second_group])
         dbscan = DBSCANGroup(crit_separation=0.6)
@@ -299,16 +299,16 @@ class TestDBSCANGroup:
 
     def test_group_stars_two(object):
         first_group = Table([1.5*np.ones(5), np.linspace(0, 1, 5),
-                             np.arange(5) + 1, np.ones(5, dtype=np.int)],
+                             np.arange(5) + 1, np.ones(5, dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         second_group = Table([1.5*np.ones(5), np.linspace(2, 3, 5),
-                              6 + np.arange(5), 2*np.ones(5, dtype=np.int)],
+                              6 + np.arange(5), 2*np.ones(5, dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         third_group = Table([np.linspace(0, 1, 5), 1.5*np.ones(5),
-                             11 + np.arange(5), 3*np.ones(5, dtype=np.int)],
+                             11 + np.arange(5), 3*np.ones(5, dtype=int)],
                             names=('x_0', 'y_0', 'id', 'group_id'))
         fourth_group = Table([np.linspace(2, 3, 5), 1.5*np.ones(5),
-                              16 + np.arange(5), 4*np.ones(5, dtype=np.int)],
+                              16 + np.arange(5), 4*np.ones(5, dtype=int)],
                              names=('x_0', 'y_0', 'id', 'group_id'))
         starlist = vstack([first_group, second_group, third_group,
                            fourth_group])

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -722,7 +722,7 @@ class SegmentationImage:
 
         if relabel:
             labels = np.unique(idx[idx != 0])
-            idx2 = np.zeros(max(labels) + 1, dtype=np.int)
+            idx2 = np.zeros(max(labels) + 1, dtype=int)
             idx2[labels] = np.arange(len(labels)) + 1
             idx = idx2[idx]
 
@@ -767,7 +767,7 @@ class SegmentationImage:
                 (self.labels[-1] - self.labels[0] + 1) == self.nlabels):
             return
 
-        new_labels = np.zeros(self.max_label + 1, dtype=np.int)
+        new_labels = np.zeros(self.max_label + 1, dtype=int)
         new_labels[self.labels] = np.arange(self.nlabels) + start_label
 
         data_new = new_labels[self.data]

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -343,8 +343,7 @@ class SourceProperties:
         # NOTE: using np.where is faster than
         #     _data = np.copy(self.data_cutout)
         #     self._data[self._total_mask] = 0.
-        return np.where(self._total_mask, 0,
-                        cutout).astype(np.float64)  # copy
+        return np.where(self._total_mask, 0, cutout).astype(float)  # copy
 
     @lazyproperty
     def _filtered_data_zeroed(self):
@@ -369,7 +368,7 @@ class SourceProperties:
 
         filt_data = np.where(self._total_mask, 0., filt_data)  # copy
         filt_data[filt_data < 0] = 0.
-        return filt_data.astype(np.float64)
+        return filt_data.astype(float)
 
     def make_cutout(self, data, masked_array=False):
         """
@@ -1080,7 +1079,7 @@ class SourceProperties:
             data = ~self._total_mask
             selem = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
             data_eroded = binary_erosion(data, selem, border_value=0)
-            border = np.logical_xor(data, data_eroded).astype(np.int)
+            border = np.logical_xor(data, data_eroded).astype(int)
 
             kernel = np.array([[10, 2, 10], [2, 1, 2], [10, 2, 10]])
             perimeter_data = convolve(border, kernel, mode='constant', cval=0)
@@ -1089,7 +1088,7 @@ class SourceProperties:
             perimeter_hist = np.bincount(perimeter_data.ravel(),
                                          minlength=size)
 
-            weights = np.zeros(size, dtype=np.float)
+            weights = np.zeros(size, dtype=float)
             weights[[5, 7, 15, 17, 25, 27]] = 1.
             weights[[21, 33]] = np.sqrt(2.)
             weights[[13, 23]] = (1 + np.sqrt(2.)) / 2.

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -310,7 +310,7 @@ class TestSegmentationImage:
 
     def test_remove_masked_segments_mask_shape(self):
         segm = SegmentationImage(np.ones((5, 5)))
-        mask = np.zeros((3, 3), dtype=np.bool)
+        mask = np.zeros((3, 3), dtype=bool)
         with pytest.raises(ValueError):
             segm.remove_masked_labels(mask)
 

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -26,7 +26,7 @@ except ImportError:
 class TestDetectSources:
     def setup_class(self):
         self.data = np.array([[0, 1, 0], [0, 2, 0],
-                              [0, 0, 0]]).astype(np.float)
+                              [0, 0, 0]]).astype(float)
         self.refdata = np.array([[0, 1, 0], [0, 1, 0], [0, 0, 0]])
 
         fwhm2sigma = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -396,7 +396,7 @@ class TestSourcePropertiesFunction:
         data[1, 1] = 1.
         mask = np.zeros(data.shape, dtype=bool)
         mask[0, 1] = True
-        segm = data.astype(np.int)
+        segm = data.astype(int)
         props = source_properties(data, segm, mask=mask)
         assert_allclose(props[0].xcentroid.value, 1)
         assert_allclose(props[0].ycentroid.value, 1)

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -151,7 +151,7 @@ class ShepardIDWInterpolator:
         self.kdtree = cKDTree(coordinates, leafsize=leafsize)
 
     def __call__(self, positions, n_neighbors=8, eps=0.0, power=1.0, reg=0.0,
-                 conf_dist=1e-12, dtype=np.float):
+                 conf_dist=1e-12, dtype=float):
         """
         Evaluate the interpolator at the given positions.
 

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -45,19 +45,19 @@ class TestFilterData:
 
         filt_data = _filter_data(self.data.astype(int),
                                  self.kernel.array.astype(int))
-        assert filt_data.dtype == np.float64
+        assert filt_data.dtype == float
 
         filt_data = _filter_data(self.data.astype(int),
                                  self.kernel.array.astype(float))
-        assert filt_data.dtype == np.float64
+        assert filt_data.dtype == float
 
         filt_data = _filter_data(self.data.astype(float),
                                  self.kernel.array.astype(int))
-        assert filt_data.dtype == np.float64
+        assert filt_data.dtype == float
 
         filt_data = _filter_data(self.data.astype(float),
                                  self.kernel.array.astype(float))
-        assert filt_data.dtype == np.float64
+        assert filt_data.dtype == float
 
     def test_filter_data_kernel_none(self):
         """

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -90,7 +90,7 @@ class TestShepardIDWInterpolator:
 
     def test_dtype_none(self):
         result = self.f(0.5, dtype=None)
-        assert result.dtype.type == np.float64
+        assert result.dtype == float
 
     def test_positions_0d_nomatch(self):
         """test when position ndim doesn't match coordinates ndim"""


### PR DESCRIPTION
These numpy dtypes are simply aliases for the Python builtin dtypes and should be avoided.