### PR TITLE
Fix the DAOStarFinder import deprecation message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -140,6 +140,17 @@ API changes
   - Importing tools from the centroids subpackge without including the
     subpackage name is deprecated. [#1190]
 
+- ``photutils.detection``
+
+  - Importing the ``DAOStarFinder``, ``IRAFStarFinder``, and
+    ``StarFinderBase`` classes from the deprecated ``findstars.py``
+    module is now deprecated. These classes can be imported using ``from
+    photutils.detection import <class>``. [#1173]
+
+  - Importing the ``find_peaks`` function from the deprecated
+    ``core.py`` module is now deprecated. This function can be imported
+    using ``from photutils.detection import find_peaks``. [#1173]
+
 - ``photutils.morphology``
 
   - Importing tools from the morphology subpackge without including the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.detection``
+
+  - Fixed the ``DAOStarFinder`` import deprecation message. [#1195]
+
 
 1.1.0 (2021-03-20)
 ------------------

--- a/photutils/detection/findstars.py
+++ b/photutils/detection/findstars.py
@@ -18,9 +18,9 @@ from ._utils import _find_stars as __find_stars  # noqa
 
 
 deprecated = {'StarFinderBase': 'photutils.detection.base',
-              'DAOStarFinder': 'photutils.detection.daostarfinder',
+              'DAOStarFinder': 'photutils.detection.daofinder',
               'IRAFStarFinder': 'photutils.detection.irafstarfinder',
-              '_DAOFindProperties': 'photutils.detection.daostarfinder',
+              '_DAOFindProperties': 'photutils.detection.daofinder',
               '_IRAFStarFindProperties': 'photutils.detection.irafstarfinder',
               '_StarFinderKernel': 'photutils.detection._utils',
               '_StarCutout': 'photutils.detection._utils',


### PR DESCRIPTION
Also adds the missing changelog entries for the deprecation of the `photutils.detection.findstars.py` module.