### PR TITLE
Add coverage_mask keyword to Background2D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.background``
+
+  - Added ``coverage_mask`` and ``fill_value`` keyword options to
+    ``Background2D``. [#1061]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -57,6 +62,9 @@ API changes
 
   - Removed the deprecated ``ax`` keyword in
     ``Background2D.plot_meshes``. [#953]
+
+  - ``Background2D`` keyword options can not be input as positional
+    arguments. [#1061]
 
 - ``photutils.datasets``
 

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -396,7 +396,6 @@ image (values assigned to ``fill_value``):
 
 .. doctest-requires:: scipy
 
-    >>> back3 = bkg3.background * ~mask
     >>> norm = ImageNormalize(stretch=SqrtStretch())  # doctest: +SKIP
     >>> plt.imshow(bkg3.background, origin='lower', cmap='Greys_r', norm=norm,
     ...            interpolation='nearest')  # doctest: +SKIP
@@ -483,9 +482,9 @@ be plotted on the original image using the
     gradient =  x * y / 5000.
     data2 = data + gradient
     data3 = rotate(data2, -45.)
-    mask = (data3 == 0)
-    bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
-    back3 = bkg3.background * ~mask
+    coverage_mask = (data3 == 0)
+    bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3),
+                        coverage_mask=coverage_mask, fill_value=0.0)
     norm = ImageNormalize(stretch=SqrtStretch())
     plt.imshow(data3, origin='lower', cmap='Greys_r', norm=norm,
                interpolation='nearest')

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -337,18 +337,21 @@ and the background-subtracted image:
 Masking
 ^^^^^^^
 
-Masks can also be input into `~photutils.background.Background2D`.  As
-described above, this can be employed to mask sources in the image
+Masks can also be input into `~photutils.background.Background2D`. The
+``mask`` keyword can be used to mask sources or bad pixels in the image
 prior to estimating the background levels.
 
-Additionally, input masks are often necessary if your data array
-includes regions without data coverage (e.g., from a rotated image or
-an image from a mosaic).  Otherwise, the data values in the regions
-without coverage (usually zeros or NaNs) will adversely contribute to
-the background statistics.
+Additionally, the ``coverage_mask`` keyword can be used to mask blank
+regions without data coverage (e.g., from a rotated image or an image
+from a mosaic). Otherwise, the data values in the regions without
+coverage (usually zeros or NaNs) will adversely affect the background
+statistics. Unlike ``mask``, ``coverage_mask`` is applied to the output
+background and background RMS maps. The ``fill_value`` keyword defines
+the value assigned in the output background and background RMS maps
+where the input ``coverage_mask`` is `True`.
 
-Let's create such an image and plot it (NOTE: this example requires
-`scipy`_):
+Let's create a rotated image that has blank areas and plot it (NOTE:
+this example requires `scipy`_):
 
 .. doctest-requires:: scipy
 
@@ -377,25 +380,25 @@ Let's create such an image and plot it (NOTE: this example requires
 
 Now we create a coverage mask and input it into
 `~photutils.background.Background2D` to exclude the regions where we
-have no data.  For real data, one can usually create a coverage mask
-from a weight or noise image.  In this example we also use a smaller
-box size to help capture the strong gradient in the background:
+have no data. For this example, we set the ``fill_value`` to 0.0. For
+real data, one can usually create a coverage mask from a weight or noise
+image. In this example we also use a smaller box size to help capture
+the strong gradient in the background:
 
 .. doctest-requires:: scipy
 
-    >>> mask = (data3 == 0)
-    >>> bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
+    >>> coverage_mask = (data3 == 0)
+    >>> bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3),
+    ...                     coverage_mask=coverage_mask, fill_value=0.0)
 
-The input masks are never applied to the returned background image
-because the input ``mask`` can represent either a coverage mask or a
-source mask, or a combination of both.  Therefore, we need to manually
-apply the coverage mask to the returned background image:
+Note that the ``coverage_mask`` is applied to the output background
+image (values assigned to ``fill_value``):
 
 .. doctest-requires:: scipy
 
     >>> back3 = bkg3.background * ~mask
     >>> norm = ImageNormalize(stretch=SqrtStretch())  # doctest: +SKIP
-    >>> plt.imshow(back3, origin='lower', cmap='Greys_r', norm=norm,
+    >>> plt.imshow(bkg3.background, origin='lower', cmap='Greys_r', norm=norm,
     ...            interpolation='nearest')  # doctest: +SKIP
 
 .. plot::
@@ -412,11 +415,11 @@ apply the coverage mask to the returned background image:
     gradient =  x * y / 5000.
     data2 = data + gradient
     data3 = rotate(data2, -45.)
-    mask = (data3 == 0)
-    bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
-    back3 = bkg3.background * ~mask
+    coverage_mask = (data3 == 0)
+    bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3),
+                        coverage_mask=coverage_mask, fill_value=0.0)
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(back3, origin='lower', cmap='Greys_r', norm=norm,
+    plt.imshow(bkg3.background, origin='lower', cmap='Greys_r', norm=norm,
                interpolation='nearest')
 
 Finally, let's subtract the background from the image and plot it:
@@ -424,8 +427,8 @@ Finally, let's subtract the background from the image and plot it:
 .. doctest-skip::
 
     >>> norm = ImageNormalize(stretch=SqrtStretch())
-    >>> plt.imshow(data3 - back3, origin='lower', cmap='Greys_r', norm=norm,
-    ...            interpolation='nearest')
+    >>> plt.imshow(data3 - bkg3.background, origin='lower', cmap='Greys_r',
+    ...            norm=norm, interpolation='nearest')
 
 .. plot::
 
@@ -441,12 +444,12 @@ Finally, let's subtract the background from the image and plot it:
     gradient =  x * y / 5000.
     data2 = data + gradient
     data3 = rotate(data2, -45.)
-    mask = (data3 == 0)
-    bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3), mask=mask)
-    back3 = bkg3.background * ~mask
+    coverage_mask = (data3 == 0)
+    bkg3 = Background2D(data3, (25, 25), filter_size=(3, 3),
+                        coverage_mask=coverage_mask, fill_value=0.0)
     norm = ImageNormalize(stretch=SqrtStretch())
-    plt.imshow(data3 - back3, origin='lower', cmap='Greys_r', norm=norm,
-               interpolation='nearest')
+    plt.imshow(data3 - bkg3.background, origin='lower', cmap='Greys_r',
+               norm=norm, interpolation='nearest')
 
 If there is any small residual background still present in the image,
 the background subtraction can be improved by masking the sources

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -192,12 +192,12 @@ class Background2D:
 
     mask : array_like (bool), optional
         A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-        Masked data are excluded from calculations. ``mask`` is intended
-        to mask bad pixels. Use ``coverage_mask`` to mask blank areas
-        of an image. ``mask`` and ``coverage_mask`` differ only in
-        that ``coverage_mask`` is applied to the output background and
-        background RMS maps (see ``fill_value``).
+        value indicates the corresponding element of ``data`` is
+        masked. Masked data are excluded from calculations. ``mask`` is
+        intended to mask sources or bad pixels. Use ``coverage_mask``
+        to mask blank areas of an image. ``mask`` and ``coverage_mask``
+        differ only in that ``coverage_mask`` is applied to the output
+        background and background RMS maps (see ``fill_value``).
 
     coverage_mask : array_like (bool), optional
         A boolean mask, with the same shape as ``data``, where a `True`

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -193,7 +193,21 @@ class Background2D:
     mask : array_like (bool), optional
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
-        Masked data are excluded from calculations.
+        Masked data are excluded from calculations. ``mask`` is intended
+        to mask bad pixels. Use ``coverage_mask`` to mask blank areas
+        of an image. ``mask`` and ``coverage_mask`` differ only in
+        that ``coverage_mask`` is applied to the output background and
+        background RMS maps.
+
+    coverage_mask : array_like (bool), optional
+        A boolean mask, with the same shape as ``data``, where a `True`
+        value indicates the corresponding element of ``data`` is masked.
+        ``coverage_mask`` should be `True` where there is no coverage
+        (i.e., no data) for a given pixel (e.g., blank areas in a mosaic
+        image). It should not be used for bad pixels (in that case use
+        ``mask`` instead). ``mask`` and ``coverage_mask`` differ only in
+        that ``coverage_mask`` is applied to the output background and
+        background RMS maps.
 
     exclude_percentile : float in the range of [0, 100], optional
         The percentage of masked pixels in a mesh, used as a threshold
@@ -281,7 +295,7 @@ class Background2D:
     be a constant image.
     """
 
-    def __init__(self, data, box_size, *, mask=None,
+    def __init__(self, data, box_size, *, mask=None, coverage_mask=None,
                  exclude_percentile=10.0, filter_size=(3, 3),
                  filter_threshold=None, edge_method='pad',
                  sigma_clip=SIGMA_CLIP,
@@ -302,13 +316,20 @@ class Background2D:
             mask = np.asanyarray(mask)
             if mask.shape != data.shape:
                 raise ValueError('mask and data must have the same shape')
+        if coverage_mask is not None:
+            coverage_mask = np.asanyarray(coverage_mask)
+            if coverage_mask.shape != data.shape:
+                raise ValueError('coverage_mask and data must have the same '
+                                 'shape')
 
         if exclude_percentile < 0 or exclude_percentile > 100:
             raise ValueError('exclude_percentile must be between 0 and 100 '
                              '(inclusive).')
 
         self.data = data
-        self.mask = mask
+        self._mask = mask
+        self.coverage_mask = coverage_mask
+        self.mask = self._combine_masks()
         self.exclude_percentile = exclude_percentile
 
         filter_size = np.atleast_1d(filter_size)
@@ -331,6 +352,16 @@ class Background2D:
         self._prepare_data()
         self._calc_bkg_bkgrms()
         self._calc_coordinates()
+
+    def _combine_masks(self):
+        if self._mask is None and self.coverage_mask is None:
+            return None
+        if self._mask is None:
+            return self.coverage_mask
+        elif self.coverage_mask is None:
+            return self._mask
+        else:
+            return np.logical_or(self._mask, self.coverage_mask)
 
     def _pad_data(self, yextra, xextra):
         """
@@ -778,14 +809,18 @@ class Background2D:
     @lazyproperty
     def background(self):
         """A 2D `~numpy.ndarray` containing the background image."""
-
-        return self.interpolator(self.background_mesh, self)
+        bkg = self.interpolator(self.background_mesh, self)
+        if self.coverage_mask is not None:
+            bkg *= np.logical_not(self.coverage_mask)
+        return bkg
 
     @lazyproperty
     def background_rms(self):
         """A 2D `~numpy.ndarray` containing the background RMS image."""
-
-        return self.interpolator(self.background_rms_mesh, self)
+        bkg_rms = self.interpolator(self.background_rms_mesh, self)
+        if self.coverage_mask is not None:
+            bkg_rms *= np.logical_not(self.coverage_mask)
+        return bkg_rms
 
     def plot_meshes(self, axes=None, marker='+', color='blue', outlines=False,
                     **kwargs):

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -281,7 +281,7 @@ class Background2D:
     be a constant image.
     """
 
-    def __init__(self, data, box_size, mask=None,
+    def __init__(self, data, box_size, *, mask=None,
                  exclude_percentile=10.0, filter_size=(3, 3),
                  filter_threshold=None, edge_method='pad',
                  sigma_clip=SIGMA_CLIP,

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -125,6 +125,17 @@ class TestBackground2D:
         assert np.ma.count(b2.background_rms_mesh_ma) < b2.nboxes
         assert np.ma.is_masked(b2.mesh_nmasked)
 
+    @pytest.mark.parametrize('fill_value', [0., np.nan, -1.])
+    def test_coverage_mask(self, fill_value):
+        data = np.copy(DATA)
+        data[:50, :50] = np.nan
+        mask = np.isnan(data)
+        b1 = Background2D(data, (25, 25), filter_size=(1, 1),
+                          coverage_mask=mask, fill_value=fill_value,
+                          bkg_estimator=MeanBackground())
+        assert_equal(b1.background[:50, :50], fill_value)
+        assert_equal(b1.background_rms[:50, :50], fill_value)
+
     def test_completely_masked(self):
         with pytest.raises(ValueError):
             mask = np.ones(DATA.shape, dtype=bool)

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -136,6 +136,17 @@ class TestBackground2D:
         assert_equal(b1.background[:50, :50], fill_value)
         assert_equal(b1.background_rms[:50, :50], fill_value)
 
+        # test combination of masks
+        mask = np.zeros(DATA.shape, dtype=bool)
+        coverage_mask = np.zeros(DATA.shape, dtype=bool)
+        mask[:50, :25] = True
+        coverage_mask[:50, 25:50] = True
+        b2 = Background2D(data, (25, 25), filter_size=(1, 1), mask=mask,
+                          coverage_mask=mask, fill_value=0.0,
+                          bkg_estimator=MeanBackground())
+        assert_equal(b1.background_mesh, b2.background_mesh)
+        assert_equal(b1.background_rms_mesh, b2.background_rms_mesh)
+
     def test_completely_masked(self):
         with pytest.raises(ValueError):
             mask = np.ones(DATA.shape, dtype=bool)
@@ -202,6 +213,11 @@ class TestBackground2D:
         with pytest.raises(ValueError):
             Background2D(DATA, (25, 25), filter_size=(1, 1),
                          mask=np.zeros((2, 2)))
+
+    def test_coverage_mask_badshape(self):
+        with pytest.raises(ValueError):
+            Background2D(DATA, (25, 25), filter_size=(1, 1),
+                         coverage_mask=np.zeros((2, 2)))
 
     def test_invalid_edge_method(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
This PR adds `coverage_mask` and `fill_value` keyword options to `Background2D`.  `coverage_mask` is used for blank areas of the image without coverage (e.g., due to an image mosaic or image rotation).  The `coverage_mask` is applied to the output `background` and `background_rms` maps -- pixels where `coverage_mask` is `True` get set to `fill_value` in these output images.

This PR also requires that all `Background2D` keywords options be input as keywords and not as positional arguments.  That is a small breaking API change.