### PR TITLE
Fix slicing EPSFStars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ New Features
 
   - The ``EPSFStars`` class is now usable with multiprocessing. [#1152]
 
+  - Slicing ``EPSFStars`` now returns an ``EPSFStars`` instance. [#1185]
+
 - ``photutils.segmentation``
 
   - Added a new, significantly faster, ``SourceCatalog`` class. [#1170]

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -312,7 +312,7 @@ class EPSFStars:
         return len(self._data)
 
     def __getitem__(self, index):
-        return self._data[index]
+        return self.__class__(self._data[index])
 
     def __delitem__(self, index):
         del self._data[index]
@@ -332,9 +332,12 @@ class EPSFStars:
     def __getattr__(self, attr):
         if attr in ['cutout_center', 'center', 'flux',
                     '_excluded_from_fit']:
-            return np.array([getattr(star, attr) for star in self._data])
+            result = np.array([getattr(star, attr) for star in self._data])
         else:
-            return [getattr(star, attr) for star in self._data]
+            result = [getattr(star, attr) for star in self._data]
+        if len(self._data) == 1:
+            result = result[0]
+        return result
 
     def _getattr_flat(self, attr):
         values = []

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
 
 from ..epsf import EPSFBuilder, EPSFFitter
-from ..epsf_stars import extract_stars, EPSFStar, EPSFStars
+from ..epsf_stars import extract_stars, EPSFStars
 from ..models import IntegratedGaussianPRF, EPSFModel
 from ...datasets import make_gaussian_prf_sources_image
 

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -77,7 +77,7 @@ class TestEPSFBuild:
 
         assert len(stars) == 81
         assert isinstance(stars, EPSFStars)
-        assert isinstance(stars[0], EPSFStar)
+        assert isinstance(stars[0], EPSFStars)
         assert stars[0].data.shape == (size, size)
 
     def test_epsf_build(self):

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -41,7 +41,7 @@ class TestExtractStars:
         stars = extract_stars(self.nddata, self.stars_tbl, size=size)
         assert len(stars) == 4
         assert isinstance(stars, EPSFStars)
-        assert isinstance(stars[0], EPSFStar)
+        assert isinstance(stars[0], EPSFStars)
         assert stars[0].data.shape == (size, size)
         assert stars.n_stars == stars.n_all_stars
         assert stars.n_stars == stars.n_good_stars

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from ..epsf_stars import extract_stars, EPSFStar, EPSFStars
+from ..epsf_stars import extract_stars, EPSFStars
 from ..models import EPSFModel, IntegratedGaussianPRF
 
 try:

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -7,7 +7,6 @@ from itertools import product
 
 from astropy.modeling.models import Gaussian2D, Moffat2D
 from astropy.nddata import NDData
-import astropy.units as u
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -14,7 +14,7 @@ import pytest
 
 from ..models import (FittableImageModel, GriddedPSFModel,
                       IntegratedGaussianPRF, PRFAdapter)
-from ...segmentation import detect_sources, source_properties
+from ...segmentation import detect_sources, SourceCatalog
 
 try:
     import scipy  # noqa
@@ -283,12 +283,12 @@ class TestGriddedPSFModel:
                                                  y_0=yyi)
 
         segm = detect_sources(data, 0., 5)
-        props = source_properties(data, segm)
-        orients = props.orientation.to(u.deg)
-        assert_allclose(orients[1].value, 50., rtol=1.e-5)
-        assert_allclose(orients[2].value, -80., rtol=1.e-5)
-        assert 88.3 < orients[0].value < 88.4
-        assert 64. < orients[3].value < 64.2
+        cat = SourceCatalog(data, segm)
+        orients = cat.orientation.value
+        assert_allclose(orients[1], 50., rtol=1.e-5)
+        assert_allclose(orients[2], -80., rtol=1.e-5)
+        assert 88.3 < orients[0] < 88.4
+        assert 64. < orients[3] < 64.2
 
 
 @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION

Slicing `EPSFStars` now returns a new `EPSFStars` instance instead of a list.

Closes #968