### PR TITLE
Update minimum numpy version for CircleCI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    circleci_32bit: numpy==1.20.*
+    circleci_32bit: numpy==1.21.*
     circleci_32bit: git+https://github.com/astropy/astropy.git#egg=astropy
 
     cov: coverage


### PR DESCRIPTION
astropy dev now requires numpy >= 1.21.