### PR TITLE
Add devinfra tox test

### DIFF
--- a/.github/workflows/cron_tests_weekly.yml
+++ b/.github/workflows/cron_tests_weekly.yml
@@ -1,0 +1,55 @@
+name: Cron Tests
+
+on:
+  schedule:
+    # run every Monday at 5am UTC
+    - cron: '0 5 * * 1'
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TOXARGS: '-v'
+
+permissions:
+  contents: read
+
+jobs:
+  cron-test:
+    name: ${{ matrix.os }}, ${{ matrix.tox_env }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: '3.11'
+            tox_env: 'py311-test-alldeps-devinfra'
+            allow_failure: false
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install base dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+    - name: Print Python, pip, setuptools, and tox versions
+      run: |
+        python -c "import sys; print(f'Python {sys.version}')"
+        python -c "import pip; print(f'pip {pip.__version__}')"
+        python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
+        python -c "import tox; print(f'tox {tox.__version__}')"
+    - name: Run tests
+      run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -9,6 +9,7 @@ import os.path as op
 import numpy as np
 import pytest
 from astropy.table import Table
+from astropy.utils import minversion
 from numpy.testing import assert_allclose
 
 from photutils.datasets import make_100gaussians_image
@@ -81,11 +82,22 @@ class TestIRAFStarFinder:
         assert len(tbl) == 4
 
     def test_irafstarfind_largesky(self):
-        with pytest.warns(NoDetectionsWarning,
-                          match='Sources were found, but none pass'):
-            starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.0)
-            tbl = starfinder(DATA)
-            assert tbl is None
+        if not minversion(pytest, '8.0.0.dev0'):
+            match1 = 'Sources were found, but none pass'
+            with pytest.warns(NoDetectionsWarning, match=match1):
+                starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0,
+                                            sky=100.0)
+                tbl = starfinder(DATA)
+                assert tbl is None
+        else:
+            match1 = 'Sources were found, but none pass'
+            match2 = 'invalid value encountered in divide'
+            with pytest.warns(NoDetectionsWarning, match=match1):
+                with pytest.warns(RuntimeWarning, match=match2):
+                    starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0,
+                                                sky=100.0)
+                    tbl = starfinder(DATA)
+                    assert tbl is None
 
     def test_irafstarfind_peakmax_filtering(self):
         """

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -9,6 +9,8 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.modeling.models import Gaussian2D
+from astropy.utils import minversion
+from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.datasets import get_path, make_noise_image
 from photutils.isophote.ellipse import Ellipse
@@ -91,8 +93,21 @@ class TestEllipse:
         # This should result in failure since the real galaxy
         # image is off-center by a large offset.
         ellipse = Ellipse(OFFSET_GALAXY)
-        with pytest.warns(RuntimeWarning, match='Degrees of freedom'):
-            isophote_list = ellipse.fit_image()
+
+        if not minversion(pytest, '8.0.0.dev0'):
+            match1 = 'Degrees of freedom'
+            with pytest.warns(RuntimeWarning, match=match1):
+                isophote_list = ellipse.fit_image()
+        else:
+            match1 = 'Degrees of freedom'
+            match2 = 'Mean of empty slice'
+            match3 = 'invalid value encountered'
+            match4 = 'No meaningful fit was possible'
+            with pytest.warns(RuntimeWarning, match=match1):
+                with pytest.warns(RuntimeWarning, match=match2):
+                    with pytest.warns(RuntimeWarning, match=match3):
+                        with pytest.warns(AstropyUserWarning, match=match4):
+                            isophote_list = ellipse.fit_image()
 
         assert len(isophote_list) == 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311}-test{,-alldeps,-devdeps,-oldestdeps}{,-cov}
+    py{39,310,311}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
     py{39,310,311}-test-numpy{121,122,123,124,125}
     py{39,310,311}-test-astropy{50,lts}
     32bit
@@ -40,6 +40,7 @@ description =
     run tests
     alldeps: with all optional dependencies
     devdeps: with the latest developer version of key dependencies
+    devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
     numpy121: with numpy 1.21.*
@@ -80,6 +81,17 @@ deps =
     devdeps: scikit-learn>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/spacetelescope/gwcs.git
+
+    # Latest developer version of infrastructure packages.
+    devinfra: git+https://github.com/pytest-dev/pytest.git
+    devinfra: git+https://github.com/astropy/extension-helpers.git
+    devinfra: git+https://github.com/astropy/pytest-doctestplus.git
+    devinfra: git+https://github.com/astropy/pytest-remotedata.git
+    devinfra: git+https://github.com/astropy/pytest-astropy-header.git
+    devinfra: git+https://github.com/astropy/pytest-arraydiff.git
+    devinfra: git+https://github.com/astropy/pytest-filter-subpackage.git
+    devinfra: git+https://github.com/matplotlib/pytest-mpl.git
+    devinfra: git+https://github.com/astropy/pytest-astropy.git
 
 # The following indicates which extras_require from setup.cfg will be
 # installed


### PR DESCRIPTION
Adds a `devinfra` tox env for testing development version of infrastructure packages and adds a weekly cron job in GA.

Also fixes warning issues from dev version of pytest 8.x.