### PR TITLE
CI: add extra astropy pip index to pick up new dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ isolated_build = true
 # Suppress display of matplotlib plots generated during docs build
 setenv =
     MPLBACKEND=agg
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple
 
 # Pass through the following environment variables which may be needed
 # for the CI
@@ -74,6 +74,7 @@ deps =
     devdeps: scikit-image>=0.0.dev0
     devdeps: scikit-learn>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
+    devdeps: astropy>=0.0.dev0
     devdeps: git+https://github.com/spacetelescope/gwcs.git
 
     # Latest developer version of infrastructure packages.
@@ -95,7 +96,6 @@ extras =
     build_docs: docs
 
 commands =
-    devdeps: pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
     pip freeze
 
     pytest --pyargs photutils {toxinidir}/docs \


### PR DESCRIPTION
This should fix the issue that we've been testing with a ~month old astropy dev version (as `astropy-iers-data` is a new dependency that hasn't been picked up with a newer dev wheel)

https://github.com/astropy/astropy/issues/15146