### PR TITLE
SourceCatalog fixes and improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,9 +13,10 @@ New Features
 
   - Added ``kron_photometry`` method to ``SourceCatalog``. [#1264]
 
-  - Added ``add_extra_property``, ``remove_extra_property``, and
-    ``remove_extra_properties`` methods and ``extra_properties``
-    attribute to ``SourceCatalog``. [#1264]
+  - Added ``add_extra_property``, ``remove_extra_property``,
+    ``remove_extra_properties``, and ``rename_extra_property`` methods
+    and ``extra_properties`` attribute to ``SourceCatalog``. [#1264,
+    #1268]
 
   - Added ``name`` and ``overwrite`` keywords to ``SourceCatalog``
     ``circular_photometry`` and ``fluxfrac_radius`` methods. [#1264]
@@ -23,6 +24,17 @@ New Features
   - ``SourceCatalog`` ``fluxfrac_radius`` was improved for cases where
     the source flux doesn't monotonically increase with increasing radius.
     [#1264]
+
+  - Added ``meta`` and ``properties`` attributes to ``SourceCatalog``.
+    [#1268]
+
+  - The ``SourceCatalog`` output table (using ``to_table``) ``meta``
+    dictionary now includes a field for the date/time. [#1268]
+
+  - Added ``SourceCatalog`` ``make_kron_apertures`` method. [#1268]
+
+  - Added ``SourceCatalog`` ``plot_circular_apertures`` and
+    ``plot_kron_apertures`` methods. [#1268]
 
 Bug Fixes
 ^^^^^^^^^
@@ -42,8 +54,29 @@ Bug Fixes
   - ``SourceCatalog`` ``fluxfrac_radius`` returns a ``Quantity`` with
     pixel units. [#1264]
 
+  - Fixed a bug where the ``SourceCatalog`` ``detection_catalog`` was
+    not indexed/sliced when ``SourceCatalog`` was indexed/sliced. [#1268]
+
+  - ``SourceCatalog`` ``circular_photometry`` now returns NaN for
+    completely-masked sources. [#1268]
+
+  - ``SourceCatalog`` ``kron_flux`` is always NaN for sources where
+    ``kron_radius`` is NaN. [#1268]
+
+  - ``SourceCatalog`` ``fluxfrac_radius`` now returns NaN if
+    ``kron_flux`` is zero. [#1268]
+
 API Changes
 ^^^^^^^^^^^
+
+- ``photutils.segmentation``
+
+  - Renamed the ``SourceCatalog`` ``circular_aperture`` method to
+    ``make_circular_apertures``. The old name is deprecated. [#1268]
+
+  - The ``SourceCatalog`` ``kron_params`` keyword must have a minimum
+    circular radius that is greater than zero. The default value is now
+    1.0. [#1268]
 
 
 1.2.0 (2021-09-23)

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -372,9 +372,8 @@ shapes of each source) on the data:
     >>> ax2.imshow(segm_deblend, origin='lower', cmap=cmap,
     ...            interpolation='nearest')
     >>> ax2.set_title('Segmentation Image')
-    >>> for aperture in cat.kron_aperture:
-    ...     aperture.plot(axes=ax1, color='white', lw=1.5)
-    ...     aperture.plot(axes=ax2, color='white', lw=1.5)
+    >>> cat.plot_kron_apertures((2.5, 1.0), axes=ax1, color='white', lw=1.5)
+    >>> cat.plot_kron_apertures((2.5, 1.0), axes=ax2, color='white', lw=1.5)
 
 .. plot::
 
@@ -409,9 +408,8 @@ shapes of each source) on the data:
     ax2.imshow(segm_deblend, origin='lower', cmap=cmap,
                interpolation='nearest')
     ax2.set_title('Segmentation Image with Kron apertures')
-    for aperture in cat.kron_aperture:
-        aperture.plot(axes=ax1, color='white', lw=1.5)
-        aperture.plot(axes=ax2, color='white', lw=1.5)
+    cat.plot_kron_apertures((2.5, 1.0), axes=ax1, color='white', lw=1.5)
+    cat.plot_kron_apertures((2.5, 1.0), axes=ax2, color='white', lw=1.5)
     plt.tight_layout()
 
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2461,7 +2461,7 @@ class SourceCatalog:
         scaling and centered at the source centroid position.
 
         If provided, the `SourceCatalog` ``detection_cat`` will be used
-        for the source centroids.
+        for the source centroids and elliptical shape parameters.
 
         Parameters
         ----------
@@ -2509,6 +2509,57 @@ class SourceCatalog:
                 kron_apertures[i] = circ_aperture[i]
 
         return kron_apertures
+
+    @as_scalar
+    def plot_kron_apertures(self, kron_params, axes=None, origin=(0, 0),
+                            **kwargs):
+        """
+        Plot Kron elliptical apertures on a matplotlib
+        `~matplotlib.axes.Axes` instance.
+
+        The apertures are defined by the specified radius and are
+        centered at the source centroid position.
+
+        If provided, the `SourceCatalog` ``detection_cat`` will be used
+        for the source centroids and elliptical shape parameters.
+
+        Parameters
+        ----------
+        kron_params : list of 2 floats, optional
+            A list of two parameters used to determine how the Kron
+            radius and flux are calculated. The first item is the
+            scaling parameter of the Kron radius (`kron_radius`)
+            and the second item represents the minimum circular
+            radius. If the Kron radius times sqrt( `semimajor_sigma` *
+            `semiminor_sigma`) is less than than this radius, then the
+            Kron flux will be measured in a circle with this minimum
+            radius.
+
+        axes : `matplotlib.axes.Axes` or `None`, optional
+            The matplotlib axes on which to plot.  If `None`, then the
+            current `~matplotlib.axes.Axes` instance is used.
+
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        **kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : list of `~matplotlib.patches.Patch`
+            A list of matplotlib patches for the plotted aperture. The
+            patches can be used, for example, when adding a plot legend.
+        """
+        apertures = self.make_kron_apertures(kron_params)
+        patches = []
+        for aperture in apertures:
+            if aperture is not None:
+                aperture.plot(axes=axes, origin=origin, **kwargs)
+                patches.append(aperture._to_patch(origin=origin, **kwargs))
+        return patches
 
     @lazyproperty
     @as_scalar

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2355,6 +2355,8 @@ class SourceCatalog:
         """
         if self._detection_cat is not None:
             kron_radius = self._detection_cat.kron_radius
+            if self.isscalar:
+                kron_radius = np.atleast_1d(kron_radius)
             kron_radius[self._all_masked] = np.nan
             return kron_radius
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -986,16 +986,22 @@ class SourceCatalog:
         """
         Get a 1D array of unmasked values from the input array within
         the source segment.
+
+        An array with a single NaN is returned for completely-masked
+        sources.
         """
         if self.isscalar:
             array = (array,)
-        return [arr.compressed() if len(arr.compressed()) > 0 else np.nan
-                for arr in array]
+        return [arr.compressed() if len(arr.compressed()) > 0
+                else np.array([np.nan]) for arr in array]
 
     @lazyproperty
     def _data_values(self):
         """
         A 1D array of unmasked data values.
+
+        An array with a single NaN is returned for completely-masked
+        sources.
         """
         return self._get_values(self.data_ma)
 
@@ -1003,6 +1009,9 @@ class SourceCatalog:
     def _error_values(self):
         """
         A 1D array of unmasked error values.
+
+        An array with a single NaN is returned for completely-masked
+        sources.
         """
         return self._get_values(self.error_ma)
 
@@ -1010,6 +1019,9 @@ class SourceCatalog:
     def _background_values(self):
         """
         A 1D array of unmasked background values.
+
+        An array with a single NaN is returned for completely-masked
+        sources.
         """
         return self._get_values(self.background_ma)
 
@@ -1589,9 +1601,9 @@ class SourceCatalog:
         if a mask is input to `SourceCatalog` or if the ``data``
         within the segment contains invalid values (NaN and inf).
         """
-        return np.array([arr.shape[0]
-                         if isinstance(arr, np.ndarray) else np.nan
-                         for arr in self._data_values]) << u.pix**2
+        areas = np.array([arr.size for arr in self._data_values]).astype(float)
+        areas[self._all_masked] = np.nan
+        return areas << (u.pix ** 2)
 
     @lazyproperty
     @as_scalar

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2701,7 +2701,8 @@ class SourceCatalog:
                 self.labels, detcat._xcentroid, detcat._ycentroid,
                 kron_flux, self._local_background, max_radius):
 
-            if np.any(~np.isfinite((xcen, ycen, kronflux, max_radius_))):
+            if (np.any(~np.isfinite((xcen, ycen, kronflux, max_radius_)))
+                    or kronflux == 0):
                 args.append(None)
                 continue
 
@@ -2745,7 +2746,8 @@ class SourceCatalog:
         -------
         radius : 1D `~numpy.ndarray`
             The circular radius that encloses the specified fraction of
-            the Kron flux. NaN is returned where no solution was found.
+            the Kron flux. NaN is returned where no solution was found
+            or if the Kron flux is zero.
         """
         if fluxfrac <= 0 or fluxfrac > 1:
             raise ValueError('fluxfrac must be > 0 and <= 1')

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -375,15 +375,22 @@ class SourceCatalog:
         # new class
         init_attr = ('_data', '_segment_img', '_error', '_mask', '_kernel',
                      '_background', '_wcs', '_data_unit', '_convolved_data',
-                     '_data_mask', '_detection_cat', '_localbkg_width',
-                     '_apermask_method', '_kron_params', 'default_columns',
-                     '_extra_properties', 'meta')
+                     '_data_mask', '_localbkg_width', '_apermask_method',
+                     '_kron_params', 'default_columns', '_extra_properties',
+                     'meta')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
         # _labels determines ordering and isscalar
         attr = '_labels'
         setattr(newcls, attr, getattr(self, attr)[index])
+
+        # need to slice detection_cat, if input
+        attr = '_detection_cat'
+        if getattr(self, attr) is None:
+            setattr(newcls, attr, None)
+        else:
+            setattr(newcls, attr, getattr(self, attr)[index])
 
         attr = '_slices'
         # Use a numpy object array to allow for fancy and bool indices.

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2343,9 +2343,8 @@ class SourceCatalog:
         to mask neighboring sources.
 
         If either the numerator or denominator above is less than or
-        equal to 0, then ``np.nan`` will be returned. In this case, the
-        Kron aperture will be defined as a circular aperture with a
-        radius equal to ``kron_params[1]``.
+        equal to 0, then ``np.nan`` will be returned for both the Kron
+        radius and Kron flux.
 
         If the source is completely masked, then ``np.nan`` will be
         returned for both the Kron radius and Kron flux.
@@ -2454,9 +2453,9 @@ class SourceCatalog:
         major_sigma = detcat.semimajor_sigma.value
         minor_sigma = detcat.semiminor_sigma.value
         circ_radius = kron_radius * np.sqrt(major_sigma * minor_sigma)
-
         min_radius = kron_params[1]
-        mask = np.isnan(kron_radius) | (circ_radius < min_radius)
+
+        mask = (circ_radius < min_radius)
         idx = np.atleast_1d(mask).nonzero()[0]
         if idx.size > 0:
             circ_aperture = self.make_circular_apertures(min_radius)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2144,6 +2144,50 @@ class SourceCatalog:
 
         return apertures
 
+    @as_scalar
+    def plot_circular_apertures(self, radius, axes=None, origin=(0, 0),
+                                **kwargs):
+        """
+        Plot circular apertures on a matplotlib `~matplotlib.axes.Axes`
+        instance.
+
+        The apertures are defined by the specified radius and are
+        centered at the source centroid position.
+
+        If provided, the `SourceCatalog` ``detection_cat`` will be used
+        for the source centroids.
+
+        Parameters
+        ----------
+        radius : float
+            The radius of the circle in pixels.
+
+        axes : `matplotlib.axes.Axes` or `None`, optional
+            The matplotlib axes on which to plot.  If `None`, then the
+            current `~matplotlib.axes.Axes` instance is used.
+
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        **kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : list of `~matplotlib.patches.Patch`
+            A list of matplotlib patches for the plotted aperture. The
+            patches can be used, for example, when adding a plot legend.
+        """
+        apertures = self.make_circular_apertures(radius)
+        patches = []
+        for aperture in apertures:
+            if aperture is not None:
+                aperture.plot(axes=axes, origin=origin, **kwargs)
+                patches.append(aperture._to_patch(origin=origin, **kwargs))
+        return patches
+
     @deprecated('1.1', alternative='make_circular_apertures')
     def circular_aperture(self, radius):
         """

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -739,7 +739,7 @@ class SourceCatalog:
         else:
             table_columns = np.atleast_1d(columns)
 
-        tbl = QTable(meta=_get_meta())
+        tbl = QTable(meta=self.meta)
         for column in table_columns:
             values = getattr(self, column)
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -20,7 +20,7 @@ from ..aperture import (BoundingBox, CircularAperture, EllipticalAperture,
                         RectangularAnnulus)
 from ..background import SExtractorBackground
 from ..utils._convolution import _filter_data
-from ..utils._misc import _get_version_info
+from ..utils._misc import _get_meta
 from ..utils._moments import _moments, _moments_central
 
 __all__ = ['SourceCatalog']
@@ -252,6 +252,8 @@ class SourceCatalog:
                                  'as the input segment_img')
         self._detection_cat = detection_cat
 
+        self.meta = _get_meta()
+
     def _process_quantities(self, data, error, background):
         """
         Check units of input arrays.
@@ -361,7 +363,7 @@ class SourceCatalog:
                      '_background', '_wcs', '_data_unit', '_convolved_data',
                      '_data_mask', '_detection_cat', '_localbkg_width',
                      '_apermask_method', '_kron_params', 'default_columns',
-                     '_extra_properties')
+                     '_extra_properties', 'meta')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
@@ -737,8 +739,7 @@ class SourceCatalog:
         else:
             table_columns = np.atleast_1d(columns)
 
-        meta = {'version': _get_version_info()}
-        tbl = QTable(meta=meta)
+        tbl = QTable(meta=_get_meta())
         for column in table_columns:
             values = getattr(self, column)
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2127,11 +2127,16 @@ class SourceCatalog:
             return self._null_object
 
         apertures = []
-        for (xcen, ycen) in zip(detcat._xcentroid, detcat._ycentroid):
-            if np.any(~np.isfinite((xcen, ycen))):
+        for (xcen, ycen, all_masked) in zip(detcat._xcentroid,
+                                            detcat._ycentroid,
+                                            self._all_masked):
+
+            if all_masked or np.any(~np.isfinite((xcen, ycen))):
                 apertures.append(None)
                 continue
+
             apertures.append(CircularAperture((xcen, ycen), r=radius))
+
         return apertures
 
     def circular_photometry(self, radius, name=None, overwrite=False):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -563,6 +563,28 @@ class SourceCatalog:
             else:
                 raise ValueError(f'{name} is not a defined extra property.')
 
+    def rename_extra_property(self, name, new_name):
+        """
+        Rename an extra property.
+
+        The renamed property will remain at the same index in the
+        ``extra_properties`` list.
+
+        Parameters
+        ----------
+        name : str
+            The old attribute name.
+
+        new_name : str
+            The new attribute name.
+        """
+        self.add_extra_property(new_name, getattr(self, name))
+        idx = self.extra_properties.index(name)
+        self.remove_extra_property(name)
+        # preserve the order of self.extra_properties
+        self.extra_properties.remove(new_name)
+        self.extra_properties.insert(idx, new_name)
+
     def _convolve_data(self):
         """
         Convolve the input data with the input kernel.

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -331,7 +331,8 @@ class SourceCatalog:
     @property
     def _properties(self):
         """
-        Return all properties (even in superclasses).
+        A list of all class properties, include lazyproperties (even in
+        superclasses).
         """
         def isproperty(obj):
             return isinstance(obj, property)
@@ -340,9 +341,22 @@ class SourceCatalog:
                                                  predicate=isproperty)]
 
     @property
+    def properties(self):
+        """
+        A list of built-in source properties.
+        """
+        lazyproperties = [name for name in self._lazyproperties if not
+                          name.startswith('_')]
+        lazyproperties.remove('isscalar')
+        lazyproperties.remove('nlabels')
+        lazyproperties.extend(['label', 'labels', 'slices'])
+        lazyproperties.sort()
+        return lazyproperties
+
+    @property
     def _lazyproperties(self):
         """
-        Return all lazyproperties (even in superclasses).
+        A list of all class lazyproperties (even in superclasses).
         """
         def islazyproperty(obj):
             return isinstance(obj, lazyproperty)
@@ -485,12 +499,11 @@ class SourceCatalog:
             If `True`, will overwrite the existing property ``name``.
         """
         internal_attributes = ((set(self.__dict__.keys())
-                               | set(self._lazyproperties)
                                | set(self._properties))
                                - set(self.extra_properties))
         if name in internal_attributes:
             raise ValueError(f'{name} cannot be set because it is a '
-                             'built-in property')
+                             'built-in attribute')
 
         if not overwrite:
             if hasattr(self, name):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -217,7 +217,7 @@ class SourceCatalog:
 
     def __init__(self, data, segment_img, *, error=None, mask=None,
                  kernel=None, background=None, wcs=None, localbkg_width=0,
-                 apermask_method='correct', kron_params=(2.5, 0.0),
+                 apermask_method='correct', kron_params=(2.5, 1.0),
                  detection_cat=None):
 
         self._data_unit = None
@@ -325,8 +325,8 @@ class SourceCatalog:
             raise ValueError('kron_params must have 2 elements')
         if kron_params[0] <= 0:
             raise ValueError('kron_params[0] must be > 0')
-        if kron_params[1] < 0:
-            raise ValueError('kron_params[1] must be >= 0')
+        if kron_params[1] <= 0:
+            raise ValueError('kron_params[1] must be > 0')
         return kron_params
 
     @property
@@ -2129,7 +2129,7 @@ class SourceCatalog:
             detcat = self
 
         if radius <= 0:
-            return self._null_object
+            raise ValueError('radius must be > 0')
 
         apertures = []
         for (xcen, ycen, all_masked) in zip(detcat._xcentroid,

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -89,7 +89,7 @@ class TestSourceCatalog:
 
         # test extra properties
         cat1.circular_photometry(5.0, name='circ5')
-        cat1.kron_photometry((2.0, 0.0), name='kron2')
+        cat1.kron_photometry((2.0, 1.0), name='kron2')
         cat1.fluxfrac_radius(0.5, name='r_hl')
         segment_snr = cat1.segment_flux / cat1.segment_fluxerr
         cat1.add_extra_property('segment_snr', segment_snr)
@@ -106,7 +106,7 @@ class TestSourceCatalog:
         # slice catalog before evaluating catalog properties
         obj = cat2[idx]
         obj.circular_photometry(5.0, name='circ5')
-        obj.kron_photometry((2.0, 0.0), name='kron2')
+        obj.kron_photometry((2.0, 1.0), name='kron2')
         obj.fluxfrac_radius(0.5, name='r_hl')
         segment_snr = obj.segment_flux / obj.segment_fluxerr
         obj.add_extra_property('segment_snr', segment_snr)
@@ -170,9 +170,9 @@ class TestSourceCatalog:
         with assert_raises(AssertionError):
             assert_equal(fluxerr1, fluxerr2)
 
-        flux1, fluxerr1 = cat1.kron_photometry((2.0, 0.0))
-        flux2, fluxerr2 = cat2.kron_photometry((2.0, 0.0))
-        flux3, fluxerr3 = cat3.kron_photometry((2.0, 0.0))
+        flux1, fluxerr1 = cat1.kron_photometry((2.0, 1.0))
+        flux2, fluxerr2 = cat2.kron_photometry((2.0, 1.0))
+        flux3, fluxerr3 = cat3.kron_photometry((2.0, 1.0))
         with assert_raises(AssertionError):
             assert_equal(flux2, flux3)
         with assert_raises(AssertionError):
@@ -469,12 +469,12 @@ class TestSourceCatalog:
         assert np.all(np.isnan(cat.kron_flux))
 
     def test_kron_photometry(self):
-        flux1, fluxerr1 = self.cat.kron_photometry((2.5, 0.0))
+        flux1, fluxerr1 = self.cat.kron_photometry((2.5, 1.0))
         assert_allclose(flux1, self.cat.kron_flux)
         assert_allclose(fluxerr1, self.cat.kron_fluxerr)
 
-        flux1, fluxerr1 = self.cat.kron_photometry((1.0, 0.0), name='kron1')
-        flux2, fluxerr2 = self.cat.kron_photometry((2.0, 0.0), name='kron2')
+        flux1, fluxerr1 = self.cat.kron_photometry((1.0, 1.0), name='kron1')
+        flux2, fluxerr2 = self.cat.kron_photometry((2.0, 1.0), name='kron2')
         assert_allclose(flux1, self.cat.kron1_flux)
         assert_allclose(fluxerr1, self.cat.kron1_fluxerr)
         assert_allclose(flux2, self.cat.kron2_flux)
@@ -485,18 +485,22 @@ class TestSourceCatalog:
                       | (np.isnan(fluxerr2) & np.isnan(fluxerr1)))
 
         obj = self.cat[1]
-        flux1, fluxerr1 = obj.kron_photometry((1.0, 0.0), name='kron0')
+        flux1, fluxerr1 = obj.kron_photometry((1.0, 1.0), name='kron0')
         assert np.isscalar(flux1)
         assert np.isscalar(fluxerr1)
         assert_allclose(flux1, obj.kron0_flux)
         assert_allclose(fluxerr1, obj.kron0_fluxerr)
 
         cat = SourceCatalog(self.data, self.segm)
-        _, fluxerr = cat.kron_photometry((2.0, 0.0))
+        _, fluxerr = cat.kron_photometry((2.0, 1.0))
         assert np.all(np.isnan(fluxerr))
 
         with pytest.raises(ValueError):
             self.cat.kron_photometry(2.0)
+        with pytest.raises(ValueError):
+            self.cat.kron_photometry((2.0, 0.0))
+        with pytest.raises(ValueError):
+            self.cat.kron_photometry((0.0, 2.0))
         with pytest.raises(ValueError):
             self.cat.kron_photometry((2.0, 0.0, 1.5))
 

--- a/photutils/utils/_misc.py
+++ b/photutils/utils/_misc.py
@@ -3,6 +3,7 @@
 This module provides tools to return the installed astropy and photutils
 versions.
 """
+from datetime import datetime, timezone
 
 
 def _get_version_info():
@@ -28,3 +29,34 @@ def _get_version_info():
         versions[package] = version
 
     return versions
+
+
+def _get_date(utc=False):
+    """
+    Return a string of the current date/time.
+
+    Parameters
+    ----------
+    utz : bool, optional
+        Whether to use the UTZ timezone instead of the local timezone.
+
+    Returns
+    -------
+    result : str
+        The current date/time.
+    """
+    if not utc:
+        now = datetime.now().astimezone()
+    else:
+        now = datetime.now(timezone.utc)
+
+    return now.strftime('%Y-%m-%d %H:%M:%S %Z')
+
+
+def _get_meta(utc=False):
+    """
+    Return a metadata dictionary with the package versions and current
+    date/time.
+    """
+    return {'date': _get_date(utc=utc),
+            'version': _get_version_info()}


### PR DESCRIPTION
This PR adds the following `SourceCatalog` features
* new `rename_extra_property` method
* new `meta` and `properties` attributes
* new `make_kron_apertures` method
* new `plot_circular_apertures` and `plot_kron_apertures` methods
* `to_table` meta now includes a field for date/time

Fixes:
* `detection_catalog` is now indexed/sliced when `SourceCatalog` is indexes/sliced
* ``circular_photometry`` now returns NaN for completely-masked sources
* ``kron_flux`` is always NaN for sources where ``kron_radius`` is NaN
* ``fluxfrac_radius`` now returns NaN if ``kron_flux`` is zero

API changes:
* Renamed the ``SourceCatalog`` ``circular_aperture`` method to ``make_circular_apertures``. The old name is deprecated.
* ``kron_params`` keyword must have a minimum circular radius that is greater than zero. The default value is now 1.0