### PR TITLE
Raise ValueError for non-positive sizes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,11 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - A ``ValueError`` is now raised if non-positive sizes are input to
+    sky-based apertures. [#1295]
+
 - ``photutils.background``
 
   - Removed the deprecated ``background_mesh_ma`` and

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -91,7 +91,7 @@ class PixelPositions(ApertureAttribute):
 
         value = np.atleast_2d(value)
         if (value.shape[1] != 2 and value.shape[0] != 2) or value.ndim > 2:
-            raise TypeError(f'{self.name} must be a (x, y) pixel position '
+            raise TypeError(f'{self.name!r} must be a (x, y) pixel position '
                             'or a list or array of (x, y) pixel positions.')
 
 
@@ -102,7 +102,7 @@ class SkyCoordPositions(ApertureAttribute):
 
     def _validate(self, value):
         if not isinstance(value, SkyCoord):
-            raise ValueError(f'{self.name} must be a SkyCoord instance')
+            raise ValueError(f'{self.name!r} must be a SkyCoord instance')
 
 
 class Scalar(ApertureAttribute):
@@ -112,7 +112,7 @@ class Scalar(ApertureAttribute):
 
     def _validate(self, value):
         if not np.isscalar(value):
-            raise ValueError(f'{self.name} must be a scalar')
+            raise ValueError(f'{self.name!r} must be a scalar')
 
 
 class PositiveScalar(ApertureAttribute):
@@ -122,7 +122,7 @@ class PositiveScalar(ApertureAttribute):
 
     def _validate(self, value):
         if not np.isscalar(value) or value <= 0:
-            raise ValueError(f'{self.name} must be a positive scalar')
+            raise ValueError(f'{self.name!r} must be a positive scalar')
 
 
 class ScalarAngle(ApertureAttribute):
@@ -134,12 +134,12 @@ class ScalarAngle(ApertureAttribute):
     def _validate(self, value):
         if isinstance(value, u.Quantity):
             if not value.isscalar:
-                raise ValueError(f'{self.name} must be a scalar')
+                raise ValueError(f'{self.name!r} must be a scalar')
 
             if not value.unit.physical_type == 'angle':
-                raise ValueError(f'{self.name} must have angular units')
+                raise ValueError(f'{self.name!r} must have angular units')
         else:
-            raise TypeError(f'{self.name} must be a scalar angle')
+            raise TypeError(f'{self.name!r} must be a scalar angle')
 
 
 class ScalarAngleOrPixel(ApertureAttribute):
@@ -154,15 +154,15 @@ class ScalarAngleOrPixel(ApertureAttribute):
     def _validate(self, value):
         if isinstance(value, u.Quantity):
             if not value.isscalar:
-                raise ValueError(f'{self.name} must be a scalar')
+                raise ValueError(f'{self.name!r} must be a scalar')
 
             if not (value.unit.physical_type == 'angle' or
                     value.unit == u.pixel):
-                raise ValueError(f'{self.name} must have angular or pixel '
+                raise ValueError(f'{self.name!r} must have angular or pixel '
                                  'units')
 
             if not value > 0:
-                raise ValueError(f'{self.name} must be strictly positive')
+                raise ValueError(f'{self.name!r} must be strictly positive')
         else:
-            raise TypeError(f'{self.name} must be a scalar angle or pixel '
+            raise TypeError(f'{self.name!r} must be a scalar angle or pixel '
                             'Quantity')

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -32,7 +32,7 @@ class ApertureAttribute:
 
     def __get__(self, instance, owner):
         if instance is None:
-            return self
+            return self  # pragma: no cover
         return instance.__dict__[self.name]
 
     def __set__(self, instance, value):
@@ -42,7 +42,7 @@ class ApertureAttribute:
         instance.__dict__[self.name] = value
 
     def __delete__(self, instance):
-        del instance.__dict__[self.name]
+        del instance.__dict__[self.name]  # pragma: no cover
 
     def _validate(self, value):
         """
@@ -50,7 +50,7 @@ class ApertureAttribute:
 
         An exception is raised if the value is invalid.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 class PixelPositions(ApertureAttribute):

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -9,7 +9,7 @@ import astropy.units as u
 import numpy as np
 
 __all__ = ['ApertureAttribute', 'PixelPositions', 'SkyCoordPositions',
-           'Scalar', 'PositiveScalar', 'AngleOrPixelScalarQuantity']
+           'Scalar', 'PositiveScalar', 'ScalarAngle', 'ScalarAngleOrPixel']
 
 
 class ApertureAttribute:
@@ -142,10 +142,13 @@ class ScalarAngle(ApertureAttribute):
             raise TypeError(f'{self.name} must be a scalar angle')
 
 
-class AngleOrPixelScalarQuantity(ApertureAttribute):
+class ScalarAngleOrPixel(ApertureAttribute):
     """
-    Check that value is either an angular or a pixel scalar
-    `~astropy.units.Quantity`.
+    Check that value is a scalar angle, either as a
+    `~astropy.coordinates.Angle` or `~astropy.units.Quantity` with
+    angular units, or a scalar `~astropy.units.Quantity` in pixel units.
+
+    The value must be strictly positive (> 0).
     """
 
     def _validate(self, value):
@@ -157,6 +160,9 @@ class AngleOrPixelScalarQuantity(ApertureAttribute):
                     value.unit == u.pixel):
                 raise ValueError(f'{self.name} must have angular or pixel '
                                  'units')
+
+            if not value > 0:
+                raise ValueError(f'{self.name} must be strictly positive')
         else:
-            raise TypeError(f'{self.name} must be an astropy Quantity '
-                            'instance')
+            raise TypeError(f'{self.name} must be a scalar angle or pixel '
+                            'Quantity')

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -125,10 +125,10 @@ class PositiveScalar(ApertureAttribute):
             raise ValueError(f'{self.name} must be a positive scalar')
 
 
-class AngleScalarQuantity(ApertureAttribute):
+class ScalarAngle(ApertureAttribute):
     """
-    Check that value is either an angular scalar
-    `~astropy.units.Quantity`.
+    Check that value is a scalar angle, either as an astropy Angle or
+    Quantity with angular units.
     """
 
     def _validate(self, value):
@@ -139,8 +139,7 @@ class AngleScalarQuantity(ApertureAttribute):
             if not value.unit.physical_type == 'angle':
                 raise ValueError(f'{self.name} must have angular units')
         else:
-            raise TypeError(f'{self.name} must be an astropy Quantity '
-                            'instance')
+            raise TypeError(f'{self.name} must be a scalar angle')
 
 
 class AngleOrPixelScalarQuantity(ApertureAttribute):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -8,8 +8,8 @@ import math
 
 import numpy as np
 
-from .attributes import (AngleOrPixelScalarQuantity, PixelPositions,
-                         PositiveScalar, SkyCoordPositions)
+from .attributes import (PixelPositions, PositiveScalar, SkyCoordPositions,
+                         ScalarAngleOrPixel)
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import circular_overlap_grid
@@ -370,7 +370,7 @@ class SkyCircularAperture(SkyAperture):
     positions = SkyCoordPositions(
         'positions',
         description='The center position(s) in sky coordinates.')
-    r = AngleOrPixelScalarQuantity(
+    r = ScalarAngleOrPixel(
         'r',
         description='The radius, in angular or pixel units.')
 
@@ -433,10 +433,10 @@ class SkyCircularAnnulus(SkyAperture):
     positions = SkyCoordPositions(
         'positions',
         description='The center position(s) in sky coordinates.')
-    r_in = AngleOrPixelScalarQuantity(
+    r_in = ScalarAngleOrPixel(
         'r_in',
         description='The inner radius, in angular or pixel units.')
-    r_out = AngleOrPixelScalarQuantity(
+    r_out = ScalarAngleOrPixel(
         'r_out',
         description='The outer radius, in angular or pixel units.')
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -9,8 +9,8 @@ import math
 import astropy.units as u
 import numpy as np
 
-from .attributes import (AngleOrPixelScalarQuantity, ScalarAngle, PixelPositions,
-                         PositiveScalar, Scalar, SkyCoordPositions)
+from .attributes import (ScalarAngle, PixelPositions, PositiveScalar, Scalar,
+                         SkyCoordPositions, ScalarAngleOrPixel)
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
@@ -455,10 +455,10 @@ class SkyEllipticalAperture(SkyAperture):
     positions = SkyCoordPositions(
         'positions',
         description='The center position(s) in sky coordinates.')
-    a = AngleOrPixelScalarQuantity(
+    a = ScalarAngleOrPixel(
         'a',
         description='The semimajor axis, in angular or pixel units.')
-    b = AngleOrPixelScalarQuantity(
+    b = ScalarAngleOrPixel(
         'b',
         description='The semiminor axis, in angular or pixel units.')
     theta = ScalarAngle(
@@ -546,16 +546,16 @@ class SkyEllipticalAnnulus(SkyAperture):
     positions = SkyCoordPositions(
         'positions',
         description='The center position(s) in sky coordinates.')
-    a_in = AngleOrPixelScalarQuantity(
+    a_in = ScalarAngleOrPixel(
         'a_in',
         description='The inner semimajor axis, in angular or pixel units.')
-    a_out = AngleOrPixelScalarQuantity(
+    a_out = ScalarAngleOrPixel(
         'a_out',
         description='The outer semimajor axis, in angular or pixel units.')
-    b_in = AngleOrPixelScalarQuantity(
+    b_in = ScalarAngleOrPixel(
         'b_in',
         description='The inner semiminor axis, in angular or pixel units.')
-    b_out = AngleOrPixelScalarQuantity(
+    b_out = ScalarAngleOrPixel(
         'b_out',
         description='The outer semiminor axis, in angular or pixel units.')
     theta = ScalarAngle(

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -9,9 +9,8 @@ import math
 import astropy.units as u
 import numpy as np
 
-from .attributes import (AngleOrPixelScalarQuantity, AngleScalarQuantity,
-                         PixelPositions, PositiveScalar, Scalar,
-                         SkyCoordPositions)
+from .attributes import (AngleOrPixelScalarQuantity, ScalarAngle, PixelPositions,
+                         PositiveScalar, Scalar, SkyCoordPositions)
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
@@ -462,7 +461,7 @@ class SkyEllipticalAperture(SkyAperture):
     b = AngleOrPixelScalarQuantity(
         'b',
         description='The semiminor axis, in angular or pixel units.')
-    theta = AngleScalarQuantity(
+    theta = ScalarAngle(
         'theta',
         description=('The position angle in angular units of the ellipse '
                      'semimajor axis.'))
@@ -559,7 +558,7 @@ class SkyEllipticalAnnulus(SkyAperture):
     b_out = AngleOrPixelScalarQuantity(
         'b_out',
         description='The outer semiminor axis, in angular or pixel units.')
-    theta = AngleScalarQuantity(
+    theta = ScalarAngle(
         'theta',
         description=('The position angle in angular units of the ellipse '
                      'semimajor axis.'))

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -9,8 +9,8 @@ import math
 import astropy.units as u
 import numpy as np
 
-from .attributes import (AngleOrPixelScalarQuantity, ScalarAngle, PixelPositions,
-                         PositiveScalar, Scalar, SkyCoordPositions)
+from .attributes import (ScalarAngle, PixelPositions, PositiveScalar, Scalar,
+                         SkyCoordPositions, ScalarAngleOrPixel)
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
@@ -493,10 +493,10 @@ class SkyRectangularAperture(SkyAperture):
     positions = SkyCoordPositions(
         'positions',
         description='The center position(s) in sky coordinates.')
-    w = AngleOrPixelScalarQuantity(
+    w = ScalarAngleOrPixel(
         'w',
         description='The full width, in angular or pixel units.')
-    h = AngleOrPixelScalarQuantity(
+    h = ScalarAngleOrPixel(
         'h',
         description='The full height, in angular or pixel units.')
     theta = ScalarAngle(
@@ -592,16 +592,16 @@ class SkyRectangularAnnulus(SkyAperture):
     positions = SkyCoordPositions(
         'positions',
         description='The center position(s) in sky coordinates.')
-    w_in = AngleOrPixelScalarQuantity(
+    w_in = ScalarAngleOrPixel(
         'w_in',
         description='The inner full width, in angular or pixel units.')
-    w_out = AngleOrPixelScalarQuantity(
+    w_out = ScalarAngleOrPixel(
         'w_out',
         description='The outer full width, in angular or pixel units.')
-    h_in = AngleOrPixelScalarQuantity(
+    h_in = ScalarAngleOrPixel(
         'h_in',
         description='The inner full height, in angular or pixel units.')
-    h_out = AngleOrPixelScalarQuantity(
+    h_out = ScalarAngleOrPixel(
         'h_out',
         description='The outer full height, in angular or pixel units.')
     theta = ScalarAngle(

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -9,9 +9,8 @@ import math
 import astropy.units as u
 import numpy as np
 
-from .attributes import (AngleOrPixelScalarQuantity, AngleScalarQuantity,
-                         PixelPositions, PositiveScalar, Scalar,
-                         SkyCoordPositions)
+from .attributes import (AngleOrPixelScalarQuantity, ScalarAngle, PixelPositions,
+                         PositiveScalar, Scalar, SkyCoordPositions)
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
@@ -500,7 +499,7 @@ class SkyRectangularAperture(SkyAperture):
     h = AngleOrPixelScalarQuantity(
         'h',
         description='The full height, in angular or pixel units.')
-    theta = AngleScalarQuantity(
+    theta = ScalarAngle(
         'theta',
         description=('The position angle (in angular units) of the '
                      'rectangle "width" side.'))
@@ -605,7 +604,7 @@ class SkyRectangularAnnulus(SkyAperture):
     h_out = AngleOrPixelScalarQuantity(
         'h_out',
         description='The outer full height, in angular or pixel units.')
-    theta = AngleScalarQuantity(
+    theta = ScalarAngle(
         'theta',
         description=('The position angle (in angular units) of the '
                      'rectangle "width" side.'))

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -19,6 +19,7 @@ POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
 SKYCOORD = SkyCoord(ra=RA, dec=DEC, unit='deg')
 UNIT = u.arcsec
+RADII = (0.0, -1.0, -np.inf)
 
 
 class TestCircularAperture(BaseTestAperture):
@@ -40,6 +41,12 @@ class TestCircularAperture(BaseTestAperture):
 
         # test creating a legend with these patches
         plt.legend(my_patches, list(range(len(my_patches))))
+
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            CircularAperture(POSITIONS, radius)
 
 
 class TestCircularAnnulus(BaseTestAperture):
@@ -64,13 +71,35 @@ class TestCircularAnnulus(BaseTestAperture):
         labels = list(range(len(my_patches)))
         plt.legend(my_patches, labels)
 
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            CircularAnnulus(POSITIONS, r_in=radius, r_out=7.)
+        with pytest.raises(ValueError):
+            CircularAnnulus(POSITIONS, r_in=3., r_out=radius)
+
 
 class TestSkyCircularAperture(BaseTestAperture):
     aperture = SkyCircularAperture(SKYCOORD, r=3.*UNIT)
 
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            SkyCircularAperture(SKYCOORD, r=radius*UNIT)
+
 
 class TestSkyCircularAnnulus(BaseTestAperture):
     aperture = SkyCircularAnnulus(SKYCOORD, r_in=3.*UNIT, r_out=7.*UNIT)
+
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            SkyCircularAnnulus(SKYCOORD, r_in=radius*UNIT, r_out=7.*UNIT)
+        with pytest.raises(ValueError):
+            SkyCircularAnnulus(SKYCOORD, r_in=3.*UNIT, r_out=radius*UNIT)
 
 
 def test_slicing():

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -6,6 +6,7 @@ Tests for the ellipse module.
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 import numpy as np
+import pytest
 
 from .test_aperture_common import BaseTestAperture
 from ..ellipse import (EllipticalAperture, EllipticalAnnulus,
@@ -16,22 +17,74 @@ POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
 SKYCOORD = SkyCoord(ra=RA, dec=DEC, unit='deg')
 UNIT = u.arcsec
+RADII = (0.0, -1.0, -np.inf)
 
 
 class TestEllipticalAperture(BaseTestAperture):
     aperture = EllipticalAperture(POSITIONS, a=10., b=5., theta=np.pi/2.)
+
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            EllipticalAperture(POSITIONS, a=radius, b=5., theta=np.pi/2.)
+        with pytest.raises(ValueError):
+            EllipticalAperture(POSITIONS, a=10., b=radius, theta=np.pi/2.)
 
 
 class TestEllipticalAnnulus(BaseTestAperture):
     aperture = EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=17,
                                  theta=np.pi/3)
 
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            EllipticalAnnulus(POSITIONS, a_in=radius, a_out=20., b_out=17,
+                              theta=np.pi/3)
+        with pytest.raises(ValueError):
+            EllipticalAnnulus(POSITIONS, a_in=10., a_out=radius, b_out=17,
+                              theta=np.pi/3)
+        with pytest.raises(ValueError):
+            EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=radius,
+                              theta=np.pi/3)
+        with pytest.raises(ValueError):
+            EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=17,
+                              b_in=radius, theta=np.pi/3)
+
 
 class TestSkyEllipticalAperture(BaseTestAperture):
     aperture = SkyEllipticalAperture(SKYCOORD, a=10.*UNIT, b=5.*UNIT,
                                      theta=30*u.deg)
 
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            SkyEllipticalAperture(SKYCOORD, a=radius*UNIT, b=5.*UNIT,
+                                  theta=30*u.deg)
+        with pytest.raises(ValueError):
+            SkyEllipticalAperture(SKYCOORD, a=10.*UNIT, b=radius*UNIT,
+                                  theta=30*u.deg)
+
 
 class TestSkyEllipticalAnnulus(BaseTestAperture):
     aperture = SkyEllipticalAnnulus(SKYCOORD, a_in=10.*UNIT, a_out=20.*UNIT,
                                     b_out=17.*UNIT, theta=60*u.deg)
+
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            SkyEllipticalAnnulus(SKYCOORD, a_in=radius*UNIT, a_out=20.*UNIT,
+                                 b_out=17.*UNIT, theta=60*u.deg)
+        with pytest.raises(ValueError):
+            SkyEllipticalAnnulus(SKYCOORD, a_in=10.*UNIT, a_out=radius*UNIT,
+                                 b_out=17.*UNIT, theta=60*u.deg)
+        with pytest.raises(ValueError):
+            SkyEllipticalAnnulus(SKYCOORD, a_in=10.*UNIT, a_out=20.*UNIT,
+                                 b_out=radius*UNIT, theta=60*u.deg)
+        with pytest.raises(ValueError):
+            SkyEllipticalAnnulus(SKYCOORD, a_in=10.*UNIT, a_out=20.*UNIT,
+                                 b_out=17.*UNIT, b_in=radius*UNIT,
+                                 theta=60*u.deg)

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -14,7 +14,6 @@ from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import Table
 import astropy.units as u
 from astropy.wcs import WCS
-from astropy.wcs.utils import pixel_to_skycoord
 
 from ..photometry import aperture_photometry
 from ..circle import (CircularAperture, CircularAnnulus, SkyCircularAperture,
@@ -330,14 +329,7 @@ def test_wcs_based_photometry():
     pos_orig_pixel = u.Quantity(([160., 25., 150., 90.],
                                  [70., 40., 25., 60.]), unit=u.pixel)
 
-    try:
-        pos_skycoord = wcs.pixel_to_world(pos_orig_pixel[0],
-                                          pos_orig_pixel[1])
-    except AttributeError:
-        # for Astropy < 3.1
-        pos_skycoord = pixel_to_skycoord(pos_orig_pixel[0],
-                                         pos_orig_pixel[1], wcs)
-
+    pos_skycoord = wcs.pixel_to_world(pos_orig_pixel[0], pos_orig_pixel[1])
     pos_skycoord_s = pos_skycoord[2]
 
     photometry_skycoord_circ = aperture_photometry(
@@ -848,13 +840,7 @@ def test_scalar_skycoord():
 
     data = make_4gaussians_image()
     wcs = make_wcs(data.shape)
-
-    try:
-        skycoord = wcs.pixel_to_world(90, 60)
-    except AttributeError:
-        # for Astropy < 3.1
-        skycoord = pixel_to_skycoord(90, 60, wcs)
-
+    skycoord = wcs.pixel_to_world(90, 60)
     aper = SkyCircularAperture(skycoord, r=0.1*u.arcsec)
     tbl = aperture_photometry(data, aper, wcs=wcs)
     assert isinstance(tbl['sky_center'], SkyCoord)
@@ -867,12 +853,7 @@ def test_nddata_input():
     mask[8:13, 8:13] = True
     unit = 'adu'
     wcs = make_wcs(data.shape)
-    try:
-        skycoord = wcs.pixel_to_world(10, 10)
-    except AttributeError:
-        # for Astropy < 3.1
-        skycoord = pixel_to_skycoord(10, 10, wcs)
-
+    skycoord = wcs.pixel_to_world(10, 10)
     aper = SkyCircularAperture(skycoord, r=0.7*u.arcsec)
 
     tbl1 = aperture_photometry(data*u.adu, aper, error=error*u.adu, mask=mask,

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -6,6 +6,7 @@ Tests for the rectangle module.
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 import numpy as np
+import pytest
 
 from .test_aperture_common import BaseTestAperture
 
@@ -17,22 +18,74 @@ POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
 SKYCOORD = SkyCoord(ra=RA, dec=DEC, unit='deg')
 UNIT = u.arcsec
+RADII = (0.0, -1.0, -np.inf)
 
 
 class TestRectangularAperture(BaseTestAperture):
     aperture = RectangularAperture(POSITIONS, w=10., h=5., theta=np.pi/2.)
+
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            RectangularAperture(POSITIONS, w=radius, h=5., theta=np.pi/2.)
+        with pytest.raises(ValueError):
+            RectangularAperture(POSITIONS, w=10., h=radius, theta=np.pi/2.)
 
 
 class TestRectangularAnnulus(BaseTestAperture):
     aperture = RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=17,
                                   theta=np.pi/3)
 
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            RectangularAnnulus(POSITIONS, w_in=radius, w_out=20., h_out=17,
+                               theta=np.pi/3)
+        with pytest.raises(ValueError):
+            RectangularAnnulus(POSITIONS, w_in=10., w_out=radius, h_out=17,
+                               theta=np.pi/3)
+        with pytest.raises(ValueError):
+            RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=radius,
+                               theta=np.pi/3)
+        with pytest.raises(ValueError):
+            RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=17,
+                               h_in=radius, theta=np.pi/3)
+
 
 class TestSkyRectangularAperture(BaseTestAperture):
     aperture = SkyRectangularAperture(SKYCOORD, w=10.*UNIT, h=5.*UNIT,
                                       theta=30*u.deg)
 
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            SkyRectangularAperture(SKYCOORD, w=radius*UNIT, h=5.*UNIT,
+                                   theta=30*u.deg)
+        with pytest.raises(ValueError):
+            SkyRectangularAperture(SKYCOORD, w=10.*UNIT, h=radius*UNIT,
+                                   theta=30*u.deg)
+
 
 class TestSkyRectangularAnnulus(BaseTestAperture):
     aperture = SkyRectangularAnnulus(SKYCOORD, w_in=10.*UNIT, w_out=20.*UNIT,
                                      h_out=17.*UNIT, theta=60*u.deg)
+
+    @staticmethod
+    @pytest.mark.parametrize('radius', RADII)
+    def test_invalid_params(radius):
+        with pytest.raises(ValueError):
+            SkyRectangularAnnulus(SKYCOORD, w_in=radius*UNIT, w_out=20.*UNIT,
+                                  h_out=17.*UNIT, theta=60*u.deg)
+        with pytest.raises(ValueError):
+            SkyRectangularAnnulus(SKYCOORD, w_in=10.*UNIT, w_out=radius*UNIT,
+                                  h_out=17.*UNIT, theta=60*u.deg)
+        with pytest.raises(ValueError):
+            SkyRectangularAnnulus(SKYCOORD, w_in=10.*UNIT, w_out=20.*UNIT,
+                                  h_out=radius*UNIT, theta=60*u.deg)
+        with pytest.raises(ValueError):
+            SkyRectangularAnnulus(SKYCOORD, w_in=10.*UNIT, w_out=20.*UNIT,
+                                  h_out=17.*UNIT, h_in=radius*UNIT,
+                                  theta=60*u.deg)


### PR DESCRIPTION
A `ValueError` is now raised if non-positive sizes are input to sky-based apertures.

This PR also renames two of the descriptor classes used for validation, but those classes are not part of the public API.