### PR TITLE
TST: Update URL for Scientific Python nightlies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ extras =
 
 commands =
     devdeps: pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
-    devdeps: pip install -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
+    devdeps: pip install -U -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scikit-learn
     pip freeze
 
     pytest --pyargs photutils {toxinidir}/docs \


### PR DESCRIPTION
Scientific Python packages have moved their nightly wheels to a new location. xref astropy/astropy#14869

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.