### PR TITLE
Remove PixelAperture and BoundingBox deprecations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ API changes
   - The ``ApertureMask.get_values()`` function now returns an empty
     array if there is no overlap with the data. [#1212]
 
+  - Removed the deprecated ``BoundingBox.slices`` and
+    ``PixelAperture.bounding_boxes`` attributes. [#1215]
+
 
 1.1.0 (2021-03-20)
 ------------------

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -158,20 +158,6 @@ class BoundingBox:
         """
         return self.iymax - self.iymin, self.ixmax - self.ixmin
 
-    @property
-    @deprecated('1.1', alternative='get_overlap_slices')
-    def slices(self):
-        """
-        The bounding box as a tuple of `slice` objects.
-
-        The slice tuple is in numpy axis order (i.e., ``(y, x)``) and
-        therefore can be used to slice numpy arrays.
-        """
-        if self.iymin < 0 or self.ixmin < 0:
-            raise ValueError('cannot create slices when ixmin or iymin is '
-                             'negative')
-        return slice(self.iymin, self.iymax), slice(self.ixmin, self.ixmax)
-
     def get_overlap_slices(self, shape):
         """
         Get slices for the overlapping part of the bounding box and an

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -9,7 +9,6 @@ import copy
 import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
-from astropy.utils import deprecated
 from astropy.wcs.utils import wcs_to_celestial_frame
 
 from .bounding_box import BoundingBox
@@ -157,15 +156,6 @@ class PixelAperture(Aperture):
         """
 
         raise NotImplementedError('Needs to be implemented in a subclass.')
-
-    @property
-    @deprecated('0.7', alternative='bbox')
-    def bounding_boxes(self):
-        """
-        The minimal bounding box for the aperture.
-        """
-
-        return self.bbox
 
     @property
     def bbox(self):

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -3,7 +3,6 @@
 Tests for the bounding_box module.
 """
 
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 import pytest
 
@@ -98,22 +97,6 @@ def test_bounding_box_get_overlap_slices():
     slc = ((slice(0, 20, None), slice(0, 10, None)),
            (slice(10, 30, None), slice(10, 20, None)))
     assert bbox.get_overlap_slices((50, 50)) == slc
-
-
-def test_bounding_box_slices():
-    bbox = BoundingBox(1, 10, 2, 20)
-    with pytest.warns(AstropyDeprecationWarning):
-        assert bbox.slices == (slice(2, 20), slice(1, 10))
-
-    with pytest.warns(AstropyDeprecationWarning):
-        with pytest.raises(ValueError):
-            bbox = BoundingBox(-1, 10, 2, 20)
-            _ = bbox.slices
-
-    with pytest.warns(AstropyDeprecationWarning):
-        with pytest.raises(ValueError):
-            bbox = BoundingBox(1, 10, -2, 20)
-            _ = bbox.slices
 
 
 def test_bounding_box_extent():


### PR DESCRIPTION
This PR removes the deprecated ``BoundingBox.slices`` and ``PixelAperture.bounding_boxes`` attributes.