### PR TITLE
Add Aperture copy method and ability to compare Aperture objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,13 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Added a ``copy`` method to ``Aperture`` objects. [#1304]
+
+  - Added the ability to compare ``Aperture`` objects for equality.
+    [#1304]
+
 - ``photutils.background``
 
   - Added an ``alpha`` keyword to the ``Background2D.plot_meshes``

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -139,7 +139,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
     >>> aper = CircularAperture((pos1, pos2, pos3), 3.)
     """
 
-    _shape_params = ('r',)
+    _params = ('positions', 'r')
     positions = PixelPositions('The center pixel position(s).')
     r = PositiveScalar('The radius in pixels.')
 
@@ -257,7 +257,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
     >>> aper = CircularAnnulus((pos1, pos2, pos3), 3., 5.)
     """
 
-    _shape_params = ('r_in', 'r_out')
+    _params = ('positions', 'r_in', 'r_out')
     positions = PixelPositions('The center pixel position(s).')
     r_in = PositiveScalar('The inner radius in pixels.')
     r_out = PositiveScalar('The outer radius in pixels.')
@@ -362,7 +362,7 @@ class SkyCircularAperture(SkyAperture):
     >>> aper = SkyCircularAperture(positions, 0.5*u.arcsec)
     """
 
-    _shape_params = ('r',)
+    _params = ('positions', 'r',)
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     r = ScalarAngleOrPixel('The radius, in angular or pixel units.')
 
@@ -421,7 +421,7 @@ class SkyCircularAnnulus(SkyAperture):
     >>> aper = SkyCircularAnnulus(positions, 0.5*u.arcsec, 1.0*u.arcsec)
     """
 
-    _shape_params = ('r_in', 'r_out')
+    _params = ('positions', 'r_in', 'r_out')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     r_in = ScalarAngleOrPixel('The inner radius, in angular or pixel units.')
     r_out = ScalarAngleOrPixel('The outer radius, in angular or pixel units.')

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -23,7 +23,7 @@ class Aperture(metaclass=abc.ABCMeta):
     Abstract base class for all apertures.
     """
 
-    _shape_params = ()
+    _params = ()
     positions = np.array(())
     theta = None
 
@@ -39,9 +39,13 @@ class Aperture(metaclass=abc.ABCMeta):
                             'cannot be indexed')
 
         kwargs = dict()
-        for param in self._shape_params:
-            kwargs[param] = getattr(self, param)
-        return self.__class__(self.positions[index], **kwargs)
+        for param in self._params:
+            if param == 'positions':
+                # slice the positions array
+                kwargs[param] = getattr(self, param)[index]
+            else:
+                kwargs[param] = getattr(self, param)
+        return self.__class__(**kwargs)
 
     def __iter__(self):
         for i in range(len(self)):
@@ -59,24 +63,24 @@ class Aperture(metaclass=abc.ABCMeta):
 
     def __repr__(self):
         prefix = f'{self.__class__.__name__}'
-        cls_info = [self._positions_str(prefix)]
-        if self._shape_params is not None:
-            for param in self._shape_params:
+        cls_info = []
+        for param in self._params:
+            if param == 'positions':
+                cls_info.append(self._positions_str(prefix))
+            else:
                 cls_info.append(f'{param}={getattr(self, param)}')
         cls_info = ', '.join(cls_info)
-
         return f'<{prefix}({cls_info})>'
 
     def __str__(self):
-        prefix = 'positions'
-        cls_info = [
-            ('Aperture', self.__class__.__name__),
-            (prefix, self._positions_str(prefix + ': '))]
-        if self._shape_params is not None:
-            for param in self._shape_params:
+        cls_info = [('Aperture', self.__class__.__name__)]
+        for param in self._params:
+            if param == 'positions':
+                prefix = 'positions'
+                cls_info.append((prefix, self._positions_str(prefix + ': ')))
+            else:
                 cls_info.append((param, getattr(self, param)))
         fmt = [f'{key}: {val}' for key, val in cls_info]
-
         return '\n'.join(fmt)
 
     @property

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -661,6 +661,10 @@ class PixelAperture(Aperture):
             if param == 'positions':
                 continue
             elif param == 'theta':
+                # photutils aperture sky angles are defined as the PA of
+                # the semimajor axis (i.e., relative to the WCS latitude
+                # axis). region sky angles are defined relative to the WCS
+                # longitude axis.
                 value = (value * u.rad) - angle.to(u.rad)
             else:
                 value = (value * u.pix * pixscale).to(u.arcsec)
@@ -739,6 +743,10 @@ class SkyAperture(Aperture):
             if param == 'positions':
                 continue
             elif param == 'theta':
+                # photutils aperture sky angles are defined as the PA of
+                # the semimajor axis (i.e., relative to the WCS latitude
+                # axis). region sky angles are defined relative to the WCS
+                # longitude axis.
                 value = (value + angle).to(u.radian).value
             else:
                 if value.unit.physical_type == 'angle':

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -4,7 +4,7 @@ This module defines the base aperture classes.
 """
 
 import abc
-import copy
+from copy import deepcopy
 
 import numpy as np
 from astropy.coordinates import SkyCoord
@@ -82,6 +82,15 @@ class Aperture(metaclass=abc.ABCMeta):
                 cls_info.append((param, getattr(self, param)))
         fmt = [f'{key}: {val}' for key, val in cls_info]
         return '\n'.join(fmt)
+
+    def copy(self):
+        """
+        Make an independent (deep) copy.
+        """
+        params_copy = {}
+        for param in list(self._params):
+            params_copy[param] = deepcopy(getattr(self, param))
+        return self.__class__(**params_copy)
 
     @property
     def shape(self):
@@ -500,7 +509,7 @@ class PixelAperture(Aperture):
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
         """
-        xy_positions = copy.deepcopy(np.atleast_2d(self.positions))
+        xy_positions = deepcopy(np.atleast_2d(self.positions))
         xy_positions[:, 0] -= origin[0]
         xy_positions[:, 1] -= origin[1]
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -167,7 +167,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     >>> aper = EllipticalAperture((pos1, pos2, pos3), 5., 3., theta=np.pi)
     """
 
-    _shape_params = ('a', 'b', 'theta')
+    _params = ('positions', 'a', 'b', 'theta')
     positions = PixelPositions('The center pixel position(s).')
     a = PositiveScalar('The semimajor axis in pixels.')
     b = PositiveScalar('The semiminor axis in pixels.')
@@ -308,7 +308,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     >>> aper = EllipticalAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=np.pi)
     """
 
-    _shape_params = ('a_in', 'a_out', 'b_in', 'b_out', 'theta')
+    _params = ('positions', 'a_in', 'a_out', 'b_in', 'b_out', 'theta')
     positions = PixelPositions('The center pixel position(s).')
     a_in = PositiveScalar('The inner semimajor axis in pixels.')
     a_out = PositiveScalar('The outer semimajor axis in pixels.')
@@ -441,7 +441,7 @@ class SkyEllipticalAperture(SkyAperture):
     >>> aper = SkyEllipticalAperture(positions, 1.0*u.arcsec, 0.5*u.arcsec)
     """
 
-    _shape_params = ('a', 'b', 'theta')
+    _params = ('positions', 'a', 'b', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     a = ScalarAngleOrPixel('The semimajor axis, in angular or pixel units.')
     b = ScalarAngleOrPixel('The semiminor axis, in angular or pixel units.')
@@ -524,7 +524,7 @@ class SkyEllipticalAnnulus(SkyAperture):
     ...                             1.0*u.arcsec)
     """
 
-    _shape_params = ('a_in', 'a_out', 'b_in', 'b_out', 'theta')
+    _params = ('positions', 'a_in', 'a_out', 'b_in', 'b_out', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     a_in = ScalarAngleOrPixel('The inner semimajor axis, in angular or pixel '
                               'units.')

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -190,7 +190,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     >>> aper = RectangularAperture((pos1, pos2, pos3), 5., 3., theta=np.pi)
     """
 
-    _shape_params = ('w', 'h', 'theta')
+    _params = ('positions', 'w', 'h', 'theta')
     positions = PixelPositions('The center pixel position(s).')
     w = PositiveScalar('The full width in pixels.')
     h = PositiveScalar('The full height in pixels.')
@@ -337,7 +337,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     >>> aper = RectangularAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=np.pi)
     """
 
-    _shape_params = ('w_in', 'w_out', 'h_in', 'h_out', 'theta')
+    _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')
     positions = PixelPositions('The center pixel position(s).')
     w_in = PositiveScalar('The inner full width in pixels.')
     w_out = PositiveScalar('The outer full width in pixels.')
@@ -479,7 +479,7 @@ class SkyRectangularAperture(SkyAperture):
     >>> aper = SkyRectangularAperture(positions, 1.0*u.arcsec, 0.5*u.arcsec)
     """
 
-    _shape_params = ('w', 'h', 'theta')
+    _params = ('positions', 'w', 'h', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     w = ScalarAngleOrPixel('The full width, in angular or pixel units.')
     h = ScalarAngleOrPixel('The full height, in angular or pixel units.')
@@ -570,7 +570,7 @@ class SkyRectangularAnnulus(SkyAperture):
     ...                              5.0*u.arcsec)
     """
 
-    _shape_params = ('w_in', 'w_out', 'h_in', 'h_out', 'theta')
+    _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     w_in = ScalarAngleOrPixel('The inner full width, in angular or pixel units.')
     w_out = ScalarAngleOrPixel('The outer full width, in angular or pixel units.')

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -572,13 +572,16 @@ class SkyRectangularAnnulus(SkyAperture):
 
     _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    w_in = ScalarAngleOrPixel('The inner full width, in angular or pixel units.')
-    w_out = ScalarAngleOrPixel('The outer full width, in angular or pixel units.')
-    h_in = ScalarAngleOrPixel('The inner full height, in angular or pixel units.')
+    w_in = ScalarAngleOrPixel('The inner full width, in angular or pixel '
+                              'units.')
+    w_out = ScalarAngleOrPixel('The outer full width, in angular or pixel '
+                               'units.')
+    h_in = ScalarAngleOrPixel('The inner full height, in angular or pixel '
+                              'units.')
     h_out = ScalarAngleOrPixel('The outer full height, in angular or pixel '
                                'units.')
-    theta = ScalarAngle('The position angle (in angular units) of the rectangle '
-                        '"width" side.')
+    theta = ScalarAngle('The position angle (in angular units) of the '
+                        'rectangle "width" side.')
 
     def __init__(self, positions, w_in, w_out, h_out, h_in=None,
                  theta=0.*u.deg):

--- a/photutils/aperture/tests/test_aperture_common.py
+++ b/photutils/aperture/tests/test_aperture_common.py
@@ -20,28 +20,37 @@ class BaseTestAperture(BaseTestApertureParams):
         assert isinstance(aper, self.aperture.__class__)
         assert aper.isscalar
         expected_positions = self.aperture.positions[self.index]
-        if isinstance(expected_positions, SkyCoord):
-            assert_quantity_allclose(aper.positions.ra, expected_positions.ra)
-            assert_quantity_allclose(aper.positions.dec,
-                                     expected_positions.dec)
-        else:
-            assert_array_equal(aper.positions, expected_positions)
-            for shape_param in aper._shape_params:
-                assert (getattr(aper, shape_param) ==
-                        getattr(self.aperture, shape_param))
+
+        for param in aper._params:
+            if param == 'positions':
+                if isinstance(expected_positions, SkyCoord):
+                    assert_quantity_allclose(aper.positions.ra,
+                                             expected_positions.ra)
+                    assert_quantity_allclose(aper.positions.dec,
+                                             expected_positions.dec)
+                else:
+                    assert_array_equal(getattr(aper, param),
+                                       expected_positions)
+            else:
+                assert (getattr(aper, param)
+                        == getattr(self.aperture, param))
 
     def test_slice(self):
         aper = self.aperture[self.slc]
         assert isinstance(aper, self.aperture.__class__)
         assert len(aper) == self.expected_slc_len
-
         expected_positions = self.aperture.positions[self.slc]
-        if isinstance(self.aperture.positions, SkyCoord):
-            assert_quantity_allclose(aper.positions.ra, expected_positions.ra)
-            assert_quantity_allclose(aper.positions.dec,
-                                     expected_positions.dec)
-        else:
-            assert_array_equal(aper.positions, expected_positions)
-            for shape_param in aper._shape_params:
-                assert (getattr(aper, shape_param) ==
-                        getattr(self.aperture, shape_param))
+
+        for param in aper._params:
+            if param == 'positions':
+                if isinstance(expected_positions, SkyCoord):
+                    assert_quantity_allclose(aper.positions.ra,
+                                             expected_positions.ra)
+                    assert_quantity_allclose(aper.positions.dec,
+                                             expected_positions.dec)
+                else:
+                    assert_array_equal(getattr(aper, param),
+                                       expected_positions)
+            else:
+                assert (getattr(aper, param)
+                        == getattr(self.aperture, param))

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -48,6 +48,12 @@ class TestCircularAperture(BaseTestAperture):
         with pytest.raises(ValueError):
             CircularAperture(POSITIONS, radius)
 
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.r = 2.
+        assert aper != self.aperture
+
 
 class TestCircularAnnulus(BaseTestAperture):
     aperture = CircularAnnulus(POSITIONS, r_in=3., r_out=7.)
@@ -79,6 +85,12 @@ class TestCircularAnnulus(BaseTestAperture):
         with pytest.raises(ValueError):
             CircularAnnulus(POSITIONS, r_in=3., r_out=radius)
 
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.r_in = 2.
+        assert aper != self.aperture
+
 
 class TestSkyCircularAperture(BaseTestAperture):
     aperture = SkyCircularAperture(SKYCOORD, r=3.*UNIT)
@@ -88,6 +100,12 @@ class TestSkyCircularAperture(BaseTestAperture):
     def test_invalid_params(radius):
         with pytest.raises(ValueError):
             SkyCircularAperture(SKYCOORD, r=radius*UNIT)
+
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.r = 2.*UNIT
+        assert aper != self.aperture
 
 
 class TestSkyCircularAnnulus(BaseTestAperture):
@@ -100,6 +118,12 @@ class TestSkyCircularAnnulus(BaseTestAperture):
             SkyCircularAnnulus(SKYCOORD, r_in=radius*UNIT, r_out=7.*UNIT)
         with pytest.raises(ValueError):
             SkyCircularAnnulus(SKYCOORD, r_in=3.*UNIT, r_out=radius*UNIT)
+
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.r_in = 2. * UNIT
+        assert aper != self.aperture
 
 
 def test_slicing():

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -31,6 +31,12 @@ class TestEllipticalAperture(BaseTestAperture):
         with pytest.raises(ValueError):
             EllipticalAperture(POSITIONS, a=10., b=radius, theta=np.pi/2.)
 
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.a = 20.
+        assert aper != self.aperture
+
 
 class TestEllipticalAnnulus(BaseTestAperture):
     aperture = EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=17,
@@ -52,6 +58,12 @@ class TestEllipticalAnnulus(BaseTestAperture):
             EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=17,
                               b_in=radius, theta=np.pi/3)
 
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.a_in = 2.
+        assert aper != self.aperture
+
 
 class TestSkyEllipticalAperture(BaseTestAperture):
     aperture = SkyEllipticalAperture(SKYCOORD, a=10.*UNIT, b=5.*UNIT,
@@ -66,6 +78,12 @@ class TestSkyEllipticalAperture(BaseTestAperture):
         with pytest.raises(ValueError):
             SkyEllipticalAperture(SKYCOORD, a=10.*UNIT, b=radius*UNIT,
                                   theta=30*u.deg)
+
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.a = 2. * UNIT
+        assert aper != self.aperture
 
 
 class TestSkyEllipticalAnnulus(BaseTestAperture):
@@ -88,3 +106,9 @@ class TestSkyEllipticalAnnulus(BaseTestAperture):
             SkyEllipticalAnnulus(SKYCOORD, a_in=10.*UNIT, a_out=20.*UNIT,
                                  b_out=17.*UNIT, b_in=radius*UNIT,
                                  theta=60*u.deg)
+
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.a_in = 2. * UNIT
+        assert aper != self.aperture

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -32,6 +32,12 @@ class TestRectangularAperture(BaseTestAperture):
         with pytest.raises(ValueError):
             RectangularAperture(POSITIONS, w=10., h=radius, theta=np.pi/2.)
 
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.w = 20.
+        assert aper != self.aperture
+
 
 class TestRectangularAnnulus(BaseTestAperture):
     aperture = RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=17,
@@ -53,6 +59,12 @@ class TestRectangularAnnulus(BaseTestAperture):
             RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=17,
                                h_in=radius, theta=np.pi/3)
 
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.w_in = 2.
+        assert aper != self.aperture
+
 
 class TestSkyRectangularAperture(BaseTestAperture):
     aperture = SkyRectangularAperture(SKYCOORD, w=10.*UNIT, h=5.*UNIT,
@@ -67,6 +79,12 @@ class TestSkyRectangularAperture(BaseTestAperture):
         with pytest.raises(ValueError):
             SkyRectangularAperture(SKYCOORD, w=10.*UNIT, h=radius*UNIT,
                                    theta=30*u.deg)
+
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.w = 20. * UNIT
+        assert aper != self.aperture
 
 
 class TestSkyRectangularAnnulus(BaseTestAperture):
@@ -89,3 +107,9 @@ class TestSkyRectangularAnnulus(BaseTestAperture):
             SkyRectangularAnnulus(SKYCOORD, w_in=10.*UNIT, w_out=20.*UNIT,
                                   h_out=17.*UNIT, h_in=radius*UNIT,
                                   theta=60*u.deg)
+
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.w_in = 2. * UNIT
+        assert aper != self.aperture


### PR DESCRIPTION
This PR adds a `copy` method to `Aperture` and adds the ability to compare `Aperture` objects for equality (or inequality). This is especially useful for testing.