### PR TITLE
Fix kron radius for sources that are completely masked

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Bug Fixes
   - Fixed ``SourceProperties`` ``local_background`` for sources near the
     image edges. [#1162]
 
+  - Fixed ``SourceProperties`` ``kron_radius`` for sources that are
+    completely masked. [#1164]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1606,6 +1606,9 @@ class SourceProperties:
                 return None
             # use circular aperture with radius=self.kron_params[2]
             xypos = (self.xcentroid.value, self.ycentroid.value)
+            values = (xypos[0], xypos[1], self.kron_params[2])
+            if np.any(~np.isfinite(values)):
+                return None
             aperture = CircularAperture(xypos, r=self.kron_params[2])
         else:
             radius = self.kron_radius.value * self.kron_params[1]

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -1468,6 +1468,9 @@ class SourceProperties:
         a = self.semimajor_axis_sigma.value * radius
         b = self.semiminor_axis_sigma.value * radius
         theta = self.orientation.to(u.radian).value
+        values = (position[0], position[1], a, b, theta)
+        if np.any(~np.isfinite(values)):
+            return None
         return EllipticalAperture(position, a, b, theta=theta)
 
     def _mask_neighbors(self, aperture_mask, method='none'):
@@ -1553,6 +1556,9 @@ class SourceProperties:
         aperture will be `None` and the Kron flux will be ``np.nan``.
         """
         aperture = self._elliptical_aperture(radius=6.0)
+        if aperture is None:
+            return np.nan << u.pixel
+
         aperture_mask = aperture.to_mask()
 
         # prepare cutouts of the data and error arrays based on the

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -636,3 +636,8 @@ class TestSourceCatalog:
 
         assert repr(cat) == str(cat)
         assert 'Catalog length:' in repr(cat)
+
+    def test_kron_radius_all_masked(self):
+        mask = np.ones(IMAGE.shape, dtype=bool)
+        cat = source_properties(IMAGE, self.segm, mask=mask)
+        assert np.all(np.isnan(cat.kron_radius))


### PR DESCRIPTION
Fixes the `kron_radius` to be `np.nan` for completely masked sources.  Previously an exception was raised.