### PR TITLE
Change BkgZoomInterpolator default method to constant

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,10 @@ New Features
     of ~4 with 2048x2048 input arrays when using the default interpolator).
     [#1103, #1108]
 
+  - Changed ``BkgZoomInterpolator`` default method to ``constant`` to
+    account for upstream changes in ``scipy.ndimage.zoom`` (scipy
+    v1.6.0). [#1137]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -37,16 +37,15 @@ class BkgZoomInterpolator:
         value must be an integer in the range 0-5.  The default is 3
         (bicubic interpolation).
 
-    mode : {'reflect', 'constant', 'nearest', 'wrap'}, optional
+    mode : {'constant', 'nearest', 'reflect', 'wrap'}, optional
         Points outside the boundaries of the input are filled according
-        to the given mode.  Default is 'reflect'.
+        to the given mode.
 
     cval : float, optional
         The value used for points outside the boundaries of the input if
         ``mode='constant'``. Default is 0.0
     """
-
-    def __init__(self, order=3, mode='reflect', cval=0.0):
+    def __init__(self, order=3, mode='constant', cval=0.0):
         self.order = order
         self.mode = mode
         self.cval = cval


### PR DESCRIPTION
This PR fixes the failing tests reported in #1136 caused by changes to `scipy.ndimage.zoom` in scipy v1.6.0.

Fixes #1136.