### PR TITLE
Deprecate axes keywords in favor of ax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 General
 ^^^^^^^
 
+- Deprecated ``axes`` keyword in favor of ``ax`` for consistency with
+  other packages. [#1432]
+
+
 New Features
 ^^^^^^^^^^^^
 - ``photutils.aperture``

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -384,8 +384,8 @@ of each source) on the data:
     >>> ax2.imshow(segm_deblend, origin='lower', cmap=segm_deblend.cmap,
     ...            interpolation='nearest')
     >>> ax2.set_title('Segmentation Image')
-    >>> cat.plot_kron_apertures(axes=ax1, color='white', lw=1.5)
-    >>> cat.plot_kron_apertures(axes=ax2, color='white', lw=1.5)
+    >>> cat.plot_kron_apertures(ax=ax1, color='white', lw=1.5)
+    >>> cat.plot_kron_apertures(ax=ax2, color='white', lw=1.5)
 
 .. plot::
 
@@ -421,8 +421,8 @@ of each source) on the data:
     ax2.imshow(segment_map, origin='lower', cmap=segment_map.cmap,
                interpolation='nearest')
     ax2.set_title('Segmentation Image with Kron apertures')
-    cat.plot_kron_apertures(axes=ax1, color='white', lw=1.5)
-    cat.plot_kron_apertures(axes=ax2, color='white', lw=1.5)
+    cat.plot_kron_apertures(ax=ax1, color='white', lw=1.5)
+    cat.plot_kron_apertures(ax=ax2, color='white', lw=1.5)
     plt.tight_layout()
 
 

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -5,6 +5,8 @@ This module defines a class for a rectangular bounding box.
 
 from astropy.io.fits.util import _is_int
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
+
 import numpy as np
 
 __all__ = ['BoundingBox']
@@ -287,14 +289,15 @@ class BoundingBox:
         height, width = self.shape
         return RectangularAperture(xypos, w=width, h=height, theta=0.)
 
-    def plot(self, axes=None, origin=(0, 0), **kwargs):
+    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
+    def plot(self, ax=None, origin=(0, 0), **kwargs):
         """
         Plot the `BoundingBox` on a matplotlib `~matplotlib.axes.Axes`
         instance.
 
         Parameters
         ----------
-        axes : `matplotlib.axes.Axes` or `None`, optional
+        ax : `matplotlib.axes.Axes` or `None`, optional
             The matplotlib axes on which to plot.  If `None`, then the
             current `~matplotlib.axes.Axes` instance is used.
 
@@ -313,7 +316,7 @@ class BoundingBox:
             legend.
         """
         aper = self.to_aperture()
-        return aper.plot(axes=axes, origin=origin, **kwargs)[0]
+        return aper.plot(ax=ax, origin=origin, **kwargs)[0]
 
     def union(self, other):
         """

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from .bounding_box import BoundingBox
 from ._photometry_utils import (_handle_units, _prepare_photometry_data,
@@ -588,14 +589,15 @@ class PixelAperture(Aperture):
         """
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
-    def plot(self, axes=None, origin=(0, 0), **kwargs):
+    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
+    def plot(self, ax=None, origin=(0, 0), **kwargs):
         """
         Plot the aperture on a matplotlib `~matplotlib.axes.Axes`
         instance.
 
         Parameters
         ----------
-        axes : `matplotlib.axes.Axes` or `None`, optional
+        ax : `matplotlib.axes.Axes` or `None`, optional
             The matplotlib axes on which to plot.  If `None`, then the
             current `~matplotlib.axes.Axes` instance is used.
 
@@ -615,15 +617,15 @@ class PixelAperture(Aperture):
         """
         import matplotlib.pyplot as plt
 
-        if axes is None:
-            axes = plt.gca()
+        if ax is None:
+            ax = plt.gca()
 
         patches = self._to_patch(origin=origin, **kwargs)
         if self.isscalar:
             patches = (patches,)
 
         for patch in patches:
-            axes.add_patch(patch)
+            ax.add_patch(patch)
 
         return patches
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -10,7 +10,9 @@ from astropy.nddata import NDData
 from astropy.stats import SigmaClip
 import astropy.units as u
 from astropy.utils import lazyproperty
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
+
 import numpy as np
 from numpy.lib.index_tricks import index_exp
 
@@ -653,7 +655,8 @@ class Background2D:
             bkg_rms <<= self.unit
         return bkg_rms
 
-    def plot_meshes(self, *, axes=None, marker='+', markersize=None,
+    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
+    def plot_meshes(self, *, ax=None, marker='+', markersize=None,
                     color='blue', alpha=None, outlines=False, **kwargs):
         """
         Plot the low-resolution mesh boxes on a matplotlib Axes
@@ -661,7 +664,7 @@ class Background2D:
 
         Parameters
         ----------
-        axes : `matplotlib.axes.Axes` or `None`, optional
+        ax : `matplotlib.axes.Axes` or `None`, optional
             The matplotlib axes on which to plot.  If `None`, then the
             current `~matplotlib.axes.Axes` instance is used.
 
@@ -695,15 +698,15 @@ class Background2D:
         import matplotlib.pyplot as plt
 
         kwargs['color'] = color
-        if axes is None:
-            axes = plt.gca()
+        if ax is None:
+            ax = plt.gca()
 
-        axes.scatter(*self._mesh_xypos, s=markersize, marker=marker,
-                     color=color, alpha=alpha)
+        ax.scatter(*self._mesh_xypos, s=markersize, marker=marker,
+                   color=color, alpha=alpha)
 
         if outlines:
             from ..aperture import RectangularAperture
             xypos = np.column_stack(self._mesh_xypos)
             apers = RectangularAperture(xypos, self.box_size[1],
                                         self.box_size[0], 0.)
-            apers.plot(axes=axes, alpha=alpha, **kwargs)
+            apers.plot(ax=ax, alpha=alpha, **kwargs)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -13,6 +13,7 @@ from astropy.stats import SigmaClip
 from astropy.table import QTable
 import astropy.units as u
 from astropy.utils import lazyproperty
+from astropy.utils.decorators import deprecated_renamed_argument
 import numpy as np
 
 from .core import SegmentationImage
@@ -2381,7 +2382,8 @@ class SourceCatalog:
         return self._make_circular_apertures(radius)
 
     @as_scalar
-    def plot_circular_apertures(self, radius, axes=None, origin=(0, 0),
+    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
+    def plot_circular_apertures(self, radius, ax=None, origin=(0, 0),
                                 **kwargs):
         """
         Plot circular apertures for each source on a matplotlib
@@ -2400,7 +2402,7 @@ class SourceCatalog:
         radius : float
             The radius of the circle in pixels.
 
-        axes : `matplotlib.axes.Axes` or `None`, optional
+        ax : `matplotlib.axes.Axes` or `None`, optional
             The matplotlib axes on which to plot.  If `None`, then the
             current `~matplotlib.axes.Axes` instance is used.
 
@@ -2423,7 +2425,7 @@ class SourceCatalog:
         patches = []
         for aperture in apertures:
             if aperture is not None:
-                aperture.plot(axes=axes, origin=origin, **kwargs)
+                aperture.plot(ax=ax, origin=origin, **kwargs)
                 patches.append(aperture._to_patch(origin=origin, **kwargs))
         return patches
 
@@ -2801,7 +2803,8 @@ class SourceCatalog:
         return self._make_kron_apertures(kron_params)
 
     @as_scalar
-    def plot_kron_apertures(self, kron_params=None, axes=None, origin=(0, 0),
+    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
+    def plot_kron_apertures(self, kron_params=None, ax=None, origin=(0, 0),
                             **kwargs):
         """
         Plot Kron apertures for each source on a matplotlib
@@ -2837,7 +2840,7 @@ class SourceCatalog:
             `SourceCatalog` will be used (the apertures will be the same
             as those in `kron_aperture`).
 
-        axes : `matplotlib.axes.Axes` or `None`, optional
+        ax : `matplotlib.axes.Axes` or `None`, optional
             The matplotlib axes on which to plot.  If `None`, then the
             current `~matplotlib.axes.Axes` instance is used.
 
@@ -2865,7 +2868,7 @@ class SourceCatalog:
         patches = []
         for aperture in apertures:
             if aperture is not None:
-                aperture.plot(axes=axes, origin=origin, **kwargs)
+                aperture.plot(ax=ax, origin=origin, **kwargs)
                 patches.append(aperture._to_patch(origin=origin, **kwargs))
         return patches
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -9,6 +9,7 @@ import inspect
 import warnings
 
 from astropy.utils import lazyproperty
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
 
@@ -1145,7 +1146,8 @@ class SegmentationImage:
 
         return outlines
 
-    def imshow(self, axes=None, figsize=None, dpi=None, cmap=None, alpha=None):
+    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
+    def imshow(self, ax=None, figsize=None, dpi=None, cmap=None, alpha=None):
         """
         Display the segmentation image in a matplotlib
         `~matplotlib.axes.Axes` instance.
@@ -1155,7 +1157,7 @@ class SegmentationImage:
 
         Parameters
         ----------
-        axes : `matplotlib.axes.Axes` or `None`, optional
+        ax : `matplotlib.axes.Axes` or `None`, optional
             The matplotlib axes on which to plot. If `None`, then a new
             `~matplotlib.axes.Axes` instance will be created.
 
@@ -1202,13 +1204,13 @@ class SegmentationImage:
         """
         import matplotlib.pyplot as plt
 
-        if axes is None:
-            _, axes = plt.subplots(figsize=figsize, dpi=dpi)
+        if ax is None:
+            _, ax = plt.subplots(figsize=figsize, dpi=dpi)
         if cmap is None:
             cmap = self.cmap
 
-        return axes.imshow(self.data, cmap=cmap, interpolation='none',
-                           origin='lower', alpha=alpha)
+        return ax.imshow(self.data, cmap=cmap, interpolation='none',
+                         origin='lower', alpha=alpha)
 
 
 class Segment:


### PR DESCRIPTION
This PR deprecates the `axes` keywords in favor of `ax` for consistency with other packages (e.g., `scipy`, `pandas`, `astropy`, `regions`).