### PR TITLE
SourceCatalog improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,49 @@
 2.0.0 (unreleased)
 ------------------
 
-- No changes yet
+General
+^^^^^^^
+
+New Features
+^^^^^^^^^^^^
+
+- ``photutils.segmentation``
+
+  - Added ``copy`` method to ``SourceCatalog``. [#1264]
+
+  - Added ``kron_photometry`` method to ``SourceCatalog``. [#1264]
+
+  - Added ``add_extra_property``, ``remove_extra_property``, and
+    ``remove_extra_properties`` methods and ``extra_properties``
+    attribute to ``SourceCatalog``. [#1264]
+
+  - Added ``name`` and ``overwrite`` keywords to ``SourceCatalog``
+    ``circular_photometry`` and ``fluxfrac_radius`` methods. [#1264]
+
+  - ``SourceCatalog`` ``fluxfrac_radius`` was improved for cases where
+    the source flux doesn't monotonically increase with increasing radius.
+    [#1264]
+
+Bug Fixes
+^^^^^^^^^
+
+- ``photutils.segmentation``
+
+  - If ``detection_catalog`` is input to ``SourceCatalog`` then the
+    detection centroids are used to calculate the ``circular_aperture``,
+    ``circular_photometry``, and ``fluxfrac_radius``. [#1264]
+
+  - Units are applied to ``SourceCatalog`` ``circular_photometry``
+    output if the input data has units. [#1264]
+
+  - ``SourceCatalog`` ``circular_photometry`` returns scalar values if
+    catalog is scalar. [#1264]
+
+  - ``SourceCatalog`` ``fluxfrac_radius`` returns a ``Quantity`` with
+    pixel units. [#1264]
+
+API Changes
+^^^^^^^^^^^
 
 
 1.2.0 (2021-09-23)
@@ -98,7 +140,7 @@ Bug Fixes
     initialization with scalar data values and coordinate arrays having
     more than one dimension. [#1226]
 
-API changes
+API Changes
 ^^^^^^^^^^^
 
 - ``photutils.aperture``
@@ -303,7 +345,7 @@ Bug Fixes
 
   - Fixed ``SourceProperties`` Kron mask correction. [#1167]
 
-API changes
+API Changes
 ^^^^^^^^^^^
 
 - ``photutils.aperture``
@@ -486,7 +528,7 @@ Bug Fixes
   - The ``effective_gain`` parameter in ``calc_total_error`` can now
     be zero (or contain zero values). [#1019]
 
-API changes
+API Changes
 ^^^^^^^^^^^
 
 - ``photutils.aperture``
@@ -793,7 +835,7 @@ Bug Fixes
   - Fixed a bug in ``filter_data`` where units were dropped for data
     ``Quantity`` objects. [#872]
 
-API changes
+API Changes
 ^^^^^^^^^^^
 
 - ``photutils.aperture``
@@ -989,7 +1031,7 @@ New Features
     ``EPSFModel`` is now deprecated.  Use the ``oversampling`` keyword
     instead. [#780]
 
-API changes
+API Changes
 ^^^^^^^^^^^
 
 - ``photutils.detection``
@@ -1252,7 +1294,7 @@ New Features
 
   - Fitted results of any free parameter are added to the final table. [#471]
 
-API changes
+API Changes
 ^^^^^^^^^^^
 
 - ``photutils.aperture``
@@ -1480,7 +1522,7 @@ New Features
   - Added ``copy`` and ``area`` methods and an ``areas`` property to
     ``SegmentationImage``. [#331]
 
-API changes
+API Changes
 ^^^^^^^^^^^
 
 - ``photutils.aperture``
@@ -1687,7 +1729,7 @@ New Features
   - The ``interpolate_masked_data`` function can now interpolate
     higher-dimensional data. [#310]
 
-API changes
+API Changes
 ^^^^^^^^^^^
 
 - ``photutils.segmentation``

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -231,9 +231,9 @@ class SourceCatalog:
             if not isinstance(detection_cat, SourceCatalog):
                 raise TypeError('detection_cat must be a SourceCatalog '
                                 'instance')
-            if len(detection_cat) != len(self):
-                raise ValueError('detection_cat must have the same number '
-                                 'of sources as the input segment_img')
+            if not np.array_equal(detection_cat.labels, self.labels):
+                raise ValueError('detection_cat must have same source labels '
+                                 'as the input segment_img')
         self._detection_cat = detection_cat
 
     def _process_quantities(self, data, error, background):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1903,10 +1903,17 @@ class SourceCatalog:
             The aperture will be `None` where the source centroid
             position is not finite.
         """
+        if self._detection_cat is not None:
+            # use source centroid defined by detection image
+            detcat = self._detection_cat
+        else:
+            detcat = self
+
         if radius <= 0:
             return self._null_object
+
         apertures = []
-        for (xcen, ycen) in zip(self._xcentroid, self._ycentroid):
+        for (xcen, ycen) in zip(detcat._xcentroid, detcat._ycentroid):
             if np.any(~np.isfinite((xcen, ycen))):
                 apertures.append(None)
                 continue
@@ -1934,12 +1941,18 @@ class SourceCatalog:
             where the circular aperture is `None` (e.g., where the
             source centroid position is not finite).
         """
+        if self._detection_cat is not None:
+            # use source centroid defined by detection image
+            detcat = self._detection_cat
+        else:
+            detcat = self
+
         apertures = self.circular_aperture(radius)
 
         flux = []
         fluxerr = []
         for (label, aperture, xcen, ycen, bkg) in zip(
-                self.labels, apertures, self._xcentroid, self._ycentroid,
+                self.labels, apertures, detcat._xcentroid, detcat._ycentroid,
                 self._local_background):
 
             if aperture is None:

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2000,7 +2000,7 @@ class SourceCatalog:
             apertures.append(CircularAperture((xcen, ycen), r=radius))
         return apertures
 
-    def circular_photometry(self, radius):
+    def circular_photometry(self, radius, name=None, overwrite=False):
         """
         Perform aperture photometry for each source using a circular
         aperture of the specified radius centered at the source centroid
@@ -2013,6 +2013,17 @@ class SourceCatalog:
         ----------
         radius : float
             The radius of the circle in pixels.
+
+        name : str or `None`, optional
+            The prefix name which will be used to define attribute
+            names for the flux and flux error. The attribute names
+            ``[name]_flux`` and ``[name]_fluxerr`` will store the
+            photometry results. For example, these names can then be
+            included in the `to_table` ``columns`` keyword list to
+            output the results in the table.
+
+        overwrite : bool, optional
+            If True, overwrite the attribute ``name`` if it exists.
 
         Returns
         -------
@@ -2058,6 +2069,14 @@ class SourceCatalog:
 
         flux = np.array(flux)
         fluxerr = np.array(fluxerr)
+
+        if name is not None:
+            flux_name = f'{name}_flux'
+            fluxerr_name = f'{name}_fluxerr'
+            self.add_extra_property(flux_name, flux, overwrite=overwrite)
+            self.add_extra_property(fluxerr_name, fluxerr,
+                                    overwrite=overwrite)
+
         return flux, fluxerr
 
     def _make_elliptical_apertures(self, scale=6.):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2035,7 +2035,7 @@ class SourceCatalog:
 
         Returns
         -------
-        flux, fluxerr : `~numpy.ndarray` of floats
+        flux, fluxerr : `~numpy.ndarray` of floats, floats, or `~astropy.units.Quantity`
             The aperture fluxes and flux errors. NaN will be returned
             where the circular aperture is `None` (e.g., where the
             source centroid position is not finite).
@@ -2077,6 +2077,14 @@ class SourceCatalog:
 
         flux = np.array(flux)
         fluxerr = np.array(fluxerr)
+
+        if self.isscalar:
+            flux = flux[0]
+            fluxerr = fluxerr[0]
+
+        if self._data_unit is not None:
+            flux <<= self._data_unit
+            fluxerr <<= self._data_unit
 
         if name is not None:
             flux_name = f'{name}_flux'
@@ -2376,7 +2384,7 @@ class SourceCatalog:
 
         Returns
         -------
-        flux, fluxerr : `~numpy.ndarray` of floats or floats or `~astropy.units.Quantity`
+        flux, fluxerr : `~numpy.ndarray` of floats, floats, or `~astropy.units.Quantity`
             The aperture fluxes and flux errors. NaN will be returned
             where the circular aperture is `None` (e.g., where the
             source centroid position is not finite).

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2041,6 +2041,9 @@ class SourceCatalog:
             where the circular aperture is `None` (e.g., where the
             source centroid position is not finite).
         """
+        if radius <= 0:
+            raise ValueError('radius must be > 0')
+
         if self._detection_cat is not None:
             # use source centroid defined by detection image
             detcat = self._detection_cat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -611,7 +611,7 @@ class SourceCatalog:
     @as_scalar
     def label(self):
         """
-        The source label number.
+        The source label number(s).
 
         This label number corresponds to the assigned pixel value in the
         `~photutils.segmentation.SegmentationImage`.
@@ -1893,8 +1893,8 @@ class SourceCatalog:
 
     def circular_aperture(self, radius):
         """
-        A list of circular apertures with the specified radius centered
-        at the source centroid position.
+        Return a list of circular apertures with the specified radius
+        centered at the source centroid position.
 
         Parameters
         ----------
@@ -1931,8 +1931,8 @@ class SourceCatalog:
         aperture of the specified radius centered at the source centroid
         position.
 
-        See the ``apermask_method`` keyword for options to mask
-        neighboring sources.
+        See the `SourceCatalog` ``apermask_method`` keyword for options
+        to mask neighboring sources.
 
         Parameters
         ----------
@@ -2052,10 +2052,10 @@ class SourceCatalog:
 
         where :math:`\bar{x}` and :math:`\bar{y}` represent
         the source centroid. The scaling parameter of
-        :attr:`~photutils.segmentation.SourceCatalog.kron_radius`
-        is defined using the ``kron_params`` keyword. See the
-        ``apermask_method`` keyword for options to mask neighboring
-        sources.
+        :attr:`~photutils.segmentation.SourceCatalog.kron_radius` is
+        defined using the `SourceCatalog` ``kron_params`` keyword. See
+        the `SourceCatalog` ``apermask_method`` keyword for options to
+        mask neighboring sources.
 
         If either the numerator or denominator is less than or equal
         to 0, then ``np.nan`` will be returned. In this case, the Kron
@@ -2124,9 +2124,9 @@ class SourceCatalog:
         Define the Kron aperture.
 
         If ``kron_radius * np.sqrt(semimajor_sigma * semiminor__sigma) <
-        kron_params[1]`` then a circular aperture with a radius equal to
-        ``kron_params[1]`` will be returned. If ``kron_params[1] <= 0``,
-        then the Kron aperture will be `None`.
+        kron_params[1]`` (see `SourceCatalog`) then a circular aperture
+        with a radius equal to ``kron_params[1]`` will be returned. If
+        ``kron_params[1] <= 0``, then the Kron aperture will be `None`.
 
         If ``kron_radius = np.nan`` then a circular aperture with a
         radius equal to ``kron_params[1]`` will be returned if the
@@ -2167,9 +2167,9 @@ class SourceCatalog:
         The Kron aperture.
 
         If ``kron_radius * np.sqrt(semimajor_sigma * semiminor__sigma) <
-        kron_params[1]`` then a circular aperture with a radius equal to
-        ``kron_params[1]`` will be returned. If ``kron_params[1] <= 0``,
-        then the Kron aperture will be `None`.
+        kron_params[1]`` (see `SourceCatalog`) then a circular aperture
+        with a radius equal to ``kron_params[1]`` will be returned. If
+        ``kron_params[1] <= 0``, then the Kron aperture will be `None`.
 
         If ``kron_radius = np.nan`` then a circular aperture with a
         radius equal to ``kron_params[1]`` will be returned if the
@@ -2189,8 +2189,8 @@ class SourceCatalog:
         Calculate the flux and flux error in the Kron aperture (without
         units).
 
-        See the ``apermask_method`` keyword for options to mask
-        neighboring sources.
+        See the `SourceCatalog` ``apermask_method`` keyword for options
+        to mask neighboring sources.
 
         If the Kron aperture is `None`, then ``np.nan`` will be
         returned.
@@ -2245,8 +2245,8 @@ class SourceCatalog:
         aperture of the specified radius centered at the source centroid
         position.
 
-        See the ``apermask_method`` keyword for options to mask
-        neighboring sources.
+        See the `SourceCatalog` ``apermask_method`` keyword for options
+        to mask neighboring sources.
 
         Parameters
         ----------
@@ -2283,8 +2283,8 @@ class SourceCatalog:
         """
         The flux and flux error in the Kron aperture (without units).
 
-        See the ``apermask_method`` keyword for options to mask
-        neighboring sources.
+        See the `SourceCatalog` ``apermask_method`` keyword for options
+        to mask neighboring sources.
 
         If the Kron aperture is `None`, then ``np.nan`` will be
         returned.
@@ -2297,8 +2297,8 @@ class SourceCatalog:
         """
         The flux in the Kron aperture.
 
-        See the ``apermask_method`` keyword for options to mask
-        neighboring sources.
+        See the `SourceCatalog` ``apermask_method`` keyword for options
+        to mask neighboring sources.
 
         If the Kron aperture is `None`, then ``np.nan`` will be returned.
         """
@@ -2313,8 +2313,8 @@ class SourceCatalog:
         """
         The flux error in the Kron aperture.
 
-        See the ``apermask_method`` keyword for options to mask
-        neighboring sources.
+        See the `SourceCatalog` ``apermask_method`` keyword for options
+        to mask neighboring sources.
 
         If the Kron aperture is `None`, then ``np.nan`` will be returned.
         """

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -4,6 +4,7 @@ This module provides tools for calculating the properties of sources
 defined by a segmentation image.
 """
 
+from copy import deepcopy
 import functools
 import inspect
 import warnings
@@ -447,6 +448,12 @@ class SourceCatalog:
         except TypeError:
             return False
         return True
+
+    def copy(self):
+        """
+        Return a deep copy of this SourceCatalog.
+        """
+        return deepcopy(self)
 
     @property
     def extra_properties(self):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -92,6 +92,14 @@ class SourceCatalog:
         values (NaN and inf) in the input ``data`` are automatically
         masked.
 
+    kernel : array-like (2D) or `~astropy.convolution.Kernel2D`, optional
+        The 2D array of the kernel used to filter the data prior to
+        calculating the source centroid and morphological parameters.
+        The kernel should be the same one used in defining the
+        source segments, i.e., the detection image (e.g., see
+        :func:`~photutils.segmentation.detect_sources`). If `None`, then
+        the unfiltered ``data`` will be used instead.
+
     background : float, 2D `~numpy.ndarray` or `~astropy.units.Quantity`, optional
         The background level that was *previously* present in the input
         ``data``. ``background`` may either be a scalar value or a 2D

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1776,6 +1776,11 @@ class SourceCatalog:
         The `~photutils.aperture.RectangularAnnulus` aperture used to
         estimate the local background.
         """
+        if self._detection_cat is not None:
+            # local background aperture defined using the source
+            # centroid and bbox defined by detection image
+            return self._detection_cat.local_background_aperture
+
         if self._localbkg_width == 0:
             return self._null_object
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2540,7 +2540,7 @@ class SourceCatalog:
                 result = np.nan
             radius.append(result)
 
-        result = np.array(radius)
+        result = np.array(radius) << u.pix
 
         if name is not None:
             self.add_extra_property(name, result, overwrite=overwrite)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2458,8 +2458,13 @@ class SourceCatalog:
         The maximum circular Kron radius used as the upper limit of
         fluxfrac_radius.
         """
-        semimajor_sig = self.semimajor_sigma.value
-        kron_radius = self.kron_radius.value
+        if self._detection_cat is not None:
+            detcat = self._detection_cat
+        else:
+            detcat = self
+
+        semimajor_sig = detcat.semimajor_sigma.value
+        kron_radius = detcat.kron_radius.value
         radius = semimajor_sig * kron_radius * self._kron_params[0]
         if self.isscalar:
             radius = np.array([radius])
@@ -2476,12 +2481,17 @@ class SourceCatalog:
 
     @lazyproperty
     def _fluxfrac_optimizer_args(self):
+        if self._detection_cat is not None:
+            detcat = self._detection_cat
+        else:
+            detcat = self
+
         kron_flux = self._kron_flux_fluxerr[:, 0]  # unitless
         max_radius = self._max_circular_kron_radius
 
         args = []
         for label, xcen, ycen, kronflux, bkg, max_radius_ in zip(
-                self.labels, self._xcentroid, self._ycentroid,
+                self.labels, detcat._xcentroid, detcat._ycentroid,
                 kron_flux, self._local_background, max_radius):
 
             if np.any(~np.isfinite((xcen, ycen, kronflux, max_radius_))):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -147,9 +147,15 @@ class SourceCatalog:
         circle with this minimum radius.
 
     detection_cat : `SourceCatalog`, optional
-        A `SourceCatalog` object for the detection image. If input, this
-        detection catalog will be used to define the Kron radius and
-        apertures of the sources.
+        A `SourceCatalog` object for the detection image. The source
+        labels in ``detection_cat`` must correspond to the labels in the
+        input ``segment_img``. If input, this detection catalog will
+        be used to define the source centroids for all aperture-based
+        photometry (e.g., local background aperture, circular aperture,
+        Kron aperture). It will also be used to define the object
+        elliptical shape parameters when calculating the Kron radius.
+        This keyword affects the local-background value, circular
+        aperture photometry, Kron radius, and Kron photometry.
 
     Notes
     -----

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2475,7 +2475,7 @@ class SourceCatalog:
         return 1.0 - (flux[0] / normflux)
 
     @as_scalar
-    def fluxfrac_radius(self, fluxfrac):
+    def fluxfrac_radius(self, fluxfrac, name=None, overwrite=False):
         """
         Calculate the circular radius that encloses the specified
         fraction of the Kron flux.
@@ -2487,6 +2487,15 @@ class SourceCatalog:
         fluxfrac : float
             The fraction of the Kron flux at which to find the circular
             radius.
+
+        name : str or `None`, optional
+            The attribute name which will be assigned to the value
+            of the output array. For example, this name can then be
+            included in the `to_table` ``columns`` keyword list to
+            output the results in the table.
+
+        overwrite : bool, optional
+            If True, overwrite the attribute ``name`` if it exists.
 
         Returns
         -------
@@ -2531,4 +2540,9 @@ class SourceCatalog:
                 result = np.nan
             radius.append(result)
 
-        return np.array(radius)
+        result = np.array(radius)
+
+        if name is not None:
+            self.add_extra_property(name, result, overwrite=overwrite)
+
+        return result

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2313,7 +2313,7 @@ class SourceCatalog:
 
         return kron_flux, kron_fluxerr
 
-    def kron_photometry(self, kron_params):
+    def kron_photometry(self, kron_params, name=None, overwrite=False):
         """
         Perform photometry for each source using an elliptical Kron
         aperture.
@@ -2335,6 +2335,17 @@ class SourceCatalog:
             `semiminor_sigma`) is less than than this radius, then the
             Kron flux will be measured in a circle with this minimum
             radius.
+
+        name : str or `None`, optional
+            The prefix name which will be used to define attribute
+            names for the Kron flux and flux error. The attribute
+            names ``[name]_flux`` and ``[name]_fluxerr`` will store
+            the photometry results. For example, these names can then
+            be included in the `to_table` ``columns`` keyword list to
+            output the results in the table.
+
+        overwrite : bool, optional
+            If True, overwrite the attribute ``name`` if it exists.
 
         Returns
         -------

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -316,6 +316,7 @@ class SourceCatalog:
 
     @staticmethod
     def _validate_kron_params(kron_params):
+        kron_params = np.atleast_1d(kron_params)
         if len(kron_params) != 2:
             raise ValueError('kron_params must have 2 elements')
         if kron_params[0] <= 0:
@@ -2309,6 +2310,9 @@ class SourceCatalog:
         kron_flux, kron_fluxerr : tuple of `~numpy.ndarray`
             The Kron flux and flux error.
         """
+        # check kron_params
+        kron_params = self._validate_kron_params(kron_params)
+
         if self._detection_cat is not None:
             detcat = self._detection_cat
         else:

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -489,6 +489,8 @@ class TestSourceCatalog:
 
         obj = self.cat[1]
         flux1, fluxerr1 = obj.kron_photometry((1.0, 0.0), name='kron0')
+        assert np.isscalar(flux1)
+        assert np.isscalar(fluxerr1)
         assert_allclose(flux1, obj.kron0_flux)
         assert_allclose(fluxerr1, obj.kron0_fluxerr)
 
@@ -516,6 +518,8 @@ class TestSourceCatalog:
         obj = self.cat[1]
         assert obj.isscalar
         flux1, fluxerr1 = obj.circular_photometry(1.0, name='circ0')
+        assert np.isscalar(flux1)
+        assert np.isscalar(fluxerr1)
         assert_allclose(flux1, obj.circ0_flux)
         assert_allclose(fluxerr1, obj.circ0_fluxerr)
 
@@ -539,6 +543,7 @@ class TestSourceCatalog:
         cat = SourceCatalog(self.data, self.segm)
         obj = cat[1]
         radius = obj.fluxfrac_radius(0.5)
+        assert radius.isscalar  # Quantity radius - can't use np.isscalar
         assert_allclose(radius.value, 7.899648)
 
         with pytest.raises(ValueError):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -396,7 +396,7 @@ class TestSourceCatalog:
         cat = SourceCatalog(self.data, self.segm)
         obj = cat[1]
         radius = obj.fluxfrac_radius(0.5)
-        assert_allclose(radius, 7.899648)
+        assert_allclose(radius.value, 7.899648)
 
         with pytest.raises(ValueError):
             radius = self.cat.fluxfrac_radius(0)

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2,9 +2,6 @@
 """
 Tests for the catalog module.
 """
-
-from copy import deepcopy
-
 from astropy.coordinates import SkyCoord
 from astropy.modeling.models import Gaussian2D
 from astropy.table import QTable
@@ -84,11 +81,11 @@ class TestSourceCatalog:
         props = tuple(self.cat.default_columns) + props1 + props2
 
         if with_units:
-            cat1 = deepcopy(self.cat_units)
-            cat2 = deepcopy(self.cat_units)
+            cat1 = self.cat_units.copy()
+            cat2 = self.cat_units.copy()
         else:
-            cat1 = deepcopy(self.cat)
-            cat2 = deepcopy(self.cat)
+            cat1 = self.cat.copy()
+            cat2 = self.cat.copy()
 
         # test extra properties
         cat1.circular_photometry(5.0, name='circ5')
@@ -125,7 +122,7 @@ class TestSourceCatalog:
         data2 = self.data + error
 
         if with_units:
-            cat1 = deepcopy(self.cat_units)
+            cat1 = self.cat_units.copy()
             cat2 = SourceCatalog(data2 << self.unit, self.segm,
                                  error=error << self.unit,
                                  background=self.background << self.unit,
@@ -137,7 +134,7 @@ class TestSourceCatalog:
                                  mask=self.mask, wcs=self.wcs,
                                  localbkg_width=24, detection_cat=cat1)
         else:
-            cat1 = deepcopy(self.cat)
+            cat1 = self.cat.copy()
             cat2 = SourceCatalog(data2, self.segm, error=error,
                                  background=self.background, mask=self.mask,
                                  wcs=self.wcs, localbkg_width=24,
@@ -438,7 +435,7 @@ class TestSourceCatalog:
             SourceCatalog(data2, self.segm, detection_cat=np.arange(4))
 
         with pytest.raises(ValueError):
-            segm = deepcopy(self.segm)
+            segm = self.segm.copy()
             segm.remove_labels((6, 7))
             cat = SourceCatalog(self.data, segm)
             SourceCatalog(self.data, self.segm, detection_cat=cat)
@@ -632,3 +629,11 @@ class TestSourceCatalog:
         with pytest.raises(ValueError):
             coord = SkyCoord([42, 43], [44, 45], unit='deg')
             obj.add_extra_property('invalid', coord)
+
+    def test_copy(self):
+        cat = SourceCatalog(self.data, self.segm)
+        cat2 = cat.copy()
+        cat.kron_flux
+        assert 'kron_flux' not in cat2.__dict__
+        tbl = cat2.to_table()
+        assert len(tbl) == 7


### PR DESCRIPTION
New features

* new `copy` method
* new `kron_photometry` method
* new `add_extra_property`, `remove_extra_property`, and `remove_extra_properties` methods and `extra_properties` attribute
* new `name` and `overwrite` keywords to `circular_photometry`
* improved `fluxfrac_radius` for cases where the source flux doesn't monotonically increase with increasing radius.

Fixes
* `detection_catalog` centroids are used to calculate `circular_aperture`, `circular_photometry`, and `fluxfrac_radius`
* Units are applied to `circular_photometry` output
* `circular_photometry` returns scalar values for scalar catalog
* `fluxfrac_radius` returns a `Quantity` with pixel units