### PR TITLE
Pin sphinx to <5.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,8 @@ test =
     pytest-astropy
 docs =
     scipy>=1.6.0
-    sphinx
-    sphinx-astropy
+    sphinx<5.2
+    sphinx-astropy>=1.6
     matplotlib>=3.1
     scikit-image>=0.15.0
     scikit-learn


### PR DESCRIPTION
With `sphinx` >= 5.2, the sidebar started getting filled with every method and attribute.  They overfill the horizontal size of the sidebar.

<img width="550" alt="sphinx523" src="https://user-images.githubusercontent.com/4992897/195221036-550038bd-5b9f-45e2-98a1-c6f548b3a4bb.png">
