### PR TITLE
BUG: Fix ApertureStats give nan centroid

### DIFF
--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -893,6 +893,12 @@ class ApertureStats:
         the centroid within the aperture.
         """
         moments = self.moments
+
+        # Just return aperture center.
+        if np.allclose(moments, 0):
+            return (np.transpose(self.aperture.positions) -
+                    np.transpose((self.bbox_xmin, self.bbox_ymin)))
+
         if self.isscalar:
             moments = moments[np.newaxis, :]
 

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -241,3 +241,10 @@ class TestApertureStats:
     def test_repr_str(self):
         assert repr(self.apstats1) == str(self.apstats1)
         assert 'Length: 3' in repr(self.apstats1)
+
+
+def test_centroid_for_zeros():
+    data = np.zeros((10, 10))
+    aperture = CircularAperture((3, 4), r=3.)
+    apstats = ApertureStats(data, aperture)
+    assert_allclose(apstats.centroid, aperture.positions)


### PR DESCRIPTION
Fix `ApertureStats` give nan centroid for array with all zeros. There is no such problem if array is all ones. Since this is a quick follow-up to unreleased #1309 , there is no need for change log.

```python
>>> import numpy as np
>>> from photutils.aperture import ApertureStats, CircularAperture
>>> aperture = CircularAperture((30, 40), r=3.)
```

Without this patch:

```python
>>> a = np.zeros((100, 100))
>>> phot_aperstats = ApertureStats(a, aperture)
>>> phot_aperstats.to_table(columns=('xcentroid', 'ycentroid'))
<QTable length=1>
xcentroid ycentroid
 float64   float64
--------- ---------
      nan       nan

>>> a = np.ones((100, 100))
>>> phot_aperstats = ApertureStats(a, aperture)
>>> phot_aperstats.to_table(columns=('xcentroid', 'ycentroid'))
<QTable length=1>
xcentroid ycentroid
 float64   float64
--------- ---------
     30.0      40.0
```

With this patch:

```python
>>> a = np.zeros((100, 100))
>>> phot_aperstats = ApertureStats(a, aperture)
>>> phot_aperstats.to_table(columns=('xcentroid', 'ycentroid'))
<QTable length=1>
xcentroid ycentroid
 float64   float64
--------- ---------
     30.0      40.0

>>> # No change for when a = np.ones((100, 100))
```