### PR TITLE
Fix SourceProperties local background

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,14 @@ Bug Fixes
   - Fixed a bug in ``EPSFBuild`` where a warning was raised if the input
     ``smoothing_kernel`` was an ``numpy.ndarray``. [#1146]
 
+- ``photutils.segmentation``
+
+  - Fixed ``SourceProperties`` ``local_background`` to work with
+    Quantity data inputs. [#1162]
+
+  - Fixed ``SourceProperties`` ``local_background`` for sources near the
+    image edges. [#1162]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -494,6 +494,10 @@ class TestSourcePropertiesFunction:
     def test_local_background(self):
         props = source_properties(IMAGE, self.segm, localbkg_width=24)
         assert_allclose(props[0].local_background, 0., atol=1.e-7)
+        props = source_properties(IMAGE << u.Jy, self.segm, localbkg_width=24)
+        local_bkg = props.local_background
+        assert isinstance(local_bkg, u.Quantity)
+        assert_allclose(local_bkg.value, 0., atol=1.e-7)
 
     def test_wcs(self):
         mywcs = make_wcs(IMAGE.shape)


### PR DESCRIPTION
This PR fixes two issues with `local_background`.  First, an exception is no longer issued if `Quantity` data inputs are used with `source_properties`/`SourceProperties`.  Second, this PR fixes the `local_background` calculation for sources near the image edges.