### PR TITLE
Force numpy-dev in devdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,9 @@ extras =
     build_docs: docs
 
 commands =
+    # Force numpy-dev after matplotlib downgrades it
+    # (https://github.com/matplotlib/matplotlib/issues/26847)
+    devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
     pytest --pyargs photutils {toxinidir}/docs \
     cov: --cov photutils --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml --cov-report term-missing \


### PR DESCRIPTION
The `contourpy` dependency of matplotlib pins `numpy < 2.0`.