### PR TITLE
Refactor area_overlap method for performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New Features
     and the ``PixelAperture`` ``do_photometry`` method for large arrays.
     [#1485]
 
+  - Significantly improved the performance of the ``PixelAperture``
+    ``area_overlap`` method, especially for large arrays. [#1490]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/docs/aperture.rst
+++ b/docs/aperture.rst
@@ -486,7 +486,7 @@ using a mask, the results are identical::
 
     >>> aperture_area = aperture.area_overlap(data)
     >>> print(aperture_area)  # doctest: +FLOAT_CMP
-    [78.53981633974485, 78.53981633974482, 78.53981633974483]
+    [78.53981634 78.53981634 78.53981634]
 
 The total background within the circular aperture is then::
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -123,7 +123,7 @@ class Aperture(metaclass=abc.ABCMeta):
         """
         Inequality operator for `Aperture`.
         """
-        return not (self == other)
+        return not self == other
 
     @property
     def _lazyproperties(self):
@@ -555,7 +555,7 @@ class PixelAperture(Aperture):
 
             data_cutout = data[slc_large]
             apermask_cutout = apermask.data[slc_small]
-            pixel_mask = (apermask_cutout > 0)  # good pixels
+            pixel_mask = apermask_cutout > 0  # good pixels
 
             if mask is not None:
                 if mask.shape != data.shape:

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -278,10 +278,19 @@ class PixelAperture(Aperture):
         """
         The exact analytical area of the aperture shape.
 
+        Use the `area_overlap` method to return the area of overlap
+        between the data and the aperture, taking into account the
+        aperture mask method, masked data pixels (``mask`` keyword), and
+        partial/no overlap of the aperture with the data.
+
         Returns
         -------
         area : float
             The aperture area.
+
+        See Also
+        --------
+        area_overlap
         """
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
@@ -336,11 +345,15 @@ class PixelAperture(Aperture):
 
     def area_overlap(self, data, *, mask=None, method='exact', subpixels=5):
         """
-        Return the pixel areas of the aperture masks that overlap with
-        the data.
+        Return the area of overlap between the data and the aperture.
 
-        In other words, this method returns the pixel area(s) within the
-        aperture(s) that are used to calculate the aperture sum(s).
+        This method takes into account the aperture mask method, masked
+        data pixels (``mask`` keyword), and partial/no overlap of the
+        aperture with the data. In other words, it returns the area that
+        used to compute the aperture sum (assuming identical inputs).
+
+        Use the `area` method to calculate the exact analytical area of
+        the aperture shape.
 
         Parameters
         ----------
@@ -387,8 +400,12 @@ class PixelAperture(Aperture):
         Returns
         -------
         areas : float or array_like
-            The overlapping areas (in pixels**2) between the aperture
-            masks and the data.
+            The area (in pixels**2) of overlap between the data and the
+            aperture.
+
+        See Also
+        --------
+        area
         """
         apermasks = self.to_mask(method=method, subpixels=subpixels)
         if self.isscalar:

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -294,55 +294,6 @@ class PixelAperture(Aperture):
         """
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
-    @abc.abstractmethod
-    def to_mask(self, method='exact', subpixels=5):
-        """
-        Return a mask for the aperture.
-
-        Parameters
-        ----------
-        method : {'exact', 'center', 'subpixel'}, optional
-            The method used to determine the overlap of the aperture on
-            the pixel grid.  Not all options are available for all
-            aperture types.  Note that the more precise methods are
-            generally slower.  The following methods are available:
-
-                * ``'exact'`` (default):
-                  The the exact fractional overlap of the aperture and
-                  each pixel is calculated. The aperture weights will
-                  contain values between 0 and 1.
-
-                * ``'center'``:
-                  A pixel is considered to be entirely in or out of the
-                  aperture depending on whether its center is in or out
-                  of the aperture. The aperture weights will contain
-                  values only of 0 (out) and 1 (in).
-
-                * ``'subpixel'``:
-                  A pixel is divided into subpixels (see the
-                  ``subpixels`` keyword), each of which are considered
-                  to be entirely in or out of the aperture depending
-                  on whether its center is in or out of the aperture.
-                  If ``subpixels=1``, this method is equivalent to
-                  ``'center'``. The aperture weights will contain values
-                  between 0 and 1.
-
-        subpixels : int, optional
-            For the ``'subpixel'`` method, resample pixels by this
-            factor in each dimension. That is, each pixel is divided
-            into ``subpixels**2`` subpixels. This keyword is ignored
-            unless ``method='subpixel'``.
-
-        Returns
-        -------
-        mask : `~photutils.aperture.ApertureMask` or list of `~photutils.aperture.ApertureMask`
-            A mask for the aperture.  If the aperture is scalar then a
-            single `~photutils.aperture.ApertureMask` is returned,
-            otherwise a list of `~photutils.aperture.ApertureMask` is
-            returned.
-        """
-        raise NotImplementedError('Needs to be implemented in a subclass.')
-
     def area_overlap(self, data, *, mask=None, method='exact', subpixels=5):
         """
         Return the area of overlap between the data and the aperture.
@@ -436,6 +387,55 @@ class PixelAperture(Aperture):
             return areas[0]
         else:
             return areas
+
+    @abc.abstractmethod
+    def to_mask(self, method='exact', subpixels=5):
+        """
+        Return a mask for the aperture.
+
+        Parameters
+        ----------
+        method : {'exact', 'center', 'subpixel'}, optional
+            The method used to determine the overlap of the aperture on
+            the pixel grid.  Not all options are available for all
+            aperture types.  Note that the more precise methods are
+            generally slower.  The following methods are available:
+
+                * ``'exact'`` (default):
+                  The the exact fractional overlap of the aperture and
+                  each pixel is calculated. The aperture weights will
+                  contain values between 0 and 1.
+
+                * ``'center'``:
+                  A pixel is considered to be entirely in or out of the
+                  aperture depending on whether its center is in or out
+                  of the aperture. The aperture weights will contain
+                  values only of 0 (out) and 1 (in).
+
+                * ``'subpixel'``:
+                  A pixel is divided into subpixels (see the
+                  ``subpixels`` keyword), each of which are considered
+                  to be entirely in or out of the aperture depending
+                  on whether its center is in or out of the aperture.
+                  If ``subpixels=1``, this method is equivalent to
+                  ``'center'``. The aperture weights will contain values
+                  between 0 and 1.
+
+        subpixels : int, optional
+            For the ``'subpixel'`` method, resample pixels by this
+            factor in each dimension. That is, each pixel is divided
+            into ``subpixels**2`` subpixels. This keyword is ignored
+            unless ``method='subpixel'``.
+
+        Returns
+        -------
+        mask : `~photutils.aperture.ApertureMask` or list of `~photutils.aperture.ApertureMask`
+            A mask for the aperture.  If the aperture is scalar then a
+            single `~photutils.aperture.ApertureMask` is returned,
+            otherwise a list of `~photutils.aperture.ApertureMask` is
+            returned.
+        """
+        raise NotImplementedError('Needs to be implemented in a subclass.')
 
     def do_photometry(self, data, error=None, mask=None, method='exact',
                       subpixels=5):


### PR DESCRIPTION
This PR significantly improves the performance of the ``PixelAperture`` ``area_overlap`` method, especially for large arrays, by avoiding copying the input array.