### PR TITLE
Add bbox attribute to SegmentationImage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,10 @@ New Features
 
 - ``photutils.segmentation``
 
-  - Added a new, significantly faster, ``SourceCatalog`` class. [#1170]
+  - Added a modified, significantly faster, ``SourceCatalog`` class.
+    [#1170]
+
+  - Added a ``bbox`` attribute to ``SegmentationImage``. [#1187]
 
 Bug Fixes
 ^^^^^^^^^
@@ -118,6 +121,9 @@ API changes
 
   - The ``detect_threshold`` function was moved to the ``segmentation``
     subpackage. [#1171]
+
+  - Removed the ability to slice ``SegmentationImage``. Instead slice
+    the ``segments`` attribute. [#1187]
 
 
 1.0.2 (2021-01-20)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -369,9 +369,9 @@ class SourceCatalog:
 
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
-        with np.printoptions(threshold=100, edgeitems=5):
-            fmt = [f'Sources: {self.nlabels}',
-                   f'Labels: {self.label}']
+        with np.printoptions(threshold=25, edgeitems=5):
+            fmt = [f'Length: {self.nlabels}',
+                   f'labels: {self.labels}']
         return f'{cls_name}\n' + '\n'.join(fmt)
 
     def __repr__(self):
@@ -620,13 +620,23 @@ class SourceCatalog:
         return self._labels
 
     @property
+    def labels(self):
+        """
+        The source label number(s).
+
+        This label number corresponds to the assigned pixel value in the
+        `~photutils.segmentation.SegmentationImage`.
+        """
+        return self._label_iter
+
+    @property
     def _label_iter(self):
         """
         The source label, always as a iterable.
         """
         _label = self.label
         if self.isscalar:
-            _label = (_label,)
+            _label = np.array((_label,))
         return _label
 
     @property

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -185,10 +185,12 @@ class SegmentationImage:
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
 
         cls_info = []
-        params = ['shape', 'nlabels', 'max_label']
+        params = ['shape', 'nlabels']
         for param in params:
             cls_info.append((param, getattr(self, param)))
-        fmt = [f'{key}: {val}' for key, val in cls_info]
+        cls_info.append(('labels', self.labels))
+        with np.printoptions(threshold=25, edgeitems=5):
+            fmt = [f'{key}: {val}' for key, val in cls_info]
 
         return f'{cls_name}\n' + '\n'.join(fmt)
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -13,148 +13,10 @@ import numpy as np
 from ..aperture import BoundingBox
 from ..utils.colormaps import make_random_cmap
 
-__all__ = ['Segment', 'SegmentationImage']
+__all__ = ['SegmentationImage', 'Segment']
 
 __doctest_requires__ = {('SegmentationImage', 'SegmentationImage.*'):
                         ['scipy']}
-
-
-class Segment:
-    """
-    Class for a single labeled region (segment) within a segmentation
-    image.
-
-    Parameters
-    ----------
-    segment_data : int `~numpy.ndarray`
-        A segmentation array where source regions are labeled by
-        different positive integer values.  A value of zero is reserved
-        for the background.
-
-    label : int
-        The segment label number.
-
-    slices : tuple of two slices
-        A tuple of two slices representing the minimal box that contains
-        the labeled region.
-
-    area : float
-        The area of the segment in pixels**2.
-    """
-
-    def __init__(self, segment_data, label, slices, area):
-        self._segment_data = segment_data
-        self.label = label
-        self.slices = slices
-        self.area = area
-
-    def __str__(self):
-        cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
-
-        cls_info = []
-        params = ['label', 'slices', 'area']
-        for param in params:
-            cls_info.append((param, getattr(self, param)))
-        fmt = [f'{key}: {val}' for key, val in cls_info]
-
-        return f'{cls_name}\n' + '\n'.join(fmt)
-
-    def __repr__(self):
-        return self.__str__()
-
-    def __array__(self):
-        """
-        Array representation of the labeled region (e.g., for
-        matplotlib).
-        """
-
-        return self.data
-
-    @lazyproperty
-    def data(self):
-        """
-        A cutout array of the segment using the minimal bounding box,
-        where pixels outside of the labeled region are set to zero
-        (i.e., neighboring segments within the rectangular cutout array
-        are not shown).
-        """
-
-        cutout = np.copy(self._segment_data[self.slices])
-        cutout[cutout != self.label] = 0
-
-        return cutout
-
-    @lazyproperty
-    def data_ma(self):
-        """
-        A `~numpy.ma.MaskedArray` cutout array of the segment using the
-        minimal bounding box.
-
-        The mask is `True` for pixels outside of the source segment
-        (i.e., neighboring segments within the rectangular cutout array
-        are masked).
-        """
-
-        mask = (self._segment_data[self.slices] != self.label)
-        return np.ma.masked_array(self._segment_data[self.slices], mask=mask)
-
-    @lazyproperty
-    def bbox(self):
-        """
-        The `~photutils.aperture.BoundingBox` of the minimal rectangular
-        region containing the source segment.
-        """
-
-        if self._segment_data.ndim != 2:
-            raise ValueError('The "bbox" attribute requires a 2D '
-                             'segmentation image.')
-
-        return BoundingBox(self.slices[1].start, self.slices[1].stop,
-                           self.slices[0].start, self.slices[0].stop)
-
-    def make_cutout(self, data, masked_array=False):
-        """
-        Create a (masked) cutout array from the input ``data`` using the
-        minimal bounding box of the segment (labeled region).
-
-        If ``masked_array`` is `False` (default), then the returned
-        cutout array is simply a `~numpy.ndarray`.  The returned cutout
-        is a view (not a copy) of the input ``data``.  No pixels are
-        altered (e.g., set to zero) within the bounding box.
-
-        If ``masked_array` is `True`, then the returned cutout array is
-        a `~numpy.ma.MaskedArray`, where the mask is `True` for pixels
-        outside of the segment (labeled region).  The data part of the
-        masked array is a view (not a copy) of the input ``data``.
-
-        Parameters
-        ----------
-        data : array-like
-            The data array from which to create the masked cutout array.
-            ``data`` must have the same shape as the segmentation array.
-
-        masked_array : bool, optional
-            If `True` then a `~numpy.ma.MaskedArray` will be created
-            where the mask is `True` for pixels outside of the segment
-            (labeled region).  If `False`, then a `~numpy.ndarray` will
-            be generated.
-
-        Returns
-        -------
-        result : `~numpy.ndarray` or `~numpy.ma.MaskedArray`
-            The cutout array.
-        """
-
-        data = np.asanyarray(data)
-        if data.shape != self._segment_data.shape:
-            raise ValueError('data must have the same shape as the '
-                             'segmentation array.')
-
-        if masked_array:
-            mask = (self._segment_data[self.slices] != self.label)
-            return np.ma.masked_array(data[self.slices], mask=mask)
-        else:
-            return data[self.slices]
 
 
 class SegmentationImage:
@@ -202,7 +64,6 @@ class SegmentationImage:
         Array representation of the segmentation array (e.g., for
         matplotlib).
         """
-
         return self._data
 
     @lazyproperty
@@ -212,7 +73,6 @@ class SegmentationImage:
 
         This is very useful for plotting the segmentation array.
         """
-
         return self.make_cmap(background_color='#000000', seed=0)
 
     @staticmethod
@@ -251,7 +111,6 @@ class SegmentationImage:
         >>> segm._get_labels(segm.data)
         array([1, 3, 4, 5, 7])
         """
-
         # np.unique also sorts elements
         return np.unique(data[data != 0])
 
@@ -264,7 +123,6 @@ class SegmentationImage:
         has a length equal to the number of labels and matches the order
         of the ``labels`` attribute.
         """
-
         segments = []
         for label, slc in zip(self.labels, self.slices):
             segments.append(Segment(self.data, label, slc,
@@ -274,7 +132,6 @@ class SegmentationImage:
     @property
     def data(self):
         """The segmentation array."""
-
         return self._data
 
     @data.setter
@@ -304,37 +161,31 @@ class SegmentationImage:
         A `~numpy.ma.MaskedArray` version of the segmentation array
         where the background (label = 0) has been masked.
         """
-
         return np.ma.masked_where(self.data == 0, self.data)
 
     @lazyproperty
     def shape(self):
         """The shape of the segmentation array."""
-
         return self._data.shape
 
     @lazyproperty
     def _ndim(self):
         """The number of array dimensions of the segmentation array."""
-
         return self._data.ndim
 
     @lazyproperty
     def labels(self):
         """The sorted non-zero labels in the segmentation array."""
-
         return self._get_labels(self.data)
 
     @lazyproperty
     def nlabels(self):
         """The number of non-zero labels in the segmentation array."""
-
         return len(self.labels)
 
     @lazyproperty
     def max_label(self):
         """The maximum non-zero label in the segmentation array."""
-
         return np.max(self.labels)
 
     def get_index(self, label):
@@ -356,7 +207,6 @@ class SegmentationImage:
         ValueError
             If ``label`` is invalid.
         """
-
         self.check_labels(label)
         return np.searchsorted(self.labels, label)
 
@@ -381,7 +231,6 @@ class SegmentationImage:
         ValueError
             If any input ``labels`` are invalid.
         """
-
         self.check_labels(labels)
         return np.searchsorted(self.labels, labels)
 
@@ -395,7 +244,6 @@ class SegmentationImage:
         has a length equal to the number of labels and matches the order
         of the ``labels`` attribute.
         """
-
         from scipy.ndimage import find_objects
 
         return [slc for slc in find_objects(self._data) if slc is not None]
@@ -403,7 +251,6 @@ class SegmentationImage:
     @lazyproperty
     def background_area(self):
         """The area (in pixel**2) of the background (label=0) region."""
-
         return len(self.data[self.data == 0])
 
     @lazyproperty
@@ -416,7 +263,6 @@ class SegmentationImage:
         returned array has a length equal to the number of labels and
         matches the order of the ``labels`` attribute.
         """
-
         return np.array([area
                          for area in np.bincount(self.data.ravel())[1:]
                          if area != 0])
@@ -435,7 +281,6 @@ class SegmentationImage:
         area : `~numpy.ndarray`
             The area of the labeled region.
         """
-
         return self.get_areas(label)
 
     def get_areas(self, labels):
@@ -453,7 +298,6 @@ class SegmentationImage:
         areas : `~numpy.ndarray`
             The areas of the labeled regions.
         """
-
         idx = self.get_indices(labels)
         return self.areas[idx]
 
@@ -463,7 +307,6 @@ class SegmentationImage:
         Determine whether or not the non-zero labels in the segmentation
         array are consecutive and start from 1.
         """
-
         return ((self.labels[-1] - self.labels[0] + 1) == self.nlabels and
                 self.labels[0] == 1)
 
@@ -474,13 +317,11 @@ class SegmentationImage:
         missing in the consecutive sequence from one to the maximum
         label number.
         """
-
         return np.array(sorted(set(range(0, self.max_label + 1))
                                .difference(np.insert(self.labels, 0, 0))))
 
     def copy(self):
         """Return a deep copy of this class instance."""
-
         return deepcopy(self)
 
     def check_label(self, label):
@@ -498,7 +339,6 @@ class SegmentationImage:
         ValueError
             If the input ``label`` is invalid.
         """
-
         self.check_labels(label)
 
     def check_labels(self, labels):
@@ -516,7 +356,6 @@ class SegmentationImage:
         ValueError
             If any input ``labels`` are invalid.
         """
-
         labels = np.atleast_1d(labels)
         bad_labels = set()
 
@@ -561,7 +400,6 @@ class SegmentationImage:
         cmap : `matplotlib.colors.ListedColormap`
             The matplotlib colormap.
         """
-
         from matplotlib import colors
 
         cmap = make_random_cmap(self.max_label + 1, seed=seed)
@@ -639,7 +477,6 @@ class SegmentationImage:
                [4, 4, 0, 3, 3, 3],
                [4, 4, 0, 0, 3, 3]])
         """
-
         self.reassign_labels(label, new_label, relabel=relabel)
 
     def reassign_labels(self, labels, new_label, relabel=False):
@@ -712,7 +549,6 @@ class SegmentationImage:
                [1, 1, 0, 4, 4, 4],
                [1, 1, 0, 0, 4, 4]])
         """
-
         self.check_labels(labels)
 
         labels = np.atleast_1d(labels)
@@ -763,7 +599,6 @@ class SegmentationImage:
                [5, 5, 0, 4, 4, 4],
                [5, 5, 0, 0, 4, 4]])
         """
-
         if start_label <= 0:
             raise ValueError('start_label must be > 0.')
 
@@ -824,7 +659,6 @@ class SegmentationImage:
                [0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0]])
         """
-
         self.keep_labels(label, relabel=relabel)
 
     def keep_labels(self, labels, relabel=False):
@@ -874,7 +708,6 @@ class SegmentationImage:
                [0, 0, 0, 2, 2, 2],
                [0, 0, 0, 0, 2, 2]])
         """
-
         self.check_labels(labels)
 
         labels = np.atleast_1d(labels)
@@ -931,7 +764,6 @@ class SegmentationImage:
                [4, 4, 0, 0, 0, 0],
                [4, 4, 0, 0, 0, 0]])
         """
-
         self.remove_labels(label, relabel=relabel)
 
     def remove_labels(self, labels, relabel=False):
@@ -1044,7 +876,6 @@ class SegmentationImage:
                [7, 7, 0, 5, 5, 5],
                [7, 7, 0, 0, 5, 5]])
         """
-
         if border_width >= min(self.shape) / 2:
             raise ValueError('border_width must be smaller than half the '
                              'array size in any dimension')
@@ -1117,7 +948,6 @@ class SegmentationImage:
                [7, 7, 0, 5, 5, 5],
                [7, 7, 0, 0, 5, 5]])
         """
-
         if mask.shape != self.shape:
             raise ValueError('mask must have the same shape as the '
                              'segmentation array')
@@ -1167,7 +997,6 @@ class SegmentationImage:
                [0, 2, 2, 2, 2, 0],
                [0, 0, 0, 0, 0, 0]])
         """
-
         from scipy.ndimage import (generate_binary_structure, grey_dilation,
                                    grey_erosion)
 
@@ -1185,3 +1014,136 @@ class SegmentationImage:
             outlines = np.ma.masked_where(outlines == 0, outlines)
 
         return outlines
+
+
+class Segment:
+    """
+    Class for a single labeled region (segment) within a segmentation
+    image.
+
+    Parameters
+    ----------
+    segment_data : int `~numpy.ndarray`
+        A segmentation array where source regions are labeled by
+        different positive integer values.  A value of zero is reserved
+        for the background.
+
+    label : int
+        The segment label number.
+
+    slices : tuple of two slices
+        A tuple of two slices representing the minimal box that contains
+        the labeled region.
+
+    area : float
+        The area of the segment in pixels**2.
+    """
+
+    def __init__(self, segment_data, label, slices, area):
+        self._segment_data = segment_data
+        self.label = label
+        self.slices = slices
+        self.area = area
+
+    def __str__(self):
+        cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
+
+        cls_info = []
+        params = ['label', 'slices', 'area']
+        for param in params:
+            cls_info.append((param, getattr(self, param)))
+        fmt = [f'{key}: {val}' for key, val in cls_info]
+
+        return f'{cls_name}\n' + '\n'.join(fmt)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __array__(self):
+        """
+        Array representation of the labeled region (e.g., for
+        matplotlib).
+        """
+        return self.data
+
+    @lazyproperty
+    def data(self):
+        """
+        A cutout array of the segment using the minimal bounding box,
+        where pixels outside of the labeled region are set to zero
+        (i.e., neighboring segments within the rectangular cutout array
+        are not shown).
+        """
+        cutout = np.copy(self._segment_data[self.slices])
+        cutout[cutout != self.label] = 0
+
+        return cutout
+
+    @lazyproperty
+    def data_ma(self):
+        """
+        A `~numpy.ma.MaskedArray` cutout array of the segment using the
+        minimal bounding box.
+
+        The mask is `True` for pixels outside of the source segment
+        (i.e., neighboring segments within the rectangular cutout array
+        are masked).
+        """
+        mask = (self._segment_data[self.slices] != self.label)
+        return np.ma.masked_array(self._segment_data[self.slices], mask=mask)
+
+    @lazyproperty
+    def bbox(self):
+        """
+        The `~photutils.aperture.BoundingBox` of the minimal rectangular
+        region containing the source segment.
+        """
+        if self._segment_data.ndim != 2:
+            raise ValueError('The "bbox" attribute requires a 2D '
+                             'segmentation image.')
+
+        return BoundingBox(self.slices[1].start, self.slices[1].stop,
+                           self.slices[0].start, self.slices[0].stop)
+
+    def make_cutout(self, data, masked_array=False):
+        """
+        Create a (masked) cutout array from the input ``data`` using the
+        minimal bounding box of the segment (labeled region).
+
+        If ``masked_array`` is `False` (default), then the returned
+        cutout array is simply a `~numpy.ndarray`.  The returned cutout
+        is a view (not a copy) of the input ``data``.  No pixels are
+        altered (e.g., set to zero) within the bounding box.
+
+        If ``masked_array` is `True`, then the returned cutout array is
+        a `~numpy.ma.MaskedArray`, where the mask is `True` for pixels
+        outside of the segment (labeled region).  The data part of the
+        masked array is a view (not a copy) of the input ``data``.
+
+        Parameters
+        ----------
+        data : array-like
+            The data array from which to create the masked cutout array.
+            ``data`` must have the same shape as the segmentation array.
+
+        masked_array : bool, optional
+            If `True` then a `~numpy.ma.MaskedArray` will be created
+            where the mask is `True` for pixels outside of the segment
+            (labeled region).  If `False`, then a `~numpy.ndarray` will
+            be generated.
+
+        Returns
+        -------
+        result : `~numpy.ndarray` or `~numpy.ma.MaskedArray`
+            The cutout array.
+        """
+        data = np.asanyarray(data)
+        if data.shape != self._segment_data.shape:
+            raise ValueError('data must have the same shape as the '
+                             'segmentation array.')
+
+        if masked_array:
+            mask = (self._segment_data[self.slices] != self.label)
+            return np.ma.masked_array(data[self.slices], mask=mask)
+        else:
+            return data[self.slices]

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -36,13 +36,6 @@ class SegmentationImage:
     def __init__(self, data):
         self.data = data
 
-    def __getitem__(self, index):
-        return self.segments[index]
-
-    def __iter__(self):
-        for i in self.segments:
-            yield i
-
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
 
@@ -98,18 +91,6 @@ class SegmentationImage:
         This is a static method so it can be used in
         :meth:`remove_masked_labels` on a masked version of the
         segmentation array.
-
-        Examples
-        --------
-        >>> from photutils import SegmentationImage
-        >>> segm = SegmentationImage([[1, 1, 0, 0, 4, 4],
-        ...                           [0, 0, 0, 0, 0, 4],
-        ...                           [0, 0, 3, 3, 0, 0],
-        ...                           [7, 0, 0, 0, 0, 5],
-        ...                           [7, 7, 0, 5, 5, 5],
-        ...                           [7, 7, 0, 0, 5, 5]])
-        >>> segm._get_labels(segm.data)
-        array([1, 3, 4, 5, 7])
         """
         # np.unique also sorts elements
         return np.unique(data[data != 0])

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -99,7 +99,6 @@ def deblend_sources(data, segment_img, npixels, filter_kernel=None,
     --------
     :func:`photutils.segmentation.detect_sources`
     """
-
     if not isinstance(segment_img, SegmentationImage):
         segment_img = SegmentationImage(segment_img)
 
@@ -217,7 +216,6 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
         value of zero is reserved for the background.  Note that the
         returned `SegmentationImage` may *not* have consecutive labels.
     """
-
     from scipy.ndimage import label as ndilabel
     from skimage.segmentation import watershed
 

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -286,7 +286,7 @@ class SourceProperties:
         segment_img.check_labels(label)
         self.label = label
 
-        self.segment = segment_img[segment_img.get_index(label)]
+        self.segment = segment_img.segments[segment_img.get_index(label)]
         self.slices = self.segment.slices
 
         if localbkg_width is not None and localbkg_width <= 0:

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -322,7 +322,7 @@ class TestSourceCatalog:
         cat = SourceCatalog(self.data, self.segm)
         assert repr(cat) == str(cat)
 
-        lines = ('Sources: 7', 'Labels: [1 2 3 4 5 6 7]')
+        lines = ('Length: 7', 'labels: [1 2 3 4 5 6 7]')
         for line in lines:
             assert line in repr(cat)
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -98,8 +98,9 @@ class TestSegmentationImage:
         label = 4
         idx = self.segm.get_index(label)
         assert self.segm.segments[idx].label == label
-        assert self.segm.segments[idx].area == self.segm.get_area(label)
+        assert self.segm.segments[idx].area == self.segm.areas[idx]
         assert self.segm.segments[idx].slices == self.segm.slices[idx]
+        assert self.segm.segments[idx].bbox == self.segm.bbox[idx]
 
     def test_repr_str(self):
         assert repr(self.segm) == str(self.segm)

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -86,52 +86,51 @@ class TestSegmentationImage:
         assert np.ma.count_masked(self.segm.data_ma) == 18
 
     def test_segments(self):
-        assert isinstance(self.segm[0], Segment)
-        assert_allclose(self.segm[0].data, self.segm[0].__array__())
+        assert isinstance(self.segm.segments[0], Segment)
+        assert_allclose(self.segm.segments[0].data,
+                        self.segm.segments[0].__array__())
 
-        assert self.segm[0].data_ma.shape == self.segm[0].data.shape
-        assert (self.segm[0].data_ma.filled(0.).sum() ==
-                self.segm[0].data.sum())
+        assert (self.segm.segments[0].data_ma.shape
+                == self.segm.segments[0].data.shape)
+        assert (self.segm.segments[0].data_ma.filled(0.).sum()
+                == self.segm.segments[0].data.sum())
 
         label = 4
         idx = self.segm.get_index(label)
-        assert self.segm[idx].label == label
-        assert self.segm[idx].area == self.segm.get_area(label)
-        assert self.segm[idx].slices == self.segm.slices[idx]
-
-        for i, segment in enumerate(self.segm):
-            assert segment.label == self.segm.labels[i]
+        assert self.segm.segments[idx].label == label
+        assert self.segm.segments[idx].area == self.segm.get_area(label)
+        assert self.segm.segments[idx].slices == self.segm.slices[idx]
 
     def test_repr_str(self):
         assert repr(self.segm) == str(self.segm)
 
-        props = ['shape', 'nlabels', 'max_label']
+        props = ['shape', 'nlabels']
         for prop in props:
             assert f'{prop}:' in repr(self.segm)
 
     def test_segment_repr_str(self):
-        assert repr(self.segm[0]) == str(self.segm[0])
-
         props = ['label', 'slices', 'area']
         for prop in props:
-            assert f'{prop}:' in repr(self.segm[0])
+            assert f'{prop}:' in repr(self.segm.segments[0])
 
     def test_segment_data(self):
-        assert_allclose(self.segm[3].data.shape, (3, 3))
-        assert_allclose(np.unique(self.segm[3].data), [0, 5])
+        assert_allclose(self.segm.segments[3].data.shape, (3, 3))
+        assert_allclose(np.unique(self.segm.segments[3].data), [0, 5])
 
     def test_segment_make_cutout(self):
-        cutout = self.segm[3].make_cutout(self.data, masked_array=False)
+        cutout = self.segm.segments[3].make_cutout(self.data,
+                                                   masked_array=False)
         assert not np.ma.is_masked(cutout)
         assert_allclose(cutout.shape, (3, 3))
 
-        cutout = self.segm[3].make_cutout(self.data, masked_array=True)
+        cutout = self.segm.segments[3].make_cutout(self.data,
+                                                   masked_array=True)
         assert np.ma.is_masked(cutout)
         assert_allclose(cutout.shape, (3, 3))
 
     def test_segment_make_cutout_input(self):
         with pytest.raises(ValueError):
-            self.segm[0].make_cutout(np.arange(10))
+            self.segm.segments[0].make_cutout(np.arange(10))
 
     def test_labels(self):
         assert_allclose(self.segm.labels, [1, 3, 4, 5, 7])
@@ -146,8 +145,8 @@ class TestSegmentationImage:
         expected = np.array([2, 2, 3, 6, 5])
         assert_allclose(self.segm.areas, expected)
 
-        assert (self.segm.get_area(1) ==
-                self.segm.areas[self.segm.get_index(1)])
+        assert (self.segm.get_area(1)
+                == self.segm.areas[self.segm.get_index(1)])
         assert_allclose(self.segm.get_areas(self.segm.labels),
                         self.segm.areas)
 


### PR DESCRIPTION
This PR adds a `bbox` attribute to `SegmentationImage`.  It also removes the ability to slice a `Segmentation`.  Instead, one should slice `SegmentationImage.segments`.