### PR TITLE
Refactor Background2D to improve performance with default interpolator

### DIFF
--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -508,7 +508,10 @@ class Background2D:
 
         if (xextra + yextra) == 0:
             # no resizing of the data is necessary
-            data_ma = np.ma.masked_array(self.data, mask=self.mask)
+            mask = self.mask
+            if mask is None:
+                mask = False
+            data_ma = np.ma.masked_array(self.data, mask=mask)
         else:
             # pad or crop the data
             if self.edge_method == 'pad':


### PR DESCRIPTION
This PR removes the private `_calc_coordinates` method.  The mesh x/y positions are now calculated as (private) cached lazy properties and the `data_coords` calculation was moved to the `BkgIDWInterpolator`, the only place where it is needed.

This PR also fixes an issue where if the input `mask=None` and the image size in each dimension is an integer multiple of the corresponding `box_size` dimension,  a masked array was created with `mask=None`.  Many thanks to @jdermigny for reporting that in #1105 

Fixes #1105.