### PR TITLE
Refactor optional dependency checking

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,6 +32,10 @@ Photutils also optionally depends on other packages for some features:
   Used in `~photutils.datasets.make_gwcs` to create a simple celestial
   gwcs object.
 
+* `bottleneck <https://github.com/pydata/bottleneck>`_: Improves the
+  performance of sigma clipping and other functionality that may require
+  computing statistics on arrays with NaN values.
+
 Photutils depends on `pytest-astropy
 <https://github.com/astropy/pytest-astropy>`_ (0.4 or later) to run
 the test suite.

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -8,12 +8,7 @@ import pytest
 
 from ..bounding_box import BoundingBox
 from ..rectangle import RectangularAperture
-
-try:
-    import matplotlib  # noqa
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
+from ...utils._optional_deps import HAS_MATPLOTLIB  # noqa
 
 
 def test_bounding_box_init():

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -12,12 +12,8 @@ import pytest
 from .test_aperture_common import BaseTestAperture
 from ..circle import (CircularAperture, CircularAnnulus, SkyCircularAperture,
                       SkyCircularAnnulus)
+from ...utils._optional_deps import HAS_MATPLOTLIB  # noqa
 
-try:
-    import matplotlib  # noqa
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
@@ -28,18 +24,19 @@ UNIT = u.arcsec
 class TestCircularAperture(BaseTestAperture):
     aperture = CircularAperture(POSITIONS, r=3.)
 
-    @pytest.mark.skipif("not HAS_MATPLOTLIB")
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_plot(self):
         self.aperture.plot()
 
-    @pytest.mark.skipif("not HAS_MATPLOTLIB")
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_plot_returns_patches(self):
         from matplotlib import pyplot as plt
+        from matplotlib.patches import Patch
 
         my_patches = self.aperture.plot()
         assert isinstance(my_patches, list)
         for patch in my_patches:
-            assert isinstance(patch, matplotlib.patches.Patch)
+            assert isinstance(patch, Patch)
 
         # test creating a legend with these patches
         plt.legend(my_patches, list(range(len(my_patches))))
@@ -48,19 +45,20 @@ class TestCircularAperture(BaseTestAperture):
 class TestCircularAnnulus(BaseTestAperture):
     aperture = CircularAnnulus(POSITIONS, r_in=3., r_out=7.)
 
-    @pytest.mark.skipif("not HAS_MATPLOTLIB")
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_plot(self):
         self.aperture.plot()
 
-    @pytest.mark.skipif("not HAS_MATPLOTLIB")
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_plot_returns_patches(self):
         from matplotlib import pyplot as plt
+        from matplotlib.patches import Patch
 
         my_patches = self.aperture.plot()
         assert isinstance(my_patches, list)
 
         for p in my_patches:
-            assert isinstance(p, matplotlib.patches.Patch)
+            assert isinstance(p, Patch)
 
         # make sure I can create a legend with these patches
         labels = list(range(len(my_patches)))

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -24,18 +24,8 @@ from ..ellipse import (EllipticalAperture, EllipticalAnnulus,
 from ..rectangle import (RectangularAperture, RectangularAnnulus,
                          SkyRectangularAperture, SkyRectangularAnnulus)
 from ...datasets import get_path, make_4gaussians_image, make_wcs, make_gwcs
+from ...utils._optional_deps import HAS_GWCS, HAS_MATPLOTLIB  # noqa
 
-try:
-    import gwcs  # noqa
-    HAS_GWCS = True
-except ImportError:
-    HAS_GWCS = False
-
-try:
-    import matplotlib  # noqa
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
 
 APERTURE_CL = [CircularAperture,
                CircularAnnulus,

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -14,18 +14,7 @@ import pytest
 from ..core import MeanBackground
 from ..background_2d import (BkgZoomInterpolator, BkgIDWInterpolator,
                              Background2D)
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
-try:
-    import matplotlib  # noqa
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
+from ...utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY  # noqa
 
 
 DATA = np.ones((100, 100))

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -16,13 +16,7 @@ from ..core import (centroid_com, centroid_quadratic, centroid_sources,
                     centroid_epsf)
 from ..gaussian import centroid_1dg
 from ...psf import IntegratedGaussianPRF
-
-try:
-    # the fitting routines in astropy use scipy.optimize
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 XCEN = 25.7
@@ -37,6 +31,7 @@ DATA[1, 0:2] = 1.
 DATA[1, 1] = 2.
 
 
+# NOTE: the fitting routines in astropy use scipy.optimize
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize(('x_std', 'y_std', 'theta'),
                          list(itertools.product(XSTDS, YSTDS, THETAS)))

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -13,13 +13,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ..gaussian import centroid_1dg, centroid_2dg, gaussian1d_moments
-
-try:
-    # the fitting routines in astropy use scipy.optimize
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 XCEN = 25.7
@@ -34,6 +28,7 @@ DATA[1, 0:2] = 1.
 DATA[1, 1] = 2.
 
 
+# NOTE: the fitting routines in astropy use scipy.optimize
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize(('x_std', 'y_std', 'theta'),
                          list(itertools.product(XSTDS, YSTDS, THETAS)))

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -15,18 +15,8 @@ from .. import (apply_poisson_noise, make_4gaussians_image,
                 make_model_sources_image, make_noise_image,
                 make_random_gaussians_table, make_random_models_table,
                 make_wcs)
+from ...utils._optional_deps import HAS_GWCS, HAS_SCIPY  # noqa
 
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
-try:
-    import gwcs  # noqa
-    HAS_GWCS = True
-except ImportError:
-    HAS_GWCS = False
 
 SOURCE_TABLE = Table()
 SOURCE_TABLE['flux'] = [1, 2, 3]
@@ -100,7 +90,7 @@ def test_make_gaussian_sources_image():
     assert_allclose(image.sum(), SOURCE_TABLE['flux'].sum())
 
 
-@pytest.mark.xfail('not HAS_SCIPY')
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_make_gaussian_prf_sources_image():
     shape = (100, 100)
     image = make_gaussian_prf_sources_image(shape, SOURCE_TABLE_PRF)

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -15,12 +15,7 @@ import pytest
 from ..daofinder import DAOStarFinder
 from ...datasets import make_100gaussians_image
 from ...utils.exceptions import NoDetectionsWarning
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 DATA = make_100gaussians_image()

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -15,12 +15,7 @@ import pytest
 from ..irafstarfinder import IRAFStarFinder
 from ...datasets import make_100gaussians_image
 from ...utils.exceptions import NoDetectionsWarning
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 DATA = make_100gaussians_image()

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -14,19 +14,8 @@ from ..peakfinder import find_peaks
 from ...centroids import centroid_com
 from ...datasets import make_4gaussians_image, make_gwcs, make_wcs
 from ...utils.exceptions import NoDetectionsWarning
+from ...utils._optional_deps import HAS_GWCS, HAS_SCIPY  # noqa
 
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
-try:
-    # shared WCS interface requires gwcs >= 0.10
-    import gwcs  # noqa
-    HAS_GWCS = True
-except ImportError:
-    HAS_GWCS = False
 
 PEAKDATA = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1]]).astype(float)
 PEAKREF1 = np.array([[0, 0], [2, 2]])

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -11,12 +11,7 @@ import pytest
 from ..starfinder import StarFinder
 from ...datasets import make_100gaussians_image
 from ...utils.exceptions import NoDetectionsWarning
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 DATA = make_100gaussians_image()

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -14,12 +14,7 @@ from ..ellipse import Ellipse
 from ..geometry import EllipseGeometry
 from ..isophote import Isophote, IsophoteList
 from ...datasets import get_path, make_noise_image
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 # define an off-center position and a tilted sma

--- a/photutils/isophote/tests/test_fitter.py
+++ b/photutils/isophote/tests/test_fitter.py
@@ -16,12 +16,7 @@ from ..integrator import MEAN
 from ..isophote import Isophote
 from ..sample import CentralEllipseSample, EllipseSample
 from ...datasets import get_path
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 DATA = make_test_image(seed=0)

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -12,17 +12,13 @@ from ..harmonics import (first_and_second_harmonic_function,
                          fit_first_and_second_harmonics, fit_upper_harmonic)
 from ..sample import EllipseSample
 from ..fitter import EllipseFitter
-
-
-try:
-    from scipy.optimize import leastsq  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_harmonics_1():
+    from scipy.optimize import leastsq  # noqa
+
     # this is an almost as-is example taken from stackoverflow
     N = 100  # number of data points
     t = np.linspace(0, 4*np.pi, N)

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -15,14 +15,10 @@ from ..geometry import EllipseGeometry
 from ..isophote import Isophote, IsophoteList
 from ..sample import EllipseSample
 from ...datasets import get_path
+from ...utils._optional_deps import HAS_SCIPY  # noqa
+
 
 DEFAULT_FIX = np.array([False, False, False, False])
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
 
 
 @pytest.mark.remote_data

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -13,12 +13,7 @@ from ..ellipse import Ellipse
 from ..geometry import EllipseGeometry
 from ..model import build_ellipse_model
 from ...datasets import get_path
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.remote_data

--- a/photutils/isophote/tests/test_regression.py
+++ b/photutils/isophote/tests/test_regression.py
@@ -57,12 +57,7 @@ import pytest
 from ..ellipse import Ellipse
 from ..integrator import BILINEAR
 from ...datasets import get_path
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.remote_data

--- a/photutils/morphology/tests/test_core.py
+++ b/photutils/morphology/tests/test_core.py
@@ -8,12 +8,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ..core import data_properties
-
-try:
-    import skimage  # noqa
-    HAS_SKIMAGE = True
-except ImportError:
-    HAS_SKIMAGE = False
+from ...utils._optional_deps import HAS_SKIMAGE  # noqa
 
 
 XCS = [25.7]

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -19,13 +19,9 @@ import numpy as np
 from .epsf_stars import EPSFStar, EPSFStars, LinkedEPSFStar
 from .models import EPSFModel
 from ..centroids import centroid_com, centroid_epsf
+from ..utils._optional_deps import HAS_BOTTLENECK  # noqa
 from ..utils._round import _py2intround
 
-try:
-    import bottleneck  # pylint: disable=W0611
-    HAS_BOTTLENECK = True
-except ImportError:
-    HAS_BOTTLENECK = False
 
 __all__ = ['EPSFFitter', 'EPSFBuilder']
 
@@ -311,6 +307,13 @@ class EPSFBuilder:
         are ignored based on the star sampling flux residuals, when
         computing the average residual of ePSF grid points in each iteration
         step.
+
+    Notes
+    -----
+    If your image image contains NaN values, you may see better
+    performance if you have the `bottleneck`_ package installed.
+
+    .. _bottleneck:  https://github.com/pydata/bottleneck
     """
 
     def __init__(self, oversampling=4., shape=None,
@@ -751,6 +754,7 @@ class EPSFBuilder:
                                                    masked=False,
                                                    return_bounds=False)
             if HAS_BOTTLENECK:
+                import bottleneck
                 residuals = bottleneck.nanmedian(residuals, axis=0)
             else:
                 residuals = np.nanmedian(residuals, axis=0)

--- a/photutils/psf/matching/tests/test_fourier.py
+++ b/photutils/psf/matching/tests/test_fourier.py
@@ -11,12 +11,7 @@ import pytest
 
 from ..fourier import create_matching_kernel, resize_psf
 from ..windows import SplitCosineBellWindow
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ....utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -9,12 +9,7 @@ import pytest
 
 from ..windows import (CosineBellWindow, HanningWindow, SplitCosineBellWindow,
                        TopHatWindow, TukeyWindow)
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ....utils._optional_deps import HAS_SCIPY  # noqa
 
 
 def test_hanning():

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -17,12 +17,7 @@ from ..epsf import EPSFBuilder, EPSFFitter
 from ..epsf_stars import extract_stars, EPSFStars
 from ..models import IntegratedGaussianPRF, EPSFModel
 from ...datasets import make_gaussian_prf_sources_image
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -12,12 +12,7 @@ import pytest
 
 from ..epsf_stars import extract_stars, EPSFStars
 from ..models import EPSFModel, IntegratedGaussianPRF
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/tests/test_groupstars.py
+++ b/photutils/psf/tests/test_groupstars.py
@@ -9,12 +9,7 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 from ..groupstars import DAOGroup, DBSCANGroup
-
-try:
-    import sklearn.cluster  # noqa
-    HAS_SKLEARN = True
-except ImportError:
-    HAS_SKLEARN = False
+from ...utils._optional_deps import HAS_SKLEARN  # noqa
 
 
 def assert_table_almost_equal(table1, table2):

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -14,12 +14,7 @@ import pytest
 from ..models import (FittableImageModel, GriddedPSFModel,
                       IntegratedGaussianPRF, PRFAdapter)
 from ...segmentation import detect_sources, SourceCatalog
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -24,12 +24,7 @@ from ..utils import prepare_psf_model
 from ...background import MMMBackground, StdBackgroundRMS
 from ...datasets import make_gaussian_prf_sources_image, make_noise_image
 from ...detection import DAOStarFinder
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 def make_psf_photometry_objs(std=1, sigma_psf=1):

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -13,12 +13,7 @@ import pytest
 from ..models import IntegratedGaussianPRF
 from ..sandbox import DiscretePRF
 from ..utils import get_grouped_psf_model, prepare_psf_model, subtract_psf
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
 
 PSF_SIZE = 11

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -17,18 +17,7 @@ from ..core import SegmentationImage
 from ..detect import detect_sources
 from ...aperture import CircularAperture, EllipticalAperture
 from ...datasets import make_gwcs, make_wcs, make_noise_image
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
-try:
-    import gwcs  # noqa
-    HAS_GWCS = True
-except ImportError:
-    HAS_GWCS = False
+from ...utils._optional_deps import HAS_GWCS, HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -8,18 +8,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ..core import Segment, SegmentationImage
-
-try:
-    import matplotlib  # noqa
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from ...utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -14,18 +14,7 @@ from ..core import SegmentationImage
 from ..deblend import deblend_sources
 from ..detect import detect_sources
 from ...utils.exceptions import NoDetectionsWarning
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
-try:
-    import skimage  # noqa
-    HAS_SKIMAGE = True
-except ImportError:
-    HAS_SKIMAGE = False
+from ...utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -14,12 +14,8 @@ import pytest
 from ...utils.exceptions import NoDetectionsWarning
 from ..detect import detect_threshold, detect_sources, make_source_mask
 from ...datasets import make_4gaussians_image
+from ...utils._optional_deps import HAS_SCIPY  # noqa
 
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
 
 DATA = np.array([[0, 1, 0], [0, 2, 0], [0, 0, 0]]).astype(float)
 REF1 = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]])

--- a/photutils/segmentation/tests/test_properties.py
+++ b/photutils/segmentation/tests/test_properties.py
@@ -21,18 +21,8 @@ from ..detect import detect_sources
 from ..properties import (LegacySourceCatalog, SourceProperties,
                           source_properties)
 from ...datasets import make_gwcs, make_wcs
+from ...utils._optional_deps import HAS_GWCS, HAS_SCIPY  # noqa
 
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
-try:
-    import gwcs  # noqa
-    HAS_GWCS = True
-except ImportError:
-    HAS_GWCS = False
 
 XCEN = 51.
 YCEN = 52.7

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -5,8 +5,9 @@
 import importlib
 
 # This list is a duplicate of the dependencies in setup.cfg "all".
-optional_deps = ['scipy', 'matplotlib', 'scikit-image', 'scikit-learn',
-                 'gwcs']
+# Note that in some cases the package names are different from the
+# pip-install name (e.g.k scikit-image -> skimage).
+optional_deps = ['scipy', 'matplotlib', 'skimage', 'sklearn', 'gwcs']
 deps = {key.upper(): key for key in optional_deps}
 __all__ = [f'HAS_{pkg}' for pkg in deps]
 

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Checks for optional dependencies using lazy import from
+`PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_.
+"""
+import importlib
+
+# This list is a duplicate of the dependencies in setup.cfg "all".
+optional_deps = ['scipy', 'matplotlib', 'scikit-image', 'scikit-learn',
+                 'gwcs']
+deps = {key.upper(): key for key in optional_deps}
+__all__ = [f'HAS_{pkg}' for pkg in deps]
+
+
+def __getattr__(name):
+    if name in __all__:
+        try:
+            importlib.import_module(deps[name[4:]])
+        except (ImportError, ModuleNotFoundError):
+            return False
+        return True
+
+    raise AttributeError(f'Module {__name__!r} has no attribute {name!r}.')

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -7,7 +7,8 @@ import importlib
 # This list is a duplicate of the dependencies in setup.cfg "all".
 # Note that in some cases the package names are different from the
 # pip-install name (e.g.k scikit-image -> skimage).
-optional_deps = ['scipy', 'matplotlib', 'skimage', 'sklearn', 'gwcs']
+optional_deps = ['scipy', 'matplotlib', 'skimage', 'sklearn', 'gwcs',
+                 'bottleneck']
 deps = {key.upper(): key for key in optional_deps}
 __all__ = [f'HAS_{pkg}' for pkg in deps]
 

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ..colormaps import make_random_cmap
-from .._optional_deps import HAS_MATPLOTLIB
+from .._optional_deps import HAS_MATPLOTLIB  # noqa
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -7,12 +7,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ..colormaps import make_random_cmap
-
-try:
-    import matplotlib  # noqa
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
+from .._optional_deps import HAS_MATPLOTLIB
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from .._convolution import _filter_data
-from .._optional_deps import HAS_SCIPY
+from .._optional_deps import HAS_SCIPY  # noqa
 from ...datasets import make_100gaussians_image
 
 

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -11,13 +11,8 @@ from numpy.testing import assert_allclose
 import pytest
 
 from .._convolution import _filter_data
+from .._optional_deps import HAS_SCIPY
 from ...datasets import make_100gaussians_image
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -8,12 +8,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from .. import ShepardIDWInterpolator as idw
-
-try:
-    import scipy  # noqa
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+from .._optional_deps import HAS_SCIPY
 
 
 SHAPE = (5, 5)

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from .. import ShepardIDWInterpolator as idw
-from .._optional_deps import HAS_SCIPY
+from .._optional_deps import HAS_SCIPY  # noqa
 
 
 SHAPE = (5, 5)

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ all =
     scikit-image>=0.14.2
     scikit-learn
     gwcs>=0.12
+    bottleneck
 test =
     pytest-astropy
 docs =


### PR DESCRIPTION
This PR centralizes the definition of `HAS_x` optional dependency package import checking, such as `HAS_SCIPY`. Now that `photutils` requires Python 3.7+, we can make use of lazy imports as implemented in PEP 0562.

This PR also makes `bottleneck` an optional dependency in the `setup.cfg` (and now listed in the docs).  This was an oversight.