### PR TITLE
Using python 3.8 for one of the jobs, and adding one more stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ env:
 
 stages:
    - name: Initial tests
+   - name: Latest versions and docs
    - name: Comprehensive tests
    - name: Cron tests
      if: type = cron
@@ -75,15 +76,18 @@ matrix:
         # All tests (with remote data) and coverage checks with the
         # latest Python version.  The duration of the slowest 50 tests
         # will also be listed.
-        - env: SETUP_CMD='test --coverage --remote-data -a "--durations=50"'
+        - env: PYTHON_VERSION=3.8
+               SETUP_CMD='test --coverage --remote-data -a "--durations=50"'
 
         # Check for Sphinx doc build warnings
-        - env: SETUP_CMD='build_docs -w'
+        - stage: Latest versions and docs
+          env: SETUP_CMD='build_docs -w'
                PIP_DEPENDENCIES='sphinx-astropy scikit-image>0.14.1'
                EVENT_TYPE='push pull_request cron'
 
         # Test with optional dependencies disabled
-        - env: CONDA_DEPENDENCIES=$CONDA_REQUIRED_DEPENDENCIES
+        - stage: Comprehensive tests
+          env: CONDA_DEPENDENCIES=$CONDA_REQUIRED_DEPENDENCIES
                PIP_DEPENDENCIES=''
 
         # Test with Windows
@@ -102,7 +106,7 @@ matrix:
           env: NUMPY_VERSION=1.15
 
         # Test with the Astropy development version
-        - stage: Comprehensive tests
+        - stage: Latest versions and docs
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,8 @@ matrix:
         # All tests (with remote data) and coverage checks with the
         # latest Python version.  The duration of the slowest 50 tests
         # will also be listed.
-        - env: PYTHON_VERSION=3.8
+        - env: PYTHON_VERSION=3.8 NUMPY_VERSION='' CONDA_DEPENDENCIES=''
+               PIP_DEPENDENCIES='Cython numpy scipy scikit-learn matplotlib scikit-image>0.14.1'
                SETUP_CMD='test --coverage --remote-data -a "--durations=50"'
 
         # Check for Sphinx doc build warnings


### PR DESCRIPTION
I'm trying to add  python 3.8 to be tested. It's possible that there are still issues with dependencies, so I would not be surprised if it is failing.

Also, noticed that there are currently 5 jobs in the initial tests. The 5. doesn't really need to be in that group, and I feel the docs build, along with passing with astropy-dev (as we don't allow that to fail) is better suited to be run once the basic tests pass.

(Double checking the last ~10 failing builds job3 is very much the dominant failure, with a few that are failing only with the astropy-dev job).