### PR TITLE
Add user to input both parameters for ellipse and rectangle inner annuli

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ General
 
 New Features
 ^^^^^^^^^^^^
+- ``photutils.aperture``
+
+  - Added ``b_in`` as an optional ellipse annulus keyword. [#1070]
+
+  - Added ``h_in`` as an optional rectangle annulus keyword. [#1070]
 
 - ``photutils.background``
 


### PR DESCRIPTION
This PR adds keywords to ellipse and rectangle annulus apertures to allow the user to input both the inner semimajor and semiminor axes (for ellipse) or both the inner width and height (for rectangles).