### PR TITLE
Add "windowed" centroids to SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ New Features
   - The progress bar used when deblending sources now is prepended with
     "Deblending". [#1439]
 
+  - Added "windowed" centroids to ``SourceCatalog``. [#1447]
+
 - ``photutils.utils``
 
   - Added ``xyorigin`` attribute to ``CutoutImage``. [#1419]

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1346,6 +1346,25 @@ class SourceCatalog:
             xcen_win.append(xcen)
             ycen_win.append(ycen)
 
+        xcen_win = np.array(xcen_win)
+        ycen_win = np.array(ycen_win)
+
+        # reset to the isophotal centroid if the windowed centroid is
+        # outside of the 1-sigma ellipse
+        dx = self._xcentroid - xcen_win
+        dy = self._ycentroid - ycen_win
+        cxx = self.cxx.value
+        cxy = self.cxy.value
+        cyy = self.cyy.value
+        if self.isscalar:
+            cxx = (cxx,)
+            cxy = (cxy,)
+            cyy = (cyy,)
+        idx = np.where((cxx * dx**2 + cxy * dx * dy + cyy * dy**2) > 1)[0]
+        if len(idx) > 0:
+            xcen_win[idx] = self._xcentroid[idx]
+            ycen_win[idx] = self._ycentroid[idx]
+
         return np.transpose((xcen_win, ycen_win))
 
     @lazyproperty

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1287,14 +1287,17 @@ class SourceCatalog:
     def centroid_win(self):
         radius_hl = self.fluxfrac_radius(0.5).value
         if self.isscalar:
-            radius_hl = (radius_hl,)
+            radius_hl = np.array([radius_hl])
+        min_radius = 0.5  # define minimum half-light radius
+        mask = (radius_hl < min_radius) | ~np.isfinite(radius_hl)
+        radius_hl[mask] = min_radius
 
         xcen_win = []
         ycen_win = []
         for label, xcen, ycen, rad_hl in zip(self.labels, self._xcentroid,
                                              self._ycentroid, radius_hl):
 
-            if np.any(~np.isfinite((xcen, ycen, rad_hl))):
+            if np.any(~np.isfinite((xcen, ycen))):
                 xcen_win.append(np.nan)
                 ycen_win.append(np.nan)
                 continue

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -307,7 +307,8 @@ class SourceCatalog:
         self._apermask_kwargs = {
             'circ': {'method': 'exact'},
             'kron': {'method': 'exact'},
-            'fluxfrac': {'method': 'exact'}
+            'fluxfrac': {'method': 'exact'},
+            'cen_win': {'method': 'center'}
         }
 
         self.default_columns = DEFAULT_COLUMNS
@@ -386,7 +387,8 @@ class SourceCatalog:
         self._apermask_kwargs = {
             'circ': {'method': 'subpixel', 'subpixels': 5},
             'kron': {'method': 'center'},
-            'fluxfrac': {'method': 'subpixel', 'subpixels': 5}
+            'fluxfrac': {'method': 'subpixel', 'subpixels': 5},
+            'cen_win': {'method': 'subpixel', 'subpixels': 11}
         }
 
     @property
@@ -1291,6 +1293,7 @@ class SourceCatalog:
         min_radius = 0.5  # define minimum half-light radius
         mask = (radius_hl < min_radius) | ~np.isfinite(radius_hl)
         radius_hl[mask] = min_radius
+        kwargs = self._apermask_kwargs['cen_win']
 
         xcen_win = []
         ycen_win = []
@@ -1312,10 +1315,7 @@ class SourceCatalog:
             centroid_threshold = 0.0001
             while iter_ < max_iters and dcen > centroid_threshold:
                 aperture = CircularAperture((xcen, ycen), radius)
-                method = 'subpixel'
-                subpixels = 11
-                aperture_mask = aperture.to_mask(method=method,
-                                                 subpixels=subpixels)
+                aperture_mask = aperture.to_mask(**kwargs)
 
                 # for consistency with the isophotal centroid, a local
                 # background is not subtracted here

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1204,7 +1204,7 @@ class SourceCatalog:
     def cutout_centroid(self):
         """
         The ``(x, y)`` coordinate, relative to the cutout data, of
-        the centroid within the source segment.
+        the centroid within the isophotal source segment.
 
         The centroid is computed as the center of mass of the unmasked
         pixels within the source segment.
@@ -1225,8 +1225,8 @@ class SourceCatalog:
     @as_scalar
     def centroid(self):
         """
-        The ``(x, y)`` coordinate of the centroid within the source
-        segment.
+        The ``(x, y)`` coordinate of the centroid within the isophotal
+        source segment.
 
         The centroid is computed as the center of mass of the unmasked
         pixels within the source segment.
@@ -1238,8 +1238,8 @@ class SourceCatalog:
     @use_detcat
     def _xcentroid(self):
         """
-        The ``x`` coordinate of the centroid within the source segment,
-        always as an iterable.
+        The ``x`` coordinate of the `centroid` within the source
+        segment, always as an iterable.
         """
         if self.isscalar:
             xcentroid = self.centroid[0:1]  # scalar array
@@ -1252,7 +1252,8 @@ class SourceCatalog:
     @as_scalar
     def xcentroid(self):
         """
-        The ``x`` coordinate of the centroid within the source segment.
+        The ``x`` coordinate of the `centroid` within the source
+        segment.
 
         The centroid is computed as the center of mass of the unmasked
         pixels within the source segment.
@@ -1263,8 +1264,8 @@ class SourceCatalog:
     @use_detcat
     def _ycentroid(self):
         """
-        The ``y`` coordinate of the centroid within the source segment,
-        always as an iterable.
+        The ``y`` coordinate of the `centroid` within the source
+        segment, always as an iterable.
         """
         if self.isscalar:
             ycentroid = self.centroid[1:2]  # scalar array
@@ -1277,7 +1278,8 @@ class SourceCatalog:
     @as_scalar
     def ycentroid(self):
         """
-        The ``y`` coordinate of the centroid within the source segment.
+        The ``y`` coordinate of the `centroid` within the source
+        segment.
 
         The centroid is computed as the center of mass of the unmasked
         pixels within the source segment.
@@ -1398,7 +1400,8 @@ class SourceCatalog:
     @as_scalar
     def xcentroid_win(self):
         """
-        The ``x`` coordinate of the "windowed" centroid.
+        The ``x`` coordinate of the "windowed" centroid
+        (`centroid_win`).
 
         The window centroid is computed using an iterative algorithm
         to derive a more accurate centroid. It is equivalent to
@@ -1415,7 +1418,8 @@ class SourceCatalog:
     @as_scalar
     def ycentroid_win(self):
         """
-        The ``y`` coordinate of the "windowed" centroid.
+        The ``y`` coordinate of the "windowed" centroid
+        (`centroid_win`).
 
         The window centroid is computed using an iterative algorithm
         to derive a more accurate centroid. It is equivalent to
@@ -1463,8 +1467,9 @@ class SourceCatalog:
     @as_scalar
     def sky_centroid_win(self):
         """
-        The sky coordinate of the "windowed" centroid within the source
-        segment, returned as a `~astropy.coordinates.SkyCoord` object.
+        The sky coordinate of the "windowed" centroid
+        (`centroid_win`) within the source segment, returned as a
+        `~astropy.coordinates.SkyCoord` object.
 
         The output coordinate frame is the same as the input ``wcs``.
 
@@ -1928,9 +1933,9 @@ class SourceCatalog:
     def background_centroid(self):
         """
         The value of the per-pixel ``background`` at the position of the
-        isophotal (center-of-mass) centroid.
+        isophotal (center-of-mass) `centroid`.
 
-        If ``detection_cat`` is input, then its centroid will be used.
+        If ``detection_cat`` is input, then its `centroid` will be used.
 
         The background value at fractional position values are
         determined using bilinear interpolation.
@@ -2531,7 +2536,7 @@ class SourceCatalog:
         """
         Make circular aperture for each source.
 
-        The aperture for each source will be centered at its centroid
+        The aperture for each source will be centered at its `centroid`
         position. If a ``detection_cat`` was input to `SourceCatalog`,
         it will be used for the source centroids.
 
@@ -2544,7 +2549,7 @@ class SourceCatalog:
         -------
         result : list of `~photutils.aperture.CircularAperture`
             A list of `~photutils.aperture.CircularAperture` instances.
-            The aperture will be `None` where the source centroid
+            The aperture will be `None` where the source `centroid`
             position is not finite or where the source is completely
             masked.
         """
@@ -2570,9 +2575,9 @@ class SourceCatalog:
         """
         Make circular aperture for each source.
 
-        The aperture for each source will be centered at its centroid
+        The aperture for each source will be centered at its `centroid`
         position. If a ``detection_cat`` was input to `SourceCatalog`,
-        it will be used for the source centroids.
+        then its `centroid` values will be used.
 
         Parameters
         ----------
@@ -2584,7 +2589,7 @@ class SourceCatalog:
         result : `~photutils.aperture.CircularAperture` or \
                  list of `~photutils.aperture.CircularAperture`
             The circular aperture for each source. The aperture will be
-            `None` where the source centroid position is not finite or
+            `None` where the source `centroid` position is not finite or
             where the source is completely masked.
         """
         return self._make_circular_apertures(radius)
@@ -2597,12 +2602,12 @@ class SourceCatalog:
         Plot circular apertures for each source on a matplotlib
         `~matplotlib.axes.Axes` instance.
 
-        The aperture for each source will be centered at its centroid
+        The aperture for each source will be centered at its `centroid`
         position. If a ``detection_cat`` was input to `SourceCatalog`,
-        it will be used for the source centroids.
+        then its `centroid` values will be used.
 
         An aperture will not be plotted for sources where the source
-        centroid position is not finite or where the source is
+        `centroid` position is not finite or where the source is
         completely masked.
 
         Parameters
@@ -2642,8 +2647,8 @@ class SourceCatalog:
         Perform circular aperture photometry for each source.
 
         The circular aperture for each source will be centered at
-        its centroid position. If a ``detection_cat`` was input to
-        `SourceCatalog`, it will be used for the source centroids.
+        its `centroid` position. If a ``detection_cat`` was input to
+        `SourceCatalog`, then its `centroid` values will be used.
 
         See the `SourceCatalog` ``apermask_method`` keyword for options
         to mask neighboring sources.
@@ -2669,8 +2674,8 @@ class SourceCatalog:
         flux, fluxerr : float or `~numpy.ndarray` of floats
             The aperture fluxes and flux errors. NaN will be returned
             where the aperture is `None` (e.g., where the source
-            centroid position is not finite or the source is completely
-            masked).
+            `centroid` position is not finite or the source is
+            completely masked).
         """
         if radius <= 0:
             raise ValueError('radius must be > 0')
@@ -2702,7 +2707,7 @@ class SourceCatalog:
         isophotal shape of the sources.
 
         If a ``detection_cat`` was input to `SourceCatalog`, then its
-        source centroids and shape parameters will be used.
+        source `centroid` and shape parameters will be used.
 
         If scale is zero (due to a minimum circular radius set in
         ``kron_params``) then a circular aperture will be returned with
@@ -2721,7 +2726,7 @@ class SourceCatalog:
         result : list of `~photutils.aperture.EllipticalAperture`
             A list of `~photutils.aperture.EllipticalAperture`
             instances. The aperture will be `None` where the source
-            centroid position or elliptical shape parameters are not
+            `centroid` position or elliptical shape parameters are not
             finite or where the source is completely masked.
         """
         xcen = self._xcentroid
@@ -2862,8 +2867,8 @@ class SourceCatalog:
                 cyy (y_i - \bar{y})^2
 
         where :math:`\bar{x}` and :math:`\bar{y}` represent the source
-        centroid and the coefficients are based on image moments (`cxx`,
-        `cxy`, and `cyy`).
+        `centroid` and the coefficients are based on image moments
+        (`cxx`, `cxy`, and `cyy`).
 
         The `kron_radius` value is the unscaled moment value. The
         minimum unscaled radius can be set using the second element of
@@ -2923,7 +2928,7 @@ class SourceCatalog:
         radius (``kron_params[2]``), then the Kron aperture will be a
         circle with this minimum radius.
 
-        The aperture will be `None` where the source centroid position
+        The aperture will be `None` where the source `centroid` position
         or elliptical shape parameters are not finite or where the
         source is completely masked.
 
@@ -2937,9 +2942,9 @@ class SourceCatalog:
         """
         Make Kron apertures for each source.
 
-        The aperture for each source will be centered at its centroid
+        The aperture for each source will be centered at its `centroid`
         position. If a ``detection_cat`` was input to `SourceCatalog`,
-        it will be used for the source centroids.
+        then its `centroid` values will be used.
 
         Note that changing ``kron_params`` from the values
         input into `SourceCatalog` does not change the Kron
@@ -2970,7 +2975,7 @@ class SourceCatalog:
             The Kron apertures for each source. Each aperture will
             either be a `~photutils.aperture.EllipticalAperture`,
             `~photutils.aperture.CircularAperture`, or `None`. The
-            aperture will be `None` where the source centroid position
+            aperture will be `None` where the source `centroid` position
             or elliptical shape parameters are not finite or where the
             source is completely masked.
         """
@@ -2986,13 +2991,13 @@ class SourceCatalog:
         Plot Kron apertures for each source on a matplotlib
         `~matplotlib.axes.Axes` instance.
 
-        The aperture for each source will be centered at its centroid
+        The aperture for each source will be centered at its `centroid`
         position. If a ``detection_cat`` was input to `SourceCatalog`,
-        it will be used for the source centroids.
+        then its `centroid` values will be used.
 
         An aperture will not be plotted for sources where the source
-        centroid position or elliptical shape parameters are not finite
-        or where the source is completely masked.
+        `centroid` position or elliptical shape parameters are not
+        finite or where the source is completely masked.
 
         Note that changing ``kron_params`` from the values
         input into `SourceCatalog` does not change the Kron
@@ -3126,7 +3131,8 @@ class SourceCatalog:
         If the Kron aperture is `None`, then ``np.nan`` will be
         returned.
 
-        If ``detection_cat`` is input, then its centroids are used.
+        If ``detection_cat`` is input, then its `centroid` values will
+        be used.
 
         Returns
         -------
@@ -3187,7 +3193,7 @@ class SourceCatalog:
         flux, fluxerr : float or `~numpy.ndarray` of floats
             The aperture fluxes and flux errors. NaN will be returned
             where the aperture is `None` (e.g., where the source
-            centroid position or elliptical shape parameters are not
+            `centroid` position or elliptical shape parameters are not
             finite or where the source is completely masked).
         """
         kron_flux, kron_fluxerr = self._calc_kron_photometry(kron_params)
@@ -3217,9 +3223,9 @@ class SourceCatalog:
         to mask neighboring sources.
 
         If the Kron aperture is `None`, then ``np.nan`` will be
-        returned. This will occur where the source centroid position or
-        elliptical shape parameters are not finite or where the source
-        is completely masked
+        returned. This will occur where the source `centroid` position
+        or elliptical shape parameters are not finite or where the
+        source is completely masked.
         """
         return np.transpose(self._calc_kron_photometry(kron_params=None))
 
@@ -3233,9 +3239,9 @@ class SourceCatalog:
         to mask neighboring sources.
 
         If the Kron aperture is `None`, then ``np.nan`` will be
-        returned. This will occur where the source centroid position or
-        elliptical shape parameters are not finite or where the source
-        is completely masked
+        returned. This will occur where the source `centroid` position
+        or elliptical shape parameters are not finite or where the
+        source is completely masked.
         """
         kron_flux = self._kron_photometry[:, 0]
         if self._data_unit is not None:
@@ -3252,9 +3258,9 @@ class SourceCatalog:
         to mask neighboring sources.
 
         If the Kron aperture is `None`, then ``np.nan`` will be
-        returned. This will occur where the source centroid position or
-        elliptical shape parameters are not finite or where the source
-        is completely masked
+        returned. This will occur where the source `centroid` position
+        or elliptical shape parameters are not finite or where the
+        source is completely masked.
         """
         kron_fluxerr = self._kron_photometry[:, 1]
         if self._data_unit is not None:
@@ -3408,9 +3414,9 @@ class SourceCatalog:
         """
         Make cutout arrays for each source.
 
-        The cutout for each source will be centered at its centroid
+        The cutout for each source will be centered at its `centroid`
         position. If a ``detection_cat`` was input to `SourceCatalog`,
-        it will be used for the source centroids.
+        then its `centroid` values will be used.
 
         Parameters
         ----------
@@ -3439,8 +3445,8 @@ class SourceCatalog:
         cutouts : `~photutils.utils.CutoutImage` \
                   or list of `~photutils.utils.CutoutImage`
             The `~photutils.utils.CutoutImage` for each source. The
-            cutout will be `None` where the source centroid position is
-            not finite or where the source is completely masked.
+            cutout will be `None` where the source `centroid` position
+            is not finite or where the source is completely masked.
         """
         if mode not in ('partial', 'trim'):
             raise ValueError('mode must be "partial" or "trim"')

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -881,3 +881,30 @@ def test_kron_params():
     rh = cat.fluxfrac_radius(0.5)
     assert_allclose(rh.value.min(), 1.3649418211298536)
     assert isinstance(cat.kron_aperture[0], CircularAperture)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_centroid_win():
+    g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
+    g2 = Gaussian2D(3596, 13.81, 8.29, 1.44, 1.27, 0.628319)
+    m = g1 + g2
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = m(xx, yy)
+    noise = make_noise_image(data.shape, mean=0, stddev=65.0, seed=123)
+    data += noise
+
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    npixels = 10
+    finder = SourceFinder(npixels=npixels, progress_bar=False)
+    threshold = 107.9
+    segment_map = finder(convolved_data, threshold)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        apermask_method='none')
+
+    assert cat.xcentroid[0] != cat.xcentroid_win[0]
+    assert cat.ycentroid[0] != cat.ycentroid_win[0]
+    # centroid_win moved beyond 1-sigma ellipse and was reset to
+    # isophotal centroid
+    assert cat.xcentroid[1] == cat.xcentroid_win[1]
+    assert cat.ycentroid[1] == cat.ycentroid_win[1]

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -351,6 +351,7 @@ class TestSourceCatalog:
         obj = cat[0]
         assert obj.sky_centroid is not None
         assert obj.sky_centroid_icrs is not None
+        assert obj.sky_centroid_win is not None
         assert obj.sky_bbox_ll is not None
         assert obj.sky_bbox_ul is not None
         assert obj.sky_bbox_lr is not None
@@ -363,6 +364,7 @@ class TestSourceCatalog:
         obj = cat[1]
         assert obj.sky_centroid is not None
         assert obj.sky_centroid_icrs is not None
+        assert obj.sky_centroid_win is not None
         assert obj.sky_bbox_ll is not None
         assert obj.sky_bbox_ul is not None
         assert obj.sky_bbox_lr is not None
@@ -373,6 +375,7 @@ class TestSourceCatalog:
         obj = cat[2]
         assert obj.sky_centroid is None
         assert obj.sky_centroid_icrs is None
+        assert obj.sky_centroid_win is None
         assert obj.sky_bbox_ll is None
         assert obj.sky_bbox_ul is None
         assert obj.sky_bbox_lr is None

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -908,3 +908,24 @@ def test_centroid_win():
     # isophotal centroid
     assert cat.xcentroid[1] == cat.xcentroid_win[1]
     assert cat.ycentroid[1] == cat.ycentroid_win[1]
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_centroid_win_migrate():
+    """
+    Test that when the windowed centroid moves the aperture completely
+    off the image the isophotal centroid is returned.
+    """
+    g1 = Gaussian2D(1621, 76.29, 185.95, 1.55, 1.29, 0.296706)
+    g2 = Gaussian2D(3596, 83.81, 182.29, 1.44, 1.27, 0.628319)
+    m = g1 + g2
+    yy, xx = np.mgrid[0:256, 0:256]
+    data = m(xx, yy)
+    noise = make_noise_image(data.shape, mean=0, stddev=65.0, seed=123)
+    data += noise
+    segm = detect_sources(data, 98.0, npixels=5)
+    cat = SourceCatalog(data, segm)
+
+    indices = (0, 3, 14, 30)
+    for idx in indices:
+        assert_equal(cat.centroid_win[idx], cat.centroid[idx])


### PR DESCRIPTION
This PR adds "windowed" centroids to `SourceCatalog`. The new properties are `centroid_win`, `xcentroid_win`, `ycentroid_win`, and `sky_centroid_win`.