### PR TITLE
Fix linkcheck tests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,6 +179,7 @@ if os.path.isfile(nitpick_filename):
 # -- Options for linkcheck output ---------------------------------------------
 linkcheck_retry = 5
 linkcheck_ignore = ['http://data.astropy.org',
+                    r'https://iraf.net/*',
                     r'https://github\.com/astropy/photutils/(?:issues|pull)/\d+']
 linkcheck_timeout = 180
 linkcheck_anchors = False

--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,7 @@ description = check the links in the HTML docs
 extras = docs
 commands =
     pip freeze
+    pip install "Sphinx<3.5"
     sphinx-build -W -b linkcheck . _build/html
 
 [testenv:codestyle]


### PR DESCRIPTION
Current `linkcheck` failures are caused by a Sphinx update and an outdated `iraf.net` certificate.