### PR TITLE
Fix SourceCatalog UFuncTypeError if data has integer dtype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,11 @@ Bug Fixes
       ``xpeak``, or ``ypeak`` to ``None`` would result in an error.
       [#1297]
 
+- ``photutils.segmentation``
+
+    - Fixed a bug in ``SourceCatalog`` where a ``UFuncTypeError`` would
+      be raised if the input ``data`` had an integer ``dtype`` [#1312].
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -673,3 +673,18 @@ class TestSourceCatalog:
         assert 'kron_flux' not in cat2.__dict__
         tbl = cat2.to_table()
         assert len(tbl) == 7
+
+    def test_data_dtype(self):
+        """
+        Regression test that input ``data`` with int dtype does not
+        raise UFuncTypeError due to subtraction of float array from int
+        array.
+        """
+        data = np.zeros((25, 25), dtype=np.uint16)
+        data[8:16, 8:16] = 10
+        segmdata = np.zeros((25, 25))
+        segmdata[8:16, 8:16] = 1
+        segm = SegmentationImage(segmdata)
+        cat = SourceCatalog(data, segm, localbkg_width=3)
+        assert cat.min_value == 10
+        assert cat.max_value == 10


### PR DESCRIPTION
This PR fixes a `SourceCatalog` bug reported in #1302 where a ``UFuncTypeError`` would be raised if the input ``data`` has an integer ``dtype``.

Fixes #1302.