### PR TITLE
Remove setuptools from install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    setuptools
     numpy>=1.20
     astropy>=5.0
 


### PR DESCRIPTION
Setuptools is not required during runtime.

Remnant of #1443, #1454 