### PR TITLE
Add missing default fixed params in EllipseSample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@ Bug Fixes
   - Fixed bug that caused an infinite loop when the sample extracted
     from an image has zero length. [#1129]
 
+  - Fixed a bug where the default ``fixed_parameters`` in
+    ``EllipseSample.update()`` were not defined. [#1139]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where negative Kron radius values could be returned,

--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -264,7 +264,7 @@ class EllipseGeometry:
 
             if verbose:
                 log.info(f'Found center at x0 = {self.x0:5.1f}, '
-                         'y0 = {self.y0:5.1f}')
+                         f'y0 = {self.y0:5.1f}')
         else:
             if verbose:
                 log.info('Result is below the threshold -- keeping the '

--- a/photutils/isophote/sample.py
+++ b/photutils/isophote/sample.py
@@ -278,7 +278,7 @@ class EllipseSample:
 
         return r_angles, r_radii, r_intensities
 
-    def update(self, fixed_parameters):
+    def update(self, fixed_parameters=None):
         """
         Update this `~photutils.isophote.EllipseSample` instance.
 
@@ -288,6 +288,9 @@ class EllipseSample:
         then computes the the mean intensity, local gradient, and other
         associated quantities.
         """
+
+        if fixed_parameters is None:
+            fixed_parameters = np.array([False, False, False, False])
         self.geometry.fix = fixed_parameters
 
         step = self.geometry.astep


### PR DESCRIPTION
I discovered an unrelated bug while testing https://github.com/astropy/photutils/pull/1089 with https://github.com/astropy/photutils-datasets/blob/master/notebooks/isophote/isophote_example4.ipynb.  PR #922 added a `fixed_parameters` parameter to the `EllipseSample.update()` method, but it did not do so as a keyword parameter with a default value of not fixing any parameters (breaking old existing code in the process). This PR defines the default parameter.