### PR TITLE
Fix warning message in EPSFFitter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,10 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.psf``
+
+  - Fixed a warning message in ``EPSFFitter``. [#1382]
+
 - ``photutils.segmentation``
 
   - Fixed an issue in generating watershed markers used for source

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -144,8 +144,8 @@ class EPSFFitter:
                                               (ycenter, xcenter),
                                               mode='strict')
             except (PartialOverlapError, NoOverlapError):
-                warnings.warn('The star at ({star.center[0]}, '
-                              '{star.center[1]}) cannot be fit because '
+                warnings.warn(f'The star at ({star.center[0]}, '
+                              f'{star.center[1]}) cannot be fit because '
                               'its fitting region extends beyond the star '
                               'cutout image.', AstropyUserWarning)
 


### PR DESCRIPTION
The star's coordinates were not being printed in the warning message.