### PR TITLE
Make EPSFStars usable with multiprocessing

### DIFF
--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -321,6 +321,13 @@ class EPSFStars:
         for i in self._data:
             yield i
 
+    # explicit set/getstate to avoid infinite recursion from pickler using __getattr__
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+
     def __getattr__(self, attr):
         if attr in ['cutout_center', 'center', 'flux',
                     '_excluded_from_fit']:

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -321,7 +321,8 @@ class EPSFStars:
         for i in self._data:
             yield i
 
-    # explicit set/getstate to avoid infinite recursion from pickler using __getattr__
+    # explicit set/getstate to avoid infinite recursion
+    # from pickler using __getattr__
     def __getstate__(self):
         return self.__dict__
 

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -85,3 +85,14 @@ def test_epsf_star_residual_image():
     # spline fitting (twice), so assert_allclose cannot be more more precise than
     # 0.001 currently.
     assert_allclose(np.sum(residual), 0., atol=1.e-3, rtol=1e-3)
+
+
+def test_stars_pickleable():
+    """
+    Verify that EPSFStars can be successfully pickled/unpickled for use multiprocessing
+    """
+    from multiprocessing.reduction import ForkingPickler
+    stars = EPSFStars([1])  # Doesn't need to actually contain anything useful
+
+    # This should not blow up
+    ForkingPickler.loads(ForkingPickler.dumps(stars))

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -89,10 +89,11 @@ def test_epsf_star_residual_image():
 
 def test_stars_pickleable():
     """
-    Verify that EPSFStars can be successfully pickled/unpickled for use multiprocessing
+    Verify that EPSFStars can be successfully
+    pickled/unpickled for use multiprocessing
     """
     from multiprocessing.reduction import ForkingPickler
-    stars = EPSFStars([1])  # Doesn't need to actually contain anything useful
-
+    # Doesn't need to actually contain anything useful
+    stars = EPSFStars([1])
     # This should not blow up
     ForkingPickler.loads(ForkingPickler.dumps(stars))


### PR DESCRIPTION
I've encountered an issue where I couldn't return EPSFStars through multiprocessing, due to the custom `__getattr__` causing infinite recursion with `multiprocessing.ForkingPickler`. It does not seem to be an issue with the regular pickle module due to some difference of how it tries to find `__getstate__` which I don't really understand...

The included test is probably not something worthwhile to keep, but should reproduce the problem.

BTW are these tiny PRs fine or should I wait until/if I get more "content"?