### PR TITLE
Add SegmentationImage.make_source_mask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,13 @@ New Features
 
   - Added a ``sigma_clip`` keyword to ``detect_threshold``. [#1354]
 
+  - Added a ``make_source_mask`` method to ``SegmentationImage``.
+    [#1355]
+
+- ``photutils.utils``
+
+  - Added a ``circular_footprint`` convenience function. [#1355]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -47,6 +54,9 @@ API Changes
   - Deprecated the ``detect_threshold`` ``sigclip_sigma`` and
     ``sigclip_iters`` keywords.  Use the ``sigma_clip`` keyword instead.
     [#1354]
+
+  - Deprecated the ``make_source_mask`` function in favor of the
+    ``SegmentationImage`` ``make_source_mask`` method. [#1355]
 
 
 1.4.0 (2022-03-25)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1008,6 +1008,25 @@ class SegmentationImage:
         -------
         mask : 2D bool `~numpy.ndarray`
             A 2D boolean image containing the source mask.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from photutils import SegmentationImage
+        >>> from photutils.utils import circular_footprint
+        >>> data = np.zeros((7, 7), dtype=int)
+        >>> data[3, 3] = 1
+        >>> segm = SegmentationImage(data)
+        >>> footprint = circular_footprint(radius=3)
+        >>> mask = segm.make_source_mask(footprint=footprint)
+        >>> mask
+        array([[False, False, False,  True, False, False, False],
+               [False,  True,  True,  True,  True,  True, False],
+               [False,  True,  True,  True,  True,  True, False],
+               [ True,  True,  True,  True,  True,  True,  True],
+               [False,  True,  True,  True,  True,  True, False],
+               [False,  True,  True,  True,  True,  True, False],
+               [False, False, False,  True, False, False, False]])
         """
         if footprint is None:
             return self._data.astype(bool)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -990,6 +990,31 @@ class SegmentationImage:
             remove_labels = list(set(remove_labels) - set(interior_labels))
         self.remove_labels(remove_labels, relabel=relabel)
 
+    def make_source_mask(self, footprint=None):
+        """
+        Make a source mask from the segmentation image.
+
+        Use the ``footprint`` keyword to perform binary dilation on the
+        segmentation image.
+
+        Parameters
+        ----------
+        footprint : 2D `~numpy.ndarray`, optional
+            The local footprint used for the source dilation. Non-zero
+            elements are considered `True`.  If `None`, then no dilation
+            is performed.
+
+        Returns
+        -------
+        mask : 2D bool `~numpy.ndarray`
+            A 2D boolean image containing the source mask.
+        """
+        if footprint is None:
+            return self._data.astype(bool)
+
+        from scipy.ndimage import binary_dilation
+        return binary_dilation(self._data.astype(bool), structure=footprint)
+
     def outline_segments(self, mask_background=False):
         """
         Outline the labeled segments.

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -8,7 +8,7 @@ import warnings
 
 from astropy.convolution import Gaussian2DKernel, convolve
 from astropy.stats import gaussian_fwhm_to_sigma, SigmaClip
-from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -461,6 +461,7 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
                            connectivity=connectivity, mask=mask)[0]
 
 
+@deprecated('1.5.0', alternative='SegmentationImage.make_source_mask')
 @deprecated_renamed_argument('filter_fwhm', None, '1.4', message='Use the '
                              'kernel keyword')
 @deprecated_renamed_argument('filter_size', None, '1.4', message='Use the '

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -242,8 +242,10 @@ class TestMakeSourceMask:
         self.data = make_4gaussians_image()
 
     def test_dilate_size(self):
-        mask1 = make_source_mask(self.data, 5, 10)
-        mask2 = make_source_mask(self.data, 5, 10, dilate_size=20)
+        with pytest.warns(AstropyDeprecationWarning):
+            mask1 = make_source_mask(self.data, 5, 10)
+        with pytest.warns(AstropyDeprecationWarning):
+            mask2 = make_source_mask(self.data, 5, 10, dilate_size=20)
         assert np.count_nonzero(mask2) > np.count_nonzero(mask1)
 
     def test_kernel(self):
@@ -252,10 +254,11 @@ class TestMakeSourceMask:
                                      filter_size=3)
         sigma = 2 * gaussian_fwhm_to_sigma
         kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
-        mask2 = make_source_mask(self.data, 5, 10, kernel=kernel)
+        with pytest.warns(AstropyDeprecationWarning):
+            mask2 = make_source_mask(self.data, 5, 10, kernel=kernel)
         assert_allclose(mask1, mask2)
 
     def test_no_detections(self):
-        with pytest.warns(NoDetectionsWarning):
+        with pytest.warns(AstropyDeprecationWarning):
             mask = make_source_mask(self.data, 100, 100)
             assert np.count_nonzero(mask) == 0

--- a/photutils/utils/__init__.py
+++ b/photutils/utils/__init__.py
@@ -6,4 +6,5 @@ This subpackage provides general-purpose utility functions.
 from .colormaps import *  # noqa
 from .errors import *  # noqa
 from .exceptions import *  # noqa
+from .footprints import *  # noqa
 from .interpolation import *  # noqa

--- a/photutils/utils/footprints.py
+++ b/photutils/utils/footprints.py
@@ -1,0 +1,50 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module provides tools for generating footprints.
+"""
+
+import numpy as np
+
+__all__ = ['circular_footprint']
+
+
+def circular_footprint(radius, dtype=int):
+    """
+    Create a circular footprint.
+
+    A pixel is considered to be entirely in or out of the footprint
+    depending on whether its center is in or out of the footprint.  The
+    size of the output array is the minimal bounding box for the
+    footprint.
+
+    Parameters
+    ----------
+    radius : int
+        The radius of the circular footprint.
+
+    dtype : data-type, optional
+        The data type of the output `~numpy.ndarray`.
+
+    Returns
+    -------
+    footprint : `~numpy.ndarray`
+        A footprint where array elements are 1 within the footprint and
+        0 otherwise.
+
+    Examples
+    --------
+    >>> from photutils.utils import circular_footprint
+    >>> circular_footprint(2)
+    array([[0, 0, 1, 0, 0],
+           [0, 1, 1, 1, 0],
+           [1, 1, 1, 1, 1],
+           [0, 1, 1, 1, 0],
+           [0, 0, 1, 0, 0]])
+    """
+    if ~np.isfinite(radius) or radius <= 0 or int(radius) != radius:
+        raise ValueError('radius must be a positive, finite integer greater '
+                         'than 0')
+
+    x = np.arange(-radius, radius + 1)
+    xx, yy = np.meshgrid(x, x)
+    return np.array((xx**2 + yy**2) <= radius**2, dtype=dtype)

--- a/photutils/utils/tests/test_footprints.py
+++ b/photutils/utils/tests/test_footprints.py
@@ -1,0 +1,41 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the footprints module.
+"""
+
+import numpy as np
+from numpy.testing import assert_equal
+import pytest
+
+from ..footprints import circular_footprint
+
+
+def test_footprints():
+    footprint = circular_footprint(1)
+    result = np.array([[0, 1, 0],
+                       [1, 1, 1],
+                       [0, 1, 0]])
+    assert_equal(footprint, result)
+
+    footprint = circular_footprint(2)
+    result = np.array([[0, 0, 1, 0, 0],
+                       [0, 1, 1, 1, 0],
+                       [1, 1, 1, 1, 1],
+                       [0, 1, 1, 1, 0],
+                       [0, 0, 1, 0, 0]])
+    assert_equal(footprint, result)
+
+    with pytest.raises(ValueError):
+        circular_footprint(5.1)
+
+    with pytest.raises(ValueError):
+        circular_footprint(0)
+
+    with pytest.raises(ValueError):
+        circular_footprint(-1)
+
+    with pytest.raises(ValueError):
+        circular_footprint(np.inf)
+
+    with pytest.raises(ValueError):
+        circular_footprint(np.nan)


### PR DESCRIPTION
This PR also deprecates the standalone `make_source_mask` method in favor of `SegmentationImage.make_source_mask`.

It also add the `circular_footprint` convenience function.  These footprints can be input into `SegmentationImage.make_source_mask` to dilate the sources when creating the mask.