### PR TITLE
Fix deprecated namespace for scipy.signal.tukey

### DIFF
--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -43,8 +43,7 @@ def test_tukey():
 def test_tukey_scipy():
     """Test Tukey window against 1D scipy version."""
 
-    # scipy.signal.tukey was introduced in Scipy v0.16.0
-    from scipy.signal import tukey
+    from scipy.signal.windows import tukey
 
     size = 101
     cen = (size - 1) // 2


### PR DESCRIPTION
`scipy.signal.tukey` is deprecated for `scipy.signal.windows.tukey` in SciPy 1.13.0+.

This fixes the failing CI devdeps test.