### PR TITLE
Allow ellipse and rectangle pixel aperture to take Quantity rotation angle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ New Features
   - Added the ability to compare ``Aperture`` objects for equality.
     [#1304]
 
+  - The ``theta`` keyword for ``EllipticalAperture``, ``EllipticalAnnulus``,
+    ``RectangularAperture``, and ``RectangularEllipse`` can now be an
+    Astropy ``Angle`` or ``Quantity`` in angular units. [#1308]
+
 - ``photutils.background``
 
   - Added an ``alpha`` keyword to the ``Background2D.plot_meshes``

--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -219,10 +219,11 @@ Other apertures have multiple parameters specifying the aperture size
 and orientation.  For example, for elliptical apertures, one must
 specify ``a``, ``b``, and ``theta``::
 
+    >>> from astropy.coordinates import Angle
     >>> from photutils.aperture import EllipticalAperture
     >>> a = 5.
     >>> b = 3.
-    >>> theta = np.pi / 4.
+    >>> theta = Angle(45, 'deg')
     >>> apertures = EllipticalAperture(positions, a, b, theta)
     >>> phot_table = aperture_photometry(data, apertures)
     >>> for col in phot_table.colnames:
@@ -239,7 +240,7 @@ objects, each with identical positions::
 
     >>> a = [5., 6., 7.]
     >>> b = [3., 4., 5.]
-    >>> theta = np.pi / 4.
+    >>> theta = Angle(45, 'deg')
     >>> apertures = [EllipticalAperture(positions, a=ai, b=bi, theta=theta)
     ...              for (ai, bi) in zip(a, b)]
     >>> phot_table = aperture_photometry(data, apertures)

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -9,7 +9,8 @@ import astropy.units as u
 import numpy as np
 
 __all__ = ['ApertureAttribute', 'PixelPositions', 'SkyCoordPositions',
-           'Scalar', 'PositiveScalar', 'ScalarAngle', 'ScalarAngleOrPixel']
+           'PositiveScalar', 'ScalarAngle', 'ScalarAngleOrValue',
+           'ScalarAngleOrPixel']
 
 
 class ApertureAttribute:

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -177,8 +177,8 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
     positions = PixelPositions('The center pixel position(s).')
     a = PositiveScalar('The semimajor axis in pixels.')
     b = PositiveScalar('The semiminor axis in pixels.')
-    theta = ScalarAngleOrValue('The counterclockwise rotation angle in '
-                               'radians of the ellipse semimajor axis from '
+    theta = ScalarAngleOrValue('The counterclockwise rotation angle as an '
+                               'angular Quantity or value in radians from '
                                'the positive x axis.')
 
     def __init__(self, positions, a, b, theta=0.):
@@ -325,8 +325,8 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
     a_out = PositiveScalar('The outer semimajor axis in pixels.')
     b_in = PositiveScalar('The inner semiminor axis in pixels.')
     b_out = PositiveScalar('The outer semiminor axis in pixels.')
-    theta = ScalarAngleOrValue('The counterclockwise rotation angle in '
-                               'radians of the ellipse semimajor axis from '
+    theta = ScalarAngleOrValue('The counterclockwise rotation angle as an '
+                               'angular Quantity or value in radians from '
                                'the positive x axis.')
 
     def __init__(self, positions, a_in, a_out, b_out, b_in=None, theta=0.):
@@ -441,8 +441,7 @@ class SkyEllipticalAperture(SkyAperture):
     theta : scalar `~astropy.units.Quantity`, optional
         The position angle (in angular units) of the ellipse semimajor
         axis.  For a right-handed world coordinate system, the position
-        angle increases counterclockwise from North (PA=0).  The default
-        is 0 degrees.
+        angle increases counterclockwise from North (PA=0).
 
     Examples
     --------
@@ -523,8 +522,7 @@ class SkyEllipticalAnnulus(SkyAperture):
     theta : scalar `~astropy.units.Quantity`, optional
         The position angle (in angular units) of the ellipse semimajor
         axis.  For a right-handed world coordinate system, the position
-        angle increases counterclockwise from North (PA=0).  The default
-        is 0 degrees.
+        angle increases counterclockwise from North (PA=0).
 
     Examples
     --------

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -159,15 +159,18 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
 
     Examples
     --------
+    >>> from astropy.coordinates import Angle
     >>> from photutils.aperture import EllipticalAperture
+
+    >>> theta = Angle(80, 'deg')
     >>> aper = EllipticalAperture([10., 20.], 5., 3.)
-    >>> aper = EllipticalAperture((10., 20.), 5., 3., theta=np.pi)
+    >>> aper = EllipticalAperture((10., 20.), 5., 3., theta=theta)
 
     >>> pos1 = (10., 20.)  # (x, y)
     >>> pos2 = (30., 40.)
     >>> pos3 = (50., 60.)
     >>> aper = EllipticalAperture([pos1, pos2, pos3], 5., 3.)
-    >>> aper = EllipticalAperture((pos1, pos2, pos3), 5., 3., theta=np.pi)
+    >>> aper = EllipticalAperture((pos1, pos2, pos3), 5., 3., theta=theta)
     """
 
     _params = ('positions', 'a', 'b', 'theta')
@@ -302,15 +305,18 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
 
     Examples
     --------
+    >>> from astropy.coordinates import Angle
     >>> from photutils.aperture import EllipticalAnnulus
+
+    >>> theta = Angle(80, 'deg')
     >>> aper = EllipticalAnnulus([10., 20.], 3., 8., 5.)
-    >>> aper = EllipticalAnnulus((10., 20.), 3., 8., 5., theta=np.pi)
+    >>> aper = EllipticalAnnulus((10., 20.), 3., 8., 5., theta=theta)
 
     >>> pos1 = (10., 20.)  # (x, y)
     >>> pos2 = (30., 40.)
     >>> pos3 = (50., 60.)
     >>> aper = EllipticalAnnulus([pos1, pos2, pos3], 3., 8., 5.)
-    >>> aper = EllipticalAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=np.pi)
+    >>> aper = EllipticalAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=theta)
     """
 
     _params = ('positions', 'a_in', 'a_out', 'b_in', 'b_out', 'theta')

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -200,8 +200,8 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
     positions = PixelPositions('The center pixel position(s).')
     w = PositiveScalar('The full width in pixels.')
     h = PositiveScalar('The full height in pixels.')
-    theta = ScalarAngleOrValue('The counterclockwise rotation angle in '
-                               'radians of the rectangle "width" side from '
+    theta = ScalarAngleOrValue('The counterclockwise rotation angle as an '
+                               'angular Quantity or value in radians from '
                                'the positive x axis.')
 
     def __init__(self, positions, w, h, theta=0.):
@@ -354,8 +354,8 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     w_out = PositiveScalar('The outer full width in pixels.')
     h_in = PositiveScalar('The inner full height in pixels.')
     h_out = PositiveScalar('The outer full height in pixels.')
-    theta = ScalarAngleOrValue('The counterclockwise rotation angle in '
-                               'radians of the rectangle "width" side from '
+    theta = ScalarAngleOrValue('The counterclockwise rotation angle as an '
+                               'angular Quantity or value in radians from '
                                'the positive x axis.')
 
     def __init__(self, positions, w_in, w_out, h_out, h_in=None, theta=0.):
@@ -479,8 +479,7 @@ class SkyRectangularAperture(SkyAperture):
     theta : scalar `~astropy.units.Quantity`, optional
         The position angle (in angular units) of the rectangle "width"
         side.  For a right-handed world coordinate system, the position
-        angle increases counterclockwise from North (PA=0).  The default
-        is 0 degrees.
+        angle increases counterclockwise from North (PA=0).
 
     Examples
     --------
@@ -569,8 +568,7 @@ class SkyRectangularAnnulus(SkyAperture):
     theta : scalar `~astropy.units.Quantity`, optional
         The position angle (in angular units) of the rectangle "width"
         side.  For a right-handed world coordinate system, the position
-        angle increases counterclockwise from North (PA=0).  The default
-        is 0 degrees.
+        angle increases counterclockwise from North (PA=0).
 
     Examples
     --------

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -182,15 +182,18 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
 
     Examples
     --------
+    >>> from astropy.coordinates import Angle
     >>> from photutils.aperture import RectangularAperture
+
+    >>> theta = Angle(80, 'deg')
     >>> aper = RectangularAperture([10., 20.], 5., 3.)
-    >>> aper = RectangularAperture((10., 20.), 5., 3., theta=np.pi)
+    >>> aper = RectangularAperture((10., 20.), 5., 3., theta=theta)
 
     >>> pos1 = (10., 20.)  # (x, y)
     >>> pos2 = (30., 40.)
     >>> pos3 = (50., 60.)
     >>> aper = RectangularAperture([pos1, pos2, pos3], 5., 3.)
-    >>> aper = RectangularAperture((pos1, pos2, pos3), 5., 3., theta=np.pi)
+    >>> aper = RectangularAperture((pos1, pos2, pos3), 5., 3., theta=theta)
     """
 
     _params = ('positions', 'w', 'h', 'theta')
@@ -331,15 +334,18 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
     Examples
     --------
+    >>> from astropy.coordinates import Angle
     >>> from photutils.aperture import RectangularAnnulus
+
+    >>> theta = Angle(80, 'deg')
     >>> aper = RectangularAnnulus([10., 20.], 3., 8., 5.)
-    >>> aper = RectangularAnnulus((10., 20.), 3., 8., 5., theta=np.pi)
+    >>> aper = RectangularAnnulus((10., 20.), 3., 8., 5., theta=theta)
 
     >>> pos1 = (10., 20.)  # (x, y)
     >>> pos2 = (30., 40.)
     >>> pos3 = (50., 60.)
     >>> aper = RectangularAnnulus([pos1, pos2, pos3], 3., 8., 5.)
-    >>> aper = RectangularAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=np.pi)
+    >>> aper = RectangularAnnulus((pos1, pos2, pos3), 3., 8., 5., theta=theta)
     """
 
     _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -3,7 +3,7 @@
 Tests for the ellipse module.
 """
 
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
 import numpy as np
 import pytest
@@ -112,3 +112,28 @@ class TestSkyEllipticalAnnulus(BaseTestAperture):
         assert aper == self.aperture
         aper.a_in = 2. * UNIT
         assert aper != self.aperture
+
+
+def test_ellipse_theta_quantity():
+    aper1 = EllipticalAperture(POSITIONS, a=10., b=5., theta=np.pi/2.)
+    theta = u.Quantity(90 * u.deg)
+    aper2 = EllipticalAperture(POSITIONS, a=10., b=5., theta=theta)
+    theta = Angle(90 * u.deg)
+    aper3 = EllipticalAperture(POSITIONS, a=10., b=5., theta=theta)
+
+    assert aper1._theta_radians == aper2._theta_radians
+    assert aper1._theta_radians == aper3._theta_radians
+
+
+def test_ellipse_annulus_theta_quantity():
+    aper1 = EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=17,
+                              theta=np.pi/3)
+    theta = u.Quantity(60 * u.deg)
+    aper2 = EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=17,
+                              theta=theta)
+    theta = Angle(60 * u.deg)
+    aper3 = EllipticalAnnulus(POSITIONS, a_in=10., a_out=20., b_out=17,
+                              theta=theta)
+
+    assert aper1._theta_radians == aper2._theta_radians
+    assert aper1._theta_radians == aper3._theta_radians

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -3,7 +3,7 @@
 Tests for the rectangle module.
 """
 
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
 import numpy as np
 import pytest
@@ -113,3 +113,28 @@ class TestSkyRectangularAnnulus(BaseTestAperture):
         assert aper == self.aperture
         aper.w_in = 2. * UNIT
         assert aper != self.aperture
+
+
+def test_rectangle_theta_quantity():
+    aper1 = RectangularAperture(POSITIONS, w=10., h=5., theta=np.pi/2.)
+    theta = u.Quantity(90 * u.deg)
+    aper2 = RectangularAperture(POSITIONS, w=10., h=5., theta=theta)
+    theta = Angle(90 * u.deg)
+    aper3 = RectangularAperture(POSITIONS, w=10., h=5., theta=theta)
+
+    assert aper1._theta_radians == aper2._theta_radians
+    assert aper1._theta_radians == aper3._theta_radians
+
+
+def test_rectangle_annulus_theta_quantity():
+    aper1 = RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=17,
+                               theta=np.pi/3)
+    theta = u.Quantity(60 * u.deg)
+    aper2 = RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=17,
+                               theta=theta)
+    theta = Angle(60 * u.deg)
+    aper3 = RectangularAnnulus(POSITIONS, w_in=10., w_out=20., h_out=17,
+                               theta=theta)
+
+    assert aper1._theta_radians == aper2._theta_radians
+    assert aper1._theta_radians == aper3._theta_radians


### PR DESCRIPTION
The PR allows the ``theta`` keyword for ``EllipticalAperture``, ``EllipticalAnnulus``,  ``RectangularAperture``, and ``RectangularEllipse`` to be an Astropy ``Angle`` or ``Quantity`` in angular units.