### PR TITLE
Restore flux_residual_sigclip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@ API changes
 
 - ``photutils.psf``
 
+  - Added ``flux_residual_sigclip`` as an input parameter, allowing for
+    custom sigma clipping options in ``EPSFBuilder``. [#984]
+
   - Added ``extra_output_cols`` as a parameter to
     ``BasicPSFPhotometry``, ``IterativelySubtractedPSFPhotometry`` and
     ``DAOPhotPSFPhotometry``. [#745]
@@ -86,8 +89,8 @@ Bug Fixes
 
 - ``photutils.psf``
 
-  - Fix to algorithm in ``EPSFBuilder``, addressing issues where ePSFs
-    failed to build (yielding striped ePSFs). [#974]
+  - Fix to algorithm in ``EPSFBuilder``, causing issues where ePSFs
+    failed to build. [#974]
 
   - Fix to ``IterativelySubtractedPSFPhotometry`` where an error could
     be thrown when a ``Finder`` was passed which did not return

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -305,14 +305,21 @@ class EPSFBuilder:
             iterations will stop if the centers of all the stars change by
             less than ``center_accuracy`` pixels between iterations.  All
             stars must meet this condition for the loop to exit.
+
+    flux_residual_sigclip : `~astropy.stats.SigmaClip` object, optional
+        A `~astropy.stats.SigmaClip` object used to determine which pixels
+        are ignored based on the star sampling flux residuals, when
+        computing the average residual of ePSF grid points in each iteration
+        step.
     """
 
     def __init__(self, oversampling=4., shape=None,
                  smoothing_kernel='quartic', recentering_func=centroid_epsf,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
                  progress_bar=True, norm_radius=5.5, shift_val=0.5,
-                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3):
-        flux_residual_sigclip = SigmaClip(sigma=3, cenfunc='median', maxiters=10)  # TODO: replace with kwarg in 8.0
+                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3,
+                 flux_residual_sigclip=SigmaClip(sigma=3, cenfunc='median',
+                                                 maxiters=10)):
 
         if oversampling is None:
             raise ValueError("'oversampling' must be specified.")

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -6,6 +6,7 @@ Tests for the epsf module.
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata import NDData
 from astropy.table import Table
+from astropy.stats import SigmaClip
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
@@ -137,6 +138,7 @@ class TestEPSFBuild:
 
 
 def test_epsfbuilder_inputs():
+    # invalid inputs
     with pytest.raises(ValueError):
         EPSFBuilder(oversampling=None)
     with pytest.raises(ValueError):
@@ -149,9 +151,19 @@ def test_epsfbuilder_inputs():
         EPSFBuilder(oversampling=[3, 6])
     with pytest.raises(ValueError):
         EPSFBuilder(oversampling=[-1, 4])
+
+    # valid inputs
+    EPSFBuilder(oversampling=6)
+    EPSFBuilder(oversampling=[4, 6])
+
+    # invalid inputs
     for sigclip in [None, [], 'a']:
         with pytest.raises(ValueError):
             EPSFBuilder(flux_residual_sigclip=sigclip)
+
+    # valid inputs
+    EPSFBuilder(flux_residual_sigclip=SigmaClip(sigma=2.5, cenfunc='mean',
+                                                maxiters=2))
 
 
 def test_epsfmodel_inputs():

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -149,6 +149,9 @@ def test_epsfbuilder_inputs():
         EPSFBuilder(oversampling=[3, 6])
     with pytest.raises(ValueError):
         EPSFBuilder(oversampling=[-1, 4])
+    for sigclip in [None, [], 'a']:
+        with pytest.raises(ValueError):
+            EPSFBuilder(flux_residual_sigclip=sigclip)
 
 
 def test_epsfmodel_inputs():


### PR DESCRIPTION
This was implemented by @Onoddil in #974 but because it was a new feature we decided to "hide" it for 0.7.2.  This PR just brings it back for 0.8.

Note I'm starting it as a "draft" because it needs to be rebased on master after #974 is in.