### PR TITLE
Change radius API for RadialProfile and CurveOfGrowth

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,11 +17,6 @@ General
 New Features
 ^^^^^^^^^^^^
 
-- ``photutils.profiles``
-
-  - Added ``EdgeRadialProfile`` class defined using radial bin edges.
-    [#1538]
-
 Bug Fixes
 ^^^^^^^^^
 
@@ -39,6 +34,13 @@ API Changes
 - ``photutils.aperture``
 
   - Removed the ``ApertureStats`` ``unpack_nddata`` method. [#1537]
+
+- ``photutils.profiles``
+
+  - The API for defining the radial bins for the ``RadialProfile`` and
+    ``CurveOfGrowth`` classes was changed. While the new API allows for
+    more flexibility, unfortunately, it is not backwards-compatible.
+    [#1540]
 
 - ``photutils.segmentation``
 

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -7,7 +7,7 @@ Introduction
 ------------
 
 `photutils.profiles` provides tools to calculate radial profiles and
-curves of growth using concentric apertures.
+curves of growth using concentric circular apertures.
 
 
 Preliminaries
@@ -50,14 +50,10 @@ data before creating a radial profile or curve of growth.
 Creating a Radial Profile
 -------------------------
 
-Photutils provides two classes for computing radial profiles. The
-classes have the same functionality, but differ in how the radial bins
-are input. The `~photutils.profiles.RadialProfile` radial bins are
-computed using inputs (minimum, maximum, and step size) defined as
-the radial bin centers. The `~photutils.profiles.EdgeRadialProfile`
-class allows the user to directly input the radial bin edges.
-Also, the radial spacing does not need to be constant for
-`~photutils.profiles.EdgeRadialProfile` class.
+Photutils provides the :class:`~photutils.profiles.RadialProfile` class
+for computing radial profiles. The radial bins are defined by inputting
+a 1D array of radial edges. The radial spacing does not need to be
+constant.
 
 First, we'll use the `~photutils.centroids.centroid_quadratic` function
 to find the source centroid::
@@ -67,53 +63,35 @@ to find the source centroid::
     >>> print(xycen)  # doctest: +FLOAT_CMP
     [47.61226319 52.04668132]
 
-Now, let's create radial profiles using both classes. The radial
-profiles will be centered at our centroid position computed above.
-
-For the `~photutils.profiles.RadialProfile` class the profile will be
-computed over the radial range from ``min_radius`` to ``max_radius``
-with steps of ``radius_step`` (note these are the centers of the radial
-bins)::
+Now, let's create a radial profile. The radial profile will be centered
+at our centroid position computed above.
 
     >>> from photutils.profiles import RadialProfile
-    >>> min_radius = 0.0
-    >>> max_radius = 25.0
-    >>> radius_step = 1.0
-    >>> rp1 = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-    ...                     error=error, mask=None)
+    >>> edge_radii = np.arange(25)
+    >>> rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
-For the `~photutils.profiles.EdgeRadialProfile` class the profile will be
-computed using the input edge radii::
-
-    >>> from photutils.profiles import EdgeRadialProfile
-    >>> edge_radii = np.arange(26)
-    >>> rp2 = EdgeRadialProfile(data, xycen, edge_radii, error=error,
-    ...                         mask=None)
-
-The `~photutils.profiles.RadialProfile.radius`,
+The `~photutils.profiles.RadialProfile.radius` (radial bin centers),
 `~photutils.profiles.RadialProfile.profile`, and
 `~photutils.profiles.RadialProfile.profile_error` attributes contain the
 output 1D `~numpy.ndarray` objects::
 
-    >>> print(rp1.radius)  # doctest: +FLOAT_CMP
-    [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11. 12. 13. 14. 15. 16. 17.
-     18. 19. 20. 21. 22. 23. 24. 25.]
+    >>> print(rp.radius)  # doctest: +FLOAT_CMP
+    [ 0.5  1.5  2.5  3.5  4.5  5.5  6.5  7.5  8.5  9.5 10.5 11.5 12.5 13.5
+     14.5 15.5 16.5 17.5 18.5 19.5 20.5 21.5 22.5 23.5]
 
-    >>> print(rp1.profile)  # doctest: +FLOAT_CMP
-    [ 4.27430150e+01  4.02150658e+01  3.81601146e+01  3.38116846e+01
-      2.89343205e+01  2.34250297e+01  1.84368533e+01  1.44310461e+01
-      9.55543388e+00  6.55415896e+00  4.49693014e+00  2.56010523e+00
-      1.50362911e+00  7.35389056e-01  6.04663625e-01  8.08820954e-01
-      2.31751912e-01 -1.39063329e-01  1.25181410e-01  4.84601845e-01
-      1.94567871e-01  4.49109676e-01 -2.00995374e-01 -7.74387397e-02
-      5.70302749e-02 -3.27578439e-02]
+    >>> print(rp.profile)  # doctest: +FLOAT_CMP
+    [ 4.15632243e+01  3.93402079e+01  3.59845746e+01  3.15540506e+01
+      2.62300757e+01  2.07297033e+01  1.65106801e+01  1.19376723e+01
+      7.75743772e+00  5.56759777e+00  3.44112671e+00  1.91350281e+00
+      1.17092981e+00  4.22261078e-01  9.70256904e-01  4.16355795e-01
+      1.52328707e-02 -6.69985111e-02  4.15522650e-01  2.48494731e-01
+      4.03348112e-01  1.43482678e-01 -2.62777461e-01  7.30653622e-02]
 
-    >>> print(rp1.profile_error)  # doctest: +FLOAT_CMP
-    [2.95008692 1.17855895 0.6610777  0.51902503 0.47524302 0.43072819
-     0.39770113 0.37667594 0.33909996 0.35356048 0.30377721 0.29455808
-     0.25670656 0.26599511 0.27354232 0.2430305  0.22910334 0.22204777
-     0.22327174 0.23816561 0.2343794  0.2232632  0.19893783 0.17888776
-     0.18228289 0.19680823]
+    >>> print(rp.profile_error)  # doctest: +FLOAT_CMP
+    [1.69588246 0.81797694 0.61132694 0.44670831 0.49499835 0.38025361
+     0.40844702 0.32906672 0.36466713 0.33059274 0.29661894 0.27314739
+     0.25551933 0.27675376 0.25553986 0.23421017 0.22966813 0.21747036
+     0.23654884 0.22760386 0.23941711 0.20661313 0.18999134 0.17469024]
 
 If desired, the radial profiles can be normalized using the
 :meth:`~photutils.profiles.RadialProfile.normalize` method.
@@ -123,10 +101,8 @@ error:
 
 .. doctest-skip::
 
-    >>> rp1.plot(label='RadialProfile')
-    >>> rp1.plot_error()
-    >>> rp2.plot(label='EdgeRadialProfile')
-    >>> rp2.plot_error()
+    >>> rp.plot(label='Radial Profile')
+    >>> rp.plot_error()
 
 .. plot::
 
@@ -135,7 +111,7 @@ error:
 
     from photutils.centroids import centroid_quadratic
     from photutils.datasets import make_noise_image
-    from photutils.profiles import EdgeRadialProfile, RadialProfile
+    from photutils.profiles import RadialProfile
 
     # create an artificial single source
     gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
@@ -148,20 +124,12 @@ error:
     xycen = centroid_quadratic(data, xpeak=47, ypeak=52)
 
     # create the radial profile
-    min_radius = 0.0
-    max_radius = 25.0
-    radius_step = 1.0
-    rp1 = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-                        error=error, mask=None)
-
     edge_radii = np.arange(26)
-    rp2 = EdgeRadialProfile(data, xycen, edge_radii, error=error, mask=None)
+    rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
     # plot the radial profile
-    rp1.plot(label='RadialProfile')
-    rp1.plot_error()
-    rp2.plot(label='EdgeRadialProfile')
-    rp2.plot_error()
+    rp.plot(label='Radial Profile')
+    rp.plot_error()
     plt.legend()
 
 The `~photutils.profiles.RadialProfile.apertures` attribute contains a
@@ -190,11 +158,8 @@ list of the apertures. Let's plot two of the annulus apertures for the
     xycen = centroid_quadratic(data, xpeak=47, ypeak=52)
 
     # create the radial profile
-    min_radius = 0.0
-    max_radius = 25.0
-    radius_step = 1.0
-    rp = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-                       error=error, mask=None)
+    edge_radii = np.arange(26)
+    rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
     norm = simple_norm(data, 'sqrt')
     plt.figure(figsize=(5, 5))
@@ -209,12 +174,7 @@ profile and return the Gaussian model using the
 
 .. doctest-requires:: scipy
 
-    >>> rp1.gaussian_fit  # doctest: +FLOAT_CMP
-    <Gaussian1D(amplitude=41.80620963, mean=0., stddev=4.69126969)>
-
-.. doctest-requires:: scipy
-
-    >>> rp2.gaussian_fit  # doctest: +FLOAT_CMP
+    >>> rp.gaussian_fit  # doctest: +FLOAT_CMP
     <Gaussian1D(amplitude=41.54880743, mean=0., stddev=4.71059406)>
 
 The FWHM of the fitted 1D Gaussian model is stored in the
@@ -222,12 +182,7 @@ The FWHM of the fitted 1D Gaussian model is stored in the
 
 .. doctest-requires:: scipy
 
-    >>> print(rp1.gaussian_fwhm)  # doctest: +FLOAT_CMP
-    11.04709589620093
-
-.. doctest-requires:: scipy
-
-    >>> print(rp2.gaussian_fwhm)  # doctest: +FLOAT_CMP
+    >>> print(rp.gaussian_fwhm)  # doctest: +FLOAT_CMP
     11.09260130738712
 
 Finally, let's plot the fitted 1D Gaussian model for the
@@ -254,16 +209,13 @@ class:`~photutils.profiles.RadialProfile` radial profile:
     xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
 
     # create the radial profile
-    min_radius = 0.0
-    max_radius = 25.0
-    radius_step = 1.0
-    rp1 = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-                        error=error, mask=None)
+    edge_radii = np.arange(26)
+    rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
     # plot the radial profile
-    rp1.plot(label='Radial Profile')
-    rp1.plot_error()
-    plt.plot(rp1.radius, rp1.gaussian_profile, label='Gaussian Fit')
+    rp.plot(label='Radial Profile')
+    rp.plot_error()
+    plt.plot(rp.radius, rp.gaussian_profile, label='Gaussian Fit')
 
     plt.legend()
 
@@ -276,16 +228,11 @@ Now let's create a curve of growth using the
 defined above and the same source centroid.
 
 The curve of growth will be centered at our centroid position. It will
-be computed over the radial range from ``min_radius`` to ``max_radius``
-with steps of ``radius_step``::
+be computed over the radial range given by the input ``radii`` array::
 
     >>> from photutils.profiles import CurveOfGrowth
-    >>> min_radius = 0.0
-    >>> max_radius = 25.0
-    >>> radius_step = 1.0
-    >>> cog = CurveOfGrowth(data, xycen, min_radius, max_radius, radius_step,
-    ...                     error=error, mask=None)
-
+    >>> radii = np.arange(1, 26)
+    >>> cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
 The `~photutils.profiles.CurveOfGrowth` instance
 has `~photutils.profiles.CurveOfGrowth.radius`,
@@ -294,24 +241,22 @@ has `~photutils.profiles.CurveOfGrowth.radius`,
 contain 1D `~numpy.ndarray` objects::
 
     >>> print(cog.radius)  # doctest: +FLOAT_CMP
-    [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11. 12. 13. 14. 15. 16. 17.
-     18. 19. 20. 21. 22. 23. 24. 25.]
+    [ 1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
+     25]
 
     >>> print(cog.profile)  # doctest: +FLOAT_CMP
-    [   0.          130.57472018  501.34744442 1066.59182074 1760.50163608
-     2502.13955554 3218.50667597 3892.81448231 4455.36403436 4869.66609313
-     5201.99745378 5429.02043984 5567.28370644 5659.24831854 5695.06577065
-     5783.46217755 5824.01080702 5825.59003768 5818.22316662 5866.52307412
-     5896.96917375 5948.92254787 5968.30540534 5931.15611704 5941.94457249
-     5942.06535486]
+    [ 130.57472018  501.34744442 1066.59182074 1760.50163608 2502.13955554
+     3218.50667597 3892.81448231 4455.36403436 4869.66609313 5201.99745378
+     5429.02043984 5567.28370644 5659.24831854 5695.06577065 5783.46217755
+     5824.01080702 5825.59003768 5818.22316662 5866.52307412 5896.96917375
+     5948.92254787 5968.30540534 5931.15611704 5941.94457249 5942.06535486]
 
     >>> print(cog.profile_error)  # doctest: +FLOAT_CMP
-    [  0.           5.32777186   9.37111012  13.41750992  16.62928904
-      21.7350922   25.39862532  30.3867526   34.11478867  39.28263973
-      43.96047829  48.11931395  52.00967328  55.7471834   60.48824739
-      64.81392778  68.71042311  72.71899201  76.54959872  81.33806741
-      85.98568713  91.34841248  95.5173253   99.22190499 102.51980185
-     106.83601366]
+    [  5.32777186   9.37111012  13.41750992  16.62928904  21.7350922
+      25.39862532  30.3867526   34.11478867  39.28263973  43.96047829
+      48.11931395  52.00967328  55.7471834   60.48824739  64.81392778
+      68.71042311  72.71899201  76.54959872  81.33806741  85.98568713
+      91.34841248  95.5173253   99.22190499 102.51980185 106.83601366]
 
 If desired, the curve of growth profile can be normalized using the
 :meth:`~photutils.profiles.RadialProfile.normalize` method.
@@ -344,11 +289,8 @@ error:
     xycen = centroid_quadratic(data, xpeak=47, ypeak=52)
 
     # create the radial profile
-    min_radius = 0.0
-    max_radius = 25.0
-    radius_step = 1.0
-    cog = CurveOfGrowth(data, xycen, min_radius, max_radius, radius_step,
-                        error=error, mask=None)
+    radii = np.arange(1, 26)
+    cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
     # plot the radial profile
     cog.plot()
@@ -379,11 +321,8 @@ list of the apertures. Let's plot a couple of the apertures on the data:
     xycen = centroid_quadratic(data, xpeak=47, ypeak=52)
 
     # create the radial profile
-    min_radius = 0.0
-    max_radius = 25.0
-    radius_step = 1.0
-    cog = CurveOfGrowth(data, xycen, min_radius, max_radius, radius_step,
-                        error=error, mask=None)
+    radii = np.arange(1, 26)
+    cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
     norm = simple_norm(data, 'sqrt')
     plt.figure(figsize=(5, 5))

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -2,7 +2,7 @@
 """
 This module provides tools for generating curves of growth.
 """
-
+import numpy as np
 from astropy.utils import lazyproperty
 
 from photutils.profiles.core import ProfileBase
@@ -28,15 +28,11 @@ class CurveOfGrowth(ProfileBase):
     xycen : tuple of 2 floats
         The ``(x, y)`` pixel coordinate of the source center.
 
-    min_radius : float
-        The minimum radius for the profile. Must be greater than or
-        equal to zero.
-
-    max_radius : float
-        The maximum radius for the profile.
-
-    radius_step : float
-        The radial step size in pixels.
+    radii : 1D float `numpy.ndarray`
+        An array of the circular radii. ``radii`` must be strictly
+        increasing with a minimum value greater than zero, and contain
+        at least 2 values. The radial spacing does not need to be
+        constant.
 
     error : 2D `numpy.ndarray`, optional
         The 1-sigma errors of the input ``data``. ``error`` is assumed
@@ -101,31 +97,26 @@ class CurveOfGrowth(ProfileBase):
     Create the curve of growth.
 
     >>> xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
-    >>> min_radius = 0.0
-    >>> max_radius = 25.0
-    >>> radius_step = 1.0
-    >>> cog = CurveOfGrowth(data, xycen, min_radius, max_radius, radius_step,
-    ...                     error=error, mask=None)
+    >>> radii = np.arange(1, 26)
+    >>> cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
     >>> print(cog.radius)  # doctest: +FLOAT_CMP
-    [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11. 12. 13. 14. 15. 16. 17.
-     18. 19. 20. 21. 22. 23. 24. 25.]
+    [ 1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
+     25]
 
     >>> print(cog.profile)  # doctest: +FLOAT_CMP
-    [   0.          130.57472018  501.34744442 1066.59182074 1760.50163608
-     2502.13955554 3218.50667597 3892.81448231 4455.36403436 4869.66609313
-     5201.99745378 5429.02043984 5567.28370644 5659.24831854 5695.06577065
-     5783.46217755 5824.01080702 5825.59003768 5818.22316662 5866.52307412
-     5896.96917375 5948.92254787 5968.30540534 5931.15611704 5941.94457249
-     5942.06535486]
+    [ 130.57472018  501.34744442 1066.59182074 1760.50163608 2502.13955554
+     3218.50667597 3892.81448231 4455.36403436 4869.66609313 5201.99745378
+     5429.02043984 5567.28370644 5659.24831854 5695.06577065 5783.46217755
+     5824.01080702 5825.59003768 5818.22316662 5866.52307412 5896.96917375
+     5948.92254787 5968.30540534 5931.15611704 5941.94457249 5942.06535486]
 
     >>> print(cog.profile_error)  # doctest: +FLOAT_CMP
-    [  0.           5.32777186   9.37111012  13.41750992  16.62928904
-      21.7350922   25.39862532  30.3867526   34.11478867  39.28263973
-      43.96047829  48.11931395  52.00967328  55.7471834   60.48824739
-      64.81392778  68.71042311  72.71899201  76.54959872  81.33806741
-      85.98568713  91.34841248  95.5173253   99.22190499 102.51980185
-     106.83601366]
+    [  5.32777186   9.37111012  13.41750992  16.62928904  21.7350922
+      25.39862532  30.3867526   34.11478867  39.28263973  43.96047829
+      48.11931395  52.00967328  55.7471834   60.48824739  64.81392778
+      68.71042311  72.71899201  76.54959872  81.33806741  85.98568713
+      91.34841248  95.5173253   99.22190499 102.51980185 106.83601366]
 
     Plot the curve of growth.
 
@@ -151,11 +142,8 @@ class CurveOfGrowth(ProfileBase):
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
 
         # create the curve of growth
-        min_radius = 0.0
-        max_radius = 25.0
-        radius_step = 1.0
-        cog = CurveOfGrowth(data, xycen, min_radius, max_radius, radius_step,
-                            error=error, mask=None)
+        radii = np.arange(1, 26)
+        cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
         # plot the curve of growth
         cog.plot()
@@ -185,11 +173,8 @@ class CurveOfGrowth(ProfileBase):
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
 
         # create the curve of growth
-        min_radius = 0.0
-        max_radius = 25.0
-        radius_step = 1.0
-        cog = CurveOfGrowth(data, xycen, min_radius, max_radius, radius_step,
-                            error=error, mask=None)
+        radii = np.arange(1, 26)
+        cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
         # plot the curve of growth
         cog.normalize()
@@ -220,11 +205,8 @@ class CurveOfGrowth(ProfileBase):
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
 
         # create the curve of growth
-        min_radius = 0.0
-        max_radius = 25.0
-        radius_step = 1.0
-        cog = CurveOfGrowth(data, xycen, min_radius, max_radius, radius_step,
-                            error=error, mask=None)
+        radii = np.arange(1, 26)
+        cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
         norm = simple_norm(data, 'sqrt')
         plt.figure(figsize=(5, 5))
@@ -233,9 +215,15 @@ class CurveOfGrowth(ProfileBase):
         cog.apertures[10].plot(color='C1', lw=2)
     """
 
-    @lazyproperty
-    def _circular_radii(self):
-        return self.radius
+    def __init__(self, data, xycen, radii, *, error=None, mask=None,
+                 method='exact', subpixels=5):
+
+        radii = np.array(radii)
+        if radii.min() <= 0:
+            raise ValueError('radii must be > 0')
+
+        super().__init__(data, xycen, radii, error=error, mask=mask,
+                         method=method, subpixels=subpixels)
 
     @lazyproperty
     def apertures(self):

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -3,7 +3,6 @@
 This module provides tools for generating radial profiles.
 """
 
-import math
 import warnings
 
 import numpy as np
@@ -14,422 +13,12 @@ from astropy.utils import lazyproperty
 
 from photutils.profiles.core import ProfileBase
 
-__all__ = ['RadialProfile', 'EdgeRadialProfile']
+__all__ = ['RadialProfile']
 
-__doctest_requires__ = {('RadialProfile', 'EdgeRadialProfile'): ['scipy']}
+__doctest_requires__ = {('RadialProfile'): ['scipy']}
 
 
 class RadialProfile(ProfileBase):
-    """
-    Class to create a radial profile using concentric circular
-    apertures.
-
-    The radial profile represents the azimuthally-averaged flux in
-    circular annuli apertures as a function of radius.
-
-    Parameters
-    ----------
-    data : 2D `numpy.ndarray`
-        The 2D data array. The data should be background-subtracted.
-        Non-finite values (e.g., NaN or inf) in the ``data`` or
-        ``error`` array are automatically masked.
-
-    xycen : tuple of 2 floats
-        The ``(x, y)`` pixel coordinate of the source center.
-
-    min_radius : float
-        The minimum radius for the profile. This radius is the minimum
-        radial bin center, not the edge.
-
-    max_radius : float
-        The maximum radius for the profile. This radius is the maximum
-        radial bin center, not the edge.
-
-    radius_step : float
-        The radial step size in pixels.
-
-    error : 2D `numpy.ndarray`, optional
-        The 1-sigma errors of the input ``data``. ``error`` is assumed
-        to include all sources of error, including the Poisson error
-        of the sources (see `~photutils.utils.calc_total_error`) .
-        ``error`` must have the same shape as the input ``data``.
-        Non-finite values (e.g., NaN or inf) in the ``data`` or
-        ``error`` array are automatically masked.
-
-    mask : 2D bool `numpy.ndarray`, optional
-        A boolean mask with the same shape as ``data`` where a `True`
-        value indicates the corresponding element of ``data`` is masked.
-        Masked data are excluded from all calculations.
-
-    method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the overlap of the aperture on the
-        pixel grid:
-
-            * ``'exact'`` (default):
-              The the exact fractional overlap of the aperture and each
-              pixel is calculated. The aperture weights will contain
-              values between 0 and 1.
-
-            * ``'center'``:
-              A pixel is considered to be entirely in or out of the
-              aperture depending on whether its center is in or out of
-              the aperture. The aperture weights will contain values
-              only of 0 (out) and 1 (in).
-
-            * ``'subpixel'``:
-              A pixel is divided into subpixels (see the ``subpixels``
-              keyword), each of which are considered to be entirely in
-              or out of the aperture depending on whether its center is
-              in or out of the aperture. If ``subpixels=1``, this method
-              is equivalent to ``'center'``. The aperture weights will
-              contain values between 0 and 1.
-
-    subpixels : int, optional
-        For the ``'subpixel'`` method, resample pixels by this factor
-        in each dimension. That is, each pixel is divided into
-        ``subpixels**2`` subpixels. This keyword is ignored unless
-        ``method='subpixel'``.
-
-    See Also
-    --------
-    EdgeRadialProfile : Allows input of the radial edges.
-
-    Notes
-    -----
-    Note that the ``min_radius``, ``max_radius``, and ``radius_step``
-    define the radial bin centers, not the edges. As a consequence,
-    if the ``min_radius`` is less than or equal to half the
-    ``radius_step``, then a circular aperture with radius equal to
-    ``min_radius + 0.5 * radius_step`` will be used for the innermost
-    aperture.
-
-    The `EdgeRadialProfile` class can be used to input an array of the
-    radial bin edges. For that class, the radial spacing does not need
-    to be constant.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from astropy.modeling.models import Gaussian2D
-    >>> from astropy.visualization import simple_norm
-    >>> from photutils.centroids import centroid_quadratic
-    >>> from photutils.datasets import make_noise_image
-    >>> from photutils.profiles import RadialProfile
-
-    Create an artificial single source. Note that this image does not
-    have any background.
-
-    >>> gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
-    >>> yy, xx = np.mgrid[0:100, 0:100]
-    >>> data = gmodel(xx, yy)
-    >>> error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    >>> data += error
-
-    Create the radial profile.
-
-    >>> xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
-    >>> min_radius = 0.0
-    >>> max_radius = 25.0
-    >>> radius_step = 1.0
-    >>> rp = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-    ...                    error=error, mask=None)
-
-    >>> print(rp.radius)  # doctest: +FLOAT_CMP
-    [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11. 12. 13. 14. 15. 16. 17.
-     18. 19. 20. 21. 22. 23. 24. 25.]
-
-    >>> print(rp.profile)  # doctest: +FLOAT_CMP
-    [ 4.27430150e+01  4.02150658e+01  3.81601146e+01  3.38116846e+01
-      2.89343205e+01  2.34250297e+01  1.84368533e+01  1.44310461e+01
-      9.55543388e+00  6.55415896e+00  4.49693014e+00  2.56010523e+00
-      1.50362911e+00  7.35389056e-01  6.04663625e-01  8.08820954e-01
-      2.31751912e-01 -1.39063329e-01  1.25181410e-01  4.84601845e-01
-      1.94567871e-01  4.49109676e-01 -2.00995374e-01 -7.74387397e-02
-      5.70302749e-02 -3.27578439e-02]
-
-    >>> print(rp.profile_error)  # doctest: +FLOAT_CMP
-    [2.95008692 1.17855895 0.6610777  0.51902503 0.47524302 0.43072819
-     0.39770113 0.37667594 0.33909996 0.35356048 0.30377721 0.29455808
-     0.25670656 0.26599511 0.27354232 0.2430305  0.22910334 0.22204777
-     0.22327174 0.23816561 0.2343794  0.2232632  0.19893783 0.17888776
-     0.18228289 0.19680823]
-
-    Plot the radial profile.
-
-    .. plot::
-
-        import matplotlib.pyplot as plt
-        import numpy as np
-        from astropy.modeling.models import Gaussian2D
-        from astropy.visualization import simple_norm
-
-        from photutils.centroids import centroid_quadratic
-        from photutils.datasets import make_noise_image
-        from photutils.profiles import RadialProfile
-
-        # create an artificial single source
-        gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
-        yy, xx = np.mgrid[0:100, 0:100]
-        data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
-
-        # find the source centroid
-        xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
-
-        # create the radial profile
-        min_radius = 0.0
-        max_radius = 25.0
-        radius_step = 1.0
-        rp = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-                           error=error, mask=None)
-
-        # plot the radial profile
-        rp.plot()
-        rp.plot_error()
-
-    Normalize the profile and plot the normalized radial profile.
-
-    .. plot::
-
-        import matplotlib.pyplot as plt
-        import numpy as np
-        from astropy.modeling.models import Gaussian2D
-        from astropy.visualization import simple_norm
-
-        from photutils.centroids import centroid_quadratic
-        from photutils.datasets import make_noise_image
-        from photutils.profiles import RadialProfile
-
-        # create an artificial single source
-        gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
-        yy, xx = np.mgrid[0:100, 0:100]
-        data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
-
-        # find the source centroid
-        xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
-
-        # create the radial profile
-        min_radius = 0.0
-        max_radius = 25.0
-        radius_step = 1.0
-        rp = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-                           error=error, mask=None)
-
-        # plot the radial profile
-        rp.normalize()
-        rp.plot()
-        rp.plot_error()
-
-    Plot two of the annulus apertures on the data.
-
-    .. plot::
-
-        import matplotlib.pyplot as plt
-        import numpy as np
-        from astropy.modeling.models import Gaussian2D
-        from astropy.visualization import simple_norm
-
-        from photutils.centroids import centroid_quadratic
-        from photutils.datasets import make_noise_image
-        from photutils.profiles import RadialProfile
-
-        # create an artificial single source
-        gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
-        yy, xx = np.mgrid[0:100, 0:100]
-        data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
-
-        # find the source centroid
-        xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
-
-        # create the radial profile
-        min_radius = 0.0
-        max_radius = 25.0
-        radius_step = 1.0
-        rp = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-                           error=error, mask=None)
-
-        norm = simple_norm(data, 'sqrt')
-        plt.figure(figsize=(5, 5))
-        plt.imshow(data, norm=norm)
-        rp.apertures[5].plot(color='C0', lw=2)
-        rp.apertures[10].plot(color='C1', lw=2)
-
-    Fit a 1D Gaussian to the radial profile and return the Gaussian
-    model.
-
-    >>> rp.gaussian_fit  # doctest: +FLOAT_CMP
-    <Gaussian1D(amplitude=41.80620963, mean=0., stddev=4.69126969)>
-
-    >>> print(rp.gaussian_fwhm)  # doctest: +FLOAT_CMP
-    11.04709589620093
-
-    Plot the fitted 1D Gaussian on the radial profile.
-
-    .. plot::
-
-        import matplotlib.pyplot as plt
-        import numpy as np
-        from astropy.modeling.models import Gaussian2D
-        from astropy.visualization import simple_norm
-
-        from photutils.centroids import centroid_quadratic
-        from photutils.datasets import make_noise_image
-        from photutils.profiles import RadialProfile
-
-        # create an artificial single source
-        gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
-        yy, xx = np.mgrid[0:100, 0:100]
-        data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
-
-        # find the source centroid
-        xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
-
-        # create the radial profile
-        min_radius = 0.0
-        max_radius = 25.0
-        radius_step = 1.0
-        rp = RadialProfile(data, xycen, min_radius, max_radius, radius_step,
-                           error=error, mask=None)
-
-        # plot the radial profile
-        rp.normalize()
-        rp.plot(label='Radial Profile')
-        rp.plot_error()
-        plt.plot(rp.radius, rp.gaussian_profile, label='Gaussian Fit')
-        plt.legend()
-    """
-
-    @lazyproperty
-    def _circular_radii(self):
-        """
-        The circular aperture radii for the radial bin edges (inner and
-        outer annulus radii).
-        """
-        shift = self.radius_step / 2
-        min_radius = self.min_radius - shift
-        max_radius = self.max_radius + shift
-        nsteps = int(math.floor((max_radius - min_radius)
-                                / self.radius_step))
-        max_radius = min_radius + (nsteps * self.radius_step)
-        return np.linspace(min_radius, max_radius, nsteps + 1)
-
-    @lazyproperty
-    def apertures(self):
-        """
-        A list of the circular annulus apertures used to measure the
-        radial profile.
-
-        If the ``min_radius`` is less than or equal to half the
-        ``radius_step``, then a circular aperture with radius equal
-        to ``min_radius + 0.5 * radius_step`` will be used for the
-        innermost aperture.
-        """
-        from photutils.aperture import CircularAnnulus, CircularAperture
-
-        apertures = []
-        for i in range(len(self._circular_radii) - 1):
-            try:
-                aperture = CircularAnnulus(self.xycen, self._circular_radii[i],
-                                           self._circular_radii[i + 1])
-            except ValueError:  # zero radius
-                aperture = CircularAperture(self.xycen,
-                                            self._circular_radii[i + 1])
-            apertures.append(aperture)
-
-        return apertures
-
-    @lazyproperty
-    def _flux(self):
-        """
-        The flux in a circular annulus.
-        """
-        return np.diff(self._photometry[0])
-
-    @lazyproperty
-    def _fluxerr(self):
-        """
-        The flux error in a circular annulus.
-        """
-        return np.sqrt(np.diff(self._photometry[1] ** 2))
-
-    @lazyproperty
-    def area(self):
-        """
-        The unmasked area in each circular annulus (or aperture) as a
-        function of radius as a 1D `~numpy.ndarray`.
-        """
-        return np.diff(self._photometry[2])
-
-    @lazyproperty
-    def profile(self):
-        """
-        The radial profile as a 1D `~numpy.ndarray`.
-        """
-        # ignore divide-by-zero RuntimeWarning
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            return self._flux / self.area
-
-    @lazyproperty
-    def profile_error(self):
-        """
-        The radial profile errors as a 1D `~numpy.ndarray`.
-        """
-        if self.error is None:
-            return self._fluxerr
-
-        # ignore divide-by-zero RuntimeWarning
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            return self._fluxerr / self.area
-
-    @lazyproperty
-    def _profile_nanmask(self):
-        return np.isfinite(self.profile)
-
-    @lazyproperty
-    def gaussian_fit(self):
-        """
-        The fitted 1D Gaussian to the radial profile as
-        a `~astropy.modeling.functional_models.Gaussian1D` model.
-        """
-        profile = self.profile[self._profile_nanmask]
-        radius = self.radius[self._profile_nanmask]
-
-        amplitude = np.max(profile)
-        std = np.sqrt(abs(np.sum(profile * radius**2) / np.sum(profile)))
-        g_init = Gaussian1D(amplitude=amplitude, mean=0.0, stddev=std)
-        g_init.mean.fixed = True
-        fitter = LevMarLSQFitter()
-        g_fit = fitter(g_init, radius, profile)
-
-        return g_fit
-
-    @lazyproperty
-    def gaussian_profile(self):
-        """
-        The fitted 1D Gaussian profile to the radial profile as a 1D
-        `~numpy.ndarray`.
-        """
-        return self.gaussian_fit(self.radius)
-
-    @lazyproperty
-    def gaussian_fwhm(self):
-        """
-        The full-width at half-maximum (FWHM) in pixels of the 1D
-        Gaussian fitted to the radial profile.
-        """
-        return self.gaussian_fit.stddev.value * gaussian_sigma_to_fwhm
-
-
-class EdgeRadialProfile(RadialProfile):
     """
     Class to create a radial profile using concentric circular
     apertures.
@@ -517,7 +106,7 @@ class EdgeRadialProfile(RadialProfile):
     >>> from astropy.visualization import simple_norm
     >>> from photutils.centroids import centroid_quadratic
     >>> from photutils.datasets import make_noise_image
-    >>> from photutils.profiles import EdgeRadialProfile
+    >>> from photutils.profiles import RadialProfile
 
     Create an artificial single source. Note that this image does not
     have any background.
@@ -532,7 +121,7 @@ class EdgeRadialProfile(RadialProfile):
 
     >>> xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
     >>> edge_radii = np.arange(26)
-    >>> rp = EdgeRadialProfile(data, xycen, edge_radii, error=error, mask=None)
+    >>> rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
     >>> print(rp.radius)  # doctest: +FLOAT_CMP
     [ 0.5  1.5  2.5  3.5  4.5  5.5  6.5  7.5  8.5  9.5 10.5 11.5 12.5 13.5
@@ -565,7 +154,7 @@ class EdgeRadialProfile(RadialProfile):
 
         from photutils.centroids import centroid_quadratic
         from photutils.datasets import make_noise_image
-        from photutils.profiles import EdgeRadialProfile
+        from photutils.profiles import RadialProfile
 
         # create an artificial single source
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
@@ -579,7 +168,7 @@ class EdgeRadialProfile(RadialProfile):
 
         # create the radial profile
         edge_radii = np.arange(26)
-        rp = EdgeRadialProfile(data, xycen, edge_radii, error=error, mask=None)
+        rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
         # plot the radial profile
         rp.plot()
@@ -596,7 +185,7 @@ class EdgeRadialProfile(RadialProfile):
 
         from photutils.centroids import centroid_quadratic
         from photutils.datasets import make_noise_image
-        from photutils.profiles import EdgeRadialProfile
+        from photutils.profiles import RadialProfile
 
         # create an artificial single source
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
@@ -610,7 +199,7 @@ class EdgeRadialProfile(RadialProfile):
 
         # create the radial profile
         edge_radii = np.arange(26)
-        rp = EdgeRadialProfile(data, xycen, edge_radii, error=error, mask=None)
+        rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
         # plot the radial profile
         rp.normalize()
@@ -628,7 +217,7 @@ class EdgeRadialProfile(RadialProfile):
 
         from photutils.centroids import centroid_quadratic
         from photutils.datasets import make_noise_image
-        from photutils.profiles import EdgeRadialProfile
+        from photutils.profiles import RadialProfile
 
         # create an artificial single source
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
@@ -642,7 +231,7 @@ class EdgeRadialProfile(RadialProfile):
 
         # create the radial profile
         edge_radii = np.arange(26)
-        rp = EdgeRadialProfile(data, xycen, edge_radii, error=error, mask=None)
+        rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
         norm = simple_norm(data, 'sqrt')
         plt.figure(figsize=(5, 5))
@@ -670,7 +259,7 @@ class EdgeRadialProfile(RadialProfile):
 
         from photutils.centroids import centroid_quadratic
         from photutils.datasets import make_noise_image
-        from photutils.profiles import EdgeRadialProfile
+        from photutils.profiles import RadialProfile
 
         # create an artificial single source
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
@@ -684,7 +273,7 @@ class EdgeRadialProfile(RadialProfile):
 
         # create the radial profile
         edge_radii = np.arange(26)
-        rp = EdgeRadialProfile(data, xycen, edge_radii, error=error, mask=None)
+        rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
         # plot the radial profile
         rp.normalize()
@@ -694,33 +283,119 @@ class EdgeRadialProfile(RadialProfile):
         plt.legend()
     """
 
-    def __init__(self, data, xycen, edge_radii, *, error=None, mask=None,
-                 method='exact', subpixels=5):
-        super().__init__(data, xycen, None, None, None, error=error, mask=mask,
-                         method=method, subpixels=subpixels)
-
-        self.edge_radii = self._validate_edge_radii(edge_radii)
-
-    def _validate_edge_radii(self, edge_radii):
-        edge_radii = np.array(edge_radii)
-        if edge_radii.ndim != 1 or edge_radii.size < 2:
-            raise ValueError('edge_radii must be a 1D array and have at '
-                             'least two values')
-        if edge_radii.min() < 0:
-            raise ValueError('minimum edge_radii must be >= 0')
-
-        if not np.all(edge_radii[1:] > edge_radii[:-1]):
-            raise ValueError('edge_radii must be strictly increasing')
-
-        return edge_radii
-
     @lazyproperty
     def radius(self):
         """
-        The profile radius in pixels as a 1D `~numpy.ndarray`.
+        The profile radius (bin centers) in pixels as a 1D
+        `~numpy.ndarray`.
         """
-        return (self.edge_radii[:-1] + self.edge_radii[1:]) / 2
+        # define the radial bin centers from the radial bin edges
+        return (self.radii[:-1] + self.radii[1:]) / 2
 
     @lazyproperty
-    def _circular_radii(self):
-        return self.edge_radii
+    def apertures(self):
+        """
+        A list of the circular annulus apertures used to measure the
+        radial profile.
+
+        If the ``min_radius`` is less than or equal to half the
+        ``radius_step``, then a circular aperture with radius equal
+        to ``min_radius + 0.5 * radius_step`` will be used for the
+        innermost aperture.
+        """
+        from photutils.aperture import CircularAnnulus, CircularAperture
+
+        apertures = []
+        for i in range(len(self.radii) - 1):
+            try:
+                aperture = CircularAnnulus(self.xycen, self.radii[i],
+                                           self.radii[i + 1])
+            except ValueError:  # zero radius
+                aperture = CircularAperture(self.xycen,
+                                            self.radii[i + 1])
+            apertures.append(aperture)
+
+        return apertures
+
+    @lazyproperty
+    def _flux(self):
+        """
+        The flux in a circular annulus.
+        """
+        return np.diff(self._photometry[0])
+
+    @lazyproperty
+    def _fluxerr(self):
+        """
+        The flux error in a circular annulus.
+        """
+        return np.sqrt(np.diff(self._photometry[1] ** 2))
+
+    @lazyproperty
+    def area(self):
+        """
+        The unmasked area in each circular annulus (or aperture) as a
+        function of radius as a 1D `~numpy.ndarray`.
+        """
+        return np.diff(self._photometry[2])
+
+    @lazyproperty
+    def profile(self):
+        """
+        The radial profile as a 1D `~numpy.ndarray`.
+        """
+        # ignore divide-by-zero RuntimeWarning
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            return self._flux / self.area
+
+    @lazyproperty
+    def profile_error(self):
+        """
+        The radial profile errors as a 1D `~numpy.ndarray`.
+        """
+        if self.error is None:
+            return self._fluxerr
+
+        # ignore divide-by-zero RuntimeWarning
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            return self._fluxerr / self.area
+
+    @lazyproperty
+    def _profile_nanmask(self):
+        return np.isfinite(self.profile)
+
+    @lazyproperty
+    def gaussian_fit(self):
+        """
+        The fitted 1D Gaussian to the radial profile as
+        a `~astropy.modeling.functional_models.Gaussian1D` model.
+        """
+        profile = self.profile[self._profile_nanmask]
+        radius = self.radius[self._profile_nanmask]
+
+        amplitude = np.max(profile)
+        std = np.sqrt(abs(np.sum(profile * radius**2) / np.sum(profile)))
+        g_init = Gaussian1D(amplitude=amplitude, mean=0.0, stddev=std)
+        g_init.mean.fixed = True
+        fitter = LevMarLSQFitter()
+        g_fit = fitter(g_init, radius, profile)
+
+        return g_fit
+
+    @lazyproperty
+    def gaussian_profile(self):
+        """
+        The fitted 1D Gaussian profile to the radial profile as a 1D
+        `~numpy.ndarray`.
+        """
+        return self.gaussian_fit(self.radius)
+
+    @lazyproperty
+    def gaussian_fwhm(self):
+        """
+        The full-width at half-maximum (FWHM) in pixels of the 1D
+        Gaussian fitted to the radial profile.
+        """
+        return self.gaussian_fit.stddev.value * gaussian_sigma_to_fwhm


### PR DESCRIPTION
This PR changes the API for defining the radial bins for the ``RadialProfile`` and ``CurveOfGrowth`` classes.  While the new API allows for more flexibility (e.g., non-uniform radial spacing), unfortunately, it is not backwards-compatible.  This is a very rare case where breaking the API is necessary.  These classes were added in the last release (1.7.0) about a month ago, so hopefully the inconvenience will be minimal. 

Followup to #1538, #1529 