### PR TITLE
Allow Quantity, NDData, and CCDData input to Background2D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New Features
   - The ``PixelAperture.plot()`` method now returns a list of
     ``matplotlib.patches.Patch`` objects. [#923]
 
+- ``photutils.background``
+
+  - The ``Background2D`` class now accepts astropy ``NDData``,
+    ``CCDData``, and ``Quantity`` objects as data inputs. [#1140]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -184,7 +184,7 @@ class Background2D:
 
     Parameters
     ----------
-    data : array_like
+    data : array_like or `~astropy.nddata.NDData`
         The 2D array from which to estimate the background and/or
         background RMS map.
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -532,12 +532,11 @@ class Background2D:
         self.nboxes = self.nxboxes * self.nyboxes
 
         # a reshaped 2D masked array with mesh data along the x axis
-        mesh_data = np.ma.swapaxes(
-                        data_ma.reshape(
-                            self.nyboxes, self.box_size[0],
-                            self.nxboxes, self.box_size[1]),
-                        1, 2).reshape(self.nyboxes * self.nxboxes,
-                                      self.box_npixels)
+        mesh_data = np.ma.swapaxes(data_ma.reshape(
+            self.nyboxes, self.box_size[0],
+            self.nxboxes, self.box_size[1]),
+            1, 2).reshape(self.nyboxes * self.nxboxes,
+                          self.box_npixels)
 
         # first cut on rejecting meshes
         self.mesh_idx = self._select_meshes(mesh_data)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -6,7 +6,9 @@ RMS in an image.
 
 from itertools import product
 
+from astropy.nddata import NDData
 from astropy.stats import SigmaClip
+import astropy.units as u
 from astropy.utils import lazyproperty
 import numpy as np
 from numpy.lib.index_tricks import index_exp
@@ -312,7 +314,12 @@ class Background2D:
                  bkgrms_estimator=StdBackgroundRMS(sigma_clip=None),
                  interpolator=BkgZoomInterpolator()):
 
-        data = np.asanyarray(data)
+        if isinstance(data, (u.Quantity, NDData)):  # includes CCDData
+            self.unit = data.unit
+            data = data.data
+        else:
+            self.unit = None
+            data = np.asanyarray(data)
 
         box_size = np.atleast_1d(box_size)
         if len(box_size) == 1:
@@ -788,8 +795,10 @@ class Background2D:
         This is equivalent to the value SourceExtractor prints to stdout
         (i.e., "(M+D) Background: <value>").
         """
-
-        return np.median(self.background_mesh)
+        _median = np.median(self.background_mesh)
+        if self.unit is not None:
+            _median <<= self.unit
+        return _median
 
     @lazyproperty
     def background_rms_median(self):
@@ -799,8 +808,10 @@ class Background2D:
         This is equivalent to the value SourceExtractor prints to stdout
         (i.e., "(M+D) RMS: <value>").
         """
-
-        return np.median(self.background_rms_mesh)
+        _rms_median = np.median(self.background_rms_mesh)
+        if self.unit is not None:
+            _rms_median <<= self.unit
+        return _rms_median
 
     @lazyproperty
     def background(self):
@@ -808,6 +819,8 @@ class Background2D:
         bkg = self.interpolator(self.background_mesh, self)
         if self.coverage_mask is not None:
             bkg[self.coverage_mask] = self.fill_value
+        if self.unit is not None:
+            bkg <<= self.unit
         return bkg
 
     @lazyproperty
@@ -816,6 +829,8 @@ class Background2D:
         bkg_rms = self.interpolator(self.background_rms_mesh, self)
         if self.coverage_mask is not None:
             bkg_rms[self.coverage_mask] = self.fill_value
+        if self.unit is not None:
+            bkg_rms <<= self.unit
         return bkg_rms
 
     def plot_meshes(self, axes=None, marker='+', color='blue', outlines=False,

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -42,6 +42,7 @@ DATA2 = NDData(DATA, unit=None)
 DATA3 = NDData(DATA, unit=u.ct)
 DATA4 = CCDData(DATA, unit=u.ct)
 
+
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestBackground2D:
     @pytest.mark.parametrize(('filter_size', 'interpolator'),


### PR DESCRIPTION
All of the following are now allowed inputs to `Background2D`:

```python
data = np.random.randn(100, 100)
data = np.random.randn(100, 100) << u.ct
data = CCDData(np.random.randn(100, 100), unit=u.ct)
data = NDData(np.random.randn(100, 100), unit=u.ct)
data = NDData(np.random.randn(100, 100), unit=None)

bkg = Background2D(data, 3)
```

The output `bkg.background`, `bkg.background_rms`, `bkg.background_median`, `bkg.background_rms_median` will be `Quantity` objects if the input has units.

Closes #696.