### PR TITLE
Fix pixel/sky aperture conversions for GWCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Fixed a bug when converting between pixel and sky apertures with a
+    ``gwcs`` object. [#1221]
+
 - ``photutils.detection``
 
   - Fixed the ``DAOStarFinder`` import deprecation message. [#1195]

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -662,18 +662,26 @@ class SkyAperture(Aperture):
         pixel_params : `dict`
             A dictionary of parameters for an equivalent pixel aperture.
         """
-
         pixel_params = {}
 
-        xpos, ypos = _world_to_pixel(self.positions, wcs)
-        pixel_params['positions'] = np.array([xpos, ypos]).transpose()
+        xpos, ypos = wcs.world_to_pixel(self.positions)
+        pixel_params['positions'] = np.transpose((xpos, ypos))
 
-        # The aperture object must have a single value for each shape
-        # parameter so we must use a single pixel scale for all positions.
-        # Here, we define the scale at the WCS CRVAL position.
-        crval = SkyCoord(*wcs.wcs.crval, frame=wcs_to_celestial_frame(wcs),
-                         unit=wcs.wcs.cunit)
-        pixscale, angle = _pixel_scale_angle_at_skycoord(crval, wcs)
+        # Aperture objects require scalar shape parameters (e.g.,
+        # radius, a, b, theta, etc.), therefore we must calculate
+        # the pixel scale and angle at only a single sky position,
+        # which we take as the first aperture position. For apertures
+        # with multiple sky positions used with a WCS that contains
+        # distortions (e.g., a spatially-dependent pixel scale), this
+        # may lead to unexpected results (e.g., results that are
+        # dependent of the order of the sky positions). There is no
+        # good way to fix this with the current Aperture API allowing
+        # multiple sky positions.
+        if self.isscalar:
+            skypos = self.positions
+        else:
+            skypos = self.positions[0]
+        _, pixscale, angle = _pixel_scale_angle_at_skycoord(skypos, wcs)
 
         shape_params = list(self._shape_params)
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -9,7 +9,6 @@ import copy
 import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
-from astropy.wcs.utils import wcs_to_celestial_frame
 
 from .bounding_box import BoundingBox
 from ._photometry_utils import (_handle_units, _prepare_photometry_data,

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -14,9 +14,7 @@ from astropy.wcs.utils import wcs_to_celestial_frame
 from .bounding_box import BoundingBox
 from ._photometry_utils import (_handle_units, _prepare_photometry_data,
                                 _validate_inputs)
-from ..utils._wcs_helpers import (_pixel_to_world,
-                                  _pixel_scale_angle_at_skycoord,
-                                  _world_to_pixel)
+from ..utils._wcs_helpers import _pixel_scale_angle_at_skycoord
 
 __all__ = ['Aperture', 'SkyAperture', 'PixelAperture']
 
@@ -593,14 +591,22 @@ class PixelAperture(Aperture):
 
         sky_params = {}
         xpos, ypos = np.transpose(self.positions)
-        sky_params['positions'] = _pixel_to_world(xpos, ypos, wcs)
+        sky_params['positions'] = wcs.pixel_to_world(xpos, ypos)
 
-        # The aperture object must have a single value for each shape
-        # parameter so we must use a single pixel scale for all positions.
-        # Here, we define the scale at the WCS CRVAL position.
-        crval = SkyCoord(*wcs.wcs.crval, frame=wcs_to_celestial_frame(wcs),
-                         unit=wcs.wcs.cunit)
-        pixscale, angle = _pixel_scale_angle_at_skycoord(crval, wcs)
+        # Aperture objects require scalar shape parameters (e.g.,
+        # radius, a, b, theta, etc.), therefore we must calculate the
+        # pixel scale and angle at only a single sky position, which
+        # we take as the first aperture position. For apertures with
+        # multiple positions used with a WCS that contains distortions
+        # (e.g., a spatially-dependent pixel scale), this may lead to
+        # unexpected results (e.g., results that are dependent of the
+        # order of the positions). There is no good way to fix this with
+        # the current Aperture API allowing multiple positions.
+        skypos = sky_params['positions']
+        if not self.isscalar:
+            skypos = skypos[0]
+
+        _, pixscale, angle = _pixel_scale_angle_at_skycoord(skypos, wcs)
 
         shape_params = list(self._shape_params)
 
@@ -668,15 +674,14 @@ class SkyAperture(Aperture):
         pixel_params['positions'] = np.transpose((xpos, ypos))
 
         # Aperture objects require scalar shape parameters (e.g.,
-        # radius, a, b, theta, etc.), therefore we must calculate
-        # the pixel scale and angle at only a single sky position,
-        # which we take as the first aperture position. For apertures
-        # with multiple sky positions used with a WCS that contains
-        # distortions (e.g., a spatially-dependent pixel scale), this
-        # may lead to unexpected results (e.g., results that are
-        # dependent of the order of the sky positions). There is no
-        # good way to fix this with the current Aperture API allowing
-        # multiple sky positions.
+        # radius, a, b, theta, etc.), therefore we must calculate the
+        # pixel scale and angle at only a single sky position, which
+        # we take as the first aperture position. For apertures with
+        # multiple positions used with a WCS that contains distortions
+        # (e.g., a spatially-dependent pixel scale), this may lead to
+        # unexpected results (e.g., results that are dependent of the
+        # order of the positions). There is no good way to fix this with
+        # the current Aperture API allowing multiple positions.
         if self.isscalar:
             skypos = self.positions
         else:

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -26,6 +26,12 @@ from ..rectangle import (RectangularAperture, RectangularAnnulus,
 from ...datasets import get_path, make_4gaussians_image, make_wcs, make_gwcs
 
 try:
+    import gwcs  # noqa
+    HAS_GWCS = True
+except ImportError:
+    HAS_GWCS = False
+
+try:
     import matplotlib  # noqa
     HAS_MATPLOTLIB = True
 except ImportError:
@@ -708,6 +714,7 @@ def test_elliptical_bbox():
     assert ap.bbox.shape == (2*a, 2*b)
 
 
+@pytest.mark.skipif('not HAS_GWCS')
 @pytest.mark.parametrize('wcs_type', ('wcs', 'gwcs'))
 def test_to_sky_pixel(wcs_type):
     data = make_4gaussians_image()

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -23,7 +23,7 @@ from ..ellipse import (EllipticalAperture, EllipticalAnnulus,
                        SkyEllipticalAperture, SkyEllipticalAnnulus)
 from ..rectangle import (RectangularAperture, RectangularAnnulus,
                          SkyRectangularAperture, SkyRectangularAnnulus)
-from ...datasets import get_path, make_4gaussians_image, make_wcs
+from ...datasets import get_path, make_4gaussians_image, make_wcs, make_gwcs
 
 try:
     import matplotlib  # noqa
@@ -708,9 +708,14 @@ def test_elliptical_bbox():
     assert ap.bbox.shape == (2*a, 2*b)
 
 
-def test_to_sky_pixel():
+@pytest.mark.parametrize('wcs_type', ('wcs', 'gwcs'))
+def test_to_sky_pixel(wcs_type):
     data = make_4gaussians_image()
-    wcs = make_wcs(data.shape)
+
+    if wcs_type == 'wcs':
+        wcs = make_wcs(data.shape)
+    elif wcs_type == 'gwcs':
+        wcs = make_gwcs(data.shape)
 
     ap = CircularAperture(((12.3, 15.7), (48.19, 98.14)), r=3.14)
     ap2 = ap.to_sky(wcs).to_pixel(wcs)

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -10,7 +10,6 @@ from astropy.table import Table
 import numpy as np
 
 from ..utils.exceptions import NoDetectionsWarning
-from ..utils._wcs_helpers import _pixel_to_world
 
 __all__ = ['find_peaks']
 
@@ -172,7 +171,7 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     table = Table(coldata, names=colnames)
 
     if wcs is not None:
-        skycoord_peaks = _pixel_to_world(x_peaks, y_peaks, wcs)
+        skycoord_peaks = wcs.pixel_to_world(x_peaks, y_peaks)
         table.add_column(skycoord_peaks, name='skycoord_peak', index=2)
 
     # perform centroiding
@@ -191,7 +190,7 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         table['y_centroid'] = y_centroids
 
         if wcs is not None:
-            skycoord_centroids = _pixel_to_world(x_centroids, y_centroids, wcs)
+            skycoord_centroids = wcs.pixel_to_world(x_centroids, y_centroids)
             idx = table.colnames.index('y_centroid') + 1
             table.add_column(skycoord_centroids, name='skycoord_centroid',
                              index=idx)

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -705,6 +705,8 @@ class SourceProperties:
         The output coordinate frame is the same as the input WCS.
         """
 
+        if self._wcs is None:
+            return None
         return self._wcs.pixel_to_world(self.xcentroid.value,
                                         self.ycentroid.value)
 
@@ -2168,6 +2170,8 @@ def _calc_sky_bbox_corner(bbox, corner, wcs):
         The sky coordinate at the bounding box corner.  If ``wcs`` is
         `None`, then `None` will be returned.
     """
+    if wcs is None:
+        return None
 
     if corner == 'll':
         xpos = bbox.ixmin - 0.5

--- a/photutils/segmentation/properties.py
+++ b/photutils/segmentation/properties.py
@@ -23,7 +23,6 @@ from ..aperture import (BoundingBox, CircularAperture, EllipticalAperture,
                         RectangularAnnulus)
 from ..utils._convolution import _filter_data
 from ..utils._moments import _moments, _moments_central
-from ..utils._wcs_helpers import _pixel_to_world
 
 __all__ = ['SourceProperties', 'source_properties', 'LegacySourceCatalog']
 
@@ -706,8 +705,8 @@ class SourceProperties:
         The output coordinate frame is the same as the input WCS.
         """
 
-        return _pixel_to_world(self.xcentroid.value, self.ycentroid.value,
-                               self._wcs)
+        return self._wcs.pixel_to_world(self.xcentroid.value,
+                                        self.ycentroid.value)
 
     @lazyproperty
     def sky_centroid_icrs(self):
@@ -1997,8 +1996,8 @@ class LegacySourceCatalog:
             # SkyCoord array from a loop-generated SkyCoord list.  The
             # assumption here is that the wcs is the same for each
             # SourceProperties instance.
-            return _pixel_to_world(self.xcentroid.value, self.ycentroid.value,
-                                   self.wcs)
+            return self.wcs.pixel_to_world(self.xcentroid.value,
+                                           self.ycentroid.value)
 
     @lazyproperty
     def sky_centroid_icrs(self):
@@ -2185,4 +2184,4 @@ def _calc_sky_bbox_corner(bbox, corner, wcs):
     else:
         raise ValueError('Invalid corner name.')
 
-    return _pixel_to_world(xpos, ypos, wcs)
+    return wcs.pixel_to_world(xpos, ypos)

--- a/photutils/utils/_wcs_helpers.py
+++ b/photutils/utils/_wcs_helpers.py
@@ -1,93 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# (taken from photutils: should probably migrate into astropy.wcs)
 """
 This module provides WCS helper tools.
 """
 
-from astropy import units as u
-from astropy.coordinates import UnitSphericalRepresentation
-from astropy.wcs import WCS
-from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
+import astropy.units as u
 import numpy as np
 
 
-def _pixel_to_world(xpos, ypos, wcs):
+def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1 * u.arcsec):
     """
-    Calculate the sky coordinates at the input pixel positions.
-
-    Parameters
-    ----------
-    xpos, ypos : float or array-like
-        The x and y pixel position(s).
-
-    wcs : WCS object or `None`
-        A world coordinate system (WCS) transformation that
-        supports the `astropy shared interface for WCS
-        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
-        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
-
-    Returns
-    -------
-    skycoord : `~astropy.coordinates.SkyCoord`
-        The sky coordinate(s) at the input position(s).
-    """
-
-    if wcs is None:
-        return None
-
-    # NOTE: unitless gwcs objects fail with Quantity inputs
-    if isinstance(xpos, u.Quantity) or isinstance(ypos, u.Quantity):
-        raise TypeError('xpos and ypos must not be Quantity objects')
-
-    try:
-        return wcs.pixel_to_world(xpos, ypos)
-    except AttributeError:
-        if isinstance(wcs, WCS):
-            # for Astropy < 3.1 WCS support
-            return pixel_to_skycoord(xpos, ypos, wcs, origin=0)
-        else:
-            raise ValueError('Input wcs does not support the shared WCS '
-                             'interface.')
-
-
-def _world_to_pixel(skycoord, wcs):
-    """
-    Calculate the sky coordinates at the input pixel positions.
-
-    Parameters
-    ----------
-    skycoord : `~astropy.coordinates.SkyCoord`
-        The sky coordinate(s).
-
-    wcs : WCS object or `None`
-        A world coordinate system (WCS) transformation that
-        supports the `astropy shared interface for WCS
-        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
-        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
-
-    Returns
-    -------
-    xpos, ypos : float or array-like
-        The x and y pixel position(s) at the input sky coordinate(s).
-    """
-
-    if wcs is None:
-        return None
-
-    try:
-        return wcs.world_to_pixel(skycoord)
-    except AttributeError:
-        if isinstance(wcs, WCS):
-            # for Astropy < 3.1 WCS support
-            return skycoord_to_pixel(skycoord, wcs, origin=0)
-        else:
-            raise ValueError('Input wcs does not support the shared WCS '
-                             'interface.')
-
-
-def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1.0*u.arcsec):
-    """
-    Calculate the pixel scale and WCS rotation angle at the position of
-    a SkyCoord coordinate.
+    Calculate the pixel coordinate and scale and WCS rotation angle at
+    the position of a SkyCoord coordinate.
 
     Parameters
     ----------
@@ -106,6 +30,9 @@ def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1.0*u.arcsec):
 
     Returns
     -------
+    xypos : tuple of float
+        The (x, y) pixel coordinate.
+
     scale : `~astropy.units.Quantity`
         The pixel scale in arcsec/pixel.
 
@@ -120,27 +47,19 @@ def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1.0*u.arcsec):
     likely differ.  This function computes a single pixel scale along
     the North/South axis.
     """
+    # Convert to pixel coordinates
+    xpos, ypos = wcs.world_to_pixel(skycoord)
 
-    try:
-        x, y = wcs.world_to_pixel(skycoord)
+    # We take a point directly North (i.e., latitude offset) the
+    # input sky coordinate and convert it to pixel coordinates,
+    # then we use the pixel deltas between the input and offset sky
+    # coordinate to calculate the pixel scale and angle.
+    skycoord_offset = skycoord.directional_offset_by(0.0, offset)
+    x_offset, y_offset = wcs.world_to_pixel(skycoord_offset)
 
-        # We take a point directly North (i.e., latitude offset) the
-        # input sky coordinate and convert it to pixel coordinates,
-        # then we use the pixel deltas between the input and offset sky
-        # coordinate to calculate the pixel scale and angle.
-        skycoord_offset = skycoord.directional_offset_by(0.0, offset)
-        x_offset, y_offset = wcs.world_to_pixel(skycoord_offset)
-    except AttributeError:
-        # for Astropy < 3.1 WCS support
-        x, y = skycoord_to_pixel(skycoord, wcs)
-        coord = skycoord.represent_as('unitspherical')
-        coord_new = UnitSphericalRepresentation(coord.lon, coord.lat + offset)
-        coord_offset = skycoord.realize_frame(coord_new)
-        x_offset, y_offset = skycoord_to_pixel(coord_offset, wcs)
-
-    dx = x_offset - x
-    dy = y_offset - y
+    dx = x_offset - xpos
+    dy = y_offset - ypos
     scale = offset.to(u.arcsec) / (np.hypot(dx, dy) * u.pixel)
     angle = (np.arctan2(dy, dx) * u.radian).to(u.deg)
 
-    return scale, angle
+    return (xpos, ypos), scale, angle


### PR DESCRIPTION
This PR fixes an issue where the `SkyAperture.to_pixel` and `PixelAperture.to_sky` methods did not work for `gwcs` objects.  

Fixes #1219.