### PR TITLE
Deprecate top-level imports from centroids and morphology subpackages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,14 @@ API changes
   - Removed the deprecated ``fit_2dgaussian`` function and
     ``GaussianConst2D`` class. [#1147]
 
+  - Importing tools from the centroids subpackge without including the
+    subpackage name is deprecated. [#1190]
+
+- ``photutils.morphology``
+
+  - Importing tools from the morphology subpackge without including the
+    subpackage name is deprecated. [#1190]
+
 - ``photutils.segmentation``
 
   - Deprecated the ``"mask_all"`` option in the ``SourceProperties``

--- a/photutils/__init__.py
+++ b/photutils/__init__.py
@@ -6,6 +6,8 @@ has tools for background estimation, ePSF building, PSF matching,
 centroiding, and morphological measurements.
 """
 
+import warnings
+
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
@@ -14,11 +16,40 @@ from ._astropy_init import *  # noqa
 
 from .aperture import *  # noqa
 from .background import *  # noqa
-from .centroids import *  # noqa
 from .detection import *  # noqa
-from .morphology import *  # noqa
 from .psf import *  # noqa
 from .segmentation import *  # noqa
+
+# deprecations
+from . import centroids
+from . import morphology
+
+__depr__ = {}
+__depr__[centroids] = ('centroid_com', 'centroid_quadratic',
+                       'centroid_sources', 'centroid_epsf',
+                       'centroid_1dg', 'gaussian1d_moments', 'centroid_2dg')
+__depr__[morphology] = ('data_properties', 'gini')
+
+__depr_mesg__ = ('`photutils.{attr}` is a deprecated alias for '
+                 '`{module}.{attr}`. Instead, please use `from {module} '
+                 'import {attr}` to silence this warning.')
+
+__depr_attrs__ = {}
+for k, vals in __depr__.items():
+    for val in vals:
+        __depr_attrs__[val] = (getattr(k, val),
+                               __depr_mesg__.format(module=k.__name__,
+                                                    attr=val))
+del k, val, vals
+
+
+def __getattr__(attr):
+    if attr in __depr_attrs__:
+        obj, message = __depr_attrs__[attr]
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
+        return obj
+    raise AttributeError('module {!r} has no attribute {!r}'
+                         .format(__name__, attr))
 
 
 # Set the bibtex entry to the article referenced in CITATION.rst.


### PR DESCRIPTION
This is the first step in the direction of requiring the subpackage name for all imports.  This PR starts with the `centroids` and `morphology` subpackges.  Other subpackages may come later.