### PR TITLE
Unpin sphinx version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,9 @@ rst_epilog = """
 .. _Astropy: https://www.astropy.org/
 """
 
+# Turn off table of contents entries for functions and classes
+toc_object_entries = False
+
 
 # -- Project information ------------------------------------------------------
 project = setup_cfg['name']

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ test =
     pytest-astropy
 docs =
     scipy>=1.6.0
-    sphinx<5.2
+    sphinx
     sphinx-astropy>=1.6
     matplotlib>=3.3.0
     scikit-image>=0.18.0


### PR DESCRIPTION
This PR unpins the sphinx version and turns off the table of contents entries for functions and classes.  This can be revisited if the astropy sphinx theme sidebar width is increased.

Followup to #1424.