### PR TITLE
Add ability to convert SegmentationImage segments to polygons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 General
 ^^^^^^^
 
+- The ``rasterio`` and ``shapely`` packages are now optional
+  dependencies. [#1509]
+
 New Features
 ^^^^^^^^^^^^
 
@@ -34,6 +37,11 @@ New Features
   - Significantly improved the performance of ``SegmentationImage``
     ``make_source_mask`` when using square footprints for source
     dilation. [#1506]
+
+  - Added the ``polygons`` property and ``to_patches`` and
+    ``plot_patches`` methods to ``SegmentationImage``. [#1509]
+
+  - Added ``polygon`` keyword to the ``Segment`` class. [#1509]
 
 Bug Fixes
 ^^^^^^^^^
@@ -82,6 +90,13 @@ API Changes
   - The ``SegmentationImage`` ``imshow`` method now uses "nearest"
     interpolation instead of "none" to avoid rendering issues with some
     backends. [#1507]
+
+  - The ``repr()`` notebook output for the ``Segment`` class now
+    includes a SVG polygon representation of the segment if the
+    ``rasterio`` and ``shapely`` packages are installed. [#1509]
+
+  - Deprecated the ``SegmentationImage`` ``outline_segments`` method.
+    Use the ``plot_patches`` method instead. [#1509]
 
 
 1.6.0 (2022-12-09)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,7 +41,7 @@ Photutils also optionally depends on other packages for some features:
 * `rasterio <https://rasterio.readthedocs.io/>`_: Used for converting
   source segments into polygon objects.
 
-* `shapely <https://shapely.readthedocs.io/>`_: Used for converting
+* `Shapely <https://shapely.readthedocs.io/>`_: Used for converting
   source segments into polygon objects.
 
 Photutils depends on `pytest-astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,6 +38,12 @@ Photutils also optionally depends on other packages for some features:
 * `tqdm <https://tqdm.github.io/>`_: Used to display optional progress
   bars.
 
+* `rasterio <https://rasterio.readthedocs.io/>`_: Used for converting
+  source segments into polygon objects.
+
+* `shapely <https://shapely.readthedocs.io/>`_: Used for converting
+  source segments into polygon objects.
+
 Photutils depends on `pytest-astropy
 <https://github.com/astropy/pytest-astropy>`_ (0.4 or later) to run
 the test suite.

--- a/docs/whats_new/1.7.rst
+++ b/docs/whats_new/1.7.rst
@@ -20,6 +20,18 @@ for computing radial profiles and curves of growth:
   *  `~photutils.profiles.CurveOfGrowth`
 
 
+Converting ``SegmentationImage`` segments to polygons
+=====================================================
+
+The ``SegmentationImage`` class now has a ``polygons`` attribute, which
+returns a list of `Shapely <https://shapely.readthedocs.io/>`_ polygons
+representing each source segment. It also now has a ``to_patches`` and
+a ``plot_patches`` method, which returns or plots, respectively, a list
+of `matplotlib.patches.Polygon` objects. These features require that
+both the `Rasterio <https://rasterio.readthedocs.io/>`_ and `Shapely
+<https://shapely.readthedocs.io/>`_ optional dependencies are installed.
+
+
 Other changes
 =============
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -14,9 +14,9 @@ from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import BoundingBox
+from photutils.utils._optional_deps import HAS_RASTERIO, HAS_SHAPELY
 from photutils.utils._parameters import as_pair
 from photutils.utils.colormaps import make_random_cmap
-from photutils.utils._optional_deps import (HAS_RASTERIO, HAS_SHAPELY)
 
 __all__ = ['SegmentationImage', 'Segment']
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1373,6 +1373,12 @@ class Segment:
     def __repr__(self):
         return self.__str__()
 
+    def _repr_svg_(self):
+        if self.polygon is not None:
+            print(repr(self))
+            return self.polygon._repr_svg_()
+        return None
+
     def __array__(self):
         """
         Array representation of the labeled region (e.g., for

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1166,6 +1166,16 @@ class SegmentationImage:
         # do not include polygons for background (label = 0)
         return polygons[1:]
 
+    @lazyproperty
+    def patches(self):
+        from matplotlib.patches import Polygon
+
+        patches = []
+        for geo_poly in self._geo_polygons:
+            xy = np.array(geo_poly[0]['coordinates'][0]) - (0.5, 0.5)
+            patches.append(Polygon(xy, edgecolor='white', facecolor='none'))
+        return patches
+
     def outline_segments(self, mask_background=False):
         """
         Outline the labeled segments.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -6,7 +6,7 @@ segment within a segmentation image.
 
 import inspect
 import warnings
-from copy import deepcopy
+from copy import copy, deepcopy
 
 import numpy as np
 from astropy.utils import lazyproperty
@@ -1181,14 +1181,32 @@ class SegmentationImage:
             polygons.append(shape(geo_poly[0]))
         return polygons
 
-    @lazyproperty
-    def patches(self):
+    def to_patches(self, origin=(0, 0), **kwargs):
         from matplotlib.patches import Polygon
+
+        origin = np.array(origin)
+        patch_kwargs = {'edgecolor': 'white', 'facecolor': 'none'}
+        patch_kwargs.update(kwargs)
 
         patches = []
         for geo_poly in self._geo_polygons:
-            xy = np.array(geo_poly[0]['coordinates'][0]) - (0.5, 0.5)
-            patches.append(Polygon(xy, edgecolor='white', facecolor='none'))
+            xy = (np.array(geo_poly[0]['coordinates'][0]) - origin
+                  - np.array((0.5, 0.5)))
+            patches.append(Polygon(xy, **patch_kwargs))
+
+        return patches
+
+    def plot_patches(self, ax=None, origin=(0, 0), **kwargs):
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            ax = plt.gca()
+
+        patches = self.to_patches(origin=origin, **kwargs)
+        for patch in patches:
+            patch = copy(patch)
+            ax.add_patch(patch)
+
         return patches
 
     def outline_segments(self, mask_background=False):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -16,6 +16,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from photutils.aperture import BoundingBox
 from photutils.utils._parameters import as_pair
 from photutils.utils.colormaps import make_random_cmap
+from photutils.utils._optional_deps import (HAS_RASTERIO, HAS_SHAPELY)
 
 __all__ = ['SegmentationImage', 'Segment']
 
@@ -121,11 +122,20 @@ class SegmentationImage:
         of the ``labels`` attribute.
         """
         segments = []
-        for label, slc, bbox, area, polygon in zip(self.labels, self.slices,
-                                                   self.bbox, self.areas,
-                                                   self.polygons):
-            segments.append(Segment(self.data, label, slc, bbox, area,
-                                    polygon=polygon))
+
+        if HAS_RASTERIO and HAS_SHAPELY:
+            for label, slc, bbox, area, polygon in zip(self.labels,
+                                                       self.slices,
+                                                       self.bbox,
+                                                       self.areas,
+                                                       self.polygons):
+                segments.append(Segment(self.data, label, slc, bbox, area,
+                                        polygon=polygon))
+        else:
+            for label, slc, bbox, area in zip(self.labels, self.slices,
+                                              self.bbox, self.areas):
+                segments.append(Segment(self.data, label, slc, bbox, area))
+
         return segments
 
     @property

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -10,7 +10,7 @@ from copy import copy, deepcopy
 
 import numpy as np
 from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import BoundingBox
@@ -1265,6 +1265,7 @@ class SegmentationImage:
 
         return patches
 
+    @deprecated('1.7.0', alternative='`plot_patches`')
     def outline_segments(self, mask_background=False):
         """
         Outline the labeled segments.
@@ -1287,24 +1288,6 @@ class SegmentationImage:
             pixel values in the outlines correspond to the labels in the
             segmentation array.  If ``mask_background`` is `True`, then
             a `~numpy.ma.MaskedArray` is returned.
-
-        Examples
-        --------
-        >>> from photutils.segmentation import SegmentationImage
-        >>> data = np.array([[0, 0, 0, 0, 0, 0],
-        ...                  [0, 2, 2, 2, 2, 0],
-        ...                  [0, 2, 2, 2, 2, 0],
-        ...                  [0, 2, 2, 2, 2, 0],
-        ...                  [0, 2, 2, 2, 2, 0],
-        ...                  [0, 0, 0, 0, 0, 0]])
-        >>> segm = SegmentationImage(data)
-        >>> segm.outline_segments()
-        array([[0, 0, 0, 0, 0, 0],
-               [0, 2, 2, 2, 2, 0],
-               [0, 2, 0, 0, 2, 0],
-               [0, 2, 0, 0, 2, 0],
-               [0, 2, 2, 2, 2, 0],
-               [0, 0, 0, 0, 0, 0]])
         """
         from scipy.ndimage import (generate_binary_structure, grey_dilation,
                                    grey_erosion)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1430,7 +1430,7 @@ class Segment:
     def __repr__(self):
         return self.__str__()
 
-    def _repr_svg_(self):
+    def _repr_svg_(self):  # pragma: no cover
         if self.polygon is not None:
             print(repr(self))
             return self.polygon._repr_svg_()

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1254,14 +1254,14 @@ class SegmentationImage:
             indices = self.get_indices(labels)
             patches = patches[indices]
             if np.isscalar(labels):
-                patches = (patches,)
+                patches = [patches]
 
         for patch in patches:
             patch = copy(patch)
             ax.add_patch(patch)
 
-        if labels is not None and np.isscalar(labels):
-            patches = patches[0]
+        if labels is not None:
+            patches = list(patches)
 
         return patches
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1252,6 +1252,24 @@ class SegmentationImage:
             A list of matplotlib polygon patches for the plotted
             polygons. The patches can be used, for example, when adding
             a plot legend.
+
+        Examples
+        --------
+        .. plot::
+            :include-source:
+
+            import numpy as np
+            from photutils.segmentation import SegmentationImage
+
+            data = np.array([[1, 1, 0, 0, 4, 4],
+                             [0, 0, 0, 0, 0, 4],
+                             [0, 0, 3, 3, 0, 0],
+                             [7, 0, 0, 0, 0, 5],
+                             [7, 7, 0, 5, 5, 5],
+                             [7, 7, 0, 0, 5, 5]])
+            segm = SegmentationImage(data)
+            segm.imshow(figsize=(5, 5))
+            segm.plot_patches(edgecolor='white', lw=2)
         """
         import matplotlib.pyplot as plt
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1149,6 +1149,23 @@ class SegmentationImage:
             from scipy.ndimage import binary_dilation
             return binary_dilation(mask, structure=footprint)
 
+    @lazyproperty
+    def _geo_polygons(self):
+        """
+        A list of polygons for each source segment.
+
+        Each item in the list is tuple of (polygon, value) where the
+        polygon is a GeoJSON-like dict and the value is the label from
+        the segmentation image.
+        """
+        from rasterio.features import shapes
+
+        polygons = list(shapes(self.data.astype('int32'), connectivity=8))
+        polygons.sort(key=lambda x: x[1])
+
+        # do not include polygons for background (label = 0)
+        return polygons[1:]
+
     def outline_segments(self, mask_background=False):
         """
         Outline the labeled segments.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1181,7 +1181,7 @@ class SegmentationImage:
             polygons.append(shape(geo_poly[0]))
         return polygons
 
-    def to_patches(self, origin=(0, 0), **kwargs):
+    def to_patches(self, *, origin=(0, 0), **kwargs):
         from matplotlib.patches import Polygon
 
         origin = np.array(origin)
@@ -1196,16 +1196,26 @@ class SegmentationImage:
 
         return patches
 
-    def plot_patches(self, ax=None, origin=(0, 0), **kwargs):
+    def plot_patches(self, *, ax=None, origin=(0, 0), labels=None, **kwargs):
         import matplotlib.pyplot as plt
 
         if ax is None:
             ax = plt.gca()
 
         patches = self.to_patches(origin=origin, **kwargs)
+        if labels is not None:
+            patches = np.array(patches)
+            indices = self.get_indices(labels)
+            patches = patches[indices]
+            if np.isscalar(labels):
+                patches = (patches,)
+
         for patch in patches:
             patch = copy(patch)
             ax.add_patch(patch)
+
+        if labels is not None and np.isscalar(labels):
+            patches = patches[0]
 
         return patches
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1182,6 +1182,23 @@ class SegmentationImage:
         return polygons
 
     def to_patches(self, *, origin=(0, 0), **kwargs):
+        """
+        Return a list of `~matplotlib.patches.Polygon` objects
+        representing each source segment.
+
+        By default, the polygon patch will have a white edge color and
+        no face color.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        **kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Polygon`.
+        """
         from matplotlib.patches import Polygon
 
         origin = np.array(origin)
@@ -1197,6 +1214,35 @@ class SegmentationImage:
         return patches
 
     def plot_patches(self, *, ax=None, origin=(0, 0), labels=None, **kwargs):
+        """
+        Plot the `~matplotlib.patches.Polygon` objects for the source
+        segments on a matplotlib `~matplotlib.axes.Axes` instance.
+
+        Parameters
+        ----------
+        ax : `matplotlib.axes.Axes` or `None`, optional
+            The matplotlib axes on which to plot.  If `None`, then the
+            current `~matplotlib.axes.Axes` instance is used.
+
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        labels: int or array of int, optional
+            The label numbers whose polygons are to be ploted. If
+            `None`, the polygons for all labels will be plotted.
+
+        **kwargs : `dict`
+            Any keyword arguments accepted by
+            `matplotlib.patches.Polygon`.
+
+        Returns
+        -------
+        patches : list of `~matplotlib.patches.Polygon`
+            A list of matplotlib polygon patches for the plotted
+            polygons. The patches can be used, for example, when adding
+            a plot legend.
+        """
         import matplotlib.pyplot as plt
 
         if ax is None:

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1152,7 +1152,7 @@ class SegmentationImage:
     @lazyproperty
     def _geo_polygons(self):
         """
-        A list of polygons for each source segment.
+        A list of polygons representing each source segment.
 
         Each item in the list is tuple of (polygon, value) where the
         polygon is a GeoJSON-like dict and the value is the label from
@@ -1165,6 +1165,19 @@ class SegmentationImage:
 
         # do not include polygons for background (label = 0)
         return polygons[1:]
+
+    @lazyproperty
+    def polygons(self):
+        """
+        A list of `Shapely <https://shapely.readthedocs.io/>`_ polygons
+        representing each source segment.
+        """
+        from shapely.geometry import shape
+
+        polygons = []
+        for geo_poly in self._geo_polygons:
+            polygons.append(shape(geo_poly[0]))
+        return polygons
 
     @lazyproperty
     def patches(self):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -121,9 +121,11 @@ class SegmentationImage:
         of the ``labels`` attribute.
         """
         segments = []
-        for label, slc, bbox, area in zip(self.labels, self.slices, self.bbox,
-                                          self.areas):
-            segments.append(Segment(self.data, label, slc, bbox, area))
+        for label, slc, bbox, area, polygon in zip(self.labels, self.slices,
+                                                   self.bbox, self.areas,
+                                                   self.polygons):
+            segments.append(Segment(self.data, label, slc, bbox, area,
+                                    polygon=polygon))
         return segments
 
     @property
@@ -1342,14 +1344,20 @@ class Segment:
 
     area : float
         The area of the segment in pixels**2.
+
+    polygon : Shapely polygon, optional
+        The outline of the segment as a `Shapely
+        <https://shapely.readthedocs.io/>`_ polygon.
     """
 
-    def __init__(self, segment_data, label, slices, bbox, area):
+    def __init__(self, segment_data, label, slices, bbox, area,
+                 polygon=None):
         self._segment_data = segment_data
         self.label = label
         self.slices = slices
         self.bbox = bbox
         self.area = area
+        self.polygon = polygon
 
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -99,8 +99,6 @@ class TestSegmentationImage:
         assert np.ma.count(self.segm.data_ma) == 18
         assert np.ma.count_masked(self.segm.data_ma) == 18
 
-    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
-    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segments(self):
         assert isinstance(self.segm.segments[0], Segment)
         assert_allclose(self.segm.segments[0].data,
@@ -125,21 +123,15 @@ class TestSegmentationImage:
         for prop in props:
             assert f'{prop}:' in repr(self.segm)
 
-    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
-    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segment_repr_str(self):
         props = ['label', 'slices', 'area']
         for prop in props:
             assert f'{prop}:' in repr(self.segm.segments[0])
 
-    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
-    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segment_data(self):
         assert_allclose(self.segm.segments[3].data.shape, (3, 3))
         assert_allclose(np.unique(self.segm.segments[3].data), [0, 5])
 
-    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
-    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segment_make_cutout(self):
         cutout = self.segm.segments[3].make_cutout(self.data,
                                                    masked_array=False)
@@ -151,8 +143,6 @@ class TestSegmentationImage:
         assert np.ma.is_masked(cutout)
         assert_allclose(cutout.shape, (3, 3))
 
-    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
-    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segment_make_cutout_input(self):
         with pytest.raises(ValueError):
             self.segm.segments[0].make_cutout(np.arange(10))
@@ -407,7 +397,7 @@ class TestSegmentationImage:
         assert isinstance(axim, AxesImage)
 
     @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_polygons(self):
         from shapely.geometry.polygon import Polygon
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_allclose, assert_equal
 from photutils.segmentation.core import Segment, SegmentationImage
 from photutils.utils import circular_footprint
 from photutils.utils._optional_deps import (HAS_MATPLOTLIB, HAS_RASTERIO,
-                                            HAS_SHAPELY, HAS_SCIPY)
+                                            HAS_SCIPY, HAS_SHAPELY)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -448,7 +448,6 @@ class TestSegmentationImage:
             assert isinstance(segm_outlines, np.ma.MaskedArray)
             assert np.ma.count(segm_outlines) == 8
             assert np.ma.count_masked(segm_outlines) == 17
-
 
 
 class CustomSegm(SegmentationImage):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -388,6 +388,35 @@ class TestSegmentationImage:
         mask = segm.make_source_mask(footprint=np.ones((3, 3)), size=5)
         assert_equal(mask, expected1)
 
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_imshow(self):
+        from matplotlib.image import AxesImage
+
+        axim = self.segm.imshow(figsize=(5, 5))
+        assert isinstance(axim, AxesImage)
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_patches(self):
+        from matplotlib.patches import Polygon
+
+        patches = self.segm.to_patches(edgecolor='blue')
+        assert isinstance(patches[0], Polygon)
+        assert patches[0].get_edgecolor() == (0, 0, 1, 1)
+
+        patches = self.segm.plot_patches(edgecolor='red')
+        assert isinstance(patches[0], Polygon)
+        assert patches[0].get_edgecolor() == (1, 0, 0, 1)
+
+        patches = self.segm.plot_patches(labels=1)
+        assert len(patches) == 1
+        assert isinstance(patches, list)
+        assert isinstance(patches[0], Polygon)
+
+        patches = self.segm.plot_patches(labels=(4, 7))
+        assert len(patches) == 2
+        assert isinstance(patches, list)
+        assert isinstance(patches[0], Polygon)
+
     def test_outline_segments(self):
         segm_array = np.zeros((5, 5)).astype(int)
         segm_array[1:4, 1:4] = 2
@@ -409,12 +438,6 @@ class TestSegmentationImage:
             assert np.ma.count(segm_outlines) == 8
             assert np.ma.count_masked(segm_outlines) == 17
 
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_imshow(self):
-        from matplotlib.image import AxesImage
-
-        axim = self.segm.imshow(figsize=(5, 5))
-        assert isinstance(axim, AxesImage)
 
 
 class CustomSegm(SegmentationImage):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -6,7 +6,8 @@ Tests for the core module.
 import numpy as np
 import pytest
 from astropy.utils import lazyproperty
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.segmentation.core import Segment, SegmentationImage
@@ -393,7 +394,8 @@ class TestSegmentationImage:
         segm = SegmentationImage(segm_array)
         segm_array_ref = np.copy(segm_array)
         segm_array_ref[2, 2] = 0
-        assert_allclose(segm.outline_segments(), segm_array_ref)
+        with pytest.warns(AstropyDeprecationWarning):
+            assert_allclose(segm.outline_segments(), segm_array_ref)
 
     def test_outline_segments_masked_background(self):
         segm_array = np.zeros((5, 5)).astype(int)
@@ -401,10 +403,11 @@ class TestSegmentationImage:
         segm = SegmentationImage(segm_array)
         segm_array_ref = np.copy(segm_array)
         segm_array_ref[2, 2] = 0
-        segm_outlines = segm.outline_segments(mask_background=True)
-        assert isinstance(segm_outlines, np.ma.MaskedArray)
-        assert np.ma.count(segm_outlines) == 8
-        assert np.ma.count_masked(segm_outlines) == 17
+        with pytest.warns(AstropyDeprecationWarning):
+            segm_outlines = segm.outline_segments(mask_background=True)
+            assert isinstance(segm_outlines, np.ma.MaskedArray)
+            assert np.ma.count(segm_outlines) == 8
+            assert np.ma.count_masked(segm_outlines) == 17
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_imshow(self):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -12,7 +12,8 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.segmentation.core import Segment, SegmentationImage
 from photutils.utils import circular_footprint
-from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY
+from photutils.utils._optional_deps import (HAS_MATPLOTLIB, HAS_RASTERIO,
+                                            HAS_SHAPELY, HAS_SCIPY)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -98,6 +99,8 @@ class TestSegmentationImage:
         assert np.ma.count(self.segm.data_ma) == 18
         assert np.ma.count_masked(self.segm.data_ma) == 18
 
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segments(self):
         assert isinstance(self.segm.segments[0], Segment)
         assert_allclose(self.segm.segments[0].data,
@@ -122,15 +125,21 @@ class TestSegmentationImage:
         for prop in props:
             assert f'{prop}:' in repr(self.segm)
 
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segment_repr_str(self):
         props = ['label', 'slices', 'area']
         for prop in props:
             assert f'{prop}:' in repr(self.segm.segments[0])
 
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segment_data(self):
         assert_allclose(self.segm.segments[3].data.shape, (3, 3))
         assert_allclose(np.unique(self.segm.segments[3].data), [0, 5])
 
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segment_make_cutout(self):
         cutout = self.segm.segments[3].make_cutout(self.data,
                                                    masked_array=False)
@@ -142,6 +151,8 @@ class TestSegmentationImage:
         assert np.ma.is_masked(cutout)
         assert_allclose(cutout.shape, (3, 3))
 
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     def test_segment_make_cutout_input(self):
         with pytest.raises(ValueError):
             self.segm.segments[0].make_cutout(np.arange(10))
@@ -395,6 +406,16 @@ class TestSegmentationImage:
         axim = self.segm.imshow(figsize=(5, 5))
         assert isinstance(axim, AxesImage)
 
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_polygons(self):
+        from shapely.geometry.polygon import Polygon
+
+        polygons = self.segm.polygons
+        assert len(polygons) == self.segm.nlabels
+        assert isinstance(polygons[0], Polygon)
+
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_patches(self):
         from matplotlib.patches import Polygon

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -9,7 +9,7 @@ import importlib
 # Note that in some cases the package names are different from the
 # pip-install name (e.g.k scikit-image -> skimage).
 optional_deps = ['scipy', 'matplotlib', 'skimage', 'sklearn', 'gwcs',
-                 'bottleneck', 'tqdm']
+                 'bottleneck', 'tqdm', 'rasterio', 'shapely']
 deps = {key.upper(): key for key in optional_deps}
 __all__ = [f'HAS_{pkg}' for pkg in deps]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ all =
     bottleneck
     tqdm
     rasterio
+    shapely
 test =
     pytest-astropy
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ docs =
     scikit-learn>=1.0
     gwcs>=0.16
     rasterio
+    shapely
 
 [options.package_data]
 photutils = CITATION.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,16 +39,18 @@ all =
     gwcs>=0.16
     bottleneck
     tqdm
+    rasterio
 test =
     pytest-astropy
 docs =
-    scipy>=1.6.0
     sphinx
     sphinx-astropy>=1.6
+    scipy>=1.6.0
     matplotlib>=3.3.0
     scikit-image>=0.18.0
     scikit-learn>=1.0
     gwcs>=0.16
+    rasterio
 
 [options.package_data]
 photutils = CITATION.rst


### PR DESCRIPTION
With the PR, the ``SegmentationImage`` class now has a ``polygons`` attribute, which returns a list of `Shapely <https://shapely.readthedocs.io/>`_ polygons representing each source segment. It also now has ``to_patches`` and ``plot_patches`` methods, which return or plot, respectively, a list of `matplotlib.patches.Polygon` objects. These features require that both the `Rasterio <https://rasterio.readthedocs.io/>`_ and `Shapely <https://shapely.readthedocs.io/>`_ optional dependencies are installed.

The ``repr()`` notebook output for the ``Segment`` class now includes a SVG polygon representation of the segment if the ``rasterio`` and ``shapely`` packages are installed.

This PR also deprecates the `SegmentationImage` `outline_segments` method in favor of `plot_patches`.