### PR TITLE
MNT: Remove outdated PSF notebooks

### DIFF
--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -678,14 +678,6 @@ Let's take a look at the residual image::
             interpolation='nearest', origin='lower')
 
 
-Additional Example Notebooks (online)
--------------------------------------
-
-* `PSF photometry on artificial Gaussian stars in crowded fields <https://github.com/astropy/photutils-datasets/blob/master/notebooks/ArtificialCrowdedFieldPSFPhotometry.ipynb>`_
-* `PSF photometry on artificial Gaussian stars <https://github.com/astropy/photutils-datasets/blob/master/notebooks/GaussianPSFPhot.ipynb>`_
-* `PSF/PRF Photometry on Spitzer Data <https://github.com/astropy/photutils-datasets/blob/master/notebooks/PSFPhotometrySpitzer.ipynb>`_
-
-
 References
 ----------
 


### PR DESCRIPTION
Fix #557 

I guess they can also be removed from https://github.com/astropy/photutils-datasets/ but I'll leave that up to the `photutils` maintainers to decide.