### PR TITLE
Cast ApertureStats input data arrays as float to prevent UFuncTypeError

### DIFF
--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -187,11 +187,12 @@ class ApertureStats:
 
         (data, error), unit = process_quantities((data, error),
                                                  ('data', 'error'))
-        self._data = self._validate_array(data, 'data', shape=False)
+        self._data = self._validate_array(data, 'data', shape=False,
+                                          dtype=float)
         self._data_unit = unit
         self.aperture = self._validate_aperture(aperture)
-        self._error = self._validate_array(error, 'error')
-        self._mask = self._validate_array(mask, 'mask')
+        self._error = self._validate_array(error, 'error', dtype=float)
+        self._mask = self._validate_array(mask, 'mask', dtype=None)
         self._wcs = wcs
 
         if sigma_clip is not None and not isinstance(sigma_clip, SigmaClip):
@@ -212,11 +213,11 @@ class ApertureStats:
             raise TypeError('aperture must be an Aperture object')
         return aperture
 
-    def _validate_array(self, array, name, shape=True):
+    def _validate_array(self, array, name, shape=True, dtype=None):
         if name == 'mask' and array is np.ma.nomask:
             array = None
         if array is not None:
-            array = np.asanyarray(array)
+            array = np.asanyarray(array, dtype=dtype)
             if array.ndim != 2:
                 raise ValueError(f'{name} must be a 2D array.')
             if shape and array.shape != self._data.shape:

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -241,3 +241,18 @@ class TestApertureStats:
     def test_repr_str(self):
         assert repr(self.apstats1) == str(self.apstats1)
         assert 'Length: 3' in repr(self.apstats1)
+
+    def test_data_dtype(self):
+        """
+        Regression test that input ``data`` with int dtype does not
+        raise UFuncTypeError due to subtraction of float array from int
+        array.
+        """
+        data = np.ones((25, 25), dtype=np.uint16)
+        aper = CircularAperture((12, 12), 5)
+        apstats = ApertureStats(data, aper)
+        assert apstats.min == 1.0
+        assert apstats.max == 1.0
+        assert apstats.mean == 1.0
+        assert apstats.xcentroid == 12.0
+        assert apstats.ycentroid == 12.0


### PR DESCRIPTION
This issue fixed in #1312 also affects `ApertureStats`, which is fixed here.