### PR TITLE
Change dtype to float for nan fill_value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,11 @@ Bug Fixes
   - Fixed a bug where ``build_ellipse_model`` falls into an infinite
     loop under certain image/parameters input combinations. [#1056]
 
+- ``photutils.psf``
+
+  - Fixed a bug in ``subtract_psf`` caused by using a fill_value of
+    np.nan with an integer input array. [#1062]
+
 - ``photutils.segmentation``
 
   - Fixed a bug where ``source_properties`` would fail with unitless

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -244,8 +244,9 @@ def subtract_psf(data, psf, posflux, subshape=None):
         for row in posflux:
             x_0, y_0 = row['x_fit'], row['y_fit']
 
-            y = extract_array(indices[0], subshape, (y_0, x_0))
-            x = extract_array(indices[1], subshape, (y_0, x_0))
+            # float dtype needed for fill_value=np.nan
+            y = extract_array(indices[0].astype(float), subshape, (y_0, x_0))
+            x = extract_array(indices[1].astype(float), subshape, (y_0, x_0))
 
             getattr(psf, xname).value = x_0
             getattr(psf, yname).value = y_0


### PR DESCRIPTION
numpy 0.20dev now raises `ValueError: cannot convert float NaN to integer` when attempting to assign to np.nan in an integer array.  This PR fixes `subtract_psf` by changing the input array dtype to float.