### PR TITLE
Add xycoords keyword to DAOStarFinder and IRAFStarFinder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ New Features
 
   - Added a ``grid_mode`` keyword to ``BkgZoomInterpolator``. [#1239]
 
+- ``photutils.detection``
+
+    - Added a ``xycoords`` keyword to ``DAOStarFinder`` and
+      ``IRAFStarFinder``. [#1248]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -86,6 +86,11 @@ class IRAFStarFinder(StarFinderBase):
             pixel values are negative. Therefore, setting ``peakmax`` to a
             non-positive value would result in exclusion of all objects.
 
+    xycoords : `None` or Nx2 `~numpy.ndarray`
+        The (x, y) pixel coordinates of the approximate centroid
+        positions of identified sources. If ``xycoords`` are input, the
+        algorithm will skip the source-finding step.
+
     Notes
     -----
     For the convolution step, this routine sets pixels beyond the image
@@ -124,7 +129,8 @@ class IRAFStarFinder(StarFinderBase):
 
     def __init__(self, threshold, fwhm, sigma_radius=1.5, minsep_fwhm=2.5,
                  sharplo=0.5, sharphi=2.0, roundlo=0.0, roundhi=0.2, sky=None,
-                 exclude_border=False, brightest=None, peakmax=None):
+                 exclude_border=False, brightest=None, peakmax=None,
+                 xycoords=None):
 
         if not np.isscalar(threshold):
             raise TypeError('threshold must be a scalar value.')
@@ -144,6 +150,12 @@ class IRAFStarFinder(StarFinderBase):
         self.exclude_border = exclude_border
         self.brightest = self._validate_brightest(brightest)
         self.peakmax = peakmax
+
+        if xycoords is not None:
+            xycoords = np.asarray(xycoords)
+            if xycoords.ndim != 2 or xycoords.shape[1] != 2:
+                raise ValueError('xycoords must be shaped as a Nx2 array')
+        self.xycoords = xycoords
 
         self.kernel = _StarFinderKernel(self.fwhm, ratio=1.0, theta=0.0,
                                         sigma_radius=self.sigma_radius)
@@ -200,9 +212,13 @@ class IRAFStarFinder(StarFinderBase):
                                       fill_value=0.0,
                                       check_normalization=False)
 
-        xypos = _find_stars(convolved_data, self.kernel, self.threshold,
-                            min_separation=self.min_separation, mask=mask,
-                            exclude_border=self.exclude_border)
+        if self.xycoords is None:
+            xypos = _find_stars(convolved_data, self.kernel, self.threshold,
+                                min_separation=self.min_separation, mask=mask,
+                                exclude_border=self.exclude_border)
+        else:
+            xypos = self.xycoords
+
         if xypos is None:
             warnings.warn('No sources were found.', NoDetectionsWarning)
             return None

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -158,3 +158,19 @@ class TestDAOStarFinder:
             DAOStarFinder(threshold=10, fwhm=1.5, brightest=-1)
         with pytest.raises(ValueError):
             DAOStarFinder(threshold=10, fwhm=1.5, brightest=3.1)
+
+    def test_xycoords(self):
+        starfinder1 = DAOStarFinder(threshold=30, fwhm=2, sigma_radius=1.5,
+                                    exclude_border=True)
+        tbl1 = starfinder1(DATA)
+
+        xycoords = np.array([[145, 169], [395, 187], [427, 211], [11, 224]])
+        starfinder2 = DAOStarFinder(threshold=30, fwhm=2, sigma_radius=1.5,
+                                    exclude_border=True, xycoords=xycoords)
+        tbl2 = starfinder2(DATA)
+        assert np.all(tbl1 == tbl2)
+
+    def test_invalid_xycoords(self):
+        xycoords = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        with pytest.raises(ValueError):
+            DAOStarFinder(threshold=10, fwhm=1.5, xycoords=xycoords)

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -133,3 +133,19 @@ class TestIRAFStarFinder:
             IRAFStarFinder(10, 1.5, brightest=-1)
         with pytest.raises(ValueError):
             IRAFStarFinder(10, 1.5, brightest=3.1)
+
+    def test_xycoords(self):
+        starfinder1 = IRAFStarFinder(threshold=30, fwhm=2, sigma_radius=1.5,
+                                     exclude_border=True)
+        tbl1 = starfinder1(DATA)
+
+        xycoords = np.array([[145, 169], [395, 187], [427, 211], [11, 224]])
+        starfinder2 = IRAFStarFinder(threshold=30, fwhm=2, sigma_radius=1.5,
+                                     exclude_border=True, xycoords=xycoords)
+        tbl2 = starfinder2(DATA)
+        assert np.all(tbl1 == tbl2)
+
+    def test_invalid_xycoords(self):
+        xycoords = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        with pytest.raises(ValueError):
+            IRAFStarFinder(threshold=10, fwhm=1.5, xycoords=xycoords)


### PR DESCRIPTION
This PR adds a `xycoords` keyword to `DAOStarFinder` and `IRAFStarFinder`.  If `xycoords` are input, then the source-detection algorithm is skipped and they are used directly.

`xycoords` are input as a `Nx2` numpy.ndarray.  If x and y are stored in a table, then one would input `xycoords` as e.g., `xycoords = np.transpose((tbl['x_peak'], tbl['y_peak']))`.

This is an alternate solution to #1231.  It was made possible by the refactoring completed in #1245.

Closes #1231.

CC: @stsci-hack