### PR TITLE
Fix invalid PSF fit uncertainties when fitter does not return a covariance matrix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,12 @@ Bug Fixes
   - Fixed a bug where the default ``fixed_parameters`` in
     ``EllipseSample.update()`` were not defined. [#1139]
 
+- ``photutils.psf``
+
+  - Fixed a bug where very incorrect PSF-fitting uncertainties could
+    be returned when the astropy fitter did not return fit
+    uncertainties. [#1143]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where negative Kron radius values could be returned,

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -6,7 +6,7 @@ This module provides classes to perform PSF-fitting photometry.
 import warnings
 
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.nddata.utils import overlap_slices
+from astropy.nddata.utils import overlap_slices, NoOverlapError
 from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Column, Table, hstack, vstack
 from astropy.utils.exceptions import AstropyUserWarning
@@ -412,11 +412,6 @@ class BasicPSFPhotometry:
                                   self._get_uncertainties(
                                       len(star_groups.groups[n]))])
 
-            try:
-                from astropy.nddata.utils import NoOverlapError
-            except ImportError:
-                raise ImportError("astropy 1.1 or greater is required in "
-                                  "order to use this class.")
             # do not subtract if the fitting did not go well
             try:
                 image = subtract_psf(image, self.psf_model, param_table,

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -38,9 +38,9 @@ def make_psf_photometry_objs(std=1, sigma_psf=1):
     modified as-needed in specific tests below
     """
 
-    daofind = DAOStarFinder(threshold=5.0*std,
-                            fwhm=sigma_psf*gaussian_sigma_to_fwhm)
-    daogroup = DAOGroup(1.5*sigma_psf*gaussian_sigma_to_fwhm)
+    daofind = DAOStarFinder(threshold=5.0 * std,
+                            fwhm=sigma_psf * gaussian_sigma_to_fwhm)
+    daogroup = DAOGroup(1.5 * sigma_psf * gaussian_sigma_to_fwhm)
     threshold = 5. * std
     fwhm = sigma_psf * gaussian_sigma_to_fwhm
     crit_separation = 1.5 * sigma_psf * gaussian_sigma_to_fwhm
@@ -163,9 +163,9 @@ def test_psf_photometry_niters(sigma_psf, sources):
                           (sigma_psfs[1], sources2),
                           # these ensure that the test *fails* if the model
                           # PSFs are the wrong shape
-                          pytest.param(sigma_psfs[0]/1.2, sources1,
+                          pytest.param(sigma_psfs[0] / 1.2, sources1,
                                        marks=pytest.mark.xfail()),
-                          pytest.param(sigma_psfs[1]*1.2, sources2,
+                          pytest.param(sigma_psfs[1] * 1.2, sources2,
                                        marks=pytest.mark.xfail())])
 def test_psf_photometry_oneiter(sigma_psf, sources):
     """
@@ -630,7 +630,7 @@ def test_psf_extra_output_cols(sigma_psf, sources):
     for i, init_guesses in enumerate([init_guess1, init_guess2, init_guess3,
                                       init_guess4]):
         dao_phot = DAOPhotPSFPhotometry(crit_separation=8, threshold=40,
-                                        fwhm=2*2*np.sqrt(2*np.log(2)),
+                                        fwhm=4 * np.sqrt(2 * np.log(2)),
                                         psf_model=psf_model, fitshape=(11, 11),
                                         extra_output_cols=['sharpness',
                                                            'roundness1',
@@ -669,13 +669,13 @@ def test_finder_return_none():
             ys, xs = np.where(image == f)
             x = np.mean(xs)
             y = np.mean(ys)
-            table.add_row([int(n+1), x, y, f*9])
+            table.add_row([int(n + 1), x, y, f * 9])
         table.sort(['flux'])
 
         return table
 
     prf = np.zeros((7, 7), float)
-    prf[2:5, 2:5] = 1/9
+    prf[2:5, 2:5] = 1 / 9
     prf = FittableImageModel(prf)
 
     img = np.zeros((50, 50), float)
@@ -683,7 +683,7 @@ def test_finder_return_none():
     y0 = [20, 5, 40]
     f0 = [50, 100, 200]
     for x, y, f in zip(x0, y0, f0):
-        img[y-1:y+2, x-1:x+2] = f/9
+        img[y - 1:y + 2, x - 1:x + 2] = f / 9
 
     intab = Table(data=[[37, 19.6, 34.9], [19.6, 4.5, 40.1], [45, 103, 210]],
                   names=['x_0', 'y_0', 'flux_0'])


### PR DESCRIPTION
In some instances (still unclear why), the astropy fitter will not return a parameter covariance matrix, despite the fitter supporting it.  In those cases where the returned `fit_info` dictionary contains a `param_cov` key set the value of `None`, the PSF-photometry function returns `flux_unc`, `x_0_unc`, and `y_0_unc` columns in the output table with garbage values.  This PR fixes that check.  If `param_cov` is `None`, then no uncertainty values will be returned in the output table.