### PR TITLE
Use keyword angle for mpl patches

### DIFF
--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -225,7 +225,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
         theta_deg = self._theta_radians * 180. / np.pi
         for xy_position in xy_positions:
             patches.append(mpatches.Ellipse(xy_position, 2. * self.a,
-                                            2. * self.b, theta_deg,
+                                            2. * self.b, angle=theta_deg,
                                             **patch_kwargs))
 
         if self.isscalar:
@@ -389,9 +389,9 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
         theta_deg = self._theta_radians * 180. / np.pi
         for xy_position in xy_positions:
             patch_inner = mpatches.Ellipse(xy_position, 2. * self.a_in,
-                                           2. * self.b_in, theta_deg)
+                                           2. * self.b_in, angle=theta_deg)
             patch_outer = mpatches.Ellipse(xy_position, 2. * self.a_out,
-                                           2. * self.b_out, theta_deg)
+                                           2. * self.b_out, angle=theta_deg)
             path = self._make_annulus_path(patch_inner, patch_outer)
             patches.append(mpatches.PathPatch(path, **patch_kwargs))
 

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -250,7 +250,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
         theta_deg = self._theta_radians * 180. / np.pi
         for xy_position in xy_positions:
             patches.append(mpatches.Rectangle(xy_position, self.w, self.h,
-                                              theta_deg, **patch_kwargs))
+                                              angle=theta_deg, **patch_kwargs))
 
         if self.isscalar:
             return patches[0]
@@ -424,9 +424,9 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
         theta_deg = self._theta_radians * 180. / np.pi
         for xy_in, xy_out in zip(inner_xy_positions, outer_xy_positions):
             patch_inner = mpatches.Rectangle(xy_in, self.w_in, self.h_in,
-                                             theta_deg)
+                                             angle=theta_deg)
             patch_outer = mpatches.Rectangle(xy_out, self.w_out, self.h_out,
-                                             theta_deg)
+                                             angle=theta_deg)
             path = self._make_annulus_path(patch_inner, patch_outer)
             patches.append(mpatches.PathPatch(path, **patch_kwargs))
 


### PR DESCRIPTION
Passing the `angle` parameter to matplotlib patches is deprecated in mpl 3.6.  This PR inputs the angle as keyword in patch objects.