### PR TITLE
Deprecate fit_2dgaussian and GaussianConst2D

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -8,6 +8,7 @@ flake8:
     - E741  # l and b are valid variable names for the galactic frame
     - E226  # Don't force "missing whitespace around arithmetic operator"
     - E402  # .conf has to be set in the __init__.py modules imports
+    - W503  # line break before binary operator
     - W504  # we've been perpetually annoyed by W504 "line break after binary operator", since there's often no real alternative
 
   exclude:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-0.8 (unreleased)
+1.0 (unreleased)
 ----------------
 
 General
@@ -73,6 +73,14 @@ API changes
 
   - ``Background2D`` keyword options can not be input as positional
     arguments. [#1061]
+
+- ``photutils.centroids``
+
+  - ``centroid_1dg``, ``centroid_2dg``, ``gaussian1d_moments``,
+    ``fit_2dgaussian``, and ``GaussianConst2D`` have been moved to a new
+    ``photutils.centroids.gaussian`` module. [#1064]
+
+  - Deprecated ``fit_2dgaussian`` and ``GaussianConst2D``. [#1064]
 
 - ``photutils.datasets``
 

--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -5,7 +5,7 @@ Introduction
 ------------
 
 `photutils.centroids` provides several functions to calculate the
-centroid of a single source.  The centroid methods are:
+centroid of a single source:
 
 * :func:`~photutils.centroids.centroid_com`: Calculates the object
   "center of mass" from 2D image moments.
@@ -20,6 +20,11 @@ centroid of a single source.  The centroid methods are:
 Masks can be input into each of these functions to mask bad pixels.
 Error arrays can be input into the two fitting methods to weight the
 fits.
+
+To calculate the centroids of many sources in an image, use the
+:func:`~photutils.centroids.centroid_sources` function. This function
+can be used with any of the above centroiding functions or a custom
+user-defined centroiding function.  See zzzzz
 
 
 Getting Started
@@ -67,19 +72,20 @@ similar, we also include an inset plot zoomed in near the centroid:
     fig, ax = plt.subplots(1, 1)
     ax.imshow(data, origin='lower', interpolation='nearest')
     marker = '+'
-    ms, mew = 30, 2.
-    plt.plot(x1, y1, color='#1f77b4', marker=marker, ms=ms, mew=mew)
-    plt.plot(x2, y2, color='#17becf', marker=marker, ms=ms, mew=mew)
-    plt.plot(x3, y3, color='#d62728', marker=marker, ms=ms, mew=mew)
+    ms, mew = 15, 2.
+    plt.plot(x1, y1, color='black', marker=marker, ms=ms, mew=mew)
+    plt.plot(x2, y2, color='white', marker=marker, ms=ms, mew=mew)
+    plt.plot(x3, y3, color='red', marker=marker, ms=ms, mew=mew)
 
     from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
     from mpl_toolkits.axes_grid1.inset_locator import mark_inset
     ax2 = zoomed_inset_axes(ax, zoom=6, loc=9)
     ax2.imshow(data, vmin=190, vmax=220, origin='lower',
                interpolation='nearest')
-    ax2.plot(x1, y1, color='#1f77b4', marker=marker, ms=ms, mew=mew)
-    ax2.plot(x2, y2, color='#17becf', marker=marker, ms=ms, mew=mew)
-    ax2.plot(x3, y3, color='#d62728', marker=marker, ms=ms, mew=mew)
+    ms, mew = 30, 2.
+    ax2.plot(x1, y1, color='white', marker=marker, ms=ms, mew=mew)
+    ax2.plot(x2, y2, color='black', marker=marker, ms=ms, mew=mew)
+    ax2.plot(x3, y3, color='red', marker=marker, ms=ms, mew=mew)
     ax2.set_xlim(13, 15)
     ax2.set_ylim(16, 18)
     mark_inset(ax, ax2, loc1=3, loc2=4, fc='none', ec='0.5')
@@ -87,6 +93,52 @@ similar, we also include an inset plot zoomed in near the centroid:
     ax2.axes.get_yaxis().set_visible(False)
     ax.set_xlim(0, data.shape[1]-1)
     ax.set_ylim(0, data.shape[0]-1)
+
+
+
+Centroiding several sources in an image
+---------------------------------------
+
+The :func:`~photutils.centroids.centroid_sources` function can be used
+to calculate the centroids of many sources in a single image given
+initial guesses for their positions. This function can be used with any
+of the above centroiding functions or a custom user-defined centroiding
+function.
+
+Here is a simple example using
+:func:`~photutils.centroids.centroid_com`. A cutout image is made
+centered at each initial position of size ``box_size``. A centroid is
+then calculated within the cutout image for each source:
+
+.. doctest-requires:: scipy
+
+    >>> from photutils import centroid_sources
+    >>> data = make_4gaussians_image()
+    >>> x_init = (25, 91, 151, 160)
+    >>> y_init = (40, 61, 24, 71)
+    >>> x, y = centroid_sources(data, x_init, y_init, box_size=21,
+    ...                         centroid_func=centroid_com)
+    >>> print(x)  # doctest: +FLOAT_CMP
+    [ 24.98911515  90.43056554 150.20332399 159.87234831]
+    >>> print(y)  # doctest: +FLOAT_CMP
+    [40.08504359 60.56869612 24.74216925 70.32723054]
+
+Let's plot the results:
+
+.. plot::
+    :include-source:
+
+    from photutils.datasets import make_4gaussians_image
+    from photutils import centroid_sources, centroid_com
+    data = make_4gaussians_image()
+    x_init = (25, 91, 151, 160)
+    y_init = (40, 61, 24, 71)
+    x, y = centroid_sources(data, x_init, y_init, box_size=21,
+                            centroid_func=centroid_com)
+    plt.figure(figsize=(8, 4))
+    plt.imshow(data, origin='lower', interpolation='nearest')
+    plt.scatter(x, y, marker='+', s=80, color='red')
+    plt.tight_layout()
 
 
 Reference/API

--- a/photutils/centroids/__init__.py
+++ b/photutils/centroids/__init__.py
@@ -4,3 +4,4 @@ This subpackage contains tools for centroiding sources.
 """
 
 from .core import *  # noqa
+from .gaussian import *  # noqa

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -125,7 +125,7 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
         calculate the centroid of a 2D array. The ``centroid_func``
         must accept a 2D `~numpy.ndarray`, have a ``mask`` keyword and
         optionally an ``error`` keyword. The callable object must return
-        a tuple of two 1D `~numpy.ndarray`s, representing the x and y
+        a tuple of two 1D `~numpy.ndarray`, representing the x and y
         centroids. The default is `~photutils.centroids.centroid_com`.
 
     Returns

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -13,12 +13,12 @@ import numpy as np
 __all__ = ['centroid_com', 'centroid_sources', 'centroid_epsf']
 
 
-def centroid_com(data, mask=None, oversampling=1.):
+def centroid_com(data, mask=None, oversampling=1):
     """
     Calculate the centroid of an n-dimensional array as its "center of
     mass" determined from moments.
 
-    Invalid values (e.g. NaNs or infs) in the ``data`` array are
+    Non-finite values (e.g., NaN or inf) in the ``data`` array are
     automatically masked.
 
     Parameters
@@ -30,7 +30,7 @@ def centroid_com(data, mask=None, oversampling=1.):
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
-    oversampling : float or tuple of two floats, optional
+    oversampling : int or tuple of two int, optional
         Oversampling factors of pixel indices. If ``oversampling`` is
         a scalar this is treated as both x and y directions having
         the same oversampling factor; otherwise it is treated as
@@ -39,16 +39,9 @@ def centroid_com(data, mask=None, oversampling=1.):
     Returns
     -------
     centroid : `~numpy.ndarray`
-        The coordinates of the centroid in pixel order (e.g. ``(x, y)``
+        The coordinates of the centroid in pixel order (e.g., ``(x, y)``
         or ``(x, y, z)``), not numpy axis order.
     """
-    oversampling = np.atleast_1d(oversampling)
-    if len(oversampling) == 1:
-        oversampling = np.repeat(oversampling, 2)
-    # as these need to match data we reverse the order to (y, x)
-    oversampling = oversampling[::-1]
-    if np.any(oversampling <= 0):
-        raise ValueError('Oversampling factors must all be positive numbers.')
     data = data.astype(float)
 
     if mask is not None and mask is not np.ma.nomask:
@@ -57,11 +50,18 @@ def centroid_com(data, mask=None, oversampling=1.):
             raise ValueError('data and mask must have the same shape.')
         data[mask] = 0.
 
-    badidx = ~np.isfinite(data)
-    if np.any(badidx):
-        warnings.warn('Input data contains input values (e.g. NaNs or infs), '
-                      'which were automatically masked.', AstropyUserWarning)
-        data[badidx] = 0.
+    oversampling = np.atleast_1d(oversampling)
+    if len(oversampling) == 1:
+        oversampling = np.repeat(oversampling, 2)
+    oversampling = oversampling[::-1]  # reverse to (y, x) order
+    if np.any(oversampling <= 0):
+        raise ValueError('Oversampling factors must all be positive numbers.')
+
+    badmask = ~np.isfinite(data)
+    if np.any(badmask):
+        warnings.warn('Input data contains non-finite values (e.g., NaNs or infs) '
+                      'that were automatically masked.', AstropyUserWarning)
+        data[badmask] = 0.
 
     total = np.sum(data)
     indices = np.ogrid[[slice(0, i) for i in data.shape]]
@@ -92,19 +92,21 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
         calculate the centroid.
 
     box_size : int or array-like of int, optional
-        The size of the cutout image along each axis.  If ``box_size``
+        The size of the cutout image along each axis. If ``box_size``
         is a number, then a square cutout of ``box_size`` will be
-        created.  If ``box_size`` has two elements, they should be in
-        ``(ny, nx)`` order.
+        created. If ``box_size`` has two elements, they should be in
+        ``(ny, nx)`` order. Either ``box_size`` or ``footprint`` must be
+        defined. If they are both defined, then ``footprint`` overrides
+        ``box_size``.
 
     footprint : `~numpy.ndarray` of bools, optional
         A 2D boolean array where `True` values describe the local
-        footprint region to cutout.  ``footprint`` can be used to create
+        footprint region to cutout. ``footprint`` can be used to create
         a non-rectangular cutout image, in which case the input ``xpos``
         and ``ypos`` represent the center of the minimal bounding box
-        for the input ``footprint``.  ``box_size=(n, m)`` is equivalent
-        to ``footprint=np.ones((n, m))``.  Either ``box_size`` or
-        ``footprint`` must be defined.  If they are both defined, then
+        for the input ``footprint``. ``box_size=(n, m)`` is equivalent
+        to ``footprint=np.ones((n, m))``. Either ``box_size`` or
+        ``footprint`` must be defined. If they are both defined, then
         ``footprint`` overrides ``box_size``.
 
     mask : array_like, bool, optional
@@ -118,13 +120,12 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
         be used only if supported by the input ``centroid_func``.
 
     centroid_func : callable, optional
-        A callable object (e.g. function or class) that is used to
-        calculate the centroid of a 2D array.  The ``centroid_func``
+        A callable object (e.g., function or class) that is used to
+        calculate the centroid of a 2D array. The ``centroid_func``
         must accept a 2D `~numpy.ndarray`, have a ``mask`` keyword and
-        optionally an ``error`` keyword.  The callable object must
-        return a tuple of two 1D `~numpy.ndarray`\\s, representing the x
-        and y centroids.  The default is
-        `~photutils.centroids.centroid_com`.
+        optionally an ``error`` keyword. The callable object must return
+        a tuple of two 1D `~numpy.ndarray`s, representing the x and y
+        centroids. The default is `~photutils.centroids.centroid_com`.
 
     Returns
     -------
@@ -165,8 +166,8 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
     xcentroids = []
     ycentroids = []
     for xp, yp in zip(xpos, ypos):
-        slices_large, slices_small = overlap_slices(data.shape,
-                                                    footprint.shape, (yp, xp))
+        slices_large, slices_small = overlap_slices(data.shape, footprint.shape,
+                                                    (yp, xp))
         data_cutout = data[slices_large]
 
         mask_cutout = None
@@ -174,7 +175,7 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
             mask_cutout = mask[slices_large]
 
         footprint_mask = ~footprint
-        # trim footprint mask if partial overlap on the data
+        # trim footprint mask if it has only partial overlap on the data
         footprint_mask = footprint_mask[slices_small]
 
         if mask_cutout is None:
@@ -198,14 +199,14 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
 
 def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     """
-    Calculates centering shift of data using pixel symmetry, as
-    described by Anderson and King (2000; PASP 112, 1360) in their
-    ePSF-fitting algorithm.
+    Calculate centering shift of data using pixel symmetry, as described
+    by Anderson and King (2000; PASP 112, 1360) in their ePSF-fitting
+    algorithm.
 
     Calculate the shift of a 2-dimensional symmetric image based on the
     asymmetry between f(x, N) and f(x, -N), along with the differential
-    df/dy(x, shift_val) and df/dy(x, -shift_val). Invalid values (e.g.
-    NaNs or infs) in the ``data`` array are automatically masked.
+    df/dy(x, shift_val) and df/dy(x, -shift_val). Non-finite values
+    (e.g., NaN or inf) in the ``data`` array are automatically masked.
 
     Parameters
     ----------
@@ -214,27 +215,20 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     mask : array_like (bool), optional
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
-    oversampling : float or tuple of two floats, optional
+    oversampling : int or tuple of two int, optional
         Oversampling factors of pixel indices. If ``oversampling`` is a
         scalar this is treated as both x and y directions having the
         same oversampling factor.  Otherwise it is treated as
         ``(x_oversamp, y_oversamp)``.
     shift_val : float, optional
         The undersampled value at which to compute the shifts. Default
-        is half a pixel. If supplied, must be a strictly positive
-        number.
+        is half a pixel. It must be a strictly positive number.
 
     Returns
     -------
     centroid : tuple of floats
         The (x, y) coordinates of the centroid in pixel order.
     """
-    oversampling = np.atleast_1d(oversampling)
-    if len(oversampling) == 1:
-        oversampling = np.repeat(oversampling, 2)
-    if np.any(oversampling <= 0):
-        raise ValueError('Oversampling factors must all be positive numbers.')
-
     data = data.astype(float)
 
     if mask is not None and mask is not np.ma.nomask:
@@ -242,6 +236,12 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
         if data.shape != mask.shape:
             raise ValueError('data and mask must have the same shape.')
         data[mask] = 0.
+
+    oversampling = np.atleast_1d(oversampling)
+    if len(oversampling) == 1:
+        oversampling = np.repeat(oversampling, 2)
+    if np.any(oversampling <= 0):
+        raise ValueError('Oversampling factors must all be positive numbers.')
 
     if shift_val <= 0:
         raise ValueError('shift_val must be a positive number.')
@@ -261,8 +261,9 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
                            for y in [yidx_0, yidx_0+y_shiftidx,
                                      yidx_0+y_shiftidx-1,
                                      yidx_0+y_shiftidx+1]])
-    if np.any(badidx):
-        raise ValueError('One or more centroiding pixels is set to a bad '
+
+    if np.any(badmask):
+        raise ValueError('One or more centroiding pixels is set to a non-finite '
                          'value, e.g., NaN or inf.')
 
     # In Anderson & King (2000) notation this is psi_E(0.5, 0.0) and

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -6,72 +6,11 @@ The module contains tools for centroiding sources.
 import inspect
 import warnings
 
-from astropy.modeling import Fittable2DModel, Parameter
-from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.modeling.models import (CONSTRAINTS_DOC, Const1D, Const2D,
-                                     Gaussian1D, Gaussian2D)
 from astropy.nddata.utils import overlap_slices
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
-__all__ = ['GaussianConst2D', 'centroid_com', 'gaussian1d_moments',
-           'fit_2dgaussian', 'centroid_1dg', 'centroid_2dg',
-           'centroid_sources', 'centroid_epsf']
-
-
-class GaussianConst2D(Fittable2DModel):
-    """
-    A model for a 2D Gaussian plus a constant.
-
-    Parameters
-    ----------
-    constant : float
-        Value of the constant.
-
-    amplitude : float
-        Amplitude of the Gaussian.
-
-    x_mean : float
-        Mean of the Gaussian in x.
-
-    y_mean : float
-        Mean of the Gaussian in y.
-
-    x_stddev : float
-        Standard deviation of the Gaussian in x.
-        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
-        matrix (``cov_matrix``) is input.
-
-    y_stddev : float
-        Standard deviation of the Gaussian in y.
-        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
-        matrix (``cov_matrix``) is input.
-
-    theta : float, optional
-        Rotation angle in radians. The rotation angle increases
-        counterclockwise.
-    """
-
-    constant = Parameter(default=1)
-    amplitude = Parameter(default=1)
-    x_mean = Parameter(default=0)
-    y_mean = Parameter(default=0)
-    x_stddev = Parameter(default=1)
-    y_stddev = Parameter(default=1)
-    theta = Parameter(default=0)
-
-    @staticmethod
-    def evaluate(x, y, constant, amplitude, x_mean, y_mean, x_stddev,
-                 y_stddev, theta):
-        """Two dimensional Gaussian plus constant function."""
-
-        model = Const2D(constant)(x, y) + Gaussian2D(amplitude, x_mean,
-                                                     y_mean, x_stddev,
-                                                     y_stddev, theta)(x, y)
-        return model
-
-
-GaussianConst2D.__doc__ += CONSTRAINTS_DOC
+__all__ = ['centroid_com', 'centroid_sources', 'centroid_epsf']
 
 
 def centroid_com(data, mask=None, oversampling=1.):
@@ -92,9 +31,10 @@ def centroid_com(data, mask=None, oversampling=1.):
         value indicates the corresponding element of ``data`` is masked.
 
     oversampling : float or tuple of two floats, optional
-        Oversampling factors of pixel indices. If ``oversampling`` is a scalar
-        this is treated as both x and y directions having the same oversampling
-        factor; otherwise it is treated as ``(x_oversamp, y_oversamp)``.
+        Oversampling factors of pixel indices. If ``oversampling`` is
+        a scalar this is treated as both x and y directions having
+        the same oversampling factor; otherwise it is treated as
+        ``(x_oversamp, y_oversamp)``.
 
     Returns
     -------
@@ -102,7 +42,6 @@ def centroid_com(data, mask=None, oversampling=1.):
         The coordinates of the centroid in pixel order (e.g. ``(x, y)``
         or ``(x, y, z)``), not numpy axis order.
     """
-
     oversampling = np.atleast_1d(oversampling)
     if len(oversampling) == 1:
         oversampling = np.repeat(oversampling, 2)
@@ -130,243 +69,6 @@ def centroid_com(data, mask=None, oversampling=1.):
     # note the output array is reversed to give (x, y) order
     return np.array([np.sum(indices[axis] * data) / total / oversampling[axis]
                      for axis in range(data.ndim)])[::-1]
-
-
-def gaussian1d_moments(data, mask=None):
-    """
-    Estimate 1D Gaussian parameters from the moments of 1D data.
-
-    This function can be useful for providing initial parameter values
-    when fitting a 1D Gaussian to the ``data``.
-
-    Parameters
-    ----------
-    data : array_like (1D)
-        The 1D array.
-
-    mask : array_like (1D bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-
-    Returns
-    -------
-    amplitude, mean, stddev : float
-        The estimated parameters of a 1D Gaussian.
-    """
-
-    if np.any(~np.isfinite(data)):
-        data = np.ma.masked_invalid(data)
-        warnings.warn('Input data contains input values (e.g. NaNs or infs), '
-                      'which were automatically masked.', AstropyUserWarning)
-    else:
-        data = np.ma.array(data)
-
-    if mask is not None and mask is not np.ma.nomask:
-        mask = np.asanyarray(mask)
-        if data.shape != mask.shape:
-            raise ValueError('data and mask must have the same shape.')
-        data.mask |= mask
-
-    data.fill_value = 0.
-    data = data.filled()
-
-    x = np.arange(data.size)
-    x_mean = np.sum(x * data) / np.sum(data)
-    x_stddev = np.sqrt(abs(np.sum(data * (x - x_mean)**2) / np.sum(data)))
-    amplitude = np.ptp(data)
-
-    return amplitude, x_mean, x_stddev
-
-
-def fit_2dgaussian(data, error=None, mask=None):
-    """
-    Fit a 2D Gaussian plus a constant to a 2D image.
-
-    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
-    arrays are automatically masked.  The mask for invalid values
-    represents the combination of the invalid-value masks for the
-    ``data`` and ``error`` arrays.
-
-    Parameters
-    ----------
-    data : array_like
-        The 2D array of the image.
-
-    error : array_like, optional
-        The 2D array of the 1-sigma errors of the input ``data``.
-
-    mask : array_like (bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-
-    Returns
-    -------
-    result : A `GaussianConst2D` model instance.
-        The best-fitting Gaussian 2D model.
-    """
-
-    from ..morphology import data_properties  # prevent circular imports
-
-    data = np.ma.asanyarray(data)
-
-    if mask is not None and mask is not np.ma.nomask:
-        mask = np.asanyarray(mask)
-        if data.shape != mask.shape:
-            raise ValueError('data and mask must have the same shape.')
-        data.mask |= mask
-
-    if np.any(~np.isfinite(data)):
-        data = np.ma.masked_invalid(data)
-        warnings.warn('Input data contains input values (e.g. NaNs or infs), '
-                      'which were automatically masked.', AstropyUserWarning)
-
-    if error is not None:
-        error = np.ma.masked_invalid(error)
-        if data.shape != error.shape:
-            raise ValueError('data and error must have the same shape.')
-        data.mask |= error.mask
-        weights = 1.0 / error.clip(min=1.e-30)
-    else:
-        weights = np.ones(data.shape)
-
-    if np.ma.count(data) < 7:
-        raise ValueError('Input data must have a least 7 unmasked values to '
-                         'fit a 2D Gaussian plus a constant.')
-
-    # assign zero weight to masked pixels
-    if data.mask is not np.ma.nomask:
-        weights[data.mask] = 0.
-
-    mask = data.mask
-    data.fill_value = 0.0
-    data = data.filled()
-
-    # Subtract the minimum of the data as a crude background estimate.
-    # This will also make the data values positive, preventing issues with
-    # the moment estimation in data_properties (moments from negative data
-    # values can yield undefined Gaussian parameters, e.g. x/y_stddev).
-    props = data_properties(data - np.min(data), mask=mask)
-
-    init_const = 0.  # subtracted data minimum above
-    init_amplitude = np.ptp(data)
-    g_init = GaussianConst2D(constant=init_const, amplitude=init_amplitude,
-                             x_mean=props.xcentroid.value,
-                             y_mean=props.ycentroid.value,
-                             x_stddev=props.semimajor_axis_sigma.value,
-                             y_stddev=props.semiminor_axis_sigma.value,
-                             theta=props.orientation.value)
-    fitter = LevMarLSQFitter()
-    y, x = np.indices(data.shape)
-    gfit = fitter(g_init, x, y, data, weights=weights)
-
-    return gfit
-
-
-def centroid_1dg(data, error=None, mask=None):
-    """
-    Calculate the centroid of a 2D array by fitting 1D Gaussians to the
-    marginal ``x`` and ``y`` distributions of the array.
-
-    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
-    arrays are automatically masked.  The mask for invalid values
-    represents the combination of the invalid-value masks for the
-    ``data`` and ``error`` arrays.
-
-    Parameters
-    ----------
-    data : array_like
-        The 2D data array.
-
-    error : array_like, optional
-        The 2D array of the 1-sigma errors of the input ``data``.
-
-    mask : array_like (bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-
-    Returns
-    -------
-    centroid : `~numpy.ndarray`
-        The ``x, y`` coordinates of the centroid.
-    """
-
-    data = np.ma.asanyarray(data)
-
-    if mask is not None and mask is not np.ma.nomask:
-        mask = np.asanyarray(mask)
-        if data.shape != mask.shape:
-            raise ValueError('data and mask must have the same shape.')
-        data.mask |= mask
-
-    if np.any(~np.isfinite(data)):
-        data = np.ma.masked_invalid(data)
-        warnings.warn('Input data contains input values (e.g. NaNs or infs), '
-                      'which were automatically masked.', AstropyUserWarning)
-
-    if error is not None:
-        error = np.ma.masked_invalid(error)
-        if data.shape != error.shape:
-            raise ValueError('data and error must have the same shape.')
-        data.mask |= error.mask
-
-        error.mask = data.mask
-        xy_error = [np.sqrt(np.ma.sum(error**2, axis=i)) for i in [0, 1]]
-        xy_weights = [(1.0 / xy_error[i].clip(min=1.e-30)) for i in [0, 1]]
-    else:
-        xy_weights = [np.ones(data.shape[i]) for i in [1, 0]]
-
-    # assign zero weight where an entire row or column is masked
-    if np.any(data.mask):
-        bad_idx = [np.all(data.mask, axis=i) for i in [0, 1]]
-        for i in [0, 1]:
-            xy_weights[i][bad_idx[i]] = 0.
-
-    xy_data = [np.ma.sum(data, axis=i).data for i in [0, 1]]
-
-    constant_init = np.ma.min(data)
-    centroid = []
-    for (data_i, weights_i) in zip(xy_data, xy_weights):
-        params_init = gaussian1d_moments(data_i)
-        g_init = Const1D(constant_init) + Gaussian1D(*params_init)
-        fitter = LevMarLSQFitter()
-        x = np.arange(data_i.size)
-        g_fit = fitter(g_init, x, data_i, weights=weights_i)
-        centroid.append(g_fit.mean_1.value)
-
-    return np.array(centroid)
-
-
-def centroid_2dg(data, error=None, mask=None):
-    """
-    Calculate the centroid of a 2D array by fitting a 2D Gaussian (plus
-    a constant) to the array.
-
-    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
-    arrays are automatically masked.  The mask for invalid values
-    represents the combination of the invalid-value masks for the
-    ``data`` and ``error`` arrays.
-
-    Parameters
-    ----------
-    data : array_like
-        The 2D data array.
-
-    error : array_like, optional
-        The 2D array of the 1-sigma errors of the input ``data``.
-
-    mask : array_like (bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-
-    Returns
-    -------
-    centroid : `~numpy.ndarray`
-        The ``x, y`` coordinates of the centroid.
-    """
-
-    gfit = fit_2dgaussian(data, error=error, mask=mask)
-
-    return np.array([gfit.x_mean.value, gfit.y_mean.value])
 
 
 def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
@@ -429,7 +131,6 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
     xcentroid, ycentroid : `~numpy.ndarray`
         The ``x`` and ``y`` pixel position(s) of the centroids.
     """
-
     xpos = np.atleast_1d(xpos)
     ypos = np.atleast_1d(ypos)
     if xpos.ndim != 1:
@@ -528,7 +229,6 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     centroid : tuple of floats
         The (x, y) coordinates of the centroid in pixel order.
     """
-
     oversampling = np.atleast_1d(oversampling)
     if len(oversampling) == 1:
         oversampling = np.repeat(oversampling, 2)

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -59,8 +59,9 @@ def centroid_com(data, mask=None, oversampling=1):
 
     badmask = ~np.isfinite(data)
     if np.any(badmask):
-        warnings.warn('Input data contains non-finite values (e.g., NaNs or infs) '
-                      'that were automatically masked.', AstropyUserWarning)
+        warnings.warn('Input data contains non-finite values (e.g., NaN or '
+                      'inf) that were automatically masked.',
+                      AstropyUserWarning)
         data[badmask] = 0.
 
     total = np.sum(data)
@@ -166,8 +167,8 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
     xcentroids = []
     ycentroids = []
     for xp, yp in zip(xpos, ypos):
-        slices_large, slices_small = overlap_slices(data.shape, footprint.shape,
-                                                    (yp, xp))
+        slices_large, slices_small = overlap_slices(data.shape,
+                                                    footprint.shape, (yp, xp))
         data_cutout = data[slices_large]
 
         mask_cutout = None
@@ -255,16 +256,17 @@ def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
     x_shiftidx = np.around((shift_val * oversampling[0])).astype(int)
     y_shiftidx = np.around((shift_val * oversampling[1])).astype(int)
 
-    badidx = ~np.isfinite([data[y, x]
-                           for x in [xidx_0, xidx_0+x_shiftidx,
-                                     xidx_0+x_shiftidx-1, xidx_0+x_shiftidx+1]
-                           for y in [yidx_0, yidx_0+y_shiftidx,
-                                     yidx_0+y_shiftidx-1,
-                                     yidx_0+y_shiftidx+1]])
+    badmask = ~np.isfinite([data[y, x]
+                            for x in [xidx_0, xidx_0 + x_shiftidx,
+                                      xidx_0 + x_shiftidx - 1,
+                                      xidx_0 + x_shiftidx + 1]
+                            for y in [yidx_0, yidx_0 + y_shiftidx,
+                                      yidx_0 + y_shiftidx - 1,
+                                      yidx_0 + y_shiftidx + 1]])
 
     if np.any(badmask):
-        raise ValueError('One or more centroiding pixels is set to a non-finite '
-                         'value, e.g., NaN or inf.')
+        raise ValueError('One or more centroiding pixels is set to a '
+                         'non-finite value, e.g., NaN or inf.')
 
     # In Anderson & King (2000) notation this is psi_E(0.5, 0.0) and
     # values used to compute derivatives.

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -7,8 +7,7 @@ import warnings
 
 from astropy.modeling import Fittable2DModel, Parameter
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.modeling.models import (CONSTRAINTS_DOC, Const1D, Const2D,
-                                     Gaussian1D, Gaussian2D)
+from astropy.modeling.models import Const1D, Const2D, Gaussian1D, Gaussian2D
 from astropy.utils import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
@@ -320,14 +319,14 @@ class GaussianConst2D(Fittable2DModel):
         Mean of the Gaussian in y.
 
     x_stddev : float
-        Standard deviation of the Gaussian in x.
-        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
-        matrix (``cov_matrix``) is input.
+        Standard deviation of the Gaussian in x. ``x_stddev`` and
+        ``y_stddev`` must be specified unless a covariance matrix
+        (``cov_matrix``) is input.
 
     y_stddev : float
-        Standard deviation of the Gaussian in y.
-        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
-        matrix (``cov_matrix``) is input.
+        Standard deviation of the Gaussian in y. ``x_stddev`` and
+        ``y_stddev`` must be specified unless a covariance matrix
+        (``cov_matrix``) is input.
 
     theta : float, optional
         Rotation angle in radians. The rotation angle increases
@@ -351,6 +350,3 @@ class GaussianConst2D(Fittable2DModel):
                                                      y_mean, x_stddev,
                                                      y_stddev, theta)(x, y)
         return model
-
-
-GaussianConst2D.__doc__ += CONSTRAINTS_DOC

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -1,135 +1,92 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-The module contains tools for centroiding sources.
+The module contains tools for centroiding sources using Gaussians.
 """
 
-import inspect
 import warnings
 
 from astropy.modeling import Fittable2DModel, Parameter
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import (CONSTRAINTS_DOC, Const1D, Const2D,
                                      Gaussian1D, Gaussian2D)
-from astropy.nddata.utils import overlap_slices
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
-__all__ = ['GaussianConst2D', 'centroid_com', 'gaussian1d_moments',
-           'fit_2dgaussian', 'centroid_1dg', 'centroid_2dg',
-           'centroid_sources', 'centroid_epsf']
+__all__ = ['centroid_1dg', 'gaussian1d_moments', 'centroid_2dg',
+           'fit_2dgaussian', 'GaussianConst2D']
 
 
-class GaussianConst2D(Fittable2DModel):
+def centroid_1dg(data, error=None, mask=None):
     """
-    A model for a 2D Gaussian plus a constant.
+    Calculate the centroid of a 2D array by fitting 1D Gaussians to the
+    marginal ``x`` and ``y`` distributions of the array.
 
-    Parameters
-    ----------
-    constant : float
-        Value of the constant.
-
-    amplitude : float
-        Amplitude of the Gaussian.
-
-    x_mean : float
-        Mean of the Gaussian in x.
-
-    y_mean : float
-        Mean of the Gaussian in y.
-
-    x_stddev : float
-        Standard deviation of the Gaussian in x.
-        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
-        matrix (``cov_matrix``) is input.
-
-    y_stddev : float
-        Standard deviation of the Gaussian in y.
-        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
-        matrix (``cov_matrix``) is input.
-
-    theta : float, optional
-        Rotation angle in radians. The rotation angle increases
-        counterclockwise.
-    """
-
-    constant = Parameter(default=1)
-    amplitude = Parameter(default=1)
-    x_mean = Parameter(default=0)
-    y_mean = Parameter(default=0)
-    x_stddev = Parameter(default=1)
-    y_stddev = Parameter(default=1)
-    theta = Parameter(default=0)
-
-    @staticmethod
-    def evaluate(x, y, constant, amplitude, x_mean, y_mean, x_stddev,
-                 y_stddev, theta):
-        """Two dimensional Gaussian plus constant function."""
-
-        model = Const2D(constant)(x, y) + Gaussian2D(amplitude, x_mean,
-                                                     y_mean, x_stddev,
-                                                     y_stddev, theta)(x, y)
-        return model
-
-
-GaussianConst2D.__doc__ += CONSTRAINTS_DOC
-
-
-def centroid_com(data, mask=None, oversampling=1.):
-    """
-    Calculate the centroid of an n-dimensional array as its "center of
-    mass" determined from moments.
-
-    Invalid values (e.g. NaNs or infs) in the ``data`` array are
-    automatically masked.
+    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
+    arrays are automatically masked.  The mask for invalid values
+    represents the combination of the invalid-value masks for the
+    ``data`` and ``error`` arrays.
 
     Parameters
     ----------
     data : array_like
-        The input n-dimensional array.
+        The 2D data array.
+
+    error : array_like, optional
+        The 2D array of the 1-sigma errors of the input ``data``.
 
     mask : array_like (bool), optional
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
-    oversampling : float or tuple of two floats, optional
-        Oversampling factors of pixel indices. If ``oversampling`` is a scalar
-        this is treated as both x and y directions having the same oversampling
-        factor; otherwise it is treated as ``(x_oversamp, y_oversamp)``.
-
     Returns
     -------
     centroid : `~numpy.ndarray`
-        The coordinates of the centroid in pixel order (e.g. ``(x, y)``
-        or ``(x, y, z)``), not numpy axis order.
+        The ``x, y`` coordinates of the centroid.
     """
-
-    oversampling = np.atleast_1d(oversampling)
-    if len(oversampling) == 1:
-        oversampling = np.repeat(oversampling, 2)
-    # as these need to match data we reverse the order to (y, x)
-    oversampling = oversampling[::-1]
-    if np.any(oversampling <= 0):
-        raise ValueError('Oversampling factors must all be positive numbers.')
-    data = data.astype(float)
+    data = np.ma.asanyarray(data)
 
     if mask is not None and mask is not np.ma.nomask:
-        mask = np.asarray(mask, dtype=bool)
+        mask = np.asanyarray(mask)
         if data.shape != mask.shape:
             raise ValueError('data and mask must have the same shape.')
-        data[mask] = 0.
+        data.mask |= mask
 
-    badidx = ~np.isfinite(data)
-    if np.any(badidx):
+    if np.any(~np.isfinite(data)):
+        data = np.ma.masked_invalid(data)
         warnings.warn('Input data contains input values (e.g. NaNs or infs), '
                       'which were automatically masked.', AstropyUserWarning)
-        data[badidx] = 0.
 
-    total = np.sum(data)
-    indices = np.ogrid[[slice(0, i) for i in data.shape]]
+    if error is not None:
+        error = np.ma.masked_invalid(error)
+        if data.shape != error.shape:
+            raise ValueError('data and error must have the same shape.')
+        data.mask |= error.mask
 
-    # note the output array is reversed to give (x, y) order
-    return np.array([np.sum(indices[axis] * data) / total / oversampling[axis]
-                     for axis in range(data.ndim)])[::-1]
+        error.mask = data.mask
+        xy_error = [np.sqrt(np.ma.sum(error**2, axis=i)) for i in [0, 1]]
+        xy_weights = [(1.0 / xy_error[i].clip(min=1.e-30)) for i in [0, 1]]
+    else:
+        xy_weights = [np.ones(data.shape[i]) for i in [1, 0]]
+
+    # assign zero weight where an entire row or column is masked
+    if np.any(data.mask):
+        bad_idx = [np.all(data.mask, axis=i) for i in [0, 1]]
+        for i in [0, 1]:
+            xy_weights[i][bad_idx[i]] = 0.
+
+    xy_data = [np.ma.sum(data, axis=i).data for i in [0, 1]]
+
+    constant_init = np.ma.min(data)
+    centroid = []
+    for (data_i, weights_i) in zip(xy_data, xy_weights):
+        params_init = gaussian1d_moments(data_i)
+        g_init = Const1D(constant_init) + Gaussian1D(*params_init)
+        fitter = LevMarLSQFitter()
+        x = np.arange(data_i.size)
+        g_fit = fitter(g_init, x, data_i, weights=weights_i)
+        centroid.append(g_fit.mean_1.value)
+
+    return np.array(centroid)
 
 
 def gaussian1d_moments(data, mask=None):
@@ -153,7 +110,6 @@ def gaussian1d_moments(data, mask=None):
     amplitude, mean, stddev : float
         The estimated parameters of a 1D Gaussian.
     """
-
     if np.any(~np.isfinite(data)):
         data = np.ma.masked_invalid(data)
         warnings.warn('Input data contains input values (e.g. NaNs or infs), '
@@ -176,6 +132,38 @@ def gaussian1d_moments(data, mask=None):
     amplitude = np.ptp(data)
 
     return amplitude, x_mean, x_stddev
+
+
+def centroid_2dg(data, error=None, mask=None):
+    """
+    Calculate the centroid of a 2D array by fitting a 2D Gaussian (plus
+    a constant) to the array.
+
+    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
+    arrays are automatically masked.  The mask for invalid values
+    represents the combination of the invalid-value masks for the
+    ``data`` and ``error`` arrays.
+
+    Parameters
+    ----------
+    data : array_like
+        The 2D data array.
+
+    error : array_like, optional
+        The 2D array of the 1-sigma errors of the input ``data``.
+
+    mask : array_like (bool), optional
+        A boolean mask, with the same shape as ``data``, where a `True`
+        value indicates the corresponding element of ``data`` is masked.
+
+    Returns
+    -------
+    centroid : `~numpy.ndarray`
+        The ``x, y`` coordinates of the centroid.
+    """
+    gfit = fit_2dgaussian(data, error=error, mask=mask)
+
+    return np.array([gfit.x_mean.value, gfit.y_mean.value])
 
 
 def fit_2dgaussian(data, error=None, mask=None):
@@ -204,7 +192,6 @@ def fit_2dgaussian(data, error=None, mask=None):
     result : A `GaussianConst2D` model instance.
         The best-fitting Gaussian 2D model.
     """
-
     from ..morphology import data_properties  # prevent circular imports
 
     data = np.ma.asanyarray(data)
@@ -262,340 +249,56 @@ def fit_2dgaussian(data, error=None, mask=None):
     return gfit
 
 
-def centroid_1dg(data, error=None, mask=None):
+class GaussianConst2D(Fittable2DModel):
     """
-    Calculate the centroid of a 2D array by fitting 1D Gaussians to the
-    marginal ``x`` and ``y`` distributions of the array.
-
-    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
-    arrays are automatically masked.  The mask for invalid values
-    represents the combination of the invalid-value masks for the
-    ``data`` and ``error`` arrays.
+    A model for a 2D Gaussian plus a constant.
 
     Parameters
     ----------
-    data : array_like
-        The 2D data array.
+    constant : float
+        Value of the constant.
 
-    error : array_like, optional
-        The 2D array of the 1-sigma errors of the input ``data``.
+    amplitude : float
+        Amplitude of the Gaussian.
 
-    mask : array_like (bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
+    x_mean : float
+        Mean of the Gaussian in x.
 
-    Returns
-    -------
-    centroid : `~numpy.ndarray`
-        The ``x, y`` coordinates of the centroid.
+    y_mean : float
+        Mean of the Gaussian in y.
+
+    x_stddev : float
+        Standard deviation of the Gaussian in x.
+        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
+        matrix (``cov_matrix``) is input.
+
+    y_stddev : float
+        Standard deviation of the Gaussian in y.
+        ``x_stddev`` and ``y_stddev`` must be specified unless a covariance
+        matrix (``cov_matrix``) is input.
+
+    theta : float, optional
+        Rotation angle in radians. The rotation angle increases
+        counterclockwise.
     """
 
-    data = np.ma.asanyarray(data)
+    constant = Parameter(default=1)
+    amplitude = Parameter(default=1)
+    x_mean = Parameter(default=0)
+    y_mean = Parameter(default=0)
+    x_stddev = Parameter(default=1)
+    y_stddev = Parameter(default=1)
+    theta = Parameter(default=0)
 
-    if mask is not None and mask is not np.ma.nomask:
-        mask = np.asanyarray(mask)
-        if data.shape != mask.shape:
-            raise ValueError('data and mask must have the same shape.')
-        data.mask |= mask
+    @staticmethod
+    def evaluate(x, y, constant, amplitude, x_mean, y_mean, x_stddev,
+                 y_stddev, theta):
+        """Two dimensional Gaussian plus constant function."""
 
-    if np.any(~np.isfinite(data)):
-        data = np.ma.masked_invalid(data)
-        warnings.warn('Input data contains input values (e.g. NaNs or infs), '
-                      'which were automatically masked.', AstropyUserWarning)
-
-    if error is not None:
-        error = np.ma.masked_invalid(error)
-        if data.shape != error.shape:
-            raise ValueError('data and error must have the same shape.')
-        data.mask |= error.mask
-
-        error.mask = data.mask
-        xy_error = [np.sqrt(np.ma.sum(error**2, axis=i)) for i in [0, 1]]
-        xy_weights = [(1.0 / xy_error[i].clip(min=1.e-30)) for i in [0, 1]]
-    else:
-        xy_weights = [np.ones(data.shape[i]) for i in [1, 0]]
-
-    # assign zero weight where an entire row or column is masked
-    if np.any(data.mask):
-        bad_idx = [np.all(data.mask, axis=i) for i in [0, 1]]
-        for i in [0, 1]:
-            xy_weights[i][bad_idx[i]] = 0.
-
-    xy_data = [np.ma.sum(data, axis=i).data for i in [0, 1]]
-
-    constant_init = np.ma.min(data)
-    centroid = []
-    for (data_i, weights_i) in zip(xy_data, xy_weights):
-        params_init = gaussian1d_moments(data_i)
-        g_init = Const1D(constant_init) + Gaussian1D(*params_init)
-        fitter = LevMarLSQFitter()
-        x = np.arange(data_i.size)
-        g_fit = fitter(g_init, x, data_i, weights=weights_i)
-        centroid.append(g_fit.mean_1.value)
-
-    return np.array(centroid)
+        model = Const2D(constant)(x, y) + Gaussian2D(amplitude, x_mean,
+                                                     y_mean, x_stddev,
+                                                     y_stddev, theta)(x, y)
+        return model
 
 
-def centroid_2dg(data, error=None, mask=None):
-    """
-    Calculate the centroid of a 2D array by fitting a 2D Gaussian (plus
-    a constant) to the array.
-
-    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
-    arrays are automatically masked.  The mask for invalid values
-    represents the combination of the invalid-value masks for the
-    ``data`` and ``error`` arrays.
-
-    Parameters
-    ----------
-    data : array_like
-        The 2D data array.
-
-    error : array_like, optional
-        The 2D array of the 1-sigma errors of the input ``data``.
-
-    mask : array_like (bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-
-    Returns
-    -------
-    centroid : `~numpy.ndarray`
-        The ``x, y`` coordinates of the centroid.
-    """
-
-    gfit = fit_2dgaussian(data, error=error, mask=mask)
-
-    return np.array([gfit.x_mean.value, gfit.y_mean.value])
-
-
-def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
-                     error=None, mask=None, centroid_func=centroid_com):
-    """
-    Calculate the centroid of sources at the defined positions.
-
-    A cutout image centered on each input position will be used to
-    calculate the centroid position.  The cutout image is defined either
-    using the ``box_size`` or ``footprint`` keyword.  The ``footprint``
-    keyword can be used to create a non-rectangular cutout image.
-
-    Parameters
-    ----------
-    data : array_like
-        The 2D array of the image.
-
-    xpos, ypos : float or array-like of float
-        The initial ``x`` and ``y`` pixel position(s) of the center
-        position.  A cutout image centered on this position be used to
-        calculate the centroid.
-
-    box_size : int or array-like of int, optional
-        The size of the cutout image along each axis.  If ``box_size``
-        is a number, then a square cutout of ``box_size`` will be
-        created.  If ``box_size`` has two elements, they should be in
-        ``(ny, nx)`` order.
-
-    footprint : `~numpy.ndarray` of bools, optional
-        A 2D boolean array where `True` values describe the local
-        footprint region to cutout.  ``footprint`` can be used to create
-        a non-rectangular cutout image, in which case the input ``xpos``
-        and ``ypos`` represent the center of the minimal bounding box
-        for the input ``footprint``.  ``box_size=(n, m)`` is equivalent
-        to ``footprint=np.ones((n, m))``.  Either ``box_size`` or
-        ``footprint`` must be defined.  If they are both defined, then
-        ``footprint`` overrides ``box_size``.
-
-    mask : array_like, bool, optional
-        A 2D boolean array with the same shape as ``data``, where a
-        `True` value indicates the corresponding element of ``data`` is
-        masked.
-
-    error : array_like, optional
-        The 2D array of the 1-sigma errors of the input ``data``.
-        ``error`` must have the same shape as ``data``.  ``error`` will
-        be used only if supported by the input ``centroid_func``.
-
-    centroid_func : callable, optional
-        A callable object (e.g. function or class) that is used to
-        calculate the centroid of a 2D array.  The ``centroid_func``
-        must accept a 2D `~numpy.ndarray`, have a ``mask`` keyword and
-        optionally an ``error`` keyword.  The callable object must
-        return a tuple of two 1D `~numpy.ndarray`\\s, representing the x
-        and y centroids.  The default is
-        `~photutils.centroids.centroid_com`.
-
-    Returns
-    -------
-    xcentroid, ycentroid : `~numpy.ndarray`
-        The ``x`` and ``y`` pixel position(s) of the centroids.
-    """
-
-    xpos = np.atleast_1d(xpos)
-    ypos = np.atleast_1d(ypos)
-    if xpos.ndim != 1:
-        raise ValueError('xpos must be a 1D array.')
-    if ypos.ndim != 1:
-        raise ValueError('ypos must be a 1D array.')
-
-    if footprint is None:
-        if box_size is None:
-            raise ValueError('box_size or footprint must be defined.')
-
-        box_size = np.atleast_1d(box_size)
-        if len(box_size) == 1:
-            box_size = np.repeat(box_size, 2)
-        if len(box_size) != 2:
-            raise ValueError('box_size must have 1 or 2 elements.')
-
-        footprint = np.ones(box_size, dtype=bool)
-    else:
-        footprint = np.asanyarray(footprint, dtype=bool)
-        if footprint.ndim != 2:
-            raise ValueError('footprint must be a 2D array.')
-
-    use_error = False
-    spec = inspect.getfullargspec(centroid_func)
-    if 'mask' not in spec.args:
-        raise ValueError('The input "centroid_func" must have a "mask" '
-                         'keyword.')
-    if 'error' in spec.args:
-        use_error = True
-
-    xcentroids = []
-    ycentroids = []
-    for xp, yp in zip(xpos, ypos):
-        slices_large, slices_small = overlap_slices(data.shape,
-                                                    footprint.shape, (yp, xp))
-        data_cutout = data[slices_large]
-
-        mask_cutout = None
-        if mask is not None:
-            mask_cutout = mask[slices_large]
-
-        footprint_mask = ~footprint
-        # trim footprint mask if partial overlap on the data
-        footprint_mask = footprint_mask[slices_small]
-
-        if mask_cutout is None:
-            mask_cutout = footprint_mask
-        else:
-            # combine the input mask and footprint mask
-            mask_cutout = np.logical_or(mask_cutout, footprint_mask)
-
-        if error is not None and use_error:
-            error_cutout = error[slices_large]
-            xcen, ycen = centroid_func(data_cutout, mask=mask_cutout,
-                                       error=error_cutout)
-        else:
-            xcen, ycen = centroid_func(data_cutout, mask=mask_cutout)
-
-        xcentroids.append(xcen + slices_large[1].start)
-        ycentroids.append(ycen + slices_large[0].start)
-
-    return np.array(xcentroids), np.array(ycentroids)
-
-
-def centroid_epsf(data, mask=None, oversampling=4, shift_val=0.5):
-    """
-    Calculates centering shift of data using pixel symmetry, as
-    described by Anderson and King (2000; PASP 112, 1360) in their
-    ePSF-fitting algorithm.
-
-    Calculate the shift of a 2-dimensional symmetric image based on the
-    asymmetry between f(x, N) and f(x, -N), along with the differential
-    df/dy(x, shift_val) and df/dy(x, -shift_val). Invalid values (e.g.
-    NaNs or infs) in the ``data`` array are automatically masked.
-
-    Parameters
-    ----------
-    data : array_like
-        The input n-dimensional array.
-    mask : array_like (bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-    oversampling : float or tuple of two floats, optional
-        Oversampling factors of pixel indices. If ``oversampling`` is a
-        scalar this is treated as both x and y directions having the
-        same oversampling factor.  Otherwise it is treated as
-        ``(x_oversamp, y_oversamp)``.
-    shift_val : float, optional
-        The undersampled value at which to compute the shifts. Default
-        is half a pixel. If supplied, must be a strictly positive
-        number.
-
-    Returns
-    -------
-    centroid : tuple of floats
-        The (x, y) coordinates of the centroid in pixel order.
-    """
-
-    oversampling = np.atleast_1d(oversampling)
-    if len(oversampling) == 1:
-        oversampling = np.repeat(oversampling, 2)
-    if np.any(oversampling <= 0):
-        raise ValueError('Oversampling factors must all be positive numbers.')
-
-    data = data.astype(float)
-
-    if mask is not None and mask is not np.ma.nomask:
-        mask = np.asarray(mask, dtype=bool)
-        if data.shape != mask.shape:
-            raise ValueError('data and mask must have the same shape.')
-        data[mask] = 0.
-
-    if shift_val <= 0:
-        raise ValueError('shift_val must be a positive number.')
-
-    # Assume the center of the ePSF is the middle of an odd-sized grid.
-    xidx_0 = int((data.shape[1] - 1) / 2)
-    x_0 = np.arange(data.shape[1], dtype=float)[xidx_0] / oversampling[0]
-    yidx_0 = int((data.shape[0] - 1) / 2)
-    y_0 = np.arange(data.shape[0], dtype=float)[yidx_0] / oversampling[1]
-
-    x_shiftidx = np.around((shift_val * oversampling[0])).astype(int)
-    y_shiftidx = np.around((shift_val * oversampling[1])).astype(int)
-
-    badidx = ~np.isfinite([data[y, x]
-                           for x in [xidx_0, xidx_0+x_shiftidx,
-                                     xidx_0+x_shiftidx-1, xidx_0+x_shiftidx+1]
-                           for y in [yidx_0, yidx_0+y_shiftidx,
-                                     yidx_0+y_shiftidx-1,
-                                     yidx_0+y_shiftidx+1]])
-    if np.any(badidx):
-        raise ValueError('One or more centroiding pixels is set to a bad '
-                         'value, e.g., NaN or inf.')
-
-    # In Anderson & King (2000) notation this is psi_E(0.5, 0.0) and
-    # values used to compute derivatives.
-    psi_pos_x = data[yidx_0, xidx_0 + x_shiftidx]
-    psi_pos_x_m1 = data[yidx_0, xidx_0 + x_shiftidx - 1]
-    psi_pos_x_p1 = data[yidx_0, xidx_0 + x_shiftidx + 1]
-
-    # Our derivatives are simple differences across two data points, but
-    # this must be in units of the undersampled grid, so 2 pixels becomes
-    # 2/oversampling pixels
-    dpsi_pos_x = np.abs(psi_pos_x_p1 - psi_pos_x_m1) / (2. / oversampling[0])
-
-    # psi_E(-0.5, 0.0) and derivative components.
-    psi_neg_x = data[yidx_0, xidx_0 - x_shiftidx]
-    psi_neg_x_m1 = data[yidx_0, xidx_0 - x_shiftidx - 1]
-    psi_neg_x_p1 = data[yidx_0, xidx_0 - x_shiftidx + 1]
-    dpsi_neg_x = np.abs(psi_neg_x_p1 - psi_neg_x_m1) / (2. / oversampling[0])
-
-    x_shift = (psi_pos_x - psi_neg_x) / (dpsi_pos_x + dpsi_neg_x)
-
-    # psi_E(0.0, 0.5) and derivatives.
-    psi_pos_y = data[yidx_0 + y_shiftidx, xidx_0]
-    psi_pos_y_m1 = data[yidx_0 + y_shiftidx - 1, xidx_0]
-    psi_pos_y_p1 = data[yidx_0 + y_shiftidx + 1, xidx_0]
-    dpsi_pos_y = np.abs(psi_pos_y_p1 - psi_pos_y_m1) / (2. / oversampling[1])
-
-    # psi_E(0.0, -0.5) and derivative components.
-    psi_neg_y = data[yidx_0 - y_shiftidx, xidx_0]
-    psi_neg_y_m1 = data[yidx_0 - y_shiftidx - 1, xidx_0]
-    psi_neg_y_p1 = data[yidx_0 - y_shiftidx + 1, xidx_0]
-    dpsi_neg_y = np.abs(psi_neg_y_p1 - psi_neg_y_m1) / (2. / oversampling[1])
-
-    y_shift = (psi_pos_y - psi_neg_y) / (dpsi_pos_y + dpsi_neg_y)
-
-    return x_0 + x_shift, y_0 + y_shift
+GaussianConst2D.__doc__ += CONSTRAINTS_DOC

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -9,6 +9,7 @@ from astropy.modeling import Fittable2DModel, Parameter
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import (CONSTRAINTS_DOC, Const1D, Const2D,
                                      Gaussian1D, Gaussian2D)
+from astropy.utils import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -159,11 +160,64 @@ def centroid_2dg(data, error=None, mask=None):
     centroid : `~numpy.ndarray`
         The ``x, y`` coordinates of the centroid.
     """
-    gfit = fit_2dgaussian(data, error=error, mask=mask)
+    from ..morphology import data_properties  # prevent circular imports
 
-    return np.array([gfit.x_mean.value, gfit.y_mean.value])
+    data = np.ma.asanyarray(data)
+
+    if mask is not None and mask is not np.ma.nomask:
+        mask = np.asanyarray(mask)
+        if data.shape != mask.shape:
+            raise ValueError('data and mask must have the same shape.')
+        data.mask |= mask
+
+    if np.any(~np.isfinite(data)):
+        data = np.ma.masked_invalid(data)
+        warnings.warn('Input data contains non-finite values (e.g., NaN or '
+                      'infs) that were automatically masked.',
+                      AstropyUserWarning)
+
+    if error is not None:
+        error = np.ma.masked_invalid(error)
+        if data.shape != error.shape:
+            raise ValueError('data and error must have the same shape.')
+        data.mask |= error.mask
+        weights = 1.0 / error.clip(min=1.e-30)
+    else:
+        weights = np.ones(data.shape)
+
+    if np.ma.count(data) < 7:
+        raise ValueError('Input data must have a least 7 unmasked values to '
+                         'fit a 2D Gaussian plus a constant.')
+
+    # assign zero weight to masked pixels
+    if data.mask is not np.ma.nomask:
+        weights[data.mask] = 0.
+
+    mask = data.mask
+    data.fill_value = 0.
+    data = data.filled()
+
+    # Subtract the minimum of the data as a rough background estimate.
+    # This will also make the data values positive, preventing issues with
+    # the moment estimation in data_properties. Moments from negative data
+    # values can yield undefined Gaussian parameters, e.g., x/y_stddev.
+    props = data_properties(data - np.min(data), mask=mask)
+
+    constant_init = 0.  # subtracted data minimum above
+    g_init = (Const2D(constant_init)
+              + Gaussian2D(amplitude=np.ptp(data),
+                           x_mean=props.xcentroid.value,
+                           y_mean=props.ycentroid.value,
+                           x_stddev=props.semimajor_axis_sigma.value,
+                           y_stddev=props.semiminor_axis_sigma.value,
+                           theta=props.orientation.value))
+    fitter = LevMarLSQFitter()
+    y, x = np.indices(data.shape)
+    gfit = fitter(g_init, x, y, data, weights=weights)
+    return np.array([gfit.x_mean_1.value, gfit.y_mean_1.value])
 
 
+@deprecated('1.0')
 def fit_2dgaussian(data, error=None, mask=None):
     """
     Fit a 2D Gaussian plus a constant to a 2D image.
@@ -246,6 +300,7 @@ def fit_2dgaussian(data, error=None, mask=None):
     return gfit
 
 
+@deprecated('1.0')
 class GaussianConst2D(Fittable2DModel):
     """
     A model for a 2D Gaussian plus a constant.

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -21,10 +21,8 @@ def centroid_1dg(data, error=None, mask=None):
     Calculate the centroid of a 2D array by fitting 1D Gaussians to the
     marginal ``x`` and ``y`` distributions of the array.
 
-    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
-    arrays are automatically masked.  The mask for invalid values
-    represents the combination of the invalid-value masks for the
-    ``data`` and ``error`` arrays.
+    Non-finite values (e.g., NaN or inf) in the ``data`` or ``error``
+    arrays are automatically masked. These masks are combined.
 
     Parameters
     ----------
@@ -53,28 +51,29 @@ def centroid_1dg(data, error=None, mask=None):
 
     if np.any(~np.isfinite(data)):
         data = np.ma.masked_invalid(data)
-        warnings.warn('Input data contains input values (e.g. NaNs or infs), '
-                      'which were automatically masked.', AstropyUserWarning)
+        warnings.warn('Input data contains non-finite values (e.g., NaN or '
+                      'inf) that were automatically masked.',
+                      AstropyUserWarning)
 
     if error is not None:
         error = np.ma.masked_invalid(error)
         if data.shape != error.shape:
             raise ValueError('data and error must have the same shape.')
         data.mask |= error.mask
-
         error.mask = data.mask
-        xy_error = [np.sqrt(np.ma.sum(error**2, axis=i)) for i in [0, 1]]
-        xy_weights = [(1.0 / xy_error[i].clip(min=1.e-30)) for i in [0, 1]]
+
+        xy_error = [np.sqrt(np.ma.sum(error**2, axis=i)) for i in (0, 1)]
+        xy_weights = [(1.0 / xy_error[i].clip(min=1.e-30)) for i in (0, 1)]
     else:
-        xy_weights = [np.ones(data.shape[i]) for i in [1, 0]]
+        xy_weights = [np.ones(data.shape[i]) for i in (1, 0)]
 
     # assign zero weight where an entire row or column is masked
     if np.any(data.mask):
-        bad_idx = [np.all(data.mask, axis=i) for i in [0, 1]]
-        for i in [0, 1]:
+        bad_idx = [np.all(data.mask, axis=i) for i in (0, 1)]
+        for i in (0, 1):
             xy_weights[i][bad_idx[i]] = 0.
 
-    xy_data = [np.ma.sum(data, axis=i).data for i in [0, 1]]
+    xy_data = [np.ma.sum(data, axis=i).data for i in (0, 1)]
 
     constant_init = np.ma.min(data)
     centroid = []
@@ -112,8 +111,9 @@ def gaussian1d_moments(data, mask=None):
     """
     if np.any(~np.isfinite(data)):
         data = np.ma.masked_invalid(data)
-        warnings.warn('Input data contains input values (e.g. NaNs or infs), '
-                      'which were automatically masked.', AstropyUserWarning)
+        warnings.warn('Input data contains non-finite values (e.g., NaN or '
+                      'inf) that were automatically masked.',
+                      AstropyUserWarning)
     else:
         data = np.ma.array(data)
 
@@ -139,10 +139,8 @@ def centroid_2dg(data, error=None, mask=None):
     Calculate the centroid of a 2D array by fitting a 2D Gaussian (plus
     a constant) to the array.
 
-    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
-    arrays are automatically masked.  The mask for invalid values
-    represents the combination of the invalid-value masks for the
-    ``data`` and ``error`` arrays.
+    Non-finite values (e.g., NaN or inf) in the ``data`` or ``error``
+    arrays are automatically masked. These masks are combined.
 
     Parameters
     ----------
@@ -170,10 +168,8 @@ def fit_2dgaussian(data, error=None, mask=None):
     """
     Fit a 2D Gaussian plus a constant to a 2D image.
 
-    Invalid values (e.g. NaNs or infs) in the ``data`` or ``error``
-    arrays are automatically masked.  The mask for invalid values
-    represents the combination of the invalid-value masks for the
-    ``data`` and ``error`` arrays.
+    Non-finite values (e.g., NaN or inf) in the ``data`` or ``error``
+    arrays are automatically masked. These masks are combined.
 
     Parameters
     ----------
@@ -204,8 +200,9 @@ def fit_2dgaussian(data, error=None, mask=None):
 
     if np.any(~np.isfinite(data)):
         data = np.ma.masked_invalid(data)
-        warnings.warn('Input data contains input values (e.g. NaNs or infs), '
-                      'which were automatically masked.', AstropyUserWarning)
+        warnings.warn('Input data contains non-finite values (e.g., NaN or '
+                      'infs) that were automatically masked.',
+                      AstropyUserWarning)
 
     if error is not None:
         error = np.ma.masked_invalid(error)
@@ -225,13 +222,13 @@ def fit_2dgaussian(data, error=None, mask=None):
         weights[data.mask] = 0.
 
     mask = data.mask
-    data.fill_value = 0.0
+    data.fill_value = 0.
     data = data.filled()
 
-    # Subtract the minimum of the data as a crude background estimate.
+    # Subtract the minimum of the data as a rough background estimate.
     # This will also make the data values positive, preventing issues with
-    # the moment estimation in data_properties (moments from negative data
-    # values can yield undefined Gaussian parameters, e.g. x/y_stddev).
+    # the moment estimation in data_properties. Moments from negative data
+    # values can yield undefined Gaussian parameters, e.g., x/y_stddev.
     props = data_properties(data - np.min(data), mask=mask)
 
     init_const = 0.  # subtracted data minimum above

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -21,11 +21,12 @@ except ImportError:
     HAS_SCIPY = False
 
 
-XCS = [25.7]
-YCS = [26.2]
-XSTDDEVS = [3.2, 4.0]
-YSTDDEVS = [5.7, 4.1]
+XCEN = 25.7
+YCEN = 26.2
+XSTDS = [3.2, 4.0]
+YSTDS = [5.7, 4.1]
 THETAS = np.array([30., 45.]) * np.pi / 180.
+
 DATA = np.zeros((3, 3))
 DATA[0:2, 1] = 1.
 DATA[1, 0:2] = 1.
@@ -33,61 +34,40 @@ DATA[1, 1] = 2.
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.parametrize(
-    ('xc_ref', 'yc_ref', 'x_stddev', 'y_stddev', 'theta'),
-    list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
-def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
-    model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
-                       y_stddev=y_stddev, theta=theta)
+@pytest.mark.parametrize(('x_std', 'y_std', 'theta'),
+                         list(itertools.product(XSTDS, YSTDS, THETAS)))
+def test_centroids(x_std, y_std, theta):
+    model = Gaussian2D(2.4, XCEN, YCEN, x_stddev=x_std, y_stddev=y_std,
+                       theta=theta)
     y, x = np.mgrid[0:50, 0:47]
     data = model(x, y)
+    xc, yc = centroid_1dg(data)
+    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.e-3)
+    xc, yc = centroid_2dg(data)
+    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.e-3)
 
-    xc2, yc2 = centroid_1dg(data)
-    assert_allclose([xc_ref, yc_ref], [xc2, yc2], rtol=0, atol=1.e-3)
-
-    xc3, yc3 = centroid_2dg(data)
-    assert_allclose([xc_ref, yc_ref], [xc3, yc3], rtol=0, atol=1.e-3)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.parametrize(
-    ('xc_ref', 'yc_ref', 'x_stddev', 'y_stddev', 'theta'),
-    list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
-def test_centroids_witherror(xc_ref, yc_ref, x_stddev, y_stddev, theta):
-    model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
-                       y_stddev=y_stddev, theta=theta)
-    y, x = np.mgrid[0:50, 0:50]
-    data = model(x, y)
+    # test with errors
     error = np.sqrt(data)
+    xc, yc = centroid_1dg(data, error=error)
+    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.e-3)
+    xc, yc = centroid_2dg(data, error=error)
+    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.e-3)
 
-    xc2, yc2 = centroid_1dg(data, error=error)
-    assert_allclose([xc_ref, yc_ref], [xc2, yc2], rtol=0, atol=1.e-3)
-
-    xc3, yc3 = centroid_2dg(data, error=error)
-    assert_allclose([xc_ref, yc_ref], [xc3, yc3], rtol=0, atol=1.e-3)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
-def test_centroids_withmask():
-    xc_ref, yc_ref = 24.7, 25.2
-    model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=5.0, y_stddev=5.0)
-    y, x = np.mgrid[0:50, 0:50]
-    data = model(x, y)
+    # test with mask
     mask = np.zeros(data.shape, dtype=bool)
     data[10, 10] = 1.e5
     mask[10, 10] = True
-
-    xc2, yc2 = centroid_1dg(data, mask=mask)
-    assert_allclose([xc2, yc2], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-
-    xc3, yc3 = centroid_2dg(data, mask=mask)
-    assert_allclose([xc3, yc3], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
+    xc, yc = centroid_1dg(data, mask=mask)
+    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.e-3)
+    xc, yc = centroid_2dg(data, mask=mask)
+    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.e-3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize('use_mask', [True, False])
 def test_centroids_nan_withmask(use_mask):
-    xc_ref, yc_ref = 24.7, 25.2
+    xc_ref = 24.7
+    yc_ref = 25.2
     model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=5.0, y_stddev=5.0)
     y, x = np.mgrid[0:50, 0:50]
     data = model(x, y)
@@ -98,42 +78,30 @@ def test_centroids_nan_withmask(use_mask):
     else:
         mask = None
 
-    xc2, yc2 = centroid_1dg(data, mask=mask)
-    assert_allclose([xc2, yc2], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-
-    xc3, yc3 = centroid_2dg(data, mask=mask)
-    assert_allclose([xc3, yc3], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
+    xc, yc = centroid_1dg(data, mask=mask)
+    assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
+    xc, yc = centroid_2dg(data, mask=mask)
+    assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_invalid_mask_shape():
-    """
-    Test if ValueError raises if mask shape doesn't match data
-    shape.
-    """
     data = np.zeros((4, 4))
     mask = np.zeros((2, 2), dtype=bool)
 
     with pytest.raises(ValueError):
         centroid_1dg(data, mask=mask)
-
     with pytest.raises(ValueError):
         centroid_2dg(data, mask=mask)
-
     with pytest.raises(ValueError):
         gaussian1d_moments(data, mask=mask)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_invalid_error_shape():
-    """
-    Test if ValueError raises if error shape doesn't match data
-    shape.
-    """
     error = np.zeros((2, 2), dtype=bool)
     with pytest.raises(ValueError):
         centroid_1dg(np.zeros((4, 4)), error=error)
-
     with pytest.raises(ValueError):
         centroid_2dg(np.zeros((4, 4)), error=error)
 

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -12,8 +12,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from ..gaussian import (centroid_1dg, centroid_2dg, fit_2dgaussian,
-                        gaussian1d_moments)
+from ..gaussian import centroid_1dg, centroid_2dg, gaussian1d_moments
 
 try:
     # the fitting routines in astropy use scipy.optimize
@@ -119,6 +118,13 @@ def test_invalid_error_shape():
         centroid_2dg(np.zeros((4, 4)), error=error)
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_centroid_2dg_dof():
+    data = np.ones((2, 2))
+    with pytest.raises(ValueError):
+        centroid_2dg(data)
+
+
 def test_gaussian1d_moments():
     x = np.arange(100)
     desired = (75, 50, 5)
@@ -141,10 +147,3 @@ def test_gaussian1d_moments():
         assert_allclose(result, desired, rtol=0, atol=1.e-6)
     assert len(warnlist) == 1
     assert issubclass(warnlist[0].category, AstropyUserWarning)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
-def test_fit2dgaussian_dof():
-    data = np.ones((2, 2))
-    with pytest.raises(ValueError):
-        fit_2dgaussian(data)

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -10,9 +10,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from ..core import (centroid_1dg, centroid_2dg, centroid_com, centroid_epsf,
-                    fit_2dgaussian, gaussian1d_moments)
-from ...psf import IntegratedGaussianPRF
+from ..gaussian import (centroid_1dg, centroid_2dg, fit_2dgaussian,
+                        gaussian1d_moments)
 
 try:
     # the fitting routines in astropy use scipy.optimize
@@ -43,9 +42,6 @@ def test_centroids(xc_ref, yc_ref, x_stddev, y_stddev, theta):
     y, x = np.mgrid[0:50, 0:47]
     data = model(x, y)
 
-    xc, yc = centroid_com(data)
-    assert_allclose([xc_ref, yc_ref], [xc, yc], rtol=0, atol=1.e-3)
-
     xc2, yc2 = centroid_1dg(data)
     assert_allclose([xc_ref, yc_ref], [xc2, yc2], rtol=0, atol=1.e-3)
 
@@ -72,29 +68,6 @@ def test_centroids_witherror(xc_ref, yc_ref, x_stddev, y_stddev, theta):
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.parametrize(
-    ('xc_ref', 'yc_ref', 'x_stddev', 'y_stddev', 'theta'),
-    list(itertools.product(XCS, YCS, XSTDDEVS, YSTDDEVS, THETAS)))
-def test_centroids_oversampling(xc_ref, yc_ref, x_stddev, y_stddev, theta):
-    model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=x_stddev,
-                       y_stddev=y_stddev, theta=theta)
-    y, x = np.mgrid[0:50, 0:50]
-    data = model(x, y)
-    mask = np.zeros(data.shape, dtype=bool)
-    data[10, 10] = 1.e5
-    mask[10, 10] = True
-    for oversampling in [4, (4, 6)]:
-        if not hasattr(oversampling, '__len__'):
-            _oversampling = (oversampling, oversampling)
-        else:
-            _oversampling = oversampling
-        xc, yc = centroid_com(data, mask=mask, oversampling=oversampling)
-        assert_allclose([xc, yc], [xc_ref / _oversampling[0],
-                                   yc_ref / _oversampling[1]], rtol=0,
-                        atol=1.e-3)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
 def test_centroids_withmask():
     xc_ref, yc_ref = 24.7, 25.2
     model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=5.0, y_stddev=5.0)
@@ -104,26 +77,11 @@ def test_centroids_withmask():
     data[10, 10] = 1.e5
     mask[10, 10] = True
 
-    xc, yc = centroid_com(data, mask=mask)
-    assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-
     xc2, yc2 = centroid_1dg(data, mask=mask)
     assert_allclose([xc2, yc2], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
 
     xc3, yc3 = centroid_2dg(data, mask=mask)
     assert_allclose([xc3, yc3], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
-def test_centroids_withmask_nonbool():
-    data = np.arange(16).reshape(4, 4)
-    mask = np.zeros(data.shape)
-    mask[0:2, :] = 1
-    mask2 = np.array(mask, dtype=bool)
-
-    xc1, yc1 = centroid_com(data, mask=mask)
-    xc2, yc2 = centroid_com(data, mask=mask2)
-    assert_allclose([xc1, yc1], [xc2, yc2])
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -140,26 +98,11 @@ def test_centroids_nan_withmask(use_mask):
     else:
         mask = None
 
-    xc, yc = centroid_com(data, mask=mask)
-    assert_allclose(xc, xc_ref, rtol=0, atol=1.e-3)
-    assert yc > yc_ref
-
     xc2, yc2 = centroid_1dg(data, mask=mask)
     assert_allclose([xc2, yc2], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
 
     xc3, yc3 = centroid_2dg(data, mask=mask)
     assert_allclose([xc3, yc3], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-
-
-def test_centroid_com_mask():
-    """Test centroid_com with and without an image_mask."""
-
-    data = np.ones((2, 2)).astype(float)
-    mask = [[False, False], [True, True]]
-    centroid = centroid_com(data, mask=None)
-    centroid_mask = centroid_com(data, mask=mask)
-    assert_allclose([0.5, 0.5], centroid, rtol=0, atol=1.e-6)
-    assert_allclose([0.5, 0.0], centroid_mask, rtol=0, atol=1.e-6)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -168,12 +111,8 @@ def test_invalid_mask_shape():
     Test if ValueError raises if mask shape doesn't match data
     shape.
     """
-
     data = np.zeros((4, 4))
     mask = np.zeros((2, 2), dtype=bool)
-
-    with pytest.raises(ValueError):
-        centroid_com(data, mask=mask)
 
     with pytest.raises(ValueError):
         centroid_1dg(data, mask=mask)
@@ -191,7 +130,6 @@ def test_invalid_error_shape():
     Test if ValueError raises if error shape doesn't match data
     shape.
     """
-
     error = np.zeros((2, 2), dtype=bool)
     with pytest.raises(ValueError):
         centroid_1dg(np.zeros((4, 4)), error=error)
@@ -226,74 +164,3 @@ def test_fit2dgaussian_dof():
     data = np.ones((2, 2))
     with pytest.raises(ValueError):
         fit_2dgaussian(data)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
-def test_centroid_epsf():
-    sigma = 0.5
-    psf = IntegratedGaussianPRF(sigma=sigma)
-    for oversampling in [4, (4, 6)]:
-        if not hasattr(oversampling, '__len__'):
-            _oversampling = (oversampling, oversampling)
-        else:
-            _oversampling = oversampling
-        x = np.arange(1 + 25 * _oversampling[0]) / _oversampling[0]
-        x0 = x[-1] / 2
-        x -= x0
-        y = np.arange(1 + 25 * _oversampling[1]) / _oversampling[1]
-        y0 = y[-1] / 2
-        y -= y0
-        offsets = np.array([0.1, 0.03])
-        data = psf.evaluate(x=x.reshape(1, -1), y=y.reshape(-1, 1), flux=1,
-                            x_0=offsets[0], y_0=offsets[1], sigma=sigma)
-
-        mask = np.zeros(data.shape, dtype=bool)
-        mask[0, 0] = 1
-        centers = centroid_epsf(data, mask=mask, oversampling=oversampling)
-        assert_allclose(centers, offsets+x0, rtol=1e-3, atol=1e-2)
-
-    psf = Gaussian2D()
-    for oversampling in [4, (6, 2)]:
-        if not hasattr(oversampling, '__len__'):
-            _oversampling = (oversampling, oversampling)
-        else:
-            _oversampling = oversampling
-        x = np.arange(1 + 25 * _oversampling[0]) / _oversampling[0]
-        x0 = x[-1] / 2
-        x -= x0
-        y = np.arange(1 + 25 * _oversampling[1]) / _oversampling[1]
-        y0 = y[-1] / 2
-        y -= y0
-        offsets = np.array([0.1, 0.03])
-        data = psf.evaluate(x=x.reshape(1, -1), y=y.reshape(-1, 1),
-                            amplitude=1, x_mean=offsets[0], y_mean=offsets[1],
-                            x_stddev=5, y_stddev=0.5, theta=0)
-
-        mask = np.zeros(data.shape, dtype=bool)
-        mask[0, 0] = 1
-        centers = centroid_epsf(data, mask=mask, oversampling=oversampling,
-                                shift_val=0.5)
-        assert_allclose(centers, offsets+x0, rtol=1e-3, atol=1e-3)
-
-
-def test_centroid_exceptions():
-    data = np.ones((5, 5), dtype=float)
-    mask = np.zeros((4, 5), dtype=int)
-    mask[2, 2] = 1
-
-    # Test data and mask having the same shape
-    with pytest.raises(ValueError):
-        centroid_epsf(data, mask)
-
-    with pytest.raises(ValueError):
-        centroid_epsf(data, shift_val=-1)
-
-    with pytest.raises(ValueError):
-        centroid_epsf(data, oversampling=-1)
-    with pytest.raises(ValueError):
-        centroid_com(data, oversampling=-1)
-
-    data = np.ones((21, 21), dtype=float)
-    data[10, 10] = np.inf
-    with pytest.raises(ValueError):
-        centroid_epsf(data)


### PR DESCRIPTION
This PR makes some changes in the `centroids` subpackage:

* Moves `centroid_1dg`, `centroid_2dg`, `gaussian1d_moments`, `fit_2dgaussian`, and `GaussianConst2D` to a new`photutils.centroids.gaussian` module
* Deprecates `fit_2dgaussian` and `GaussianConst2D`
* Adds `centroid_sources` to the narrative docs
* Code cleanup/PEP8

I preserved the git history of both `core.py` and `gaussian.py`.
