### PR TITLE
Drop support for Python 3.7 and update minimum dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install dependencies for Python 3.7
-          command: /opt/python/cp37-cp37m/bin/pip install tox
+          name: Install dependencies for Python 3.8
+          command: /opt/python/cp38-cp38/bin/pip install tox
       - run:
-          name: Run tests for Python 3.7
-          command: /opt/python/cp37-cp37m/bin/python -m tox -e py37-test
+          name: Run tests for Python 3.8
+          command: /opt/python/cp38-cp38/bin/python -m tox -e py38-numpy120-test

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -18,9 +18,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.7'
-            tox_env: 'py37-test-alldeps'
-          - os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps'
             toxposargs: --remote-data=any
@@ -43,8 +40,8 @@ jobs:
             python: '3.9'
             tox_env: 'bandit'
           - os: ubuntu-latest
-            python: '3.7'
-            tox_env: 'py37-test-alldeps-astropylts-numpy118'
+            python: '3.8'
+            tox_env: 'py38-test-alldeps-astropylts-numpy118'
 
     steps:
     - name: Check out repository

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,18 @@
 General
 ^^^^^^^
 
+- The minimum required Python is now 3.8. [#1279]
+
+- The minimum required Numpy is now 1.18. [#1279]
+
+- The minimum required Astropy is now 5.0. [#1279]
+
+- The minimum required Matplotlib is now 3.1. [#1279]
+
+- The minimum required scikit-image is now 0.15.0 [#1279]
+
+- The minimum required gwcs is now 0.16.0 [#1279]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,28 +7,28 @@ Requirements
 
 Photutils has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.7 or later
+* `Python <https://www.python.org/>`_ 3.8 or later
 
-* `Numpy <https://numpy.org/>`_ 1.17 or later
+* `Numpy <https://numpy.org/>`_ 1.18 or later
 
-* `Astropy`_ 4.0 or later
+* `Astropy`_ 5.0 or later
 
 Photutils also optionally depends on other packages for some features:
 
 * `Scipy <https://www.scipy.org/>`_ 1.6.0 or later:  To power a variety of
   features in several modules (strongly recommended).
 
-* `matplotlib <https://matplotlib.org/>`_ 2.2 or later:  To power a
+* `matplotlib <https://matplotlib.org/>`_ 3.1 or later:  To power a
   variety of plotting features (e.g., plotting apertures).
 
-* `scikit-image <https://scikit-image.org/>`_ 0.14.2 or later:  Used in
+* `scikit-image <https://scikit-image.org/>`_ 0.15.0 or later:  Used in
   `~photutils.segmentation.deblend_sources` for deblending segmented
   sources.
 
 * `scikit-learn <https://scikit-learn.org/>`_ 0.19 or later:  Used in
   `~photutils.psf.DBSCANGroup` to create star groups.
 
-* `gwcs <https://github.com/spacetelescope/gwcs>`_ 0.12 or later:
+* `gwcs <https://github.com/spacetelescope/gwcs>`_ 0.16 or later:
   Used in `~photutils.datasets.make_gwcs` to create a simple celestial
   gwcs object.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,19 +24,19 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.17
-    astropy>=4.0
+    numpy>=1.18
+    astropy>=5.0
 
 [options.extras_require]
 all =
     scipy>=1.6.0
-    matplotlib>=2.2
-    scikit-image>=0.14.2
+    matplotlib>=3.1
+    scikit-image>=0.15.0
     scikit-learn
-    gwcs>=0.12
+    gwcs>=0.16
     bottleneck
 test =
     pytest-astropy
@@ -44,10 +44,10 @@ docs =
     scipy>=1.6.0
     sphinx<4
     sphinx-astropy
-    matplotlib>=2.2
-    scikit-image>=0.14.2
+    matplotlib>=3.1
+    scikit-image>=0.15.0
     scikit-learn
-    gwcs>=0.12
+    gwcs>=0.16
 
 [options.package_data]
 photutils = CITATION.rst

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-alldeps,-devdeps}{,-cov}
-    py{37,38,39,310}-test-numpy{117,118,119,120,121}
-    py{37,38,39,310}-test-astropy{40,50,lts}
+    py{38,39,310}-test{,-alldeps,-devdeps,-oldestdeps}{,-cov}
+    py{38,39,310}-test-numpy{118,119,120,121}
+    py{38,39,310}-test-astropy{50,lts}
     build_docs
     linkcheck
     codestyle
@@ -37,12 +37,11 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
     numpy119: with numpy 1.19.*
     numpy120: with numpy 1.20.*
     numpy121: with numpy 1.21.*
-    astropy40: with astropy 4.0.*
+
     astropy50: with astropy 5.0.*
     astropylts: with the latest astropy LTS
 
@@ -50,23 +49,21 @@ description =
 deps =
     cov: coverage
 
-    numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
 
-    astropy40: astropy==4.0.*
     astropy50: astropy==5.0.*
-    astropylts: astropy==4.0.*
+    astropylts: astropy==5.0.*
 
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    oldestdeps: numpy==1.17
+    oldestdeps: numpy==1.18
     oldestdeps: astropy==4.0
-    oldestdeps: scipy==0.19
-    oldestdeps: matplotlib==2.2
+    oldestdeps: scipy==1.6.0
+    oldestdeps: matplotlib==3.1
     oldestdeps: scikit-image==0.14.2
     oldestdeps: scikit-learn==0.19
     oldestdeps: gwcs==0.12


### PR DESCRIPTION
This PR drops support for Python 3.7 and updates the following minimum dependencies:
* numpy 1.18+
* Astropy 5.0+
* Matplotlib 3.1+
* scikit-image 0.15.0+
* gwcs 0.16.0+