### PR TITLE
Fix source_properties for unitless gwcs objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.segmentation``
+
+  - Fixed a bug where ``source_properties`` would fail with unitless
+    ``gwcs.wcs.WCS`` objects. [#1020]
+
 - ``photutils.utils``
 
   - The ``effective_gain`` parameter in ``calc_total_error`` can now

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1677,7 +1677,8 @@ class SourceCatalog:
             # SkyCoord array from a loop-generated SkyCoord list.  The
             # assumption here is that the wcs is the same for each
             # SourceProperties instance.
-            return _pixel_to_world(self.xcentroid, self.ycentroid, self.wcs)
+            return _pixel_to_world(self.xcentroid.value, self.ycentroid.value,
+                                   self.wcs)
 
     @lazyproperty
     def sky_centroid_icrs(self):

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -19,6 +19,7 @@ import pytest
 from ..core import SegmentationImage
 from ..detect import detect_sources
 from ..properties import SourceCatalog, SourceProperties, source_properties
+from ...datasets import make_gwcs, make_wcs
 
 try:
     import scipy  # noqa
@@ -98,13 +99,22 @@ class TestSourceProperties:
             SourceProperties(IMAGE, segm, label=label)
 
     def test_wcs(self):
-        mywcs = WCS.WCS(naxis=2)
-        rho = np.pi / 3.
-        scale = 0.1 / 3600.
-        mywcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
-                        [scale*np.sin(rho), scale*np.cos(rho)]]
-        mywcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+        mywcs = make_wcs(IMAGE.shape)
         props = SourceProperties(IMAGE, self.segm, wcs=mywcs, label=1)
+        assert props.sky_centroid is not None
+        assert props.sky_centroid_icrs is not None
+        assert props.sky_bbox_ll is not None
+        assert props.sky_bbox_ul is not None
+        assert props.sky_bbox_lr is not None
+        assert props.sky_bbox_ur is not None
+
+        tbl = props.to_table()
+        assert len(tbl) == 1
+
+    def test_gwcs(self):
+        mywcs = make_gwcs(IMAGE.shape)
+        props = SourceProperties(IMAGE, self.segm, wcs=mywcs, label=1)
+        assert props.sky_centroid is not None
         assert props.sky_centroid_icrs is not None
         assert props.sky_bbox_ll is not None
         assert props.sky_bbox_ul is not None
@@ -470,6 +480,34 @@ class TestSourcePropertiesFunction:
         assert cat[0].id == 2
         assert cat[1].id == 3
         assert cat[segm.get_index(label=1000)].id == 1000
+
+    def test_wcs(self):
+        mywcs = make_wcs(IMAGE.shape)
+        props = source_properties(IMAGE, self.segm, wcs=mywcs)
+
+        assert props.sky_centroid is not None
+        assert props.sky_centroid_icrs is not None
+        assert props.sky_bbox_ll is not None
+        assert props.sky_bbox_ul is not None
+        assert props.sky_bbox_lr is not None
+        assert props.sky_bbox_ur is not None
+
+        tbl = props.to_table()
+        assert len(tbl) == 3
+
+    def test_gwcs(self):
+        mywcs = make_gwcs(IMAGE.shape)
+        props = source_properties(IMAGE, self.segm, wcs=mywcs)
+
+        assert props.sky_centroid is not None
+        assert props.sky_centroid_icrs is not None
+        assert props.sky_bbox_ll is not None
+        assert props.sky_bbox_ul is not None
+        assert props.sky_bbox_lr is not None
+        assert props.sky_bbox_ur is not None
+
+        tbl = props.to_table()
+        assert len(tbl) == 3
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -27,6 +27,12 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
+try:
+    import gwcs  # noqa
+    HAS_GWCS = True
+except ImportError:
+    HAS_GWCS = False
+
 XCEN = 51.
 YCEN = 52.7
 MAJOR_SIG = 8.
@@ -111,6 +117,7 @@ class TestSourceProperties:
         tbl = props.to_table()
         assert len(tbl) == 1
 
+    @pytest.mark.skipif('not HAS_GWCS')
     def test_gwcs(self):
         mywcs = make_gwcs(IMAGE.shape)
         props = SourceProperties(IMAGE, self.segm, wcs=mywcs, label=1)
@@ -495,10 +502,10 @@ class TestSourcePropertiesFunction:
         tbl = props.to_table()
         assert len(tbl) == 3
 
+    @pytest.mark.skipif('not HAS_GWCS')
     def test_gwcs(self):
         mywcs = make_gwcs(IMAGE.shape)
         props = source_properties(IMAGE, self.segm, wcs=mywcs)
-
         assert props.sky_centroid is not None
         assert props.sky_centroid_icrs is not None
         assert props.sky_bbox_ll is not None

--- a/photutils/utils/_wcs_helpers.py
+++ b/photutils/utils/_wcs_helpers.py
@@ -34,6 +34,10 @@ def _pixel_to_world(xpos, ypos, wcs):
     if wcs is None:
         return None
 
+    # NOTE: unitless gwcs objects fail with Quantity inputs
+    if isinstance(xpos, u.Quantity) or isinstance(ypos, u.Quantity):
+        raise TypeError('xpos and ypos must not be Quantity objects')
+
     try:
         return wcs.pixel_to_world(xpos, ypos)
     except AttributeError:


### PR DESCRIPTION
This PR fixes a bug where `source_properties` would fail with unitless `gwcs.wcs.WCS` objects.  For unitless `gwcs` objects, the x, y input to `pixel_to_world` must not be `Quantity` objects.