### PR TITLE
Add codespell to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,14 @@ repos:
     hooks:
       - id: yesqa
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        args: ["--write-changes", "--ignore-words-list", "exten, conver, fom"]
+        additional_dependencies:
+          - tomli
+
   # - repo: https://github.com/MarcoGorelli/absolufy-imports
   #   rev: v0.3.1
   #   hooks:

--- a/docs/whats_new/1.6.rst
+++ b/docs/whats_new/1.6.rst
@@ -16,7 +16,7 @@ New centroids available in SourceCatalog
 New centroids were added to the
 :class:`~photutils.segmentation.SourceCatalog` class, including
 iteratively-calculated "windowed" centroids and centroids calculated by
-fitting a 2D quadratic polynomical to the unmasked pixels in the source
+fitting a 2D quadratic polynomial to the unmasked pixels in the source
 segment.
 
 The "windowed" centroids are equivalent the SourceExtractors
@@ -52,7 +52,7 @@ New ImageDepth class
 ====================
 
 A new :class:`~photutils.utils.ImageDepth` class was added to compute
-the limitiing fluxes and magnitudes of an image.o
+the limiting fluxes and magnitudes of an image.
 
 
 ApertureStats

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -17,7 +17,7 @@ __all__ = ['ProfileBase']
 
 class ProfileBase(metaclass=abc.ABCMeta):
     """
-    Abtract base class for profile classes.
+    Abstract base class for profile classes.
 
     Parameters
     ----------

--- a/photutils/psf/griddedpsfmodel.py
+++ b/photutils/psf/griddedpsfmodel.py
@@ -186,7 +186,7 @@ class ModelGridPlotMixin:
             cbar.ax.set_yscale('log')
 
         if self.meta.get('detector', '') == 'NRCSW':
-            # NIRCam NRCSW STDPSF files constain all detectors.
+            # NIRCam NRCSW STDPSF files contain all detectors.
             # The plot gets extra divider lines and SCA name labels.
             nxpsfs = len(self._xgrid)
             nypsfs = len(self._ygrid)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -823,7 +823,7 @@ class PSFPhotometry:
             model parameters for each source. If the x and y values are
             not input, then the ``finder`` keyword must be defined. If
             the flux values are not input, then the ``aperture_radius``
-            keyword must be defined. Note that the initital flux
+            keyword must be defined. Note that the initial flux
             values refer to the model flux parameters and are not
             corrected for local background values (computed using
             ``localbkg_estimator`` or input in a ``local_bkg`` column)
@@ -861,7 +861,7 @@ class PSFPhotometry:
               * ``x_init``, ``x_fit``, ``x_err`` : the initial, fit, and
                 error of the source x center
               * ``y_init``, ``y_fit``, ``y_err`` : the initial, fit, and
-                error of the soruce y center
+                error of the source y center
               * ``flux_init``, ``flux_fit``, ``flux_err`` : the initial,
                 fit, and error of the source flux
               * ``npixfit`` : the number of unmasked pixels used to fit
@@ -1253,7 +1253,7 @@ class IterativePSFPhotometry:
               * ``x_init``, ``x_fit``, ``x_err`` : the initial, fit, and
                 error of the source x center
               * ``y_init``, ``y_fit``, ``y_err`` : the initial, fit, and
-                error of the soruce y center
+                error of the source y center
               * ``flux_init``, ``flux_fit``, ``flux_err`` : the initial,
                 fit, and error of the source flux
               * ``npixfit`` : the number of unmasked pixels used to fit

--- a/photutils/psf/photometry_depr.py
+++ b/photutils/psf/photometry_depr.py
@@ -119,7 +119,7 @@ class BasicPSFPhotometry:
     ``init_guesses`` (keyword argument for ``do_photometry``) are both
     not ``None``. In this case, ``finder`` is ignored and initial
     guesses are taken from ``init_guesses``. In addition, an warning is
-    raised to remaind the user about this behavior.
+    raised to remind the user about this behavior.
 
     If there are problems with fitting large groups, change the
     parameters of the grouping algorithm to reduce the number of sources

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -426,7 +426,7 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):
 
             flux = epsf.flux
 
-            # if theres a unit, those should also all be the same
+            # if there's a unit, those should also all be the same
             try:
                 dat_unit = epsf.data.unit
             except AttributeError:

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1479,7 +1479,7 @@ class SourceCatalog:
         The window centroid is computed using an iterative algorithm
         to derive a more accurate centroid. It is equivalent to
         `SourceExtractor`_'s XWIN_IMAGE and YWIN_IMAGE parameters. See
-        `centroid_win` for futher details about the algorithm.
+        `centroid_win` for further details about the algorithm.
         """
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.centroid_win - origin
@@ -1490,7 +1490,7 @@ class SourceCatalog:
     def cutout_centroid_quad(self):
         """
         The ``(x, y)`` centroid coordinate, relative to the cutout data,
-        calculated by fitting a 2D quadratic polynomical to the unmasked
+        calculated by fitting a 2D quadratic polynomial to the unmasked
         pixels in the source segment.
 
         Notes
@@ -1552,7 +1552,7 @@ class SourceCatalog:
     def centroid_quad(self):
         """
         The ``(x, y)`` centroid coordinate, calculated by fitting a 2D
-        quadratic polynomical to the unmasked pixels in the source
+        quadratic polynomial to the unmasked pixels in the source
         segment.
 
         Notes
@@ -1581,7 +1581,7 @@ class SourceCatalog:
     def xcentroid_quad(self):
         """
         The ``x`` coordinate of the centroid (`centroid_quad`),
-        calculated by fitting a 2D quadratic polynomical to the unmasked
+        calculated by fitting a 2D quadratic polynomial to the unmasked
         pixels in the source segment.
         """
         if self.isscalar:
@@ -1596,7 +1596,7 @@ class SourceCatalog:
     def ycentroid_quad(self):
         """
         The ``y`` coordinate of the centroid (`centroid_quad`),
-        calculated by fitting a 2D quadratic polynomical to the unmasked
+        calculated by fitting a 2D quadratic polynomial to the unmasked
         pixels in the source segment.
         """
         if self.isscalar:
@@ -1659,7 +1659,7 @@ class SourceCatalog:
     def sky_centroid_quad(self):
         """
         The sky coordinate of the centroid (`centroid_quad`), calculated
-        by fitting a 2D quadratic polynomical to the unmasked pixels in
+        by fitting a 2D quadratic polynomial to the unmasked pixels in
         the source segment.
 
         The output coordinate frame is the same as the input ``wcs``.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1314,7 +1314,7 @@ class SegmentationImage:
             The scale factor applied to the polygon vertices.
 
         labels: int or array of int, optional
-            The label numbers whose polygons are to be ploted. If
+            The label numbers whose polygons are to be plotted. If
             `None`, the polygons for all labels will be plotted.
 
         **kwargs : `dict`


### PR DESCRIPTION
The following words are ignored: 

- "exten" for "extension" (psf)
- "conver" for "convergence" (isophote)
- "fom" for "figure of merit" (isophote)