### PR TITLE
Fix GriddedPSFModel plot_grid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,10 @@ Bug Fixes
   - Fixed a bug where ``SourceGrouper`` would fail if only one source
     was input. [#1617]
 
+  - Fixed a bug in ``GriddedPSFModel`` ``plot_grid`` where the grid
+    could be plotted incorrectly if the input ``xygrid`` was not sorted
+    in y then x order. [#1661]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where ``deblend_sources`` and ``SourceFinder`` would
@@ -85,6 +89,10 @@ API Changes
 
   - Deprecated the ``prepare_psf_model`` function. Use the new
     ``make_psf_model`` function instead. [#1658]
+
+  - The ``GriddedPSFModel`` now stores the ePSF grid such that it is
+    first sorted by y then by x. As a result, the order of the ``data``
+    and ``xygrid`` attributes may be different. [#1661]
 
 - ``photutils.segmentation``
 

--- a/photutils/psf/tests/test_griddedpsfmodel.py
+++ b/photutils/psf/tests/test_griddedpsfmodel.py
@@ -62,10 +62,15 @@ class TestGriddedPSFModel:
         keys = ['grid_xypos', 'oversampling']
         for key in keys:
             assert key in psfmodel.meta
-        assert len(psfmodel.meta['grid_xypos']) == 16
+        grid_xypos = psfmodel.grid_xypos
+        assert len(grid_xypos) == 16
         assert psfmodel.oversampling == 4
         assert psfmodel.meta['oversampling'] == psfmodel.oversampling
         assert psfmodel.data.shape == (16, 101, 101)
+
+        idx = np.lexsort((grid_xypos[:, 0], grid_xypos[:, 1]))
+        xypos = grid_xypos[idx]
+        assert_allclose(xypos, grid_xypos)
 
     @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_gridded_psf_model_basic_eval(self, psfmodel):


### PR DESCRIPTION
This PR fixed a bug in ``GriddedPSFModel`` ``plot_grid`` where the grid could be plotted incorrectly if the input ``xygrid`` was not sorted in y then x order. The ``GriddedPSFModel`` now stores the ePSF grid such that it is first sorted by y then by x. As a result, the order of the ``data`` and ``xygrid`` attributes may be different.
