### PR TITLE
Return a matplotlib Patch from BoundingBox plot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ API Changes
   - A ``ValueError`` is now raised if non-positive sizes are input to
     sky-based apertures. [#1295]
 
+  - The ``BoundingBox.plot()`` method now returns a
+    ``matplotlib.patches.Patch`` object. [#1305]
+
 - ``photutils.background``
 
   - Removed the deprecated ``background_mesh_ma`` and

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -303,9 +303,16 @@ class BoundingBox:
 
         **kwargs : dict
             Any keyword arguments accepted by `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : `matplotlib.patches.Patch`
+            The matplotlib patch object for the plotted bounding box.
+            The patch can be used, for example, when adding a plot
+            legend.
         """
         aper = self.to_aperture()
-        aper.plot(axes=axes, origin=origin, **kwargs)
+        return aper.plot(axes=axes, origin=origin, **kwargs)[0]
 
     def union(self, other):
         """

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -110,6 +110,14 @@ def test_bounding_box_as_artist():
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_bounding_box_plot():
+    from matplotlib.patches import Rectangle
+    bbox = BoundingBox(1, 10, 2, 20)
+    patch = bbox.plot()
+    assert isinstance(patch, Rectangle)
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_bounding_box_to_aperture():
     bbox = BoundingBox(1, 10, 2, 20)
     aper = RectangularAperture((5.0, 10.5), w=9., h=18., theta=0.)
@@ -119,13 +127,6 @@ def test_bounding_box_to_aperture():
     assert bbox_aper.w == aper.w
     assert bbox_aper.h == aper.h
     assert bbox_aper.theta == aper.theta
-
-
-@pytest.mark.skipif('not HAS_MATPLOTLIB')
-def test_bounding_box_plot():
-    # TODO: check the content of the plot
-    bbox = BoundingBox(1, 10, 2, 20)
-    bbox.plot()
 
 
 def test_bounding_box_union():


### PR DESCRIPTION
The PR updates the ``BoundingBox.plot()`` method to now return a ``matplotlib.patches.Patch`` object.  This is useful, for example, when creating plot legends.