### PR TITLE
Adjust to numpy 2+ scalar format

### DIFF
--- a/docs/background.rst
+++ b/docs/background.rst
@@ -109,8 +109,8 @@ levels::
 
     >>> from astropy.stats import sigma_clipped_stats
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)
-    >>> print((mean, median, std))  # doctest: +FLOAT_CMP
-    (5.199138651621793, 5.155587433358291, 2.094275212132969)
+    >>> print(np.array((mean, median, std)))  # doctest: +FLOAT_CMP
+    [5.19913865 5.15558743 2.09427521]
 
 
 Masking Sources
@@ -142,8 +142,8 @@ method with a circular dilation footprint to create the source mask:
     >>> footprint = circular_footprint(radius=10)
     >>> mask = segment_img.make_source_mask(footprint=footprint)
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0, mask=mask)
-    >>> print((mean, median, std))  # doctest: +FLOAT_CMP
-    (4.994042038715669, 4.991333562774164, 1.9699473426119296)
+    >>> print(np.array((mean, median, std)))  # doctest: +FLOAT_CMP
+    [4.99404204 4.99133356 1.96994734]
 
 The source detection and masking procedure can be iterated further. Even
 with one iteration we are within 0.2% of the true background value and

--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -38,6 +38,7 @@ centroid with each of these methods.  For this simple example we will
 not subtract the background from the data (but in practice, one should
 subtract the background)::
 
+    >>> import numpy as np
     >>> from photutils.datasets import make_4gaussians_image
     >>> from photutils.centroids import (centroid_1dg, centroid_2dg,
     ...                                  centroid_com, centroid_quadratic)
@@ -45,24 +46,24 @@ subtract the background)::
     >>> data = make_4gaussians_image()[43:79, 76:104]
 
     >>> x1, y1 = centroid_com(data)
-    >>> print((x1, y1))  # doctest: +FLOAT_CMP
-    (13.93157998341213, 17.051234441067088)
+    >>> print(np.array((x1, y1)))  # doctest: +FLOAT_CMP
+    [13.93157998 17.05123444]
 
     >>> x2, y2 = centroid_quadratic(data)
-    >>> print((x2, y2))  # doctest: +FLOAT_CMP
-    (13.948284438186919, 16.98788199435759)
+    >>> print(np.array((x2, y2)))  # doctest: +FLOAT_CMP
+    [13.94828444 16.98788199]
 
 .. doctest-requires:: scipy
 
     >>> x3, y3 = centroid_1dg(data)
-    >>> print((x3, y3))  # doctest: +FLOAT_CMP
-    (14.040352707371396, 16.962306463644801)
+    >>> print(np.array((x3, y3)))  # doctest: +FLOAT_CMP
+    [14.04035271 16.96230646]
 
 .. doctest-requires:: scipy
 
     >>> x4, y4 = centroid_2dg(data)
-    >>> print((x4, y4))  # doctest: +FLOAT_CMP
-    (14.002212073733611, 16.996134592982017)
+    >>> print(np.array((x4, y4)))  # doctest: +FLOAT_CMP
+    [14.00221339 16.99613642]
 
 Now let's plot the results.  Because the centroids are all very
 similar, we also include an inset plot zoomed in near the centroid:

--- a/docs/detection.rst
+++ b/docs/detection.rst
@@ -52,13 +52,14 @@ As an example, let's load an image from the bundled datasets and select
 a subset of the image. We will estimate the background and background
 noise using sigma-clipped statistics::
 
+    >>> import numpy as np
     >>> from astropy.stats import sigma_clipped_stats
     >>> from photutils.datasets import load_star_image
     >>> hdu = load_star_image()  # doctest: +REMOTE_DATA
     >>> data = hdu.data[0:401, 0:401]  # doctest: +REMOTE_DATA
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)  # doctest: +REMOTE_DATA
-    >>> print((mean, median, std))  # doctest: +REMOTE_DATA, +FLOAT_CMP
-    (3668.09661145823, 3649.0, 204.41388592022315)
+    >>> print(np.array((mean, median, std)))  # doctest: +REMOTE_DATA, +FLOAT_CMP
+    [3668.09661146 3649.          204.41388592]
 
 Now we will subtract the background and use an instance of
 :class:`~photutils.detection.DAOStarFinder` to find the stars in the

--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -3,19 +3,12 @@
 # get picked up when running the tests inside an interpreter using
 # packagename.test
 
-import numpy as np
-from astropy.utils import minversion
-
 try:
     from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
                                                TESTED_VERSIONS)
     ASTROPY_HEADER = True
 except ImportError:
     ASTROPY_HEADER = False
-
-# do not remove until we drop support for NumPy < 2.0
-if minversion(np, '2.0.0.dev0+git20230726'):
-    np.set_printoptions(legacy='1.25')
 
 
 def pytest_configure(config):

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -144,8 +144,8 @@ class ImageDepth:
     ...                    mask_pad=5, overlap=False, seed=123,
     ...                    zeropoint=23.9, progress_bar=False)
     >>> limits = depth(data, mask)
-    >>> print(limits)  # doctest: +FLOAT_CMP
-    (68.0112578151062, 19.318547982855563)
+    >>> print(np.array(limits))  # doctest: +FLOAT_CMP
+    [68.01125782 19.31854798]
 
     .. plot::
         :include-source:

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -88,9 +88,9 @@ class ShepardIDWInterpolator:
         >>> x = rng.random(100)  # 100 random values
         >>> y = np.sin(x)
         >>> f = idw(x, y)
-        >>> f(0.4)  # doctest: +FLOAT_CMP
+        >>> float(f(0.4))  # doctest: +FLOAT_CMP
         0.38937843420912366
-        >>> np.sin(0.4)  # doctest: +FLOAT_CMP
+        >>> float(np.sin(0.4))  # doctest: +FLOAT_CMP
         0.3894183423086505
 
         >>> xi = rng.random(4)  # 4 random values
@@ -110,9 +110,9 @@ class ShepardIDWInterpolator:
         >>> pos = rng.random((1000, 2))
         >>> val = np.sin(pos[:, 0] + pos[:, 1])
         >>> f = idw(pos, val)
-        >>> f([0.5, 0.6])  # doctest: +FLOAT_CMP
+        >>> float(f([0.5, 0.6]))  # doctest: +FLOAT_CMP
         0.8948257014687874
-        >>> np.sin(0.5 + 0.6)  # doctest: +FLOAT_CMP
+        >>> float(np.sin(0.5 + 0.6))  # doctest: +FLOAT_CMP
         0.8912073600614354
     """
 


### PR DESCRIPTION
Starting with NumPy 2.0, numpy scalar representations changed from, e.g., `7.0 -> np.float64(7.0)`.  In this PR, I change numpy floats to Python floats (and float tuples are converted to arrays) in doctests so that they will pass for both NumPy1.x and NumPy 2.x.