### PR TITLE
Add a check for valid labels in get_labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,11 @@ API Changes
   - The ``GridddedPSFModel`` string representations now include the
     model ``flux``, ``x_0``, and ``y_0`` parameters. [#1680]
 
+- ``photutils.segmentation``
+
+  - The ``SourceCatalog`` ``get_label`` and ``get_labels`` methods now
+    raise a ``ValueError`` if any of the input labels are invalid. [#1694]
+
 
 1.10.0 (2023-11-21)
 -------------------

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -916,6 +916,7 @@ class SourceCatalog:
             A new `SourceCatalog` object containing only the sources with
             the input ``labels``.
         """
+        self._segment_img.check_labels(labels)
         sorter = np.argsort(self.labels)
         indices = sorter[np.searchsorted(self.labels, labels, sorter=sorter)]
         return self[indices]

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -419,7 +419,7 @@ class SegmentationImage:
         # check if label is in the segmentation array
         bad_labels.update(np.setdiff1d(labels, self.labels))
 
-        if bad_labels:
+        if bad_labels:  # bad_labels is a set
             if len(bad_labels) == 1:
                 raise ValueError(f'label {bad_labels} is invalid')
             raise ValueError(f'labels {bad_labels} are invalid')

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -258,6 +258,13 @@ class TestSourceCatalog:
             obj1 = self.cat[0]
             obj2 = obj1[0]
 
+        match = 'is invalid'
+        with pytest.raises(ValueError, match=match):
+            self.cat.get_label(1000)
+
+        with pytest.raises(ValueError, match=match):
+            self.cat.get_labels([1, 2, 1000])
+
     def test_iter(self):
         labels = []
         for obj in self.cat:


### PR DESCRIPTION
The ``SourceCatalog`` ``get_label`` and ``get_labels`` methods now raise a ``ValueError`` if any of the input labels are invalid.