### PR TITLE
Add notes about surface brightness units

### DIFF
--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -26,6 +26,12 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     Perform aperture photometry on the input data by summing the flux
     within the given aperture(s).
 
+    Note that this function returns the sum of the (weighted) input
+    ``data`` values within the aperture. It does not convert data
+    in surface brightness units to flux or counts. Conversion from
+    surface-brightness units should be performed before using this
+    function.
+
     Parameters
     ----------
     data : array_like, `~astropy.units.Quantity`, `~astropy.nddata.NDData`

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -57,6 +57,12 @@ class ApertureStats:
     Class to create a catalog of statistics for pixels within an
     aperture.
 
+    Note that this class returns the statistics of the input
+    ``data`` values within the aperture. It does not convert data
+    in surface brightness units to flux or counts. Conversion from
+    surface-brightness units should be performed before using this
+    function.
+
     Parameters
     ----------
     data : 2D `~numpy.ndarray`, `~astropy.units.Quantity`, `~astropy.nddata.NDData`

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -236,6 +236,15 @@ class SourceCatalog:
     be passed into this class to calculate properties of the background
     for each source.
 
+    Note that this class does not convert input data in
+    surface-brightness units to flux or counts. Conversion from
+    surface-brightness units should be performed before using this
+    class.
+
+    function returns the sum of the (weighted) input
+    ``data`` values within the aperture. It does not convert data in
+    surface brightness units to flux or counts.
+
     `SourceExtractor`_'s centroid and morphological parameters are
     always calculated from a convolved, or filtered, "detection"
     image (``convolved_data``), i.e., the image used to define the


### PR DESCRIPTION
This PR adds a note in the docstrings of `aperture_photometry`, `ApertureStats`, and `SourceCatalog` that these functions/classes do not convert the input data from surface brightness to flux.  The user will need to do that before using these functions/classes.

ref: https://github.com/astropy/photutils/issues/1403