### PR TITLE
Allow ApertureStats local_bkg to be broadcast

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,11 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - The ``ApertureStats`` ``local_bkg`` keyword can now be broadcast for
+    apertures with multiple positions. [#1504]
+
 - ``photutils.datasets``
 
   - Removed the deprecated ``load_fermi_image`` function. [#1479]

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -171,14 +171,16 @@ class TestApertureStats:
                 assert_equal(getattr(apstats[i], prop),
                              getattr(apstats0, prop))
 
-        with pytest.raises(ValueError):
-            _ = ApertureStats(data, self.aperture, local_bkg=10)
+        # test broadcasting
+        local_bkg = (12, 12, 12)
+        apstats1 = ApertureStats(data, self.aperture, local_bkg=local_bkg)
+        apstats2 = ApertureStats(data, self.aperture, local_bkg=local_bkg[0])
+        assert_equal(apstats1.sum, apstats2.sum)
+
         with pytest.raises(ValueError):
             _ = ApertureStats(data, self.aperture, local_bkg=(10, 20))
         with pytest.raises(ValueError):
             _ = ApertureStats(data, self.aperture[0:2], local_bkg=(10, np.nan))
-        with pytest.raises(ValueError):
-            _ = ApertureStats(data, self.aperture[0:2], local_bkg=(10, None))
         with pytest.raises(ValueError):
             _ = ApertureStats(data, self.aperture[0:2],
                               local_bkg=(-np.inf, 10))


### PR DESCRIPTION
The ``ApertureStats`` ``local_bkg`` keyword can now be broadcast for apertures with multiple positions.