### PR TITLE
Updates to table metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,14 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- The metadata in output tables now contains a timestamp. [#1640]
+
+- Package versions in table metadata are now stored in the "versions"
+  key. [#1640]
+
+- The order of the metadata in a table is now preserved when writing to
+  a file. [#1640]
+
 - ``photutils.segmentation``
 
   - Removed the deprecated ``kernel`` keyword from ``SourceCatalog``.

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -202,7 +202,8 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     calling_args = f"method='{method}', subpixels={subpixels}"
     meta['aperture_photometry_args'] = calling_args
 
-    tbl = QTable(meta=meta)
+    tbl = QTable()
+    tbl.meta.update(meta)  # keep tbl.meta type
 
     positions = np.atleast_2d(apertures[0].positions)
     tbl['id'] = np.arange(positions.shape[0], dtype=int) + 1

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -12,7 +12,7 @@ from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture.core import Aperture, SkyAperture
-from photutils.utils._misc import _get_version_info
+from photutils.utils._misc import _get_meta
 
 __all__ = ['aperture_photometry']
 
@@ -196,9 +196,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
                              'positions.')
 
     # define output table meta data
-    meta = {}
-    meta['name'] = 'Aperture photometry results'
-    meta['version'] = _get_version_info()
+    meta = _get_meta()
     calling_args = f"method='{method}', subpixels={subpixels}"
     meta['aperture_photometry_args'] = calling_args
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -509,7 +509,9 @@ class ApertureStats:
         else:
             table_columns = np.atleast_1d(columns)
 
-        tbl = QTable(meta=self.meta)
+        tbl = QTable()
+        tbl.meta.update(self.meta)  # keep tbl.meta type
+
         for column in table_columns:
             values = getattr(self, column)
 

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -18,7 +18,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 
 from photutils.psf import IntegratedGaussianPRF
-from photutils.utils._misc import _get_version_info
+from photutils.utils._misc import _get_meta
 from photutils.utils._progress_bars import add_progress_bar
 
 __all__ = ['apply_poisson_noise', 'make_noise_image',
@@ -235,9 +235,8 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
     """
     rng = np.random.default_rng(seed)
 
-    meta = {'version': _get_version_info()}
     sources = QTable()
-    sources.meta.update(meta)  # keep sources.meta type
+    sources.meta.update(_get_meta())  # keep sources.meta type
     for param_name, (lower, upper) in param_ranges.items():
         # Generate a column for every item in param_ranges, even if it
         # is not in the model (e.g., flux). However, such columns will be

--- a/photutils/datasets/make.py
+++ b/photutils/datasets/make.py
@@ -236,7 +236,8 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
     rng = np.random.default_rng(seed)
 
     meta = {'version': _get_version_info()}
-    sources = QTable(meta=meta)
+    sources = QTable()
+    sources.meta.update(meta)  # keep sources.meta type
     for param_name, (lower, upper) in param_ranges.items():
         # Generate a column for every item in param_ranges, even if it
         # is not in the model (e.g., flux). However, such columns will be

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -13,7 +13,7 @@ from astropy.utils import lazyproperty
 
 from photutils.detection.core import StarFinderBase, _StarFinderKernel
 from photutils.utils._convolution import _filter_data
-from photutils.utils._misc import _get_version_info
+from photutils.utils._misc import _get_meta
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['DAOStarFinder']
@@ -691,9 +691,8 @@ class _DAOStarFinderCatalog:
         return cat
 
     def to_table(self, columns=None):
-        meta = {'version': _get_version_info()}
         table = QTable()
-        table.meta.update(meta)  # keep table.meta type
+        table.meta.update(_get_meta())  # keep table.meta type
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -692,7 +692,8 @@ class _DAOStarFinderCatalog:
 
     def to_table(self, columns=None):
         meta = {'version': _get_version_info()}
-        table = QTable(meta=meta)
+        table = QTable()
+        table.meta.update(meta)  # keep table.meta type
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -13,7 +13,7 @@ from astropy.utils import lazyproperty
 
 from photutils.detection.core import StarFinderBase, _StarFinderKernel
 from photutils.utils._convolution import _filter_data
-from photutils.utils._misc import _get_version_info
+from photutils.utils._misc import _get_meta
 from photutils.utils._moments import _moments, _moments_central
 from photutils.utils.exceptions import NoDetectionsWarning
 
@@ -529,9 +529,8 @@ class _IRAFStarFinderCatalog:
         return cat
 
     def to_table(self, columns=None):
-        meta = {'version': _get_version_info()}
         table = QTable()
-        table.meta.update(meta)  # keep table.meta type
+        table.meta.update(_get_meta())  # keep table.meta type
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -530,7 +530,8 @@ class _IRAFStarFinderCatalog:
 
     def to_table(self, columns=None):
         meta = {'version': _get_version_info()}
-        table = QTable(meta=meta)
+        table = QTable()
+        table.meta.update(meta)  # keep table.meta type
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -9,7 +9,7 @@ import warnings
 import numpy as np
 from astropy.table import QTable
 
-from photutils.utils._misc import _get_version_info
+from photutils.utils._misc import _get_meta
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['find_peaks']
@@ -175,10 +175,10 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         return None
 
     # construct the output table
-    meta = {'version': _get_version_info()}
     colnames = ['x_peak', 'y_peak', 'peak_value']
     coldata = [x_peaks, y_peaks, peak_values]
-    table = QTable(coldata, names=colnames, meta=meta)
+    table = QTable(coldata, names=colnames)
+    table.meta.update(_get_meta())  # keep table.meta type
 
     if wcs is not None:
         skycoord_peaks = wcs.pixel_to_world(x_peaks, y_peaks)

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -388,7 +388,8 @@ class _StarFinderCatalog:
 
     def to_table(self, columns=None):
         meta = {'version': _get_version_info()}
-        table = QTable(meta=meta)
+        table = QTable()
+        table.meta.update(meta)  # keep table.meta type
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -13,7 +13,7 @@ from astropy.utils import lazyproperty
 
 from photutils.detection.core import StarFinderBase
 from photutils.utils._convolution import _filter_data
-from photutils.utils._misc import _get_version_info
+from photutils.utils._misc import _get_meta
 from photutils.utils._moments import _moments, _moments_central
 from photutils.utils.exceptions import NoDetectionsWarning
 
@@ -387,9 +387,8 @@ class _StarFinderCatalog:
         return cat
 
     def to_table(self, columns=None):
-        meta = {'version': _get_version_info()}
         table = QTable()
-        table.meta.update(meta)  # keep table.meta type
+        table.meta.update(_get_meta())  # keep table.meta type
         if columns is None:
             columns = self.default_columns
         for column in columns:

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -823,7 +823,8 @@ def _isophote_list_to_table(isophote_list, columns='main'):
     """
     properties = {}
     meta = {'version': _get_version_info()}
-    isotable = QTable(meta=meta)
+    isotable = QTable()
+    isotable.meta.update(meta)  # keep isotable.meta type
 
     # main_properties: `List`
     # A list of main parameters matching the original names of

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -10,7 +10,7 @@ from astropy.table import QTable
 from photutils.isophote.harmonics import (first_and_second_harmonic_function,
                                           fit_first_and_second_harmonics,
                                           fit_upper_harmonic)
-from photutils.utils._misc import _get_version_info
+from photutils.utils._misc import _get_meta
 
 __all__ = ['Isophote', 'IsophoteList']
 
@@ -822,9 +822,8 @@ def _isophote_list_to_table(isophote_list, columns='main'):
         An astropy QTable with the selected or all isophote parameters.
     """
     properties = {}
-    meta = {'version': _get_version_info()}
     isotable = QTable()
-    isotable.meta.update(meta)  # keep isotable.meta type
+    isotable.meta.update(_get_meta())  # keep isotable.meta type
 
     # main_properties: `List`
     # A list of main parameters matching the original names of

--- a/photutils/psf/photometry_depr.py
+++ b/photutils/psf/photometry_depr.py
@@ -20,7 +20,7 @@ from photutils.detection import DAOStarFinder
 from photutils.psf.groupstars import DAOGroup
 from photutils.psf.utils import (_extract_psf_fitting_names,
                                  get_grouped_psf_model, subtract_psf)
-from photutils.utils._misc import _get_version_info
+from photutils.utils._misc import _get_meta
 from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils.exceptions import NoDetectionsWarning
 
@@ -452,7 +452,7 @@ class BasicPSFPhotometry:
                 else:
                     star_groups.add_column(col, name=name, copy=True)
 
-        star_groups.meta = {'version': _get_version_info()}
+        star_groups.meta = _get_meta()
 
         return star_groups
 
@@ -905,7 +905,7 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
                                                progress_bar=progress_bar,
                                                uncertainty=uncertainty)
 
-        output_table.meta = {'version': _get_version_info()}
+        output_table.meta = _get_meta()
 
         return QTable(output_table)
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -952,7 +952,8 @@ class SourceCatalog:
         else:
             table_columns = np.atleast_1d(columns)
 
-        tbl = QTable(meta=self.meta)
+        tbl = QTable()
+        tbl.meta.update(self.meta)  # keep tbl.meta type
         for column in table_columns:
             values = getattr(self, column)
 

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -3,6 +3,8 @@
 Tests for the catalog module.
 """
 
+from io import StringIO
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -806,9 +808,20 @@ class TestSourceCatalog:
 
     def test_meta(self):
         meta = self.cat.meta
-        attrs = ('localbkg_width', 'apermask_method', 'kron_params')
-        for attr in attrs:
+        date_ver_meta = ['date', 'versions']
+        attrs = ['localbkg_width', 'apermask_method', 'kron_params']
+        for attr in date_ver_meta + attrs:
             assert attr in meta
+        assert list(meta.keys())[0:2] == date_ver_meta
+
+        tbl = self.cat.to_table()
+        assert tbl.meta == self.cat.meta
+
+        out = StringIO()
+        tbl.write(out, format='ascii.ecsv')
+        tbl2 = QTable.read(out.getvalue(), format='ascii.ecsv')
+        # check order of meta keys
+        assert list(tbl2.meta.keys()) == list(tbl.meta.keys())
 
     def test_semode(self):
         self.cat._set_semode()

--- a/photutils/utils/_misc.py
+++ b/photutils/utils/_misc.py
@@ -42,7 +42,7 @@ def _get_date(utc=False):
     Parameters
     ----------
     utz : bool, optional
-        Whether to use the UTZ timezone instead of the local timezone.
+        Whether to use the UTC timezone instead of the local timezone.
 
     Returns
     -------

--- a/photutils/utils/_misc.py
+++ b/photutils/utils/_misc.py
@@ -63,4 +63,4 @@ def _get_meta(utc=False):
     date/time.
     """
     return {'date': _get_date(utc=utc),
-            'version': _get_version_info()}
+            'versions': _get_version_info()}

--- a/photutils/utils/tests/test_misc.py
+++ b/photutils/utils/tests/test_misc.py
@@ -11,11 +11,11 @@ from photutils.utils._misc import _get_meta
 @pytest.mark.parametrize('utc', (False, True))
 def test_get_meta(utc):
     meta = _get_meta(utc)
-    keys = ('date', 'version')
+    keys = ('date', 'versions')
     for key in keys:
         assert key in meta
 
-    versions = meta['version']
+    versions = meta['versions']
     assert isinstance(versions, dict)
     keys = ('Python', 'photutils', 'astropy', 'numpy', 'scipy', 'skimage',
             'sklearn', 'matplotlib', 'gwcs', 'bottleneck')


### PR DESCRIPTION
The metadata in output tables now contains a timestamp (also with package versions).

Package versions in table metadata are now stored in the "versions" key.  Previously, this key was named "version".

Also, the order of the metadata in a table is now preserved when writing to a file.  The astropy Table class currently does not preserve key order when serializing `dict` objects (using yaml).  However, Table.meta currently uses `OrderedDict` and its key order is preserved when serializing.  Here, we use the default meta type to preserve key order.