### PR TITLE
BLD: build with numpy 2.0.0rc1 (or newer)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ requires = [
     'setuptools>=61.2',
     'setuptools_scm>=6.2',
     'cython>=3.0.0,<3.1.0',
-    'numpy>=1.25',
+    'numpy>=2.0.0rc1',
     'extension-helpers==1.*',
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
This is needed for runtime compatibility with the upcoming numpy 2.0, and I *think* that it's also sufficient, but maybe I'm missing something ? anyway feel free to push to this branch or to incorporate it some other way.