### PR TITLE
Improve "size" parameter validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,8 +31,14 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+
 API Changes
 ^^^^^^^^^^^
+
+- ``photutils.centroids``
+
+  - Changed the axes order of ``oversampling`` keyword in
+    ``centroid_com`` when input as a tuple. [#1358]
 
 - ``photutils.psf``
 
@@ -41,6 +47,9 @@ API Changes
 
   - Deprecated the ``sandbox`` classes ``DiscretePRF`` and
     ``Reproject``. [#1357]
+
+  - Changed the axes order of ``oversampling`` keywords when input as a
+    tuple. [#1358]
 
 - ``photutils.segmentation``
 
@@ -57,12 +66,11 @@ API Changes
   - ``SegmentationImage`` no longer allows array-like input. It must be
     a numpy ``ndarray``. [#1347]
 
-  - Deprecated the ``detect_threshold`` ``sigclip_sigma`` and
-    ``sigclip_iters`` keywords.  Use the ``sigma_clip`` keyword instead.
-    [#1354]
+  - Deprecated the ``sigclip_sigma`` and ``sigclip_iters`` keywords in
+    ``detect_threshold``. Use the ``sigma_clip`` keyword instead. [#1354]
 
   - Deprecated the ``make_source_mask`` function in favor of the
-    ``SegmentationImage`` ``make_source_mask`` method. [#1355]
+    ``SegmentationImage.make_source_mask`` method. [#1355]
 
 
 1.4.0 (2022-03-25)

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -638,7 +638,7 @@ def test_sky_aperture_repr():
 
 
 def test_rectangular_bbox():
-    # odd sizes
+    # test odd sizes
     width = 7
     height = 3
     a = RectangularAperture((50, 50), w=width, h=height, theta=0)
@@ -650,7 +650,7 @@ def test_rectangular_bbox():
     a = RectangularAperture((50, 50), w=width, h=height, theta=90.*np.pi/180.)
     assert a.bbox.shape == (width, height)
 
-    # even sizes
+    # test even sizes
     width = 8
     height = 4
     a = RectangularAperture((50, 50), w=width, h=height, theta=0)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -17,6 +17,7 @@ from numpy.lib.index_tricks import index_exp
 from .core import SExtractorBackground, StdBackgroundRMS
 from .interpolators import BkgZoomInterpolator
 from ..utils import ShepardIDWInterpolator
+from ..utils._parameters import as_pair
 from ..utils._stats import nanmedian
 
 __all__ = ['Background2D']
@@ -45,13 +46,13 @@ class Background2D:
         background RMS map.
 
     box_size : int or array_like (int)
-        The box size along each axis.  If ``box_size`` is a scalar then
-        a square box of size ``box_size`` will be used.  If ``box_size``
-        has two elements, they should be in ``(ny, nx)`` order.  For
-        best results, the box shape should be chosen such that the
-        ``data`` are covered by an integer number of boxes in both
-        dimensions.  When this is not the case, see the ``edge_method``
-        keyword for more options.
+        The box size along each axis. If ``box_size`` is a scalar then
+        a square box of size ``box_size`` will be used. If ``box_size``
+        has two elements, they must be in ``(ny, nx)`` order. For best
+        results, the box shape should be chosen such that the ``data``
+        are covered by an integer number of boxes in both dimensions.
+        When this is not the case, see the ``edge_method`` keyword for
+        more options.
 
     mask : array_like (bool), optional
         A boolean mask, with the same shape as ``data``, where a `True`
@@ -93,11 +94,11 @@ class Background2D:
 
     filter_size : int or array_like (int), optional
         The window size of the 2D median filter to apply to the
-        low-resolution background map.  If ``filter_size`` is a scalar
-        then a square box of size ``filter_size`` will be used.  If
-        ``filter_size`` has two elements, they should be in ``(ny, nx)``
-        order.  A filter size of ``1`` (or ``(1, 1)``) means no
-        filtering.
+        low-resolution background map. If ``filter_size`` is a scalar
+        then a square box of size ``filter_size`` will be used. If
+        ``filter_size`` has two elements, they must be in ``(ny, nx)``
+        order. ``filter_size`` must be odd along both axes. A filter
+        size of ``1`` (or ``(1, 1)``) means no filtering.
 
     filter_threshold : int, optional
         The threshold value for used for selective median filtering of
@@ -197,17 +198,17 @@ class Background2D:
                                                   'coverage_mask')
         self.total_mask = self._combine_masks()
 
-        box_size = self._process_size_input(box_size)
         # box_size cannot be larger than the data array size
-        self.box_size = np.array((min(box_size[0], data.shape[0]),
-                                  min(box_size[1], data.shape[1])))
+        self.box_size = as_pair('box_size', box_size, lower_bound=(0, 1),
+                                upper_bound=data.shape)
 
         self.fill_value = fill_value
         if exclude_percentile < 0 or exclude_percentile > 100:
             raise ValueError('exclude_percentile must be between 0 and 100 '
                              '(inclusive).')
         self.exclude_percentile = exclude_percentile
-        self.filter_size = self._process_size_input(filter_size)
+        self.filter_size = as_pair('filter_size', filter_size,
+                                   lower_bound=(0, 1), check_odd=True)
         self.filter_threshold = filter_threshold
         self.edge_method = edge_method
         self.sigma_clip = sigma_clip
@@ -227,16 +228,6 @@ class Background2D:
         self._bkgrms_stats = None
 
         self._prepare_box_data()
-
-    @staticmethod
-    def _process_size_input(array):
-        array = np.atleast_1d(array).astype(int)
-        if len(array) == 1:
-            array = np.repeat(array, 2)
-        if len(array) != 2:
-            raise ValueError('box_size and filter_size inputs must have only '
-                             '1 or 2 elements')
-        return array
 
     def _validate_array(self, array, name, shape=True):
         if name in ('mask', 'coverage_mask') and array is np.ma.nomask:

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -355,13 +355,13 @@ class Background2D:
         box_idx = np.where(nmasked <= self._box_npixels_threshold)[0]
 
         if box_idx.size == 0:
-            raise ValueError('All boxes contain > {0} ({1} percent per '
+            raise ValueError('All boxes contain > '
+                             f'{self._box_npixels_threshold} '
+                             f'({self.exclude_percentile} percent per '
                              'box) masked pixels (or all are completely '
                              'masked). Please check your data or increase '
                              '"exclude_percentile" to allow more boxes to '
-                             'be included.'
-                             .format(self._box_npixels_threshold,
-                                     self.exclude_percentile))
+                             'be included.')
 
         return box_idx
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -33,11 +33,10 @@ def centroid_com(data, mask=None, oversampling=1):
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
-    oversampling : int or tuple of two int, optional
-        Oversampling factors of pixel indices. If ``oversampling`` is
-        a scalar this is treated as both x and y directions having
-        the same oversampling factor; otherwise it is treated as
-        ``(x_oversamp, y_oversamp)``.
+    oversampling : int or array_like (int)
+        The integer oversampling factor(s). If ``oversampling`` is a
+        scalar then it will be used for both axes. If ``oversampling``
+        has two elements, they must be in ``(y, x)`` order.
 
     Returns
     -------
@@ -54,7 +53,6 @@ def centroid_com(data, mask=None, oversampling=1):
         data[mask] = 0.
 
     oversampling = as_pair('oversampling', oversampling, lower_bound=(0, 1))
-    oversampling = oversampling[::-1]  # reverse to (y, x) order
 
     badmask = ~np.isfinite(data)
     if np.any(badmask):

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -11,6 +11,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
 from ..utils._round import _py2intround
+from ..utils._parameters import as_pair
 
 __all__ = ['centroid_com', 'centroid_quadratic', 'centroid_sources']
 
@@ -52,12 +53,8 @@ def centroid_com(data, mask=None, oversampling=1):
             raise ValueError('data and mask must have the same shape.')
         data[mask] = 0.
 
-    oversampling = np.atleast_1d(oversampling)
-    if len(oversampling) == 1:
-        oversampling = np.repeat(oversampling, 2)
+    oversampling = as_pair('oversampling', oversampling, lower_bound=(0, 1))
     oversampling = oversampling[::-1]  # reverse to (y, x) order
-    if np.any(oversampling <= 0):
-        raise ValueError('Oversampling factors must all be positive numbers.')
 
     badmask = ~np.isfinite(data)
     if np.any(badmask):
@@ -111,18 +108,20 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
 
     fit_boxsize : int or tuple of int, optional
         The size (in pixels) of the box used to define the fitting
-        region. If ``fit_boxsize`` has two elements, they should be in
+        region. If ``fit_boxsize`` has two elements, they must be in
         ``(ny, nx)`` order. If ``fit_boxsize`` is a scalar then a square
-        box of size ``fit_boxsize`` will be used.
+        box of size ``fit_boxsize`` will be used. ``fit_boxsize`` must
+        have odd values for both axes.
 
     search_boxsize : int or tuple of int, optional
         The size (in pixels) of the box used to search for the maximum
         pixel value if ``xpeak`` and ``ypeak`` are both specified. If
-        ``fit_boxsize`` has two elements, they should be in ``(ny,
-        nx)`` order. If ``fit_boxsize`` is a scalar then a square box
-        of size ``fit_boxsize`` will be used. This parameter is ignored
+        ``fit_boxsize`` has two elements, they must be in ``(ny,
+        nx)`` order. If ``search_boxsize`` is a scalar then a square
+        box of size ``search_boxsize`` will be used. ``search_boxsize``
+        must have odd values for both axes. This parameter is ignored
         if either ``xpeak`` or ``ypeak`` is `None`. In that case, the
-        entire array is search for the maximum value.
+        entire array is searched for the maximum value.
 
     mask : bool `~numpy.ndarray`, optional
         A boolean mask, with the same shape as ``data``, where a `True`
@@ -169,7 +168,8 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
             raise ValueError('data and mask must have the same shape.')
         data[mask] = np.nan
 
-    fit_boxsize = _process_boxsize(fit_boxsize, data.shape)
+    fit_boxsize = as_pair('fit_boxsize', fit_boxsize, lower_bound=(0, 1),
+                          upper_bound=data.shape, check_odd=True)
 
     if np.product(fit_boxsize) < 6:
         raise ValueError('fit_boxsize is too small.  6 values are required '
@@ -182,7 +182,9 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
         yidx = _py2intround(ypeak)
 
         if search_boxsize is not None:
-            search_boxsize = _process_boxsize(search_boxsize, data.shape)
+            search_boxsize = as_pair('search_boxsize', search_boxsize,
+                                     lower_bound=(0, 1),
+                                     upper_bound=data.shape, check_odd=True)
 
             slc_data, _ = overlap_slices(data.shape, search_boxsize,
                                          (yidx, xidx), mode='trim')
@@ -257,20 +259,6 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
     return xycen
 
 
-def _process_boxsize(box_size, data_shape):
-    box_size = np.round(np.atleast_1d(box_size)).astype(int)
-    if len(box_size) == 1:
-        box_size = np.repeat(box_size, 2)
-    if len(box_size) > 2:
-        raise ValueError('box size must contain only 1 or 2 values')
-    if np.any(box_size < 0):
-        raise ValueError('box size must be >= 0')
-    # box_size cannot be larger than the data shape
-    box_size = (min(box_size[0], data_shape[0]),
-                min(box_size[1], data_shape[1]))
-    return box_size
-
-
 def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
                      centroid_func=centroid_com, **kwargs):
     """
@@ -292,14 +280,14 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
         calculate the centroid.
 
     box_size : int or array-like of int, optional
-        The size of the cutout image along each axis. If ``box_size``
-        is a number, then a square cutout of ``box_size`` will be
-        created. If ``box_size`` has two elements, they should be in
-        ``(ny, nx)`` order. Either ``box_size`` or ``footprint`` must be
-        defined. If they are both defined, then ``footprint`` overrides
-        ``box_size``.
+        The size of the cutout image along each axis. If ``box_size`` is
+        a number, then a square cutout of ``box_size`` will be created.
+        If ``box_size`` has two elements, they must be in ``(ny, nx)``
+        order. ``box_size`` must have odd values for both axes. Either
+        ``box_size`` or ``footprint`` must be defined. If they are both
+        defined, then ``footprint`` overrides ``box_size``.
 
-    footprint : `~numpy.ndarray` of bools, optional
+    footprint : bool `~numpy.ndarray`, optional
         A 2D boolean array where `True` values describe the local
         footprint region to cutout. ``footprint`` can be used to create
         a non-rectangular cutout image, in which case the input ``xpos``
@@ -356,13 +344,8 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
     if footprint is None:
         if box_size is None:
             raise ValueError('box_size or footprint must be defined.')
-
-        box_size = np.atleast_1d(box_size)
-        if len(box_size) == 1:
-            box_size = np.repeat(box_size, 2)
-        if len(box_size) != 2:
-            raise ValueError('box_size must have 1 or 2 elements.')
-
+        box_size = as_pair('box_size', box_size, lower_bound=(0, 1),
+                           check_odd=True)
         footprint = np.ones(box_size, dtype=bool)
     else:
         footprint = np.asanyarray(footprint, dtype=bool)

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -58,14 +58,14 @@ def test_centroid_com(x_std, y_std, theta):
     assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=0.015)
 
     # test with oversampling
-    for oversampling in [4, (4, 6)]:
+    for oversampling in [4, (6, 4)]:
         if not hasattr(oversampling, '__len__'):
             _oversampling = (oversampling, oversampling)
         else:
             _oversampling = oversampling
         xc, yc = centroid_com(data, mask=mask, oversampling=oversampling)
 
-        desired = [XCEN / _oversampling[0], YCEN / _oversampling[1]]
+        desired = [XCEN / _oversampling[1], YCEN / _oversampling[0]]
         assert_allclose((xc, yc), desired, rtol=0, atol=1.e-3)
 
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -226,13 +226,11 @@ class EPSFBuilder:
 
     Parameters
     ----------
-    oversampling : int or tuple of two int, optional
-        The oversampling factor(s) of the ePSF relative to the input
-        ``stars`` along the x and y axes. The ``oversampling`` can
-        either be a single float or a tuple of two floats of the form
-        ``(x_oversamp, y_oversamp)``.  If ``oversampling`` is a scalar
-        then the oversampling will be the same for both the x and y
-        axes.
+    oversampling : int or array_like (int)
+        The integer oversampling factor(s) of the ePSF relative to the
+        input ``stars`` along each axis. If ``oversampling`` is a scalar
+        then it will be used for both axes. If ``oversampling`` has two
+        elements, they must be in ``(y, x)`` order.
 
     shape : float, tuple of two floats, or `None`, optional
         The shape of the output ePSF.  If the ``shape`` is not `None`,

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -109,11 +109,11 @@ class FittableImageModel(Fittable2DModel):
         the `compute_interpolator` method.  See `compute_interpolator`
         for more details.
 
-    oversampling : int or tuple of two int, optional
-        The oversampling factor(s) of the model in the ``x`` and ``y``
-        directions.  If ``oversampling`` is a scalar it will be treated
-        as being the same in both x and y; otherwise a tuple of two
-        floats will be treated as ``(x_oversamp, y_oversamp)``.
+    oversampling : int or array_like (int)
+        The integer oversampling factor(s) of the ePSF relative to the
+        input ``stars`` along each axis. If ``oversampling`` is a scalar
+        then it will be used for both axes. If ``oversampling`` has two
+        elements, they must be in ``(y, x)`` order.
     """
 
     flux = Parameter(description='Intensity scaling factor for image data.',
@@ -496,11 +496,11 @@ class EPSFModel(FittableImageModel):
 
     Parameters
     ----------
-    oversampling : int or tuple of two int, optional
-        The oversampling factor(s) of the model in the ``x`` and ``y``
-        directions.  If ``oversampling`` is a scalar it will be treated
-        as being the same in both x and y; otherwise a tuple of two
-        floats will be treated as ``(x_oversamp, y_oversamp)``.
+    oversampling : int or array_like (int)
+        The integer oversampling factor(s) of the ePSF relative to the
+        input ``stars`` along each axis. If ``oversampling`` is a scalar
+        then it will be used for both axes. If ``oversampling`` has two
+        elements, they must be in ``(y, x)`` order.
 
     norm_radius : float, optional
         The radius inside which the ePSF is normalized by the sum over

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -27,7 +27,6 @@ class TestEPSFBuild:
         """
         Create a simulated image for testing.
         """
-
         from scipy.spatial import cKDTree
 
         shape = (750, 750)
@@ -81,9 +80,8 @@ class TestEPSFBuild:
         """
         This is an end-to-end test of EPSFBuilder on a simulated image.
         """
-
         size = 25
-        oversampling = 4.
+        oversampling = 4
         with pytest.warns(AstropyUserWarning, match='were not extracted'):
             stars = extract_stars(self.nddata, self.init_stars, size=size)
         epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=15,
@@ -99,21 +97,23 @@ class TestEPSFBuild:
 
         psf_model = IntegratedGaussianPRF(sigma=self.stddev)
         z = epsf.data
-        x = psf_model.evaluate(y.reshape(-1, 1), y.reshape(1, -1), 1, y0, y0, self.stddev)
+        x = psf_model.evaluate(y.reshape(-1, 1), y.reshape(1, -1), 1, y0, y0,
+                               self.stddev)
         assert_allclose(z, x, rtol=1e-2, atol=1e-5)
 
         resid_star = fitted_stars[0].compute_residual_image(epsf)
-        assert_almost_equal(np.sum(resid_star)/fitted_stars[0].flux, 0, decimal=3)
+        assert_almost_equal(np.sum(resid_star)/fitted_stars[0].flux, 0,
+                            decimal=3)
 
     def test_epsf_fitting_bounds(self):
         size = 25
-        oversampling = 4.
+        oversampling = 4
         with pytest.warns(AstropyUserWarning, match='were not extracted'):
             stars = extract_stars(self.nddata, self.init_stars, size=size)
         epsf_builder = EPSFBuilder(oversampling=oversampling, maxiters=8,
                                    progress_bar=True, norm_radius=25,
                                    recentering_maxiters=5,
-                                   fitter=EPSFFitter(fit_boxsize=30),
+                                   fitter=EPSFFitter(fit_boxsize=31),
                                    smoothing_kernel='quadratic')
         # With a boxsize larger than the cutout we expect the fitting to
         # fail for all stars, due to star._fit_error_status
@@ -124,7 +124,6 @@ class TestEPSFBuild:
         """
         Test that the input fitter is an EPSFFitter instance.
         """
-
         with pytest.raises(TypeError):
             EPSFBuilder(fitter=EPSFFitter, maxiters=3)
 

--- a/photutils/segmentation/utils.py
+++ b/photutils/segmentation/utils.py
@@ -28,9 +28,9 @@ def make_2dgaussian_kernel(fwhm, size, mode='oversample', oversampling=10):
 
     size : int or (2,) int array_like
         The size of the kernel along each axis. If ``size`` is a scalar
-        then a square size of ``size`` will be used. If ``size`` has two
-        elements, they should be in ``(ny, nx)`` (i.e., array shape)
-        order.
+        then a square size of ``size`` will be used. If ``size`` has
+        two elements, they must be in ``(ny, nx)`` (i.e., array shape)
+        order. ``size`` must have odd values for both axes.
 
     mode : {'oversample', 'center', 'linear_interp', 'integrate'}, optional
         The mode to use for discretizing the 2D Gaussian model:
@@ -54,7 +54,7 @@ def make_2dgaussian_kernel(fwhm, size, mode='oversample', oversampling=10):
     kernel : `astropy.convolution.Kernel2D`
         The output smoothing kernel, normalized such that it sums to 1.
     """
-    ysize, xsize = as_pair('size', size, lower_bound=(0, 0))
+    ysize, xsize = as_pair('size', size, lower_bound=(0, 1), check_odd=True)
 
     kernel = Gaussian2DKernel(fwhm * gaussian_fwhm_to_sigma,
                               x_size=xsize, y_size=ysize, mode=mode,

--- a/photutils/utils/tests/test_parameters.py
+++ b/photutils/utils/tests/test_parameters.py
@@ -1,0 +1,33 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the parameters module.
+"""
+
+import numpy as np
+from numpy.testing import assert_equal
+import pytest
+
+from .._parameters import as_pair
+
+
+def test_as_pair():
+    assert_equal(as_pair('myparam', 4), (4, 4))
+
+    assert_equal(as_pair('myparam', (3, 4)), (3, 4))
+
+    assert_equal(as_pair('myparam', 0), (0, 0))
+
+    with pytest.raises(ValueError):
+        as_pair('myparam', 0, lower_bound=(0, 1))
+
+    with pytest.raises(ValueError):
+        as_pair('myparam', (1, np.nan))
+
+    with pytest.raises(ValueError):
+        as_pair('myparam', (1, np.inf))
+
+    with pytest.raises(ValueError):
+        as_pair('myparam', (3, 4), check_odd=True)
+
+    with pytest.raises(ValueError):
+        as_pair('myparam', 4, check_odd=True)


### PR DESCRIPTION
This PR uses the new `as_pair` helper function for more robust size-related parameter validation.

This PR also changes the `oversampling` keyword axes order when input as a tuple so as to not violate the principle of least surprise.  This a breaking changing, but using different oversampling for each axis is not a common use case.