### PR TITLE
Fix negative Kron radius

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,11 @@ Bug Fixes
   - Fixed bug that caused an infinite loop when the sample extracted
     from an image has zero length. [#1129]
 
+- ``photutils.segmentation``
+
+  - Fixed an issue where negative Kron radius values could be returned,
+    which would cause an error when calculating Kron fluxes. [#1132]
+
 
 1.0.1 (2020-09-24)
 ------------------

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1614,7 +1614,7 @@ class SourceProperties:
         """
         The flux in the Kron aperture.
 
-        If the Kron aperture is `None`, then `np.nan` will be returned.
+        If the Kron aperture is `None`, then ``np.nan`` will be returned.
         """
         if self.kron_aperture is None:
             self._kron_fluxerr = np.nan * self._data_unit
@@ -1643,7 +1643,7 @@ class SourceProperties:
         """
         The flux error in the Kron aperture.
 
-        If the Kron aperture is `None`, then `np.nan` will be returned.
+        If the Kron aperture is `None`, then ``np.nan`` will be returned.
         """
         if self._kron_fluxerr is None:
             _ = self.kron_flux  # run kron_flux to computer kron_fluxerr


### PR DESCRIPTION
As reported in #1122, if the numerator or denominator of the Kron radius calculation were negative, then the Kron radius would be negative.  With a negative Kron radius, the Kron flux raises an exception because the aperture radius must be >= 0.

This PR fixes this issue.  If either the numerator or denominator <= 0 in the Kron radius formula, then ``np.nan`` will be returned. In this case, the Kron aperture will be defined as a circular aperture with a radius equal to ``kron_params[2]``. If ``kron_params[2] <= 0``, then the Kron aperture will be `None` and the Kron flux will be ``np.nan``.