### PR TITLE
Remove deprecated kernel keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.segmentation``
+
+  - Removed the deprecated ``kernel`` keyword from ``SourceCatalog``.
+    [#1613]
+
 
 1.9.0 (2023-08-14)
 ------------------

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -10,7 +10,6 @@ from astropy.convolution import convolve
 from astropy.coordinates import SkyCoord
 from astropy.modeling.models import Gaussian2D
 from astropy.table import QTable
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture import (BoundingBox, CircularAperture,
@@ -23,7 +22,6 @@ from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.detect import detect_sources
 from photutils.segmentation.finder import SourceFinder
 from photutils.segmentation.utils import make_2dgaussian_kernel
-from photutils.utils._convolution import _filter_data
 from photutils.utils._optional_deps import (HAS_GWCS, HAS_MATPLOTLIB,
                                             HAS_SCIPY, HAS_SKIMAGE)
 from photutils.utils.cutouts import CutoutImage
@@ -436,24 +434,6 @@ class TestSourceCatalog:
         lines = ('Length: 7', 'labels: [1 2 3 4 5 6 7]')
         for line in lines:
             assert line in repr(cat)
-
-    def test_kernel(self):
-        kernel = np.array([[1.0, 2, 1], [2, 4, 2], [1, 2, 100]])
-        kernel /= kernel.sum()
-
-        with pytest.warns(AstropyDeprecationWarning):
-            cat1 = SourceCatalog(self.data, self.segm, kernel=None)
-            cat2 = SourceCatalog(self.data, self.segm, kernel=kernel)
-            assert not np.array_equal(cat1.xcentroid, cat2.xcentroid)
-            assert not np.array_equal(cat1.ycentroid, cat2.ycentroid)
-
-        convolved_data = _filter_data(self.data, kernel, mode='constant',
-                                      fill_value=0.0,
-                                      check_normalization=True)
-        cat3 = SourceCatalog(self.data, self.segm,
-                             convolved_data=convolved_data)
-        assert_allclose(cat2.centroid, cat3.centroid)
-        assert_allclose(cat2.covariance, cat3.covariance)
 
     def test_detection_cat(self):
         data2 = self.data - 5


### PR DESCRIPTION
This PR removes the deprecated `kernel` keyword from `SourceCatalog`.  Instead users should input a convolved image directly into the `convolved_data` keyword.