### PR TITLE
Update scikit-image watershed import

### DIFF
--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -43,7 +43,7 @@ def apply_poisson_noise(data, random_state=None):
         The array on which to apply Poisson noise.  Every pixel in the
         array must have a positive value (i.e. counts).
 
-    random_state : int or `~numpy.random.mtrand.RandomState`, optional
+    random_state : int or `~numpy.random.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
 
     Returns
@@ -109,7 +109,7 @@ def make_noise_image(shape, distribution='gaussian', mean=None, stddev=None,
         Poisson noise (the variance of the Poisson distribution is equal
         to its mean).
 
-    random_state : int or `~numpy.random.mtrand.RandomState`, optional
+    random_state : int or `~numpy.random.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
         Separate function calls with the same noise parameters and
         ``random_state`` will generate the identical noise image.
@@ -184,7 +184,7 @@ def make_random_models_table(n_sources, param_ranges, random_state=None):
         as a `dict` mapping the parameter name to its ``(lower, upper)``
         bounds.
 
-    random_state : int or `~numpy.random.mtrand.RandomState`, optional
+    random_state : int or `~numpy.random.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
 
     Returns
@@ -274,7 +274,7 @@ def make_random_gaussians_table(n_sources, param_ranges, random_state=None):
         ignored.  Model parameters not defined in ``param_ranges`` will
         be set to the default value.
 
-    random_state : int or `~numpy.random.mtrand.RandomState`, optional
+    random_state : int or `~numpy.random.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
 
     Returns

--- a/photutils/isophote/tests/make_test_data.py
+++ b/photutils/isophote/tests/make_test_data.py
@@ -34,7 +34,7 @@ def make_test_image(nx=512, ny=512, x0=None, y0=None,
         The ellipticity of the reference isophote.
     pa : float, optional
         The position angle of the reference isophote.
-    random_state : int or `~numpy.random.mtrand.RandomState`, optional
+    random_state : int or `~numpy.random.RandomState`, optional
         Pseudo-random number generator state used for random sampling.
         Separate function calls with the same ``random_state`` will
         generate the identical noise image.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -548,7 +548,7 @@ class SegmentationImage:
             background color (label = 0) when plotting the segmentation
             array.  The default is black ('#000000').
 
-        random_state : int or `~numpy.random.mtrand.RandomState`, optional
+        random_state : int or `~numpy.random.RandomState`, optional
             The pseudo-random number generator state used for random
             sampling.  Separate function calls with the same
             ``random_state`` will generate the same colormap.

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -219,7 +219,7 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     """
 
     from scipy.ndimage import label as ndilabel
-    from skimage.morphology import watershed
+    from skimage.segmentation import watershed
 
     if nlevels < 1:
         raise ValueError('nlevels must be >= 1, got "{0}"'.format(nlevels))

--- a/photutils/utils/check_random_state.py
+++ b/photutils/utils/check_random_state.py
@@ -12,22 +12,22 @@ __all__ = ['check_random_state']
 
 def check_random_state(seed):
     """
-    Turn seed into a `numpy.random.mtrand.RandomState` instance.
+    Turn seed into a `numpy.random.RandomState` instance.
 
     Parameters
     ----------
-    seed : `None`, int, or `numpy.random.mtrand.RandomState`
+    seed : `None`, int, or `numpy.random.RandomState`
         If ``seed`` is `None`, return the
-        `~numpy.random.mtrand.RandomState` singleton used by
+        `~numpy.random.RandomState` singleton used by
         ``numpy.random``.  If ``seed`` is an `int`, return a new
-        `~numpy.random.mtrand.RandomState` instance seeded with
+        `~numpy.random.RandomState` instance seeded with
         ``seed``.  If ``seed`` is already a
-        `~numpy.random.mtrand.RandomState`, return it.  Otherwise raise
+        `~numpy.random.RandomState`, return it.  Otherwise raise
         ``ValueError``.
 
     Returns
     -------
-    random_state : `numpy.random.mtrand.RandomState`
+    random_state : `numpy.random.RandomState`
         RandomState object.
 
     Notes

--- a/photutils/utils/colormaps.py
+++ b/photutils/utils/colormaps.py
@@ -21,7 +21,7 @@ def make_random_cmap(ncolors=256, random_state=None):
     ncolors : int, optional
         The number of colors in the colormap.  The default is 256.
 
-    random_state : int or `~numpy.random.mtrand.RandomState`, optional
+    random_state : int or `~numpy.random.RandomState`, optional
         The pseudo-random number generator state used for random
         sampling.  Separate function calls with the same
         ``random_state`` will generate the same colormap.


### PR DESCRIPTION
The scikit-image watershed function was moved from morphology to segmentation.    Note that the import from segmentation has worked since at least 0.14 (i.e., all scikit-image dependent versions), so there's no need to have an alternate import for older scikit-image versions.  The import from segmentation was deprecated in `skimage 0.17.2`.

This fixes the failing travis-ci test, which was triggered by the deprecation warning.