### PR TITLE
Update attribute descriptors to use __set_name__

### DIFF
--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -18,13 +18,12 @@ class ApertureAttribute:
 
     Parameters
     ----------
-    description : str, optional
-        The description of the attribute, which will be used as the
-        attribute documentation.
+    doc : str, optional
+        The description string for the attribute.
     """
 
-    def __init__(self, description=''):
-        self.__doc__ = description
+    def __init__(self, doc=''):
+        self.__doc__ = doc
 
     def __set_name__(self, owner, name):
         self.name = name

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -18,17 +18,16 @@ class ApertureAttribute:
 
     Parameters
     ----------
-    name : str
-        The name of the attribute.
-
     description : str, optional
         The description of the attribute, which will be used as the
         attribute documentation.
     """
 
-    def __init__(self, name, description=''):
-        self.name = name
+    def __init__(self, description=''):
         self.__doc__ = description
+
+    def __set_name__(self, owner, name):
+        self.name = name
 
     def __get__(self, instance, owner):
         if instance is None:

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -140,8 +140,8 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('r',)
-    positions = PixelPositions(description='The center pixel position(s).')
-    r = PositiveScalar(description='The radius in pixels.')
+    positions = PixelPositions('The center pixel position(s).')
+    r = PositiveScalar('The radius in pixels.')
 
     def __init__(self, positions, r):
         self.positions = positions
@@ -258,9 +258,9 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('r_in', 'r_out')
-    positions = PixelPositions(description='The center pixel position(s).')
-    r_in = PositiveScalar(description='The inner radius in pixels.')
-    r_out = PositiveScalar(description='The outer radius in pixels.')
+    positions = PixelPositions('The center pixel position(s).')
+    r_in = PositiveScalar('The inner radius in pixels.')
+    r_out = PositiveScalar('The outer radius in pixels.')
 
     def __init__(self, positions, r_in, r_out):
         if not r_out > r_in:
@@ -363,10 +363,8 @@ class SkyCircularAperture(SkyAperture):
     """
 
     _shape_params = ('r',)
-    positions = SkyCoordPositions(description='The center position(s) in sky '
-                                  'coordinates.')
-    r = ScalarAngleOrPixel(
-        description='The radius, in angular or pixel units.')
+    positions = SkyCoordPositions('The center position(s) in sky coordinates.')
+    r = ScalarAngleOrPixel('The radius, in angular or pixel units.')
 
     def __init__(self, positions, r):
         self.positions = positions
@@ -424,12 +422,9 @@ class SkyCircularAnnulus(SkyAperture):
     """
 
     _shape_params = ('r_in', 'r_out')
-    positions = SkyCoordPositions(
-        description='The center position(s) in sky coordinates.')
-    r_in = ScalarAngleOrPixel(
-        description='The inner radius, in angular or pixel units.')
-    r_out = ScalarAngleOrPixel(
-        description='The outer radius, in angular or pixel units.')
+    positions = SkyCoordPositions('The center position(s) in sky coordinates.')
+    r_in = ScalarAngleOrPixel('The inner radius, in angular or pixel units.')
+    r_out = ScalarAngleOrPixel('The outer radius, in angular or pixel units.')
 
     def __init__(self, positions, r_in, r_out):
         if r_in.unit.physical_type != r_out.unit.physical_type:

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -140,9 +140,8 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('r',)
-    positions = PixelPositions('positions',
-                               description='The center pixel position(s).')
-    r = PositiveScalar('r', description='The radius in pixels.')
+    positions = PixelPositions(description='The center pixel position(s).')
+    r = PositiveScalar(description='The radius in pixels.')
 
     def __init__(self, positions, r):
         self.positions = positions
@@ -259,12 +258,9 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('r_in', 'r_out')
-    positions = PixelPositions('positions',
-                               description='The center pixel position(s).')
-    r_in = PositiveScalar('r_in',
-                          description='The inner radius in pixels.')
-    r_out = PositiveScalar('r_out',
-                           description='The outer radius in pixels.')
+    positions = PixelPositions(description='The center pixel position(s).')
+    r_in = PositiveScalar(description='The inner radius in pixels.')
+    r_out = PositiveScalar(description='The outer radius in pixels.')
 
     def __init__(self, positions, r_in, r_out):
         if not r_out > r_in:
@@ -367,11 +363,9 @@ class SkyCircularAperture(SkyAperture):
     """
 
     _shape_params = ('r',)
-    positions = SkyCoordPositions(
-        'positions',
-        description='The center position(s) in sky coordinates.')
+    positions = SkyCoordPositions(description='The center position(s) in sky '
+                                  'coordinates.')
     r = ScalarAngleOrPixel(
-        'r',
         description='The radius, in angular or pixel units.')
 
     def __init__(self, positions, r):
@@ -431,13 +425,10 @@ class SkyCircularAnnulus(SkyAperture):
 
     _shape_params = ('r_in', 'r_out')
     positions = SkyCoordPositions(
-        'positions',
         description='The center position(s) in sky coordinates.')
     r_in = ScalarAngleOrPixel(
-        'r_in',
         description='The inner radius, in angular or pixel units.')
     r_out = ScalarAngleOrPixel(
-        'r_out',
         description='The outer radius, in angular or pixel units.')
 
     def __init__(self, positions, r_in, r_out):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -168,12 +168,11 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     """
 
     _shape_params = ('a', 'b', 'theta')
-    positions = PixelPositions(description='The center pixel position(s).')
-    a = PositiveScalar(description='The semimajor axis in pixels.')
-    b = PositiveScalar(description='The semiminor axis in pixels.')
-    theta = Scalar(description=('The counterclockwise rotation angle in '
-                                'radians of the ellipse semimajor axis from '
-                                'the positive x axis.'))
+    positions = PixelPositions('The center pixel position(s).')
+    a = PositiveScalar('The semimajor axis in pixels.')
+    b = PositiveScalar('The semiminor axis in pixels.')
+    theta = Scalar('The counterclockwise rotation angle in radians of the '
+                   'ellipse semimajor axis from the positive x axis.')
 
     def __init__(self, positions, a, b, theta=0.):
         self.positions = positions
@@ -310,14 +309,13 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     """
 
     _shape_params = ('a_in', 'a_out', 'b_in', 'b_out', 'theta')
-    positions = PixelPositions(description='The center pixel position(s).')
-    a_in = PositiveScalar(description='The inner semimajor axis in pixels.')
-    a_out = PositiveScalar(description='The outer semimajor axis in pixels.')
-    b_in = PositiveScalar(description='The inner semiminor axis in pixels.')
-    b_out = PositiveScalar(description='The outer semiminor axis in pixels.')
-    theta = Scalar(description=('The counterclockwise rotation angle in '
-                                'radians of the ellipse semimajor axis from '
-                                'the positive x axis.'))
+    positions = PixelPositions('The center pixel position(s).')
+    a_in = PositiveScalar('The inner semimajor axis in pixels.')
+    a_out = PositiveScalar('The outer semimajor axis in pixels.')
+    b_in = PositiveScalar('The inner semiminor axis in pixels.')
+    b_out = PositiveScalar('The outer semiminor axis in pixels.')
+    theta = Scalar('The counterclockwise rotation angle in radians of the '
+                   'ellipse semimajor axis from the positive x axis.')
 
     def __init__(self, positions, a_in, a_out, b_out, b_in=None, theta=0.):
         if not a_out > a_in:
@@ -444,15 +442,11 @@ class SkyEllipticalAperture(SkyAperture):
     """
 
     _shape_params = ('a', 'b', 'theta')
-    positions = SkyCoordPositions(
-        description='The center position(s) in sky coordinates.')
-    a = ScalarAngleOrPixel(
-        description='The semimajor axis, in angular or pixel units.')
-    b = ScalarAngleOrPixel(
-        description='The semiminor axis, in angular or pixel units.')
-    theta = ScalarAngle(
-        description=('The position angle in angular units of the ellipse '
-                     'semimajor axis.'))
+    positions = SkyCoordPositions('The center position(s) in sky coordinates.')
+    a = ScalarAngleOrPixel('The semimajor axis, in angular or pixel units.')
+    b = ScalarAngleOrPixel('The semiminor axis, in angular or pixel units.')
+    theta = ScalarAngle('The position angle in angular units of the ellipse '
+                        'semimajor axis.')
 
     def __init__(self, positions, a, b, theta=0.*u.deg):
         if a.unit.physical_type != b.unit.physical_type:
@@ -531,19 +525,17 @@ class SkyEllipticalAnnulus(SkyAperture):
     """
 
     _shape_params = ('a_in', 'a_out', 'b_in', 'b_out', 'theta')
-    positions = SkyCoordPositions(
-        description='The center position(s) in sky coordinates.')
-    a_in = ScalarAngleOrPixel(
-        description='The inner semimajor axis, in angular or pixel units.')
-    a_out = ScalarAngleOrPixel(
-        description='The outer semimajor axis, in angular or pixel units.')
-    b_in = ScalarAngleOrPixel(
-        description='The inner semiminor axis, in angular or pixel units.')
-    b_out = ScalarAngleOrPixel(
-        description='The outer semiminor axis, in angular or pixel units.')
-    theta = ScalarAngle(
-        description=('The position angle in angular units of the ellipse '
-                     'semimajor axis.'))
+    positions = SkyCoordPositions('The center position(s) in sky coordinates.')
+    a_in = ScalarAngleOrPixel('The inner semimajor axis, in angular or pixel '
+                              'units.')
+    a_out = ScalarAngleOrPixel('The outer semimajor axis, in angular or pixel '
+                               'units.')
+    b_in = ScalarAngleOrPixel('The inner semiminor axis, in angular or pixel '
+                              'units.')
+    b_out = ScalarAngleOrPixel('The outer semiminor axis, in angular or pixel '
+                               'units.')
+    theta = ScalarAngle('The position angle in angular units of the ellipse '
+                        'semimajor axis.')
 
     def __init__(self, positions, a_in, a_out, b_out, b_in=None,
                  theta=0.*u.deg):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -168,12 +168,10 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     """
 
     _shape_params = ('a', 'b', 'theta')
-    positions = PixelPositions('positions',
-                               description='The center pixel position(s).')
-    a = PositiveScalar('a', description='The semimajor axis in pixels.')
-    b = PositiveScalar('b', description='The semiminor axis in pixels.')
-    theta = Scalar('theta',
-                   description=('The counterclockwise rotation angle in '
+    positions = PixelPositions(description='The center pixel position(s).')
+    a = PositiveScalar(description='The semimajor axis in pixels.')
+    b = PositiveScalar(description='The semiminor axis in pixels.')
+    theta = Scalar(description=('The counterclockwise rotation angle in '
                                 'radians of the ellipse semimajor axis from '
                                 'the positive x axis.'))
 
@@ -312,18 +310,12 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     """
 
     _shape_params = ('a_in', 'a_out', 'b_in', 'b_out', 'theta')
-    positions = PixelPositions('positions',
-                               description='The center pixel position(s).')
-    a_in = PositiveScalar('a_in',
-                          description='The inner semimajor axis in pixels.')
-    a_out = PositiveScalar('a_out',
-                           description='The outer semimajor axis in pixels.')
-    b_in = PositiveScalar('b_in',
-                          description='The inner semiminor axis in pixels.')
-    b_out = PositiveScalar('b_out',
-                           description='The outer semiminor axis in pixels.')
-    theta = Scalar('theta',
-                   description=('The counterclockwise rotation angle in '
+    positions = PixelPositions(description='The center pixel position(s).')
+    a_in = PositiveScalar(description='The inner semimajor axis in pixels.')
+    a_out = PositiveScalar(description='The outer semimajor axis in pixels.')
+    b_in = PositiveScalar(description='The inner semiminor axis in pixels.')
+    b_out = PositiveScalar(description='The outer semiminor axis in pixels.')
+    theta = Scalar(description=('The counterclockwise rotation angle in '
                                 'radians of the ellipse semimajor axis from '
                                 'the positive x axis.'))
 
@@ -453,16 +445,12 @@ class SkyEllipticalAperture(SkyAperture):
 
     _shape_params = ('a', 'b', 'theta')
     positions = SkyCoordPositions(
-        'positions',
         description='The center position(s) in sky coordinates.')
     a = ScalarAngleOrPixel(
-        'a',
         description='The semimajor axis, in angular or pixel units.')
     b = ScalarAngleOrPixel(
-        'b',
         description='The semiminor axis, in angular or pixel units.')
     theta = ScalarAngle(
-        'theta',
         description=('The position angle in angular units of the ellipse '
                      'semimajor axis.'))
 
@@ -544,22 +532,16 @@ class SkyEllipticalAnnulus(SkyAperture):
 
     _shape_params = ('a_in', 'a_out', 'b_in', 'b_out', 'theta')
     positions = SkyCoordPositions(
-        'positions',
         description='The center position(s) in sky coordinates.')
     a_in = ScalarAngleOrPixel(
-        'a_in',
         description='The inner semimajor axis, in angular or pixel units.')
     a_out = ScalarAngleOrPixel(
-        'a_out',
         description='The outer semimajor axis, in angular or pixel units.')
     b_in = ScalarAngleOrPixel(
-        'b_in',
         description='The inner semiminor axis, in angular or pixel units.')
     b_out = ScalarAngleOrPixel(
-        'b_out',
         description='The outer semiminor axis, in angular or pixel units.')
     theta = ScalarAngle(
-        'theta',
         description=('The position angle in angular units of the ellipse '
                      'semimajor axis.'))
 

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -191,12 +191,11 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('w', 'h', 'theta')
-    positions = PixelPositions(description='The center pixel position(s).')
-    w = PositiveScalar(description='The full width in pixels.')
-    h = PositiveScalar(description='The full height in pixels.')
-    theta = Scalar(description=('The counterclockwise rotation angle in '
-                                'radians of the rectangle "width" side from '
-                                'the positive x axis.'))
+    positions = PixelPositions('The center pixel position(s).')
+    w = PositiveScalar('The full width in pixels.')
+    h = PositiveScalar('The full height in pixels.')
+    theta = Scalar('The counterclockwise rotation angle in radians of the '
+                   'rectangle "width" side from the positive x axis.')
 
     def __init__(self, positions, w, h, theta=0.):
         self.positions = positions
@@ -339,14 +338,13 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('w_in', 'w_out', 'h_in', 'h_out', 'theta')
-    positions = PixelPositions(description='The center pixel position(s).')
-    w_in = PositiveScalar(description='The inner full width in pixels.')
-    w_out = PositiveScalar(description='The outer full width in pixels.')
-    h_in = PositiveScalar(description='The inner full height in pixels.')
-    h_out = PositiveScalar(description='The outer full height in pixels.')
-    theta = Scalar(description=('The counterclockwise rotation angle in '
-                                'radians of the rectangle "width" side from '
-                                'the positive x axis.'))
+    positions = PixelPositions('The center pixel position(s).')
+    w_in = PositiveScalar('The inner full width in pixels.')
+    w_out = PositiveScalar('The outer full width in pixels.')
+    h_in = PositiveScalar('The inner full height in pixels.')
+    h_out = PositiveScalar('The outer full height in pixels.')
+    theta = Scalar('The counterclockwise rotation angle in radians of the '
+                   'rectangle "width" side from the positive x axis.')
 
     def __init__(self, positions, w_in, w_out, h_out, h_in=None, theta=0.):
         if not w_out > w_in:
@@ -482,15 +480,11 @@ class SkyRectangularAperture(SkyAperture):
     """
 
     _shape_params = ('w', 'h', 'theta')
-    positions = SkyCoordPositions(
-        description='The center position(s) in sky coordinates.')
-    w = ScalarAngleOrPixel(
-        description='The full width, in angular or pixel units.')
-    h = ScalarAngleOrPixel(
-        description='The full height, in angular or pixel units.')
-    theta = ScalarAngle(
-        description=('The position angle (in angular units) of the '
-                     'rectangle "width" side.'))
+    positions = SkyCoordPositions('The center position(s) in sky coordinates.')
+    w = ScalarAngleOrPixel('The full width, in angular or pixel units.')
+    h = ScalarAngleOrPixel('The full height, in angular or pixel units.')
+    theta = ScalarAngle('The position angle (in angular units) of the '
+                        'rectangle "width" side.')
 
     def __init__(self, positions, w, h, theta=0.*u.deg):
         if w.unit.physical_type != h.unit.physical_type:
@@ -577,19 +571,14 @@ class SkyRectangularAnnulus(SkyAperture):
     """
 
     _shape_params = ('w_in', 'w_out', 'h_in', 'h_out', 'theta')
-    positions = SkyCoordPositions(
-        description='The center position(s) in sky coordinates.')
-    w_in = ScalarAngleOrPixel(
-        description='The inner full width, in angular or pixel units.')
-    w_out = ScalarAngleOrPixel(
-        description='The outer full width, in angular or pixel units.')
-    h_in = ScalarAngleOrPixel(
-        description='The inner full height, in angular or pixel units.')
-    h_out = ScalarAngleOrPixel(
-        description='The outer full height, in angular or pixel units.')
-    theta = ScalarAngle(
-        description=('The position angle (in angular units) of the '
-                     'rectangle "width" side.'))
+    positions = SkyCoordPositions('The center position(s) in sky coordinates.')
+    w_in = ScalarAngleOrPixel('The inner full width, in angular or pixel units.')
+    w_out = ScalarAngleOrPixel('The outer full width, in angular or pixel units.')
+    h_in = ScalarAngleOrPixel('The inner full height, in angular or pixel units.')
+    h_out = ScalarAngleOrPixel('The outer full height, in angular or pixel '
+                               'units.')
+    theta = ScalarAngle('The position angle (in angular units) of the rectangle '
+                        '"width" side.')
 
     def __init__(self, positions, w_in, w_out, h_out, h_in=None,
                  theta=0.*u.deg):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -191,12 +191,10 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('w', 'h', 'theta')
-    positions = PixelPositions('positions',
-                               description='The center pixel position(s).')
-    w = PositiveScalar('w', description='The full width in pixels.')
-    h = PositiveScalar('h', description='The full height in pixels.')
-    theta = Scalar('theta',
-                   description=('The counterclockwise rotation angle in '
+    positions = PixelPositions(description='The center pixel position(s).')
+    w = PositiveScalar(description='The full width in pixels.')
+    h = PositiveScalar(description='The full height in pixels.')
+    theta = Scalar(description=('The counterclockwise rotation angle in '
                                 'radians of the rectangle "width" side from '
                                 'the positive x axis.'))
 
@@ -341,18 +339,12 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     """
 
     _shape_params = ('w_in', 'w_out', 'h_in', 'h_out', 'theta')
-    positions = PixelPositions('positions',
-                               description='The center pixel position(s).')
-    w_in = PositiveScalar('w_in',
-                          description='The inner full width in pixels.')
-    w_out = PositiveScalar('w_out',
-                           description='The outer full width in pixels.')
-    h_in = PositiveScalar('h_in',
-                          description='The inner full height in pixels.')
-    h_out = PositiveScalar('h_out',
-                           description='The outer full height in pixels.')
-    theta = Scalar('theta',
-                   description=('The counterclockwise rotation angle in '
+    positions = PixelPositions(description='The center pixel position(s).')
+    w_in = PositiveScalar(description='The inner full width in pixels.')
+    w_out = PositiveScalar(description='The outer full width in pixels.')
+    h_in = PositiveScalar(description='The inner full height in pixels.')
+    h_out = PositiveScalar(description='The outer full height in pixels.')
+    theta = Scalar(description=('The counterclockwise rotation angle in '
                                 'radians of the rectangle "width" side from '
                                 'the positive x axis.'))
 
@@ -491,16 +483,12 @@ class SkyRectangularAperture(SkyAperture):
 
     _shape_params = ('w', 'h', 'theta')
     positions = SkyCoordPositions(
-        'positions',
         description='The center position(s) in sky coordinates.')
     w = ScalarAngleOrPixel(
-        'w',
         description='The full width, in angular or pixel units.')
     h = ScalarAngleOrPixel(
-        'h',
         description='The full height, in angular or pixel units.')
     theta = ScalarAngle(
-        'theta',
         description=('The position angle (in angular units) of the '
                      'rectangle "width" side.'))
 
@@ -590,22 +578,16 @@ class SkyRectangularAnnulus(SkyAperture):
 
     _shape_params = ('w_in', 'w_out', 'h_in', 'h_out', 'theta')
     positions = SkyCoordPositions(
-        'positions',
         description='The center position(s) in sky coordinates.')
     w_in = ScalarAngleOrPixel(
-        'w_in',
         description='The inner full width, in angular or pixel units.')
     w_out = ScalarAngleOrPixel(
-        'w_out',
         description='The outer full width, in angular or pixel units.')
     h_in = ScalarAngleOrPixel(
-        'h_in',
         description='The inner full height, in angular or pixel units.')
     h_out = ScalarAngleOrPixel(
-        'h_out',
         description='The outer full height, in angular or pixel units.')
     theta = ScalarAngle(
-        'theta',
         description=('The position angle (in angular units) of the '
                      'rectangle "width" side.'))
 


### PR DESCRIPTION
This PR updates the descriptors (used as aperture attribute validators) to use `__set_name__` (PEP-487). 