### PR TITLE
Add bandit to tox and add as a CI job

### DIFF
--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -1,0 +1,3 @@
+exclude_dirs:
+  - photutils/*test*
+  - photutils/**/*test*

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,13 @@ matrix:
           stage: Initial tests
           env: TOXENV=codestyle
 
+        # Do a code style check
+        - os: linux
+          python: 3.8
+          name: Security check
+          stage: Comprehensive tests
+          env: TOXENV=bandit
+
     allow_failures:
         # Do a PEP8 test with flake8
         # (do allow to fail unless your code completely compliant)

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     build_docs
     linkcheck
     codestyle
+    bandit
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -98,3 +99,10 @@ changedir = .
 description = check code style, e.g., with flake8
 deps = flake8
 commands = flake8 photutils --count --max-line-length=100
+
+[testenv:bandit]
+skip_install = true
+changedir = .
+description = security check with bandit
+deps = bandit
+commands = bandit -r photutils -c .bandit.yaml


### PR DESCRIPTION
This PR adds the python security analysis tool `bandit` (https://bandit.readthedocs.io/en/latest/) as a `tox` test environment.  It also adds `bandit` to the `travis` CI test matrix. 