### PR TITLE
Fix PRFAdapter for numpy 1.25+ deprecation

### DIFF
--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -1093,6 +1093,13 @@ class PRFAdapter(Fittable2DModel):
 
     def evaluate(self, x, y, flux, x_0, y_0):
         """The evaluation function for PRFAdapter."""
+        if not np.isscalar(flux):
+            flux = flux[0]
+        if not np.isscalar(x_0):
+            x_0 = x_0[0]
+        if not np.isscalar(y_0):
+            y_0 = y_0[0]
+
         if self.xname is None:
             dx = x - x_0
         else:


### PR DESCRIPTION
The `devdeps` CI tests are failing due to a new numpy `DeprecationWarning` (Conversion of an array with ndim > 0 to a scalar is deprecated).  This PR fixes that issue to prevent the warnings.