### PR TITLE
Switch to linear deblending mode if there are too many watershed markers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,11 @@ API Changes
     mode. The affected labels is available in a new "info" attribute.
     [#1368]
 
+  - If the mode in ``deblend_sources`` is "exponential" or "sinh" and there
+    are too many potential deblended sources within a given source
+    (watershed markers), a warning will be raised and the mode will be
+    changed to "linear". [#1369]
+
 - ``photutils.utils``
 
   - The colormap returned from ``make_random_cmap`` now has colors in

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -175,13 +175,13 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
     selem = _make_binary_structure(data.ndim, connectivity)
 
     if kernel is not None:
-        data = _filter_data(data, kernel, mode='constant', fill_value=0.0)
+        data = _filter_data(data, kernel, mode='constant', fill_value=0.0)  # pragma: no cover
 
     if nproc is None:
-        nproc = cpu_count()
+        nproc = cpu_count()  # pragma: no cover
 
     if progress_bar and HAS_TQDM:
-        from tqdm.auto import tqdm
+        from tqdm.auto import tqdm  # pragma: no cover
 
     segm_deblended = object.__new__(SegmentationImage)
     segm_deblended._data = np.copy(segment_img.data)
@@ -203,7 +203,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
 
     if nproc == 1:
         if progress_bar and HAS_TQDM:
-            all_source_data = tqdm(all_source_data)
+            all_source_data = tqdm(all_source_data)  # pragma: no cover
 
         all_source_deblends = []
         for source_data, source_segment in zip(all_source_data,
@@ -220,7 +220,7 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
                        (nlevels,) * nlabels, (contrast,) * nlabels,
                        (mode,) * nlabels)
         if progress_bar and HAS_TQDM:
-            args_all = tqdm(args_all, total=nlabels)
+            args_all = tqdm(args_all, total=nlabels)  # pragma: no cover
 
         with get_context('spawn').Pool(processes=nproc) as executor:
             all_source_deblends = executor.starmap(_deblend_source, args_all)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -187,9 +187,9 @@ def _detect_sources(data, thresholds, npixels, selem, inverse_mask,
         ``data``.
 
     npixels : int
-        The number of connected pixels, each greater than ``threshold``,
-        that an object must have to be detected. ``npixels`` must be a
-        positive integer.
+        The minimum number of connected pixels, each greater than
+        ``threshold``, that an object must have to be detected.
+        ``npixels`` must be a positive integer.
 
     selem : array_like
         A structuring element that defines feature connections. As
@@ -323,9 +323,9 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
         shape as ``data``.
 
     npixels : int
-        The number of connected pixels, each greater than ``threshold``,
-        that an object must have to be detected. ``npixels`` must be a
-        positive integer.
+        The minimum number of connected pixels, each greater than
+        ``threshold``, that an object must have to be detected.
+        ``npixels`` must be a positive integer.
 
     kernel : 2D `~numpy.ndarray` or `~astropy.convolution.Kernel2D`, optional
         Deprecated. If filtering is desired, please input a convolved
@@ -341,8 +341,7 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
         The type of pixel connectivity used in determining how pixels
         are grouped into a detected source. The options are 4 or
         8 (default). 4-connected pixels touch along their edges.
-        8-connected pixels touch along their edges or corners. For
-        reference, SourceExtractor uses 8-connected pixels.
+        8-connected pixels touch along their edges or corners.
 
     mask : 2D bool `~numpy.ndarray`, optional
         A boolean mask, with the same shape as the input ``data``, where
@@ -458,9 +457,9 @@ def make_source_mask(data, nsigma, npixels, mask=None, filter_fwhm=None,
         part of a source.
 
     npixels : int
-        The number of connected pixels, each greater than ``threshold``,
-        that an object must have to be detected.  ``npixels`` must be a
-        positive integer.
+        The minimum number of connected pixels, each greater than
+        ``threshold``, that an object must have to be detected.
+        ``npixels`` must be a positive integer.
 
     mask : 2D bool `~numpy.ndarray`, optional
         A boolean mask with the same shape as ``data``, where a `True`

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -26,16 +26,15 @@ class SourceFinder:
     Parameters
     ----------
     npixels : int
-        The number of connected pixels, each greater than a specified
-        threshold, that an object must have to be detected. ``npixels``
-        must be a positive integer.
+        The minimum number of connected pixels, each greater than a
+        specified threshold, that an object must have to be detected.
+        ``npixels`` must be a positive integer.
 
     connectivity : {4, 8}, optional
         The type of pixel connectivity used in determining how pixels
         are grouped into a detected source. The options are 4 or
         8 (default). 4-connected pixels touch along their edges.
-        8-connected pixels touch along their edges or corners. For
-        reference, SourceExtractor uses 8-connected pixels.
+        8-connected pixels touch along their edges or corners.
 
     deblend : bool, optional
         Whether to deblend overlapping sources.


### PR DESCRIPTION
If the mode in ``deblend_sources`` is "exponential" or "sinh" and there are too many potential deblended sources within a given source (watershed markers), a warning will be raised and the mode will be changed to "linear".  This sometimes occurs, especially with "exponential" mode (where there are many thresholds at low detection levels), where the detection threshold and/or `npixels` was too low, resulting in many noise spikes being found.  That in turn causes the watershed algorithm to run for a long time for non-real sources.