### PR TITLE
Update ApertureStats and SourceCatalog centroid docstrings

### DIFF
--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -944,6 +944,9 @@ class ApertureStats:
         """
         The ``(x, y)`` coordinate, relative to the cutout data, of
         the centroid within the aperture.
+
+        The centroid is computed as the center of mass of the unmasked
+        pixels within the aperture.
         """
         moments = self.moments
         if self.isscalar:
@@ -960,8 +963,10 @@ class ApertureStats:
     @as_scalar
     def centroid(self):
         """
-        The ``(x, y)`` coordinate of the centroid of the unmasked pixels
-        within the aperture.
+        The ``(x, y)`` coordinate of the centroid.
+
+        The centroid is computed as the center of mass of the unmasked
+        pixels within the aperture.
         """
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.cutout_centroid + origin
@@ -969,8 +974,7 @@ class ApertureStats:
     @lazyproperty
     def _xcentroid(self):
         """
-        The ``x`` coordinate of the centroid of the unmasked pixels
-        within the aperture, always as an iterable.
+        The ``x`` coordinate of the centroid, always as an iterable.
         """
         xcentroid = np.transpose(self.centroid)[0]
         if self.isscalar:
@@ -981,16 +985,17 @@ class ApertureStats:
     @as_scalar
     def xcentroid(self):
         """
-        The ``x`` coordinate of the centroid of the unmasked pixels
-        within the aperture.
+        The ``x`` coordinate of the centroid.
+
+        The centroid is computed as the center of mass of the unmasked
+        pixels within the aperture.
         """
         return self._xcentroid
 
     @lazyproperty
     def _ycentroid(self):
         """
-        The ``y`` coordinate of the centroid of the unmasked pixels
-        within the aperture, always as an iterable.
+        The ``y`` coordinate of the centroid, always as an iterable.
         """
         ycentroid = np.transpose(self.centroid)[1]
         if self.isscalar:
@@ -1001,8 +1006,10 @@ class ApertureStats:
     @as_scalar
     def ycentroid(self):
         """
-        The ``y`` coordinate of the centroid of the unmasked pixels
-        within the aperture.
+        The ``y`` coordinate of the centroid.
+
+        The centroid is computed as the center of mass of the unmasked
+        pixels within the aperture.
         """
         return self._ycentroid
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1188,6 +1188,9 @@ class SourceCatalog:
         """
         The ``(x, y)`` coordinate, relative to the cutout data, of
         the centroid within the source segment.
+
+        The centroid is computed as the center of mass of the unmasked
+        pixels within the source segment.
         """
         moments = self.moments
         if self.isscalar:
@@ -1207,6 +1210,9 @@ class SourceCatalog:
         """
         The ``(x, y)`` coordinate of the centroid within the source
         segment.
+
+        The centroid is computed as the center of mass of the unmasked
+        pixels within the source segment.
         """
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.cutout_centroid + origin
@@ -1229,6 +1235,9 @@ class SourceCatalog:
     def xcentroid(self):
         """
         The ``x`` coordinate of the centroid within the source segment.
+
+        The centroid is computed as the center of mass of the unmasked
+        pixels within the source segment.
         """
         return self._xcentroid
 
@@ -1250,6 +1259,9 @@ class SourceCatalog:
     def ycentroid(self):
         """
         The ``y`` coordinate of the centroid within the source segment.
+
+        The centroid is computed as the center of mass of the unmasked
+        pixels within the source segment.
         """
         return self._ycentroid
 


### PR DESCRIPTION
This PR updates the `ApertureStats` and `SourceCatalog` centroid docstrings to note that the centroid is calculated as the center of mass of the unmasked pixels within the aperture or segment.

Closes #1435 