### PR TITLE
Fix Background2D bug with 'pad' edge method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ Bug Fixes
   - Fixed a bug when converting between pixel and sky apertures with a
     ``gwcs`` object. [#1221]
 
+- ``photutils.background``
+
+  - Fixed an issue where ``Background2D`` could fail when using the
+    ``'pad'`` edge method. [#1227]
+
 - ``photutils.detection``
 
   - Fixed the ``DAOStarFinder`` import deprecation message. [#1195]
@@ -1571,7 +1576,7 @@ API changes
 Bug Fixes
 ^^^^^^^^^
 
-- ``photutils.aperture_photometry``
+- ``photutils.aperture``
 
   - Fixed an issue where ``np.nan`` or ``np.inf`` were not properly
     masked. [#267]

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -223,19 +223,20 @@ class Background2D:
 
     exclude_percentile : float in the range of [0, 100], optional
         The percentage of masked pixels in a mesh, used as a threshold
-        for determining if the mesh is excluded.  If a mesh has more
-        than ``exclude_percentile`` percent of its pixels masked then it
-        will be excluded from the low-resolution map.  Masked pixels
-        include those from the input ``mask``, those resulting from the
-        data padding (i.e., if ``edge_method='pad'``), and those
-        resulting from any sigma clipping (i.e., if ``sigma_clip`` is
-        used).  Setting ``exclude_percentile=0`` will exclude meshes
-        that have any masked pixels.  Setting ``exclude_percentile=100``
-        will only exclude meshes that are completely masked.  Note that
-        completely masked meshes are *always* excluded.  For best
-        results, ``exclude_percentile`` should be kept as low as
-        possible (as long as there are sufficient pixels for reasonable
-        statistical estimates).  The default is 10.0.
+        for determining if the mesh is excluded. If a mesh has
+        more than ``exclude_percentile`` percent of its pixels
+        masked then it will be excluded from the low-resolution map.
+        Masked pixels include those from the input ``mask`` and
+        ``coverage_mask``, those resulting from the data padding
+        (i.e., if ``edge_method='pad'``), and those resulting from
+        any sigma clipping (i.e., if ``sigma_clip`` is used). Setting
+        ``exclude_percentile=0`` will exclude meshes that have any
+        masked pixels. Setting ``exclude_percentile=100`` will only
+        exclude meshes that are completely masked. Note that completely
+        masked meshes are *always* excluded. For best results,
+        ``exclude_percentile`` should be kept as low as possible (as
+        long as there are sufficient pixels for reasonable statistical
+        estimates). The default is 10.0.
 
     filter_size : int or array_like (int), optional
         The window size of the 2D median filter to apply to the
@@ -488,7 +489,8 @@ class Background2D:
         if mesh_idx.size == 0:
             raise ValueError('All meshes contain > {0} ({1} percent per '
                              'mesh) masked pixels.  Please check your data '
-                             'or decrease "exclude_percentile".'
+                             'or increase "exclude_percentile" to allow more '
+                             'meshes to be included.'
                              .format(threshold_npixels,
                                      self.exclude_percentile))
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -441,8 +441,8 @@ class Background2D:
             The cropped data and mask as a masked array.
         """
 
-        ny_crop = self.nyboxes * self.box_size[1]
-        nx_crop = self.nxboxes * self.box_size[0]
+        ny_crop = self.nyboxes * self.box_size[0]
+        nx_crop = self.nxboxes * self.box_size[1]
         crop_slc = index_exp[0:ny_crop, 0:nx_crop]
         if self.mask is not None:
             mask = self.mask[crop_slc]

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -141,7 +141,7 @@ class TestBackground2D:
         assert_allclose(b.background, DATA, rtol=2.e-5)
         assert_allclose(b.background_rms, BKG_RMS)
 
-        # test edge crop with
+        # test edge crop with mask
         b2 = Background2D(data, box_size, filter_size=(1, 1), mask=mask,
                           bkg_estimator=MeanBackground(), edge_method='crop')
         assert_allclose(b2.background, DATA, rtol=2.e-5)
@@ -275,6 +275,12 @@ class TestBackground2D:
         This test should run without any errors, but there is no return
         value.
         """
-
         b = Background2D(DATA, (25, 25))
         b.plot_meshes(outlines=True)
+
+    def test_crop(self):
+        data = np.ones((300, 500))
+        bkg = Background2D(data, (74, 99), edge_method='crop')
+        assert_allclose(bkg.background_median, 1.0)
+        assert_allclose(bkg.background_rms_median, 0.0)
+        assert_allclose(bkg.background_mesh.shape, (4, 5))


### PR DESCRIPTION
This PR fixes an issue where ``Background2D`` could fail when using the ``'pad'`` edge method.

It also updates the `Background2D` `exclude_percentile` docs.