### PR TITLE
Add unnormalize method to profiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,15 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.profiles``
+
+  - Added an ``unnormalize`` method to ``RadialProfile`` and
+    ``CurveOfGrowth`` to return the profile to the state before any
+    ``normalize`` calls were run. [#1732]
+
 Bug Fixes
 ^^^^^^^^^
+
 - ``photutils.background``
 
   - No longer warn about NaNs in the data if those NaNs are masked in

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -20,7 +20,6 @@ data before creating a radial profile or curve of growth.
     >>> import numpy as np
     >>> from astropy.modeling.models import Gaussian2D
     >>> from photutils.datasets import make_noise_image
-
     >>> gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     >>> yy, xx = np.mgrid[0:100, 0:100]
     >>> data = gmodel(xx, yy)
@@ -50,34 +49,45 @@ data before creating a radial profile or curve of growth.
 Creating a Radial Profile
 -------------------------
 
-Photutils provides the :class:`~photutils.profiles.RadialProfile` class
-for computing radial profiles. The radial bins are defined by inputting
-a 1D array of radial edges. The radial spacing does not need to be
-constant.
-
 First, we'll use the `~photutils.centroids.centroid_quadratic` function
-to find the source centroid::
+to find the source centroid from the simulated image defined above::
 
     >>> from photutils.centroids import centroid_quadratic
     >>> xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
     >>> print(xycen)  # doctest: +FLOAT_CMP
     [47.61226319 52.04668132]
 
-Now, let's create a radial profile. The radial profile will be centered
-at our centroid position computed above.
+We'll use this centroid position as the center of our radial profile.
+
+We create a radial profile using the `~photutils.profiles.RadialProfile`
+class. The radial bins are defined by inputing a 1D array of radii that
+represent the radial *edges* of circular annulus apertures. The radial
+spacing does not need to be constant. The input ``error`` array is the
+uncertainty in the data values. The input ``mask`` array is a boolean
+mask with the same shape as the data, where a `True` value indicates a
+masked pixel::
 
     >>> from photutils.profiles import RadialProfile
     >>> edge_radii = np.arange(25)
     >>> rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
-The `~photutils.profiles.RadialProfile.radius` (radial bin centers),
-`~photutils.profiles.RadialProfile.profile`, and
-`~photutils.profiles.RadialProfile.profile_error` attributes contain the
-output 1D `~numpy.ndarray` objects::
+The output `~photutils.profiles.RadialProfile.radius` attribute values
+are defined as the arithmetic means of the input radial-bins edges
+(``radii``). Note this is different from the input ``radii``, which
+represents the radial bin edges::
+
+    >>> print(rp.radii)  # doctest: +FLOAT_CMP
+    [ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+     24]
 
     >>> print(rp.radius)  # doctest: +FLOAT_CMP
     [ 0.5  1.5  2.5  3.5  4.5  5.5  6.5  7.5  8.5  9.5 10.5 11.5 12.5 13.5
      14.5 15.5 16.5 17.5 18.5 19.5 20.5 21.5 22.5 23.5]
+
+The `~photutils.profiles.RadialProfile.profile` and
+`~photutils.profiles.RadialProfile.profile_error` attributes contain the
+output 1D `~numpy.ndarray` objects containing the radial profile and
+propagated errors::
 
     >>> print(rp.profile)  # doctest: +FLOAT_CMP
     [ 4.15632243e+01  3.93402079e+01  3.59845746e+01  3.15540506e+01
@@ -93,11 +103,24 @@ output 1D `~numpy.ndarray` objects::
      0.25551933 0.27675376 0.25553986 0.23421017 0.22966813 0.21747036
      0.23654884 0.22760386 0.23941711 0.20661313 0.18999134 0.17469024]
 
-If desired, the radial profiles can be normalized using the
-:meth:`~photutils.profiles.RadialProfile.normalize` method.
+If desired, the radial profile can be normalized using the
+:meth:`~photutils.profiles.RadialProfile.normalize` method. By default
+(``method='max'``), the profile is normalized such that its maximum
+value is 1. Setting ``method='sum'`` can be used to normalize the
+profile such that its sum (integral) is 1::
 
-There are also convenience methods to plot the radial profile and its
-error:
+    >> rp.normalize(method='max')
+
+There is also a method to "unnormalize" the radial profile
+back to the original values prior to running any calls to the
+:meth:`~photutils.profiles.RadialProfile.normalize` method::
+
+    >> rp.unnormalize()
+
+There are also convenience methods to plot the radial profile and
+its error. These methods plot ``rp.radius`` versus ``rp.profile`` (with
+``rp.profile_error`` as error bars). The ``label`` keyword can be used
+to set the plot label.
 
 .. doctest-skip::
 
@@ -133,8 +156,9 @@ error:
     plt.legend()
 
 The `~photutils.profiles.RadialProfile.apertures` attribute contains a
-list of the apertures. Let's plot two of the annulus apertures for the
-`~photutils.profiles.RadialProfile` instance on the data:
+list of the apertures. Let's plot a few of the annulus apertures (the 6th
+11th, and 16th) for the `~photutils.profiles.RadialProfile` instance on
+the data:
 
 .. plot::
 
@@ -165,10 +189,10 @@ list of the apertures. Let's plot two of the annulus apertures for the
     plt.imshow(data, norm=norm)
     rp.apertures[5].plot(color='C0', lw=2)
     rp.apertures[10].plot(color='C1', lw=2)
+    rp.apertures[15].plot(color='C3', lw=2)
 
-
-Now let's fit a 1D Gaussian to the radial
-profile and return the Gaussian model using the
+Now let's fit a 1D Gaussian to the radial profile and return the
+`~astropy.modeling.functional_models.Gaussian1D` model using the
 `~photutils.profiles.RadialProfile.gaussian_fit` attribute:
 
 .. doctest-requires:: scipy
@@ -214,7 +238,6 @@ class:`~photutils.profiles.RadialProfile` radial profile:
     rp.plot(label='Radial Profile')
     rp.plot_error()
     plt.plot(rp.radius, rp.gaussian_profile, label='Gaussian Fit')
-
     plt.legend()
 
 
@@ -232,15 +255,20 @@ be computed over the radial range given by the input ``radii`` array::
     >>> radii = np.arange(1, 26)
     >>> cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
-The `~photutils.profiles.CurveOfGrowth` instance
-has `~photutils.profiles.CurveOfGrowth.radius`,
-`~photutils.profiles.CurveOfGrowth.profile`, and
-`~photutils.profiles.CurveOfGrowth.profile_error` attributes which
-contain 1D `~numpy.ndarray` objects::
+Here, the `~photutils.profiles.CurveOfGrowth.radius` attribute values
+are identical to the input ``radii``. Because these values are the radii
+of the circular apertures used to measure the profile, they can be used
+directly to measure the encircled energy/flux at a given radius. In
+other words, they are the radial values that enclose the given flux::
 
     >>> print(cog.radius)  # doctest: +FLOAT_CMP
     [ 1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
      25]
+
+The `~photutils.profiles.CurveOfGrowth.profile` and
+`~photutils.profiles.CurveOfGrowth.profile_error` attributes contain
+output 1D `~numpy.ndarray` objects containing the curve-of-growth
+profile and propagated errors::
 
     >>> print(cog.profile)  # doctest: +FLOAT_CMP
     [ 130.57472018  501.34744442 1066.59182074 1760.50163608 2502.13955554
@@ -256,15 +284,29 @@ contain 1D `~numpy.ndarray` objects::
       68.71042311  72.71899201  76.54959872  81.33806741  85.98568713
       91.34841248  95.5173253   99.22190499 102.51980185 106.83601366]
 
-If desired, the curve of growth profile can be normalized using the
-:meth:`~photutils.profiles.RadialProfile.normalize` method.
+
+If desired, the curve-of-growth profile can be normalized using the
+:meth:`~photutils.profiles.CurveOfGrowth.normalize` method. By default
+(``method='max'``), the profile is normalized such that its maximum
+value is 1. Setting ``method='sum'`` can also be used to normalize the
+profile such that its sum (integral) is 1::
+
+    >> cog.normalize(method='max')
+
+There is also a method to "unnormalize" the radial profile
+back to the original values prior to running any calls to the
+:meth:`~photutils.profiles.CurveOfGrowth.normalize` method::
+
+    >> cog.unnormalize()
 
 There are also convenience methods to plot the curve of growth and its
-error:
+error. These methods plot ``cog.radius`` versus ``cog.profile`` (with
+``cog.profile_error`` as error bars). The ``label`` keyword can be used
+to set the plot label.
 
 .. doctest-skip::
 
-    >>> rp.plot()
+    >>> rp.plot(label='Curve of Growth')
     >>> rp.plot_error()
 
 .. plot::
@@ -290,11 +332,13 @@ error:
     cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
     # plot the radial profile
-    cog.plot()
+    cog.plot(label='Curve of Growth')
     cog.plot_error()
+    plt.legend()
 
 The `~photutils.profiles.CurveOfGrowth.apertures` attribute contains a
-list of the apertures. Let's plot a couple of the apertures on the data:
+list of the apertures. Let's plot a few of the circular apertures (the
+6th, 11th, and 16th) on the data:
 
 .. plot::
 
@@ -325,6 +369,7 @@ list of the apertures. Let's plot a couple of the apertures on the data:
     plt.imshow(data, norm=norm)
     cog.apertures[5].plot(color='C0', lw=2)
     cog.apertures[10].plot(color='C1', lw=2)
+    cog.apertures[15].plot(color='C3', lw=2)
 
 
 Reference/API

--- a/photutils/profiles/tests/test_curve_of_growth.py
+++ b/photutils/profiles/tests/test_curve_of_growth.py
@@ -97,15 +97,34 @@ def test_curve_of_growth_normalize(profile_data):
 
     radii = np.arange(1, 36)
     cg1 = CurveOfGrowth(data, xycen, radii, error=None, mask=None)
+    cg2 = CurveOfGrowth(data, xycen, radii, error=None, mask=None)
 
     profile1 = cg1.profile
     cg1.normalize()
     profile2 = cg1.profile
     assert np.mean(profile2) < np.mean(profile1)
 
+    cg1.unnormalize()
+    assert_allclose(cg1.profile, cg2.profile)
+
+    cg1.normalize(method='sum')
+    cg1.normalize(method='max')
+    cg1.unnormalize()
+    assert_allclose(cg1.profile, cg2.profile)
+
+    cg1.normalize(method='max')
+    cg1.normalize(method='sum')
+    cg1.normalize(method='max')
+    cg1.normalize(method='max')
+    cg1.unnormalize()
+    assert_allclose(cg1.profile, cg2.profile)
+
     cg1.normalize(method='sum')
     profile3 = cg1.profile
     assert np.mean(profile3) < np.mean(profile1)
+
+    cg1.unnormalize()
+    assert_allclose(cg1.profile, cg2.profile)
 
     with pytest.raises(ValueError):
         cg1.normalize(method='invalid')


### PR DESCRIPTION
This PR adds an ``unnormalize`` method to ``RadialProfile`` and ``CurveOfGrowth`` to return the profile to the state before any ``normalize`` calls were run.