### PR TITLE
Deprecate top level imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,6 @@
 General
 ^^^^^^^
 
-- Deprecated ``axes`` keyword in favor of ``ax`` for consistency with
-  other packages. [#1432]
-
-
 New Features
 ^^^^^^^^^^^^
 - ``photutils.aperture``
@@ -54,6 +50,12 @@ Bug Fixes
 
 API Changes
 ^^^^^^^^^^^
+
+- Deprecated ``axes`` keyword in favor of ``ax`` for consistency with
+  other packages. [#1432]
+
+- Importing tools from all subpackages now requires including the
+  subpackage name.
 
 - ``photutils.aperture``
 

--- a/photutils/__init__.py
+++ b/photutils/__init__.py
@@ -6,17 +6,83 @@ has tools for background estimation, ePSF building, PSF matching,
 centroiding, and morphological measurements.
 """
 
+import warnings
+
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *  # noqa
 # ----------------------------------------------------------------------------
 
-from .aperture import *  # noqa
-from .background import *  # noqa
-from .detection import *  # noqa
-from .psf import *  # noqa
-from .segmentation import *  # noqa
+from . import aperture
+from . import background
+from . import detection
+from . import psf
+from . import segmentation
+
+# deprecations
+__depr__ = {}
+
+__depr__[aperture] = ('BoundingBox', 'CircularMaskMixin',
+                      'CircularAperture', 'CircularAnnulus',
+                      'SkyCircularAperture', 'SkyCircularAnnulus', 'Aperture',
+                      'SkyAperture', 'PixelAperture', 'EllipticalMaskMixin',
+                      'EllipticalAperture', 'EllipticalAnnulus',
+                      'SkyEllipticalAperture', 'SkyEllipticalAnnulus',
+                      'ApertureMask', 'aperture_photometry',
+                      'RectangularMaskMixin', 'RectangularAperture',
+                      'RectangularAnnulus', 'SkyRectangularAperture',
+                      'SkyRectangularAnnulus', 'ApertureStats')
+
+__depr__[background] = ('Background2D', 'BackgroundBase', 'BackgroundRMSBase',
+                        'MeanBackground', 'MedianBackground',
+                        'ModeEstimatorBackground', 'MMMBackground',
+                        'SExtractorBackground', 'BiweightLocationBackground',
+                        'StdBackgroundRMS', 'MADStdBackgroundRMS',
+                        'BiweightScaleBackgroundRMS', 'BkgZoomInterpolator',
+                        'BkgIDWInterpolator')
+
+__depr__[detection] = ('StarFinderBase', 'DAOStarFinder', 'IRAFStarFinder',
+                       'find_peaks', 'StarFinder')
+
+__depr__[psf] = ('EPSFFitter', 'EPSFBuilder', 'EPSFStar', 'EPSFStars',
+                 'LinkedEPSFStar', 'extract_stars', 'DAOGroup', 'DBSCANGroup',
+                 'GroupStarsBase', 'NonNormalizable', 'FittableImageModel',
+                 'EPSFModel', 'GriddedPSFModel', 'IntegratedGaussianPRF',
+                 'PRFAdapter', 'BasicPSFPhotometry',
+                 'IterativelySubtractedPSFPhotometry', 'DAOPhotPSFPhotometry',
+                 'prepare_psf_model',
+                 'get_grouped_psf_model', 'subtract_psf',
+                 'resize_psf', 'create_matching_kernel',
+                 'SplitCosineBellWindow', 'HanningWindow', 'TukeyWindow',
+                 'CosineBellWindow', 'TopHatWindow')
+
+__depr__[segmentation] = ('SourceCatalog', 'SegmentationImage', 'Segment',
+                          'deblend_sources', 'detect_threshold',
+                          'detect_sources', 'make_source_mask',
+                          'SourceFinder', 'make_2dgaussian_kernel')
+
+__depr_mesg__ = ('`photutils.{attr}` is a deprecated alias for '
+                 '`{module}.{attr}` and will be removed in the future. '
+                 'Instead, please use `from {module} import {attr}` to '
+                 'silence this warning.')
+
+__depr_attrs__ = {}
+for k, vals in __depr__.items():
+    for val in vals:
+        __depr_attrs__[val] = (getattr(k, val),
+                               __depr_mesg__.format(module=k.__name__,
+                                                    attr=val))
+del k, val, vals
+
+
+def __getattr__(attr):
+    if attr in __depr_attrs__:
+        obj, message = __depr_attrs__[attr]
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
+        return obj
+    raise AttributeError('module {!r} has no attribute {!r}'
+                         .format(__name__, attr))
 
 
 # Set the bibtex entry to the article referenced in CITATION.rst.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1065,7 +1065,7 @@ class SegmentationImage:
         Examples
         --------
         >>> import numpy as np
-        >>> from photutils import SegmentationImage
+        >>> from photutils.segmentation import SegmentationImage
         >>> from photutils.utils import circular_footprint
         >>> data = np.zeros((7, 7), dtype=int)
         >>> data[3, 3] = 1


### PR DESCRIPTION
This PR requires that importing tools from all subpackages now requires including the subpackage name, e.g., `from photutils.aperture import CircularAperture` instead of `from photutils import CircularAperture`.  The photutils package has significantly grown over time with many different subpackages.  Requiring the using the user to explicitly use the subpackage name improves the import performance and is common in other packages (e.g. `scipy`, `astropy`, `specutils`, etc.).  It also prevents namespace confusion (e.g., #1065).

Closes #1065.
Followup to #1190.