### PR TITLE
MNT: Replace master with main

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,1 +1,1 @@
-See https://github.com/astropy/photutils/blob/master/photutils/CITATION.rst
+See https://github.com/astropy/photutils/blob/main/photutils/CITATION.rst

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ workflow
 <https://docs.astropy.org/en/latest/development/workflow/development_workflow.html>`_.
 
 Once you open a pull request (which should be opened against the
-``master`` branch, not against any other branch), please make sure
+``main`` branch, not against any other branch), please make sure
 that you include the following:
 
 - **Code**: the code you are adding, which should follow as much as

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ where (Bradley et al. 20XX) is a citation to the `Zenodo record
 <https://doi.org/10.5281/zenodo.596036>`_ of the Photutils version
 that was used.  We also encourage citations in the main text wherever
 appropriate.  Please see the `CITATION
-<https://github.com/astropy/photutils/blob/master/photutils/CITATION.rst>`_
+<https://github.com/astropy/photutils/blob/main/photutils/CITATION.rst>`_
 file for details and an example BibTeX entry.
 
 
@@ -41,7 +41,7 @@ License
 
 Photutils is licensed under a 3-clause BSD license.  Please see the
 `LICENSE
-<https://github.com/astropy/photutils/blob/master/LICENSE.rst>`_ file
+<https://github.com/astropy/photutils/blob/main/LICENSE.rst>`_ file
 for details.
 
 
@@ -73,7 +73,7 @@ for details.
     :target: https://codecov.io/gh/astropy/photutils
     :alt: Coverage Status
 
-.. |CircleCI Status| image:: https://img.shields.io/circleci/build/github/astropy/photutils/master?logo=circleci&label=CircleCI
+.. |CircleCI Status| image:: https://img.shields.io/circleci/build/github/astropy/photutils/main?logo=circleci&label=CircleCI
     :target: https://circleci.com/gh/astropy/photutils
     :alt: CircleCI Status
 

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -6,14 +6,14 @@ Package Release Instructions
 
 This document outlines the steps for releasing Photutils to PyPI. This
 process currently requires admin-level access to the Photutils GitHub
-repository, as it relies on the ability to commit to master directly. It
+repository, as it relies on the ability to commit to main directly. It
 also requires a PyPI account with admin-level access for Photutils.
 
 These instructions assume the name of the git remote for the repo is
 called ``upstream``.
 
 #. Check out the branch that you are going to release. This will usually
-   be the ``master`` branch, unless you are making a bugfix release.
+   be the ``main`` branch, unless you are making a bugfix release.
 
    For a bugfix release, check out the ``A.B.x`` branch. Use ``git
    cherry-pick <hash>`` (or ``git cherry-pick -m1 <hash>`` for merge
@@ -114,9 +114,9 @@ called ``upstream``.
    Check that the entry on PyPI (https://pypi.org/project/photutils/) is
    correct, and that the tarfile is present.
 
-#. Go back to the master branch::
+#. Go back to the main branch::
 
-    git checkout master
+    git checkout main
 
 #. Push the released tag to the upstream repo::
 
@@ -136,12 +136,12 @@ called ``upstream``.
 
         git add CHANGES.rst
         git commit -m'Add version <x.y.z> to the changelog'
-        git push upstream master
+        git push upstream main
 
 #. After releasing a major version, tag this new commit with the
    development version of the next major version and push the tag to
    the upstream repo. This is needed if the latest package release is
-   the first bugfix release tagged on a bugfix branch (not the master
+   the first bugfix release tagged on a bugfix branch (not the main
    branch)::
 
         git tag -a <x.y.z.dev> -m'<x.y.z.dev>'

--- a/docs/isophote.rst
+++ b/docs/isophote.rst
@@ -249,13 +249,13 @@ Additional Example Notebooks (online)
 Additional example notebooks showing examples with real data and
 advanced usage are available online:
 
-* `Basic example of the Ellipse fitting tool <https://github.com/astropy/photutils-datasets/blob/master/notebooks/isophote/isophote_example1.ipynb>`_
+* `Basic example of the Ellipse fitting tool <https://github.com/astropy/photutils-datasets/blob/main/notebooks/isophote/isophote_example1.ipynb>`_
 
-* `Running Ellipse with sigma-clipping <https://github.com/astropy/photutils-datasets/blob/master/notebooks/isophote/isophote_example2.ipynb>`_
+* `Running Ellipse with sigma-clipping <https://github.com/astropy/photutils-datasets/blob/main/notebooks/isophote/isophote_example2.ipynb>`_
 
-* `Building an image model from results obtained by Ellipse fitting <https://github.com/astropy/photutils-datasets/blob/master/notebooks/isophote/isophote_example3.ipynb>`_
+* `Building an image model from results obtained by Ellipse fitting <https://github.com/astropy/photutils-datasets/blob/main/notebooks/isophote/isophote_example3.ipynb>`_
 
-* `Advanced Ellipse example: multi-band photometry and masked arrays <https://github.com/astropy/photutils-datasets/blob/master/notebooks/isophote/isophote_example4.ipynb>`_
+* `Advanced Ellipse example: multi-band photometry and masked arrays <https://github.com/astropy/photutils-datasets/blob/main/notebooks/isophote/isophote_example4.ipynb>`_
 
 
 Reference/API

--- a/photutils/datasets/load.py
+++ b/photutils/datasets/load.py
@@ -49,7 +49,7 @@ def get_path(filename, location='local', cache=True, show_progress=False):
     """
 
     datasets_url = ('https://github.com/astropy/photutils-datasets/raw/'
-                    f'master/data/{filename}')
+                    f'main/data/{filename}')
 
     if location == 'local':
         path = get_pkg_data_filename('data/' + filename)


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #1176 