### PR TITLE
GriddedPSF oversampling in x and y

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,10 @@ New Features
   - Added ``make_psf_model`` function for making a PSF model from a
     2D Astropy model. Compound models are also supported. [#1658]
 
+  - The ``GriddedPSFModel`` oversampling can now be different in the x
+    and y directions. The ``oversampling`` attribute is now stored as
+    a 1D ``numpy.ndarray`` with two elements. [#1664]
+
 - ``photutils.segmentation``
 
   - The ``SegmentationImage`` ``make_source_mask`` method now uses a
@@ -98,6 +102,9 @@ API Changes
   - The ``GriddedPSFModel`` now stores the ePSF grid such that it is
     first sorted by y then by x. As a result, the order of the ``data``
     and ``xygrid`` attributes may be different. [#1661]
+
+  - The ``oversampling`` attribute is now stored as a 1D
+    ``numpy.ndarray`` with two elements. [#1664]
 
   - A ``ValueError`` is raised if ``GriddedPSFModel`` is called with x
     and y arrays that have more than 2 dimensions. [#1662]

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -11,7 +11,7 @@ from astropy.modeling.models import Const2D, Gaussian2D, Moffat2D
 from astropy.nddata import NDData
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyDeprecationWarning
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from photutils import datasets
 from photutils.detection import find_peaks
@@ -475,8 +475,8 @@ class TestGridFromEPSFs:
         psf_grid = grid_from_epsfs(self.epsfs)
 
         assert np.all(psf_grid.oversampling == self.epsfs[0].oversampling)
-        assert psf_grid.data.shape == (4, psf_grid.oversampling * 25 + 1,
-                                       psf_grid.oversampling * 25 + 1)
+        assert psf_grid.data.shape == (4, psf_grid.oversampling[0] * 25 + 1,
+                                       psf_grid.oversampling[1] * 25 + 1)
 
     def test_grid_xypos(self):
         """
@@ -514,5 +514,5 @@ class TestGridFromEPSFs:
         for key in keys + ['extra_key']:
             assert key in psf_grid.meta
         assert psf_grid.meta['grid_xypos'].sort() == self.grid_xypos.sort()
-        assert psf_grid.meta['oversampling'] == 4
+        assert_equal(psf_grid.meta['oversampling'], [4, 4])
         assert psf_grid.meta['fill_value'] == 0.0

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -692,16 +692,7 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):
         data_arrs.append(epsf.data)
 
         if i == 0:
-            # EPSFModel allows a tuple for oversampling factor in x, y,
-            # but GriddedPSFModel requires it to be a single scalar value.
-            # Keep this condition for now by checking that x and y match
-            if np.isscalar(epsf.oversampling):
-                oversampling = epsf.oversampling
-            else:
-                if epsf.oversampling[0] != epsf.oversampling[1]:
-                    raise ValueError('Oversampling must be the same in x and '
-                                     'y.')
-                oversampling = epsf.oversampling[0]
+            oversampling = epsf.oversampling
 
             # same for fill value and flux, grid will have a single value
             # so it should be the same for all input, and error if not.
@@ -720,14 +711,9 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):
                 pass  # just keep as None
 
         else:
-            if np.isscalar(epsf.oversampling):
-                if epsf.oversampling != oversampling:
-                    raise ValueError('All input EPSFModels must have the same '
-                                     'value for ``oversampling``.')
-                if (epsf.oversampling[0] != epsf.oversampling[1]
-                        != oversampling):
-                    raise ValueError('All input EPSFModels must have the '
-                                     'same value for ``oversampling``.')
+            if np.any(epsf.oversampling != oversampling):
+                raise ValueError('All input EPSFModels must have the same '
+                                 'value for ``oversampling``.')
 
             if epsf.fill_value != fill_value:
                 raise ValueError('All input EPSFModels must have the same '


### PR DESCRIPTION
With this PR, the ``GriddedPSFModel`` oversampling can now be different in the x and y directions. The ``oversampling`` attribute is now stored as a 1D ``numpy.ndarray`` with two elements. 