### PR TITLE
Add quadratic centroids to SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ New Features
 
   - Added "windowed" centroids to ``SourceCatalog``. [#1447]
 
+  - Added quadratic centroids to ``SourceCatalog``. [#1467]
+
 - ``photutils.utils``
 
   - Added ``xyorigin`` attribute to ``CutoutImage``. [#1419]

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -133,6 +133,18 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
     Hogg (2016) <https://arxiv.org/abs/1610.05873>`_ for their 2D
     second-order polynomial centroiding method.
 
+    Because this centroid is based on fitting data, it can fail for many
+    reasons, returning (np.nan, np.nan):
+
+        * quadratic fit failed
+        * quadratic fit does not have a maximum
+        * quadratic fit maximum falls outside image
+        * not enough unmasked data points (6 are required)
+
+    Also note that a fit is not performed if the maximum data value is
+    at the edge of the data. In this case, the position of the maximum
+    pixel will be returned.
+
     References
     ----------
     .. [1] Vakili and Hogg 2016; arXiv:1610.05873

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -43,6 +43,12 @@ DEFAULT_COLUMNS = ['label', 'xcentroid', 'ycentroid', 'sky_centroid',
 def as_scalar(method):
     """
     Return a scalar value from a method if the class is scalar.
+
+    Note that lazyproperties that begin with '_' should not have this
+    decorator applied. Such properties are assumed to always be iterable
+    and when slicing (see __getitem__) from a cached multi-object
+    catalog to create a single-object catalog, they will no longer be
+    scalar.
     """
 
     @functools.wraps(method)
@@ -485,7 +491,8 @@ class SourceCatalog:
                 continue
 
             try:
-                # keep _<attrs> as length-1 iterables
+                # keep _<attr> lazyproperties as length-1 iterables;
+                # _<attr> lazyproperties should not have @as_scalar applied
                 if newcls.isscalar and key.startswith('_'):
                     if isinstance(value, np.ndarray):
                         val = value[:, np.newaxis][index]

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -19,6 +19,7 @@ from astropy.utils.decorators import deprecated_renamed_argument
 from photutils.aperture import (BoundingBox, CircularAperture,
                                 EllipticalAperture, RectangularAnnulus)
 from photutils.background import SExtractorBackground
+from photutils.centroids import centroid_quadratic
 from photutils.segmentation.core import SegmentationImage
 from photutils.utils._convolution import _filter_data
 from photutils.utils._misc import _get_meta
@@ -1442,6 +1443,24 @@ class SourceCatalog:
         else:
             ycentroid = self.centroid_win[:, 1]
         return ycentroid
+
+    @lazyproperty
+    @use_detcat
+    @as_scalar
+    def centroid_quad(self):
+        """
+        The ``(x, y)`` centroid coordinate calculated by fitting a 2D
+        quadratic polynomical to the unmasked pixels in the source
+        segment.
+
+        `~photutils.centroids.centroid_quadratic` is used to calculate
+        the centroid.
+        """
+        centroid_quad = []
+        for data, mask in zip(self._data_cutouts, self._cutout_total_masks):
+            centroid_quad.append(centroid_quadratic(data, mask=mask))
+
+        return centroid_quad
 
     @lazyproperty
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1468,6 +1468,7 @@ class SourceCatalog:
 
         Because this centroid is based on fitting data, it can fail for
         many reasons, returning (np.nan, np.nan):
+
             * quadratic fit failed
             * quadratic fit does not have a maximum
             * quadratic fit maximum falls outside image
@@ -1514,6 +1515,7 @@ class SourceCatalog:
 
         Because this centroid is based on fitting data, it can fail for
         many reasons, returning (np.nan, np.nan):
+
             * quadratic fit failed
             * quadratic fit does not have a maximum
             * quadratic fit maximum falls outside image


### PR DESCRIPTION
This PR adds `centroid_quad` and `cutout_centroid_quad`, calculated using `centroid_quadratic` (2D quadratic fit), to `SourceCatalog`.