### PR TITLE
Fix Sphinx warnings about duplicate objects

### DIFF
--- a/photutils/psf/__init__.py
+++ b/photutils/psf/__init__.py
@@ -4,10 +4,24 @@ This subpackage contains tools to perform point-spread-function (PSF)
 photometry.
 """
 
+from . import epsf
 from .epsf import *  # noqa
+from . import epsf_stars
 from .epsf_stars import *  # noqa
+from . import groupstars
 from .groupstars import *  # noqa
 from .matching import *  # noqa
+from . import models
 from .models import *  # noqa
+from . import photometry
 from .photometry import *  # noqa
+from . import utils
 from .utils import *  # noqa
+
+__all__ = []
+__all__.extend(epsf.__all__)
+__all__.extend(epsf_stars.__all__)
+__all__.extend(groupstars.__all__)
+__all__.extend(models.__all__)
+__all__.extend(photometry.__all__)
+__all__.extend(utils.__all__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ test =
     pytest-astropy
 docs =
     scipy>=1.6.0
-    sphinx<4
+    sphinx
     sphinx-astropy
     matplotlib>=3.1
     scikit-image>=0.15.0


### PR DESCRIPTION
Starting with `Sphinx 4.0`, when building the docs warnings were issued about duplicate objects for the `psf.matching` functions.  `psf.__init__` is importing all from `psf.matching`, and I think Sphinx is getting confused by seeing these tools both as `psf.<tool>` and `psf.matching.<tool>`.

I don't know if this is the best solution, but explicitly removing the `psf.matching` tools from `psf.__all__` seems to solve the issue.

Closes #1238