### PR TITLE
PSF photometry deprecations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,19 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.psf``
+
+  - Deprecated the PSF photometry classes ``BasicPSFPhotometry``,
+    ``IterativelySubtractedPSFPhotometry``, and
+    ``DAOPhotPSFPhotometry``. Use the new ``PSFPhotometry`` or
+    ``IterativePSFPhotometry`` class instead. [#1578]
+
+  - Deprecated the ``DAOGroup``, ``DBSCANGroup``, and ``GroupStarsBase``
+    classes. Use the new ``SourceGrouper`` class instead. [#1578]
+
+  - Deprecated the ``get_grouped_psf_model`` and ``subtract_psf``
+    function. [#1578]
+
 
 1.8.0 (2023-05-17)
 ------------------

--- a/photutils/psf/groupstars.py
+++ b/photutils/psf/groupstars.py
@@ -12,7 +12,7 @@ from astropy.utils.decorators import deprecated
 __all__ = ['DAOGroup', 'DBSCANGroup', 'GroupStarsBase']
 
 
-@deprecated('1.9.0', alternative='photutils.psf.SourceGrouper')
+@deprecated('1.9.0', alternative='`photutils.psf.SourceGrouper`')
 class GroupStarsBase(metaclass=abc.ABCMeta):
     """
     This base class provides the basic interface for subclasses that
@@ -61,7 +61,7 @@ class GroupStarsBase(metaclass=abc.ABCMeta):
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
 
-@deprecated('1.9.0', alternative='photutils.psf.SourceGrouper')
+@deprecated('1.9.0', alternative='`photutils.psf.SourceGrouper`')
 class DAOGroup(GroupStarsBase):
     """
     This class implements the DAOGROUP algorithm presented by
@@ -177,7 +177,7 @@ class DAOGroup(GroupStarsBase):
         return np.asarray(starlist[distance_criteria]['id'])
 
 
-@deprecated('1.9.0', alternative='photutils.psf.SourceGrouper')
+@deprecated('1.9.0', alternative='`photutils.psf.SourceGrouper`')
 class DBSCANGroup(GroupStarsBase):
     """
     Class to create star groups according to a distance criteria using

--- a/photutils/psf/groupstars.py
+++ b/photutils/psf/groupstars.py
@@ -7,10 +7,12 @@ import abc
 
 import numpy as np
 from astropy.table import Column
+from astropy.utils.decorators import deprecated
 
 __all__ = ['DAOGroup', 'DBSCANGroup', 'GroupStarsBase']
 
 
+@deprecated('1.9.0', alternative='photutils.psf.SourceGrouper')
 class GroupStarsBase(metaclass=abc.ABCMeta):
     """
     This base class provides the basic interface for subclasses that
@@ -59,6 +61,7 @@ class GroupStarsBase(metaclass=abc.ABCMeta):
         raise NotImplementedError('Needs to be implemented in a subclass.')
 
 
+@deprecated('1.9.0', alternative='photutils.psf.SourceGrouper')
 class DAOGroup(GroupStarsBase):
     """
     This class implements the DAOGROUP algorithm presented by
@@ -174,6 +177,7 @@ class DAOGroup(GroupStarsBase):
         return np.asarray(starlist[distance_criteria]['id'])
 
 
+@deprecated('1.9.0', alternative='photutils.psf.SourceGrouper')
 class DBSCANGroup(GroupStarsBase):
     """
     Class to create star groups according to a distance criteria using

--- a/photutils/psf/photometry_depr.py
+++ b/photutils/psf/photometry_depr.py
@@ -11,6 +11,7 @@ from astropy.nddata import StdDevUncertainty
 from astropy.nddata.utils import NoOverlapError, overlap_slices
 from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Column, QTable, hstack, vstack
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import CircularAperture, aperture_photometry
@@ -27,6 +28,7 @@ __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
            'DAOPhotPSFPhotometry']
 
 
+@deprecated('1.9.0', alternative='photutils.psf.PSFPhotometry')
 class BasicPSFPhotometry:
     """
     This class implements a PSF photometry algorithm that can find
@@ -685,6 +687,7 @@ class BasicPSFPhotometry:
         return param_tab
 
 
+@deprecated('1.9.0', alternative='photutils.psf.PSFPhotometry')
 class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
     """
     This class implements an iterative algorithm to perform point spread
@@ -981,6 +984,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         return output_table
 
 
+@deprecated('1.9.0', alternative='photutils.psf.PSFPhotometry')
 class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
     """
     This class implements  an iterative algorithm based on the DAOPHOT

--- a/photutils/psf/photometry_depr.py
+++ b/photutils/psf/photometry_depr.py
@@ -28,7 +28,7 @@ __all__ = ['BasicPSFPhotometry', 'IterativelySubtractedPSFPhotometry',
            'DAOPhotPSFPhotometry']
 
 
-@deprecated('1.9.0', alternative='photutils.psf.PSFPhotometry')
+@deprecated('1.9.0', alternative='`photutils.psf.PSFPhotometry`')
 class BasicPSFPhotometry:
     """
     This class implements a PSF photometry algorithm that can find
@@ -687,7 +687,7 @@ class BasicPSFPhotometry:
         return param_tab
 
 
-@deprecated('1.9.0', alternative='photutils.psf.PSFPhotometry')
+@deprecated('1.9.0', alternative='`photutils.psf.IterativePSFPhotometry`')
 class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
     """
     This class implements an iterative algorithm to perform point spread
@@ -984,7 +984,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
         return output_table
 
 
-@deprecated('1.9.0', alternative='photutils.psf.PSFPhotometry')
+@deprecated('1.9.0', alternative='`photutils.psf.IterativePSFPhotometry`')
 class DAOPhotPSFPhotometry(IterativelySubtractedPSFPhotometry):
     """
     This class implements  an iterative algorithm based on the DAOPHOT

--- a/photutils/psf/tests/test_groupstars.py
+++ b/photutils/psf/tests/test_groupstars.py
@@ -6,6 +6,7 @@ Tests for the groupstars module.
 import numpy as np
 import pytest
 from astropy.table import Table, vstack
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_almost_equal
 
 from photutils.psf.groupstars import DAOGroup, DBSCANGroup
@@ -42,22 +43,22 @@ class TestDAOGROUP:
         x and y axis are in pixel coordinates. Each asterisk represents
         the centroid of a star.
         """
-
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        x_1 = x_0 + 2.0
-        first_group = Table([x_0, y_0, np.arange(len(x_0)) + 1,
-                            np.ones(len(x_0), dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        second_group = Table([x_1, y_0, len(x_0) + np.arange(len(x_0)) + 1,
-                              2 * np.ones(len(x_0), dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        starlist = vstack([first_group, second_group])
-        daogroup = DAOGroup(crit_separation=0.6)
-        test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            x_1 = x_0 + 2.0
+            first_group = Table([x_0, y_0, np.arange(len(x_0)) + 1,
+                                 np.ones(len(x_0), dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            second_group = Table([x_1, y_0, len(x_0) + np.arange(len(x_0)) + 1,
+                                  2 * np.ones(len(x_0), dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            starlist = vstack([first_group, second_group])
+            daogroup = DAOGroup(crit_separation=0.6)
+            test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_daogroup_two(self):
         """
@@ -78,17 +79,17 @@ class TestDAOGROUP:
             +--------------+--------------+-------------+--------------+
            -1            -0.5             0            0.5             1
         """
-
-        first_group = Table([np.zeros(5), np.linspace(0, 1, 5),
-                             np.arange(5) + 1, np.ones(5, dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        second_group = Table([np.zeros(5), np.linspace(2, 3, 5),
-                              6 + np.arange(5), 2 * np.ones(5, dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        starlist = vstack([first_group, second_group])
-        daogroup = DAOGroup(crit_separation=0.3)
-        test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            first_group = Table([np.zeros(5), np.linspace(0, 1, 5),
+                                 np.arange(5) + 1, np.ones(5, dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            second_group = Table([np.zeros(5), np.linspace(2, 3, 5),
+                                  6 + np.arange(5), 2 * np.ones(5, dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            starlist = vstack([first_group, second_group])
+            daogroup = DAOGroup(crit_separation=0.3)
+            test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_daogroup_three(self):
         """
@@ -109,17 +110,17 @@ class TestDAOGROUP:
           -1 +--+-------+--------+--------+--------+-------+--------+--+
                 0      0.5       1       1.5       2      2.5       3
         """
-
-        first_group = Table([np.linspace(0, 1, 5), np.zeros(5),
-                             np.arange(5) + 1, np.ones(5, dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        second_group = Table([np.linspace(2, 3, 5), np.zeros(5),
-                              6 + np.arange(5), 2 * np.ones(5, dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        starlist = vstack([first_group, second_group])
-        daogroup = DAOGroup(crit_separation=0.3)
-        test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            first_group = Table([np.linspace(0, 1, 5), np.zeros(5),
+                                 np.arange(5) + 1, np.ones(5, dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            second_group = Table([np.linspace(2, 3, 5), np.zeros(5),
+                                  6 + np.arange(5), 2 * np.ones(5, dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            starlist = vstack([first_group, second_group])
+            daogroup = DAOGroup(crit_separation=0.3)
+            test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_daogroup_four(self):
         """
@@ -143,17 +144,17 @@ class TestDAOGROUP:
              +-+---------+---------+---------+---------+-+
               -1       -0.5        0        0.5        1
         """
-
-        x = np.linspace(-1.0, 1.0, 5)
-        y = np.sqrt(1.0 - x**2)
-        xx = np.hstack((x, x))
-        yy = np.hstack((y, -y))
-        starlist = Table([xx, yy, np.arange(10) + 1,
-                          np.ones(10, dtype=int)],
-                         names=('x_0', 'y_0', 'id', 'group_id'))
-        daogroup = DAOGroup(crit_separation=2.5)
-        test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            x = np.linspace(-1.0, 1.0, 5)
+            y = np.sqrt(1.0 - x**2)
+            xx = np.hstack((x, x))
+            yy = np.hstack((y, -y))
+            starlist = Table([xx, yy, np.arange(10) + 1,
+                              np.ones(10, dtype=int)],
+                             names=('x_0', 'y_0', 'id', 'group_id'))
+            daogroup = DAOGroup(crit_separation=2.5)
+            test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_daogroup_five(self):
         """
@@ -174,24 +175,25 @@ class TestDAOGROUP:
             +--+--------+--------+-------+--------+--------+--------+--+
                0       0.5       1      1.5       2       2.5       3
         """
-
-        first_group = Table([1.5 * np.ones(5), np.linspace(0, 1, 5),
-                             np.arange(5) + 1, np.ones(5, dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        second_group = Table([1.5 * np.ones(5), np.linspace(2, 3, 5),
-                              6 + np.arange(5), 2 * np.ones(5, dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        third_group = Table([np.linspace(0, 1, 5), 1.5 * np.ones(5),
-                             11 + np.arange(5), 3 * np.ones(5, dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        fourth_group = Table([np.linspace(2, 3, 5), 1.5 * np.ones(5),
-                              16 + np.arange(5), 4 * np.ones(5, dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        starlist = vstack([first_group, second_group, third_group,
-                           fourth_group])
-        daogroup = DAOGroup(crit_separation=0.3)
-        test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            first_group = Table([1.5 * np.ones(5), np.linspace(0, 1, 5),
+                                 np.arange(5) + 1, np.ones(5, dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            second_group = Table([1.5 * np.ones(5), np.linspace(2, 3, 5),
+                                  6 + np.arange(5), 2 * np.ones(5, dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            third_group = Table([np.linspace(0, 1, 5), 1.5 * np.ones(5),
+                                 11 + np.arange(5), 3 * np.ones(5, dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            fourth_group = Table([np.linspace(2, 3, 5), 1.5 * np.ones(5),
+                                  16 + np.arange(5),
+                                  4 * np.ones(5, dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            starlist = vstack([first_group, second_group, third_group,
+                               fourth_group])
+            daogroup = DAOGroup(crit_separation=0.3)
+            test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_daogroup_six(self):
         """
@@ -212,140 +214,149 @@ class TestDAOGROUP:
              +------+----------+----------+----------+----------+------+
                     0          1          2          3          4
         """
-
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        x_1 = x_0 + 2.0
-        x_2 = x_0 + 4.0
-        first_group = Table([x_0, y_0, np.arange(5) + 1,
-                             np.ones(5, dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        second_group = Table([x_1, y_0, 6 + np.arange(5),
-                              2 * np.ones(5, dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        third_group = Table([x_2, y_0, 11 + np.arange(5),
-                             3 * np.ones(5, dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        starlist = vstack([first_group, second_group, third_group])
-        daogroup = DAOGroup(crit_separation=0.6)
-        test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            x_1 = x_0 + 2.0
+            x_2 = x_0 + 4.0
+            first_group = Table([x_0, y_0, np.arange(5) + 1,
+                                 np.ones(5, dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            second_group = Table([x_1, y_0, 6 + np.arange(5),
+                                  2 * np.ones(5, dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            third_group = Table([x_2, y_0, 11 + np.arange(5),
+                                 3 * np.ones(5, dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            starlist = vstack([first_group, second_group, third_group])
+            daogroup = DAOGroup(crit_separation=0.6)
+            test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_isolated_sources(self):
         """
         Test case when all sources are isolated.
         """
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        starlist = Table([x_0, y_0, np.arange(len(x_0)) + 1,
-                          np.arange(len(x_0)) + 1],
-                         names=('x_0', 'y_0', 'id', 'group_id'))
-        daogroup = DAOGroup(crit_separation=0.01)
-        test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            starlist = Table([x_0, y_0, np.arange(len(x_0)) + 1,
+                              np.arange(len(x_0)) + 1],
+                             names=('x_0', 'y_0', 'id', 'group_id'))
+            daogroup = DAOGroup(crit_separation=0.01)
+            test_starlist = daogroup(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_id_column(self):
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        starlist = Table([x_0, y_0, np.arange(len(x_0)) + 1,
-                          np.arange(len(x_0)) + 1],
-                         names=('x_0', 'y_0', 'id', 'group_id'))
-        daogroup = DAOGroup(crit_separation=0.01)
-        test_starlist = daogroup(starlist['x_0', 'y_0'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            starlist = Table([x_0, y_0, np.arange(len(x_0)) + 1,
+                              np.arange(len(x_0)) + 1],
+                             names=('x_0', 'y_0', 'id', 'group_id'))
+            daogroup = DAOGroup(crit_separation=0.01)
+            test_starlist = daogroup(starlist['x_0', 'y_0'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_id_column_raise_error(self):
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        starlist = Table([x_0, y_0, np.arange(len(x_0)),
-                          np.arange(len(x_0)) + 1],
-                         names=('x_0', 'y_0', 'id', 'group_id'))
-        daogroup = DAOGroup(crit_separation=0.01)
-        with pytest.raises(ValueError):
-            daogroup(starlist['x_0', 'y_0', 'id'])
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            starlist = Table([x_0, y_0, np.arange(len(x_0)),
+                              np.arange(len(x_0)) + 1],
+                             names=('x_0', 'y_0', 'id', 'group_id'))
+            daogroup = DAOGroup(crit_separation=0.01)
+            with pytest.raises(ValueError):
+                daogroup(starlist['x_0', 'y_0', 'id'])
 
 
 @pytest.mark.skipif(not HAS_SKLEARN, reason='sklearn is required')
 class TestDBSCANGroup:
     def test_group_stars_one(self):
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        x_1 = x_0 + 2.0
-        first_group = Table([x_0, y_0, np.arange(len(x_0)) + 1,
-                            np.ones(len(x_0), dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        second_group = Table([x_1, y_0, len(x_0) + np.arange(len(x_0)) + 1,
-                              2 * np.ones(len(x_0), dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        starlist = vstack([first_group, second_group])
-        dbscan = DBSCANGroup(crit_separation=0.6)
-        test_starlist = dbscan(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            x_1 = x_0 + 2.0
+            first_group = Table([x_0, y_0, np.arange(len(x_0)) + 1,
+                                np.ones(len(x_0), dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            second_group = Table([x_1, y_0, len(x_0) + np.arange(len(x_0)) + 1,
+                                  2 * np.ones(len(x_0), dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            starlist = vstack([first_group, second_group])
+            dbscan = DBSCANGroup(crit_separation=0.6)
+            test_starlist = dbscan(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_group_stars_two(self):
-        first_group = Table([1.5 * np.ones(5), np.linspace(0, 1, 5),
-                             np.arange(5) + 1, np.ones(5, dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        second_group = Table([1.5 * np.ones(5), np.linspace(2, 3, 5),
-                              6 + np.arange(5), 2 * np.ones(5, dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        third_group = Table([np.linspace(0, 1, 5), 1.5 * np.ones(5),
-                             11 + np.arange(5), 3 * np.ones(5, dtype=int)],
-                            names=('x_0', 'y_0', 'id', 'group_id'))
-        fourth_group = Table([np.linspace(2, 3, 5), 1.5 * np.ones(5),
-                              16 + np.arange(5), 4 * np.ones(5, dtype=int)],
-                             names=('x_0', 'y_0', 'id', 'group_id'))
-        starlist = vstack([first_group, second_group, third_group,
-                           fourth_group])
-        dbscan = DBSCANGroup(crit_separation=0.3)
-        test_starlist = dbscan(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            first_group = Table([1.5 * np.ones(5), np.linspace(0, 1, 5),
+                                 np.arange(5) + 1, np.ones(5, dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            second_group = Table([1.5 * np.ones(5), np.linspace(2, 3, 5),
+                                  6 + np.arange(5), 2 * np.ones(5, dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            third_group = Table([np.linspace(0, 1, 5), 1.5 * np.ones(5),
+                                 11 + np.arange(5), 3 * np.ones(5, dtype=int)],
+                                names=('x_0', 'y_0', 'id', 'group_id'))
+            fourth_group = Table([np.linspace(2, 3, 5), 1.5 * np.ones(5),
+                                  16 + np.arange(5),
+                                  4 * np.ones(5, dtype=int)],
+                                 names=('x_0', 'y_0', 'id', 'group_id'))
+            starlist = vstack([first_group, second_group, third_group,
+                               fourth_group])
+            dbscan = DBSCANGroup(crit_separation=0.3)
+            test_starlist = dbscan(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_isolated_sources(self):
         """
         Test case when all sources are isolated.
         """
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        starlist = Table([x_0, y_0, np.arange(len(x_0)) + 1,
-                          np.arange(len(x_0)) + 1],
-                         names=('x_0', 'y_0', 'id', 'group_id'))
-        dbscan = DBSCANGroup(crit_separation=0.01)
-        test_starlist = dbscan(starlist['x_0', 'y_0', 'id'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            starlist = Table([x_0, y_0, np.arange(len(x_0)) + 1,
+                              np.arange(len(x_0)) + 1],
+                             names=('x_0', 'y_0', 'id', 'group_id'))
+            dbscan = DBSCANGroup(crit_separation=0.01)
+            test_starlist = dbscan(starlist['x_0', 'y_0', 'id'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_id_column(self):
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        starlist = Table([x_0, y_0, np.arange(len(x_0)) + 1,
-                          np.arange(len(x_0)) + 1],
-                         names=('x_0', 'y_0', 'id', 'group_id'))
-        dbscan = DBSCANGroup(crit_separation=0.01)
-        test_starlist = dbscan(starlist['x_0', 'y_0'])
-        assert_table_almost_equal(starlist, test_starlist)
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            starlist = Table([x_0, y_0, np.arange(len(x_0)) + 1,
+                              np.arange(len(x_0)) + 1],
+                             names=('x_0', 'y_0', 'id', 'group_id'))
+            dbscan = DBSCANGroup(crit_separation=0.01)
+            test_starlist = dbscan(starlist['x_0', 'y_0'])
+            assert_table_almost_equal(starlist, test_starlist)
 
     def test_id_column_raise_error(self):
-        x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
-                        -np.sqrt(2) / 4])
-        starlist = Table([x_0, y_0, np.arange(len(x_0)),
-                          np.arange(len(x_0)) + 1],
-                         names=('x_0', 'y_0', 'id', 'group_id'))
-        dbscan = DBSCANGroup(crit_separation=0.01)
-        with pytest.raises(ValueError):
-            dbscan(starlist['x_0', 'y_0', 'id'])
+        with pytest.warns(AstropyDeprecationWarning):
+            x_0 = np.array([0, np.sqrt(2) / 4, np.sqrt(2) / 4, -np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            y_0 = np.array([0, np.sqrt(2) / 4, -np.sqrt(2) / 4, np.sqrt(2) / 4,
+                            -np.sqrt(2) / 4])
+            starlist = Table([x_0, y_0, np.arange(len(x_0)),
+                              np.arange(len(x_0)) + 1],
+                             names=('x_0', 'y_0', 'id', 'group_id'))
+            dbscan = DBSCANGroup(crit_separation=0.01)
+            with pytest.raises(ValueError):
+                dbscan(starlist['x_0', 'y_0', 'id'])

--- a/photutils/psf/tests/test_photometry-depr.py
+++ b/photutils/psf/tests/test_photometry-depr.py
@@ -13,7 +13,8 @@ from astropy.modeling.models import Gaussian2D, Moffat2D
 from astropy.stats import SigmaClip, gaussian_sigma_to_fwhm
 from astropy.table import Table
 from astropy.utils import minversion
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 
 from photutils.background import MMMBackground, StdBackgroundRMS
@@ -34,40 +35,38 @@ def make_psf_photometry_objs(std=1, sigma_psf=1):
     Produces baseline photometry objects which are then
     modified as-needed in specific tests below
     """
+    with pytest.warns(AstropyDeprecationWarning):
+        daofind = DAOStarFinder(threshold=5.0 * std,
+                                fwhm=sigma_psf * gaussian_sigma_to_fwhm)
+        daogroup = DAOGroup(1.5 * sigma_psf * gaussian_sigma_to_fwhm)
+        threshold = 5.0 * std
+        fwhm = sigma_psf * gaussian_sigma_to_fwhm
+        crit_separation = 1.5 * sigma_psf * gaussian_sigma_to_fwhm
 
-    daofind = DAOStarFinder(threshold=5.0 * std,
-                            fwhm=sigma_psf * gaussian_sigma_to_fwhm)
-    daogroup = DAOGroup(1.5 * sigma_psf * gaussian_sigma_to_fwhm)
-    threshold = 5.0 * std
-    fwhm = sigma_psf * gaussian_sigma_to_fwhm
-    crit_separation = 1.5 * sigma_psf * gaussian_sigma_to_fwhm
+        daofind = DAOStarFinder(threshold=threshold, fwhm=fwhm)
+        daogroup = DAOGroup(crit_separation)
+        mode_bkg = MMMBackground()
+        psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
+        fitter = LevMarLSQFitter()
 
-    daofind = DAOStarFinder(threshold=threshold, fwhm=fwhm)
-    daogroup = DAOGroup(crit_separation)
-    mode_bkg = MMMBackground()
-    psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
-    fitter = LevMarLSQFitter()
+        basic_phot_obj = BasicPSFPhotometry(finder=daofind,
+                                            group_maker=daogroup,
+                                            bkg_estimator=mode_bkg,
+                                            psf_model=psf_model,
+                                            fitter=fitter,
+                                            fitshape=(11, 11))
 
-    basic_phot_obj = BasicPSFPhotometry(finder=daofind,
-                                        group_maker=daogroup,
-                                        bkg_estimator=mode_bkg,
-                                        psf_model=psf_model,
-                                        fitter=fitter,
-                                        fitshape=(11, 11))
+        iter_phot_obj = IterativelySubtractedPSFPhotometry(
+            finder=daofind, group_maker=daogroup, bkg_estimator=mode_bkg,
+            psf_model=psf_model, fitter=fitter, niters=1, fitshape=(11, 11))
 
-    iter_phot_obj = IterativelySubtractedPSFPhotometry(finder=daofind,
-                                                       group_maker=daogroup,
-                                                       bkg_estimator=mode_bkg,
-                                                       psf_model=psf_model,
-                                                       fitter=fitter, niters=1,
-                                                       fitshape=(11, 11))
+        dao_phot_obj = DAOPhotPSFPhotometry(crit_separation=crit_separation,
+                                            threshold=threshold, fwhm=fwhm,
+                                            psf_model=psf_model,
+                                            fitshape=(11, 11),
+                                            niters=1)
 
-    dao_phot_obj = DAOPhotPSFPhotometry(crit_separation=crit_separation,
-                                        threshold=threshold, fwhm=fwhm,
-                                        psf_model=psf_model, fitshape=(11, 11),
-                                        niters=1)
-
-    return (basic_phot_obj, iter_phot_obj, dao_phot_obj)
+        return (basic_phot_obj, iter_phot_obj, dao_phot_obj)
 
 
 sigma_psfs = []
@@ -287,16 +286,17 @@ def test_aperture_radius_errors():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_finder_errors():
-    iter_phot_obj = make_psf_photometry_objs()[1]
+    with pytest.warns(AstropyDeprecationWarning):
+        iter_phot_obj = make_psf_photometry_objs()[1]
 
-    with pytest.raises(ValueError):
-        iter_phot_obj.finder = None
+        with pytest.raises(ValueError):
+            iter_phot_obj.finder = None
 
-    with pytest.raises(ValueError):
-        iter_phot_obj = IterativelySubtractedPSFPhotometry(
-            finder=None, group_maker=DAOGroup(1),
-            bkg_estimator=MMMBackground(),
-            psf_model=IntegratedGaussianPRF(1), fitshape=(11, 11))
+        with pytest.raises(ValueError):
+            iter_phot_obj = IterativelySubtractedPSFPhotometry(
+                finder=None, group_maker=DAOGroup(1),
+                bkg_estimator=MMMBackground(),
+                psf_model=IntegratedGaussianPRF(1), fitshape=(11, 11))
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -447,72 +447,71 @@ def test_default_aperture_radius():
 
         return table
 
-    prf = np.zeros((7, 7), float)
-    prf[2:5, 2:5] = 1 / 9
-    prf = FittableImageModel(prf)
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = np.zeros((7, 7), float)
+        prf[2:5, 2:5] = 1 / 9
+        prf = FittableImageModel(prf)
 
-    img = np.zeros((50, 50), float)
-    x0 = [38, 20, 35]
-    y0 = [20, 5, 40]
-    f0 = [50, 100, 200]
-    for x, y, f in zip(x0, y0, f0):
-        img[y - 1:y + 2, x - 1:x + 2] = f / 9
+        img = np.zeros((50, 50), float)
+        x0 = [38, 20, 35]
+        y0 = [20, 5, 40]
+        f0 = [50, 100, 200]
+        for x, y, f in zip(x0, y0, f0):
+            img[y - 1:y + 2, x - 1:x + 2] = f / 9
 
-    intab = Table(data=[[37, 19.6, 34.9], [19.6, 4.5, 40.1]],
-                  names=['x_0', 'y_0'])
+        intab = Table(data=[[37, 19.6, 34.9], [19.6, 4.5, 40.1]],
+                      names=['x_0', 'y_0'])
 
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=prf,
-                                    fitshape=7, finder=tophatfinder)
-    # Test for init_guesses is None
-    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
-                                                'could not be determined'):
-        results = basic_phot(image=img)
-    assert_allclose(results['flux_fit'], f0, rtol=0.05)
+        basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
+                                        bkg_estimator=None, psf_model=prf,
+                                        fitshape=7, finder=tophatfinder)
+        # Test for init_guesses is None
+        match = 'aperture_radius is None and could not be determined'
+        with pytest.warns(AstropyUserWarning, match=match):
+            results = basic_phot(image=img)
+        assert_allclose(results['flux_fit'], f0, rtol=0.05)
 
-    # Have to reset the object or it saves any updates, and we wish to
-    # re-verify the aperture_radius assignment
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=prf,
-                                    fitshape=7)
+        # Have to reset the object or it saves any updates, and we wish to
+        # re-verify the aperture_radius assignment
+        basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
+                                        bkg_estimator=None, psf_model=prf,
+                                        fitshape=7)
 
-    # Test for init_guesses is not None, but lacks a flux_0 column
-    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
-                                                'could not be determined'):
-        results = basic_phot(image=img, init_guesses=intab)
-    assert_allclose(results['flux_fit'], f0, rtol=0.05)
-
-    iter_phot = IterativelySubtractedPSFPhotometry(finder=tophatfinder,
-                                                   group_maker=DAOGroup(2),
-                                                   bkg_estimator=None,
-                                                   psf_model=prf,
-                                                   fitshape=7, niters=2)
-
-    if not minversion(pytest, '8.0.0.dev0'):
-        match1 = 'aperture_radius is None and could not be determined'
-        with pytest.warns(AstropyUserWarning, match=match1):
-            results = iter_phot(image=img, init_guesses=intab)
-            assert_allclose(results['flux_fit'], f0, rtol=0.05)
-    else:
         # Test for init_guesses is not None, but lacks a flux_0 column
-        match1 = 'aperture_radius is None and could not be determined'
-        match2 = 'Both init_guesses and finder are different than None'
-        with pytest.warns(AstropyUserWarning, match=match1):
-            with pytest.warns(AstropyUserWarning, match=match2):
+        match = 'aperture_radius is None and could not be determined'
+        with pytest.warns(AstropyUserWarning, match=match):
+            results = basic_phot(image=img, init_guesses=intab)
+        assert_allclose(results['flux_fit'], f0, rtol=0.05)
+
+        iter_phot = IterativelySubtractedPSFPhotometry(finder=tophatfinder,
+                                                       group_maker=DAOGroup(2),
+                                                       bkg_estimator=None,
+                                                       psf_model=prf,
+                                                       fitshape=7, niters=2)
+
+        if not minversion(pytest, '8.0.0.dev0'):
+            match1 = 'aperture_radius is None and could not be determined'
+            with pytest.warns(AstropyUserWarning, match=match1):
                 results = iter_phot(image=img, init_guesses=intab)
                 assert_allclose(results['flux_fit'], f0, rtol=0.05)
+        else:
+            # Test for init_guesses is not None, but lacks a flux_0 column
+            match1 = 'aperture_radius is None and could not be determined'
+            match2 = 'Both init_guesses and finder are different than None'
+            with pytest.warns(AstropyUserWarning, match=match1):
+                with pytest.warns(AstropyUserWarning, match=match2):
+                    results = iter_phot(image=img, init_guesses=intab)
+                    assert_allclose(results['flux_fit'], f0, rtol=0.05)
 
-    iter_phot = IterativelySubtractedPSFPhotometry(finder=tophatfinder,
-                                                   group_maker=DAOGroup(2),
-                                                   bkg_estimator=None,
-                                                   psf_model=prf,
-                                                   fitshape=7, niters=2)
+        iter_phot = IterativelySubtractedPSFPhotometry(
+            finder=tophatfinder, group_maker=DAOGroup(2), bkg_estimator=None,
+            psf_model=prf, fitshape=7, niters=2)
 
-    # Test for init_guesses is None
-    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
-                                                'could not be determined'):
-        results = iter_phot(image=img)
-    assert_allclose(results['flux_fit'], f0, rtol=0.05)
+        # Test for init_guesses is None
+        match = 'aperture_radius is None and could not be determined'
+        with pytest.warns(AstropyUserWarning, match=match):
+            results = iter_phot(image=img)
+        assert_allclose(results['flux_fit'], f0, rtol=0.05)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -520,15 +519,16 @@ def test_psf_boundary_gaussian():
     """
     Test psf_photometry with discrete PRF model at the boundary of the data.
     """
-    psf = IntegratedGaussianPRF(GAUSSIAN_WIDTH)
+    with pytest.warns(AstropyDeprecationWarning):
+        psf = IntegratedGaussianPRF(GAUSSIAN_WIDTH)
 
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=psf,
-                                    fitshape=7)
+        basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
+                                        bkg_estimator=None, psf_model=psf,
+                                        fitshape=7)
 
-    intab = Table(data=[[1], [1]], names=['x_0', 'y_0'])
-    f = basic_phot(image=image, init_guesses=intab)
-    assert_allclose(f['flux_fit'], 0, atol=1e-8)
+        intab = Table(data=[[1], [1]], names=['x_0', 'y_0'])
+        f = basic_phot(image=image, init_guesses=intab)
+        assert_allclose(f['flux_fit'], 0, atol=1e-8)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -536,14 +536,15 @@ def test_psf_photometry_gaussian():
     """
     Test psf_photometry with Gaussian PSF model.
     """
-    psf = IntegratedGaussianPRF(sigma=GAUSSIAN_WIDTH)
+    with pytest.warns(AstropyDeprecationWarning):
+        psf = IntegratedGaussianPRF(sigma=GAUSSIAN_WIDTH)
 
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=psf,
-                                    fitshape=7)
-    f = basic_phot(image=image, init_guesses=INTAB)
-    for n in ['x', 'y', 'flux']:
-        assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
+        basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
+                                        bkg_estimator=None, psf_model=psf,
+                                        fitshape=7)
+        f = basic_phot(image=image, init_guesses=INTAB)
+        for n in ['x', 'y', 'flux']:
+            assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -552,21 +553,24 @@ def test_psf_photometry_gaussian2(renormalize_psf):
     """
     Test psf_photometry with Gaussian PSF model from Astropy.
     """
-    psf = Gaussian2D(1.0 / (2 * np.pi * GAUSSIAN_WIDTH ** 2), PSF_SIZE // 2,
-                     PSF_SIZE // 2, GAUSSIAN_WIDTH, GAUSSIAN_WIDTH)
-    psf = prepare_psf_model(psf, xname='x_mean', yname='y_mean',
-                            renormalize_psf=renormalize_psf)
+    with pytest.warns(AstropyDeprecationWarning):
+        psf = Gaussian2D(1.0 / (2 * np.pi * GAUSSIAN_WIDTH ** 2),
+                         PSF_SIZE // 2, PSF_SIZE // 2, GAUSSIAN_WIDTH,
+                         GAUSSIAN_WIDTH)
+        psf = prepare_psf_model(psf, xname='x_mean', yname='y_mean',
+                                renormalize_psf=renormalize_psf)
 
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=psf,
-                                    fitshape=7)
-    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
-                      'could not be determined by psf_model'):
-        f = basic_phot(image=image, init_guesses=INTAB)
+        basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
+                                        bkg_estimator=None, psf_model=psf,
+                                        fitshape=7)
+        match = ('aperture_radius is None and could not be determined by '
+                 'psf_model')
+        with pytest.warns(AstropyUserWarning, match=match):
+            f = basic_phot(image=image, init_guesses=INTAB)
 
-    for n in ['x', 'y']:
-        assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-1)
-    assert_allclose(f['flux_0'], f['flux_fit'], rtol=1e-1)
+        for n in ['x', 'y']:
+            assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-1)
+        assert_allclose(f['flux_0'], f['flux_fit'], rtol=1e-1)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -574,23 +578,25 @@ def test_psf_photometry_moffat():
     """
     Test psf_photometry with Moffat PSF model from Astropy.
     """
-    psf = Moffat2D(1.0 / (2 * np.pi * GAUSSIAN_WIDTH ** 2), PSF_SIZE // 2,
-                   PSF_SIZE // 2, 1, 1)
-    psf = prepare_psf_model(psf, xname='x_0', yname='y_0',
-                            renormalize_psf=False)
+    with pytest.warns(AstropyDeprecationWarning):
+        psf = Moffat2D(1.0 / (2 * np.pi * GAUSSIAN_WIDTH ** 2), PSF_SIZE // 2,
+                       PSF_SIZE // 2, 1, 1)
+        psf = prepare_psf_model(psf, xname='x_0', yname='y_0',
+                                renormalize_psf=False)
 
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=psf,
-                                    fitshape=7)
-    with pytest.warns(AstropyUserWarning, match='aperture_radius is None and '
-                      'could not be determined by psf_model'):
-        f = basic_phot(image=image, init_guesses=INTAB)
-    f.pprint(max_width=-1)
+        basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
+                                        bkg_estimator=None, psf_model=psf,
+                                        fitshape=7)
+        match = ('aperture_radius is None and could not be determined by '
+                 'psf_model')
+        with pytest.warns(AstropyUserWarning, match=match):
+            f = basic_phot(image=image, init_guesses=INTAB)
+        f.pprint(max_width=-1)
 
-    for n in ['x', 'y']:
-        assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
-    # image was created with a gaussian, so flux won't match exactly
-    assert_allclose(f['flux_0'], f['flux_fit'], rtol=1e-1)
+        for n in ['x', 'y']:
+            assert_allclose(f[n + '_0'], f[n + '_fit'], rtol=1e-3)
+        # image was created with a gaussian, so flux won't match exactly
+        assert_allclose(f['flux_0'], f['flux_fit'], rtol=1e-1)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -599,17 +605,19 @@ def test_psf_fitting_data_on_edge():
     No mask is input explicitly here, but source 2 is so close to the
     edge that the subarray that's extracted gets a mask internally.
     """
-    psf_guess = IntegratedGaussianPRF(flux=1, sigma=WIDE_GAUSSIAN_WIDTH)
-    psf_guess.flux.fixed = psf_guess.x_0.fixed = psf_guess.y_0.fixed = False
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=psf_guess,
-                                    fitshape=7)
+    with pytest.warns(AstropyDeprecationWarning):
+        psf_guess = IntegratedGaussianPRF(flux=1, sigma=WIDE_GAUSSIAN_WIDTH)
+        psf_guess.flux.fixed = psf_guess.x_0.fixed = False
+        psf_guess.y_0.fixed = False
+        basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
+                                        bkg_estimator=None,
+                                        psf_model=psf_guess, fitshape=7)
 
-    outtab = basic_phot(image=wide_image, init_guesses=WIDE_INTAB)
+        outtab = basic_phot(image=wide_image, init_guesses=WIDE_INTAB)
 
-    for n in ['x', 'y', 'flux']:
-        assert_allclose(outtab[n + '_0'], outtab[n + '_fit'],
-                        rtol=0.05, atol=0.1)
+        for n in ['x', 'y', 'flux']:
+            assert_allclose(outtab[n + '_0'], outtab[n + '_fit'],
+                            rtol=0.05, atol=0.1)
 
 
 @pytest.mark.filterwarnings('ignore:Both init_guesses and finder '
@@ -620,47 +628,50 @@ def test_psf_extra_output_cols(sigma_psf, sources):
     """
     Test the handling of a non-None extra_output_cols
     """
-    psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
-    tshape = (32, 32)
-    image = (make_gaussian_prf_sources_image(tshape, sources)
-             + make_noise_image(tshape, distribution='poisson', mean=6.0,
-                                seed=0)
-             + make_noise_image(tshape, distribution='gaussian', mean=0.0,
-                                stddev=2.0, seed=0))
+    with pytest.warns(AstropyDeprecationWarning):
+        psf_model = IntegratedGaussianPRF(sigma=sigma_psf)
+        tshape = (32, 32)
+        image = (make_gaussian_prf_sources_image(tshape, sources)
+                 + make_noise_image(tshape, distribution='poisson', mean=6.0,
+                                    seed=0)
+                 + make_noise_image(tshape, distribution='gaussian', mean=0.0,
+                                    stddev=2.0, seed=0))
 
-    init_guess1 = None
-    init_guess2 = Table(names=['x_0', 'y_0', 'sharpness', 'roundness1',
-                               'roundness2'],
-                        data=[[17.4], [16], [0.4], [0], [0]])
-    init_guess3 = Table(names=['x_0', 'y_0'],
-                        data=[[17.4], [16]])
-    init_guess4 = Table(names=['x_0', 'y_0', 'sharpness'],
-                        data=[[17.4], [16], [0.4]])
-    for i, init_guesses in enumerate([init_guess1, init_guess2, init_guess3,
-                                      init_guess4]):
-        dao_phot = DAOPhotPSFPhotometry(crit_separation=8, threshold=40,
-                                        fwhm=4 * np.sqrt(2 * np.log(2)),
-                                        psf_model=psf_model, fitshape=(11, 11),
-                                        extra_output_cols=['sharpness',
-                                                           'roundness1',
-                                                           'roundness2'])
-        phot_results = dao_phot(image, init_guesses=init_guesses)
-        # test that the original required columns are also passed back, as well
-        # as extra_output_cols
-        assert np.all([name in phot_results.colnames for name in
-                       ['x_0', 'y_0']])
-        assert np.all([name in phot_results.colnames for name in
-                       ['sharpness', 'roundness1', 'roundness2']])
-        assert len(phot_results) == 2
-        # checks to verify that half-passing init_guesses results in NaN output
-        # for extra_output_cols not passed as initial guesses
-        if i == 2:  # init_guess3
-            assert np.all(np.all(np.isnan(phot_results[o])) for o in
-                          ['sharpness', 'roundness1', 'roundness2'])
-        if i == 3:  # init_guess4
-            assert np.all(np.all(np.isnan(phot_results[o])) for o in
-                          ['roundness1', 'roundness2'])
-            assert np.all(~np.isnan(phot_results['sharpness']))
+        init_guess1 = None
+        init_guess2 = Table(names=['x_0', 'y_0', 'sharpness', 'roundness1',
+                                   'roundness2'],
+                            data=[[17.4], [16], [0.4], [0], [0]])
+        init_guess3 = Table(names=['x_0', 'y_0'],
+                            data=[[17.4], [16]])
+        init_guess4 = Table(names=['x_0', 'y_0', 'sharpness'],
+                            data=[[17.4], [16], [0.4]])
+        for i, init_guesses in enumerate([init_guess1, init_guess2,
+                                          init_guess3, init_guess4]):
+            dao_phot = DAOPhotPSFPhotometry(crit_separation=8, threshold=40,
+                                            fwhm=4 * np.sqrt(2 * np.log(2)),
+                                            psf_model=psf_model,
+                                            fitshape=(11, 11),
+                                            extra_output_cols=['sharpness',
+                                                               'roundness1',
+                                                               'roundness2'])
+            phot_results = dao_phot(image, init_guesses=init_guesses)
+            # test that the original required columns are also passed
+            # back, as well as extra_output_cols
+            assert np.all([name in phot_results.colnames for name in
+                           ['x_0', 'y_0']])
+            assert np.all([name in phot_results.colnames for name in
+                           ['sharpness', 'roundness1', 'roundness2']])
+            assert len(phot_results) == 2
+            # checks to verify that half-passing init_guesses results
+            # in NaN output for extra_output_cols not passed as initial
+            # guesses
+            if i == 2:  # init_guess3
+                assert np.all(np.all(np.isnan(phot_results[o])) for o in
+                              ['sharpness', 'roundness1', 'roundness2'])
+            if i == 3:  # init_guess4
+                assert np.all(np.all(np.isnan(phot_results[o])) for o in
+                              ['roundness1', 'roundness2'])
+                assert np.all(~np.isnan(phot_results['sharpness']))
 
 
 @pytest.fixture(params=[2, 3])
@@ -690,29 +701,31 @@ def test_psf_fitting_group(overlap_image):
     Test psf_photometry when two input stars are close and need to be
     fit together.
     """
-    from photutils.background import MADStdBackgroundRMS
+    with pytest.warns(AstropyDeprecationWarning):
+        from photutils.background import MADStdBackgroundRMS
 
-    # There are a few models here that fail, be it something
-    # created by EPSFBuilder or simpler the Moffat2D one
-    # unprepared_psf = Moffat2D(amplitude=1, gamma=2, alpha=2.8, x_0=0, y_0=0)
-    # psf = prepare_psf_model(unprepared_psf, xname='x_0', yname='y_0',
-    #                         fluxname=None)
-    psf = prepare_psf_model(Gaussian2D(), renormalize_psf=False)
+        # There are a few models here that fail, be it something created
+        # by EPSFBuilder or simpler the Moffat2D one unprepared_psf =
+        # Moffat2D(amplitude=1, gamma=2, alpha=2.8, x_0=0, y_0=0) psf =
+        # prepare_psf_model(unprepared_psf, xname='x_0', yname='y_0',
+        # fluxname=None)
+        psf = prepare_psf_model(Gaussian2D(), renormalize_psf=False)
 
-    psf.fwhm = Parameter('fwhm', 'this is not the way to add this I think')
-    psf.fwhm.value = 10
+        psf.fwhm = Parameter('fwhm', 'this is not the way to add this I think')
+        psf.fwhm.value = 10
 
-    separation_crit = 10
+        separation_crit = 10
 
-    # choose low threshold and fwhm to find stars no matter what
-    basic_phot = BasicPSFPhotometry(finder=DAOStarFinder(1, 1),
-                                    group_maker=DAOGroup(separation_crit),
-                                    bkg_estimator=MADStdBackgroundRMS(),
-                                    fitter=LevMarLSQFitter(),
-                                    psf_model=psf,
-                                    fitshape=31)
-    # this should not raise AttributeError: Attribute "offset_0_0" not found
-    basic_phot(image=overlap_image)
+        # choose low threshold and fwhm to find stars no matter what
+        basic_phot = BasicPSFPhotometry(finder=DAOStarFinder(1, 1),
+                                        group_maker=DAOGroup(separation_crit),
+                                        bkg_estimator=MADStdBackgroundRMS(),
+                                        fitter=LevMarLSQFitter(),
+                                        psf_model=psf,
+                                        fitshape=31)
+        # this should not raise AttributeError: Attribute "offset_0_0"
+        # not found
+        basic_phot(image=overlap_image)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -736,31 +749,32 @@ def test_finder_return_none():
 
         return table
 
-    prf = np.zeros((7, 7), float)
-    prf[2:5, 2:5] = 1 / 9
-    prf = FittableImageModel(prf)
+    with pytest.warns(AstropyDeprecationWarning):
+        prf = np.zeros((7, 7), float)
+        prf[2:5, 2:5] = 1 / 9
+        prf = FittableImageModel(prf)
 
-    img = np.zeros((50, 50), float)
-    x0 = [38, 20, 35]
-    y0 = [20, 5, 40]
-    f0 = [50, 100, 200]
-    for x, y, f in zip(x0, y0, f0):
-        img[y - 1:y + 2, x - 1:x + 2] = f / 9
+        img = np.zeros((50, 50), float)
+        x0 = [38, 20, 35]
+        y0 = [20, 5, 40]
+        f0 = [50, 100, 200]
+        for x, y, f in zip(x0, y0, f0):
+            img[y - 1:y + 2, x - 1:x + 2] = f / 9
 
-    intab = Table(data=[[37, 19.6, 34.9], [19.6, 4.5, 40.1], [45, 103, 210]],
-                  names=['x_0', 'y_0', 'flux_0'])
+        intab = Table(data=[[37, 19.6, 34.9], [19.6, 4.5, 40.1],
+                            [45, 103, 210]], names=['x_0', 'y_0', 'flux_0'])
 
-    iter_phot = IterativelySubtractedPSFPhotometry(finder=tophatfinder,
-                                                   group_maker=DAOGroup(2),
-                                                   bkg_estimator=None,
-                                                   psf_model=prf,
-                                                   fitshape=7, niters=2,
-                                                   aperture_radius=3)
+        iter_phot = IterativelySubtractedPSFPhotometry(finder=tophatfinder,
+                                                       group_maker=DAOGroup(2),
+                                                       bkg_estimator=None,
+                                                       psf_model=prf,
+                                                       fitshape=7, niters=2,
+                                                       aperture_radius=3)
 
-    with pytest.warns(AstropyUserWarning, match='Both init_guesses and finder '
-                      'are different than None'):
-        results = iter_phot(image=img, init_guesses=intab)
-    assert_allclose(results['flux_fit'], f0, rtol=0.05)
+        match = 'Both init_guesses and finder are different than None'
+        with pytest.warns(AstropyUserWarning, match=match):
+            results = iter_phot(image=img, init_guesses=intab)
+        assert_allclose(results['flux_fit'], f0, rtol=0.05)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -770,17 +784,19 @@ def test_psf_photometry_uncertainties():
     covariance matrix (param_cov). The output table should not
     contain flux_unc, x_0_unc, and y_0_unc columns.
     """
-    psf = IntegratedGaussianPRF(sigma=GAUSSIAN_WIDTH)
+    with pytest.warns(AstropyDeprecationWarning):
+        psf = IntegratedGaussianPRF(sigma=GAUSSIAN_WIDTH)
 
-    basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
-                                    bkg_estimator=None, psf_model=psf,
-                                    fitter=SimplexLSQFitter(),
-                                    fitshape=7)
-    with pytest.warns(AstropyUserWarning, match='The fit may be unsuccessful'):
-        phot_tbl = basic_phot(image=image, init_guesses=INTAB)
-    columns = ('flux_unc', 'x_0_unc', 'y_0_unc')
-    for column in columns:
-        assert column not in phot_tbl.colnames
+        basic_phot = BasicPSFPhotometry(group_maker=DAOGroup(2),
+                                        bkg_estimator=None, psf_model=psf,
+                                        fitter=SimplexLSQFitter(),
+                                        fitshape=7)
+        match = 'The fit may be unsuccessful'
+        with pytest.warns(AstropyUserWarning, match=match):
+            phot_tbl = basic_phot(image=image, init_guesses=INTAB)
+        columns = ('flux_unc', 'x_0_unc', 'y_0_unc')
+        for column in columns:
+            assert column not in phot_tbl.colnames
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -821,94 +837,97 @@ def test_re_use_result_as_initial_guess():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_photometry_mask_nan():
-    size = 64
-    sources1 = Table()
-    sources1['flux'] = [800]
-    sources1['x_0'] = [size / 2]
-    sources1['y_0'] = [size / 2]
-    sources1['sigma'] = [6]
-    sources1['theta'] = [0]
+    with pytest.warns(AstropyDeprecationWarning):
+        size = 64
+        sources1 = Table()
+        sources1['flux'] = [800]
+        sources1['x_0'] = [size / 2]
+        sources1['y_0'] = [size / 2]
+        sources1['sigma'] = [6]
+        sources1['theta'] = [0]
 
-    img_shape = (size, size)
-    data = make_gaussian_prf_sources_image(img_shape, sources1)
-    data[30, 20:40] = np.nan
+        img_shape = (size, size)
+        data = make_gaussian_prf_sources_image(img_shape, sources1)
+        data[30, 20:40] = np.nan
 
-    daogroup = DAOGroup(3.0)
-    psf_model = IntegratedGaussianPRF(sigma=2.0)
-    psfphot = BasicPSFPhotometry(group_maker=daogroup, finder=None,
-                                 bkg_estimator=None, psf_model=psf_model,
-                                 fitshape=(11, 11))
+        daogroup = DAOGroup(3.0)
+        psf_model = IntegratedGaussianPRF(sigma=2.0)
+        psfphot = BasicPSFPhotometry(group_maker=daogroup, finder=None,
+                                     bkg_estimator=None, psf_model=psf_model,
+                                     fitshape=(11, 11))
 
-    init = Table()
-    init['x_0'] = [30]
-    init['y_0'] = [30]
-    init['flux_0'] = [200.0]
+        init = Table()
+        init['x_0'] = [30]
+        init['y_0'] = [30]
+        init['flux_0'] = [200.0]
 
-    mask = ~np.isfinite(data)
-    tbl = psfphot(data, init_guesses=init, mask=mask)
-    assert tbl['x_fit'] != init['x_0']
-    assert tbl['y_fit'] != init['y_0']
-    assert tbl['flux_fit'] != init['flux_0']
+        mask = ~np.isfinite(data)
+        tbl = psfphot(data, init_guesses=init, mask=mask)
+        assert tbl['x_fit'] != init['x_0']
+        assert tbl['y_fit'] != init['y_0']
+        assert tbl['flux_fit'] != init['flux_0']
 
-    with pytest.warns(AstropyUserWarning, match='Input data contains unmasked '
-                      'non-finite values'):
-        tbl2 = psfphot(data, init_guesses=init)
-        assert tbl == tbl2
+        match = 'Input data contains unmasked non-finite values'
+        with pytest.warns(AstropyUserWarning, match=match):
+            tbl2 = psfphot(data, init_guesses=init)
+            assert tbl == tbl2
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_photometry_subshape():
-    size = 21
-    cen = (size - 1) // 2
-    sigma = 2.0
-    sources = Table()
-    sources['flux'] = [1]
-    sources['x_0'] = [cen]
-    sources['y_0'] = [cen]
-    sources['sigma'] = [sigma]
-    psf = make_gaussian_prf_sources_image((size, size), sources)
-    psf_model = FittableImageModel(psf)
+    with pytest.warns(AstropyDeprecationWarning):
+        size = 21
+        cen = (size - 1) // 2
+        sigma = 2.0
+        sources = Table()
+        sources['flux'] = [1]
+        sources['x_0'] = [cen]
+        sources['y_0'] = [cen]
+        sources['sigma'] = [sigma]
+        psf = make_gaussian_prf_sources_image((size, size), sources)
+        psf_model = FittableImageModel(psf)
 
-    sources = Table()
-    sources['flux'] = [2000, 1000]
-    sources['x_0'] = [18, 7]
-    sources['y_0'] = [17, 25]
-    sources['sigma'] = [sigma, sigma]
-    shape = (33, 33)
-    image = make_gaussian_prf_sources_image(shape, sources)
+        sources = Table()
+        sources['flux'] = [2000, 1000]
+        sources['x_0'] = [18, 7]
+        sources['y_0'] = [17, 25]
+        sources['sigma'] = [sigma, sigma]
+        shape = (33, 33)
+        image = make_gaussian_prf_sources_image(shape, sources)
 
-    daogroup = DAOGroup(crit_separation=8)
-    mmm_bkg = MMMBackground()
-    iraffind = IRAFStarFinder(threshold=10, fwhm=5, roundlo=-1, minsep_fwhm=1)
-    fitter = LevMarLSQFitter()
+        daogroup = DAOGroup(crit_separation=8)
+        mmm_bkg = MMMBackground()
+        iraffind = IRAFStarFinder(threshold=10, fwhm=5, roundlo=-1,
+                                  minsep_fwhm=1)
+        fitter = LevMarLSQFitter()
 
-    pobj1 = BasicPSFPhotometry(finder=iraffind, group_maker=daogroup,
-                               bkg_estimator=mmm_bkg, psf_model=psf_model,
-                               fitter=fitter, fitshape=(7, 7),
-                               aperture_radius=5, subshape=(3, 3))
-    pobj2 = BasicPSFPhotometry(finder=iraffind, group_maker=daogroup,
-                               bkg_estimator=mmm_bkg, psf_model=psf_model,
-                               fitter=fitter, fitshape=(7, 7),
-                               aperture_radius=5, subshape=5)
-    pobj3 = BasicPSFPhotometry(finder=iraffind, group_maker=daogroup,
-                               bkg_estimator=mmm_bkg, psf_model=psf_model,
-                               fitter=fitter, fitshape=(7, 7),
-                               aperture_radius=5, subshape=None)
-    pobj4 = BasicPSFPhotometry(finder=iraffind, group_maker=daogroup,
-                               bkg_estimator=mmm_bkg, psf_model=psf_model,
-                               fitter=fitter, fitshape=(7, 7),
-                               aperture_radius=5, subshape=7)
+        pobj1 = BasicPSFPhotometry(finder=iraffind, group_maker=daogroup,
+                                   bkg_estimator=mmm_bkg, psf_model=psf_model,
+                                   fitter=fitter, fitshape=(7, 7),
+                                   aperture_radius=5, subshape=(3, 3))
+        pobj2 = BasicPSFPhotometry(finder=iraffind, group_maker=daogroup,
+                                   bkg_estimator=mmm_bkg, psf_model=psf_model,
+                                   fitter=fitter, fitshape=(7, 7),
+                                   aperture_radius=5, subshape=5)
+        pobj3 = BasicPSFPhotometry(finder=iraffind, group_maker=daogroup,
+                                   bkg_estimator=mmm_bkg, psf_model=psf_model,
+                                   fitter=fitter, fitshape=(7, 7),
+                                   aperture_radius=5, subshape=None)
+        pobj4 = BasicPSFPhotometry(finder=iraffind, group_maker=daogroup,
+                                   bkg_estimator=mmm_bkg, psf_model=psf_model,
+                                   fitter=fitter, fitshape=(7, 7),
+                                   aperture_radius=5, subshape=7)
 
-    _ = pobj1(image)
-    _ = pobj2(image)
-    _ = pobj3(image)
-    _ = pobj4(image)
-    resid1 = pobj1.get_residual_image()
-    resid2 = pobj2.get_residual_image()
-    resid3 = pobj3.get_residual_image()
-    resid4 = pobj4.get_residual_image()
-    assert np.sum(resid1) > np.sum(resid2)
-    assert_allclose(np.sum(resid3), np.sum(resid4))
+        _ = pobj1(image)
+        _ = pobj2(image)
+        _ = pobj3(image)
+        _ = pobj4(image)
+        resid1 = pobj1.get_residual_image()
+        resid2 = pobj2.get_residual_image()
+        resid3 = pobj3.get_residual_image()
+        resid4 = pobj4.get_residual_image()
+        assert np.sum(resid1) > np.sum(resid2)
+        assert_allclose(np.sum(resid3), np.sum(resid4))
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')

--- a/photutils/psf/tests/test_photometry-depr.py
+++ b/photutils/psf/tests/test_photometry-depr.py
@@ -130,8 +130,9 @@ def test_psf_photometry_niters(sigma_psf, sources):
     for iter_phot_obj in phot_obj:
         iter_phot_obj.niters = None
 
-        result_tab = iter_phot_obj(image)
-        residual_image = iter_phot_obj.get_residual_image()
+        with pytest.warns(AstropyDeprecationWarning):
+            result_tab = iter_phot_obj(image)
+            residual_image = iter_phot_obj.get_residual_image()
 
         assert (result_tab['x_0_unc'] < 1.96 * sigma_psf
                 / np.sqrt(sources['flux'])).all()
@@ -182,8 +183,9 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
     phot_objs = make_psf_photometry_objs(std, sigma_psf)
 
     for phot_proc in phot_objs:
-        result_tab = phot_proc(image)
-        residual_image = phot_proc.get_residual_image()
+        with pytest.warns(AstropyDeprecationWarning):
+            result_tab = phot_proc(image)
+            residual_image = phot_proc.get_residual_image()
         assert (result_tab['x_0_unc'] < 1.96 * sigma_psf
                 / np.sqrt(sources['flux'])).all()
         assert (result_tab['y_0_unc'] < 1.96 * sigma_psf
@@ -205,8 +207,9 @@ def test_psf_photometry_oneiter(sigma_psf, sources):
                                                 sources['y_0']])
         cp_pos = pos.copy()
 
-        result_tab = phot_proc(image, init_guesses=pos)
-        residual_image = phot_proc.get_residual_image()
+        with pytest.warns(AstropyDeprecationWarning):
+            result_tab = phot_proc(image, init_guesses=pos)
+            residual_image = phot_proc.get_residual_image()
         assert 'x_0_unc' not in result_tab.colnames
         assert 'y_0_unc' not in result_tab.colnames
         assert (result_tab['flux_unc'] < 1.96
@@ -354,7 +357,8 @@ def test_aperture_radius():
 
     psf_model = PSFModelWithFWHM()
     basic_phot_obj.psf_model = psf_model
-    basic_phot_obj(image)
+    with pytest.warns(AstropyDeprecationWarning):
+        basic_phot_obj(image)
     assert_equal(basic_phot_obj.aperture_radius, psf_model.fwhm.value)
 
 
@@ -380,7 +384,8 @@ def test_define_fit_param_names(actual_pars_to_set, actual_pars_to_output,
     basic_phot_obj = make_psf_photometry_objs()[0]
     basic_phot_obj.psf_model = psf_model
 
-    basic_phot_obj._define_fit_param_names()
+    with pytest.warns(AstropyDeprecationWarning):
+        basic_phot_obj._define_fit_param_names()
     assert_equal(basic_phot_obj._pars_to_set, actual_pars_to_set)
     assert_equal(basic_phot_obj._pars_to_output, actual_pars_to_output)
 
@@ -983,7 +988,8 @@ def test_psf_photometry_oneiter_uncert(sigma_psf, sources):
             uncertainty = (
                 uncertainty_scale_factor * np.std(image) * np.ones_like(image)
             )
-            result_tab = phot_proc(image, uncertainty=uncertainty)
+            with pytest.warns(AstropyDeprecationWarning):
+                result_tab = phot_proc(image, uncertainty=uncertainty)
             flux_uncert.append(np.array(result_tab['flux_unc']))
 
     for uncert_0, uncert_1 in zip(flux_uncertainties_0, flux_uncertainties_1):

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -9,7 +9,8 @@ import pytest
 from astropy.modeling.fitting import LMLSQFitter, SimplexLSQFitter
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable, Table
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.background import LocalBackground, MMMBackground
@@ -53,8 +54,8 @@ def test_inputs():
 
     match = 'Invalid grouper class. Please use SourceGrouper.'
     with pytest.raises(ValueError, match=match):
-        grouper = DAOGroup(1)
-        _ = PSFPhotometry(model, 1, grouper=grouper)
+        with pytest.warns(AstropyDeprecationWarning):
+            _ = PSFPhotometry(model, 1, grouper=DAOGroup(1))
 
     match = 'localbkg_estimator must be a LocalBackground instance'
     with pytest.raises(ValueError, match=match):

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -253,9 +253,10 @@ def test_get_grouped_psf_model_submodel_names(prf_model):
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_subtract_psf():
     """Test subtract_psf."""
-    psf = IntegratedGaussianPRF(sigma=1.0)
-    posflux = INTAB.copy()
-    for n in posflux.colnames:
-        posflux.rename_column(n, n.split('_')[0] + '_fit')
-    residuals = subtract_psf(image, psf, posflux)
-    assert np.max(np.abs(residuals)) < 0.0052
+    with pytest.warns(AstropyDeprecationWarning):
+        psf = IntegratedGaussianPRF(sigma=1.0)
+        posflux = INTAB.copy()
+        for n in posflux.colnames:
+            posflux.rename_column(n, n.split('_')[0] + '_fit')
+        residuals = subtract_psf(image, psf, posflux)
+        assert np.max(np.abs(residuals)) < 0.0052

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 from astropy.convolution.utils import discretize_model
 from astropy.modeling.models import Gaussian2D
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 
 from photutils.psf.groupstars import DAOGroup
@@ -149,60 +150,61 @@ def test_prepare_psf_model_offset():
     """
     Regression test to ensure the offset is in the correct direction.
     """
-    norm = False
-    sigma = 3.0
-    amplitude = 1.0 / (2 * np.pi * sigma**2)
-    xcen = ycen = 0.0
-    psf0 = Gaussian2D(amplitude, xcen, ycen, sigma, sigma)
-    psf1 = prepare_psf_model(psf0, xname='x_mean', yname='y_mean',
-                             renormalize_psf=norm)
-    psf2 = prepare_psf_model(psf0, renormalize_psf=norm)
-    psf3 = prepare_psf_model(psf0, xname='x_mean', renormalize_psf=norm)
-    psf4 = prepare_psf_model(psf0, yname='y_mean', renormalize_psf=norm)
+    with pytest.warns(AstropyDeprecationWarning):
+        norm = False
+        sigma = 3.0
+        amplitude = 1.0 / (2 * np.pi * sigma**2)
+        xcen = ycen = 0.0
+        psf0 = Gaussian2D(amplitude, xcen, ycen, sigma, sigma)
+        psf1 = prepare_psf_model(psf0, xname='x_mean', yname='y_mean',
+                                 renormalize_psf=norm)
+        psf2 = prepare_psf_model(psf0, renormalize_psf=norm)
+        psf3 = prepare_psf_model(psf0, xname='x_mean', renormalize_psf=norm)
+        psf4 = prepare_psf_model(psf0, yname='y_mean', renormalize_psf=norm)
 
-    yy, xx = np.mgrid[0:101, 0:101]
-    psf = psf1.copy()
-    xval = 48
-    yval = 52
-    flux = 14.51
-    psf.x_mean_2 = xval
-    psf.y_mean_2 = yval
-    data = psf(xx, yy) * flux
+        yy, xx = np.mgrid[0:101, 0:101]
+        psf = psf1.copy()
+        xval = 48
+        yval = 52
+        flux = 14.51
+        psf.x_mean_2 = xval
+        psf.y_mean_2 = yval
+        data = psf(xx, yy) * flux
 
-    group_maker = DAOGroup(2)
-    bkg_estimator = None
-    fitshape = 7
-    init_guesses = Table([[46.1], [57.3], [7.1]],
-                         names=['x_0', 'y_0', 'flux_0'])
+        group_maker = DAOGroup(2)
+        bkg_estimator = None
+        fitshape = 7
+        init_guesses = Table([[46.1], [57.3], [7.1]],
+                             names=['x_0', 'y_0', 'flux_0'])
 
-    phot1 = BasicPSFPhotometry(group_maker=group_maker,
-                               bkg_estimator=bkg_estimator, fitshape=fitshape,
-                               psf_model=psf1)
-    tbl1 = phot1(image=data, init_guesses=init_guesses)
+        phot1 = BasicPSFPhotometry(group_maker=group_maker,
+                                   bkg_estimator=bkg_estimator,
+                                   fitshape=fitshape, psf_model=psf1)
+        tbl1 = phot1(image=data, init_guesses=init_guesses)
 
-    phot2 = BasicPSFPhotometry(group_maker=group_maker,
-                               bkg_estimator=bkg_estimator, fitshape=fitshape,
-                               psf_model=psf2)
-    tbl2 = phot2(image=data, init_guesses=init_guesses)
+        phot2 = BasicPSFPhotometry(group_maker=group_maker,
+                                   bkg_estimator=bkg_estimator,
+                                   fitshape=fitshape, psf_model=psf2)
+        tbl2 = phot2(image=data, init_guesses=init_guesses)
 
-    phot3 = BasicPSFPhotometry(group_maker=group_maker,
-                               bkg_estimator=bkg_estimator, fitshape=fitshape,
-                               psf_model=psf3)
-    tbl3 = phot3(image=data, init_guesses=init_guesses)
+        phot3 = BasicPSFPhotometry(group_maker=group_maker,
+                                   bkg_estimator=bkg_estimator,
+                                   fitshape=fitshape, psf_model=psf3)
+        tbl3 = phot3(image=data, init_guesses=init_guesses)
 
-    phot4 = BasicPSFPhotometry(group_maker=group_maker,
-                               bkg_estimator=bkg_estimator, fitshape=fitshape,
-                               psf_model=psf4)
-    tbl4 = phot4(image=data, init_guesses=init_guesses)
+        phot4 = BasicPSFPhotometry(group_maker=group_maker,
+                                   bkg_estimator=bkg_estimator,
+                                   fitshape=fitshape, psf_model=psf4)
+        tbl4 = phot4(image=data, init_guesses=init_guesses)
 
-    assert_allclose((tbl1['x_fit'][0], tbl1['y_fit'][0], tbl1['flux_fit'][0]),
-                    (xval, yval, flux))
-    assert_allclose((tbl2['x_fit'][0], tbl2['y_fit'][0], tbl2['flux_fit'][0]),
-                    (xval, yval, flux))
-    assert_allclose((tbl3['x_fit'][0], tbl3['y_fit'][0], tbl3['flux_fit'][0]),
-                    (xval, yval, flux))
-    assert_allclose((tbl4['x_fit'][0], tbl4['y_fit'][0], tbl4['flux_fit'][0]),
-                    (xval, yval, flux))
+        assert_allclose((tbl1['x_fit'][0], tbl1['y_fit'][0],
+                         tbl1['flux_fit'][0]), (xval, yval, flux))
+        assert_allclose((tbl2['x_fit'][0], tbl2['y_fit'][0],
+                         tbl2['flux_fit'][0]), (xval, yval, flux))
+        assert_allclose((tbl3['x_fit'][0], tbl3['y_fit'][0],
+                         tbl3['flux_fit'][0]), (xval, yval, flux))
+        assert_allclose((tbl4['x_fit'][0], tbl4['y_fit'][0],
+                         tbl4['flux_fit'][0]), (xval, yval, flux))
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -212,7 +214,8 @@ def test_get_grouped_psf_model():
                 data=[[1, 2], [3, 4], [0.5, 1]])
     pars_to_set = {'x_0': 'x_0', 'y_0': 'y_0', 'flux_0': 'flux'}
 
-    gpsf = get_grouped_psf_model(igp, tab, pars_to_set)
+    with pytest.warns(AstropyDeprecationWarning):
+        gpsf = get_grouped_psf_model(igp, tab, pars_to_set)
 
     assert gpsf.x_0_0 == 1
     assert gpsf.y_0_1 == 4
@@ -238,12 +241,13 @@ def test_get_grouped_psf_model_submodel_names(prf_model):
                 data=[[1, 2], [3, 4], [0.5, 1]])
     pars_to_set = {'x_0': 'x_0', 'y_0': 'y_0', 'flux_0': 'flux'}
 
-    gpsf = get_grouped_psf_model(prf_model, tab, pars_to_set)
-    # There should be two submodels one named 0 and one named 1
-    assert len([submodel for submodel in gpsf.traverse_postorder()
-                if submodel.name == 0]) == 1
-    assert len([submodel for submodel in gpsf.traverse_postorder()
-                if submodel.name == 1]) == 1
+    with pytest.warns(AstropyDeprecationWarning):
+        gpsf = get_grouped_psf_model(prf_model, tab, pars_to_set)
+        # There should be two submodels one named 0 and one named 1
+        assert len([submodel for submodel in gpsf.traverse_postorder()
+                    if submodel.name == 0]) == 1
+        assert len([submodel for submodel in gpsf.traverse_postorder()
+                    if submodel.name == 1]) == 1
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -7,6 +7,7 @@ import numpy as np
 from astropy.modeling.models import Const2D, Identity, Shift
 from astropy.nddata.utils import add_array, extract_array
 from astropy.table import QTable
+from astropy.utils.decorators import deprecated
 
 __all__ = ['prepare_psf_model', 'get_grouped_psf_model', 'subtract_psf']
 
@@ -129,6 +130,7 @@ def prepare_psf_model(psfmodel, *, xname=None, yname=None, fluxname=None,
     return outmod
 
 
+@deprecated('1.9.0')
 def get_grouped_psf_model(template_psf_model, star_group, pars_to_set):
     """
     Construct a joint PSF model which consists of a sum of PSF's templated on
@@ -173,6 +175,7 @@ def get_grouped_psf_model(template_psf_model, star_group, pars_to_set):
     return group_psf
 
 
+@deprecated('1.9.0')
 def _extract_psf_fitting_names(psf):
     """
     Determine the names of the x coordinate, y coordinate, and flux from

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -130,6 +130,62 @@ def prepare_psf_model(psfmodel, *, xname=None, yname=None, fluxname=None,
     return outmod
 
 
+def _interpolate_missing_data(data, mask, method='cubic'):
+    """
+    Interpolate missing data as identified by the ``mask`` keyword.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        An array containing the 2D image.
+
+    mask : 2D bool `~numpy.ndarray`
+        A 2D boolean mask array with the same shape as the input
+        ``data``, where a `True` value indicates the corresponding
+        element of ``data`` is masked.  The masked data points are
+        those that will be interpolated.
+
+    method : {'cubic', 'nearest'}, optional
+        The method of used to interpolate the missing data:
+
+        * ``'cubic'``:  Masked data are interpolated using 2D cubic
+            splines.  This is the default.
+
+        * ``'nearest'``:  Masked data are interpolated using
+            nearest-neighbor interpolation.
+
+    Returns
+    -------
+    data_interp : 2D `~numpy.ndarray`
+        The interpolated 2D image.
+    """
+    from scipy import interpolate
+
+    data_interp = np.array(data, copy=True)
+
+    if len(data_interp.shape) != 2:
+        raise ValueError("'data' must be a 2D array.")
+
+    if mask.shape != data.shape:
+        raise ValueError("'mask' and 'data' must have the same shape.")
+
+    y, x = np.indices(data_interp.shape)
+    xy = np.dstack((x[~mask].ravel(), y[~mask].ravel()))[0]
+    z = data_interp[~mask].ravel()
+
+    if method == 'nearest':
+        interpol = interpolate.NearestNDInterpolator(xy, z)
+    elif method == 'cubic':
+        interpol = interpolate.CloughTocher2DInterpolator(xy, z)
+    else:
+        raise ValueError('Unsupported interpolation method.')
+
+    xy_missing = np.dstack((x[mask].ravel(), y[mask].ravel()))[0]
+    data_interp[mask] = interpol(xy_missing)
+
+    return data_interp
+
+
 @deprecated('1.9.0')
 def get_grouped_psf_model(template_psf_model, star_group, pars_to_set):
     """
@@ -279,59 +335,3 @@ def subtract_psf(data, psf, posflux, *, subshape=None):
             subbeddata = add_array(subbeddata, -psf(x, y), (y_0, x_0))
 
     return subbeddata
-
-
-def _interpolate_missing_data(data, mask, method='cubic'):
-    """
-    Interpolate missing data as identified by the ``mask`` keyword.
-
-    Parameters
-    ----------
-    data : 2D `~numpy.ndarray`
-        An array containing the 2D image.
-
-    mask : 2D bool `~numpy.ndarray`
-        A 2D boolean mask array with the same shape as the input
-        ``data``, where a `True` value indicates the corresponding
-        element of ``data`` is masked.  The masked data points are
-        those that will be interpolated.
-
-    method : {'cubic', 'nearest'}, optional
-        The method of used to interpolate the missing data:
-
-        * ``'cubic'``:  Masked data are interpolated using 2D cubic
-            splines.  This is the default.
-
-        * ``'nearest'``:  Masked data are interpolated using
-            nearest-neighbor interpolation.
-
-    Returns
-    -------
-    data_interp : 2D `~numpy.ndarray`
-        The interpolated 2D image.
-    """
-    from scipy import interpolate
-
-    data_interp = np.array(data, copy=True)
-
-    if len(data_interp.shape) != 2:
-        raise ValueError("'data' must be a 2D array.")
-
-    if mask.shape != data.shape:
-        raise ValueError("'mask' and 'data' must have the same shape.")
-
-    y, x = np.indices(data_interp.shape)
-    xy = np.dstack((x[~mask].ravel(), y[~mask].ravel()))[0]
-    z = data_interp[~mask].ravel()
-
-    if method == 'nearest':
-        interpol = interpolate.NearestNDInterpolator(xy, z)
-    elif method == 'cubic':
-        interpol = interpolate.CloughTocher2DInterpolator(xy, z)
-    else:
-        raise ValueError('Unsupported interpolation method.')
-
-    xy_missing = np.dstack((x[mask].ravel(), y[mask].ravel()))[0]
-    data_interp[mask] = interpol(xy_missing)
-
-    return data_interp

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -207,6 +207,7 @@ def _extract_psf_fitting_names(psf):
     return xname, yname, fluxname
 
 
+@deprecated('1.9.0')
 def subtract_psf(data, psf, posflux, *, subshape=None):
     """
     Subtract PSF/PRFs from an image.

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -204,17 +204,6 @@ def _extract_psf_fitting_names(psf):
     return xname, yname, fluxname
 
 
-def _call_fitter(fitter, psf, x, y, data, weights):
-    """
-    Not all fitters have to support a weight array. This function
-    includes the weight in the fitter call only if really needed.
-    """
-    if np.all(weights == 1.0):
-        return fitter(psf, x, y, data)
-    else:
-        return fitter(psf, x, y, data, weights=weights)
-
-
 def subtract_psf(data, psf, posflux, *, subshape=None):
     """
     Subtract PSF/PRFs from an image.


### PR DESCRIPTION
This PR deprecates:

- `BasicPSFPhotometry`, `IterativelySubtractedPSFPhotometry`, and `DAOPhotPSFPhotometry` in favor of the new `PSFPhotometry` and `IterativePSFPhotometry` classes
- `DAOGroup`, `DBSCANGroup`, and `GroupStarsBase` in favor of the new `SourceGrouper` class
- `get_grouped_psf_model` and `subtract_psf` functions