### PR TITLE
Fix unit check in aperture_photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.4.0 (unreleased)
+2.0.0 (unreleased)
 ------------------
 
 General
@@ -21,6 +21,11 @@ New Features
 
 Bug Fixes
 ^^^^^^^^^
+
+- ``photutils.aperture``
+
+  - Fixed a bug in ``aperture_photometry`` where an error was not raised
+    if the data and error arrays have different units. [#1285].
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/aperture/_photometry_utils.py
+++ b/photutils/aperture/_photometry_utils.py
@@ -41,22 +41,20 @@ def _handle_units(data, error):
     and `~photutils.aperture.PixelAperture.do_photometry`.
     """
     # check Quantity inputs
-    inputs = (data, error)
-    has_unit = [hasattr(x, 'unit') for x in inputs if x is not None]
-    use_units = all(has_unit)
-    if any(has_unit) and not use_units:
+    unit = set(getattr(arr, 'unit', None)
+               for arr in (data, error) if arr is not None)
+    if len(unit) > 1:
         raise ValueError('If data or error has units, then they both must '
                          'have the same units.')
 
     # strip data and error units for performance
-    if use_units:
+    unit = unit.pop()
+    if unit is not None:
         unit = data.unit
         data = data.value
 
         if error is not None:
             error = error.value
-    else:
-        unit = None
 
     return data, error, unit
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -266,23 +266,22 @@ class SourceCatalog:
         self._data_unit.
         """
         inputs = (data, error, background)
-        has_unit = [hasattr(x, 'unit') for x in inputs if x is not None]
-        use_units = all(has_unit)
-        if any(has_unit) and not use_units:
-            raise ValueError('If any of data, error, or background has '
-                             'units, then they all must all have units.')
-        if use_units:
+        unit = set(getattr(arr, 'unit', None)
+                   for arr in inputs if arr is not None)
+        if len(unit) > 1:
+            raise ValueError('If data, error, or background has units, then '
+                             'they must all have the same units.')
+
+        unit = unit.pop()
+        if unit is not None:
             self._data_unit = data.unit
             data = data.value
+
             if error is not None:
-                if error.unit != self._data_unit:
-                    raise ValueError('error must have the same units as data')
                 error = error.value
             if background is not None:
-                if background.unit != self._data_unit:
-                    raise ValueError('background must have the same units as '
-                                     'data')
                 background = background.value
+
         return data, error, background
 
     def _validate_segment_img(self, segment_img):


### PR DESCRIPTION
This PR fixes a bug in ``aperture_photometry`` where an error was not raised if the data and error arrays have different units.