### PR TITLE
SegmentationImage improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,11 @@ New Features
   - Added an ``alpha`` keyword to the ``Background2D.plot_meshes``
     method. [#1286]
 
+- ``photutils.segmentation``
+
+  - Added ``SegmentationImage`` ``cmap`` attribute containing a default
+    colormap. [#1319]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -109,6 +114,11 @@ API Changes
   - Removed the deprecated the ``filter_kernel`` keyword in the
     ``detect_sources``, ``deblend_sources``, and ``make_source_mask``
     functions. [#1280]
+
+  - A ``TypeError`` is raised if the input array to
+    ``SegmentationImage`` does not have integer type. [#1319]
+
+  - A ``SegmentationImage`` may contain an array of all zeros. [#1319]
 
 
 1.3.0 (2021-12-21)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -263,6 +263,9 @@ class SourceCatalog:
             raise TypeError('segment_img must be a SegmentationImage')
         if segment_img.shape != self._data.shape:
             raise ValueError('segment_img and data must have the same shape.')
+        if np.sum(segment_img.data) == 0:
+            raise ValueError('segment_img must have at least one non-zero '
+                             'label.')
         return segment_img
 
     def _validate_array(self, array, name, shape=True, dtype=None):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -58,15 +58,6 @@ class SegmentationImage:
         """
         return self._data
 
-    @lazyproperty
-    def _cmap(self):
-        """
-        A matplotlib colormap consisting of (random) muted colors.
-
-        This is useful for plotting the segmentation array.
-        """
-        return self.make_cmap(background_color='#000000', seed=0)
-
     @staticmethod
     def _get_labels(data):
         """
@@ -401,6 +392,15 @@ class SegmentationImage:
             cmap.colors[0] = colors.hex2color(background_color)
 
         return cmap
+
+    @lazyproperty
+    def cmap(self):
+        """
+        A matplotlib colormap consisting of (random) muted colors.
+
+        This is useful for plotting the segmentation array.
+        """
+        return self.make_cmap(background_color='#000000', seed=0)
 
     def reassign_label(self, label, new_label, relabel=False):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -120,16 +120,16 @@ class SegmentationImage:
         if not np.issubdtype(value.dtype, np.integer):
             raise TypeError('data must be have integer type')
 
-        if not np.any(value):
-            raise ValueError('The segmentation image must contain at least '
-                             'one non-zero pixel.')
-
         if np.min(value) < 0:
             raise ValueError('The segmentation image cannot contain '
                              'negative integers.')
 
+        if np.sum(value) == 0:
+            raise ValueError('The segmentation image must contain at least '
+                             'one non-zero pixel.')
+
         if '_data' in self.__dict__:
-            # needed only when data is reassigned, not on init
+            # reset instance properties when data is reassigned, not on init
             self.__dict__ = {}
 
         self._data = value  # pylint: disable=attribute-defined-outside-init

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -63,7 +63,7 @@ class SegmentationImage:
         """
         A matplotlib colormap consisting of (random) muted colors.
 
-        This is very useful for plotting the segmentation array.
+        This is useful for plotting the segmentation array.
         """
         return self.make_cmap(background_color='#000000', seed=0)
 
@@ -272,10 +272,10 @@ class SegmentationImage:
 
         Returns
         -------
-        area : `~numpy.ndarray`
+        area : float
             The area of the labeled region.
         """
-        return self.get_areas(label)
+        return self.get_areas(label)[0]
 
     def get_areas(self, labels):
         """
@@ -292,17 +292,17 @@ class SegmentationImage:
         areas : `~numpy.ndarray`
             The areas of the labeled regions.
         """
-        idx = self.get_indices(labels)
+        idx = self.get_indices(np.atleast_1d(labels))
         return self.areas[idx]
 
     @lazyproperty
     def is_consecutive(self):
         """
-        Determine whether or not the non-zero labels in the segmentation
-        array are consecutive and start from 1.
+        Boolean value indicating whether or not the non-zero labels in
+        the segmentation array are consecutive and start from 1.
         """
-        return ((self.labels[-1] - self.labels[0] + 1) == self.nlabels and
-                self.labels[0] == 1)
+        return ((self.labels[-1] - self.labels[0] + 1) == self.nlabels
+                and self.labels[0] == 1)
 
     @lazyproperty
     def missing_labels(self):
@@ -372,7 +372,7 @@ class SegmentationImage:
         Define a matplotlib colormap consisting of (random) muted
         colors.
 
-        This is very useful for plotting the segmentation array.
+        This is useful for plotting the segmentation array.
 
         Parameters
         ----------

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -116,11 +116,10 @@ class SegmentationImage:
 
     @data.setter
     def data(self, value):
-        if np.any(~np.isfinite(value)):
-            raise ValueError('data must not contain any non-finite values '
-                             '(e.g., NaN, inf)')
+        value = np.asarray(value)
+        if not np.issubdtype(value.dtype, np.integer):
+            raise TypeError('data must be have integer type')
 
-        value = np.asarray(value, dtype=int)
         if not np.any(value):
             raise ValueError('The segmentation image must contain at least '
                              'one non-zero pixel.')

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -244,7 +244,7 @@ class SegmentationImage:
     @lazyproperty
     def background_area(self):
         """The area (in pixel**2) of the background (label=0) region."""
-        return len(self.data[self.data == 0])
+        return self._data.size - np.count_nonzero(self._data)
 
     @lazyproperty
     def areas(self):
@@ -256,9 +256,10 @@ class SegmentationImage:
         returned array has a length equal to the number of labels and
         matches the order of the ``labels`` attribute.
         """
-        return np.array([area
-                         for area in np.bincount(self.data.ravel())[1:]
-                         if area != 0])
+        areas = []
+        for label, slices in zip(self.labels, self.slices):
+            areas.append(np.count_nonzero(self._data[slices] == label))
+        return np.array(areas)
 
     def get_area(self, label):
         """

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -105,6 +105,9 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
     if segment_img.shape != data.shape:
         raise ValueError('The data and segmentation image must have '
                          'the same shape')
+    if np.sum(segment_img.data) == 0:
+        raise ValueError('The segmentation image must have at least one '
+                         'non-zero label.')
 
     if labels is None:
         labels = segment_img.labels

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -269,7 +269,7 @@ class TestSourceCatalog:
         with pytest.raises(ValueError):
             SourceCatalog(img1d, segm)
 
-        wrong_shape = np.ones((3, 3))
+        wrong_shape = np.ones((3, 3), dtype=int)
         with pytest.raises(ValueError):
             SourceCatalog(wrong_shape, self.segm)
 
@@ -682,7 +682,7 @@ class TestSourceCatalog:
         """
         data = np.zeros((25, 25), dtype=np.uint16)
         data[8:16, 8:16] = 10
-        segmdata = np.zeros((25, 25))
+        segmdata = np.zeros((25, 25), dtype=int)
         segmdata[8:16, 8:16] = 1
         segm = SegmentationImage(segmdata)
         cat = SourceCatalog(data, segm, localbkg_width=3)

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -34,26 +34,18 @@ class TestSegmentationImage:
         assert segm.data[0, 0] != segm2.data[0, 0]
 
     def test_invalid_data(self):
+        # is float dtype
+        data = np.zeros((3, 3), dtype=float)
+        with pytest.raises(TypeError):
+            SegmentationImage(data)
+
         # contains all zeros
-        data = np.zeros((3, 3))
-        with pytest.raises(ValueError):
-            SegmentationImage(data)
-
-        # contains a NaN
-        data = np.zeros((5, 5))
-        data[2, 2] = np.nan
-        with pytest.raises(ValueError):
-            SegmentationImage(data)
-
-        # contains an inf
-        data = np.zeros((5, 5))
-        data[2, 2] = np.inf
-        data[0, 0] = -np.inf
+        data = np.zeros((3, 3), dtype=int)
         with pytest.raises(ValueError):
             SegmentationImage(data)
 
         # contains a negative value
-        data = np.arange(-1, 8).reshape(3, 3)
+        data = np.arange(-1, 8).reshape(3, 3).astype(int)
         with pytest.raises(ValueError):
             SegmentationImage(data)
 
@@ -170,7 +162,7 @@ class TestSegmentationImage:
         assert len(cmap.colors) == (self.segm.max_label + 1)
         assert_allclose(cmap.colors[0], [0, 0, 0])
 
-        assert_allclose(self.segm._cmap.colors,
+        assert_allclose(self.segm.cmap.colors,
                         self.segm.make_cmap(background_color='#000000',
                                             seed=0).colors)
 
@@ -304,7 +296,7 @@ class TestSegmentationImage:
         assert_allclose(segm.data, ref_data)
 
     def test_remove_masked_segments_mask_shape(self):
-        segm = SegmentationImage(np.ones((5, 5)))
+        segm = SegmentationImage(np.ones((5, 5), dtype=int))
         mask = np.zeros((3, 3), dtype=bool)
         with pytest.raises(ValueError):
             segm.remove_masked_labels(mask)

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -171,7 +171,7 @@ class TestDeblendSources:
         assert result.nlabels == 2
 
     def test_segment_img_badshape(self):
-        segm_wrong = np.ones((2, 2))
+        segm_wrong = np.ones((2, 2), dtype=int)
         with pytest.raises(ValueError):
             deblend_sources(self.data, segm_wrong, self.npixels)
 


### PR DESCRIPTION
This PR make the following changes to `SegmentationImage`:

  * performance improvements when initializing with large datasets
  * performance improvements for the `areas` and `background_area` attributes
  * adds a `cmap` attribute defining a default mpl colormap
  * a `TypeError` is now raised if the input data does not have integer type
  * allows initialization with an array of all zeros