### PR TITLE
Add mask keyword to aperture area_overlap method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Add ``mask`` keyword to the ``area_overlap`` method. [#1241]
+
 - ``photutils.background``
 
   - Improved the performance of ``Background2D`` by up to 10-50% when

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -95,6 +95,10 @@ def test_area_overlap():
     areas = aper.area_overlap(data)
     assert_allclose(areas, [10.304636, np.pi*9., np.nan])
 
+    aper2 = CircularAperture(xypos[1], r=3)
+    area2 = aper2.area_overlap(data)
+    assert_allclose(area2, np.pi * 9.)
+
 
 def test_area_overlap_mask():
     data = np.ones((11, 11))
@@ -106,3 +110,7 @@ def test_area_overlap_mask():
     areas = aper.area_overlap(data, mask=mask)
     areas_exp = np.array([10.304636, np.pi*9., np.nan]) - 2.
     assert_allclose(areas, areas_exp)
+
+    with pytest.raises(ValueError):
+        mask = np.zeros((3, 3), dtype=bool)
+        aper.area_overlap(data, mask=mask)

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -94,3 +94,15 @@ def test_area_overlap():
     aper = CircularAperture(xypos, r=3)
     areas = aper.area_overlap(data)
     assert_allclose(areas, [10.304636, np.pi*9., np.nan])
+
+
+def test_area_overlap_mask():
+    data = np.ones((11, 11))
+    mask = np.zeros((11, 11), dtype=bool)
+    mask[0, 0:2] = True
+    mask[5, 5:7] = True
+    xypos = [(0, 0), (5, 5), (50, 50)]
+    aper = CircularAperture(xypos, r=3)
+    areas = aper.area_overlap(data, mask=mask)
+    areas_exp = np.array([10.304636, np.pi*9., np.nan]) - 2.
+    assert_allclose(areas, areas_exp)


### PR DESCRIPTION
This PR adds a `mask` keyword to the aperture `area_overlap` method to account for any masked pixels in the data.