### PR TITLE
Add docstrings for aperture attributes

### DIFF
--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -15,10 +15,20 @@ __all__ = ['ApertureAttribute', 'PixelPositions', 'SkyCoordPositions',
 class ApertureAttribute:
     """
     Base descriptor class for aperture attribute validation.
+
+    Parameters
+    ----------
+    name : str
+        The name of the attribute.
+
+    description : str, optional
+        The description of the attribute, which will be used as the
+        attribute documentation.
     """
 
-    def __init__(self, name):
+    def __init__(self, name, description=''):
         self.name = name
+        self.__doc__ = description
 
     def __get__(self, instance, owner):
         if instance is None:

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -140,8 +140,9 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('r',)
-    positions = PixelPositions('positions')
-    r = PositiveScalar('r')
+    positions = PixelPositions('positions',
+                               description='The center pixel position(s).')
+    r = PositiveScalar('r', description='The radius in pixels.')
 
     def __init__(self, positions, r):
         self.positions = positions
@@ -258,9 +259,12 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('r_in', 'r_out')
-    positions = PixelPositions('positions')
-    r_in = PositiveScalar('r_in')
-    r_out = PositiveScalar('r_out')
+    positions = PixelPositions('positions',
+                               description='The center pixel position(s).')
+    r_in = PositiveScalar('r_in',
+                          description='The inner radius in pixels.')
+    r_out = PositiveScalar('r_out',
+                           description='The outer radius in pixels.')
 
     def __init__(self, positions, r_in, r_out):
         if not r_out > r_in:
@@ -363,8 +367,12 @@ class SkyCircularAperture(SkyAperture):
     """
 
     _shape_params = ('r',)
-    positions = SkyCoordPositions('positions')
-    r = AngleOrPixelScalarQuantity('r')
+    positions = SkyCoordPositions(
+        'positions',
+        description='The center position(s) in sky coordinates.')
+    r = AngleOrPixelScalarQuantity(
+        'r',
+        description='The radius, in angular or pixel units.')
 
     def __init__(self, positions, r):
         self.positions = positions
@@ -422,9 +430,15 @@ class SkyCircularAnnulus(SkyAperture):
     """
 
     _shape_params = ('r_in', 'r_out')
-    positions = SkyCoordPositions('positions')
-    r_in = AngleOrPixelScalarQuantity('r_in')
-    r_out = AngleOrPixelScalarQuantity('r_out')
+    positions = SkyCoordPositions(
+        'positions',
+        description='The center position(s) in sky coordinates.')
+    r_in = AngleOrPixelScalarQuantity(
+        'r_in',
+        description='The inner radius, in angular or pixel units.')
+    r_out = AngleOrPixelScalarQuantity(
+        'r_out',
+        description='The outer radius, in angular or pixel units.')
 
     def __init__(self, positions, r_in, r_out):
         if r_in.unit.physical_type != r_out.unit.physical_type:

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -199,7 +199,7 @@ class PixelAperture(Aperture):
     @property
     def area(self):
         """
-        Return the exact area of the aperture shape.
+        The exact area of the aperture shape.
 
         Returns
         -------

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -169,10 +169,14 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     """
 
     _shape_params = ('a', 'b', 'theta')
-    positions = PixelPositions('positions')
-    a = PositiveScalar('a')
-    b = PositiveScalar('b')
-    theta = Scalar('theta')
+    positions = PixelPositions('positions',
+                               description='The center pixel position(s).')
+    a = PositiveScalar('a', description='The semimajor axis in pixels.')
+    b = PositiveScalar('b', description='The semiminor axis in pixels.')
+    theta = Scalar('theta',
+                   description=('The counterclockwise rotation angle in '
+                                'radians of the ellipse semimajor axis from '
+                                'the positive x axis.'))
 
     def __init__(self, positions, a, b, theta=0.):
         self.positions = positions
@@ -309,12 +313,20 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     """
 
     _shape_params = ('a_in', 'a_out', 'b_in', 'b_out', 'theta')
-    positions = PixelPositions('positions')
-    a_in = PositiveScalar('a_in')
-    a_out = PositiveScalar('a_out')
-    b_in = PositiveScalar('b_in')
-    b_out = PositiveScalar('b_out')
-    theta = Scalar('theta')
+    positions = PixelPositions('positions',
+                               description='The center pixel position(s).')
+    a_in = PositiveScalar('a_in',
+                          description='The inner semimajor axis in pixels.')
+    a_out = PositiveScalar('a_out',
+                           description='The outer semimajor axis in pixels.')
+    b_in = PositiveScalar('b_in',
+                          description='The inner semiminor axis in pixels.')
+    b_out = PositiveScalar('b_out',
+                           description='The outer semiminor axis in pixels.')
+    theta = Scalar('theta',
+                   description=('The counterclockwise rotation angle in '
+                                'radians of the ellipse semimajor axis from '
+                                'the positive x axis.'))
 
     def __init__(self, positions, a_in, a_out, b_out, b_in=None, theta=0.):
         if not a_out > a_in:
@@ -441,10 +453,19 @@ class SkyEllipticalAperture(SkyAperture):
     """
 
     _shape_params = ('a', 'b', 'theta')
-    positions = SkyCoordPositions('positions')
-    a = AngleOrPixelScalarQuantity('a')
-    b = AngleOrPixelScalarQuantity('b')
-    theta = AngleScalarQuantity('theta')
+    positions = SkyCoordPositions(
+        'positions',
+        description='The center position(s) in sky coordinates.')
+    a = AngleOrPixelScalarQuantity(
+        'a',
+        description='The semimajor axis, in angular or pixel units.')
+    b = AngleOrPixelScalarQuantity(
+        'b',
+        description='The semiminor axis, in angular or pixel units.')
+    theta = AngleScalarQuantity(
+        'theta',
+        description=('The position angle in angular units of the ellipse '
+                     'semimajor axis.'))
 
     def __init__(self, positions, a, b, theta=0.*u.deg):
         if a.unit.physical_type != b.unit.physical_type:
@@ -523,12 +544,25 @@ class SkyEllipticalAnnulus(SkyAperture):
     """
 
     _shape_params = ('a_in', 'a_out', 'b_in', 'b_out', 'theta')
-    positions = SkyCoordPositions('positions')
-    a_in = AngleOrPixelScalarQuantity('a_in')
-    a_out = AngleOrPixelScalarQuantity('a_out')
-    b_in = AngleOrPixelScalarQuantity('b_in')
-    b_out = AngleOrPixelScalarQuantity('b_out')
-    theta = AngleScalarQuantity('theta')
+    positions = SkyCoordPositions(
+        'positions',
+        description='The center position(s) in sky coordinates.')
+    a_in = AngleOrPixelScalarQuantity(
+        'a_in',
+        description='The inner semimajor axis, in angular or pixel units.')
+    a_out = AngleOrPixelScalarQuantity(
+        'a_out',
+        description='The outer semimajor axis, in angular or pixel units.')
+    b_in = AngleOrPixelScalarQuantity(
+        'b_in',
+        description='The inner semiminor axis, in angular or pixel units.')
+    b_out = AngleOrPixelScalarQuantity(
+        'b_out',
+        description='The outer semiminor axis, in angular or pixel units.')
+    theta = AngleScalarQuantity(
+        'theta',
+        description=('The position angle in angular units of the ellipse '
+                     'semimajor axis.'))
 
     def __init__(self, positions, a_in, a_out, b_out, b_in=None,
                  theta=0.*u.deg):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -192,10 +192,14 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('w', 'h', 'theta')
-    positions = PixelPositions('positions')
-    w = PositiveScalar('w')
-    h = PositiveScalar('h')
-    theta = Scalar('theta')
+    positions = PixelPositions('positions',
+                               description='The center pixel position(s).')
+    w = PositiveScalar('w', description='The full width in pixels.')
+    h = PositiveScalar('h', description='The full height in pixels.')
+    theta = Scalar('theta',
+                   description=('The counterclockwise rotation angle in '
+                                'radians of the rectangle "width" side from '
+                                'the positive x axis.'))
 
     def __init__(self, positions, w, h, theta=0.):
         self.positions = positions
@@ -338,12 +342,20 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('w_in', 'w_out', 'h_in', 'h_out', 'theta')
-    positions = PixelPositions('positions')
-    w_in = PositiveScalar('w_in')
-    w_out = PositiveScalar('w_out')
-    h_in = PositiveScalar('h_in')
-    h_out = PositiveScalar('h_out')
-    theta = Scalar('theta')
+    positions = PixelPositions('positions',
+                               description='The center pixel position(s).')
+    w_in = PositiveScalar('w_in',
+                          description='The inner full width in pixels.')
+    w_out = PositiveScalar('w_out',
+                           description='The outer full width in pixels.')
+    h_in = PositiveScalar('h_in',
+                          description='The inner full height in pixels.')
+    h_out = PositiveScalar('h_out',
+                           description='The outer full height in pixels.')
+    theta = Scalar('theta',
+                   description=('The counterclockwise rotation angle in '
+                                'radians of the rectangle "width" side from '
+                                'the positive x axis.'))
 
     def __init__(self, positions, w_in, w_out, h_out, h_in=None, theta=0.):
         if not w_out > w_in:
@@ -479,10 +491,19 @@ class SkyRectangularAperture(SkyAperture):
     """
 
     _shape_params = ('w', 'h', 'theta')
-    positions = SkyCoordPositions('positions')
-    w = AngleOrPixelScalarQuantity('w')
-    h = AngleOrPixelScalarQuantity('h')
-    theta = AngleScalarQuantity('theta')
+    positions = SkyCoordPositions(
+        'positions',
+        description='The center position(s) in sky coordinates.')
+    w = AngleOrPixelScalarQuantity(
+        'w',
+        description='The full width, in angular or pixel units.')
+    h = AngleOrPixelScalarQuantity(
+        'h',
+        description='The full height, in angular or pixel units.')
+    theta = AngleScalarQuantity(
+        'theta',
+        description=('The position angle (in angular units) of the '
+                     'rectangle "width" side.'))
 
     def __init__(self, positions, w, h, theta=0.*u.deg):
         if w.unit.physical_type != h.unit.physical_type:
@@ -569,12 +590,25 @@ class SkyRectangularAnnulus(SkyAperture):
     """
 
     _shape_params = ('w_in', 'w_out', 'h_in', 'h_out', 'theta')
-    positions = SkyCoordPositions('positions')
-    w_in = AngleOrPixelScalarQuantity('w_in')
-    w_out = AngleOrPixelScalarQuantity('w_out')
-    h_in = AngleOrPixelScalarQuantity('h_in')
-    h_out = AngleOrPixelScalarQuantity('h_out')
-    theta = AngleScalarQuantity('theta')
+    positions = SkyCoordPositions(
+        'positions',
+        description='The center position(s) in sky coordinates.')
+    w_in = AngleOrPixelScalarQuantity(
+        'w_in',
+        description='The inner full width, in angular or pixel units.')
+    w_out = AngleOrPixelScalarQuantity(
+        'w_out',
+        description='The outer full width, in angular or pixel units.')
+    h_in = AngleOrPixelScalarQuantity(
+        'h_in',
+        description='The inner full height, in angular or pixel units.')
+    h_out = AngleOrPixelScalarQuantity(
+        'h_out',
+        description='The outer full height, in angular or pixel units.')
+    theta = AngleScalarQuantity(
+        'theta',
+        description=('The position angle (in angular units) of the '
+                     'rectangle "width" side.'))
 
     def __init__(self, positions, w_in, w_out, h_out, h_in=None,
                  theta=0.*u.deg):


### PR DESCRIPTION
This PR adds descriptions for the aperture attributes (defined using descriptor classes) that is used for attribute documentation.