### PR TITLE
Add get_overlap_slices method to BoundingBox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ New Features
   - Added an ``area_overlap`` method for ``PixelAperture`` objects that
     gives the overlapping area of the aperture on the data. [#874]
 
+  - Added a ``get_overlap_slices`` method and a ``center`` attribute to
+    ``BoundingBox``. [#1157]
+
 - ``photutils.background``
 
   - The ``Background2D`` class now accepts astropy ``NDData``,
@@ -42,6 +45,11 @@ Bug Fixes
 
 API changes
 ^^^^^^^^^^^
+
+- ``photutils.aperture``
+
+  - Deprecated the ``BoundingBox`` ``slices`` attribute. Use the
+    ``get_overlap_slices`` method instead. [#1157]
 
 - ``photutils.centroid``
 

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -162,7 +162,9 @@ class BoundingBox:
         The slice tuple is in numpy axis order (i.e., ``(y, x)``) and
         therefore can be used to slice numpy arrays.
         """
-
+        if self.iymin < 0 or self.ixmin < 0:
+            return ValueError('cannot create slices when ixmin or iymin '
+                              'is negative')
         return (slice(self.iymin, self.iymax), slice(self.ixmin, self.ixmax))
 
     @property

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -155,6 +155,7 @@ class BoundingBox:
         return self.iymax - self.iymin, self.ixmax - self.ixmin
 
     @property
+    @deprecated('1.1', alternative='get_overlap_slices')
     def slices(self):
         """
         The bounding box as a tuple of `slice` objects.
@@ -166,6 +167,50 @@ class BoundingBox:
             return ValueError('cannot create slices when ixmin or iymin '
                               'is negative')
         return (slice(self.iymin, self.iymax), slice(self.ixmin, self.ixmax))
+
+    def get_overlap_slices(self, shape):
+        """
+        Get slices for the overlapping part of the bounding box and an
+        2D array.
+
+        Parameters
+        ----------
+        shape : 2-tuple of int
+            The shape of the 2D array.
+
+        Returns
+        -------
+        slices_large : tuple of slices or `None`
+            A tuple of slice objects for each axis of the large array,
+            such that ``large_array[slices_large]`` extracts the region
+            of the large array that overlaps with the small array.
+            `None` is returned if there is no overlap of the bounding
+            box with the given image shape.
+        slices_small : tuple of slices or `None`
+            A tuple of slice objects for each axis of an array enclosed
+            by the bounding box such that ``small_array[slices_small]``
+            extracts the region that is inside the large array. `None`
+            is returned if there is no overlap of the bounding box with
+            the given image shape.
+        """
+        if len(shape) != 2:
+            raise ValueError('input shape must have 2 elements.')
+
+        xmin = self.ixmin
+        xmax = self.ixmax
+        ymin = self.iymin
+        ymax = self.iymax
+        if xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0:
+            # no overlap of the bounding box with the input shape
+            return None, None
+
+        slices_large = (slice(max(ymin, 0), min(ymax, shape[0])),
+                        slice(max(xmin, 0), min(xmax, shape[1])))
+        slices_small = (slice(max(-ymin, 0),
+                              min(ymax - ymin, shape[0] - ymin)),
+                        slice(max(-xmin, 0),
+                              min(xmax - xmin, shape[1] - xmin)))
+        return slices_large, slices_small
 
     @property
     def extent(self):

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -38,7 +38,6 @@ class ApertureMask:
         """
         Array representation of the mask data array (e.g., for matplotlib).
         """
-
         return self.data
 
     @property
@@ -46,71 +45,7 @@ class ApertureMask:
         """
         The shape of the mask data array.
         """
-
         return self.data.shape
-
-    def _overlap_slices(self, shape):
-        """
-        Calculate the slices for the overlapping part of the bounding
-        box and an array of the given shape.
-
-        Parameters
-        ----------
-        shape : tuple of int
-            The ``(ny, nx)`` shape of array where the slices are to be
-            applied.
-
-        Returns
-        -------
-        slices_large : tuple of slices
-            A tuple of slice objects for each axis of the large array,
-            such that ``large_array[slices_large]`` extracts the region
-            of the large array that overlaps with the small array.
-
-        slices_small : slice
-            A tuple of slice objects for each axis of the small array,
-            such that ``small_array[slices_small]`` extracts the region
-            of the small array that is inside the large array.
-        """
-
-        if len(shape) != 2:
-            raise ValueError('input shape must have 2 elements.')
-
-        xmin = self.bbox.ixmin
-        xmax = self.bbox.ixmax
-        ymin = self.bbox.iymin
-        ymax = self.bbox.iymax
-
-        if xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0:
-            # no overlap of the aperture with the data
-            return None, None
-
-        slices_large = (slice(max(ymin, 0), min(ymax, shape[0])),
-                        slice(max(xmin, 0), min(xmax, shape[1])))
-
-        slices_small = (slice(max(-ymin, 0),
-                              min(ymax - ymin, shape[0] - ymin)),
-                        slice(max(-xmin, 0),
-                              min(xmax - xmin, shape[1] - xmin)))
-
-        return slices_large, slices_small
-
-    def _to_image_partial_overlap(self, image):
-        """
-        Return an image of the mask in a 2D array, where the mask
-        is not fully within the image (i.e., partial or no overlap).
-        """
-
-        # find the overlap of the mask on the output image shape
-        slices_large, slices_small = self._overlap_slices(image.shape)
-
-        if slices_small is None:
-            return None  # no overlap
-
-        # insert the mask into the output image
-        image[slices_large] = self.data[slices_small]
-
-        return image
 
     def to_image(self, shape):
         """
@@ -127,20 +62,18 @@ class ApertureMask:
         result : `~numpy.ndarray`
             A 2D array of the mask.
         """
-
         if len(shape) != 2:
             raise ValueError('input shape must have 2 elements.')
 
+        # find the overlap of the mask on the output image shape
+        slices_large, slices_small = self.bbox.get_overlap_slices(shape)
+
+        if slices_small is None:
+            return None  # no overlap
+
+        # insert the mask into the output image
         image = np.zeros(shape)
-
-        if self.bbox.ixmin < 0 or self.bbox.iymin < 0:
-            return self._to_image_partial_overlap(image)
-
-        try:
-            image[self.bbox.slices] = self.data
-        except ValueError:  # partial or no overlap
-            image = self._to_image_partial_overlap(image)
-
+        image[slices_large] = self.data[slices_small]
         return image
 
     def cutout(self, data, fill_value=0., copy=False):
@@ -177,36 +110,32 @@ class ApertureMask:
             ``fill_value``.  `None` is returned if there is no overlap
             of the aperture with the input ``data``.
         """
-
         data = np.asanyarray(data)
         if data.ndim != 2:
             raise ValueError('data must be a 2D array.')
 
-        partial_overlap = False
-        if self.bbox.ixmin < 0 or self.bbox.iymin < 0:
-            partial_overlap = True
+        # find the overlap of the mask on the output image shape
+        slices_large, slices_small = self.bbox.get_overlap_slices(data.shape)
 
-        if not partial_overlap:
-            # try this for speed -- the result may still be a partial
-            # overlap, in which case the next block will be triggered
+        if slices_small is None:
+            return None  # no overlap
+
+        cutout_shape = (slices_small[0].stop - slices_small[0].start,
+                        slices_small[1].stop - slices_small[1].start)
+
+        if cutout_shape == self.shape:
+            cutout = data[slices_large]
             if copy:
-                cutout = data[self.bbox.slices].copy()  # preserves Quantity
-            else:
-                cutout = data[self.bbox.slices]
+                cutout = np.copy(cutout)
+            return cutout
 
-        if partial_overlap or (cutout.shape != self.shape):
-            slices_large, slices_small = self._overlap_slices(data.shape)
+        # cutout is always a copy for partial overlap
+        cutout = np.zeros(self.shape, dtype=data.dtype)
+        cutout[:] = fill_value
+        cutout[slices_small] = data[slices_large]
 
-            if slices_small is None:
-                return None  # no overlap
-
-            # cutout is a copy
-            cutout = np.zeros(self.shape, dtype=data.dtype)
-            cutout[:] = fill_value
-            cutout[slices_small] = data[slices_large]
-
-            if isinstance(data, u.Quantity):
-                cutout = u.Quantity(cutout, unit=data.unit)
+        if isinstance(data, u.Quantity):
+            cutout <<= data.unit
 
         return cutout
 
@@ -236,7 +165,6 @@ class ApertureMask:
             is returned if there is no overlap of the aperture with the
             input ``data``.
         """
-
         cutout = self.cutout(data, fill_value=fill_value)
         if cutout is None:
             return None

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -3,6 +3,7 @@
 Tests for the bounding_box module.
 """
 
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 import pytest
 
@@ -79,9 +80,30 @@ def test_bounding_box_shape():
     assert bbox.shape == (18, 9)
 
 
+def test_bounding_box_center():
+    bbox = BoundingBox(1, 10, 2, 20)
+    assert bbox.center == (10.5, 5)
+
+
+def test_bounding_box_get_overlap_slices():
+    bbox = BoundingBox(1, 10, 2, 20)
+    slc = ((slice(2, 20, None), slice(1, 10, None)),
+           (slice(0, 18, None), slice(0, 9, None)))
+    assert bbox.get_overlap_slices((50, 50)) == slc
+
+    bbox = BoundingBox(-10, -1, 2, 20)
+    assert bbox.get_overlap_slices((50, 50)) == (None, None)
+
+    bbox = BoundingBox(-10, 10, -10, 20)
+    slc = ((slice(0, 20, None), slice(0, 10, None)),
+           (slice(10, 30, None), slice(10, 20, None)))
+    assert bbox.get_overlap_slices((50, 50)) == slc
+
+
 def test_bounding_box_slices():
     bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox.slices == (slice(2, 20), slice(1, 10))
+    with pytest.warns(AstropyDeprecationWarning):
+        assert bbox.slices == (slice(2, 20), slice(1, 10))
 
 
 def test_bounding_box_extent():

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -46,9 +46,6 @@ def test_mask_cutout_shape():
         mask.cutout(np.arange(10))
 
     with pytest.raises(ValueError):
-        mask._overlap_slices((10,))
-
-    with pytest.raises(ValueError):
         mask.to_image((10,))
 
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -98,7 +98,6 @@ class TestSegmentationImage:
         assert self.segm[idx].label == label
         assert self.segm[idx].area == self.segm.get_area(label)
         assert self.segm[idx].slices == self.segm.slices[idx]
-        assert self.segm[idx].bbox.slices == self.segm[idx].slices
 
         for i, segment in enumerate(self.segm):
             assert segment.label == self.segm.labels[i]


### PR DESCRIPTION
This PR also deprecates the `BoundingBox.slices` attribute in favor of this new method, which is better for partial overlaps.