### PR TITLE
Update min versions of dependencies

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'linkcheck'
             allow_failure: false
             prefix: ''

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -37,8 +37,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.11'
-            tox_env: 'py311-test-alldeps-devinfra'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps-devinfra'
             allow_failure: false
 
     steps:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,12 +31,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.9'
-            tox_env: 'py39-test-alldeps'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-alldeps'
             allow_failure: false
@@ -44,56 +38,62 @@ jobs:
 
           - os: ubuntu-latest
             python: '3.11'
-            tox_env: 'py311-test-alldeps-cov'
+            tox_env: 'py311-test-alldeps'
+            allow_failure: false
+            prefix: ''
+
+          - os: ubuntu-latest
+            python: '3.12'
+            tox_env: 'py312-test-alldeps-cov'
             toxposargs: --remote-data=any
             allow_failure: false
             prefix: ''
 
           - os: macos-latest
-            python: '3.11'
-            tox_env: 'py311-test-alldeps'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps'
             allow_failure: false
             prefix: ''
 
           - os: macos-14
-            python: '3.11'
-            tox_env: 'py311-test-alldeps'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps'
             allow_failure: false
             prefix: 'M1'
 
           - os: windows-latest
-            python: '3.11'
-            tox_env: 'py311-test-alldeps'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.11'
-            tox_env: 'py311-test'
+            python: '3.12'
+            tox_env: 'py312-test'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'codestyle'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'pep517'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'bandit'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.9'
-            tox_env: 'py39-test-oldestdeps'
+            python: '3.10'
+            tox_env: 'py310-test-oldestdeps'
             allow_failure: false
             prefix: ''
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,6 @@ jobs:
       test_command: pytest -p no:warnings --pyargs photutils
       targets: |
         # Linux wheels
-        - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
         - cp312-manylinux_x86_64
@@ -51,18 +50,15 @@ jobs:
         # MacOS X wheels
         # Note that the arm64 wheels are not actually tested so we rely
         # on local manual testing of these to make sure they are ok.
-        - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
         - cp312*macosx_x86_64
 
-        - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
         - cp312*macosx_arm64
 
         # Windows wheels
-        - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64
         - cp312*win_amd64

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,21 @@
 General
 ^^^^^^^
 
+- The minimum required Python is now 3.10. [#1719]
+
+- The minimum required NumPy is now 1.23. [#1719]
+
+- The minimum required SciPy is now 1.8. [#1719]
+
+- The minimum required scikit-learn is now 1.1. [#1719]
+
+- The minimum required pytest-astropy is now 0.11. [#1719]
+
+- The minimum required sphinx-astropy is now 1.9. [#1719]
+
+- NumPy 2.0 is supported.
+
+
 New Features
 ^^^^^^^^^^^^
 
@@ -12,8 +27,8 @@ Bug Fixes
 
 - ``photutils.background``
 
-  - No longer warn about NaNs in the data if those NaNs are masked in ``mask``
-    passed to ``Background2D``. [#1712]
+  - No longer warn about NaNs in the data if those NaNs are masked in
+    ``mask`` passed to ``Background2D``. [#1712]
 
 API Changes
 ^^^^^^^^^^^

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,15 +7,15 @@ Requirements
 
 Photutils has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.9 or later
+* `Python <https://www.python.org/>`_ 3.10 or later
 
-* `NumPy <https://numpy.org/>`_ 1.22 or later
+* `NumPy <https://numpy.org/>`_ 1.23 or later
 
 * `Astropy`_ 5.1 or later
 
 Photutils also optionally depends on other packages for some features:
 
-* `SciPy <https://scipy.org/>`_ 1.7.2 or later:  To power a variety of
+* `SciPy <https://scipy.org/>`_ 1.8 or later:  To power a variety of
   features in several modules (strongly recommended).
 
 * `Matplotlib <https://matplotlib.org/>`_ 3.5 or later:  To power a
@@ -24,7 +24,7 @@ Photutils also optionally depends on other packages for some features:
 * `scikit-image <https://scikit-image.org/>`_ 0.19 or later: Used for
   deblending segmented sources.
 
-* `scikit-learn <https://scikit-learn.org/>`_ 1.0 or later: Used in the
+* `scikit-learn <https://scikit-learn.org/>`_ 1.1 or later: Used in the
   deprecated `~photutils.psf.DBSCANGroup` class to create star groups.
 
 * `GWCS <https://gwcs.readthedocs.io/en/stable/>`_ 0.18 or later:
@@ -45,7 +45,7 @@ Photutils also optionally depends on other packages for some features:
   source segments into polygon objects.
 
 Photutils depends on `pytest-astropy
-<https://github.com/astropy/pytest-astropy>`_ (0.10 or later) to run
+<https://github.com/astropy/pytest-astropy>`_ (0.11 or later) to run
 the test suite.
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -21,7 +21,7 @@ Photutils also optionally depends on other packages for some features:
 * `Matplotlib <https://matplotlib.org/>`_ 3.5 or later:  To power a
   variety of plotting features (e.g., plotting apertures).
 
-* `scikit-image <https://scikit-image.org/>`_ 0.19 or later: Used for
+* `scikit-image <https://scikit-image.org/>`_ 0.20 or later: Used for
   deblending segmented sources.
 
 * `scikit-learn <https://scikit-learn.org/>`_ 1.1 or later: Used in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Documentation = 'https://photutils.readthedocs.io/en/stable/'
 all = [
     'scipy>=1.8',
     'matplotlib>=3.5',
-    'scikit-image>=0.19',
+    'scikit-image>=0.20',
     'scikit-learn>=1.1',
     'gwcs>=0.18',
     'bottleneck',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Astronomy',
 ]
 dynamic = ['version']
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
-    'numpy>=1.22',
+    'numpy>=1.23',
     'astropy>=5.1',
 ]
 
@@ -43,10 +43,10 @@ Documentation = 'https://photutils.readthedocs.io/en/stable/'
 
 [project.optional-dependencies]
 all = [
-    'scipy>=1.7.2',
+    'scipy>=1.8',
     'matplotlib>=3.5',
     'scikit-image>=0.19',
-    'scikit-learn>=1.0',
+    'scikit-learn>=1.1',
     'gwcs>=0.18',
     'bottleneck',
     'tqdm',
@@ -54,12 +54,12 @@ all = [
     'shapely',
 ]
 test = [
-    'pytest-astropy>=0.10',
+    'pytest-astropy>=0.11',
 ]
 docs = [
     'photutils[all]',
     'sphinx',
-    'sphinx-astropy>=1.6',
+    'sphinx-astropy>=1.9',
     'tomli; python_version < "3.11"',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     oldestdeps: astropy==5.1
     oldestdeps: scipy==1.8
     oldestdeps: matplotlib==3.5
-    oldestdeps: scikit-image==0.19
+    oldestdeps: scikit-image==0.20
     oldestdeps: scikit-learn==1.1
     oldestdeps: gwcs==0.18
     oldestdeps: pytest-astropy==0.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{39,310,311,312}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{39,310,311,312}-test-numpy{122,123,124,125,126}
+    py{310,311,312}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
+    py{310,311,312}-test-numpy{123,124,125,126}
     build_docs
     linkcheck
     codestyle
@@ -38,7 +38,6 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy122: with numpy 1.22.*
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
@@ -48,20 +47,19 @@ description =
 deps =
     cov: pytest-cov
 
-    numpy122: numpy==1.22.*
     numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
     numpy126: numpy==1.26.*
 
-    oldestdeps: numpy==1.22
+    oldestdeps: numpy==1.23
     oldestdeps: astropy==5.1
-    oldestdeps: scipy==1.7.2
+    oldestdeps: scipy==1.8
     oldestdeps: matplotlib==3.5
     oldestdeps: scikit-image==0.19
-    oldestdeps: scikit-learn==1.0
+    oldestdeps: scikit-learn==1.1
     oldestdeps: gwcs==0.18
-    oldestdeps: pytest-astropy==0.10
+    oldestdeps: pytest-astropy==0.11
 
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0


### PR DESCRIPTION
Following NEP-29, the minimum supported Python version is 3.10.  Also, the minimum NumPy is 1.23.

Other dependencies:

* Scipy >= 1.8
* scikit-learn >= 1.1
* pytest-astropy >= 0.11
* sphinx-astropy >= 1.9
* scikit-image >= 0.20