### PR TITLE
add friendly messages about missing Cython or extension_helpers python packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,17 +76,14 @@ except Exception:
 import os  # noqa
 from setuptools import setup  # noqa
 
-try:
-    import Cython
-except ImportError:
-    print('To build photutils, you need the Cython package.  Try "pip install Cython" or similar.')
-    sys.exit(-1)
-
-try:
-    import extension_helpers
-except ImportError:
-    print('To build photutils, you need the extension_helpers package.  Try "pip install extension_helpers" or similar.')
-    sys.exit(-1)
+import importlib
+for dep in ['Cython', 'extension_helpers']:
+    try:
+        importlib.import_module(dep)
+    except ImportError:
+        print('To build photutils, you need the "%s" package.' % dep)
+        print('Try "pip install %s" to install it.' % dep)
+        sys.exit(-1)
 
 from extension_helpers import get_extensions  # noqa
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,19 @@ except Exception:
 # extensions_helpers is not installed
 import os  # noqa
 from setuptools import setup  # noqa
+
+try:
+    import Cython
+except ImportError:
+    print('To build photutils, you need the Cython package.  Try "pip install Cython" or similar.')
+    sys.exit(-1)
+
+try:
+    import extension_helpers
+except ImportError:
+    print('To build photutils, you need the extension_helpers package.  Try "pip install extension_helpers" or similar.')
+    sys.exit(-1)
+
 from extension_helpers import get_extensions  # noqa
 
 setup(use_scm_version={'write_to': os.path.join('photutils', 'version.py'),


### PR DESCRIPTION
just try to import them in setup.py immediately before use, and print a helpful error message.
