### PR TITLE
Return finder_results as a QTable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,9 @@ API Changes
     backwards-incompatible change. If the previous behavior is desired,
     set ``include_localbkg=True``. [#1703]
 
+  - The PSF photometry ``finder_results`` attribute is now returned as a
+    ``QTable`` instead of a list of ``QTable``. [#1704]
+
 - ``photutils.segmentation``
 
   - The ``SourceCatalog`` ``get_label`` and ``get_labels`` methods now

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -314,13 +314,13 @@ astropy table):
 
 .. doctest-requires:: scipy
 
-    >>> psfphot.finder_results[0]['xcentroid'].info.format = '.4f'  # optional format
-    >>> psfphot.finder_results[0]['ycentroid'].info.format = '.4f'  # optional format
-    >>> psfphot.finder_results[0]['sharpness'].info.format = '.4f'  # optional format
-    >>> psfphot.finder_results[0]['peak'].info.format = '.4f'
-    >>> psfphot.finder_results[0]['flux'].info.format = '.4f'
-    >>> psfphot.finder_results[0]['mag'].info.format = '.4f'
-    >>> print(psfphot.finder_results[0])  # doctest: +FLOAT_CMP
+    >>> psfphot.finder_results['xcentroid'].info.format = '.4f'  # optional format
+    >>> psfphot.finder_results['ycentroid'].info.format = '.4f'  # optional format
+    >>> psfphot.finder_results['sharpness'].info.format = '.4f'  # optional format
+    >>> psfphot.finder_results['peak'].info.format = '.4f'
+    >>> psfphot.finder_results['flux'].info.format = '.4f'
+    >>> psfphot.finder_results['mag'].info.format = '.4f'
+    >>> print(psfphot.finder_results)  # doctest: +FLOAT_CMP
      id xcentroid ycentroid sharpness ... sky   peak    flux    mag
     --- --------- --------- --------- ... --- ------- ------- -------
       1   54.5300    7.7508    0.5996 ... 0.0 67.0314  8.7012 -2.3490

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -131,13 +131,13 @@ class PSFPhotometry:
         self.progress_bar = progress_bar
 
         # reset these attributes for each __call__ (see _reset_results)
-        self.finder_results = []
+        self.finder_results = None
         self.fit_results = defaultdict(list)
         self._group_results = defaultdict(list)
         self._fit_models = None
 
     def _reset_results(self):
-        self.finder_results = []
+        self.finder_results = None
         self.fit_results = defaultdict(list)
         self._group_results = defaultdict(list)
         self._fit_models = None
@@ -378,7 +378,7 @@ class PSFPhotometry:
                                  'is not input')
 
             sources = self.finder(data, mask=mask)
-            self.finder_results.append(sources)
+            self.finder_results = sources
             if sources is None:
                 return None
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -156,6 +156,7 @@ def test_psf_photometry(test_data):
     phot = psfphot(data, error=error)
     resid_data = psfphot.make_residual_image(data, fit_shape)
 
+    assert isinstance(psfphot.finder_results, QTable)
     assert isinstance(phot, QTable)
     assert len(phot) == len(sources)
     assert isinstance(resid_data, np.ndarray)


### PR DESCRIPTION
The PSF photometry ``finder_results`` attribute is now returned as a ``QTable`` instead of a list of ``QTable``.