### PR TITLE
Remove legacy PRF test due to excessive memory usage

### DIFF
--- a/photutils/psf/tests/test_sandbox.py
+++ b/photutils/psf/tests/test_sandbox.py
@@ -8,7 +8,6 @@ from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
 import numpy as np
 from numpy.testing import assert_allclose
-import pytest
 
 from ..sandbox import DiscretePRF
 
@@ -99,16 +98,3 @@ def test_create_prf_flux():
                                         mode='median', fluxes=INTAB['flux_0'])
     assert_allclose(prf._prf_array[0, 0].sum(), 1)
     assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
-
-
-def test_create_prf_excessive_subsampling():
-    """
-    Check if a helpful error is raised if the subsampling parameter is
-    too high.
-    """
-
-    with pytest.raises(ValueError) as exc:
-        DiscretePRF.create_from_image(image,
-                                      list(INTAB['x_0', 'y_0'].as_array()),
-                                      PSF_SIZE, subsampling=999)
-    assert('subsampling' in exc.value.args[0])


### PR DESCRIPTION
This test creates an array of shape (999, 999, 11, 11), requiring 922 MiB.  This can cause failures with some CI services.