### PR TITLE
Fix source deblending if contrast = 1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ Bug Fixes
   - Fixed a bug where ``SourceGrouper`` would fail if only one source
     was input. [#1617]
 
+- ``photutils.segmentation``
+
+  - Fixed an issue where ``deblend_sources`` and ``SourceFinder`` would
+    raise an error if the ``contrast`` keyword was set to 1 (meaning no
+    deblending). [#1636]
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -461,15 +461,18 @@ class _Deblender:
                                 connectivity=self.footprint)
 
             labels = np.unique(markers[markers != 0])
-            flux_frac = (sum_labels(self.source_data, markers, index=labels)
-                         / self.source_sum)
-            remove_marker = any(flux_frac < self.contrast)
+            if labels.size == 1:  # only 1 source left
+                remove_marker = False
+            else:
+                flux_frac = sum_labels(self.source_data, markers,
+                                       index=labels) / self.source_sum
+                remove_marker = any(flux_frac < self.contrast)
 
-            if remove_marker:
-                # remove only the faintest source (one at a time) because
-                # several faint sources could combine to meet the contrast
-                # criterion
-                markers[markers == labels[np.argmin(flux_frac)]] = 0.0
+                if remove_marker:
+                    # remove only the faintest source (one at a time)
+                    # because several faint sources could combine to meet
+                    # the contrast criterion
+                    markers[markers == labels[np.argmin(flux_frac)]] = 0.0
 
         return markers
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -138,6 +138,9 @@ def deblend_sources(data, segment_img, npixels, *, labels=None, nlevels=32,
     if contrast < 0 or contrast > 1:
         raise ValueError('contrast must be >= 0 and <= 1')
 
+    if contrast == 1:  # no deblending
+        return segment_img.copy()
+
     if mode not in ('exponential', 'linear', 'sinh'):
         raise ValueError('mode must be "exponential", "linear", or "sinh"')
 

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -113,6 +113,25 @@ class TestDeblendSources:
                                 progress_bar=False)
         assert segm2.nlabels == nlabels
 
+    def test_deblend_contrast_levels(self):
+        # regression test for case where contrast = 1.0
+        y, x = np.mgrid[0:51, 0:151]
+        y0 = 25
+        data = (Gaussian2D(9.5, 16, y0, 5, 5)(x, y)
+                + Gaussian2D(51, 30, y0, 3, 3)(x, y)
+                + Gaussian2D(30, 42, y0, 5, 5)(x, y)
+                + Gaussian2D(80, 66, y0, 8, 8)(x, y)
+                + Gaussian2D(71, 88, y0, 8, 8)(x, y)
+                + Gaussian2D(18, 119, y0, 7, 7)(x, y))
+
+        npixels = 5
+        segm = detect_sources(data, 1.0, npixels)
+        for contrast in np.arange(1, 11) / 10.0:
+            segm3 = deblend_sources(data, segm, npixels, mode='linear',
+                                    nlevels=32, contrast=contrast,
+                                    progress_bar=False)
+            assert segm3.nlabels >= 1
+
     def test_deblend_connectivity(self):
         data = np.zeros((51, 51))
         data[15:36, 15:36] = 10.0


### PR DESCRIPTION
This PR fixes an issue where ``deblend_sources`` and ``SourceFinder`` would raise an error if the ``contrast`` keyword was set to 1 (meaning no deblending).