### PR TITLE
Remove ApertureStats unpack_nddata from public API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ API Changes
 - Removed the deprecated ``axes`` keyword in favor of ``ax`` for
   consistency with other packages. [#1523]
 
+- ``photutils.aperture``
+
+  - Removed the ``ApertureStats`` ``unpack_nddata`` method. [#1537]
+
 - ``photutils.segmentation``
 
   - Removed the deprecated ``kernel`` keyword from ``detect_sources``

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -213,7 +213,8 @@ class ApertureStats:
                  local_bkg=None):
 
         if isinstance(data, NDData):
-            data, error, mask, wcs = self.unpack_nddata(data, error, mask, wcs)
+            data, error, mask, wcs = self._unpack_nddata(data, error, mask,
+                                                         wcs)
 
         (data, error, local_bkg), unit = process_quantities(
             (data, error, local_bkg), ('data', 'error', 'local_bkg'))
@@ -258,7 +259,7 @@ class ApertureStats:
         self.meta = _get_meta()
 
     @staticmethod
-    def unpack_nddata(data, error, mask, wcs):
+    def _unpack_nddata(data, error, mask, wcs):
         nddata_attr = {'error': error, 'mask': mask, 'wcs': wcs}
         for key, value in nddata_attr.items():
             if value is not None:


### PR DESCRIPTION
This method is used only internally for handling `NDData` inputs.  It's not useful for the user. 