### PR TITLE
Extending ePSF building framework to accept odd oversampling factors and non-zero offset grid points

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,15 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.psf``
+
+  - Removed the restriction on ``oversampling`` having to be even
+    in ``EPSFModel`` and ``EPSFBuilder``, allowing all integer
+    oversampling factors now. [#989]
+
+  - Added the ability for arbitrary offsets between ePSF grid points
+    and detector pixel edges to be used. [#989]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -37,6 +46,10 @@ API changes
   - Removed the deprecated ``ax`` keyword in
     ``Background2D.plot_meshes``. [#953]
 
+- ``photutils.centroid``
+
+  - Added the ``grid_offset`` keyword to ``centroid_epsf``. [#989]
+
 - ``photutils.datasets``
 
   - Removed the deprecated ``type`` keyword in ``make_noise_image``.
@@ -52,6 +65,9 @@ API changes
   - Added ``extra_output_cols`` as a parameter to
     ``BasicPSFPhotometry``, ``IterativelySubtractedPSFPhotometry`` and
     ``DAOPhotPSFPhotometry``. [#745]
+
+  - Added ``grid_offset`` as a parameter to ``EPSFModel`` and
+    ``EPSFBuilder``. [#989]
 
 - ``photutils.segmentation``
 

--- a/docs/epsf.rst
+++ b/docs/epsf.rst
@@ -314,13 +314,20 @@ Finally, let's show the constructed ePSF:
     plt.imshow(epsf.data, norm=norm, origin='lower', cmap='viridis')
     plt.colorbar()
 
-We could also use a non-even oversampling factor -- say, 3:
+We could also use a non-even oversampling factor -- say, 5 -- with an arbitrary grid
+offset, say ``grid_offset=0.1``, representing a shift of a tenth of a detector
+pixel in all ePSF grid point mappings. Note that because grid offsets are defined as
+being the amount the grid points are offset from the initial point mapping to the edge
+of the detector pixel, for ``oversampling=5`` a shift of one-tenth of a pixel
+would put a grid point back exactly representing the case where a star is perfectly
+centered on its central pixel, crucial for correctly building the PRF of such an
+undersampled detector.
 
 .. doctest-requires:: scipy
 
     >>> from photutils import EPSFBuilder
-    >>> epsf_builder = EPSFBuilder(oversampling=3, maxiters=3,
-    ...                            progress_bar=False)  # doctest: +REMOTE_DATA
+    >>> epsf_builder = EPSFBuilder(oversampling=5, maxiters=3,
+    ...                            progress_bar=False, grid_offset=0.1)  # doctest: +REMOTE_DATA
     >>> epsf, fitted_stars = epsf_builder(stars)  # doctest: +REMOTE_DATA
 
 Let's again plot the results:
@@ -370,8 +377,8 @@ Let's again plot the results:
     stars = extract_stars(nddata, stars_tbl, size=25)
 
     from photutils import EPSFBuilder
-    epsf_builder = EPSFBuilder(oversampling=3, maxiters=3,
-                               progress_bar=False)
+    epsf_builder = EPSFBuilder(oversampling=5, maxiters=3,
+                               progress_bar=False, grid_offset=0.1)
     epsf, fitted_stars = epsf_builder(stars)
 
     import matplotlib.pyplot as plt
@@ -379,6 +386,8 @@ Let's again plot the results:
     plt.imshow(epsf.data, norm=norm, origin='lower', cmap='viridis')
     plt.colorbar()
 
+Here we can see the effect the increased oversampling factor has on the resultant
+ePSF, as the grid is finer than the ``oversampling=4`` case.
 
 
 The :class:`~photutils.psf.EPSFModel` object is a subclass of

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -273,3 +273,19 @@ def test_centroid_exceptions():
     data[10, 10] = np.inf
     with pytest.raises(ValueError):
         centroid_epsf(data)
+
+    # These combinations should fail due to being incompatible
+    # with centroid_epsf
+    for oversampling, grid_offset in zip([1, 2, 4, 3, 5],
+                                         [0, 0.1, 0.2, 0, 0.01]):
+        with pytest.raises(TypeError):
+            centroid_epsf(data, oversampling=oversampling,
+                          grid_offset=grid_offset)
+
+    data = np.ones((11, 11), dtype=float)
+    # These should return a value successfully
+    for oversampling, grid_offset, shift_val in zip([1, 2, 4, 3, 5],
+                                                    [0.5, 0, 0, 1/6, 0.1],
+                                                    [1, 0.5, 0.5, 0.5, 0.5]):
+        centroid_epsf(data, oversampling=oversampling,
+                      grid_offset=grid_offset)

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -305,13 +305,21 @@ class EPSFBuilder:
             iterations will stop if the centers of all the stars change by
             less than ``center_accuracy`` pixels between iterations.  All
             stars must meet this condition for the loop to exit.
+
+    grid_offset : float or tuple of two floats, optional
+        The fractional detector pixel amount by which to offset the
+        ePSF interpolation points, relative to the left hand edge of
+        a pixel. A scalar is interpreted as having the same offset
+        in both x and y, otherwise it is treated as
+        ``(x_grid_offset, y_grid_offset)``.
     """
 
     def __init__(self, oversampling=4., shape=None,
                  smoothing_kernel='quartic', recentering_func=centroid_epsf,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
                  progress_bar=True, norm_radius=5.5, shift_val=0.5,
-                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3):
+                 recentering_boxsize=(5, 5), center_accuracy=1.0e-3,
+                 grid_offset=None):
         flux_residual_sigclip = SigmaClip(sigma=3, cenfunc='median', maxiters=10)  # TODO: replace with kwarg in 8.0
 
         if oversampling is None:
@@ -324,6 +332,32 @@ class EPSFBuilder:
         self._norm_radius = norm_radius
         self._shift_val = shift_val
         self.oversampling = oversampling
+
+        # Without any other information we assume the ePSF oversampled
+        # grid points start aligned with the left hand edge of a
+        # detector pixel, except when there is no oversampling, for
+        # which the assumption is that the grid points lie in the middle
+        # of each detector pixel.
+        if grid_offset is None:
+            self.grid_offset = np.array([0.5 if i == 1 else 0 for i in
+                                         self.oversampling])
+        else:
+            try:
+                grid_offset = np.asleast_1d(grid_offset).astype(float)
+                if len(grid_offset) == 1:
+                    grid_offset = np.repeat(grid_offset, 2)
+            except ValueError:
+                raise ValueError('Grid offset must be a scalar.')
+            # Keep the grid offset within its principle range, to avoid
+            # pixels "falling off the edge" of the ePSF region in question
+            # with larger shifts than the spacing between grid points.
+            if (np.any(grid_offset < 0) or np.any(grid_offset >
+                                                  1/self.oversampling)):
+                raise ValueError('Grid offset should be greater than '
+                                 'or equal to zero, and less than '
+                                 '1/oversampling.')
+            self.grid_offset = grid_offset
+
         self.shape = self._init_img_params(shape)
         if self.shape is not None:
             self.shape = self.shape.astype(int)

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -319,8 +319,6 @@ class EPSFBuilder:
         oversampling = np.atleast_1d(oversampling).astype(int)
         if len(oversampling) == 1:
             oversampling = np.repeat(oversampling, 2)
-        if np.any(oversampling % 2 != 0):
-            raise ValueError('Oversampling factor must be a multiple of two.')
         if np.any(oversampling <= 0.0):
             raise ValueError('oversampling must be a positive number.')
         self._norm_radius = norm_radius

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -315,7 +315,7 @@ class EPSFBuilder:
     """
 
     def __init__(self, oversampling=4., shape=None,
-                 smoothing_kernel='quartic', recentering_func=centroid_com,
+                 smoothing_kernel='quartic', recentering_func=centroid_epsf,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
                  progress_bar=True, norm_radius=5.5, shift_val=0.5,
                  recentering_boxsize=(5, 5), center_accuracy=1.0e-3,
@@ -357,19 +357,6 @@ class EPSFBuilder:
                                  'or equal to zero, and less than '
                                  '1/oversampling.')
             self.grid_offset = grid_offset
-
-        # To use centroid_epsf as the centroiding algorithm for EPSFBuilder
-        # requires even oversampling with zero offset, such that there
-        # is a grid point exactly on top of the middle of the central
-        # detector pixel.
-        if (recentering_func is centroid_epsf and
-                np.any((self.oversampling % 2 != 0) |
-                       (self.grid_offset > 0))):
-            raise TypeError('centroid_epsf cannot be used if '
-                            'oversampling is not even or grid '
-                            'offset is not zero. Please select '
-                            'a different centroiding algorithm '
-                            'or change oversampling/offset factors.')
 
         self.shape = self._init_img_params(shape)
         if self.shape is not None:
@@ -756,10 +743,10 @@ class EPSFBuilder:
                 # find a new center position
                 xcenter_new, ycenter_new = centroid_func(
                     epsf_cutout, mask=mask, oversampling=epsf.oversampling,
-                    shift_val=epsf._shift_val)
+                    shift_val=epsf._shift_val, grid_offset=epsf.grid_offset)
             except TypeError:
                 # centroid_func doesn't accept oversampling and/or shift_val
-                # keywords - try oversampling alone
+                # or grid_offset keywords - try oversampling alone
                 try:
                     xcenter_new, ycenter_new = centroid_func(
                         epsf_cutout, mask=mask,

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -481,10 +481,16 @@ class EPSFBuilder:
                         raise ValueError('ePSF grid shape and grid offset '
                                          'incompatible with one another.')
             else:
-                # For grid offsets, we do not want the extra grid point
-                if shape[i] % self.oversampling[i] != 0:
-                    raise ValueError('ePSF grid shape and grid offset '
-                                     'incompatible with one another.')
+                if self.oversampling[i] > 1:
+                    # For grid offsets, we do not want the extra grid point
+                    if shape[i] % self.oversampling[i] != 0:
+                        raise ValueError('ePSF grid shape and grid offset '
+                                         'incompatible with one another.')
+                else:
+                    if (shape[len(shape)-1-i] -
+                            np.ceil(stars._max_shape[i]) != 0):
+                        raise ValueError('ePSF grid shape and grid offset '
+                                         'incompatible with one another.')
 
         data = np.zeros(shape, dtype=np.float)
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -548,9 +548,9 @@ class EPSFBuilder:
         epsf_ycenter = int((epsf.data.shape[0] - y_extra_pix) /
                            2) / self.oversampling[1]
 
-        _xvals, _yvals = (np.arange(epsf.data.shape[1], float) /
+        _xvals, _yvals = (np.arange(epsf.data.shape[1], dtype=float) /
                           self.oversampling[0] + self.grid_offset[0],
-                          np.arange(epsf.data.shape[0], float) /
+                          np.arange(epsf.data.shape[0], dtype=float) /
                           self.oversampling[1] + self.grid_offset[1])
         xidx = _nearestfloatidx(x + epsf_xcenter, _xvals)
         yidx = _nearestfloatidx(y + epsf_ycenter, _yvals)
@@ -972,7 +972,7 @@ def _nearestfloatidx(a, b):
     of ``a``.
     """
 
-    idxs = np.array([np.abs(a - b[i]).argmin() for i in range(len(b))])
+    idxs = np.array([np.abs(b - a[i]).argmin() for i in range(len(a))])
 
     return idxs
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -767,10 +767,9 @@ class EPSFBuilder:
                 xcenter_new += slices_large[1].start/self.oversampling[0]
                 ycenter_new += slices_large[0].start/self.oversampling[1]
 
-            # Default centroiding algorithm, centroid_com, cannot handle
-            # grid offsets, as it assumes indices to detector pixel mapping
-            # is index / oversampling (i.e., zero-indexed fractions). We
-            # therefore correct for this here
+            # centroid_com cannot handle grid offsets, as it assumes indices
+            # to detector pixel mapping is index / oversampling (i.e.,
+            # zero-indexed fractions). We therefore correct for this here
             if self.recentering_func == centroid_com:
                 xcenter_new += self.grid_offset[0]
                 ycenter_new += self.grid_offset[1]

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -451,10 +451,10 @@ class EPSFBuilder:
             # we do not need the extra grid point.
             x_extra_grid = 1 if self.grid_offset[0] == 0 else 0
             y_extra_grid = 1 if self.grid_offset[1] == 0 else 0
-            x_shape = np.int(np.ceil(stars._max_shape[0]) * oversampling[0]
-                             + x_extra_grid)
-            y_shape = np.int(np.ceil(stars._max_shape[1]) * oversampling[1]
-                             + y_extra_grid)
+            x_shape = np.int(np.ceil(stars._max_shape[0]) * oversampling[0] +
+                             x_extra_grid)
+            y_shape = np.int(np.ceil(stars._max_shape[1]) * oversampling[1] +
+                             y_extra_grid)
             shape = np.array((y_shape, x_shape))
 
         # Verify the sizes of shape -- remembering shape should be (y, x)

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -878,8 +878,10 @@ class EPSFBuilder:
 
         # Return the new ePSF object, but with undersampled grid pixel
         # coordinates.
-        xcenter = (epsf._data.shape[1] - 1) / 2. / epsf.oversampling[0]
-        ycenter = (epsf._data.shape[0] - 1) / 2. / epsf.oversampling[1]
+        xcenter = (epsf._data.shape[1] - (1 if self.grid_offset[0] == 0
+                   else 0)) / 2. / epsf.oversampling[0]
+        ycenter = (epsf._data.shape[0] - (1 if self.grid_offset[1] == 0
+                   else 0)) / 2. / epsf.oversampling[1]
 
         return EPSFModel(data=epsf._data, origin=(xcenter, ycenter),
                          oversampling=epsf.oversampling,

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -740,7 +740,8 @@ class EPSFBuilder:
                 # keywords - try oversampling alone
                 try:
                     xcenter_new, ycenter_new = centroid_func(
-                        epsf_cutout, mask=mask, oversampling=epsf.oversampling)
+                        epsf_cutout, mask=mask,
+                        oversampling=epsf.oversampling)
                 except TypeError:
                     # centroid_func doesn't accept oversampling and
                     # shift_val
@@ -750,6 +751,14 @@ class EPSFBuilder:
             if self.recentering_func != centroid_epsf:
                 xcenter_new += slices_large[1].start/self.oversampling[0]
                 ycenter_new += slices_large[0].start/self.oversampling[1]
+
+            # Default centroiding algorithm, centroid_com, cannot handle
+            # grid offsets, as it assumes indices to detector pixel mapping
+            # is index / oversampling (i.e., zero-indexed fractions). We
+            # therefore correct for this here
+            if self.recentering_func == centroid_com:
+                xcenter_new += self.grid_offset[0]
+                ycenter_new += self.grid_offset[1]
 
             # Calculate the shift; dx = i - x_star so if dx was positively
             # incremented then x_star was negatively incremented for a given i.

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -486,7 +486,6 @@ class EPSFBuilder:
                     # For oversampling of 1, % operations don't work, so we
                     # assume that we have one more grid point than the
                     # largest star cutout.
-                    print(shape[len(shape)-1-i], np.ceil(stars._max_shape[i]))
                     if (shape[len(shape)-1-i] -
                             np.ceil(stars._max_shape[i]) == 0):
                         shape[len(shape)-1-i] += 1

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -339,7 +339,7 @@ class EPSFBuilder:
         # grid points have a grid point in the exact middle of a
         # detector pixel. For even oversampling this requires no offset,
         # but odd oversampling needs a half-oversampling spacing shift.
-        if grid_offset == "center":
+        if isinstance(grid_offset, str) and grid_offset == "center":
             self.grid_offset = np.array([0 if i % 2 == 0 else 0.5/i for i in
                                          self.oversampling])
         else:

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -366,7 +366,7 @@ class EPSFBuilder:
                 np.any((self.oversampling % 2 != 0) |
                        (self.grid_offset > 0))):
             raise TypeError('centroid_epsf cannot be used if '
-                            'oversampling is not even and grid '
+                            'oversampling is not even or grid '
                             'offset is not zero. Please select '
                             'a different centroiding algorithm '
                             'or change oversampling/offset factors.')

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -638,9 +638,9 @@ class EPSFModel(FittableImageModel):
         y_closest_offset = _y_grid[np.argmin(np.abs(_y_grid - 0.5))]
 
         cut = (((x.reshape(1, -1) - x_0)**2 + (y.reshape(-1, 1) - y_0)**2 <=
-                self._norm_radius**2)
-               & (np.abs((x.reshape(1, -1) % 1.0) - x_closest_offset) < 0.01)
-               & (np.abs((y.reshape(-1, 1) % 1.0) - y_closest_offset) < 0.01))
+                self._norm_radius**2) &
+               (np.abs((x.reshape(1, -1) % 1.0) - x_closest_offset) < 0.01) &
+               (np.abs((y.reshape(-1, 1) % 1.0) - y_closest_offset) < 0.01))
 
         return np.sum(self._data[cut], dtype=np.float64)
 

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -557,7 +557,7 @@ class EPSFModel(FittableImageModel):
         # detector pixel, except when there is no oversampling, for
         # which the assumption is that the grid points lie in the middle
         # of each detector pixel.
-        if grid_offset == "center":
+        if isinstance(grid_offset, str) and grid_offset == "center":
             self.grid_offset = np.array([0 if i % 2 == 0 else 0.5/i for i in
                                          self.oversampling])
         else:

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -533,13 +533,15 @@ class EPSFModel(FittableImageModel):
         ePSF interpolation points, relative to the left hand edge of
         a pixel. A scalar is interpreted as having the same offset
         in both x and y, otherwise it is treated as
-        ``(x_grid_offset, y_grid_offset)``.
+        ``(x_grid_offset, y_grid_offset)``. The string "center" is also
+        accepted, treating the grid offset in both dimensions such that
+        there is a grid point exactly at 0.5 detector pixel spacing.
     """
 
     def __init__(self, data, flux=1.0, x_0=0.0, y_0=0.0, normalize=True,
                  normalization_correction=1.0, origin=None, oversampling=1,
                  fill_value=0.0, norm_radius=5.5, shift_val=0.5,
-                 grid_offset=None, **kwargs):
+                 grid_offset="center", **kwargs):
 
         self._norm_radius = norm_radius
         self._shift_val = shift_val
@@ -555,8 +557,8 @@ class EPSFModel(FittableImageModel):
         # detector pixel, except when there is no oversampling, for
         # which the assumption is that the grid points lie in the middle
         # of each detector pixel.
-        if grid_offset is None:
-            self.grid_offset = np.array([0.5 if i == 1 else 0. for i in
+        if grid_offset == "center":
+            self.grid_offset = np.array([0 if i % 2 == 0 else 0.5/i for i in
                                          self.oversampling])
         else:
             try:

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -544,11 +544,11 @@ class EPSFModel(FittableImageModel):
         self._norm_radius = norm_radius
         self._shift_val = shift_val
 
-        super().__init__(data=data, flux=flux, x_0=x_0, y_0=y_0,
-                         normalize=normalize,
-                         normalization_correction=normalization_correction,
-                         origin=origin, oversampling=oversampling,
-                         fill_value=fill_value, **kwargs)
+        # Require an initial oversampling check, although there's one in
+        # FittableImageModel's __init__, as we need the 2D broadcasting
+        # before we can set grid_offset, but need grid_offset in the
+        # overall init call for setting origin.
+        self._set_oversampling(oversampling)
 
         # Without any other information we assume the ePSF oversampled
         # grid points start aligned with the left hand edge of a
@@ -574,6 +574,12 @@ class EPSFModel(FittableImageModel):
                                  'or equal to zero, and less than '
                                  '1/oversampling.')
             self.grid_offset = grid_offset
+
+        super().__init__(data=data, flux=flux, x_0=x_0, y_0=y_0,
+                         normalize=normalize,
+                         normalization_correction=normalization_correction,
+                         origin=origin, oversampling=oversampling,
+                         fill_value=fill_value, **kwargs)
 
     def _initial_norm(self, flux, normalize):
         if flux is None:

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -560,7 +560,7 @@ class EPSFModel(FittableImageModel):
                                          self.oversampling])
         else:
             try:
-                grid_offset = np.asleast_1d(grid_offset).astype(float)
+                grid_offset = np.atleast_1d(grid_offset).astype(float)
                 if len(grid_offset) == 1:
                     grid_offset = np.repeat(grid_offset, 2)
             except ValueError:

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -622,12 +622,6 @@ class EPSFModel(FittableImageModel):
             value = np.atleast_1d(value).astype(int)
             if len(value) == 1:
                 value = np.repeat(value, 2)
-            # We need oversampling to be a factor of 2 for ``middle of
-            # pixel'' in the undersampled regime to have a pixel placed at
-            # it in the oversampled regime.
-            if np.any(value % 2 != 0) and np.logical_not(np.all(value == 1)):
-                raise ValueError('Oversampling factor must be a multiple of '
-                                 'two')
         except ValueError:
             raise ValueError('Oversampling factor must be a scalar')
         if np.any(value <= 0):

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -301,7 +301,7 @@ def test_epsf_offset():
     nddata = NDData(data=data)
 
     for oversampling, offset in zip([1, 4, 3, 3, [1, 2]],
-                                    ["center", "center", "center", 1/6,
+                                    ["center", "center", "center", 0,
                                      [0, 0.25]]):
         _oversampling = np.atleast_1d(oversampling)
         if len(_oversampling) == 1:

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -166,11 +166,6 @@ class TestEPSFBuild:
                                            recentering_maxiters=5,
                                            grid_offset=grid_offset)
 
-            with pytest.raises(ValueError):
-                EPSFModel(data=np.arange(30).reshape(5, 6),
-                          grid_offset=grid_offset,
-                          oversampling=oversampling)
-
 
 def test_epsfbuilder_inputs():
     with pytest.raises(ValueError):

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -144,10 +144,6 @@ def test_epsfbuilder_inputs():
     with pytest.raises(ValueError):
         EPSFBuilder(maxiters=-1)
     with pytest.raises(ValueError):
-        EPSFBuilder(oversampling=3)
-    with pytest.raises(ValueError):
-        EPSFBuilder(oversampling=[3, 6])
-    with pytest.raises(ValueError):
         EPSFBuilder(oversampling=[-1, 4])
 
 
@@ -166,7 +162,7 @@ def test_epsfmodel_inputs():
         EPSFModel(data, flux=None)
 
     data[2, 2] = 1
-    for oversampling in [3, np.NaN, 'a', -1, [3, 4], [-2, 4]]:
+    for oversampling in [np.NaN, 'a', -1, [-2, 4]]:
         with pytest.raises(ValueError):
             EPSFModel(data, oversampling=oversampling)
 

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -281,9 +281,9 @@ def test_epsf_offset():
                           0:size*oversampling + extra_pixel]
         if offset is None:
             if oversampling == 1:
-                offset = 0.5
+                _offset = 0.5
             else:
-                offset = 0
+                _offset = 0
         else:
             _offset = offset
         xx = xx / oversampling + _offset

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -279,8 +279,15 @@ def test_epsf_offset():
         extra_pixel = 1 if offset is not None else 0
         yy, xx = np.mgrid[0:size*oversampling + extra_pixel,
                           0:size*oversampling + extra_pixel]
-        xx = xx / oversampling + offset
-        yy = yy / oversampling + offset
+        if offset is None:
+            if oversampling == 1:
+                offset = 0.5
+            else:
+                offset = 0
+        else:
+            _offset = offset
+        xx = xx / oversampling + _offset
+        yy = yy / oversampling + _offset
         truth_epsf = m(xx, yy)
 
         stars = extract_stars(nddata, stars_tbl, size=size)

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -135,6 +135,42 @@ class TestEPSFBuild:
         with pytest.raises(TypeError):
             EPSFBuilder(fitter=LevMarLSQFitter, maxiters=3)
 
+    def test_epsf_input(self):
+        """
+        Test various inputs raise errors as expected.
+        """
+
+        size = 25
+
+        for oversampling, grid_offset in zip([4, 4, 1, 1], [0, 0.25, 0, 0.5]):
+            if oversampling == 4:
+                shape = (99, 101)
+            else:
+                shape = (24, 26)
+            stars = extract_stars(self.nddata, self.init_stars, size=size)
+            epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=8,
+                                       progress_bar=False, norm_radius=25,
+                                       recentering_maxiters=5, shape=shape,
+                                       grid_offset=grid_offset)
+
+            with pytest.raises(ValueError):
+                epsf, fitted_stars = epsf_builder(stars)
+
+        oversampling = 4
+        for grid_offset in ['a', -1, 0.3, [0, 0.4], [0.5, 0.1]]:
+            stars = extract_stars(self.nddata, self.init_stars, size=size)
+            with pytest.raises(ValueError):
+                epsf_builder = EPSFBuilder(oversampling=oversampling,
+                                           maxiters=8, progress_bar=False,
+                                           norm_radius=25,
+                                           recentering_maxiters=5,
+                                           grid_offset=grid_offset)
+
+            with pytest.raises(ValueError):
+                EPSFModel(data=np.arange(30).reshape(5, 6),
+                          grid_offset=grid_offset,
+                          oversampling=oversampling)
+
 
 def test_epsfbuilder_inputs():
     with pytest.raises(ValueError):

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -301,18 +301,19 @@ def test_epsf_offset():
     nddata = NDData(data=data)
 
     for oversampling, offset in zip([1, 4, 3, 3, [1, 2]],
-                                    [None, None, None, 1/6, [0, 0.25]]):
+                                    ["center", "center", "center", 1/6,
+                                     [0, 0.25]]):
         _oversampling = np.atleast_1d(oversampling)
         if len(_oversampling) == 1:
             _oversampling = np.repeat(_oversampling, 2)
 
         # should be "truth" ePSF
         m = IntegratedGaussianPRF(sigma=sigma, x_0=12.5, y_0=12.5, flux=1)
-        if offset is None:
+        if offset == "center":
             _offset = [0, 0]
             for i in range(2):
-                if _oversampling[i] == 1:
-                    _offset[i] = 0.5
+                if _oversampling[i] % 2 != 0:
+                    _offset[i] = 0.5/_oversampling[i]
         else:
             _offset = np.atleast_1d(offset)
             if len(_offset) == 1:
@@ -349,3 +350,11 @@ def test_epsf_offset():
 
         assert np.all(epsf_data.shape == truth_epsf.shape)
         assert_allclose(epsf_data, truth_epsf, rtol=0.05, atol=0.03)
+
+    for oversampling, grid_offset in zip([1, 2, 4, 5, [1, 2], [2, 1], [2, 2],
+                                          [4, 4], [4, 5]],
+                                         [[0.5, 0.5], [0, 0], [0, 0],
+                                          [0.1, 0.1], [0.5, 0], [0, 0.5],
+                                          [0, 0], [0, 0], [0, 0.1]]):
+        a = EPSFBuilder(oversampling=oversampling)
+        assert np.all(a.grid_offset == grid_offset)

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ..models import (FittableImageModel, GriddedPSFModel,
-                      IntegratedGaussianPRF, PRFAdapter)
+                      IntegratedGaussianPRF, PRFAdapter, EPSFModel)
 from ...segmentation import detect_sources, source_properties
 
 try:
@@ -390,3 +390,13 @@ class TestPRFAdapter:
         # it's a bit of a guess that the above itol is appropriate, but
         # it should be close
         assert_allclose(np.sum(eval11), np.sum(eval22), atol=itol*100)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def epsfmodel_test_offsets():
+    oversampling = 4
+    for grid_offset in ['a', -1, 0.3, [0, 0.4], [0.5, 0.1]]:
+        with pytest.raises(ValueError):
+            EPSFModel(data=np.arange(30).reshape(5, 6),
+                      grid_offset=grid_offset,
+                      oversampling=oversampling)

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -400,3 +400,11 @@ def epsfmodel_test_offsets():
             EPSFModel(data=np.arange(30).reshape(5, 6),
                       grid_offset=grid_offset,
                       oversampling=oversampling)
+
+    for oversampling, grid_offset in zip([1, 2, 4, 5, [1, 2], [2, 1], [2, 2],
+                                          [4, 4], [4, 5]],
+                                         [[0.5, 0.5], [0, 0], [0, 0],
+                                          [0.1, 0.1], [0.5, 0], [0, 0.5],
+                                          [0, 0], [0, 0], [0, 0.1]]):
+        a = EPSFModel(oversampling=oversampling)
+        assert np.all(a.grid_offset == grid_offset)


### PR DESCRIPTION
This PR extends `EPSFBuilder` and `EPSFModel` to accept more than the currently assumed even oversampling with grid points representing the left/right hand edges and center of each given pixel (and other linearly spaced grid points, for oversampling > 2), allowing for odd oversampling factors (including 1), and an arbitrary grid offset, displacing the first grid point from the left hand edge of a pixel, towards the right of a given pixel.

This adds the argument `grid_offset` representing this right hand shift of all grid points (representing the evaluation of a PRF with star offset from its central pixel by some dx, dy position), allowing for more flexible ePSF creation. Previously, the assumption was that even oversampling and zero offset meant that grid points [0, 1, 2, 3, [4]] mapped to [0, 1/4, 1/2, 3/4, [1]] detector pixel offsets (where [1] is the 0 of the next-but-one pixel) -- now grid point indices can map [0, 1, 2] to `dx`s of [0.1, 1/3+0.1, 2/3+0.1] for `oversampling=3` and `grid_offset=0.1`.

This primarily is necessary to allow for `oversampling=1`, as otherwise each single grid point per detector pixel would have been assumed to sit in a corner of a pixel, whereas most use cases would want the grid point to represent the center of a pixel. Thus, the default inputs are 0.5 offset for `oversampling=1`, or no offset otherwise.

`centroid_epsf` was extended to accept the `grid_offset` argument too, as it is now necessary to check whether this algorithm can be used with the combination of `oversampling` and `grid_offset` -- this is because the algorithm, tuned to the previous defaults of `oversampling=4` and `grid_offset=0` from Anderson & King (2000), _requires_ a grid point representing the center of the pixel, such that N grid points either side of this central point are equally spaced, symmetrically, either side of the middle. This symmetry evaluation is how `centroid_epsf` centers its `data` input, so this is fundamental. Thus `centroid_epsf` can only be used for even oversampling with zero offset, OR odd oversampling with an offset of half a grid spacing (i.e., `grid_offset=0.5/oversampling`). Offline discussions with @eteq resulted in the decision to keep backwards compatibility as much as possible, so `centroid_epsf` has been left as the default input, but I've been back and forth on that so if anyone has strong opinions the other way let me know. If _all_ defaults are input I believe `centroid_epsf` should be fine (`oversampling=4` and `grid_offset=0` would be set by default), which makes it slightly less precarious...

Two outstanding issues I haven't dealt with (or am unsure of whether I need to deal with) are:
1. Does this change need to go anywhere in narrative documentation?
2. I haven't touched the changelog yet, primarily because of the milestone assignment (presumably this is `0.8` not being bug fixes?) but also because I'm not sure what of all of this needs to go in the changelog: `grid_offset` added to the three functions is API change, and I'd guess the extension of odd oversampling + arbitrary grid offsets is "New Features", but let me know what else needs to be added to the changelog and I'll add a quick commit!

cc @eteq @larrybradley for review