### PR TITLE
Apply correct shift in prepare_psf_model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,13 @@ Bug Fixes
   - Fixed an issue in ``data_properties`` where a scalar background
     input would raise an error. [#1198]
 
+- ``photutils.psf``
+
+  - Fixed an issue in ``prepare_psf_model`` when ``xname`` or ``yname``
+    was ``None`` where the model offsets were applied in the wrong
+    direction, resulting in the initial photometry guesses not being
+    improved by the fit. [#1199]
+
 - ``photutils.segmentation``
 
   - Fixed an issue in ``SourceCatalog`` where the user-input ``mask``

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -84,7 +84,7 @@ def prepare_psf_model(psfmodel, xname=None, yname=None, fluxname=None,
         yname = yname + '_2'
     yinmod.fittable = True
 
-    outmod = (xinmod & yinmod) | psfmodel
+    outmod = (xinmod & yinmod) | psfmodel.copy()
 
     if fluxname is None:
         outmod = outmod * Const2D(1, name='flux_scaling')


### PR DESCRIPTION
With regards to issue #1163 I'm now reasonably sure that the model to fit the EPSF to a star in EPSF photometry needs to be inverted. 
This seemed to produce sensible results in multiple trials on simulated and real images, while the original shift produces results indistinguishable from just running the respective starfinder on the image.