### PR TITLE
Pin Sphinx<4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ test =
     pytest-astropy
 docs =
     scipy
+    sphinx<4
     sphinx-astropy
     matplotlib>=2.2
     scikit-image>=0.14.2


### PR DESCRIPTION
Sphinx 4 starting giving warnings about duplicate references, e.g. https://github.com/astropy/astropy/issues/11723.

This PR is to temporarily pin the max version of Sphinx until we figure out how to fix the failure permanently.