### PR TITLE
Bump minimum Astropy to 5.1

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -87,7 +87,7 @@ jobs:
 
           - os: ubuntu-latest
             python: '3.9'
-            tox_env: 'py39-test-alldeps-astropylts-numpy122'
+            tox_env: 'py39-test-oldestdeps'
             allow_failure: false
             prefix: ''
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 General
 ^^^^^^^
 
+- The minimum required Astropy is now 5.1. [#1627]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,13 +15,13 @@ Photutils has the following strict requirements:
 
 Photutils also optionally depends on other packages for some features:
 
-* `SciPy <https://scipy.org/>`_ 1.7.0 or later:  To power a variety of
+* `SciPy <https://scipy.org/>`_ 1.7.2 or later:  To power a variety of
   features in several modules (strongly recommended).
 
-* `Matplotlib <https://matplotlib.org/>`_ 3.5.0 or later:  To power a
+* `Matplotlib <https://matplotlib.org/>`_ 3.5 or later:  To power a
   variety of plotting features (e.g., plotting apertures).
 
-* `scikit-image <https://scikit-image.org/>`_ 0.19.0 or later: Used for
+* `scikit-image <https://scikit-image.org/>`_ 0.19 or later: Used for
   deblending segmented sources.
 
 * `scikit-learn <https://scikit-learn.org/>`_ 1.0 or later: Used in the

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,7 +11,7 @@ Photutils has the following strict requirements:
 
 * `NumPy <https://numpy.org/>`_ 1.22 or later
 
-* `Astropy`_ 5.0 or later
+* `Astropy`_ 5.1 or later
 
 Photutils also optionally depends on other packages for some features:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ documentation = 'https://photutils.readthedocs.io/en/stable/'
 
 [project.optional-dependencies]
 all = [
-    'scipy>=1.7.0',
+    'scipy>=1.7.2',
     'matplotlib>=3.5',
     'scikit-image>=0.19',
     'scikit-learn>=1.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = ['version']
 requires-python = '>=3.9'
 dependencies = [
     'numpy>=1.22',
-    'astropy>=5.0',
+    'astropy>=5.1',
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{39,310,311}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
     py{39,310,311}-test-numpy{122,123,124,125}
-    py{39,310,311}-test-astropy{50,lts}
+    py{39,310,311}-test-astropy50
     build_docs
     linkcheck
     codestyle
@@ -47,7 +47,6 @@ description =
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
     astropy50: with astropy 5.0.*
-    astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -59,13 +58,12 @@ deps =
     numpy125: numpy==1.25.*
 
     astropy50: astropy==5.0.*
-    astropylts: astropy==5.0.*
 
     oldestdeps: numpy==1.22
     oldestdeps: astropy==5.0
-    oldestdeps: scipy==1.7.0
+    oldestdeps: scipy==1.7.2
     oldestdeps: matplotlib==3.5
-    oldestdeps: scikit-image==0.19.0
+    oldestdeps: scikit-image==0.19
     oldestdeps: scikit-learn==1.0
     oldestdeps: gwcs==0.18
     oldestdeps: pytest-astropy==0.10

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     py{39,310,311}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
     py{39,310,311}-test-numpy{122,123,124,125}
-    py{39,310,311}-test-astropy50
     build_docs
     linkcheck
     codestyle
@@ -46,7 +45,6 @@ description =
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
-    astropy50: with astropy 5.0.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -57,10 +55,8 @@ deps =
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
 
-    astropy50: astropy==5.0.*
-
     oldestdeps: numpy==1.22
-    oldestdeps: astropy==5.0
+    oldestdeps: astropy==5.1
     oldestdeps: scipy==1.7.2
     oldestdeps: matplotlib==3.5
     oldestdeps: scikit-image==0.19

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{39,310,311}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{39,310,311}-test-numpy{122,123,124,125}
+    py{39,310,311}-test-numpy{122,123,124,125,126}
     build_docs
     linkcheck
     codestyle
@@ -45,6 +45,7 @@ description =
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
+    numpy126: with numpy 1.26.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -54,6 +55,7 @@ deps =
     numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
+    numpy126: numpy==1.26.*
 
     oldestdeps: numpy==1.22
     oldestdeps: astropy==5.1


### PR DESCRIPTION
Testing revealed that Astropy 5.1+ is required for a few recent features in photutils.
