### PR TITLE
Add __repr__ to background classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ New Features
   - Added a ``markersize`` keyword to the ``Background2D`` method
     ``plot_meshes``. [#1234]
 
+  - Added ``__repr__`` methods to all background classes. [#1236]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -42,6 +42,10 @@ class BackgroundBase(metaclass=abc.ABCMeta):
                             'instance or None')
         self.sigma_clip = sigma_clip
 
+    def __repr__(self):
+        return (f'<{self.__class__.__name__}'
+                f'(sigma_clip={repr(self.sigma_clip)})>')
+
     def __call__(self, data, axis=None, masked=False):
         return self.calc_background(data, axis=axis, masked=masked)
 
@@ -93,6 +97,10 @@ class BackgroundRMSBase(metaclass=abc.ABCMeta):
             raise TypeError('sigma_clip must be an astropy SigmaClip '
                             'instance or None')
         self.sigma_clip = sigma_clip
+
+    def __repr__(self):
+        return (f'<{self.__class__.__name__}'
+                f'(sigma_clip={repr(self.sigma_clip)})>')
 
     def __call__(self, data, axis=None, masked=False):
         return self.calc_background_rms(data, axis=axis, masked=masked)

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -221,3 +221,19 @@ def test_background_invalid_sigmaclip(bkg_class):
 def test_background_rms_invalid_sigmaclip(rms_class):
     with pytest.raises(TypeError):
         rms_class(sigma_clip=3)
+
+
+@pytest.mark.parametrize('bkg_class', BKG_CLASS)
+def test_background_repr(bkg_class):
+    bkg = bkg_class()
+    bkg_repr = repr(bkg)
+    assert bkg_repr == str(bkg)
+    assert bkg_repr.startswith(f'<{bkg.__class__.__name__}(sigma_clip=')
+
+
+@pytest.mark.parametrize('rms_class', RMS_CLASS)
+def test_background_rms_repr(rms_class):
+    bkgrms = rms_class()
+    rms_repr = repr(bkgrms)
+    assert rms_repr == str(bkgrms)
+    assert rms_repr.startswith(f'<{bkgrms.__class__.__name__}(sigma_clip=')


### PR DESCRIPTION
This PR adds `__repr__` to all background classes.  Example:

```python
>>> from photutils.background import MeanBackground
>>> bkg = MeanBackground()
>>> bkg
<MeanBackground(sigma_clip=SigmaClip(sigma=3.0, sigma_lower=3.0, sigma_upper=3.0, maxiters=10, cenfunc='median', stdfunc='std', grow=False))>
```