### PR TITLE
Handle renamed keywords in astropy visualization

### DIFF
--- a/photutils/psf/griddedpsfmodel.py
+++ b/photutils/psf/griddedpsfmodel.py
@@ -10,11 +10,13 @@ import os
 import warnings
 from functools import lru_cache
 
+import astropy
 import numpy as np
 from astropy.io import fits, registry
 from astropy.io.fits.verify import VerifyWarning
 from astropy.modeling import Fittable2DModel, Parameter
 from astropy.nddata import NDData, reshape_as_blocks
+from astropy.utils import minversion
 from astropy.visualization import simple_norm
 
 from photutils.utils._parameters import as_pair
@@ -136,7 +138,10 @@ class ModelGridPlotMixin:
                 vmax_scale = 0.03
             vmax = data.max() * vmax_scale
             vmin = -vmax
-            norm = simple_norm(data, 'linear', min_cut=vmin, max_cut=vmax)
+            if minversion(astropy, '6.1.dev'):
+                norm = simple_norm(data, 'linear', vmin=vmin, vmax=vmax)
+            else:
+                norm = simple_norm(data, 'linear', min_cut=vmin, max_cut=vmax)
         else:
             if cmap is None:
                 cmap = cm.viridis.copy()
@@ -145,8 +150,12 @@ class ModelGridPlotMixin:
                 vmax_scale = 1.0
             vmax = data.max() * vmax_scale
             vmin = vmax / 1.0e4
-            norm = simple_norm(data, 'log', min_cut=vmin, max_cut=vmax,
-                               log_a=1.0e4)
+            if minversion(astropy, '6.1.dev'):
+                norm = simple_norm(data, 'log', vmin=vmin, vmax=vmax,
+                                   log_a=1.0e4)
+            else:
+                norm = simple_norm(data, 'log', min_cut=vmin, max_cut=vmax,
+                                   log_a=1.0e4)
 
         # Set up the coordinate axes to later set tick labels based on
         # detector ePSF coordinates. This sets up axes to have, behind the


### PR DESCRIPTION
In astropy 6.1, `min_cut` and `max_cut` are renamed to `vmin` and `vmax`, respectively.