### PR TITLE
Update devdeps URL for nightly wheels

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ isolated_build = true
 # Suppress display of matplotlib plots generated during docs build
 setenv =
     MPLBACKEND=agg
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 # Pass through the following environment variables which may be needed
 # for the CI

--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ deps =
 
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0
+    devdeps: scikit-image>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/spacetelescope/gwcs.git
 


### PR DESCRIPTION
Also includes `scikit-image` dev in `devdeps` tests.