### PR TITLE
Fix Kron photometry for custom minimum Kron or circular radius

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,16 @@ Bug Fixes
   - Fixed a bug in the ``PixelAperture`` ``area_overlap`` method so that
     the returned value does not inherit the data units. [#1408]
 
+- ``photutils.segmentation``
+
+  - Fixed an issue in the ``SourceCatalog`` ``kron_photometry``,
+    ``make_kron_apertures``, and ``plot_kron_apertures`` methods where
+    the input minimum Kron and circular radii would not be applied.
+    Instead the instance-level minima would always be used. [#1421]
+
+  - Fixed an issue where the ``SourceCatalog`` ``plot_kron_apertures``
+    method would raise an error for a scalar ``SourceCatalog``. [#1421]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2507,6 +2507,91 @@ class SourceCatalog:
         return aperture
 
     @lazyproperty
+    def _measured_kron_radius(self):
+        r"""
+        The *unscaled* first-moment Kron radius, always as an array
+        (without units).
+
+        The returned value is the measured Kron radius without applying
+        any minimum Kron or circular radius.
+        """
+        if self._detection_cat is not None:
+            return self._detection_cat._measured_kron_radius
+
+        labels = self._label_iter
+        apertures = self._make_elliptical_apertures(scale=6.0)
+        xcen = self._xcentroid
+        ycen = self._ycentroid
+        cxx = self.cxx.value
+        cxy = self.cxy.value
+        cyy = self.cyy.value
+        if self.isscalar:
+            cxx = (cxx,)
+            cxy = (cxy,)
+            cyy = (cyy,)
+
+        kron_radius = []
+        for (label, aperture, xcen_, ycen_, cxx_, cxy_, cyy_) in zip(
+                labels, apertures, xcen, ycen, cxx, cxy, cyy):
+
+            if aperture is None:
+                kron_radius.append(np.nan)
+                continue
+
+            # use 'center' (whole pixels) to compute Kron radius
+            aperture_mask = aperture.to_mask(method='center')
+
+            # prepare cutouts of the data based on the aperture size
+            # local background explicitly set to zero for SE agreement
+            data, _, mask, xycen, slc_sm = self._make_aperture_data(
+                label, xcen_, ycen_, aperture_mask.bbox, 0.0, make_error=False)
+
+            xval = np.arange(data.shape[1]) - xycen[0]
+            yval = np.arange(data.shape[0]) - xycen[1]
+            xx, yy = np.meshgrid(xval, yval)
+            rr = np.sqrt(cxx_ * xx**2 + cxy_ * xx * yy + cyy_ * yy**2)
+
+            aperture_weights = aperture_mask.data[slc_sm]
+            pixel_mask = (aperture_weights > 0) & ~mask  # good pixels
+
+            # ignore RuntimeWarning for invalid data values
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', RuntimeWarning)
+                flux_numer = np.sum((aperture_weights * data * rr)[pixel_mask])
+                flux_denom = np.sum((aperture_weights * data)[pixel_mask])
+
+            # set Kron radius to the minimum Kron radius if numerator or
+            # denominator is negative
+            if flux_numer <= 0 or flux_denom <= 0:
+                kron_radius.append(self._kron_params[1])
+                continue
+
+            kron_radius.append(flux_numer / flux_denom)
+
+        return np.array(kron_radius)
+
+    def _calc_kron_radius(self, kron_params):
+        """
+        Calculate the *unscaled* first-moment Kron radius, applying any
+        minimum Kron or circular radius to the measured Kron radius.
+
+        Returned as a Quantity array with pixel units.
+        """
+        kron_radius = self._measured_kron_radius.copy()
+        # set minimum (unscaled) kron radius
+        kron_radius[kron_radius < kron_params[1]] = kron_params[1]
+
+        # check for minimum circular radius
+        if len(kron_params) == 3:
+            major_sigma = self.semimajor_sigma.value
+            minor_sigma = self.semiminor_sigma.value
+            circ_radius = (kron_params[0] * kron_radius
+                           * np.sqrt(major_sigma * minor_sigma))
+            kron_radius[circ_radius <= kron_params[2]] = 0.0
+
+        return kron_radius << u.pix
+
+    @lazyproperty
     @as_scalar
     def kron_radius(self):
         r"""
@@ -2565,70 +2650,7 @@ class SourceCatalog:
         """
         if self._detection_cat is not None:
             return self._detection_cat.kron_radius
-
-        labels = self._label_iter
-        apertures = self._make_elliptical_apertures(scale=6.0)
-        xcen = self._xcentroid
-        ycen = self._ycentroid
-        cxx = self.cxx.value
-        cxy = self.cxy.value
-        cyy = self.cyy.value
-        if self.isscalar:
-            cxx = (cxx,)
-            cxy = (cxy,)
-            cyy = (cyy,)
-
-        kron_radius = []
-        for (label, aperture, xcen_, ycen_, cxx_, cxy_, cyy_) in zip(
-                labels, apertures, xcen, ycen, cxx, cxy, cyy):
-
-            if aperture is None:
-                kron_radius.append(np.nan)
-                continue
-
-            # use 'center' (whole pixels) to compute Kron radius
-            aperture_mask = aperture.to_mask(method='center')
-
-            # prepare cutouts of the data based on the aperture size
-            # local background explicitly set to zero for SE agreement
-            data, _, mask, xycen, slc_sm = self._make_aperture_data(
-                label, xcen_, ycen_, aperture_mask.bbox, 0.0, make_error=False)
-
-            xval = np.arange(data.shape[1]) - xycen[0]
-            yval = np.arange(data.shape[0]) - xycen[1]
-            xx, yy = np.meshgrid(xval, yval)
-            rr = np.sqrt(cxx_ * xx**2 + cxy_ * xx * yy + cyy_ * yy**2)
-
-            aperture_weights = aperture_mask.data[slc_sm]
-            pixel_mask = (aperture_weights > 0) & ~mask  # good pixels
-
-            # ignore RuntimeWarning for invalid data values
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', RuntimeWarning)
-                flux_numer = np.sum((aperture_weights * data * rr)[pixel_mask])
-                flux_denom = np.sum((aperture_weights * data)[pixel_mask])
-
-            # set Kron radius to the minimum Kron radius if numerator or
-            # denominator is negative
-            if flux_numer <= 0 or flux_denom <= 0:
-                kron_radius.append(self._kron_params[1])
-                continue
-
-            kron_radius.append(flux_numer / flux_denom)
-
-        # set minimum (unscaled) kron radius
-        kron_radius = np.array(kron_radius)
-        kron_radius[kron_radius < self._kron_params[1]] = self._kron_params[1]
-
-        # check for minimum circular radius
-        if len(self._kron_params) == 3:
-            major_sigma = self.semimajor_sigma.value
-            minor_sigma = self.semiminor_sigma.value
-            circ_radius = (self._kron_params[0] * kron_radius
-                           * np.sqrt(major_sigma * minor_sigma))
-            kron_radius[circ_radius <= self._kron_params[2]] = 0.0
-
-        return kron_radius << u.pix
+        return self._calc_kron_radius(self._kron_params)
 
     def _make_kron_apertures(self, kron_params):
         """
@@ -2677,6 +2699,7 @@ class SourceCatalog:
 
         kron_radius = detcat.kron_radius.value
         scale = kron_radius * kron_params[0]
+
         # NOTE: if kron_radius = NaN, scale = NaN and kron_aperture = None
         kron_apertures = self._make_elliptical_apertures(scale=scale)
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2791,6 +2791,8 @@ class SourceCatalog:
         """
         if kron_params is None:
             apertures = self.kron_aperture
+            if self.isscalar:
+                apertures = (apertures,)
         else:
             apertures = self._make_kron_apertures(kron_params)
 

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -27,39 +27,44 @@ from ...utils._optional_deps import HAS_GWCS, HAS_MATPLOTLIB, HAS_SCIPY  # noqa
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSourceCatalog:
-    xcen = 51.
-    ycen = 52.7
-    major_sigma = 8.
-    minor_sigma = 3.
-    theta = np.pi / 6.
-    g1 = Gaussian2D(111., xcen, ycen, major_sigma, minor_sigma,
-                    theta=theta)
-    g2 = Gaussian2D(50, 20, 80, 5.1, 4.5)
-    g3 = Gaussian2D(70, 75, 18, 9.2, 4.5)
-    g4 = Gaussian2D(111., 11.1, 12.2, major_sigma, minor_sigma,
-                    theta=theta)
-    g5 = Gaussian2D(81., 61, 42.7, major_sigma, minor_sigma, theta=theta)
-    g6 = Gaussian2D(107., 75, 61, major_sigma, minor_sigma, theta=-theta)
-    g7 = Gaussian2D(107., 90, 90, 4, 2, theta=-theta)
+    def setup_class(self):
+        xcen = 51.
+        ycen = 52.7
+        major_sigma = 8.
+        minor_sigma = 3.
+        theta = np.pi / 6.
+        g1 = Gaussian2D(111., xcen, ycen, major_sigma, minor_sigma,
+                        theta=theta)
+        g2 = Gaussian2D(50, 20, 80, 5.1, 4.5)
+        g3 = Gaussian2D(70, 75, 18, 9.2, 4.5)
+        g4 = Gaussian2D(111., 11.1, 12.2, major_sigma, minor_sigma,
+                        theta=theta)
+        g5 = Gaussian2D(81., 61, 42.7, major_sigma, minor_sigma, theta=theta)
+        g6 = Gaussian2D(107., 75, 61, major_sigma, minor_sigma, theta=-theta)
+        g7 = Gaussian2D(107., 90, 90, 4, 2, theta=-theta)
 
-    yy, xx = np.mgrid[0:101, 0:101]
-    data = (g1(xx, yy) + g2(xx, yy) + g3(xx, yy) + g4(xx, yy) + g5(xx, yy)
-            + g6(xx, yy) + g7(xx, yy))
-    threshold = 27.
-    segm = detect_sources(data, threshold, npixels=5)
-    error = make_noise_image(data.shape, mean=0, stddev=2., seed=123)
-    background = np.ones(data.shape) * 5.1
-    mask = np.zeros(data.shape, dtype=bool)
-    mask[0:30, 0:30] = True
+        yy, xx = np.mgrid[0:101, 0:101]
+        self.data = (g1(xx, yy) + g2(xx, yy) + g3(xx, yy) + g4(xx, yy)
+                     + g5(xx, yy) + g6(xx, yy) + g7(xx, yy))
+        threshold = 27.
+        self.segm = detect_sources(self.data, threshold, npixels=5)
+        self.error = make_noise_image(self.data.shape, mean=0, stddev=2.,
+                                      seed=123)
+        self.background = np.ones(self.data.shape) * 5.1
+        self.mask = np.zeros(self.data.shape, dtype=bool)
+        self.mask[0:30, 0:30] = True
 
-    wcs = make_wcs(data.shape)
-    cat = SourceCatalog(data, segm, error=error, background=background,
-                        mask=mask, wcs=wcs, localbkg_width=24)
-    unit = u.nJy
-    unit = unit
-    cat_units = SourceCatalog(data << unit, segm, error=error << unit,
-                              background=background << unit, mask=mask,
-                              wcs=wcs, localbkg_width=24)
+        self.wcs = make_wcs(self.data.shape)
+        self.cat = SourceCatalog(self.data, self.segm, error=self.error,
+                                 background=self.background, mask=self.mask,
+                                 wcs=self.wcs, localbkg_width=24)
+        unit = u.nJy
+        self.unit = unit
+        self.cat_units = SourceCatalog(self.data << unit, self.segm,
+                                       error=self.error << unit,
+                                       background=self.background << unit,
+                                       mask=self.mask, wcs=self.wcs,
+                                       localbkg_width=24)
 
     @pytest.mark.parametrize('with_units', (True, False))
     def test_catalog(self, with_units):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -593,6 +593,13 @@ class TestSourceCatalog:
         for patch in patches2:
             assert isinstance(patch, Patch)
 
+        # test scalar
+        obj = self.cat[1]
+        patch1 = obj.plot_kron_apertures()
+        assert isinstance(patch1, Patch)
+        patch2 = obj.plot_kron_apertures((2.0, 1.2))
+        assert isinstance(patch2, Patch)
+
     def test_fluxfrac_radius(self):
         radius1 = self.cat.fluxfrac_radius(0.1, name='fluxfrac_r1')
         radius2 = self.cat.fluxfrac_radius(0.5, name='fluxfrac_r5')

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -27,44 +27,39 @@ from ...utils._optional_deps import HAS_GWCS, HAS_MATPLOTLIB, HAS_SCIPY  # noqa
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestSourceCatalog:
-    def setup_class(self):
-        xcen = 51.
-        ycen = 52.7
-        major_sigma = 8.
-        minor_sigma = 3.
-        theta = np.pi / 6.
-        g1 = Gaussian2D(111., xcen, ycen, major_sigma, minor_sigma,
-                        theta=theta)
-        g2 = Gaussian2D(50, 20, 80, 5.1, 4.5)
-        g3 = Gaussian2D(70, 75, 18, 9.2, 4.5)
-        g4 = Gaussian2D(111., 11.1, 12.2, major_sigma, minor_sigma,
-                        theta=theta)
-        g5 = Gaussian2D(81., 61, 42.7, major_sigma, minor_sigma, theta=theta)
-        g6 = Gaussian2D(107., 75, 61, major_sigma, minor_sigma, theta=-theta)
-        g7 = Gaussian2D(107., 90, 90, 4, 2, theta=-theta)
+    xcen = 51.
+    ycen = 52.7
+    major_sigma = 8.
+    minor_sigma = 3.
+    theta = np.pi / 6.
+    g1 = Gaussian2D(111., xcen, ycen, major_sigma, minor_sigma,
+                    theta=theta)
+    g2 = Gaussian2D(50, 20, 80, 5.1, 4.5)
+    g3 = Gaussian2D(70, 75, 18, 9.2, 4.5)
+    g4 = Gaussian2D(111., 11.1, 12.2, major_sigma, minor_sigma,
+                    theta=theta)
+    g5 = Gaussian2D(81., 61, 42.7, major_sigma, minor_sigma, theta=theta)
+    g6 = Gaussian2D(107., 75, 61, major_sigma, minor_sigma, theta=-theta)
+    g7 = Gaussian2D(107., 90, 90, 4, 2, theta=-theta)
 
-        yy, xx = np.mgrid[0:101, 0:101]
-        self.data = (g1(xx, yy) + g2(xx, yy) + g3(xx, yy) + g4(xx, yy)
-                     + g5(xx, yy) + g6(xx, yy) + g7(xx, yy))
-        threshold = 27.
-        self.segm = detect_sources(self.data, threshold, npixels=5)
-        self.error = make_noise_image(self.data.shape, mean=0, stddev=2.,
-                                      seed=123)
-        self.background = np.ones(self.data.shape) * 5.1
-        self.mask = np.zeros(self.data.shape, dtype=bool)
-        self.mask[0:30, 0:30] = True
+    yy, xx = np.mgrid[0:101, 0:101]
+    data = (g1(xx, yy) + g2(xx, yy) + g3(xx, yy) + g4(xx, yy) + g5(xx, yy)
+            + g6(xx, yy) + g7(xx, yy))
+    threshold = 27.
+    segm = detect_sources(data, threshold, npixels=5)
+    error = make_noise_image(data.shape, mean=0, stddev=2., seed=123)
+    background = np.ones(data.shape) * 5.1
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[0:30, 0:30] = True
 
-        self.wcs = make_wcs(self.data.shape)
-        self.cat = SourceCatalog(self.data, self.segm, error=self.error,
-                                 background=self.background, mask=self.mask,
-                                 wcs=self.wcs, localbkg_width=24)
-        unit = u.nJy
-        self.unit = unit
-        self.cat_units = SourceCatalog(self.data << unit, self.segm,
-                                       error=self.error << unit,
-                                       background=self.background << unit,
-                                       mask=self.mask, wcs=self.wcs,
-                                       localbkg_width=24)
+    wcs = make_wcs(data.shape)
+    cat = SourceCatalog(data, segm, error=error, background=background,
+                        mask=mask, wcs=wcs, localbkg_width=24)
+    unit = u.nJy
+    unit = unit
+    cat_units = SourceCatalog(data << unit, segm, error=error << unit,
+                              background=background << unit, mask=mask,
+                              wcs=wcs, localbkg_width=24)
 
     @pytest.mark.parametrize('with_units', (True, False))
     def test_catalog(self, with_units):
@@ -96,7 +91,7 @@ class TestSourceCatalog:
 
         # test extra properties
         cat1.circular_photometry(5.0, name='circ5')
-        cat1.kron_photometry((2.0, 1.0), name='kron2')
+        cat1.kron_photometry((2.5, 1.4), name='kron2')
         cat1.fluxfrac_radius(0.5, name='r_hl')
         segment_snr = cat1.segment_flux / cat1.segment_fluxerr
         cat1.add_extra_property('segment_snr', segment_snr)
@@ -113,7 +108,7 @@ class TestSourceCatalog:
         # slice catalog before evaluating catalog properties
         obj = cat2[idx]
         obj.circular_photometry(5.0, name='circ5')
-        obj.kron_photometry((2.0, 1.0), name='kron2')
+        obj.kron_photometry((2.5, 1.4), name='kron2')
         obj.fluxfrac_radius(0.5, name='r_hl')
         segment_snr = obj.segment_flux / obj.segment_fluxerr
         obj.add_extra_property('segment_snr', segment_snr)
@@ -177,9 +172,9 @@ class TestSourceCatalog:
         with assert_raises(AssertionError):
             assert_equal(fluxerr1, fluxerr2)
 
-        flux1, fluxerr1 = cat1.kron_photometry((2.0, 1.0))
-        flux2, fluxerr2 = cat2.kron_photometry((2.0, 1.0))
-        flux3, fluxerr3 = cat3.kron_photometry((2.0, 1.0))
+        flux1, fluxerr1 = cat1.kron_photometry((2.5, 1.4))
+        flux2, fluxerr2 = cat2.kron_photometry((2.5, 1.4))
+        flux3, fluxerr3 = cat3.kron_photometry((2.5, 1.4))
         with assert_raises(AssertionError):
             assert_equal(flux2, flux3)
         with assert_raises(AssertionError):
@@ -505,12 +500,12 @@ class TestSourceCatalog:
         assert_allclose(cat.kron_radius.value, cat._kron_params[1])
 
     def test_kron_photometry(self):
-        flux1, fluxerr1 = self.cat.kron_photometry((2.5, 1.0))
-        assert_allclose(flux1, self.cat.kron_flux)
-        assert_allclose(fluxerr1, self.cat.kron_fluxerr)
+        flux0, fluxerr0 = self.cat.kron_photometry((2.5, 1.4))
+        assert_allclose(flux0, self.cat.kron_flux)
+        assert_allclose(fluxerr0, self.cat.kron_fluxerr)
 
-        flux1, fluxerr1 = self.cat.kron_photometry((1.0, 1.0), name='kron1')
-        flux2, fluxerr2 = self.cat.kron_photometry((2.0, 1.0), name='kron2')
+        flux1, fluxerr1 = self.cat.kron_photometry((1.0, 1.4), name='kron1')
+        flux2, fluxerr2 = self.cat.kron_photometry((2.0, 1.4), name='kron2')
         assert_allclose(flux1, self.cat.kron1_flux)
         assert_allclose(fluxerr1, self.cat.kron1_fluxerr)
         assert_allclose(flux2, self.cat.kron2_flux)
@@ -520,25 +515,31 @@ class TestSourceCatalog:
         assert np.all((fluxerr2 > fluxerr1)
                       | (np.isnan(fluxerr2) & np.isnan(fluxerr1)))
 
+        # test different min Kron radius
+        flux3, fluxerr3 = self.cat.kron_photometry((2.5, 2.5))
+        assert np.all((flux3 > flux0) | (np.isnan(flux3) & np.isnan(flux0)))
+        assert np.all((fluxerr3 > fluxerr0)
+                      | (np.isnan(fluxerr3) & np.isnan(fluxerr0)))
+
         obj = self.cat[1]
-        flux1, fluxerr1 = obj.kron_photometry((1.0, 1.0), name='kron0')
+        flux1, fluxerr1 = obj.kron_photometry((1.0, 1.4), name='kron0')
         assert np.isscalar(flux1)
         assert np.isscalar(fluxerr1)
         assert_allclose(flux1, obj.kron0_flux)
         assert_allclose(fluxerr1, obj.kron0_fluxerr)
 
         cat = SourceCatalog(self.data, self.segm)
-        _, fluxerr = cat.kron_photometry((2.0, 1.0))
+        _, fluxerr = cat.kron_photometry((2.0, 1.4))
         assert np.all(np.isnan(fluxerr))
 
         with pytest.raises(ValueError):
-            self.cat.kron_photometry(2.0)
+            self.cat.kron_photometry(2.5)
         with pytest.raises(ValueError):
-            self.cat.kron_photometry((2.0, 0.0))
+            self.cat.kron_photometry((2.5, 0.0))
         with pytest.raises(ValueError):
-            self.cat.kron_photometry((0.0, 2.0))
+            self.cat.kron_photometry((0.0, 1.4))
         with pytest.raises(ValueError):
-            self.cat.kron_photometry((2.0, 0.0, 1.5))
+            self.cat.kron_photometry((2.5, 0.0, 1.5))
 
     def test_circular_photometry(self):
         flux1, fluxerr1 = self.cat.circular_photometry(1.0, name='circ1')
@@ -587,7 +588,7 @@ class TestSourceCatalog:
         for patch in patches:
             assert isinstance(patch, Patch)
 
-        patches2 = self.cat.plot_kron_apertures((2.5, 1.0))
+        patches2 = self.cat.plot_kron_apertures((2.0, 1.2))
         assert isinstance(patches2, list)
         for patch in patches2:
             assert isinstance(patch, Patch)
@@ -744,7 +745,7 @@ class TestSourceCatalog:
         assert len(aper) == len(self.cat)
         assert isinstance(aper[1], EllipticalAperture)
 
-        aper2 = self.cat.make_kron_apertures((2.5, 1))
+        aper2 = self.cat.make_kron_apertures((2.0, 1.4))
         assert len(aper2) == len(self.cat)
 
         obj = self.cat[1]


### PR DESCRIPTION
This PR fixes an issue in the ``SourceCatalog`` ``kron_photometry``, ``make_kron_apertures``, and ``plot_kron_apertures`` methods where the input minimum Kron and circular radii would not be applied. Instead the instance-level minima would always be used.  This does not affect the `kron_flux` and `kron_fluxerr` values, which are based on the instance-level `kron_params`.

It also fixes an issue where the ``SourceCatalog`` ``plot_kron_apertures`` method would raise an error for a scalar ``SourceCatalog``.