### PR TITLE
Add CutoutImage class and SourceCatalog.make_cutouts method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ __pycache__
 */cython_version.py
 MANIFEST
 htmlcov
-.coverage
+.coverage*
 .ipynb_checkpoints
 .pytest_cache
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,9 +47,14 @@ New Features
   - Added a ``nproc`` keyword to enable multiprocessing in
     ``deblend_sources`` and ``SourceFinder``. [#1372]
 
+  - Added a ``make_cutouts`` method to ``SourceCatalog`` for making
+    custom-shaped cutout images. [#1376]
+
 - ``photutils.utils``
 
   - Added a ``circular_footprint`` convenience function. [#1355]
+
+  - Added a ``CutoutImage`` class. [#1376]
 
 Bug Fixes
 ^^^^^^^^^
@@ -112,6 +117,11 @@ API Changes
     are too many potential deblended sources within a given source
     (watershed markers), a warning will be raised and the mode will be
     changed to "linear". [#1369]
+
+  - The ``SourceCatalog`` ``make_circular_apertures`` and
+    ``make_kron_apertures`` methods now return a single aperture
+    (instead of a list with one item) for a scalar ``SourceCatalog``.
+    [#1376]
 
 - ``photutils.utils``
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2300,14 +2300,12 @@ class SourceCatalog:
     def plot_circular_apertures(self, radius, axes=None, origin=(0, 0),
                                 **kwargs):
         """
-        Plot circular apertures on a matplotlib `~matplotlib.axes.Axes`
-        instance.
+        Plot circular apertures for each source on a matplotlib
+        `~matplotlib.axes.Axes` instance.
 
-        The apertures are defined by the specified radius and are
-        centered at the source centroid position.
-
-        If provided, the `SourceCatalog` ``detection_cat`` will be used
-        for the source centroids.
+        The aperture for each source will be centered at its centroid
+        position. If a ``detection_cat`` was input to `SourceCatalog`,
+        it will be used for the source centroids.
 
         Parameters
         ----------
@@ -2698,35 +2696,32 @@ class SourceCatalog:
     def plot_kron_apertures(self, kron_params=None, axes=None, origin=(0, 0),
                             **kwargs):
         """
-        Plot Kron elliptical apertures on a matplotlib
+        Plot Kron apertures for each source on a matplotlib
         `~matplotlib.axes.Axes` instance.
 
-        If a ``detection_cat`` was input to `SourceCatalog`, it will be
-        used for the source centroids and elliptical shape parameters.
+        The aperture for each source will be centered at its centroid
+        position. If a ``detection_cat`` was input to `SourceCatalog`,
+        it will be used for the source centroids.
 
-        ``kron_params`` controls the scaling of the Kron aperture.
-
-        Note that changing ``kron_params`` from the values input
-        into `SourceCatalog` does not change the Kron apertures
-        `kron_aperture` and photometry (`kron_flux` and `kron_fluxerr`)
-        in source catalog. Changing the default ``kron_params`` should
-        be used only to visualize/explore alternative ``kron_params``.
+        ``kron_params`` controls the scaling of the Kron aperture and
+        its minimum radius. Note that changing ``kron_params`` from
+        the values input into `SourceCatalog` does not change the Kron
+        apertures (`kron_aperture`) and photometry (`kron_flux` and
+        `kron_fluxerr`) in the source catalog. This method should be
+        used only to visualize/explore alternative ``kron_params``.
 
         Parameters
         ----------
-        kron_params : `None` or list of 2 floats, optional
-            If `None` (default), then the ``kron_params`` input to
-            `SourceCatalog` will be used. These are the Kron parameters
-            used to define the Kron radii and photometry in the
-            catalog. Instead, one may input ``kron_params`` to plot
-            different Kron apertures, but note that doing so does
-            not change the Kron radii and photometry in the source
-            catalog. The first item is the scaling parameter of the
+        kron_params : list of 2 floats or `None`, optional
+            A list of two parameters used to determine the Kron
+            aperture. The first item is the scaling parameter of the
             Kron radius (`kron_radius`) and the second item represents
             the minimum circular radius. If the Kron radius times sqrt(
             `semimajor_sigma` * `semiminor_sigma`) is less than than
-            this radius, then the Kron flux will be measured in a circle
-            with this minimum radius.
+            this radius, then the Kron aperture will be a circle with
+            this minimum radius. If `None`, then the ``kron_params``
+            input into `SourceCatalog` will be used (the plotted
+            apertures will be the same as those in `kron_aperture`).
 
         axes : `matplotlib.axes.Axes` or `None`, optional
             The matplotlib axes on which to plot.  If `None`, then the

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2289,7 +2289,8 @@ class SourceCatalog:
 
         Returns
         -------
-        result : `~photutils.aperture.CircularAperture` or list of `~photutils.aperture.CircularAperture`
+        result : `~photutils.aperture.CircularAperture` or \
+                 list of `~photutils.aperture.CircularAperture`
             The circular aperture for each source. The aperture will be
             `None` where the source centroid position is not finite or
             where the source is completely masked.

--- a/photutils/utils/__init__.py
+++ b/photutils/utils/__init__.py
@@ -4,6 +4,7 @@ This subpackage provides general-purpose utility functions.
 """
 
 from .colormaps import *  # noqa
+from .cutouts import *  # noqa
 from .errors import *  # noqa
 from .exceptions import *  # noqa
 from .footprints import *  # noqa

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -1,0 +1,154 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module provides tools for generating 2D image cutouts.
+"""
+
+import numpy as np
+
+from astropy.nddata import extract_array, overlap_slices
+from astropy.utils import lazyproperty
+
+from ..aperture import BoundingBox
+
+__all__ = ['CutoutImage']
+
+
+class CutoutImage:
+    """
+    Create a cutout object from a 2D array.
+
+    The returned object will contain a 2D cutout array.  If
+    ``copy=False`` (default), the cutout array is a view into the
+    original ``data`` array, otherwise the cutout array will contain a
+    copy of the original data.
+
+    Parameters
+    ----------
+    data : ndarray
+        The 2D data array from which to extract the cutout array.
+
+    position : 2 tuple
+        The ``(y, x)`` position of the center of the cutout array with
+        respect to the ``data`` array.
+
+    shape : 2 tuple of int
+        The shape of the cutout array along each axis in ``(ny, nx)``
+        order.
+
+    mode : {'trim', 'partial', 'strict'}, optional
+        The mode used for creating the cutout data array. For the
+        ``'partial'`` and ``'trim'`` modes, a partial overlap
+        of the cutout array and the input ``data`` array is
+        sufficient. For the ``'strict'`` mode, the cutout array
+        has to be fully contained within the ``data`` array,
+        otherwise an `~astropy.nddata.utils.PartialOverlapError`
+        is raised. In all modes, non-overlapping arrays will raise
+        a `~astropy.nddata.utils.NoOverlapError`. In ``'partial'``
+        mode, positions in the cutout array that do not overlap with
+        the ``data`` array will be filled with ``fill_value``. In
+        ``'trim'`` mode only the overlapping elements are returned, thus
+        the resulting cutout array may be smaller than the requested
+        ``shape``.
+
+    fill_value : float or int, optional
+        If ``mode='partial'``, the value to fill pixels in the
+        cutout array that do not overlap with the input ``data``.
+        ``fill_value`` must have the same ``dtype`` as the input
+        ``data`` array.
+
+    copy : bool, optional
+        If `False` (default), then the cutout data will be a view into
+        the original ``data`` array. If `True`, then the cutout data
+        will hold a copy of the original ``data`` array.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from photutils.utils import CutoutImage
+    >>> data = np.arange(20.).reshape(5, 4)
+    >>> cutout = CutoutImage(data, (2, 2), (3, 3))
+    >>> print(cutout.data)  # doctest: +FLOAT_CMP
+    [[ 5.  6.  7.]
+     [ 9. 10. 11.]
+     [13. 14. 15.]]
+
+    >>> cutout2 = CutoutImage(data, (0, 0), (3, 3), mode='partial')
+    >>> print(cutout2.data)  # doctest: +FLOAT_CMP
+    [[nan nan nan]
+     [nan  0.  1.]
+     [nan  4.  5.]]
+    """
+    def __init__(self, data, position, shape, mode='trim', fill_value=np.nan,
+                 copy=False):
+
+        data = np.asanyarray(data)
+        cutout_data = extract_array(data, shape, position, mode=mode,
+                                    fill_value=fill_value,
+                                    return_position=False)
+        if copy:
+            cutout_data = np.copy(cutout_data)
+        self.data = cutout_data
+        self._overlap_slices = overlap_slices(data.shape, shape, position,
+                                              mode=mode)
+
+    def __array__(self, dtype=None):
+        """
+        Array representation of the cutout data array (e.g., for
+        matplotlib).
+        """
+        return np.asarray(self.data, dtype=dtype)
+
+    def __str__(self):
+        cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
+        props = (f'Shape: {self.data.shape}')
+        return f'{cls_name}\n' + props
+
+    def __repr__(self):
+        return self.__str__()
+
+    @lazyproperty
+    def slices_original(self):
+        """
+        A tuple of slice objects for the minimal bounding box
+        of the cutout with respect to the original array. For
+        ``mode='partial'``, the slices are for the valid (non-filled)
+        cutout values.
+        """
+        return self._overlap_slices[0]
+
+    @lazyproperty
+    def slices_cutout(self):
+        """
+        A tuple of slice objects for the minimal bounding box of the
+        cutout with respect to the cutout array. For ``mode='partial'``,
+        the slices are for the valid (non-filled) cutout values.
+        """
+        return self._overlap_slices[1]
+
+    def _calc_bbox(self, slices):
+        """
+        Calculate the `~photutils.aperture.BoundingBox` of the
+        rectangular bounding box from the input slices.
+        """
+        return BoundingBox(ixmin=slices[1].start, ixmax=slices[1].stop,
+                           iymin=slices[0].start, iymax=slices[0].stop)
+
+    @lazyproperty
+    def bbox_original(self):
+        """
+        The `~photutils.aperture.BoundingBox` of the minimal rectangular
+        region of the cutout array with respect to the original array.
+        For ``mode='partial'``, the bounding box indices are for the
+        valid (non-filled) cutout values.
+        """
+        return self._calc_bbox(self.slices_original)
+
+    @lazyproperty
+    def bbox_cutout(self):
+        """
+        The `~photutils.aperture.BoundingBox` of the minimal rectangular
+        region of the cutout array with respect to the cutout array. For
+        ``mode='partial'``, the bounding box indices are for the valid
+        (non-filled) cutout values.
+        """
+        return self._calc_bbox(self.slices_cutout)

--- a/photutils/utils/tests/test_cutouts.py
+++ b/photutils/utils/tests/test_cutouts.py
@@ -1,0 +1,40 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the cutouts module.
+"""
+
+import numpy as np
+from numpy.testing import assert_equal
+
+from ...aperture import BoundingBox
+from ...datasets import make_100gaussians_image
+from ..cutouts import CutoutImage
+
+
+def test_cutout():
+    data = make_100gaussians_image()
+    shape = (24, 57)
+    cutout = CutoutImage(data, (100, 51), shape)
+    assert cutout.data.shape == shape
+    assert_equal(cutout.__array__(), cutout.data)
+
+    assert isinstance(cutout.bbox_original, BoundingBox)
+    assert isinstance(cutout.bbox_cutout, BoundingBox)
+    assert cutout.slices_original == (slice(88, 112, None),
+                                      slice(23, 80, None))
+    assert cutout.slices_cutout == (slice(0, 24, None), slice(0, 57, None))
+
+    assert f'Shape: {shape}' in repr(cutout)
+    assert f'Shape: {shape}' in str(cutout)
+
+
+def test_cutout_copy():
+    data = make_100gaussians_image()
+
+    cutout1 = CutoutImage(data, (1, 1), (3, 3), copy=True)
+    cutout1.data[0, 0] = np.nan
+    assert not np.isnan(data[0, 0])
+
+    cutout2 = CutoutImage(data, (1, 1), (3, 3), copy=False)
+    cutout2.data[0, 0] = np.nan
+    assert np.isnan(data[0, 0])


### PR DESCRIPTION
This PR adds a `CutoutImage` class for making cutouts.

This PR also adds a `make_cutouts` method to `SourceCatalog`, which can be used to make custom-shaped cutout images for each source in the catalog.

The PR also changes the `SourceCatalog` `make_circular_apertures` and `make_kron_apertures` methods to return an aperture object instead of a list with one aperture for scalar `SourceCatalog` objects.