### PR TITLE
Fix segmentation bug: remove_border_labels and relabel=True when no remaining segments

### DIFF
--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -723,9 +723,10 @@ class SegmentationImage:
 
         if relabel:
             labels = np.unique(idx[idx != 0])
-            idx2 = np.zeros(max(labels) + 1, dtype=int)
-            idx2[labels] = np.arange(len(labels)) + 1
-            idx = idx2[idx]
+            if not len(labels) == 0:
+                idx2 = np.zeros(max(labels) + 1, dtype=int)
+                idx2[labels] = np.arange(len(labels)) + 1
+                idx = idx2[idx]
 
         data_new = idx[self.data]
         self.__dict__ = {}  # reset all cached properties

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -282,6 +282,13 @@ class TestSegmentationImage:
             segm = SegmentationImage(self.data)
             segm.remove_border_labels(border_width=3)
 
+    def test_remove_border_labels_no_remaining_segments(self):
+        alt_data = np.copy(self.data)
+        alt_data[alt_data == 3] = 0
+        segm = SegmentationImage(alt_data)
+        segm.remove_border_labels(border_width=1, relabel=True)
+        assert segm.nlabels == 0
+
     def test_remove_masked_labels(self):
         ref_data = np.array([[0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0],


### PR DESCRIPTION
Hi, I found that when calling SegmentationImage.remove_border_labels(relabel=True) on a segmentation image where all segments lie within the specified border, resulting in zero segments remaining, the relabelling throws a ValueError. Example code:

```
data = [[1, 1, 0, 0, 4, 4],
        [0, 0, 0, 0, 0, 4],
        [0, 0, 0, 0, 0, 0],
        [7, 0, 0, 0, 0, 5],
        [7, 7, 0, 5, 5, 5],
        [7, 7, 0, 0, 5, 5]]
segm = SegmentationImage(data)
segm.remove_border_labels(border_width=1, relabel=True)
```
Result:
```
Traceback (most recent call last):
  File "test_photutils_segmentation.py", line 11, in <module>
    segm.remove_border_labels(border_width=1, relabel=True)
  File "/Users/davidgrant/Work/Code/ResearchScience/photutils/photutils/segmentation/core.py", line 1058, in remove_border_labels
    relabel=relabel)
  File "/Users/davidgrant/Work/Code/ResearchScience/photutils/photutils/segmentation/core.py", line 1125, in remove_masked_labels
    self.remove_labels(remove_labels, relabel=relabel)
  File "/Users/davidgrant/Work/Code/ResearchScience/photutils/photutils/segmentation/core.py", line 985, in remove_labels
    self.reassign_labels(labels, new_label=0, relabel=relabel)
  File "/Users/davidgrant/Work/Code/ResearchScience/photutils/photutils/segmentation/core.py", line 726, in reassign_labels
    idx2 = np.zeros(max(labels) + 1, dtype=int)
ValueError: max() arg is an empty sequence
```
The problem is that max() is called on an empty array of remaining segment labels.

I have updated SegmentationImage.reassign_labels to simply check the number of labels remaining after reassignment when relabel=True. In this way, if no labels remain there is no need to relabel, and an empty segmentation image results.

I have added an additional test dealing with the example case above, which now passes.
