### PR TITLE
Use nearest interpolation for SegmentationImage.imshow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,10 @@ API Changes
   - Removed the deprecated ``make_source_mask`` function in favor of the
     ``SegmentationImage.make_source_mask`` method. [#1479]
 
+  - The ``SegmentationImage`` ``imshow`` method now uses "nearest"
+    interpolation instead of "none" to avoid rendering issues with some
+    backends. [#1507]
+
 
 1.6.0 (2022-12-09)
 ------------------

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1274,7 +1274,7 @@ class SegmentationImage:
         if cmap is None:
             cmap = self.cmap
 
-        return ax.imshow(self.data, cmap=cmap, interpolation='none',
+        return ax.imshow(self.data, cmap=cmap, interpolation='nearest',
                          origin='lower', alpha=alpha)
 
 


### PR DESCRIPTION
This PR changes the ``SegmentationImage`` ``imshow`` method to now use "nearest" interpolation instead of "none" to avoid rendering issues with some backends.

xref: https://github.com/matplotlib/matplotlib/issues/25575