### PR TITLE
Fix to centroid_epsf, where y_shiftidx was using the x-axis oversampling for its calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,9 @@ Bug Fixes
     be thrown when a ``Finder`` was passed which did not return ``None``
     if no sources were found. [#986]
 
+  - Fix to ``centroid_epsf`` where ``y_shiftidx`` was using the wrong
+    oversampling factor in its calculation. [#1002]
+
 
 0.7.1 (2019-10-09)
 ------------------

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -554,7 +554,7 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     y_0 = np.arange(data.shape[0], dtype=float)[yidx_0] / oversampling[1]
 
     x_shiftidx = np.around((shift_val * oversampling[0])).astype(int)
-    y_shiftidx = np.around((shift_val * oversampling[0])).astype(int)
+    y_shiftidx = np.around((shift_val * oversampling[1])).astype(int)
 
     badidx = ~np.isfinite([data[y, x]
                            for x in [xidx_0, xidx_0+x_shiftidx,

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -251,6 +251,29 @@ def test_centroid_epsf():
         centers = centroid_epsf(data, mask=mask, oversampling=oversampling)
         assert_allclose(centers, offsets+x0, rtol=1e-3, atol=1e-2)
 
+    psf = Gaussian2D()
+    for oversampling in [4, (6, 2)]:
+        if not hasattr(oversampling, '__len__'):
+            _oversampling = (oversampling, oversampling)
+        else:
+            _oversampling = oversampling
+        x = np.arange(1 + 25 * _oversampling[0]) / _oversampling[0]
+        x0 = x[-1] / 2
+        x -= x0
+        y = np.arange(1 + 25 * _oversampling[1]) / _oversampling[1]
+        y0 = y[-1] / 2
+        y -= y0
+        offsets = np.array([0.1, 0.03])
+        data = psf.evaluate(x=x.reshape(1, -1), y=y.reshape(-1, 1),
+                            amplitude=1, x_mean=offsets[0], y_mean=offsets[1],
+                            x_stddev=5, y_stddev=0.5, theta=0)
+
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0, 0] = 1
+        centers = centroid_epsf(data, mask=mask, oversampling=oversampling,
+                                shift_val=0.5)
+        assert_allclose(centers, offsets+x0, rtol=1e-3, atol=1e-3)
+
 
 def test_centroid_exceptions():
     data = np.ones((5, 5), dtype=float)


### PR DESCRIPTION
Minor PR to fix a typo where `y_shiftidx` used `oversampling[0]`, rather than `oversampling[1]` for deriving the grid point index distance to compute the difference and gradients at; includes verification test (fails on master, passes in this branch).

Closes #996 