### PR TITLE
Bump minimum astropy to 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,12 +107,11 @@ matrix:
         # the Numpy developers have taken care of testing Numpy with different
         # versions of Python, we can vary Python and Numpy versions at the same
         # time.
-
         - os: linux
           python: 3.7
-          name: Python 3.7 with astropy 3.2 and Numpy 1.17
+          name: Python 3.7 with astropy 4.0 and Numpy 1.17
           stage: Comprehensive tests
-          env: TOXENV=py37-test-astropy32-numpy117
+          env: TOXENV=py37-test-astropy40-numpy117
 
         # Do a code style check
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ General
 
 - The minimum required python version is 3.6. [#952]
 
-- The minimum required astropy version is 3.2. [#952]
+- The minimum required astropy version is 4.0. [#1081]
 
 - The minimum required numpy version is 1.17. [#1079]
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,7 +11,7 @@ Photutils has the following strict requirements:
 
 * `Numpy <https://numpy.org/>`_ 1.17 or later
 
-* `Astropy`_ 3.2 or later
+* `Astropy`_ 4.0 or later
 
 Photutils also optionally depends on other packages for some features:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.17
-    astropy>=3.2
+    astropy>=4.0
 
 [options.extras_require]
 all =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
     py{36,37,38}-test-numpy{117,118,119}
-    py{36,37,38}-test-astropy{32,40,lts}
+    py{36,37,38}-test-astropy{40,lts}
     build_docs
     linkcheck
     codestyle
@@ -39,7 +39,6 @@ description =
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
     numpy119: with numpy 1.19.*
-    astropy32: with astropy 3.2.*
     astropy40: with astropy 4.0.*
     astropylts: with the latest astropy LTS
 
@@ -49,7 +48,6 @@ deps =
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
 
-    astropy32: astropy==3.2.*
     astropy40: astropy==4.0.*
     astropylts: astropy==4.0.*
 


### PR DESCRIPTION
`gwcs 0.12` (an optional `photutils` dependency) requires `astropy >= 4.0`.

`specutils` also requires `astropy >= 4.0`.