### PR TITLE
Ensure load functions close FITS files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,11 @@ Bug Fixes
   - Fixed a bug in the ``PixelAperture`` ``area_overlap`` method so that
     the returned value does not inherit the data units. [#1408]
 
+- ``photutils.datasets``
+
+  - Fixed a bug in the various ``load`` functions where FITS files were
+    not closed. [#1455]
+
 - ``photutils.segmentation``
 
   - Fixed an issue in the ``SourceCatalog`` ``kron_photometry``,

--- a/photutils/datasets/load.py
+++ b/photutils/datasets/load.py
@@ -107,9 +107,12 @@ def load_spitzer_image(show_progress=False):  # pragma: no cover
     """
     path = get_path('spitzer_example_image.fits', location='remote',
                     show_progress=show_progress)
-    hdu = fits.open(path)[0]
 
-    return hdu
+    with fits.open(path) as hdulist:
+        data = hdulist[0].data
+        header = hdulist[0].header
+
+    return fits.ImageHDU(data, header)
 
 
 def load_spitzer_catalog(show_progress=False):  # pragma: no cover
@@ -217,9 +220,11 @@ def load_irac_psf(channel, show_progress=False):  # pragma: no cover
 
     filepath = f'irac_ch{channel}_flight.fits'
     path = get_path(filepath, location='remote', show_progress=show_progress)
-    hdu = fits.open(path)[0]
+    with fits.open(path) as hdulist:
+        data = hdulist[0].data
+        header = hdulist[0].header
 
-    return hdu
+    return fits.ImageHDU(data, header)
 
 
 def load_fermi_image(show_progress=False):
@@ -250,9 +255,11 @@ def load_fermi_image(show_progress=False):
     """
     path = get_path('fermi_counts.fits.gz', location='local',
                     show_progress=show_progress)
-    hdu = fits.open(path)[1]
+    with fits.open(path) as hdulist:
+        data = hdulist[1].data
+        header = hdulist[1].header
 
-    return hdu
+    return fits.ImageHDU(data, header)
 
 
 def load_star_image(show_progress=False):  # pragma: no cover
@@ -289,9 +296,11 @@ def load_star_image(show_progress=False):  # pragma: no cover
     """
     path = get_path('M6707HH.fits', location='remote',
                     show_progress=show_progress)
-    hdu = fits.open(path)[0]
+    with fits.open(path) as hdulist:
+        data = hdulist[0].data
+        header = hdulist[0].header
 
-    return hdu
+    return fits.ImageHDU(data, header)
 
 
 def load_simulated_hst_star_image(show_progress=False):  # pragma: no cover
@@ -325,6 +334,8 @@ def load_simulated_hst_star_image(show_progress=False):  # pragma: no cover
     path = get_path('hst_wfc3ir_f160w_simulated_starfield.fits',
                     location='photutils-datasets',
                     show_progress=show_progress)
-    hdu = fits.open(path)[0]
+    with fits.open(path) as hdulist:
+        data = hdulist[0].data
+        header = hdulist[0].header
 
-    return hdu
+    return fits.ImageHDU(data, header)

--- a/photutils/datasets/load.py
+++ b/photutils/datasets/load.py
@@ -17,7 +17,7 @@ __all__ = ['get_path', 'load_spitzer_image', 'load_spitzer_catalog',
 
 def get_path(filename, location='local', cache=True, show_progress=False):
     """
-    Get path (location on your disk) for a given file.
+    Get the local path for a given file.
 
     Parameters
     ----------
@@ -25,30 +25,31 @@ def get_path(filename, location='local', cache=True, show_progress=False):
         File name in the local or remote data folder.
 
     location : {'local', 'remote', 'photutils-datasets'}
-        File location.  ``'local'`` means bundled with ``photutils``.
+        File location. ``'local'`` means bundled with ``photutils``.
         ``'remote'`` means the astropy data server (or the
-        photutils-datasets repo as a backup) or the Astropy cache on
-        your machine. ``'photutils-datasets'`` means the
+        photutils-datasets repo as a backup) or the Astropy cache
+        on your machine. ``'photutils-datasets'`` means the
         photutils-datasets repo or the Astropy cache on your machine.
 
     cache : bool, optional
-        Whether to cache the contents of remote URLs.  Default is
-        `True`.
+        Whether to cache the contents of remote URLs. Default is `True`.
 
     show_progress : bool, optional
         Whether to display a progress bar during the download (default
-        is `False`).
+        is `False`). The progress bar is displayed only when outputting
+        to a terminal.
 
     Returns
     -------
     path : str
-        Path (location on your disk) of the file.
+        The local path of the file.
 
     Examples
     --------
     >>> from astropy.io import fits
     >>> from photutils.datasets import get_path
     >>> hdulist = fits.open(get_path('fermi_counts.fits.gz'))
+    >>> hdulist.close()
     """
     datasets_url = ('https://github.com/astropy/photutils-datasets/raw/'
                     f'main/data/{filename}')

--- a/photutils/datasets/tests/test_load.py
+++ b/photutils/datasets/tests/test_load.py
@@ -22,5 +22,5 @@ def test_load_fermi_image():
 @pytest.mark.remote_data
 def test_load_star_image():
     hdu = load.load_star_image()
-    assert len(hdu.header) == 104
+    assert len(hdu.header) == 106
     assert hdu.data.shape == (1059, 1059)

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,6 @@ filterwarnings =
     # TODO: Revisit these in the future.
     # Extra warnings seen in other jobs.
     ignore:invalid value encountered:RuntimeWarning
-    ignore:unclosed file:ResourceWarning
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:.*converting a masked element to nan
     ignore:Mean of empty slice:RuntimeWarning


### PR DESCRIPTION
Also removes the ignoring of `pytest` warnings for unclosed files during tests.