### PR TITLE
Segmentation imshow improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,16 @@ New Features
   - Added a ``scale`` keyword to the ``SegmentationImage.to_patches()``
     method to scale the sizes of the polygon patches. [#1641, #1646]
 
+  - Improved the ``SegmentationImage`` ``imshow`` method to ensure that
+    labels are plotted with unique colors. [#1649]
+
+  - Added a ``imshow_map`` method to ``SegmentationImage`` for plotting
+    segmentation images with a small number of non-consecutive labels.
+    [#1649]
+
+  - Added a ``reset_cmap`` method to ``SegmentationImage`` for resetting
+    the colormap to a new random colormap. [#1649]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -501,6 +501,20 @@ class SegmentationImage:
                                background_color=background_color,
                                seed=seed)
 
+    def reset_cmap(self, seed=None):
+        """
+        Reset the colormap (`cmap` attribute) to a new random colormap.
+
+        Parameters
+        ----------
+        seed : int, optional
+            A seed to initialize the `numpy.random.BitGenerator`. If
+            `None`, then fresh, unpredictable entropy will be pulled
+            from the OS. Separate function calls with the same ``seed``
+            will generate the same colormap.
+        """
+        self.cmap = self.make_cmap(background_color='#000000ff', seed=seed)
+
     @lazyproperty
     def cmap(self):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1323,8 +1323,8 @@ class SegmentationImage:
         Display the segmentation image in a matplotlib
         `~matplotlib.axes.Axes` instance.
 
-        The segmentation image will be displayed with no interpolation
-        and with the origin set to "lower".
+        The segmentation image will be displayed with "nearest"
+        interpolation and with the origin set to "lower".
 
         Parameters
         ----------
@@ -1372,7 +1372,10 @@ class SegmentationImage:
                              [7, 7, 0, 5, 5, 5],
                              [7, 7, 0, 0, 5, 5]])
             segm = SegmentationImage(data)
-            segm.imshow(figsize=(5, 5))
+
+            fig, ax = plt.subplots()
+            im = segm.imshow(ax=ax)
+            fig.colorbar(im, ax=ax)
         """
         import matplotlib.pyplot as plt
 
@@ -1382,7 +1385,8 @@ class SegmentationImage:
             cmap = self.cmap
 
         return ax.imshow(self.data, cmap=cmap, interpolation='nearest',
-                         origin='lower', alpha=alpha)
+                         origin='lower', alpha=alpha, vmin=-0.5,
+                         vmax=self.max_label + 0.5)
 
 
 class Segment:

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -194,6 +194,13 @@ class TestSegmentationImage:
             _ = segm.bbox
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_reset_cmap(self):
+        segm = self.segm.copy()
+        cmap = segm.cmap.copy()
+        segm.reset_cmap(seed=123)
+        assert not np.array_equal(cmap.colors, segm.cmap.colors)
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_make_cmap(self):
         cmap = self.segm.make_cmap()
         assert len(cmap.colors) == (self.segm.max_label + 1)
@@ -393,6 +400,9 @@ class TestSegmentationImage:
         from matplotlib.image import AxesImage
 
         axim = self.segm.imshow(figsize=(5, 5))
+        assert isinstance(axim, AxesImage)
+
+        axim, cbar = self.segm.imshow_map(figsize=(5, 5))
         assert isinstance(axim, AxesImage)
 
     @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')


### PR DESCRIPTION
This PR makes three improvements to `Segmentation` image plotting:

- Improved the ``imshow`` method to ensure that labels are plotted with unique colors
- Added a ``imshow_map`` method for plotting segmentation images with a small number of non-consecutive labels.
- Added a ``reset_cmap`` method for resetting the colormap to a new random colormap.