### PR TITLE
Allow NDData input to ApertureStats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ General
 
 New Features
 ^^^^^^^^^^^^
+- ``photutils.aperture``
+
+  - The ``ApertureStats`` class now accepts astropy ``NDData`` objects
+    as input. [#1409]
 
 Bug Fixes
 ^^^^^^^^^


### PR DESCRIPTION
This PR allows astropy `NDData` objects to be input to the ``ApertureStats`` class.