### PR TITLE
Ignore RunTimeWarning when calculating PSF parameter uncertainties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ General
 
 New Features
 ^^^^^^^^^^^^
+
 - ``photutils.aperture``
 
   - The ``ApertureStats`` class now accepts astropy ``NDData`` objects
@@ -105,6 +106,9 @@ API Changes
 
   - Removed the deprecated ``flux_residual_sigclip`` keyword in
     ``EPSFBuilder``. Use ``sigma_clip`` instead. [#1398]
+
+  - PSF photometry classes will no longer emit a RuntimeWarning if the
+    fitted parameter variance is negative. [#1458]
 
 - ``photutils.segmentation``
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -567,9 +567,14 @@ class BasicPSFPhotometry:
         k = 0
         n_fit_params = len(unc_tab.colnames)
         param_cov = self.fitter.fit_info.get('param_cov', None)
-        for i in range(star_group_size):
-            unc_tab[i] = np.sqrt(np.diag(param_cov))[k: k + n_fit_params]
-            k = k + n_fit_params
+
+        # variance is sometimes returned as a negative value
+        # ignore sqrt(negative value) RuntimeWarnings
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            for i in range(star_group_size):
+                unc_tab[i] = np.sqrt(np.diag(param_cov))[k: k + n_fit_params]
+                k = k + n_fit_params
 
         return unc_tab
 


### PR DESCRIPTION
The PSF photometry classes will no longer emit a RuntimeWarning if the fit parameter variance is negative (returned from scipy).