### PR TITLE
Remove setuptools pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools<65.6.0',
+requires = ['setuptools',
             'setuptools_scm',
             'wheel',
             'cython>=0.29.30',

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    setuptools<65.6.0
+    setuptools
     numpy>=1.20
     astropy>=5.0
 


### PR DESCRIPTION
`astropy` has replaced `numpy.ctypeslib` with `cython`, which resolves the convolution input error with setuptools 65.6.0. This PR removes the version pin set in #1443.

Closes: #1444 