### PR TITLE
Change Default EPSFBuilder Recentering Function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,7 +74,7 @@ Bug Fixes
 - ``photutils.psf``
 
   - Changed the default ``recentering_func`` in ``EPSFBuilder``, to avoid
-    convergence issues. [#1143]
+    convergence issues. [#1144]
 
 
 1.0.1 (2020-09-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,11 @@ Bug Fixes
     ``SegmentationImage.remove_border_labels()`` with ``relabel=True``
     when no segments remain. [#1133]
 
+- ``photutils.psf``
+
+  - Changed the default ``recentering_func`` in ``EPSFBuilder``, to avoid
+    convergence issues. [#1143]
+
 
 1.0.1 (2020-09-24)
 ------------------

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from .epsf_stars import EPSFStar, EPSFStars, LinkedEPSFStar
 from .models import EPSFModel
-from ..centroids import centroid_epsf
+from ..centroids import centroid_com, centroid_epsf
 from ..utils._round import _py2intround
 
 try:
@@ -314,7 +314,7 @@ class EPSFBuilder:
     """
 
     def __init__(self, oversampling=4., shape=None,
-                 smoothing_kernel='quartic', recentering_func=centroid_epsf,
+                 smoothing_kernel='quartic', recentering_func=centroid_com,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
                  progress_bar=True, norm_radius=5.5, shift_val=0.5,
                  recentering_boxsize=(5, 5), center_accuracy=1.0e-3,
@@ -591,7 +591,7 @@ class EPSFBuilder:
 
         return convolve(epsf_data, kernel)
 
-    def _recenter_epsf(self, epsf, centroid_func=centroid_epsf,
+    def _recenter_epsf(self, epsf, centroid_func=centroid_com,
                        box_size=(5, 5), maxiters=20, center_accuracy=1.0e-4):
         """
         Calculate the center of the ePSF data and shift the data so the

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -88,9 +88,9 @@ class TestEPSFBuild:
         size = 25
         oversampling = 4.
         stars = extract_stars(self.nddata, self.init_stars, size=size)
-        epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=8,
+        epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=15,
                                    progress_bar=False, norm_radius=25,
-                                   recentering_maxiters=5)
+                                   recentering_maxiters=15)
         epsf, fitted_stars = epsf_builder(stars)
 
         ref_size = (size * oversampling) + 1
@@ -211,8 +211,8 @@ def test_epsf_build_oversampling(oversamp):
     stars_tbl['x'] = sources['x_0']
     stars_tbl['y'] = sources['y_0']
     stars = extract_stars(nddata, stars_tbl, size=25)
-    epsf_builder = EPSFBuilder(oversampling=oversamp, maxiters=10,
-                               progress_bar=False)
+    epsf_builder = EPSFBuilder(oversampling=oversamp, maxiters=15,
+                               progress_bar=False, recentering_maxiters=20)
     epsf, fitted_stars = epsf_builder(stars)
 
     # input PSF shape
@@ -223,4 +223,4 @@ def test_epsf_build_oversampling(oversamp):
     yy, xx = np.mgrid[0:size, 0:size]
     psf = m(xx, yy)
 
-    assert_allclose(epsf.data, psf*epsf.data.sum(), atol=2e-4)
+    assert_allclose(epsf.data, psf*epsf.data.sum(), atol=2.5e-4)


### PR DESCRIPTION
As per several issues raised, but most recently #969, there remains an outstanding issue in some cases with ePSF building. It seems that the issue now lies in the recentering function used during the process, which was left as `centroid_epsf` after #974 fixed some issues with the original bug fix of #817.

Thus this PR is a minor one to change the default `recentering_func` within `EPSFBuilder` to `centroid_com`, reverting the implementation of `centroid_epsf`. This seems to solve the issue raised in #969, and likely closes several related issues at the same time.

The change makes our unit tests converge a little bit slower than they did with `centroid_epsf`, so I tweaked a few parameters in the various `EPSFBuilder` calls to pass again. I also wasn't sure whether this was an API change or a bug fix, so let me know if this should really be an API change rather than a bug fix in the changelog.

cc @larrybradley as follow on from the discussion on #969