### PR TITLE
correcting upper harmonics (and related errors)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ Bug Fixes
 
 - ``photutils.isophote``
 
+  - Corrected calculations of upper harmonics and their errors [#1089]
+
   - Fixed bug that caused an infinite loop when the sample extracted
     from an image has zero length. [#1129]
 

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -227,13 +227,6 @@ class Isophote:
         subtract the first and second harmonics from the raw data.
         """
         try:
-            # first and second harmonics
-            coeffs, _ = fit_first_and_second_harmonics(self.sample.values[0],
-                                                       self.sample.values[2])
-            model = first_and_second_harmonic_function(self.sample.values[0],
-                                                       coeffs)
-            residual = self.sample.values[2] - model
-
             # upper (third and fourth) harmonics
             up_coeffs, up_inv_hessian = fit_upper_harmonic(sample.values[0],
                                                            sample.values[2],

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -198,7 +198,7 @@ class Isophote:
         jmax = min(ysize, int(y0 + sma + 0.5) + 1)
 
         # Integrate
-        if (jmax-jmin > 1) and (imax-imin) > 1:
+        if (jmax - jmin > 1) and (imax - imin) > 1:
             y, x = np.mgrid[jmin:jmax, imin:imax]
             radius, angle = self.sample.geometry.to_polar(x, y)
             radius_e = self.sample.geometry.radius(angle)
@@ -228,33 +228,27 @@ class Isophote:
         """
         try:
             # first and second harmonics
-            coeffs, _ = fit_first_and_second_harmonics(
-                            self.sample.values[0],
-                            self.sample.values[2]
-                        )
-            model = first_and_second_harmonic_function(
-                        self.sample.values[0],
-                        coeffs
-                    )
+            coeffs, _ = fit_first_and_second_harmonics(self.sample.values[0],
+                                                       self.sample.values[2])
+            model = first_and_second_harmonic_function(self.sample.values[0],
+                                                       coeffs)
             residual = self.sample.values[2] - model
 
             # upper (third and fourth) harmonics
-            up_coeffs, up_inv_hessian = fit_upper_harmonic(
-                sample.values[0],
-                sample.values[2],
-                n
-            )
+            up_coeffs, up_inv_hessian = fit_upper_harmonic(sample.values[0],
+                                                           sample.values[2],
+                                                           n)
 
             a = up_coeffs[1] / self.sma / sample.gradient
             b = up_coeffs[2] / self.sma / sample.gradient
 
             def errfunc(x, phi, order, intensities):
-                return (x[0] + x[1]*np.sin(order*phi) +
-                        x[2]*np.cos(order*phi) - intensities)
+                return (x[0] + x[1] * np.sin(order * phi) +
+                        x[2] * np.cos(order * phi) - intensities)
 
             up_var_residual = np.std(errfunc(up_coeffs, self.sample.values[0],
-                                            n, self.sample.values[2]),
-                                            ddof=len(up_coeffs))**2
+                                             n, self.sample.values[2]),
+                                     ddof=len(up_coeffs))**2
             up_covariance = up_inv_hessian * up_var_residual
 
             ce = np.sqrt(np.diag(up_covariance))
@@ -281,13 +275,11 @@ class Isophote:
 
         try:
             coeffs, covariance = fit_first_and_second_harmonics(
-                self.sample.values[0],
-                self.sample.values[2]
-            )
+                self.sample.values[0], self.sample.values[2])
             model = first_and_second_harmonic_function(self.sample.values[0],
                                                        coeffs)
             var_residual = np.std(self.sample.values[2] - model,
-                                    ddof=len(coeffs))**2
+                                  ddof=len(coeffs)) ** 2
             errors = np.sqrt(np.diagonal(covariance * var_residual))
 
             eps = self.sample.geometry.eps

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -235,8 +235,14 @@ class Isophote:
                                                        coeffs)
             residual = self.sample.values[2] - model
 
-            c = fit_upper_harmonic(sample.values[0], residual, n)
-            covariance = c[1]
+            c = fit_upper_harmonic(sample.values[0], sample.values[2], n)
+
+            # compute covariance matrix (leastsq gives inv. of Hessian)
+            if (len(sample.values[2] > len(c[0]))) and c[1] is not None:
+                covariance = - c[1] * residual
+            else:
+                covariance = np.inf
+
             ce = np.diagonal(covariance)
             c = c[0]
 

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -181,12 +181,12 @@ class TestFitEllipseSamples:
         fitter = EllipseFitter(sample)
         iso = fitter.fit(maxit=400)
 
-        assert_allclose(iso.a3, -6.87e-7, atol=1.e-9)
+        assert_allclose(iso.a3, -6.825e-7, atol=1.e-9)
         assert_allclose(iso.b3, 1.68e-6, atol=1.e-8)
         assert_allclose(iso.a4, -4.36e-6, atol=1.e-8)
         assert_allclose(iso.b4, 4.73e-5, atol=1.e-7)
 
-        assert_allclose(iso.a3_err, 5.28e-5, atol=1.e-7)
-        assert_allclose(iso.b3_err, 5.24e-5, atol=1.e-7)
-        assert_allclose(iso.a4_err, 5.28e-5, atol=1.e-7)
-        assert_allclose(iso.b4_err, 5.24e-5, atol=1.e-7)
+        assert_allclose(iso.a3_err, 8.152e-6, atol=1.e-7)
+        assert_allclose(iso.b3_err, 8.115e-6, atol=1.e-7)
+        assert_allclose(iso.a4_err, 7.501e-6, atol=1.e-7)
+        assert_allclose(iso.b4_err, 7.473e-6, atol=1.e-7)


### PR DESCRIPTION
The upper harmonics and related errors are corrected. (`scipy.optimize.leastsq()` returns the inverse of Hessian matrix) 
Was previously discussed in #1004 and #1008.