### PR TITLE
Use np.prod instead of deprecated np.product

### DIFF
--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -182,7 +182,7 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
     fit_boxsize = as_pair('fit_boxsize', fit_boxsize, lower_bound=(0, 1),
                           upper_bound=data.shape, check_odd=True)
 
-    if np.product(fit_boxsize) < 6:
+    if np.prod(fit_boxsize) < 6:
         raise ValueError('fit_boxsize is too small.  6 values are required '
                          'to fit a 2D quadratic polynomial.')
 

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -544,7 +544,7 @@ class EPSFModel(FittableImageModel):
         radius = self._norm_radius * self.oversampling[0]
         aper = CircularAperture(xypos, r=radius)
         flux, _ = aper.do_photometry(self._data, method='exact')
-        return flux[0] / np.product(self.oversampling)
+        return flux[0] / np.prod(self.oversampling)
 
     def _compute_normalization(self, normalize=True):
         """


### PR DESCRIPTION
Numpy 1.25 will deprecate `np.product` in favor of `np.prod` (https://github.com/numpy/numpy/pull/23314).