### PR TITLE
Explicitly add to_mask method to pixel apertures

### DIFF
--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -193,6 +193,10 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         else:
             return patches
 
+    def to_mask(self, method='exact', subpixels=5):
+        return CircularMaskMixin.to_mask(self, method=method,
+                                         subpixels=subpixels)
+
     def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyCircularAperture` object defined
@@ -318,6 +322,10 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
             return patches[0]
         else:
             return patches
+
+    def to_mask(self, method='exact', subpixels=5):
+        return CircularMaskMixin.to_mask(self, method=method,
+                                         subpixels=subpixels)
 
     def to_sky(self, wcs):
         """

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -234,6 +234,10 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         else:
             return patches
 
+    def to_mask(self, method='exact', subpixels=5):
+        return EllipticalMaskMixin.to_mask(self, method=method,
+                                           subpixels=subpixels)
+
     def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyEllipticalAperture` object defined
@@ -398,6 +402,10 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
             return patches[0]
         else:
             return patches
+
+    def to_mask(self, method='exact', subpixels=5):
+        return EllipticalMaskMixin.to_mask(self, method=method,
+                                           subpixels=subpixels)
 
     def to_sky(self, wcs):
         """

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -187,6 +187,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         self.positions = positions
         self.a = a
         self.b = b
+        self._theta_radians = 0.0  # defined by theta setter
         self.theta = theta
 
     @property
@@ -352,6 +353,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
                 raise ValueError('"b_out" must be greater than "b_in".')
         self.b_in = b_in
 
+        self._theta_radians = 0.0  # defined by theta setter
         self.theta = theta
 
     @property

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -210,6 +210,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         self.positions = positions
         self.w = w
         self.h = h
+        self._theta_radians = 0.0  # defined by theta setter
         self.theta = theta
 
     @property
@@ -381,6 +382,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
                 raise ValueError('"h_out" must be greater than "h_in"')
         self.h_in = h_in
 
+        self._theta_radians = 0.0  # defined by theta setter
         self.theta = theta
 
     @property

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -259,6 +259,10 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         else:
             return patches
 
+    def to_mask(self, method='exact', subpixels=5):
+        return RectangularMaskMixin.to_mask(self, method=method,
+                                            subpixels=subpixels)
+
     def to_sky(self, wcs):
         """
         Convert the aperture to a `SkyRectangularAperture` object
@@ -434,6 +438,10 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
             return patches[0]
         else:
             return patches
+
+    def to_mask(self, method='exact', subpixels=5):
+        return RectangularMaskMixin.to_mask(self, method=method,
+                                            subpixels=subpixels)
 
     def to_sky(self, wcs):
         """


### PR DESCRIPTION
Pixel apertures currently inherit `to_mask` from the mask `Mixin` classes, but the `to_mask` is also defined as an abstract method in the `PixelAperture` base class.  In this PR, `to_mask` is explicitly added to point to the `to_mask` methods of the `Mixin` classes.  Note that everything currently works given the python class MRO, but this PR makes it explicit.