### PR TITLE
Add new feature to_table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ New Features
 - ``photutils.isophote``
 
   - Added the ability to specify the output columns in the
-  ``IsophoteList`` ``to_table`` method. [#1117]
+    ``IsophoteList`` ``to_table`` method. [#1117]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ New Features
   - The ``Background2D`` class now accepts astropy ``NDData``,
     ``CCDData``, and ``Quantity`` objects as data inputs. [#1140]
 
+- ``photutils.isophote``
+
+  - Added the ability to specify the output columns in the
+  ``IsophoteList`` ``to_table`` method. [#1117]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -716,7 +716,7 @@ class IsophoteList:
         """
         return self._collect_as_array('b4_err')
 
-    def to_table(self):
+    def to_table(self, key_properties=['main']):
         """
         Convert an `~photutils.isophote.IsophoteList` instance to a
         `~astropy.table.QTable` with the main isophote parameters.
@@ -726,10 +726,41 @@ class IsophoteList:
         result : `~astropy.table.QTable`
             An astropy QTable with the main isophote parameters.
         """
-        return _isophote_list_to_table(self)
+        return _isophote_list_to_table(self, key_properties)
+
+    def get_names(self):
+        '''Print the names of the properties of an \
+                `~photutils.isophote.IsophoteList` instance.
+        '''
+        list_names = list(_get_properties(self).keys())
+        return list_names
 
 
-def _isophote_list_to_table(isophote_list):
+def _get_properties(isophote_list):
+    """
+    Return the properties of an \
+            `~photutils.isophote.IsophoteList` instance.
+
+    Parameters
+    ----------
+    isophote_list : `~photutils.isophote.IsophoteList` instance
+        A list of isophotes.
+
+    Returns
+    -------
+    result : `OrderedDict`
+        An OrderedDict with the list of the isophote_list properties
+    """
+    properties = OrderedDict()
+    for an_item in isophote_list.__class__.__dict__:
+        p_type = isophote_list.__class__.__dict__[an_item]
+        '''Exclude the sample property'''
+        if type(p_type) == property and 'sample' not in an_item:
+            properties[str(an_item)] = str(an_item)
+    return properties
+
+
+def _isophote_list_to_table(isophote_list, key_properties=['main']):
     """
     Convert an `~photutils.isophote.IsophoteList` instance to
     a `~astropy.table.QTable`.
@@ -740,33 +771,70 @@ def _isophote_list_to_table(isophote_list):
             `~photutils.isophote.IsophoteList` instance
         A list of isophotes.
 
+    key_properties : A list of properties to export from the isophote_list
+        If key_properties = ['all'] or ['main'], it will pick all or few
+        selected main properties
+
     Returns
     -------
     result : `~astropy.table.QTable`
-        An astropy QTable with the main isophote parameters.
+        An astropy QTable with the selected or all isophote parameters.
     """
 
-    properties = {}
-    properties['sma'] = 'sma'
-    properties['intens'] = 'intens'
-    properties['int_err'] = 'intens_err'
-    properties['eps'] = 'ellipticity'
-    properties['ellip_err'] = 'ellipticity_err'
-    properties['pa'] = 'pa'
-    properties['pa_err'] = 'pa_err'
-    properties['grad'] = 'grad'
-    properties['grad_error'] = 'grad_err'
-    properties['grad_r_error'] = 'grad_rerr'
-    properties['x0'] = 'x0'
-    properties['x0_err'] = 'x0_err'
-    properties['y0'] = 'y0'
-    properties['y0_err'] = 'y0_err'
-    properties['ndata'] = 'ndata'
-    properties['nflag'] = 'flag'
-    properties['niter'] = 'niter'
-    properties['stop_code'] = 'stop_code'
-
+    properties = OrderedDict()
     isotable = QTable()
+
+    # main_properties: `List`
+    # A list of main parameters matching the original names of
+    # the isophote_list parameters
+
+    def __rename_properties(properties,
+                            orig_names = ['int_err', 'eps', 'ellip_err',
+                                          'grad_r_error', 'nflag'],
+                            new_names = ['intens_err', 'ellipticity',
+                                         'ellipticity_err', 'grad_rerror',
+                                         'nflag']
+                            ):
+        '''
+        Simple renaming for some of the isophote_list parameters.
+
+        Parameters
+        ----------
+        properties: `OrderedDict`
+            An OrderedDict with the list of the isophote_list parameters
+        orig_names: `List`
+            A list of original names in the isophote_list parameters
+            to be renamed
+        new_names: `List`
+            A list of new names matching in length of the orig_names
+
+        Returns
+        -------
+        properties: `OrderedDict`
+            An OrderedDict with the list of the renamed isophote_list
+            parameters
+        '''
+        main_properties = ['sma', 'intens', 'int_err', 'eps', 'ellip_err',
+                           'pa', 'pa_err', 'grad', 'grad_error',
+                           'grad_r_error', 'x0', 'x0_err', 'y0', 'y0_err',
+                           'ndata', 'nflag', 'niter', 'stop_code']
+
+        for an_item in main_properties:
+            if an_item in orig_names:
+                properties[an_item] = new_names[orig_names.index(an_item)]
+            else:
+                properties[an_item] = an_item
+        return properties
+
+    if 'all' in key_properties:
+        properties = _get_properties(isophote_list)
+        properties = __rename_properties(properties)
+
+    elif 'main' in key_properties:
+        properties = __rename_properties(properties)
+    else:
+        for an_item in key_properties:
+            properties[an_item] = an_item
 
     for k, v in properties.items():
         isotable[v] = np.array([getattr(iso, k) for iso in isophote_list])

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -781,7 +781,7 @@ def _isophote_list_to_table(isophote_list, columns='main'):
         An astropy QTable with the selected or all isophote parameters.
     """
 
-    properties = OrderedDict()
+    properties = dict()
     isotable = QTable()
 
     # main_properties: `List`
@@ -789,12 +789,11 @@ def _isophote_list_to_table(isophote_list, columns='main'):
     # the isophote_list parameters
 
     def __rename_properties(properties,
-                            orig_names = ['int_err', 'eps', 'ellip_err',
-                                          'grad_r_error', 'nflag'],
-                            new_names = ['intens_err', 'ellipticity',
-                                         'ellipticity_err', 'grad_rerror',
-                                         'nflag']
-                            ):
+                            orig_names=['int_err', 'eps', 'ellip_err',
+                                        'grad_r_error', 'nflag'],
+                            new_names=['intens_err', 'ellipticity',
+                                       'ellipticity_err', 'grad_rerror',
+                                       'nflag']):
         '''
         Simple renaming for some of the isophote_list parameters.
 

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -716,7 +716,7 @@ class IsophoteList:
         """
         return self._collect_as_array('b4_err')
 
-    def to_table(self, key_properties=['main']):
+    def to_table(self, columns='main'):
         """
         Convert an `~photutils.isophote.IsophoteList` instance to a
         `~astropy.table.QTable` with the main isophote parameters.
@@ -726,7 +726,7 @@ class IsophoteList:
         result : `~astropy.table.QTable`
             An astropy QTable with the main isophote parameters.
         """
-        return _isophote_list_to_table(self, key_properties)
+        return _isophote_list_to_table(self, columns)
 
     def get_names(self):
         '''Print the names of the properties of an \
@@ -751,7 +751,7 @@ def _get_properties(isophote_list):
     result : `OrderedDict`
         An OrderedDict with the list of the isophote_list properties
     """
-    properties = OrderedDict()
+    properties = dict()
     for an_item in isophote_list.__class__.__dict__:
         p_type = isophote_list.__class__.__dict__[an_item]
         '''Exclude the sample property'''
@@ -760,7 +760,7 @@ def _get_properties(isophote_list):
     return properties
 
 
-def _isophote_list_to_table(isophote_list, key_properties=['main']):
+def _isophote_list_to_table(isophote_list, columns='main'):
     """
     Convert an `~photutils.isophote.IsophoteList` instance to
     a `~astropy.table.QTable`.
@@ -772,8 +772,8 @@ def _isophote_list_to_table(isophote_list, key_properties=['main']):
         A list of isophotes.
 
     key_properties : A list of properties to export from the isophote_list
-        If key_properties = ['all'] or ['main'], it will pick all or few
-        selected main properties
+        If ``columns`` is 'all' or 'main', it will pick all or few
+        of the main properties.
 
     Returns
     -------
@@ -800,18 +800,18 @@ def _isophote_list_to_table(isophote_list, key_properties=['main']):
 
         Parameters
         ----------
-        properties: `OrderedDict`
-            An OrderedDict with the list of the isophote_list parameters
-        orig_names: `List`
+        properties: `dict`
+            A dictionary with the list of the isophote_list parameters
+        orig_names: list
             A list of original names in the isophote_list parameters
             to be renamed
-        new_names: `List`
+        new_names: list
             A list of new names matching in length of the orig_names
 
         Returns
         -------
-        properties: `OrderedDict`
-            An OrderedDict with the list of the renamed isophote_list
+        properties: `dict`
+            A dictionary with the list of the renamed isophote_list
             parameters
         '''
         main_properties = ['sma', 'intens', 'int_err', 'eps', 'ellip_err',
@@ -826,14 +826,14 @@ def _isophote_list_to_table(isophote_list, key_properties=['main']):
                 properties[an_item] = an_item
         return properties
 
-    if 'all' in key_properties:
+    if columns == 'all':
         properties = _get_properties(isophote_list)
         properties = __rename_properties(properties)
 
-    elif 'main' in key_properties:
+    elif columns == 'main':
         properties = __rename_properties(properties)
     else:
-        for an_item in key_properties:
+        for an_item in columns:
             properties[an_item] = an_item
 
     for k, v in properties.items():

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -9,7 +9,9 @@ from numpy.testing import assert_allclose
 import pytest
 
 from .make_test_data import make_test_image
+from ..ellipse import Ellipse
 from ..fitter import EllipseFitter
+from ..geometry import EllipseGeometry
 from ..isophote import Isophote, IsophoteList
 from ..sample import EllipseSample
 from ...datasets import get_path
@@ -246,8 +248,8 @@ class TestIsophoteList:
         result.sort()
         assert result[-1].sma > result[0].sma
 
+    @pytest.mark.skipif('not HAS_SCIPY')
     def test_to_table(self):
-        from photutils.isophote import EllipseGeometry, Ellipse
         test_img = make_test_image(nx=55, ny=55, x0=27, y0=27,
                                    background=100., noise=1.e-6, i0=100.,
                                    sma=10., eps=0.2, pa=0., seed=1)

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -245,3 +245,30 @@ class TestIsophoteList:
         assert result[-1].sma < result[0].sma
         result.sort()
         assert result[-1].sma > result[0].sma
+
+    def test_to_table(self):
+        from photutils.isophote import EllipseGeometry, Ellipse
+        test_img = make_test_image(nx=55, ny=55, x0=27, y0=27,
+                                   background=100., noise=1.e-6, i0=100., sma=10.,
+                                   eps=0.2, pa=0., seed=1)
+        g = EllipseGeometry(27,27,5,0.2,0)
+        ellipse = Ellipse(test_img, geometry=g,threshold=0.1)
+        isolist = ellipse.fit_image(maxsma=27)
+        
+        assert len(isolist.get_names()) >= 30
+
+        tbl = isolist.to_table()
+        assert len(tbl.colnames) == 18
+
+        tbl = isolist.to_table(key_properties=['all'])
+        assert len(tbl.colnames) >= 30
+
+        tbl = isolist.to_table(key_properties=['main'])
+        assert len(tbl.colnames) == 18
+
+        tbl = isolist.to_table(key_properties=['sma'])
+        assert len(tbl.colnames) == 1
+
+        tbl = isolist.to_table(key_properties=['tflux_e', 'tflux_c', 'npix_e', 'npix_c'])
+        assert len(tbl.colnames) == 4
+        

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -269,6 +269,6 @@ class TestIsophoteList:
         tbl = isolist.to_table(columns=['sma'])
         assert len(tbl.colnames) == 1
 
-        tbl = isolist.to_table(columns=['tflux_e', 'tflux_c',
-                                               'npix_e', 'npix_c'])
+        tbl = isolist.to_table(columns=['tflux_e', 'tflux_c', 'npix_e',
+                                        'npix_c'])
         assert len(tbl.colnames) == 4

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -260,15 +260,15 @@ class TestIsophoteList:
         tbl = isolist.to_table()
         assert len(tbl.colnames) == 18
 
-        tbl = isolist.to_table(key_properties=['all'])
+        tbl = isolist.to_table(columns='all')
         assert len(tbl.colnames) >= 30
 
-        tbl = isolist.to_table(key_properties=['main'])
+        tbl = isolist.to_table(columns='main')
         assert len(tbl.colnames) == 18
 
-        tbl = isolist.to_table(key_properties=['sma'])
+        tbl = isolist.to_table(columns=['sma'])
         assert len(tbl.colnames) == 1
 
-        tbl = isolist.to_table(key_properties=['tflux_e', 'tflux_c',
+        tbl = isolist.to_table(columns=['tflux_e', 'tflux_c',
                                                'npix_e', 'npix_c'])
         assert len(tbl.colnames) == 4

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -249,13 +249,13 @@ class TestIsophoteList:
     def test_to_table(self):
         from photutils.isophote import EllipseGeometry, Ellipse
         test_img = make_test_image(nx=55, ny=55, x0=27, y0=27,
-                                   background=100., noise=1.e-6, i0=100., sma=10.,
-                                   eps=0.2, pa=0., seed=1)
-        g = EllipseGeometry(27,27,5,0.2,0)
-        ellipse = Ellipse(test_img, geometry=g,threshold=0.1)
+                                   background=100., noise=1.e-6, i0=100.,
+                                   sma=10., eps=0.2, pa=0., seed=1)
+        g = EllipseGeometry(27, 27, 5, 0.2, 0)
+        ellipse = Ellipse(test_img, geometry=g, threshold=0.1)
         isolist = ellipse.fit_image(maxsma=27)
-        
-        assert len(isolist.get_names()) >= 30
+
+        assert len(isolist.get_names()) >= 30  # test for get_names
 
         tbl = isolist.to_table()
         assert len(tbl.colnames) == 18
@@ -269,6 +269,6 @@ class TestIsophoteList:
         tbl = isolist.to_table(key_properties=['sma'])
         assert len(tbl.colnames) == 1
 
-        tbl = isolist.to_table(key_properties=['tflux_e', 'tflux_c', 'npix_e', 'npix_c'])
+        tbl = isolist.to_table(key_properties=['tflux_e', 'tflux_c',
+                                               'npix_e', 'npix_c'])
         assert len(tbl.colnames) == 4
-        


### PR DESCRIPTION
I wanted to be able to export to_table all, or some of the properties of an isophote_list. Thus, I:

            Added an option key_properties to ``to_table()`` in the ``IsophoteList`` class. 
                 This allows to select which properties to be exported.'

            Added a new function ``get_names`` in the ``IsophoteList`` class. 
                 It prints the IsophoteList key_properties that can be used with ``to_table()``

            Added a test_to_table() test function in test_isophote.py

I run the pytest and all seemed fine. 
Old functionality of ``to_table()`` is preserved.