### PR TITLE
Pin setuptools max version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools',
+requires = ['setuptools<65.6.0',
             'setuptools_scm',
             'wheel',
             'cython>=0.29.30',

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
+    setuptools<65.6.0
     numpy>=1.20
     astropy>=5.0
 


### PR DESCRIPTION
This PR pins the  `setuptools` max version to workaround https://github.com/numpy/numpy/issues/22623 and https://github.com/pypa/setuptools/issues/3693 until a more permanent solution for `astropy` can be found.