### PR TITLE
Deprecate kernel keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,10 @@ API Changes
   - Deprecated the ``make_source_mask`` function in favor of the
     ``SegmentationImage.make_source_mask`` method. [#1355]
 
+  - Deprecated the ``kernel`` keyword in ``detect_sources`` and
+    ``deblend_sources``. Instead, if filtering is desired, input a
+    convolved image directly into the ``data`` parameter. [#1365]
+
 - ``photutils.utils``
 
   - The colormap returned from ``make_random_cmap`` now has colors in

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -6,6 +6,7 @@ a segmentation image.
 
 import warnings
 
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -17,6 +18,11 @@ from ..utils._optional_deps import HAS_TQDM  # noqa
 __all__ = ['deblend_sources']
 
 
+@deprecated_renamed_argument('kernel', None, '1.5', message='"kernel" was '
+                             'deprecated in version 1.5 and will be removed '
+                             'in a future version. Instead, if filtering is '
+                             'desired, please input a convolved image '
+                             'directly into the "data" parameter.')
 def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
                     nlevels=32, contrast=0.001, mode='exponential',
                     connectivity=8, relabel=True, progress_bar=True):
@@ -49,6 +55,9 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         positive integer.
 
     kernel : 2D `~numpy.ndarray` or `~astropy.convolution.Kernel2D`, optional
+        Deprecated. If filtering is desired, please input a convolved
+        image directly into the ``data`` parameter.
+
         The 2D kernel used to filter the image before thresholding.
         Filtering the image will smooth the noise and maximize
         detectability of objects with a shape similar to the kernel.

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -286,6 +286,11 @@ def _detect_sources(data, thresholds, npixels, *, selem, inverse_mask,
     return segms
 
 
+@deprecated_renamed_argument('kernel', None, '1.5', message='"kernel" was '
+                             'deprecated in version 1.5 and will be removed '
+                             'in a future version. Instead, if filtering is '
+                             'desired, please input a convolved image '
+                             'directly into the "data" parameter.')
 def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
                    mask=None):
     """
@@ -323,6 +328,9 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
         positive integer.
 
     kernel : 2D `~numpy.ndarray` or `~astropy.convolution.Kernel2D`, optional
+        Deprecated. If filtering is desired, please input a convolved
+        image directly into the ``data`` parameter.
+
         The 2D array of the kernel used to filter the image before
         thresholding. Filtering the image will smooth the noise and
         maximize detectability of objects with a shape similar to the

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -198,8 +198,10 @@ class TestDetectSources:
         threshold = 0.3
         expected = np.ones((3, 3))
         expected[2] = 0
-        segm = detect_sources(self.data, threshold, npixels=1, kernel=kernel)
-        assert_array_equal(segm.data, expected)
+        with pytest.warns(AstropyDeprecationWarning):
+            segm = detect_sources(self.data, threshold, npixels=1,
+                                  kernel=kernel)
+            assert_array_equal(segm.data, expected)
 
     def test_npixels_nonint(self):
         """Test if error raises if npixel is non-integer."""
@@ -217,13 +219,16 @@ class TestDetectSources:
             detect_sources(self.data, threshold=1, npixels=1, connectivity=10)
 
     def test_kernel_array(self):
-        segm = detect_sources(self.data, 0.1, npixels=1,
-                              kernel=self.kernel.array)
-        assert_array_equal(segm.data, np.ones((3, 3)))
+        with pytest.warns(AstropyDeprecationWarning):
+            segm = detect_sources(self.data, 0.1, npixels=1,
+                                  kernel=self.kernel.array)
+            assert_array_equal(segm.data, np.ones((3, 3)))
 
     def test_kernel(self):
-        segm = detect_sources(self.data, 0.1, npixels=1, kernel=self.kernel)
-        assert_array_equal(segm.data, np.ones((3, 3)))
+        with pytest.warns(AstropyDeprecationWarning):
+            segm = detect_sources(self.data, 0.1, npixels=1,
+                                  kernel=self.kernel)
+            assert_array_equal(segm.data, np.ones((3, 3)))
 
     def test_mask(self):
         data = np.zeros((11, 11))


### PR DESCRIPTION
This PR deprecates the `kernel` keyword in ``detect_sources`` and ``deblend_sources``. Instead, if filtering is desired, input a convolved image directly into the ``data`` parameter.