### PR TITLE
Mark test that requires remote data

### DIFF
--- a/photutils/isophote/tests/test_regression.py
+++ b/photutils/isophote/tests/test_regression.py
@@ -64,6 +64,7 @@ from ...utils._optional_deps import HAS_SCIPY  # noqa
 # @pytest.mark.parametrize('name', ['M51', 'synth', 'synth_lowsnr',
 #                                   'synth_highsnr'])
 @pytest.mark.parametrize('name', ['synth_highsnr'])
+@pytest.mark.remote_data
 def test_regression(name, integrmode=BILINEAR, verbose=False):
     """
     NOTE:  The original code in SPP won't create the right table for the MEAN


### PR DESCRIPTION
Now that `remote_data_strict = true`