### PR TITLE
Fix centroid_quadratic when mask is input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ Bug Fixes
     ``xpeak``, or ``ypeak`` to ``None`` would result in an error.
     [#1297]
 
+  - Fixed a bug in ``centroid_quadratic`` where inputting a mask
+    would alter the input data array. [#1317]
+
 - ``photutils.segmentation``
 
   - Fixed a bug in ``SourceCatalog`` where a ``UFuncTypeError`` would

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -154,7 +154,7 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
     if ypeak is not None and ((ypeak < 0) or (ypeak > data.shape[0] - 1)):
         raise ValueError('ypeak is outside of the input data')
 
-    data = np.asanyarray(data, dtype=float)
+    data = np.asanyarray(data, dtype=float).copy()
     ny, nx = data.shape
 
     badmask = ~np.isfinite(data)

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -305,6 +305,21 @@ class TestCentroidSources:
                                   fit_boxsize=5)
         assert_allclose(xycen5, ([7], [7]))
 
+    def test_centroid_quadratic_mask(self):
+        """
+        Regression test to check that when a mask is input the original
+        data is not alterned.
+        """
+        xc_ref = 24.7
+        yc_ref = 25.2
+        model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=5.0, y_stddev=5.0)
+        y, x = np.mgrid[0:51, 0:51]
+        data = model(x, y)
+        mask = data < 1
+        xycen = centroid_quadratic(data, mask=mask)
+        assert ~np.any(np.isnan(data))
+        assert_allclose(xycen, (xc_ref, yc_ref), atol=0.01)
+
     def test_mask(self):
         mask = np.ones(self.data.shape, dtype=bool)
         xcen1, ycen1 = centroid_sources(self.data, 25, 23, box_size=(55, 55))


### PR DESCRIPTION
This PR fixes a bug in ``centroid_quadratic`` where inputting a mask would alter the input data array.