### PR TITLE
Remove deprecated circular_aperture method from SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.segmentation``
+
+  - Removed the deprecated ``circular_aperture`` method from
+    ``SourceCatalog``. [#1329]
+
 
 1.4.0 (2022-03-25)
 ------------------

--- a/docs/whats_new/1.1.rst
+++ b/docs/whats_new/1.1.rst
@@ -63,7 +63,6 @@ New methods and attributes
 The new `~photutils.segmentation.SourceCatalog` class has the following
 new methods:
 
-    * :meth:`~photutils.segmentation.SourceCatalog.circular_aperture`
     * :meth:`~photutils.segmentation.SourceCatalog.circular_photometry`
     * :meth:`~photutils.segmentation.SourceCatalog.fluxfrac_radius`
     * :meth:`~photutils.segmentation.SourceCatalog.get_label`

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -13,7 +13,6 @@ from astropy.stats import SigmaClip
 from astropy.table import QTable
 import astropy.units as u
 from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated
 import numpy as np
 
 from .core import SegmentationImage
@@ -2316,27 +2315,6 @@ class SourceCatalog:
                 aperture.plot(axes=axes, origin=origin, **kwargs)
                 patches.append(aperture._to_patch(origin=origin, **kwargs))
         return patches
-
-    @deprecated('1.3', alternative='make_circular_apertures')
-    def circular_aperture(self, radius):
-        """
-        Return a list of circular apertures with the specified radius
-        centered at the source centroid position.
-
-        Parameters
-        ----------
-        radius : float
-            The radius of the circle in pixels.
-
-        Returns
-        -------
-        result : list of `~photutils.aperture.CircularAperture`
-            A list of `~photutils.aperture.CircularAperture` instances.
-            The aperture will be `None` where the source centroid
-            position is not finite or where the source is completely
-            masked.
-        """
-        return self.make_circular_apertures(radius)
 
     def circular_photometry(self, radius, name=None, overwrite=False):
         """

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -37,6 +37,7 @@ class TestDeblendSources:
     def test_deblend_sources(self, mode):
         # scipy DeprecationWarning is currently raised from skimage
         # (https://github.com/scikit-image/scikit-image/pull/6231)
+        # This can be removed for skimage >= 0.19.2.
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
             result = deblend_sources(self.data, self.segm, self.npixels,


### PR DESCRIPTION
Removes the deprecated ``circular_aperture`` method from ``SourceCatalog`.  Use `make_circular_apertures` instead.