### PR TITLE
Add ability to use Quantity arrays in detection functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ New Features
     ``localbkg_width``, ``apermask_method``, and ``kron_params``
     attributes to ``SourceCatalog``. [#1425]
 
+  - Added the ability to use ``Quantity`` arrays with
+    ``detect_threshold``, ``detect_sources``, ``deblend_sources``, and
+    ``SourceFinder``. [#1436]
+
 - ``photutils.utils``
 
   - Added ``xyorigin`` attribute to ``CutoutImage``. [#1419]

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -7,6 +7,7 @@ a segmentation image.
 from multiprocessing import cpu_count, get_context
 import warnings
 
+from astropy.units import Quantity
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 import numpy as np
@@ -144,6 +145,9 @@ def deblend_sources(data, segment_img, npixels, kernel=None, labels=None,
     :func:`photutils.segmentation.detect_sources`
     :class:`photutils.segmentation.SourceFinder`
     """
+    if isinstance(data, Quantity):
+        data = data.value
+
     if not isinstance(segment_img, SegmentationImage):
         raise ValueError('segment_img must be a SegmentationImage')
 

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -87,6 +87,10 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
     sigma-clipped background statistics. If ``background`` and ``error``
     are both input, then ``mask`` and ``sigma_clip`` are ignored.
     """
+    arrays, unit = process_quantities((data, background, error),
+                                      ('data', 'background', 'error'))
+    data, background, error = arrays
+
     if not isinstance(sigma_clip, SigmaClip):
         raise TypeError('sigma_clip must be a SigmaClip object')
 
@@ -99,6 +103,7 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
 
     if background is None:
         background = nanmean(clipped_data)
+
     if not np.isscalar(background) and background.shape != data.shape:
         raise ValueError('If input background is 2D, then it must have the '
                          'same shape as the input data.')
@@ -109,8 +114,13 @@ def detect_threshold(data, nsigma, background=None, error=None, mask=None,
         raise ValueError('If input error is 2D, then it must have the same '
                          'shape as the input data.')
 
-    return (np.broadcast_to(background, data.shape)
-            + np.broadcast_to(error * nsigma, data.shape))
+    threshold = (np.broadcast_to(background, data.shape)
+                 + np.broadcast_to(error * nsigma, data.shape))
+
+    if unit:
+        threshold <<= unit
+
+    return threshold
 
 
 def _detect_sources(data, thresholds, npixels, footprint, inverse_mask,

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from .core import SegmentationImage
 from .utils import _make_binary_structure
+from ..utils._quantity_helpers import process_quantities
 from ..utils._stats import nanmean, nanstd
 from ..utils.exceptions import NoDetectionsWarning
 
@@ -280,7 +281,7 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
     threshold : float or 2D `~numpy.ndarray`
         The data value or pixel-wise data values to be used for the
         detection threshold. A 2D ``threshold`` array must have the same
-        shape as ``data``.
+        shape and units as ``data``.
 
     npixels : int
         The minimum number of connected pixels, each greater than
@@ -359,6 +360,8 @@ def detect_sources(data, threshold, npixels, kernel=None, connectivity=8,
                    cmap=segm.make_cmap(seed=1234))
         plt.tight_layout()
     """
+    _ = process_quantities((data, threshold), ('data', 'threshold'))
+
     if (npixels <= 0) or (int(npixels) != npixels):
         raise ValueError('npixels must be a positive integer, got '
                          f'"{npixels}"')


### PR DESCRIPTION
This PR adds the ability to use `Quantity` arrays with `detect_threshold`, `detect_sources`, `deblend_sources`, and `SourceFinder`.