### PR TITLE
Fix RectangularAnnulus ApertureMask for non-default h_in

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@ Bug Fixes
     if ``fill_value`` was non-finite and the input array was integer
     type. [#1158]
 
+  - Fixed an issue where ``RectangularAnnulus`` with a non-default
+    ``h_in`` would give an incorrect ``ApertureMask``. [#1160]
+
 - ``photutils.psf``
 
   - Fixed a bug in ``EPSFBuild`` where a warning was raised if the input

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -82,7 +82,6 @@ class RectangularMaskMixin:
         elif hasattr(self, 'w_out'):  # annulus
             w = self.w_out
             h = self.h_out
-            h_in = self.w_in * self.h_out / self.w_out
         else:
             raise ValueError('Cannot determine the aperture radius.')
 
@@ -98,7 +97,7 @@ class RectangularMaskMixin:
             if hasattr(self, 'w_in'):
                 mask -= rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                                  edges[3], nx, ny, self.w_in,
-                                                 h_in, self.theta, 0,
+                                                 self.h_in, self.theta, 0,
                                                  subpixels)
 
             masks.append(ApertureMask(mask, bbox))

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -10,6 +10,7 @@ import pytest
 
 from ..bounding_box import BoundingBox
 from ..circle import CircularAperture, CircularAnnulus
+from ..rectangle import RectangularAnnulus
 from ..mask import ApertureMask
 
 try:
@@ -165,3 +166,10 @@ def test_mask_get_values_no_overlap():
     values = aper.to_mask().get_values(data)
     assert values.size == 1
     assert np.isnan(values[0])
+
+
+def test_rectangular_annulus_hin():
+    aper = RectangularAnnulus((25, 25), 2, 4, 20, h_in=18, theta=0)
+    mask = aper.to_mask(method='center')
+    assert mask.data.shape == (21, 5)
+    assert np.count_nonzero(mask.data) == 40


### PR DESCRIPTION
This PR fixes a bug where `RectangularAnnulus` instances with a non-default `h_in` parameter would produce an incorrect `ApertureMask`.