### PR TITLE
Add support for units in peak_finder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,14 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.detection``
+
+  - The ``find_peaks`` function now supports ``Quantity`` inputs.
+    [#1743]
+
+  - The ``Table`` returned from ``find_peaks`` now has an ``id`` column
+    that contains unique integer IDs for each peak. [#1743]
+
 - ``photutils.profiles``
 
   - Added an ``unnormalize`` method to ``RadialProfile`` and

--- a/docs/detection.rst
+++ b/docs/detection.rst
@@ -212,18 +212,18 @@ sigma above the background and a separated by at least 5 pixels:
     >>> tbl = find_peaks(data, threshold, box_size=11)
     >>> tbl['peak_value'].info.format = '%.8g'  # for consistent table output
     >>> print(tbl[:10])  # print only the first 10 peaks
-    x_peak y_peak peak_value
-    ------ ------ ----------
-       233      0  27.477852
-       493      6  20.404769
-       207     11  24.075798
-       258     12  17.395025
-       366     12  18.729726
-       289     22  35.853276
-       380     29  19.261986
-       442     31  30.239994
-       359     36  19.771626
-       471     38   25.45583
+     id x_peak y_peak peak_value
+    --- ------ ------ ----------
+      1    233      0  27.477852
+      2    493      6  20.404769
+      3    207     11  24.075798
+      4    258     12  17.395025
+      5    366     12  18.729726
+      6    289     22  35.853276
+      7    380     29  19.261986
+      8    442     31  30.239994
+      9    359     36  19.771626
+     10    471     38   25.45583
 
 And let's plot the location of the detected peaks in the image:
 

--- a/docs/epsf.rst
+++ b/docs/epsf.rst
@@ -83,19 +83,19 @@ stars:
     >>> peaks_tbl = find_peaks(data, threshold=500.0)  # doctest: +REMOTE_DATA
     >>> peaks_tbl['peak_value'].info.format = '%.8g'  # for consistent table output  # doctest: +REMOTE_DATA
     >>> print(peaks_tbl)  # doctest: +REMOTE_DATA
-    x_peak y_peak peak_value
-    ------ ------ ----------
-       849      2  1076.7026
-       182      4  1709.5671
-       324      4  3006.0086
-       100      9  1142.9915
-       824      9  1302.8604
-       ...    ...        ...
-       751    992  801.23834
-       114    994  1595.2804
-       299    994  648.18539
-       207    998  2810.6503
-       691    999  2611.0464
+     id x_peak y_peak peak_value
+    --- ------ ------ ----------
+      1    849      2  1076.7026
+      2    182      4  1709.5671
+      3    324      4  3006.0086
+      4    100      9  1142.9915
+      5    824      9  1302.8604
+    ...    ...    ...        ...
+    427    751    992  801.23834
+    428    114    994  1595.2804
+    429    299    994  648.18539
+    430    207    998  2810.6503
+    431    691    999  2611.0464
     Length = 431 rows
 
 Note that the stars are sufficiently separated in the simulated image

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -10,33 +10,34 @@ import numpy as np
 from astropy.table import QTable
 
 from photutils.utils._misc import _get_meta
+from photutils.utils._quantity_helpers import process_quantities
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['find_peaks']
 
 
-def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
+def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
                border_width=None, npeaks=np.inf, centroid_func=None,
                error=None, wcs=None):
     """
     Find local peaks in an image that are above above a specified
     threshold value.
 
-    Peaks are the maxima above the ``threshold`` within a local region.
-    The local regions are defined by either the ``box_size`` or
-    ``footprint`` parameters.  ``box_size`` defines the local region
-    around each pixel as a square box.  ``footprint`` is a boolean array
+    Peaks are the maxima above the ``threshold`` within a local
+    region. The local regions are defined by either the ``box_size``
+    or ``footprint`` parameters. ``box_size`` defines the local region
+    around each pixel as a square box. ``footprint`` is a boolean array
     where `True` values specify the region shape.
 
     If multiple pixels within a local region have identical intensities,
-    then the coordinates of all such pixels are returned.  Otherwise,
-    there will be only one peak pixel per local region.  Thus, the
+    then the coordinates of all such pixels are returned. Otherwise,
+    there will be only one peak pixel per local region. Thus, the
     defined region effectively imposes a minimum separation between
     peaks unless there are identical peaks within the region.
 
     If ``centroid_func`` is input, then it will be used to calculate a
     centroid within the defined local region centered on each detected
-    peak pixel.  In this case, the centroid will also be returned in the
+    peak pixel. In this case, the centroid will also be returned in the
     output table.
 
     Parameters
@@ -44,25 +45,27 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     data : array_like
         The 2D array of the image.
 
-    threshold : float or array_like
+    threshold : float, scalar `~astropy.units.Quantity` or array_like
         The data value or pixel-wise data values to be used for the
-        detection threshold. A 2D ``threshold`` must have the same shape
-        as ``data``. See `~photutils.segmentation.detect_threshold` for
-        one way to create a ``threshold`` image.
+        detection threshold. If ``data`` is a `~astropy.units.Quantity`
+        array, then ``threshold`` must have the same units as ``data``.
+        A 2D ``threshold`` must have the same shape as ``data``. See
+        `~photutils.segmentation.detect_threshold` for one way to create
+        a ``threshold`` image.
 
     box_size : scalar or tuple, optional
         The size of the local region to search for peaks at every point
-        in ``data``.  If ``box_size`` is a scalar, then the region shape
-        will be ``(box_size, box_size)``.  Either ``box_size`` or
-        ``footprint`` must be defined.  If they are both defined, then
+        in ``data``. If ``box_size`` is a scalar, then the region
+        shape will be ``(box_size, box_size)``. Either ``box_size`` or
+        ``footprint`` must be defined. If they are both defined, then
         ``footprint`` overrides ``box_size``.
 
     footprint : `~numpy.ndarray` of bools, optional
-        A boolean array where `True` values describe the local footprint
-        region within which to search for peaks at every point in
-        ``data``.  ``box_size=(n, m)`` is equivalent to
-        ``footprint=np.ones((n, m))``.  Either ``box_size`` or
-        ``footprint`` must be defined.  If they are both defined, then
+        A boolean array where `True` values describe the local
+        footprint region within which to search for peaks at every
+        point in ``data``. ``box_size=(n, m)`` is equivalent to
+        ``footprint=np.ones((n, m))``. Either ``box_size`` or
+        ``footprint`` must be defined. If they are both defined, then
         ``footprint`` overrides ``box_size``.
 
     mask : array_like, bool, optional
@@ -74,7 +77,7 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
         ``data``.
 
     npeaks : int, optional
-        The maximum number of peaks to return.  When the number of
+        The maximum number of peaks to return. When the number of
         detected peaks exceeds ``npeaks``, the peaks with the highest
         peak intensities will be returned.
 
@@ -89,7 +92,9 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     error : array_like, optional
         The 2D array of the 1-sigma errors of the input ``data``.
         ``error`` is used only if ``centroid_func`` is input (the
-        ``error`` array is passed directly to the ``centroid_func``).
+        ``error`` array is passed directly to the ``centroid_func``). If
+        ``data`` is a `~astropy.units.Quantity` array, then ``error``
+        must have the same units as ``data``.
 
     wcs : `None` or WCS object, optional
         A world coordinate system (WCS) transformation that
@@ -103,9 +108,9 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     -------
     output : `~astropy.table.Table` or `None`
         A table containing the x and y pixel location of the peaks and
-        their values.  If ``centroid_func`` is input, then the table
-        will also contain the centroid position.  If no peaks are found
-        then `None` is returned.
+        their values. If ``centroid_func`` is input, then the table will
+        also contain the centroid position. If no peaks are found then
+        `None` is returned.
 
     Notes
     -----
@@ -117,6 +122,10 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     input ``box_size`` or ``footprint``.
     """
     from scipy.ndimage import maximum_filter
+
+    arrays, unit = process_quantities((data, threshold, error),
+                                      ('data', 'threshold', 'error'))
+    data, threshold, error = arrays
 
     data = np.asanyarray(data)
 
@@ -162,6 +171,9 @@ def find_peaks(data, threshold, box_size=3, footprint=None, mask=None,
     peak_goodmask = np.logical_and(peak_goodmask, (data > threshold))
     y_peaks, x_peaks = peak_goodmask.nonzero()
     peak_values = data[y_peaks, x_peaks]
+
+    if unit is not None:
+        peak_values <<= unit
 
     nxpeaks = len(x_peaks)
     if nxpeaks > npeaks:

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -187,8 +187,9 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
         return None
 
     # construct the output table
-    colnames = ['x_peak', 'y_peak', 'peak_value']
-    coldata = [x_peaks, y_peaks, peak_values]
+    ids = np.arange(len(x_peaks)) + 1
+    colnames = ['id', 'x_peak', 'y_peak', 'peak_value']
+    coldata = [ids, x_peaks, y_peaks, peak_values]
     table = QTable(coldata, names=colnames)
     table.meta.update(_get_meta())  # keep table.meta type
 

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -3,6 +3,7 @@
 Tests for the peakfinder module.
 """
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.tests.helper import assert_quantity_allclose
@@ -26,9 +27,20 @@ class TestFindPeaks:
     def test_box_size(self):
         """Test with box_size."""
         tbl = find_peaks(PEAKDATA, 0.1, box_size=3)
+        assert tbl['id'][0] == 1
         assert_array_equal(tbl['x_peak'], PEAKREF1[:, 1])
         assert_array_equal(tbl['y_peak'], PEAKREF1[:, 0])
         assert_array_equal(tbl['peak_value'], [1.0, 1.0])
+
+        # test with units
+        unit = u.Jy
+        tbl2 = find_peaks(PEAKDATA << unit, 0.1 << unit, box_size=3)
+        columns = ['id', 'x_peak', 'y_peak']
+        for column in columns:
+            assert_array_equal(tbl[column], tbl2[column])
+        col = 'peak_value'
+        assert tbl2[col].unit == unit
+        assert_array_equal(tbl[col], tbl2[col].value)
 
     def test_footprint(self):
         """Test with footprint."""


### PR DESCRIPTION
Wit this PR:

* The ``find_peaks`` function now supports ``Quantity`` inputs.
* The ``Table`` returned from ``find_peaks`` now has an ``id`` column that contains unique integer IDs for each peak.
