### PR TITLE
Add get_overlap_slices to ApertureMask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ New Features
   - Added a ``get_values`` method to ``ApertureMask`` that returns a 1D
     array of mask-weighted values. [#1158, #1161]
 
+  - Added ``get_overlap_slices`` method to ``ApertureMask``. [#1165]
+
 - ``photutils.background``
 
   - The ``Background2D`` class now accepts astropy ``NDData``,

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -48,6 +48,33 @@ class ApertureMask:
         """
         return self.data.shape
 
+    def get_overlap_slices(self, shape):
+        """
+        Get slices for the overlapping part of the aperture mask and a
+        2D array.
+
+        Parameters
+        ----------
+        shape : 2-tuple of int
+            The shape of the 2D array.
+
+        Returns
+        -------
+        slices_large : tuple of slices or `None`
+            A tuple of slice objects for each axis of the large array,
+            such that ``large_array[slices_large]`` extracts the region
+            of the large array that overlaps with the small array.
+            `None` is returned if there is no overlap of the bounding
+            box with the given image shape.
+        slices_small : tuple of slices or `None`
+            A tuple of slice objects for each axis of the aperture mask
+            array such that ``small_array[slices_small]`` extracts the
+            region that is inside the large array. `None` is returned if
+            there is no overlap of the bounding box with the given image
+            shape.
+        """
+        return self.bbox.get_overlap_slices(shape)
+
     def to_image(self, shape):
         """
         Return an image of the mask in a 2D array of the given shape,

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -168,6 +168,14 @@ def test_rectangular_annulus_hin():
     assert np.count_nonzero(mask.data) == 40
 
 
+def test_mask_get_overlap_slices():
+    aper = CircularAperture((5, 5), r=10.)
+    mask = aper.to_mask()
+    slc = ((slice(0, 16, None), slice(0, 16, None)),
+           (slice(5, 21, None), slice(5, 21, None)))
+    assert mask.get_overlap_slices((25, 25)) == slc
+
+
 def test_mask_get_values_mask():
     aper = CircularAperture((24.5, 24.5), r=10.)
     data = np.ones((51, 51))

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =
     pip freeze
+    pip install "Sphinx<3.5"
     sphinx-build -W -b html . _build/html
 
 [testenv:linkcheck]


### PR DESCRIPTION
This new method gets a tuple of slices for the overlapping part of the aperture mask and a 2D array.