### PR TITLE
Rename output columns in make_test_psf_data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,14 +18,14 @@ New Features
 
 - ``photutils.datasets``
 
-  - Added new ``make_test_psf_data`` function. [#1558]
+  - Added new ``make_test_psf_data`` function. [#1558, #1582]
 
 - ``photutils.psf``
 
   - Propagate measurement uncertainties in PSF fitting. [#1543]
 
   - Added new ``PSFPhotometry``, ``IterativePSFPhotometry``, and
-    ``SourceGrouper`` classes. [#1558,#1581]
+    ``SourceGrouper`` classes. [#1558, #1581]
 
 Bug Fixes
 ^^^^^^^^^

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -1053,8 +1053,8 @@ def make_test_psf_data(shape, psf_model, psf_shape, nsources,
         yy, xx = np.mgrid[slc_lg]
         data[slc_lg] += psf_model(xx, yy)
 
-    sources.rename_column('x_0', 'x_true')
-    sources.rename_column('y_0', 'y_true')
-    sources.rename_column('flux', 'flux_true')
+    sources.rename_column('x_0', 'x')
+    sources.rename_column('y_0', 'y')
+    sources.rename_column('flux', 'flux')
 
     return data, sources


### PR DESCRIPTION
This makes it easy to directly input the table into `PSFPhotometry`.