### PR TITLE
Update dev install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -115,6 +115,11 @@ Then to build and install Photutils, run::
     cd photutils
     pip install .[all]
 
+If you wish to install the package in "editable" mode, instead include
+the "-e" option::
+
+    pip install -e .[all]
+
 
 Building and installing using pip
 ---------------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -113,7 +113,7 @@ version of the Photutils source code can be retrieved using git::
 Then to build and install Photutils, run::
 
     cd photutils
-    python setup.py install
+    pip install .[all]
 
 
 Building and installing using pip


### PR DESCRIPTION
All installs should be done using `pip install`, not `python setup.py install`.