### PR TITLE
 Add interpolation="nearest" for imshow plots in documentation

### DIFF
--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -361,7 +361,7 @@ apertures (red) on the image:
    annulus_aperture = CircularAnnulus(positions, r_in=10, r_out=15)
 
    norm = simple_norm(data, 'sqrt', percent=99)
-   plt.imshow(data, norm=norm)
+   plt.imshow(data, norm=norm, interpolation='nearest')
    aperture.plot(color='white', lw=2)
    annulus_aperture.plot(color='red', lw=2)
    plt.xlim(0, 170)
@@ -388,7 +388,7 @@ Let's focus on just the first annulus.  Let's plot its aperture mask:
 .. doctest-skip::
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.imshow(annulus_masks[0])
+    >>> plt.imshow(annulus_masks[0], interpolation='nearest')
     >>> plt.colorbar()
 
 .. plot::
@@ -399,7 +399,7 @@ Let's focus on just the first annulus.  Let's plot its aperture mask:
     aperture = CircularAperture(positions, r=5)
     annulus_aperture = CircularAnnulus(positions, r_in=10, r_out=15)
     annulus_masks = annulus_aperture.to_mask(method='center')
-    plt.imshow(annulus_masks[0])
+    plt.imshow(annulus_masks[0], interpolation='nearest')
     plt.colorbar()
 
 We can now use the :meth:`photutils.aperture.ApertureMask.multiply`
@@ -422,7 +422,7 @@ Let's plot the annulus data:
     annulus_masks = annulus_aperture.to_mask(method='center')
     data = make_100gaussians_image()
     annulus_data = annulus_masks[0].multiply(data)
-    plt.imshow(annulus_data)
+    plt.imshow(annulus_data, interpolation='nearest')
     plt.colorbar()
 
 From this 2D array, you can extract a 1D array of data values (e.g. if

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -59,7 +59,8 @@ Let's plot the image:
     >>> from astropy.visualization import SqrtStretch
     >>> from astropy.visualization.mpl_normalize import ImageNormalize
     >>> norm = ImageNormalize(stretch=SqrtStretch())
-    >>> plt.imshow(data, norm=norm, origin='lower', cmap='Greys_r')
+    >>> plt.imshow(data, norm=norm, origin='lower', cmap='Greys_r',
+    ...            interpolation='nearest')
 
 .. plot::
 
@@ -69,7 +70,8 @@ Let's plot the image:
     from photutils.datasets import make_100gaussians_image
     data = make_100gaussians_image()
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data, norm=norm, origin='lower', cmap='Greys_r')
+    plt.imshow(data, norm=norm, origin='lower', cmap='Greys_r',
+               interpolation='nearest')
 
 The image median and biweight location are both larger than the true
 background level of 5::
@@ -229,7 +231,8 @@ background gradient to the image defined above::
     >>> y, x = np.mgrid[:ny, :nx]
     >>> gradient =  x * y / 5000.
     >>> data2 = data + gradient
-    >>> plt.imshow(data2, norm=norm, origin='lower', cmap='Greys_r')  # doctest: +SKIP
+    >>> plt.imshow(data2, norm=norm, origin='lower', cmap='Greys_r',
+    ...            interpolation='nearest')  # doctest: +SKIP
 
 .. plot::
 
@@ -243,7 +246,8 @@ background gradient to the image defined above::
     gradient =  x * y / 5000.
     data2 = data + gradient
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data2, norm=norm, origin='lower', cmap='Greys_r')
+    plt.imshow(data2, norm=norm, origin='lower', cmap='Greys_r',
+               interpolation='nearest')
 
 We start by creating a `~photutils.background.Background2D` object
 using a box size of 50x50 and a 3x3 median filter.  We will estimate
@@ -280,7 +284,8 @@ Let's plot the background image:
 
 .. doctest-skip::
 
-    >>> plt.imshow(bkg.background, origin='lower', cmap='Greys_r')
+    >>> plt.imshow(bkg.background, origin='lower', cmap='Greys_r',
+    ...            interpolation='nearest')
 
 .. plot::
 
@@ -297,14 +302,15 @@ Let's plot the background image:
     bkg_estimator = MedianBackground()
     bkg = Background2D(data2, (50, 50), filter_size=(3, 3),
                        sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
-    plt.imshow(bkg.background, origin='lower', cmap='Greys_r')
+    plt.imshow(bkg.background, origin='lower', cmap='Greys_r',
+               interpolation='nearest')
 
 and the background-subtracted image:
 
 .. doctest-skip::
 
     >>> plt.imshow(data2 - bkg.background, norm=norm, origin='lower',
-    ...            cmap='Greys_r')
+    ...            cmap='Greys_r', interpolation='nearest')
 
 .. plot::
 
@@ -325,7 +331,7 @@ and the background-subtracted image:
                        sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)
     norm = ImageNormalize(stretch=SqrtStretch())
     plt.imshow(data2 - bkg.background, norm=norm, origin='lower',
-               cmap='Greys_r')
+               cmap='Greys_r', interpolation='nearest')
 
 
 Masking
@@ -349,7 +355,8 @@ Let's create such an image and plot it (NOTE: this example requires
     >>> from scipy.ndimage import rotate
     >>> data3 = rotate(data2, -45.)
     >>> norm = ImageNormalize(stretch=SqrtStretch())  # doctest: +SKIP
-    >>> plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm)  # doctest: +SKIP
+    >>> plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm,
+    ...            interpolation='nearest')  # doctest: +SKIP
 
 .. plot::
 
@@ -365,7 +372,8 @@ Let's create such an image and plot it (NOTE: this example requires
     data2 = data + gradient
     data3 = rotate(data2, -45.)
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm)
+    plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm,
+               interpolation='nearest')
 
 Now we create a coverage mask and input it into
 `~photutils.background.Background2D` to exclude the regions where we
@@ -387,7 +395,8 @@ apply the coverage mask to the returned background image:
 
     >>> back3 = bkg3.background * ~mask
     >>> norm = ImageNormalize(stretch=SqrtStretch())  # doctest: +SKIP
-    >>> plt.imshow(back3, origin='lower', cmap='Greys_r', norm=norm)  # doctest: +SKIP
+    >>> plt.imshow(back3, origin='lower', cmap='Greys_r', norm=norm,
+    ...            interpolation='nearest')  # doctest: +SKIP
 
 .. plot::
 
@@ -407,14 +416,16 @@ apply the coverage mask to the returned background image:
     bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
     back3 = bkg3.background * ~mask
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(back3, origin='lower', cmap='Greys_r', norm=norm)
+    plt.imshow(back3, origin='lower', cmap='Greys_r', norm=norm,
+               interpolation='nearest')
 
 Finally, let's subtract the background from the image and plot it:
 
 .. doctest-skip::
 
     >>> norm = ImageNormalize(stretch=SqrtStretch())
-    >>> plt.imshow(data3 - back3, origin='lower', cmap='Greys_r', norm=norm)
+    >>> plt.imshow(data3 - back3, origin='lower', cmap='Greys_r', norm=norm,
+    ...            interpolation='nearest')
 
 .. plot::
 
@@ -434,7 +445,8 @@ Finally, let's subtract the background from the image and plot it:
     bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
     back3 = bkg3.background * ~mask
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data3 - back3, origin='lower', cmap='Greys_r', norm=norm)
+    plt.imshow(data3 - back3, origin='lower', cmap='Greys_r', norm=norm,
+               interpolation='nearest')
 
 If there is any small residual background still present in the image,
 the background subtraction can be improved by masking the sources
@@ -450,7 +462,8 @@ be plotted on the original image using the
 
 .. doctest-skip::
 
-    >>> plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm)
+    >>> plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm,
+    ...            interpolation='nearest')
     >>> bkg3.plot_meshes(outlines=True, color='#1f77b4')
 
 .. plot::
@@ -471,7 +484,8 @@ be plotted on the original image using the
     bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
     back3 = bkg3.background * ~mask
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm)
+    plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm,
+               interpolation='nearest')
     bkg3.plot_meshes(outlines=True, color='#17becf')
 
 The meshes extended beyond the original image on the top and right

--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -65,7 +65,7 @@ similar, we also include an inset plot zoomed in near the centroid:
     x2, y2 = centroid_1dg(data)
     x3, y3 = centroid_2dg(data)
     fig, ax = plt.subplots(1, 1)
-    ax.imshow(data, origin='lower', interpolation='nearest', cmap='viridis')
+    ax.imshow(data, origin='lower', interpolation='nearest')
     marker = '+'
     ms, mew = 30, 2.
     plt.plot(x1, y1, color='#1f77b4', marker=marker, ms=ms, mew=mew)
@@ -75,8 +75,8 @@ similar, we also include an inset plot zoomed in near the centroid:
     from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
     from mpl_toolkits.axes_grid1.inset_locator import mark_inset
     ax2 = zoomed_inset_axes(ax, zoom=6, loc=9)
-    ax2.imshow(data, interpolation='nearest', origin='lower',
-               cmap='viridis', vmin=190, vmax=220)
+    ax2.imshow(data, vmin=190, vmax=220, origin='lower',
+               interpolation='nearest')
     ax2.plot(x1, y1, color='#1f77b4', marker=marker, ms=ms, mew=mew)
     ax2.plot(x2, y2, color='#17becf', marker=marker, ms=ms, mew=mew)
     ax2.plot(x3, y3, color='#d62728', marker=marker, ms=ms, mew=mew)

--- a/docs/detection.rst
+++ b/docs/detection.rst
@@ -93,7 +93,8 @@ Let's plot the image and mark the location of detected sources:
     >>> positions = np.transpose((sources['xcentroid'], sources['ycentroid']))
     >>> apertures = CircularAperture(positions, r=4.)
     >>> norm = ImageNormalize(stretch=SqrtStretch())
-    >>> plt.imshow(data, cmap='Greys', origin='lower', norm=norm)
+    >>> plt.imshow(data, cmap='Greys', origin='lower', norm=norm,
+    ...            interpolation='nearest')
     >>> apertures.plot(color='blue', lw=1.5, alpha=0.5)
 
 .. plot::
@@ -113,7 +114,8 @@ Let's plot the image and mark the location of detected sources:
     positions = np.transpose((sources['xcentroid'], sources['ycentroid']))
     apertures = CircularAperture(positions, r=4.)
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data, cmap='Greys', origin='lower', norm=norm)
+    plt.imshow(data, cmap='Greys', origin='lower', norm=norm,
+               interpolation='nearest')
     apertures.plot(color='blue', lw=1.5, alpha=0.5)
 
 
@@ -160,7 +162,8 @@ regions:
     positions = np.transpose((sources['xcentroid'], sources['ycentroid']))
     apertures = CircularAperture(positions, r=4.)
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data, cmap='Greys', origin='lower', norm=norm)
+    plt.imshow(data, cmap='Greys', origin='lower', norm=norm,
+               interpolation='nearest')
     plt.title('Star finder with a mask to exclude regions')
     apertures.plot(color='blue', lw=1.5, alpha=0.5)
     rect1 = RectangularAperture((200, 100), 300, 100, theta=0.)
@@ -228,7 +231,8 @@ And let's plot the location of the detected peaks in the image:
     >>> positions = np.transpose((tbl['x_peak'], tbl['y_peak']))
     >>> apertures = CircularAperture(positions, r=5.)
     >>> norm = simple_norm(data, 'sqrt', percent=99.9)
-    >>> plt.imshow(data, cmap='Greys_r', origin='lower', norm=norm)
+    >>> plt.imshow(data, cmap='Greys_r', origin='lower', norm=norm,
+    ...            interpolation='nearest')
     >>> apertures.plot(color='#0547f9', lw=1.5)
     >>> plt.xlim(0, data.shape[1]-1)
     >>> plt.ylim(0, data.shape[0]-1)
@@ -249,7 +253,8 @@ And let's plot the location of the detected peaks in the image:
     positions = np.transpose((tbl['x_peak'], tbl['y_peak']))
     apertures = CircularAperture(positions, r=5.)
     norm = simple_norm(data, 'sqrt', percent=99.9)
-    plt.imshow(data, cmap='Greys_r', origin='lower', norm=norm)
+    plt.imshow(data, cmap='Greys_r', origin='lower', norm=norm,
+               interpolation='nearest')
     apertures.plot(color='#0547f9', lw=1.5)
     plt.xlim(0, data.shape[1]-1)
     plt.ylim(0, data.shape[0]-1)

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -228,7 +228,7 @@ Let's plot one of the deblended sources:
     ax1.set_title('Data')
     cmap1 = segm.make_cmap(random_state=123)
     ax2.imshow(segm.data[slc], origin='lower', cmap=cmap1,
-               interpolation='nearest)
+               interpolation='nearest')
     ax2.set_title('Original Segment')
     cmap2 = segm_deblend.make_cmap(random_state=123)
     ax3.imshow(segm_deblend.data[slc], origin='lower', cmap=cmap2,

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -104,7 +104,7 @@ segmentation image showing the detected sources:
     >>> ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     >>> ax1.set_title('Data')
     >>> cmap = segm.make_cmap(random_state=12345)
-    >>> ax2.imshow(segm, origin='lower', cmap=cmap)
+    >>> ax2.imshow(segm, origin='lower', cmap=cmap, interpolation='nearest')
     >>> ax2.set_title('Segmentation Image')
 
 .. plot::
@@ -128,7 +128,7 @@ segmentation image showing the detected sources:
     ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     ax1.set_title('Data')
     cmap = segm.make_cmap(random_state=12345)
-    ax2.imshow(segm, origin='lower', cmap=cmap)
+    ax2.imshow(segm, origin='lower', cmap=cmap, interpolation='nearest')
     ax2.set_title('Segmentation Image')
     plt.tight_layout()
 
@@ -197,7 +197,7 @@ the deblended segmentation image:
     norm = ImageNormalize(stretch=SqrtStretch())
     fig, ax = plt.subplots(1, 1, figsize=(10, 6.5))
     cmap = segm_deblend.make_cmap(random_state=12345)
-    ax.imshow(segm_deblend, origin='lower', cmap=cmap)
+    ax.imshow(segm_deblend, origin='lower', cmap=cmap, interpolation='nearest')
     ax.set_title('Deblended Segmentation Image')
     plt.tight_layout()
 
@@ -227,10 +227,12 @@ Let's plot one of the deblended sources:
     ax1.imshow(data[slc], origin='lower')
     ax1.set_title('Data')
     cmap1 = segm.make_cmap(random_state=123)
-    ax2.imshow(segm.data[slc], origin='lower', cmap=cmap1)
+    ax2.imshow(segm.data[slc], origin='lower', cmap=cmap1,
+               interpolation='nearest)
     ax2.set_title('Original Segment')
     cmap2 = segm_deblend.make_cmap(random_state=123)
-    ax3.imshow(segm_deblend.data[slc], origin='lower', cmap=cmap2)
+    ax3.imshow(segm_deblend.data[slc], origin='lower', cmap=cmap2,
+               interpolation='nearest')
     ax3.set_title('Deblended Segments')
     plt.tight_layout()
 
@@ -409,7 +411,8 @@ Now let's plot the derived elliptical apertures on the data:
     >>> ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     >>> ax1.set_title('Data')
     >>> cmap = segm_deblend.make_cmap(random_state=12345)
-    >>> ax2.imshow(segm_deblend, origin='lower', cmap=cmap)
+    >>> ax2.imshow(segm_deblend, origin='lower', cmap=cmap,
+    ...            interpolation='nearest')
     >>> ax2.set_title('Segmentation Image')
     >>> for aperture in apertures:
     ...     aperture.plot(axes=ax1, color='white', lw=1.5)
@@ -457,7 +460,8 @@ Now let's plot the derived elliptical apertures on the data:
     ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     ax1.set_title('Data')
     cmap = segm_deblend.make_cmap(random_state=12345)
-    ax2.imshow(segm_deblend, origin='lower', cmap=cmap)
+    ax2.imshow(segm_deblend, origin='lower', cmap=cmap,
+               interpolation='nearest')
     ax2.set_title('Segmentation Image')
     for aperture in apertures:
         aperture.plot(axes=ax1, color='white', lw=1.5)


### PR DESCRIPTION
`matplotlib 3.2` changed the default `imshow` interpolation from `"nearest"` to `"antialiased"` (https://github.com/matplotlib/matplotlib/pull/13724). This breaking change causes "rainbow" outlines when plotting segmentation images (integer data).  This PR explicitly sets the `interpolation="nearest"` to restore the correct plots.

interpolation='nearest':
![segm1](https://user-images.githubusercontent.com/4992897/81132656-3426c100-8f1d-11ea-9ecc-058aa476efdc.png)

interpolation='antialiased':
![segm2](https://user-images.githubusercontent.com/4992897/81132667-3c7efc00-8f1d-11ea-9732-686c242fa476.png)
