### PR TITLE
Fix centroid_1dg to prevent deprecations with numpy-dev

### DIFF
--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -310,19 +310,18 @@ def centroid_1dg(data, error=None, mask=None):
         data.mask |= error.mask
 
         error.mask = data.mask
-        xy_error = np.array([np.sqrt(np.ma.sum(error**2, axis=i))
-                             for i in [0, 1]])
+        xy_error = [np.sqrt(np.ma.sum(error**2, axis=i)) for i in [0, 1]]
         xy_weights = [(1.0 / xy_error[i].clip(min=1.e-30)) for i in [0, 1]]
     else:
         xy_weights = [np.ones(data.shape[i]) for i in [1, 0]]
 
-    # assign zero weight to masked pixels
-    if data.mask is not np.ma.nomask:
+    # assign zero weight where an entire row or column is masked
+    if np.any(data.mask):
         bad_idx = [np.all(data.mask, axis=i) for i in [0, 1]]
         for i in [0, 1]:
             xy_weights[i][bad_idx[i]] = 0.
 
-    xy_data = np.array([np.ma.sum(data, axis=i) for i in [0, 1]])
+    xy_data = [np.ma.sum(data, axis=i).data for i in [0, 1]]
 
     constant_init = np.ma.min(data)
     centroid = []

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -89,8 +89,9 @@ def test_centroids_oversampling(xc_ref, yc_ref, x_stddev, y_stddev, theta):
         else:
             _oversampling = oversampling
         xc, yc = centroid_com(data, mask=mask, oversampling=oversampling)
-        assert_allclose([xc, yc], [xc_ref / _oversampling[0], yc_ref / _oversampling[1]],
-                        rtol=0, atol=1.e-3)
+        assert_allclose([xc, yc], [xc_ref / _oversampling[0],
+                                   yc_ref / _oversampling[1]], rtol=0,
+                        atol=1.e-3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -243,8 +244,8 @@ def test_centroid_epsf():
         y0 = y[-1] / 2
         y -= y0
         offsets = np.array([0.1, 0.03])
-        data = psf.evaluate(x=x.reshape(1, -1), y=y.reshape(-1, 1), flux=1, x_0=offsets[0],
-                            y_0=offsets[1], sigma=sigma)
+        data = psf.evaluate(x=x.reshape(1, -1), y=y.reshape(-1, 1), flux=1,
+                            x_0=offsets[0], y_0=offsets[1], sigma=sigma)
 
         mask = np.zeros(data.shape, dtype=bool)
         mask[0, 0] = 1


### PR DESCRIPTION
Fixes `centroid_1dg` to prevent `numpy-dev` deprecations where object arrays are no long created automatically for lists with unequal numbers of elements.