### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,12 +31,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test-alldeps'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps'
             allow_failure: false
@@ -56,44 +50,44 @@ jobs:
             prefix: ''
 
           - os: macos-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps'
+            python: '3.11'
+            tox_env: 'py311-test-alldeps'
             allow_failure: false
             prefix: ''
 
           - os: windows-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps'
+            python: '3.11'
+            tox_env: 'py311-test-alldeps'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test'
+            python: '3.11'
+            tox_env: 'py311-test'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             tox_env: 'codestyle'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             tox_env: 'pep517'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             tox_env: 'bandit'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test-alldeps-astropylts-numpy118'
+            python: '3.9'
+            tox_env: 'py39-test-alldeps-astropylts-numpy121'
             allow_failure: false
             prefix: ''
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,6 @@ jobs:
       test_command: pytest -p no:warnings --pyargs photutils
       targets: |
         # Linux wheels
-        - cp38-manylinux_x86_64
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
@@ -48,23 +47,19 @@ jobs:
         # MacOS X wheels
         # Note that the arm64 wheels are not actually tested so we rely
         # on local manual testing of these to make sure they are ok.
-        - cp38*macosx_x86_64
         - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
 
-        - cp38*macosx_arm64
         - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
 
         # Windows wheels
-        - cp38*win32
         - cp39*win32
         - cp310*win32
         - cp311*win32
 
-        - cp38*win_amd64
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     rev: v3.8.0
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
         exclude: ".*(extern.*)$"
 
   - repo: https://github.com/pycqa/isort

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 General
 ^^^^^^^
 
+- The minimum required Python is now 3.9. [#1569]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Requirements
 
 Photutils has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.8 or later
+* `Python <https://www.python.org/>`_ 3.9 or later
 
 * `Numpy <https://numpy.org/>`_ 1.21 or later
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.21

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310,311}-test{,-alldeps,-devdeps,-oldestdeps}{,-cov}
-    py{38,39,310,311}-test-numpy{121,122,123,124}
-    py{38,39,310,311}-test-astropy{50,lts}
+    py{39,310,311}-test{,-alldeps,-devdeps,-oldestdeps}{,-cov}
+    py{39,310,311}-test-numpy{121,122,123,124,125}
+    py{39,310,311}-test-astropy{50,lts}
     32bit
     build_docs
     linkcheck
@@ -46,6 +46,7 @@ description =
     numpy122: with numpy 1.22.*
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
+    numpy125: with numpy 1.25.*
 
     astropy50: with astropy 5.0.*
     astropylts: with the latest astropy LTS
@@ -59,6 +60,7 @@ deps =
     numpy122: numpy==1.22.*
     numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
+    numpy125: numpy==1.25.*
 
     astropy50: astropy==5.0.*
     astropylts: astropy==5.0.*


### PR DESCRIPTION
Per [NEP-0029](https://numpy.org/neps/nep-0029-deprecation_policy.html), "On Apr 14, 2023 drop support for Python 3.8 (initially released on Oct 14, 2019)".