### PR TITLE
Fix Background2D pad bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,12 @@ Bug Fixes
   - Fixed a bug in ``aperture_photometry`` where an error was not raised
     if the data and error arrays have different units. [#1285].
 
+- ``photutils.background``
+
+  - Fixed a bug in ``Background2D`` where using the ``pad`` edge method
+    would result in incorrect image padding if only one of the axes needed
+    padding. [#1292]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -305,7 +305,9 @@ class Background2D:
         if np.sum(extra_size) != 0:
             # pad or crop the data
             if self.edge_method == 'pad':
-                pad_size = self.box_size - extra_size
+                pad_size = (np.ceil(self.data.shape /
+                                    self.box_size).astype(int)
+                            * self.box_size) - self.data.shape
                 pad_width = ((0, pad_size[0]), (0, pad_size[1]))
                 data = np.pad(self.data, pad_width, mode='constant',
                               constant_values=np.nan)

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -115,6 +115,18 @@ class TestBackground2D:
         assert_allclose(bkg1.background, bkg2.background, rtol=2e-6)
         assert_allclose(bkg1.background_rms, bkg2.background_rms)
 
+        shape1 = (128, 256)
+        shape2 = (129, 256)
+        box_size = (16, 16)
+        data1 = np.ones(shape1)
+        data2 = np.ones(shape2)
+        bkg1 = Background2D(data1, box_size)
+        bkg2 = Background2D(data2, box_size)
+        assert bkg1.background_mesh.shape == (8, 16)
+        assert bkg2.background_mesh.shape == (9, 16)
+        assert bkg1.background.shape == shape1
+        assert bkg2.background.shape == shape2
+
     @pytest.mark.parametrize('box_size', ([(25, 25), (23, 22)]))
     def test_background_mask(self, box_size):
         """


### PR DESCRIPTION
This PR fixes a bug in `Background2D` where using the `pad` edge method would result in incorrect image padding if only one of the axes needed padding.

Fixes #1289 