### PR TITLE
Prevent zero-divide runtime error in centroid_com

### DIFF
--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -62,6 +62,9 @@ def centroid_com(data, mask=None, oversampling=1):
         data[badmask] = 0.
 
     total = np.sum(data)
+    if total == 0:
+        return np.array((np.nan, np.nan))
+
     indices = np.ogrid[[slice(0, i) for i in data.shape]]
 
     # note the output array is reversed to give (x, y) order

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -81,15 +81,15 @@ def test_centroids_nan_withmask(use_mask):
 
     with ctx as warnlist:
         xc, yc = centroid_1dg(data, mask=mask)
-    assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-    if nwarn == 1:
-        assert len(warnlist) == nwarn
+        assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
+        if nwarn == 1:
+            assert len(warnlist) == nwarn
 
     with ctx as warnlist:
         xc, yc = centroid_2dg(data, mask=mask)
-    assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
-    if nwarn == 1:
-        assert len(warnlist) == nwarn
+        assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.e-3)
+        if nwarn == 1:
+            assert len(warnlist) == nwarn
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -138,7 +138,10 @@ def test_gaussian1d_moments():
     data[0] = np.nan
     mask = np.zeros(data.shape).astype(bool)
     mask[0] = True
-    with pytest.warns(AstropyUserWarning) as warnlist:
+
+    ctx = pytest.warns(AstropyUserWarning,
+                       match='Input data contains non-finite values')
+    with ctx as warnlist:
         result = _gaussian1d_moments(data, mask=mask)
-    assert_allclose(result, desired, rtol=0, atol=1.e-6)
-    assert len(warnlist) == 1
+        assert_allclose(result, desired, rtol=0, atol=1.e-6)
+        assert len(warnlist) == 1


### PR DESCRIPTION
This could occur if the (masked) array sums to zero.