### PR TITLE
Check dimensionality of PSF model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,12 @@ API Changes
     functions from ``photutils.datasets.make``, import functions from
     ``photutils.datasets``. [#1726]
 
+- ``photutils.psf``
+
+  - ``PSFPhotometry`` and ``IterativePSFPhotometry`` now raise a
+    ``ValueError`` if the input ``psf_model`` is not two-dimensional
+    with ``n_inputs=2`` and ``n_outputs=1``. [#1741]
+
 
 1.12.0 (2024-04-12)
 -------------------

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -43,12 +43,14 @@ class PSFPhotometry:
 
     Parameters
     ----------
-    psf_model : `astropy.modeling.Fittable2DModel`
+    psf_model : 2D `astropy.modeling.Model`
         The PSF model to fit to the data. The model must have parameters
         named ``x_0``, ``y_0``, and ``flux``, corresponding to the
         center (x, y) position and flux, or it must have 'x_name',
         'y_name', and 'flux_name' attributes that map to the x, y, and
         flux parameters (i.e., a model output from `prepare_psf_model`).
+        The model must be two-dimensional such that it accepts 2 inputs
+        (e.g., x and y) and provides 1 output.
 
     fit_shape : int or length-2 array_like
         The rectangular shape around the center of a star that will
@@ -219,6 +221,9 @@ class PSFPhotometry:
         """
         Validate the input PSF model.
 
+        The PSF model must be a subclass of `astropy.modeling.Model`. It
+        must also be two-dimensional and have a single output.
+
         The PSF model must have parameters called 'x_0', 'y_0', and
         'flux' or it must have 'x_name', 'y_name', and 'flux_name'
         attributes (i.e., output from `prepare_psf_model`). Otherwise, a
@@ -226,6 +231,13 @@ class PSFPhotometry:
         """
         if not isinstance(self.psf_model, Model):
             raise TypeError('psf_model must be an Astropy Model subclass.')
+
+        if self.psf_model.n_inputs != 2:
+            raise ValueError('psf_model must be two-dimensional.')
+        if self.psf_model.n_outputs != 1:
+            raise ValueError('psf_model must have a single output.')
+
+        # check for required PSF model parameters
         _ = self._psf_param_names
 
     @staticmethod
@@ -1189,10 +1201,14 @@ class IterativePSFPhotometry:
 
     Parameters
     ----------
-    psf_model : `astropy.modeling.Fittable2DModel`
-        The PSF model to fit to the data. The model needs to have
-        three parameters named ``x_0``, ``y_0``, and ``flux``,
-        corresponding to the center (x, y) position and flux.
+    psf_model : 2D `astropy.modeling.Model`
+        The PSF model to fit to the data. The model must have parameters
+        named ``x_0``, ``y_0``, and ``flux``, corresponding to the
+        center (x, y) position and flux, or it must have 'x_name',
+        'y_name', and 'flux_name' attributes that map to the x, y, and
+        flux parameters (i.e., a model output from `prepare_psf_model`).
+        The model must be two-dimensional such that it accepts 2 inputs
+        (e.g., x and y) and provides 1 output.
 
     fit_shape : int or length-2 array_like
         The rectangular shape around the center of a star that will

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -232,10 +232,9 @@ class PSFPhotometry:
         if not isinstance(self.psf_model, Model):
             raise TypeError('psf_model must be an Astropy Model subclass.')
 
-        if self.psf_model.n_inputs != 2:
-            raise ValueError('psf_model must be two-dimensional.')
-        if self.psf_model.n_outputs != 1:
-            raise ValueError('psf_model must have a single output.')
+        if self.psf_model.n_inputs != 2 or self.psf_model.n_outputs != 1:
+            raise ValueError('psf_model must be two-dimensional with '
+                             'n_inputs=2 and n_outputs=1.')
 
         # check for required PSF model parameters
         _ = self._psf_param_names
@@ -653,7 +652,7 @@ class PSFPhotometry:
             fit_infos.extend([info] * npsf_models)  # views
             fit_param_errs.extend(self._split_param_errs(param_err, nfitparam))
 
-        if len(fit_models) != len(fit_infos):
+        if len(fit_models) != len(fit_infos):  # pragma: no cover
             raise ValueError('fit_models and fit_infos have different lengths')
 
         # change the sorting from group_id to source id order
@@ -678,9 +677,9 @@ class PSFPhotometry:
         ungroup_idx = np.argsort(sources['id'].value)
         self._group_results['ungroup_indices'] = ungroup_idx
         sources = sources.groups
-        if self.progress_bar:
+        if self.progress_bar:  # pragma: no cover
             desc = 'Fit source/group'
-            sources = add_progress_bar(sources, desc=desc)  # pragma: no cover
+            sources = add_progress_bar(sources, desc=desc)
 
         # Save the fit_info results for these keys if they are present.
         # Some of these keys are returned only by some fitters. These
@@ -807,10 +806,10 @@ class PSFPhotometry:
 
         for npixfit, residuals in zip(self.fit_results['npixfit'],
                                       fit_residuals):
-            if len(residuals) != npixfit:
+            if len(residuals) != npixfit:  # pragma: no cover
                 raise ValueError('size of residuals does not match npixfit')
 
-        if len(fit_residuals) != len(source_tbl):
+        if len(fit_residuals) != len(source_tbl):  # pragma: no cover
             raise ValueError('fit_residuals does not match the source '
                              'table length')
 
@@ -1039,14 +1038,14 @@ class PSFPhotometry:
 
         # create output table
         fit_sources = self._model_params_to_table(fit_models)  # ungrouped
-        if len(init_params) != len(fit_sources):
+        if len(init_params) != len(fit_sources):  # pragma: no cover
             raise ValueError('init_params and fit_sources tables have '
                              'different lengths')
         source_tbl = hstack((init_params, fit_sources))
 
         param_errors = self._param_errors_to_table()
         if len(param_errors) > 0:
-            if len(param_errors) != len(source_tbl):
+            if len(param_errors) != len(source_tbl):  # pragma: no cover
                 raise ValueError('param errors and fit sources tables have '
                                  'different lengths')
             source_tbl = hstack((source_tbl, param_errors))
@@ -1116,9 +1115,9 @@ class PSFPhotometry:
         data = np.zeros(shape)
         xname, yname = self._psf_param_names[0:2]
 
-        if self.progress_bar:
+        if self.progress_bar:  # pragma: no cover
             desc = 'Model image'
-            fit_models = add_progress_bar(fit_models, desc=desc)  # pragma: no cover
+            fit_models = add_progress_bar(fit_models, desc=desc)
 
         # fit_models must be a list of individual, not grouped, PSF
         # models, i.e., there should be one PSF model (which may be
@@ -1579,9 +1578,9 @@ class IterativePSFPhotometry:
         data = np.zeros(shape)
         xname, yname = self.fit_results[0]._psf_param_names[0:2]
 
-        if self.psfphot.progress_bar:
+        if self.psfphot.progress_bar:  # pragma: no cover
             desc = 'Model image'
-            fit_models = add_progress_bar(fit_models, desc=desc)  # pragma: no cover
+            fit_models = add_progress_bar(fit_models, desc=desc)
 
         # fit_models must be a list of individual, not grouped, PSF
         # models, i.e., there should be one PSF model (which may be

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -7,7 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.modeling.fitting import LMLSQFitter, SimplexLSQFitter
-from astropy.modeling.models import Gaussian2D
+from astropy.modeling.models import Gaussian1D, Gaussian2D
 from astropy.nddata import NDData, StdDevUncertainty, overlap_slices
 from astropy.table import QTable, Table
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
@@ -32,6 +32,11 @@ def test_inputs():
     match = 'psf_model must be an Astropy Model subclass'
     with pytest.raises(TypeError, match=match):
         _ = PSFPhotometry(1, 3)
+
+    match = 'psf_model must be two-dimensional'
+    with pytest.raises(ValueError, match=match):
+        psf_model = Gaussian1D()
+        _ = PSFPhotometry(psf_model, 3)
 
     match = 'fit_shape must have an odd value for both axes'
     for shape in ((0, 0), (4, 3)):


### PR DESCRIPTION
This PR checks the that the input `psf_model` to `PSFPhotometry` and `IterativePSFPhotometry` is two-dimensional with `n_inputs = 2` and `n_outputs = 1`.