### PR TITLE
Fix ImageCutout xyorigin with partial mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,12 @@ Bug Fixes
   - Fixed a bug in the calculation of the upper harmonic errors (a3_err,
     a4_err, b3_err, and b4_err). [#1501].
 
+- ``photutils.utils``
+
+  - Fixed a bug in the calculation of ``ImageCutout`` ``xyorigin`` when
+    using the ``'partial'`` mode when the cutout extended beyond the
+    right or top edge. [#1508]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -167,29 +167,16 @@ class CutoutImage:
         """
         return self._calc_bbox(self.slices_cutout)
 
-    def _calc_origin_offset(self):
-        """
-        For ``mode='partial'``, calculate the origin offset for cases of
-        partial overlap.
-        """
-        yshape = self.slices_original[0].stop - self.slices_original[0].start
-        xshape = self.slices_original[1].stop - self.slices_original[1].start
-        yoffset, xoffset = 0, 0
-        if self.shape != (yshape, xshape):
-            yoffset = yshape - self.shape[0]
-            xoffset = xshape - self.shape[1]
-        return yoffset, xoffset
-
     def _calc_xyorigin(self, slices):
         """
-        Calculate the (x, y) origin.
+        Calculate the (x, y) origin, taking into account partial
+        overlaps.
         """
         xorigin, yorigin = (slices[1].start, slices[0].start)
 
         if self.mode == 'partial':
-            yoffset, xoffset = self._calc_origin_offset()
-            xorigin += xoffset
-            yorigin += yoffset
+            yorigin -= self.slices_cutout[0].start
+            xorigin -= self.slices_cutout[1].start
 
         return np.array((xorigin, yorigin))
 

--- a/photutils/utils/tests/test_cutouts.py
+++ b/photutils/utils/tests/test_cutouts.py
@@ -67,6 +67,21 @@ def test_cutout_partial_overlap():
 
     assert_equal(cutout.xyorigin, np.array((-18, -1)))
 
+    # regression test for xyorgin in partial mode when cutout extends
+    # beyond right or top edge
+    data = make_100gaussians_image()
+    shape = (54, 57)
+    cutout = CutoutImage(data, (281, 485), shape, mode='partial')
+
+    assert_equal(cutout.xyorigin, np.array((457, 254)))
+    assert (cutout.bbox_original
+            == BoundingBox(ixmin=457, ixmax=500, iymin=254, iymax=300))
+    assert (cutout.bbox_cutout
+            == BoundingBox(ixmin=0, ixmax=43, iymin=0, iymax=46))
+    assert cutout.slices_original == (slice(254, 300, None),
+                                      slice(457, 500, None))
+    assert cutout.slices_cutout == (slice(0, 46, None), slice(0, 43, None))
+
 
 def test_cutout_copy():
     data = make_100gaussians_image()


### PR DESCRIPTION
This PR fixes a bug in the calculation of ``ImageCutout`` ``xyorigin`` when using the ``'partial'`` mode when the cutout extended beyond the right or top edge.