### PR TITLE
Improve performance of aperture photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New Features
   - The ``ApertureStats`` class now accepts astropy ``NDData`` objects
     as input. [#1409]
 
+  - Improved the performance of aperture photometry by 10-25% (depending
+    on the number of aperture positions). [#1438]
+
 - ``photutils.segmentation``
 
   - Added the ability to slice ``SegmentationImage`` objects. [#1413]

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -38,7 +38,19 @@ class ApertureAttribute:
         self._validate(value)
         if not isinstance(value, (u.Quantity, SkyCoord)):
             value = float(value)
+        # no need to reset if not already in the instance dict
+        if self.name in instance.__dict__:
+            self._reset_lazyproperties(instance)
         instance.__dict__[self.name] = value
+
+    def _reset_lazyproperties(self, instance):
+        # reset lazyproperties (if they exist) for aperture
+        # parameter changes
+        try:
+            for key in instance._lazyproperties:
+                instance.__dict__.pop(key, None)
+        except AttributeError:
+            pass
 
     def __delete__(self, instance):
         del instance.__dict__[self.name]  # pragma: no cover
@@ -66,6 +78,9 @@ class PixelPositions(ApertureAttribute):
 
         value = np.asanyarray(value).astype(float)  # np.ndarray
         self._validate(value)
+        # no need to reset if not already in the instance dict
+        if self.name in instance.__dict__:
+            self._reset_lazyproperties(instance)
         instance.__dict__[self.name] = value
 
     def _validate(self, value):
@@ -151,6 +166,9 @@ class ScalarAngleOrValue(ApertureAttribute):
 
     def __set__(self, instance, value):
         self._validate(value)
+        # no need to reset if not already in the instance dict
+        if self.name in instance.__dict__:
+            self._reset_lazyproperties(instance)
         instance.__dict__[self.name] = value
 
         # also store the angle in radians as a float

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -2,8 +2,8 @@
 """
 This module defines a class for a rectangular bounding box.
 """
+import math
 
-from astropy.io.fits.util import _is_int
 from astropy.utils import deprecated
 from astropy.utils.decorators import deprecated_renamed_argument
 
@@ -55,14 +55,10 @@ class BoundingBox:
     """
 
     def __init__(self, ixmin, ixmax, iymin, iymax):
-        if not _is_int(ixmin):
-            raise TypeError('ixmin must be an integer')
-        if not _is_int(ixmax):
-            raise TypeError('ixmax must be an integer')
-        if not _is_int(iymin):
-            raise TypeError('iymin must be an integer')
-        if not _is_int(iymax):
-            raise TypeError('iymax must be an integer')
+        for value in (ixmin, ixmax, iymin, iymax):
+            if not isinstance(value, (int, np.integer)):
+                raise TypeError('ixmin, ixmax, iymin, and iymax must all be '
+                                'integers')
 
         if ixmin > ixmax:
             raise ValueError('ixmin must be <= ixmax')
@@ -115,10 +111,10 @@ class BoundingBox:
         >>> BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
         BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
         """
-        ixmin = int(np.floor(xmin + 0.5))
-        ixmax = int(np.ceil(xmax + 0.5))
-        iymin = int(np.floor(ymin + 0.5))
-        iymax = int(np.ceil(ymax + 0.5))
+        ixmin = math.floor(xmin + 0.5)
+        ixmax = math.ceil(xmax + 0.5)
+        iymin = math.floor(ymin + 0.5)
+        iymax = math.ceil(ymax + 0.5)
 
         return cls(ixmin, ixmax, iymin, iymax)
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -6,6 +6,7 @@ pixel and sky coordinates.
 
 import math
 
+from astropy.utils import lazyproperty
 import numpy as np
 
 from .attributes import (PixelPositions, PositiveScalar, SkyCoordPositions,
@@ -146,11 +147,11 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
         self.positions = positions
         self.r = r
 
-    @property
+    @lazyproperty
     def _xy_extents(self):
         return self.r, self.r
 
-    @property
+    @lazyproperty
     def area(self):
         return math.pi * self.r ** 2
 
@@ -271,11 +272,11 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
         self.r_in = r_in
         self.r_out = r_out
 
-    @property
+    @lazyproperty
     def _xy_extents(self):
         return self.r_out, self.r_out
 
-    @property
+    @lazyproperty
     def area(self):
         return math.pi * (self.r_out ** 2 - self.r_in ** 2)
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -7,7 +7,6 @@ pixel and sky coordinates.
 import math
 
 from astropy.utils import lazyproperty
-import numpy as np
 
 from .attributes import (PixelPositions, PositiveScalar, SkyCoordPositions,
                          PositiveScalarAngle)

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -81,8 +81,7 @@ class CircularMaskMixin:
             raise ValueError('Cannot determine the aperture radius.')
 
         masks = []
-        for bbox, edges in zip(np.atleast_1d(self.bbox),
-                               self._centered_edges):
+        for bbox, edges in zip(self._bbox, self._centered_edges):
             ny, nx = bbox.shape
             mask = circular_overlap_grid(edges[0], edges[1], edges[2],
                                          edges[3], nx, ny, radius, use_exact,

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -5,10 +5,12 @@ This module defines the base aperture classes.
 
 import abc
 from copy import deepcopy
+import inspect
 
 import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
+from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
 
 from .bounding_box import BoundingBox
@@ -124,6 +126,17 @@ class Aperture(metaclass=abc.ABCMeta):
         """
         return not (self == other)
 
+    @property
+    def _lazyproperties(self):
+        """
+        A list of all class lazyproperties (even in superclasses).
+        """
+        def islazyproperty(obj):
+            return isinstance(obj, lazyproperty)
+
+        return [i[0] for i in inspect.getmembers(self.__class__,
+                                                 predicate=islazyproperty)]
+
     def copy(self):
         """
         Make an independent (deep) copy.
@@ -133,7 +146,7 @@ class Aperture(metaclass=abc.ABCMeta):
             params_copy[param] = deepcopy(getattr(self, param))
         return self.__class__(**params_copy)
 
-    @property
+    @lazyproperty
     def shape(self):
         """
         The shape of the instance.
@@ -143,7 +156,7 @@ class Aperture(metaclass=abc.ABCMeta):
         else:
             return self.positions.shape[:-1]
 
-    @property
+    @lazyproperty
     def isscalar(self):
         """
         Whether the instance is scalar (i.e., a single position).
@@ -156,7 +169,7 @@ class PixelAperture(Aperture):
     Abstract base class for apertures defined in pixel coordinates.
     """
 
-    @property
+    @lazyproperty
     def _default_patch_properties(self):
         """
         A dictionary of default matplotlib.patches.Patch properties.
@@ -193,7 +206,7 @@ class PixelAperture(Aperture):
 
         return use_exact, subpixels
 
-    @property
+    @lazyproperty
     @abc.abstractmethod
     def _xy_extents(self):
         """
@@ -205,7 +218,7 @@ class PixelAperture(Aperture):
         """
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
-    @property
+    @lazyproperty
     def bbox(self):
         """
         The minimal bounding box for the aperture.
@@ -229,7 +242,7 @@ class PixelAperture(Aperture):
         else:
             return bboxes
 
-    @property
+    @lazyproperty
     def _centered_edges(self):
         """
         A list of ``(xmin, xmax, ymin, ymax)`` tuples, one for each
@@ -250,7 +263,7 @@ class PixelAperture(Aperture):
 
         return edges
 
-    @property
+    @lazyproperty
     def area(self):
         """
         The exact analytical area of the aperture shape.

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -219,17 +219,23 @@ class PixelAperture(Aperture):
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
     @lazyproperty
+    def _positions(self):
+        """
+        The aperture positions, always as a 2D ndarray.
+        """
+        return np.atleast_2d(self.positions)
+
+    @lazyproperty
     def _bbox(self):
         """
         The minimal bounding box for the aperture, always as a list of
         `~photutils.aperture.BoundingBox` instances.
         """
-        positions = np.atleast_2d(self.positions)
         x_delta, y_delta = self._xy_extents
-        xmin = positions[:, 0] - x_delta
-        xmax = positions[:, 0] + x_delta
-        ymin = positions[:, 1] - y_delta
-        ymax = positions[:, 1] + y_delta
+        xmin = self._positions[:, 0] - x_delta
+        xmax = self._positions[:, 0] + x_delta
+        ymin = self._positions[:, 1] - y_delta
+        ymax = self._positions[:, 1] + y_delta
 
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax)]
@@ -259,7 +265,7 @@ class PixelAperture(Aperture):
         functions.
         """
         edges = []
-        for position, bbox in zip(np.atleast_2d(self.positions), self._bbox):
+        for position, bbox in zip(self._positions, self._bbox):
             xmin = bbox.ixmin - 0.5 - position[0]
             xmax = bbox.ixmax - 0.5 - position[0]
             ymin = bbox.iymin - 0.5 - position[1]
@@ -574,7 +580,7 @@ class PixelAperture(Aperture):
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
         """
-        xy_positions = deepcopy(np.atleast_2d(self.positions))
+        xy_positions = deepcopy(self._positions)
         xy_positions[:, 0] -= origin[0]
         xy_positions[:, 1] -= origin[1]
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -84,8 +84,7 @@ class EllipticalMaskMixin:
             raise ValueError('Cannot determine the aperture shape.')
 
         masks = []
-        for bbox, edges in zip(np.atleast_1d(self.bbox),
-                               self._centered_edges):
+        for bbox, edges in zip(self._bbox, self._centered_edges):
             ny, nx = bbox.shape
             mask = elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                            edges[3], nx, ny, a, b,

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -86,8 +86,7 @@ class RectangularMaskMixin:
             raise ValueError('Cannot determine the aperture radius.')
 
         masks = []
-        for bbox, edges in zip(np.atleast_1d(self.bbox),
-                               self._centered_edges):
+        for bbox, edges in zip(self._bbox, self._centered_edges):
             ny, nx = bbox.shape
             mask = rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                             edges[3], nx, ny, w, h,


### PR DESCRIPTION
This PR improves the performance of aperture photometry by 10-25% (depending on the number of aperture positions) by caching certain aperture properties using `lazyproperty`.