### PR TITLE
Remove deprecated outline_segments method from SegmentationImage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ API Changes
 
   - Deprecated the ``kernel`` keyword in ``SourceCatalog``. [#1525]
 
+  - Removed the deprecated ``outline_segmentsl`` method from
+    ``SegmentationImage``. [#1526]
+
 
 1.7.0 (2023-04-05)
 ------------------

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -278,7 +278,7 @@ the background-subtracted (convolved) image and threshold:
 Modifying a Segmentation Image
 ------------------------------
 The :class:`~photutils.segmentation.SegmentationImage` object provides
-several methods that can be used to visualize or modify itself (e.g.,
+several methods that can be used to modify itself (e.g.,
 combining labels, removing labels, removing border segments) prior to
 measuring source photometry and other source properties, including:
 
@@ -300,9 +300,6 @@ measuring source photometry and other source properties, including:
 
   * :meth:`~photutils.segmentation.SegmentationImage.remove_masked_labels`:
     Remove labeled segments located within a masked region.
-
-  * :meth:`~photutils.segmentation.SegmentationImage.outline_segments`:
-    Outline the labeled segments for plotting.
 
 
 Photometry, Centroids, and Shape Properties

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -10,7 +10,6 @@ from copy import copy, deepcopy
 
 import numpy as np
 from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import BoundingBox
@@ -1292,50 +1291,6 @@ class SegmentationImage:
             patches = list(patches)
 
         return patches
-
-    @deprecated('1.7.0', alternative='`plot_patches`')
-    def outline_segments(self, mask_background=False):
-        """
-        Outline the labeled segments.
-
-        The "outlines" represent the pixels *just inside* the segments,
-        leaving the background pixels unmodified.
-
-        Parameters
-        ----------
-        mask_background : bool, optional
-            Set to `True` to mask the background pixels (labels = 0) in
-            the returned array.  This is useful for overplotting the
-            segment outlines.  The default is `False`.
-
-        Returns
-        -------
-        boundaries : `~numpy.ndarray` or `~numpy.ma.MaskedArray`
-            An array with the same shape of the segmentation array
-            containing only the outlines of the labeled segments.  The
-            pixel values in the outlines correspond to the labels in the
-            segmentation array.  If ``mask_background`` is `True`, then
-            a `~numpy.ma.MaskedArray` is returned.
-        """
-        from scipy.ndimage import (generate_binary_structure, grey_dilation,
-                                   grey_erosion)
-
-        # edge connectivity
-        footprint = generate_binary_structure(self._ndim, 1)
-
-        # mode='constant' ensures outline is included on the array borders
-        eroded = grey_erosion(self.data, footprint=footprint, mode='constant',
-                              cval=0.0)
-        dilated = grey_dilation(self.data, footprint=footprint,
-                                mode='constant', cval=0.0)
-
-        outlines = ((dilated != eroded) & (self.data != 0)).astype(int)
-        outlines *= self.data
-
-        if mask_background:
-            outlines = np.ma.masked_where(outlines == 0, outlines)
-
-        return outlines
 
     def imshow(self, ax=None, figsize=None, dpi=None, cmap=None, alpha=None):
         """

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -6,8 +6,7 @@ Tests for the core module.
 import numpy as np
 import pytest
 from astropy.utils import lazyproperty
-from astropy.utils.exceptions import (AstropyDeprecationWarning,
-                                      AstropyUserWarning)
+from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.segmentation.core import Segment, SegmentationImage
@@ -427,27 +426,6 @@ class TestSegmentationImage:
         assert len(patches) == 2
         assert isinstance(patches, list)
         assert isinstance(patches[0], Polygon)
-
-    def test_outline_segments(self):
-        segm_array = np.zeros((5, 5)).astype(int)
-        segm_array[1:4, 1:4] = 2
-        segm = SegmentationImage(segm_array)
-        segm_array_ref = np.copy(segm_array)
-        segm_array_ref[2, 2] = 0
-        with pytest.warns(AstropyDeprecationWarning):
-            assert_allclose(segm.outline_segments(), segm_array_ref)
-
-    def test_outline_segments_masked_background(self):
-        segm_array = np.zeros((5, 5)).astype(int)
-        segm_array[1:4, 1:4] = 2
-        segm = SegmentationImage(segm_array)
-        segm_array_ref = np.copy(segm_array)
-        segm_array_ref[2, 2] = 0
-        with pytest.warns(AstropyDeprecationWarning):
-            segm_outlines = segm.outline_segments(mask_background=True)
-            assert isinstance(segm_outlines, np.ma.MaskedArray)
-            assert np.ma.count(segm_outlines) == 8
-            assert np.ma.count_masked(segm_outlines) == 17
 
 
 class CustomSegm(SegmentationImage):


### PR DESCRIPTION
This PR removes the deprecated `outline_segments` method from `SegmentationImage`.  The `plot_patches` method should be used instead.