### PR TITLE
Deprecating pixel Quantity inputs in apertures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,12 @@ API Changes
   - The ``BoundingBox.plot()`` method now returns a
     ``matplotlib.patches.Patch`` object. [#1305]
 
+  - Inputting ``PixelAperture`` positions as an Astropy ``Quantity`` in
+    pixel units is deprecated. [#1310]
+
+  - Inputting ``SkyAperture`` shape parameters as an Astropy
+    ``Quantity`` in pixel units is deprecated. [#1310]
+
 - ``photutils.background``
 
   - Removed the deprecated ``background_mesh_ma`` and

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -192,6 +192,11 @@ class ScalarAngleOrPixel(ApertureAttribute):
                 raise ValueError(f'{self.name!r} must have angular or pixel '
                                  'units')
 
+            if value.unit == u.pixel:
+                warnings.warn('Inputing sky aperture quantities in pixel '
+                              'units is deprecated and will be removed in '
+                              'a future version.', AstropyDeprecationWarning)
+
             if not value > 0:
                 raise ValueError(f'{self.name!r} must be strictly positive')
         else:

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -4,8 +4,11 @@ This module defines descriptor classes for aperture attribute
 validation.
 """
 
+import warnings
+
 from astropy.coordinates import SkyCoord
 import astropy.units as u
+from astropy.utils.exceptions import AstropyDeprecationWarning
 import numpy as np
 
 __all__ = ['ApertureAttribute', 'PixelPositions', 'SkyCoordPositions',
@@ -70,6 +73,13 @@ class PixelPositions(ApertureAttribute):
         self._validate(value)
 
         if isinstance(value, u.Quantity):
+            # deprecated in version 1.4.0
+            warnings.warn('Inputing positions as a Quantity is deprecated '
+                          'and will be removed in a future version.',
+                          AstropyDeprecationWarning)
+
+            if value.unit != u.pixel:
+                raise ValueError('Input positions must have pixel units')
             value = value.value
 
         if value.ndim == 2 and value.shape[1] != 2 and value.shape[0] == 2:

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -354,7 +354,8 @@ class SkyCircularAperture(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     r : scalar `~astropy.units.Quantity`
-        The radius of the circle, either in angular or pixel units.
+        The radius of the circle in angular units. Pixel units are now
+        deprecated.
 
     Examples
     --------
@@ -367,7 +368,7 @@ class SkyCircularAperture(SkyAperture):
 
     _params = ('positions', 'r',)
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    r = ScalarAngleOrPixel('The radius, in angular or pixel units.')
+    r = ScalarAngleOrPixel('The radius in angular units.')
 
     def __init__(self, positions, r):
         self.positions = positions
@@ -408,12 +409,12 @@ class SkyCircularAnnulus(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     r_in : scalar `~astropy.units.Quantity`
-        The inner radius of the circular annulus, either in angular or
-        pixel units.
+        The inner radius of the circular annulus in angular units. Pixel
+        units are now deprecated.
 
     r_out : scalar `~astropy.units.Quantity`
-        The outer radius of the circular annulus, either in angular or
-        pixel units.
+        The outer radius of the circular annulus in angular units. Pixel
+        units are now deprecated.
 
     Examples
     --------
@@ -426,8 +427,8 @@ class SkyCircularAnnulus(SkyAperture):
 
     _params = ('positions', 'r_in', 'r_out')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    r_in = ScalarAngleOrPixel('The inner radius, in angular or pixel units.')
-    r_out = ScalarAngleOrPixel('The outer radius, in angular or pixel units.')
+    r_in = ScalarAngleOrPixel('The inner radius in angular units.')
+    r_out = ScalarAngleOrPixel('The outer radius in angular units.')
 
     def __init__(self, positions, r_in, r_out):
         if r_in.unit.physical_type != r_out.unit.physical_type:

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -110,14 +110,15 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
     Parameters
     ----------
-    positions : array_like or `~astropy.units.Quantity`
+    positions : array_like
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
             * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units
+              pixel units (this is Deprecated and will be removed in a
+              future version)
 
     r : float
         The radius of the circle in pixels.
@@ -222,14 +223,15 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
 
     Parameters
     ----------
-    positions : array_like or `~astropy.units.Quantity`
+    positions : array_like
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
             * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units
+              pixel units (this is Deprecated and will be removed in a
+              future version)
 
     r_in : float
         The inner radius of the circular annulus in pixels.

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -434,12 +434,12 @@ class SkyEllipticalAperture(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     a : scalar `~astropy.units.Quantity`
-        The semimajor axis of the ellipse, either in angular or pixel
-        units.
+        The semimajor axis of the ellipse in angular units. Pixel units
+        are now deprecated.
 
     b : scalar `~astropy.units.Quantity`
-        The semiminor axis of the ellipse, either in angular or pixel
-        units.
+        The semiminor axis of the ellipse in angular units. Pixel units
+        are now deprecated.
 
     theta : scalar `~astropy.units.Quantity`, optional
         The position angle (in angular units) of the ellipse semimajor
@@ -457,8 +457,8 @@ class SkyEllipticalAperture(SkyAperture):
 
     _params = ('positions', 'a', 'b', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    a = ScalarAngleOrPixel('The semimajor axis, in angular or pixel units.')
-    b = ScalarAngleOrPixel('The semiminor axis, in angular or pixel units.')
+    a = ScalarAngleOrPixel('The semimajor axis in angular units.')
+    b = ScalarAngleOrPixel('The semiminor axis in angular units.')
     theta = ScalarAngle('The position angle in angular units of the ellipse '
                         'semimajor axis.')
 
@@ -507,17 +507,21 @@ class SkyEllipticalAnnulus(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     a_in : scalar `~astropy.units.Quantity`
-        The inner semimajor axis, either in angular or pixel units.
+        The inner semimajor axis in angular units. Pixel units are now
+        deprecated.
 
     a_out : scalar `~astropy.units.Quantity`
-        The outer semimajor axis, either in angular or pixel units.
+        The outer semimajor axis in angular units. Pixel units are now
+        deprecated.
 
     b_out : scalar `~astropy.units.Quantity`
-        The outer semiminor axis, either in angular or pixel units.
+        The outer semiminor axis in angular units. Pixel units are now
+        deprecated.
 
     b_in : `None` or scalar `~astropy.units.Quantity`
-        The inner semiminor axis, either in angular or pixel units.
-        If `None`, then the inner semiminor axis is calculated as:
+        The inner semiminor axis in angular units. Pixel units are
+        now deprecated. If `None`, then the inner semiminor axis is
+        calculated as:
 
             .. math:: b_{in} = b_{out}
                 \left(\frac{a_{in}}{a_{out}}\right)
@@ -539,14 +543,10 @@ class SkyEllipticalAnnulus(SkyAperture):
 
     _params = ('positions', 'a_in', 'a_out', 'b_in', 'b_out', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    a_in = ScalarAngleOrPixel('The inner semimajor axis, in angular or pixel '
-                              'units.')
-    a_out = ScalarAngleOrPixel('The outer semimajor axis, in angular or pixel '
-                               'units.')
-    b_in = ScalarAngleOrPixel('The inner semiminor axis, in angular or pixel '
-                              'units.')
-    b_out = ScalarAngleOrPixel('The outer semiminor axis, in angular or pixel '
-                               'units.')
+    a_in = ScalarAngleOrPixel('The inner semimajor axis in angular units.')
+    a_out = ScalarAngleOrPixel('The outer semimajor axis in angular units.')
+    b_in = ScalarAngleOrPixel('The inner semiminor axis in angular units.')
+    b_out = ScalarAngleOrPixel('The outer semiminor axis in angular units.')
     theta = ScalarAngle('The position angle in angular units of the ellipse '
                         'semimajor axis.')
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -132,14 +132,15 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
 
     Parameters
     ----------
-    positions : array_like or `~astropy.units.Quantity`
+    positions : array_like
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
             * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units
+              pixel units (this is Deprecated and will be removed in a
+              future version)
 
     a : float
         The semimajor axis of the ellipse in pixels.
@@ -263,14 +264,15 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
 
     Parameters
     ----------
-    positions : array_like or `~astropy.units.Quantity`
+    positions : array_like
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
             * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units
+              pixel units (this is Deprecated and will be removed in a
+              future version)
 
     a_in : float
         The inner semimajor axis of the elliptical annulus in pixels.

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -470,14 +470,14 @@ class SkyRectangularAperture(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     w : scalar `~astropy.units.Quantity`
-        The full width of the rectangle, either in angular or pixel
-        units.  For ``theta=0`` the width side is along the North-South
-        axis.
+        The full width of the rectangle in angular units. Pixel units
+        are now deprecated. For ``theta=0`` the width side is along the
+        North-South axis.
 
     h :  scalar `~astropy.units.Quantity`
-        The full height of the rectangle, either in angular or pixel
-        units.  For ``theta=0`` the height side is along the East-West
-        axis.
+        The full height of the rectangle in angular units. Pixel units
+        are now deprecated. For ``theta=0`` the height side is along the
+        East-West axis.
 
     theta : scalar `~astropy.units.Quantity`, optional
         The position angle (in angular units) of the rectangle "width"
@@ -495,8 +495,8 @@ class SkyRectangularAperture(SkyAperture):
 
     _params = ('positions', 'w', 'h', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    w = ScalarAngleOrPixel('The full width, in angular or pixel units.')
-    h = ScalarAngleOrPixel('The full height, in angular or pixel units.')
+    w = ScalarAngleOrPixel('The full width in angular units.')
+    h = ScalarAngleOrPixel('The full height in angular units.')
     theta = ScalarAngle('The position angle (in angular units) of the '
                         'rectangle "width" side.')
 
@@ -545,23 +545,23 @@ class SkyRectangularAnnulus(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     w_in : scalar `~astropy.units.Quantity`
-        The inner full width of the rectangular annulus, either in
-        angular or pixel units.  For ``theta=0`` the width side is along
-        the North-South axis.
+        The inner full width of the rectangular annulus in angular
+        units. Pixel units are now deprecated. For ``theta=0`` the width
+        side is along the North-South axis.
 
     w_out : scalar `~astropy.units.Quantity`
-        The outer full width of the rectangular annulus, either in
-        angular or pixel units.  For ``theta=0`` the width side is along
-        the North-South axis.
+        The outer full width of the rectangular annulus in angular
+        units. Pixel units are now deprecated. For ``theta=0`` the width
+        side is along the North-South axis.
 
     h_out : scalar `~astropy.units.Quantity`
-        The outer full height of the rectangular annulus, either in
-        angular or pixel units.
+        The outer full height of the rectangular annulus in angular
+        units. Pixel units are now deprecated.
 
     h_in : `None` or scalar `~astropy.units.Quantity`
-        The outer full height of the rectangular annulus, either in
-        angular or pixel units.  If `None`, then the inner full height
-        is calculated as:
+        The outer full height of the rectangular annulus in angular
+        units. Pixel units are now deprecated. If `None`, then the inner
+        full height is calculated as:
 
             .. math:: h_{in} = h_{out}
                 \left(\frac{w_{in}}{w_{out}}\right)
@@ -585,14 +585,10 @@ class SkyRectangularAnnulus(SkyAperture):
 
     _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    w_in = ScalarAngleOrPixel('The inner full width, in angular or pixel '
-                              'units.')
-    w_out = ScalarAngleOrPixel('The outer full width, in angular or pixel '
-                               'units.')
-    h_in = ScalarAngleOrPixel('The inner full height, in angular or pixel '
-                              'units.')
-    h_out = ScalarAngleOrPixel('The outer full height, in angular or pixel '
-                               'units.')
+    w_in = ScalarAngleOrPixel('The inner full width in angular units.')
+    w_out = ScalarAngleOrPixel('The outer full width in angular units.')
+    h_in = ScalarAngleOrPixel('The inner full height in angular units.')
+    h_out = ScalarAngleOrPixel('The outer full height in angular units.')
     theta = ScalarAngle('The position angle (in angular units) of the '
                         'rectangle "width" side.')
 

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -153,14 +153,15 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
 
     Parameters
     ----------
-    positions : array_like or `~astropy.units.Quantity`
+    positions : array_like
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
             * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units
+              pixel units (this is Deprecated and will be removed in a
+              future version)
 
     w : float
         The full width of the rectangle in pixels.  For ``theta=0`` the
@@ -288,14 +289,15 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
     Parameters
     ----------
-    positions : array_like or `~astropy.units.Quantity`
+    positions : array_like
         The pixel coordinates of the aperture center(s) in one of the
         following formats:
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
             * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units
+              pixel units (this is Deprecated and will be removed in a
+              future version)
 
     w_in : float
         The inner full width of the rectangular annulus in pixels.  For

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -280,7 +280,6 @@ def test_wcs_based_photometry_to_catalogue():
     hdu = fits.open(pathhdu)
     data = u.Quantity(hdu[0].data, unit=hdu[0].header['BUNIT'])
     wcs = WCS(hdu[0].header)
-    scale = hdu[0].header['PIXSCAL1']
 
     catalog = Table.read(pathcat)
 
@@ -288,13 +287,6 @@ def test_wcs_based_photometry_to_catalogue():
 
     photometry_skycoord = aperture_photometry(
         data, SkyCircularAperture(pos_skycoord, 4 * u.arcsec), wcs=wcs)
-
-    photometry_skycoord_pix = aperture_photometry(
-        data, SkyCircularAperture(pos_skycoord, 4. / scale * u.pixel),
-        wcs=wcs)
-
-    assert_allclose(photometry_skycoord['aperture_sum'],
-                    photometry_skycoord_pix['aperture_sum'])
 
     # Photometric unit conversion is needed to match the catalogue
     factor = (1.2 * u.arcsec) ** 2 / u.pixel
@@ -574,72 +566,72 @@ def test_pixel_aperture_repr():
 def test_sky_aperture_repr():
     s = SkyCoord([1, 2], [3, 4], unit='deg')
 
-    aper = SkyCircularAperture(s, r=3*u.pix)
+    aper = SkyCircularAperture(s, r=3*u.deg)
     a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-              '    [(1., 3.), (2., 4.)]>, r=3.0 pix)>')
+              '    [(1., 3.), (2., 4.)]>, r=3.0 deg)>')
     a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
              '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'r: 3.0 pix')
+             'r: 3.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
-    aper = SkyCircularAnnulus(s, r_in=3.*u.pix, r_out=5*u.pix)
+    aper = SkyCircularAnnulus(s, r_in=3.*u.deg, r_out=5*u.deg)
     a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
-              '    [(1., 3.), (2., 4.)]>, r_in=3.0 pix, r_out=5.0 pix)>')
+              '    [(1., 3.), (2., 4.)]>, r_in=3.0 deg, r_out=5.0 deg)>')
     a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
              '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'r_in: 3.0 pix\nr_out: 5.0 pix')
+             'r_in: 3.0 deg\nr_out: 5.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
-    aper = SkyEllipticalAperture(s, a=3*u.pix, b=5*u.pix, theta=15*u.deg)
+    aper = SkyEllipticalAperture(s, a=3*u.deg, b=5*u.deg, theta=15*u.deg)
     a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
-              'deg\n    [(1., 3.), (2., 4.)]>, a=3.0 pix, b=5.0 pix,'
-              ' theta=15.0 deg)>')
+              'deg\n    [(1., 3.), (2., 4.)]>, a=3.0 deg, b=5.0 deg, '
+              'theta=15.0 deg)>')
     a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
              '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'a: 3.0 pix\nb: 5.0 pix\ntheta: 15.0 deg')
+             'a: 3.0 deg\nb: 5.0 deg\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
-    aper = SkyEllipticalAnnulus(s, a_in=3*u.pix, a_out=5*u.pix, b_out=3*u.pix,
+    aper = SkyEllipticalAnnulus(s, a_in=3*u.deg, a_out=5*u.deg, b_out=3*u.deg,
                                 theta=15*u.deg)
     a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
-              'deg\n    [(1., 3.), (2., 4.)]>, a_in=3.0 pix, '
-              'a_out=5.0 pix, b_in=1.8 pix, b_out=3.0 pix, '
+              'deg\n    [(1., 3.), (2., 4.)]>, a_in=3.0 deg, '
+              'a_out=5.0 deg, b_in=1.8 deg, b_out=3.0 deg, '
               'theta=15.0 deg)>')
     a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
              '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'a_in: 3.0 pix\na_out: 5.0 pix\nb_in: 1.8 pix\n'
-             'b_out: 3.0 pix\ntheta: 15.0 deg')
+             'a_in: 3.0 deg\na_out: 5.0 deg\nb_in: 1.8 deg\n'
+             'b_out: 3.0 deg\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
-    aper = SkyRectangularAperture(s, w=3*u.pix, h=5*u.pix, theta=15*u.deg)
+    aper = SkyRectangularAperture(s, w=3*u.deg, h=5*u.deg, theta=15*u.deg)
     a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
-              'deg\n    [(1., 3.), (2., 4.)]>, w=3.0 pix, h=5.0 pix'
+              'deg\n    [(1., 3.), (2., 4.)]>, w=3.0 deg, h=5.0 deg'
               ', theta=15.0 deg)>')
     a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
              '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'w: 3.0 pix\nh: 5.0 pix\ntheta: 15.0 deg')
+             'w: 3.0 deg\nh: 5.0 deg\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
 
-    aper = SkyRectangularAnnulus(s, w_in=5*u.pix, w_out=10*u.pix,
-                                 h_out=6*u.pix, theta=15*u.deg)
+    aper = SkyRectangularAnnulus(s, w_in=5*u.deg, w_out=10*u.deg,
+                                 h_out=6*u.deg, theta=15*u.deg)
     a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-              '\n    [(1., 3.), (2., 4.)]>, w_in=5.0 pix, '
-              'w_out=10.0 pix, h_in=3.0 pix, h_out=6.0 pix, '
+              '\n    [(1., 3.), (2., 4.)]>, w_in=5.0 deg, '
+              'w_out=10.0 deg, h_in=3.0 deg, h_out=6.0 deg, '
               'theta=15.0 deg)>')
     a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
              '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'w_in: 5.0 pix\nw_out: 10.0 pix\nh_in: 3.0 pix\n'
-             'h_out: 6.0 pix\ntheta: 15.0 deg')
+             'w_in: 5.0 deg\nw_out: 10.0 deg\nh_in: 3.0 deg\n'
+             'h_out: 6.0 deg\ntheta: 15.0 deg')
 
     assert repr(aper) == a_repr
     assert str(aper) == a_str
@@ -769,9 +761,10 @@ def test_radius_units():
     pos = SkyCoord(10, 10, unit='deg')
     r = 3.*u.pix
     r = np.sqrt(r**2)
-    ap = SkyCircularAperture(pos, r=r)
-    assert ap.r.value == 3.0
-    assert ap.r.unit == u.pix
+    with pytest.warns(AstropyDeprecationWarning):
+        ap = SkyCircularAperture(pos, r=r)
+        assert ap.r.value == 3.0
+        assert ap.r.unit == u.pix
 
 
 def test_scalar_aperture():

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -13,6 +13,7 @@ from astropy.io import fits
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import Table
 import astropy.units as u
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.wcs import WCS
 
 from ..photometry import aperture_photometry
@@ -81,18 +82,10 @@ def test_aperture_plots(aperture_class, params):
 def test_aperture_pixel_positions():
     pos1 = (10, 20)
     pos2 = [(10, 20)]
-    pos3 = u.Quantity((10, 20), unit=u.pixel)
-    pos4 = u.Quantity([(10, 20)], unit=u.pixel)
-
     r = 3
     ap1 = CircularAperture(pos1, r)
     ap2 = CircularAperture(pos2, r)
-    ap3 = CircularAperture(pos3, r)
-    ap4 = CircularAperture(pos4, r)
-
     assert not np.array_equal(ap1.positions, ap2.positions)
-    assert_allclose(ap1.positions, ap3.positions)
-    assert_allclose(ap2.positions, ap4.positions)
 
 
 class BaseTestAperturePhotometry:
@@ -766,8 +759,9 @@ def test_position_units():
     """Regression test for unit check."""
     pos = (10, 10) * u.pix
     pos = np.sqrt(pos**2)
-    ap = CircularAperture(pos, r=3.)
-    assert_allclose(ap.positions, np.array([10, 10]))
+    with pytest.warns(AstropyDeprecationWarning):
+        ap = CircularAperture(pos, r=3.)
+        assert_allclose(ap.positions, np.array([10, 10]))
 
 
 def test_radius_units():


### PR DESCRIPTION
This PR deprecates:
  * Inputting ``PixelAperture`` positions as an Astropy ``Quantity`` in pixel units
  * Inputting ``SkyAperture`` shape parameters as an Astropy ``Quantity`` in pixel units