### PR TITLE
Use QTable with version metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,25 @@ API changes
     ``make_random_models_table``, and ``make_random_gaussians_table``
     functions. [#1244]
 
+  - ``make_random_models_table`` and ``make_random_gaussians_table`` now
+    return an astropy ``QTable`` with version metadata. [#1247]
+
+- ``photutils.detection``
+
+  - ``DAOStarFinder``, ``IRAFStarFinder``, and ``find_peaks`` now return
+    an astropy ``QTable`` with version metadata. [#1247]
+
+- ``photutils.isophote``
+
+  - The ``Isophote`` ``to_table`` method nows return an astropy
+    ``QTable`` with version metadata. [#1247]
+
+- ``photutils.psf``
+
+  - ``BasicPSFPhotometry``, ``IterativelySubtractedPSFPhotometry``, and
+    ``DAOPhotPSFPhotometry`` now return an astropy ``QTable`` with
+    version metadata. [#1247]
+
 - ``photutils.segmentation``
 
   - Deprecated the ``filter_kernel`` keyword in the ``detect_sources``,
@@ -130,6 +149,9 @@ API changes
 
   - Removed the deprecated ``random_state`` keyword in the ``make_cmap``
     method. [#1244]
+
+  - The ``SourceCatalog`` ``to_table`` method nows return an astropy
+    ``QTable`` with version metadata. [#1247]
 
 - ``photutils.utils``
 

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -14,6 +14,7 @@ from astropy.wcs import WCS
 import numpy as np
 
 from ..psf import IntegratedGaussianPRF
+from ..utils._misc import _get_version_info
 
 __all__ = ['apply_poisson_noise', 'make_noise_image',
            'make_random_models_table', 'make_random_gaussians_table',
@@ -229,7 +230,8 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
 
     rng = np.random.default_rng(seed)
 
-    sources = Table()
+    meta = {'version': _get_version_info()}
+    sources = Table(meta=meta)
     for param_name, (lower, upper) in param_ranges.items():
         # Generate a column for every item in param_ranges, even if it
         # is not in the model (e.g., flux). However, such columns will be

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -8,7 +8,7 @@ from astropy import coordinates as coord
 from astropy.convolution import discretize_model
 from astropy.io import fits
 from astropy.modeling import models
-from astropy.table import Table
+from astropy.table import QTable
 import astropy.units as u
 from astropy.wcs import WCS
 import numpy as np
@@ -162,7 +162,7 @@ def make_noise_image(shape, distribution='gaussian', mean=None, stddev=None,
 
 def make_random_models_table(n_sources, param_ranges, seed=None):
     """
-    Make a `~astropy.table.Table` containing randomly generated
+    Make a `~astropy.table.QTable` containing randomly generated
     parameters for an Astropy model to simulate a set of sources.
 
     Each row of the table corresponds to a source whose parameters are
@@ -188,7 +188,7 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
 
     Returns
     -------
-    table : `~astropy.table.Table`
+    table : `~astropy.table.QTable`
         A table of parameters for the randomly generated sources.  Each
         row of the table corresponds to a source whose model parameters
         are defined by the column names.  The column names will be the
@@ -231,7 +231,7 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
     rng = np.random.default_rng(seed)
 
     meta = {'version': _get_version_info()}
-    sources = Table(meta=meta)
+    sources = QTable(meta=meta)
     for param_name, (lower, upper) in param_ranges.items():
         # Generate a column for every item in param_ranges, even if it
         # is not in the model (e.g., flux). However, such columns will be
@@ -243,7 +243,7 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
 
 def make_random_gaussians_table(n_sources, param_ranges, seed=None):
     """
-    Make a `~astropy.table.Table` containing randomly generated
+    Make a `~astropy.table.QTable` containing randomly generated
     parameters for 2D Gaussian sources.
 
     Each row of the table corresponds to a Gaussian source whose
@@ -278,7 +278,7 @@ def make_random_gaussians_table(n_sources, param_ranges, seed=None):
 
     Returns
     -------
-    table : `~astropy.table.Table`
+    table : `~astropy.table.QTable`
         A table of parameters for the randomly generated Gaussian
         sources.  Each row of the table corresponds to a Gaussian source
         whose parameters are defined by the column names.
@@ -502,8 +502,8 @@ def make_gaussian_sources_image(shape, source_table, oversample=1):
         :include-source:
 
         # make a table of Gaussian sources
-        from astropy.table import Table
-        table = Table()
+        from astropy.table import QTable
+        table = QTable()
         table['amplitude'] = [50, 70, 150, 210]
         table['x_mean'] = [160, 25, 150, 90]
         table['y_mean'] = [70, 40, 25, 60]
@@ -589,8 +589,8 @@ def make_gaussian_prf_sources_image(shape, source_table):
         :include-source:
 
         # make a table of Gaussian sources
-        from astropy.table import Table
-        table = Table()
+        from astropy.table import QTable
+        table = QTable()
         table['amplitude'] = [50, 70, 150, 210]
         table['x_0'] = [160, 25, 150, 90]
         table['y_0'] = [70, 40, 25, 60]
@@ -671,7 +671,7 @@ def make_4gaussians_image(noise=True):
         plt.imshow(image, origin='lower', interpolation='nearest')
     """
 
-    table = Table()
+    table = QTable()
     table['amplitude'] = [50, 70, 150, 210]
     table['x_mean'] = [160, 25, 150, 90]
     table['y_mean'] = [70, 40, 25, 60]
@@ -738,7 +738,7 @@ def make_100gaussians_image(noise=True):
               'theta': [0, 2 * np.pi]}
 
     rng = np.random.RandomState(12345)
-    sources = Table()
+    sources = QTable()
     for param_name, (lower, upper) in params.items():
         # Generate a column for every item in param_ranges, even if it
         # is not in the model (e.g., flux).  However, such columns will

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -14,6 +14,7 @@ from .base import StarFinderBase
 from ._utils import _StarFinderKernel, _find_stars
 from ..utils._convolution import _filter_data
 from ..utils.exceptions import NoDetectionsWarning
+from ..utils._misc import _get_version_info
 
 __all__ = ['DAOStarFinder']
 
@@ -625,7 +626,8 @@ class _DAOStarFinderCatalog:
         return np.full(len(self), fill_value=self.kernel.data.size)
 
     def to_table(self, columns=None):
-        table = Table()
+        meta = {'version': _get_version_info()}
+        table = Table(meta=meta)
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -6,7 +6,7 @@ import inspect
 import warnings
 
 from astropy.nddata import extract_array
-from astropy.table import Table
+from astropy.table import QTable
 from astropy.utils import lazyproperty
 import numpy as np
 
@@ -206,7 +206,7 @@ class DAOStarFinder(StarFinderBase):
 
         Returns
         -------
-        table : `~astropy.table.Table` or `None`
+        table : `~astropy.table.QTable` or `None`
             A table of found stars with the following parameters:
 
             * ``id``: unique object identification number.
@@ -627,7 +627,7 @@ class _DAOStarFinderCatalog:
 
     def to_table(self, columns=None):
         meta = {'version': _get_version_info()}
-        table = Table(meta=meta)
+        table = QTable(meta=meta)
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -6,7 +6,7 @@ import inspect
 import warnings
 
 from astropy.nddata import extract_array
-from astropy.table import Table
+from astropy.table import QTable
 from astropy.utils import lazyproperty
 import numpy as np
 
@@ -178,7 +178,7 @@ class IRAFStarFinder(StarFinderBase):
 
         Returns
         -------
-        table : `~astropy.table.Table` or `None`
+        table : `~astropy.table.QTable` or `None`
             A table of found objects with the following parameters:
 
             * ``id``: unique object identification number.
@@ -461,7 +461,7 @@ class _IRAFStarFinderCatalog:
 
     def to_table(self, columns=None):
         meta = {'version': _get_version_info()}
-        table = Table(meta=meta)
+        table = QTable(meta=meta)
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -13,6 +13,7 @@ import numpy as np
 from .base import StarFinderBase
 from ._utils import _StarFinderKernel, _find_stars
 from ..utils._convolution import _filter_data
+from ..utils._misc import _get_version_info
 from ..utils._moments import _moments, _moments_central
 from ..utils.exceptions import NoDetectionsWarning
 
@@ -459,7 +460,8 @@ class _IRAFStarFinderCatalog:
         return pa
 
     def to_table(self, columns=None):
-        table = Table()
+        meta = {'version': _get_version_info()}
+        table = Table(meta=meta)
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -6,7 +6,7 @@ image.
 
 import warnings
 
-from astropy.table import Table
+from astropy.table import QTable
 import numpy as np
 
 from ..utils.exceptions import NoDetectionsWarning
@@ -166,11 +166,11 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         warnings.warn('No local peaks were found.', NoDetectionsWarning)
         return None
 
-    # construct the output Table
+    # construct the output table
     meta = {'version': _get_version_info()}
     colnames = ['x_peak', 'y_peak', 'peak_value']
     coldata = [x_peaks, y_peaks, peak_values]
-    table = Table(coldata, names=colnames, meta=meta)
+    table = QTable(coldata, names=colnames, meta=meta)
 
     if wcs is not None:
         skycoord_peaks = wcs.pixel_to_world(x_peaks, y_peaks)

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -10,6 +10,7 @@ from astropy.table import Table
 import numpy as np
 
 from ..utils.exceptions import NoDetectionsWarning
+from ..utils._misc import _get_version_info
 
 __all__ = ['find_peaks']
 
@@ -166,9 +167,10 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         return None
 
     # construct the output Table
+    meta = {'version': _get_version_info()}
     colnames = ['x_peak', 'y_peak', 'peak_value']
     coldata = [x_peaks, y_peaks, peak_values]
-    table = Table(coldata, names=colnames)
+    table = Table(coldata, names=colnames, meta=meta)
 
     if wcs is not None:
         skycoord_peaks = wcs.pixel_to_world(x_peaks, y_peaks)

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -14,6 +14,7 @@ import numpy as np
 from .base import StarFinderBase
 from ._utils import _find_stars
 from ..utils._convolution import _filter_data
+from ..utils._misc import _get_version_info
 from ..utils._moments import _moments, _moments_central
 from ..utils.exceptions import NoDetectionsWarning
 
@@ -345,7 +346,8 @@ class _StarFinderCatalog:
         return pa
 
     def to_table(self, columns=None):
-        table = QTable()
+        meta = {'version': _get_version_info()}
+        table = QTable(meta=meta)
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from .harmonics import (first_and_second_harmonic_function,
                         fit_first_and_second_harmonics, fit_upper_harmonic)
+from ..utils._misc import _get_version_info
 
 __all__ = ['Isophote', 'IsophoteList']
 
@@ -782,9 +783,9 @@ def _isophote_list_to_table(isophote_list, columns='main'):
     result : `~astropy.table.QTable`
         An astropy QTable with the selected or all isophote parameters.
     """
-
-    properties = dict()
-    isotable = QTable()
+    properties = {}
+    meta = {'version': _get_version_info()}
+    isotable = QTable(meta=meta)
 
     # main_properties: `List`
     # A list of main parameters matching the original names of

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -19,6 +19,7 @@ from ..aperture import CircularAperture, aperture_photometry
 from ..background import MMMBackground
 from ..detection import DAOStarFinder
 from ..utils.exceptions import NoDetectionsWarning
+from ..utils._misc import _get_version_info
 
 __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
            'DAOPhotPSFPhotometry']
@@ -346,6 +347,8 @@ class BasicPSFPhotometry:
 
         star_groups = star_groups.group_by('group_id')
         output_tab = hstack([star_groups, output_tab])
+
+        output_tab.meta = {'version': _get_version_info()}
 
         return output_tab
 
@@ -743,6 +746,9 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
                 self.set_aperture_radius()
 
             output_table = self._do_photometry()
+
+        output_table.meta = {'version': _get_version_info()}
+
         return output_table
 
     def _do_photometry(self, n_start=1):

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -8,7 +8,7 @@ import warnings
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import overlap_slices, NoOverlapError
 from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
-from astropy.table import Column, Table, hstack, vstack
+from astropy.table import Column, QTable, hstack, vstack
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -326,13 +326,13 @@ class BasicPSFPhotometry:
                 # init_guesses should be the initial 3 required
                 # parameters (x, y, flux) and then concatenated with any
                 # additional sources, if there are any
-                init_guesses = Table(names=['x_0', 'y_0', 'flux_0'],
-                                     data=[sources['xcentroid'],
-                                           sources['ycentroid'],
-                                           sources['aperture_flux']])
+                init_guesses = QTable(names=['x_0', 'y_0', 'flux_0'],
+                                      data=[sources['xcentroid'],
+                                            sources['ycentroid'],
+                                            sources['aperture_flux']])
 
                 # Currently only needed for the finder, as group_maker and
-                # nstar return the original Table with new columns, unlike
+                # nstar return the original table with new columns, unlike
                 # finder
                 self._get_additional_columns(sources, init_guesses)
 
@@ -350,7 +350,7 @@ class BasicPSFPhotometry:
 
         output_tab.meta = {'version': _get_version_info()}
 
-        return output_tab
+        return QTable(output_tab)
 
     def nstar(self, image, star_groups):
         """
@@ -375,18 +375,18 @@ class BasicPSFPhotometry:
 
         Returns
         -------
-        result_tab : `~astropy.table.Table`
+        result_tab : `~astropy.table.QTable`
             Astropy table that contains photometry results.
 
         image : numpy.ndarray
             Residual image.
         """
 
-        result_tab = Table()
+        result_tab = QTable()
         for param_tab_name in self._pars_to_output.keys():
             result_tab.add_column(Column(name=param_tab_name))
 
-        unc_tab = Table()
+        unc_tab = QTable()
         for param, isfixed in self.psf_model.fixed.items():
             if not isfixed:
                 unc_tab.add_column(Column(name=param + "_unc"))
@@ -480,12 +480,12 @@ class BasicPSFPhotometry:
 
         Returns
         -------
-        unc_tab : `~astropy.table.Table`
-            Table which contains uncertainties on the fitted parameters.
+        unc_tab : `~astropy.table.QTable`
+            A table which contains uncertainties on the fitted parameters.
             The uncertainties are reported as one standard deviation.
         """
 
-        unc_tab = Table()
+        unc_tab = QTable()
         for param_name in self.psf_model.param_names:
             if not self.psf_model.fixed[param_name]:
                 unc_tab.add_column(Column(name=param_name + "_unc",
@@ -517,11 +517,11 @@ class BasicPSFPhotometry:
 
         Returns
         -------
-        param_tab : `~astropy.table.Table`
-            Table that contains the fitted parameters.
+        param_tab : `~astropy.table.QTable`
+            A table that contains the fitted parameters.
         """
 
-        param_tab = Table()
+        param_tab = QTable()
 
         for param_tab_name in self._pars_to_output.keys():
             param_tab.add_column(Column(name=param_tab_name,
@@ -719,7 +719,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         Returns
         -------
         output_table : `~astropy.table.Table` or None
-            Table with the photometry results, i.e., centroids and
+            A table with the photometry results, i.e., centroids and
             fluxes estimations and the initial estimates used to start
             the fitting process. Uncertainties on the fitted parameters
             are reported as columns called ``<paramname>_unc`` provided
@@ -749,7 +749,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
 
         output_table.meta = {'version': _get_version_info()}
 
-        return output_table
+        return QTable(output_table)
 
     def _do_photometry(self, n_start=1):
         """
@@ -770,7 +770,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
             the fitting process.
         """
 
-        output_table = Table()
+        output_table = QTable()
         self._define_fit_param_names()
 
         for (init_parname, fit_parname) in zip(self._pars_to_set.keys(),
@@ -790,10 +790,10 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
             sources['aperture_flux'] = aperture_photometry(
                 self._residual_image, apertures)['aperture_sum']
 
-            init_guess_tab = Table(names=['id', 'x_0', 'y_0', 'flux_0'],
-                                   data=[sources['id'], sources['xcentroid'],
-                                         sources['ycentroid'],
-                                         sources['aperture_flux']])
+            init_guess_tab = QTable(names=['id', 'x_0', 'y_0', 'flux_0'],
+                                    data=[sources['id'], sources['xcentroid'],
+                                          sources['ycentroid'],
+                                          sources['aperture_flux']])
             self._get_additional_columns(sources, init_guess_tab)
 
             for param_tab_name, param_name in self._pars_to_set.items():

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -3,7 +3,7 @@
 This module provides utilities for PSF-fitting photometry.
 """
 
-from astropy.table import Table
+from astropy.table import QTable
 from astropy.modeling import models
 from astropy.nddata.utils import add_array, extract_array
 import numpy as np
@@ -238,7 +238,7 @@ def subtract_psf(data, psf, posflux, subshape=None):
         if 'flux_fit' not in posflux.colnames:
             raise ValueError('Input table does not have flux_fit')
     else:
-        posflux = Table(names=['x_fit', 'y_fit', 'flux_fit'], data=posflux)
+        posflux = QTable(names=['x_fit', 'y_fit', 'flux_fit'], data=posflux)
 
     # Set up constants across the loop
     psf = psf.copy()

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -20,6 +20,7 @@ from ..aperture import (BoundingBox, CircularAperture, EllipticalAperture,
                         RectangularAnnulus)
 from ..background import SExtractorBackground
 from ..utils._convolution import _filter_data
+from ..utils._misc import _get_version_info
 from ..utils._moments import _moments, _moments_central
 
 __all__ = ['SourceCatalog']
@@ -580,7 +581,8 @@ class SourceCatalog:
         else:
             table_columns = np.atleast_1d(columns)
 
-        tbl = QTable()
+        meta = {'version': _get_version_info()}
+        tbl = QTable(meta=meta)
         for column in table_columns:
             values = getattr(self, column)
 

--- a/photutils/utils/_misc.py
+++ b/photutils/utils/_misc.py
@@ -7,15 +7,24 @@ versions.
 
 def _get_version_info():
     """
-    Return astropy and photutils versions.
+    Return a dictionary of the installed version numbers for photutils
+    and its dependencies.
 
     Returns
     -------
-    result : str
-        The astropy and photutils versions.
+    result : dict
+        A dictionary containing the version numbers for photutils and
+        its dependencies.
     """
+    versions = {}
+    packages = ('photutils', 'astropy', 'numpy', 'scipy', 'skimage')
+    for package in packages:
+        try:
+            pkg = __import__(package)
+            version = pkg.__version__
+        except ImportError:
+            version = None
 
-    from astropy import __version__ as astropy_version
-    from photutils import __version__ as photutils_version
+        versions[package] = version
 
-    return f'astropy: {astropy_version}, photutils: {photutils_version}'
+    return versions


### PR DESCRIPTION
This PR adds package version metadata to all output tables and also uses `QTable` for all output tables instead of `Table`.  The version metadata is stored as a dictionary keyed on the package name with the values being the package version.