### PR TITLE
Deprecate segmentation detect keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -129,6 +129,12 @@ API Changes
 
   - A ``SegmentationImage`` may contain an array of all zeros. [#1319]
 
+  - Deprecated the ``mask_value`` keyword in ``detect_threshold``. Use
+    the ``mask`` keyword instead. [#1322]
+
+  - Deprecated the ``filter_fwhm`` and ``filter_size`` keywords in
+    ``make_source_mask``. Use the ``kernel`` keyword instead. [#1322]
+
 
 1.3.0 (2021-12-21)
 ------------------

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -7,6 +7,7 @@ import warnings
 
 from astropy.convolution import Gaussian2DKernel, convolve
 from astropy.stats import gaussian_fwhm_to_sigma, sigma_clipped_stats
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -16,6 +17,8 @@ from ..utils.exceptions import NoDetectionsWarning
 __all__ = ['detect_threshold', 'detect_sources', 'make_source_mask']
 
 
+@deprecated_renamed_argument('mask_value', None, '1.4', message='Use the '
+                             'mask keyword')
 def detect_threshold(data, nsigma, background=None, error=None, mask=None,
                      mask_value=None, sigclip_sigma=3.0, sigclip_iters=None):
     """
@@ -56,6 +59,7 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
         statistics.
 
     mask_value : float, optional
+        Deprecated.
         An image data value (e.g., ``0.0``) that is ignored when
         computing the image background statistics.  ``mask_value`` will
         be ignored if ``mask`` is input.
@@ -82,10 +86,10 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
 
     Notes
     -----
-    The ``mask``, ``mask_value``, ``sigclip_sigma``, and
-    ``sigclip_iters`` inputs are used only if it is necessary to
+    The ``mask``, ``mask_value`` (deprecated), ``sigclip_sigma``,
+    and ``sigclip_iters`` inputs are used only if it is necessary to
     estimate ``background`` or ``error`` using sigma-clipped background
-    statistics.  If ``background`` and ``error`` are both input, then
+    statistics. If ``background`` and ``error`` are both input, then
     ``mask``, ``mask_value``, ``sigclip_sigma``, and ``sigclip_iters``
     are ignored.
     """
@@ -407,6 +411,10 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
                            connectivity=connectivity, mask=mask)[0]
 
 
+@deprecated_renamed_argument('filter_fwhm', None, '1.4', message='Use the '
+                             'kernel keyword')
+@deprecated_renamed_argument('filter_size', None, '1.4', message='Use the '
+                             'kernel keyword')
 def make_source_mask(data, nsigma, npixels, mask=None, filter_fwhm=None,
                      filter_size=3, kernel=None, sigclip_sigma=3.0,
                      sigclip_iters=5, dilate_size=11):
@@ -441,6 +449,7 @@ def make_source_mask(data, nsigma, npixels, mask=None, filter_fwhm=None,
         statistics.
 
     filter_fwhm : float, optional
+        Deprecated (use the ``kernel`` keyword).
         The full-width at half-maximum (FWHM) of the Gaussian kernel
         to filter the image before thresholding. ``filter_fwhm``
         and ``filter_size`` are ignored if ``kernel`` is defined.
@@ -448,6 +457,7 @@ def make_source_mask(data, nsigma, npixels, mask=None, filter_fwhm=None,
         convolved.
 
     filter_size : float, optional
+        Deprecated (use the ``kernel`` keyword).
         The size of the square Gaussian kernel image. Used only if
         ``filter_fwhm`` is defined. ``filter_fwhm`` and ``filter_size``
         are ignored if ``kernel`` is defined. ``filter_size`` must be

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -5,6 +5,7 @@ Tests for the detect module.
 
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
+from astropy.utils.exceptions import AstropyDeprecationWarning
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
@@ -83,8 +84,8 @@ class TestDetectThreshold:
 
     def test_mask_value(self):
         """Test detection with mask_value."""
-
-        threshold = detect_threshold(DATA, nsigma=1.0, mask_value=0.0)
+        with pytest.warns(AstropyDeprecationWarning):
+            threshold = detect_threshold(DATA, nsigma=1.0, mask_value=0.0)
         ref = 2. * np.ones((3, 3))
         assert_array_equal(threshold, ref)
 
@@ -103,13 +104,14 @@ class TestDetectThreshold:
 
     def test_image_mask_override(self):
         """Test that image_mask overrides mask_value."""
-
         mask = REF1.astype(bool)
-        threshold = detect_threshold(DATA, nsigma=0.1, error=0, mask_value=0.0,
-                                     mask=mask, sigclip_sigma=10,
-                                     sigclip_iters=1)
-        ref = np.ones((3, 3))
-        assert_array_equal(threshold, ref)
+        with pytest.raises(AstropyDeprecationWarning):
+            threshold = detect_threshold(DATA, nsigma=0.1, error=0,
+                                         mask_value=0.0,
+                                         mask=mask, sigclip_sigma=10,
+                                         sigclip_iters=1)
+            ref = np.ones((3, 3))
+            assert_array_equal(threshold, ref)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -258,8 +260,9 @@ class TestMakeSourceMask:
         assert np.count_nonzero(mask2) > np.count_nonzero(mask1)
 
     def test_kernel(self):
-        mask1 = make_source_mask(self.data, 5, 10, filter_fwhm=2,
-                                 filter_size=3)
+        with pytest.warns(AstropyDeprecationWarning):
+            mask1 = make_source_mask(self.data, 5, 10, filter_fwhm=2,
+                                     filter_size=3)
         sigma = 2 * gaussian_fwhm_to_sigma
         kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
         mask2 = make_source_mask(self.data, 5, 10, kernel=kernel)


### PR DESCRIPTION
This PR  deprecates the ``mask_value`` keyword in ``detect_threshold`` (use the ``mask`` keyword instead) and the  ``filter_fwhm`` and ``filter_size`` keywords in ``make_source_mask`` (use the ``kernel`` keyword instead).