### PR TITLE
Fix bug in Background2D when using BkgIDWInterpolator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,18 @@ New Features
     ``matplotlib.patches.Patch`` objects. [#923]
 
 
+1.0.2 (unreleased)
+------------------
+
+Bug Fixes
+^^^^^^^^^
+
+- ``photutils.background``
+
+  - Fixed a bug with ``Background2D`` where using ``BkgIDWInterpolator``
+    would give incorrect results. [#1104]
+
+
 1.0.1 (2020-09-24)
 ------------------
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -745,7 +745,7 @@ class Background2D:
         self.yx = np.column_stack([self.y, self.x])
 
         # the position coordinates used when calling an interpolator
-        nx, ny = self.data.shape
+        ny, nx = self.data.shape
         self.data_coords = np.array(list(product(range(ny), range(nx))))
 
     @lazyproperty

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -52,6 +52,22 @@ class TestBackground2D:
         assert b.background_rms_median == 0.0
 
     @pytest.mark.parametrize('interpolator', INTERPOLATORS)
+    def test_background_rect(self, interpolator):
+        """
+        Regression test for interpolators with non-square input data.
+        """
+        data = np.arange(12).reshape(3, 4)
+        rms = np.zeros((3, 4))
+        b = Background2D(data, (1, 1), filter_size=1,
+                         interpolator=interpolator)
+        assert_allclose(b.background, data, atol=1.e-7)
+        assert_allclose(b.background_rms, rms)
+        assert_allclose(b.background_mesh, data)
+        assert_allclose(b.background_rms_mesh, rms)
+        assert b.background_median == 5.5
+        assert b.background_rms_median == 0.0
+
+    @pytest.mark.parametrize('interpolator', INTERPOLATORS)
     def test_background_nonconstant(self, interpolator):
         data = np.copy(DATA)
         data[25:50, 50:75] = 10.


### PR DESCRIPTION
This PR fixes a bug I discovered (while reviewing #1103) where `Background2D` with `BkgIDWInterpolator` would give incorrect results for the full-sized interpolated background image.