### PR TITLE
Add option to scale polygon patches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New Features
   - The ``SegmentationImage`` ``make_source_mask`` method now uses a
     much faster implementation of binary dilation. [#1638]
 
+  - Added a ``scale`` keyword to the ``SegmentationImage.to_patches()``
+    method to scale the sizes of the polygon patches. [#1641]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1198,7 +1198,7 @@ class SegmentationImage:
             polygons.append(shape(geo_poly[0]))
         return polygons
 
-    def to_patches(self, *, origin=(0, 0), **kwargs):
+    def to_patches(self, *, origin=(0, 0), scale=1.0, **kwargs):
         """
         Return a list of `~matplotlib.patches.Polygon` objects
         representing each source segment.
@@ -1210,7 +1210,11 @@ class SegmentationImage:
         ----------
         origin : array_like, optional
             The ``(x, y)`` position of the origin of the displayed
-            image.
+            image. This effectively translates the position of the
+            polygons.
+
+        scale : float, optional
+            The size scale factor applied to the polygons.
 
         **kwargs : `dict`
             Any keyword arguments accepted by
@@ -1222,10 +1226,20 @@ class SegmentationImage:
         patch_kwargs = {'edgecolor': 'white', 'facecolor': 'none'}
         patch_kwargs.update(kwargs)
 
+        # This is the shapely equivalent for patches instead of using
+        # self._geo_polygons below.
+        # patches = []
+        # for poly in self.polygons:
+        #     x = np.array(poly.exterior.coords.xy[0])
+        #     y = np.array(poly.exterior.coords.xy[1])
+        #     xy = np.column_stack((x, y)) - origin - np.array((0.5, 0.5))
+        #     patches.append(Polygon(xy, **patch_kwargs))
+
         patches = []
         for geo_poly in self._geo_polygons:
             xy = (np.array(geo_poly[0]['coordinates'][0]) - origin
                   - np.array((0.5, 0.5)))
+            xy *= scale
             patches.append(Polygon(xy, **patch_kwargs))
 
         return patches

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -413,6 +413,12 @@ class TestSegmentationImage:
         assert isinstance(patches[0], Polygon)
         assert patches[0].get_edgecolor() == (0, 0, 1, 1)
 
+        scale = 2.0
+        patches2 = self.segm.to_patches(scale=scale)
+        v1 = patches[0].get_verts()
+        v2 = patches2[0].get_verts()
+        assert_allclose(v2, v1 * scale)
+
         patches = self.segm.plot_patches(edgecolor='red')
         assert isinstance(patches[0], Polygon)
         assert patches[0].get_edgecolor() == (1, 0, 0, 1)


### PR DESCRIPTION
This PR adds a `scale` keyword to `SegmentationImage.to_patches` to scale the size of the polygon patches.