### PR TITLE
Use absolute imports

### DIFF
--- a/photutils/aperture/_photometry_utils.py
+++ b/photutils/aperture/_photometry_utils.py
@@ -3,7 +3,6 @@
 This module contains tools to validate and handle photometry inputs.
 """
 
-
 import numpy as np
 
 

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -2,6 +2,7 @@
 """
 This module defines a class for a rectangular bounding box.
 """
+
 import math
 
 import numpy as np
@@ -278,7 +279,8 @@ class BoundingBox:
         Return a `~photutils.aperture.RectangularAperture` that
         represents the bounding box.
         """
-        from .rectangle import RectangularAperture  # prevent circular import
+        # prevent circular import
+        from photutils.aperture.rectangle import RectangularAperture
 
         xypos = self.center[::-1]  # xy order
         height, width = self.shape

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -7,6 +7,7 @@ pixel and sky coordinates.
 import math
 
 from astropy.utils import lazyproperty
+
 from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            PositiveScalarAngle,
                                            SkyCoordPositions)

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -7,12 +7,12 @@ pixel and sky coordinates.
 import math
 
 from astropy.utils import lazyproperty
-
-from ..geometry import circular_overlap_grid
-from .attributes import (PixelPositions, PositiveScalar, PositiveScalarAngle,
-                         SkyCoordPositions)
-from .core import PixelAperture, SkyAperture
-from .mask import ApertureMask
+from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
+                                           PositiveScalarAngle,
+                                           SkyCoordPositions)
+from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.aperture.mask import ApertureMask
+from photutils.geometry import circular_overlap_grid
 
 __all__ = ['CircularMaskMixin', 'CircularAperture', 'CircularAnnulus',
            'SkyCircularAperture', 'SkyCircularAnnulus']

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -12,11 +12,11 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
-
-from ..utils._wcs_helpers import _pixel_scale_angle_at_skycoord
-from ._photometry_utils import (_handle_units, _prepare_photometry_data,
-                                _validate_inputs)
-from .bounding_box import BoundingBox
+from photutils.aperture._photometry_utils import (_handle_units,
+                                                  _prepare_photometry_data,
+                                                  _validate_inputs)
+from photutils.aperture.bounding_box import BoundingBox
+from photutils.utils._wcs_helpers import _pixel_scale_angle_at_skycoord
 
 __all__ = ['Aperture', 'SkyAperture', 'PixelAperture']
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -12,6 +12,7 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
+
 from photutils.aperture._photometry_utils import (_handle_units,
                                                   _prepare_photometry_data,
                                                   _validate_inputs)

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -8,6 +8,7 @@ import math
 
 import astropy.units as u
 import numpy as np
+
 from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            PositiveScalarAngle, ScalarAngle,
                                            ScalarAngleOrValue,

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -8,12 +8,13 @@ import math
 
 import astropy.units as u
 import numpy as np
-
-from ..geometry import elliptical_overlap_grid
-from .attributes import (PixelPositions, PositiveScalar, PositiveScalarAngle,
-                         ScalarAngle, ScalarAngleOrValue, SkyCoordPositions)
-from .core import PixelAperture, SkyAperture
-from .mask import ApertureMask
+from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
+                                           PositiveScalarAngle, ScalarAngle,
+                                           ScalarAngleOrValue,
+                                           SkyCoordPositions)
+from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.aperture.mask import ApertureMask
+from photutils.geometry import elliptical_overlap_grid
 
 __all__ = ['EllipticalMaskMixin', 'EllipticalAperture', 'EllipticalAnnulus',
            'SkyEllipticalAperture', 'SkyEllipticalAnnulus']

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -2,6 +2,7 @@
 """
 This module defines a class for aperture masks.
 """
+
 import warnings
 
 import astropy.units as u

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.aperture._photometry_utils import (_handle_units,
                                                   _prepare_photometry_data,
                                                   _validate_inputs)

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -10,11 +10,11 @@ import numpy as np
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..utils._misc import _get_version_info
-from ._photometry_utils import (_handle_units, _prepare_photometry_data,
-                                _validate_inputs)
-from .core import Aperture, SkyAperture
+from photutils.aperture._photometry_utils import (_handle_units,
+                                                  _prepare_photometry_data,
+                                                  _validate_inputs)
+from photutils.aperture.core import Aperture, SkyAperture
+from photutils.utils._misc import _get_version_info
 
 __all__ = ['aperture_photometry']
 

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -8,12 +8,13 @@ import math
 
 import astropy.units as u
 import numpy as np
-
-from ..geometry import rectangular_overlap_grid
-from .attributes import (PixelPositions, PositiveScalar, PositiveScalarAngle,
-                         ScalarAngle, ScalarAngleOrValue, SkyCoordPositions)
-from .core import PixelAperture, SkyAperture
-from .mask import ApertureMask
+from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
+                                           PositiveScalarAngle, ScalarAngle,
+                                           ScalarAngleOrValue,
+                                           SkyCoordPositions)
+from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.aperture.mask import ApertureMask
+from photutils.geometry import rectangular_overlap_grid
 
 __all__ = ['RectangularMaskMixin', 'RectangularAperture',
            'RectangularAnnulus', 'SkyRectangularAperture',

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -8,6 +8,7 @@ import math
 
 import astropy.units as u
 import numpy as np
+
 from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            PositiveScalarAngle, ScalarAngle,
                                            ScalarAngleOrValue,

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -17,11 +17,10 @@ from astropy.stats import (SigmaClip, biweight_location, biweight_midvariance,
 from astropy.table import QTable
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..utils._misc import _get_meta
-from ..utils._moments import _moments, _moments_central
-from ..utils._quantity_helpers import process_quantities
-from . import Aperture, SkyAperture
+from photutils.aperture import Aperture, SkyAperture
+from photutils.utils._misc import _get_meta
+from photutils.utils._moments import _moments, _moments_central
+from photutils.utils._quantity_helpers import process_quantities
 
 __all__ = ['ApertureStats']
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -17,6 +17,7 @@ from astropy.stats import (SigmaClip, biweight_location, biweight_midvariance,
 from astropy.table import QTable
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.aperture import Aperture, SkyAperture
 from photutils.utils._misc import _get_meta
 from photutils.utils._moments import _moments, _moments_central

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -5,10 +5,9 @@ Tests for the bounding_box module.
 
 import pytest
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_MATPLOTLIB  # noqa
-from ..bounding_box import BoundingBox
-from ..rectangle import RectangularAperture
+from photutils.aperture.bounding_box import BoundingBox
+from photutils.aperture.rectangle import RectangularAperture
+from photutils.utils._optional_deps import HAS_MATPLOTLIB  # noqa
 
 
 def test_bounding_box_init():

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -5,6 +5,7 @@ Tests for the bounding_box module.
 
 import pytest
 from numpy.testing import assert_allclose
+
 from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.rectangle import RectangularAperture
 from photutils.utils._optional_deps import HAS_MATPLOTLIB  # noqa

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
+
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAnnulus, SkyCircularAperture)
 from photutils.aperture.tests.test_aperture_common import BaseTestAperture

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -8,11 +8,10 @@ import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_MATPLOTLIB  # noqa
-from ..circle import (CircularAnnulus, CircularAperture, SkyCircularAnnulus,
-                      SkyCircularAperture)
-from .test_aperture_common import BaseTestAperture
+from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
+                                       SkyCircularAnnulus, SkyCircularAperture)
+from photutils.aperture.tests.test_aperture_common import BaseTestAperture
+from photutils.utils._optional_deps import HAS_MATPLOTLIB  # noqa
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
+
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus,
                                         SkyEllipticalAperture)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -7,10 +7,10 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
-
-from ..ellipse import (EllipticalAnnulus, EllipticalAperture,
-                       SkyEllipticalAnnulus, SkyEllipticalAperture)
-from .test_aperture_common import BaseTestAperture
+from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
+                                        SkyEllipticalAnnulus,
+                                        SkyEllipticalAperture)
+from photutils.aperture.tests.test_aperture_common import BaseTestAperture
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -7,11 +7,10 @@ import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal
-
-from ..bounding_box import BoundingBox
-from ..circle import CircularAnnulus, CircularAperture
-from ..mask import ApertureMask
-from ..rectangle import RectangularAnnulus
+from photutils.aperture.bounding_box import BoundingBox
+from photutils.aperture.circle import CircularAnnulus, CircularAperture
+from photutils.aperture.mask import ApertureMask
+from photutils.aperture.rectangle import RectangularAnnulus
 
 POSITIONS = [(-20, -20), (-20, 20), (20, -20), (60, 60)]
 

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal
+
 from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.circle import CircularAnnulus, CircularAperture
 from photutils.aperture.mask import ApertureMask

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -13,16 +13,19 @@ from astropy.table import Table
 from astropy.wcs import WCS
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_less)
-
-from ...datasets import get_path, make_4gaussians_image, make_gwcs, make_wcs
-from ...utils._optional_deps import HAS_GWCS, HAS_MATPLOTLIB  # noqa
-from ..circle import (CircularAnnulus, CircularAperture, SkyCircularAnnulus,
-                      SkyCircularAperture)
-from ..ellipse import (EllipticalAnnulus, EllipticalAperture,
-                       SkyEllipticalAnnulus, SkyEllipticalAperture)
-from ..photometry import aperture_photometry
-from ..rectangle import (RectangularAnnulus, RectangularAperture,
-                         SkyRectangularAnnulus, SkyRectangularAperture)
+from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
+                                       SkyCircularAnnulus, SkyCircularAperture)
+from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
+                                        SkyEllipticalAnnulus,
+                                        SkyEllipticalAperture)
+from photutils.aperture.photometry import aperture_photometry
+from photutils.aperture.rectangle import (RectangularAnnulus,
+                                          RectangularAperture,
+                                          SkyRectangularAnnulus,
+                                          SkyRectangularAperture)
+from photutils.datasets import (get_path, make_4gaussians_image, make_gwcs,
+                                make_wcs)
+from photutils.utils._optional_deps import HAS_GWCS, HAS_MATPLOTLIB  # noqa
 
 APERTURE_CL = [CircularAperture,
                CircularAnnulus,

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -13,6 +13,7 @@ from astropy.table import Table
 from astropy.wcs import WCS
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_less)
+
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAnnulus, SkyCircularAperture)
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
+
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture,
                                           SkyRectangularAnnulus,

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -7,10 +7,11 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
-
-from ..rectangle import (RectangularAnnulus, RectangularAperture,
-                         SkyRectangularAnnulus, SkyRectangularAperture)
-from .test_aperture_common import BaseTestAperture
+from photutils.aperture.rectangle import (RectangularAnnulus,
+                                          RectangularAperture,
+                                          SkyRectangularAnnulus,
+                                          SkyRectangularAperture)
+from photutils.aperture.tests.test_aperture_common import BaseTestAperture
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -9,10 +9,9 @@ import pytest
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.stats import SigmaClip
 from numpy.testing import assert_allclose, assert_equal
-
-from ...datasets import make_100gaussians_image, make_wcs
-from ..circle import CircularAperture
-from ..stats import ApertureStats
+from photutils.aperture.circle import CircularAperture
+from photutils.aperture.stats import ApertureStats
+from photutils.datasets import make_100gaussians_image, make_wcs
 
 
 class TestApertureStats:

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -9,6 +9,7 @@ import pytest
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.stats import SigmaClip
 from numpy.testing import assert_allclose, assert_equal
+
 from photutils.aperture.circle import CircularAperture
 from photutils.aperture.stats import ApertureStats
 from photutils.datasets import make_100gaussians_image, make_wcs

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -14,12 +14,12 @@ from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.lib.index_tricks import index_exp
-
-from ..utils import ShepardIDWInterpolator
-from ..utils._parameters import as_pair
-from ..utils._stats import nanmedian
-from .core import SExtractorBackground, StdBackgroundRMS
-from .interpolators import BkgZoomInterpolator
+from photutils.aperture import RectangularAperture
+from photutils.background.core import SExtractorBackground, StdBackgroundRMS
+from photutils.background.interpolators import BkgZoomInterpolator
+from photutils.utils import ShepardIDWInterpolator
+from photutils.utils._parameters import as_pair
+from photutils.utils._stats import nanmedian
 
 __all__ = ['Background2D']
 
@@ -704,7 +704,6 @@ class Background2D:
                    color=color, alpha=alpha)
 
         if outlines:
-            from ..aperture import RectangularAperture
             xypos = np.column_stack(self._mesh_xypos)
             apers = RectangularAperture(xypos, self.box_size[1],
                                         self.box_size[0], 0.)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -14,6 +14,7 @@ from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.lib.index_tricks import index_exp
+
 from photutils.aperture import RectangularAperture
 from photutils.background.core import SExtractorBackground, StdBackgroundRMS
 from photutils.background.interpolators import BkgZoomInterpolator

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -9,8 +9,7 @@ import warnings
 
 import numpy as np
 from astropy.stats import SigmaClip, biweight_location, biweight_scale, mad_std
-
-from ..utils._stats import nanmean, nanmedian, nanstd
+from photutils.utils._stats import nanmean, nanmedian, nanstd
 
 SIGMA_CLIP = SigmaClip(sigma=3.0, maxiters=10)
 

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -9,6 +9,7 @@ import warnings
 
 import numpy as np
 from astropy.stats import SigmaClip, biweight_location, biweight_scale, mad_std
+
 from photutils.utils._stats import nanmean, nanmedian, nanstd
 
 SIGMA_CLIP = SigmaClip(sigma=3.0, maxiters=10)

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -4,6 +4,7 @@ This module defines interpolator classes for Background2D.
 """
 
 import numpy as np
+
 from photutils.utils import ShepardIDWInterpolator
 
 __all__ = ['BkgZoomInterpolator', 'BkgIDWInterpolator']

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -4,8 +4,7 @@ This module defines interpolator classes for Background2D.
 """
 
 import numpy as np
-
-from ..utils import ShepardIDWInterpolator
+from photutils.utils import ShepardIDWInterpolator
 
 __all__ = ['BkgZoomInterpolator', 'BkgIDWInterpolator']
 

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -11,6 +11,7 @@ import pytest
 from astropy.nddata import CCDData, NDData
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
+
 from photutils.background.background_2d import Background2D
 from photutils.background.core import MeanBackground
 from photutils.background.interpolators import (BkgIDWInterpolator,

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -11,11 +11,11 @@ import pytest
 from astropy.nddata import CCDData, NDData
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
-
-from ...utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY  # noqa
-from ..background_2d import Background2D
-from ..core import MeanBackground
-from ..interpolators import BkgIDWInterpolator, BkgZoomInterpolator
+from photutils.background.background_2d import Background2D
+from photutils.background.core import MeanBackground
+from photutils.background.interpolators import (BkgIDWInterpolator,
+                                                BkgZoomInterpolator)
+from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY  # noqa
 
 DATA = np.ones((100, 100))
 BKG_RMS = np.zeros((100, 100))

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from astropy.stats import SigmaClip
 from numpy.testing import assert_allclose
+
 from photutils.background.core import (BiweightLocationBackground,
                                        BiweightScaleBackgroundRMS,
                                        MADStdBackgroundRMS, MeanBackground,

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -8,12 +8,13 @@ import numpy as np
 import pytest
 from astropy.stats import SigmaClip
 from numpy.testing import assert_allclose
-
-from ...datasets import make_noise_image
-from ..core import (BiweightLocationBackground, BiweightScaleBackgroundRMS,
-                    MADStdBackgroundRMS, MeanBackground, MedianBackground,
-                    MMMBackground, ModeEstimatorBackground,
-                    SExtractorBackground, StdBackgroundRMS)
+from photutils.background.core import (BiweightLocationBackground,
+                                       BiweightScaleBackgroundRMS,
+                                       MADStdBackgroundRMS, MeanBackground,
+                                       MedianBackground, MMMBackground,
+                                       ModeEstimatorBackground,
+                                       SExtractorBackground, StdBackgroundRMS)
+from photutils.datasets import make_noise_image
 
 BKG = 0.0
 STD = 0.5

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 from astropy.nddata.utils import overlap_slices
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.utils._parameters import as_pair
 from photutils.utils._round import _py2intround
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -9,9 +9,8 @@ import warnings
 import numpy as np
 from astropy.nddata.utils import overlap_slices
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..utils._parameters import as_pair
-from ..utils._round import _py2intround
+from photutils.utils._parameters import as_pair
+from photutils.utils._round import _py2intround
 
 __all__ = ['centroid_com', 'centroid_quadratic', 'centroid_sources']
 

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -156,7 +156,8 @@ def centroid_2dg(data, error=None, mask=None):
     centroid : `~numpy.ndarray`
         The ``x, y`` coordinates of the centroid.
     """
-    from ..morphology import data_properties  # prevent circular imports
+    # prevent circular import
+    from photutils.morphology import data_properties
 
     data = np.ma.asanyarray(data)
 

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -11,6 +11,7 @@ import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
+
 from photutils.centroids.core import (centroid_com, centroid_quadratic,
                                       centroid_sources)
 from photutils.centroids.gaussian import centroid_1dg, centroid_2dg

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -11,10 +11,10 @@ import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..core import centroid_com, centroid_quadratic, centroid_sources
-from ..gaussian import centroid_1dg, centroid_2dg
+from photutils.centroids.core import (centroid_com, centroid_quadratic,
+                                      centroid_sources)
+from photutils.centroids.gaussian import centroid_1dg, centroid_2dg
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 XCEN = 25.7
 YCEN = 26.2

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -11,9 +11,9 @@ import pytest
 from astropy.modeling.models import Gaussian1D, Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..gaussian import _gaussian1d_moments, centroid_1dg, centroid_2dg
+from photutils.centroids.gaussian import (_gaussian1d_moments, centroid_1dg,
+                                          centroid_2dg)
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 XCEN = 25.7
 YCEN = 26.2

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -11,6 +11,7 @@ import pytest
 from astropy.modeling.models import Gaussian1D, Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
+
 from photutils.centroids.gaussian import (_gaussian1d_moments, centroid_1dg,
                                           centroid_2dg)
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -12,6 +12,7 @@ from astropy.io import fits
 from astropy.modeling import models
 from astropy.table import QTable
 from astropy.wcs import WCS
+
 from photutils.psf import IntegratedGaussianPRF
 from photutils.utils._misc import _get_version_info
 

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -12,9 +12,8 @@ from astropy.io import fits
 from astropy.modeling import models
 from astropy.table import QTable
 from astropy.wcs import WCS
-
-from ..psf import IntegratedGaussianPRF
-from ..utils._misc import _get_version_info
+from photutils.psf import IntegratedGaussianPRF
+from photutils.utils._misc import _get_version_info
 
 __all__ = ['apply_poisson_noise', 'make_noise_image',
            'make_random_models_table', 'make_random_gaussians_table',

--- a/photutils/datasets/tests/test_load.py
+++ b/photutils/datasets/tests/test_load.py
@@ -4,8 +4,7 @@ Tests for the load module.
 """
 
 import pytest
-
-from .. import get_path, load
+from photutils.datasets import get_path, load
 
 
 def test_get_path():

--- a/photutils/datasets/tests/test_load.py
+++ b/photutils/datasets/tests/test_load.py
@@ -4,6 +4,7 @@ Tests for the load module.
 """
 
 import pytest
+
 from photutils.datasets import get_path, load
 
 

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -8,14 +8,14 @@ import pytest
 from astropy.modeling.models import Moffat2D
 from astropy.table import Table
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_GWCS, HAS_SCIPY  # noqa
-from .. import (apply_poisson_noise, make_4gaussians_image,
-                make_100gaussians_image, make_gaussian_prf_sources_image,
-                make_gaussian_sources_image, make_gwcs,
-                make_model_sources_image, make_noise_image,
-                make_random_gaussians_table, make_random_models_table,
-                make_wcs)
+from photutils.datasets import (apply_poisson_noise, make_4gaussians_image,
+                                make_100gaussians_image,
+                                make_gaussian_prf_sources_image,
+                                make_gaussian_sources_image, make_gwcs,
+                                make_model_sources_image, make_noise_image,
+                                make_random_gaussians_table,
+                                make_random_models_table, make_wcs)
+from photutils.utils._optional_deps import HAS_GWCS, HAS_SCIPY  # noqa
 
 SOURCE_TABLE = Table()
 SOURCE_TABLE['flux'] = [1, 2, 3]

--- a/photutils/datasets/tests/test_make.py
+++ b/photutils/datasets/tests/test_make.py
@@ -8,6 +8,7 @@ import pytest
 from astropy.modeling.models import Moffat2D
 from astropy.table import Table
 from numpy.testing import assert_allclose
+
 from photutils.datasets import (apply_poisson_noise, make_4gaussians_image,
                                 make_100gaussians_image,
                                 make_gaussian_prf_sources_image,

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -11,9 +11,8 @@ import warnings
 
 import numpy as np
 from astropy.stats import gaussian_fwhm_to_sigma
-
-from ..utils.exceptions import NoDetectionsWarning
-from .peakfinder import find_peaks
+from photutils.detection.peakfinder import find_peaks
+from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['StarFinderBase']
 

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -11,6 +11,7 @@ import warnings
 
 import numpy as np
 from astropy.stats import gaussian_fwhm_to_sigma
+
 from photutils.detection.peakfinder import find_peaks
 from photutils.utils.exceptions import NoDetectionsWarning
 

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.nddata import extract_array
 from astropy.table import QTable
 from astropy.utils import lazyproperty
+
 from photutils.detection.core import StarFinderBase, _StarFinderKernel
 from photutils.utils._convolution import _filter_data
 from photutils.utils._misc import _get_version_info

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -2,6 +2,7 @@
 """
 This module implements the DAOStarFinder class.
 """
+
 import inspect
 import warnings
 
@@ -9,11 +10,10 @@ import numpy as np
 from astropy.nddata import extract_array
 from astropy.table import QTable
 from astropy.utils import lazyproperty
-
-from ..utils._convolution import _filter_data
-from ..utils._misc import _get_version_info
-from ..utils.exceptions import NoDetectionsWarning
-from .core import StarFinderBase, _StarFinderKernel
+from photutils.detection.core import StarFinderBase, _StarFinderKernel
+from photutils.utils._convolution import _filter_data
+from photutils.utils._misc import _get_version_info
+from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['DAOStarFinder']
 

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.nddata import extract_array
 from astropy.table import QTable
 from astropy.utils import lazyproperty
+
 from photutils.detection.core import StarFinderBase, _StarFinderKernel
 from photutils.utils._convolution import _filter_data
 from photutils.utils._misc import _get_version_info

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -2,6 +2,7 @@
 """
 This module implements the IRAFStarFinder class.
 """
+
 import inspect
 import warnings
 
@@ -9,12 +10,11 @@ import numpy as np
 from astropy.nddata import extract_array
 from astropy.table import QTable
 from astropy.utils import lazyproperty
-
-from ..utils._convolution import _filter_data
-from ..utils._misc import _get_version_info
-from ..utils._moments import _moments, _moments_central
-from ..utils.exceptions import NoDetectionsWarning
-from .core import StarFinderBase, _StarFinderKernel
+from photutils.detection.core import StarFinderBase, _StarFinderKernel
+from photutils.utils._convolution import _filter_data
+from photutils.utils._misc import _get_version_info
+from photutils.utils._moments import _moments, _moments_central
+from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['IRAFStarFinder']
 

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -8,9 +8,8 @@ import warnings
 
 import numpy as np
 from astropy.table import QTable
-
-from ..utils._misc import _get_version_info
-from ..utils.exceptions import NoDetectionsWarning
+from photutils.utils._misc import _get_version_info
+from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['find_peaks']
 
@@ -177,7 +176,8 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
 
     # perform centroiding
     if centroid_func is not None:
-        from ..centroids import centroid_sources  # prevents circular import
+        # prevent circular import
+        from photutils.centroids import centroid_sources
 
         if not callable(centroid_func):
             raise TypeError('centroid_func must be a callable object')

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -8,6 +8,7 @@ import warnings
 
 import numpy as np
 from astropy.table import QTable
+
 from photutils.utils._misc import _get_version_info
 from photutils.utils.exceptions import NoDetectionsWarning
 

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -10,12 +10,11 @@ import numpy as np
 from astropy.nddata import overlap_slices
 from astropy.table import QTable
 from astropy.utils import lazyproperty
-
-from ..utils._convolution import _filter_data
-from ..utils._misc import _get_version_info
-from ..utils._moments import _moments, _moments_central
-from ..utils.exceptions import NoDetectionsWarning
-from .core import StarFinderBase
+from photutils.detection.core import StarFinderBase
+from photutils.utils._convolution import _filter_data
+from photutils.utils._misc import _get_version_info
+from photutils.utils._moments import _moments, _moments_central
+from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['StarFinder']
 

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.nddata import overlap_slices
 from astropy.table import QTable
 from astropy.utils import lazyproperty
+
 from photutils.detection.core import StarFinderBase
 from photutils.utils._convolution import _filter_data
 from photutils.utils._misc import _get_version_info

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -10,11 +10,10 @@ import numpy as np
 import pytest
 from astropy.table import Table
 from numpy.testing import assert_allclose
-
-from ...datasets import make_100gaussians_image
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ...utils.exceptions import NoDetectionsWarning
-from ..daofinder import DAOStarFinder
+from photutils.datasets import make_100gaussians_image
+from photutils.detection.daofinder import DAOStarFinder
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
+from photutils.utils.exceptions import NoDetectionsWarning
 
 DATA = make_100gaussians_image()
 THRESHOLDS = [8.0, 10.0]

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from astropy.table import Table
 from numpy.testing import assert_allclose
+
 from photutils.datasets import make_100gaussians_image
 from photutils.detection.daofinder import DAOStarFinder
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from astropy.table import Table
 from numpy.testing import assert_allclose
+
 from photutils.datasets import make_100gaussians_image
 from photutils.detection.irafstarfinder import IRAFStarFinder
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -10,11 +10,10 @@ import numpy as np
 import pytest
 from astropy.table import Table
 from numpy.testing import assert_allclose
-
-from ...datasets import make_100gaussians_image
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ...utils.exceptions import NoDetectionsWarning
-from ..irafstarfinder import IRAFStarFinder
+from photutils.datasets import make_100gaussians_image
+from photutils.detection.irafstarfinder import IRAFStarFinder
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
+from photutils.utils.exceptions import NoDetectionsWarning
 
 DATA = make_100gaussians_image()
 THRESHOLDS = [8.0, 10.0]

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -7,12 +7,11 @@ import numpy as np
 import pytest
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_array_equal
-
-from ...centroids import centroid_com
-from ...datasets import make_4gaussians_image, make_gwcs, make_wcs
-from ...utils._optional_deps import HAS_GWCS, HAS_SCIPY  # noqa
-from ...utils.exceptions import NoDetectionsWarning
-from ..peakfinder import find_peaks
+from photutils.centroids import centroid_com
+from photutils.datasets import make_4gaussians_image, make_gwcs, make_wcs
+from photutils.detection.peakfinder import find_peaks
+from photutils.utils._optional_deps import HAS_GWCS, HAS_SCIPY  # noqa
+from photutils.utils.exceptions import NoDetectionsWarning
 
 PEAKDATA = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1]]).astype(float)
 PEAKREF1 = np.array([[0, 0], [2, 2]])

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_array_equal
+
 from photutils.centroids import centroid_com
 from photutils.datasets import make_4gaussians_image, make_gwcs, make_wcs
 from photutils.detection.peakfinder import find_peaks

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -6,6 +6,7 @@ Tests for StarFinder.
 import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
+
 from photutils.datasets import make_100gaussians_image
 from photutils.detection.starfinder import StarFinder
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -6,11 +6,10 @@ Tests for StarFinder.
 import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
-
-from ...datasets import make_100gaussians_image
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ...utils.exceptions import NoDetectionsWarning
-from ..starfinder import StarFinder
+from photutils.datasets import make_100gaussians_image
+from photutils.detection.starfinder import StarFinder
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
+from photutils.utils.exceptions import NoDetectionsWarning
 
 DATA = make_100gaussians_image()
 y, x = np.mgrid[0:25, 0:25]

--- a/photutils/geometry/tests/test_circular_overlap_grid.py
+++ b/photutils/geometry/tests/test_circular_overlap_grid.py
@@ -8,7 +8,7 @@ import itertools
 import pytest
 from numpy.testing import assert_allclose
 
-from .. import circular_overlap_grid
+from photutils.geometry import circular_overlap_grid
 
 grid_sizes = [50, 500, 1000]
 circ_sizes = [0.2, 0.4, 0.8]

--- a/photutils/geometry/tests/test_elliptical_overlap_grid.py
+++ b/photutils/geometry/tests/test_elliptical_overlap_grid.py
@@ -8,7 +8,7 @@ import itertools
 import pytest
 from numpy.testing import assert_allclose
 
-from .. import elliptical_overlap_grid
+from photutils.geometry import elliptical_overlap_grid
 
 grid_sizes = [50, 500, 1000]
 maj_sizes = [0.2, 0.4, 0.8]

--- a/photutils/geometry/tests/test_rectangular_overlap_grid.py
+++ b/photutils/geometry/tests/test_rectangular_overlap_grid.py
@@ -8,7 +8,7 @@ import itertools
 import pytest
 from numpy.testing import assert_allclose
 
-from .. import rectangular_overlap_grid
+from photutils.geometry import rectangular_overlap_grid
 
 grid_sizes = [50, 500, 1000]
 rect_sizes = [0.2, 0.4, 0.8]

--- a/photutils/isophote/ellipse.py
+++ b/photutils/isophote/ellipse.py
@@ -7,14 +7,14 @@ import warnings
 
 import numpy as np
 from astropy.utils.exceptions import AstropyUserWarning
-
-from .fitter import (DEFAULT_CONVERGENCE, DEFAULT_FFLAG, DEFAULT_MAXGERR,
-                     DEFAULT_MAXIT, DEFAULT_MINIT, CentralEllipseFitter,
-                     EllipseFitter)
-from .geometry import EllipseGeometry
-from .integrator import BILINEAR
-from .isophote import Isophote, IsophoteList
-from .sample import CentralEllipseSample, EllipseSample
+from photutils.isophote.fitter import (DEFAULT_CONVERGENCE, DEFAULT_FFLAG,
+                                       DEFAULT_MAXGERR, DEFAULT_MAXIT,
+                                       DEFAULT_MINIT, CentralEllipseFitter,
+                                       EllipseFitter)
+from photutils.isophote.geometry import EllipseGeometry
+from photutils.isophote.integrator import BILINEAR
+from photutils.isophote.isophote import Isophote, IsophoteList
+from photutils.isophote.sample import CentralEllipseSample, EllipseSample
 
 __all__ = ['Ellipse']
 

--- a/photutils/isophote/ellipse.py
+++ b/photutils/isophote/ellipse.py
@@ -7,6 +7,7 @@ import warnings
 
 import numpy as np
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.isophote.fitter import (DEFAULT_CONVERGENCE, DEFAULT_FFLAG,
                                        DEFAULT_MAXGERR, DEFAULT_MAXIT,
                                        DEFAULT_MINIT, CentralEllipseFitter,

--- a/photutils/isophote/fitter.py
+++ b/photutils/isophote/fitter.py
@@ -7,6 +7,7 @@ import math
 
 import numpy as np
 from astropy import log
+
 from photutils.isophote.harmonics import (first_and_second_harmonic_function,
                                           fit_first_and_second_harmonics)
 from photutils.isophote.isophote import CentralPixel, Isophote

--- a/photutils/isophote/fitter.py
+++ b/photutils/isophote/fitter.py
@@ -7,11 +7,10 @@ import math
 
 import numpy as np
 from astropy import log
-
-from .harmonics import (first_and_second_harmonic_function,
-                        fit_first_and_second_harmonics)
-from .isophote import CentralPixel, Isophote
-from .sample import EllipseSample
+from photutils.isophote.harmonics import (first_and_second_harmonic_function,
+                                          fit_first_and_second_harmonics)
+from photutils.isophote.isophote import CentralPixel, Isophote
+from photutils.isophote.sample import EllipseSample
 
 __all__ = ['EllipseFitter']
 

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -6,6 +6,7 @@ This module provides classes to store the results of isophote fits.
 import astropy.units as u
 import numpy as np
 from astropy.table import QTable
+
 from photutils.isophote.harmonics import (first_and_second_harmonic_function,
                                           fit_first_and_second_harmonics,
                                           fit_upper_harmonic)

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -6,10 +6,10 @@ This module provides classes to store the results of isophote fits.
 import astropy.units as u
 import numpy as np
 from astropy.table import QTable
-
-from ..utils._misc import _get_version_info
-from .harmonics import (first_and_second_harmonic_function,
-                        fit_first_and_second_harmonics, fit_upper_harmonic)
+from photutils.isophote.harmonics import (first_and_second_harmonic_function,
+                                          fit_first_and_second_harmonics,
+                                          fit_upper_harmonic)
+from photutils.utils._misc import _get_version_info
 
 __all__ = ['Isophote', 'IsophoteList']
 

--- a/photutils/isophote/model.py
+++ b/photutils/isophote/model.py
@@ -4,10 +4,8 @@ This module profiles tools for building a model elliptical galaxy image
 from a list of isophotes.
 """
 
-
 import numpy as np
-
-from .geometry import EllipseGeometry
+from photutils.isophote.geometry import EllipseGeometry
 
 __all__ = ['build_ellipse_model']
 

--- a/photutils/isophote/model.py
+++ b/photutils/isophote/model.py
@@ -5,6 +5,7 @@ from a list of isophotes.
 """
 
 import numpy as np
+
 from photutils.isophote.geometry import EllipseGeometry
 
 __all__ = ['build_ellipse_model']

--- a/photutils/isophote/sample.py
+++ b/photutils/isophote/sample.py
@@ -6,9 +6,8 @@ This module provides a class to sample data along an elliptical path.
 import copy
 
 import numpy as np
-
-from .geometry import EllipseGeometry
-from .integrator import INTEGRATORS
+from photutils.isophote.geometry import EllipseGeometry
+from photutils.isophote.integrator import INTEGRATORS
 
 __all__ = ['EllipseSample']
 

--- a/photutils/isophote/sample.py
+++ b/photutils/isophote/sample.py
@@ -6,6 +6,7 @@ This module provides a class to sample data along an elliptical path.
 import copy
 
 import numpy as np
+
 from photutils.isophote.geometry import EllipseGeometry
 from photutils.isophote.integrator import INTEGRATORS
 

--- a/photutils/isophote/tests/make_test_data.py
+++ b/photutils/isophote/tests/make_test_data.py
@@ -5,9 +5,8 @@ This module provides tools for making a simulated image for tests.
 
 import numpy as np
 from astropy.io import fits
-
-from ...datasets import make_noise_image
-from ..geometry import EllipseGeometry
+from photutils.datasets import make_noise_image
+from photutils.isophote.geometry import EllipseGeometry
 
 
 def make_test_image(nx=512, ny=512, x0=None, y0=None,

--- a/photutils/isophote/tests/make_test_data.py
+++ b/photutils/isophote/tests/make_test_data.py
@@ -5,6 +5,7 @@ This module provides tools for making a simulated image for tests.
 
 import numpy as np
 from astropy.io import fits
+
 from photutils.datasets import make_noise_image
 from photutils.isophote.geometry import EllipseGeometry
 

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.modeling.models import Gaussian2D
+
 from photutils.datasets import get_path, make_noise_image
 from photutils.isophote.ellipse import Ellipse
 from photutils.isophote.geometry import EllipseGeometry

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -9,13 +9,12 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.modeling.models import Gaussian2D
-
-from ...datasets import get_path, make_noise_image
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..ellipse import Ellipse
-from ..geometry import EllipseGeometry
-from ..isophote import Isophote, IsophoteList
-from .make_test_data import make_test_image
+from photutils.datasets import get_path, make_noise_image
+from photutils.isophote.ellipse import Ellipse
+from photutils.isophote.geometry import EllipseGeometry
+from photutils.isophote.isophote import Isophote, IsophoteList
+from photutils.isophote.tests.make_test_data import make_test_image
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 # define an off-center position and a tilted sma
 POS = 384

--- a/photutils/isophote/tests/test_fitter.py
+++ b/photutils/isophote/tests/test_fitter.py
@@ -7,16 +7,15 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from numpy.testing import assert_allclose
-
-from ...datasets import get_path
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..fitter import CentralEllipseFitter, EllipseFitter
-from ..geometry import EllipseGeometry
-from ..harmonics import fit_first_and_second_harmonics
-from ..integrator import MEAN
-from ..isophote import Isophote
-from ..sample import CentralEllipseSample, EllipseSample
-from .make_test_data import make_test_image
+from photutils.datasets import get_path
+from photutils.isophote.fitter import CentralEllipseFitter, EllipseFitter
+from photutils.isophote.geometry import EllipseGeometry
+from photutils.isophote.harmonics import fit_first_and_second_harmonics
+from photutils.isophote.integrator import MEAN
+from photutils.isophote.isophote import Isophote
+from photutils.isophote.sample import CentralEllipseSample, EllipseSample
+from photutils.isophote.tests.make_test_data import make_test_image
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 DATA = make_test_image(seed=0)
 DEFAULT_POS = 256

--- a/photutils/isophote/tests/test_fitter.py
+++ b/photutils/isophote/tests/test_fitter.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from numpy.testing import assert_allclose
+
 from photutils.datasets import get_path
 from photutils.isophote.fitter import CentralEllipseFitter, EllipseFitter
 from photutils.isophote.geometry import EllipseGeometry

--- a/photutils/isophote/tests/test_geometry.py
+++ b/photutils/isophote/tests/test_geometry.py
@@ -6,8 +6,7 @@ Tests for the geometry module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-
-from ..geometry import EllipseGeometry
+from photutils.isophote.geometry import EllipseGeometry
 
 
 @pytest.mark.parametrize('astep, linear_growth', [(0.2, False), (20., True)])

--- a/photutils/isophote/tests/test_geometry.py
+++ b/photutils/isophote/tests/test_geometry.py
@@ -6,6 +6,7 @@ Tests for the geometry module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from photutils.isophote.geometry import EllipseGeometry
 
 

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -6,13 +6,13 @@ Tests for the harmonics module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..fitter import EllipseFitter
-from ..harmonics import (first_and_second_harmonic_function,
-                         fit_first_and_second_harmonics, fit_upper_harmonic)
-from ..sample import EllipseSample
-from .make_test_data import make_test_image
+from photutils.isophote.fitter import EllipseFitter
+from photutils.isophote.harmonics import (first_and_second_harmonic_function,
+                                          fit_first_and_second_harmonics,
+                                          fit_upper_harmonic)
+from photutils.isophote.sample import EllipseSample
+from photutils.isophote.tests.make_test_data import make_test_image
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -6,6 +6,7 @@ Tests for the harmonics module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from photutils.isophote.fitter import EllipseFitter
 from photutils.isophote.harmonics import (first_and_second_harmonic_function,
                                           fit_first_and_second_harmonics,

--- a/photutils/isophote/tests/test_integrator.py
+++ b/photutils/isophote/tests/test_integrator.py
@@ -7,10 +7,10 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from numpy.testing import assert_allclose
-
-from ...datasets import get_path
-from ..integrator import BILINEAR, MEAN, MEDIAN, NEAREST_NEIGHBOR
-from ..sample import EllipseSample
+from photutils.datasets import get_path
+from photutils.isophote.integrator import (BILINEAR, MEAN, MEDIAN,
+                                           NEAREST_NEIGHBOR)
+from photutils.isophote.sample import EllipseSample
 
 
 @pytest.mark.remote_data

--- a/photutils/isophote/tests/test_integrator.py
+++ b/photutils/isophote/tests/test_integrator.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from numpy.testing import assert_allclose
+
 from photutils.datasets import get_path
 from photutils.isophote.integrator import (BILINEAR, MEAN, MEDIAN,
                                            NEAREST_NEIGHBOR)

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -7,15 +7,14 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from numpy.testing import assert_allclose
-
-from ...datasets import get_path
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..ellipse import Ellipse
-from ..fitter import EllipseFitter
-from ..geometry import EllipseGeometry
-from ..isophote import Isophote, IsophoteList
-from ..sample import EllipseSample
-from .make_test_data import make_test_image
+from photutils.datasets import get_path
+from photutils.isophote.ellipse import Ellipse
+from photutils.isophote.fitter import EllipseFitter
+from photutils.isophote.geometry import EllipseGeometry
+from photutils.isophote.isophote import Isophote, IsophoteList
+from photutils.isophote.sample import EllipseSample
+from photutils.isophote.tests.make_test_data import make_test_image
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 DEFAULT_FIX = np.array([False, False, False, False])
 

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from numpy.testing import assert_allclose
+
 from photutils.datasets import get_path
 from photutils.isophote.ellipse import Ellipse
 from photutils.isophote.fitter import EllipseFitter

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
+
 from photutils.datasets import get_path
 from photutils.isophote.ellipse import Ellipse
 from photutils.isophote.geometry import EllipseGeometry

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -2,19 +2,19 @@
 """
 Tests for the model module.
 """
+
 import warnings
 
 import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
-
-from ...datasets import get_path
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..ellipse import Ellipse
-from ..geometry import EllipseGeometry
-from ..model import build_ellipse_model
-from .make_test_data import make_test_image
+from photutils.datasets import get_path
+from photutils.isophote.ellipse import Ellipse
+from photutils.isophote.geometry import EllipseGeometry
+from photutils.isophote.model import build_ellipse_model
+from photutils.isophote.tests.make_test_data import make_test_image
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.remote_data

--- a/photutils/isophote/tests/test_regression.py
+++ b/photutils/isophote/tests/test_regression.py
@@ -53,6 +53,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.table import Table
+
 from photutils.datasets import get_path
 from photutils.isophote.ellipse import Ellipse
 from photutils.isophote.integrator import BILINEAR

--- a/photutils/isophote/tests/test_regression.py
+++ b/photutils/isophote/tests/test_regression.py
@@ -53,11 +53,10 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.table import Table
-
-from ...datasets import get_path
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..ellipse import Ellipse
-from ..integrator import BILINEAR
+from photutils.datasets import get_path
+from photutils.isophote.ellipse import Ellipse
+from photutils.isophote.integrator import BILINEAR
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/isophote/tests/test_sample.py
+++ b/photutils/isophote/tests/test_sample.py
@@ -5,6 +5,7 @@ Tests for the sample module.
 
 import numpy as np
 import pytest
+
 from photutils.isophote.integrator import (BILINEAR, MEAN, MEDIAN,
                                            NEAREST_NEIGHBOR)
 from photutils.isophote.isophote import Isophote

--- a/photutils/isophote/tests/test_sample.py
+++ b/photutils/isophote/tests/test_sample.py
@@ -5,11 +5,11 @@ Tests for the sample module.
 
 import numpy as np
 import pytest
-
-from ..integrator import BILINEAR, MEAN, MEDIAN, NEAREST_NEIGHBOR
-from ..isophote import Isophote
-from ..sample import EllipseSample
-from .make_test_data import make_test_image
+from photutils.isophote.integrator import (BILINEAR, MEAN, MEDIAN,
+                                           NEAREST_NEIGHBOR)
+from photutils.isophote.isophote import Isophote
+from photutils.isophote.sample import EllipseSample
+from photutils.isophote.tests.make_test_data import make_test_image
 
 DEFAULT_FIX = np.array([False, False, False, False])
 

--- a/photutils/morphology/core.py
+++ b/photutils/morphology/core.py
@@ -38,8 +38,8 @@ def data_properties(data, mask=None, background=None):
     result : `~photutils.segmentation.SourceCatalog` instance
         A `~photutils.segmentation.SourceCatalog` object.
     """
-    # prevent circular imports
-    from ..segmentation import SegmentationImage, SourceCatalog
+    # prevent circular import
+    from photutils.segmentation import SegmentationImage, SourceCatalog
 
     segment_image = SegmentationImage(np.ones(data.shape, dtype=int))
 

--- a/photutils/morphology/tests/test_core.py
+++ b/photutils/morphology/tests/test_core.py
@@ -6,9 +6,8 @@ Tests for the core module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_SKIMAGE  # noqa
-from ..core import data_properties
+from photutils.morphology.core import data_properties
+from photutils.utils._optional_deps import HAS_SKIMAGE  # noqa
 
 XCS = [25.7]
 YCS = [26.2]

--- a/photutils/morphology/tests/test_core.py
+++ b/photutils/morphology/tests/test_core.py
@@ -6,6 +6,7 @@ Tests for the core module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from photutils.morphology.core import data_properties
 from photutils.utils._optional_deps import HAS_SKIMAGE  # noqa
 

--- a/photutils/morphology/tests/test_non_parametric.py
+++ b/photutils/morphology/tests/test_non_parametric.py
@@ -4,6 +4,7 @@ Tests for the non_parametric module.
 """
 
 import numpy as np
+
 from photutils.morphology.non_parametric import gini
 
 

--- a/photutils/morphology/tests/test_non_parametric.py
+++ b/photutils/morphology/tests/test_non_parametric.py
@@ -4,8 +4,7 @@ Tests for the non_parametric module.
 """
 
 import numpy as np
-
-from ..non_parametric import gini
+from photutils.morphology.non_parametric import gini
 
 
 def test_gini():

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -14,14 +14,13 @@ from astropy.nddata.utils import (NoOverlapError, PartialOverlapError,
                                   overlap_slices)
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..centroids import centroid_com
-from ..utils._optional_deps import HAS_BOTTLENECK, HAS_TQDM  # noqa
-from ..utils._parameters import as_pair
-from ..utils._round import _py2intround
-from .epsf_stars import EPSFStar, EPSFStars, LinkedEPSFStar
-from .models import EPSFModel
-from .utils import _interpolate_missing_data
+from photutils.centroids import centroid_com
+from photutils.psf.epsf_stars import EPSFStar, EPSFStars, LinkedEPSFStar
+from photutils.psf.models import EPSFModel
+from photutils.psf.utils import _interpolate_missing_data
+from photutils.utils._optional_deps import HAS_BOTTLENECK, HAS_TQDM  # noqa
+from photutils.utils._parameters import as_pair
+from photutils.utils._round import _py2intround
 
 __all__ = ['EPSFFitter', 'EPSFBuilder']
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -14,6 +14,7 @@ from astropy.nddata.utils import (NoOverlapError, PartialOverlapError,
                                   overlap_slices)
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.centroids import centroid_com
 from photutils.psf.epsf_stars import EPSFStar, EPSFStars, LinkedEPSFStar
 from photutils.psf.models import EPSFModel

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -13,10 +13,9 @@ from astropy.nddata.utils import (NoOverlapError, PartialOverlapError,
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..aperture import BoundingBox
-from ..utils._parameters import as_pair
-from .utils import _interpolate_missing_data
+from photutils.aperture import BoundingBox
+from photutils.psf.utils import _interpolate_missing_data
+from photutils.utils._parameters import as_pair
 
 __all__ = ['EPSFStar', 'EPSFStars', 'LinkedEPSFStar', 'extract_stars']
 

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -13,6 +13,7 @@ from astropy.nddata.utils import (NoOverlapError, PartialOverlapError,
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.aperture import BoundingBox
 from photutils.psf.utils import _interpolate_missing_data
 from photutils.utils._parameters import as_pair

--- a/photutils/psf/matching/tests/test_fourier.py
+++ b/photutils/psf/matching/tests/test_fourier.py
@@ -8,10 +8,9 @@ import pytest
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import Gaussian2D
 from numpy.testing import assert_allclose
-
-from ....utils._optional_deps import HAS_SCIPY  # noqa
-from ..fourier import create_matching_kernel, resize_psf
-from ..windows import SplitCosineBellWindow
+from photutils.psf.matching.fourier import create_matching_kernel, resize_psf
+from photutils.psf.matching.windows import SplitCosineBellWindow
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/matching/tests/test_fourier.py
+++ b/photutils/psf/matching/tests/test_fourier.py
@@ -8,6 +8,7 @@ import pytest
 from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import Gaussian2D
 from numpy.testing import assert_allclose
+
 from photutils.psf.matching.fourier import create_matching_kernel, resize_psf
 from photutils.psf.matching.windows import SplitCosineBellWindow
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa

--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -6,10 +6,10 @@ Tests for the windows module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-
-from ....utils._optional_deps import HAS_SCIPY  # noqa
-from ..windows import (CosineBellWindow, HanningWindow, SplitCosineBellWindow,
-                       TopHatWindow, TukeyWindow)
+from photutils.psf.matching.windows import (CosineBellWindow, HanningWindow,
+                                            SplitCosineBellWindow,
+                                            TopHatWindow, TukeyWindow)
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 def test_hanning():

--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -6,6 +6,7 @@ Tests for the windows module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from photutils.psf.matching.windows import (CosineBellWindow, HanningWindow,
                                             SplitCosineBellWindow,
                                             TopHatWindow, TukeyWindow)

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -11,6 +11,7 @@ import numpy as np
 from astropy.modeling import Fittable2DModel, Parameter
 from astropy.nddata import NDData
 from astropy.utils.exceptions import AstropyWarning
+
 from photutils.aperture import CircularAperture
 from photutils.utils._parameters import as_pair
 

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -11,9 +11,8 @@ import numpy as np
 from astropy.modeling import Fittable2DModel, Parameter
 from astropy.nddata import NDData
 from astropy.utils.exceptions import AstropyWarning
-
-from ..aperture import CircularAperture
-from ..utils._parameters import as_pair
+from photutils.aperture import CircularAperture
+from photutils.utils._parameters import as_pair
 
 __all__ = ['NonNormalizable', 'FittableImageModel', 'EPSFModel',
            'GriddedPSFModel', 'IntegratedGaussianPRF', 'PRFAdapter']

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -11,6 +11,7 @@ from astropy.nddata.utils import NoOverlapError, overlap_slices
 from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Column, QTable, hstack, vstack
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.aperture import CircularAperture, aperture_photometry
 from photutils.background import MMMBackground
 from photutils.detection import DAOStarFinder

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -11,16 +11,15 @@ from astropy.nddata.utils import NoOverlapError, overlap_slices
 from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Column, QTable, hstack, vstack
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..aperture import CircularAperture, aperture_photometry
-from ..background import MMMBackground
-from ..detection import DAOStarFinder
-from ..utils._misc import _get_version_info
-from ..utils._optional_deps import HAS_TQDM  # noqa
-from ..utils.exceptions import NoDetectionsWarning
-from .groupstars import DAOGroup
-from .utils import (_extract_psf_fitting_names, get_grouped_psf_model,
-                    subtract_psf)
+from photutils.aperture import CircularAperture, aperture_photometry
+from photutils.background import MMMBackground
+from photutils.detection import DAOStarFinder
+from photutils.psf.groupstars import DAOGroup
+from photutils.psf.utils import (_extract_psf_fitting_names,
+                                 get_grouped_psf_model, subtract_psf)
+from photutils.utils._misc import _get_version_info
+from photutils.utils._optional_deps import HAS_TQDM  # noqa
+from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
            'DAOPhotPSFPhotometry']

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -11,8 +11,7 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import extract_array, subpixel_indices
 from astropy.table import Table
 from astropy.utils.decorators import deprecated
-
-from ..segmentation.utils import _mask_to_mirrored_value
+from photutils.segmentation.utils import _mask_to_mirrored_value
 
 __all__ = ['DiscretePRF', 'Reproject']
 

--- a/photutils/psf/sandbox.py
+++ b/photutils/psf/sandbox.py
@@ -11,6 +11,7 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import extract_array, subpixel_indices
 from astropy.table import Table
 from astropy.utils.decorators import deprecated
+
 from photutils.segmentation.utils import _mask_to_mirrored_value
 
 __all__ = ['DiscretePRF', 'Reproject']

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -13,12 +13,11 @@ from astropy.stats import SigmaClip
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_almost_equal
-
-from ...datasets import make_gaussian_prf_sources_image
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..epsf import EPSFBuilder, EPSFFitter
-from ..epsf_stars import EPSFStars, extract_stars
-from ..models import EPSFModel, IntegratedGaussianPRF
+from photutils.datasets import make_gaussian_prf_sources_image
+from photutils.psf.epsf import EPSFBuilder, EPSFFitter
+from photutils.psf.epsf_stars import EPSFStars, extract_stars
+from photutils.psf.models import EPSFModel, IntegratedGaussianPRF
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -13,6 +13,7 @@ from astropy.stats import SigmaClip
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_almost_equal
+
 from photutils.datasets import make_gaussian_prf_sources_image
 from photutils.psf.epsf import EPSFBuilder, EPSFFitter
 from photutils.psf.epsf_stars import EPSFStars, extract_stars

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -9,6 +9,7 @@ from astropy.modeling.models import Moffat2D
 from astropy.nddata import NDData
 from astropy.table import Table
 from numpy.testing import assert_allclose
+
 from photutils.psf.epsf_stars import EPSFStars, extract_stars
 from photutils.psf.models import EPSFModel, IntegratedGaussianPRF
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -9,10 +9,9 @@ from astropy.modeling.models import Moffat2D
 from astropy.nddata import NDData
 from astropy.table import Table
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..epsf_stars import EPSFStars, extract_stars
-from ..models import EPSFModel, IntegratedGaussianPRF
+from photutils.psf.epsf_stars import EPSFStars, extract_stars
+from photutils.psf.models import EPSFModel, IntegratedGaussianPRF
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/tests/test_groupstars.py
+++ b/photutils/psf/tests/test_groupstars.py
@@ -7,9 +7,8 @@ import numpy as np
 import pytest
 from astropy.table import Table, vstack
 from numpy.testing import assert_almost_equal
-
-from ...utils._optional_deps import HAS_SKLEARN  # noqa
-from ..groupstars import DAOGroup, DBSCANGroup
+from photutils.psf.groupstars import DAOGroup, DBSCANGroup
+from photutils.utils._optional_deps import HAS_SKLEARN  # noqa
 
 
 def assert_table_almost_equal(table1, table2):

--- a/photutils/psf/tests/test_groupstars.py
+++ b/photutils/psf/tests/test_groupstars.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from astropy.table import Table, vstack
 from numpy.testing import assert_almost_equal
+
 from photutils.psf.groupstars import DAOGroup, DBSCANGroup
 from photutils.utils._optional_deps import HAS_SKLEARN  # noqa
 

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -10,6 +10,7 @@ import pytest
 from astropy.modeling.models import Gaussian2D, Moffat2D
 from astropy.nddata import NDData
 from numpy.testing import assert_allclose
+
 from photutils.psf.models import (FittableImageModel, GriddedPSFModel,
                                   IntegratedGaussianPRF, PRFAdapter)
 from photutils.segmentation import SourceCatalog, detect_sources

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -10,11 +10,10 @@ import pytest
 from astropy.modeling.models import Gaussian2D, Moffat2D
 from astropy.nddata import NDData
 from numpy.testing import assert_allclose
-
-from ...segmentation import SourceCatalog, detect_sources
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..models import (FittableImageModel, GriddedPSFModel,
-                      IntegratedGaussianPRF, PRFAdapter)
+from photutils.psf.models import (FittableImageModel, GriddedPSFModel,
+                                  IntegratedGaussianPRF, PRFAdapter)
+from photutils.segmentation import SourceCatalog, detect_sources
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -13,16 +13,16 @@ from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
-
-from ...background import MMMBackground, StdBackgroundRMS
-from ...datasets import make_gaussian_prf_sources_image, make_noise_image
-from ...detection import DAOStarFinder
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..groupstars import DAOGroup
-from ..models import FittableImageModel, IntegratedGaussianPRF
-from ..photometry import (BasicPSFPhotometry, DAOPhotPSFPhotometry,
-                          IterativelySubtractedPSFPhotometry)
-from ..utils import prepare_psf_model
+from photutils.background import MMMBackground, StdBackgroundRMS
+from photutils.datasets import (make_gaussian_prf_sources_image,
+                                make_noise_image)
+from photutils.detection import DAOStarFinder
+from photutils.psf.groupstars import DAOGroup
+from photutils.psf.models import FittableImageModel, IntegratedGaussianPRF
+from photutils.psf.photometry import (BasicPSFPhotometry, DAOPhotPSFPhotometry,
+                                      IterativelySubtractedPSFPhotometry)
+from photutils.psf.utils import prepare_psf_model
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 def make_psf_photometry_objs(std=1, sigma_psf=1):

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -13,6 +13,7 @@ from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
+
 from photutils.background import MMMBackground, StdBackgroundRMS
 from photutils.datasets import (make_gaussian_prf_sources_image,
                                 make_noise_image)

--- a/photutils/psf/tests/test_sandbox.py
+++ b/photutils/psf/tests/test_sandbox.py
@@ -10,6 +10,7 @@ from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
+
 from photutils.psf.sandbox import DiscretePRF
 
 PSF_SIZE = 11

--- a/photutils/psf/tests/test_sandbox.py
+++ b/photutils/psf/tests/test_sandbox.py
@@ -10,8 +10,7 @@ from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
-
-from ..sandbox import DiscretePRF
+from photutils.psf.sandbox import DiscretePRF
 
 PSF_SIZE = 11
 GAUSSIAN_WIDTH = 1.

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -9,6 +9,7 @@ from astropy.convolution.utils import discretize_model
 from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
 from numpy.testing import assert_allclose
+
 from photutils.psf.groupstars import DAOGroup
 from photutils.psf.models import IntegratedGaussianPRF
 from photutils.psf.photometry import BasicPSFPhotometry

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -9,12 +9,12 @@ from astropy.convolution.utils import discretize_model
 from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
 from numpy.testing import assert_allclose
-
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..groupstars import DAOGroup
-from ..models import IntegratedGaussianPRF
-from ..photometry import BasicPSFPhotometry
-from ..utils import get_grouped_psf_model, prepare_psf_model, subtract_psf
+from photutils.psf.groupstars import DAOGroup
+from photutils.psf.models import IntegratedGaussianPRF
+from photutils.psf.photometry import BasicPSFPhotometry
+from photutils.psf.utils import (get_grouped_psf_model, prepare_psf_model,
+                                 subtract_psf)
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 PSF_SIZE = 11
 GAUSSIAN_WIDTH = 1.

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -15,6 +15,7 @@ from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
 from astropy.table import QTable
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
+
 from photutils.aperture import (BoundingBox, CircularAperture,
                                 EllipticalAperture, RectangularAnnulus)
 from photutils.background import SExtractorBackground

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -15,16 +15,15 @@ from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
 from astropy.table import QTable
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
-
-from ..aperture import (BoundingBox, CircularAperture, EllipticalAperture,
-                        RectangularAnnulus)
-from ..background import SExtractorBackground
-from ..utils._convolution import _filter_data
-from ..utils._misc import _get_meta
-from ..utils._moments import _moments, _moments_central
-from ..utils._quantity_helpers import process_quantities
-from ..utils.cutouts import CutoutImage
-from .core import SegmentationImage
+from photutils.aperture import (BoundingBox, CircularAperture,
+                                EllipticalAperture, RectangularAnnulus)
+from photutils.background import SExtractorBackground
+from photutils.segmentation.core import SegmentationImage
+from photutils.utils._convolution import _filter_data
+from photutils.utils._misc import _get_meta
+from photutils.utils._moments import _moments, _moments_central
+from photutils.utils._quantity_helpers import process_quantities
+from photutils.utils.cutouts import CutoutImage
 
 __all__ = ['SourceCatalog']
 __doctest_requires__ = {('SourceCatalog', 'SourceCatalog.*'): ['scipy']}
@@ -2534,7 +2533,7 @@ class SourceCatalog:
             mask = data_mask
 
         if self.apermask_method == 'correct':
-            from .utils import _mask_to_mirrored_value
+            from photutils.segmentation.utils import _mask_to_mirrored_value
             data = _mask_to_mirrored_value(data, segm_mask, cutout_xycen,
                                            mask=mask)
             if error is not None:

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -12,6 +12,7 @@ import numpy as np
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.aperture import BoundingBox
 from photutils.utils.colormaps import make_random_cmap
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -12,9 +12,8 @@ import numpy as np
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..aperture import BoundingBox
-from ..utils.colormaps import make_random_cmap
+from photutils.aperture import BoundingBox
+from photutils.utils.colormaps import make_random_cmap
 
 __all__ = ['SegmentationImage', 'Segment']
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -11,6 +11,7 @@ import numpy as np
 from astropy.units import Quantity
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.detect import _detect_sources
 from photutils.segmentation.utils import _make_binary_structure

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -11,12 +11,11 @@ import numpy as np
 from astropy.units import Quantity
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..utils._convolution import _filter_data
-from ..utils._optional_deps import HAS_TQDM  # noqa
-from .core import SegmentationImage
-from .detect import _detect_sources
-from .utils import _make_binary_structure
+from photutils.segmentation.core import SegmentationImage
+from photutils.segmentation.detect import _detect_sources
+from photutils.segmentation.utils import _make_binary_structure
+from photutils.utils._convolution import _filter_data
+from photutils.utils._optional_deps import HAS_TQDM  # noqa
 
 __all__ = ['deblend_sources']
 

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -10,6 +10,7 @@ from astropy.convolution import convolve
 from astropy.stats import SigmaClip
 from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
+
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.utils import _make_binary_structure
 from photutils.utils._quantity_helpers import process_quantities

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -10,12 +10,11 @@ from astropy.convolution import convolve
 from astropy.stats import SigmaClip
 from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ..utils._quantity_helpers import process_quantities
-from ..utils._stats import nanmean, nanstd
-from ..utils.exceptions import NoDetectionsWarning
-from .core import SegmentationImage
-from .utils import _make_binary_structure
+from photutils.segmentation.core import SegmentationImage
+from photutils.segmentation.utils import _make_binary_structure
+from photutils.utils._quantity_helpers import process_quantities
+from photutils.utils._stats import nanmean, nanstd
+from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['detect_threshold', 'detect_sources', 'make_source_mask']
 

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -3,8 +3,8 @@
 This module provides tools for detecting sources in an image.
 """
 
-from .deblend import deblend_sources
-from .detect import detect_sources
+from photutils.segmentation.deblend import deblend_sources
+from photutils.segmentation.detect import detect_sources
 
 __all__ = ['SourceFinder']
 

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -11,6 +11,7 @@ from astropy.coordinates import SkyCoord
 from astropy.modeling.models import Gaussian2D
 from astropy.table import QTable
 from numpy.testing import assert_allclose, assert_equal
+
 from photutils.aperture import (BoundingBox, CircularAperture,
                                 EllipticalAperture)
 from photutils.background import Background2D, MedianBackground

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2,6 +2,7 @@
 """
 Tests for the catalog module.
 """
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -10,19 +11,20 @@ from astropy.coordinates import SkyCoord
 from astropy.modeling.models import Gaussian2D
 from astropy.table import QTable
 from numpy.testing import assert_allclose, assert_equal
-
-from ...aperture import BoundingBox, CircularAperture, EllipticalAperture
-from ...background import Background2D, MedianBackground
-from ...datasets import (make_100gaussians_image, make_gwcs, make_noise_image,
-                         make_wcs)
-from ...utils._convolution import _filter_data
-from ...utils._optional_deps import HAS_GWCS, HAS_MATPLOTLIB, HAS_SCIPY  # noqa
-from ...utils.cutouts import CutoutImage
-from ..catalog import SourceCatalog
-from ..core import SegmentationImage
-from ..detect import detect_sources
-from ..finder import SourceFinder
-from ..utils import make_2dgaussian_kernel
+from photutils.aperture import (BoundingBox, CircularAperture,
+                                EllipticalAperture)
+from photutils.background import Background2D, MedianBackground
+from photutils.datasets import (make_100gaussians_image, make_gwcs,
+                                make_noise_image, make_wcs)
+from photutils.segmentation.catalog import SourceCatalog
+from photutils.segmentation.core import SegmentationImage
+from photutils.segmentation.detect import detect_sources
+from photutils.segmentation.finder import SourceFinder
+from photutils.segmentation.utils import make_2dgaussian_kernel
+from photutils.utils._convolution import _filter_data
+from photutils.utils._optional_deps import (HAS_GWCS, HAS_MATPLOTLIB,  # noqa
+                                            HAS_SCIPY)
+from photutils.utils.cutouts import CutoutImage
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -8,6 +8,7 @@ import pytest
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
+
 from photutils.segmentation.core import Segment, SegmentationImage
 from photutils.utils import circular_footprint
 from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY  # noqa

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -8,10 +8,9 @@ import pytest
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
-
-from ...utils import circular_footprint
-from ...utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY  # noqa
-from ..core import Segment, SegmentationImage
+from photutils.segmentation.core import Segment, SegmentationImage
+from photutils.utils import circular_footprint
+from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -10,6 +10,7 @@ import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
+
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.deblend import deblend_sources
 from photutils.segmentation.detect import detect_sources

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -2,6 +2,7 @@
 """
 Tests for the deblend module.
 """
+
 import warnings
 
 import numpy as np
@@ -9,11 +10,10 @@ import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
-
-from ...utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE  # noqa
-from ..core import SegmentationImage
-from ..deblend import deblend_sources
-from ..detect import detect_sources
+from photutils.segmentation.core import SegmentationImage
+from photutils.segmentation.deblend import deblend_sources
+from photutils.segmentation.detect import detect_sources
+from photutils.utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -9,6 +9,7 @@ import pytest
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_array_equal
+
 from photutils.datasets import make_4gaussians_image
 from photutils.segmentation.detect import (detect_sources, detect_threshold,
                                            make_source_mask)

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -9,12 +9,12 @@ import pytest
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_array_equal
-
-from ...datasets import make_4gaussians_image
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ...utils.exceptions import NoDetectionsWarning
-from ..detect import detect_sources, detect_threshold, make_source_mask
-from ..utils import make_2dgaussian_kernel
+from photutils.datasets import make_4gaussians_image
+from photutils.segmentation.detect import (detect_sources, detect_threshold,
+                                           make_source_mask)
+from photutils.segmentation.utils import make_2dgaussian_kernel
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
+from photutils.utils.exceptions import NoDetectionsWarning
 
 DATA = np.array([[0, 1, 0], [0, 2, 0], [0, 0, 0]]).astype(float)
 REF1 = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]])

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.convolution import convolve
+
 from photutils.datasets import make_100gaussians_image
 from photutils.segmentation.finder import SourceFinder
 from photutils.segmentation.utils import make_2dgaussian_kernel

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -7,12 +7,11 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.convolution import convolve
-
-from ...datasets import make_100gaussians_image
-from ...utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE  # noqa
-from ...utils.exceptions import NoDetectionsWarning
-from ..finder import SourceFinder
-from ..utils import make_2dgaussian_kernel
+from photutils.datasets import make_100gaussians_image
+from photutils.segmentation.finder import SourceFinder
+from photutils.segmentation.utils import make_2dgaussian_kernel
+from photutils.utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE  # noqa
+from photutils.utils.exceptions import NoDetectionsWarning
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/segmentation/tests/test_utils.py
+++ b/photutils/segmentation/tests/test_utils.py
@@ -6,10 +6,10 @@ Tests for the _utils module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
-
-from ...utils._optional_deps import HAS_SCIPY  # noqa
-from ..utils import (_make_binary_structure, _mask_to_mirrored_value,
-                     make_2dgaussian_kernel)
+from photutils.segmentation.utils import (_make_binary_structure,
+                                          _mask_to_mirrored_value,
+                                          make_2dgaussian_kernel)
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 def test_make_2dgaussian_kernel():

--- a/photutils/segmentation/tests/test_utils.py
+++ b/photutils/segmentation/tests/test_utils.py
@@ -6,6 +6,7 @@ Tests for the _utils module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
+
 from photutils.segmentation.utils import (_make_binary_structure,
                                           _mask_to_mirrored_value,
                                           make_2dgaussian_kernel)

--- a/photutils/segmentation/utils.py
+++ b/photutils/segmentation/utils.py
@@ -6,6 +6,7 @@ This module provides utility functions for image segmentation.
 import numpy as np
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
+
 from photutils.utils._parameters import as_pair
 
 __all__ = ['make_2dgaussian_kernel']

--- a/photutils/segmentation/utils.py
+++ b/photutils/segmentation/utils.py
@@ -6,8 +6,7 @@ This module provides utility functions for image segmentation.
 import numpy as np
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
-
-from ..utils._parameters import as_pair
+from photutils.utils._parameters import as_pair
 
 __all__ = ['make_2dgaussian_kernel']
 

--- a/photutils/utils/_misc.py
+++ b/photutils/utils/_misc.py
@@ -3,6 +3,7 @@
 This module provides tools to return the installed astropy and photutils
 versions.
 """
+
 import sys
 from datetime import datetime, timezone
 

--- a/photutils/utils/_moments.py
+++ b/photutils/utils/_moments.py
@@ -35,7 +35,7 @@ def _moments_central(data, center=None, order=1):
         raise ValueError('data must be a 2D array.')
 
     if center is None:
-        from ..centroids import centroid_com
+        from photutils.centroids import centroid_com
         center = centroid_com(data)
 
     indices = np.ogrid[tuple(slice(0, i) for i in data.shape)]

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -2,6 +2,7 @@
 """Checks for optional dependencies using lazy import from
 `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_.
 """
+
 import importlib
 
 # This list is a duplicate of the dependencies in setup.cfg "all".

--- a/photutils/utils/_stats.py
+++ b/photutils/utils/_stats.py
@@ -6,6 +6,7 @@ for performance if available.
 
 import astropy.units as u
 import numpy as np
+
 from photutils.utils._optional_deps import HAS_BOTTLENECK
 
 if HAS_BOTTLENECK:

--- a/photutils/utils/_stats.py
+++ b/photutils/utils/_stats.py
@@ -6,8 +6,7 @@ for performance if available.
 
 import astropy.units as u
 import numpy as np
-
-from ._optional_deps import HAS_BOTTLENECK
+from photutils.utils._optional_deps import HAS_BOTTLENECK
 
 if HAS_BOTTLENECK:
     import bottleneck as bn

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -6,8 +6,7 @@ This module provides tools for generating 2D image cutouts.
 import numpy as np
 from astropy.nddata import extract_array, overlap_slices
 from astropy.utils import lazyproperty
-
-from ..aperture import BoundingBox
+from photutils.aperture import BoundingBox
 
 __all__ = ['CutoutImage']
 

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -6,6 +6,7 @@ This module provides tools for generating 2D image cutouts.
 import numpy as np
 from astropy.nddata import extract_array, overlap_slices
 from astropy.utils import lazyproperty
+
 from photutils.aperture import BoundingBox
 
 __all__ = ['CutoutImage']

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -9,9 +9,9 @@ import astropy.units as u
 import numpy as np
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
-
-from ._optional_deps import HAS_TQDM  # pylint: disable=E0611  # noqa: F401
-from .footprints import circular_footprint
+from photutils.utils._optional_deps import (
+    HAS_TQDM)  # pylint: disable=E0611  # noqa: F401
+from photutils.utils.footprints import circular_footprint
 
 __all__ = ['ImageDepth']
 __doctest_requires__ = {('ImageDepth', 'ImageDepth.*'): ['scipy']}
@@ -241,7 +241,7 @@ class ImageDepth:
             calculated from the flux limit and the input ``zeropoint``.
         """
         # prevent circular import
-        from ..aperture import CircularAperture
+        from photutils.aperture import CircularAperture
 
         iter_range = range(self.niters)
         if self.progress_bar and HAS_TQDM:

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -9,8 +9,9 @@ import astropy.units as u
 import numpy as np
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
-from photutils.utils._optional_deps import (
-    HAS_TQDM)  # pylint: disable=E0611  # noqa: F401
+
+# pylint: disable-next=E0611
+from photutils.utils._optional_deps import HAS_TQDM  # noqa: F401
 from photutils.utils.footprints import circular_footprint
 
 __all__ = ['ImageDepth']

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -5,6 +5,7 @@ Tests for the colormaps module.
 
 import pytest
 from numpy.testing import assert_allclose
+
 from photutils.utils._optional_deps import HAS_MATPLOTLIB  # noqa
 from photutils.utils.colormaps import make_random_cmap
 

--- a/photutils/utils/tests/test_colormaps.py
+++ b/photutils/utils/tests/test_colormaps.py
@@ -5,9 +5,8 @@ Tests for the colormaps module.
 
 import pytest
 from numpy.testing import assert_allclose
-
-from .._optional_deps import HAS_MATPLOTLIB  # noqa
-from ..colormaps import make_random_cmap
+from photutils.utils._optional_deps import HAS_MATPLOTLIB  # noqa
+from photutils.utils.colormaps import make_random_cmap
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -7,10 +7,9 @@ import astropy.units as u
 import pytest
 from astropy.convolution import Gaussian2DKernel
 from numpy.testing import assert_allclose
-
-from ...datasets import make_100gaussians_image
-from .._convolution import _filter_data
-from .._optional_deps import HAS_SCIPY  # noqa
+from photutils.datasets import make_100gaussians_image
+from photutils.utils._convolution import _filter_data
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import pytest
 from astropy.convolution import Gaussian2DKernel
 from numpy.testing import assert_allclose
+
 from photutils.datasets import make_100gaussians_image
 from photutils.utils._convolution import _filter_data
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa

--- a/photutils/utils/tests/test_cutouts.py
+++ b/photutils/utils/tests/test_cutouts.py
@@ -7,10 +7,9 @@ import numpy as np
 import pytest
 from astropy.nddata.utils import PartialOverlapError
 from numpy.testing import assert_equal
-
-from ...aperture import BoundingBox
-from ...datasets import make_100gaussians_image
-from ..cutouts import CutoutImage
+from photutils.aperture import BoundingBox
+from photutils.datasets import make_100gaussians_image
+from photutils.utils.cutouts import CutoutImage
 
 
 def test_cutout():

--- a/photutils/utils/tests/test_cutouts.py
+++ b/photutils/utils/tests/test_cutouts.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from astropy.nddata.utils import PartialOverlapError
 from numpy.testing import assert_equal
+
 from photutils.aperture import BoundingBox
 from photutils.datasets import make_100gaussians_image
 from photutils.utils.cutouts import CutoutImage

--- a/photutils/utils/tests/test_depths.py
+++ b/photutils/utils/tests/test_depths.py
@@ -2,6 +2,7 @@
 """
 Tests for the depths module.
 """
+
 import itertools
 
 import astropy.units as u
@@ -11,11 +12,10 @@ from astropy.convolution import convolve
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
-
-from ...datasets import make_100gaussians_image
-from ...segmentation import SourceFinder, make_2dgaussian_kernel
-from .._optional_deps import HAS_SCIPY  # noqa
-from ..depths import ImageDepth
+from photutils.datasets import make_100gaussians_image
+from photutils.segmentation import SourceFinder, make_2dgaussian_kernel
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
+from photutils.utils.depths import ImageDepth
 
 bool_vals = (True, False)
 

--- a/photutils/utils/tests/test_depths.py
+++ b/photutils/utils/tests/test_depths.py
@@ -12,6 +12,7 @@ from astropy.convolution import convolve
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
+
 from photutils.datasets import make_100gaussians_image
 from photutils.segmentation import SourceFinder, make_2dgaussian_kernel
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa

--- a/photutils/utils/tests/test_errors.py
+++ b/photutils/utils/tests/test_errors.py
@@ -7,8 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-
-from ..errors import calc_total_error
+from photutils.utils.errors import calc_total_error
 
 SHAPE = (5, 5)
 DATAVAL = 2.

--- a/photutils/utils/tests/test_errors.py
+++ b/photutils/utils/tests/test_errors.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from photutils.utils.errors import calc_total_error
 
 SHAPE = (5, 5)

--- a/photutils/utils/tests/test_footprints.py
+++ b/photutils/utils/tests/test_footprints.py
@@ -6,6 +6,7 @@ Tests for the footprints module.
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
+
 from photutils.utils.footprints import circular_footprint
 
 

--- a/photutils/utils/tests/test_footprints.py
+++ b/photutils/utils/tests/test_footprints.py
@@ -6,8 +6,7 @@ Tests for the footprints module.
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
-
-from ..footprints import circular_footprint
+from photutils.utils.footprints import circular_footprint
 
 
 def test_footprints():

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -6,9 +6,8 @@ Tests for the interpolation module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-
-from .. import ShepardIDWInterpolator as idw
-from .._optional_deps import HAS_SCIPY  # noqa
+from photutils.utils import ShepardIDWInterpolator as idw
+from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 
 SHAPE = (5, 5)
 DATA = np.ones(SHAPE) * 2.0

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -6,6 +6,7 @@ Tests for the interpolation module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+
 from photutils.utils import ShepardIDWInterpolator as idw
 from photutils.utils._optional_deps import HAS_SCIPY  # noqa
 

--- a/photutils/utils/tests/test_misc.py
+++ b/photutils/utils/tests/test_misc.py
@@ -4,6 +4,7 @@ Tests for the _misc module.
 """
 
 import pytest
+
 from photutils.utils._misc import _get_meta
 
 

--- a/photutils/utils/tests/test_misc.py
+++ b/photutils/utils/tests/test_misc.py
@@ -4,8 +4,7 @@ Tests for the _misc module.
 """
 
 import pytest
-
-from .._misc import _get_meta
+from photutils.utils._misc import _get_meta
 
 
 @pytest.mark.parametrize('utc', (False, True))

--- a/photutils/utils/tests/test_moments.py
+++ b/photutils/utils/tests/test_moments.py
@@ -6,8 +6,7 @@ Tests for the moments module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
-
-from .._moments import _moments, _moments_central
+from photutils.utils._moments import _moments, _moments_central
 
 
 def test_moments():

--- a/photutils/utils/tests/test_moments.py
+++ b/photutils/utils/tests/test_moments.py
@@ -6,6 +6,7 @@ Tests for the moments module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
+
 from photutils.utils._moments import _moments, _moments_central
 
 

--- a/photutils/utils/tests/test_parameters.py
+++ b/photutils/utils/tests/test_parameters.py
@@ -6,8 +6,7 @@ Tests for the parameters module.
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
-
-from .._parameters import as_pair
+from photutils.utils._parameters import as_pair
 
 
 def test_as_pair():

--- a/photutils/utils/tests/test_parameters.py
+++ b/photutils/utils/tests/test_parameters.py
@@ -6,6 +6,7 @@ Tests for the parameters module.
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
+
 from photutils.utils._parameters import as_pair
 
 

--- a/photutils/utils/tests/test_quantity_helpers.py
+++ b/photutils/utils/tests/test_quantity_helpers.py
@@ -7,8 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
-
-from .._quantity_helpers import process_quantities
+from photutils.utils._quantity_helpers import process_quantities
 
 
 @pytest.mark.parametrize('all_units', (False, True))

--- a/photutils/utils/tests/test_quantity_helpers.py
+++ b/photutils/utils/tests/test_quantity_helpers.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
+
 from photutils.utils._quantity_helpers import process_quantities
 
 


### PR DESCRIPTION
This PR converts relative imports to absolute imports.  ``__init__.py`` files are left unchanged.