### PR TITLE
Add subshape keyword to PSF-fitting classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ New Features
 
   - Added a progress bar for fitting PSF photometry [#1426]
 
+  - Added a ``subshape`` keyword to the PSF-fitting classes to define
+    the shape over which the PSF is subtracted. [#1477]
+
 - ``photutils.segmentation``
 
   - Added the ability to slice ``SegmentationImage`` objects. [#1413]

--- a/docs/whats_new/1.6.rst
+++ b/docs/whats_new/1.6.rst
@@ -81,6 +81,17 @@ The progress bars require installation of the `tqdm
 <https://tqdm.github.io/>`_ optional dependency.
 
 
+New subshape keyword in PSF fitting
+===================================
+
+A new ``subshape`` keyword was added to the PSF-fitting classes to
+define the shape over which the PSF is subtracted when computing the
+residual image. Previously, the PSF-subtraction region was always
+defined by the ``fitshape`` keyword. By default (and for backwards
+compatibility), ``subshape`` is set to `None`, which means the
+``fitshape`` value will be used.
+
+
 Other changes
 =============
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -68,12 +68,11 @@ class BasicPSFPhotometry:
         ``y_0`` and ``flux``. `~photutils.psf.prepare_psf_model` can be
         used to prepare any 2D model to match this assumption.
     fitshape : int or length-2 array-like
-        Rectangular shape around the center of a star which will be
-        used to collect the data to do the fitting. Can be an integer
-        to be the same along both axes. For example, 5 is the same as
-        (5, 5), which means to fit only at the following relative pixel
-        positions: [-2, -1, 0, 1, 2]. Each element of ``fitshape`` must
-        be an odd number.
+        Rectangular shape around the center of a star that will be
+        used to define the PSF-fitting region. If ``fitshape`` is a
+        scalar then a square shape of size ``fitshape`` will be used.
+        If ``fitshape`` has two elements, they must be in ``(ny, nx)``
+        order. Each element of ``fitshape`` must be an odd number.
     finder : callable or instance of any \
             `~photutils.detection.StarFinderBase` subclasses or None
         ``finder`` should be able to identify stars, i.e., compute a
@@ -103,6 +102,13 @@ class BasicPSFPhotometry:
         List of additional columns for parameters derived by any of the
         intermediate fitting steps (e.g., ``finder``), such as roundness
         or sharpness.
+    subshape : `None`, int, or length-2 array-like
+        Rectangular shape around the center of a star that will be
+        used to define the PSF-subtraction region. If `None`, then
+        ``fitshape`` will be used. If ``subshape`` is a scalar then a
+        square shape of size ``subshape`` will be used. If ``subshape``
+        has two elements, they must be in ``(ny, nx)`` order. Each
+        element of ``subshape`` must be an odd number.
 
     Notes
     -----
@@ -696,12 +702,11 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         ``y_0`` and ``flux``. `~photutils.psf.prepare_psf_model` can be
         used to prepare any 2D model to match this assumption.
     fitshape : int or length-2 array-like
-        Rectangular shape around the center of a star which will be
-        used to collect the data to do the fitting. Can be an integer
-        to be the same along both axes. For example, 5 is the same as
-        (5, 5), which means to fit only at the following relative pixel
-        positions: [-2, -1, 0, 1, 2]. Each element of ``fitshape`` must
-        be an odd number.
+        Rectangular shape around the center of a star that will be
+        used to define the PSF-fitting region. If ``fitshape`` is a
+        scalar then a square shape of size ``fitshape`` will be used.
+        If ``fitshape`` has two elements, they must be in ``(ny, nx)``
+        order. Each element of ``fitshape`` must be an odd number.
     finder : callable or instance of any \
             `~photutils.detection.StarFinderBase` subclasses
         ``finder`` should be able to identify stars, i.e., compute a
@@ -732,6 +737,13 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         List of additional columns for parameters derived by any of the
         intermediate fitting steps (e.g., ``finder``), such as roundness
         or sharpness.
+    subshape : `None`, int, or length-2 array-like
+        Rectangular shape around the center of a star that will be
+        used to define the PSF-subtraction region. If `None`, then
+        ``fitshape`` will be used. If ``subshape`` is a scalar then a
+        square shape of size ``subshape`` will be used. If ``subshape``
+        has two elements, they must be in ``(ny, nx)`` order. Each
+        element of ``subshape`` must be an odd number.
 
     Notes
     -----
@@ -985,12 +997,11 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
         ``y_0`` and ``flux``. `~photutils.psf.prepare_psf_model` can be
         used to prepare any 2D model to match this assumption.
     fitshape : int or length-2 array-like
-        Rectangular shape around the center of a star which will be
-        used to collect the data to do the fitting. Can be an integer
-        to be the same along both axes. For example, 5 is the same as
-        (5, 5), which means to fit only at the following relative pixel
-        positions: [-2, -1, 0, 1, 2]. Each element of ``fitshape`` must
-        be an odd number.
+        Rectangular shape around the center of a star that will be
+        used to define the PSF-fitting region. If ``fitshape`` is a
+        scalar then a square shape of size ``fitshape`` will be used.
+        If ``fitshape`` has two elements, they must be in ``(ny, nx)``
+        order. Each element of ``fitshape`` must be an odd number.
     sigma : float, optional
         Number of standard deviations used to perform sigma clip with a
         `astropy.stats.SigmaClip` object.
@@ -1033,6 +1044,13 @@ class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
         List of additional columns for parameters derived by any of the
         intermediate fitting steps (e.g., ``finder``), such as roundness
         or sharpness.
+    subshape : `None`, int, or length-2 array-like
+        Rectangular shape around the center of a star that will be
+        used to define the PSF-subtraction region. If `None`, then
+        ``fitshape`` will be used. If ``subshape`` is a scalar then a
+        square shape of size ``subshape`` will be used. If ``subshape``
+        has two elements, they must be in ``(ny, nx)`` order. Each
+        element of ``subshape`` must be an odd number.
 
     Notes
     -----


### PR DESCRIPTION
As requested in #1427, this PR adds a new ``subshape`` keyword to the PSF-fitting classes to define the shape over which the PSF is subtracted when computing the residual image. Previously, the PSF-subtraction region was always defined by the ``fitshape`` keyword. By default (and for backwards compatibility), ``subshape`` is set to `None`, which means the ``fitshape`` value will be used.

Closes #1427.