### PR TITLE
Add progress_bar option to SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@ New Features
 
   - Added quadratic centroids to ``SourceCatalog``. [#1467, #1469]
 
+  - Added a ``progress_bar`` option to ``SourceCatalog`` for displaying
+    progress bars when calculating some source properties. [#1471]
+
 - ``photutils.utils``
 
   - Added ``xyorigin`` attribute to ``CutoutImage``. [#1419]

--- a/docs/whats_new/1.6.rst
+++ b/docs/whats_new/1.6.rst
@@ -64,14 +64,21 @@ The :class:`~photutils.aperture.ApertureStats` class now accepts
 `~astropy.nddata.NDData` objects as input.
 
 
-Progress Bars in PSF Fitting
-============================
+Progress Bars in SourceCatalog and PSF fitting
+==============================================
+
+An ``progress_bar`` keyword option was added to
+`~photutils.segmentation.SourceCatalog` to enable progress bars when
+calculating some properties (e.g., ``kron_radius``, ``kron_flux``,
+``fluxfrac_radius``, ``circular_photometry``, ``centroid_win``,
+``centroid_quad``).
 
 An option to enable progress bars during PSF fitting was added. To
 enable it, set ``progress_bar=True`` when calling the PSF-fitting object
-on your data. The progress bar tracks progress over the star groups. It
-requires installation of the `tqdm <https://tqdm.github.io/>`_ optional
-dependency.
+on your data. The progress bar tracks progress over the star groups.
+
+The progress bars require installation of the `tqdm
+<https://tqdm.github.io/>`_ optional dependency.
 
 
 Other changes


### PR DESCRIPTION
This PR adds a `progress_bar` keyword to `SourceCatalog` for displaying progress bars when calculating some source properties.