### PR TITLE
Automatically mask non-finite values in profile classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ New Features
 - ``photutils.profiles``
 
   - Added a new ``profiles`` subpackage containing ``RadialProfile`` and
-    ``CurveOfGrowth`` classes. [#1494, #1496]
+    ``CurveOfGrowth`` classes. [#1494, #1496, #1498]
 
 Bug Fixes
 ^^^^^^^^^

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -86,7 +86,29 @@ class ProfileBase:
 
         (data, error), unit = process_quantities((data, error),
                                                  ('data', 'error'))
+
+        if error is not None and error.shape != data.shape:
+            raise ValueError('error must have the same same as data')
+
+        badmask = ~np.isfinite(data)
+        if error is not None:
+            badmask |= ~np.isfinite(error)
+        if mask is not None:
+            if mask.shape != data.shape:
+                raise ValueError('mask must have the same same as data')
+            badmask &= ~mask  # non-finite values not in input mask
+            mask |= badmask  # all masked pixels
+        else:
+            mask = badmask
+
+        if np.any(badmask):
+            warnings.warn('Input data contains non-finite values (e.g., NaN '
+                          'or inf) that were automatically masked.',
+                          AstropyUserWarning)
+
         self.data = data
+        self.error = error
+        self.mask = mask
         self.unit = unit
         self.xycen = xycen
 
@@ -99,14 +121,6 @@ class ProfileBase:
         self.min_radius = min_radius
         self.max_radius = max_radius
         self.radius_step = radius_step
-
-        if error is not None and error.shape != data.shape:
-            raise ValueError('error must have the same same as data')
-        self.error = error
-        if mask is not None and mask.shape != data.shape:
-            raise ValueError('mask must have the same same as data')
-        self.mask = mask
-
         self.method = method
         self.subpixels = subpixels
 

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -203,9 +203,9 @@ class ProfileBase:
                   is 1.
         """
         if method == 'max':
-            normalization = self.profile.max()
+            normalization = np.nanmax(self.profile)
         elif method == 'sum':
-            normalization = self.profile.sum()
+            normalization = np.nansum(self.profile)
         else:
             raise ValueError('invalid method, must be "peak" or "integral"')
 

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -18,6 +18,9 @@ class CurveOfGrowth(ProfileBase):
     The curve of growth profile represents the circular aperture flux as
     a function of circular radius.
 
+    Non-finite values (e.g., NaN or inf) in the ``data`` or ``error``
+    array are automatically masked.
+
     Parameters
     ----------
     data : 2D `numpy.ndarray`

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -26,6 +26,9 @@ class RadialProfile(ProfileBase):
     The radial profile represents the azimuthally-averaged flux in
     circular annuli apertures as a function of radius.
 
+    Non-finite values (e.g., NaN or inf) in the ``data`` or ``error``
+    array are automatically masked.
+
     Parameters
     ----------
     data : 2D `numpy.ndarray`

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -377,18 +377,24 @@ class RadialProfile(ProfileBase):
             return self._fluxerr / self.area
 
     @lazyproperty
+    def _profile_nanmask(self):
+        return np.isfinite(self.profile)
+
+    @lazyproperty
     def gaussian_fit(self):
         """
         The fitted 1D Gaussian to the radial profile as
         a `~astropy.modeling.functional_models.Gaussian1D` model.
         """
-        amplitude = np.max(self.profile)
-        std = np.sqrt(abs(np.sum(self.profile * self.radius**2)
-                          / np.sum(self.profile)))
+        profile = self.profile[self._profile_nanmask]
+        radius = self.radius[self._profile_nanmask]
+
+        amplitude = np.max(profile)
+        std = np.sqrt(abs(np.sum(profile * radius**2) / np.sum(profile)))
         g_init = Gaussian1D(amplitude=amplitude, mean=0.0, stddev=std)
         g_init.mean.fixed = True
         fitter = LevMarLSQFitter()
-        g_fit = fitter(g_init, self.radius, self.profile)
+        g_fit = fitter(g_init, radius, profile)
 
         return g_fit
 

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -7,7 +7,8 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian1D, Gaussian2D
-from numpy.testing import assert_equal
+from astropy.utils.exceptions import AstropyUserWarning
+from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture import CircularAnnulus, CircularAperture
 from photutils.profiles import RadialProfile
@@ -111,3 +112,34 @@ def test_radial_profile_error(profile_data):
     assert len(rp1.apertures) == 36
     assert isinstance(rp1.apertures[0], CircularAperture)
     assert isinstance(rp1.apertures[1], CircularAnnulus)
+
+
+def test_radial_profile_nonfinite(profile_data):
+    xycen, data, error, _ = profile_data
+    data2 = data.copy()
+    data2[40, 40] = np.nan
+    mask = ~np.isfinite(data2)
+
+    min_radius = 0.0
+    max_radius = 35.0
+    radius_step = 1.0
+
+    rp1 = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
+                        error=None, mask=mask)
+
+    rp2 = RadialProfile(data2, xycen, min_radius, max_radius, radius_step,
+                        error=error, mask=mask)
+    assert_allclose(rp1.profile, rp2.profile)
+
+    msg = 'Input data contains non-finite values'
+    with pytest.raises(AstropyUserWarning, match=msg):
+        rp3 = RadialProfile(data2, xycen, min_radius, max_radius, radius_step,
+                            error=error, mask=None)
+        assert_allclose(rp1.profile, rp3.profile)
+
+    error2 = error.copy()
+    error2[40, 40] = np.inf
+    with pytest.raises(AstropyUserWarning, match=msg):
+        rp4 = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
+                            error=error2, mask=None)
+        assert_allclose(rp1.profile, rp4.profile)

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -114,6 +114,22 @@ def test_radial_profile_error(profile_data):
     assert isinstance(rp1.apertures[1], CircularAnnulus)
 
 
+def test_radial_profile_normalize_nan(profile_data):
+    """
+    If the profile has NaNs (e.g., aperture outside of the image),
+    make sure the normalization ignores them.
+    """
+    xycen, data, _, _ = profile_data
+
+    min_radius = 0.0
+    max_radius = 100.0
+    radius_step = 1.0
+
+    rp1 = RadialProfile(data, xycen, min_radius, max_radius, radius_step)
+    rp1.normalize()
+    assert not np.isnan(rp1.profile[0])
+
+
 def test_radial_profile_nonfinite(profile_data):
     xycen, data, error, _ = profile_data
     data2 = data.copy()

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -35,7 +35,6 @@ def fixture_profile_data():
     return xycen, data, error, mask
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_radial_profile(profile_data):
     xycen, data, _, _ = profile_data
 
@@ -76,6 +75,13 @@ def test_radial_profile_gaussian(profile_data):
     assert isinstance(rp1.gaussian_fit, Gaussian1D)
     assert rp1.gaussian_profile.shape == (36,)
     assert rp1.gaussian_fwhm < 23.6
+
+    max_radius = 200
+    rp2 = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
+                        error=None, mask=None)
+    assert isinstance(rp2.gaussian_fit, Gaussian1D)
+    assert rp2.gaussian_profile.shape == (201,)
+    assert rp2.gaussian_fwhm < 23.6
 
 
 def test_radial_profile_unit(profile_data):


### PR DESCRIPTION
This PR updates the new profile classes (`RadialProfile` and `CurveOfGrowth`) to automatically mask non-finite values in the data or error arrays.  It also fixed the `normalize` method to ignore non-finite values.  Finally, it fixes the`RadialProfile` Gaussian fitter to ignore non-finite values.