### PR TITLE
Fix xy coordinates of SegmentationImage polygon vertices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New Features
     much faster implementation of binary dilation. [#1638]
 
   - Added a ``scale`` keyword to the ``SegmentationImage.to_patches()``
-    method to scale the sizes of the polygon patches. [#1641]
+    method to scale the sizes of the polygon patches. [#1641, #1646]
 
 Bug Fixes
 ^^^^^^^^^
@@ -30,6 +30,9 @@ Bug Fixes
   - Fixed an issue where ``deblend_sources`` and ``SourceFinder`` would
     raise an error if the ``contrast`` keyword was set to 1 (meaning no
     deblending). [#1636]
+
+  - Fixed an issue where the vertices of the ``SegmentationImage``
+    ``polygons`` were shifted by 0.5 pixels in both x and y. [#1646]
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -404,6 +404,16 @@ class TestSegmentationImage:
         assert len(polygons) == self.segm.nlabels
         assert isinstance(polygons[0], Polygon)
 
+        data = np.zeros((5, 5), dtype=int)
+        data[2, 2] = 10
+        segm = SegmentationImage(data)
+        polygons = segm.polygons
+        assert len(polygons) == 1
+        verts = np.array(polygons[0].exterior.coords)
+        expected_verts = np.array([[1.5, 1.5], [1.5, 2.5], [2.5, 2.5],
+                                   [2.5, 1.5], [1.5, 1.5]])
+        assert_equal(verts, expected_verts)
+
     @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_patches(self):
@@ -417,7 +427,8 @@ class TestSegmentationImage:
         patches2 = self.segm.to_patches(scale=scale)
         v1 = patches[0].get_verts()
         v2 = patches2[0].get_verts()
-        assert_allclose(v2, v1 * scale)
+        v3 = scale * (v1 + 0.5) - 0.5
+        assert_allclose(v2, v3)
 
         patches = self.segm.plot_patches(edgecolor='red')
         assert isinstance(patches[0], Polygon)


### PR DESCRIPTION
This PR fixes an issue where the vertices of the `SegmentationImage` `polygons` were shifted by 0.5 pixels in both x and y.  This is because `rasterio.features.shapes` uses a coordinate frame with the (0, 0) origin at the *lower-left* corner of the lower-left pixel.