### PR TITLE
Add fluxfrac_radius method to SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,9 @@ New Features
 
   - Added ``fwhm`` property to the ``SourceCatalog`` class. [#1191]
 
+  - Added ``fluxfrac_radius`` method to the ``SourceCatalog`` class.
+    [#1192]
+
   - Added a ``bbox`` attribute to ``SegmentationImage``. [#1187]
 
 Bug Fixes

--- a/docs/whats_new/1.1.rst
+++ b/docs/whats_new/1.1.rst
@@ -68,6 +68,7 @@ new methods:
 
     * :meth:`~photutils.segmentation.SourceCatalog.circular_aperture`
     * :meth:`~photutils.segmentation.SourceCatalog.circular_photometry`
+    * :meth:`~photutils.segmentation.SourceCatalog.fluxfrac_radius`
     * :meth:`~photutils.segmentation.SourceCatalog.get_label`
     * :meth:`~photutils.segmentation.SourceCatalog.get_labels`
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2246,7 +2246,7 @@ class SourceCatalog:
         kron_flux = self._kron_flux_fluxerr[:, 0]
 
         for label, xcen, ycen, kronflux, bkg, max_radius_ in zip(
-                self._labels, self._xcentroid, self._ycentroid,
+                self.labels, self._xcentroid, self._ycentroid,
                 kron_flux, self._local_background, max_radius):
 
             if np.any(~np.isfinite((xcen, ycen))):
@@ -2268,7 +2268,8 @@ class SourceCatalog:
                 result = root_scalar(self._fluxfrac_radius_fcn, args=args,
                                      bracket=bracket, method='brentq')
                 result = result.root
-            except ValueError:  # bracket points must have different signs
+            # bracket points must have different signs
+            except ValueError:  # pragma: no cover
                 result = np.nan
             radius.append(result)
 

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -386,5 +386,21 @@ class TestSourceCatalog:
                       | (np.isnan(fluxerr2) & np.isnan(fluxerr1)))
 
         cat = SourceCatalog(self.data, self.segm)
-        flux, fluxerr = cat.circular_photometry(1.0)
+        _, fluxerr = cat.circular_photometry(1.0)
         assert np.all(np.isnan(fluxerr))
+
+    def test_fluxfrac_radius(self):
+        radius1 = self.cat.fluxfrac_radius(0.1)
+        radius2 = self.cat.fluxfrac_radius(0.5)
+        assert np.all((radius2 > radius1)
+                      | (np.isnan(radius2) & np.isnan(radius1)))
+
+        cat = SourceCatalog(self.data, self.segm)
+        obj = cat[1]
+        radius = obj.fluxfrac_radius(0.5)
+        assert_allclose(radius, 7.899648)
+
+        with pytest.raises(ValueError):
+            radius = self.cat.fluxfrac_radius(0)
+        with pytest.raises(ValueError):
+            radius = self.cat.fluxfrac_radius(-1)


### PR DESCRIPTION
The `fluxfrac_radius` method can be used to estimate the half-light radius.