### PR TITLE
DEBUG: try a different way of passing tox anv variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,4 @@ jobs:
           command: /opt/python/cp38-cp38/bin/pip install tox
       - run:
           name: Run tests for Python 3.8
-          command: |
-            stty rows 50 cols 80
-            /opt/python/cp38-cp38/bin/python -m tox -e circleci_32bit
+          command: /opt/python/cp38-cp38/bin/python -m tox -e circleci_32bit

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,13 @@ setenv =
 
 # Pass through the following environment variables which may be needed
 # for the CI
-passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI
+passenv =
+    HOME
+    WINDIR
+    LC_ALL
+    LC_CTYPE
+    CC
+    CI
 
 # Run the tests in a temporary directory to make sure that we don't
 # import this package from the source tree


### PR DESCRIPTION
This is a follow-up debug to #1480, close if it keeps failing on circleCI.