### PR TITLE
Add ability to use multiprocessing in source deblender

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ New Features
   - Improved the resetting of cached ``SegmentationImage`` properties so
     that custom (non-cached) attributes can be kept. [#1368]
 
+  - Added a ``nproc`` keyword to enable multiprocessing in
+    ``deblend_sources`` and ``SourceFinder``. [#1372]
+
 - ``photutils.utils``
 
   - Added a ``circular_footprint`` convenience function. [#1355]

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -161,7 +161,8 @@ Here's a simple example of source deblending:
 
     >>> from photutils.segmentation import deblend_sources
     >>> segm_deblend = deblend_sources(convolved_data, segment_map,
-    ...                                npixels=10, nlevels=32, contrast=0.001)
+    ...                                npixels=10, nlevels=32, contrast=0.001,
+    ...                                progress_bar=False)
 
 where ``segment_map`` is the
 :class:`~photutils.segmentation.SegmentationImage` that was
@@ -198,7 +199,7 @@ deblended segmentation image:
     npixels = 10
     segment_map = detect_sources(convolved_data, threshold, npixels=npixels)
     segm_deblend = deblend_sources(convolved_data, segment_map,
-                                   npixels=npixels)
+                                   npixels=npixels, progress_bar=False)
 
     norm = ImageNormalize(stretch=SqrtStretch())
     fig, ax = plt.subplots(1, 1, figsize=(10, 6.5))
@@ -235,7 +236,7 @@ Let's plot one of the deblended sources:
     npixels = 10
     segment_map = detect_sources(convolved_data, threshold, npixels=npixels)
     segm_deblend = deblend_sources(convolved_data, segment_map,
-                                   npixels=npixels)
+                                   npixels=npixels, progress_bar=False)
 
     norm = ImageNormalize(stretch=SqrtStretch())
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(10, 4))
@@ -265,7 +266,7 @@ the background-subtracted (convolved) image and threshold:
 .. doctest-requires:: scipy, skimage
 
     >>> from photutils.segmentation import SourceFinder
-    >>> finder = SourceFinder(npixels=10)
+    >>> finder = SourceFinder(npixels=10, progress_bar=False)
     >>> segment_map = finder(convolved_data, threshold)
     >>> print(segment_map)
     <photutils.segmentation.core.SegmentationImage>
@@ -409,7 +410,7 @@ of each source) on the data:
     convolved_data = convolve(data, kernel)
 
     npixels = 10
-    finder = SourceFinder(npixels=npixels)
+    finder = SourceFinder(npixels=npixels, progress_bar=False)
     segment_map = finder(convolved_data, threshold)
 
     kron_params = (2.5, 0.5)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -4,7 +4,7 @@ This module provides tools for deblending overlapping sources labeled in
 a segmentation image.
 """
 
-from multiprocessing import cpu_count, Pool
+from multiprocessing import cpu_count, get_context
 import warnings
 
 from astropy.utils.decorators import deprecated_renamed_argument
@@ -217,7 +217,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         if progress_bar and HAS_TQDM:
             args_all = tqdm(args_all, total=nlabels)
 
-        with Pool(processes=nproc) as executor:
+        with get_context('spawn').Pool(processes=nproc) as executor:
             all_source_deblends = executor.starmap(_deblend_source, args_all)
 
     nonposmin_labels = []

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -116,7 +116,11 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         than 1). If set to 1, then a serial implementation is used
         instead of a parallel one. If `None`, then the number of
         processes will be set to the number of CPUs detected on the
-        machine.
+        machine. Please note that due to overheads, multiprocessing may
+        be slower than serial processing. This is especially true if one
+        only has a small number of sources to deblend. The benefits of
+        multiprocessing require ~1000 or more sources to deblend, with
+        large gains as the number of sources increase.
 
      progress_bar : bool, optional
         Whether to display a progress bar. Note that if multiprocessing

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -62,11 +62,23 @@ class SourceFinder:
         multi-thresholding levels (see the ``nlevels`` keyword) during
         deblending. This keyword is ignored unless ``deblend=True``.
 
-    relabel : bool
+    relabel : bool, optional
         If `True` (default), then the segmentation image will be
         relabeled after deblending such that the labels are in
         consecutive order starting from 1. This keyword is ignored
         unless ``deblend=True``.
+
+    nproc : int, optional
+        The number of processes to use for multiprocessing (if larger
+        than 1). If set to 1, then a serial implementation is used
+        instead of a parallel one. If `None`, then the number of
+        processes will be set to the number of CPUs detected on the
+        machine. Please note that due to overheads, multiprocessing may
+        be slower than serial processing. This is especially true if one
+        only has a small number of sources to deblend. The benefits of
+        multiprocessing require ~1000 or more sources to deblend, with
+        large gains as the number of sources increase. This keyword is
+        ignored unless ``deblend=True``.
 
     progress_bar : bool, optional
        Whether to display a progress bar during source deblending. The
@@ -122,7 +134,7 @@ class SourceFinder:
     """
 
     def __init__(self, npixels, *, connectivity=8, deblend=True, nlevels=32,
-                 contrast=0.001, mode='exponential', relabel=True,
+                 contrast=0.001, mode='exponential', relabel=True, nproc=1,
                  progress_bar=True):
         self.npixels = npixels
         self.deblend = deblend
@@ -131,6 +143,7 @@ class SourceFinder:
         self.contrast = contrast
         self.mode = mode
         self.relabel = relabel
+        self.nproc = nproc
         self.progress_bar = progress_bar
 
     def __call__(self, data, threshold, mask=None):
@@ -176,6 +189,7 @@ class SourceFinder:
                                           mode=self.mode,
                                           connectivity=self.connectivity,
                                           relabel=self.relabel,
+                                          nproc=self.nproc,
                                           progress_bar=self.progress_bar)
 
         return segment_img

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -120,7 +120,7 @@ class SourceFinder:
 
         # detect the sources
         threshold = 1.5 * bkg.background_rms  # per-pixel threshold
-        finder = SourceFinder(npixels=10)
+        finder = SourceFinder(npixels=10, progress_bar=False)
         segm = finder(convolved_data, threshold)
 
         # plot the image and the segmentation image

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -7,7 +7,7 @@ import warnings
 from astropy.modeling.models import Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import pytest
 
 from ..core import SegmentationImage
@@ -42,6 +42,13 @@ class TestDeblendSources:
             warnings.simplefilter('ignore', DeprecationWarning)
             result = deblend_sources(self.data, self.segm, self.npixels,
                                      mode=mode, progress_bar=False)
+
+            if mode == 'linear':
+                # test multiprocessing
+                result2 = deblend_sources(self.data, self.segm, self.npixels,
+                                          mode=mode, progress_bar=False,
+                                          nproc=2)
+                assert_equal(result.data, result2.data)
 
         assert result.nlabels == 2
         assert result.nlabels == len(result.slices)

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -41,7 +41,7 @@ class TestDeblendSources:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
             result = deblend_sources(self.data, self.segm, self.npixels,
-                                     mode=mode)
+                                     mode=mode, progress_bar=False)
 
         assert result.nlabels == 2
         assert result.nlabels == len(result.slices)
@@ -60,7 +60,7 @@ class TestDeblendSources:
         y = self.y
         data = self.data + g4(x, y) + g5(x, y) + g6(x, y) + g7(x, y)
         segm = detect_sources(data, self.threshold, self.npixels)
-        result = deblend_sources(data, segm, self.npixels)
+        result = deblend_sources(data, segm, self.npixels, progress_bar=False)
         assert result.nlabels == 6
         assert result.nlabels == len(result.slices)
         assert result.areas[0] == result.areas[1]
@@ -78,7 +78,7 @@ class TestDeblendSources:
         y = self.y
         data = (g1 + g2 + g3)(x, y)
         segm = detect_sources(data, self.threshold, self.npixels)
-        result = deblend_sources(data, segm, self.npixels)
+        result = deblend_sources(data, segm, self.npixels, progress_bar=False)
         assert result.nlabels == 3
 
     def test_deblend_labels(self):
@@ -89,7 +89,8 @@ class TestDeblendSources:
         y = self.y
         data = (g1 + g2 + g3)(x, y)
         segm = detect_sources(data, self.threshold, self.npixels)
-        result = deblend_sources(data, segm, self.npixels, labels=1)
+        result = deblend_sources(data, segm, self.npixels, labels=1,
+                                 progress_bar=False)
         assert result.nlabels == 2
 
     @pytest.mark.parametrize('contrast, nlabels',
@@ -108,7 +109,8 @@ class TestDeblendSources:
         npixels = 5
         segm = detect_sources(data, 1.0, npixels)
         segm2 = deblend_sources(data, segm, npixels, mode='linear',
-                                nlevels=32, contrast=contrast)
+                                nlevels=32, contrast=contrast,
+                                progress_bar=False)
         assert segm2.nlabels == nlabels
 
     def test_deblend_connectivity(self):
@@ -125,16 +127,19 @@ class TestDeblendSources:
 
         segm = detect_sources(data, 0.1, 1, connectivity=4)
         assert segm.nlabels == 9
-        segm2 = deblend_sources(data, segm, 1, mode='linear', connectivity=4)
+        segm2 = deblend_sources(data, segm, 1, mode='linear', connectivity=4,
+                                progress_bar=False)
         assert segm2.nlabels == 9
 
         segm = detect_sources(data, 0.1, 1, connectivity=8)
         assert segm.nlabels == 1
-        segm2 = deblend_sources(data, segm, 1, mode='linear', connectivity=8)
+        segm2 = deblend_sources(data, segm, 1, mode='linear', connectivity=8,
+                                progress_bar=False)
         assert segm2.nlabels == 3
 
         with pytest.raises(ValueError):
-            deblend_sources(data, segm, 1, mode='linear', connectivity=4)
+            deblend_sources(data, segm, 1, mode='linear', connectivity=4,
+                            progress_bar=False)
 
     def test_deblend_label_assignment(self):
         """
@@ -159,13 +164,13 @@ class TestDeblendSources:
         npixels = 5
         segm1 = detect_sources(data, 5.0, npixels)
         segm2 = deblend_sources(data, segm1, npixels, mode='linear',
-                                nlevels=32, contrast=0.3)
+                                nlevels=32, contrast=0.3, progress_bar=False)
         assert segm2.nlabels == 4
 
     @pytest.mark.parametrize('mode', ['exponential', 'linear'])
     def test_deblend_sources_norelabel(self, mode):
         result = deblend_sources(self.data, self.segm, self.npixels,
-                                 mode=mode, relabel=False)
+                                 mode=mode, relabel=False, progress_bar=False)
         assert result.nlabels == 2
         assert len(result.slices) <= result.max_label
         assert len(result.slices) == result.nlabels
@@ -174,55 +179,62 @@ class TestDeblendSources:
     @pytest.mark.parametrize('mode', ['exponential', 'linear'])
     def test_deblend_three_sources(self, mode):
         result = deblend_sources(self.data3, self.segm3, self.npixels,
-                                 mode=mode)
+                                 mode=mode, progress_bar=False)
         assert result.nlabels == 3
         assert_allclose(np.nonzero(self.segm3), np.nonzero(result))
 
     def test_segment_img(self):
         segm_wrong = np.ones((2, 2), dtype=int)  # ndarray
         with pytest.raises(ValueError):
-            deblend_sources(self.data, segm_wrong, self.npixels)
+            deblend_sources(self.data, segm_wrong, self.npixels,
+                            progress_bar=False)
 
         segm_wrong = SegmentationImage(segm_wrong)  # wrong shape
         with pytest.raises(ValueError):
-            deblend_sources(self.data, segm_wrong, self.npixels)
+            deblend_sources(self.data, segm_wrong, self.npixels,
+                            progress_bar=False)
 
     def test_invalid_nlevels(self):
         with pytest.raises(ValueError):
-            deblend_sources(self.data, self.segm, self.npixels, nlevels=0)
+            deblend_sources(self.data, self.segm, self.npixels, nlevels=0,
+                            progress_bar=False)
 
     def test_invalid_contrast(self):
         with pytest.raises(ValueError):
-            deblend_sources(self.data, self.segm, self.npixels, contrast=-1)
+            deblend_sources(self.data, self.segm, self.npixels, contrast=-1,
+                            progress_bar=False)
 
     def test_invalid_mode(self):
         with pytest.raises(ValueError):
             deblend_sources(self.data, self.segm, self.npixels,
-                            mode='invalid')
+                            mode='invalid', progress_bar=False)
 
     def test_invalid_connectivity(self):
         with pytest.raises(ValueError):
             deblend_sources(self.data, self.segm, self.npixels,
-                            connectivity='invalid')
+                            connectivity='invalid', progress_bar=False)
 
     def test_constant_source(self):
         data = self.data.copy()
         data[data.nonzero()] = 1.
-        result = deblend_sources(data, self.segm, self.npixels)
+        result = deblend_sources(data, self.segm, self.npixels,
+                                 progress_bar=False)
         assert_allclose(result, self.segm)
 
     def test_source_with_negval(self):
         data = self.data.copy()
         data -= 20
         with pytest.warns(AstropyUserWarning, match='The deblending mode'):
-            segm = deblend_sources(data, self.segm, self.npixels)
+            segm = deblend_sources(data, self.segm, self.npixels,
+                                   progress_bar=False)
             assert segm.info['warnings']['nonposmin']['input_labels'] == 1
 
     def test_source_zero_min(self):
         data = self.data.copy()
         data -= data[self.segm.data > 0].min()
         with pytest.warns(AstropyUserWarning, match='The deblending mode'):
-            segm = deblend_sources(data, self.segm, self.npixels)
+            segm = deblend_sources(data, self.segm, self.npixels,
+                                   progress_bar=False)
             assert segm.info['warnings']['nonposmin']['input_labels'] == 1
 
     def test_connectivity(self):
@@ -235,10 +247,12 @@ class TestDeblendSources:
         segm[data.nonzero()] = 1
         segm = SegmentationImage(segm)
         data = data * 100.
-        segm_deblend = deblend_sources(data, segm, npixels=1, connectivity=8)
+        segm_deblend = deblend_sources(data, segm, npixels=1, connectivity=8,
+                                       progress_bar=False)
         assert segm_deblend.nlabels == 1
         with pytest.raises(ValueError):
-            deblend_sources(data, segm, npixels=1, connectivity=4)
+            deblend_sources(data, segm, npixels=1, connectivity=4,
+                            progress_bar=False)
 
     def test_data_nan(self):
         """
@@ -248,7 +262,7 @@ class TestDeblendSources:
 
         data = self.data.copy()
         data[50, 50] = np.nan
-        segm2 = deblend_sources(data, self.segm, 5)
+        segm2 = deblend_sources(data, self.segm, 5, progress_bar=False)
         assert segm2.nlabels == 2
 
     def test_watershed(self):
@@ -262,7 +276,8 @@ class TestDeblendSources:
 
         segm = self.segm.copy()
         segm.reassign_label(1, 512)
-        result = deblend_sources(self.data, segm, self.npixels)
+        result = deblend_sources(self.data, segm, self.npixels,
+                                 progress_bar=False)
         assert result.nlabels == 2
 
     def test_nondetection(self):
@@ -278,10 +293,11 @@ class TestDeblendSources:
         data[50, 50] = 1000.
         data[50, 70] = 500.
         self.segm = detect_sources(data, self.threshold, self.npixels)
-        deblend_sources(data, self.segm, self.npixels)
+        deblend_sources(data, self.segm, self.npixels, progress_bar=False)
 
     def test_nonconsecutive_labels(self):
         segm = self.segm.copy()
         segm.reassign_label(1, 1000)
-        result = deblend_sources(self.data, segm, self.npixels)
+        result = deblend_sources(self.data, segm, self.npixels,
+                                 progress_bar=False)
         assert result.nlabels == 2


### PR DESCRIPTION
This PR adds a `nproc` keyword to `deblend_sources` and `SourceFinder` to optionally enable multiprocessing when deblending sources.