### PR TITLE
Lower tolerance of isophote harmonics test

### DIFF
--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -181,7 +181,7 @@ class TestFitEllipseSamples:
         fitter = EllipseFitter(sample)
         iso = fitter.fit(maxit=400)
 
-        assert_allclose(iso.a3, 6.825e-7, atol=1.0e-9)
+        assert_allclose(iso.a3, 6.825e-7, atol=1.0e-8)
         assert_allclose(iso.b3, -1.68e-6, atol=1.0e-8)
         assert_allclose(iso.a4, 4.36e-6, atol=1.0e-8)
         assert_allclose(iso.b4, -4.73e-5, atol=1.0e-7)


### PR DESCRIPTION
This test is randomly failing with `numpy` dev (likely due to recently precision changes with `numpy` sin/cos).  This PR lowers the test tolerance.