### PR TITLE
Replace OrderedDict with dict

### DIFF
--- a/docs/grouping.rst
+++ b/docs/grouping.rst
@@ -48,7 +48,6 @@ sources and the latter will make an actual image using that table.
 .. plot::
     :include-source:
 
-    from collections import OrderedDict
     import numpy as np
     from photutils.datasets import (make_random_gaussians_table,
                                     make_gaussian_sources_image)
@@ -57,14 +56,12 @@ sources and the latter will make an actual image using that table.
     n_sources = 350
     sigma_psf = 2.0
 
-    # use an OrderedDict to ensure reproducibility
-    params = OrderedDict([('flux', [500, 5000]),
-                          ('x_mean', [6, 250]),
-                          ('y_mean', [6, 250]),
-                          ('x_stddev', [sigma_psf, sigma_psf]),
-                          ('y_stddev', [sigma_psf, sigma_psf]),
-                          ('theta', [0, np.pi])])
-
+    params = {'flux': [500, 5000],
+              'x_mean': [6, 250],
+              'y_mean': [6, 250],
+              'x_stddev': [sigma_psf, sigma_psf],
+              'y_stddev': [sigma_psf, sigma_psf],
+              'theta': [0, np.pi]}
     starlist = make_random_gaussians_table(n_sources, params, seed=123)
 
     shape = (256, 256)
@@ -158,8 +155,6 @@ in the same group have the same aperture color:
 
 .. plot::
 
-    from collections import OrderedDict
-
     import numpy as np
     from astropy.stats import gaussian_sigma_to_fwhm
     from photutils.datasets import (make_random_gaussians_table,
@@ -175,14 +170,12 @@ in the same group have the same aperture color:
 
     n_sources = 350
     sigma_psf = 2.0
-    # use an OrderedDict to ensure reproducibility
-    params = OrderedDict([('flux', [500, 5000]),
-                          ('x_mean', [6, 250]),
-                          ('y_mean', [6, 250]),
-                          ('x_stddev', [sigma_psf, sigma_psf]),
-                          ('y_stddev', [sigma_psf, sigma_psf]),
-                          ('theta', [0, np.pi])])
-
+    params = {'flux': [500, 5000],
+              'x_mean': [6, 250],
+              'y_mean': [6, 250],
+              'x_stddev': [sigma_psf, sigma_psf],
+              'y_stddev': [sigma_psf, sigma_psf],
+              'theta': [0, np.pi]}
     starlist = make_random_gaussians_table(n_sources, params, seed=123)
 
     shape = (256, 256)
@@ -224,8 +217,6 @@ to use :class:`~photutils.psf.DBSCANGroup`.
 
 .. plot::
 
-    from collections import OrderedDict
-
     import numpy as np
     from astropy.stats import gaussian_sigma_to_fwhm
     from photutils.datasets import (make_random_gaussians_table,
@@ -241,14 +232,12 @@ to use :class:`~photutils.psf.DBSCANGroup`.
 
     n_sources = 350
     sigma_psf = 2.0
-    # use an OrderedDict to ensure reproducibility
-    params = OrderedDict([('flux', [500, 5000]),
-                          ('x_mean', [6, 250]),
-                          ('y_mean', [6, 250]),
-                          ('x_stddev', [sigma_psf, sigma_psf]),
-                          ('y_stddev', [sigma_psf, sigma_psf]),
-                          ('theta', [0, np.pi])])
-
+    params = {'flux': [500, 5000],
+              'x_mean': [6, 250],
+              'y_mean': [6, 250],
+              'x_stddev': [sigma_psf, sigma_psf],
+              'y_stddev': [sigma_psf, sigma_psf],
+              'theta': [0, np.pi]}
     starlist = make_random_gaussians_table(n_sources, params, seed=123)
 
     shape = (256, 256)

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -4,7 +4,6 @@ This module defines tools to perform aperture photometry.
 """
 
 import warnings
-from collections import OrderedDict
 
 import numpy as np
 from astropy.nddata import NDData, StdDevUncertainty
@@ -193,7 +192,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
                              'positions.')
 
     # define output table meta data
-    meta = OrderedDict()
+    meta = {}
     meta['name'] = 'Aperture photometry results'
     meta['version'] = _get_version_info()
     calling_args = f"method='{method}', subpixels={subpixels}"

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -4,8 +4,6 @@ This module provides tools for making example datasets for examples and
 tests.
 """
 
-from collections import OrderedDict
-
 from astropy import coordinates as coord
 from astropy.convolution import discretize_model
 from astropy.io import fits
@@ -184,8 +182,8 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
 
     param_ranges : dict
         The lower and upper boundaries for each of the model parameters
-        as a `dict` mapping the parameter name to its ``(lower, upper)``
-        bounds.
+        as a dictionary mapping the parameter name to its ``(lower,
+        upper)`` bounds.
 
     seed : int, optional
         A seed to initialize the `numpy.random.BitGenerator`. If `None`,
@@ -205,22 +203,20 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
 
     Notes
     -----
-    To generate identical parameter values from separate function calls,
-    ``param_ranges`` must be input as an `~collections.OrderedDict` with
-    the same parameter ranges and the ``seed`` must be the same.
+    To generate identical parameter values from separate function
+    calls, ``param_ranges`` must have the same parameter ranges and the
+    ``seed`` must be the same.
 
     Examples
     --------
-    >>> from collections import OrderedDict
     >>> from photutils.datasets import make_random_models_table
     >>> n_sources = 5
-    >>> param_ranges = [('amplitude', [500, 1000]),
-    ...                 ('x_mean', [0, 500]),
-    ...                 ('y_mean', [0, 300]),
-    ...                 ('x_stddev', [1, 5]),
-    ...                 ('y_stddev', [1, 5]),
-    ...                 ('theta', [0, np.pi])]
-    >>> param_ranges = OrderedDict(param_ranges)
+    >>> param_ranges = {'amplitude': [500, 1000],
+    ...                 'x_mean': [0, 500],
+    ...                 'y_mean': [0, 300],
+    ...                 'x_stddev': [1, 5],
+    ...                 'y_stddev': [1, 5],
+    ...                 'theta': [0, np.pi]}
     >>> sources = make_random_models_table(n_sources, param_ranges,
     ...                                    seed=0)
     >>> for col in sources.colnames:
@@ -268,15 +264,15 @@ def make_random_gaussians_table(n_sources, param_ranges, seed=None):
 
     param_ranges : dict
         The lower and upper boundaries for each of the
-        `~astropy.modeling.functional_models.Gaussian2D` parameters as a
-        `dict` mapping the parameter name to its ``(lower, upper)``
-        bounds.  The dictionary keys must be valid
-        `~astropy.modeling.functional_models.Gaussian2D` parameter names
-        or ``'flux'``.  If ``'flux'`` is specified, but not
+        `~astropy.modeling.functional_models.Gaussian2D` parameters
+        as a dictionary mapping the parameter name to its ``(lower,
+        upper)`` bounds. The dictionary keys must be valid
+        `~astropy.modeling.functional_models.Gaussian2D` parameter
+        names or ``'flux'``. If ``'flux'`` is specified, but not
         ``'amplitude'`` then the 2D Gaussian amplitudes will be
-        calculated and placed in the output table.  If both ``'flux'``
+        calculated and placed in the output table. If both ``'flux'``
         and ``'amplitude'`` are specified, then ``'flux'`` will be
-        ignored.  Model parameters not defined in ``param_ranges`` will
+        ignored. Model parameters not defined in ``param_ranges`` will
         be set to the default value.
 
     seed : int, optional
@@ -296,22 +292,20 @@ def make_random_gaussians_table(n_sources, param_ranges, seed=None):
 
     Notes
     -----
-    To generate identical parameter values from separate function calls,
-    ``param_ranges`` must be input as an `~collections.OrderedDict` with
-    the same parameter ranges and the ``seed`` must be the same.
+    To generate identical parameter values from separate function
+    calls, ``param_ranges`` must have the same parameter ranges and the
+    ``seed`` must be the same.
 
     Examples
     --------
-    >>> from collections import OrderedDict
     >>> from photutils.datasets import make_random_gaussians_table
     >>> n_sources = 5
-    >>> param_ranges = [('amplitude', [500, 1000]),
-    ...                 ('x_mean', [0, 500]),
-    ...                 ('y_mean', [0, 300]),
-    ...                 ('x_stddev', [1, 5]),
-    ...                 ('y_stddev', [1, 5]),
-    ...                 ('theta', [0, np.pi])]
-    >>> param_ranges = OrderedDict(param_ranges)
+    >>> param_ranges = {'amplitude': [500, 1000],
+    ...                 'x_mean': [0, 500],
+    ...                 'y_mean': [0, 300],
+    ...                 'x_stddev': [1, 5],
+    ...                 'y_stddev': [1, 5],
+    ...                 'theta': [0, np.pi]}
     >>> sources = make_random_gaussians_table(n_sources, param_ranges,
     ...                                       seed=0)
     >>> for col in sources.colnames:
@@ -327,13 +321,12 @@ def make_random_gaussians_table(n_sources, param_ranges, seed=None):
 
     To specifying the flux range instead of the amplitude range:
 
-    >>> param_ranges = [('flux', [500, 1000]),
-    ...                 ('x_mean', [0, 500]),
-    ...                 ('y_mean', [0, 300]),
-    ...                 ('x_stddev', [1, 5]),
-    ...                 ('y_stddev', [1, 5]),
-    ...                 ('theta', [0, np.pi])]
-    >>> param_ranges = OrderedDict(param_ranges)
+    >>> param_ranges = {'flux': [500, 1000],
+    ...                 'x_mean': [0, 500],
+    ...                 'y_mean': [0, 300],
+    ...                 'x_stddev': [1, 5],
+    ...                 'y_stddev': [1, 5],
+    ...                 'theta': [0, np.pi]}
     >>> sources = make_random_gaussians_table(n_sources, param_ranges,
     ...                                       seed=0)
     >>> for col in sources.colnames:
@@ -418,7 +411,6 @@ def make_model_sources_image(shape, model, source_table, oversample=1):
     .. plot::
         :include-source:
 
-        from collections import OrderedDict
         from astropy.modeling.models import Moffat2D
         from photutils.datasets import (make_random_models_table,
                                         make_model_sources_image)
@@ -426,12 +418,11 @@ def make_model_sources_image(shape, model, source_table, oversample=1):
         model = Moffat2D()
         n_sources = 10
         shape = (100, 100)
-        param_ranges = [('amplitude', [100, 200]),
-                        ('x_0', [0, shape[1]]),
-                        ('y_0', [0, shape[0]]),
-                        ('gamma', [5, 10]),
-                        ('alpha', [1, 2])]
-        param_ranges = OrderedDict(param_ranges)
+        param_ranges = {'amplitude': [100, 200],
+                        'x_0': [0, shape[1]],
+                        'y_0': [0, shape[0]],
+                        'gamma': [5, 10],
+                        'alpha': [1, 2]}
         sources = make_random_models_table(n_sources, param_ranges,
                                            seed=0)
 
@@ -742,12 +733,12 @@ def make_100gaussians_image(noise=True):
     ymean_range = [0, 300]
     xstddev_range = [1, 5]
     ystddev_range = [1, 5]
-    params = OrderedDict([('flux', flux_range),
-                          ('x_mean', xmean_range),
-                          ('y_mean', ymean_range),
-                          ('x_stddev', xstddev_range),
-                          ('y_stddev', ystddev_range),
-                          ('theta', [0, 2 * np.pi])])
+    params = {'flux': flux_range,
+              'x_mean': xmean_range,
+              'y_mean': ymean_range,
+              'x_stddev': xstddev_range,
+              'y_stddev': ystddev_range,
+              'theta': [0, 2 * np.pi]}
 
     rng = np.random.RandomState(12345)
     sources = Table()

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -3,8 +3,6 @@
 This module provides classes to store the results of isophote fits.
 """
 
-from collections import OrderedDict
-
 from astropy.table import QTable
 import astropy.units as u
 import numpy as np
@@ -746,7 +744,7 @@ def _isophote_list_to_table(isophote_list):
         An astropy QTable with the main isophote parameters.
     """
 
-    properties = OrderedDict()
+    properties = {}
     properties['sma'] = 'sma'
     properties['intens'] = 'intens'
     properties['int_err'] = 'intens_err'


### PR DESCRIPTION
Photutils 1.1 will require python >3.7, so we can replace `OrderedDict` with `dict`.  `dict` insertion-order is preserved in python 3.7+.