### PR TITLE
Update RTD config to use Python 3.10

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,11 @@
 version: 2
 
-# bottlneck does not install with python 3.10
 build:
   os: ubuntu-20.04
   apt_packages:
     - graphviz
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
   builder: html


### PR DESCRIPTION
`bottleneck` wheels are now available for Python 3.10.