### PR TITLE
Fix `PixelAperture` `area_overlap` unit bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Fixed a bug in the ``PixelAperture`` ``area_overlap`` method so that
+    the returned value does not inherit the data units. [#1408]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -312,9 +312,11 @@ class PixelAperture(Aperture):
 
     def area_overlap(self, data, *, mask=None, method='exact', subpixels=5):
         """
-        Return the areas of the aperture masks that overlap with the
-        data, i.e., how many pixels are actually used to calculate each
-        sum.
+        Return the pixel areas of the aperture masks that overlap with
+        the data.
+
+        In other words, this method returns the pixel area(s) within the
+        aperture(s) that are used to calculate the aperture sum(s).
 
         Parameters
         ----------
@@ -361,7 +363,8 @@ class PixelAperture(Aperture):
         Returns
         -------
         areas : float or array_like
-            The overlapping areas between the aperture masks and the data.
+            The overlapping areas (in pixels**2) between the aperture
+            masks and the data.
         """
         apermasks = self.to_mask(method=method, subpixels=subpixels)
         if self.isscalar:
@@ -372,7 +375,7 @@ class PixelAperture(Aperture):
             if mask.shape != data.shape:
                 raise ValueError('mask and data must have the same shape')
 
-        data = np.ones_like(data)
+        data = np.ones(data.shape)  # pixels
         vals = [apermask.get_values(data, mask=mask) for apermask in apermasks]
         # if the aperture does not overlap the data return np.nan
         areas = [val.sum() if val.shape != (0,) else np.nan for val in vals]

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -148,8 +148,17 @@ def test_area_overlap():
     areas = aper.area_overlap(data)
     assert_allclose(areas, [10.304636, np.pi * 9., np.nan])
 
+    data2 = np.ones((11, 11)) * u.Jy
+    areas = aper.area_overlap(data2)
+    assert not isinstance(areas[0], u.Quantity)
+    assert_allclose(areas, [10.304636, np.pi * 9., np.nan])
+
     aper2 = CircularAperture(xypos[1], r=3)
     area2 = aper2.area_overlap(data)
+    assert_allclose(area2, np.pi * 9.)
+
+    area2 = aper2.area_overlap(data2)
+    assert not isinstance(area2, u.Quantity)
     assert_allclose(area2, np.pi * 9.)
 
 


### PR DESCRIPTION
This PR fixes a bug in the `PixelAperture.area_overlap` method so that it no longer returns values with the same units as the input data.