### PR TITLE
Remove support for numpy 1.21

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -87,7 +87,7 @@ jobs:
 
           - os: ubuntu-latest
             python: '3.9'
-            tox_env: 'py39-test-alldeps-astropylts-numpy121'
+            tox_env: 'py39-test-alldeps-astropylts-numpy122'
             allow_failure: false
             prefix: ''
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,10 +56,6 @@ jobs:
         - cp311*macosx_arm64
 
         # Windows wheels
-        - cp39*win32
-        - cp310*win32
-        - cp311*win32
-
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ General
 
 - The minimum required Python is now 3.9. [#1569]
 
+- The minimum required Numpy is now 1.22. [#1572]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Photutils has the following strict requirements:
 
 * `Python <https://www.python.org/>`_ 3.9 or later
 
-* `Numpy <https://numpy.org/>`_ 1.21 or later
+* `Numpy <https://numpy.org/>`_ 1.22 or later
 
 * `Astropy`_ 5.0 or later
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.21
+    numpy>=1.22
     astropy>=5.0
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
     py{39,310,311}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{39,310,311}-test-numpy{121,122,123,124,125}
+    py{39,310,311}-test-numpy{122,123,124,125}
     py{39,310,311}-test-astropy{50,lts}
-    32bit
     build_docs
     linkcheck
     codestyle
@@ -43,7 +42,6 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy121: with numpy 1.21.*
     numpy122: with numpy 1.22.*
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
@@ -54,10 +52,6 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    32bit: numpy==1.21.*
-    32bit: git+https://github.com/astropy/astropy.git#egg=astropy
-
-    numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
     numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
@@ -66,7 +60,7 @@ deps =
     astropy50: astropy==5.0.*
     astropylts: astropy==5.0.*
 
-    oldestdeps: numpy==1.21
+    oldestdeps: numpy==1.22
     oldestdeps: astropy==5.0
     oldestdeps: scipy==1.7.0
     oldestdeps: matplotlib==3.5.0
@@ -107,14 +101,6 @@ commands =
     pytest --pyargs photutils {toxinidir}/docs \
     cov: --cov photutils --cov-config={toxinidir}/setup.cfg --cov-report xml:{toxinidir}/coverage.xml \
     {posargs}
-
-[testenv:32bit]
-changedir = .tmp/{envname}
-description = 32-bit tests
-extras = test
-commands =
-    pip freeze
-    !cov: pytest --pyargs photutils {toxinidir}/docs {posargs}
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
Per [NEP-0029](https://numpy.org/neps/nep-0029-deprecation_policy.html), "On Jun 23, 2023 drop support for NumPy 1.21 (initially released on Jun 22, 2021)".

Note the `numpy` stopped building wheels for 32-bit systems starting with `numpy 1.22`.  The weekly CI cron job still tests 32-bit versions of some architectures using 32-bit version of numpy from Debian.  If Debian stops providing 32-bit numpy, then those test will be removed.