### PR TITLE
Replace numpy dtypes in psf subpackage

### DIFF
--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -187,7 +187,7 @@ class EPSFFitter:
         # Define positions in the undersampled grid. The fitter will
         # evaluate on the defined interpolation grid, currently in the
         # range [0, len(undersampled grid)].
-        yy, xx = np.indices(data.shape, dtype=np.float)
+        yy, xx = np.indices(data.shape, dtype=float)
         xx = xx + x0 - star.cutout_center[0]
         yy = yy + y0 - star.cutout_center[1]
 
@@ -422,16 +422,17 @@ class EPSFBuilder:
             # Stars class should have odd-sized dimensions, and thus we
             # get the oversampled shape as oversampling * len + 1; if
             # len=25, then newlen=101, for example.
-            x_shape = np.int(np.ceil(stars._max_shape[0]) * oversampling[0]
-                             + 1)
-            y_shape = np.int(np.ceil(stars._max_shape[1]) * oversampling[1]
-                             + 1)
+            x_shape = (np.ceil(stars._max_shape[0]) * oversampling[0] +
+                       1).astype(int)
+            y_shape = (np.ceil(stars._max_shape[1]) * oversampling[1] +
+                       1).astype(int)
+
             shape = np.array((y_shape, x_shape))
 
         # verify odd sizes of shape
         shape = [(i + 1) if i % 2 == 0 else i for i in shape]
 
-        data = np.zeros(shape, dtype=np.float)
+        data = np.zeros(shape, dtype=float)
 
         # ePSF origin should be in the undersampled pixel units, not the
         # oversampled grid units. The middle, fractional (as we wish for
@@ -639,7 +640,7 @@ class EPSFBuilder:
 
         xcenter, ycenter = epsf.origin
 
-        y, x = np.indices(epsf._data.shape, dtype=np.float)
+        y, x = np.indices(epsf._data.shape, dtype=float)
         x /= epsf.oversampling[0]
         y /= epsf.oversampling[1]
 

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -71,9 +71,9 @@ class EPSFStar:
             if weights.shape != data.shape:
                 raise ValueError('weights must have the same shape as the '
                                  'input data array.')
-            self.weights = np.asanyarray(weights, dtype=np.float).copy()
+            self.weights = np.asanyarray(weights, dtype=float).copy()
         else:
-            self.weights = np.ones_like(self._data, dtype=np.float)
+            self.weights = np.ones_like(self._data, dtype=float)
 
         self.mask = (self.weights <= 0.)
 
@@ -173,10 +173,10 @@ class EPSFStar:
             data_interp = _interpolate_missing_data(data_interp,
                                                     method='nearest',
                                                     mask=self.mask)
-            flux = np.sum(data_interp, dtype=np.float64)
+            flux = np.sum(data_interp, dtype=float)
 
         else:
-            flux = np.sum(self.data, dtype=np.float64)
+            flux = np.sum(self.data, dtype=float)
 
         return flux
 
@@ -195,7 +195,7 @@ class EPSFStar:
             A 2D array of the registered/scaled ePSF.
         """
 
-        yy, xx = np.indices(self.shape, dtype=np.float)
+        yy, xx = np.indices(self.shape, dtype=float)
         xx = xx - self.cutout_center[0]
         yy = yy - self.cutout_center[1]
 
@@ -765,19 +765,19 @@ def _extract_stars(data, catalog, size=(11, 11), use_xy=True):
                                                    data.wcs, origin=0,
                                                    mode='all')
     else:
-        xcenters = catalog['x'].data.astype(np.float)
-        ycenters = catalog['y'].data.astype(np.float)
+        xcenters = catalog['x'].data.astype(float)
+        ycenters = catalog['y'].data.astype(float)
 
     if 'id' in colnames:
         ids = catalog['id']
     else:
-        ids = np.arange(len(catalog), dtype=np.int) + 1
+        ids = np.arange(len(catalog), dtype=int) + 1
 
     if data.uncertainty is None:
         weights = np.ones_like(data.data)
     else:
         if data.uncertainty.uncertainty_type == 'weights':
-            weights = np.asanyarray(data.uncertainty.array, dtype=np.float)
+            weights = np.asanyarray(data.uncertainty.array, dtype=float)
         else:
             warnings.warn('The data uncertainty attribute has an unsupported '
                           'type.  Only uncertainty_type="weights" can be '

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -138,7 +138,7 @@ class FittableImageModel(Fittable2DModel):
                              "positive.")
         self._normalization_correction = normalization_correction
 
-        self._data = np.array(data, copy=True, dtype=np.float64)
+        self._data = np.array(data, copy=True, dtype=float)
 
         if not np.all(np.isfinite(self._data)):
             raise ValueError("All elements of input 'data' must be finite.")
@@ -182,7 +182,7 @@ class FittableImageModel(Fittable2DModel):
             computed.
 
         """
-        return np.sum(self._data, dtype=np.float64)
+        return np.sum(self._data, dtype=float)
 
     def _compute_normalization(self, normalize):
         """
@@ -459,8 +459,8 @@ class FittableImageModel(Fittable2DModel):
 
         smoothness = kwargs.get('s', 0)
 
-        x = np.arange(self._nx, dtype=np.float)
-        y = np.arange(self._ny, dtype=np.float)
+        x = np.arange(self._nx, dtype=float)
+        y = np.arange(self._ny, dtype=float)
         self.interpolator = RectBivariateSpline(
             x, y, self._data.T, kx=degx, ky=degy, s=smoothness
         )
@@ -565,8 +565,8 @@ class EPSFModel(FittableImageModel):
 
         # First need the indices of each axis at the oversampled
         # resolution; if oversampling = 4 then x = [0, 0.25, 0.5, 0.75, ...]
-        x = np.arange(self._nx, dtype=np.float64) / self.oversampling[0]
-        y = np.arange(self._ny, dtype=np.float64) / self.oversampling[1]
+        x = np.arange(self._nx, dtype=float) / self.oversampling[0]
+        y = np.arange(self._ny, dtype=float) / self.oversampling[1]
 
         # Take indices where the undersampled grid is an integer --
         # i.e., the actual undersampled grid -- and find the cut where
@@ -591,7 +591,7 @@ class EPSFModel(FittableImageModel):
                & (x.reshape(1, -1) % 1.0 == over_index_middle)
                & (y.reshape(-1, 1) % 1.0 == over_index_middle))
 
-        return np.sum(self._data[cut], dtype=np.float64)
+        return np.sum(self._data[cut], dtype=float)
 
     def _compute_normalization(self):
         """
@@ -719,8 +719,8 @@ class EPSFModel(FittableImageModel):
 
         # Interpolator must be set to interpolate on the undersampled
         # pixel grid, going from 0 to len(undersampled_grid)
-        x = np.arange(self._nx, dtype=np.float) / self.oversampling[0]
-        y = np.arange(self._ny, dtype=np.float) / self.oversampling[1]
+        x = np.arange(self._nx, dtype=float) / self.oversampling[0]
+        y = np.arange(self._ny, dtype=float) / self.oversampling[1]
         self.interpolator = RectBivariateSpline(
             x, y, self._data.T, kx=degx, ky=degy, s=smoothness)
 
@@ -806,7 +806,7 @@ class GriddedPSFModel(Fittable2DModel):
         if not np.isscalar(data.meta['oversampling']):
             raise ValueError('oversampling must be a scalar value')
 
-        self.data = np.array(data.data, copy=True, dtype=np.float)
+        self.data = np.array(data.data, copy=True, dtype=float)
         self.meta = data.meta
         self.grid_xypos = data.meta['grid_xypos']
         self.oversampling = data.meta['oversampling']

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -718,8 +718,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
 
         if init_guesses is not None:
             table = super().do_photometry(image, init_guesses)
-            table['iter_detected'] = np.ones(table['x_fit'].shape,
-                                             dtype=np.int32)
+            table['iter_detected'] = np.ones(table['x_fit'].shape, dtype=int)
 
             # n_start = 2 because it starts in the second iteration
             # since the first iteration is above
@@ -802,7 +801,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
             table = hstack([star_groups, table])
 
             table['iter_detected'] = n*np.ones(table['x_fit'].shape,
-                                               dtype=np.int32)
+                                               dtype=int)
 
             output_table = vstack([output_table, table])
 

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -176,7 +176,7 @@ def test_epsfmodel_inputs():
     with pytest.raises(ValueError):
         EPSFModel(data)
 
-    data[2, 2] = np.finfo(np.float64).max * 2
+    data[2, 2] = np.finfo(float).max * 2
     with pytest.raises(ValueError):
         EPSFModel(data, flux=None)
 

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -254,17 +254,17 @@ class TestGriddedPSFModel:
 
         shape = (200, 200)
         data = np.zeros(shape)
-        eval_xshape = np.int(np.ceil(self.psfmodel.data.shape[2] /
-                                     self.psfmodel.oversampling))
-        eval_yshape = np.int(np.ceil(self.psfmodel.data.shape[1] /
-                                     self.psfmodel.oversampling))
+        eval_xshape = (np.ceil(self.psfmodel.data.shape[2] /
+                               self.psfmodel.oversampling)).astype(int)
+        eval_yshape = (np.ceil(self.psfmodel.data.shape[1] /
+                               self.psfmodel.oversampling)).astype(int)
 
         xx = [40, 50, 160, 160]
         yy = [60, 150, 50, 140]
         zz = [100, 100, 100, 100]
         for xxi, yyi, zzi in zip(xx, yy, zz):
-            x0 = np.int(np.floor(xxi - (eval_xshape - 1) / 2.))
-            y0 = np.int(np.floor(yyi - (eval_yshape - 1) / 2.))
+            x0 = np.floor(xxi - (eval_xshape - 1) / 2.).astype(int)
+            y0 = np.floor(yyi - (eval_yshape - 1) / 2.).astype(int)
             x1 = x0 + eval_xshape
             y1 = y0 + eval_yshape
 


### PR DESCRIPTION
These numpy dtypes are simply aliases for the Python builtin dtypes and should be avoided.  Followup to #982.