### PR TITLE
Return an empty array for no aperture overlap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,14 @@ Bug Fixes
     was ignored when ``apermask_method='correct'`` for Kron-related
     calculations. [#1210]
 
+API changes
+^^^^^^^^^^^
+
+- ``photutils.aperture``
+
+  - The ``ApertureMask.get_values()`` function now returns an empty
+    array if there is no overlap with the data. [#1212]
+
 
 1.1.0 (2021-03-20)
 ------------------

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -322,12 +322,13 @@ class PixelAperture(Aperture):
         areas : float or array_like
             The overlapping areas between the aperture masks and the data.
         """
-
         masks = self.to_mask(method=method, subpixels=subpixels)
         if self.isscalar:
             masks = (masks,)
         data = np.ones_like(data)
-        areas = [mask.get_values(data).sum() for mask in masks]
+        values = [mask.get_values(data) for mask in masks]
+        # if the aperture does not overlap the data return np.nan
+        areas = [val.sum() if val.shape != (0,) else np.nan for val in vals]
         if self.isscalar:
             return areas[0]
         else:
@@ -344,10 +345,16 @@ class PixelAperture(Aperture):
             masks = (masks,)
 
         for apermask in masks:
-            aperture_sums.append(apermask.get_values(data).sum())
+            values = apermask.get_values(data)
+            # if the aperture does not overlap the data return np.nan
+            aper_sum = values.sum() if values.shape != (0,) else np.nan
+            aperture_sums.append(aper_sum)
+
             if variance is not None:
-                aperture_sum_errs.append(
-                    np.sqrt(apermask.get_values(variance).sum()))
+                values = apermask.get_values(variance)
+                # if the aperture does not overlap the data return np.nan
+                aper_var = values.sum() if values.shape != (0,) else np.nan
+                aperture_sum_errs.append(np.sqrt(aper_var))
 
         aperture_sums = np.array(aperture_sums)
         aperture_sum_errs = np.array(aperture_sum_errs)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -326,7 +326,7 @@ class PixelAperture(Aperture):
         if self.isscalar:
             masks = (masks,)
         data = np.ones_like(data)
-        values = [mask.get_values(data) for mask in masks]
+        vals = [mask.get_values(data) for mask in masks]
         # if the aperture does not overlap the data return np.nan
         areas = [val.sum() if val.shape != (0,) else np.nan for val in vals]
         if self.isscalar:

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -233,12 +233,12 @@ class ApertureMask:
         result : `~numpy.ndarray`
             A 1D array of mask-weighted pixel values from the input
             ``data``. If there is no overlap of the aperture with the
-            input ``data``, the result will be a 1-element array of
-            ``numpy.nan``.
+            input ``data``, the result will be an empty array with shape
+            (0,).
         """
         slc_large, slc_small = self.get_overlap_slices(data.shape)
         if slc_large is None:
-            return np.array([np.nan])
+            return np.array([])
         cutout = data[slc_large]
         apermask = self.data[slc_small]
         pixel_mask = (apermask > 0)  # good pixels

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -37,7 +37,8 @@ class ApertureMask:
 
     def __array__(self):
         """
-        Array representation of the mask data array (e.g., for matplotlib).
+        Array representation of the mask data array (e.g., for
+        matplotlib).
         """
         return self.data
 
@@ -95,7 +96,7 @@ class ApertureMask:
             raise ValueError('input shape must have 2 elements.')
 
         # find the overlap of the mask on the output image shape
-        slices_large, slices_small = self.bbox.get_overlap_slices(shape)
+        slices_large, slices_small = self.get_overlap_slices(shape)
 
         if slices_small is None:
             return None  # no overlap
@@ -131,7 +132,7 @@ class ApertureMask:
 
         Returns
         -------
-        result : `~numpy.ndarray`
+        result : `~numpy.ndarray` or `None`
             A 2D array cut out from the input ``data`` representing the
             same cutout region as the aperture mask.  If there is a
             partial overlap of the aperture mask with the input data,
@@ -144,7 +145,7 @@ class ApertureMask:
             raise ValueError('data must be a 2D array.')
 
         # find the overlap of the mask on the output image shape
-        slices_large, slices_small = self.bbox.get_overlap_slices(data.shape)
+        slices_large, slices_small = self.get_overlap_slices(data.shape)
 
         if slices_small is None:
             return None  # no overlap
@@ -235,7 +236,7 @@ class ApertureMask:
             input ``data``, the result will be a 1-element array of
             ``numpy.nan``.
         """
-        slc_large, slc_small = self.bbox.get_overlap_slices(data.shape)
+        slc_large, slc_small = self.get_overlap_slices(data.shape)
         if slc_large is None:
             return np.array([np.nan])
         cutout = data[slc_large]

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -6,6 +6,7 @@ Tests for the circle module.
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 
 from .test_aperture_common import BaseTestAperture
@@ -86,4 +87,12 @@ def test_slicing():
         len(aper3)
 
     with pytest.raises(TypeError):
-        aper3[0]
+        _ = aper3[0]
+
+
+def test_area_overlap():
+    data = np.ones((11, 11))
+    xypos = [(0, 0), (5, 5), (50, 50)]
+    aper = CircularAperture(xypos, r=3)
+    areas = aper.area_overlap(data)
+    assert_allclose(areas, [10.304636, np.pi*9., np.nan])

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -183,8 +183,7 @@ def test_mask_get_values_no_overlap():
     aper = CircularAperture((-100, -100), r=3)
     data = np.ones((51, 51))
     values = aper.to_mask().get_values(data)
-    assert values.size == 1
-    assert np.isnan(values[0])
+    assert values.shape == (0,)
 
 
 def test_mask_get_values_mask():


### PR DESCRIPTION
This PR changes  `ApertureMask.get_values()` to return an empty array if there is no overlap with the data.