### PR TITLE
Change meta key name back to version

### DIFF
--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -808,11 +808,9 @@ class TestSourceCatalog:
 
     def test_meta(self):
         meta = self.cat.meta
-        date_ver_meta = ['date', 'versions']
         attrs = ['localbkg_width', 'apermask_method', 'kron_params']
-        for attr in date_ver_meta + attrs:
+        for attr in attrs:
             assert attr in meta
-        assert list(meta.keys())[0:2] == date_ver_meta
 
         tbl = self.cat.to_table()
         assert tbl.meta == self.cat.meta

--- a/photutils/utils/_misc.py
+++ b/photutils/utils/_misc.py
@@ -63,4 +63,4 @@ def _get_meta(utc=False):
     date/time.
     """
     return {'date': _get_date(utc=utc),
-            'versions': _get_version_info()}
+            'version': _get_version_info()}

--- a/photutils/utils/tests/test_misc.py
+++ b/photutils/utils/tests/test_misc.py
@@ -11,11 +11,11 @@ from photutils.utils._misc import _get_meta
 @pytest.mark.parametrize('utc', (False, True))
 def test_get_meta(utc):
     meta = _get_meta(utc)
-    keys = ('date', 'versions')
+    keys = ('date', 'version')
     for key in keys:
         assert key in meta
 
-    versions = meta['versions']
+    versions = meta['version']
     assert isinstance(versions, dict)
     keys = ('Python', 'photutils', 'astropy', 'numpy', 'scipy', 'skimage',
             'sklearn', 'matplotlib', 'gwcs', 'bottleneck')


### PR DESCRIPTION
Revert https://github.com/astropy/photutils/pull/1640/commits/b016c2c6e87879de7c54bfd9035989cae4a83755 because it breaks `jwst`.