### PR TITLE
MNT: Drop Numpy 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,9 @@ matrix:
         # And with an older Python, Astropy LTS, and the oldest supported Numpy
         - os: linux
           python: 3.6
-          name: Python 3.6 astropy LTS and Numpy 1.16
+          name: Python 3.6 astropy LTS and Numpy 1.17
           stage: Comprehensive tests
-          env: TOXENV=py36-test-alldeps-astropylts-numpy116
+          env: TOXENV=py36-test-alldeps-astropylts-numpy117
 
         # Add a job that runs from cron only and tests against astropy dev and
         # numpy dev to give a change for early discovery of issues and feedback

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ General
 
 - The minimum required astropy version is 3.2. [#952]
 
+- The minimum required numpy version is 1.17. [#1079]
+
 - Removed ``astropy-helpers`` and updated the package infrastructure
   as described in Astropy APE 17. [#915]
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,17 +9,17 @@ Photutils has the following strict requirements:
 
 * `Python <https://www.python.org/>`_ 3.6 or later
 
-* `Numpy <https://numpy.org/>`_ 1.13 or later
+* `Numpy <https://numpy.org/>`_ 1.17 or later
 
 * `Astropy`_ 3.2 or later
 
 Photutils also optionally depends on other packages for some features:
 
-* `Scipy <https://www.scipy.org/>`_ 0.19 or later:  To power a variety of features in several
-  modules (strongly recommended).
+* `Scipy <https://www.scipy.org/>`_ 0.19 or later:  To power a variety of
+  features in several modules (strongly recommended).
 
 * `matplotlib <https://matplotlib.org/>`_ 2.2 or later:  To power a
-  variety of plotting features (e.g. plotting apertures).
+  variety of plotting features (e.g., plotting apertures).
 
 * `scikit-image <https://scikit-image.org/>`_ 0.14.2 or later:  Used in
   `~photutils.segmentation.deblend_sources` for deblending segmented
@@ -28,7 +28,7 @@ Photutils also optionally depends on other packages for some features:
 * `scikit-learn <https://scikit-learn.org/>`_ 0.19 or later:  Used in
   `~photutils.psf.DBSCANGroup` to create star groups.
 
-* `gwcs <https://github.com/spacetelescope/gwcs>`_ 0.11 or later:
+* `gwcs <https://github.com/spacetelescope/gwcs>`_ 0.12 or later:
   Used in `~photutils.datasets.make_gwcs` to create a simple celestial
   gwcs object.
 
@@ -55,8 +55,8 @@ upgraded, instead you can do::
 
     pip install photutils --no-deps
 
-Note that you may need a C compiler (e.g. ``gcc`` or
-``clang``) to be installed for the installation to succeed.
+Note that you may need a C compiler (e.g., ``gcc`` or ``clang``) to be
+installed for the installation to succeed.
 
 If you get a ``PermissionError``, this means that you do not have the
 required administrative access to install new packages to your Python

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -32,8 +32,6 @@ try:
 except ImportError:
     HAS_MATPLOTLIB = False
 
-NUMPY_LT_1_14 = not minversion('numpy', '1.14dev')
-
 APERTURE_CL = [CircularAperture,
                CircularAnnulus,
                EllipticalAperture,
@@ -588,122 +586,71 @@ def test_sky_aperture_repr():
     s = SkyCoord([1, 2], [3, 4], unit='deg')
 
     aper = SkyCircularAperture(s, r=3*u.pix)
-    if NUMPY_LT_1_14:
-        a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                  '    [( 1.,  3.), ( 2.,  4.)]>, r=3.0 pix)>')
-        a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'r: 3.0 pix')
-    else:
-        a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                  '    [(1., 3.), (2., 4.)]>, r=3.0 pix)>')
-        a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                 'r: 3.0 pix')
+    a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                '    [(1., 3.), (2., 4.)]>, r=3.0 pix)>')
+    a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
+                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                'r: 3.0 pix')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyCircularAnnulus(s, r_in=3.*u.pix, r_out=5*u.pix)
-    if NUMPY_LT_1_14:
-        a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                  '    [( 1.,  3.), ( 2.,  4.)]>, r_in=3.0 pix, '
-                  'r_out=5.0 pix)>')
-        a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'r_in: 3.0 pix\nr_out: 5.0 pix')
-    else:
-        a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                  '    [(1., 3.), (2., 4.)]>, r_in=3.0 pix, r_out=5.0 pix)>')
-        a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                 'r_in: 3.0 pix\nr_out: 5.0 pix')
+    a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                '    [(1., 3.), (2., 4.)]>, r_in=3.0 pix, r_out=5.0 pix)>')
+    a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
+                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                'r_in: 3.0 pix\nr_out: 5.0 pix')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyEllipticalAperture(s, a=3*u.pix, b=5*u.pix, theta=15*u.deg)
-    if NUMPY_LT_1_14:
-        a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, a=3.0 pix, b=5.0 pix,'
-                  ' theta=15.0 deg)>')
-        a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
-    else:
-        a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [(1., 3.), (2., 4.)]>, a=3.0 pix, b=5.0 pix,'
-                  ' theta=15.0 deg)>')
-        a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                 'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
+    a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
+                'deg\n    [(1., 3.), (2., 4.)]>, a=3.0 pix, b=5.0 pix,'
+                ' theta=15.0 deg)>')
+    a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
+                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyEllipticalAnnulus(s, a_in=3*u.pix, a_out=5*u.pix, b_out=3*u.pix,
                                 theta=15*u.deg)
-    if NUMPY_LT_1_14:
-        a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, a_in=3.0 pix, '
-                  'a_out=5.0 pix, b_in=1.8 pix, b_out=3.0 pix, '
-                  'theta=15.0 deg)>')
-        a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'a_in: 3.0 pix\na_out: 5.0 pix\nb_in=1.8: 1.8 pix\n'
-                 'b_out: 3.0 pix\ntheta: 15.0 deg')
-    else:
-        a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [(1., 3.), (2., 4.)]>, a_in=3.0 pix, '
-                  'a_out=5.0 pix, b_in=1.8 pix, b_out=3.0 pix, '
-                  'theta=15.0 deg)>')
-        a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                 'a_in: 3.0 pix\na_out: 5.0 pix\nb_in: 1.8 pix\n'
-                 'b_out: 3.0 pix\ntheta: 15.0 deg')
+    a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
+                'deg\n    [(1., 3.), (2., 4.)]>, a_in=3.0 pix, '
+                'a_out=5.0 pix, b_in=1.8 pix, b_out=3.0 pix, '
+                'theta=15.0 deg)>')
+    a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
+                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                'a_in: 3.0 pix\na_out: 5.0 pix\nb_in: 1.8 pix\n'
+                'b_out: 3.0 pix\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyRectangularAperture(s, w=3*u.pix, h=5*u.pix, theta=15*u.deg)
-    if NUMPY_LT_1_14:
-        a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [( 1.,  3.), ( 2.,  4.)]>, w=3.0 pix, h=5.0 pix'
-                  ', theta=15.0 deg)>')
-        a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
-    else:
-        a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
-                  'deg\n    [(1., 3.), (2., 4.)]>, w=3.0 pix, h=5.0 pix'
-                  ', theta=15.0 deg)>')
-        a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                 'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
+    a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
+                'deg\n    [(1., 3.), (2., 4.)]>, w=3.0 pix, h=5.0 pix'
+                ', theta=15.0 deg)>')
+    a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
+                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyRectangularAnnulus(s, w_in=5*u.pix, w_out=10*u.pix,
                                  h_out=6*u.pix, theta=15*u.deg)
-    if NUMPY_LT_1_14:
-        a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-                  '\n    [( 1.,  3.), ( 2.,  4.)]>, w_in=5.0 pix, '
-                  'w_out=10.0 pix, h_in=3.0 pix, h_out=6.0 pix, '
-                  'theta=15.0 deg)>')
-        a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [( 1.,  3.), ( 2.,  4.)]>\n'
-                 'w_in: 5.0 pix\nw_out: 10.0 pix\nh_in: 3.0 pix\n'
-                 'h_out: 6.0 pix\ntheta: 15.0 deg')
-    else:
-        a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-                  '\n    [(1., 3.), (2., 4.)]>, w_in=5.0 pix, '
-                  'w_out=10.0 pix, h_in=3.0 pix, h_out=6.0 pix, '
-                  'theta=15.0 deg)>')
-        a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
-                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                 'w_in: 5.0 pix\nw_out: 10.0 pix\nh_in: 3.0 pix\n'
-                 'h_out: 6.0 pix\ntheta: 15.0 deg')
+    a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
+                '\n    [(1., 3.), (2., 4.)]>, w_in=5.0 pix, '
+                'w_out=10.0 pix, h_in=3.0 pix, h_out=6.0 pix, '
+                'theta=15.0 deg)>')
+    a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
+                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                'w_in: 5.0 pix\nw_out: 10.0 pix\nh_in: 3.0 pix\n'
+                'h_out: 6.0 pix\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -13,7 +13,6 @@ from astropy.io import fits
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import Table
 import astropy.units as u
-from astropy.utils import minversion
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_skycoord
 
@@ -587,31 +586,31 @@ def test_sky_aperture_repr():
 
     aper = SkyCircularAperture(s, r=3*u.pix)
     a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                '    [(1., 3.), (2., 4.)]>, r=3.0 pix)>')
+              '    [(1., 3.), (2., 4.)]>, r=3.0 pix)>')
     a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
-                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                'r: 3.0 pix')
+             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+             'r: 3.0 pix')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyCircularAnnulus(s, r_in=3.*u.pix, r_out=5*u.pix)
     a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                '    [(1., 3.), (2., 4.)]>, r_in=3.0 pix, r_out=5.0 pix)>')
+              '    [(1., 3.), (2., 4.)]>, r_in=3.0 pix, r_out=5.0 pix)>')
     a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
-                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                'r_in: 3.0 pix\nr_out: 5.0 pix')
+             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+             'r_in: 3.0 pix\nr_out: 5.0 pix')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyEllipticalAperture(s, a=3*u.pix, b=5*u.pix, theta=15*u.deg)
     a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
-                'deg\n    [(1., 3.), (2., 4.)]>, a=3.0 pix, b=5.0 pix,'
-                ' theta=15.0 deg)>')
+              'deg\n    [(1., 3.), (2., 4.)]>, a=3.0 pix, b=5.0 pix,'
+              ' theta=15.0 deg)>')
     a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
-                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
+             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+             'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
@@ -619,24 +618,24 @@ def test_sky_aperture_repr():
     aper = SkyEllipticalAnnulus(s, a_in=3*u.pix, a_out=5*u.pix, b_out=3*u.pix,
                                 theta=15*u.deg)
     a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
-                'deg\n    [(1., 3.), (2., 4.)]>, a_in=3.0 pix, '
-                'a_out=5.0 pix, b_in=1.8 pix, b_out=3.0 pix, '
-                'theta=15.0 deg)>')
+              'deg\n    [(1., 3.), (2., 4.)]>, a_in=3.0 pix, '
+              'a_out=5.0 pix, b_in=1.8 pix, b_out=3.0 pix, '
+              'theta=15.0 deg)>')
     a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
-                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                'a_in: 3.0 pix\na_out: 5.0 pix\nb_in: 1.8 pix\n'
-                'b_out: 3.0 pix\ntheta: 15.0 deg')
+             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+             'a_in: 3.0 pix\na_out: 5.0 pix\nb_in: 1.8 pix\n'
+             'b_out: 3.0 pix\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
     aper = SkyRectangularAperture(s, w=3*u.pix, h=5*u.pix, theta=15*u.deg)
     a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
-                'deg\n    [(1., 3.), (2., 4.)]>, w=3.0 pix, h=5.0 pix'
-                ', theta=15.0 deg)>')
+              'deg\n    [(1., 3.), (2., 4.)]>, w=3.0 pix, h=5.0 pix'
+              ', theta=15.0 deg)>')
     a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
-                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
+             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+             'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
@@ -644,13 +643,13 @@ def test_sky_aperture_repr():
     aper = SkyRectangularAnnulus(s, w_in=5*u.pix, w_out=10*u.pix,
                                  h_out=6*u.pix, theta=15*u.deg)
     a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-                '\n    [(1., 3.), (2., 4.)]>, w_in=5.0 pix, '
-                'w_out=10.0 pix, h_in=3.0 pix, h_out=6.0 pix, '
-                'theta=15.0 deg)>')
+              '\n    [(1., 3.), (2., 4.)]>, w_in=5.0 pix, '
+              'w_out=10.0 pix, h_in=3.0 pix, h_out=6.0 pix, '
+              'theta=15.0 deg)>')
     a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
-                '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-                'w_in: 5.0 pix\nw_out: 10.0 pix\nh_in: 3.0 pix\n'
-                'h_out: 6.0 pix\ntheta: 15.0 deg')
+             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+             'w_in: 5.0 pix\nw_out: 10.0 pix\nh_in: 3.0 pix\n'
+             'h_out: 6.0 pix\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -396,11 +396,7 @@ class Background2D:
         if xextra > 0:
             xpad = self.box_size[1] - xextra
         pad_width = ((0, ypad), (0, xpad))
-
-        # mode must be a string for numpy < 0.11
-        # (see https://github.com/numpy/numpy/issues/7112)
-        mode = str('constant')
-        data = np.pad(self.data, pad_width, mode=mode,
+        data = np.pad(self.data, pad_width, mode='constant',
                       constant_values=[1.e10])
 
         # mask the padded regions
@@ -412,7 +408,7 @@ class Background2D:
 
         # pad the input mask separately (there is no np.ma.pad function)
         if self.mask is not None:
-            mask = np.pad(self.mask, pad_width, mode=mode,
+            mask = np.pad(self.mask, pad_width, mode='constant',
                           constant_values=[True])
             mask = np.logical_or(mask, pad_mask)
         else:

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -656,13 +656,11 @@ def _find_stars(data, kernel, threshold_eff, min_separation=None,
         ypad = kernel.yradius
         xpad = kernel.xradius
         pad = ((ypad, ypad), (xpad, xpad))
-        # mode must be a string for numpy < 0.11
-        # (see https://github.com/numpy/numpy/issues/7112)
-        mode = str('constant')
-        data = np.pad(data, pad, mode=mode, constant_values=[0.])
+        pad_mode = 'constant'
+        data = np.pad(data, pad, mode=pad_mode, constant_values=[0.])
         if mask is not None:
-            mask = np.pad(mask, pad, mode=mode, constant_values=[0.])
-        convolved_data = np.pad(convolved_data, pad, mode=mode,
+            mask = np.pad(mask, pad, mode=pad_mode, constant_values=[0.])
+        convolved_data = np.pad(convolved_data, pad, mode=pad_mode,
                                 constant_values=[0.])
 
     # find local peaks in the convolved data

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.13
+    numpy>=1.17
     astropy>=3.2
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{116,117,118}
+    py{36,37,38}-test-numpy{117,118,119}
     py{36,37,38}-test-astropy{32,40,lts}
     build_docs
     linkcheck
@@ -36,18 +36,18 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
+    numpy119: with numpy 1.19.*
     astropy32: with astropy 3.2.*
     astropy40: with astropy 4.0.*
     astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
-    numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
+    numpy119: numpy==1.19.*
 
     astropy32: astropy==3.2.*
     astropy40: astropy==4.0.*


### PR DESCRIPTION
This PR bumps the minimum supported version of Numpy from 1.16 to 1.17.  This mirrors the minimum supported numpy version for `astropy 4.2`.