### PR TITLE
Fix an issue in generating watershed markers used for source deblending

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,9 @@ New Features
   - Added a ``make_cutouts`` method to ``SourceCatalog`` for making
     custom-shaped cutout images. [#1376]
 
+  - Added the ability to set a minimum unscaled Kron radius in
+    ``SourceCatalog``. [#1381]
+
 - ``photutils.utils``
 
   - Added a ``circular_footprint`` convenience function. [#1355]
@@ -61,9 +64,8 @@ Bug Fixes
 
 - ``photutils.segmentation``
 
-  - Fixed the ability to set a minimum unscaled Kron radius in
-    ``SourceCatalog``. [#1381]
-
+  - Fixed an issue in generating watershed markers used for source
+    deblending. [#1383]
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -249,18 +249,18 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
         segm_deblended.info = {'warnings': {}}
         warnings.warn('The deblending mode of one or more source labels from '
                       'the input segmentation image was changed from '
-                      '"exponential" to "linear". See the "info" attribute '
+                      f'"{mode}" to "linear". See the "info" attribute '
                       'for the list of affected input labels.',
                       AstropyUserWarning)
 
         if nonposmin_labels:
-            warn = {'message': 'Deblending mode changed from exponential to '
+            warn = {'message': f'Deblending mode changed from {mode} to '
                     'linear due to non-positive minimum data values.',
                     'input_labels': np.array(nonposmin_labels)}
             segm_deblended.info['warnings']['nonposmin'] = warn
 
         if nmarkers_labels:
-            warn = {'message': 'Deblending mode changed from exponential to '
+            warn = {'message': f'Deblending mode changed from {mode} to '
                     'linear due to too many potential deblended sources.',
                     'input_labels': np.array(nmarkers_labels)}
         segm_deblended.info['warnings']['nmarkers'] = warn

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -417,11 +417,12 @@ class _Deblender:
             as markers. The last list element contains all of the
             potential source markers.
         """
-        from scipy.ndimage import label as ndilabel
+        from scipy.ndimage import label as ndi_label
 
         for i in range(len(segments) - 1):
             segm_lower = segments[i].data
             segm_upper = segments[i + 1].data
+            markers = segm_lower.astype(bool)
             relabel = False
             # if the are more sources at the upper level, then
             # remove the parent source(s) from the lower level,
@@ -429,16 +430,18 @@ class _Deblender:
             # multiple children in the upper level
             for label in segments[i].labels:
                 mask = (segm_lower == label)
-                # checks for 1-to-1 label mapping n -> m (where m >= 0)
+                # find label mapping from the lower to upper level
                 upper_labels = segm_upper[mask]
                 upper_labels = np.unique(upper_labels[upper_labels != 0])
                 if upper_labels.size >= 2:
                     relabel = True
-                    segm_lower[mask] = segm_upper[mask]
+                    markers[mask] = segm_upper[mask].astype(bool)
 
             if relabel:
+                segm_data, nlabels = ndi_label(markers, structure=self.selem)
                 segm_new = object.__new__(SegmentationImage)
-                segm_new._data = ndilabel(segm_lower, structure=self.selem)[0]
+                segm_new._data = segm_data
+                segm_new.__dict__['labels'] = np.arange(nlabels) + 1
                 segments[i + 1] = segm_new
             else:
                 segments[i + 1] = segments[i]

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -255,9 +255,9 @@ def _detect_sources(data, thresholds, npixels, selem, inverse_mask,
             segment_mask = (cutout == label)
             if np.count_nonzero(segment_mask) < npixels:
                 cutout[segment_mask] = 0
-            else:
-                segm_labels.append(label)
-                segm_slices.append(slc)
+                continue
+            segm_labels.append(label)
+            segm_slices.append(slc)
 
         if np.count_nonzero(segment_img) == 0:
             if not deblend_mode:
@@ -265,13 +265,16 @@ def _detect_sources(data, thresholds, npixels, selem, inverse_mask,
                 segms.append(None)
             continue
 
-        # relabel the segmentation image with consecutive numbers
-        nlabels = len(segm_labels)
-        if len(labels) != nlabels:
-            label_map = np.zeros(np.max(labels) + 1, dtype=int)
-            labels = np.arange(nlabels) + 1
-            label_map[segm_labels] = labels
-            segment_img = label_map[segment_img]
+        if not deblend_mode:
+            # relabel the segmentation image with consecutive numbers
+            nlabels = len(segm_labels)
+            if len(labels) != nlabels:
+                label_map = np.zeros(np.max(labels) + 1, dtype=int)
+                labels = np.arange(nlabels) + 1
+                label_map[segm_labels] = labels
+                segment_img = label_map[segment_img]
+        else:
+            labels = segm_labels
 
         segm = object.__new__(SegmentationImage)
         segm._data = segment_img


### PR DESCRIPTION
This PR fixes a small issue that sometimes could occur when generating watershed markers used for source deblending.  It also skips source relabeling (unnecessary) in the detection step used for source deblending.