### PR TITLE
CI: minor fixes to tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ deps =
     astropylts: astropy==5.0.*
 
     devdeps: git+https://github.com/spacetelescope/gwcs.git
+    devdeps: git+https://github.com/scikit-image/scikit-image.git
 
     oldestdeps: numpy==1.18
     oldestdeps: astropy==5.0
@@ -82,12 +83,12 @@ extras =
     build_docs: docs
 
 commands =
-    pip freeze
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-image
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
     devdeps: pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
+    pip freeze
     !cov: pytest --pyargs photutils {toxinidir}/docs {posargs}
     cov: pytest --pyargs photutils {toxinidir}/docs --cov photutils --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml


### PR DESCRIPTION
Minor changes, I think only the first one is controversial, I opted into building the dev version, but it's probably not worth the added extra minutes:

- scikit-image doesn't seem to have nightly wheels. We can either build a dev version or only test releases.
- mpl has nightly
- pip freeze once we installed everything
- duplicate conftest, so CI will show the custom test header