### PR TITLE
Deprecate DiscretePRF and Reproject classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ General
 
 New Features
 ^^^^^^^^^^^^
+
 - ``photutils.psf``
 
   - Added a ``mask`` keyword when calling the PSF-fitting classes.
@@ -37,6 +38,9 @@ API Changes
 
   - Invalid data values (i.e., NaN or inf) are now automatically masked
     when performing PSF fitting. [#1350]
+
+  - Deprecated the ``sandbox`` classes ``DiscretePRF`` and
+    ``Reproject``. [#1357]
 
 - ``photutils.segmentation``
 

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -9,6 +9,7 @@ from astropy.modeling import Fittable2DModel, Parameter
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import extract_array, subpixel_indices
 from astropy.table import Table
+from astropy.utils.decorators import deprecated
 import numpy as np
 
 from ..segmentation.utils import _mask_to_mirrored_value
@@ -18,6 +19,7 @@ __all__ = ['DiscretePRF', 'Reproject']
 __doctest_requires__ = {('Reproject'): ['gwcs']}
 
 
+@deprecated('1.5.0')
 class DiscretePRF(Fittable2DModel):
     """
     A discrete Pixel Response Function (PRF) model.
@@ -299,6 +301,7 @@ class DiscretePRF(Fittable2DModel):
         return cls(prf_model, subsampling=subsampling)
 
 
+@deprecated('1.5.0')
 class Reproject:
     """
     Class to reproject pixel coordinates between unrectified and

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -9,7 +9,8 @@ from astropy.modeling.fitting import LevMarLSQFitter, SimplexLSQFitter
 from astropy.modeling.models import Gaussian2D, Moffat2D
 from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Table
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyUserWarning,
+                                      AstropyDeprecationWarning)
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 import pytest
@@ -431,8 +432,8 @@ for x, y, flux in WIDE_INTAB:
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_psf_photometry_discrete():
     """ Test psf_photometry with discrete PRF model. """
-
-    prf = DiscretePRF(test_psf, subsampling=1)
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = DiscretePRF(test_psf, subsampling=1)
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
                                     bkg_estimator=None, psf_model=prf,
                                     fitshape=7)
@@ -450,8 +451,8 @@ def test_tune_coordinates():
     Test psf_photometry with discrete PRF model and coordinates that need
     to be adjusted in the fit.
     """
-
-    prf = DiscretePRF(test_psf, subsampling=1)
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = DiscretePRF(test_psf, subsampling=1)
     prf.x_0.fixed = False
     prf.y_0.fixed = False
     # Shift all sources by 0.3 pixels
@@ -474,8 +475,8 @@ def test_psf_boundary():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
     """
-
-    prf = DiscretePRF(test_psf, subsampling=1)
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = DiscretePRF(test_psf, subsampling=1)
 
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
                                     bkg_estimator=None, psf_model=prf,
@@ -570,7 +571,6 @@ def test_psf_boundary_gaussian():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
     """
-
     psf = IntegratedGaussianPRF(GAUSSIAN_WIDTH)
 
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
@@ -587,7 +587,6 @@ def test_psf_photometry_gaussian():
     """
     Test psf_photometry with Gaussian PSF model.
     """
-
     psf = IntegratedGaussianPRF(sigma=GAUSSIAN_WIDTH)
 
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
@@ -604,7 +603,6 @@ def test_psf_photometry_gaussian2(renormalize_psf):
     """
     Test psf_photometry with Gaussian PSF model from Astropy.
     """
-
     psf = Gaussian2D(1. / (2 * np.pi * GAUSSIAN_WIDTH ** 2), PSF_SIZE // 2,
                      PSF_SIZE // 2, GAUSSIAN_WIDTH, GAUSSIAN_WIDTH)
     psf = prepare_psf_model(psf, xname='x_mean', yname='y_mean',
@@ -627,7 +625,6 @@ def test_psf_photometry_moffat():
     """
     Test psf_photometry with Moffat PSF model from Astropy.
     """
-
     psf = Moffat2D(1. / (2 * np.pi * GAUSSIAN_WIDTH ** 2), PSF_SIZE // 2,
                    PSF_SIZE // 2, 1, 1)
     psf = prepare_psf_model(psf, xname='x_0', yname='y_0',
@@ -653,7 +650,6 @@ def test_psf_fitting_data_on_edge():
     No mask is input explicitly here, but source 2 is so close to the
     edge that the subarray that's extracted gets a mask internally.
     """
-
     psf_guess = IntegratedGaussianPRF(flux=1, sigma=WIDE_GAUSSIAN_WIDTH)
     psf_guess.flux.fixed = psf_guess.x_0.fixed = psf_guess.y_0.fixed = False
     basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
@@ -675,7 +671,6 @@ def test_psf_extra_output_cols(sigma_psf, sources):
     """
     Test the handling of a non-None extra_output_cols
     """
-
     psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
     tshape = (32, 32)
     image = (make_gaussian_prf_sources_image(tshape, sources) +
@@ -721,7 +716,6 @@ def test_psf_extra_output_cols(sigma_psf, sources):
 
 @pytest.fixture(params=[2, 3])
 def overlap_image(request):
-
     if request.param == 2:
         close_tab = Table([[50., 53.], [50., 50.], [25., 25.]], names=['x_0', 'y_0', 'flux_0'])
     elif request.param == 3:
@@ -742,7 +736,10 @@ def overlap_image(request):
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_psf_fitting_group(overlap_image):
-    """ Test psf_photometry when two input stars are close and need to be fit together """
+    """
+    Test psf_photometry when two input stars are close and need to be
+    fit together.
+    """
     from photutils.background import MADStdBackgroundRMS
 
     # There are a few models here that fail, be it something
@@ -836,7 +833,6 @@ def test_psf_photometry_uncertainties():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_re_use_result_as_initial_guess():
-
     img_shape = (32, 32)
     # generate image with read-out noise (Gaussian) and
     # background noise (Poisson)

--- a/photutils/psf/tests/test_sandbox.py
+++ b/photutils/psf/tests/test_sandbox.py
@@ -6,8 +6,10 @@ Tests for the sandbox module.
 from astropy.convolution.utils import discretize_model
 from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyDeprecationWarning
 import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 
 from ..sandbox import DiscretePRF
 
@@ -56,11 +58,11 @@ def test_create_prf_mean():
     Check if create_prf works correctly on simulated data.
     Position input format: list
     """
-
-    prf = DiscretePRF.create_from_image(image,
-                                        list(INTAB['x_0', 'y_0'].as_array()),
-                                        PSF_SIZE, subsampling=1, mode='mean')
-    assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
+    sources = list(INTAB['x_0', 'y_0'].as_array())
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = DiscretePRF.create_from_image(image, sources, PSF_SIZE,
+                                            subsampling=1, mode='mean')
+        assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
 
 
 def test_create_prf_median():
@@ -68,11 +70,12 @@ def test_create_prf_median():
     Check if create_prf works correctly on simulated data.
     Position input format: astropy.table.Table
     """
-
-    prf = DiscretePRF.create_from_image(image, np.array(INTAB['x_0', 'y_0']),
-                                        PSF_SIZE, subsampling=1,
-                                        mode='median')
-    assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = DiscretePRF.create_from_image(image,
+                                            np.array(INTAB['x_0', 'y_0']),
+                                            PSF_SIZE, subsampling=1,
+                                            mode='median')
+        assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
 
 
 def test_create_prf_nan():
@@ -83,18 +86,23 @@ def test_create_prf_nan():
     image_nan = image.copy()
     image_nan[52, 52] = np.nan
     image_nan[52, 48] = np.nan
-    prf = DiscretePRF.create_from_image(image, np.array(INTAB['x_0', 'y_0']),
-                                        PSF_SIZE, subsampling=1, fix_nan=True)
-    assert not np.isnan(prf._prf_array[0, 0]).any()
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = DiscretePRF.create_from_image(image,
+                                            np.array(INTAB['x_0', 'y_0']),
+                                            PSF_SIZE, subsampling=1,
+                                            fix_nan=True)
+        assert not np.isnan(prf._prf_array[0, 0]).any()
 
 
 def test_create_prf_flux():
     """
     Check if create_prf works correctly when FLUXES are specified.
     """
-
-    prf = DiscretePRF.create_from_image(image, np.array(INTAB['x_0', 'y_0']),
-                                        PSF_SIZE, subsampling=1,
-                                        mode='median', fluxes=INTAB['flux_0'])
-    assert_allclose(prf._prf_array[0, 0].sum(), 1)
-    assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = DiscretePRF.create_from_image(image,
+                                            np.array(INTAB['x_0', 'y_0']),
+                                            PSF_SIZE, subsampling=1,
+                                            mode='median',
+                                            fluxes=INTAB['flux_0'])
+        assert_allclose(prf._prf_array[0, 0].sum(), 1)
+        assert_allclose(prf._prf_array[0, 0], test_psf, atol=1E-8)

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -6,6 +6,7 @@ Tests for the utils module.
 from astropy.convolution.utils import discretize_model
 from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyDeprecationWarning
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -250,8 +251,8 @@ def test_get_grouped_psf_model_submodel_names(prf_model):
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_subtract_psf():
     """Test subtract_psf."""
-
-    prf = DiscretePRF(test_psf, subsampling=1)
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = DiscretePRF(test_psf, subsampling=1)
     posflux = INTAB.copy()
     for n in posflux.colnames:
         posflux.rename_column(n, n.split('_')[0] + '_fit')


### PR DESCRIPTION
This PR deprecates the `DiscretePRF` and `Reproject` classes.  These classes are part of the PSF "sandbox" module as experimental tools.  For discrete PSFs, one may use the `EPSFModel` or `GriddedPSFModel` classes.