### PR TITLE
Make result of psf-photometry re-usable as initial guess

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,14 @@ New Features
   - Added a ``xycoords`` keyword to ``DAOStarFinder`` and
     ``IRAFStarFinder``. [#1248]
 
+- ``photutils.psf``
+
+  - Enabled the reuse of an output table from ``BasicPSFPhotometry`` and
+    its subclasses as an initial guess for another photometry run. [#1251]
+
+  - Added the ability to skip the ``group_maker`` step by inputing an
+    initial guess table with a ``group_id`` column. [#1251]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -816,3 +816,25 @@ def test_psf_photometry_uncertainties():
     columns = ('flux_unc', 'x_0_unc', 'y_0_unc')
     for column in columns:
         assert column not in phot_tbl.colnames
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_re_use_result_as_initial_guess():
+
+    img_shape = (32, 32)
+    # generate image with read-out noise (Gaussian) and
+    # background noise (Poisson)
+    image = (make_gaussian_prf_sources_image(img_shape, sources1) +
+             make_noise_image(img_shape, distribution='poisson', mean=6.,
+                              seed=0) +
+             make_noise_image(img_shape, distribution='gaussian', mean=0.,
+                              stddev=2., seed=0))
+
+    _, _, dao_phot_obj = make_psf_photometry_objs()
+
+    result_table = dao_phot_obj(image)
+    result_table['x'] = result_table['x_fit']
+    result_table['y'] = result_table['y_fit']
+    result_table['flux'] = result_table['flux_fit']
+    second_result = dao_phot_obj(image, result_table)
+    assert second_result


### PR DESCRIPTION
when doing something like

```python
  result_table = photometry(image)
  result_table['x'] = result_table['x_fit']
  result_table['y'] = result_table['y_fit']
  result_table['flux'] = result_table['flux_fit']
  second_result = other_photometry(image, result_table)
```

a bunch of errors occur due to the re-naming of columns by `Table.hstack`, trying to create existing column `group_id` and caring about the order of the `id` column. These changes should enable the `Photometry`-classes to update tables with the fields already defined.
