### PR TITLE
Break the while loop outside the image [Fixes #1038]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Bug Fixes
 - ``photutils.isophote``
 
   - Fix a bug that ``build_ellipse_model`` falls into an infinite loop
-    when the pixel to fit is outside of the image. [#1038]
+    when the pixel to fit is outside of the image. [#1039]
 
 - ``photutils.segmentation``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.isophote``
+
+  - Fix a bug that ``build_ellipse_model`` falls into an infinite loop
+    when the pixel to fit is outside of the image. [#1038]
+
 - ``photutils.segmentation``
 
   - Fixed a bug where ``source_properties`` would fail with unitless

--- a/photutils/isophote/model.py
+++ b/photutils/isophote/model.py
@@ -128,7 +128,6 @@ def build_ellipse_model(shape, isolist, fill=0., high_harmonics=False):
             i = int(x)
             j = int(y)
 
-            # if outside image boundaries, ignore.
             if (i > 0 and i < shape[1] - 1 and j > 0 and j < shape[0] - 1):
                 # get fractional deviations relative to target array
                 fx = x - float(i)
@@ -150,6 +149,9 @@ def build_ellipse_model(shape, isolist, fill=0., high_harmonics=False):
                 # step towards next pixel on ellipse
                 phi = max((phi + 0.75 / r), geometry._phi_min)
                 r = geometry.radius(phi)
+            # if outside image boundaries, ignore.
+            else:
+                break
 
     # zero weight values must be set to 1.
     weight[np.where(weight <= 0.)] = 1.


### PR DESCRIPTION
This PR fixes the issue #1038 (``build_ellipse_model``). 

Only two lines are added
```python
    else:
        break
```
and moved a one-line coment just above this ``else``. (Tests passed on my computer, just for confirmation)

Fix #1038