### PR TITLE
Fix sign of isophote upper harmonics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,14 @@ Bug Fixes
   - Fixed an issue where ``centroid_quadratic`` would sometimes fail if
     the input data contained NaNs. [#1495]
 
+- ``photutils.isophote``
+
+  - Fixed a bug where the upper harmonics (a3, a4, b3, and b4) had the
+    incorrect sign. [#1501]
+
+  - Fixed a bug in the calculation of the upper harmonic errors (a3_err,
+    a4_err, b3_err, and b4_err). [#1501].
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -271,8 +271,8 @@ class Isophote:
                                                            sample.values[2],
                                                            n)
 
-            a = up_coeffs[1] / self.sma / sample.gradient
-            b = up_coeffs[2] / self.sma / sample.gradient
+            a = up_coeffs[1] / self.sma / abs(sample.gradient)
+            b = up_coeffs[2] / self.sma / abs(sample.gradient)
 
             def errfunc(x, phi, order, intensities):
                 return (x[0] + x[1] * np.sin(order * phi)

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -288,7 +288,7 @@ class Isophote:
             # this comes from the old code. Likely it was based on
             # empirical experience with the STSDAS task, so we leave
             # it here without too much thought.
-            gre = self.grad_r_error if self.grad_r_error is not None else 0.64
+            gre = self.grad_r_error if self.grad_r_error is not None else 0.8
 
             a_err = abs(a) * np.sqrt((ce[1] / up_coeffs[1])**2 + gre**2)
             b_err = abs(b) * np.sqrt((ce[2] / up_coeffs[2])**2 + gre**2)

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -5,9 +5,12 @@ Tests for the harmonics module.
 
 import numpy as np
 import pytest
+from astropy.modeling.models import Gaussian2D
 from numpy.testing import assert_allclose
 
+from photutils.isophote.ellipse import Ellipse
 from photutils.isophote.fitter import EllipseFitter
+from photutils.isophote.geometry import EllipseGeometry
 from photutils.isophote.harmonics import (first_and_second_harmonic_function,
                                           fit_first_and_second_harmonics,
                                           fit_upper_harmonic)
@@ -187,3 +190,29 @@ class TestFitEllipseSamples:
         assert_allclose(iso.b3_err, 8.115e-6, atol=1.0e-7)
         assert_allclose(iso.a4_err, 7.501e-6, atol=1.0e-7)
         assert_allclose(iso.b4_err, 7.473e-6, atol=1.0e-7)
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+def test_upper_harmonics_sign():
+    """
+    Regression test for #1486/#1501.
+    """
+
+    angle = 40.0 * np.pi / 180.0
+    g1 = Gaussian2D(100.0, 75, 75, 15, 3, theta=angle)
+    g2 = Gaussian2D(100.0, 75, 75, 10, 8, theta=angle)
+
+    ny = nx = 150
+    y, x = np.mgrid[0:ny, 0:nx]
+    data = g1(x, y) + g2(x, y)
+    geometry = EllipseGeometry(x0=75, y0=75, sma=20, eps=0.9, pa=angle)
+    ellipse = Ellipse(data, geometry)
+    isolist = ellipse.fit_image()
+
+    # test image is "disky: disky isophotes have b4 > 0
+    # (boxy isophotes have b4 < 0)
+    assert np.all(isolist.b4[30:] > 0)
+    assert isolist.a3[-1] < 0
+    assert isolist.a4[-1] < 0
+    assert isolist.b3[-1] > 0
+    assert isolist.b4[-1] > 0

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -178,10 +178,10 @@ class TestFitEllipseSamples:
         fitter = EllipseFitter(sample)
         iso = fitter.fit(maxit=400)
 
-        assert_allclose(iso.a3, -6.825e-7, atol=1.0e-9)
-        assert_allclose(iso.b3, 1.68e-6, atol=1.0e-8)
-        assert_allclose(iso.a4, -4.36e-6, atol=1.0e-8)
-        assert_allclose(iso.b4, 4.73e-5, atol=1.0e-7)
+        assert_allclose(iso.a3, 6.825e-7, atol=1.0e-9)
+        assert_allclose(iso.b3, -1.68e-6, atol=1.0e-8)
+        assert_allclose(iso.a4, 4.36e-6, atol=1.0e-8)
+        assert_allclose(iso.b4, -4.73e-5, atol=1.0e-7)
 
         assert_allclose(iso.a3_err, 8.152e-6, atol=1.0e-7)
         assert_allclose(iso.b3_err, 8.115e-6, atol=1.0e-7)


### PR DESCRIPTION
This PR fixes a bug in the sign of the isophote upper harmonics (a3, a4, b3, and b4).  I confirmed that these coefficients are fit to the correct equation in [Jedrzejewski 1987](https://ui.adsabs.harvard.edu/abs/1987MNRAS.226..747J/abstract), however, they are later scaled by the SMA and the local gradient.  Because the local gradient is negative, the sign of the upper harmonic values changes.  The original scaling in the IRAF/STSDAS version uses the absolute value of the gradient (see https://github.com/spacetelescope/stsdas_stripped/blob/043c173fd5497c18c2b1bfe8bcff65180bca3996/stsdas/pkg/analysis/isophote/src/elfit.x#L476-L477).  This PR updates the scaling to use the absolute value.

While investigating this PR, I also discovered a bug in the calculation of the upper harmonic errors.  The original code uses a factor of `0.8**2`, but the photutils version was using (`0.64**2`) (0.8 was incorrectly squared *twice*).  cf: https://github.com/spacetelescope/stsdas_stripped/blob/043c173fd5497c18c2b1bfe8bcff65180bca3996/stsdas/pkg/analysis/isophote/src/elfit.x#L487-L490

Many thanks to @perwin for reporting this bug!

Fixes: #1486.