### PR TITLE
Fix to IterativelySubtractedPSFPhotometry failing when Finder does not return None if no sources are detected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.psf``
+
+  - Fix to ``IterativelySubtractedPSFPhotometry`` where an error could
+    be thrown when a ``Finder`` was passed which did not return ``None``
+    if no sources were found. [#986]
+
 API changes
 ^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,12 +14,6 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
-- ``photutils.psf``
-
-  - Fix to ``IterativelySubtractedPSFPhotometry`` where an error could
-    be thrown when a ``Finder`` was passed which did not return ``None``
-    if no sources were found. [#986]
-
 API changes
 ^^^^^^^^^^^
 
@@ -94,6 +88,10 @@ Bug Fixes
 
   - Fix to algorithm in ``EPSFBuilder``, addressing issues where ePSFs
     failed to build (yielding striped ePSFs). [#974]
+
+  - Fix to ``IterativelySubtractedPSFPhotometry`` where an error could
+    be thrown when a ``Finder`` was passed which did not return ``None``
+    if no sources were found. [#986]
 
 
 0.7.1 (2019-10-09)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -767,7 +767,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         sources = self.finder(self._residual_image)
 
         n = n_start
-        while(sources is not None and
+        while((sources is not None and len(sources) > 0) and
               (self.niters is None or n <= self.niters)):
             positions = np.transpose((sources['xcentroid'],
                                       sources['ycentroid']))

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -16,7 +16,7 @@ from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 import pytest
 
 from ..groupstars import DAOGroup
-from ..models import IntegratedGaussianPRF
+from ..models import IntegratedGaussianPRF, FittableImageModel
 from ..photometry import (BasicPSFPhotometry, DAOPhotPSFPhotometry,
                           IterativelySubtractedPSFPhotometry)
 from ..sandbox import DiscretePRF
@@ -652,3 +652,48 @@ def test_psf_extra_output_cols(sigma_psf, sources):
             assert(np.all(np.all(np.isnan(phot_results[o])) for o in
                    ['roundness1', 'roundness2']))
             assert(np.all(~np.isnan(phot_results['sharpness'])))
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_finder_return_none():
+    """
+    Test psf_photometry with finder that does not return None if no
+    sources are detected, to test Iterative PSF fitting.
+    """
+    def tophatfinder(image):
+        """ Simple top hat finder function for use with a top hat PRF"""
+        fluxes = np.unique(image[image > 1])
+        table = Table(names=['id', 'xcentroid', 'ycentroid', 'flux'],
+                      dtype=[int, float, float, float])
+        for n, f in enumerate(fluxes):
+            ys, xs = np.where(image == f)
+            x = np.mean(xs)
+            y = np.mean(ys)
+            table.add_row([int(n+1), x, y, f*9])
+        table.sort(['flux'])
+
+        return table
+
+    prf = np.zeros((7, 7), float)
+    prf[2:5, 2:5] = 1/9
+    prf = FittableImageModel(prf)
+
+    img = np.zeros((50, 50), float)
+    x0 = [38, 20, 35]
+    y0 = [20, 5, 40]
+    f0 = [50, 100, 200]
+    for x, y, f in zip(x0, y0, f0):
+        img[y-1:y+2, x-1:x+2] = f/9
+
+    intab = Table(data=[[37, 19.6, 34.9], [19.6, 4.5, 40.1], [45, 103, 210]],
+                  names=['x_0', 'y_0', 'flux_0'])
+
+    iter_phot = IterativelySubtractedPSFPhotometry(finder=tophatfinder,
+                                                   group_maker=DAOGroup(2),
+                                                   bkg_estimator=None,
+                                                   psf_model=prf,
+                                                   fitshape=7, niters=2,
+                                                   aperture_radius=3)
+
+    results = iter_phot(image=img, init_guesses=intab)
+    assert_allclose(results['flux_fit'], f0, rtol=0.05)


### PR DESCRIPTION
Currently the `_do_photometry` loop of `IterativelySubtractedPSFPhotometry` assumes that if no sources are detected then the returned variable will be `None`. If a user provides a custom finder which instead returns an empty `Table` object, this won't be caught by the while loop and will error. This PR makes a simple fix to this, adding a check for a zero-length variable returned by `self.finder` in addition to a `None` variable.

This PR blocks #740, which needs this PR merged before one of its tests will pass.