### PR TITLE
Remove deprecations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,38 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Inputting ``PixelAperture`` positions as an Astropy ``Quantity`` in
+    pixel units is no longer allowed. [#1398]
+
+  - Inputting ``SkyAperture`` shape parameters as an Astropy
+    ``Quantity`` in pixel units is no longer allowed. [#1398]
+
+- ``photutils.centroids``
+
+  - Removed the deprecated ``oversampling`` keyword in ``centroid_com``.
+    [#1398]
+
+- ``photutils.psf``
+
+  - Removed the deprecated ``flux_residual_sigclip`` keyword in
+    ``EPSFBuilder``. Use ``sigma_clip`` instead. [#1398]
+
+- ``photutils.segmentation``
+
+  - Removed the deprecated ``sigclip_sigma`` and ``sigclip_iters``
+    keywords in ``detect_threshold``. Use the ``sigma_clip`` keyword
+    instead. [#1398]
+
+  - Removed the ``mask_value``, ``sigclip_sigma``, and ``sigclip_iters``
+    keywords in ``detect_threshold``. Use the ``mask`` or ``sigma_clip``
+    keywords instead. [#1398]
+
+  - Removed the deprecated the ``filter_fwhm`` and ``filter_size``
+    keywords in ``make_source_mask``. Use the ``kernel`` keyword instead.
+    [#1398]
+
 
 1.5.0 (2022-07-12)
 ------------------

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -9,7 +9,7 @@ import math
 import numpy as np
 
 from .attributes import (PixelPositions, PositiveScalar, SkyCoordPositions,
-                         ScalarAngleOrPixel)
+                         PositiveScalarAngle)
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import circular_overlap_grid
@@ -116,9 +116,6 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
-            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units (this is Deprecated and will be removed in a
-              future version)
 
     r : float
         The radius of the circle in pixels.
@@ -233,9 +230,6 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
-            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units (this is Deprecated and will be removed in a
-              future version)
 
     r_in : float
         The inner radius of the circular annulus in pixels.
@@ -362,8 +356,7 @@ class SkyCircularAperture(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     r : scalar `~astropy.units.Quantity`
-        The radius of the circle in angular units. Pixel units are now
-        deprecated.
+        The radius of the circle in angular units.
 
     Examples
     --------
@@ -376,7 +369,7 @@ class SkyCircularAperture(SkyAperture):
 
     _params = ('positions', 'r',)
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    r = ScalarAngleOrPixel('The radius in angular units.')
+    r = PositiveScalarAngle('The radius in angular units.')
 
     def __init__(self, positions, r):
         self.positions = positions
@@ -417,12 +410,10 @@ class SkyCircularAnnulus(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     r_in : scalar `~astropy.units.Quantity`
-        The inner radius of the circular annulus in angular units. Pixel
-        units are now deprecated.
+        The inner radius of the circular annulus in angular units.
 
     r_out : scalar `~astropy.units.Quantity`
-        The outer radius of the circular annulus in angular units. Pixel
-        units are now deprecated.
+        The outer radius of the circular annulus in angular units.
 
     Examples
     --------
@@ -435,8 +426,8 @@ class SkyCircularAnnulus(SkyAperture):
 
     _params = ('positions', 'r_in', 'r_out')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    r_in = ScalarAngleOrPixel('The inner radius in angular units.')
-    r_out = ScalarAngleOrPixel('The outer radius in angular units.')
+    r_in = PositiveScalarAngle('The inner radius in angular units.')
+    r_out = PositiveScalarAngle('The outer radius in angular units.')
 
     def __init__(self, positions, r_in, r_out):
         if r_in.unit.physical_type != r_out.unit.physical_type:

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -10,8 +10,8 @@ import astropy.units as u
 import numpy as np
 
 from .attributes import (ScalarAngle, PixelPositions, PositiveScalar,
-                         SkyCoordPositions, ScalarAngleOrPixel,
-                         ScalarAngleOrValue)
+                         SkyCoordPositions, ScalarAngleOrValue,
+                         PositiveScalarAngle)
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import elliptical_overlap_grid
@@ -138,9 +138,6 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
-            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units (this is Deprecated and will be removed in a
-              future version)
 
     a : float
         The semimajor axis of the ellipse in pixels.
@@ -276,9 +273,6 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
-            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units (this is Deprecated and will be removed in a
-              future version)
 
     a_in : float
         The inner semimajor axis of the elliptical annulus in pixels.
@@ -445,12 +439,10 @@ class SkyEllipticalAperture(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     a : scalar `~astropy.units.Quantity`
-        The semimajor axis of the ellipse in angular units. Pixel units
-        are now deprecated.
+        The semimajor axis of the ellipse in angular units.
 
     b : scalar `~astropy.units.Quantity`
-        The semiminor axis of the ellipse in angular units. Pixel units
-        are now deprecated.
+        The semiminor axis of the ellipse in angular units.
 
     theta : scalar `~astropy.units.Quantity`, optional
         The position angle (in angular units) of the ellipse semimajor
@@ -468,16 +460,12 @@ class SkyEllipticalAperture(SkyAperture):
 
     _params = ('positions', 'a', 'b', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    a = ScalarAngleOrPixel('The semimajor axis in angular units.')
-    b = ScalarAngleOrPixel('The semiminor axis in angular units.')
+    a = PositiveScalarAngle('The semimajor axis in angular units.')
+    b = PositiveScalarAngle('The semiminor axis in angular units.')
     theta = ScalarAngle('The position angle in angular units of the ellipse '
                         'semimajor axis.')
 
     def __init__(self, positions, a, b, theta=0. * u.deg):
-        if a.unit.physical_type != b.unit.physical_type:
-            raise ValueError('a and b should either both be angles '
-                             'or in pixels')
-
         self.positions = positions
         self.a = a
         self.b = b
@@ -518,21 +506,17 @@ class SkyEllipticalAnnulus(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     a_in : scalar `~astropy.units.Quantity`
-        The inner semimajor axis in angular units. Pixel units are now
-        deprecated.
+        The inner semimajor axis in angular units.
 
     a_out : scalar `~astropy.units.Quantity`
-        The outer semimajor axis in angular units. Pixel units are now
-        deprecated.
+        The outer semimajor axis in angular units.
 
     b_out : scalar `~astropy.units.Quantity`
-        The outer semiminor axis in angular units. Pixel units are now
-        deprecated.
+        The outer semiminor axis in angular units.
 
     b_in : `None` or scalar `~astropy.units.Quantity`
-        The inner semiminor axis in angular units. Pixel units are
-        now deprecated. If `None`, then the inner semiminor axis is
-        calculated as:
+        The inner semiminor axis in angular units. If `None`, then the
+        inner semiminor axis is calculated as:
 
             .. math:: b_{in} = b_{out}
                 \left(\frac{a_{in}}{a_{out}}\right)
@@ -554,21 +538,15 @@ class SkyEllipticalAnnulus(SkyAperture):
 
     _params = ('positions', 'a_in', 'a_out', 'b_in', 'b_out', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    a_in = ScalarAngleOrPixel('The inner semimajor axis in angular units.')
-    a_out = ScalarAngleOrPixel('The outer semimajor axis in angular units.')
-    b_in = ScalarAngleOrPixel('The inner semiminor axis in angular units.')
-    b_out = ScalarAngleOrPixel('The outer semiminor axis in angular units.')
+    a_in = PositiveScalarAngle('The inner semimajor axis in angular units.')
+    a_out = PositiveScalarAngle('The outer semimajor axis in angular units.')
+    b_in = PositiveScalarAngle('The inner semiminor axis in angular units.')
+    b_out = PositiveScalarAngle('The outer semiminor axis in angular units.')
     theta = ScalarAngle('The position angle in angular units of the ellipse '
                         'semimajor axis.')
 
     def __init__(self, positions, a_in, a_out, b_out, b_in=None,
                  theta=0. * u.deg):
-        if a_in.unit.physical_type != a_out.unit.physical_type:
-            raise ValueError('a_in and a_out should either both be angles '
-                             'or in pixels')
-        if a_out.unit.physical_type != b_out.unit.physical_type:
-            raise ValueError('a_out and b_out should either both be angles '
-                             'or in pixels')
         if not a_out > a_in:
             raise ValueError('"a_out" must be greater than "a_in".')
 
@@ -580,9 +558,6 @@ class SkyEllipticalAnnulus(SkyAperture):
         if b_in is None:
             b_in = self.b_out * self.a_in / self.a_out
         else:
-            if b_in.unit.physical_type != b_out.unit.physical_type:
-                raise ValueError('b_in and b_out should either both be '
-                                 'angles or in pixels')
             if not b_out > b_in:
                 raise ValueError('"b_out" must be greater than "b_in".')
         self.b_in = b_in

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -10,8 +10,8 @@ import astropy.units as u
 import numpy as np
 
 from .attributes import (ScalarAngle, PixelPositions, PositiveScalar,
-                         SkyCoordPositions, ScalarAngleOrPixel,
-                         ScalarAngleOrValue)
+                         SkyCoordPositions, ScalarAngleOrValue,
+                         PositiveScalarAngle)
 from .core import PixelAperture, SkyAperture
 from .mask import ApertureMask
 from ..geometry import rectangular_overlap_grid
@@ -159,9 +159,6 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
-            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units (this is Deprecated and will be removed in a
-              future version)
 
     w : float
         The full width of the rectangle in pixels.  For ``theta=0`` the
@@ -300,9 +297,6 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
             * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
             * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
-            * `~astropy.units.Quantity` instance of ``(x, y)`` pairs in
-              pixel units (this is Deprecated and will be removed in a
-              future version)
 
     w_in : float
         The inner full width of the rectangular annulus in pixels.  For
@@ -480,14 +474,12 @@ class SkyRectangularAperture(SkyAperture):
         either scalar coordinates or an array of coordinates.
 
     w : scalar `~astropy.units.Quantity`
-        The full width of the rectangle in angular units. Pixel units
-        are now deprecated. For ``theta=0`` the width side is along the
-        North-South axis.
+        The full width of the rectangle in angular units. For
+        ``theta=0`` the width side is along the North-South axis.
 
     h :  scalar `~astropy.units.Quantity`
-        The full height of the rectangle in angular units. Pixel units
-        are now deprecated. For ``theta=0`` the height side is along the
-        East-West axis.
+        The full height of the rectangle in angular units. For
+        ``theta=0`` the height side is along the East-West axis.
 
     theta : scalar `~astropy.units.Quantity`, optional
         The position angle (in angular units) of the rectangle "width"
@@ -505,16 +497,12 @@ class SkyRectangularAperture(SkyAperture):
 
     _params = ('positions', 'w', 'h', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    w = ScalarAngleOrPixel('The full width in angular units.')
-    h = ScalarAngleOrPixel('The full height in angular units.')
+    w = PositiveScalarAngle('The full width in angular units.')
+    h = PositiveScalarAngle('The full height in angular units.')
     theta = ScalarAngle('The position angle (in angular units) of the '
                         'rectangle "width" side.')
 
     def __init__(self, positions, w, h, theta=0. * u.deg):
-        if w.unit.physical_type != h.unit.physical_type:
-            raise ValueError('"w" and "h" should either both be angles or '
-                             'in pixels')
-
         self.positions = positions
         self.w = w
         self.h = h
@@ -556,22 +544,21 @@ class SkyRectangularAnnulus(SkyAperture):
 
     w_in : scalar `~astropy.units.Quantity`
         The inner full width of the rectangular annulus in angular
-        units. Pixel units are now deprecated. For ``theta=0`` the width
-        side is along the North-South axis.
+        units. For ``theta=0`` the width side is along the North-South
+        axis.
 
     w_out : scalar `~astropy.units.Quantity`
         The outer full width of the rectangular annulus in angular
-        units. Pixel units are now deprecated. For ``theta=0`` the width
-        side is along the North-South axis.
+        units. For ``theta=0`` the width side is along the North-South
+        axis.
 
     h_out : scalar `~astropy.units.Quantity`
         The outer full height of the rectangular annulus in angular
-        units. Pixel units are now deprecated.
+        units.
 
     h_in : `None` or scalar `~astropy.units.Quantity`
         The outer full height of the rectangular annulus in angular
-        units. Pixel units are now deprecated. If `None`, then the inner
-        full height is calculated as:
+        units. If `None`, then the inner full height is calculated as:
 
             .. math:: h_{in} = h_{out}
                 \left(\frac{w_{in}}{w_{out}}\right)
@@ -595,21 +582,15 @@ class SkyRectangularAnnulus(SkyAperture):
 
     _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
-    w_in = ScalarAngleOrPixel('The inner full width in angular units.')
-    w_out = ScalarAngleOrPixel('The outer full width in angular units.')
-    h_in = ScalarAngleOrPixel('The inner full height in angular units.')
-    h_out = ScalarAngleOrPixel('The outer full height in angular units.')
+    w_in = PositiveScalarAngle('The inner full width in angular units.')
+    w_out = PositiveScalarAngle('The outer full width in angular units.')
+    h_in = PositiveScalarAngle('The inner full height in angular units.')
+    h_out = PositiveScalarAngle('The outer full height in angular units.')
     theta = ScalarAngle('The position angle (in angular units) of the '
                         'rectangle "width" side.')
 
     def __init__(self, positions, w_in, w_out, h_out, h_in=None,
                  theta=0. * u.deg):
-        if w_in.unit.physical_type != w_out.unit.physical_type:
-            raise ValueError('w_in and w_out should either both be angles or '
-                             'in pixels')
-        if w_out.unit.physical_type != h_out.unit.physical_type:
-            raise ValueError('w_out and h_out should either both be angles '
-                             'or in pixels')
         if not w_out > w_in:
             raise ValueError('"w_out" must be greater than "w_in".')
 
@@ -621,9 +602,6 @@ class SkyRectangularAnnulus(SkyAperture):
         if h_in is None:
             h_in = self.w_in * self.h_out / self.w_out
         else:
-            if h_in.unit.physical_type != h_out.unit.physical_type:
-                raise ValueError('h_in and h_out should either both be '
-                                 'angles or in pixels')
             if not h_out > h_in:
                 raise ValueError('"h_out" must be greater than "h_in".')
         self.h_in = h_in

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -13,7 +13,6 @@ from astropy.io import fits
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import Table
 import astropy.units as u
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.wcs import WCS
 
 from ..photometry import aperture_photometry
@@ -274,7 +273,7 @@ class TestInputNDData(BaseTestDifferentData):
 
 
 @pytest.mark.remote_data
-def test_wcs_based_photometry_to_catalogue():
+def test_wcs_based_photometry_to_catalog():
     pathcat = get_path('spitzer_example_catalog.xml', location='remote')
     pathhdu = get_path('spitzer_example_image.fits', location='remote')
     hdu = fits.open(pathhdu)
@@ -288,7 +287,7 @@ def test_wcs_based_photometry_to_catalogue():
     photometry_skycoord = aperture_photometry(
         data, SkyCircularAperture(pos_skycoord, 4 * u.arcsec), wcs=wcs)
 
-    # Photometric unit conversion is needed to match the catalogue
+    # Photometric unit conversion is needed to match the catalog
     factor = (1.2 * u.arcsec) ** 2 / u.pixel
     converted_aperture_sum = (photometry_skycoord['aperture_sum']
                               * factor).to(u.mJy / u.pixel)
@@ -747,28 +746,6 @@ def test_to_sky_pixel(wcs_type):
     assert_allclose(ap.w_out, ap2.w_out)
     assert_allclose(ap.h_out, ap2.h_out)
     assert_allclose(ap.theta, ap2.theta)
-
-
-def test_position_units():
-    """Regression test for unit check."""
-    pos = (10, 10) * u.pix
-    pos = np.sqrt(pos**2)
-    with pytest.warns(AstropyDeprecationWarning,
-                      match='Inputing positions as a Quantity'):
-        ap = CircularAperture(pos, r=3.)
-        assert_allclose(ap.positions, np.array([10, 10]))
-
-
-def test_radius_units():
-    """Regression test for unit check."""
-    pos = SkyCoord(10, 10, unit='deg')
-    r = 3. * u.pix
-    r = np.sqrt(r**2)
-    with pytest.warns(AstropyDeprecationWarning, match='Inputing sky '
-                      'aperture quantities in pixel units'):
-        ap = SkyCircularAperture(pos, r=r)
-        assert ap.r.value == 3.0
-        assert ap.r.unit == u.pix
 
 
 def test_scalar_aperture():

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -7,7 +7,6 @@ import inspect
 import warnings
 
 from astropy.nddata.utils import overlap_slices
-from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -17,8 +16,7 @@ from ..utils._parameters import as_pair
 __all__ = ['centroid_com', 'centroid_quadratic', 'centroid_sources']
 
 
-@deprecated_renamed_argument('oversampling', None, '1.5')
-def centroid_com(data, mask=None, oversampling=1):
+def centroid_com(data, mask=None):
     """
     Calculate the centroid of an n-dimensional array as its "center of
     mass" determined from moments.
@@ -35,12 +33,6 @@ def centroid_com(data, mask=None, oversampling=1):
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
-    oversampling : int or array_like (int)
-        Deprecated.
-        The integer oversampling factor(s). If ``oversampling`` is a
-        scalar then it will be used for both axes. If ``oversampling``
-        has two elements, they must be in ``(y, x)`` order.
-
     Returns
     -------
     centroid : `~numpy.ndarray`
@@ -54,8 +46,6 @@ def centroid_com(data, mask=None, oversampling=1):
         if data.shape != mask.shape:
             raise ValueError('data and mask must have the same shape.')
         data[mask] = 0.
-
-    oversampling = as_pair('oversampling', oversampling, lower_bound=(0, 1))
 
     badmask = ~np.isfinite(data)
     if np.any(badmask):
@@ -71,7 +61,7 @@ def centroid_com(data, mask=None, oversampling=1):
     indices = np.ogrid[tuple(slice(0, i) for i in data.shape)]
 
     # note the output array is reversed to give (x, y) order
-    return np.array([np.sum(indices[axis] * data) / total / oversampling[axis]
+    return np.array([np.sum(indices[axis] * data) / total
                      for axis in range(data.ndim)])[::-1]
 
 

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -7,8 +7,7 @@ import itertools
 from contextlib import nullcontext
 
 from astropy.modeling.models import Gaussian2D
-from astropy.utils.exceptions import (AstropyUserWarning,
-                                      AstropyDeprecationWarning)
+from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -58,18 +57,6 @@ def test_centroid_com(x_std, y_std, theta):
     xc, yc = centroid_quadratic(data, mask=mask)
     assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=0.015)
 
-    # test with oversampling
-    with pytest.warns(AstropyDeprecationWarning):
-        for oversampling in [4, (6, 4)]:
-            if not hasattr(oversampling, '__len__'):
-                _oversampling = (oversampling, oversampling)
-            else:
-                _oversampling = oversampling
-            xc, yc = centroid_com(data, mask=mask, oversampling=oversampling)
-
-            desired = [XCEN / _oversampling[1], YCEN / _oversampling[0]]
-            assert_allclose((xc, yc), desired, rtol=0, atol=1.e-3)
-
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.parametrize('use_mask', [True, False])
@@ -112,8 +99,6 @@ def test_centroid_com_invalid_inputs():
     mask = np.zeros((2, 2), dtype=bool)
     with pytest.raises(ValueError):
         centroid_com(data, mask=mask)
-    with pytest.warns(AstropyDeprecationWarning), pytest.raises(ValueError):
-        centroid_com(data, oversampling=-1)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -12,7 +12,6 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import (overlap_slices, PartialOverlapError,
                                   NoOverlapError)
 from astropy.stats import SigmaClip
-from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -307,7 +306,6 @@ class EPSFBuilder:
     .. _bottleneck:  https://github.com/pydata/bottleneck
     """
 
-    @deprecated_renamed_argument('flux_residual_sigclip', 'sigma_clip', '1.5')
     def __init__(self, *, oversampling=4, shape=None,
                  smoothing_kernel='quartic', recentering_func=centroid_com,
                  recentering_maxiters=20, fitter=EPSFFitter(), maxiters=10,

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -59,14 +59,13 @@ class BasicPSFPhotometry:
         background subtraction is performed.
     psf_model : `astropy.modeling.Fittable2DModel` instance
         PSF or PRF model to fit the data. Could be one of the models in
-        this package like `~photutils.psf.sandbox.DiscretePRF`,
-        `~photutils.psf.IntegratedGaussianPRF`, or any other suitable 2D
-        model.  This object needs to identify three parameters (position
-        of center in x and y coordinates and the flux) in order to set
-        them to suitable starting values for each fit. The names of
-        these parameters should be given as ``x_0``, ``y_0`` and
-        ``flux``.  `~photutils.psf.prepare_psf_model` can be used to
-        prepare any 2D model to match this assumption.
+        this package like `~photutils.psf.IntegratedGaussianPRF` or any
+        other suitable 2D model. This object needs to identify three
+        parameters (position of center in x and y coordinates and the
+        flux) in order to set them to suitable starting values for each
+        fit. The names of these parameters should be given as ``x_0``,
+        ``y_0`` and ``flux``. `~photutils.psf.prepare_psf_model` can be
+        used to prepare any 2D model to match this assumption.
     fitshape : int or length-2 array-like
         Rectangular shape around the center of a star which will be
         used to collect the data to do the fitting. Can be an integer
@@ -559,9 +558,8 @@ class BasicPSFPhotometry:
         ----------
         fit_model : `astropy.modeling.Fittable2DModel` instance
             PSF or PRF model to fit the data. Could be one of the models
-            in this package like `~photutils.psf.sandbox.DiscretePRF`,
-            `~photutils.psf.IntegratedGaussianPRF`, or any other
-            suitable 2D model.
+            in this package like `~photutils.psf.IntegratedGaussianPRF`
+            or any other suitable 2D model.
 
         star_group : `~astropy.table.Table`
             the star group instance.
@@ -631,14 +629,13 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         background subtraction is performed.
     psf_model : `astropy.modeling.Fittable2DModel` instance
         PSF or PRF model to fit the data. Could be one of the models in
-        this package like `~photutils.psf.sandbox.DiscretePRF`,
-        `~photutils.psf.IntegratedGaussianPRF`, or any other suitable 2D
-        model.  This object needs to identify three parameters (position
-        of center in x and y coordinates and the flux) in order to set
-        them to suitable starting values for each fit. The names of
-        these parameters should be given as ``x_0``, ``y_0`` and
-        ``flux``.  `~photutils.psf.prepare_psf_model` can be used to
-        prepare any 2D model to match this assumption.
+        this package like `~photutils.psf.IntegratedGaussianPRF` or any
+        other suitable 2D model. This object needs to identify three
+        parameters (position of center in x and y coordinates and the
+        flux) in order to set them to suitable starting values for each
+        fit. The names of these parameters should be given as ``x_0``,
+        ``y_0`` and ``flux``. `~photutils.psf.prepare_psf_model` can be
+        used to prepare any 2D model to match this assumption.
     fitshape : int or length-2 array-like
         Rectangular shape around the center of a star which will be
         used to collect the data to do the fitting. Can be an integer
@@ -918,14 +915,13 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
         Gaussian kernel in units of pixels.
     psf_model : `astropy.modeling.Fittable2DModel` instance
         PSF or PRF model to fit the data. Could be one of the models in
-        this package like `~photutils.psf.sandbox.DiscretePRF`,
-        `~photutils.psf.IntegratedGaussianPRF`, or any other suitable 2D
-        model.  This object needs to identify three parameters (position
-        of center in x and y coordinates and the flux) in order to set
-        them to suitable starting values for each fit. The names of
-        these parameters should be given as ``x_0``, ``y_0`` and
-        ``flux``.  `~photutils.psf.prepare_psf_model` can be used to
-        prepare any 2D model to match this assumption.
+        this package like `~photutils.psf.IntegratedGaussianPRF` or any
+        other suitable 2D model. This object needs to identify three
+        parameters (position of center in x and y coordinates and the
+        flux) in order to set them to suitable starting values for each
+        fit. The names of these parameters should be given as ``x_0``,
+        ``y_0`` and ``flux``. `~photutils.psf.prepare_psf_model` can be
+        used to prepare any 2D model to match this assumption.
     fitshape : int or length-2 array-like
         Rectangular shape around the center of a star which will be
         used to collect the data to do the fitting. Can be an integer

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -6,7 +6,6 @@ Tests for the utils module.
 from astropy.convolution.utils import discretize_model
 from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
-from astropy.utils.exceptions import AstropyDeprecationWarning
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -14,7 +13,6 @@ import pytest
 from ..groupstars import DAOGroup
 from ..models import IntegratedGaussianPRF
 from ..photometry import BasicPSFPhotometry
-from ..sandbox import DiscretePRF
 from ..utils import get_grouped_psf_model, prepare_psf_model, subtract_psf
 from ...utils._optional_deps import HAS_SCIPY  # noqa
 
@@ -251,10 +249,9 @@ def test_get_grouped_psf_model_submodel_names(prf_model):
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_subtract_psf():
     """Test subtract_psf."""
-    with pytest.warns(AstropyDeprecationWarning):
-        prf = DiscretePRF(test_psf, subsampling=1)
+    psf = IntegratedGaussianPRF(sigma=1.0)
     posflux = INTAB.copy()
     for n in posflux.colnames:
         posflux.rename_column(n, n.split('_')[0] + '_fit')
-    residuals = subtract_psf(image, prf, posflux)
-    assert_allclose(residuals, np.zeros_like(image), atol=1E-4)
+    residuals = subtract_psf(image, psf, posflux)
+    assert np.max(np.abs(residuals)) < 0.0052

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -3,8 +3,7 @@
 Tests for the detect module.
 """
 
-from astropy.convolution import Gaussian2DKernel
-from astropy.stats import gaussian_fwhm_to_sigma, SigmaClip
+from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyDeprecationWarning
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
@@ -81,13 +80,6 @@ class TestDetectThreshold:
         ref = 12. * np.ones((3, 3))
         assert_allclose(threshold, ref)
 
-    def test_mask_value(self):
-        """Test detection with mask_value."""
-        with pytest.warns(AstropyDeprecationWarning):
-            threshold = detect_threshold(DATA, nsigma=1.0, mask_value=0.0)
-        ref = 2. * np.ones((3, 3))
-        assert_array_equal(threshold, ref)
-
     def test_image_mask(self):
         """
         Test detection with image_mask.
@@ -100,17 +92,6 @@ class TestDetectThreshold:
                                      sigma_clip=sigma_clip)
         ref = (1. / 8.) * np.ones((3, 3))
         assert_array_equal(threshold, ref)
-
-    def test_image_mask_override(self):
-        """Test that image_mask overrides mask_value."""
-        mask = REF1.astype(bool)
-        sigma_clip = SigmaClip(sigma=10, maxiters=1)
-        with pytest.warns(AstropyDeprecationWarning):
-            threshold = detect_threshold(DATA, nsigma=0.1, error=0,
-                                         mask_value=0.0,
-                                         mask=mask, sigma_clip=sigma_clip)
-            ref = np.ones((3, 3))
-            assert_array_equal(threshold, ref)
 
     def test_invalid_sigma_clip(self):
         with pytest.raises(TypeError):
@@ -260,16 +241,6 @@ class TestMakeSourceMask:
         with pytest.warns(AstropyDeprecationWarning):
             mask2 = make_source_mask(self.data, 5, 10, dilate_size=20)
         assert np.count_nonzero(mask2) > np.count_nonzero(mask1)
-
-    def test_kernel(self):
-        with pytest.warns(AstropyDeprecationWarning):
-            mask1 = make_source_mask(self.data, 5, 10, filter_fwhm=2,
-                                     filter_size=3)
-        sigma = 2 * gaussian_fwhm_to_sigma
-        kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
-        with pytest.warns(AstropyDeprecationWarning):
-            mask2 = make_source_mask(self.data, 5, 10, kernel=kernel)
-        assert_allclose(mask1, mask2)
 
     def test_no_detections(self):
         with pytest.warns(AstropyDeprecationWarning):


### PR DESCRIPTION
This PR removes various deprecations from the `aperture`, `centroids`, `psf`, and `segmentation` subpackages.