### PR TITLE
Add SourceFinder class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ General
 
 New Features
 ^^^^^^^^^^^^
+- ``photutils.segmentation``
+
+    - Added ``SourceFinder`` class, which is a convenience class
+      combining ``detect_sources`` and ``deblend_sources``. [#1344]
 
 Bug Fixes
 ^^^^^^^^^

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -247,6 +247,20 @@ Let's plot one of the deblended sources:
     plt.tight_layout()
 
 
+SourceFinder
+------------
+The :class:`~photutils.segmentation.SourceFinder` class
+is a convenience class that combines the functionality
+of `~photutils.segmentation.detect_sources` and
+`~photutils.segmentation.deblend_sources`. After defining the object
+with the desired detection and deblending parameters, you call it with
+the (convolved) image and threshold::
+
+    >>> from photutils.segmentation import SourceFinder
+    >>> finder = SourceFinder(npixels=10)
+    >>> segment_map = finder(convolved_data, threshold)
+
+
 Modifying a Segmentation Image
 ------------------------------
 The :class:`~photutils.segmentation.SegmentationImage` object provides

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -32,7 +32,9 @@ Let's start by making a synthetic image provided by the
 
 Next, we need to subtract the background from the image. In this
 example, we'll use the :class:`~photutils.background.Background2D` class
-to produce a background and background noise image::
+to produce a background and background noise image:
+
+.. doctest-requires:: scipy
 
     >>> from photutils.background import Background2D, MedianBackground
     >>> bkg_estimator = MedianBackground()
@@ -43,7 +45,9 @@ to produce a background and background noise image::
 After subtracting the background, we need to define the detection
 threshold. In this example, we'll define a 2D detection threshold image
 using the background RMS image. We set the threshold at the 1.5-sigma (per
-pixel) noise level::
+pixel) noise level:
+
+.. doctest-requires:: scipy
 
     >>> threshold = 1.5 * bkg.background_rms
 
@@ -64,7 +68,9 @@ defined above (i.e., 1.5 sigma per pixel above the background noise).
 Note that by default "connected pixels" means "8-connected" pixels,
 where pixels touch along their edges or corners. One can also use
 "4-connected" pixels that touch only along their edges by setting
-``connectivity=4``::
+``connectivity=4``:
+
+.. doctest-requires:: scipy
 
     >>> from photutils.segmentation import detect_sources
     >>> segment_map = detect_sources(convolved_data, threshold, npixels=10)
@@ -154,7 +160,7 @@ peak must have to be considered as a separate object.
 
 Here's a simple example of source deblending:
 
-.. doctest-requires:: skimage
+.. doctest-requires:: scipy, skimage
 
     >>> from photutils.segmentation import deblend_sources
     >>> segm_deblend = deblend_sources(convolved_data, segment_map,
@@ -259,7 +265,9 @@ is a convenience class that combines the functionality
 of `~photutils.segmentation.detect_sources` and
 `~photutils.segmentation.deblend_sources`. After defining the object
 with the desired detection and deblending parameters, you call it with
-the background-subtracted (convolved) image and threshold::
+the background-subtracted (convolved) image and threshold:
+
+.. doctest-requires:: scipy, skimage
 
     >>> from photutils.segmentation import SourceFinder
     >>> finder = SourceFinder(npixels=10)
@@ -312,7 +320,9 @@ from which the source centroids and shape/morphological properties are
 measured (if not input, the unconvolved image is used instead).
 
 Let's continue our example from above and measure the properties of the
-detected sources::
+detected sources:
+
+.. doctest-requires:: scipy, skimage
 
     >>> from photutils.segmentation import SourceCatalog
     >>> cat = SourceCatalog(data, segm_deblend, convolved_data=convolved_data)
@@ -337,7 +347,7 @@ properties. The ``label`` column corresponds to the label value in the
 input segmentation image. Note that only a small subset of the source
 properties are shown below:
 
-.. doctest-requires:: scipy>=1.6.0
+.. doctest-requires:: scipy, skimage
 
     >>> tbl = cat.to_table()
     >>> tbl['xcentroid'].info.format = '.2f'  # optional format
@@ -428,7 +438,7 @@ We can also create a `~photutils.segmentation.SourceCatalog` object
 containing only a specific subset of sources, defined by their
 label numbers in the segmentation image:
 
-.. doctest-requires:: scipy>=1.6.0
+.. doctest-requires:: scipy, skimage
 
     >>> cat = SourceCatalog(data, segm_deblend, convolved_data=convolved_data)
     >>> labels = [1, 5, 20, 50, 75, 80]
@@ -453,7 +463,7 @@ includes only a small subset of source properties. The output table
 properties can be customized in the `~astropy.table.QTable` using the
 ``columns`` keyword:
 
-.. doctest-requires:: scipy>=1.6.0
+.. doctest-requires:: scipy, skimage
 
     >>> cat = SourceCatalog(data, segm_deblend, convolved_data=convolved_data)
     >>> labels = [1, 5, 20, 50, 75, 80]
@@ -489,7 +499,7 @@ that was subtracted from the data into the ``background`` keyword
 of :class:`~photutils.segmentation.SourceCatalog`, the background
 properties for each source will also be calculated:
 
-.. doctest-requires:: scipy>=1.6.0, skimage
+.. doctest-requires:: scipy, skimage
 
     >>> cat = SourceCatalog(data, segm_deblend, background=bkg.background)
     >>> labels = [1, 5, 20, 50, 75, 80]
@@ -542,7 +552,7 @@ calculated. `~photutils.segmentation.SourceCatalog.segment_flux`
 and `~photutils.segmentation.SourceCatalog.segment_fluxerr` are the
 instrumental flux and propagated flux error within the source segments:
 
-.. doctest-requires:: scipy>=1.6.0
+.. doctest-requires:: scipy, skimage
 
     >>> from photutils.utils import calc_total_error
     >>> effective_gain = 500.

--- a/photutils/segmentation/__init__.py
+++ b/photutils/segmentation/__init__.py
@@ -9,3 +9,4 @@ from .catalog import *  # noqa
 from .core import *  # noqa
 from .deblend import *  # noqa
 from .detect import *  # noqa
+from .finder import *  # noqa

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -106,6 +106,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
     See Also
     --------
     :func:`photutils.segmentation.detect_sources`
+    :class:`photutils.segmentation.SourceFinder`
     """
     if not isinstance(segment_img, SegmentationImage):
         segment_img = SegmentationImage(segment_img)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -83,6 +83,7 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
     See Also
     --------
     :func:`photutils.segmentation.detect_sources`
+    :class:`photutils.segmentation.SourceFinder`
 
     Notes
     -----
@@ -194,11 +195,9 @@ def _detect_sources(data, thresholds, npixels, kernel=None, connectivity=8,
            otherwise the data will be convolved twice.
 
     thresholds : array-like of floats or arrays
-        The data value or pixel-wise data values to
-        be used for the detection thresholds. A 2D
-        ``threshold`` must have the same shape as ``data``. See
-        `~photutils.segmentation.detect_threshold` for one way to create
-        a ``threshold`` image.
+        The data value or pixel-wise data values to be used for the
+        detection thresholds. A 2D ``threshold`` must have the same
+        shape as ``data``.
 
     npixels : int
         The number of connected pixels, each greater than ``threshold``,
@@ -335,8 +334,7 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
     threshold : float or array-like
         The data value or pixel-wise data values to be used for the
         detection threshold. A 2D ``threshold`` must have the same shape
-        as ``data``. See `~photutils.segmentation.detect_threshold` for
-        one way to create a ``threshold`` image.
+        as ``data``.
 
     npixels : int
         The number of connected pixels, each greater than ``threshold``,
@@ -372,9 +370,8 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
 
     See Also
     --------
-    :func:`photutils.segmentation.detect_threshold`
-    :class:`photutils.segmentation.SegmentationImage`
     :func:`photutils.segmentation.deblend_sources`
+    :class:`photutils.segmentation.SourceFinder`
 
     Examples
     --------

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -149,8 +149,6 @@ def _make_binary_structure(ndim, connectivity):
         The binary structure element.  If ``ndim <= 2`` an array of int
         is returned, otherwise an array of bool is returned.
     """
-    from scipy.ndimage import generate_binary_structure
-
     if ndim == 1:
         selem = np.array((1, 1, 1))
     elif ndim == 2:
@@ -162,6 +160,7 @@ def _make_binary_structure(ndim, connectivity):
             raise ValueError(f'Invalid connectivity={connectivity}.  '
                              'Options are 4 or 8.')
     else:
+        from scipy.ndimage import generate_binary_structure
         selem = generate_binary_structure(ndim, 1)
 
     return selem

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -14,6 +14,10 @@ class SourceFinder:
     Class to detect sources, including deblending, in an image using
     segmentation.
 
+    This is a convenience class that combines the functionality
+    of `~photutils.segmentation.detect_sources` and
+    `~photutils.segmentation.deblend_sources`.
+
     Sources are deblended using a combination of
     multi-thresholding and `watershed segmentation
     <https://en.wikipedia.org/wiki/Watershed_(image_processing)>`_. In
@@ -57,6 +61,11 @@ class SourceFinder:
         The mode used in defining the spacing between the
         multi-thresholding levels (see the ``nlevels`` keyword) during
         deblending. This keyword is ignored unless ``deblend=True``.
+
+    See Also
+    --------
+    :func:`photutils.segmentation.detect_sources`
+    :func:`photutils.segmentation.deblend_sources`
 
     Examples
     --------

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -1,0 +1,115 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module provides tools for detecting sources in an image.
+"""
+
+from .detect import detect_sources
+from .deblend import deblend_sources
+
+__all__ = ['SourceFinder']
+
+
+class SourceFinder:
+    """
+    Class to detect sources, including deblending, in an image using
+    segmentation.
+
+    Sources are deblended using a combination of
+    multi-thresholding and `watershed segmentation
+    <https://en.wikipedia.org/wiki/Watershed_(image_processing)>`_. In
+    order to deblend sources, there must be a saddle between them.
+
+    Parameters
+    ----------
+    npixels : int
+        The number of connected pixels, each greater than a specified
+        threshold, that an object must have to be detected. ``npixels``
+        must be a positive integer.
+
+    connectivity : {4, 8}, optional
+        The type of pixel connectivity used in determining how pixels
+        are grouped into a detected source. The options are 4 or
+        8 (default). 4-connected pixels touch along their edges.
+        8-connected pixels touch along their edges or corners. For
+        reference, SourceExtractor uses 8-connected pixels.
+
+    deblend : bool, optional
+        Whether to deblend overlapping sources.
+
+    nlevels : int, optional
+        The number of multi-thresholding levels to use for deblending.
+        Each source will be re-thresholded at ``nlevels`` levels spaced
+        exponentially or linearly (see the ``mode`` keyword) between
+        its minimum and maximum values. This keyword is ignored unless
+        ``deblend=True``.
+
+    contrast : float, optional
+        The fraction of the total source flux that a local peak must
+        have (at any one of the multi-thresholds) to be deblended
+        as a separate object. ``contrast`` must be between 0 and 1,
+        inclusive. If ``contrast=0`` then every local peak will be made
+        a separate object (maximum deblending). If ``contrast=1`` then
+        no deblending will occur. The default is 0.001, which will
+        deblend sources with a 7.5 magnitude difference. This keyword is
+        ignored unless ``deblend=True``.
+
+    mode : {'exponential', 'linear'}, optional
+        The mode used in defining the spacing between the
+        multi-thresholding levels (see the ``nlevels`` keyword) during
+        deblending. This keyword is ignored unless ``deblend=True``.
+    """
+
+    def __init__(self, npixels, *, connectivity=8, deblend=True, nlevels=32,
+                 contrast=0.001, mode='exponential'):
+        self.npixels = npixels
+        self.deblend = deblend
+        self.connectivity = connectivity
+        self.nlevels = nlevels
+        self.contrast = contrast
+        self.mode = mode
+
+    def __call__(self, data, threshold, mask=None):
+        """
+        Detect sources, including deblending, in an image using using
+        segmentation.
+
+        Parameters
+        ----------
+        data : 2D `~numpy.ndarray`
+            The 2D array from which to detect sources. Typically, this
+            array should be an image that has been convolved with a
+            smoothing kernel.
+
+        threshold : 2D `~numpy.ndarray` or float
+            The data value or pixel-wise data values (as an array)
+            to be used as the per-pixel detection threshold. A 2D
+            ``threshold`` array must have the same shape as ``data``.
+
+        mask : 2D bool `~numpy.ndarray`, optional
+            A boolean mask with the same shape as ``data``, where a
+            `True` value indicates the corresponding element of ``data``
+            is masked. Masked pixels will not be included in any source.
+
+        Returns
+        -------
+        segment_image : `~photutils.segmentation.SegmentationImage` or `None`
+            A 2D segmentation image, with the same shape as the input data,
+            where sources are marked by different positive integer values. A
+            value of zero is reserved for the background. If no sources are
+            found then `None` is returned.
+        """
+        segment_img = detect_sources(data, threshold, self.npixels, mask=mask,
+                                     connectivity=self.connectivity)
+        if segment_img is None:
+            return None
+
+        # source deblending requires scikit-image
+        if self.deblend:
+            segment_img = deblend_sources(data, segment_img, self.npixels,
+                                          nlevels=self.nlevels,
+                                          contrast=self.contrast,
+                                          mode=self.mode,
+                                          connectivity=self.connectivity,
+                                          relabel=True)
+
+        return segment_img

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the finder module.
+"""
+
+from astropy.convolution import Gaussian2DKernel, convolve
+from astropy.stats import gaussian_fwhm_to_sigma
+import pytest
+
+from ..finder import SourceFinder
+from ...datasets import make_100gaussians_image
+from ...utils.exceptions import NoDetectionsWarning
+from ...utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE  # noqa
+
+
+class TestSourceFinder:
+    data = make_100gaussians_image() - 5.0  # subtract background
+    sigma = 3. * gaussian_fwhm_to_sigma  # FWHM = 3.
+    kernel = Gaussian2DKernel(sigma, x_size=5, y_size=5)
+    convolved_data = convolve(data, kernel, normalize_kernel=True)
+    threshold = 1.5 * 2.0
+    npixels = 10
+
+    def test_deblend(self):
+        finder = SourceFinder(npixels=self.npixels)
+        segm = finder(self.convolved_data, self.threshold)
+        assert segm.nlabels == 94
+
+    def test_no_deblend(self):
+        finder = SourceFinder(npixels=self.npixels, deblend=False)
+        segm = finder(self.convolved_data, self.threshold)
+        assert segm.nlabels == 86
+
+    def test_no_sources(self):
+        finder = SourceFinder(npixels=self.npixels, deblend=True)
+        with pytest.warns(NoDetectionsWarning):
+            segm = finder(self.convolved_data, 1000)
+            assert segm is None

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -13,6 +13,7 @@ from ...utils.exceptions import NoDetectionsWarning
 from ...utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE  # noqa
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 class TestSourceFinder:
     data = make_100gaussians_image() - 5.0  # subtract background
     sigma = 3. * gaussian_fwhm_to_sigma  # FWHM = 3.
@@ -21,6 +22,7 @@ class TestSourceFinder:
     threshold = 1.5 * 2.0
     npixels = 10
 
+    @pytest.mark.skipif('not HAS_SKIMAGE')
     def test_deblend(self):
         finder = SourceFinder(npixels=self.npixels)
         segm = finder(self.convolved_data, self.threshold)


### PR DESCRIPTION
This PR adds a `SourceFinder` class, which is a convenience class combining ``detect_sources`` and ``deblend_sources``.  This PR also updates and improves the segmentation narrative docs.