### PR TITLE
Require a SegmentationImage be input to deblend_sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,13 @@ API Changes
   - The ``SourceCatalog`` ``plot_kron_apertures`` method now sets a
     default ``kron_apers`` value. [#1346]
 
+  - ``deblend_sources`` no longer allows an array to be input as a
+    segmentation image. It must be a ``SegmentationImage`` object.
+    [#1347]
+
+  - ``SegmentationImage`` no longer allows array-like input. It must be
+    a numpy ``ndarray``. [#1347]
+
 
 1.4.0 (2022-03-25)
 ------------------

--- a/photutils/segmentation/_utils.py
+++ b/photutils/segmentation/_utils.py
@@ -16,10 +16,10 @@ def mask_to_mirrored_value(data, replace_mask, xycenter, mask=None):
 
     Parameters
     ----------
-    data : `numpy.ndarray`, 2D
+    data : 2D `~numpy.ndarray`
         A 2D array.
 
-    replace_mask : array-like, bool
+    replace_mask : 2D bool `~numpy.ndarray`
         A boolean mask where `True` values indicate the pixels that
         should be replaced, if possible, by mirrored pixel values. It
         must have the same shape as ``data``.
@@ -28,7 +28,7 @@ def mask_to_mirrored_value(data, replace_mask, xycenter, mask=None):
         The (x, y) center coordinates around which masked pixels will be
         mirrored.
 
-    mask : array-like, bool
+    mask : 2D bool `~numpy.ndarray`
         A boolean mask where `True` values indicate ``replace_mask``
         *mirrored* pixels that should never be used to fix
         ``replace_mask`` pixels. In other words, if a pixel in
@@ -38,7 +38,7 @@ def mask_to_mirrored_value(data, replace_mask, xycenter, mask=None):
 
     Returns
     -------
-    result : `numpy.ndarray`, 2D
+    result : 2D `~numpy.ndarray`
         A 2D array with replaced masked pixels.
     """
     outdata = np.copy(data)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -106,10 +106,10 @@ class SourceCatalog:
         values (NaN and inf) in the input ``data`` are automatically
         masked.
 
-    kernel : array-like (2D) or `~astropy.convolution.Kernel2D`, optional
-        The 2D array of the kernel used to filter the data prior to
-        calculating the source centroid and morphological parameters.
-        The kernel should be the same one used in defining the
+    kernel : 2D `~numpy.ndarray` or `~astropy.convolution.Kernel2D`, optional
+        The 2D kernel used to filter the data prior to calculating
+        the source centroid and morphological parameters. The
+        kernel should be the same one used in defining the
         source segments, i.e., the detection image (e.g., see
         :func:`~photutils.segmentation.detect_sources`). If `None`, then
         the unfiltered ``data`` will be used instead. This keyword is

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1139,7 +1139,6 @@ class Segment:
         result : 2D `~numpy.ndarray` or `~numpy.ma.MaskedArray`
             The cutout array.
         """
-        data = np.asanyarray(data)
         if data.shape != self._segment_data.shape:
             raise ValueError('data must have the same shape as the '
                              'segmentation array.')

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -26,10 +26,10 @@ class SegmentationImage:
 
     Parameters
     ----------
-    data : array_like (int)
-        A segmentation array where source regions are labeled by
+    data : 2D int `~numpy.ndarray`
+        A 2D segmentation array where source regions are labeled by
         different positive integer values. A value of zero is reserved
-        for the background. The segmentation image must have an integer
+        for the background. The segmentation image must have integer
         type.
     """
 
@@ -1124,7 +1124,7 @@ class Segment:
 
         Parameters
         ----------
-        data : array-like
+        data : 2D `~numpy.ndarray`
             The data array from which to create the masked cutout array.
             ``data`` must have the same shape as the segmentation array.
 
@@ -1136,7 +1136,7 @@ class Segment:
 
         Returns
         -------
-        result : `~numpy.ndarray` or `~numpy.ma.MaskedArray`
+        result : 2D `~numpy.ndarray` or `~numpy.ma.MaskedArray`
             The cutout array.
         """
         data = np.asanyarray(data)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -30,8 +30,8 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
 
     Parameters
     ----------
-    data : array_like
-        The data array. This array should be the same array used in
+    data : 2D `~numpy.ndarray`
+        The 2D data array. This array should be the same array used in
         `~photutils.segmentation.detect_sources`.
 
         .. note::
@@ -52,43 +52,42 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         that an object must have to be detected.  ``npixels`` must be a
         positive integer.
 
-    kernel : array-like or `~astropy.convolution.Kernel2D`, optional
-        The array of the kernel used to filter the image before
-        thresholding. Filtering the image will smooth the noise and
-        maximize detectability of objects with a shape similar to the
-        kernel. ``kernel`` must be `None` if the input ``data`` are
-        already convolved.
+    kernel : 2D `~numpy.ndarray` or `~astropy.convolution.Kernel2D`, optional
+        The 2D kernel used to filter the image before thresholding.
+        Filtering the image will smooth the noise and maximize
+        detectability of objects with a shape similar to the kernel.
+        ``kernel`` must be `None` if the input ``data`` are already
+        convolved.
 
     labels : int or array-like of int, optional
         The label numbers to deblend.  If `None` (default), then all
         labels in the segmentation image will be deblended.
 
     nlevels : int, optional
-        The number of multi-thresholding levels to use.  Each source
-        will be re-thresholded at ``nlevels`` levels spaced
+        The number of multi-thresholding levels to use for deblending.
+        Each source will be re-thresholded at ``nlevels`` levels spaced
         exponentially or linearly (see the ``mode`` keyword) between its
-        minimum and maximum values within the source segment.
+        minimum and maximum values.
 
     contrast : float, optional
-        The fraction of the total (blended) source flux that a local
-        peak must have (at any one of the multi-thresholds) to be
-        considered as a separate object.  ``contrast`` must be between 0
-        and 1, inclusive.  If ``contrast = 0`` then every local peak
-        will be made a separate object (maximum deblending).  If
-        ``contrast = 1`` then no deblending will occur.  The default is
-        0.001, which will deblend sources with a 7.5 magnitude
-        difference.
+        The fraction of the total source flux that a local peak must
+        have (at any one of the multi-thresholds) to be deblended
+        as a separate object. ``contrast`` must be between 0 and 1,
+        inclusive. If ``contrast=0`` then every local peak will be made
+        a separate object (maximum deblending). If ``contrast=1`` then
+        no deblending will occur. The default is 0.001, which will
+        deblend sources with a 7.5 magnitude difference.
 
     mode : {'exponential', 'linear'}, optional
         The mode used in defining the spacing between the
-        multi-thresholding levels (see the ``nlevels`` keyword).  The
-        default is 'exponential'.
+        multi-thresholding levels (see the ``nlevels`` keyword) during
+        deblending.
 
     connectivity : {8, 4}, optional
         The type of pixel connectivity used in determining how pixels
-        are grouped into a detected source.  The options are 8 (default)
-        or 4.  8-connected pixels touch along their edges or corners.
-        4-connected pixels touch along their edges.  For reference,
+        are grouped into a detected source. The options are 8 (default)
+        or 4. 8-connected pixels touch along their edges or corners.
+        4-connected pixels touch along their edges. For reference,
         SourceExtractor uses 8-connected pixels.
 
     relabel : bool
@@ -177,7 +176,7 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
 
     Parameters
     ----------
-    data : array_like
+    data : 2D `~numpy.ndarray`
         The cutout data array for a single source. ``data`` should
         also already be smoothed by the same filter used in
         :func:`~photutils.segmentation.detect_sources`, if applicable.

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -40,12 +40,8 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
            ``data`` parameter. In this case do not input a ``kernel``,
            otherwise the data will be convolved twice.
 
-    segment_img : `~photutils.segmentation.SegmentationImage` or array_like (int)
-        A segmentation image, either as a
-        `~photutils.segmentation.SegmentationImage` object or an
-        `~numpy.ndarray`, with the same shape as ``data`` where sources
-        are labeled by different positive integer values.  A value of
-        zero is reserved for the background.
+    segment_img : `~photutils.segmentation.SegmentationImage`
+        The segmentation image to deblend.
 
     npixels : int
         The number of connected pixels, each greater than ``threshold``,
@@ -108,7 +104,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
     :class:`photutils.segmentation.SourceFinder`
     """
     if not isinstance(segment_img, SegmentationImage):
-        segment_img = SegmentationImage(segment_img)
+        raise ValueError('segment_img must be a SegmentationImage')
 
     if segment_img.shape != data.shape:
         raise ValueError('The data and segmentation image must have '

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -239,6 +239,10 @@ def _detect_sources(data, thresholds, npixels, kernel=None, connectivity=8,
         if mask.shape != data.shape:
             raise ValueError('mask must have the same shape as the input '
                              'image.')
+        if mask.all():
+            raise ValueError('mask must not be True for every pixel. There '
+                             'are no unmasked pixels in the image to detect '
+                             'sources.')
 
     if kernel is not None:
         with warnings.catch_warnings():

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -103,32 +103,20 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
             data, mask=mask, mask_value=mask_value, sigma=sigclip_sigma,
             maxiters=sigclip_iters)
 
-        bkgrd_image = np.zeros_like(data) + data_mean
-        bkgrdrms_image = np.zeros_like(data) + data_std
-
     if background is None:
-        background = bkgrd_image
-    else:
-        if np.isscalar(background):
-            background = np.zeros_like(data) + background
-        else:
-            if background.shape != data.shape:
-                raise ValueError('If input background is 2D, then it '
-                                 'must have the same shape as the input '
-                                 'data.')
+        background = data_mean
+    if not np.isscalar(background) and background.shape != data.shape:
+        raise ValueError('If input background is 2D, then it must have the '
+                         'same shape as the input data.')
 
     if error is None:
-        error = bkgrdrms_image
-    else:
-        if np.isscalar(error):
-            error = np.zeros_like(data) + error
-        else:
-            if error.shape != data.shape:
-                raise ValueError('If input error is 2D, then it '
-                                 'must have the same shape as the input '
-                                 'data.')
+        error = data_std
+    if not np.isscalar(error) and error.shape != data.shape:
+        raise ValueError('If input error is 2D, then it must have the same '
+                         'shape as the input data.')
 
-    return background + (error * nsigma)
+    return (np.broadcast_to(background, data.shape)
+            + np.broadcast_to(error * nsigma, data.shape))
 
 
 def _make_binary_structure(ndim, connectivity):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -15,19 +15,19 @@ from ...utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY  # noqa
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSegmentationImage:
     def setup_class(self):
-        self.data = [[1, 1, 0, 0, 4, 4],
-                     [0, 0, 0, 0, 0, 4],
-                     [0, 0, 3, 3, 0, 0],
-                     [7, 0, 0, 0, 0, 5],
-                     [7, 7, 0, 5, 5, 5],
-                     [7, 7, 0, 0, 5, 5]]
+        self.data = np.array([[1, 1, 0, 0, 4, 4],
+                              [0, 0, 0, 0, 0, 4],
+                              [0, 0, 3, 3, 0, 0],
+                              [7, 0, 0, 0, 0, 5],
+                              [7, 7, 0, 5, 5, 5],
+                              [7, 7, 0, 0, 5, 5]])
         self.segm = SegmentationImage(self.data)
 
     def test_array(self):
         assert_allclose(self.segm.data, self.segm.__array__())
 
     def test_copy(self):
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         segm2 = segm.copy()
         assert segm.data is not segm2.data
         assert segm.labels is not segm2.labels
@@ -44,8 +44,8 @@ class TestSegmentationImage:
             segm.relabel_consecutive()
 
     def test_data_reassignment(self):
-        segm = SegmentationImage(self.data)
-        segm.data = np.array(self.data)[0:3, :].copy()
+        segm = SegmentationImage(self.data.copy())
+        segm.data = self.data[0:3, :].copy()
         assert_equal(segm.labels, [1, 3, 4])
 
     def test_invalid_data(self):
@@ -182,7 +182,7 @@ class TestSegmentationImage:
                                             seed=0).colors)
 
     def test_reassign_labels(self):
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         segm.reassign_labels(labels=[1, 7], new_label=2)
         ref_data = np.array([[2, 2, 0, 0, 4, 4],
                              [0, 0, 0, 0, 0, 4],
@@ -195,7 +195,7 @@ class TestSegmentationImage:
 
     @pytest.mark.parametrize('start_label', [1, 5])
     def test_relabel_consecutive(self, start_label):
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         ref_data = np.array([[1, 1, 0, 0, 3, 3],
                              [0, 0, 0, 0, 0, 3],
                              [0, 0, 2, 2, 0, 0],
@@ -214,7 +214,7 @@ class TestSegmentationImage:
     @pytest.mark.parametrize('start_label', [0, -1])
     def test_relabel_consecutive_start_invalid(self, start_label):
         with pytest.raises(ValueError):
-            segm = SegmentationImage(self.data)
+            segm = SegmentationImage(self.data.copy())
             segm.relabel_consecutive(start_label=start_label)
 
     def test_keep_labels(self):
@@ -224,7 +224,7 @@ class TestSegmentationImage:
                              [0, 0, 0, 0, 0, 5],
                              [0, 0, 0, 5, 5, 5],
                              [0, 0, 0, 0, 5, 5]])
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         segm.keep_labels([5, 3])
         assert_allclose(segm.data, ref_data)
 
@@ -235,7 +235,7 @@ class TestSegmentationImage:
                              [0, 0, 0, 0, 0, 2],
                              [0, 0, 0, 2, 2, 2],
                              [0, 0, 0, 0, 2, 2]])
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         segm.keep_labels([5, 3], relabel=True)
         assert_allclose(segm.data, ref_data)
 
@@ -246,7 +246,7 @@ class TestSegmentationImage:
                              [7, 0, 0, 0, 0, 0],
                              [7, 7, 0, 0, 0, 0],
                              [7, 7, 0, 0, 0, 0]])
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         segm.remove_labels(labels=[5, 3])
         assert_allclose(segm.data, ref_data)
 
@@ -257,7 +257,7 @@ class TestSegmentationImage:
                              [3, 0, 0, 0, 0, 0],
                              [3, 3, 0, 0, 0, 0],
                              [3, 3, 0, 0, 0, 0]])
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         segm.remove_labels(labels=[5, 3], relabel=True)
         assert_allclose(segm.data, ref_data)
 
@@ -268,17 +268,17 @@ class TestSegmentationImage:
                              [0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0]])
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         segm.remove_border_labels(border_width=1)
         assert_allclose(segm.data, ref_data)
 
     def test_remove_border_labels_border_width(self):
         with pytest.raises(ValueError):
-            segm = SegmentationImage(self.data)
+            segm = SegmentationImage(self.data.copy())
             segm.remove_border_labels(border_width=3)
 
     def test_remove_border_labels_no_remaining_segments(self):
-        alt_data = np.copy(self.data)
+        alt_data = self.data.copy()
         alt_data[alt_data == 3] = 0
         segm = SegmentationImage(alt_data)
         segm.remove_border_labels(border_width=1, relabel=True)
@@ -291,7 +291,7 @@ class TestSegmentationImage:
                              [7, 0, 0, 0, 0, 5],
                              [7, 7, 0, 5, 5, 5],
                              [7, 7, 0, 0, 5, 5]])
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         mask = np.zeros(segm.data.shape, dtype=bool)
         mask[0, :] = True
         segm.remove_masked_labels(mask)
@@ -304,7 +304,7 @@ class TestSegmentationImage:
                              [7, 0, 0, 0, 0, 5],
                              [7, 7, 0, 5, 5, 5],
                              [7, 7, 0, 0, 5, 5]])
-        segm = SegmentationImage(self.data)
+        segm = SegmentationImage(self.data.copy())
         mask = np.zeros(segm.data.shape, dtype=bool)
         mask[0, :] = True
         segm.remove_masked_labels(mask, partial_overlap=False)

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -167,10 +167,6 @@ class TestDeblendSources:
         assert result.nlabels == 3
         assert_allclose(np.nonzero(self.segm3), np.nonzero(result))
 
-    def test_deblend_sources_segm_array(self):
-        result = deblend_sources(self.data, self.segm.data, self.npixels)
-        assert result.nlabels == 2
-
     def test_segment_img_badshape(self):
         segm_wrong = np.ones((2, 2), dtype=int)
         with pytest.raises(ValueError):


### PR DESCRIPTION
Inputing an `ndarray` is no longer allowed.

This PR also makes several small improvements to the segmentation docstrings.