### PR TITLE
DOC: Encourage local_bkg in ApertureStats

### DIFF
--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -375,6 +375,13 @@ subtract the background from the data::
 
     >>> phot_table = aperture_photometry(data - bkg, aperture)  # doctest: +SKIP
 
+In the case of a constant background, you can pass it in as global background
+using ``local_bkg`` in :class:`~photutils.aperture.ApertureStats`, which
+would prevent the need of reading the entire memory-mapped data into memory
+before hand, as what would happen if you subtract it manually above;
+so instead you could do this::
+
+    >>> aperstats = ApertureStats(data, aperture, local_bkg=bkg)  # doctest: +SKIP
 
 Local Background Subtraction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -375,11 +375,11 @@ subtract the background from the data::
 
     >>> phot_table = aperture_photometry(data - bkg, aperture)  # doctest: +SKIP
 
-In the case of a constant background, you can pass it in as global background
-using ``local_bkg`` in :class:`~photutils.aperture.ApertureStats`, which
-would prevent the need of reading the entire memory-mapped data into memory
-before hand, as what would happen if you subtract it manually above;
-so instead you could do this::
+In the case of a constant global background, you can pass in the background
+value using ``local_bkg`` in :class:`~photutils.aperture.ApertureStats`.
+This would avoid reading an entire memory-mapped array into memory
+beforehand, as would happen if you manually subtract the background as
+shown above. So instead you could do this::
 
     >>> aperstats = ApertureStats(data, aperture, local_bkg=bkg)  # doctest: +SKIP
 


### PR DESCRIPTION
No reason not to use ``local_bkg``, right? Should put best practice in example? xref:

* #1316 