### PR TITLE
Add encircled energy methods to CurveOfGrowth

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New Features
     ``CurveOfGrowth`` to return the profile to the state before any
     ``normalize`` calls were run. [#1732]
 
+  - Added ``calc_ee_from_radius`` and ``calc_radius_from_ee`` methods to
+    ``CurveOfGrowth``. [#1733]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -372,6 +372,48 @@ list of the apertures. Let's plot a few of the circular apertures (the
     cog.apertures[15].plot(color='C3', lw=2)
 
 
+Encircled Energy
+^^^^^^^^^^^^^^^^
+
+Often, one is interested in the encircled energy (or flux) within
+a given radius, where the encircled energy is generally expressed
+as a normalized value between 0 and 1. If the curve of growth is
+monotonically increasing and normalized such that its maximum value is
+1 for an infinitely large radius, then the encircled energy is simply
+the value of the curve of growth at a given radius. To achieve this, one
+can input a normalized version of the ``data`` array (e.g., a normalized
+PSF) to the `~photutils.profiles.CurveOfGrowth` class. One can also
+use the :meth:`~photutils.profiles.CurveOfGrowth.normalize` method to
+normalize the curve of growth profile to be 1 at the largest input
+``radii`` value.
+
+If the curve of growth is normalized, the encircled energy at
+a given radius is simply the value of the curve of growth at
+that radius. The `~photutils.profiles.CurveOfGrowth` class
+provides two convenience methods to calculate the encircled
+energy at a given radius (or radii) and the radius corresponding
+to the given encircled energy (or energies). These methods are
+:meth:`~photutils.profiles.CurveOfGrowth.calc_ee_at_radius` and
+:meth:`~photutils.profiles.CurveOfGrowth.calc_radius_at_ee`,
+respectively. They are implemented as interpolation functions using the
+calculated curve-of-growth profile. The performance of these methods
+is dependent on the quality of the curve-of-growth profile (e.g., it's
+generally better to have a curve-of-growth profile with more radial
+bins):
+
+.. doctest-requires:: scipy
+
+    >>> cog.normalize(method='max')
+    >>> ee_vals = cog.calc_ee_at_radius([5, 10, 15])  # doctest: +FLOAT_CMP
+    >>> ee_vals
+    array([0.41923785, 0.87160376, 0.96902919])
+
+.. doctest-requires:: scipy
+
+    >>> cog.calc_radius_at_ee(ee_vals)  # doctest: +FLOAT_CMP
+    array([ 5., 10., 15.])
+
+
 Reference/API
 -------------
 

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -213,6 +213,7 @@ class CurveOfGrowth(ProfileBase):
         plt.imshow(data, norm=norm)
         cog.apertures[5].plot(color='C0', lw=2)
         cog.apertures[10].plot(color='C1', lw=2)
+        cog.apertures[15].plot(color='C3', lw=2)
     """
 
     def __init__(self, data, xycen, radii, *, error=None, mask=None,

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -270,3 +270,64 @@ class CurveOfGrowth(ProfileBase):
         radius as a 1D `~numpy.ndarray`.
         """
         return self._photometry[2]
+
+    def calc_ee_at_radius(self, radius):
+        """
+        Calculate the encircled energy at a given radius using a cubic
+        interpolator based on the profile data.
+
+        Note that this function assumes that input data has been
+        normalized such that the total enclosed flux is 1 for an
+        infinitely large radius. You can also use the `normalize` method
+        before calling this method to normalize the profile to be 1 at
+        the largest input `radii`.
+
+        Parameters
+        ----------
+        radius : float or 1D `~numpy.ndarray`
+            The circular radius/radii.
+
+        Returns
+        -------
+        ee : `~numpy.ndarray`
+            The encircled energy at each radius/radii.
+        """
+        from scipy.interpolate import interp1d
+
+        return interp1d(self.radius, self.profile, kind='cubic',
+                        bounds_error=False)(radius)
+
+    def calc_radius_at_ee(self, ee):
+        """
+        Calculate the radius at a given encircled energy using a cubic
+        interpolator based on the profile data.
+
+        Note that this function assumes that input data has been
+        normalized such that the total enclosed flux is 1 for an
+        infinitely large radius. You can also use the `normalize` method
+        before calling this method to normalize the profile to be 1 at
+        the largest input `radii`.
+
+        If the profile is not monotonically increasing, then the
+        returned radius will be the radius at the first occurrence of
+        the given encircled energy.
+
+        Parameters
+        ----------
+        ee : float or 1D `~numpy.ndarray`
+            The encircled energy.
+
+        Returns
+        -------
+        radius : `~numpy.ndarray`
+            The radius at each encircled energy.
+        """
+        from scipy.interpolate import interp1d
+
+        # need to remove repeated profiles values for interp1d
+        _, idx = np.unique(self.profile, return_index=True)
+        radius = self.radius[idx]
+        profile = self.profile[idx]
+
+        return interp1d(profile, radius, kind='cubic',
+                        bounds_error=False)(ee)

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -240,6 +240,7 @@ class RadialProfile(ProfileBase):
         plt.imshow(data, norm=norm)
         rp.apertures[5].plot(color='C0', lw=2)
         rp.apertures[10].plot(color='C1', lw=2)
+        rp.apertures[15].plot(color='C3', lw=2)
 
     Fit a 1D Gaussian to the radial profile and return the Gaussian
     model.

--- a/photutils/profiles/tests/test_curve_of_growth.py
+++ b/photutils/profiles/tests/test_curve_of_growth.py
@@ -135,6 +135,22 @@ def test_curve_of_growth_normalize(profile_data):
         cg1.normalize(method='max')
 
 
+def test_curve_of_growth_interp(profile_data):
+    xycen, data, error, _ = profile_data
+    radii = np.arange(1, 36)
+    cg1 = CurveOfGrowth(data, xycen, radii, error=None, mask=None)
+    cg1.normalize()
+    ee_radii = np.array([0, 5, 10, 20, 25, 50], dtype=float)
+    ee_vals = cg1.calc_ee_at_radius(ee_radii)
+    ee_expected = np.array([np.nan, 0.1176754, 0.39409357, 0.86635049,
+                            0.95805792, np.nan])
+    assert_allclose(ee_vals, ee_expected, rtol=1e-6)
+
+    rr = cg1.calc_radius_at_ee(ee_vals)
+    ee_radii[[0, -1]] = np.nan
+    assert_allclose(rr, ee_radii, rtol=1e-6)
+
+
 def test_curve_of_growth_inputs(profile_data):
     xycen, data, error, _ = profile_data
 

--- a/photutils/profiles/tests/test_curve_of_growth.py
+++ b/photutils/profiles/tests/test_curve_of_growth.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture import CircularAperture
 from photutils.profiles import CurveOfGrowth
-from photutils.utils._optional_deps import HAS_MATPLOTLIB
+from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY
 
 
 @pytest.fixture(name='profile_data')
@@ -135,6 +135,7 @@ def test_curve_of_growth_normalize(profile_data):
         cg1.normalize(method='max')
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_curve_of_growth_interp(profile_data):
     xycen, data, error, _ = profile_data
     radii = np.arange(1, 36)
@@ -149,6 +150,14 @@ def test_curve_of_growth_interp(profile_data):
     rr = cg1.calc_radius_at_ee(ee_vals)
     ee_radii[[0, -1]] = np.nan
     assert_allclose(rr, ee_radii, rtol=1e-6)
+
+    radii = np.linspace(0.1, 36, 200)
+    cg1 = CurveOfGrowth(data, xycen, radii, error=None, mask=None,
+                        method='center')
+    ee_vals = cg1.calc_ee_at_radius(ee_radii)
+    match = 'The curve-of-growth profile is not monotonically increasing'
+    with pytest.raises(ValueError, match=match):
+        cg1.calc_radius_at_ee(ee_vals)
 
 
 def test_curve_of_growth_inputs(profile_data):


### PR DESCRIPTION
This PR adds ``calc_ee_from_radius`` and ``calc_radius_from_ee`` methods to ``CurveOfGrowth``, which use an interpolation function to compute encircled energy (EE) at a specified radius or vice versa.