### PR TITLE
Changed "info" log to warning to allow for infinte loop catching.

### DIFF
--- a/photutils/isophote/fitter.py
+++ b/photutils/isophote/fitter.py
@@ -160,7 +160,7 @@ class EllipseFitter:
                 coeffs = fit_first_and_second_harmonics(values[0], values[2])
                 coeffs = coeffs[0]
             except Exception as e:
-                log.info(e)
+                log.warning(e)
                 sample.geometry.fix = fixed_parameters
                 return Isophote(sample, i + 1, False, 3)
 


### PR DESCRIPTION
In the below issue thread, I mentioned an infinite loop that can rarely occur when using photutils for elliptical isophote analysis.
https://github.com/astropy/photutils/issues/707

Changing the log message from info to a warning allows users to catch it using ```warnings.filterwarnings("error")```. 