### PR TITLE
Rename flux_residual_sigclip to sigma_clip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,9 @@ API Changes
   - Removed the unused ``shift_val`` keyword in ``EPSFBuilder`` and
     ``EPSFModel``. [#1377]
 
+  - Renamed the ``flux_residual_sigclip`` keyword (now deprecated) to
+    ``sigma_clip`` in ``EPSFBuilder``. [#1378]
+
 - ``photutils.segmentation``
 
   - Removed the deprecated ``circular_aperture`` method from

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -150,13 +150,12 @@ def test_epsfbuilder_inputs():
     EPSFBuilder(oversampling=[4, 6])
 
     # invalid inputs
-    for sigclip in [None, [], 'a']:
+    for sigma_clip in [None, [], 'a']:
         with pytest.raises(ValueError):
-            EPSFBuilder(flux_residual_sigclip=sigclip)
+            EPSFBuilder(sigma_clip=sigma_clip)
 
     # valid inputs
-    EPSFBuilder(flux_residual_sigclip=SigmaClip(sigma=2.5, cenfunc='mean',
-                                                maxiters=2))
+    EPSFBuilder(sigma_clip=SigmaClip(sigma=2.5, cenfunc='mean', maxiters=2))
 
 
 def test_epsfmodel_inputs():


### PR DESCRIPTION
This PR renames the ``flux_residual_sigclip`` keyword (now deprecated) to ``sigma_clip`` in ``EPSFBuilder`` for consistency with other functions in `photutils`.