### PR TITLE
MNT: Stop using deprecated astropy.tests stuff

### DIFF
--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -174,16 +174,20 @@ class TestBackground2D:
         coverage_mask = np.zeros(DATA.shape, dtype=bool)
         mask[:50, :25] = True
         coverage_mask[:50, 25:50] = True
-        bkg2 = Background2D(data, (25, 25), filter_size=(1, 1), mask=mask,
-                            coverage_mask=mask, fill_value=0.0,
-                            bkg_estimator=MeanBackground())
+        with pytest.warns(AstropyUserWarning,
+                          match='Input data contains invalid values'):
+            bkg2 = Background2D(data, (25, 25), filter_size=(1, 1), mask=mask,
+                                coverage_mask=mask, fill_value=0.0,
+                                bkg_estimator=MeanBackground())
         assert_equal(bkg1.background_mesh, bkg2.background_mesh)
         assert_equal(bkg1.background_rms_mesh, bkg2.background_rms_mesh)
 
     def test_mask_nonfinite(self):
         data = DATA.copy()
         data[0, 0:50] = np.nan
-        bkg = Background2D(data, (25, 25), filter_size=(1, 1))
+        with pytest.warns(AstropyUserWarning,
+                          match='Input data contains invalid values'):
+            bkg = Background2D(data, (25, 25), filter_size=(1, 1))
         assert_allclose(bkg.background, DATA, rtol=1e-5)
 
     def test_masked_array(self):
@@ -217,8 +221,10 @@ class TestBackground2D:
         """Only meshes greater than filter_threshold are filtered."""
         data = np.copy(DATA)
         data[0:50, 0:50] = np.nan
-        bkg = Background2D(data, (25, 25), filter_size=(1, 1),
-                           exclude_percentile=100.)
+        with pytest.warns(AstropyUserWarning,
+                          match='Input data contains invalid values'):
+            bkg = Background2D(data, (25, 25), filter_size=(1, 1),
+                               exclude_percentile=100.)
         assert len(bkg._box_idx) == 12
 
     def test_filter_threshold(self):

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -6,7 +6,6 @@ Tests for the background_2d module.
 import itertools
 
 from astropy.nddata import NDData, CCDData
-from astropy.tests.helper import catch_warnings
 import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
@@ -163,7 +162,7 @@ class TestBackground2D:
         data[:50, :50] = np.nan
         mask = np.isnan(data)
 
-        with catch_warnings(AstropyUserWarning):
+        with pytest.warns(AstropyUserWarning):
             bkg1 = Background2D(data, (25, 25), filter_size=(1, 1),
                                 coverage_mask=mask, fill_value=fill_value,
                                 bkg_estimator=MeanBackground())

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -144,9 +144,8 @@ def test_centroid_quadratic_npts():
     mask = np.zeros(data.shape, dtype=bool)
     mask[0, :] = True
     mask[2, :] = True
-    with warnings.catch_warnings(record=True) as warnlist:
+    with pytest.warns(AstropyUserWarning):
         centroid_quadratic(data, mask=mask)
-    assert issubclass(warnlist[0].category, AstropyUserWarning)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -181,10 +180,9 @@ def test_centroid_quadratic_edge():
 
     data = np.zeros((5, 5))
     data[0, 0] = 100
-    with warnings.catch_warnings(record=True) as warnlist:
+    with pytest.warns(AstropyUserWarning):
         xycen = centroid_quadratic(data)
     assert_allclose(xycen, (0, 0))
-    assert issubclass(warnlist[0].category, AstropyUserWarning)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -137,8 +137,7 @@ def test_gaussian1d_moments():
     data[0] = np.nan
     mask = np.zeros(data.shape).astype(bool)
     mask[0] = True
-    with warnings.catch_warnings(record=True) as warnlist:
+    with pytest.warns(AstropyUserWarning) as warnlist:
         result = _gaussian1d_moments(data, mask=mask)
-        assert_allclose(result, desired, rtol=0, atol=1.e-6)
+    assert_allclose(result, desired, rtol=0, atol=1.e-6)
     assert len(warnlist) == 1
-    assert issubclass(warnlist[0].category, AstropyUserWarning)

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -4,7 +4,7 @@ Tests for the core module.
 """
 
 import itertools
-import warnings
+from contextlib import nullcontext
 
 from astropy.modeling.models import Gaussian1D, Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
@@ -72,23 +72,24 @@ def test_centroids_nan_withmask(use_mask):
         mask = np.zeros(data.shape, dtype=bool)
         mask[20, :] = True
         nwarn = 0
+        ctx = nullcontext()
     else:
         mask = None
         nwarn = 1
+        ctx = pytest.warns(AstropyUserWarning,
+                           match='Input data contains non-finite values')
 
-    with warnings.catch_warnings(record=True) as warnlist:
+    with ctx as warnlist:
         xc, yc = centroid_1dg(data, mask=mask)
-        assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-    assert len(warnlist) == nwarn
+    assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
     if nwarn == 1:
-        assert issubclass(warnlist[0].category, AstropyUserWarning)
+        assert len(warnlist) == nwarn
 
-    with warnings.catch_warnings(record=True) as warnlist:
+    with ctx as warnlist:
         xc, yc = centroid_2dg(data, mask=mask)
-        assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-    assert len(warnlist) == nwarn
+    assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
     if nwarn == 1:
-        assert issubclass(warnlist[0].category, AstropyUserWarning)
+        assert len(warnlist) == nwarn
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -3,8 +3,6 @@
 # get picked up when running the tests inside an interpreter using
 # packagename.test
 
-import os
-
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
     ASTROPY_HEADER = True
@@ -29,19 +27,5 @@ def pytest_configure(config):
         PYTEST_HEADER_MODULES.pop('Pandas', None)  # noqa
         PYTEST_HEADER_MODULES.pop('h5py', None)  # noqa
 
-        from . import __version__
-        packagename = os.path.basename(os.path.dirname(__file__))
-        TESTED_VERSIONS[packagename] = __version__
-
-# Uncomment the last two lines in this block to treat all DeprecationWarnings as
-# exceptions. For Astropy v2.0 or later, there are 2 additional keywords,
-# as follow (although default should work for most cases).
-# To ignore some packages that produce deprecation warnings on import
-# (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
-# 'setuptools'), add:
-#     modules_to_ignore_on_import=['module_1', 'module_2']
-# To ignore some specific deprecation warning messages for Python version
-# MAJOR.MINOR or later, add:
-#     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
-from astropy.tests.helper import enable_deprecations_as_exceptions  # noqa
-enable_deprecations_as_exceptions()
+        from photutils import __version__
+        TESTED_VERSIONS['photutils'] = __version__

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -7,7 +7,6 @@ import itertools
 import os.path as op
 
 from astropy.table import Table
-from astropy.tests.helper import catch_warnings
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -59,38 +58,34 @@ class TestDAOStarFinder:
 
     def test_daofind_nosources(self):
         data = np.ones((3, 3))
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
             starfinder = DAOStarFinder(threshold=10, fwhm=1)
             tbl = starfinder(data)
             assert tbl is None
-            assert 'No sources were found.' in str(warning_lines[0].message)
 
     def test_daofind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning,
+                          match='Sources were found, but none pass'):
             starfinder = DAOStarFinder(threshold=50, fwhm=1.0, sharplo=1.)
             tbl = starfinder(DATA)
             assert tbl is None
-            assert ('Sources were found, but none pass' in
-                    str(warning_lines[0].message))
 
     def test_daofind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning,
+                          match='Sources were found, but none pass'):
             starfinder = DAOStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
             tbl = starfinder(DATA)
             assert tbl is None
-            assert ('Sources were found, but none pass' in
-                    str(warning_lines[0].message))
 
     def test_daofind_peakmax(self):
         """Sources found, but none pass the peakmax criteria."""
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning,
+                          match='Sources were found, but none pass'):
             starfinder = DAOStarFinder(threshold=50, fwhm=1.0, peakmax=1.0)
             tbl = starfinder(DATA)
             assert tbl is None
-            assert ('Sources were found, but none pass' in
-                    str(warning_lines[0].message))
 
     def test_daofind_flux_negative(self):
         """Test handling of negative flux (here created by large sky)."""

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -82,8 +82,8 @@ class TestIRAFStarFinder:
         assert len(tbl) == 4
 
     def test_irafstarfind_largesky(self):
-        with pytest.warnss(NoDetectionsWarning,
-                           match='Sources were found, but none pass'):
+        with pytest.warns(NoDetectionsWarning,
+                          match='Sources were found, but none pass'):
             starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
             tbl = starfinder(DATA)
             assert tbl is None

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -7,7 +7,6 @@ import itertools
 import os.path as op
 
 from astropy.table import Table
-from astropy.tests.helper import catch_warnings
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -48,38 +47,34 @@ class TestIRAFStarFinder:
 
     def test_irafstarfind_nosources(self):
         data = np.ones((3, 3))
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
             starfinder = IRAFStarFinder(threshold=10, fwhm=1)
             tbl = starfinder(data)
             assert tbl is None
-            assert 'No sources were found.' in str(warning_lines[0].message)
 
     def test_irafstarfind_sharpness(self):
         """Sources found, but none pass the sharpness criteria."""
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning,
+                          match='Sources were found, but none pass'):
             starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, sharplo=2.)
             tbl = starfinder(DATA)
             assert tbl is None
-            assert ('Sources were found, but none pass' in
-                    str(warning_lines[0].message))
 
     def test_irafstarfind_roundness(self):
         """Sources found, but none pass the roundness criteria."""
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning,
+                          match='Sources were found, but none pass'):
             starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, roundlo=1.)
             tbl = starfinder(DATA)
             assert tbl is None
-            assert ('Sources were found, but none pass' in
-                    str(warning_lines[0].message))
 
     def test_irafstarfind_peakmax(self):
         """Sources found, but none pass the peakmax criteria."""
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning,
+                          match='Sources were found, but none pass'):
             starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, peakmax=1.)
             tbl = starfinder(DATA)
             assert tbl is None
-            assert ('Sources were found, but none pass' in
-                    str(warning_lines[0].message))
 
     def test_irafstarfind_sky(self):
         starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=10.)
@@ -87,12 +82,11 @@ class TestIRAFStarFinder:
         assert len(tbl) == 4
 
     def test_irafstarfind_largesky(self):
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warnss(NoDetectionsWarning,
+                           match='Sources were found, but none pass'):
             starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.)
             tbl = starfinder(DATA)
             assert tbl is None
-            assert ('Sources were found, but none pass' in
-                    str(warning_lines[0].message))
 
     def test_irafstarfind_peakmax_filtering(self):
         """

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -4,7 +4,6 @@ Tests for StarFinder.
 """
 
 from astropy.modeling.models import Gaussian2D
-from astropy.tests.helper import catch_warnings
 import numpy as np
 import pytest
 
@@ -38,11 +37,10 @@ class TestStarFinder:
             StarFinder(10, PSF, brightest=3.1)
 
     def test_nosources(self):
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
             finder = StarFinder(100, PSF)
             tbl = finder(DATA)
             assert tbl is None
-            assert 'No sources were found.' in str(warning_lines[0].message)
 
     def test_min_separation(self):
         finder1 = StarFinder(10, PSF, min_separation=0)
@@ -58,12 +56,11 @@ class TestStarFinder:
         tbl2 = finder2(DATA)
         assert len(tbl1) > len(tbl2)
 
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning,
+                          match='Sources were found, but none pass'):
             starfinder = StarFinder(10, PSF, peakmax=5)
             tbl = starfinder(DATA)
             assert tbl is None
-            assert ('Sources were found, but none pass'
-                    in str(warning_lines[0].message))
 
     def test_brightest(self):
         finder = StarFinder(10, PSF, brightest=10)

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -91,7 +91,8 @@ class TestEllipse:
         # This should result in failure since the real galaxy
         # image is off-center by a large offset.
         ellipse = Ellipse(OFFSET_GALAXY)
-        isophote_list = ellipse.fit_image()
+        with pytest.warns(RuntimeWarning, match='Degrees of freedom'):
+            isophote_list = ellipse.fit_image()
 
         assert len(isophote_list) == 0
 

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -27,7 +27,8 @@ def test_model():
 
     g = EllipseGeometry(530., 511, 10., 0.1, 10./180.*np.pi)
     ellipse = Ellipse(data, geometry=g, threshold=1.e5)
-    isophote_list = ellipse.fit_image()
+    with pytest.warns(RuntimeWarning, match='Degrees of freedom'):
+        isophote_list = ellipse.fit_image()
     model = build_ellipse_model(data.shape, isophote_list,
                                 fill=np.mean(data[10:100, 10:100]))
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -9,7 +9,6 @@ from astropy.modeling.fitting import LevMarLSQFitter, SimplexLSQFitter
 from astropy.modeling.models import Gaussian2D, Moffat2D
 from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Table
-from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
@@ -311,15 +310,15 @@ def test_finder_positions_warning():
              make_noise_image((32, 32), distribution='poisson', mean=6.,
                               seed=0))
 
-    with catch_warnings(AstropyUserWarning):
+    with pytest.warns(AstropyUserWarning):
         result_tab = basic_phot_obj(image=image, init_guesses=positions)
-        assert_array_equal(result_tab['x_0'], positions['x_0'])
-        assert_array_equal(result_tab['y_0'], positions['y_0'])
-        assert_allclose(result_tab['x_fit'], positions['x_0'], rtol=1e-1)
-        assert_allclose(result_tab['y_fit'], positions['y_0'], rtol=1e-1)
+    assert_array_equal(result_tab['x_0'], positions['x_0'])
+    assert_array_equal(result_tab['y_0'], positions['y_0'])
+    assert_allclose(result_tab['x_fit'], positions['x_0'], rtol=1e-1)
+    assert_allclose(result_tab['y_fit'], positions['y_0'], rtol=1e-1)
 
+    basic_phot_obj.finder = None
     with pytest.raises(ValueError):
-        basic_phot_obj.finder = None
         result_tab = basic_phot_obj(image=image)
 
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -355,9 +355,7 @@ def test_aperture_radius():
 
     psf_model = PSFModelWithFWHM()
     basic_phot_obj.psf_model = psf_model
-    with pytest.warns(RuntimeWarning, match='invalid value encountered in '
-                      'sqrt'):
-        basic_phot_obj(image)
+    basic_phot_obj(image)
     assert_equal(basic_phot_obj.aperture_radius, psf_model.fwhm.value)
 
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -325,6 +325,7 @@ def test_finder_positions_warning():
         result_tab = basic_phot_obj(image=image)
 
 
+@pytest.mark.filterwarnings('ignore:The fit may be unsuccessful')
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_aperture_radius():
     img_shape = (32, 32)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -151,6 +151,9 @@ def test_psf_photometry_niters(sigma_psf, sources):
         assert_array_equal(cp_image, image)
 
 
+@pytest.mark.filterwarnings('ignore:Both init_guesses and finder are '
+                            'different than None')
+@pytest.mark.filterwarnings('ignore:No sources were found')
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize("sigma_psf, sources",
                          [(sigma_psfs[0], sources1),
@@ -352,7 +355,9 @@ def test_aperture_radius():
 
     psf_model = PSFModelWithFWHM()
     basic_phot_obj.psf_model = psf_model
-    basic_phot_obj(image)
+    with pytest.warns(RuntimeWarning, match='invalid value encountered in '
+                      'sqrt'):
+        basic_phot_obj(image)
     assert_equal(basic_phot_obj.aperture_radius, psf_model.fwhm.value)
 
 
@@ -432,7 +437,9 @@ def test_psf_photometry_discrete():
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
                                     bkg_estimator=None, psf_model=prf,
                                     fitshape=7)
-    f = basic_phot(image=image, init_guesses=INTAB)
+    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
+                      'could not be determined by psf_model'):
+        f = basic_phot(image=image, init_guesses=INTAB)
 
     for n in ['x', 'y', 'flux']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-6)
@@ -456,7 +463,9 @@ def test_tune_coordinates():
                                     bkg_estimator=None, psf_model=prf,
                                     fitshape=7)
 
-    f = basic_phot(image=image, init_guesses=intab)
+    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
+                      'could not be determined by psf_model'):
+        f = basic_phot(image=image, init_guesses=intab)
     for n in ['x', 'y', 'flux']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
 
@@ -605,7 +614,9 @@ def test_psf_photometry_gaussian2(renormalize_psf):
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
                                     bkg_estimator=None, psf_model=psf,
                                     fitshape=7)
-    f = basic_phot(image=image, init_guesses=INTAB)
+    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
+                      'could not be determined by psf_model'):
+        f = basic_phot(image=image, init_guesses=INTAB)
 
     for n in ['x', 'y']:
         assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-1)
@@ -626,7 +637,9 @@ def test_psf_photometry_moffat():
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
                                     bkg_estimator=None, psf_model=psf,
                                     fitshape=7)
-    f = basic_phot(image=image, init_guesses=INTAB)
+    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
+                      'could not be determined by psf_model'):
+        f = basic_phot(image=image, init_guesses=INTAB)
     f.pprint(max_width=-1)
 
     for n in ['x', 'y']:
@@ -655,6 +668,8 @@ def test_psf_fitting_data_on_edge():
                         rtol=0.05, atol=0.1)
 
 
+@pytest.mark.filterwarnings('ignore:Both init_guesses and finder '
+                            'are different than None')
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize("sigma_psf, sources", [(sigma_psfs[2], sources3)])
 def test_psf_extra_output_cols(sigma_psf, sources):
@@ -794,7 +809,9 @@ def test_finder_return_none():
                                                    fitshape=7, niters=2,
                                                    aperture_radius=3)
 
-    results = iter_phot(image=img, init_guesses=intab)
+    with pytest.warns(AstropyUserWarning, match='Both init_guesses and finder '
+                      'are different than None'):
+        results = iter_phot(image=img, init_guesses=intab)
     assert_allclose(results['flux_fit'], f0, rtol=0.05)
 
 
@@ -811,7 +828,8 @@ def test_psf_photometry_uncertainties():
                                     bkg_estimator=None, psf_model=psf,
                                     fitter=SimplexLSQFitter(),
                                     fitshape=7)
-    phot_tbl = basic_phot(image=image, init_guesses=INTAB)
+    with pytest.warns(AstropyUserWarning, match='The fit may be unsuccessful'):
+        phot_tbl = basic_phot(image=image, init_guesses=INTAB)
     columns = ('flux_unc', 'x_0_unc', 'y_0_unc')
     for column in columns:
         assert column not in phot_tbl.colnames
@@ -831,9 +849,12 @@ def test_re_use_result_as_initial_guess():
 
     _, _, dao_phot_obj = make_psf_photometry_objs()
 
-    result_table = dao_phot_obj(image)
+    with pytest.warns(AstropyUserWarning, match='The fit may be unsuccessful'):
+        result_table = dao_phot_obj(image)
     result_table['x'] = result_table['x_fit']
     result_table['y'] = result_table['y_fit']
     result_table['flux'] = result_table['flux_fit']
-    second_result = dao_phot_obj(image, result_table)
+    with pytest.warns(AstropyUserWarning, match='Both init_guesses and finder '
+                      'are different than None'):
+        second_result = dao_phot_obj(image, result_table)
     assert second_result

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -143,6 +143,8 @@ def test_prepare_psf_model(moffimg, prepkwargs, tols):
         assert fit_psfmod.psfmodel.amplitude == guess_moffat.amplitude
 
 
+@pytest.mark.filterwarnings('ignore:aperture_radius is None and could not '
+                            'be determined by psf_model')
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_prepare_psf_model_offset():
     """

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -4,7 +4,6 @@ Tests for the deblend module.
 """
 
 from astropy.modeling.models import Gaussian2D
-from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 from numpy.testing import assert_allclose
@@ -13,7 +12,6 @@ import pytest
 from ..core import SegmentationImage
 from ..deblend import deblend_sources
 from ..detect import detect_sources
-from ...utils.exceptions import NoDetectionsWarning
 from ...utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE  # noqa
 
 
@@ -198,10 +196,9 @@ class TestDeblendSources:
     def test_source_with_negval(self):
         data = self.data.copy()
         data -= 20
-        with catch_warnings(AstropyUserWarning) as warning_lines:
+        with pytest.warns(AstropyUserWarning,
+                          match='contains negative values'):
             deblend_sources(data, self.segm, self.npixels)
-            assert ('contains negative values' in
-                    str(warning_lines[0].message))
 
     def test_source_zero_min(self):
         data = self.data.copy()
@@ -263,10 +260,7 @@ class TestDeblendSources:
         data[50, 50] = 1000.
         data[50, 70] = 500.
         self.segm = detect_sources(data, self.threshold, self.npixels)
-
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
-            deblend_sources(data, self.segm, self.npixels)
-            assert len(warning_lines) == 0
+        deblend_sources(data, self.segm, self.npixels)
 
     def test_nonconsecutive_labels(self):
         segm = self.segm.copy()

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -5,7 +5,6 @@ Tests for the detect module.
 
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
-from astropy.tests.helper import catch_warnings
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
@@ -134,10 +133,8 @@ class TestDetectSources:
     def test_small_sources(self):
         """Test detection where sources are smaller than npixels size."""
 
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
             detect_sources(self.data, threshold=0.9, npixels=5)
-            assert warning_lines[0].category == NoDetectionsWarning
-            assert 'No sources were found.' in str(warning_lines[0].message)
 
     def test_npixels(self):
         """
@@ -169,10 +166,8 @@ class TestDetectSources:
             assert segm.nlabels == 1
             assert segm.areas[0] == 13
 
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
             detect_sources(data, 0, npixels=14)
-            assert warning_lines[0].category == NoDetectionsWarning
-            assert 'No sources were found.' in str(warning_lines[0].message)
 
     def test_zerothresh(self):
         """Test detection with zero threshold."""
@@ -183,10 +178,8 @@ class TestDetectSources:
     def test_zerodet(self):
         """Test detection with large threshold giving no detections."""
 
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
             detect_sources(self.data, threshold=7, npixels=2)
-            assert warning_lines[0].category == NoDetectionsWarning
-            assert 'No sources were found.' in str(warning_lines[0].message)
 
     def test_8connectivity(self):
         """Test detection with connectivity=8."""
@@ -273,7 +266,6 @@ class TestMakeSourceMask:
         assert_allclose(mask1, mask2)
 
     def test_no_detections(self):
-        with catch_warnings(NoDetectionsWarning) as warning_lines:
+        with pytest.warns(NoDetectionsWarning):
             mask = make_source_mask(self.data, 100, 100)
             assert np.count_nonzero(mask) == 0
-            assert warning_lines[0].category == NoDetectionsWarning

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -4,7 +4,6 @@ Tests for the convolution module.
 """
 
 from astropy.convolution import Gaussian2DKernel
-from astropy.tests.helper import catch_warnings
 import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
@@ -67,6 +66,6 @@ class TestFilterData:
         Test kernel normalization check.
         """
 
-        with catch_warnings(AstropyUserWarning) as w:
+        with pytest.warns(AstropyUserWarning) as w:
             _filter_data(self.data, self.kernel, check_normalization=True)
-            assert len(w) == 1
+        assert len(w) == 1

--- a/photutils/utils/tests/test_errors.py
+++ b/photutils/utils/tests/test_errors.py
@@ -47,14 +47,16 @@ def test_gain_array():
 
 
 def test_gain_zero():
-    error_tot = calc_total_error(DATA, BKG_ERROR, 0.)
+    with pytest.warns(RuntimeWarning, match='divide by zero'):
+        error_tot = calc_total_error(DATA, BKG_ERROR, 0.)
     assert_allclose(error_tot, BKG_ERROR)
 
     effgain = np.copy(EFFGAIN)
     effgain[0, 0] = 0
     effgain[1, 1] = 0
     mask = (effgain == 0)
-    error_tot = calc_total_error(DATA, BKG_ERROR, effgain)
+    with pytest.warns(RuntimeWarning, match='divide by zero'):
+        error_tot = calc_total_error(DATA, BKG_ERROR, effgain)
     assert_allclose(error_tot[mask], BKG_ERROR[mask])
     assert_allclose(error_tot[~mask], np.sqrt(2))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,13 @@ filterwarnings =
     error
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
+    # TODO: Revisit these in the future.
+    # Extra warnings seen in other jobs.
+    ignore:invalid value encountered:RuntimeWarning
+    ignore:unclosed file:ResourceWarning
+    ignore:distutils Version classes are deprecated:DeprecationWarning
+    ignore:.*converting a masked element to nan
+    ignore:Mean of empty slice:RuntimeWarning
 
 [coverage:run]
 omit =

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,9 @@ doctest_plus = enabled
 text_file_format = rst
 addopts = --doctest-rst
 filterwarnings =
-    ignore:numpy.ufunc size changed:RuntimeWarning
+    error
+    ignore:numpy\.ufunc size changed:RuntimeWarning
+    ignore:numpy\.ndarray size changed:RuntimeWarning
 
 [coverage:run]
 omit =


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .

* MNT: Stop using deprecated astropy.tests stuff
* TST: Turn unhandled warnings into exceptions.