### PR TITLE
Add FWHM property to SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,10 +49,12 @@ New Features
 - ``photutils.segmentation``
 
   - Added a modified, significantly faster, ``SourceCatalog`` class.
-    [#1170, #1188]
+    [#1170, #1188, #1191]
 
   - Added ``circular_aperture`` and ``circular_phometry`` methods to the
     ``SourceCatalog`` class. [#1188]
+
+  - Added ``fwhm`` property to the ``SourceCatalog`` class. [#1191]
 
   - Added a ``bbox`` attribute to ``SegmentationImage``. [#1187]
 

--- a/docs/whats_new/1.1.rst
+++ b/docs/whats_new/1.1.rst
@@ -73,5 +73,6 @@ new methods:
 
 and new attributes:
 
+    * :attr:`~photutils.segmentation.SourceCatalog.fwhm`
     * :attr:`~photutils.segmentation.SourceCatalog.segment`
     * :attr:`~photutils.segmentation.SourceCatalog.segment_ma`

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1558,6 +1558,25 @@ class SourceCatalog:
 
     @lazyproperty
     @as_scalar
+    def fwhm(self):
+        """
+        Circularized FWHM of the 2D Gaussian function that has the same
+        second-order central moments as the source.
+
+        .. math::
+
+           \\mathrm{FWHM} & = 2 \\sqrt{2 \\ln(2)} \\sqrt{0.5 (a^2 + b^2)}
+           \\\\
+                          & = 2 \\sqrt{\\ln(2) \\ (a^2 + b^2)}
+
+        where :math:`a` and :math:`b` are the 1-sigma lengths of the
+        semimajor and semiminor axes, respectively.
+        """
+        return 2.0 * np.sqrt(np.log(2.0) * (self.semimajor_sigma**2
+                                            + self.semiminor_sigma**2))
+
+    @lazyproperty
+    @as_scalar
     def orientation(self):
         """
         The angle between the ``x`` axis and the major axis of the 2D

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -75,7 +75,7 @@ class TestSourceCatalog:
     def test_catalog(self, with_units):
         props1 = ('background_centroid', 'background_mean', 'background_sum',
                   'bbox', 'covar_sigx2', 'covar_sigxy', 'covar_sigy2', 'cxx',
-                  'cxy', 'cyy', 'ellipticity', 'elongation',
+                  'cxy', 'cyy', 'ellipticity', 'elongation', 'fwhm',
                   'equivalent_radius', 'gini', 'kron_radius', 'maxval_xindex',
                   'maxval_yindex', 'minval_xindex', 'minval_yindex',
                   'perimeter', 'sky_bbox_ll', 'sky_bbox_lr', 'sky_bbox_ul',


### PR DESCRIPTION
The FHWM is estimated as the circularized FWHM of the 2D Gaussian function that has the same second-order central moments as the source.  `fwhm = 2 sqrt(ln(2) * (a^2 + b^2))`, where a and b are the 1-sigma semimajor and semiminor lengths, respectively.