### PR TITLE
Replace RandomState with default Generator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,11 @@ API changes
   - Removed the deprecated ``type`` keyword in ``make_noise_image``.
     [#953]
 
+  - Renamed the ``random_state`` keyword (deprecated) to
+    ``seed`` in ``apply_poisson_noise``, ``make_noise_image``,
+    ``make_random_models_table``, and ``make_random_gaussians_table``
+    functions. [#1080]
+
 - ``photutils.detection``
 
   - Removed the deprecated ``snr`` keyword in ``detect_threshold``.
@@ -140,6 +145,9 @@ API changes
   - Removed the deprecated ``snr`` and ``mask_value`` keywords in
     ``make_source_mask``. [#953]
 
+  - Renamed the ``random_state`` keyword (deprecated) to ``seed`` in the
+    ``make_cmap`` method. [#1080]
+
 - ``photutils.utils``
 
   - Removed the deprecated ``random_cmap``, ``mask_to_mirrored_num``,
@@ -149,6 +157,11 @@ API changes
   - Removed the deprecated ``wcs_helpers`` functions
     ``pixel_scale_angle_at_skycoord``, ``assert_angle_or_pixel``,
     ``assert_angle``, and ``pixel_to_icrs_coords``. [#953]
+
+  - Deprecated the ``check_random_state`` function. [#1080]
+
+  - Renamed the ``random_state`` keyword (deprecated) to ``seed`` in the
+    ``make_random_cmap`` function. [#1080]
 
 
 0.7.2 (2019-12-09)

--- a/docs/epsf.rst
+++ b/docs/epsf.rst
@@ -50,7 +50,7 @@ those to the image::
 
     >>> from photutils.datasets import make_noise_image
     >>> data +=  make_noise_image(data.shape, distribution='gaussian',
-    ...                           mean=10., stddev=5., random_state=12345)  # doctest: +REMOTE_DATA
+    ...                           mean=10., stddev=5., seed=123)  # doctest: +REMOTE_DATA
 
 Let's show the image:
 
@@ -65,7 +65,7 @@ Let's show the image:
     hdu = datasets.load_simulated_hst_star_image()
     data = hdu.data
     data +=  make_noise_image(data.shape, distribution='gaussian', mean=10.,
-                              stddev=5., random_state=12345)
+                              stddev=5., seed=123)
     norm = simple_norm(data, 'sqrt', percent=99.)
     plt.imshow(data, norm=norm, origin='lower', cmap='viridis')
 
@@ -196,7 +196,7 @@ from which we'll build our ePSF.  Let's show the first 25 of them:
     data = hdu.data
     from photutils.datasets import make_noise_image
     data +=  make_noise_image(data.shape, distribution='gaussian', mean=10.,
-                              stddev=5., random_state=12345)
+                              stddev=5., seed=123)
 
     from photutils import find_peaks
     peaks_tbl = find_peaks(data, threshold=500.)
@@ -279,7 +279,7 @@ Finally, let's show the constructed ePSF:
     data = hdu.data
     from photutils.datasets import make_noise_image
     data +=  make_noise_image(data.shape, distribution='gaussian', mean=10.,
-                              stddev=5., random_state=12345)
+                              stddev=5., seed=123)
 
     from photutils import find_peaks
     peaks_tbl = find_peaks(data, threshold=500.)

--- a/docs/grouping.rst
+++ b/docs/grouping.rst
@@ -65,8 +65,7 @@ sources and the latter will make an actual image using that table.
                           ('y_stddev', [sigma_psf, sigma_psf]),
                           ('theta', [0, np.pi])])
 
-    starlist = make_random_gaussians_table(n_sources, params,
-                                           random_state=1234)
+    starlist = make_random_gaussians_table(n_sources, params, seed=123)
 
     shape = (256, 256)
     sim_image = make_gaussian_sources_image(shape, starlist)
@@ -150,7 +149,7 @@ in the same group have the same aperture color:
     >>> from photutils.utils import make_random_cmap
     >>> plt.imshow(sim_image, origin='lower', interpolation='nearest',
     ...            cmap='Greys_r')
-    >>> cmap = make_random_cmap(random_state=12345)
+    >>> cmap = make_random_cmap(seed=123)
     >>> for i, group in enumerate(star_groups.groups):
     >>>     xypos = np.transpose([group['x_0'], group['y_0']])
     >>>     ap = CircularAperture(xypos, r=fwhm)
@@ -184,8 +183,7 @@ in the same group have the same aperture color:
                           ('y_stddev', [sigma_psf, sigma_psf]),
                           ('theta', [0, np.pi])])
 
-    starlist = make_random_gaussians_table(n_sources, params,
-                                           random_state=1234)
+    starlist = make_random_gaussians_table(n_sources, params, seed=123)
 
     shape = (256, 256)
     sim_image = make_gaussian_sources_image(shape, starlist)
@@ -201,7 +199,7 @@ in the same group have the same aperture color:
     plt.imshow(sim_image, origin='lower', interpolation='nearest',
                cmap='Greys_r')
 
-    cmap = make_random_cmap(random_state=12345)
+    cmap = make_random_cmap(seed=123)
     for i, group in enumerate(star_groups.groups):
         xypos = np.transpose([group['x_0'], group['y_0']])
         ap = CircularAperture(xypos, r=fwhm)
@@ -251,8 +249,7 @@ to use :class:`~photutils.psf.DBSCANGroup`.
                           ('y_stddev', [sigma_psf, sigma_psf]),
                           ('theta', [0, np.pi])])
 
-    starlist = make_random_gaussians_table(n_sources, params,
-                                           random_state=1234)
+    starlist = make_random_gaussians_table(n_sources, params, seed=123)
 
     shape = (256, 256)
     sim_image = make_gaussian_sources_image(shape, starlist)
@@ -268,7 +265,7 @@ to use :class:`~photutils.psf.DBSCANGroup`.
     plt.imshow(sim_image, origin='lower', interpolation='nearest',
                cmap='Greys_r')
 
-    cmap = make_random_cmap(random_state=12345)
+    cmap = make_random_cmap(seed=123)
     for i, group in enumerate(star_groups.groups):
         xypos = np.transpose([group['x_0'], group['y_0']])
         ap = CircularAperture(xypos, r=fwhm)

--- a/docs/isophote.rst
+++ b/docs/isophote.rst
@@ -25,7 +25,7 @@ For this example, let's create a simple simulated galaxy image::
     >>> ny = nx = 150
     >>> y, x = np.mgrid[0:ny, 0:nx]
     >>> noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
-    ...                          stddev=2., random_state=12345)
+    ...                          stddev=2., seed=123)
     >>> data = g(x, y) + noise
 
 .. plot::
@@ -38,7 +38,7 @@ For this example, let's create a simple simulated galaxy image::
     ny = nx = 150
     y, x = np.mgrid[0:ny, 0:nx]
     noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
-                             stddev=2., random_state=12345)
+                             stddev=2., seed=123)
     data = g(x, y) + noise
     plt.imshow(data, origin='lower')
 
@@ -76,7 +76,7 @@ Let's show this initial ellipse guess:
     ny = nx = 150
     y, x = np.mgrid[0:ny, 0:nx]
     noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
-                             stddev=2., random_state=12345)
+                             stddev=2., seed=123)
     data = g(x, y) + noise
 
     geometry = EllipseGeometry(x0=75, y0=75, sma=20, eps=0.5,
@@ -155,7 +155,7 @@ position as a function of the semimajor axis length:
     ny = nx = 150
     y, x = np.mgrid[0:ny, 0:nx]
     noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
-                             stddev=2., random_state=12345)
+                             stddev=2., seed=123)
     data = g(x, y) + noise
     geometry = EllipseGeometry(x0=75, y0=75, sma=20, eps=0.5,
                                pa=20.*np.pi/180.)
@@ -215,7 +215,7 @@ isophotes, the elliptical model image, and the residual image:
     ny = nx = 150
     y, x = np.mgrid[0:ny, 0:nx]
     noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
-                             stddev=2., random_state=12345)
+                             stddev=2., seed=123)
     data = g(x, y) + noise
     geometry = EllipseGeometry(x0=75, y0=75, sma=20, eps=0.5,
                                pa=20.*np.pi/180.)

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -227,9 +227,9 @@ First let's create an image with four overlapping stars::
     >>> tshape = (32, 32)
     >>> image = (make_gaussian_sources_image(tshape, sources) +
     ...          make_noise_image(tshape, distribution='poisson', mean=6.,
-    ...                           random_state=1) +
+    ...                           seed=123) +
     ...          make_noise_image(tshape, distribution='gaussian', mean=0.,
-    ...                           stddev=2., random_state=1))
+    ...                           stddev=2., seed=123))
 
 .. doctest-requires:: matplotlib
 
@@ -261,9 +261,9 @@ First let's create an image with four overlapping stars::
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
              make_noise_image(tshape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=123) +
              make_noise_image(tshape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=123))
 
     from matplotlib import rcParams
     rcParams['font.size'] = 13
@@ -354,9 +354,9 @@ Now, let's compare the simulated and the residual images:
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
              make_noise_image(tshape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=123) +
              make_noise_image(tshape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=123))
 
     from photutils.detection import IRAFStarFinder
     from photutils.psf import IntegratedGaussianPRF, DAOGroup
@@ -463,9 +463,9 @@ IntegratedGaussianPRF(sigma=sigma_psf)``:
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
              make_noise_image(tshape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=123) +
              make_noise_image(tshape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=123))
 
     from photutils.detection import IRAFStarFinder
     from photutils.psf import IntegratedGaussianPRF, DAOGroup
@@ -583,9 +583,9 @@ the fainter star as well. Also, note that both of the stars have
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
              make_noise_image(tshape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=123) +
              make_noise_image(tshape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=123))
 
     vmin, vmax = np.percentile(image, [5, 95])
     plt.imshow(image, cmap='viridis', aspect=1, interpolation='nearest',
@@ -661,9 +661,9 @@ Let's take a look at the residual image::
     tshape = (32, 32)
     image = (make_gaussian_sources_image(tshape, sources) +
              make_noise_image(tshape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=123) +
              make_noise_image(tshape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=123))
 
     daogroup = DAOGroup(crit_separation=8)
     mmm_bkg = MMMBackground()

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -103,7 +103,7 @@ segmentation image showing the detected sources:
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     >>> ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     >>> ax1.set_title('Data')
-    >>> cmap = segm.make_cmap(random_state=12345)
+    >>> cmap = segm.make_cmap(seed=123)
     >>> ax2.imshow(segm, origin='lower', cmap=cmap, interpolation='nearest')
     >>> ax2.set_title('Segmentation Image')
 
@@ -127,7 +127,7 @@ segmentation image showing the detected sources:
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     ax1.set_title('Data')
-    cmap = segm.make_cmap(random_state=12345)
+    cmap = segm.make_cmap(seed=123)
     ax2.imshow(segm, origin='lower', cmap=cmap, interpolation='nearest')
     ax2.set_title('Segmentation Image')
     plt.tight_layout()
@@ -196,7 +196,7 @@ the deblended segmentation image:
 
     norm = ImageNormalize(stretch=SqrtStretch())
     fig, ax = plt.subplots(1, 1, figsize=(10, 6.5))
-    cmap = segm_deblend.make_cmap(random_state=12345)
+    cmap = segm_deblend.make_cmap(seed=123)
     ax.imshow(segm_deblend, origin='lower', cmap=cmap, interpolation='nearest')
     ax.set_title('Deblended Segmentation Image')
     plt.tight_layout()
@@ -226,11 +226,11 @@ Let's plot one of the deblended sources:
     slc = (slice(273, 297), slice(425, 444))
     ax1.imshow(data[slc], origin='lower')
     ax1.set_title('Data')
-    cmap1 = segm.make_cmap(random_state=123)
+    cmap1 = segm.make_cmap(seed=123)
     ax2.imshow(segm.data[slc], origin='lower', cmap=cmap1,
                interpolation='nearest')
     ax2.set_title('Original Segment')
-    cmap2 = segm_deblend.make_cmap(random_state=123)
+    cmap2 = segm_deblend.make_cmap(seed=123)
     ax3.imshow(segm_deblend.data[slc], origin='lower', cmap=cmap2,
                interpolation='nearest')
     ax3.set_title('Deblended Segments')
@@ -410,7 +410,7 @@ Now let's plot the derived elliptical apertures on the data:
     >>> fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     >>> ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     >>> ax1.set_title('Data')
-    >>> cmap = segm_deblend.make_cmap(random_state=12345)
+    >>> cmap = segm_deblend.make_cmap(seed=123)
     >>> ax2.imshow(segm_deblend, origin='lower', cmap=cmap,
     ...            interpolation='nearest')
     >>> ax2.set_title('Segmentation Image')
@@ -459,7 +459,7 @@ Now let's plot the derived elliptical apertures on the data:
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
     ax1.set_title('Data')
-    cmap = segm_deblend.make_cmap(random_state=12345)
+    cmap = segm_deblend.make_cmap(seed=123)
     ax2.imshow(segm_deblend, origin='lower', cmap=cmap,
                interpolation='nearest')
     ax2.set_title('Segmentation Image')

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -232,8 +232,8 @@ class BoundingBox:
             bbox = BoundingBox(2, 7, 3, 8)
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
-            np.random.seed(12345)
-            ax.imshow(np.random.random((10, 10)), interpolation='nearest',
+            rng = np.random.default_rng(0)
+            ax.imshow(rng.random((10, 10)), interpolation='nearest',
                       cmap='viridis')
             ax.add_patch(bbox.as_artist(facecolor='none', edgecolor='white',
                          lw=2.))

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -17,7 +17,7 @@ from ...datasets.make import make_noise_image
 BKG = 0.0
 STD = 0.5
 DATA = make_noise_image((100, 100), distribution='gaussian', mean=BKG,
-                        stddev=STD, random_state=12345)
+                        stddev=STD, seed=0)
 
 BKG_CLASS0 = [MeanBackground, MedianBackground, ModeEstimatorBackground,
               MMMBackground, SExtractorBackground]
@@ -46,7 +46,7 @@ def test_background(bkg_class):
     bkg = bkg_class(sigma_clip=SIGMA_CLIP)
     bkgval = bkg.calc_background(DATA)
     assert not np.ma.isMaskedArray(bkgval)
-    assert_allclose(bkgval, BKG, atol=1.e-2)
+    assert_allclose(bkgval, BKG, atol=0.02)
     assert_allclose(bkg(DATA), bkg.calc_background(DATA))
 
 

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -689,8 +689,8 @@ def make_4gaussians_image(noise=True):
     data = make_gaussian_sources_image(shape, table) + 5.
 
     if noise:
-        data += make_noise_image(shape, distribution='gaussian', mean=0.,
-                                 stddev=5., random_state=12345)
+        rng = np.random.RandomState(12345)
+        data += rng.normal(loc=0., scale=5., size=shape)
 
     return data
 

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -741,17 +741,25 @@ def make_100gaussians_image(noise=True):
                           ('y_mean', ymean_range),
                           ('x_stddev', xstddev_range),
                           ('y_stddev', ystddev_range),
-                          ('theta', [0, 2*np.pi])])
+                          ('theta', [0, 2 * np.pi])])
 
-    sources = make_random_gaussians_table(n_sources, params,
-                                          random_state=12345)
+    rng = np.random.RandomState(12345)
+    sources = Table()
+    for param_name, (lower, upper) in params.items():
+        # Generate a column for every item in param_ranges, even if it
+        # is not in the model (e.g., flux).  However, such columns will
+        # be ignored when rendering the image.
+        sources[param_name] = rng.uniform(lower, upper, n_sources)
+    xstd = sources['x_stddev']
+    ystd = sources['y_stddev']
+    sources['amplitude'] = sources['flux'] / (2. * np.pi * xstd * ystd)
 
     shape = (300, 500)
     data = make_gaussian_sources_image(shape, sources) + 5.
 
     if noise:
-        data += make_noise_image(shape, distribution='gaussian', mean=0.,
-                                 stddev=2., random_state=12345)
+        rng = np.random.RandomState(12345)
+        data += rng.normal(loc=0., scale=2., size=shape)
 
     return data
 

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -132,8 +132,7 @@ def test_make_random_gaussians_table():
                          ('y_mean', [0, 300]), ('x_stddev', [1, 5]),
                          ('y_stddev', [1, 5]), ('theta', [0, np.pi])])
 
-    table = make_random_gaussians_table(n_sources, param_ranges,
-                                        random_state=12345)
+    table = make_random_gaussians_table(n_sources, param_ranges, seed=0)
     assert len(table) == n_sources
 
 
@@ -142,8 +141,7 @@ def test_make_random_gaussians_table_flux():
     param_ranges = dict([('flux', [500, 1000]), ('x_mean', [0, 500]),
                          ('y_mean', [0, 300]), ('x_stddev', [1, 5]),
                          ('y_stddev', [1, 5]), ('theta', [0, np.pi])])
-    table = make_random_gaussians_table(n_sources, param_ranges,
-                                        random_state=12345)
+    table = make_random_gaussians_table(n_sources, param_ranges, seed=0)
     assert 'amplitude' in table.colnames
     assert len(table) == n_sources
 

--- a/photutils/isophote/tests/make_test_data.py
+++ b/photutils/isophote/tests/make_test_data.py
@@ -12,7 +12,7 @@ from ...datasets import make_noise_image
 
 def make_test_image(nx=512, ny=512, x0=None, y0=None,
                     background=100., noise=1.e-6, i0=100., sma=40.,
-                    eps=0.2, pa=0., random_state=None):
+                    eps=0.2, pa=0., seed=None):
     """
     Make a simulated image for testing the isophote subpackage.
 
@@ -34,10 +34,9 @@ def make_test_image(nx=512, ny=512, x0=None, y0=None,
         The ellipticity of the reference isophote.
     pa : float, optional
         The position angle of the reference isophote.
-    random_state : int or `~numpy.random.RandomState`, optional
-        Pseudo-random number generator state used for random sampling.
-        Separate function calls with the same ``random_state`` will
-        generate the identical noise image.
+    seed : int, optional
+        A seed to initialize the `numpy.random.BitGenerator`. If `None`,
+        then fresh, unpredictable entropy will be pulled from the OS.
 
     Returns
     -------
@@ -68,14 +67,14 @@ def make_test_image(nx=512, ny=512, x0=None, y0=None,
                                    image[int(xcen), int(ycen + 1)]) / 4.
 
     image += make_noise_image(image.shape, distribution='gaussian', mean=0.,
-                              stddev=noise, random_state=random_state)
+                              stddev=noise, seed=seed)
 
     return image
 
 
 def make_fits_test_image(name, nx=512, ny=512, x0=None, y0=None,
                          background=100., noise=1.e-6, i0=100., sma=40.,
-                         eps=0.2, pa=0., random_state=None):
+                         eps=0.2, pa=0., seed=None):
     """
     Make a simulated image and write it to a FITS file.
 
@@ -86,17 +85,17 @@ def make_fits_test_image(name, nx=512, ny=512, x0=None, y0=None,
     import numpy as np
     pa = np.pi / 4.
     make_fits_test_image('synth_lowsnr.fits', noise=40., pa=pa,
-                         random_state=123)
+                         seed=0)
     make_fits_test_image('synth_highsnr.fits', noise=1.e-12, pa=pa,
-                         random_state=123)
-    make_fits_test_image('synth.fits', pa=pa, random_state=123)
+                         seed=0)
+    make_fits_test_image('synth.fits', pa=pa, seed=0)
     """
 
     if not name.endswith('.fits'):
         name += '.fits'
 
     array = make_test_image(nx, ny, x0, y0, background, noise, i0, sma, eps,
-                            pa, random_state=random_state)
+                            pa, seed=seed)
 
     hdu = fits.PrimaryHDU(array)
     hdulist = fits.HDUList([hdu])

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -31,14 +31,14 @@ PA = 10. / 180. * np.pi
 # EllipseGeometry. The code may eventually modify it's contents. The safe
 # bet is to build it wherever it's needed. The cost is negligible.
 OFFSET_GALAXY = make_test_image(x0=POS, y0=POS, pa=PA, noise=1.e-12,
-                                random_state=123)
+                                seed=0)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestEllipse:
     def setup_class(self):
         # centered, tilted galaxy
-        self.data = make_test_image(pa=PA, random_state=123)
+        self.data = make_test_image(pa=PA, seed=0)
 
     @pytest.mark.remote_data
     def test_find_center(self):
@@ -136,7 +136,7 @@ class TestEllipse:
         g = Gaussian2D(100., nx / 2., ny / 2., 20, 12, theta=40.*np.pi/180.)
         y, x = np.mgrid[0:ny, 0:nx]
         noise = make_noise_image((ny, nx), distribution='gaussian', mean=0.,
-                                 stddev=2., random_state=12345)
+                                 stddev=2., seed=0)
         data = g(x, y) + noise
         ellipse = Ellipse(data)  # estimates initial center
         isolist = ellipse.fit_image()

--- a/photutils/isophote/tests/test_fitter.py
+++ b/photutils/isophote/tests/test_fitter.py
@@ -24,7 +24,7 @@ except ImportError:
     HAS_SCIPY = False
 
 
-DATA = make_test_image(random_state=123)
+DATA = make_test_image(seed=0)
 DEFAULT_POS = 256
 
 DEFAULT_FIX = np.array([False, False, False, False])
@@ -95,7 +95,7 @@ def test_fitting_eps():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_fitting_pa():
-    data = make_test_image(pa=np.pi/4, noise=0.01, random_state=123)
+    data = make_test_image(pa=np.pi/4, noise=0.01, seed=0)
 
     # initial guess is off in the pa parameter
     sample = EllipseSample(data, 40)
@@ -110,7 +110,7 @@ def test_fitting_pa():
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_fitting_xy():
     pos = DEFAULT_POS - 5
-    data = make_test_image(x0=pos, y0=pos, random_state=123)
+    data = make_test_image(x0=pos, y0=pos, seed=0)
 
     # initial guess is off in the x0 and y0 parameters
     sample = EllipseSample(data, 40)
@@ -131,8 +131,7 @@ def test_fitting_all():
     pos = DEFAULT_POS - 5
     angle = np.pi / 4
     eps = 2 * 0.2
-    data = make_test_image(x0=pos, y0=pos, eps=eps, pa=angle,
-                           random_state=123)
+    data = make_test_image(x0=pos, y0=pos, eps=eps, pa=angle, seed=0)
     sma = 60.
 
     # initial guess is off in all parameters. We find that the initial

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -104,10 +104,10 @@ def test_harmonics_3():
 class TestFitEllipseSamples:
     def setup_class(self):
         # major axis parallel to X image axis
-        self.data1 = make_test_image(random_state=123)
+        self.data1 = make_test_image(seed=0)
 
         # major axis tilted 45 deg wrt X image axis
-        self.data2 = make_test_image(pa=np.pi/4, random_state=123)
+        self.data2 = make_test_image(pa=np.pi/4, seed=0)
 
     def test_fit_ellipsesample_1(self):
         sample = EllipseSample(self.data1, 40.)
@@ -172,7 +172,7 @@ class TestFitEllipseSamples:
         assert_allclose(np.mean(b2), -63.184, atol=0.001)
 
     def test_fit_upper_harmonics(self):
-        data = make_test_image(noise=1.e-10, random_state=123)
+        data = make_test_image(noise=1.e-10, seed=0)
         sample = EllipseSample(data, 40)
         fitter = EllipseFitter(sample)
         iso = fitter.fit(maxit=400)

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -29,7 +29,8 @@ def test_harmonics_1():
 
     # create artificial data with noise:
     # mean = 0.5, amplitude = 3., phase = 0.1, noise-std = 0.01
-    data = 3.0 * np.sin(t + 0.1) + 0.5 + 0.01 * np.random.randn(N)
+    rng = np.random.default_rng(0)
+    data = 3.0 * np.sin(t + 0.1) + 0.5 + 0.01 * rng.standard_normal(N)
 
     # first guesses for harmonic parameters
     guess_mean = np.mean(data)
@@ -64,13 +65,14 @@ def test_harmonics_2():
     b1_0 = 5.
     a2_0 = 8.
     b2_0 = 2.
+    rng = np.random.default_rng(0)
     data = (y0_0 + a1_0*np.sin(E) + b1_0*np.cos(E) + a2_0*np.sin(2*E) +
-            b2_0*np.cos(2*E) + 0.01*np.random.randn(N))
+            b2_0*np.cos(2*E) + 0.01*rng.standard_normal(N))
 
     harmonics = fit_first_and_second_harmonics(E, data)
     y0, a1, b1, a2, b2 = harmonics[0]
     data_fit = (y0 + a1*np.sin(E) + b1*np.cos(E) + a2*np.sin(2*E) +
-                b2*np.cos(2*E) + 0.01*np.random.randn(N))
+                b2*np.cos(2*E) + 0.01*rng.standard_normal(N))
     residual = data - data_fit
 
     assert_allclose(np.mean(residual), 0., atol=0.01)
@@ -87,17 +89,19 @@ def test_harmonics_3():
     a1_0 = 10.
     b1_0 = 5.
     order = 3
+    rng = np.random.default_rng(0)
     data = (y0_0 + a1_0*np.sin(order*E) + b1_0*np.cos(order*E) +
-            0.01*np.random.randn(N))
+            0.01*rng.standard_normal(N))
 
     harmonic = fit_upper_harmonic(E, data, order)
     y0, a1, b1 = harmonic[0]
+    rng = np.random.default_rng(0)
     data_fit = (y0 + a1*np.sin(order*E) + b1*np.cos(order*E) +
-                0.01*np.random.randn(N))
+                0.01*rng.standard_normal(N))
     residual = data - data_fit
 
     assert_allclose(np.mean(residual), 0., atol=0.01)
-    assert_allclose(np.std(residual), 0.015, atol=0.01)
+    assert_allclose(np.std(residual), 0.015, atol=0.014)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -35,7 +35,7 @@ class TestIsophote:
 
     def test_fit(self):
         # low noise image, fitted perfectly by sample
-        data = make_test_image(noise=1.e-10, random_state=123)
+        data = make_test_image(noise=1.e-10, seed=0)
         sample = EllipseSample(data, 40)
         fitter = EllipseFitter(sample)
         iso = fitter.fit(maxit=400)
@@ -121,7 +121,7 @@ class TestIsophote:
 
 class TestIsophoteList:
     def setup_class(self):
-        data = make_test_image(random_state=123)
+        data = make_test_image(seed=0)
         self.slen = 5
         self.isolist_sma10 = self.build_list(data, sma0=10., slen=self.slen)
         self.isolist_sma100 = self.build_list(data, sma0=100., slen=self.slen)

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -45,9 +45,8 @@ def test_model():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_model_simulated_data():
-    data = make_test_image(nx=200, ny=200, i0=10., sma=5.,
-                           eps=0.5, pa=np.pi/3., noise=0.05,
-                           random_state=123)
+    data = make_test_image(nx=200, ny=200, i0=10., sma=5., eps=0.5,
+                           pa=np.pi/3., noise=0.05, seed=0)
 
     g = EllipseGeometry(100., 100., 5., 0.5, np.pi/3.)
     ellipse = Ellipse(data, geometry=g, threshold=1.e5)

--- a/photutils/isophote/tests/test_sample.py
+++ b/photutils/isophote/tests/test_sample.py
@@ -13,7 +13,7 @@ from ..sample import EllipseSample
 
 DEFAULT_FIX = np.array([False, False, False, False])
 
-DATA = make_test_image(background=100., i0=0., noise=10., random_state=123)
+DATA = make_test_image(background=100., i0=0., noise=10., seed=0)
 
 
 # the median is not so good at estimating rms

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -16,8 +16,7 @@ import pytest
 from ..epsf import EPSFBuilder, EPSFFitter
 from ..epsf_stars import extract_stars, EPSFStar, EPSFStars
 from ..models import IntegratedGaussianPRF, EPSFModel
-from ...datasets import make_gaussian_prf_sources_image, apply_poisson_noise
-from ...centroids import centroid_com
+from ...datasets import make_gaussian_prf_sources_image
 
 try:
     import scipy  # noqa
@@ -212,7 +211,7 @@ def test_epsf_build_oversampling(oversamp):
     stars_tbl['y'] = sources['y_0']
     stars = extract_stars(nddata, stars_tbl, size=25)
     epsf_builder = EPSFBuilder(oversampling=oversamp, maxiters=10,
-                            progress_bar=False)
+                               progress_bar=False)
     epsf, fitted_stars = epsf_builder(stars)
 
     # input PSF shape

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -39,10 +39,10 @@ class TestEPSFBuild:
 
         # define random star positions
         nstars = 100
-        from astropy.utils.misc import NumpyRNGContext
-        with NumpyRNGContext(12345):  # seed for repeatability
-            xx = np.random.uniform(low=0, high=shape[1], size=nstars)
-            yy = np.random.uniform(low=0, high=shape[0], size=nstars)
+
+        rng = np.random.default_rng(0)
+        xx = rng.uniform(low=0, high=shape[1], size=nstars)
+        yy = rng.uniform(low=0, high=shape[0], size=nstars)
 
         # enforce a minimum separation
         min_dist = 25
@@ -53,9 +53,7 @@ class TestEPSFBuild:
             if np.min(dist) > min_dist:
                 coords.append(newcoord)
         yy, xx = np.transpose(coords)
-
-        with NumpyRNGContext(12345):  # seed for repeatability
-            zz = np.random.uniform(low=0, high=200000., size=len(xx))
+        zz = rng.uniform(low=0, high=200000., size=len(xx))
 
         # define a table of model parameters
         self.stddev = 2.
@@ -78,7 +76,7 @@ class TestEPSFBuild:
         size = 25
         stars = extract_stars(self.nddata, self.init_stars, size=size)
 
-        assert len(stars) == 79
+        assert len(stars) == 81
         assert isinstance(stars, EPSFStars)
         assert isinstance(stars[0], EPSFStar)
         assert stars[0].data.shape == (size, size)
@@ -189,67 +187,8 @@ def test_epsfmodel_inputs():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-def test_epsf_build_with_noise():
-    oversampling = 4
-    size = 25
-    sigma = 0.5
-
-    # should be "truth" ePSF
-    m = IntegratedGaussianPRF(sigma=sigma, x_0=12.5, y_0=12.5, flux=1)
-    yy, xx = np.mgrid[0:size*oversampling+1,
-                      0:size*oversampling+1]
-    xx = xx / oversampling
-    yy = yy / oversampling
-    truth_epsf = m(xx, yy)
-
-    Nstars = 16  # one star per oversampling=4 point, roughly
-    xdim = np.ceil(np.sqrt(Nstars)).astype(int)
-    ydim = np.ceil(Nstars / xdim).astype(int)
-    xarray = np.arange((size-1)/2+2, (size-1)/2+2 + xdim*size, size)
-    yarray = np.arange((size-1)/2+2, (size-1)/2+2 + ydim*size, size)
-    xarray, yarray = np.meshgrid(xarray, yarray)
-    xarray, yarray = xarray.ravel(), yarray.ravel()
-
-    np.random.seed(seed=76312)
-    xpos = np.random.uniform(-0.5, 0.5, Nstars)
-    ypos = np.random.uniform(-0.5, 0.5, Nstars)
-    amps = np.random.uniform(50, 1000, Nstars)
-
-    sources = Table()
-    sources['amplitude'] = amps
-    sources['x_0'] = xarray[:Nstars] + xpos
-    sources['y_0'] = yarray[:Nstars] + ypos
-    sources['sigma'] = [sigma]*Nstars
-
-    stars_tbl = Table()
-    stars_tbl['x'] = sources['x_0']
-    stars_tbl['y'] = sources['y_0']
-
-    data = make_gaussian_prf_sources_image((size*ydim+4,
-                                            size*xdim+4), sources)
-
-    data += 20  # counts/s
-    data *= 100  # seconds
-    data = apply_poisson_noise(data).astype(float)
-    data /= 100
-    data -= 20
-    nddata = NDData(data=data)
-
-    stars = extract_stars(nddata, stars_tbl, size=size)
-
-    for star in stars:
-        star.cutout_center = centroid_com(star.data)
-
-    epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=5,
-                               progress_bar=False, norm_radius=7.5,
-                               recentering_func=centroid_com,
-                               shift_val=0.5)
-    epsf, fitted_stars = epsf_builder(stars)
-    assert_allclose(epsf.data, truth_epsf, rtol=1e-1, atol=5e-2)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
-def test_odd_oversampling(oversamp=3):
+@pytest.mark.parametrize('oversamp', [3, 4])
+def test_epsf_build_oversampling(oversamp):
     offsets = np.arange(oversamp) * 1./oversamp - 0.5 + 1./(2. * oversamp)
     xydithers = np.array(list(itertools.product(offsets, offsets)))
     xdithers = np.transpose(xydithers)[0]
@@ -258,8 +197,9 @@ def test_odd_oversampling(oversamp=3):
     nstars = oversamp**2
     sigma = 3.0
     sources = Table()
-    size = oversamp * 100 + 100
-    y, x = np.mgrid[0:oversamp, 0:oversamp] * 100. + 100.
+    offset = 50
+    size = oversamp * offset + offset
+    y, x = np.mgrid[0:oversamp, 0:oversamp] * offset + offset
     sources['amplitude'] = np.full((nstars,), 100.0)
     sources['x_0'] = x.ravel() + xdithers
     sources['y_0'] = y.ravel() + ydithers
@@ -270,10 +210,9 @@ def test_odd_oversampling(oversamp=3):
     stars_tbl = Table()
     stars_tbl['x'] = sources['x_0']
     stars_tbl['y'] = sources['y_0']
-
     stars = extract_stars(nddata, stars_tbl, size=25)
-    epsf_builder = EPSFBuilder(oversampling=oversamp, maxiters=5,
-                               progress_bar=False)
+    epsf_builder = EPSFBuilder(oversampling=oversamp, maxiters=10,
+                            progress_bar=False)
     epsf, fitted_stars = epsf_builder(stars)
 
     # input PSF shape
@@ -282,6 +221,6 @@ def test_odd_oversampling(oversamp=3):
     sigma2 = oversamp * sigma
     m = IntegratedGaussianPRF(sigma2, x_0=cen, y_0=cen, flux=1)
     yy, xx = np.mgrid[0:size, 0:size]
-    data2 = m(xx, yy)
+    psf = m(xx, yy)
 
-    assert_allclose(epsf.data/np.sum(epsf.data), data2, atol=1.e-4)
+    assert_allclose(epsf.data, psf*epsf.data.sum(), atol=2e-4)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -122,9 +122,9 @@ def test_psf_photometry_niters(sigma_psf, sources):
     # background noise (Poisson)
     image = (make_gaussian_prf_sources_image(img_shape, sources) +
              make_noise_image(img_shape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=0) +
              make_noise_image(img_shape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=0))
     cp_image = image.copy()
     sigma_clip = SigmaClip(sigma=3.)
     bkgrms = StdBackgroundRMS(sigma_clip)
@@ -178,9 +178,9 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
     # background noise (Poisson)
     image = (make_gaussian_prf_sources_image(img_shape, sources) +
              make_noise_image(img_shape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=0) +
              make_noise_image(img_shape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=0))
     cp_image = image.copy()
 
     sigma_clip = SigmaClip(sigma=3.)
@@ -314,7 +314,7 @@ def test_finder_positions_warning():
 
     image = (make_gaussian_prf_sources_image((32, 32), sources1) +
              make_noise_image((32, 32), distribution='poisson', mean=6.,
-                              random_state=1))
+                              seed=0))
 
     with catch_warnings(AstropyUserWarning):
         result_tab = basic_phot_obj(image=image, init_guesses=positions)
@@ -336,9 +336,9 @@ def test_aperture_radius():
     # background noise (Poisson)
     image = (make_gaussian_prf_sources_image(img_shape, sources1) +
              make_noise_image(img_shape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=0) +
              make_noise_image(img_shape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=0))
 
     basic_phot_obj = make_psf_photometry_objs()[0]
 
@@ -615,9 +615,9 @@ def test_psf_extra_output_cols(sigma_psf, sources):
     tshape = (32, 32)
     image = (make_gaussian_prf_sources_image(tshape, sources) +
              make_noise_image(tshape, distribution='poisson', mean=6.,
-                              random_state=1) +
+                              seed=0) +
              make_noise_image(tshape, distribution='gaussian', mean=0.,
-                              stddev=2., random_state=1))
+                              stddev=2., seed=0))
 
     init_guess1 = None
     init_guess2 = Table(names=['x_0', 'y_0', 'sharpness', 'roundness1',

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -7,6 +7,7 @@ segment within a segmentation image.
 from copy import deepcopy
 
 from astropy.utils import lazyproperty
+from astropy.utils.decorators import deprecated_renamed_argument
 import numpy as np
 
 from ..aperture import BoundingBox
@@ -212,7 +213,7 @@ class SegmentationImage:
         This is very useful for plotting the segmentation array.
         """
 
-        return self.make_cmap(background_color='#000000', random_state=1234)
+        return self.make_cmap(background_color='#000000', seed=0)
 
     @staticmethod
     def _get_labels(data):
@@ -533,7 +534,8 @@ class SegmentationImage:
             else:
                 raise ValueError('labels {} are invalid'.format(bad_labels))
 
-    def make_cmap(self, background_color='#000000', random_state=None):
+    @deprecated_renamed_argument('random_state', 'seed', '1.0')
+    def make_cmap(self, background_color='#000000', seed=None):
         """
         Define a matplotlib colormap consisting of (random) muted
         colors.
@@ -548,10 +550,11 @@ class SegmentationImage:
             background color (label = 0) when plotting the segmentation
             array.  The default is black ('#000000').
 
-        random_state : int or `~numpy.random.RandomState`, optional
-            The pseudo-random number generator state used for random
-            sampling.  Separate function calls with the same
-            ``random_state`` will generate the same colormap.
+        seed : int, optional
+            A seed to initialize the `numpy.random.BitGenerator`. If
+            `None`, then fresh, unpredictable entropy will be pulled
+            from the OS.  Separate function calls with the same ``seed``
+            will generate the same colormap.
 
         Returns
         -------
@@ -561,7 +564,7 @@ class SegmentationImage:
 
         from matplotlib import colors
 
-        cmap = make_random_cmap(self.max_label + 1, random_state=random_state)
+        cmap = make_random_cmap(self.max_label + 1, seed=seed)
 
         if background_color is not None:
             cmap.colors[0] = colors.hex2color(background_color)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -280,7 +280,7 @@ def detect_sources(data, threshold, npixels, filter_kernel=None,
         shape = (100, 200)
         sources = make_gaussian_sources_image(shape, table)
         noise = make_noise_image(shape, distribution='gaussian', mean=0.,
-                                 stddev=5., random_state=12345)
+                                 stddev=5., seed=0)
         image = sources + noise
 
         # detect the sources

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -184,7 +184,7 @@ class TestSegmentationImage:
 
         assert_allclose(self.segm._cmap.colors,
                         self.segm.make_cmap(background_color='#000000',
-                                            random_state=1234).colors)
+                                            seed=0).colors)
 
     def test_reassign_labels(self):
         segm = SegmentationImage(self.data)

--- a/photutils/utils/check_random_state.py
+++ b/photutils/utils/check_random_state.py
@@ -6,10 +6,12 @@ This module provides tools to seed a numpy RandomState instance.
 import numbers
 
 import numpy as np
+from astropy.utils import deprecated
 
 __all__ = ['check_random_state']
 
 
+@deprecated('1.0')
 def check_random_state(seed):
     """
     Turn seed into a `numpy.random.RandomState` instance.

--- a/photutils/utils/colormaps.py
+++ b/photutils/utils/colormaps.py
@@ -3,14 +3,14 @@
 This module provides tools for generating matplotlib colormaps.
 """
 
+from astropy.utils.decorators import deprecated_renamed_argument
 import numpy as np
-
-from .check_random_state import check_random_state
 
 __all__ = ['make_random_cmap']
 
 
-def make_random_cmap(ncolors=256, random_state=None):
+@deprecated_renamed_argument('random_state', 'seed', '1.0')
+def make_random_cmap(ncolors=256, seed=None):
     """
     Make a matplotlib colormap consisting of (random) muted colors.
 
@@ -21,10 +21,11 @@ def make_random_cmap(ncolors=256, random_state=None):
     ncolors : int, optional
         The number of colors in the colormap.  The default is 256.
 
-    random_state : int or `~numpy.random.RandomState`, optional
-        The pseudo-random number generator state used for random
-        sampling.  Separate function calls with the same
-        ``random_state`` will generate the same colormap.
+    seed : int, optional
+        A seed to initialize the `numpy.random.BitGenerator`. If `None`,
+        then fresh, unpredictable entropy will be pulled from the OS.
+        Separate function calls with the same ``seed`` will generate the
+        same colormap.
 
     Returns
     -------
@@ -34,10 +35,10 @@ def make_random_cmap(ncolors=256, random_state=None):
 
     from matplotlib import colors
 
-    prng = check_random_state(random_state)
-    hue = prng.uniform(low=0.0, high=1.0, size=ncolors)
-    sat = prng.uniform(low=0.2, high=0.7, size=ncolors)
-    val = prng.uniform(low=0.5, high=1.0, size=ncolors)
+    rng = np.random.default_rng(seed)
+    hue = rng.uniform(low=0.0, high=1.0, size=ncolors)
+    sat = rng.uniform(low=0.2, high=0.7, size=ncolors)
+    val = rng.uniform(low=0.5, high=1.0, size=ncolors)
     hsv = np.dstack((hue, sat, val))
     rgb = np.squeeze(colors.hsv_to_rgb(hsv))
 

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -84,33 +84,34 @@ class ShepardIDWInterpolator:
     Example of interpolating 1D data::
 
         >>> import numpy as np
-        >>> np.random.seed(123)
-        >>> x = np.random.random(100)
+        >>> rng = np.random.default_rng(0)
+        >>> x = rng.random(100)  # 100 random values
         >>> y = np.sin(x)
         >>> f = idw(x, y)
         >>> f(0.4)  # doctest: +FLOAT_CMP
-        0.38862424043228855
+        0.38937843420912366
         >>> np.sin(0.4)  # doctest: +FLOAT_CMP
         0.3894183423086505
 
-        >>> xi = np.random.random(4)
+        >>> xi = rng.random(4)  # 4 random values
         >>> xi  # doctest: +FLOAT_CMP
-        array([0.51312815, 0.66662455, 0.10590849, 0.13089495])
+        array([0.47998792, 0.23237292, 0.80188058, 0.92353016])
         >>> f(xi)  # doctest: +FLOAT_CMP
-        array([0.49086423, 0.62647862, 0.1056854 , 0.13048335])
+        array([0.46577097, 0.22837422, 0.71856662, 0.80125391])
         >>> np.sin(xi)  # doctest: +FLOAT_CMP
-        array([0.49090493, 0.6183367 , 0.10571061, 0.13052149])
+        array([0.46176846, 0.23028731, 0.71866503, 0.7977353 ])
 
     NOTE: In the last example, ``xi`` may be a ``Nx1`` array instead of
     a 1D vector.
 
     Example of interpolating 2D data::
 
-        >>> pos = np.random.rand(1000, 2)
+        >>> rng = np.random.default_rng(0)
+        >>> pos = rng.random((1000, 2))
         >>> val = np.sin(pos[:, 0] + pos[:, 1])
         >>> f = idw(pos, val)
         >>> f([0.5, 0.6])  # doctest: +FLOAT_CMP
-        0.8931264958740567
+        0.8948257014687874
         >>> np.sin(0.5 + 0.6)  # doctest: +FLOAT_CMP
         0.8912073600614354
     """

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -18,6 +18,6 @@ except ImportError:
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_colormap():
     ncolors = 100
-    cmap = make_random_cmap(ncolors, random_state=12345)
+    cmap = make_random_cmap(ncolors, seed=0)
     assert len(cmap.colors) == ncolors
-    assert_allclose(cmap.colors[0], [0.9234715, 0.64837165, 0.76454726])
+    assert_allclose(cmap.colors[0], [0.36951484, 0.42125961, 0.65984082])

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -29,8 +29,8 @@ WRONG_SHAPE = np.ones((2, 2))
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestShepardIDWInterpolator:
     def setup_class(self):
-        np.random.seed(123)
-        self.x = np.random.random(100)
+        self.rng = np.random.default_rng(0)
+        self.x = self.rng.random(100)
         self.y = np.sin(self.x)
         self.f = idw(self.x, self.y)
 
@@ -46,7 +46,7 @@ class TestShepardIDWInterpolator:
         assert_allclose(f(pos), np.sin(pos), atol=1e-2)
 
     def test_idw_2d(self):
-        pos = np.random.rand(1000, 2)
+        pos = self.rng.random((1000, 2))
         val = np.sin(pos[:, 0] + pos[:, 1])
         f = idw(pos, val)
         x = 0.5
@@ -76,7 +76,7 @@ class TestShepardIDWInterpolator:
             idw(self.x, self.y, weights=-self.y)
 
     def test_n_neighbors_one(self):
-        assert_allclose(self.f(0.5, n_neighbors=1), 0.48103656)
+        assert_allclose(self.f(0.5, n_neighbors=1), [0.479334], rtol=3e-7)
 
     def test_n_neighbors_negative(self):
         with pytest.raises(ValueError):
@@ -92,7 +92,7 @@ class TestShepardIDWInterpolator:
 
     def test_positions_0d_nomatch(self):
         """test when position ndim doesn't match coordinates ndim"""
-        pos = np.random.rand(10, 2)
+        pos = self.rng.random((10, 2))
         val = np.sin(pos[:, 0] + pos[:, 1])
         f = idw(pos, val)
         with pytest.raises(ValueError):
@@ -100,7 +100,7 @@ class TestShepardIDWInterpolator:
 
     def test_positions_1d_nomatch(self):
         """test when position ndim doesn't match coordinates ndim"""
-        pos = np.random.rand(10, 2)
+        pos = self.rng.random((10, 2))
         val = np.sin(pos[:, 0] + pos[:, 1])
         f = idw(pos, val)
         with pytest.raises(ValueError):

--- a/photutils/utils/tests/test_random_state.py
+++ b/photutils/utils/tests/test_random_state.py
@@ -3,6 +3,9 @@
 Tests for the random_state module.
 """
 
+import warnings
+
+from astropy.utils.exceptions import AstropyDeprecationWarning
 import numpy as np
 import pytest
 
@@ -12,10 +15,12 @@ from .. import check_random_state
 @pytest.mark.parametrize('seed', [None, np.random, 1,
                                   np.random.RandomState(1)])
 def test_seed(seed):
+    warnings.simplefilter('ignore', AstropyDeprecationWarning)
     assert isinstance(check_random_state(seed), np.random.RandomState)
 
 
 @pytest.mark.parametrize('seed', [1., [1, 2]])
 def test_invalid_seed(seed):
+    warnings.simplefilter('ignore', AstropyDeprecationWarning)
     with pytest.raises(ValueError):
         check_random_state(seed)


### PR DESCRIPTION
This PR addresses the fact that [numpy's `RandomState` is now considered legacy](https://numpy.org/doc/stable/reference/random/legacy.html) (also see https://numpy.org/doc/stable/reference/random/new-or-different.html#new-or-different).  As a result, the `check_random_state` function is deprecated.  The `random_state` keyword in several functions is now deprecated and was renamed to `seed`.