### PR TITLE
Centroid improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.centroid``
+
+  - Extra keyword arguments can be input to ``centroid_sources`` that
+    are then passed on to the ``centroid_func`` if supported. [#1276]
+
 - ``photutils.segmentation``
 
   - Added ``copy`` method to ``SourceCatalog``. [#1264]
@@ -71,6 +76,18 @@ Bug Fixes
 
 API Changes
 ^^^^^^^^^^^
+
+- ``photutils.centroids``
+
+  - A ``ValueError`` is now raised in ``centroid_sources`` if the input
+    ``xpos`` or ``ypos`` is outside of the input ``data``. [#1276]
+
+  - A ``ValueError`` is now raised in ``centroid_quadratic`` if the input
+    ``xpeak`` or ``ypeak`` is outside of the input ``data``. [#1276]
+
+  - NaNs are now returned from ``centroid_sources`` where the centroid
+    failed. This is usually due to a ``box_size`` that is too small when
+    using a fitting-based centroid function. [#1276]
 
 - ``photutils.segmentation``
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -273,8 +273,8 @@ def _process_boxsize(box_size, data_shape):
     return box_size
 
 
-def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
-                     error=None, mask=None, centroid_func=centroid_com):
+def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
+                     centroid_func=centroid_com, **kwargs):
     """
     Calculate the centroid of sources at the defined positions.
 
@@ -329,6 +329,10 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
         a tuple of two 1D `~numpy.ndarray`, representing the x and y
         centroids. The default is `~photutils.centroids.centroid_com`.
 
+    **kwargs : `dict`
+        Any additional keyword arguments accepted by the
+        ``centroid_func``.
+
     Returns
     -------
     xcentroid, ycentroid : `~numpy.ndarray`
@@ -367,13 +371,16 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
         if footprint.ndim != 2:
             raise ValueError('footprint must be a 2D array.')
 
-    use_error = False
     spec = inspect.getfullargspec(centroid_func)
     if 'mask' not in spec.args:
         raise ValueError('The input "centroid_func" must have a "mask" '
                          'keyword.')
-    if 'error' in spec.args:
-        use_error = True
+
+    # drop any **kwargs not supported by the centroid_func
+    centroid_kwargs = {}
+    for key, val in kwargs.items():
+        if key in spec.args:
+            centroid_kwargs[key] = val
 
     xcentroids = []
     ycentroids = []
@@ -386,7 +393,7 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
         if mask is not None:
             mask_cutout = mask[slices_large]
 
-        footprint_mask = ~footprint
+        footprint_mask = np.logical_not(footprint)
         # trim footprint mask if it has only partial overlap on the data
         footprint_mask = footprint_mask[slices_small]
 
@@ -396,12 +403,16 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
             # combine the input mask and footprint mask
             mask_cutout = np.logical_or(mask_cutout, footprint_mask)
 
-        kwargs = {'mask': mask_cutout}
-        if error is not None and use_error:
-            kwargs['error'] = error[slices_large]
+        if 'error' in centroid_kwargs:
+            error_cutout = centroid_kwargs['error'][slices_large]
+            centroid_kwargs['error'] = error_cutout
+
+        if 'xpeak' in centroid_kwargs and 'ypeak' in centroid_kwargs:
+            centroid_kwargs['xpeak'] -= slices_large[1].start
+            centroid_kwargs['ypeak'] -= slices_large[0].start
 
         try:
-            xcen, ycen = centroid_func(data_cutout, **kwargs)
+            xcen, ycen = centroid_func(data_cutout, **centroid_kwargs)
         except (ValueError, TypeError):
             xcen, ycen = np.nan, np.nan
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -89,7 +89,7 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
     are `None`, then the box will be centered at the position of the
     maximum value in the input ``data``.
 
-    If ``xmax`` and ``ymax`` are specified, the ``search_boxsize``
+    If ``xpeak`` and ``ypeak`` are specified, the ``search_boxsize``
     optional keyword can be used to further refine the initial center of
     the fitting box by searching for the position of the maximum pixel
     within a box of size ``search_boxsize``.
@@ -106,8 +106,8 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
         Image data.
 
     xpeak, ypeak : float or `None`, optional
-        The initial guess of the position of the centroid. When both
-        ``xpeak`` and ``ypeak`` are `None` then the position of the
+        The initial guess of the position of the centroid. If either
+        ``xpeak`` or ``ypeak`` is `None` then the position of the
         maximum value in the input ``data`` will be used as the initial
         guess.
 
@@ -119,12 +119,12 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
 
     search_boxsize : int or tuple of int, optional
         The size (in pixels) of the box used to search for the maximum
-        pixel value if ``xpeak`` and ``ypeak`` are both `None`. If
-        ``fit_boxsize`` has two elements, they should be in ``(ny, nx)``
-        order. If ``fit_boxsize`` is a scalar then a square box of size
-        ``fit_boxsize`` will be used.  This parameter is ignored when
-        ``xmax`` and ``ymax`` are both `None`.  In that case, the entire
-        array is search for the maximum value.
+        pixel value if ``xpeak`` and ``ypeak`` are both specified. If
+        ``fit_boxsize`` has two elements, they should be in ``(ny,
+        nx)`` order. If ``fit_boxsize`` is a scalar then a square box
+        of size ``fit_boxsize`` will be used. This parameter is ignored
+        if either ``xpeak`` or ``ypeak`` is `None`. In that case, the
+        entire array is search for the maximum value.
 
     mask : bool `~numpy.ndarray`, optional
         A boolean mask, with the same shape as ``data``, where a `True`

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -336,6 +336,12 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
     if ypos.ndim != 1:
         raise ValueError('ypos must be a 1D array.')
 
+    if (np.any(np.min(xpos) < 0) or np.any(np.min(ypos) < 0)
+            or np.any(np.max(xpos) > data.shape[1] - 1)
+            or np.any(np.max(ypos) > data.shape[0] - 1)):
+        raise ValueError('xpos, ypos values contains point(s) outside of '
+                         'input data')
+
     if footprint is None:
         if box_size is None:
             raise ValueError('box_size or footprint must be defined.')

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -327,7 +327,11 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
     Returns
     -------
     xcentroid, ycentroid : `~numpy.ndarray`
-        The ``x`` and ``y`` pixel position(s) of the centroids.
+        The ``x`` and ``y`` pixel position(s) of the centroids. NaNs
+        will be returned where the centroid failed. This is usually due
+        a ``box_size`` that is too small when using a fitting-based
+        centroid function (e.g., `centroid_1dg`, `centroid_2dg`, or
+        `centroid_quadratic`.
     """
     xpos = np.atleast_1d(xpos)
     ypos = np.atleast_1d(ypos)
@@ -390,7 +394,11 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None,
         kwargs = {'mask': mask_cutout}
         if error is not None and use_error:
             kwargs['error'] = error[slices_large]
-        xcen, ycen = centroid_func(data_cutout, **kwargs)
+
+        try:
+            xcen, ycen = centroid_func(data_cutout, **kwargs)
+        except (ValueError, TypeError):
+            xcen, ycen = np.nan, np.nan
 
         xcentroids.append(xcen + slices_large[1].start)
         ycentroids.append(ycen + slices_large[0].start)

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -138,9 +138,9 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
 
     Notes
     -----
-    Use ``fit_boxsize = (3, 3)`` to match the work of `Vakili & Hogg
-    (2016) <https://arxiv.org/abs/1610.05873>`_ for ther 2D second-order
-    polynomial centroiding method.
+    Use ``fit_boxsize = (3, 3)`` to match the work of `Vakili &
+    Hogg (2016) <https://arxiv.org/abs/1610.05873>`_ for their 2D
+    second-order polynomial centroiding method.
 
     References
     ----------

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -151,6 +151,11 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
             or (xpeak is not None and ypeak is None)):
         raise ValueError('xpeak and ypeak must both be input or "None"')
 
+    if xpeak is not None and ((xpeak < 0) or (xpeak > data.shape[1] - 1)):
+        raise ValueError('xpeak is outside of the input data')
+    if ypeak is not None and ((ypeak < 0) or (ypeak > data.shape[0] - 1)):
+        raise ValueError('ypeak is outside of the input data')
+
     data = np.asanyarray(data, dtype=float)
     ny, nx = data.shape
 
@@ -172,7 +177,7 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
         raise ValueError('fit_boxsize is too small.  6 values are required '
                          'to fit a 2D quadratic polynomial.')
 
-    if xpeak is None:  # and ypeak too
+    if xpeak is None or ypeak is None:
         yidx, xidx = np.unravel_index(np.nanargmax(data), data.shape)
     else:
         xidx = _py2intround(xpeak)

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -33,6 +33,7 @@ DATA[1, 1] = 2.
 
 CENTROID_FUNCS = (centroid_com, centroid_quadratic, centroid_1dg,
                   centroid_2dg)
+CENTROID_GFITS = (centroid_1dg, centroid_2dg)
 
 
 # NOTE: the fitting routines in astropy use scipy.optimize
@@ -236,6 +237,32 @@ class TestCentroidSources:
         with pytest.raises(ValueError):
             centroid_sources(self.data, 47, 50, box_size=5,
                              centroid_func=centroid_func)
+
+    def test_gaussian_fits_npts(self):
+        xcen, ycen = centroid_sources(self.data, self.xpos, self.ypos,
+                                      box_size=3, centroid_func=centroid_1dg)
+        assert_allclose(xcen, np.full(5, np.nan))
+        assert_allclose(ycen, np.full(5, np.nan))
+
+        xcen, ycen = centroid_sources(self.data, self.xpos, self.ypos,
+                                      box_size=3, centroid_func=centroid_2dg)
+        xres = np.copy(self.xpos).astype(float)
+        yres = np.copy(self.ypos).astype(float)
+        xres[-1] = np.nan
+        yres[-1] = np.nan
+        assert_allclose(xcen, xres)
+        assert_allclose(ycen, yres)
+
+        xcen, ycen = centroid_sources(self.data, self.xpos, self.ypos,
+                                      box_size=5, centroid_func=centroid_1dg)
+        assert_allclose(xcen, xres)
+        assert_allclose(ycen, yres)
+
+        xcen, ycen = centroid_sources(self.data, self.xpos, self.ypos,
+                                      box_size=3,
+                                      centroid_func=centroid_quadratic)
+        assert_allclose(xcen, xres)
+        assert_allclose(ycen, yres)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -127,6 +127,13 @@ def test_centroid_quadratic_xypeak():
     assert_allclose(xycen1, xycen2)
     assert_allclose(xycen1, xycen3)
 
+    with pytest.raises(ValueError):
+        centroid_quadratic(data, xpeak=15, ypeak=5)
+    with pytest.raises(ValueError):
+        centroid_quadratic(data, xpeak=5, ypeak=15)
+    with pytest.raises(ValueError):
+        centroid_quadratic(data, xpeak=15, ypeak=15)
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_centroid_quadratic_npts():

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -276,6 +276,38 @@ class TestCentroidSources:
         assert_allclose(xcen, xres)
         assert_allclose(ycen, yres)
 
+    @staticmethod
+    def test_centroid_quadratic_kwargs():
+        data = np.zeros((11, 11))
+        data[5, 5] = 100
+        data[7, 7] = 110
+        data[9, 9] = 120
+
+        xycen1 = centroid_sources(data, xpos=5, ypos=5, box_size=9,
+                                  centroid_func=centroid_quadratic,
+                                  fit_boxsize=3)
+        assert_allclose(xycen1, ([9], [9]))
+
+        xycen2 = centroid_sources(data, xpos=7, ypos=7, box_size=5,
+                                  centroid_func=centroid_quadratic,
+                                  fit_boxsize=3)
+        assert_allclose(xycen2, ([9], [9]))
+
+        xycen3 = centroid_sources(data, xpos=7, ypos=7, box_size=5,
+                                  centroid_func=centroid_quadratic,
+                                  xpeak=7, ypeak=7, fit_boxsize=3)
+        assert_allclose(xycen3, ([7], [7]))
+
+        xycen4 = centroid_sources(data, xpos=5, ypos=5, box_size=5,
+                                  centroid_func=centroid_quadratic,
+                                  xpeak=5, ypeak=5, fit_boxsize=3)
+        assert_allclose(xycen4, ([5], [5]))
+
+        xycen5 = centroid_sources(data, xpos=5, ypos=5, box_size=5,
+                                  centroid_func=centroid_quadratic,
+                                  fit_boxsize=5)
+        assert_allclose(xycen5, ([7], [7]))
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize('oversampling', (4, (4, 6)))

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -15,7 +15,7 @@ import pytest
 
 from ..core import (centroid_com, centroid_quadratic, centroid_sources,
                     centroid_epsf)
-from ..gaussian import centroid_1dg
+from ..gaussian import centroid_1dg, centroid_2dg
 from ...psf import IntegratedGaussianPRF
 from ...utils._optional_deps import HAS_SCIPY  # noqa
 
@@ -30,6 +30,9 @@ DATA = np.zeros((3, 3))
 DATA[0:2, 1] = 1.
 DATA[1, 0:2] = 1.
 DATA[1, 1] = 2.
+
+CENTROID_FUNCS = (centroid_com, centroid_quadratic, centroid_1dg,
+                  centroid_2dg)
 
 
 # NOTE: the fitting routines in astropy use scipy.optimize
@@ -175,41 +178,64 @@ def test_centroid_quadratic_edge():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-def test_centroid_sources():
-    theta = np.pi / 6.
-    model = Gaussian2D(2.4, XCEN, YCEN, x_stddev=3.2, y_stddev=5.7,
-                       theta=theta)
-    y, x = np.mgrid[0:50, 0:47]
-    data = model(x, y)
-    error = np.ones(data.shape, dtype=float)
-    mask = np.zeros(data.shape, dtype=bool)
-    mask[10, 10] = True
-    xpos = [25.]
-    ypos = [26.]
-    xc, yc = centroid_sources(data, xpos, ypos, box_size=21, mask=mask)
-    assert_allclose(xc, (25.67,), atol=1e-1)
-    assert_allclose(yc, (26.18,), atol=1e-1)
+class TestCentroidSources:
+    def setup_class(self):
+        ysize = 50
+        xsize = 47
+        yy, xx = np.mgrid[0:ysize, 0:xsize]
+        data = np.zeros((ysize, xsize))
+        xcen = (1, 25, 25, 35, 46)
+        ycen = (1, 25, 12, 35, 49)
+        for xc, yc in zip(xcen, ycen):
+            model = Gaussian2D(10.0, xc, yc, x_stddev=2, y_stddev=2,
+                               theta=0)
+            data += model(xx, yy)
+        self.xpos = xcen
+        self.ypos = ycen
+        self.data = data
 
-    xc, yc = centroid_sources(data, xpos, ypos, error=error, box_size=11,
-                              centroid_func=centroid_1dg)
-    assert_allclose(xc, (25.67,), atol=1e-1)
-    assert_allclose(yc, (26.41,), atol=1e-1)
+    @staticmethod
+    def test_centroid_sources():
+        theta = np.pi / 6.
+        model = Gaussian2D(2.4, XCEN, YCEN, x_stddev=3.2, y_stddev=5.7,
+                           theta=theta)
+        y, x = np.mgrid[0:50, 0:47]
+        data = model(x, y)
+        error = np.ones(data.shape, dtype=float)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[10, 10] = True
+        xpos = [25.]
+        ypos = [26.]
+        xc, yc = centroid_sources(data, xpos, ypos, box_size=21, mask=mask)
+        assert_allclose(xc, (25.67,), atol=1e-1)
+        assert_allclose(yc, (26.18,), atol=1e-1)
 
-    with pytest.raises(ValueError):
-        centroid_sources(data, 25, [[26]], box_size=11)
-    with pytest.raises(ValueError):
-        centroid_sources(data, [[25]], 26, box_size=11)
-    with pytest.raises(ValueError):
-        centroid_sources(data, 25, 26, box_size=(1, 2, 3))
-    with pytest.raises(ValueError):
-        centroid_sources(data, 25, 26, box_size=None, footprint=None)
-    with pytest.raises(ValueError):
-        centroid_sources(data, 25, 26, footprint=np.ones((3, 3, 3)))
+        xc, yc = centroid_sources(data, xpos, ypos, error=error, box_size=11,
+                                  centroid_func=centroid_1dg)
+        assert_allclose(xc, (25.67,), atol=1e-1)
+        assert_allclose(yc, (26.41,), atol=1e-1)
 
-    def test_func(data):
-        return 1
-    with pytest.raises(ValueError):
-        centroid_sources(data, [25], 26, centroid_func=test_func)
+        with pytest.raises(ValueError):
+            centroid_sources(data, 25, [[26]], box_size=11)
+        with pytest.raises(ValueError):
+            centroid_sources(data, [[25]], 26, box_size=11)
+        with pytest.raises(ValueError):
+            centroid_sources(data, 25, 26, box_size=(1, 2, 3))
+        with pytest.raises(ValueError):
+            centroid_sources(data, 25, 26, box_size=None, footprint=None)
+        with pytest.raises(ValueError):
+            centroid_sources(data, 25, 26, footprint=np.ones((3, 3, 3)))
+
+        def test_func(data):
+            return 1
+        with pytest.raises(ValueError):
+            centroid_sources(data, [25], 26, centroid_func=test_func)
+
+    @pytest.mark.parametrize('centroid_func', CENTROID_FUNCS)
+    def test_xypos(self, centroid_func):
+        with pytest.raises(ValueError):
+            centroid_sources(self.data, 47, 50, box_size=5,
+                             centroid_func=centroid_func)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -33,7 +33,6 @@ DATA[1, 1] = 2.
 
 CENTROID_FUNCS = (centroid_com, centroid_quadratic, centroid_1dg,
                   centroid_2dg)
-CENTROID_GFITS = (centroid_1dg, centroid_2dg)
 
 
 # NOTE: the fitting routines in astropy use scipy.optimize
@@ -119,13 +118,19 @@ def test_centroid_com_invalid_inputs():
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_centroid_quadratic_xypeak():
     data = np.zeros((11, 11))
-    data[4:7, 4:7] = 10
     data[5, 5] = 100
-    xycen1 = centroid_quadratic(data)
-    xycen2 = centroid_quadratic(data, xpeak=5, ypeak=5)
-    xycen3 = centroid_quadratic(data, xpeak=5, ypeak=5, search_boxsize=3)
-    assert_allclose(xycen1, xycen2)
-    assert_allclose(xycen1, xycen3)
+    data[7, 7] = 110
+    data[9, 9] = 120
+
+    xycen1 = centroid_quadratic(data, fit_boxsize=3)
+    assert_allclose(xycen1, (9, 9))
+
+    xycen2 = centroid_quadratic(data, xpeak=5, ypeak=5, fit_boxsize=3)
+    assert_allclose(xycen2, (5, 5))
+
+    xycen3 = centroid_quadratic(data, xpeak=5, ypeak=5, fit_boxsize=3,
+                                search_boxsize=5)
+    assert_allclose(xycen3, (7, 7))
 
     with pytest.raises(ValueError):
         centroid_quadratic(data, xpeak=15, ypeak=5)

--- a/photutils/utils/_round.py
+++ b/photutils/utils/_round.py
@@ -17,6 +17,6 @@ def _py2intround(a):
                      np.ceil(data - 0.5)).astype(int)
 
     if not hasattr(a, '__iter__'):
-        value = np.asscalar(value)
+        value = value.item()
 
     return value


### PR DESCRIPTION
This PR makes a number of improvements to the centroid functions:

* Extra keyword arguments can be input to ``centroid_sources`` that are then passed on to the ``centroid_func`` if supported.  This feature was requested in #1270.
*  A ``ValueError`` is now raised in ``centroid_sources`` if the input ``xpos`` or ``ypos`` is outside of the input ``data``.
* A ``ValueError`` is now raised in ``centroid_quadratic`` if the input``xpeak`` or ``ypeak`` is outside of the input ``data``.
*  NaNs are now returned from ``centroid_sources`` where the centroid failed. This is usually due to a ``box_size`` that is too small when using a fitting-based centroid function.

Closes #1270 