### PR TITLE
Check GriddedPSFModel inputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,9 @@ API Changes
     first sorted by y then by x. As a result, the order of the ``data``
     and ``xygrid`` attributes may be different. [#1661]
 
+  - A ``ValueError`` is raised if ``GriddedPSFModel`` is called with x
+    and y arrays that have more than 2 dimensions. [#1662]
+
 - ``photutils.segmentation``
 
   - Removed the deprecated ``kernel`` keyword from ``SourceCatalog``.

--- a/photutils/psf/griddedpsfmodel.py
+++ b/photutils/psf/griddedpsfmodel.py
@@ -291,6 +291,9 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
     bilinearly interpolated to calculate an ePSF model at an arbitrary
     (x, y) detector position.
 
+    When evaluating this model, it cannot be called with x and y arrays
+    that have greater than 2 dimensions.
+
     Parameters
     ----------
     nddata : `~astropy.nddata.NDData`
@@ -611,6 +614,9 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
         """
         Evaluate the `GriddedPSFModel` for the input parameters.
         """
+        if x.ndim > 2:
+            raise ValueError('x and y must be 1D or 2D.')
+
         # NOTE: the astropy base Model.__call__() method converts scalar
         # inputs to size-1 arrays before calling evaluate().
         if not np.isscalar(flux):

--- a/photutils/psf/tests/test_griddedpsfmodel.py
+++ b/photutils/psf/tests/test_griddedpsfmodel.py
@@ -78,6 +78,11 @@ class TestGriddedPSFModel:
         psf = psfmodel.evaluate(x=x, y=y, flux=100, x_0=40, y_0=60)
         assert psf.shape == (100, 100)
 
+        z2, y2, x2 = np.mgrid[0:100, 0:100, 0:100]
+        match = 'x and y must be 1D or 2D'
+        with pytest.raises(ValueError, match=match):
+            psfmodel.evaluate(x=x2, y=y2, flux=100, x_0=40, y_0=60)
+
     @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_gridded_psf_model_eval_outside_grid(self, psfmodel):
         y, x = np.mgrid[-50:50, -50:50]


### PR DESCRIPTION
`GriddedPSFModel` does not work with 3D input x and y arrays.  With this PR, a ``ValueError`` is raised if it is called with x and y arrays that have more than 2 dimensions.

Closes: #1660