### PR TITLE
Refactor ApertureMask get_values for reuseability

### DIFF
--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -569,8 +569,6 @@ class PixelAperture(Aperture):
             aperture_sums.append(values.sum())
 
             if error is not None:
-                if error.shape != data.shape:
-                    raise ValueError('error and data must have the same shape')
                 var_cutout = error[slc_large]**2
 
                 # ignore multiplication with non-finite data values
@@ -580,8 +578,6 @@ class PixelAperture(Aperture):
                 aperture_sum_errs.append(np.sqrt(values.sum()))
 
         aperture_sums = np.array(aperture_sums)
-        if error is None:
-            aperture_sum_errs = []
         aperture_sum_errs = np.array(aperture_sum_errs)
 
         # apply units

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -253,6 +253,13 @@ class ApertureMask:
 
         pixel_mask: 2D bool `~numpy.ndarray`
             The cutout pixel mask for the overlap.
+
+        Notes
+        -----
+        This method is separate from ``get_values`` to facilitate
+        applying the same slices, aper_weights, and pixel_mask to
+        multiple associated arrays (e.g., data and error arrays). It is
+        used in this way by the `PixelAperture.do_photometry` method.
         """
         if mask is not None:
             if mask.shape != shape:


### PR DESCRIPTION
This PR splits the `ApertureMask.get_values` method into two methods.  The new (private) method is separate from ``get_values`` to facilitate applying the same slices, aper_weights, and pixel_mask to multiple associated arrays (e.g., data and error arrays). It is used in this way by the `PixelAperture.do_photometry` method.