### PR TITLE
Use single quotes for consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,8 @@ repos:
         # source.
       - id: detect-private-key
         # Checks for the existence of private keys.
+      - id: double-quote-string-fixer
+        # Replace double-quoted strings with single-quoted strings.
       - id: end-of-file-fixer
         # Makes sure files end in a newline and only a newline.
         exclude: ".*(svg.*|extern.*)$"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,7 +170,7 @@ nitpick_ignore = []
 nitpick_filename = 'nitpick-exceptions.txt'
 if os.path.isfile(nitpick_filename):
     for line in open(nitpick_filename):
-        if line.strip() == "" or line.startswith("#"):
+        if line.strip() == '' or line.startswith('#'):
             continue
         dtype, target = line.split(None, 1)
         target = target.strip()

--- a/photutils/__init__.py
+++ b/photutils/__init__.py
@@ -91,7 +91,7 @@ def _get_bibtex():
         refs = citation.read().split('@software')[1:]
         if len(refs) == 0:
             return ''
-        bibtexreference = f"@software{refs[0]}"
+        bibtexreference = f'@software{refs[0]}'
     return bibtexreference
 
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -431,8 +431,8 @@ class SkyCircularAnnulus(SkyAperture):
 
     def __init__(self, positions, r_in, r_out):
         if r_in.unit.physical_type != r_out.unit.physical_type:
-            raise ValueError("r_in and r_out should either both be angles "
-                             "or in pixels.")
+            raise ValueError('r_in and r_out should either both be angles '
+                             'or in pixels.')
 
         self.positions = positions
         self.r_in = r_in

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -373,7 +373,7 @@ class Background2D:
 
     def _sigmaclip_boxes(self):
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=AstropyUserWarning)
+            warnings.simplefilter('ignore', category=AstropyUserWarning)
             if self.sigma_clip is not None:
                 self._box_data = self.sigma_clip(self._box_data, axis=1,
                                                  masked=False)

--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -14,7 +14,7 @@ except ImportError:
     ASTROPY_HEADER = False
 
 # do not remove until we drop support for NumPy < 2.0
-if minversion(np, "2.0.0.dev0+git20230726"):
+if minversion(np, '2.0.0.dev0+git20230726'):
     np.set_printoptions(legacy='1.25')
 
 

--- a/photutils/isophote/fitter.py
+++ b/photutils/isophote/fitter.py
@@ -162,7 +162,7 @@ class EllipseFitter:
             # This may result in an infinite loop.
             if len(values[2]) < 1:
                 s = str(sample.geometry.sma)
-                log.warning("Too small sample to warrant a fit. SMA is " + s)
+                log.warning('Too small sample to warrant a fit. SMA is ' + s)
                 sample.geometry.fix = fixed_parameters
                 return Isophote(sample, i + 1, False, 3)
 

--- a/photutils/isophote/harmonics.py
+++ b/photutils/isophote/harmonics.py
@@ -17,7 +17,7 @@ def _least_squares_fit(optimize_func, parameters):
     solution = leastsq(optimize_func, parameters, full_output=True)
 
     if solution[4] > 4:
-        raise RuntimeError("Error in least squares fit: " + solution[3])
+        raise RuntimeError('Error in least squares fit: ' + solution[3])
 
     # return coefficients and covariance matrix
     return (solution[0], solution[1])

--- a/photutils/isophote/tests/test_regression.py
+++ b/photutils/isophote/tests/test_regression.py
@@ -87,8 +87,8 @@ def test_regression(name, integrmode=BILINEAR, verbose=False):
     isophote_list = ellipse.fit_image()
     # isophote_list = ellipse.fit_image(sclip=2.0, nclip=3)
 
-    fmt = ("%5.2f  %6.1f    %8.3f %8.3f %8.3f        %9.5f  %6.2f   "
-           "%6.2f %6.2f   %5.2f   %4d  %3d  %3d  %2d")
+    fmt = ('%5.2f  %6.1f    %8.3f %8.3f %8.3f        %9.5f  %6.2f   '
+           '%6.2f %6.2f   %5.2f   %4d  %3d  %3d  %2d')
 
     for row in range(nrows):
         try:
@@ -154,18 +154,18 @@ def test_regression(name, integrmode=BILINEAR, verbose=False):
         stop_d = 0 if stop_i == stop_t else -1
 
         if verbose:
-            print("* data " + fmt % (sma_i, intens_i, int_err_i, pix_stddev_i,
+            print('* data ' + fmt % (sma_i, intens_i, int_err_i, pix_stddev_i,
                                      rms_i, ellip_i, pa_i, x0_i, y0_i, rerr_i,
                                      ndata_i, nflag_i, niter_i, stop_i))
-            print("  ref  " + fmt % (sma_t, intens_t, int_err_t, pix_stddev_t,
+            print('  ref  ' + fmt % (sma_t, intens_t, int_err_t, pix_stddev_t,
                                      rms_t, ellip_t, pa_t, x0_t, y0_t, rerr_t,
                                      ndata_t, nflag_t, niter_t, stop_t))
-            print("  diff " + fmt % (sma_d, intens_d, int_err_d, pix_stddev_d,
+            print('  diff ' + fmt % (sma_d, intens_d, int_err_d, pix_stddev_d,
                                      rms_d, ellip_d, pa_d, x0_d, y0_d, rerr_d,
                                      ndata_d, nflag_d, niter_d, stop_d))
             print()
 
-        if name == "synth_highsnr" and integrmode == BILINEAR:
+        if name == 'synth_highsnr' and integrmode == BILINEAR:
             assert abs(x0_d) <= 0.21
             assert abs(y0_d) <= 0.21
 

--- a/photutils/psf/griddedpsfmodel.py
+++ b/photutils/psf/griddedpsfmodel.py
@@ -242,7 +242,7 @@ class GriddedPSFModelRead(registry.UnifiedReadWrite):
         A gridded ePSF Model corresponding to FITS file contents.
     """
     def __init__(self, instance, cls):
-        super().__init__(instance, cls, "read", registry=None)
+        super().__init__(instance, cls, 'read', registry=None)
         # uses default global registry
 
     def __call__(self, *args, **kwargs):

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -137,7 +137,7 @@ class FittableImageModel(Fittable2DModel):
 
         if normalization_correction <= 0:
             raise ValueError("'normalization_correction' must be strictly "
-                             "positive.")
+                             'positive.')
         self._normalization_correction = normalization_correction
         self._normalization_constant = 1.0 / self._normalization_correction
 
@@ -150,7 +150,7 @@ class FittableImageModel(Fittable2DModel):
         self._ny, self._nx = self._data.shape
         self._shape = self._data.shape
         if self._data.size < 1:
-            raise ValueError("Image data array cannot be zero-sized.")
+            raise ValueError('Image data array cannot be zero-sized.')
 
         # set the origin of the coordinate system in image's pixel grid:
         self.origin = origin
@@ -225,9 +225,9 @@ class FittableImageModel(Fittable2DModel):
             else:
                 self._normalization_constant = 1.0
                 self._normalization_status = 1
-                warnings.warn("Overflow encountered while computing "
-                              "normalization constant. Normalization "
-                              "constant will be set to 1.", NonNormalizable)
+                warnings.warn('Overflow encountered while computing '
+                              'normalization constant. Normalization '
+                              'constant will be set to 1.', NonNormalizable)
 
         else:
             self._normalization_status = 2
@@ -335,8 +335,8 @@ class FittableImageModel(Fittable2DModel):
         elif hasattr(origin, '__iter__') and len(origin) == 2:
             self._x_origin, self._y_origin = origin
         else:
-            raise TypeError("Parameter 'origin' must be either None or an "
-                            "iterable with two elements.")
+            raise TypeError('Parameter "origin" must be either None or an '
+                            'iterable with two elements.')
 
     @property
     def x_origin(self):
@@ -426,8 +426,8 @@ class FittableImageModel(Fittable2DModel):
                 degx = int(degree)
                 degy = int(degree)
             if degx < 0 or degy < 0:
-                raise ValueError("Interpolator degree must be a non-negative "
-                                 "integer")
+                raise ValueError('Interpolator degree must be a non-negative '
+                                 'integer')
         else:
             degx = 3
             degy = 3
@@ -588,8 +588,8 @@ class EPSFModel(FittableImageModel):
         elif (hasattr(origin, '__iter__') and len(origin) == 2):
             self._x_origin, self._y_origin = origin
         else:
-            raise TypeError("Parameter 'origin' must be either None or an "
-                            "iterable with two elements.")
+            raise TypeError('Parameter "origin" must be either None or an '
+                            'iterable with two elements.')
 
     def compute_interpolator(self, **kwargs):
         """
@@ -640,8 +640,8 @@ class EPSFModel(FittableImageModel):
                 degx = int(degree)
                 degy = int(degree)
             if degx < 0 or degy < 0:
-                raise ValueError("Interpolator degree must be a non-negative "
-                                 "integer")
+                raise ValueError('Interpolator degree must be a non-negative '
+                                 'integer')
         else:
             degx = 3
             degy = 3

--- a/photutils/psf/photometry_depr.py
+++ b/photutils/psf/photometry_depr.py
@@ -509,7 +509,7 @@ class BasicPSFPhotometry:
         unc_tab = QTable()
         for param, isfixed in self.psf_model.fixed.items():
             if not isfixed:
-                unc_tab.add_column(Column(name=param + "_unc"))
+                unc_tab.add_column(Column(name=param + '_unc'))
 
         y, x = np.indices(image.shape)
 
@@ -616,7 +616,7 @@ class BasicPSFPhotometry:
         unc_tab = QTable()
         for param_name in self.psf_model.param_names:
             if not self.psf_model.fixed[param_name]:
-                unc_tab.add_column(Column(name=param_name + "_unc",
+                unc_tab.add_column(Column(name=param_name + '_unc',
                                           data=np.empty(star_group_size)))
 
         k = 0
@@ -819,10 +819,10 @@ class IterativelySubtractedPSFPhotometry(BasicPSFPhotometry):
     @finder.setter
     def finder(self, value):
         if value is None:
-            raise ValueError("finder cannot be None for "
-                             "IterativelySubtractedPSFPhotometry - you may "
-                             "want to use BasicPSFPhotometry. Please see the "
-                             "Detection section on photutils documentation.")
+            raise ValueError('finder cannot be None for '
+                             'IterativelySubtractedPSFPhotometry - you may '
+                             'want to use BasicPSFPhotometry. Please see the '
+                             'Detection section on photutils documentation.')
         self._finder = value
 
     def do_photometry(self, image, *, mask=None, init_guesses=None,

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -154,7 +154,7 @@ class TestPRFAdapter:
         mof.amplitude = (mof.alpha - 1) / (np.pi * mof.gamma**2)
         return mof
 
-    @pytest.mark.parametrize("adapterkwargs", [
+    @pytest.mark.parametrize('adapterkwargs', [
         {'xname': 'x_0', 'yname': 'y_0', 'fluxname': None,
          'renormalize_psf': False},
         {'xname': None, 'yname': None, 'fluxname': None,
@@ -171,7 +171,7 @@ class TestPRFAdapter:
         prf.flux = 1.2
         prf(0, 0)
 
-    @pytest.mark.parametrize("adapterkwargs", [
+    @pytest.mark.parametrize('adapterkwargs', [
         {'xname': 'x_0', 'yname': 'y_0', 'fluxname': None,
          'renormalize_psf': True},
         {'xname': 'x_0', 'yname': 'y_0', 'fluxname': None,
@@ -198,7 +198,7 @@ class TestPRFAdapter:
                                   lambda x: 1.5)
         assert_allclose(np.sum(evalmod), integrand, atol=itol * 10)
 
-    @pytest.mark.parametrize("adapterkwargs", [
+    @pytest.mark.parametrize('adapterkwargs', [
         {'xname': 'x_0', 'yname': 'y_0', 'fluxname': None,
          'renormalize_psf': False},
         {'xname': None, 'yname': None, 'fluxname': None,

--- a/photutils/psf/tests/test_photometry-depr.py
+++ b/photutils/psf/tests/test_photometry-depr.py
@@ -114,7 +114,7 @@ sources3['iter_detected'] = [1, 2]
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.parametrize("sigma_psf, sources", [(sigma_psfs[2], sources3)])
+@pytest.mark.parametrize('sigma_psf, sources', [(sigma_psfs[2], sources3)])
 def test_psf_photometry_niters(sigma_psf, sources):
     img_shape = (32, 32)
     # generate image with read-out noise (Gaussian) and
@@ -161,7 +161,7 @@ def test_psf_photometry_niters(sigma_psf, sources):
                             'different than None')
 @pytest.mark.filterwarnings('ignore:No sources were found')
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.parametrize("sigma_psf, sources",
+@pytest.mark.parametrize('sigma_psf, sources',
                          [(sigma_psfs[0], sources1),
                           (sigma_psfs[1], sources2)])
 def test_psf_photometry_oneiter(sigma_psf, sources):
@@ -378,8 +378,8 @@ PARS_TO_OUTPUT_1 = PARS_TO_OUTPUT_0.copy()
 PARS_TO_OUTPUT_1['sigma_fit'] = 'sigma'
 
 
-@pytest.mark.parametrize("actual_pars_to_set, actual_pars_to_output,"
-                         "is_sigma_fixed", [(PARS_TO_SET_0, PARS_TO_OUTPUT_0,
+@pytest.mark.parametrize('actual_pars_to_set, actual_pars_to_output,'
+                         'is_sigma_fixed', [(PARS_TO_SET_0, PARS_TO_OUTPUT_0,
                                              True),
                                             (PARS_TO_SET_1, PARS_TO_OUTPUT_1,
                                              False)])
@@ -558,7 +558,7 @@ def test_psf_photometry_gaussian():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.parametrize("renormalize_psf", (True, False))
+@pytest.mark.parametrize('renormalize_psf', (True, False))
 def test_psf_photometry_gaussian2(renormalize_psf):
     """
     Test psf_photometry with Gaussian PSF model from Astropy.
@@ -633,7 +633,7 @@ def test_psf_fitting_data_on_edge():
 @pytest.mark.filterwarnings('ignore:Both init_guesses and finder '
                             'are different than None')
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.parametrize("sigma_psf, sources", [(sigma_psfs[2], sources3)])
+@pytest.mark.parametrize('sigma_psf, sources', [(sigma_psfs[2], sources3)])
 def test_psf_extra_output_cols(sigma_psf, sources):
     """
     Test the handling of a non-None extra_output_cols
@@ -966,7 +966,7 @@ def test_subshape_invalid():
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.skipif(not minversion(astropy, '5.3'),
                     reason='astropy 5.3 is required')
-@pytest.mark.parametrize("sigma_psf, sources",
+@pytest.mark.parametrize('sigma_psf, sources',
                          [(sigma_psfs[0], sources1),
                           (sigma_psfs[1], sources2)])
 def test_psf_photometry_oneiter_uncert(sigma_psf, sources):

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -48,7 +48,7 @@ for x, y, flux in INTAB:
                               mode='oversample')
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def moffimg():
     """
     This fixture requires scipy so don't call it from non-scipy tests
@@ -93,7 +93,7 @@ def test_moffat_fitting(moffimg):
 
 # we set the tolerances in flux to be 2-3% because the shape paraameters of
 # the guessed version are known to be wrong.
-@pytest.mark.parametrize("prepkwargs,tols", [
+@pytest.mark.parametrize('prepkwargs,tols', [
                          (dict(xname='x_0', yname='y_0', fluxname=None,
                                renormalize_psf=True), (1e-3, 0.02)),
                          (dict(xname=None, yname=None, fluxname=None,


### PR DESCRIPTION
This PR adds the `double-quote-string-fixer` hook to pre-commit to replace double-quoted strings with single-quoted strings.