### PR TITLE
Fix centroid_quadratic for data with NaNs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.centroid``
+
+  - Fixed an issue where ``centroid_quadratic`` would sometimes fail if
+    the input data contained NaNs. [#1495]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -239,6 +239,12 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
     y = y.ravel()
     coeff_matrix = np.vstack((np.ones_like(x), x, y, x * y, x * x, y * y)).T
 
+    # remove NaNs from data to be fit
+    mask = ~np.isnan(cutout)
+    if np.any(mask):
+        coeff_matrix = coeff_matrix[mask]
+        cutout = cutout[mask]
+
     try:
         c = np.linalg.lstsq(coeff_matrix, cutout, rcond=None)[0]
     except np.linalg.LinAlgError:

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -26,10 +26,11 @@ def centroid_com(data, mask=None):
 
     Parameters
     ----------
-    data : array_like
-        The input n-dimensional array.
+    data : `~numpy.ndarray`
+        The input n-dimensional array. The image should be a
+        background-subtracted cutout image containing a single source.
 
-    mask : array_like (bool), optional
+    mask : bool `~numpy.ndarray`, optional
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
@@ -93,8 +94,8 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
     Parameters
     ----------
     data : 2D `~numpy.ndarray`
-        The 2D image data. The image should be a cutout image containing
-        a single source.
+        The 2D image data. The image should be a background-subtracted
+        cutout image containing a single source.
 
     xpeak, ypeak : float or `None`, optional
         The initial guess of the position of the centroid. If either
@@ -287,8 +288,8 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
 
     Parameters
     ----------
-    data : array_like
-        The 2D array of the image.
+    data : 2D `~numpy.ndarray`
+        The 2D image data. The image should be background-subtracted.
 
     xpos, ypos : float or array-like of float
         The initial ``x`` and ``y`` pixel position(s) of the center
@@ -313,12 +314,12 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
         ``footprint`` must be defined. If they are both defined, then
         ``footprint`` overrides ``box_size``.
 
-    mask : array_like, bool, optional
+    mask : 2D bool `~numpy.ndarray`, optional
         A 2D boolean array with the same shape as ``data``, where a
         `True` value indicates the corresponding element of ``data`` is
         masked.
 
-    error : array_like, optional
+    error : 2D `~numpy.ndarray`, optional
         The 2D array of the 1-sigma errors of the input ``data``.
         ``error`` must have the same shape as ``data``.  ``error`` will
         be used only if supported by the input ``centroid_func``.

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -23,13 +23,14 @@ def centroid_1dg(data, error=None, mask=None):
 
     Parameters
     ----------
-    data : array_like
-        The 2D data array.
+    data : 2D `~numpy.ndarray`
+        The 2D image data. The image should be a background-subtracted
+        cutout image containing a single source.
 
-    error : array_like, optional
+    error : 2D `~numpy.ndarray`, optional
         The 2D array of the 1-sigma errors of the input ``data``.
 
-    mask : array_like (bool), optional
+    mask : 2D bool `~numpy.ndarray`, optional
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
@@ -94,10 +95,10 @@ def _gaussian1d_moments(data, mask=None):
 
     Parameters
     ----------
-    data : array_like (1D)
-        The 1D array.
+    data : 1D `~numpy.ndarray`
+        The 1D data array.
 
-    mask : array_like (1D bool), optional
+    mask : 1D bool `~numpy.ndarray`, optional
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
@@ -141,13 +142,14 @@ def centroid_2dg(data, error=None, mask=None):
 
     Parameters
     ----------
-    data : array_like
-        The 2D data array.
+    data : 2D `~numpy.ndarray`
+        The 2D image data. The image should be a background-subtracted
+        cutout image containing a single source.
 
-    error : array_like, optional
+    error : 2D `~numpy.ndarray`, optional
         The 2D array of the 1-sigma errors of the input ``data``.
 
-    mask : array_like (bool), optional
+    mask : 2D bool `~numpy.ndarray`, optional
         A boolean mask, with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
@@ -170,7 +172,7 @@ def centroid_2dg(data, error=None, mask=None):
     if np.any(~np.isfinite(data)):
         data = np.ma.masked_invalid(data)
         warnings.warn('Input data contains non-finite values (e.g., NaN or '
-                      'infs) that were automatically masked.',
+                      'inf) that were automatically masked.',
                       AstropyUserWarning)
 
     if error is not None:

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -85,12 +85,11 @@ def test_centroid_com_nan_withmask(use_mask):
         if nwarn == 1:
             assert len(warnlist) == nwarn
 
-    ctx = pytest.warns(AstropyUserWarning,
-                       match='Input data contains non-finite values')
     with ctx as warnlist:
         xc, yc = centroid_quadratic(data, mask=mask)
         assert_allclose(xc, xc_ref, rtol=0, atol=0.15)
-        assert len(warnlist) == 1
+        if nwarn == 1:
+            assert len(warnlist) == nwarn
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')


### PR DESCRIPTION
This PR fixes an issue where ``centroid_quadratic`` would sometimes fail if the input data contained NaNs.