### PR TITLE
Fix for PSF fitting cfit column with out of bounds centroids

### DIFF
--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -750,7 +750,7 @@ class PSFPhotometry:
                     if cen_in_data:
                         cen_residual = data[ycen, xcen] - model(xcen, ycen)
                     else:
-                        cen_residual = np.ma.masked
+                        cen_residual = np.nan
                 else:
                     # find residual at (xcen, ycen)
                     cen_residual = -residual[cen_idx_]

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -741,8 +741,16 @@ class PSFPhotometry:
                 qfit.append(np.sum(np.abs(residual)) / flux_fit)
 
                 if np.isnan(cen_idx_):
-                    # calculate residual at central pixel
-                    cen_residual = data[ycen, xcen] - model(xcen, ycen)
+                    # calculate residual at central pixel if the central pixel
+                    # is within the bounds of the ``data``, otherwise mask it:
+                    cen_in_data = (
+                        0 <= ycen <= data.shape[0] - 1 and
+                        0 <= xcen <= data.shape[1] - 1
+                    )
+                    if cen_in_data:
+                        cen_residual = data[ycen, xcen] - model(xcen, ycen)
+                    else:
+                        cen_residual = np.ma.masked
                 else:
                     # find residual at (xcen, ycen)
                     cen_residual = -residual[cen_idx_]


### PR DESCRIPTION
If a PSF fit's central pixel is outside the bounds of the image (`data`), the calculation for the `cfit` column in the photometry result table tries to index `data` out of bounds and fails with an error. This PR checks before it indexes out of bounds, and masks the result in that case.