### PR TITLE
Remove invalid value from pytest filterwarnings

### DIFF
--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -17,7 +17,7 @@ from photutils.datasets import make_100gaussians_image, make_wcs
 
 class TestApertureStats:
     data = make_100gaussians_image()
-    error = np.sqrt(data)
+    error = np.sqrt(np.abs(data))
     wcs = make_wcs(data.shape)
     positions = [(145.1, 168.3), (84.7, 224.1), (48.3, 200.3)]
     aperture = CircularAperture(positions, r=5)

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,6 @@ filterwarnings =
     ignore:numpy\.ndarray size changed:RuntimeWarning
     # TODO: Revisit these in the future.
     # Extra warnings seen in other jobs.
-    ignore:invalid value encountered:RuntimeWarning
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:.*converting a masked element to nan
     ignore:Mean of empty slice:RuntimeWarning


### PR DESCRIPTION
Also fixes the test that generated the warning.