### PR TITLE
Fix GriddedPSFModel copy method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ Bug Fixes
     raise an error with ``PSFPhotometry`` if the fit did not converge.
     [#1672]
 
+  - Fixed an issue where ``GriddedPSFModel`` fixed model parameters were
+    not respected when copying the model or fitting with the PSF
+    photometry classes. [#1679]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/psf/griddedpsfmodel.py
+++ b/photutils/psf/griddedpsfmodel.py
@@ -446,14 +446,29 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
 
     def copy(self):
         """
-        Return a copy of this model.
+        Return a copy of this model where only the model parameters are
+        copied.
 
-        Note that the ePSF grid data is not copied. Use the `deepcopy`
-        method if you want to copy the ePSF grid data.
+        All other copied model attributes are references to the
+        original model. This prevents copying the ePSF grid data, which
+        may contain a large array.
+
+        This method is useful if one is interested in only changing
+        the model parameters in a model copy. It is used in the PSF
+        photometry classes during model fitting.
+
+        Use the `deepcopy` method if you want to copy all of the model
+        attributes, including the ePSF grid data.
         """
-        return self.__class__(self._nddata, flux=self.flux.value,
-                              x_0=self.x_0.value, y_0=self.y_0.value,
-                              fill_value=self.fill_value)
+        newcls = object.__new__(self.__class__)
+
+        for key, val in self.__dict__.items():
+            if key in self.param_names:  # copy only the parameter values
+                newcls.__dict__[key] = copy.deepcopy(val)
+            else:
+                newcls.__dict__[key] = val
+
+        return newcls
 
     def deepcopy(self):
         """

--- a/photutils/psf/tests/test_griddedpsfmodel.py
+++ b/photutils/psf/tests/test_griddedpsfmodel.py
@@ -203,9 +203,19 @@ class TestGriddedPSFModel:
     def test_copy(self, psfmodel):
         flux = psfmodel.flux.value
         new_model = psfmodel.copy()
+
+        assert_equal(new_model.data, psfmodel.data)
+        assert_equal(new_model.grid_xypos, psfmodel.grid_xypos)
+
         new_model.flux = 100
         assert new_model.flux.value != flux
         assert new_model._nddata is psfmodel._nddata
+
+        new_model.x_0.fixed = True
+        new_model.y_0.fixed = True
+        new_model2 = new_model.copy()
+        assert new_model2.x_0.fixed
+        assert new_model.fixed == new_model2.fixed
 
     def test_deepcopy(self, psfmodel):
         flux = psfmodel.flux.value


### PR DESCRIPTION
 This PR fixes an issue in the `GriddedPSFModel.copy()` method where the "fixed" values of parameters were not preserved in the model copy.

Many thanks to @aarranshaw for reporting #1678, which uncovered this bug.

Fixes #1678.