### PR TITLE
Add make_psf_model function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ New Features
   - PSF models output from ``prepare_psf_model`` can now be input into
     the PSF photometry classes. [#1657]
 
+  - Added ``make_psf_model`` function for making a PSF model from a
+    2D Astropy model. Compound models are also supported. [#1658]
+
 - ``photutils.segmentation``
 
   - The ``SegmentationImage`` ``make_source_mask`` method now uses a
@@ -77,6 +80,11 @@ API Changes
 
 - The order of the metadata in a table is now preserved when writing to
   a file. [#1640]
+
+- ``photutils.psf``
+
+  - Deprecated the ``prepare_psf_model`` function. Use the new
+    ``make_psf_model`` function instead. [#1658]
 
 - ``photutils.segmentation``
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -19,7 +19,7 @@ from photutils.datasets import (make_gaussian_prf_sources_image,
                                 make_noise_image, make_test_psf_data)
 from photutils.detection import DAOStarFinder
 from photutils.psf import (IntegratedGaussianPRF, IterativePSFPhotometry,
-                           PSFPhotometry, SourceGrouper, prepare_psf_model)
+                           PSFPhotometry, SourceGrouper, make_psf_model)
 from photutils.psf.photometry_depr import DAOGroup
 from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
@@ -599,17 +599,17 @@ def test_out_of_bounds_centroids():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-def test_prepare_psf_model():
-    norm = False
+def test_make_psf_model():
+    normalize = False
     sigma = 3.0
     amplitude = 1.0 / (2 * np.pi * sigma**2)
     xcen = ycen = 0.0
     psf0 = Gaussian2D(amplitude, xcen, ycen, sigma, sigma)
-    psf1 = prepare_psf_model(psf0, xname='x_mean', yname='y_mean',
-                             renormalize_psf=norm)
-    psf2 = prepare_psf_model(psf0, renormalize_psf=norm)
-    psf3 = prepare_psf_model(psf0, xname='x_mean', renormalize_psf=norm)
-    psf4 = prepare_psf_model(psf0, yname='y_mean', renormalize_psf=norm)
+    psf1 = make_psf_model(psf0, x_name='x_mean', y_name='y_mean',
+                          normalize=normalize)
+    psf2 = make_psf_model(psf0, normalize=normalize)
+    psf3 = make_psf_model(psf0, x_name='x_mean', normalize=normalize)
+    psf4 = make_psf_model(psf0, y_name='y_mean', normalize=normalize)
 
     yy, xx = np.mgrid[0:101, 0:101]
     psf = psf1.copy()
@@ -620,19 +620,19 @@ def test_prepare_psf_model():
     psf.y_mean_2 = yval
     data = psf(xx, yy) * flux
 
-    fitshape = 7
+    fit_shape = 7
     init_params = Table([[46.1], [57.3], [7.1]],
                         names=['x_0', 'y_0', 'flux_0'])
-    phot1 = PSFPhotometry(psf1, fitshape, aperture_radius=None)
+    phot1 = PSFPhotometry(psf1, fit_shape, aperture_radius=None)
     tbl1 = phot1(data, init_params=init_params)
 
-    phot2 = PSFPhotometry(psf2, fitshape, aperture_radius=None)
+    phot2 = PSFPhotometry(psf2, fit_shape, aperture_radius=None)
     tbl2 = phot2(data, init_params=init_params)
 
-    phot3 = PSFPhotometry(psf3, fitshape, aperture_radius=None)
+    phot3 = PSFPhotometry(psf3, fit_shape, aperture_radius=None)
     tbl3 = phot3(data, init_params=init_params)
 
-    phot4 = PSFPhotometry(psf4, fitshape, aperture_radius=None)
+    phot4 = PSFPhotometry(psf4, fit_shape, aperture_radius=None)
     tbl4 = phot4(data, init_params=init_params)
 
     assert_allclose((tbl1['x_fit'][0], tbl1['y_fit'][0],

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -252,38 +252,39 @@ def test_prepare_psf_model(moffat_source, prepkwargs, tols):
     """
     Test that prepare_psf_model behaves as expected for fitting.
     """
-    model, (xx, yy, data) = moffat_source
-    fitter = LevMarLSQFitter()
+    with pytest.warns(AstropyDeprecationWarning):
+        model, (xx, yy, data) = moffat_source
+        fitter = LevMarLSQFitter()
 
-    # a close-but-wrong "guessed Moffat"
-    guess_moffat = Moffat2D(x_0=.1, y_0=-.05, gamma=1.01,
-                            amplitude=model.amplitude * 1.01, alpha=4.79)
-    if prepkwargs['renormalize_psf']:
-        # definitely very wrong, so this ensures the re-normalization
-        # works
-        guess_moffat.amplitude = 5.0
+        # a close-but-wrong "guessed Moffat"
+        guess_moffat = Moffat2D(x_0=.1, y_0=-.05, gamma=1.01,
+                                amplitude=model.amplitude * 1.01, alpha=4.79)
+        if prepkwargs['renormalize_psf']:
+            # definitely very wrong, so this ensures the re-normalization
+            # works
+            guess_moffat.amplitude = 5.0
 
-    if prepkwargs['xname'] is None:
-        guess_moffat.x_0 = 0
-    if prepkwargs['yname'] is None:
-        guess_moffat.y_0 = 0
+        if prepkwargs['xname'] is None:
+            guess_moffat.x_0 = 0
+        if prepkwargs['yname'] is None:
+            guess_moffat.y_0 = 0
 
-    psfmod = prepare_psf_model(guess_moffat, **prepkwargs)
-    xytol, fluxtol = tols
+        psfmod = prepare_psf_model(guess_moffat, **prepkwargs)
+        xytol, fluxtol = tols
 
-    fit_psfmod = fitter(psfmod, xx, yy, data)
+        fit_psfmod = fitter(psfmod, xx, yy, data)
 
-    if xytol is not None:
-        assert np.abs(getattr(fit_psfmod, fit_psfmod.xname)) < xytol
-        assert np.abs(getattr(fit_psfmod, fit_psfmod.yname)) < xytol
-    if fluxtol is not None:
-        assert np.abs(1 - getattr(fit_psfmod, fit_psfmod.fluxname)) < fluxtol
+        if xytol is not None:
+            assert np.abs(getattr(fit_psfmod, fit_psfmod.xname)) < xytol
+            assert np.abs(getattr(fit_psfmod, fit_psfmod.yname)) < xytol
+        if fluxtol is not None:
+            assert np.abs(1 - getattr(fit_psfmod, fit_psfmod.fluxname)) < fluxtol
 
-    # ensure the model parameters did not change
-    assert fit_psfmod.psfmodel.gamma == guess_moffat.gamma
-    assert fit_psfmod.psfmodel.alpha == guess_moffat.alpha
-    if prepkwargs['fluxname'] is None:
-        assert fit_psfmod.psfmodel.amplitude == guess_moffat.amplitude
+        # ensure the model parameters did not change
+        assert fit_psfmod.psfmodel.gamma == guess_moffat.gamma
+        assert fit_psfmod.psfmodel.alpha == guess_moffat.alpha
+        if prepkwargs['fluxname'] is None:
+            assert fit_psfmod.psfmodel.amplitude == guess_moffat.amplitude
 
 
 @pytest.mark.filterwarnings('ignore:aperture_radius is None and could not '
@@ -371,9 +372,11 @@ def test_get_grouped_psf_model():
 def prf_model(request):
     # use this instead of pytest.mark.parameterize as we use scipy and
     # it still calls that even if not HAS_SCIPY is set...
-    prfs = [IntegratedGaussianPRF(sigma=1.2),
-            Gaussian2D(x_stddev=2),
-            prepare_psf_model(Gaussian2D(x_stddev=2), renormalize_psf=False)]
+    with pytest.warns(AstropyDeprecationWarning):
+        prfs = [IntegratedGaussianPRF(sigma=1.2),
+                Gaussian2D(x_stddev=2),
+                prepare_psf_model(Gaussian2D(x_stddev=2),
+                                  renormalize_psf=False)]
     return prfs[request.param]
 
 

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -187,6 +187,33 @@ def test_make_psf_model(moffat_source, kwargs, tols):
         assert fit_model[2].amplitude == guess_moffat.amplitude
 
 
+def test_make_psf_model_compound():
+    model = (Const2D(0.0) + Const2D(1.0) + Gaussian2D(1, 5, 5, 1, 1)
+             * Const2D(1.0) * Const2D(1.0))
+    psf_model = make_psf_model(model, x_name='x_mean_2', y_name='y_mean_2',
+                               normalize=True)
+    assert psf_model.x_name == 'x_mean_4'
+    assert psf_model.y_name == 'y_mean_4'
+    assert psf_model.flux_name == 'amplitude_7'
+
+
+def test_make_psf_model_inputs():
+    model = Gaussian2D(1, 5, 5, 1, 1)
+    match = 'parameter name not found in the input model'
+    with pytest.raises(ValueError, match=match):
+        make_psf_model(model, x_name='x_mean_0', y_name='y_mean')
+    with pytest.raises(ValueError, match=match):
+        make_psf_model(model, x_name='x_mean', y_name='y_mean_10')
+
+
+def test_make_psf_model_integral():
+    model = Gaussian2D(1, 5, 5, 1, 1) * Const2D(0.0)
+    match = 'Cannot normalize the model because the integrated flux is zero'
+    with pytest.raises(ValueError, match=match):
+        make_psf_model(model, x_name='x_mean_0', y_name='y_mean_0',
+                       normalize=True)
+
+
 def test_make_psf_model_offset():
     """
     Test to ensure the offset is in the correct direction.

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -56,6 +56,7 @@ def test_InverseShift():
     assert model.fit_deriv(10)[0] == -1.0
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_interpolate_missing_data():
     data = np.arange(100).reshape(10, 10)
     mask = np.zeros_like(data, dtype=bool)
@@ -80,6 +81,7 @@ def test_interpolate_missing_data():
         _interpolate_missing_data(data, mask, method='invalid')
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_integrate_model():
     model = Gaussian2D(1, 5, 5, 1, 1) * Const2D(0.0)
     integral = _integrate_model(model, x_name='x_mean_0', y_name='y_mean_0')
@@ -187,6 +189,7 @@ def test_make_psf_model(moffat_source, kwargs, tols):
         assert fit_model[2].amplitude == guess_moffat.amplitude
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_compound():
     model = (Const2D(0.0) + Const2D(1.0) + Gaussian2D(1, 5, 5, 1, 1)
              * Const2D(1.0) * Const2D(1.0))
@@ -206,6 +209,7 @@ def test_make_psf_model_inputs():
         make_psf_model(model, x_name='x_mean', y_name='y_mean_10')
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_integral():
     model = Gaussian2D(1, 5, 5, 1, 1) * Const2D(0.0)
     match = 'Cannot normalize the model because the integrated flux is zero'

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -158,8 +158,8 @@ def _integrate_model(model, x_name=None, y_name=None, dx=50, dy=50,
     xc = getattr(model, x_name)
     yc = getattr(model, y_name)
 
-    if not np.any(np.isfinite((xc.value, yc.value))):
-        raise ValueError('model x and y position must be finite')
+    if np.any(~np.isfinite((xc.value, yc.value))):
+        raise ValueError('model x and y positions must be finite')
 
     hx = (dx - 1) / 2
     hy = (dy - 1) / 2

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -365,6 +365,7 @@ def make_psf_model(model, *, x_name=None, y_name=None, flux_name=None,
     return psf_model
 
 
+@deprecated('1.9.0', alternative='make_psf_model')
 def prepare_psf_model(psfmodel, *, xname=None, yname=None, fluxname=None,
                       renormalize_psf=True):
     """


### PR DESCRIPTION
This PR adds a `make_psf_model` function that replaces the `prepare_psf_model` function.  The new function is faster when normalizing models (using subsampling) and supports input `CompoundModels`, which the old function did not.  The `prepare_psf_model` function is now deprecated.