### PR TITLE
Move linkcheck to weekly cron job

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -41,9 +41,6 @@ jobs:
             tox_env: 'build_docs'
           - os: ubuntu-latest
             python: '3.8'
-            tox_env: 'linkcheck'
-          - os: ubuntu-latest
-            python: '3.8'
             tox_env: 'bandit'
           - os: ubuntu-latest
             python: '3.7'

--- a/.github/workflows/cron_tests.yml
+++ b/.github/workflows/cron_tests.yml
@@ -17,6 +17,9 @@ jobs:
         include:
           - os: ubuntu-latest
             python: '3.8'
+            tox_env: 'linkcheck'
+          - os: ubuntu-latest
+            python: '3.8'
             tox_env: 'py38-test-alldeps-devdeps'
 
     steps:


### PR DESCRIPTION
The linkcheck sometimes fails due to remote server failures.