### PR TITLE
modify _data_coords calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,15 @@ New Features
 1.0.2 (unreleased)
 ------------------
 
+New Features
+^^^^^^^^^^^^
+
+- ``photutils.background``
+
+  - Improved the performance of ``Background2D`` (e.g., by a factor
+    of ~4 with 2048x2048 input arrays when using the default interpolator).
+    [#1103]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -746,7 +746,7 @@ class Background2D:
 
         # the position coordinates used when calling an interpolator
         ny, nx = self.data.shape
-        self.data_coords = np.array(list(product(range(ny), range(nx))))
+        self.data_coords = np.indices((nx, ny)).T.reshape(nx*ny, 2)[:, [1, 0]]
 
     @lazyproperty
     def mesh_nmasked(self):


### PR DESCRIPTION
Using numpy.indices is a factor of 25 faster than the itertools.product method. This is a dramatic improvement for the Background2D execution time when analyzing large (2048x2048) images.