### PR TITLE
Update minimum versions of dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,13 @@
 General
 ^^^^^^^
 
-- Following NEP 29, the minimum required Numpy is now 1.20. [#xxxx]
+- Following NEP 29, the minimum required Numpy is now 1.20. [#1442]
+
+- The minimum required Matplotlib is now 3.3.0. [#1442]
+
+- The minimum required scikit-image is now 0.18.0. [#1442]
+
+- The minimum required scikit-learn is now 1.0. [#1442]
 
 New Features
 ^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 General
 ^^^^^^^
 
+- Following NEP 29, the minimum required Numpy is now 1.20. [#xxxx]
+
 New Features
 ^^^^^^^^^^^^
 - ``photutils.aperture``

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Photutils has the following strict requirements:
 
 * `Python <https://www.python.org/>`_ 3.8 or later
 
-* `Numpy <https://numpy.org/>`_ 1.18 or later
+* `Numpy <https://numpy.org/>`_ 1.20 or later
 
 * `Astropy`_ 5.0 or later
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -18,13 +18,13 @@ Photutils also optionally depends on other packages for some features:
 * `Scipy <https://www.scipy.org/>`_ 1.6.0 or later:  To power a variety of
   features in several modules (strongly recommended).
 
-* `matplotlib <https://matplotlib.org/>`_ 3.1 or later:  To power a
+* `matplotlib <https://matplotlib.org/>`_ 3.3.0 or later:  To power a
   variety of plotting features (e.g., plotting apertures).
 
-* `scikit-image <https://scikit-image.org/>`_ 0.15.0 or later: Used for
+* `scikit-image <https://scikit-image.org/>`_ 0.18.0 or later: Used for
   deblending segmented sources.
 
-* `scikit-learn <https://scikit-learn.org/>`_ 0.19 or later:  Used in
+* `scikit-learn <https://scikit-learn.org/>`_ 1.0 or later:  Used in
   `~photutils.psf.DBSCANGroup` to create star groups.
 
 * `gwcs <https://github.com/spacetelescope/gwcs>`_ 0.16 or later:

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ install_requires =
 [options.extras_require]
 all =
     scipy>=1.6.0
-    matplotlib>=3.1
-    scikit-image>=0.15.0
-    scikit-learn
+    matplotlib>=3.3.0
+    scikit-image>=0.18.0
+    scikit-learn>=1.0
     gwcs>=0.16
     bottleneck
     tqdm
@@ -45,9 +45,9 @@ docs =
     scipy>=1.6.0
     sphinx<5.2
     sphinx-astropy>=1.6
-    matplotlib>=3.1
-    scikit-image>=0.15.0
-    scikit-learn
+    matplotlib>=3.3.0
+    scikit-image>=0.18.0
+    scikit-learn>=1.0
     gwcs>=0.16
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.18
+    numpy>=1.20
     astropy>=5.0
 
 [options.extras_require]


### PR DESCRIPTION
Following NEP 29, the minimum required Numpy is now 1.20.

Optional dependencies:

- matplotlib 3.3.0+
- scikit-image 0.18.0+
- scikit-learn 1.0+
