### PR TITLE
Fix SourceCatalog aperture masking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,12 @@ Bug Fixes
   - Fixed an issue in ``data_properties`` where a scalar background
     input would raise an error. [#1198]
 
+- ``photutils.segmentation``
+
+  - Fixed an issue in ``SourceCatalog`` where the user-input ``mask``
+    was ignored when ``apermask_method='correct'`` for Kron-related
+    calculations. [#1210]
+
 
 1.1.0 (2021-03-20)
 ------------------

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2270,7 +2270,7 @@ class SourceCatalog:
                 self.labels, self._xcentroid, self._ycentroid,
                 kron_flux, self._local_background, max_radius):
 
-            if np.any(~np.isfinite((xcen, ycen))):
+            if np.any(~np.isfinite((xcen, ycen, kronflux, max_radius_))):
                 radius.append(np.nan)
                 continue
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2029,9 +2029,7 @@ class SourceCatalog:
         If either the numerator or denominator is less than or equal
         to 0, then ``np.nan`` will be returned. In this case, the Kron
         aperture will be defined as a circular aperture with a radius
-        equal to ``kron_params[1]``. If ``kron_params[1] <= 0``, then
-        the Kron aperture will be `None` and the Kron flux will be
-        ``np.nan``.
+        equal to ``kron_params[1]``.
 
         If the source is completely masked, then ``np.nan`` will be
         returned for both the Kron radius and Kron flux.

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1871,9 +1871,11 @@ class SourceCatalog:
 
         if self._apermask_method == 'correct':
             from ._utils import mask_to_mirrored_value
-            data = mask_to_mirrored_value(data, segm_mask, cutout_xycen)
+            data = mask_to_mirrored_value(data, segm_mask, cutout_xycen,
+                                          mask=mask)
             if error is not None:
-                error = mask_to_mirrored_value(error, segm_mask, cutout_xycen)
+                error = mask_to_mirrored_value(error, segm_mask, cutout_xycen,
+                                               mask=mask)
 
         return data, error, mask, cutout_xycen, slc_sm
 

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -413,3 +413,9 @@ class TestSourceCatalog:
             radius = self.cat.fluxfrac_radius(0)
         with pytest.raises(ValueError):
             radius = self.cat.fluxfrac_radius(-1)
+
+        cat = SourceCatalog(self.data - 50., self.segm, error=self.error,
+                            background=self.background, mask=self.mask,
+                            wcs=self.wcs, localbkg_width=24)
+        radius_hl = cat.fluxfrac_radius(0.5)
+        assert np.all(np.isnan(radius_hl))

--- a/photutils/segmentation/tests/test_utils.py
+++ b/photutils/segmentation/tests/test_utils.py
@@ -43,7 +43,8 @@ def testmask_to_mirrored_value_range():
 
 def testmask_to_mirrored_value_masked():
     """
-    Test mask_to_mirrored_value when mirrored pixels are also masked.
+    Test mask_to_mirrored_value when mirrored pixels are also in the
+    replace_mask.
     """
     center = (2.0, 2.0)
     data = np.arange(25).reshape(5, 5)
@@ -60,3 +61,19 @@ def testmask_to_mirrored_value_masked():
     mirror_data = mask_to_mirrored_value(data, mask, center)
     mirror_data = mask_to_mirrored_value(data, mask, center)
     assert_allclose(mirror_data, data_ref, rtol=0, atol=1.e-6)
+
+
+def testmask_to_mirrored_value_mask_keyword():
+    """
+    Test mask_to_mirrored_value when mirrored pixels are masked (via the
+    mask keyword).
+    """
+    center = (2.0, 2.0)
+    data = np.arange(25.).reshape(5, 5)
+    replace_mask = np.zeros(data.shape, dtype=bool)
+    mask = np.zeros(data.shape, dtype=bool)
+    replace_mask[0, 2] = True
+    data[4, 2] = np.nan
+    mask[4, 2] = True
+    result = mask_to_mirrored_value(data, replace_mask, center, mask=mask)
+    assert result[0, 2] == 0


### PR DESCRIPTION
This PR fixes a corner-case issue where `apermask_method = 'correct'` would ignore the user-input `mask` when calculating Kron-related properties.