### PR TITLE
Fix SourceCatalog segment units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Bug Fixes
     was ignored when ``apermask_method='correct'`` for Kron-related
     calculations. [#1210]
 
+  - Fixed an issue in ``SourceCatalog`` where the ``segment`` array
+    could incorrectly have units. [#1220]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -658,7 +658,7 @@ class SourceCatalog:
         A 2D `~numpy.ndarray` cutout of the segmentation image using the
         minimal bounding box of the source.
         """
-        return self._make_cutout(self._segment_img.data, units=True,
+        return self._make_cutout(self._segment_img.data, units=False,
                                  masked=False)
 
     @lazyproperty

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -419,3 +419,13 @@ class TestSourceCatalog:
                             wcs=self.wcs, localbkg_width=24)
         radius_hl = cat.fluxfrac_radius(0.5)
         assert np.all(np.isnan(radius_hl))
+
+    def test_cutout_units(self):
+        obj = self.cat_units[0]
+        quantities = (obj.data, obj.error, obj.background)
+        ndarray = (obj.segment, obj.segment_ma, obj.data_ma, obj.error_ma,
+                   obj.background_ma)
+        for arr in quantities:
+            assert isinstance(arr, u.Quantity)
+        for arr in ndarray:
+            assert not isinstance(arr, u.Quantity)


### PR DESCRIPTION
`SourceCatalog` `segment` arrays should never have units.