### PR TITLE
Added method to compute local model from GriddedPSFModel (issue #1011)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,8 +53,6 @@ API changes
     ``BasicPSFPhotometry``, ``IterativelySubtractedPSFPhotometry`` and
     ``DAOPhotPSFPhotometry``. [#745]
 
-  - Added method ``_compute_local_model`` to ``GriddedPSFModel``. [#1012]
-
 - ``photutils.segmentation``
 
   - Removed the deprecated ``SegmentationImage`` methods ``cmap`` and

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,7 +53,7 @@ API changes
     ``BasicPSFPhotometry``, ``IterativelySubtractedPSFPhotometry`` and
     ``DAOPhotPSFPhotometry``. [#745]
 
-  - Added method ``_compute_local_model`` method to ``GriddedPSFModel``.
+  - Added method ``_compute_local_model`` to ``GriddedPSFModel``. [#1012]
 
 - ``photutils.segmentation``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,8 @@ API changes
     ``BasicPSFPhotometry``, ``IterativelySubtractedPSFPhotometry`` and
     ``DAOPhotPSFPhotometry``. [#745]
 
+  - Added method ``_compute_local_model`` method to ``GriddedPSFModel``.
+
 - ``photutils.segmentation``
 
   - Removed the deprecated ``SegmentationImage`` methods ``cmap`` and

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -994,7 +994,7 @@ class GriddedPSFModel(Fittable2DModel):
 
         # Get the local PSF at the (x_0,y_0)
         psfmodel = self._compute_local_model(x_0, y_0)
-        
+
         # now evaluate the PSF at the (x_0, y_0) subpixel position on
         # the input (x, y) values
         return psfmodel.evaluate(x, y, flux, x_0, y_0)


### PR DESCRIPTION
This addresses #1011 

This adds the method `_compute_local_model` to `photutils.psf.models.GriddedPSFModel`.   There was really no change to the code, just splitting the previous `evaluate()` method into two separate methods.

This allows the user to generate a FittableImageModel for the PSF around some (x,y).  Currently, every time `evaluate()` is called, the gridded model is bilinearly interpolated, then turned into a FittableImageModel, which is then interpolated/evaluated onto the image grid.  This is very slow when doing something like fitting an object iteratively.  Splitting the evaluate method into two parts allows for the FittableImageModel to be computed just once, and then that output model to be evaluated for any small changes in position.  This shouldn't be much different in terms of results, as as the FittableImageModel changes very very little when shifting it's center by a pixel or less.  However, the performance difference could be as high as factor of 10, when evaluating the PSF many times.