### PR TITLE
Update RTD config

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -41,9 +41,6 @@ jobs:
             tox_env: 'codestyle'
           - os: ubuntu-latest
             python: '3.8'
-            tox_env: 'build_docs'
-          - os: ubuntu-latest
-            python: '3.8'
             tox_env: 'bandit'
           - os: ubuntu-latest
             python: '3.7'
@@ -65,9 +62,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
-    - name: Install graphviz dependency
-      if: "contains(matrix.tox_env, 'build_docs')"
-      run: sudo apt-get -y install graphviz
     - name: Print Python, pip, setuptools, and tox versions
       run: |
         python -c "import sys; print(f'Python {sys.version}')"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,13 @@ version: 2
 build:
   image: latest
 
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD is now configured to build on PRs.  This PR updates the RTD config to fail on warnings  and updates python to ~3.9~ 3.8.

EDIT:  This PR also removes `build_docs` from the GitHub Actions CI tests.