### PR TITLE
Remove centroid deprecations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,14 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+API changes
+^^^^^^^^^^^
+
+- ``photutils.centroid``
+
+  - Removed the deprecated ``fit_2dgaussian`` function and
+    ``GaussianConst2D`` class. [#1147]
+
 
 1.0.2 (unreleased)
 ------------------

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -5,15 +5,12 @@ The module contains tools for centroiding sources using Gaussians.
 
 import warnings
 
-from astropy.modeling import Fittable2DModel, Parameter
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import Const1D, Const2D, Gaussian1D, Gaussian2D
-from astropy.utils import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
-__all__ = ['centroid_1dg', 'gaussian1d_moments', 'centroid_2dg',
-           'fit_2dgaussian', 'GaussianConst2D']
+__all__ = ['centroid_1dg', 'gaussian1d_moments', 'centroid_2dg']
 
 
 def centroid_1dg(data, error=None, mask=None):
@@ -214,139 +211,3 @@ def centroid_2dg(data, error=None, mask=None):
     y, x = np.indices(data.shape)
     gfit = fitter(g_init, x, y, data, weights=weights)
     return np.array([gfit.x_mean_1.value, gfit.y_mean_1.value])
-
-
-@deprecated('1.0')
-def fit_2dgaussian(data, error=None, mask=None):
-    """
-    Fit a 2D Gaussian plus a constant to a 2D image.
-
-    Non-finite values (e.g., NaN or inf) in the ``data`` or ``error``
-    arrays are automatically masked. These masks are combined.
-
-    Parameters
-    ----------
-    data : array_like
-        The 2D array of the image.
-
-    error : array_like, optional
-        The 2D array of the 1-sigma errors of the input ``data``.
-
-    mask : array_like (bool), optional
-        A boolean mask, with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-
-    Returns
-    -------
-    result : A `GaussianConst2D` model instance.
-        The best-fitting Gaussian 2D model.
-    """
-    from ..morphology import data_properties  # prevent circular imports
-
-    data = np.ma.asanyarray(data)
-
-    if mask is not None and mask is not np.ma.nomask:
-        mask = np.asanyarray(mask)
-        if data.shape != mask.shape:
-            raise ValueError('data and mask must have the same shape.')
-        data.mask |= mask
-
-    if np.any(~np.isfinite(data)):
-        data = np.ma.masked_invalid(data)
-        warnings.warn('Input data contains non-finite values (e.g., NaN or '
-                      'infs) that were automatically masked.',
-                      AstropyUserWarning)
-
-    if error is not None:
-        error = np.ma.masked_invalid(error)
-        if data.shape != error.shape:
-            raise ValueError('data and error must have the same shape.')
-        data.mask |= error.mask
-        weights = 1.0 / error.clip(min=1.e-30)
-    else:
-        weights = np.ones(data.shape)
-
-    if np.ma.count(data) < 7:
-        raise ValueError('Input data must have a least 7 unmasked values to '
-                         'fit a 2D Gaussian plus a constant.')
-
-    # assign zero weight to masked pixels
-    if data.mask is not np.ma.nomask:
-        weights[data.mask] = 0.
-
-    mask = data.mask
-    data.fill_value = 0.
-    data = data.filled()
-
-    # Subtract the minimum of the data as a rough background estimate.
-    # This will also make the data values positive, preventing issues with
-    # the moment estimation in data_properties. Moments from negative data
-    # values can yield undefined Gaussian parameters, e.g., x/y_stddev.
-    props = data_properties(data - np.min(data), mask=mask)
-
-    init_const = 0.  # subtracted data minimum above
-    init_amplitude = np.ptp(data)
-    g_init = GaussianConst2D(constant=init_const, amplitude=init_amplitude,
-                             x_mean=props.xcentroid.value,
-                             y_mean=props.ycentroid.value,
-                             x_stddev=props.semimajor_axis_sigma.value,
-                             y_stddev=props.semiminor_axis_sigma.value,
-                             theta=props.orientation.value)
-    fitter = LevMarLSQFitter()
-    y, x = np.indices(data.shape)
-    gfit = fitter(g_init, x, y, data, weights=weights)
-
-    return gfit
-
-
-@deprecated('1.0')
-class GaussianConst2D(Fittable2DModel):
-    """
-    A model for a 2D Gaussian plus a constant.
-
-    Parameters
-    ----------
-    constant : float
-        Value of the constant.
-
-    amplitude : float
-        Amplitude of the Gaussian.
-
-    x_mean : float
-        Mean of the Gaussian in x.
-
-    y_mean : float
-        Mean of the Gaussian in y.
-
-    x_stddev : float
-        Standard deviation of the Gaussian in x. ``x_stddev`` and
-        ``y_stddev`` must be specified unless a covariance matrix
-        (``cov_matrix``) is input.
-
-    y_stddev : float
-        Standard deviation of the Gaussian in y. ``x_stddev`` and
-        ``y_stddev`` must be specified unless a covariance matrix
-        (``cov_matrix``) is input.
-
-    theta : float, optional
-        Rotation angle in radians. The rotation angle increases
-        counterclockwise.
-    """
-
-    constant = Parameter(default=1)
-    amplitude = Parameter(default=1)
-    x_mean = Parameter(default=0)
-    y_mean = Parameter(default=0)
-    x_stddev = Parameter(default=1)
-    y_stddev = Parameter(default=1)
-    theta = Parameter(default=0)
-
-    @staticmethod
-    def evaluate(x, y, constant, amplitude, x_mean, y_mean, x_stddev,
-                 y_stddev, theta):
-        """Two dimensional Gaussian plus constant function."""
-
-        model = Const2D(constant)(x, y) + Gaussian2D(amplitude, x_mean,
-                                                     y_mean, x_stddev,
-                                                     y_stddev, theta)(x, y)
-        return model

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -7,14 +7,12 @@ import itertools
 import warnings
 
 from astropy.modeling.models import Gaussian1D, Gaussian2D
-from astropy.utils.exceptions import (AstropyDeprecationWarning,
-                                      AstropyUserWarning)
+from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from ..gaussian import (centroid_1dg, centroid_2dg, gaussian1d_moments,
-                        fit_2dgaussian)
+from ..gaussian import centroid_1dg, centroid_2dg, gaussian1d_moments
 
 try:
     # the fitting routines in astropy use scipy.optimize
@@ -149,17 +147,3 @@ def test_gaussian1d_moments():
         assert_allclose(result, desired, rtol=0, atol=1.e-6)
     assert len(warnlist) == 1
     assert issubclass(warnlist[0].category, AstropyUserWarning)
-
-
-@pytest.mark.skipif('not HAS_SCIPY')
-def test_fitgaussian2d():
-    model = Gaussian2D(2.4, XCEN, YCEN, x_stddev=3.2, y_stddev=5.7,
-                       theta=np.pi/6.)
-    y, x = np.mgrid[0:50, 0:47]
-    data = model(x, y)
-    error = np.ones(data.shape, dtype=float)
-    mask = np.zeros(data.shape, dtype=bool)
-    with pytest.warns(AstropyDeprecationWarning):
-        gfit = fit_2dgaussian(data, error=error, mask=mask)
-    assert_allclose(gfit.x_mean.value, XCEN)
-    assert_allclose(gfit.y_mean.value, YCEN)


### PR DESCRIPTION
This PR removes the deprecated `fit_2dgaussian` function and `GaussianConst2D` class.