### PR TITLE
Improve performance of source deblending

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 General
 ^^^^^^^
 
+- Added ``tqdm`` as an optional dependency. [#1364]
+
 New Features
 ^^^^^^^^^^^^
 
@@ -29,6 +31,10 @@ New Features
 
   - Added an ``imshow`` convenience method to ``SegmentationImage``.
     [#1362]
+
+  - Improved performance of ``deblend_sources``. [#1364]
+
+  - Added a ``progress_bar`` keyword to ``deblend_sources``. [#1364]
 
 - ``photutils.utils``
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -36,6 +36,9 @@ Photutils also optionally depends on other packages for some features:
   performance of sigma clipping and other functionality that may require
   computing statistics on arrays with NaN values.
 
+* `tqdm <https://tqdm.github.io/>`_: Used to display optional progress
+  bars.
+
 Photutils depends on `pytest-astropy
 <https://github.com/astropy/pytest-astropy>`_ (0.4 or later) to run
 the test suite.

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -136,6 +136,9 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
     if kernel is not None:
         data = _filter_data(data, kernel, mode='constant', fill_value=0.0)
 
+    # suppress NoDetectionsWarning during deblending
+    warnings.filterwarnings('ignore', category=NoDetectionsWarning)
+
     segm_deblended = object.__new__(SegmentationImage)
     segm_deblended._data = np.copy(segment_img.data)
     last_label = segment_img.max_label
@@ -263,9 +266,6 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
     elif mode == 'linear':
         thresholds = source_min + ((source_max - source_min) /
                                    (nlevels + 1)) * steps
-
-    # suppress NoDetectionsWarning during deblending
-    warnings.filterwarnings('ignore', category=NoDetectionsWarning)
 
     mask = ~segm_mask
     segments = _detect_sources(data, thresholds, npixels=npixels,

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -12,7 +12,6 @@ import numpy as np
 from .core import SegmentationImage
 from .detect import _make_binary_structure, _detect_sources
 from ..utils._convolution import _filter_data
-from ..utils.exceptions import NoDetectionsWarning
 from ..utils._optional_deps import HAS_TQDM  # noqa
 
 __all__ = ['deblend_sources']
@@ -141,9 +140,6 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
 
     if kernel is not None:
         data = _filter_data(data, kernel, mode='constant', fill_value=0.0)
-
-    # suppress NoDetectionsWarning during deblending
-    warnings.filterwarnings('ignore', category=NoDetectionsWarning)
 
     segm_deblended = object.__new__(SegmentationImage)
     segm_deblended._data = np.copy(segment_img.data)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -183,7 +183,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
 
 
 def multithreshold(data, segment_img, mode, nlevels, segm_mask, npixels,
-                   connectivity, source_min, source_max):
+                   connectivity, selem, source_min, source_max):
 
     if mode == 'exponential' and source_min < 0:
         warnings.warn(f'Source "{segment_img.labels[0]}" contains negative '
@@ -201,10 +201,9 @@ def multithreshold(data, segment_img, mode, nlevels, segm_mask, npixels,
         thresholds = source_min + ((source_max - source_min) /
                                    (nlevels + 1)) * steps
 
-    mask = ~segm_mask
     segments = _detect_sources(data, thresholds, npixels=npixels,
-                               connectivity=connectivity, mask=mask,
-                               deblend_skip=True)
+                               connectivity=connectivity, selem=selem,
+                               inverse_mask=segm_mask, deblend_skip=True)
 
     return segments
 
@@ -329,7 +328,8 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
         return segment_img  # no deblending
 
     segments = multithreshold(data, segment_img, mode, nlevels, segm_mask,
-                              npixels, connectivity, source_min, source_max)
+                              npixels, connectivity, selem, source_min,
+                              source_max)
 
     if len(segments) == 0:  # no deblending
         return segment_img

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -36,10 +36,10 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         `~photutils.segmentation.detect_sources`.
 
         .. note::
-           It is recommended that the user convolve the data with
-           ``kernel`` and input the convolved data directly into the
-           ``data`` parameter. In this case do not input a ``kernel``,
-           otherwise the data will be convolved twice.
+           It is strongly recommended that the user convolve the data
+           with ``kernel`` and input the convolved data directly
+           into the ``data`` parameter. In this case do not input a
+           ``kernel``, otherwise the data will be convolved twice.
 
     segment_img : `~photutils.segmentation.SegmentationImage`
         The segmentation image to deblend.
@@ -117,13 +117,12 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
                          'the same shape')
 
     if nlevels < 1:
-        raise ValueError(f'nlevels must be >= 1, got "{nlevels}"')
+        raise ValueError('nlevels must be >= 1')
     if contrast < 0 or contrast > 1:
-        raise ValueError(f'contrast must be >= 0 and <= 1, got "{contrast}"')
+        raise ValueError('contrast must be >= 0 and <= 1')
 
     if mode not in ('exponential', 'linear'):
-        raise ValueError(f'"{mode}" is an invalid mode; mode must be '
-                         '"exponential" or "linear"')
+        raise ValueError('mode must be "exponential" or "linear"')
 
     if labels is None:
         labels = segment_img.labels
@@ -133,8 +132,9 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
 
     selem = _make_binary_structure(data.ndim, connectivity)
 
-    # a source must have at least 2 * npixels to be deblended into
-    # multiple sources, each with a minimum of npixels
+    # include only sources that have at least (2 * npixels);
+    # this is required for it to be deblended into multiple sources,
+    # each with a minimum of npixels
     mask = (segment_img.areas[segment_img.get_indices(labels)]
             >= (npixels * 2))
     labels = labels[mask]

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -205,7 +205,7 @@ def multithreshold(data, segment_img, mode, nlevels, segm_mask, npixels,
         warnings.simplefilter('ignore', category=RuntimeWarning)
         segments = _detect_sources(data, thresholds, npixels=npixels,
                                    connectivity=connectivity, selem=selem,
-                                   inverse_mask=segm_mask, deblend_skip=True)
+                                   inverse_mask=segm_mask, deblend_mode=True)
 
     return segments
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -351,6 +351,11 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
     markers = apply_watershed(data, markers, selem, segm_mask, source_sum,
                               contrast)
 
+    if not np.array_equal(segment_img.data.astype(bool), markers.astype(bool)):
+        raise ValueError(f'Deblending failed for source "{label}". Please '
+                         'ensure you used the same pixel connectivity in '
+                         'detect_sources and deblend_sources.')
+
     segm_new = object.__new__(SegmentationImage)
     segm_new._data = markers
     segm_new.relabel_consecutive()

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -125,6 +125,8 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         labels = np.atleast_1d(labels)
         segment_img.check_labels(labels)
 
+    selem = _make_binary_structure(data.ndim, connectivity)
+
     # a source must have at least 2 * npixels to be deblended into
     # multiple sources, each with a minimum of npixels
     mask = (segment_img.areas[segment_img.get_indices(labels)]
@@ -146,7 +148,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
 
         source_segm.keep_labels(label)  # include only one label
         source_deblended = _deblend_source(
-            source_data, source_segm, npixels, nlevels=nlevels,
+            source_data, source_segm, npixels, selem, nlevels=nlevels,
             contrast=contrast, mode=mode, connectivity=connectivity)
 
         if not np.array_equal(source_deblended.data.astype(bool),
@@ -177,8 +179,8 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
     return segm_deblended
 
 
-def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
-                    mode='exponential', connectivity=8):
+def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
+                    contrast=0.001, mode='exponential', connectivity=8):
     """
     Deblend a single labeled source.
 
@@ -269,8 +271,6 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     segments = _detect_sources(data, thresholds, npixels=npixels,
                                connectivity=connectivity, mask=mask,
                                deblend_skip=True)
-
-    selem = _make_binary_structure(data.ndim, connectivity)
 
     # define the sources (markers) for the watershed algorithm
     nsegments = len(segments)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -353,4 +353,5 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
 
     segm_new = object.__new__(SegmentationImage)
     segm_new._data = markers
+    segm_new.relabel_consecutive()
     return segm_new

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -110,6 +110,11 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         raise ValueError('The data and segmentation image must have '
                          'the same shape')
 
+    if nlevels < 1:
+        raise ValueError(f'nlevels must be >= 1, got "{nlevels}"')
+    if contrast < 0 or contrast > 1:
+        raise ValueError(f'contrast must be >= 0 and <= 1, got "{contrast}"')
+
     if mode not in ('exponential', 'linear'):
         raise ValueError(f'"{mode}" is an invalid mode; mode must be '
                          '"exponential" or "linear"')
@@ -232,11 +237,6 @@ def _deblend_source(data, segment_img, npixels, nlevels=32, contrast=0.001,
     """
     from scipy.ndimage import label as ndilabel
     from skimage.segmentation import watershed
-
-    if nlevels < 1:
-        raise ValueError(f'nlevels must be >= 1, got "{nlevels}"')
-    if contrast < 0 or contrast > 1:
-        raise ValueError(f'contrast must be >= 0 and <= 1, got "{contrast}"')
 
     segm_mask = (segment_img.data > 0)
     source_values = data[segm_mask]

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -194,11 +194,11 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
     return segm_deblended
 
 
-def multithreshold(data, segment_img, mode, nlevels, segm_mask, npixels,
+def multithreshold(data, label, mode, nlevels, segm_mask, npixels,
                    selem, source_min, source_max):
 
     if mode == 'exponential' and source_min < 0:
-        warnings.warn(f'Source "{segment_img.labels[0]}" contains negative '
+        warnings.warn(f'Source label "{label}" contains negative '
                       'values, setting deblending mode to "linear"',
                       AstropyUserWarning)
         mode = 'linear'
@@ -341,7 +341,8 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
     if source_min == source_max:
         return segment_img  # no deblending
 
-    segments = multithreshold(data, segment_img, mode, nlevels, segm_mask,
+    label = segment_img.labels[0]  # should only be 1 label
+    segments = multithreshold(data, label, mode, nlevels, segm_mask,
                               npixels, selem, source_min, source_max)
 
     if len(segments) == 0:  # no deblending

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -152,7 +152,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         source_segm.keep_labels(label)  # include only one label
         source_deblended = _deblend_source(
             source_data, source_segm, npixels, selem, nlevels=nlevels,
-            contrast=contrast, mode=mode, connectivity=connectivity)
+            contrast=contrast, mode=mode)
 
         if not np.array_equal(source_deblended.data.astype(bool),
                               source_segm.data.astype(bool)):
@@ -183,7 +183,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
 
 
 def multithreshold(data, segment_img, mode, nlevels, segm_mask, npixels,
-                   connectivity, selem, source_min, source_max):
+                   selem, source_min, source_max):
 
     if mode == 'exponential' and source_min < 0:
         warnings.warn(f'Source "{segment_img.labels[0]}" contains negative '
@@ -204,8 +204,8 @@ def multithreshold(data, segment_img, mode, nlevels, segm_mask, npixels,
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', category=RuntimeWarning)
         segments = _detect_sources(data, thresholds, npixels=npixels,
-                                   connectivity=connectivity, selem=selem,
-                                   inverse_mask=segm_mask, deblend_mode=True)
+                                   selem=selem, inverse_mask=segm_mask,
+                                   deblend_mode=True)
 
     return segments
 
@@ -264,7 +264,7 @@ def apply_watershed(data, markers, selem, mask, source_sum, contrast):
 
 
 def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
-                    contrast=0.001, mode='exponential', connectivity=8):
+                    contrast=0.001, mode='exponential'):
     """
     Deblend a single labeled source.
 
@@ -330,8 +330,7 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
         return segment_img  # no deblending
 
     segments = multithreshold(data, segment_img, mode, nlevels, segm_mask,
-                              npixels, connectivity, selem, source_min,
-                              source_max)
+                              npixels, selem, source_min, source_max)
 
     if len(segments) == 0:  # no deblending
         return segment_img

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -320,7 +320,7 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
         value of zero is reserved for the background.  Note that the
         returned `SegmentationImage` may *not* have consecutive labels.
     """
-    segm_mask = (segment_img.data > 0)
+    segm_mask = segment_img.data.astype(bool)
     source_values = data[segm_mask]
     source_sum = float(np.nansum(source_values))
     source_min = np.nanmin(source_values)
@@ -338,8 +338,7 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
     segments = make_markers(segments, selem)
 
     markers = segments[-1].data
-    mask = segment_img.data.astype(bool)
-    markers = apply_watershed(data, markers, selem, mask, source_sum,
+    markers = apply_watershed(data, markers, selem, segm_mask, source_sum,
                               contrast)
 
     segm_new = object.__new__(SegmentationImage)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -201,9 +201,11 @@ def multithreshold(data, segment_img, mode, nlevels, segm_mask, npixels,
         thresholds = source_min + ((source_max - source_min) /
                                    (nlevels + 1)) * steps
 
-    segments = _detect_sources(data, thresholds, npixels=npixels,
-                               connectivity=connectivity, selem=selem,
-                               inverse_mask=segm_mask, deblend_skip=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        segments = _detect_sources(data, thresholds, npixels=npixels,
+                                   connectivity=connectivity, selem=selem,
+                                   inverse_mask=segm_mask, deblend_skip=True)
 
     return segments
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -322,7 +322,7 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
     """
     segm_mask = segment_img.data.astype(bool)
     source_values = data[segm_mask]
-    source_sum = float(np.nansum(source_values))
+    source_sum = np.nansum(source_values)
     source_min = np.nanmin(source_values)
     source_max = np.nanmax(source_values)
     if source_min == source_max:
@@ -331,10 +331,10 @@ def _deblend_source(data, segment_img, npixels, selem, nlevels=32,
     segments = multithreshold(data, segment_img, mode, nlevels, segm_mask,
                               npixels, connectivity, source_min, source_max)
 
-    # define the sources (markers) for the watershed algorithm
     if len(segments) == 0:  # no deblending
         return segment_img
 
+    # define the sources (markers) for the watershed algorithm
     segments = make_markers(segments, selem)
 
     markers = segments[-1].data

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -156,7 +156,7 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
 
 
 def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
-                    selem=None, inverse_mask=None, deblend_skip=False):
+                    selem=None, inverse_mask=None, deblend_mode=False):
     """
     Detect sources above a specified threshold value in an image.
 
@@ -210,7 +210,7 @@ def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
         `True` values indicate masked pixels. Masked pixels will not be
         included in any source.
 
-    deblend_skip : bool, optional
+    deblend_mode : bool, optional
         If `True` do not include the segmentation image in the output
         list for any threshold level where the number of detected
         sources is less than 2. This is useful for source deblending and
@@ -224,7 +224,7 @@ def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
         values. A value of zero is reserved for the background. If
         no sources are found for a given threshold, then the output
         list will contain `None` for that threshold. Also see the
-        ``deblend_skip`` keyword.
+        ``deblend_mode`` keyword.
     """
     from scipy.ndimage import label as ndi_label
     from scipy.ndimage import find_objects
@@ -241,7 +241,7 @@ def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
         # return if threshold was too high to detect any sources
         if np.count_nonzero(segment_img) == 0:
             warnings.warn('No sources were found.', NoDetectionsWarning)
-            if not deblend_skip:
+            if not deblend_mode:
                 segms.append(None)
             continue
 
@@ -268,7 +268,7 @@ def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
 
         if np.count_nonzero(segment_img) == 0:
             warnings.warn('No sources were found.', NoDetectionsWarning)
-            if not deblend_skip:
+            if not deblend_mode:
                 segms.append(None)
             continue
 
@@ -285,7 +285,7 @@ def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
         segm.__dict__['labels'] = labels
         segm.__dict__['slices'] = segm_slices
 
-        if deblend_skip and segm.nlabels == 1:
+        if deblend_mode and segm.nlabels == 1:
             continue
 
         segms.append(segm)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -231,10 +231,9 @@ def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
 
     segms = []
     for threshold in thresholds:
-        # ignore RuntimeWarning caused by > comparison when data contains NaNs
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-            segment_img = data > threshold
+        # RuntimeWarning caused by > comparison when data contains NaNs
+        # is ignored when calling _detect_sources
+        segment_img = data > threshold
 
         if inverse_mask is not None:
             segment_img &= inverse_mask
@@ -423,9 +422,11 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
 
     selem = _make_binary_structure(data.ndim, connectivity)
 
-    return _detect_sources(data, (threshold,), npixels, kernel=kernel,
-                           connectivity=connectivity, selem=selem,
-                           inverse_mask=inverse_mask)[0]
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        return _detect_sources(data, (threshold,), npixels, kernel=kernel,
+                               connectivity=connectivity, selem=selem,
+                               inverse_mask=inverse_mask)[0]
 
 
 @deprecated('1.5.0', alternative='SegmentationImage.make_source_mask')

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -248,6 +248,9 @@ def _detect_sources(data, thresholds, npixels, kernel=None, connectivity=8,
 
     selem = _make_binary_structure(data.ndim, connectivity)
 
+    if mask is not None:
+        mask_inv = np.logical_not(mask)
+
     segms = []
     for threshold in thresholds:
         # ignore RuntimeWarning caused by > comparison when data contains NaNs
@@ -256,7 +259,7 @@ def _detect_sources(data, thresholds, npixels, kernel=None, connectivity=8,
             segment_img = data > threshold
 
         if mask is not None:
-            segment_img &= ~mask
+            segment_img &= mask_inv
 
         # return if threshold was too high to detect any sources
         if np.count_nonzero(segment_img) == 0:

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -154,8 +154,8 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
             + np.broadcast_to(error * nsigma, data.shape))
 
 
-def _detect_sources(data, thresholds, npixels, *, selem=None,
-                    inverse_mask=None, deblend_mode=False):
+def _detect_sources(data, thresholds, npixels, *, selem, inverse_mask,
+                    deblend_mode=False):
     """
     Detect sources above a specified threshold value in an image.
 
@@ -197,7 +197,7 @@ def _detect_sources(data, thresholds, npixels, *, selem=None,
         structuring element is ``np.array([[0, 1, 0]], [1, 1, 1],
         [0, 1, 0]])``.
 
-    inverse_mask : 2D bool `~numpy.ndarray`, optional
+    inverse_mask : 2D bool `~numpy.ndarray`
         A boolean mask, with the same shape as the input ``data``, where
         `False` values indicate masked pixels (the inverse of usual
         pixel masks). Masked pixels will not be included in any source.

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -155,8 +155,8 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
             + np.broadcast_to(error * nsigma, data.shape))
 
 
-def _detect_sources(data, thresholds, npixels, kernel=None, connectivity=8,
-                    mask=None, deblend_skip=False):
+def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
+                    selem=None, inverse_mask=None, deblend_skip=False):
     """
     Detect sources above a specified threshold value in an image.
 
@@ -226,30 +226,8 @@ def _detect_sources(data, thresholds, npixels, kernel=None, connectivity=8,
         list will contain `None` for that threshold. Also see the
         ``deblend_skip`` keyword.
     """
-    from scipy import ndimage
-
-    if (npixels <= 0) or (int(npixels) != npixels):
-        raise ValueError('npixels must be a positive integer, got '
-                         f'"{npixels}"')
-
-    if mask is not None:
-        if mask.shape != data.shape:
-            raise ValueError('mask must have the same shape as the input '
-                             'image.')
-        if mask.all():
-            raise ValueError('mask must not be True for every pixel. There '
-                             'are no unmasked pixels in the image to detect '
-                             'sources.')
-
-    if kernel is not None:
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', AstropyUserWarning)
-            data = convolve(data, kernel, mask=mask, normalize_kernel=True)
-
-    selem = _make_binary_structure(data.ndim, connectivity)
-
-    if mask is not None:
-        mask_inv = np.logical_not(mask)
+    from scipy.ndimage import label as ndi_label
+    from scipy.ndimage import find_objects
 
     segms = []
     for threshold in thresholds:
@@ -258,8 +236,8 @@ def _detect_sources(data, thresholds, npixels, kernel=None, connectivity=8,
             warnings.simplefilter('ignore', category=RuntimeWarning)
             segment_img = data > threshold
 
-        if mask is not None:
-            segment_img &= mask_inv
+        if inverse_mask is not None:
+            segment_img &= inverse_mask
 
         # return if threshold was too high to detect any sources
         if np.count_nonzero(segment_img) == 0:
@@ -270,14 +248,14 @@ def _detect_sources(data, thresholds, npixels, kernel=None, connectivity=8,
 
         # this is faster than recasting segment_img to int and using
         # output=segment_img
-        segment_img, nlabels = ndimage.label(segment_img, structure=selem)
+        segment_img, nlabels = ndi_label(segment_img, structure=selem)
         labels = np.arange(nlabels) + 1
 
         # remove objects with less than npixels
         # NOTE: making cutout images and setting their pixels to 0 is
         # ~10x faster than using segment_img directly and ~2x faster
         # than using ndimage.sum_labels.
-        slices = ndimage.find_objects(segment_img)
+        slices = find_objects(segment_img)
         segm_labels = []
         segm_slices = []
         for label, slc in zip(labels, slices):
@@ -422,8 +400,32 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
                    cmap=segm.make_cmap(seed=1234))
         plt.tight_layout()
     """
+    if (npixels <= 0) or (int(npixels) != npixels):
+        raise ValueError('npixels must be a positive integer, got '
+                         f'"{npixels}"')
+
+    if mask is not None:
+        if mask.shape != data.shape:
+            raise ValueError('mask must have the same shape as the input '
+                             'image.')
+        if mask.all():
+            raise ValueError('mask must not be True for every pixel. There '
+                             'are no unmasked pixels in the image to detect '
+                             'sources.')
+        inverse_mask = np.logical_not(mask)
+    else:
+        inverse_mask = None
+
+    if kernel is not None:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            data = convolve(data, kernel, mask=mask, normalize_kernel=True)
+
+    selem = _make_binary_structure(data.ndim, connectivity)
+
     return _detect_sources(data, (threshold,), npixels, kernel=kernel,
-                           connectivity=connectivity, mask=mask)[0]
+                           connectivity=connectivity, selem=selem,
+                           inverse_mask=inverse_mask)[0]
 
 
 @deprecated('1.5.0', alternative='SegmentationImage.make_source_mask')

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -123,11 +123,10 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
     if not isinstance(sigma_clip, SigmaClip):
         raise TypeError('sigma_clip must be a SigmaClip object')
 
-    if sigclip_sigma != sigma_clip.sigma:
+    if (sigclip_sigma != sigma_clip.sigma
+            or sigclip_iters != sigma_clip.maxiters):
         sigma_clip = deepcopy(sigma_clip)
         sigma_clip.sigma = sigclip_sigma
-    if sigclip_iters != sigma_clip.maxiters:
-        sigma_clip = deepcopy(sigma_clip)
         sigma_clip.maxiters = sigclip_iters
 
     if background is None or error is None:

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -233,8 +233,8 @@ def _detect_sources(data, thresholds, npixels, *, selem=None,
 
         # return if threshold was too high to detect any sources
         if np.count_nonzero(segment_img) == 0:
-            warnings.warn('No sources were found.', NoDetectionsWarning)
             if not deblend_mode:
+                warnings.warn('No sources were found.', NoDetectionsWarning)
                 segms.append(None)
             continue
 
@@ -260,8 +260,8 @@ def _detect_sources(data, thresholds, npixels, *, selem=None,
                 segm_slices.append(slc)
 
         if np.count_nonzero(segment_img) == 0:
-            warnings.warn('No sources were found.', NoDetectionsWarning)
             if not deblend_mode:
+                warnings.warn('No sources were found.', NoDetectionsWarning)
                 segms.append(None)
             continue
 

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -176,55 +176,49 @@ def _detect_sources(data, thresholds, npixels, *, selem=None,
         The 2D array of the image.
 
         .. note::
-           It is recommended that the user convolve the data with
-           ``kernel`` and input the convolved data directly into the
-           ``data`` parameter. In this case do not input a ``kernel``,
-           otherwise the data will be convolved twice.
+           It is strongly recommended that the user convolve the data
+           with ``kernel`` and input the convolved data directly
+           into the ``data`` parameter. In this case do not input a
+           ``kernel``, otherwise the data will be convolved twice.
 
-    thresholds : 2D `~numpy.ndarray` or 1D array of floats
-        The data values (as a 1D array of floats) or pixel-wise
-        data values to be used for the detection thresholds. A 2D
-        ``threshold`` must have the same shape as ``data``.
+    thresholds : list of 2D `~numpy.ndarray` or 1D array of floats
+        The data values (as a 1D array of floats) or pixel-wise data
+        values (as a sequence of 2D arrays) to be used for the detection
+        thresholds. 2D threshold arrays must have the same shape as
+        ``data``.
 
     npixels : int
         The number of connected pixels, each greater than ``threshold``,
         that an object must have to be detected. ``npixels`` must be a
         positive integer.
 
-    kernel : 2D `~numpy.ndarray` or `~astropy.convolution.Kernel2D`, optional
-        The 2D array of the kernel used to filter the image before
-        thresholding. Filtering the image will smooth the noise and
-        maximize detectability of objects with a shape similar to the
-        kernel. ``kernel`` must be `None` if the input ``data`` are
-        already convolved.
+    selem : array_like
+        A structuring element that defines feature connections. As
+        an example, for connectivity along pixel edges only, the
+        structuring element is ``np.array([[0, 1, 0]], [1, 1, 1],
+        [0, 1, 0]])``.
 
-    connectivity : {4, 8}, optional
-        The type of pixel connectivity used in determining how pixels
-        are grouped into a detected source. The options are 4 or
-        8 (default). 4-connected pixels touch along their edges.
-        8-connected pixels touch along their edges or corners. For
-        reference, SourceExtractor uses 8-connected pixels.
-
-    mask : 2D bool `~numpy.ndarray`, optional
+    inverse_mask : 2D bool `~numpy.ndarray`, optional
         A boolean mask, with the same shape as the input ``data``, where
-        `True` values indicate masked pixels. Masked pixels will not be
-        included in any source.
+        `False` values indicate masked pixels (the inverse of usual
+        pixel masks). Masked pixels will not be included in any source.
 
     deblend_mode : bool, optional
         If `True` do not include the segmentation image in the output
         list for any threshold level where the number of detected
-        sources is less than 2. This is useful for source deblending and
-        improves its performance.
+        sources is less than 2. The deblend mode also does not relabel
+        the output segmentation image to have consecutive label. This
+        keyword improves performance of source deblending.
 
     Returns
     -------
     segment_image : list of `~photutils.segmentation.SegmentationImage`
-        A list of 2D segmentation images, with the same shape as
-        ``data``, where sources are marked by different positive integer
-        values. A value of zero is reserved for the background. If
-        no sources are found for a given threshold, then the output
-        list will contain `None` for that threshold. Also see the
-        ``deblend_mode`` keyword.
+        A list of 2D segmentation images, one for each input threshold,
+        with the same shape as ``data``, where sources are marked
+        by different positive integer values. A value of zero is
+        reserved for the background. If no sources are found for a given
+        threshold, then the output list will contain `None` for that
+        threshold. Also see the ``deblend_mode`` keyword.
     """
     from scipy.ndimage import label as ndi_label
     from scipy.ndimage import find_objects
@@ -314,10 +308,10 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
         The 2D array of the image.
 
         .. note::
-           It is recommended that the user convolve the data with
-           ``kernel`` and input the convolved data directly into the
-           ``data`` parameter. In this case do not input a ``kernel``,
-           otherwise the data will be convolved twice.
+           It is strongly recommended that the user convolve the data
+           with ``kernel`` and input the convolved data directly
+           into the ``data`` parameter. In this case do not input a
+           ``kernel``, otherwise the data will be convolved twice.
 
     threshold : float or 2D `~numpy.ndarray`
         The data value or pixel-wise data values to be used for the

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -155,8 +155,8 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
             + np.broadcast_to(error * nsigma, data.shape))
 
 
-def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
-                    selem=None, inverse_mask=None, deblend_mode=False):
+def _detect_sources(data, thresholds, npixels, *, selem=None,
+                    inverse_mask=None, deblend_mode=False):
     """
     Detect sources above a specified threshold value in an image.
 
@@ -245,14 +245,14 @@ def _detect_sources(data, thresholds, npixels, *, kernel=None, connectivity=8,
                 segms.append(None)
             continue
 
-        # this is faster than recasting segment_img to int and using
-        # output=segment_img
+        # recasting segment_img to int and using output=segment_img
+        # gives similar performance
         segment_img, nlabels = ndi_label(segment_img, structure=selem)
         labels = np.arange(nlabels) + 1
 
         # remove objects with less than npixels
         # NOTE: making cutout images and setting their pixels to 0 is
-        # ~10x faster than using segment_img directly and ~2x faster
+        # ~10x faster than using segment_img directly and ~50% faster
         # than using ndimage.sum_labels.
         slices = find_objects(segment_img)
         segm_labels = []
@@ -424,8 +424,7 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', category=RuntimeWarning)
-        return _detect_sources(data, (threshold,), npixels, kernel=kernel,
-                               connectivity=connectivity, selem=selem,
+        return _detect_sources(data, (threshold,), npixels, selem=selem,
                                inverse_mask=inverse_mask)[0]
 
 

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -8,7 +8,7 @@ import importlib
 # Note that in some cases the package names are different from the
 # pip-install name (e.g.k scikit-image -> skimage).
 optional_deps = ['scipy', 'matplotlib', 'skimage', 'sklearn', 'gwcs',
-                 'bottleneck']
+                 'bottleneck', 'tqdm']
 deps = {key.upper(): key for key in optional_deps}
 __all__ = [f'HAS_{pkg}' for pkg in deps]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ all =
     scikit-learn
     gwcs>=0.16
     bottleneck
+    tqdm
 test =
     pytest-astropy
 docs =


### PR DESCRIPTION
For a large number of labels, this PR makes deblending ~2 times faster.

This PR also adds `tqdm` as an optional dependency and adds a `progress_bar` keyword to `deblend_sources` (using `tqdm`).