### PR TITLE
Add LocalBackground class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.background``
+
+  - Added ``LocalBackground`` class for computing local backgrounds in a
+    circular annulus aperture. [#1556]
+
 - ``photutils.psf``
 
   - Propagate measurement uncertainties in PSF fitting. [#1543]

--- a/photutils/background/__init__.py
+++ b/photutils/background/__init__.py
@@ -7,3 +7,4 @@ RMS in an image.
 from .background_2d import *  # noqa: F401, F403
 from .core import *  # noqa: F401, F403
 from .interpolators import *  # noqa: F401, F403
+from .local_background import *  # noqa: F401, F403

--- a/photutils/background/local_background.py
+++ b/photutils/background/local_background.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module defines classes to estimate local background using a
+circular annulus aperture.
+"""
+
+import numpy as np
+
+from photutils.aperture import CircularAnnulus
+from photutils.background import MedianBackground
+
+__all__ = ['LocalBackground']
+
+
+class LocalBackground:
+    def __init__(self, inner_radius, outer_radius,
+                 bkg_estimator=MedianBackground()):
+        self.inner_radius = inner_radius
+        self.outer_radius = outer_radius
+        self.bkg_estimator = bkg_estimator
+        self._aperture = CircularAnnulus((0, 0), inner_radius, outer_radius)
+
+    def __call__(self, data, x, y, mask=None):
+        """
+        Measure the local background in a circular annulus.
+
+        Parameters
+        ----------
+        data : 2D `~numpy.ndarray`
+            The 2D array on which to measure the local background.
+
+        x, y : float or 1D float `~numpy.nddarray`
+            The aperture center (x, y) position(s) at which to measure
+            the local background.
+
+        mask : 2D bool `~numpy.ndarray`, optional
+            A boolean mask with the same shape as ``data`` where a
+            `True` value indicates the corresponding element of ``data``
+            is masked. Masked data are excluded from all calculations.
+
+        Returns
+        -------
+        value : float or 1D float `~numpy.ndarray`
+            The local background values.
+        """
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
+
+        self._aperture.positions = np.array(list(zip(x, y)))
+        apermasks = self._aperture.to_mask(method='center')
+
+        bkg = []
+        for apermask in apermasks:
+            values = apermask.get_values(data, mask=mask)
+            bkg.append(self.bkg_estimator(values))
+        bkg = np.array(bkg)
+
+        if bkg.size == 1:
+            bkg = bkg[0]
+
+        return bkg

--- a/photutils/background/local_background.py
+++ b/photutils/background/local_background.py
@@ -13,6 +13,27 @@ __all__ = ['LocalBackground']
 
 
 class LocalBackground:
+    """
+    Class to compute a local background using a circular annulus
+    aperture.
+
+    Parameters
+    ----------
+    inner_radius : float
+        The inner radius of the circular annulus in pixels.
+
+    outer_radius : float
+        The outer radius of the circular annulus in pixels.
+
+    bkg_estimator : callable, optional
+        A callable object (a function or e.g., an instance of any
+        `~photutils.background.BackgroundBase` subclass) used to
+        estimate the background in each aperture. The callable object
+        must take in a 2D `~numpy.ndarray` or `~numpy.ma.MaskedArray`
+        and have an ``axis`` keyword. The default is an instance of
+        `~photutils.background.MedianBackground` with sigma clipping
+        (i.e. sigma-clipped median).
+    """
     def __init__(self, inner_radius, outer_radius,
                  bkg_estimator=MedianBackground()):
         self.inner_radius = inner_radius
@@ -29,7 +50,7 @@ class LocalBackground:
         data : 2D `~numpy.ndarray`
             The 2D array on which to measure the local background.
 
-        x, y : float or 1D float `~numpy.nddarray`
+        x, y : float or 1D float `~numpy.ndarray`
             The aperture center (x, y) position(s) at which to measure
             the local background.
 

--- a/photutils/background/tests/test_local_background.py
+++ b/photutils/background/tests/test_local_background.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the local_background module.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from photutils.background import LocalBackground, MedianBackground
+
+
+def test_local_background():
+    data = np.ones((101, 101))
+    local_bkg = LocalBackground(5, 10, bkg_estimator=MedianBackground())
+
+    x = np.arange(1, 7) * 10
+    y = np.arange(1, 7) * 10
+    bkg = local_bkg(data, x, y)
+    assert_allclose(bkg, np.ones(len(x)))
+
+    # test scalar x and y
+    bkg2 = local_bkg(data, x[2], y[2])
+    assert not isinstance(bkg2, np.ndarray)
+    assert_allclose(bkg[2], bkg2)
+
+    bkg3 = local_bkg(data, -100, -100)
+    assert np.isnan(bkg3)
+
+    with pytest.raises(ValueError):
+        _ = local_bkg(data, x[2], np.inf)


### PR DESCRIPTION
This PR adds a `LocalBackground` class for computing local backgrounds in a circular annulus aperture.