### PR TITLE
Add markersize keyword to Background2D plot_meshes method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ New Features
   - Enable all background classes to work with ``Quantity`` inputs.
     [#1233]
 
+  - Added a ``markersize`` keyword to the ``Background2D`` method
+    ``plot_meshes``. [#1234]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -665,8 +665,8 @@ class Background2D:
             bkg_rms <<= self.unit
         return bkg_rms
 
-    def plot_meshes(self, axes=None, marker='+', color='blue', outlines=False,
-                    **kwargs):
+    def plot_meshes(self, *, axes=None, marker='+', markersize=None,
+                    color='blue', outlines=False, **kwargs):
         """
         Plot the low-resolution mesh boxes on a matplotlib Axes
         instance.
@@ -680,6 +680,11 @@ class Background2D:
         marker : str, optional
             The marker to use to mark the center of the boxes.  Default
             is '+'.
+
+        markersize: float, optional
+            The marker size in points**2. The default is
+            ``matplotlib.rcParams['lines.markersize'] ** 2``. If set to
+            0, then the box center markers will not be plotted.
 
         color : str, optional
             The color for the markers and the box outlines.  Default is
@@ -699,7 +704,8 @@ class Background2D:
         kwargs['color'] = color
         if axes is None:
             axes = plt.gca()
-        axes.scatter(*self._mesh_xypos, marker=marker, color=color)
+        axes.scatter(*self._mesh_xypos, s=markersize, marker=marker,
+                     color=color)
         if outlines:
             from ..aperture import RectangularAperture
             xypos = np.column_stack(self._mesh_xypos)


### PR DESCRIPTION
This PR adds a `markersize` keyword to the `Background2D.plot_meshes()` method.