### PR TITLE
Allow effective_gain to be zero in calc_total_error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.utils``
+
+  - The ``effective_gain`` parameter in ``calc_total_error`` can now
+    be zero (or contain zero values). [#1019]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/utils/errors.py
+++ b/photutils/utils/errors.py
@@ -18,19 +18,25 @@ def calc_total_error(data, bkg_error, effective_gain):
     Parameters
     ----------
     data : array_like or `~astropy.units.Quantity`
-        The data array.
+        The background-subtracted data array.
 
     bkg_error : array_like or `~astropy.units.Quantity`
-        The pixel-wise Gaussian 1-sigma background-only errors of the
-        input ``data``.  ``bkg_error`` should include all sources of
-        "background" error but *exclude* the Poisson error of the
-        sources.  ``bkg_error`` must have the same shape as ``data``.
-        If ``data`` and ``bkg_error`` are `~astropy.units.Quantity`
-        objects, then they must have the same units.
+        The 1-sigma background-only errors of the input ``data``.
+        ``bkg_error`` should include all sources of "background" error
+        but *exclude* the Poisson error of the sources.  ``bkg_error``
+        must have the same shape as ``data``.  If ``data`` and
+        ``bkg_error`` are `~astropy.units.Quantity` objects, then they
+        must have the same units.
 
     effective_gain : float, array-like, or `~astropy.units.Quantity`
         Ratio of counts (e.g., electrons or photons) to the units of
-        ``data`` used to calculate the Poisson error of the sources.
+        ``data`` used to calculate the Poisson error of the sources.  If
+        ``effective_gain`` is zero (or contains zero values in an
+        array), then the source Poisson noise component will not be
+        included.  In other words, the returned total error value will
+        simply be the ``bkg_error`` value for pixels where
+        ``effective_gain`` is zero.  ``effective_gain`` cannot not be
+        negative or contain negative values.
 
     Returns
     -------
@@ -89,9 +95,15 @@ def calc_total_error(data, bkg_error, effective_gain):
     example, if your input ``data`` are in units of electrons/s then
     ideally ``effective_gain`` should be an exposure-time map.
 
-    Pixels where ``data`` (:math:`I_i)` is negative are excluded from
-    the total error calculation, i.e. :math:`\\sigma_{\\mathrm{tot}, i}
-    = \\sigma_{\\mathrm{bkg}, i}`.
+    The Poisson noise component is not included in the output total
+    error for pixels where ``data`` (:math:`I_i)` is negative.  For such
+    pixels, :math:`\\sigma_{\\mathrm{tot}, i} = \\sigma_{\\mathrm{bkg},
+    i}`.
+
+    The Poisson noise component is also not included in the output total
+    error for pixels where the effective gain (:math:`g_{\\mathrm{eff},
+    i}`) is zero.  For such pixels, :math:`\\sigma_{\\mathrm{tot}, i} =
+    \\sigma_{\\mathrm{bkg}, i}`.
 
     To replicate `SExtractor`_ errors when it is configured to consider
     weight maps as gain maps (i.e. 'WEIGHT_GAIN=Y'; which is the

--- a/photutils/utils/tests/test_errors.py
+++ b/photutils/utils/tests/test_errors.py
@@ -20,66 +20,75 @@ BACKGROUND = np.ones(SHAPE)
 WRONG_SHAPE = np.ones((2, 2))
 
 
-class TestCalculateTotalError:
-    def test_error_shape(self):
-        with pytest.raises(ValueError):
-            calc_total_error(DATA, WRONG_SHAPE, EFFGAIN)
+def test_error_shape():
+    with pytest.raises(ValueError):
+        calc_total_error(DATA, WRONG_SHAPE, EFFGAIN)
 
-    def test_gain_shape(self):
-        with pytest.raises(ValueError):
-            calc_total_error(DATA, BKG_ERROR, WRONG_SHAPE)
 
-    @pytest.mark.parametrize('effective_gain', (-1, -100))
-    def test_gain_negative(self, effective_gain):
-        with pytest.raises(ValueError):
-            calc_total_error(DATA, BKG_ERROR, effective_gain)
+def test_gain_shape():
+    with pytest.raises(ValueError):
+        calc_total_error(DATA, BKG_ERROR, WRONG_SHAPE)
 
-    def test_gain_scalar(self):
-        error_tot = calc_total_error(DATA, BKG_ERROR, 2.)
-        assert_allclose(error_tot, np.sqrt(2.) * BKG_ERROR)
 
-    def test_gain_array(self):
-        error_tot = calc_total_error(DATA, BKG_ERROR, EFFGAIN)
-        assert_allclose(error_tot, np.sqrt(2.) * BKG_ERROR)
+@pytest.mark.parametrize('effective_gain', (-1, -100))
+def test_gain_negative(effective_gain):
+    with pytest.raises(ValueError):
+        calc_total_error(DATA, BKG_ERROR, effective_gain)
 
-    def test_gain_zero(self):
-        error_tot = calc_total_error(DATA, BKG_ERROR, 0.)
-        assert_allclose(error_tot, BKG_ERROR)
 
-        effgain = np.copy(EFFGAIN)
-        effgain[0, 0] = 0
-        effgain[1, 1] = 0
-        mask = (effgain == 0)
-        error_tot = calc_total_error(DATA, BKG_ERROR, effgain)
-        assert_allclose(error_tot[mask], BKG_ERROR[mask])
-        assert_allclose(error_tot[~mask], np.sqrt(2))
+def test_gain_scalar():
+    error_tot = calc_total_error(DATA, BKG_ERROR, 2.)
+    assert_allclose(error_tot, np.sqrt(2.) * BKG_ERROR)
 
-    def test_units(self):
-        units = u.electron / u.s
-        error_tot1 = calc_total_error(DATA * units, BKG_ERROR * units,
-                                      EFFGAIN * u.s)
-        assert error_tot1.unit == units
-        error_tot2 = calc_total_error(DATA, BKG_ERROR, EFFGAIN)
-        assert_allclose(error_tot1.value, error_tot2)
 
-    def test_error_units(self):
-        units = u.electron / u.s
-        with pytest.raises(ValueError):
-            calc_total_error(DATA * units, BKG_ERROR * u.electron,
-                             EFFGAIN * u.s)
+def test_gain_array():
+    error_tot = calc_total_error(DATA, BKG_ERROR, EFFGAIN)
+    assert_allclose(error_tot, np.sqrt(2.) * BKG_ERROR)
 
-    def test_effgain_units(self):
-        units = u.electron / u.s
-        with pytest.raises(u.UnitsError):
-            calc_total_error(DATA * units, BKG_ERROR * units, EFFGAIN * u.km)
 
-    def test_missing_bkgerror_units(self):
-        units = u.electron / u.s
-        with pytest.raises(ValueError):
-            calc_total_error(DATA * units, BKG_ERROR, EFFGAIN * u.s)
+def test_gain_zero():
+    error_tot = calc_total_error(DATA, BKG_ERROR, 0.)
+    assert_allclose(error_tot, BKG_ERROR)
 
-    def test_missing_effgain_units(self):
-        units = u.electron / u.s
-        with pytest.raises(ValueError):
-            calc_total_error(DATA * units, BKG_ERROR * units,
-                             EFFGAIN)
+    effgain = np.copy(EFFGAIN)
+    effgain[0, 0] = 0
+    effgain[1, 1] = 0
+    mask = (effgain == 0)
+    error_tot = calc_total_error(DATA, BKG_ERROR, effgain)
+    assert_allclose(error_tot[mask], BKG_ERROR[mask])
+    assert_allclose(error_tot[~mask], np.sqrt(2))
+
+
+def test_units():
+    units = u.electron / u.s
+    error_tot1 = calc_total_error(DATA * units, BKG_ERROR * units,
+                                  EFFGAIN * u.s)
+    assert error_tot1.unit == units
+    error_tot2 = calc_total_error(DATA, BKG_ERROR, EFFGAIN)
+    assert_allclose(error_tot1.value, error_tot2)
+
+
+def test_error_units():
+    units = u.electron / u.s
+    with pytest.raises(ValueError):
+        calc_total_error(DATA * units, BKG_ERROR * u.electron,
+                         EFFGAIN * u.s)
+
+
+def test_effgain_units():
+    units = u.electron / u.s
+    with pytest.raises(u.UnitsError):
+        calc_total_error(DATA * units, BKG_ERROR * units, EFFGAIN * u.km)
+
+
+def test_missing_bkgerror_units():
+    units = u.electron / u.s
+    with pytest.raises(ValueError):
+        calc_total_error(DATA * units, BKG_ERROR, EFFGAIN * u.s)
+
+
+def test_missing_effgain_units():
+    units = u.electron / u.s
+    with pytest.raises(ValueError):
+        calc_total_error(DATA * units, BKG_ERROR * units,
+                         EFFGAIN)


### PR DESCRIPTION
This PR allows the `effective_gain` parameter in `calc_total_error` to be zero (or contain zeros in an array).  For pixels where `effective_gain` is zero, the source Poisson noise component is not included in the total error array.  Thanks to @dancoe for discovering this issue.