### PR TITLE
Fix ShepardIDWInterpolator for scalar data values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,12 @@ Bug Fixes
   - Fixed an issue in ``SourceCatalog`` where the ``segment`` array
     could incorrectly have units. [#1220]
 
+- ``photutils.utils``
+
+  - Fixed an issue in ``ShepardIDWInterpolator`` to allow its
+    initialization with scalar data values and coordinate arrays having
+    more than one dimension. [#1226]
+
 API changes
 ^^^^^^^^^^^
 

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -119,10 +119,14 @@ class ShepardIDWInterpolator:
     def __init__(self, coordinates, values, weights=None, leafsize=10):
         from scipy.spatial import cKDTree
 
-        coordinates = np.atleast_2d(coordinates)
-        if coordinates.shape[0] == 1:
-            coordinates = np.transpose(coordinates)
-        if coordinates.ndim != 2:
+        coordinates = np.asarray(coordinates)
+        if coordinates.ndim == 0:  # scalar coordinate
+            coordinates = np.atleast_2d(coordinates)
+
+        if coordinates.ndim == 1:
+            coordinates = np.transpose(np.atleast_2d(coordinates))
+
+        if coordinates.ndim > 2:
             coordinates = np.reshape(coordinates, (-1, coordinates.shape[-1]))
 
         values = np.asanyarray(values).ravel()

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -108,3 +108,25 @@ class TestShepardIDWInterpolator:
     def test_positions_3d(self):
         with pytest.raises(ValueError):
             self.f(np.ones((3, 3, 3)))
+
+    def test_scalar_values_1d(self):
+        value = 10.
+        f = idw(2, value)
+        assert_allclose(f(2), value)
+        assert_allclose(f(-1), value)
+        assert_allclose(f(0), value)
+        assert_allclose(f(142), value)
+
+    def test_scalar_values_2d(self):
+        value = 10.
+        f = idw([[1, 2]], value)
+        assert_allclose(f([1, 2]), value)
+        assert_allclose(f([-1, 0]), value)
+        assert_allclose(f([142, 213]), value)
+
+    def test_scalar_values_3d(self):
+        value = 10.
+        f = idw([[7, 4, 1]], value)
+        assert_allclose(f([7, 4, 1]), value)
+        assert_allclose(f([-1, 0, 7]), value)
+        assert_allclose(f([142, 213, 5]), value)


### PR DESCRIPTION
This PR fixes an issue in ``ShepardIDWInterpolator`` to allow its initialization with scalar data values and coordinate arrays having more than one dimension.

Examples:
```python
>>> from photutils.utils import ShepardIDWInterpolator as idw
>>> value = 10.
>>> f = idw(2, value)  # 1D
>>> f = idw([[1, 2]], value)  # 2D
>>> f = idw([[7, 4, 1]], value)  # 3D
```

Fixes #1224 