### PR TITLE
formerly hacky fix for incorrect model names trying to be accessed if more than two stars in group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,9 @@ Bug Fixes
   - Fixed a bug in ``EPSFBuild`` where a warning was raised if the input
     ``smoothing_kernel`` was an ``numpy.ndarray``. [#1146]
 
+  - Fixed a bug that caused photometry to fail on an ``EPSFmodel`` with
+    multiple stars in a group. [#1135]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceProperties`` ``local_background`` to work with

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -505,7 +505,7 @@ class BasicPSFPhotometry:
             in this package like `~photutils.psf.sandbox.DiscretePRF`,
             `~photutils.psf.IntegratedGaussianPRF`, or any other
             suitable 2D model.
-        star_group : TODO
+        star_group : `~astropy.table.Table`
             the star group instance.
 
         Returns

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from .groupstars import DAOGroup
 from .utils import (_extract_psf_fitting_names, get_grouped_psf_model,
-                    subtract_psf)
+                    subtract_psf, _split)
 from ..aperture import CircularAperture, aperture_photometry
 from ..background import MMMBackground
 from ..detection import DAOStarFinder
@@ -523,9 +523,22 @@ class BasicPSFPhotometry:
         if star_group_size > 1:
             for i in range(star_group_size):
                 for param_tab_name, param_name in self._pars_to_output.items():
+                    param_prefix, param_postfix = _split(param_name)
+                    # TODO sometimes we need to match prefixes (if its param_i+j) and sometimes the whole name
+                    #  if its param_i_j
+                    #  Find out why why combining e.g. IntegratedGaussianPRF works differently than Gaussian2D
+                    #  Maybe it would be better to unify names already at the point where the models are combined?
+                    model_name_candidates = [name for name in fit_model.param_names if name.startswith(param_name)]
+                    if len(model_name_candidates) < 2:
+                        model_name_candidates = [name for name in fit_model.param_names if name.startswith(param_prefix)]
+                        # this is needed for the case that we have param_0 param_1 ->
+                        #  param_0 param_1 [...] param_N param_N+1
+                        model_name_candidates = [name for name in model_name_candidates if
+                                                 int(_split(name)[1]) >= int(param_postfix)]
+
                     param_tab[param_tab_name][i] = getattr(fit_model,
-                                                           param_name +
-                                                           '_' + str(i)).value
+                                                           model_name_candidates[i]
+                                                           ).value
         else:
             for param_tab_name, param_name in self._pars_to_output.items():
                 param_tab[param_tab_name] = getattr(fit_model,

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -530,7 +530,8 @@ class BasicPSFPhotometry:
                     # node of the tree
                     sub_models = [model for model
                                   in fit_model.traverse_postorder() if model.name == i]
-                    assert len(sub_models) == 1
+                    if len(sub_models) != 1:
+                        raise ValueError('sub_models must have a length of 1')            
                     sub_model = sub_models[0]
 
                     param_tab[param_tab_name][i] = getattr(sub_model,

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -531,7 +531,7 @@ class BasicPSFPhotometry:
                     sub_models = [model for model
                                   in fit_model.traverse_postorder() if model.name == i]
                     if len(sub_models) != 1:
-                        raise ValueError('sub_models must have a length of 1')            
+                        raise ValueError('sub_models must have a length of 1')
                     sub_model = sub_models[0]
 
                     param_tab[param_tab_name][i] = getattr(sub_model,

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from .groupstars import DAOGroup
 from .utils import (_extract_psf_fitting_names, get_grouped_psf_model,
-                    subtract_psf, _split_parameter_name)
+                    subtract_psf)
 from ..aperture import CircularAperture, aperture_photometry
 from ..background import MMMBackground
 from ..detection import DAOStarFinder
@@ -403,7 +403,7 @@ class BasicPSFPhotometry:
             fit_model = self.fitter(group_psf, x[usepixel], y[usepixel],
                                     image[usepixel])
             param_table = self._model_params2table(fit_model,
-                                                   len(star_groups.groups[n]))
+                                                   star_groups.groups[n])
             result_tab = vstack([result_tab, param_table])
 
             param_cov = self.fitter.fit_info.get('param_cov', None)
@@ -494,7 +494,7 @@ class BasicPSFPhotometry:
 
         return unc_tab
 
-    def _model_params2table(self, fit_model, star_group_size):
+    def _model_params2table(self, fit_model, star_group):
         """
         Place fitted parameters into an astropy table.
 
@@ -505,8 +505,8 @@ class BasicPSFPhotometry:
             in this package like `~photutils.psf.sandbox.DiscretePRF`,
             `~photutils.psf.IntegratedGaussianPRF`, or any other
             suitable 2D model.
-        star_group_size : int
-            Number of stars in the given group.
+        star_group : TODO
+            the star group instance.
 
         Returns
         -------
@@ -518,47 +518,23 @@ class BasicPSFPhotometry:
 
         for param_tab_name in self._pars_to_output.keys():
             param_tab.add_column(Column(name=param_tab_name,
-                                        data=np.empty(star_group_size)))
+                                        data=np.empty(len(star_group))))
 
-        # TODO sometimes we need to match prefixes (if its param_i+j) and sometimes the whole name
-        #  if its param_i_j
-        #  Find out why why combining e.g. IntegratedGaussianPRF works differently than Gaussian2D
-        #  Maybe it would be better to unify names already at the point where the models are
-        #  combined?
-        # If we encounter a group with two or more stars, the model will have been combined in
-        # psf/utils.py:get_grouped_psf_model() by adding the models. But if
-        # psf/utils.py:prepare_psf_model() has been called on the model before it is already a
-        # compound model.
-        # The parameter names of the combined model are built from a flattened version of the
-        # expression tree so two models with "myparam" don't necessarily combine to a model with
-        # "myparam_0" and "myparam_1" if they have submodels themselves:
-        #  model(submodel('subparam'), 'param', 'second_param') +
-        #  model(submodel('subparam'), 'param')
-        #  ->
-        #  combined_model('param_0', 'second_param_0', 'subparam_1', 'param_2', 'subparam_3')
-        # But this behaviour is different for e.g. IntegratedGaussianPRF compared to
-        # Gaussian2D, so we need to check if there are any candidate parameters that have the
-        # whole parameter name with an attached '_N' prefix or that increment the
-        # existing '_N' prefix of the name
-        if star_group_size > 1:
-            for i in range(star_group_size):
+        if len(star_group) > 1:
+            for i in range(len(star_group)):
                 for param_tab_name, param_name in self._pars_to_output.items():
-                    param_prefix, param_postfix = _split_parameter_name(param_name)
+                    # get sub_model corresponding to star with index i as name
+                    # name was set in utils.get_grouped_psf_model()
+                    # we can't use model['name'] here as that only
+                    # searches leaves and we might want a intermediate
+                    # node of the tree
+                    sub_models = [model for model
+                                  in fit_model.traverse_postorder() if model.name == i]
+                    assert len(sub_models) == 1
+                    sub_model = sub_models[0]
 
-                    model_name_candidates = [name for name in fit_model.param_names
-                                             if name.startswith(param_name)]
-                    if len(model_name_candidates) < 2:
-                        model_name_candidates = [name for name in fit_model.param_names
-                                                 if name.startswith(param_prefix)]
-                        # this is needed for the case that we have param_0 param_1 ->
-                        #  param_0 param_1 [...] param_N param_N+1
-                        model_name_candidates = \
-                            [name for name in model_name_candidates if
-                             int(_split_parameter_name(name)[1]) >= int(param_postfix)]
-
-                    param_tab[param_tab_name][i] = getattr(fit_model,
-                                                           model_name_candidates[i]
-                                                           ).value
+                    param_tab[param_tab_name][i] = getattr(sub_model,
+                                                           param_name).value
         else:
             for param_tab_name, param_name in self._pars_to_output.items():
                 param_tab[param_tab_name] = getattr(fit_model,

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -658,9 +658,10 @@ def test_psf_extra_output_cols(sigma_psf, sources):
 def overlap_image(request):
 
     if request.param == 2:
-        close_tab = Table([[50., 53.], [50., 50.], [25., 25.,]], names=['x_0', 'y_0', 'flux_0'])
+        close_tab = Table([[50., 53.], [50., 50.], [25., 25.]], names=['x_0', 'y_0', 'flux_0'])
     elif request.param == 3:
-        close_tab = Table([[50., 55., 50.], [50., 50., 55.], [25., 25., 25.]], names=['x_0', 'y_0', 'flux_0'])
+        close_tab = Table([[50., 55., 50.], [50., 50., 55.], [25., 25., 25.]],
+                          names=['x_0', 'y_0', 'flux_0'])
     else:
         raise ValueError
 
@@ -679,13 +680,8 @@ def test_psf_fitting_group(overlap_image):
     """ Test psf_photometry when two input stars are close and need to be fit together """
     from photutils.background import MADStdBackgroundRMS
 
-    # TODO remove debug
-    import matplotlib.pyplot as plt
-    # plt.imshow(close_image)
-    # plt.colorbar()
-    # plt.show()
-
-    # There are a few models here that fail, be it something created by EPSFBuilder or simpler the Moffat2D one
+    # There are a few models here that fail, be it something
+    # created by EPSFBuilder or simpler the Moffat2D one
     # unprepared_psf = Moffat2D(amplitude=1, gamma=2, alpha=2.8, x_0=0, y_0=0)
     # psf = prepare_psf_model(unprepared_psf, xname='x_0', yname='y_0', fluxname=None)
     psf = prepare_psf_model(Gaussian2D(), renormalize_psf=False)
@@ -704,7 +700,7 @@ def test_psf_fitting_group(overlap_image):
                                     psf_model=psf,
                                     fitshape=31)
     # this should not raise AttributeError: Attribute "offset_0_0" not found
-    f = basic_phot(image=overlap_image)
+    basic_phot(image=overlap_image)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -691,9 +691,8 @@ def test_psf_fitting_group(overlap_image):
 
     separation_crit = 10
 
-    basic_phot = BasicPSFPhotometry(
-                                    # choose low threshold and fwhm to find stars no matter what
-                                    finder=DAOStarFinder(1, 1),
+    # choose low threshold and fwhm to find stars no matter what
+    basic_phot = BasicPSFPhotometry(finder=DAOStarFinder(1, 1),
                                     group_maker=DAOGroup(separation_crit),
                                     bkg_estimator=MADStdBackgroundRMS(),
                                     fitter=LevMarLSQFitter(),

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -12,7 +12,7 @@ import pytest
 
 from ..models import IntegratedGaussianPRF
 from ..sandbox import DiscretePRF
-from ..utils import get_grouped_psf_model, prepare_psf_model, subtract_psf
+from ..utils import get_grouped_psf_model, prepare_psf_model, subtract_psf, _split_parameter_name
 
 try:
     import scipy  # noqa
@@ -172,3 +172,13 @@ def test_subtract_psf():
         posflux.rename_column(n, n.split('_')[0] + '_fit')
     residuals = subtract_psf(image, prf, posflux)
     assert_allclose(residuals, np.zeros_like(image), atol=1E-4)
+
+
+def test_split():
+    assert(_split_parameter_name('foo') == ['foo', '-1'])
+    assert(_split_parameter_name('foo_1') == ['foo', '1'])
+    assert(_split_parameter_name('foo_20') == ['foo', '20'])
+    assert(_split_parameter_name('foo_bar') == ['foo_bar', '-1'])
+    assert(_split_parameter_name('foo_bar_1') == ['foo_bar', '1'])
+    assert(_split_parameter_name('foo_bar_baz') == ['foo_bar_baz', '-1'])
+    assert(_split_parameter_name('foo_10_bar') == ['foo_10_bar', '-1'])

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -166,10 +166,9 @@ def test_get_grouped_psf_model():
 def prf_model(request):
     # use this instead of pytest.mark.parameterize as we use scipy and
     # it still calls that even if not HAS_SCIPY is set...
-    prfs = [
-             IntegratedGaussianPRF(sigma=1.2),
-             Gaussian2D(x_stddev=2),
-             prepare_psf_model(Gaussian2D(x_stddev=2), renormalize_psf=False)]
+    prfs = [IntegratedGaussianPRF(sigma=1.2),
+            Gaussian2D(x_stddev=2),
+            prepare_psf_model(Gaussian2D(x_stddev=2), renormalize_psf=False)]
     return prfs[request.param]
 
 

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -185,3 +185,15 @@ def test_get_grouped_psf_model_submodel_names(prf_model):
                 if submodel.name == 0]) == 1
     assert len([submodel for submodel in gpsf.traverse_postorder()
                 if submodel.name == 1]) == 1
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_subtract_psf():
+    """Test subtract_psf."""
+
+    prf = DiscretePRF(test_psf, subsampling=1)
+    posflux = INTAB.copy()
+    for n in posflux.colnames:
+        posflux.rename_column(n, n.split('_')[0] + '_fit')
+    residuals = subtract_psf(image, prf, posflux)
+    assert_allclose(residuals, np.zeros_like(image), atol=1E-4)

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -162,19 +162,25 @@ def test_get_grouped_psf_model():
     assert gpsf.sigma_0 == gpsf.sigma_1 == 1.2
 
 
-@pytest.mark.parametrize('igp',
-    [IntegratedGaussianPRF(sigma=1.2),
-     Gaussian2D(x_stddev=2),
-     prepare_psf_model(Gaussian2D(x_stddev=2),
-                       xname='x_mean', yname='y_mean', renormalize_psf=False)])
+@pytest.fixture(params=[0, 1, 2])
+def prf_model(request):
+    # use this instead of pytest.mark.parameterize as we use scipy and
+    # it still calls that even if not HAS_SCIPY is set...
+    prfs = [
+             IntegratedGaussianPRF(sigma=1.2),
+             Gaussian2D(x_stddev=2),
+             prepare_psf_model(Gaussian2D(x_stddev=2), renormalize_psf=False)]
+    return prfs[request.param]
+
+
 @pytest.mark.skipif('not HAS_SCIPY')
-def test_get_grouped_psf_model_submodel_names(igp):
+def test_get_grouped_psf_model_submodel_names(prf_model):
     """Verify that submodel tagging works"""
     tab = Table(names=['x_0', 'y_0', 'flux_0'],
                 data=[[1, 2], [3, 4], [0.5, 1]])
     pars_to_set = {'x_0': 'x_0', 'y_0': 'y_0', 'flux_0': 'flux'}
 
-    gpsf = get_grouped_psf_model(igp, tab, pars_to_set)
+    gpsf = get_grouped_psf_model(prf_model, tab, pars_to_set)
     # There should be two submodels one named 0 and one named 1
     assert len([submodel for submodel in gpsf.traverse_postorder()
                 if submodel.name == 0]) == 1

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -129,8 +129,12 @@ def get_grouped_psf_model(template_psf_model, star_group, pars_to_set):
 
     group_psf = None
 
-    for star in star_group:
+    for index, star in enumerate(star_group):
         psf_to_add = template_psf_model.copy()
+        # we 'tag' the model here so that later we don't have to rely
+        # on possibly mangled names of the compound model to find
+        # the parameters again
+        psf_to_add.name = index
         for param_tab_name, param_name in pars_to_set.items():
             setattr(psf_to_add, param_name, star[param_tab_name])
 
@@ -138,7 +142,7 @@ def get_grouped_psf_model(template_psf_model, star_group, pars_to_set):
             # this is the first one only
             group_psf = psf_to_add
         else:
-            group_psf += psf_to_add
+            group_psf = group_psf + psf_to_add
 
     return group_psf
 
@@ -257,27 +261,3 @@ def subtract_psf(data, psf, posflux, subshape=None):
 
     return subbeddata
 
-
-def _split_parameter_name(name: str) -> List[str]:
-    """When combining astropy models, parameter names have a number attached
-    as a postfix. This function extracts that number. If no number is
-    present, '-1' is returned as the postfix
-
-    Parameters
-    ----------
-    name: parameter name that may or may not contain a numerical postfix
-
-    Returns
-    -------
-    components: 2 Element List[str]
-    First element contains the base-name, the second the numerical
-    postfix.
-    """
-    components = name.split('_')
-    if not components[-1].isnumeric():  # no number prefix present
-        components = ['_'.join(components), '-1']
-    elif len(components) == 1:  # contained no _
-        components = components + ['-1']
-    elif len(components) > 2:  # contained multiple _
-        components = ['_'.join(components[:-1]), components[-1]]
-    return components

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -7,7 +7,6 @@ from astropy.table import Table
 from astropy.modeling import models
 from astropy.nddata.utils import add_array, extract_array
 import numpy as np
-from typing import List
 
 __all__ = ['prepare_psf_model', 'get_grouped_psf_model', 'subtract_psf']
 
@@ -260,4 +259,3 @@ def subtract_psf(data, psf, posflux, subshape=None):
             subbeddata = add_array(subbeddata, -psf(x, y), (y_0, x_0))
 
     return subbeddata
-

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -7,6 +7,7 @@ from astropy.table import Table
 from astropy.modeling import models
 from astropy.nddata.utils import add_array, extract_array
 import numpy as np
+from typing import List
 
 __all__ = ['prepare_psf_model', 'get_grouped_psf_model', 'subtract_psf']
 
@@ -257,10 +258,21 @@ def subtract_psf(data, psf, posflux, subshape=None):
     return subbeddata
 
 
-from typing import List
+def _split_parameter_name(name: str) -> List[str]:
+    """When combining astropy models, parameter names have a number attached
+    as a postfix. This function extracts that number. If no number is
+    present, '-1' is returned as the postfix
 
-def _split(name: str) -> List[str]:
+    Parameters
+    ----------
+    name: parameter name that may or may not contain a numerical postfix
 
+    Returns
+    -------
+    components: 2 Element List[str]
+    First element contains the base-name, the second the numerical
+    postfix.
+    """
     components = name.split('_')
     if not components[-1].isnumeric():  # no number prefix present
         components = ['_'.join(components), '-1']

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -255,3 +255,17 @@ def subtract_psf(data, psf, posflux, subshape=None):
             subbeddata = add_array(subbeddata, -psf(x, y), (y_0, x_0))
 
     return subbeddata
+
+
+from typing import List
+
+def _split(name: str) -> List[str]:
+
+    components = name.split('_')
+    if not components[-1].isnumeric():  # no number prefix present
+        components = ['_'.join(components), '-1']
+    elif len(components) == 1:  # contained no _
+        components = components + ['-1']
+    elif len(components) > 2:  # contained multiple _
+        components = ['_'.join(components[:-1]), components[-1]]
+    return components


### PR DESCRIPTION
After running into https://github.com/astropy/photutils/issues/845 I tried to fix it generically (https://github.com/krachyon/photutils/tree/parameter_name_matching) by comparing the parameter names of the psf model and matching them to those that should be output in `_model_params2table()` but ran into the issue that sometimes a compound model seems to have the parameters combined by adding a postfix (param_i->param_i_j) or by incrementing a existing postfix(param_i -> param_j). More Details on that train of thought in the comment in `photometry.py`

I decided it's not really worth trying to predict that behaviour and came up with this pretty hacky way to handle both. I'm not sure if this is something merge worthy, but for now it seems to solve the issue on my end. 

I guess the proper solution would involve modifying the way that the expected parameter names are derived in the combination of `prepare_psf_model` and `photometry._define_fit_param_names()` `get_grouped_psf_model()`. I suspect in the latter function we could always compare the before-after state, but ideally there should probably be a way to access the parameters of submodels by their original names in a compound model implemented in astropy.