### PR TITLE
Add warning for large groups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ New Features
   - Propagate measurement uncertainties in PSF fitting. [#1543]
 
   - Added new ``PSFPhotometry``, ``IterativePSFPhotometry``, and
-    ``SourceGrouper`` classes. [#1558, #1581]
+    ``SourceGrouper`` classes. [#1558, #1581, #1594]
 
   - Added a ``GriddedPSFModel`` ``fill_value`` attribute, [#1583]
 

--- a/docs/grouping.rst
+++ b/docs/grouping.rst
@@ -15,11 +15,11 @@ Stetson, in his seminal paper (`Stetson 1987, PASP 99, 191
 <https://ui.adsabs.harvard.edu/abs/1987PASP...99..191S/abstract>`_),
 provided a simple and powerful grouping algorithm to decide whether
 the profile of a given star extends into the fitting region of any
-other star. Stetson defines this in terms of a "critical separation"
+other star. The paper defines this in terms of a "critical separation"
 parameter, which is defined as the minimal distance that any two stars
-must be separated by in order to be in different groups. Stetson gives
-intuitive reasoning to suggest that the critical separation may be
-defined as a multiple of the stellar full width at half maximum (FWHM).
+must be separated by in order to be in different groups. The critical
+separation is generally defined as a multiple of the stellar full width
+at half maximum (FWHM).
 
 
 Getting Started
@@ -53,7 +53,10 @@ sources and the latter will make an actual image using that table::
     >>> shape = (size, size)
     >>> data = make_gaussian_sources_image(shape, stars)
 
-Now let's display the image:
+``stars`` is an astropy `~astropy.table.Table` of parameters defining
+the position and shape of the stars.
+
+Let's display the image:
 
 .. doctest-skip::
 
@@ -83,9 +86,6 @@ Now let's display the image:
 
     plt.imshow(data, origin='lower', interpolation='nearest')
     plt.show()
-
-``stars`` is an astropy `~astropy.table.Table` of parameters defining
-the position and shape of the stars.
 
 Now, let's find the stellar groups. We start by creating
 a `~photutils.psf.SourceGrouper` object. Here we set the

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -69,7 +69,7 @@ crowded-field stellar photometry.
 
 The star-finding step is controlled by the ``finder``
 keyword, where one inputs a callable function or class
-instance. Typically this would be one of the star-detection
+instance. Typically, this would be one of the star-detection
 classes implemented in the `photutils.detection`
 subpackage, e.g., `~photutils.detection.DAOStarFinder`,
 `~photutils.detection.IRAFStarFinder`, or
@@ -101,11 +101,11 @@ The next step is to fit the sources and/or groups. This
 task is performed using an astropy fitter, for example
 `~astropy.modeling.fitting.LevMarLSQFitter`, input via the ``fitter``
 keyword. The shape of the region to be fitted can be configured using
-the ``fit_shape`` parameter. In general, fit_shape should be set to
-a small size (e.g., (5, 5)) that covers the central star region with
-the highest flux signal-to-noise. The initial positions are derived
-from the ``finder`` algorithm. The initial flux values for the fit
-are derived from measuring the flux in a circular aperture with
+the ``fit_shape`` parameter. In general, ``fit_shape`` should be set
+to a small size (e.g., (5, 5)) that covers the central star region
+with the highest flux signal-to-noise. The initial positions are
+derived from the ``finder`` algorithm. The initial flux values for the
+fit are derived from measuring the flux in a circular aperture with
 radius ``aperture_radius``. The initial positions and fluxes can be
 alternatively input via the ``init_params`` keyword when calling the
 class.
@@ -125,7 +125,7 @@ The `~photutils.psf.PSFPhotometry` and
 in which the PSF-fitting steps described above are performed, but
 all the stages can be turned on or off or replaced with different
 implementations as the user desires. This makes the tools very flexible.
-One can also bypass several of the steps by directly inputing to
+One can also bypass several of the steps by directly inputting to
 ``init_params`` an astropy table containing the initial parameters for
 the source centers, fluxes, group identifiers, and local backgrounds.
 This is also useful if one is interested in fitting only one or a few
@@ -188,9 +188,9 @@ include background.
 
 We'll use the `~photutils.detection.DAOStarFinder` class for
 source detection. We'll estimate the initial fluxes of each
-source using a circular apertures with a radius 4 pixels.
-We'll fit the central 5x5 pixel region of each star using an
-`~photutils.psf.IntegratedGaussianPRF` PSF model. We first create an
+source using a circular aperture with a radius 4 pixels. The
+central 5x5 pixel region of each star will be fit using an
+`~photutils.psf.IntegratedGaussianPRF` PSF model. First, let's create an
 instance of the `~photutils.psf.PSFPhotometry` class:
 
 .. doctest-requires:: scipy
@@ -234,8 +234,8 @@ fit, the group size, quality-of-fit metrics, and flags. See the
 `~photutils.psf.PSFPhotometry` documentation for descriptions of the
 output columns.
 
-The full table cannot be shown here as it has a large number of columns,
-but let's print the source ID along with the fit x, y, and flux values:
+The full table cannot be shown here as it has many columns, but let's
+print the source ID along with the fit x, y, and flux values:
 
 .. doctest-requires:: scipy
 
@@ -507,8 +507,9 @@ two stars). The stars in each group were simultaneously fit.
      10        5          2
 
 Care should be taken in defining the star groups. As noted above,
-simulataneouly fitting very large star groups is computationally
-expensive and error-prone.
+simultaneously fitting very large star groups is computationally
+expensive and error-prone. A warning will be raised if the number of
+sources in a group exceeds 25.
 
 
 Local Background Subtraction

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -79,7 +79,8 @@ class PSFPhotometry:
         in which a given source belongs. If `None`, then no grouping
         is performed, i.e. each source is fit independently. The
         ``group_id`` values in ``init_params`` override this keyword
-        *only for the first iteration*.
+        *only for the first iteration*. A warning is raised if any group
+        size is larger than 25 sources.
 
     fitter : `~astropy.modeling.fitting.Fitter`, optional
         The fitter object used to perform the fit of the model to the
@@ -911,6 +912,15 @@ class PSFPhotometry:
             # TODO: raise warning
             return None
 
+        _, counts = np.unique(init_params['group_id'], return_counts=True)
+        if max(counts) > 25:
+            warnings.warn('Some groups have more than 25 sources. Fitting '
+                          'such groups may take a long time and be '
+                          'error-prone. You may want to consider using '
+                          'different `SourceGrouper` parameters or '
+                          'changing the "group_id" column in "init_params".',
+                          AstropyUserWarning)
+
         fit_models = self._fit_sources(data, init_params, error=error,
                                        mask=mask)
 
@@ -1064,8 +1074,11 @@ class IterativePSFPhotometry:
         The rectangular shape around the center of a star that will
         be used to define the PSF-fitting data. If ``fit_shape`` is a
         scalar then a square shape of size ``fit_shape`` will be used.
-        If ``fit_shape`` has two elements, they must be in ``(ny, nx)``
-        order. Each element of ``fit_shape`` must be an odd number.
+        If ``fit_shape`` has two elements, they must be in ``(ny,
+        nx)`` order. Each element of ``fit_shape`` must be an odd
+        number. In general, ``fit_shape`` should be set to a small size
+        (e.g., ``(5, 5)``) that covers the region with the highest flux
+        signal-to-noise.
 
     finder : callable or `~photutils.detection.StarFinderBase`
         A callable used to identify stars in an image. The
@@ -1090,7 +1103,8 @@ class IterativePSFPhotometry:
         in which a given source belongs. If `None`, then no grouping
         is performed, i.e. each source is fit independently. The
         ``group_id`` values in ``init_params`` override this keyword
-        *only for the first iteration*.
+        *only for the first iteration*. A warning is raised if any group
+        size is larger than 25 sources.
 
     fitter : `~astropy.modeling.fitting.Fitter`, optional
         The fitter object used to perform the fit of the model to the

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -378,6 +378,24 @@ def test_grouper(test_data):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.skipif(not HAS_SKLEARN, reason='sklearn is required')
+def test_large_group_warning():
+    psf_model = IntegratedGaussianPRF(flux=1, sigma=1.0)
+    grouper = SourceGrouper(min_separation=50)
+    psf_shape = (5, 5)
+    fit_shape = (5, 5)
+    nsources = 50
+    shape = (301, 301)
+    data, true_params = make_test_psf_data(shape, psf_model, psf_shape,
+                                           nsources, flux_range=(500, 700),
+                                           min_separation=10, seed=0)
+    match = 'Some groups have more than'
+    with pytest.warns(AstropyUserWarning, match=match):
+        psfphot = PSFPhotometry(psf_model, fit_shape, grouper=grouper)
+        psfphot(data, init_params=true_params)
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+@pytest.mark.skipif(not HAS_SKLEARN, reason='sklearn is required')
 def test_local_bkg(test_data):
     data, error, sources = test_data
 


### PR DESCRIPTION
As noted in the narrative docs, simultaneously fitting very large star groups is computationally expensive and error-prone.