### PR TITLE
Deprecate load_fermi_image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,10 @@ API Changes
   - Removed the deprecated ``oversampling`` keyword in ``centroid_com``.
     [#1398]
 
+- ``photutils.datasets``
+
+  - Deprecated the ``load_fermi_image`` function. [#1455]
+
 - ``photutils.psf``
 
   - Removed the deprecated ``flux_residual_sigclip`` keyword in

--- a/photutils/datasets/load.py
+++ b/photutils/datasets/load.py
@@ -9,6 +9,7 @@ from urllib.error import HTTPError, URLError
 from astropy.io import fits
 from astropy.table import Table
 from astropy.utils.data import download_file, get_pkg_data_filename
+from astropy.utils.decorators import deprecated
 
 __all__ = ['get_path', 'load_spitzer_image', 'load_spitzer_catalog',
            'load_irac_psf', 'load_fermi_image', 'load_star_image',
@@ -43,13 +44,6 @@ def get_path(filename, location='local', cache=True, show_progress=False):
     -------
     path : str
         The local path of the file.
-
-    Examples
-    --------
-    >>> from astropy.io import fits
-    >>> from photutils.datasets import get_path
-    >>> hdulist = fits.open(get_path('fermi_counts.fits.gz'))
-    >>> hdulist.close()
     """
     datasets_url = ('https://github.com/astropy/photutils-datasets/raw/'
                     f'main/data/{filename}')
@@ -228,6 +222,7 @@ def load_irac_psf(channel, show_progress=False):  # pragma: no cover
     return fits.ImageHDU(data, header)
 
 
+@deprecated('1.6.0')
 def load_fermi_image(show_progress=False):
     """
     Load a Fermi counts image for the Galactic center region.

--- a/photutils/datasets/tests/test_load.py
+++ b/photutils/datasets/tests/test_load.py
@@ -4,6 +4,7 @@ Tests for the load module.
 """
 
 import pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.datasets import get_path, load
 
@@ -14,9 +15,10 @@ def test_get_path():
 
 
 def test_load_fermi_image():
-    hdu = load.load_fermi_image()
-    assert len(hdu.header) == 81
-    assert hdu.data.shape == (201, 401)
+    with pytest.warns(AstropyDeprecationWarning):
+        hdu = load.load_fermi_image()
+        assert len(hdu.header) == 81
+        assert hdu.data.shape == (201, 401)
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
This dataset is not used anywhere in `photutils` for testing or documentation.