### PR TITLE
Check that cutout mask in centroid_sources is not all True

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,7 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
-- ``photutils.centroid``
+- ``photutils.centroids``
 
   - Fixed an issue where ``centroid_quadratic`` would sometimes fail if
     the input data contained NaNs. [#1495]
@@ -79,6 +79,11 @@ API Changes
 
   - The ``ApertureStats`` ``local_bkg`` keyword can now be broadcast for
     apertures with multiple positions. [#1504]
+
+- ``photutils.centroids``
+
+  - The ``centroid_sources`` function will now raise an error if the
+    cutout mask contains all ``True`` values. [#1516]
 
 - ``photutils.datasets``
 
@@ -490,7 +495,7 @@ Bug Fixes
     would result in incorrect image padding if only one of the axes needed
     padding. [#1292]
 
-- ``photutils.centroid``
+- ``photutils.centroids``
 
   - Fixed a bug in ``centroid_sources`` where setting ``error``,
     ``xpeak``, or ``ypeak`` to ``None`` would result in an error.
@@ -531,7 +536,7 @@ API Changes
     range. If backwards-compatibility is needed with older Photutils
     versions, set ``clip=False``. [#1324]
 
-- ``photutils.centroid``
+- ``photutils.centroids``
 
   - Removed the deprecated ``centroid_epsf`` and ``gaussian1d_moments``
     functions. [#1280]
@@ -577,7 +582,7 @@ General
 New Features
 ^^^^^^^^^^^^
 
-- ``photutils.centroid``
+- ``photutils.centroids``
 
   - Extra keyword arguments can be input to ``centroid_sources`` that
     are then passed on to the ``centroid_func`` if supported.
@@ -801,7 +806,7 @@ API Changes
     ``OpenCV (cv2.resize)``. If backwards-compatibility is needed with
     older Photutils versions, set ``grid_mode=False``. [#1239]
 
-- ``photutils.centroid``
+- ``photutils.centroids``
 
   - Deprecated the ``gaussian1d_moments`` and ``centroid_epsf``
     functions. [#1240]
@@ -977,7 +982,7 @@ API Changes
   - Deprecated the ``BoundingBox`` ``slices`` attribute. Use the
     ``get_overlap_slices`` method instead. [#1157]
 
-- ``photutils.centroid``
+- ``photutils.centroids``
 
   - Removed the deprecated ``fit_2dgaussian`` function and
     ``GaussianConst2D`` class. [#1147]
@@ -1730,7 +1735,7 @@ New Features
   - Added default theta value for elliptical and rectangular
     apertures. [#674]
 
-- ``photutils.centroid``
+- ``photutils.centroids``
 
   - Added a ``centroid_sources`` function to calculate centroid of
     many sources in a single image. [#656]

--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -149,7 +149,8 @@ Let's plot the results:
                             centroid_func=centroid_com)
     plt.figure(figsize=(8, 4))
     plt.imshow(data, origin='lower', interpolation='nearest')
-    plt.scatter(x, y, marker='+', s=80, color='red')
+    plt.scatter(x, y, marker='+', s=80, color='red', label='Centroids')
+    plt.legend()
     plt.tight_layout()
 
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -347,7 +347,6 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
 
     Examples
     --------
-    >>> import matplotlib.pyplot as plt
     >>> from photutils.centroids import centroid_com, centroid_sources
     >>> from photutils.datasets import make_4gaussians_image
     >>> from photutils.utils import circular_footprint

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -397,6 +397,12 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
         else:
             mask_cutout = footprint_mask
 
+        if np.all(mask_cutout):
+            raise ValueError(f'The cutout for the source at ({xp, yp}) is '
+                             'completely masked. Please check your input '
+                             'mask and footprint. Also note that footprint '
+                             'must be a small, local footprint.')
+
         centroid_kwargs.update({'mask': mask_cutout})
 
         error = centroid_kwargs.get('error', None)

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -344,6 +344,43 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
         a ``box_size`` that is too small when using a fitting-based
         centroid function (e.g., `centroid_1dg`, `centroid_2dg`, or
         `centroid_quadratic`.
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> from photutils.centroids import centroid_com, centroid_sources
+    >>> from photutils.datasets import make_4gaussians_image
+    >>> from photutils.utils import circular_footprint
+    >>> data = make_4gaussians_image()
+
+    >>> x_init = (25, 91, 151, 160)
+    >>> y_init = (40, 61, 24, 71)
+    >>> footprint = circular_footprint(5.0)
+    >>> x, y = centroid_sources(data, x_init, y_init, footprint=footprint,
+    ...                         centroid_func=centroid_com)
+    >>> print(x)  # doctest: +FLOAT_CMP
+    [ 24.9865905   90.84751557 150.50228056 159.74319544]
+    >>> print(y)  # doctest: +FLOAT_CMP
+    [40.01096547 60.92509086 24.52986889 70.57971148]
+
+    .. plot::
+        :include-source:
+
+        import matplotlib.pyplot as plt
+        from photutils.centroids import centroid_com, centroid_sources
+        from photutils.datasets import make_4gaussians_image
+        from photutils.utils import circular_footprint
+        data = make_4gaussians_image()
+        x_init = (25, 91, 151, 160)
+        y_init = (40, 61, 24, 71)
+        footprint = circular_footprint(5.0)
+        x, y = centroid_sources(data, x_init, y_init, footprint=footprint,
+                                centroid_func=centroid_com)
+        plt.figure(figsize=(8, 4))
+        plt.imshow(data, origin='lower', interpolation='nearest')
+        plt.scatter(x, y, marker='+', s=80, color='red', label='Centroids')
+        plt.legend()
+        plt.tight_layout()
     """
     xpos = np.atleast_1d(xpos)
     ypos = np.atleast_1d(ypos)

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -93,7 +93,23 @@ def test_centroid_comquad_nan_withmask(use_mask):
             assert len(warnlist) == nwarn
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+def test_centroid_com_allmask():
+    xc_ref = 24.7
+    yc_ref = 25.2
+    model = Gaussian2D(2.4, xc_ref, yc_ref, x_stddev=5.0, y_stddev=5.0)
+    y, x = np.mgrid[0:50, 0:50]
+    data = model(x, y)
+    mask = np.ones(data.shape, dtype=bool)
+    xc, yc = centroid_com(data, mask=mask)
+    assert np.isnan(xc)
+    assert np.isnan(yc)
+
+    data = np.zeros((25, 25))
+    xc, yc = centroid_com(data, mask=None)
+    assert np.isnan(xc)
+    assert np.isnan(yc)
+
+
 def test_centroid_com_invalid_inputs():
     data = np.zeros((4, 4))
     mask = np.zeros((2, 2), dtype=bool)


### PR DESCRIPTION
This PR updates `centroid_sources` to raise an error if the cutout mask is all `True` (completely masked), leaving no valid pixels from which to calculate the centroid.

It also adds an example to `centroid_sources`.

Closes https://github.com/astropy/photutils/issues/1514