### PR TITLE
Bump minimum pytest version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,7 +83,7 @@ build-dir = docs/_build
 all_files = 1
 
 [tool:pytest]
-minversion = 3.1
+minversion = 4.6
 testpaths = "photutils" "docs"
 norecursedirs = "docs[\/]_build" "photutils[\/]extern"
 doctest_plus = enabled


### PR DESCRIPTION
`pytest 4.6` is the oldest currently-supported version.