### PR TITLE
Return colormap with RGBA colors from make_random_cmap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ New Features
 
   - Added a ``make_2dgaussian_kernel`` convenience function. [#1356]
 
+  - Allow ``SegmentationImage.make_cmap`` ``background_color`` to be in
+    any matplotlib color format. [#1361]
+
 - ``photutils.utils``
 
   - Added a ``circular_footprint`` convenience function. [#1355]
@@ -71,6 +74,11 @@ API Changes
 
   - Deprecated the ``make_source_mask`` function in favor of the
     ``SegmentationImage.make_source_mask`` method. [#1355]
+
+- ``photutils.utils``
+
+  - The colormap returned from ``make_random_cmap`` now has colors in
+    RGBA format. [#1361]
 
 
 1.4.0 (2022-03-25)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -370,7 +370,7 @@ class SegmentationImage:
                 raise ValueError(f'label {bad_labels} is invalid')
             raise ValueError(f'labels {bad_labels} are invalid')
 
-    def make_cmap(self, background_color='#000000', seed=None):
+    def make_cmap(self, background_color='#000000ff', seed=None):
         """
         Define a matplotlib colormap consisting of (random) muted
         colors.
@@ -379,22 +379,25 @@ class SegmentationImage:
 
         Parameters
         ----------
-        background_color : str or `None`, optional
-            A hex string in the "#rrggbb" format defining the first
-            color in the colormap.  This color will be used as the
-            background color (label = 0) when plotting the segmentation
-            array.  The default is black ('#000000').
+        background_color : Matplotlib color, optional
+            The color of the first color in the colormap.
+            The color may be specified using any of
+            the `Matplotlib color formats
+            <https://matplotlib.org/stable/tutorials/colors/colors.html>`_.
+            This color will be used as the background color (label = 0)
+            when plotting the segmentation image. The default color is
+            black with alpha=1.0 ('#000000ff').
 
         seed : int, optional
             A seed to initialize the `numpy.random.BitGenerator`. If
             `None`, then fresh, unpredictable entropy will be pulled
-            from the OS.  Separate function calls with the same ``seed``
+            from the OS. Separate function calls with the same ``seed``
             will generate the same colormap.
 
         Returns
         -------
         cmap : `matplotlib.colors.ListedColormap`
-            The matplotlib colormap.
+            The matplotlib colormap with colors in RGBA format.
         """
         if self.nlabels == 0:
             return None
@@ -404,7 +407,7 @@ class SegmentationImage:
         cmap = make_random_cmap(self.max_label + 1, seed=seed)
 
         if background_color is not None:
-            cmap.colors[0] = colors.hex2color(background_color)
+            cmap.colors[0] = colors.to_rgba(background_color)
 
         return cmap
 
@@ -415,7 +418,7 @@ class SegmentationImage:
 
         This is useful for plotting the segmentation array.
         """
-        return self.make_cmap(background_color='#000000', seed=0)
+        return self.make_cmap(background_color='#000000ff', seed=0)
 
     def reassign_label(self, label, new_label, relabel=False):
         """

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -181,7 +181,7 @@ class TestSegmentationImage:
     def test_make_cmap(self):
         cmap = self.segm.make_cmap()
         assert len(cmap.colors) == (self.segm.max_label + 1)
-        assert_allclose(cmap.colors[0], [0, 0, 0])
+        assert_allclose(cmap.colors[0], [0, 0, 0, 1])
 
         assert_allclose(self.segm.cmap.colors,
                         self.segm.make_cmap(background_color='#000000',

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -184,8 +184,18 @@ class TestSegmentationImage:
         assert_allclose(cmap.colors[0], [0, 0, 0, 1])
 
         assert_allclose(self.segm.cmap.colors,
-                        self.segm.make_cmap(background_color='#000000',
+                        self.segm.make_cmap(background_color='#000000ff',
                                             seed=0).colors)
+
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
+    @pytest.mark.parametrize('color, alpha', (('#00000000', 0.),
+                                              ('#00000040', 64/255),
+                                              ('#00000080', 128/255),
+                                              ('#000000C0', 192/255),
+                                              ('#000000FF', 1.)))
+    def test_make_cmap_alpha(self, color, alpha):
+        cmap = self.segm.make_cmap(background_color=color)
+        assert_allclose(cmap.colors[0], (0, 0, 0, alpha))
 
     def test_reassign_labels(self):
         segm = SegmentationImage(self.data.copy())

--- a/photutils/utils/colormaps.py
+++ b/photutils/utils/colormaps.py
@@ -28,7 +28,7 @@ def make_random_cmap(ncolors=256, seed=None):
     Returns
     -------
     cmap : `matplotlib.colors.ListedColormap`
-        The matplotlib colormap with random colors.
+        The matplotlib colormap with random colors in RGBA format.
     """
     from matplotlib import colors
 
@@ -39,4 +39,4 @@ def make_random_cmap(ncolors=256, seed=None):
     hsv = np.dstack((hue, sat, val))
     rgb = np.squeeze(colors.hsv_to_rgb(hsv))
 
-    return colors.ListedColormap(rgb)
+    return colors.ListedColormap(colors.to_rgba_array(rgb))

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -15,4 +15,5 @@ def test_colormap():
     ncolors = 100
     cmap = make_random_cmap(ncolors, seed=0)
     assert len(cmap.colors) == ncolors
-    assert_allclose(cmap.colors[0], [0.36951484, 0.42125961, 0.65984082])
+    assert cmap.colors.shape == (100, 4)
+    assert_allclose(cmap.colors[0], [0.36951484, 0.42125961, 0.65984082, 1.])


### PR DESCRIPTION
With this PR, the colormap returned from `make_random_cmap` will have colors in RGBA format.  Also, the `SegmentationImage.make_cmap` `background_color` keyword can now be input in `#rrggbbaa` format (for RGBA) colors.