### PR TITLE
Update RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,8 @@ build:
   jobs:
     post_checkout:
       - git fetch --shallow-since=2023-05-01 || true
+    pre_install:
+      - git update-index --assume-unchanged docs/conf.py
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,9 @@ build:
     - graphviz
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      - git fetch --shallow-since=2023-05-01 || true
 
 sphinx:
   builder: html


### PR DESCRIPTION
RTD "latest" (dev) builds show a wrong version number because they perform a shallow clone (depth 50) of the repo (https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-git-clone). This often prevents `setuptools_scm` from finding the most-recent tag from which to build the version number.  This PR fixes that issue by "unshallowing" the clone back to at least the latest tag.  It also prevents having a dirty git index (which can also alter the version) during the RTD build (https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index).

Fixes: #1588 