### PR TITLE
Used SPDX license expression in project metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = photutils
 author = Photutils Developers
 author_email = photutils.team@gmail.com
-license = BSD 3-Clause
+license = BSD-3-Clause
 license_file = LICENSE.rst
 url = https://github.com/astropy/photutils
 github_project = astropy/photutils


### PR DESCRIPTION
The emerging convention for licenses is the [SPDX License List](https://spdx.org/licenses/). 