### PR TITLE
Fix the ability to set a minimum unscaled Kron radius

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.segmentation``
+
+  - Fixed the ability to set a minimum unscaled Kron radius in
+    ``SourceCatalog``. [#1381]
+
 
 API Changes
 ^^^^^^^^^^^
@@ -133,6 +138,13 @@ API Changes
     ``make_kron_apertures`` methods now return a single aperture
     (instead of a list with one item) for a scalar ``SourceCatalog``.
     [#1376]
+
+  - The ``SourceCatalog`` ``kron_params`` keyword now has an optional
+    third item representing the minimum circular radius. [#1381]
+
+  - The ``SourceCatalog`` ``kron_radius`` is now set to the minimum Kron
+    radius (the second element of ``kron_params``) if the data or
+    radially weighted data sum to zero. [#1381]
 
 - ``photutils.utils``
 

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -353,17 +353,17 @@ properties are shown below:
     label xcentroid ycentroid ... segment_fluxerr kron_flux kron_fluxerr
                               ...
     ----- --------- --------- ... --------------- --------- ------------
-        1    235.31      1.45 ...             nan    506.24          nan
-        2    493.92      5.79 ...             nan    540.31          nan
-        3    207.42      9.81 ...             nan    666.76          nan
+        1    235.31      1.45 ...             nan    509.74          nan
+        2    493.92      5.79 ...             nan    544.31          nan
+        3    207.42      9.81 ...             nan    722.26          nan
         4    364.86     11.11 ...             nan    704.23          nan
         5    258.27     11.94 ...             nan    661.22          nan
       ...       ...       ... ...             ...       ...          ...
-       90    419.52    216.55 ...             nan    842.48          nan
-       91     74.55    259.86 ...             nan    865.56          nan
-       92     82.56    267.55 ...             nan    787.72          nan
+       90    419.52    216.55 ...             nan    866.40          nan
+       91     74.55    259.86 ...             nan    870.31          nan
+       92     82.56    267.55 ...             nan    811.81          nan
        93    433.88    280.75 ...             nan    652.12          nan
-       94    434.07    288.90 ...             nan    917.41          nan
+       94    434.07    288.90 ...             nan    942.22          nan
     Length = 94 rows
 
 The error columns are NaN because we did not input an error array (see
@@ -413,9 +413,7 @@ of each source) on the data:
     finder = SourceFinder(npixels=npixels, progress_bar=False)
     segment_map = finder(convolved_data, threshold)
 
-    kron_params = (2.5, 0.5)
-    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
-                        kron_params=kron_params)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data)
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12.5))
     norm = simple_norm(data, 'sqrt')
     ax1.imshow(data, origin='lower', cmap='Greys_r', norm=norm)
@@ -445,7 +443,7 @@ label numbers in the segmentation image:
     label xcentroid ycentroid ... segment_fluxerr kron_flux kron_fluxerr
                               ...
     ----- --------- --------- ... --------------- --------- ------------
-        1    235.31      1.45 ...             nan    506.24          nan
+        1    235.31      1.45 ...             nan    509.74          nan
         5    258.27     11.94 ...             nan    661.22          nan
        20    346.99     66.83 ...             nan    811.70          nan
        50      5.29    178.94 ...             nan    614.46          nan

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2248,14 +2248,14 @@ class SourceCatalog:
             position is not finite or where the source is completely
             masked.
         """
+        if radius <= 0:
+            raise ValueError('radius must be > 0')
+
         if self._detection_cat is not None:
             # use detection catalog for centroids
             detcat = self._detection_cat
         else:
             detcat = self
-
-        if radius <= 0:
-            raise ValueError('radius must be > 0')
 
         apertures = []
         for (xcen, ycen, all_masked) in zip(detcat._xcentroid,

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2448,6 +2448,10 @@ class SourceCatalog:
         If a ``detection_cat`` was input to `SourceCatalog`, it will be
         used for the source centroids.
 
+        If scale is zero (due to a minimum circular radius set in
+        ``kron_params``) then a circular aperture will be returned with
+        the minimum circular radius.
+
         Parameters
         ----------
         scale : float or `~numpy.ndarray`, optional
@@ -2488,9 +2492,16 @@ class SourceCatalog:
                 aperture.append(None)
                 continue
 
+            # kron_radius = 0 -> scale = 0 -> major/minor_size = 0
+            if values[2] == 0 and values[3] == 0:
+                aperture.append(CircularAperture((values[0], values[1]),
+                                                 r=self._kron_params[2]))
+                continue
+
             (xcen_, ycen_, major_, minor_, theta_) = values[:-1]
             aperture.append(EllipticalAperture((xcen_, ycen_), major_, minor_,
                                                theta=theta_))
+
         return aperture
 
     @lazyproperty
@@ -2585,8 +2596,10 @@ class SourceCatalog:
                 flux_numer = np.sum((aperture_weights * data * rr)[pixel_mask])
                 flux_denom = np.sum((aperture_weights * data)[pixel_mask])
 
+            # set Kron radius to the minimum Kron radius if numerator or
+            # denominator is negative
             if flux_numer <= 0 or flux_denom <= 0:
-                kron_radius.append(np.nan)
+                kron_radius.append(self._kron_params[1])
                 continue
 
             kron_radius.append(flux_numer / flux_denom)
@@ -2594,6 +2607,14 @@ class SourceCatalog:
         # set minimum (unscaled) kron radius
         kron_radius = np.array(kron_radius)
         kron_radius[kron_radius < self._kron_params[1]] = self._kron_params[1]
+
+        # check for minimum circular radius
+        if len(self._kron_params) == 3:
+            major_sigma = self.semimajor_sigma.value
+            minor_sigma = self.semiminor_sigma.value
+            circ_radius = (self._kron_params[0] * kron_radius
+                           * np.sqrt(major_sigma * minor_sigma))
+            kron_radius[circ_radius <= self._kron_params[2]] = 0.0
 
         return kron_radius << u.pix
 
@@ -2642,22 +2663,6 @@ class SourceCatalog:
         scale = kron_radius * kron_params[0]
         # NOTE: if kron_radius = NaN, scale = NaN and kron_aperture = None
         kron_apertures = self._make_elliptical_apertures(scale=scale)
-
-        # check for minimum circular radius
-        if len(kron_params) == 3:
-            min_radius = kron_params[2]
-            major_sigma = detcat.semimajor_sigma.value
-            minor_sigma = detcat.semiminor_sigma.value
-            circ_radius = (kron_params[0] * kron_radius
-                           * np.sqrt(major_sigma * minor_sigma))
-            mask = (circ_radius <= min_radius)
-            idx = np.atleast_1d(mask).nonzero()[0]
-            if idx.size > 0:
-                circ_aperture = self._make_circular_apertures(min_radius)
-                for i in idx:
-                    kron_apertures[i] = circ_aperture[i]
-                    # TODO
-                    # kron_radius[i] = 0.0
 
         return kron_apertures
 
@@ -2984,6 +2989,9 @@ class SourceCatalog:
         semimajor_sig = detcat.semimajor_sigma.value
         kron_radius = detcat.kron_radius.value
         radius = semimajor_sig * kron_radius * self._kron_params[0]
+        mask = radius == 0
+        if np.any(mask):
+            radius[mask] = self._kron_params[2]
         if self.isscalar:
             radius = np.array([radius])
         return radius

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -162,13 +162,10 @@ class SourceCatalog:
             in SourceExtractor).
 
     kron_params : list of 2 floats, optional
-        A list of two parameters used to determine how the Kron
-        radius and flux are calculated. The first item is the scaling
-        parameter of the Kron radius and the second item represents
-        the minimum circular radius. If the Kron radius times
-        sqrt(``semimajor_sigma`` * ``semiminor_sigma``) is less than
-        than this radius, then the Kron flux will be measured in a
-        circle with this minimum radius.
+        A list of two parameters used to determine the Kron aperture.
+        The first item is the scaling parameter of the unscaled Kron
+        radius and the second item represents the minimum value for the
+        unscaled Kron radius in pixels.
 
     detection_cat : `SourceCatalog`, optional
         A `SourceCatalog` object for the detection image. The source
@@ -235,7 +232,7 @@ class SourceCatalog:
     def __init__(self, data, segment_img, *, convolved_data=None, error=None,
                  mask=None, kernel=None, background=None, wcs=None,
                  localbkg_width=0, apermask_method='correct',
-                 kron_params=(2.5, 1.0), detection_cat=None):
+                 kron_params=(2.5, 1.4), detection_cat=None):
 
         arrays, unit = process_quantities(
             (data, convolved_data, error, background),
@@ -2584,8 +2581,11 @@ class SourceCatalog:
 
             kron_radius.append(flux_numer / flux_denom)
 
-        kron_radius = np.array(kron_radius) * u.pix
-        return kron_radius
+        # set minimum (unscaled) kron radius
+        kron_radius = np.array(kron_radius)
+        kron_radius[kron_radius < self._kron_params[1]] = self._kron_params[1]
+
+        return kron_radius << u.pix
 
     def _make_kron_apertures(self, kron_params):
         """
@@ -2604,16 +2604,11 @@ class SourceCatalog:
 
         Parameters
         ----------
-        kron_params : list of 2 floats or `None`, optional
+        kron_params : list of 2 floats, optional
             A list of two parameters used to determine the Kron
             aperture. The first item is the scaling parameter of the
-            Kron radius (`kron_radius`) and the second item represents
-            the minimum circular radius. If the Kron radius times sqrt(
-            `semimajor_sigma` * `semiminor_sigma`) is less than than
-            this radius, then the Kron aperture will be a circle with
-            this minimum radius. If `None`, then the ``kron_params``
-            input into `SourceCatalog` will be used (the returned
-            apertures will be the same as those in `kron_aperture`).
+            unscaled Kron radius and the second item represents the
+            minimum value for the unscaled Kron radius in pixels.
 
         Returns
         -------
@@ -2635,19 +2630,6 @@ class SourceCatalog:
         scale = kron_radius * kron_params[0]
         # NOTE: if kron_radius = NaN, scale = NaN and kron_aperture = None
         kron_apertures = self._make_elliptical_apertures(scale=scale)
-
-        # check for minimum Kron radius
-        major_sigma = detcat.semimajor_sigma.value
-        minor_sigma = detcat.semiminor_sigma.value
-        circ_radius = kron_radius * np.sqrt(major_sigma * minor_sigma)
-        min_radius = kron_params[1]
-
-        mask = (circ_radius < min_radius)
-        idx = np.atleast_1d(mask).nonzero()[0]
-        if idx.size > 0:
-            circ_aperture = self._make_circular_apertures(min_radius)
-            for i in idx:
-                kron_apertures[i] = circ_aperture[i]
 
         return kron_apertures
 
@@ -2672,13 +2654,11 @@ class SourceCatalog:
         kron_params : list of 2 floats or `None`, optional
             A list of two parameters used to determine the Kron
             aperture. The first item is the scaling parameter of the
-            Kron radius (`kron_radius`) and the second item represents
-            the minimum circular radius. If the Kron radius times sqrt(
-            `semimajor_sigma` * `semiminor_sigma`) is less than than
-            this radius, then the Kron aperture will be a circle with
-            this minimum radius. If `None`, then the ``kron_params``
-            input into `SourceCatalog` will be used (the returned
-            apertures will be the same as those in `kron_aperture`).
+            unscaled Kron radius and the second item represents the
+            minimum value for the unscaled Kron radius in pixels. If
+            `None`, then the ``kron_params`` input into `SourceCatalog`
+            will be used (the apertures will be the same as those in
+            `kron_aperture`).
 
         Returns
         -------
@@ -2716,13 +2696,11 @@ class SourceCatalog:
         kron_params : list of 2 floats or `None`, optional
             A list of two parameters used to determine the Kron
             aperture. The first item is the scaling parameter of the
-            Kron radius (`kron_radius`) and the second item represents
-            the minimum circular radius. If the Kron radius times sqrt(
-            `semimajor_sigma` * `semiminor_sigma`) is less than than
-            this radius, then the Kron aperture will be a circle with
-            this minimum radius. If `None`, then the ``kron_params``
-            input into `SourceCatalog` will be used (the plotted
-            apertures will be the same as those in `kron_aperture`).
+            unscaled Kron radius and the second item represents the
+            minimum value for the unscaled Kron radius in pixels. If
+            `None`, then the ``kron_params`` input into `SourceCatalog`
+            will be used (the apertures will be the same as those in
+            `kron_aperture`).
 
         axes : `matplotlib.axes.Axes` or `None`, optional
             The matplotlib axes on which to plot.  If `None`, then the
@@ -2858,14 +2836,10 @@ class SourceCatalog:
         Parameters
         ----------
         kron_params : list of 2 floats, optional
-            A list of two parameters used to determine how the Kron
-            radius and flux are calculated. The first item is the
-            scaling parameter of the Kron radius (`kron_radius`)
-            and the second item represents the minimum circular
-            radius. If the Kron radius times sqrt( `semimajor_sigma` *
-            `semiminor_sigma`) is less than than this radius, then the
-            Kron flux will be measured in a circle with this minimum
-            radius.
+            A list of two parameters used to determine the Kron
+            aperture. The first item is the scaling parameter of the
+            unscaled Kron radius and the second item represents the
+            minimum value for the unscaled Kron radius in pixels.
 
         name : str or `None`, optional
             The prefix name which will be used to define attribute

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -312,13 +312,19 @@ class TestSourceCatalog:
             SourceCatalog(self.data, self.segm,
                           apermask_method=apermask_method)
         with pytest.raises(ValueError):
-            kron_params = (2.5, 0.0, 3.0)
+            kron_params = (0.0, 1.0)
+            SourceCatalog(self.data, self.segm, kron_params=kron_params)
+        with pytest.raises(ValueError):
+            kron_params = (2.5, 0.0)
             SourceCatalog(self.data, self.segm, kron_params=kron_params)
         with pytest.raises(ValueError):
             kron_params = (-2.5, 0.0)
             SourceCatalog(self.data, self.segm, kron_params=kron_params)
         with pytest.raises(ValueError):
             kron_params = (2.5, -4.0)
+            SourceCatalog(self.data, self.segm, kron_params=kron_params)
+        with pytest.raises(ValueError):
+            kron_params = (2.5, 1.4, -2.0)
             SourceCatalog(self.data, self.segm, kron_params=kron_params)
 
     def test_invalid_units(self):
@@ -491,8 +497,7 @@ class TestSourceCatalog:
 
     def test_kron_negative(self):
         cat = SourceCatalog(self.data - 10, self.segm)
-        assert np.all(np.isnan(cat.kron_radius.value))
-        assert np.all(np.isnan(cat.kron_flux))
+        assert_allclose(cat.kron_radius.value, cat._kron_params[1])
 
     def test_kron_photometry(self):
         flux1, fluxerr1 = self.cat.kron_photometry((2.5, 1.0))
@@ -605,7 +610,7 @@ class TestSourceCatalog:
                             background=self.background, mask=self.mask,
                             wcs=self.wcs, localbkg_width=24)
         radius_hl = cat.fluxfrac_radius(0.5)
-        assert np.all(np.isnan(radius_hl))
+        assert np.isnan(radius_hl[0])
 
     def test_cutout_units(self):
         obj = self.cat_units[0]

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -463,12 +463,16 @@ class TestSourceCatalog:
             SourceCatalog(self.data, self.segm, detection_cat=cat)
 
     def test_kron_minradius(self):
-        kron_params = (2.5, 10.0)
+        kron_params = (2.5, 2.5)
         cat = SourceCatalog(self.data, self.segm, mask=self.mask,
                             apermask_method='none', kron_params=kron_params)
         assert cat.kron_aperture[0] is None
+        assert np.isnan(cat.kron_radius[0])
+        kronrad = cat.kron_radius.value
+        kronrad = kronrad[~np.isnan(kronrad)]
+        assert np.min(kronrad) == kron_params[1]
         assert isinstance(cat.kron_aperture[2], EllipticalAperture)
-        assert isinstance(cat.kron_aperture[4], CircularAperture)
+        assert isinstance(cat.kron_aperture[4], EllipticalAperture)
 
     def test_kron_masking(self):
         apermask_method = 'none'


### PR DESCRIPTION
This PR fixes the ability to set a minimum unscaled Kron radius in `SourceCatalog`.  

It also adds an optional third item to `kron_params` to allow the user to define a minimum circular radius.

Finally, the ``SourceCatalog`` ``kron_radius`` is now set to the minimum Kron radius (the second element of ``kron_params``) if the data or radially weighted data sum to zero.