### PR TITLE
Fix centroid_sources mask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,8 @@ New Features
 - ``photutils.centroid``
 
   - Extra keyword arguments can be input to ``centroid_sources`` that
-    are then passed on to the ``centroid_func`` if supported. [#1276]
+    are then passed on to the ``centroid_func`` if supported.
+    [#1276,#1278]
 
 - ``photutils.segmentation``
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -389,19 +389,16 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
                                                     footprint.shape, (yp, xp))
         data_cutout = data[slices_large]
 
-        mask_cutout = None
-        if mask is not None:
-            mask_cutout = mask[slices_large]
-
         footprint_mask = np.logical_not(footprint)
         # trim footprint mask if it has only partial overlap on the data
         footprint_mask = footprint_mask[slices_small]
 
-        if mask_cutout is None:
-            mask_cutout = footprint_mask
+        if mask is not None:
+            # combine the input mask cutout and footprint mask
+            mask_cutout = np.logical_or(mask[slices_large], footprint_mask)
         else:
-            # combine the input mask and footprint mask
-            mask_cutout = np.logical_or(mask_cutout, footprint_mask)
+            mask_cutout = footprint_mask
+
 
         if 'error' in centroid_kwargs:
             error_cutout = centroid_kwargs['error'][slices_large]

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -399,6 +399,7 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
         else:
             mask_cutout = footprint_mask
 
+        centroid_kwargs.update({'mask': mask_cutout})
 
         if 'error' in centroid_kwargs:
             error_cutout = centroid_kwargs['error'][slices_large]

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -308,6 +308,14 @@ class TestCentroidSources:
                                   fit_boxsize=5)
         assert_allclose(xycen5, ([7], [7]))
 
+    def test_mask(self):
+        mask = np.ones(self.data.shape, dtype=bool)
+        xcen1, ycen1 = centroid_sources(self.data, 25, 23, box_size=(55, 55))
+        xcen2, ycen2 = centroid_sources(self.data, 25, 23, box_size=(55, 55),
+                                        mask=mask)
+        assert not np.allclose(xcen1, xcen2)
+        assert not np.allclose(ycen1, ycen2)
+
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize('oversampling', (4, (4, 6)))


### PR DESCRIPTION
This is a followup fix to PR #1276, where the `mask` keyword in `centroid_sources` was not passed to the `centroid_func`.