### PR TITLE
Improve performance of apply_separation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,16 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.datasets``
+
+  - Improved the performance of ``make_test_psf_data`` when generating
+    random coordinates with a minimum separation. [#1668]
+
+- ``photutils.utils``
+
+  - Improved the performance of ``ImageDepth`` when generating
+    random coordinates with a minimum separation. [#1668]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/utils/_coords.py
+++ b/photutils/utils/_coords.py
@@ -18,22 +18,19 @@ def apply_separation(xycoords, min_separation):
     # create a dictionary of nearest neighbors (within min_separation)
     nn = {}
     nn = defaultdict(set)
-    for p1, p2 in xycoords[pairs]:
-        nn[tuple(p1)].add(tuple(p2))
-        nn[tuple(p2)].add(tuple(p1))
+    for i, j in pairs:
+        nn[i].add(j)
+        nn[j].add(i)
 
-    keep = []
-    discard = set()
-    for xycoord in xycoords:
-        xycoord = tuple(xycoord)
-        if xycoord not in discard:
-            keep.append(xycoord)
+    keep_idx = []
+    discard_idx = set()
+    for idx in range(xycoords.shape[0]):
+        if idx not in discard_idx:
+            keep_idx.append(idx)
             # remove nearest neighbors from the output
-            neighbors = nn.get(xycoord, None)
-            if neighbors is not None:
-                discard.update(neighbors)
+            discard_idx.update(nn.get(idx, set()))
 
-    return np.array(keep)
+    return xycoords[keep_idx]
 
 
 def make_random_xycoords(size, x_range, y_range, min_separation=0.0,


### PR DESCRIPTION
This PR improves the performance of the (private) `apply_separation` function used in `ImageDepth` and `make_test_psf_data` when generating random coordinates.