### PR TITLE
Use optional tqdm progress_bar in EPSFBuilder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New Features
   - Added a ``mask`` keyword when calling the PSF-fitting classes.
     [#1350, #1351]
 
+  - The ``EPSFBuilder`` progress bar will use ``tqdm`` if the optional
+    package is installed. [#1367]
+
 - ``photutils.segmentation``
 
   - Added ``SourceFinder`` class, which is a convenience class


### PR DESCRIPTION
If `tqdm` is not installed, the progress bar will fall back to the previous (simpler) text-based version.