### PR TITLE
Replace CITATION symlink

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,1 +1,0 @@
-photutils/CITATION

--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,0 +1,1 @@
+See https://github.com/astropy/photutils/blob/master/photutils/CITATION

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include README.rst
 include CHANGES.rst
 include CODE_OF_CONDUCT.rst
 include CONTRIBUTING.rst
-include CITATION
+include CITATION.rst
 include photutils/CITATION
 
 include ah_bootstrap.py

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,3 +1,3 @@
 .. _photutils_citation:
 
-.. include:: ../CITATION
+.. include:: ../photutils/CITATION


### PR DESCRIPTION
Replaces `CITATION` symlink with a file containing a URL to citation file.