### PR TITLE
Add py311 to CI tests

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -48,13 +48,11 @@ jobs:
             allow_failure: false
             prefix: ''
 
-          # Python 3.11 wheels are not yet available for scikit-image and
-          # scikit-learn releases
-          # - os: ubuntu-latest
-          #   python: '3.11'
-          #   tox_env: 'py311-test-alldeps'
-          #   allow_failure: false
-          #   prefix: ''
+          - os: ubuntu-latest
+            python: '3.11'
+            tox_env: 'py311-test-alldeps'
+            allow_failure: false
+            prefix: ''
 
           - os: macos-latest
             python: '3.10'
@@ -99,20 +97,11 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps-devdeps'
+            python: '3.11'
+            tox_env: 'py311-test-alldeps-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'
-
-          # Python 3.11 wheels are not yet available for scikit-image dev
-          # version
-          # - os: ubuntu-latest
-          #   python: '3.11'
-          #   tox_env: 'py311-test-devdeps'
-          #   toxposargs: --remote-data=any
-          #   allow_failure: true
-          #   prefix: '(Allowed failure)'
 
     steps:
     - name: Check out repository

--- a/.github/workflows/cron_tests.yml
+++ b/.github/workflows/cron_tests.yml
@@ -25,8 +25,8 @@ jobs:
             allow_failure: false
 
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps-devdeps'
+            python: '3.11'
+            tox_env: 'py311-test-alldeps-devdeps'
             toxposargs: --remote-data=any
             allow_failure: false
 


### PR DESCRIPTION
Python 3.11 wheels are now available for `scikit-image` and `scikit-learn`.