### PR TITLE
Remove pytest filterwarnings from setup

### DIFF
--- a/photutils/isophote/tests/test_regression.py
+++ b/photutils/isophote/tests/test_regression.py
@@ -174,6 +174,10 @@ def test_regression(name, integrmode=BILINEAR, verbose=False):
             else:
                 assert abs(intens_d) <= 5.
 
+            # prevent "converting a masked element to nan" warning
+            if ellip_d is np.ma.masked:
+                continue
+
             if not math.isnan(ellip_d):
                 if sma_i > 3.:
                     assert abs(ellip_d) <= 1.  # 1%

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,11 +72,6 @@ filterwarnings =
     error
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
-    # TODO: Revisit these in the future.
-    # Extra warnings seen in other jobs.
-    ignore:distutils Version classes are deprecated:DeprecationWarning
-    ignore:.*converting a masked element to nan
-    ignore:Mean of empty slice:RuntimeWarning
     # numpy 1.24 deprecation from skimage (can remove for skimage >= 0.20)
     ignore:`np.bool8` is a deprecated alias for `np.bool_`:DeprecationWarning
 


### PR DESCRIPTION
This PR resolves a warning in an `isophote` test and also removes all the pytest warningfilters that are resolved.