### PR TITLE
Update Python version for Astropy dev test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,4 @@ jobs:
           name: Run tests for Python 3.9
           command: |
             stty rows 50 cols 80
-            /opt/python/cp39-cp39/bin/python -m tox -e circleci_32bit
+            /opt/python/cp39-cp39/bin/python -m tox -e 32bit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install dependencies for Python 3.8
-          command: /opt/python/cp38-cp38/bin/pip install tox
+          name: Install dependencies for Python 3.9
+          command: /opt/python/cp39-cp39/bin/pip install tox
       - run:
-          name: Run tests for Python 3.8
+          name: Run tests for Python 3.9
           command: |
             stty rows 50 cols 80
-            /opt/python/cp38-cp38/bin/python -m tox -e circleci_32bit
+            /opt/python/cp39-cp39/bin/python -m tox -e circleci_32bit

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{38,39,310,311}-test{,-alldeps,-devdeps,-oldestdeps}{,-cov}
     py{38,39,310,311}-test-numpy{121,122,123,124}
     py{38,39,310,311}-test-astropy{50,lts}
-    circleci_32bit
+    32bit
     build_docs
     linkcheck
     codestyle
@@ -52,8 +52,8 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    circleci_32bit: numpy==1.21.*
-    circleci_32bit: git+https://github.com/astropy/astropy.git#egg=astropy
+    32bit: numpy==1.21.*
+    32bit: git+https://github.com/astropy/astropy.git#egg=astropy
 
     cov: coverage
 
@@ -94,9 +94,9 @@ commands =
     cov: pytest --pyargs photutils {toxinidir}/docs --cov photutils --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
-[testenv:circleci_32bit]
+[testenv:32bit]
 changedir = .tmp/{envname}
-description = 32-bit CircleCI tests
+description = 32-bit tests
 extras = test
 commands =
     pip freeze


### PR DESCRIPTION
Astropy dev now requires Python 3.9+