### PR TITLE
Apply mask to IterativelySubtractedPSFPhotometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ New Features
 - ``photutils.psf``
 
   - Added a ``mask`` keyword when calling the PSF-fitting classes.
-    [#1350]
+    [#1350, #1351]
 
 - ``photutils.segmentation``
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -864,7 +864,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
 
             star_groups = self.group_maker(init_guess_tab)
             table, self._residual_image = super().nstar(
-                self._residual_image, star_groups)
+                self._residual_image, star_groups, mask=mask)
 
             star_groups = star_groups.group_by('group_id')
             table = hstack([star_groups, table])


### PR DESCRIPTION
This PR fixes a bug where the `mask` was not passed to the `nstar` method in `IterativelySubtractedPSFPhotometry`.  Followup to #1350.