### PR TITLE
Deprecate oversampling keyword in centroid_com

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,8 @@ API Changes
   - Changed the axes order of ``oversampling`` keyword in
     ``centroid_com`` when input as a tuple. [#1358]
 
+  - Deprecated the ``oversampling`` keyword in ``centroid_com``. [#1377]
+
 - ``photutils.psf``
 
   - Invalid data values (i.e., NaN or inf) are now automatically masked
@@ -78,6 +80,9 @@ API Changes
 
   - Changed the axes order of ``oversampling`` keywords when input as a
     tuple. [#1358]
+
+  - Removed the unused ``shift_val`` keyword in ``EPSFBuilder`` and
+    ``EPSFModel``. [#1377]
 
 - ``photutils.segmentation``
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -356,15 +356,15 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
         if footprint.ndim != 2:
             raise ValueError('footprint must be a 2D array.')
 
-    spec = inspect.getfullargspec(centroid_func)
-    if 'mask' not in spec.args:
+    spec = inspect.signature(centroid_func)
+    if 'mask' not in spec.parameters:
         raise ValueError('The input "centroid_func" must have a "mask" '
                          'keyword.')
 
     # drop any **kwargs not supported by the centroid_func
     centroid_kwargs = {}
     for key, val in kwargs.items():
-        if key in spec.args:
+        if key in spec.parameters:
             centroid_kwargs[key] = val
 
     xcentroids = []

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -7,6 +7,7 @@ import inspect
 import warnings
 
 from astropy.nddata.utils import overlap_slices
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -16,6 +17,7 @@ from ..utils._parameters import as_pair
 __all__ = ['centroid_com', 'centroid_quadratic', 'centroid_sources']
 
 
+@deprecated_renamed_argument('oversampling', None, '1.5')
 def centroid_com(data, mask=None, oversampling=1):
     """
     Calculate the centroid of an n-dimensional array as its "center of
@@ -34,6 +36,7 @@ def centroid_com(data, mask=None, oversampling=1):
         value indicates the corresponding element of ``data`` is masked.
 
     oversampling : int or array_like (int)
+        Deprecated.
         The integer oversampling factor(s). If ``oversampling`` is a
         scalar then it will be used for both axes. If ``oversampling``
         has two elements, they must be in ``(y, x)`` order.

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -7,7 +7,8 @@ import itertools
 from contextlib import nullcontext
 
 from astropy.modeling.models import Gaussian2D
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyUserWarning,
+                                      AstropyDeprecationWarning)
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -58,15 +59,16 @@ def test_centroid_com(x_std, y_std, theta):
     assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=0.015)
 
     # test with oversampling
-    for oversampling in [4, (6, 4)]:
-        if not hasattr(oversampling, '__len__'):
-            _oversampling = (oversampling, oversampling)
-        else:
-            _oversampling = oversampling
-        xc, yc = centroid_com(data, mask=mask, oversampling=oversampling)
+    with pytest.warns(AstropyDeprecationWarning):
+        for oversampling in [4, (6, 4)]:
+            if not hasattr(oversampling, '__len__'):
+                _oversampling = (oversampling, oversampling)
+            else:
+                _oversampling = oversampling
+            xc, yc = centroid_com(data, mask=mask, oversampling=oversampling)
 
-        desired = [XCEN / _oversampling[1], YCEN / _oversampling[0]]
-        assert_allclose((xc, yc), desired, rtol=0, atol=1.e-3)
+            desired = [XCEN / _oversampling[1], YCEN / _oversampling[0]]
+            assert_allclose((xc, yc), desired, rtol=0, atol=1.e-3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -110,7 +112,7 @@ def test_centroid_com_invalid_inputs():
     mask = np.zeros((2, 2), dtype=bool)
     with pytest.raises(ValueError):
         centroid_com(data, mask=mask)
-    with pytest.raises(ValueError):
+    with pytest.warns(AstropyDeprecationWarning), pytest.raises(ValueError):
         centroid_com(data, oversampling=-1)
 
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -638,22 +638,11 @@ class EPSFBuilder:
             epsf_cutout = epsf_data[slices_large]
             mask = ~np.isfinite(epsf_cutout)
 
-            try:
-                # find a new center position
-                xcenter_new, ycenter_new = centroid_func(
-                    epsf_cutout, mask=mask, oversampling=epsf.oversampling,
-                    shift_val=epsf._shift_val)
-            except TypeError:
-                # centroid_func doesn't accept oversampling and/or shift_val
-                # keywords - try oversampling alone
-                try:
-                    xcenter_new, ycenter_new = centroid_func(
-                        epsf_cutout, mask=mask, oversampling=epsf.oversampling)
-                except TypeError:
-                    # centroid_func doesn't accept oversampling and
-                    # shift_val
-                    xcenter_new, ycenter_new = centroid_func(epsf_cutout,
-                                                             mask=mask)
+            # find a new center position
+            xcenter_new, ycenter_new = centroid_func(epsf_cutout,
+                                                     mask=mask)
+            xcenter_new /= self.oversampling[1]
+            ycenter_new /= self.oversampling[0]
 
             xcenter_new += slices_large[1].start/self.oversampling[0]
             ycenter_new += slices_large[0].start/self.oversampling[1]

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -390,9 +390,9 @@ class EPSFBuilder:
             # Stars class should have odd-sized dimensions, and thus we
             # get the oversampled shape as oversampling * len + 1; if
             # len=25, then newlen=101, for example.
-            x_shape = (np.ceil(stars._max_shape[0]) * oversampling[0] +
+            x_shape = (np.ceil(stars._max_shape[0]) * oversampling[1] +
                        1).astype(int)
-            y_shape = (np.ceil(stars._max_shape[1]) * oversampling[1] +
+            y_shape = (np.ceil(stars._max_shape[1]) * oversampling[0] +
                        1).astype(int)
 
             shape = np.array((y_shape, x_shape))
@@ -450,8 +450,8 @@ class EPSFBuilder:
         stardata = (star._data_values_normalized -
                     epsf.evaluate(x=x, y=y, flux=1.0, x_0=0.0, y_0=0.0))
 
-        x = epsf.oversampling[0] * star._xidx_centered
-        y = epsf.oversampling[1] * star._yidx_centered
+        x = epsf.oversampling[1] * star._xidx_centered
+        y = epsf.oversampling[0] * star._yidx_centered
 
         epsf_xcenter, epsf_ycenter = (int((epsf.data.shape[1] -
                                            1) / 2),
@@ -608,8 +608,8 @@ class EPSFBuilder:
         xcenter, ycenter = epsf.origin
 
         y, x = np.indices(epsf._data.shape, dtype=float)
-        x /= epsf.oversampling[0]
-        y /= epsf.oversampling[1]
+        x /= epsf.oversampling[1]
+        y /= epsf.oversampling[0]
 
         dx_total, dy_total = 0, 0
         iter_num = 0
@@ -624,9 +624,9 @@ class EPSFBuilder:
             # on specific pixels, and thus does not need a cutout
             slices_large, _ = overlap_slices(epsf_data.shape, box_size,
                                              (ycenter *
-                                              self.oversampling[1],
+                                              self.oversampling[0],
                                               xcenter *
-                                              self.oversampling[0]))
+                                              self.oversampling[1]))
             epsf_cutout = epsf_data[slices_large]
             mask = ~np.isfinite(epsf_cutout)
 
@@ -636,8 +636,8 @@ class EPSFBuilder:
             xcenter_new /= self.oversampling[1]
             ycenter_new /= self.oversampling[0]
 
-            xcenter_new += slices_large[1].start/self.oversampling[0]
-            ycenter_new += slices_large[0].start/self.oversampling[1]
+            xcenter_new += slices_large[1].start/self.oversampling[1]
+            ycenter_new += slices_large[0].start/self.oversampling[0]
 
             # Calculate the shift; dx = i - x_star so if dx was positively
             # incremented then x_star was negatively incremented for a given i.
@@ -732,8 +732,8 @@ class EPSFBuilder:
 
         # Return the new ePSF object, but with undersampled grid pixel
         # coordinates.
-        xcenter = (epsf._data.shape[1] - 1) / 2. / epsf.oversampling[0]
-        ycenter = (epsf._data.shape[0] - 1) / 2. / epsf.oversampling[1]
+        xcenter = (epsf._data.shape[1] - 1) / 2. / epsf.oversampling[1]
+        ycenter = (epsf._data.shape[0] - 1) / 2. / epsf.oversampling[0]
 
         return EPSFModel(data=epsf._data, origin=(xcenter, ycenter),
                          oversampling=epsf.oversampling,

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -277,10 +277,6 @@ class EPSFBuilder:
     norm_radius : float, optional
         The pixel radius over which the ePSF is normalized.
 
-    shift_val : float, optional
-        The undersampled value at which to compute the shifts.  It must
-        be a strictly positive number.
-
     recentering_boxsize : float or tuple of two floats, optional
             The size (in pixels) of the box used to calculate the
             centroid of the ePSF during each build iteration. If a
@@ -313,7 +309,7 @@ class EPSFBuilder:
     def __init__(self, oversampling=4, shape=None,
                  smoothing_kernel='quartic', recentering_func=centroid_com,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,
-                 progress_bar=True, norm_radius=5.5, shift_val=0.5,
+                 progress_bar=True, norm_radius=5.5,
                  recentering_boxsize=(5, 5), center_accuracy=1.0e-3,
                  flux_residual_sigclip=SigmaClip(sigma=3, cenfunc='median',
                                                  maxiters=10)):
@@ -323,7 +319,6 @@ class EPSFBuilder:
         self.oversampling = as_pair('oversampling', oversampling,
                                     lower_bound=(0, 1))
         self._norm_radius = norm_radius
-        self._shift_val = shift_val
         if shape is not None:
             self.shape = as_pair('shape', shape, lower_bound=(0, 1))
         else:
@@ -385,7 +380,6 @@ class EPSFBuilder:
             The initial ePSF model.
         """
         norm_radius = self._norm_radius
-        shift_val = self._shift_val
         oversampling = self.oversampling
         shape = self.shape
 
@@ -417,8 +411,7 @@ class EPSFBuilder:
         ycenter = stars._max_shape[1] / 2.
 
         epsf = EPSFModel(data=data, origin=(xcenter, ycenter),
-                         oversampling=oversampling, norm_radius=norm_radius,
-                         shift_val=shift_val)
+                         oversampling=oversampling, norm_radius=norm_radius)
 
         return epsf
 
@@ -610,8 +603,7 @@ class EPSFBuilder:
 
         epsf = EPSFModel(data=epsf._data, origin=epsf.origin,
                          oversampling=epsf.oversampling,
-                         norm_radius=epsf._norm_radius,
-                         shift_val=epsf._shift_val, normalize=False)
+                         norm_radius=epsf._norm_radius, normalize=False)
 
         xcenter, ycenter = epsf.origin
 
@@ -731,8 +723,7 @@ class EPSFBuilder:
 
         epsf = EPSFModel(data=new_epsf, origin=epsf.origin,
                          oversampling=epsf.oversampling,
-                         norm_radius=epsf._norm_radius,
-                         shift_val=epsf._shift_val, normalize=False)
+                         norm_radius=epsf._norm_radius, normalize=False)
 
         epsf._data = self._recenter_epsf(
             epsf, centroid_func=self.recentering_func,
@@ -746,8 +737,7 @@ class EPSFBuilder:
 
         return EPSFModel(data=epsf._data, origin=(xcenter, ycenter),
                          oversampling=epsf.oversampling,
-                         norm_radius=epsf._norm_radius,
-                         shift_val=epsf._shift_val)
+                         norm_radius=epsf._norm_radius)
 
     def build_epsf(self, stars, init_epsf=None):
         """

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -505,19 +505,13 @@ class EPSFModel(FittableImageModel):
     norm_radius : float, optional
         The radius inside which the ePSF is normalized by the sum over
         undersampled integer pixel values inside a circular aperture.
-
-    shift_val : float, optional
-        The fractional undersampled pixel amount (equivalent to an
-        integer oversampled pixel value) at which to evaluate the
-        asymmetric ePSF centroid corrections.
     """
 
     def __init__(self, data, flux=1.0, x_0=0.0, y_0=0.0, normalize=True,
                  normalization_correction=1.0, origin=None, oversampling=1,
-                 fill_value=0.0, norm_radius=5.5, shift_val=0.5, **kwargs):
+                 fill_value=0.0, norm_radius=5.5, **kwargs):
 
         self._norm_radius = norm_radius
-        self._shift_val = shift_val
 
         super().__init__(data=data, flux=flux, x_0=x_0, y_0=y_0,
                          normalize=normalize,

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -456,8 +456,8 @@ class FittableImageModel(Fittable2DModel):
             input indices will be multiplied by this factor.
         """
         if use_oversampling:
-            xi = self._oversampling[0] * (np.asarray(x) - x_0)
-            yi = self._oversampling[1] * (np.asarray(y) - y_0)
+            xi = self._oversampling[1] * (np.asarray(x) - x_0)
+            yi = self._oversampling[0] * (np.asarray(y) - y_0)
         else:
             xi = np.asarray(x) - x_0
             yi = np.asarray(y) - y_0
@@ -580,8 +580,8 @@ class EPSFModel(FittableImageModel):
     @FittableImageModel.origin.setter
     def origin(self, origin):
         if origin is None:
-            self._x_origin = (self._nx - 1) / 2.0 / self.oversampling[0]
-            self._y_origin = (self._ny - 1) / 2.0 / self.oversampling[1]
+            self._x_origin = (self._nx - 1) / 2.0 / self.oversampling[1]
+            self._y_origin = (self._ny - 1) / 2.0 / self.oversampling[0]
         elif (hasattr(origin, '__iter__') and len(origin) == 2):
             self._x_origin, self._y_origin = origin
         else:
@@ -650,8 +650,8 @@ class EPSFModel(FittableImageModel):
 
         # Interpolator must be set to interpolate on the undersampled
         # pixel grid, going from 0 to len(undersampled_grid)
-        x = np.arange(self._nx, dtype=float) / self.oversampling[0]
-        y = np.arange(self._ny, dtype=float) / self.oversampling[1]
+        x = np.arange(self._nx, dtype=float) / self.oversampling[1]
+        y = np.arange(self._ny, dtype=float) / self.oversampling[0]
         self.interpolator = RectBivariateSpline(
             x, y, self._data.T, kx=degx, ky=degy, s=smoothness)
 
@@ -671,9 +671,9 @@ class EPSFModel(FittableImageModel):
             # find indices of pixels that are outside the input pixel
             # grid and set these pixels to the 'fill_value':
             invalid = (((xi < 0) | (xi > (self._nx - 1)
-                                    / self.oversampling[0])) |
+                                    / self.oversampling[1])) |
                        ((yi < 0) | (yi > (self._ny - 1)
-                                    / self.oversampling[1])))
+                                    / self.oversampling[0])))
             evaluated_model[invalid] = self._fill_value
 
         return evaluated_model


### PR DESCRIPTION
This PR:
  * Deprecates the ``oversampling`` keyword in ``centroid_com``. 
  * Removes the unused  ``shift_val`` keyword in ``EPSFBuilder`` and ``EPSFModel``.  This keyword value was not used in the code.
  * Fixed the oversampling axis order (followup to #1358).
