### PR TITLE
Update installation of scikit-learn dev

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,7 @@ deps =
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0
     devdeps: scikit-image>=0.0.dev0
+    devdeps: scikit-learn>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/spacetelescope/gwcs.git
 
@@ -87,7 +88,6 @@ extras =
 
 commands =
     devdeps: pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
-    devdeps: pip install -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
     pip freeze
 
     pytest --pyargs photutils {toxinidir}/docs \


### PR DESCRIPTION
`scikit-learn` dev is now available from https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/scikit-learn/

closes #1551 