### PR TITLE
Remove deprecated axes keyword in favor of ax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- Removed the deprecated ``axes`` keyword in favor of ``ax`` for
+  consistency with other packages. [#1523]
+
 
 1.7.0 (2023-04-05)
 ------------------

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -6,7 +6,6 @@ This module defines a class for a rectangular bounding box.
 import math
 
 import numpy as np
-from astropy.utils.decorators import deprecated_renamed_argument
 
 __all__ = ['BoundingBox']
 
@@ -270,7 +269,6 @@ class BoundingBox:
         height, width = self.shape
         return RectangularAperture(xypos, w=width, h=height, theta=0.0)
 
-    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
     def plot(self, ax=None, origin=(0, 0), **kwargs):
         """
         Plot the `BoundingBox` on a matplotlib `~matplotlib.axes.Axes`

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -12,7 +12,6 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated_renamed_argument
 
 from photutils.aperture.bounding_box import BoundingBox
 from photutils.utils._wcs_helpers import _pixel_scale_angle_at_skycoord
@@ -675,7 +674,6 @@ class PixelAperture(Aperture):
         """
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
-    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
     def plot(self, ax=None, origin=(0, 0), **kwargs):
         """
         Plot the aperture on a matplotlib `~matplotlib.axes.Axes`

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -11,7 +11,6 @@ import numpy as np
 from astropy.nddata import NDData
 from astropy.stats import SigmaClip
 from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.lib.index_tricks import index_exp
 
@@ -655,7 +654,6 @@ class Background2D:
             bkg_rms <<= self.unit
         return bkg_rms
 
-    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
     def plot_meshes(self, *, ax=None, marker='+', markersize=None,
                     color='blue', alpha=None, outlines=False, **kwargs):
         """

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -14,7 +14,6 @@ import numpy as np
 from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
 from astropy.table import QTable
 from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import (BoundingBox, CircularAperture,
@@ -2801,7 +2800,6 @@ class SourceCatalog:
         return self._make_circular_apertures(radius)
 
     @as_scalar
-    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
     def plot_circular_apertures(self, radius, ax=None, origin=(0, 0),
                                 **kwargs):
         """
@@ -3192,7 +3190,6 @@ class SourceCatalog:
         return self._make_kron_apertures(kron_params)
 
     @as_scalar
-    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
     def plot_kron_apertures(self, kron_params=None, ax=None, origin=(0, 0),
                             **kwargs):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -10,7 +10,7 @@ from copy import copy, deepcopy
 
 import numpy as np
 from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated, deprecated_renamed_argument
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import BoundingBox
@@ -1337,7 +1337,6 @@ class SegmentationImage:
 
         return outlines
 
-    @deprecated_renamed_argument('axes', 'ax', '1.6.0')
     def imshow(self, ax=None, figsize=None, dpi=None, cmap=None, alpha=None):
         """
         Display the segmentation image in a matplotlib


### PR DESCRIPTION
This PR removes the deprecated ``axes`` keyword in favor of ``ax`` for consistency with matplotlib and other packages