### PR TITLE
Change SourceGrouper to use scipy instead of scikit-learn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,11 +24,13 @@ New Features
 
   - Propagate measurement uncertainties in PSF fitting. [#1543]
 
-  - Added new ``PSFPhotometry``, ``IterativePSFPhotometry``, and
-    ``SourceGrouper`` classes. [#1558, #1559, #1563, #1566, #1567,
-    #1581, #1586, #1590, #1594, #1603, #1604]
+  - Added new ``PSFPhotometry`` and ``IterativePSFPhotometry`` classes
+    for performing PSF-fitting photometry. [#1558, #1559, #1563, #1566,
+    #1567, #1581, #1586, #1590, #1594, #1603, #1604]
 
-  - Added a ``GriddedPSFModel`` ``fill_value`` attribute, [#1583]
+  - Added a new ``SourceGrouper`` class. [#1558, #1605]
+
+  - Added a ``GriddedPSFModel`` ``fill_value`` attribute. [#1583]
 
   - Added a ``grid_from_epsfs`` function to make a ``GriddedPSFModel``
     from ePSFs. [#1596]

--- a/docs/grouping.rst
+++ b/docs/grouping.rst
@@ -26,10 +26,9 @@ Getting Started
 ---------------
 
 Photutils provides the :class:`~photutils.psf.SourceGrouper`
-class to group stars. The class is based on the `Density-Based
-Spatial Clustering of Applications with Noise (DBSCAN)
-<https://en.wikipedia.org/wiki/DBSCAN>`_ algorithm and requires
-`scikit-learn <https://scikit-learn.org/>`_ to be installed.
+class to group stars. The groups are formed using hierarchical
+agglomerative clustering with a distance criterion, calling the
+`scipy.cluster.hierarchy.fclusterdata` function.
 
 First, let's make some Gaussian sources using
 `~photutils.datasets.make_random_gaussians_table` and
@@ -94,7 +93,7 @@ calculated from the 2D Gaussian standard deviation used to generate
 the stars. In general one will need to measure the FWHM of the stellar
 profiles.
 
-.. doctest-requires:: sklearn
+.. doctest-requires:: scipy
 
     >>> from astropy.stats import gaussian_sigma_to_fwhm
     >>> from photutils.psf import SourceGrouper
@@ -107,7 +106,7 @@ Here will use the known positions of the stars when we generated the
 image. In general, one can use a star finder (:ref:`source_detection`)
 to find the sources.
 
-.. doctest-requires:: sklearn
+.. doctest-requires:: scipy
 
    >>> import numpy as np
    >>> x = np.array(stars['x_mean'])
@@ -120,7 +119,7 @@ index are in the same group.
 
 For example, to find all the stars in group 3:
 
-.. doctest-requires:: sklearn
+.. doctest-requires:: scipy
 
    >>> mask = groups == 3
    >>> x[mask], y[mask]

--- a/photutils/psf/groupers.py
+++ b/photutils/psf/groupers.py
@@ -3,6 +3,8 @@
 This module provides classes to perform grouping of stars.
 """
 
+from collections import defaultdict
+
 import numpy as np
 
 __all__ = ['SourceGrouper']
@@ -71,11 +73,5 @@ class SourceGrouper:
 
         # reorder the group_ids so that that unique group_ids start from 1
         # and increase (this matches the output of DBSCAN)
-        mapping = {}
-        i = 1
-        for group in group_id:
-            if group not in mapping:
-                mapping[group] = i
-                i += 1
-
+        mapping = defaultdict(lambda: len(mapping) + 1)
         return np.array([mapping[group] for group in group_id])

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -20,7 +20,7 @@ from photutils.detection import DAOStarFinder
 from photutils.psf import (IntegratedGaussianPRF, IterativePSFPhotometry,
                            PSFPhotometry, SourceGrouper)
 from photutils.psf.photometry_depr import DAOGroup
-from photutils.utils._optional_deps import HAS_SCIPY, HAS_SKLEARN
+from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
@@ -359,7 +359,6 @@ def test_psf_photometry_init_params_columns(test_data):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.skipif(not HAS_SKLEARN, reason='sklearn is required')
 def test_grouper(test_data):
     data, error, sources = test_data
 
@@ -377,7 +376,6 @@ def test_grouper(test_data):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.skipif(not HAS_SKLEARN, reason='sklearn is required')
 def test_large_group_warning():
     psf_model = IntegratedGaussianPRF(flux=1, sigma=1.0)
     grouper = SourceGrouper(min_separation=50)
@@ -395,7 +393,6 @@ def test_large_group_warning():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.skipif(not HAS_SKLEARN, reason='sklearn is required')
 def test_local_bkg(test_data):
     data, error, sources = test_data
 


### PR DESCRIPTION
This PR changes the `SourceGrouper` class to use the `scipy.cluster.hierarchy.fclusterdata` function instead of the `sklearn.cluster.DBSCAN` class.  In my testing they produce the same results (for the default DBSCAN kwargs).  I don't know that the extra DBSCAN options are actually useful.  With this change, we can eventually remove `scikit-learn` as an optional dependency (after the deprecated `DBSCANGroup` class is removed).

CC: @bmorris3 