### PR TITLE
Use detection catalog centroids and shape parameters in SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ New Features
   - Added ``mode`` and ``fill_value`` keywords to ``SourceCatalog``
     ``make_cutouts`` method. [#1420]
 
+  - Added ``segment_area`` source property and ``wcs``,
+    ``localbkg_width``, ``apermask_method``, and ``kron_params``
+    attributes to ``SourceCatalog``. [#1425]
+
 - ``photutils.utils``
 
   - Added ``xyorigin`` attribute to ``CutoutImage``. [#1419]
@@ -78,6 +82,13 @@ API Changes
   - Removed the deprecated the ``filter_fwhm`` and ``filter_size``
     keywords in ``make_source_mask``. Use the ``kernel`` keyword instead.
     [#1398]
+
+  - If ``detection_cat`` is input to ``SourceCatalog``, then the
+    detection catalog source centroids and morphological/shape
+    properties will be returned instead of calculating them from the
+    input data. Also, if ``detection_cat`` is input, then the input
+    ``wcs``, ``apermask_method``, and ``kron_params`` keywords will be
+    ignored. [#1425]
 
 
 1.5.0 (2022-07-12)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2162,11 +2162,9 @@ class SourceCatalog:
             xpos = 0.5 * (bbox_.ixmin + bbox_.ixmax - 1)
             ypos = 0.5 * (bbox_.iymin + bbox_.iymax - 1)
             scale = 1.5
-            width_bbox = bbox_.ixmax - bbox_.ixmin
-            width_in = width_bbox * scale
+            width_in = (bbox_.ixmax - bbox_.ixmin) * scale
             width_out = width_in + 2 * self.localbkg_width
-            height_bbox = bbox_.iymax - bbox_.iymin
-            height_in = height_bbox * scale
+            height_in = (bbox_.iymax - bbox_.iymin) * scale
             height_out = height_in + 2 * self.localbkg_width
             apertures.append(RectangularAnnulus((xpos, ypos), width_in,
                                                 width_out, height_out,

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1141,6 +1141,7 @@ class SourceCatalog:
         return self._get_values(self.background_ma)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def moments(self):
         """
@@ -1150,6 +1151,7 @@ class SourceCatalog:
                          self._moment_data_cutouts])
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def moments_central(self):
         """
@@ -1165,6 +1167,7 @@ class SourceCatalog:
                              cutout_centroid[:, 1])])
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def cutout_centroid(self):
         """
@@ -1183,6 +1186,7 @@ class SourceCatalog:
         return np.transpose((xcentroid, ycentroid))
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def centroid(self):
         """
@@ -1193,6 +1197,7 @@ class SourceCatalog:
         return self.cutout_centroid + origin
 
     @lazyproperty
+    @use_detcat
     def _xcentroid(self):
         """
         The ``x`` coordinate of the centroid within the source segment,
@@ -1204,6 +1209,7 @@ class SourceCatalog:
         return xcentroid
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def xcentroid(self):
         """
@@ -1212,6 +1218,7 @@ class SourceCatalog:
         return self._xcentroid
 
     @lazyproperty
+    @use_detcat
     def _ycentroid(self):
         """
         The ``y`` coordinate of the centroid within the source segment,
@@ -1223,6 +1230,7 @@ class SourceCatalog:
         return ycentroid
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def ycentroid(self):
         """
@@ -1231,6 +1239,7 @@ class SourceCatalog:
         return self._ycentroid
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def sky_centroid(self):
         """
@@ -1246,6 +1255,7 @@ class SourceCatalog:
         return self._wcs.pixel_to_world(self.xcentroid, self.ycentroid)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def sky_centroid_icrs(self):
         """
@@ -1260,6 +1270,7 @@ class SourceCatalog:
         return self.sky_centroid.icrs
 
     @lazyproperty
+    @use_detcat
     def _bbox(self):
         """
         The `~photutils.aperture.BoundingBox` of the minimal rectangular
@@ -1270,6 +1281,7 @@ class SourceCatalog:
                 for slc in self._slices_iter]
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def bbox(self):
         """
@@ -1279,6 +1291,7 @@ class SourceCatalog:
         return self._bbox
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def bbox_xmin(self):
         """
@@ -1288,6 +1301,7 @@ class SourceCatalog:
         return np.array([slc[1].start for slc in self._slices_iter])
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def bbox_xmax(self):
         """
@@ -1299,6 +1313,7 @@ class SourceCatalog:
         return np.array([slc[1].stop - 1 for slc in self._slices_iter])
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def bbox_ymin(self):
         """
@@ -1308,6 +1323,7 @@ class SourceCatalog:
         return np.array([slc[0].start for slc in self._slices_iter])
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def bbox_ymax(self):
         """
@@ -1319,6 +1335,7 @@ class SourceCatalog:
         return np.array([slc[0].stop - 1 for slc in self._slices_iter])
 
     @lazyproperty
+    @use_detcat
     def _bbox_corner_ll(self):
         """
         Lower-left *outside* pixel corner location (not index).
@@ -1329,6 +1346,7 @@ class SourceCatalog:
         return np.array(xypos)
 
     @lazyproperty
+    @use_detcat
     def _bbox_corner_ul(self):
         """
         Upper-left *outside* pixel corner location (not index).
@@ -1339,6 +1357,7 @@ class SourceCatalog:
         return np.array(xypos)
 
     @lazyproperty
+    @use_detcat
     def _bbox_corner_lr(self):
         """
         Lower-right *outside* pixel corner location (not index).
@@ -1349,6 +1368,7 @@ class SourceCatalog:
         return np.array(xypos)
 
     @lazyproperty
+    @use_detcat
     def _bbox_corner_ur(self):
         """
         Upper-right *outside* pixel corner location (not index).
@@ -1359,6 +1379,7 @@ class SourceCatalog:
         return np.array(xypos)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def sky_bbox_ll(self):
         """
@@ -1377,6 +1398,7 @@ class SourceCatalog:
         return self._wcs.pixel_to_world(*np.transpose(self._bbox_corner_ll))
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def sky_bbox_ul(self):
         """
@@ -1395,6 +1417,7 @@ class SourceCatalog:
         return self._wcs.pixel_to_world(*np.transpose(self._bbox_corner_ul))
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def sky_bbox_lr(self):
         """
@@ -1413,6 +1436,7 @@ class SourceCatalog:
         return self._wcs.pixel_to_world(*np.transpose(self._bbox_corner_lr))
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def sky_bbox_ur(self):
         """
@@ -1706,6 +1730,7 @@ class SourceCatalog:
         return bkg
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def area(self):
         """
@@ -1721,6 +1746,7 @@ class SourceCatalog:
         return areas << (u.pix ** 2)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def equivalent_radius(self):
         """
@@ -1730,6 +1756,7 @@ class SourceCatalog:
         return np.sqrt(self.area / np.pi)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def perimeter(self):
         """
@@ -1776,6 +1803,7 @@ class SourceCatalog:
         return np.array(perimeter) * u.pix
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def inertia_tensor(self):
         """
@@ -1792,6 +1820,7 @@ class SourceCatalog:
         return tensor.reshape((tensor.shape[0], 2, 2)) * u.pix**2
 
     @lazyproperty
+    @use_detcat
     def _covariance(self):
         """
         The covariance matrix of the 2D Gaussian function that has the
@@ -1827,6 +1856,7 @@ class SourceCatalog:
         return covar
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def covariance(self):
         """
@@ -1836,6 +1866,7 @@ class SourceCatalog:
         return self._covariance * (u.pix**2)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def covariance_eigvals(self):
         """
@@ -1860,6 +1891,7 @@ class SourceCatalog:
         return eigvals * u.pix**2
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def semimajor_sigma(self):
         """
@@ -1874,6 +1906,7 @@ class SourceCatalog:
         return np.sqrt(eigvals[:, 0])
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def semiminor_sigma(self):
         """
@@ -1888,6 +1921,7 @@ class SourceCatalog:
         return np.sqrt(eigvals[:, 1])
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def fwhm(self):
         r"""
@@ -1909,6 +1943,7 @@ class SourceCatalog:
                                             + self.semiminor_sigma**2))
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def orientation(self):
         """
@@ -1922,6 +1957,7 @@ class SourceCatalog:
         return orient_radians * 180. / np.pi * u.deg
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def eccentricity(self):
         r"""
@@ -1940,6 +1976,7 @@ class SourceCatalog:
         return np.sqrt(1. - (semiminor_var / semimajor_var))
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def elongation(self):
         r"""
@@ -1953,6 +1990,7 @@ class SourceCatalog:
         return self.semimajor_sigma / self.semiminor_sigma
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def ellipticity(self):
         r"""
@@ -1967,6 +2005,7 @@ class SourceCatalog:
         return 1.0 - (self.semiminor_sigma / self.semimajor_sigma)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def covar_sigx2(self):
         r"""
@@ -1976,6 +2015,7 @@ class SourceCatalog:
         return self._covariance[:, 0, 0] * u.pix**2
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def covar_sigy2(self):
         r"""
@@ -1985,6 +2025,7 @@ class SourceCatalog:
         return self._covariance[:, 1, 1] * u.pix**2
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def covar_sigxy(self):
         r"""
@@ -1995,6 +2036,7 @@ class SourceCatalog:
         return self._covariance[:, 0, 1] * u.pix**2
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def cxx(self):
         r"""
@@ -2016,6 +2058,7 @@ class SourceCatalog:
                 + (np.sin(self.orientation) / self.semiminor_sigma)**2)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def cyy(self):
         r"""
@@ -2037,6 +2080,7 @@ class SourceCatalog:
                 + (np.cos(self.orientation) / self.semiminor_sigma)**2)
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def cxy(self):
         r"""
@@ -2059,6 +2103,7 @@ class SourceCatalog:
                    - (1. / self.semiminor_sigma**2)))
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def gini(self):
         r"""
@@ -2099,6 +2144,7 @@ class SourceCatalog:
         return np.array(gini)
 
     @lazyproperty
+    @use_detcat
     def _local_background_apertures(self):
         """
         The `~photutils.aperture.RectangularAnnulus` aperture used to
@@ -2129,6 +2175,7 @@ class SourceCatalog:
         return apertures
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def local_background_aperture(self):
         """
@@ -2522,6 +2569,7 @@ class SourceCatalog:
         return aperture
 
     @lazyproperty
+    @use_detcat
     def _measured_kron_radius(self):
         r"""
         The *unscaled* first-moment Kron radius, always as an array
@@ -2609,6 +2657,7 @@ class SourceCatalog:
         return kron_radius << u.pix
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def kron_radius(self):
         r"""
@@ -2680,6 +2729,7 @@ class SourceCatalog:
         return kron_apertures
 
     @lazyproperty
+    @use_detcat
     @as_scalar
     def kron_aperture(self):
         r"""

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1748,14 +1748,30 @@ class SourceCatalog:
     @lazyproperty
     @use_detcat
     @as_scalar
+    def segment_area(self):
+        """
+        The total area of the source segment in units of pixels**2.
+
+        This area is simply the area of the source segment from the
+        input ``segment_img``. It does not take into account any data
+        masking (i.e., a ``mask`` input to `SourceCatalog` or invalid
+        ``data`` values).
+        """
+        areas = []
+        for label, slices in zip(self.labels, self._slices_iter):
+            areas.append(np.count_nonzero(self._segment_img[slices] == label))
+        return np.array(areas) << (u.pix ** 2)
+
+    @lazyproperty
+    @use_detcat
+    @as_scalar
     def area(self):
         """
-        The total unmasked area of the source segment in units of
-        pixels**2.
+        The total unmasked area of the source in units of pixels**2.
 
-        Note that the source area may be smaller than its segment area
-        if a mask is input to `SourceCatalog` or if the ``data``
-        within the segment contains invalid values (NaN and inf).
+        Note that the source area may be smaller than its `segment_area`
+        if a mask is input to `SourceCatalog` or if the ``data`` within
+        the segment contains invalid values (NaN and inf).
         """
         areas = np.array([arr.size for arr in self._data_values]).astype(float)
         areas[self._all_masked] = np.nan

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -43,14 +43,28 @@ def as_scalar(method):
     Return a scalar value from a method if the class is scalar.
     """
     @functools.wraps(method)
-    def _decorator(*args, **kwargs):
+    def _as_scalar(*args, **kwargs):
         result = method(*args, **kwargs)
         try:
             return (result[0] if args[0].isscalar and len(result) == 1
                     else result)
         except TypeError:  # if result has no len
             return result
-    return _decorator
+    return _as_scalar
+
+
+def use_detcat(method):
+    """
+    Return the value from the detection image catalog instead of
+    using the method to calculate it.
+    """
+    @functools.wraps(method)
+    def _use_detcat(self, *args, **kwargs):
+        if self._detection_cat is None:
+            return method(self, *args, **kwargs)
+        else:
+            return getattr(self._detection_cat, method.__name__)
+    return _use_detcat
 
 
 class SourceCatalog:

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -508,7 +508,7 @@ class TestSourceCatalog:
 
     def test_kron_negative(self):
         cat = SourceCatalog(self.data - 10, self.segm)
-        assert_allclose(cat.kron_radius.value, cat._kron_params[1])
+        assert_allclose(cat.kron_radius.value, cat.kron_params[1])
 
     def test_kron_photometry(self):
         flux0, fluxerr0 = self.cat.kron_photometry((2.5, 1.4))
@@ -811,6 +811,12 @@ class TestSourceCatalog:
 
         cutouts = cat.make_cutouts(shape, mode='partial', fill_value=-100)
         assert cutouts[0].data[0, 0] == -100
+
+    def test_meta(self):
+        meta = self.cat.meta
+        attrs = ('localbkg_width', 'apermask_method', 'kron_params')
+        for attr in attrs:
+            assert attr in meta
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -68,25 +68,6 @@ class TestSourceCatalog:
 
     @pytest.mark.parametrize('with_units', (True, False))
     def test_catalog(self, with_units):
-        props1 = ('background_centroid', 'background_mean', 'background_sum',
-                  'bbox', 'covar_sigx2', 'covar_sigxy', 'covar_sigy2', 'cxx',
-                  'cxy', 'cyy', 'ellipticity', 'elongation', 'fwhm',
-                  'equivalent_radius', 'gini', 'kron_radius', 'maxval_xindex',
-                  'maxval_yindex', 'minval_xindex', 'minval_yindex',
-                  'perimeter', 'sky_bbox_ll', 'sky_bbox_lr', 'sky_bbox_ul',
-                  'sky_bbox_ur', 'sky_centroid_icrs', 'local_background',
-                  'segment_flux', 'segment_fluxerr', 'kron_flux',
-                  'kron_fluxerr')
-
-        props2 = ('centroid', 'covariance', 'covariance_eigvals',
-                  'cutout_centroid', 'cutout_maxval_index',
-                  'cutout_minval_index', 'inertia_tensor', 'maxval_index',
-                  'minval_index', 'moments', 'moments_central', 'background',
-                  'background_ma', 'convdata', 'convdata_ma', 'data',
-                  'data_ma', 'error', 'error_ma', 'segment', 'segment_ma')
-
-        props = tuple(self.cat.default_columns) + props1 + props2
-
         if with_units:
             cat1 = self.cat_units.copy()
             cat2 = self.cat_units.copy()
@@ -94,7 +75,9 @@ class TestSourceCatalog:
             cat1 = self.cat.copy()
             cat2 = self.cat.copy()
 
-        # test extra properties
+        props = self.cat.properties
+
+        # add extra properties
         cat1.circular_photometry(5.0, name='circ5')
         cat1.kron_photometry((2.5, 1.4), name='kron2')
         cat1.fluxfrac_radius(0.5, name='r_hl')
@@ -103,7 +86,7 @@ class TestSourceCatalog:
         props = list(props)
         props.extend(cat1.extra_properties)
 
-        idx = 1
+        idx = 1  # no NaN values
 
         # evaluate (cache) catalog properties before slice
         obj = cat1[idx]

--- a/photutils/segmentation/utils.py
+++ b/photutils/segmentation/utils.py
@@ -34,16 +34,16 @@ def make_2dgaussian_kernel(fwhm, size, mode='oversample', oversampling=10):
 
     mode : {'oversample', 'center', 'linear_interp', 'integrate'}, optional
         The mode to use for discretizing the 2D Gaussian model:
-            * 'oversample' (default)
+            * 'oversample' (default):
               Discretize model by taking the average on an oversampled
               grid.
-            * 'center'
+            * 'center':
               Discretize model by taking the value at the center of the
               bin.
-            * 'linear_interp'
+            * 'linear_interp':
               Discretize model by performing a bilinear interpolation
               between the values at the corners of the bin.
-            * 'integrate'
+            * 'integrate':
               Discretize model by integrating the model over the bin.
 
     oversampling : int, optional


### PR DESCRIPTION
This PR introduces an API change to `SourceCatalog` when `detection_cat` is input.  If ``detection_cat`` is input to ``SourceCatalog``, then the detection catalog source centroids and morphological/shape properties will be returned instead of calculating them from the input data. Also, if ``detection_cat`` is input, then the input ``wcs``, ``apermask_method``, and ``kron_params`` keywords will be ignored.  This makes the output catalog self-consistent and removes any potential confusion about which centroids and elliptical shape parameters are used for the circular and elliptical Kron aperture photometry (even though this was previously documented).

This PR also adds a ``segment_area`` source property and ``wcs``, ``localbkg_width``, ``apermask_method``, and ``kron_params``  attributes to ``SourceCatalog``