### PR TITLE
Fix star finders if exclude_border=True and there are no detections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,13 @@ Bug Fixes
   - Fixed an issue where ``centroid_quadratic`` would sometimes fail if
     the input data contained NaNs. [#1495]
 
+- ``photutils.detection``
+
+  - Fixed an issue with the starfinders (``DAOStarFinder``,
+    ``IRAFStarFinder``, and ``StarFinder``) where an exception was
+    raised if ``exclude_border=True`` and there were no detections.
+    [#1512].
+
 - ``photutils.isophote``
 
   - Fixed a bug where the upper harmonics (a3, a4, b3, and b4) had the

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -105,15 +105,15 @@ class StarFinderBase(metaclass=abc.ABCMeta):
             tbl = find_peaks(convolved_data, threshold, footprint=footprint,
                              mask=mask)
 
+        if tbl is None:
+            return None
+
         if exclude_border:
             xmax = convolved_data.shape[1] - xpad
             ymax = convolved_data.shape[0] - ypad
             mask = ((tbl['x_peak'] > xpad) & (tbl['y_peak'] > ypad)
                     & (tbl['x_peak'] < xmax) & (tbl['y_peak'] < ymax))
             tbl = tbl[mask]
-
-        if tbl is None:
-            return None
 
         xpos, ypos = tbl['x_peak'], tbl['y_peak']
         if not exclude_border:

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -49,11 +49,25 @@ class TestDAOStarFinder:
         tbl = starfinder(DATA)
         assert len(tbl) == 20
 
+        # test when no detections
+        starfinder = DAOStarFinder(threshold=100, fwhm=2, sigma_radius=1.5,
+                                   exclude_border=False)
+        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
+            tbl = starfinder(DATA)
+            assert tbl is None
+
     def test_daofind_exclude_border(self):
         starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
                                    exclude_border=True)
         tbl = starfinder(DATA)
         assert len(tbl) == 19
+
+        # test when no detections
+        starfinder = DAOStarFinder(threshold=100, fwhm=2, sigma_radius=1.5,
+                                   exclude_border=True)
+        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
+            tbl = starfinder(DATA)
+            assert tbl is None
 
     def test_daofind_nosources(self):
         data = np.ones((3, 3))


### PR DESCRIPTION
This PR fixes an issue with the starfinders (``DAOStarFinder``, ``IRAFStarFinder``, and ``StarFinder``) where an exception was raised if ``exclude_border=True`` and there were no detections.

Thanks to @cmccully for reporting this bug.

Fixes #1510 