### PR TITLE
Fix aperture plot kwargs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Fixed an issue where the aperture ``plot`` method ``**kwargs`` were
+    not reset to the default values when called multiple times. [#1655]
+
 - ``photutils.psf``
 
   - Fixed a bug where ``SourceGrouper`` would fail if only one source

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -630,7 +630,7 @@ class PixelAperture(Aperture):
         xy_positions[:, 0] -= origin[0]
         xy_positions[:, 1] -= origin[1]
 
-        patch_params = self._default_patch_properties
+        patch_params = self._default_patch_properties.copy()
         patch_params.update(kwargs)
 
         return xy_positions, patch_params


### PR DESCRIPTION
This PR fixes an issue where the aperture ``plot`` method ``**kwargs`` were stored and not reset to the default values when called multiple times.