### PR TITLE
Add sigma_clip keyword in detect_threshold and deprecate sigclip_* keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ New Features
   - Added ``SourceFinder`` class, which is a convenience class
     combining ``detect_sources`` and ``deblend_sources``. [#1344]
 
+  - Added a ``sigma_clip`` keyword to ``detect_threshold``. [#1354]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -41,6 +43,10 @@ API Changes
 
   - ``SegmentationImage`` no longer allows array-like input. It must be
     a numpy ``ndarray``. [#1347]
+
+  - Deprecated the ``detect_threshold`` ``sigclip_sigma`` and
+    ``sigclip_iters`` keywords.  Use the ``sigma_clip`` keyword instead.
+    [#1354]
 
 
 1.4.0 (2022-03-25)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -16,8 +16,8 @@ from numpy.lib.index_tricks import index_exp
 
 from .core import SExtractorBackground, StdBackgroundRMS
 from .interpolators import BkgZoomInterpolator
-from ._utils import nanmedian
 from ..utils import ShepardIDWInterpolator
+from ..utils._stats import nanmedian
 
 __all__ = ['Background2D']
 

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -11,7 +11,7 @@ from astropy.stats import (biweight_location, biweight_scale, mad_std,
                            SigmaClip)
 import numpy as np
 
-from ._utils import nanmean, nanmedian, nanstd
+from ..utils._stats import nanmean, nanmedian, nanstd
 
 SIGMA_CLIP = SigmaClip(sigma=3.0, maxiters=10)
 

--- a/photutils/utils/_stats.py
+++ b/photutils/utils/_stats.py
@@ -7,7 +7,7 @@ for performance if available.
 import astropy.units as u
 import numpy as np
 
-from ..utils._optional_deps import HAS_BOTTLENECK
+from ._optional_deps import HAS_BOTTLENECK
 
 if HAS_BOTTLENECK:
     import bottleneck as bn


### PR DESCRIPTION
The `sigma_clip` keyword accepts an `astropy.stats.SigmaClip` object, which has more options than using the `sigclip_*` keywords.