### PR TITLE
DOC: Add ref to Aperture Photometry top level

### DIFF
--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -1,3 +1,5 @@
+.. _photutils-aperture:
+
 Aperture Photometry (`photutils.aperture`)
 ==========================================
 


### PR DESCRIPTION
I want to be able to reference to this page by intersphinx.