### PR TITLE
Add support for units in DAOStarFinder, IRAFStarFinder, and StarFinder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,11 +9,14 @@ New Features
 
 - ``photutils.detection``
 
-  - The ``find_peaks`` function now supports ``Quantity`` inputs.
+  - The ``find_peaks`` function now supports input arrays with units.
     [#1743]
 
   - The ``Table`` returned from ``find_peaks`` now has an ``id`` column
     that contains unique integer IDs for each peak. [#1743]
+
+  - The ``DAOStarFinder``, ``IRAFStarFinder``, and ``StarFinder``
+    classes now support input arrays with units. [#1746]
 
 - ``photutils.profiles``
 

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -200,7 +200,7 @@ class _StarFinderKernel:
     .. [1] https://en.wikipedia.org/wiki/Gaussian_function
     """
 
-    def __init__(self, fwhm, ratio=1.0, theta=0.0, sigma_radius=1.5,
+    def __init__(self, fwhm, *, ratio=1.0, theta=0.0, sigma_radius=1.5,
                  normalize_zerosum=True):
 
         if fwhm < 0:

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -41,23 +41,26 @@ class StarFinderBase(metaclass=abc.ABCMeta):
             The convolution kernel.
 
         threshold : float
-            The absolute image value above which to select sources.  This
-            threshold should be the threshold input to the star finder class
-            multiplied by the kernel relerr.
+            The absolute image value above which to select sources. This
+            threshold should be the threshold input to the star finder
+            class multiplied by the kernel relerr. If ``convolved_data``
+            is a `~astropy.units.Quantity` array, then ``threshold``
+            must have the same units.
 
         min_separation : float, optional
             The minimum separation for detected objects in pixels.
 
         mask : 2D bool array, optional
-            A boolean mask with the same shape as ``data``, where a `True`
-            value indicates the corresponding element of ``data`` is masked.
-            Masked pixels are ignored when searching for stars.
+            A boolean mask with the same shape as ``data``, where a
+            `True` value indicates the corresponding element of ``data``
+            is masked. Masked pixels are ignored when searching for
+            stars.
 
         exclude_border : bool, optional
-            Set to `True` to exclude sources found within half the size of
-            the convolution kernel from the image borders.  The default is
-            `False`, which is the mode used by IRAF's `DAOFIND`_ and
-            `starfind`_ tasks.
+            Set to `True` to exclude sources found within half the
+            size of the convolution kernel from the image borders.
+            The default is `False`, which is the mode used by IRAF's
+            `DAOFIND`_ and `starfind`_ tasks.
 
         Returns
         -------
@@ -151,7 +154,7 @@ class _StarFinderKernel:
     """
     Container class for a 2D Gaussian density enhancement kernel.
 
-    The kernel has negative wings and sums to zero.  It is used by both
+    The kernel has negative wings and sums to zero. It is used by both
     `DAOStarFinder` and `IRAFStarFinder`.
 
     Parameters
@@ -161,9 +164,9 @@ class _StarFinderKernel:
         Gaussian kernel in units of pixels.
 
     ratio : float, optional
-        The ratio of the minor and major axis standard deviations of the
-        Gaussian kernel.  ``ratio`` must be strictly positive and less
-        than or equal to 1.0.  The default is 1.0 (i.e., a circular
+        The ratio of the minor and major axis standard deviations of
+        the Gaussian kernel. ``ratio`` must be strictly positive and
+        less than or equal to 1.0. The default is 1.0 (i.e., a circular
         Gaussian kernel).
 
     theta : float, optional
@@ -172,9 +175,9 @@ class _StarFinderKernel:
         axis.
 
     sigma_radius : float, optional
-        The truncation radius of the Gaussian kernel in units of sigma
-        (standard deviation) [``1 sigma = FWHM /
-        2.0*sqrt(2.0*log(2.0))``].  The default is 1.5.
+        The truncation radius of the Gaussian kernel in units
+        of sigma (standard deviation) [``1 sigma = FWHM /
+        2.0*sqrt(2.0*log(2.0))``]. The default is 1.5.
 
     normalize_zerosum : bool, optional
         Whether to normalize the Gaussian kernel to have zero sum, The

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -275,3 +275,19 @@ class _StarFinderKernel:
             self.data = self.gaussian_kernel
 
         self.shape = self.data.shape
+
+
+def _validate_brightest(brightest):
+    """
+    Validate the ``brightest`` parameter.
+
+    It must be >0 and an integer.
+    """
+    if brightest is not None:
+        if brightest <= 0:
+            raise ValueError('brightest must be >= 0')
+        bright_int = int(brightest)
+        if bright_int != brightest:
+            raise ValueError('brightest must be an integer')
+        brightest = bright_int
+    return brightest

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -271,7 +271,7 @@ class _StarFinderKernel:
             self.data = ((self.gaussian_kernel
                           - (self.gaussian_kernel.sum() / self.npixels))
                          / denom) * self.mask
-        else:
+        else:  # pragma: no cover
             self.data = self.gaussian_kernel
 
         self.shape = self.data.shape

--- a/photutils/detection/tests/conftest.py
+++ b/photutils/detection/tests/conftest.py
@@ -1,0 +1,35 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Fixtures used in tests.
+"""
+
+import numpy as np
+import pytest
+from astropy.modeling.models import Gaussian2D
+
+from photutils.datasets import make_test_psf_data
+from photutils.psf import IntegratedGaussianPRF
+
+
+@pytest.fixture(name='kernel')
+def fixture_kernel():
+    size = 5
+    cen = (size - 1) / 2
+    y, x = np.mgrid[0:size, 0:size]
+    g = Gaussian2D(1, cen, cen, 1.2, 1.2, theta=0)
+    return g(x, y)
+
+
+@pytest.fixture(name='data')
+def fixture_data():
+    shape = (101, 101)
+    psf_shape = (11, 11)
+    psf_model = IntegratedGaussianPRF(flux=1, sigma=1.5)
+    nsources = 25
+    data, _ = make_test_psf_data(shape, psf_model, psf_shape, nsources,
+                                 flux_range=(100, 200),
+                                 min_separation=10,
+                                 seed=0,
+                                 border_size=(10, 10),
+                                 progress_bar=False)
+    return data

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -37,7 +37,7 @@ class TestDAOStarFinder:
             assert_allclose(tbl[col], tbl_ref[col])
 
     def test_daofind_threshold_fwhm_inputs(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             DAOStarFinder(threshold=np.ones((2, 2)), fwhm=3.0)
 
         with pytest.raises(TypeError):

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -6,193 +6,210 @@ Tests for DAOStarFinder.
 import itertools
 import os.path as op
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.table import Table
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from photutils.datasets import make_100gaussians_image
 from photutils.detection.daofinder import DAOStarFinder
 from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
-DATA = make_100gaussians_image()
-THRESHOLDS = [8.0, 10.0]
-FWHMS = [1.0, 1.5, 2.0]
-
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestDAOStarFinder:
-    @pytest.mark.parametrize(('threshold', 'fwhm'),
-                             list(itertools.product(THRESHOLDS, FWHMS)))
-    def test_daofind(self, threshold, fwhm):
-        starfinder = DAOStarFinder(threshold, fwhm, sigma_radius=1.5)
-        tbl = starfinder(DATA)
-        datafn = f'daofind_test_thresh{threshold:04.1f}_fwhm{fwhm:04.1f}.txt'
-        datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
-        tbl_ref = Table.read(datafn, format='ascii')
+    def test_daostarfind(self, data):
+        units = u.Jy
+        threshold = 5.0
+        fwhm = 1.0
+        finder0 = DAOStarFinder(threshold, fwhm)
+        finder1 = DAOStarFinder(threshold * units, fwhm, sky=0 * units)
 
-        assert tbl.colnames == tbl_ref.colnames
-        for col in tbl.colnames:
-            assert_allclose(tbl[col], tbl_ref[col])
+        tbl0 = finder0(data)
+        tbl1 = finder1(data << units)
+        assert_array_equal(tbl0, tbl1)
 
-    def test_daofind_threshold_fwhm_inputs(self):
+    def test_daofind_inputs(self):
         with pytest.raises(ValueError):
             DAOStarFinder(threshold=np.ones((2, 2)), fwhm=3.0)
 
         with pytest.raises(TypeError):
             DAOStarFinder(threshold=3.0, fwhm=np.ones((2, 2)))
 
-    def test_daofind_include_border(self):
-        starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
-                                   exclude_border=False)
-        tbl = starfinder(DATA)
-        assert len(tbl) == 20
+        with pytest.raises(ValueError):
+            DAOStarFinder(threshold=3.0, fwhm=-10)
 
-        # test when no detections
-        starfinder = DAOStarFinder(threshold=100, fwhm=2, sigma_radius=1.5,
-                                   exclude_border=False)
-        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
-            tbl = starfinder(DATA)
+        with pytest.raises(ValueError):
+            DAOStarFinder(threshold=3.0, fwhm=2, ratio=-10)
+
+        with pytest.raises(ValueError):
+            DAOStarFinder(threshold=3.0, fwhm=2, sigma_radius=-10)
+
+        with pytest.raises(ValueError):
+            DAOStarFinder(threshold=10, fwhm=1.5, brightest=-1)
+
+        with pytest.raises(ValueError):
+            DAOStarFinder(threshold=10, fwhm=1.5, brightest=3.1)
+
+        xycoords = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        with pytest.raises(ValueError):
+            DAOStarFinder(threshold=10, fwhm=1.5, xycoords=xycoords)
+
+    def test_daofind_nosources(self, data):
+        match = 'No sources were found'
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = DAOStarFinder(threshold=100, fwhm=2)
+            tbl = finder(data)
             assert tbl is None
 
     def test_daofind_exclude_border(self):
-        starfinder = DAOStarFinder(threshold=10, fwhm=2, sigma_radius=1.5,
-                                   exclude_border=True)
-        tbl = starfinder(DATA)
-        assert len(tbl) == 19
+        data = np.zeros((9, 9))
+        data[0, 0] = 1
+        data[2, 2] = 1
+        data[4, 4] = 1
+        data[6, 6] = 1
 
-        # test when no detections
-        starfinder = DAOStarFinder(threshold=100, fwhm=2, sigma_radius=1.5,
-                                   exclude_border=True)
-        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
-            tbl = starfinder(DATA)
-            assert tbl is None
+        finder0 = DAOStarFinder(threshold=0.1, fwhm=0.5, exclude_border=False)
+        finder1 = DAOStarFinder(threshold=0.1, fwhm=0.5, exclude_border=True)
+        tbl0 = finder0(data)
+        tbl1 = finder1(data)
+        assert len(tbl0) > len(tbl1)
 
-    def test_daofind_nosources(self):
-        data = np.ones((3, 3))
-        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
-            starfinder = DAOStarFinder(threshold=10, fwhm=1)
-            tbl = starfinder(data)
-            assert tbl is None
-
-    def test_daofind_sharpness(self):
+    def test_daofind_sharpness(self, data):
         """Sources found, but none pass the sharpness criteria."""
-        with pytest.warns(NoDetectionsWarning,
-                          match='Sources were found, but none pass'):
-            starfinder = DAOStarFinder(threshold=50, fwhm=1.0, sharplo=1.0)
-            tbl = starfinder(DATA)
+        match = 'Sources were found, but none pass'
+
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = DAOStarFinder(threshold=1, fwhm=1.0, sharplo=1.0)
+            tbl = finder(data)
             assert tbl is None
 
-    def test_daofind_roundness(self):
+    def test_daofind_roundness(self, data):
         """Sources found, but none pass the roundness criteria."""
-        with pytest.warns(NoDetectionsWarning,
-                          match='Sources were found, but none pass'):
-            starfinder = DAOStarFinder(threshold=50, fwhm=1.0, roundlo=1.0)
-            tbl = starfinder(DATA)
+        match = 'Sources were found, but none pass'
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = DAOStarFinder(threshold=1, fwhm=1.0, roundlo=1.0)
+            tbl = finder(data)
             assert tbl is None
 
-    def test_daofind_peakmax(self):
+    def test_daofind_peakmax(self, data):
         """Sources found, but none pass the peakmax criteria."""
-        with pytest.warns(NoDetectionsWarning,
-                          match='Sources were found, but none pass'):
-            starfinder = DAOStarFinder(threshold=50, fwhm=1.0, peakmax=1.0)
-            tbl = starfinder(DATA)
+        match = 'Sources were found, but none pass'
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = DAOStarFinder(threshold=1, fwhm=1.0, peakmax=1.0)
+            tbl = finder(data)
             assert tbl is None
 
     def test_daofind_flux_negative(self):
         """Test handling of negative flux (here created by large sky)."""
         data = np.ones((5, 5))
         data[2, 2] = 10.0
-        starfinder = DAOStarFinder(threshold=0.1, fwhm=1.0, sky=10)
-        tbl = starfinder(data)
+        finder = DAOStarFinder(threshold=0.1, fwhm=1.0, sky=10)
+        tbl = finder(data)
         assert not np.isfinite(tbl['mag'])
 
-    def test_daofind_negative_fit_peak(self):
+    def test_daofind_peakmax_filtering(self, data):
         """
-        Regression test that sources with negative fit peaks (i.e.,
-        hx/hy<=0) are excluded.
+        Regression test that objects with peak >= peakmax are filtered
+        out.
         """
-        starfinder = DAOStarFinder(threshold=7.0, fwhm=1.5, roundlo=-np.inf,
-                                   roundhi=np.inf, sharplo=-np.inf,
-                                   sharphi=np.inf)
-        tbl = starfinder(DATA)
-        assert len(tbl) == 102
+        peakmax = 8
+        finder0 = DAOStarFinder(threshold=1.0, fwhm=1.5, roundlo=-np.inf,
+                                roundhi=np.inf, sharplo=-np.inf,
+                                sharphi=np.inf)
+        finder1 = DAOStarFinder(threshold=1.0, fwhm=1.5, roundlo=-np.inf,
+                                roundhi=np.inf, sharplo=-np.inf,
+                                sharphi=np.inf, peakmax=peakmax)
 
-    def test_daofind_peakmax_filtering(self):
-        """
-        Regression test that objects with ``peak`` >= ``peakmax`` are
-        filtered out.
-        """
-        peakmax = 20
-        starfinder = DAOStarFinder(threshold=7.0, fwhm=1.5, roundlo=-np.inf,
-                                   roundhi=np.inf, sharplo=-np.inf,
-                                   sharphi=np.inf, peakmax=peakmax)
-        tbl = starfinder(DATA)
-        assert len(tbl) == 37
-        assert all(tbl['peak'] < peakmax)
+        tbl0 = finder0(data)
+        tbl1 = finder1(data)
+        assert len(tbl0) > len(tbl1)
+        assert all(tbl1['peak'] < peakmax)
 
-    def test_daofind_brightest_filtering(self):
+    def test_daofind_brightest_filtering(self, data):
         """
         Regression test that only top ``brightest`` objects are
         selected.
         """
-        brightest = 40
-        peakmax = 20
-        starfinder = DAOStarFinder(threshold=7.0, fwhm=1.5, roundlo=-np.inf,
-                                   roundhi=np.inf, sharplo=-np.inf,
-                                   sharphi=np.inf, brightest=brightest)
-        tbl = starfinder(DATA)
-        # combined with peakmax
+        brightest = 10
+        finder = DAOStarFinder(threshold=1.0, fwhm=1.5, roundlo=-np.inf,
+                               roundhi=np.inf, sharplo=-np.inf,
+                               sharphi=np.inf, brightest=brightest)
+        tbl = finder(data)
         assert len(tbl) == brightest
-        starfinder = DAOStarFinder(threshold=7.0, fwhm=1.5, roundlo=-np.inf,
-                                   roundhi=np.inf, sharplo=-np.inf,
-                                   sharphi=np.inf, brightest=brightest,
-                                   peakmax=peakmax)
-        tbl = starfinder(DATA)
-        assert len(tbl) == 37
 
-    def test_daofind_mask(self):
+        # combined with peakmax
+        peakmax = 8
+        finder = DAOStarFinder(threshold=1.0, fwhm=1.5, roundlo=-np.inf,
+                               roundhi=np.inf, sharplo=-np.inf,
+                               sharphi=np.inf, brightest=brightest,
+                               peakmax=peakmax)
+        tbl = finder(data)
+        assert len(tbl) == 7
+
+    def test_daofind_mask(self, data):
         """Test DAOStarFinder with a mask."""
-        starfinder = DAOStarFinder(threshold=10, fwhm=1.5)
-        mask = np.zeros(DATA.shape, dtype=bool)
-        mask[100:200] = True
-        tbl1 = starfinder(DATA)
-        tbl2 = starfinder(DATA, mask=mask)
-        assert len(tbl1) > len(tbl2)
+        finder = DAOStarFinder(threshold=1.0, fwhm=1.5)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0:50, :] = True
+        tbl0 = finder(data)
+        tbl1 = finder(data, mask=mask)
+        assert len(tbl0) > len(tbl1)
 
-    def test_inputs(self):
-        with pytest.raises(ValueError):
-            DAOStarFinder(threshold=10, fwhm=1.5, brightest=-1)
-        with pytest.raises(ValueError):
-            DAOStarFinder(threshold=10, fwhm=1.5, brightest=3.1)
+    def test_xycoords(self, data):
+        finder0 = DAOStarFinder(threshold=8.0, fwhm=2)
+        tbl0 = finder0(data)
+        xycoords = list(zip(tbl0['xcentroid'], tbl0['ycentroid']))
+        xycoords = np.round(xycoords).astype(int)
 
-    def test_xycoords(self):
-        starfinder1 = DAOStarFinder(threshold=30, fwhm=2, sigma_radius=1.5,
-                                    exclude_border=True)
-        tbl1 = starfinder1(DATA)
+        finder1 = DAOStarFinder(threshold=8.0, fwhm=2, xycoords=xycoords)
+        tbl1 = finder1(data)
+        assert_array_equal(tbl0, tbl1)
 
-        xycoords = np.array([[145, 169], [395, 187], [427, 211], [11, 224]])
-        starfinder2 = DAOStarFinder(threshold=30, fwhm=2, sigma_radius=1.5,
-                                    exclude_border=True, xycoords=xycoords)
-        tbl2 = starfinder2(DATA)
-        assert np.all(tbl1 == tbl2)
-
-    def test_invalid_xycoords(self):
-        xycoords = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
-        with pytest.raises(ValueError):
-            DAOStarFinder(threshold=10, fwhm=1.5, xycoords=xycoords)
-
-    def test_min_separation(self):
-        threshold = 5
+    def test_min_separation(self, data):
+        threshold = 1.0
         fwhm = 1.0
-        finder1 = DAOStarFinder(threshold, fwhm, sigma_radius=1.5)
-        tbl1 = finder1(DATA)
-        finder2 = DAOStarFinder(threshold, fwhm, sigma_radius=1.5,
-                                min_separation=3.0)
-        tbl2 = finder2(DATA)
+        finder1 = DAOStarFinder(threshold, fwhm)
+        tbl1 = finder1(data)
+        finder2 = DAOStarFinder(threshold, fwhm, min_separation=10.0)
+        tbl2 = finder2(data)
         assert len(tbl1) > len(tbl2)
 
         match = 'min_separation must be >= 0'
         with pytest.raises(ValueError, match=match):
             DAOStarFinder(threshold=10, fwhm=1.5, min_separation=-1.0)
+
+    def test_single_detected_source(self, data):
+        finder = DAOStarFinder(8.0, 2, brightest=1)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0:50] = True
+        tbl = finder(data, mask=mask)
+        assert len(tbl) == 1
+
+        # test slicing with scalar catalog to improve coverage
+        cat = finder._get_raw_catalog(data, mask=mask)
+        assert cat.isscalar
+        flux = cat.flux[0]  # evaluate the flux so it can be sliced
+        assert cat[0].flux == flux
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+@pytest.mark.parametrize(('threshold', 'fwhm'),
+                         list(itertools.product((8.0, 10.0),
+                                                (1.0, 1.5, 2.0))))
+def test_daofind_legacy(threshold, fwhm):
+    """
+    Test DAOStarFinder against the IRAF DAOFind implementation.
+    """
+    data = make_100gaussians_image()
+    finder = DAOStarFinder(threshold, fwhm, sigma_radius=1.5)
+    tbl = finder(data)
+    datafn = f'daofind_test_thresh{threshold:04.1f}_fwhm{fwhm:04.1f}.txt'
+    datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
+    tbl_ref = Table.read(datafn, format='ascii')
+
+    assert tbl.colnames == tbl_ref.colnames
+    for col in tbl.colnames:
+        assert_allclose(tbl[col], tbl_ref[col])

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -7,83 +7,90 @@ import itertools
 import os.path as op
 from contextlib import nullcontext
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.table import Table
 from astropy.utils import minversion
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from photutils.datasets import make_100gaussians_image
-from photutils.detection.irafstarfinder import IRAFStarFinder
+from photutils.detection import IRAFStarFinder
 from photutils.tests.helper import PYTEST_LT_80
 from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
-DATA = make_100gaussians_image()
-THRESHOLDS = [8.0, 10.0]
-FWHMS = [1.0, 1.5, 2.0]
-
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestIRAFStarFinder:
-    @pytest.mark.parametrize(('threshold', 'fwhm'),
-                             list(itertools.product(THRESHOLDS, FWHMS)))
-    def test_irafstarfind(self, threshold, fwhm):
-        starfinder = IRAFStarFinder(threshold, fwhm, sigma_radius=1.5)
-        tbl = starfinder(DATA)
-        datafn = (f'irafstarfind_test_thresh{threshold:04.1f}_'
-                  f'fwhm{fwhm:04.1f}.txt')
-        datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
-        tbl_ref = Table.read(datafn, format='ascii')
+    def test_irafstarfind(self, data):
+        units = u.Jy
+        threshold = 5.0
+        fwhm = 1.0
+        finder0 = IRAFStarFinder(threshold, fwhm)
+        finder1 = IRAFStarFinder(threshold * units, fwhm)
 
-        assert tbl.colnames == tbl_ref.colnames
-        for col in tbl.colnames:
-            assert_allclose(tbl[col], tbl_ref[col])
+        tbl0 = finder0(data)
+        tbl1 = finder1(data << units)
+        assert_array_equal(tbl0, tbl1)
 
-    def test_irafstarfind_threshold_fwhm_inputs(self):
+    def test_irafstarfind_inputs(self):
         with pytest.raises(TypeError):
             IRAFStarFinder(threshold=np.ones((2, 2)), fwhm=3.0)
 
         with pytest.raises(TypeError):
             IRAFStarFinder(threshold=3.0, fwhm=np.ones((2, 2)))
 
+        with pytest.raises(ValueError):
+            IRAFStarFinder(10, 1.5, brightest=-1)
+
+        with pytest.raises(ValueError):
+            IRAFStarFinder(10, 1.5, brightest=3.1)
+
+        xycoords = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        with pytest.raises(ValueError):
+            IRAFStarFinder(threshold=10, fwhm=1.5, xycoords=xycoords)
+
     def test_irafstarfind_nosources(self):
         data = np.ones((3, 3))
-        with pytest.warns(NoDetectionsWarning, match='No sources were found'):
-            starfinder = IRAFStarFinder(threshold=10, fwhm=1)
-            tbl = starfinder(data)
+        match = 'No sources were found'
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = IRAFStarFinder(threshold=10, fwhm=1)
+            tbl = finder(data)
             assert tbl is None
 
-    def test_irafstarfind_sharpness(self):
+    def test_irafstarfind_sharpness(self, data):
         """Sources found, but none pass the sharpness criteria."""
-        with pytest.warns(NoDetectionsWarning,
-                          match='Sources were found, but none pass'):
-            starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, sharplo=2.0)
-            tbl = starfinder(DATA)
+        match = 'Sources were found, but none pass'
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = IRAFStarFinder(threshold=1, fwhm=1.0, sharplo=2.0)
+            tbl = finder(data)
             assert tbl is None
 
-    def test_irafstarfind_roundness(self):
+    def test_irafstarfind_roundness(self, data):
         """Sources found, but none pass the roundness criteria."""
-        with pytest.warns(NoDetectionsWarning,
-                          match='Sources were found, but none pass'):
-            starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, roundlo=1.0)
-            tbl = starfinder(DATA)
+        match = 'Sources were found, but none pass'
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = IRAFStarFinder(threshold=1, fwhm=1.0, roundlo=1.0)
+            tbl = finder(data)
             assert tbl is None
 
-    def test_irafstarfind_peakmax(self):
+    def test_irafstarfind_peakmax(self, data):
         """Sources found, but none pass the peakmax criteria."""
-        with pytest.warns(NoDetectionsWarning,
-                          match='Sources were found, but none pass'):
-            starfinder = IRAFStarFinder(threshold=50, fwhm=1.0, peakmax=1.0)
-            tbl = starfinder(DATA)
+        match = 'Sources were found, but none pass'
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = IRAFStarFinder(threshold=1, fwhm=1.0, peakmax=1.0)
+            tbl = finder(data)
             assert tbl is None
 
-    def test_irafstarfind_sky(self):
-        starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=10.0)
-        tbl = starfinder(DATA)
-        assert len(tbl) == 4
+    def test_irafstarfind_sky(self, data):
+        finder0 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=0.0)
+        finder1 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=5.0)
+        tbl0 = finder0(data)
+        tbl1 = finder1(data)
+        assert np.all(tbl0['flux'] > tbl1['flux'])
 
-    def test_irafstarfind_largesky(self):
+    def test_irafstarfind_largesky(self, data):
         match1 = 'Sources were found, but none pass'
         ctx1 = pytest.warns(NoDetectionsWarning, match=match1)
         if PYTEST_LT_80:
@@ -95,81 +102,105 @@ class TestIRAFStarFinder:
                 match2 = 'invalid value encountered in divide'
             ctx2 = pytest.warns(RuntimeWarning, match=match2)
         with ctx1, ctx2:
-            starfinder = IRAFStarFinder(threshold=25.0, fwhm=2.0, sky=100.0)
-            tbl = starfinder(DATA)
+            finder = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=100.0)
+            tbl = finder(data)
             assert tbl is None
 
-    def test_irafstarfind_peakmax_filtering(self):
+    def test_irafstarfind_peakmax_filtering(self, data):
         """
-        Regression test that objects with ``peak`` >= ``peakmax`` are
-        filtered out.
+        Regression test that objects with peak >= peakmax are filtered
+        out.
         """
-        peakmax = 20
-        starfinder = IRAFStarFinder(threshold=7.0, fwhm=2, roundlo=-np.inf,
-                                    roundhi=np.inf, sharplo=-np.inf,
-                                    sharphi=np.inf, peakmax=peakmax)
-        tbl = starfinder(DATA)
-        assert len(tbl) == 117
-        assert all(tbl['peak'] < peakmax)
+        peakmax = 8
+        finder0 = IRAFStarFinder(threshold=1.0, fwhm=2, roundlo=-np.inf,
+                                 roundhi=np.inf, sharplo=-np.inf,
+                                 sharphi=np.inf)
+        finder1 = IRAFStarFinder(threshold=1.0, fwhm=2, roundlo=-np.inf,
+                                 roundhi=np.inf, sharplo=-np.inf,
+                                 sharphi=np.inf, peakmax=peakmax)
 
-    def test_irafstarfind_brightest_filtering(self):
+        tbl0 = finder0(data)
+        tbl1 = finder1(data)
+        assert len(tbl0) > len(tbl1)
+        assert all(tbl1['peak'] < peakmax)
+
+    def test_irafstarfind_brightest_filtering(self, data):
         """
         Regression test that only top ``brightest`` objects are selected.
         """
-        brightest = 40
-        starfinder = IRAFStarFinder(threshold=7.0, fwhm=2, roundlo=-np.inf,
-                                    roundhi=np.inf, sharplo=-np.inf,
-                                    sharphi=np.inf, brightest=brightest)
-        tbl = starfinder(DATA)
+        brightest = 10
+        finder = IRAFStarFinder(threshold=1.0, fwhm=2, roundlo=-np.inf,
+                                roundhi=np.inf, sharplo=-np.inf,
+                                sharphi=np.inf, brightest=brightest)
+        tbl = finder(data)
         assert len(tbl) == brightest
 
-    def test_irafstarfind_mask(self):
+    def test_irafstarfind_mask(self, data):
         """Test IRAFStarFinder with a mask."""
+        finder = IRAFStarFinder(threshold=1.0, fwhm=1.5)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0:50, :] = True
+        tbl0 = finder(data)
+        tbl1 = finder(data, mask=mask)
+        assert len(tbl0) > len(tbl1)
 
-        starfinder = IRAFStarFinder(threshold=10, fwhm=1.5)
-        mask = np.zeros(DATA.shape, dtype=bool)
-        mask[100:200] = True
-        tbl1 = starfinder(DATA)
-        tbl2 = starfinder(DATA, mask=mask)
-        assert len(tbl1) > len(tbl2)
+    def test_xycoords(self, data):
+        finder0 = IRAFStarFinder(threshold=8.0, fwhm=2)
+        tbl0 = finder0(data)
+        xycoords = list(zip(tbl0['xcentroid'], tbl0['ycentroid']))
+        xycoords = np.round(xycoords).astype(int)
 
-    def test_inputs(self):
-        with pytest.raises(ValueError):
-            IRAFStarFinder(10, 1.5, brightest=-1)
-        with pytest.raises(ValueError):
-            IRAFStarFinder(10, 1.5, brightest=3.1)
+        finder1 = IRAFStarFinder(threshold=8.0, fwhm=2, xycoords=xycoords)
+        tbl1 = finder1(data)
+        assert_array_equal(tbl0, tbl1)
 
-    def test_xycoords(self):
-        starfinder1 = IRAFStarFinder(threshold=30, fwhm=2, sigma_radius=1.5,
-                                     exclude_border=True)
-        tbl1 = starfinder1(DATA)
-
-        xycoords = np.array([[145, 169], [395, 187], [427, 211], [11, 224]])
-        starfinder2 = IRAFStarFinder(threshold=30, fwhm=2, sigma_radius=1.5,
-                                     exclude_border=True, xycoords=xycoords)
-        tbl2 = starfinder2(DATA)
-        assert np.all(tbl1 == tbl2)
-
-    def test_invalid_xycoords(self):
-        xycoords = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
-        with pytest.raises(ValueError):
-            IRAFStarFinder(threshold=10, fwhm=1.5, xycoords=xycoords)
-
-    def test_min_separation(self):
-        threshold = 5
+    def test_min_separation(self, data):
+        threshold = 1.0
         fwhm = 1.0
-        starfinder1 = IRAFStarFinder(threshold, fwhm, sigma_radius=1.5)
-        tbl1 = starfinder1(DATA)
-        starfinder2 = IRAFStarFinder(threshold, fwhm, sigma_radius=1.5,
-                                     min_separation=3.0)
-        tbl2 = starfinder2(DATA)
+        finder1 = IRAFStarFinder(threshold, fwhm)
+        tbl1 = finder1(data)
+        finder2 = IRAFStarFinder(threshold, fwhm, min_separation=3.0)
+        tbl2 = finder2(data)
         assert np.all(tbl1 == tbl2)
 
-        starfinder3 = IRAFStarFinder(threshold, fwhm, sigma_radius=1.5,
-                                     min_separation=2.0)
-        tbl3 = starfinder3(DATA)
-        assert len(tbl3) > len(tbl2)
+        finder3 = IRAFStarFinder(threshold, fwhm, min_separation=10.0)
+        tbl3 = finder3(data)
+        assert len(tbl2) > len(tbl3)
 
         match = 'min_separation must be >= 0'
         with pytest.raises(ValueError, match=match):
             IRAFStarFinder(threshold=10, fwhm=1.5, min_separation=-1.0)
+
+    def test_single_detected_source(self, data):
+        finder = IRAFStarFinder(8.0, 2, brightest=1)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0:50] = True
+        tbl = finder(data, mask=mask)
+        assert len(tbl) == 1
+
+        # test slicing with scalar catalog to improve coverage
+        cat = finder._get_raw_catalog(data, mask=mask)
+        assert cat.isscalar
+        flux = cat.flux[0]  # evaluate the flux so it can be sliced
+        assert cat[0].flux == flux
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+@pytest.mark.parametrize(('threshold', 'fwhm'),
+                         list(itertools.product((8.0, 10.0),
+                                                (1.0, 1.5, 2.0))))
+def test_irafstarfind_legacy(threshold, fwhm):
+    """
+    Test IRAFStarFinder against the IRAF starfind implementation.
+    """
+    data = make_100gaussians_image()
+    finder = IRAFStarFinder(threshold, fwhm, sigma_radius=1.5)
+    tbl = finder(data)
+    datafn = (f'irafstarfind_test_thresh{threshold:04.1f}_'
+              f'fwhm{fwhm:04.1f}.txt')
+    datafn = op.join(op.dirname(op.abspath(__file__)), 'data', datafn)
+    tbl_ref = Table.read(datafn, format='ascii')
+
+    assert tbl.colnames == tbl_ref.colnames
+    for col in tbl.colnames:
+        assert_allclose(tbl[col], tbl_ref[col])

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -10,31 +10,30 @@ from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_array_equal, assert_equal
 
 from photutils.centroids import centroid_com
-from photutils.datasets import make_4gaussians_image, make_gwcs, make_wcs
-from photutils.detection.peakfinder import find_peaks
+from photutils.datasets import make_gwcs, make_wcs
+from photutils.detection import find_peaks
 from photutils.utils._optional_deps import HAS_GWCS, HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
-
-PEAKDATA = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 1]]).astype(float)
-PEAKREF1 = np.array([[0, 0], [2, 2]])
-
-IMAGE = make_4gaussians_image()
-FITSWCS = make_wcs(IMAGE.shape)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestFindPeaks:
-    def test_box_size(self):
+    def test_box_size(self, data):
         """Test with box_size."""
-        tbl = find_peaks(PEAKDATA, 0.1, box_size=3)
+        tbl = find_peaks(data, 0.1, box_size=3)
         assert tbl['id'][0] == 1
-        assert_equal(tbl['x_peak'], PEAKREF1[:, 1])
-        assert_equal(tbl['y_peak'], PEAKREF1[:, 0])
-        assert_equal(tbl['peak_value'], [1.0, 1.0])
+        assert len(tbl) == 25
+        columns = ['id', 'x_peak', 'y_peak', 'peak_value']
+        assert all(column in tbl.colnames for column in columns)
+        assert np.min(tbl['x_peak']) > 0
+        assert np.max(tbl['x_peak']) < 101
+        assert np.min(tbl['y_peak']) > 0
+        assert np.max(tbl['y_peak']) < 101
+        assert np.max(tbl['peak_value']) < 13.1
 
         # test with units
         unit = u.Jy
-        tbl2 = find_peaks(PEAKDATA << unit, 0.1 << unit, box_size=3)
+        tbl2 = find_peaks(data << unit, 0.1 << unit, box_size=3)
         columns = ['id', 'x_peak', 'y_peak']
         for column in columns:
             assert_equal(tbl[column], tbl2[column])
@@ -42,62 +41,58 @@ class TestFindPeaks:
         assert tbl2[col].unit == unit
         assert_equal(tbl[col], tbl2[col].value)
 
-    def test_footprint(self):
+    def test_footprint(self, data):
         """Test with footprint."""
-        tbl = find_peaks(PEAKDATA, 0.1, footprint=np.ones((3, 3)))
-        assert_equal(tbl['x_peak'], PEAKREF1[:, 1])
-        assert_equal(tbl['y_peak'], PEAKREF1[:, 0])
-        assert_equal(tbl['peak_value'], [1.0, 1.0])
+        tbl0 = find_peaks(data, 0.1, box_size=3)
+        tbl1 = find_peaks(data, 0.1, footprint=np.ones((3, 3)))
+        assert_array_equal(tbl0, tbl1)
 
-    def test_mask(self):
+    def test_mask(self, data):
         """Test with mask."""
-        mask = np.zeros(PEAKDATA.shape, dtype=bool)
-        mask[0, 0] = True
-        tbl = find_peaks(PEAKDATA, 0.1, box_size=3, mask=mask)
-        assert len(tbl) == 1
-        assert_equal(tbl['x_peak'], PEAKREF1[1, 0])
-        assert_equal(tbl['y_peak'], PEAKREF1[1, 1])
-        assert_equal(tbl['peak_value'], 1.0)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0:50, :] = True
+        tbl0 = find_peaks(data, 0.1, box_size=3)
+        tbl1 = find_peaks(data, 0.1, box_size=3, mask=mask)
+        assert len(tbl1) < len(tbl0)
 
-    def test_maskshape(self):
+    def test_maskshape(self, data):
         """Test if make shape doesn't match data shape."""
         with pytest.raises(ValueError):
-            find_peaks(PEAKDATA, 0.1, mask=np.ones((5, 5)))
+            find_peaks(data, 0.1, mask=np.ones((5, 5)))
 
-    def test_thresholdshape(self):
+    def test_thresholdshape(self, data):
         """Test if threshold shape doesn't match data shape."""
         with pytest.raises(ValueError):
-            find_peaks(PEAKDATA, np.ones((2, 2)))
+            find_peaks(data, np.ones((2, 2)))
 
-    def test_npeaks(self):
+    def test_npeaks(self, data):
         """Test npeaks."""
-        tbl = find_peaks(PEAKDATA, 0.1, box_size=3, npeaks=1)
-        assert_equal(tbl['x_peak'], PEAKREF1[1, 1])
-        assert_equal(tbl['y_peak'], PEAKREF1[1, 0])
+        tbl = find_peaks(data, 0.1, box_size=3, npeaks=1)
+        assert len(tbl) == 1
 
-    def test_border_width(self):
+    def test_border_width(self, data):
         """Test border exclusion."""
-        with pytest.warns(NoDetectionsWarning,
-                          match='No local peaks were found'):
-            tbl = find_peaks(PEAKDATA, 0.1, box_size=3, border_width=3)
-            assert tbl is None
+        tbl0 = find_peaks(data, 0.1, box_size=3)
+        tbl1 = find_peaks(data, 0.1, box_size=3, border_width=25)
+        assert len(tbl1) < len(tbl0)
 
-    def test_box_size_int(self):
+    def test_box_size_int(self, data):
         """Test non-integer box_size."""
-        tbl1 = find_peaks(PEAKDATA, 0.1, box_size=5.0)
-        tbl2 = find_peaks(PEAKDATA, 0.1, box_size=5.5)
+        tbl1 = find_peaks(data, 0.1, box_size=5.0)
+        tbl2 = find_peaks(data, 0.1, box_size=5.5)
         assert_array_equal(tbl1, tbl2)
 
-    def test_centroid_func_callable(self):
+    def test_centroid_func_callable(self, data):
         """Test that centroid_func is callable."""
         with pytest.raises(TypeError):
-            find_peaks(PEAKDATA, 0.1, box_size=2, centroid_func=True)
+            find_peaks(data, 0.1, box_size=2, centroid_func=True)
 
-    def test_wcs(self):
+    def test_wcs(self, data):
         """Test with astropy WCS."""
         columns = ['skycoord_peak', 'skycoord_centroid']
 
-        tbl = find_peaks(IMAGE, 100, wcs=FITSWCS, centroid_func=centroid_com)
+        fits_wcs = make_wcs(data.shape)
+        tbl = find_peaks(data, 1, wcs=fits_wcs, centroid_func=centroid_com)
         for column in columns:
             assert column in tbl.colnames
         assert tbl.colnames == ['id', 'x_peak', 'y_peak', 'skycoord_peak',
@@ -105,21 +100,21 @@ class TestFindPeaks:
                                 'skycoord_centroid']
 
     @pytest.mark.skipif(not HAS_GWCS, reason='gwcs is required')
-    def test_gwcs(self):
+    def test_gwcs(self, data):
         """Test with gwcs."""
         columns = ['skycoord_peak', 'skycoord_centroid']
 
-        gwcs_obj = make_gwcs(IMAGE.shape)
-        tbl = find_peaks(IMAGE, 100, wcs=gwcs_obj, centroid_func=centroid_com)
+        gwcs_obj = make_gwcs(data.shape)
+        tbl = find_peaks(data, 1, wcs=gwcs_obj, centroid_func=centroid_com)
         for column in columns:
             assert column in tbl.colnames
 
     @pytest.mark.skipif(not HAS_GWCS, reason='gwcs is required')
-    def test_wcs_values(self):
-        gwcs_obj = make_gwcs(IMAGE.shape)
-        tbl1 = find_peaks(IMAGE, 100, wcs=FITSWCS, centroid_func=centroid_com)
-        tbl2 = find_peaks(IMAGE, 100, wcs=gwcs_obj,
-                          centroid_func=centroid_com)
+    def test_wcs_values(self, data):
+        fits_wcs = make_wcs(data.shape)
+        gwcs_obj = make_gwcs(data.shape)
+        tbl1 = find_peaks(data, 1, wcs=fits_wcs, centroid_func=centroid_com)
+        tbl2 = find_peaks(data, 1, wcs=gwcs_obj, centroid_func=centroid_com)
         columns = ['skycoord_peak', 'skycoord_centroid']
         for column in columns:
             assert_quantity_allclose(tbl1[column].ra, tbl2[column].ra)
@@ -128,34 +123,37 @@ class TestFindPeaks:
     def test_constant_array(self):
         """Test for empty output table when data is constant."""
         data = np.ones((10, 10))
-        with pytest.warns(NoDetectionsWarning, match='Input data is constant'):
+        match = 'Input data is constant'
+        with pytest.warns(NoDetectionsWarning, match=match):
             tbl = find_peaks(data, 0.0)
             assert tbl is None
 
-    def test_no_peaks(self):
+    def test_no_peaks(self, data):
         """
         Tests for when no peaks are found.
         """
-        with pytest.warns(NoDetectionsWarning,
-                          match='No local peaks were found'):
-            tbl = find_peaks(IMAGE, 10000)
+        fits_wcs = make_wcs(data.shape)
+
+        match = 'No local peaks were found'
+        with pytest.warns(NoDetectionsWarning, match=match):
+            tbl = find_peaks(data, 10000)
             assert tbl is None
-        with pytest.warns(NoDetectionsWarning,
-                          match='No local peaks were found'):
-            tbl = find_peaks(IMAGE, 100000, centroid_func=centroid_com)
+
+        with pytest.warns(NoDetectionsWarning, match=match):
+            tbl = find_peaks(data, 100000, centroid_func=centroid_com)
             assert tbl is None
-        with pytest.warns(NoDetectionsWarning,
-                          match='No local peaks were found'):
-            tbl = find_peaks(IMAGE, 100000, wcs=FITSWCS)
+
+        with pytest.warns(NoDetectionsWarning, match=match):
+            tbl = find_peaks(data, 100000, wcs=fits_wcs)
             assert tbl is None
-        with pytest.warns(NoDetectionsWarning,
-                          match='No local peaks were found'):
-            tbl = find_peaks(IMAGE, 100000, wcs=FITSWCS,
+
+        with pytest.warns(NoDetectionsWarning, match=match):
+            tbl = find_peaks(data, 100000, wcs=fits_wcs,
                              centroid_func=centroid_com)
             assert tbl is None
 
-    def test_data_nans(self):
+    def test_data_nans(self, data):
         """Test that data with NaNs does not issue Runtime warning."""
-        data = np.copy(PEAKDATA)
-        data[1, 1] = np.nan
-        find_peaks(data, 0.0)
+        data = np.copy(data)
+        data[50:, :] = np.nan
+        find_peaks(data, 0.1)

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -7,7 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.tests.helper import assert_quantity_allclose
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_equal
 
 from photutils.centroids import centroid_com
 from photutils.datasets import make_4gaussians_image, make_gwcs, make_wcs
@@ -28,26 +28,26 @@ class TestFindPeaks:
         """Test with box_size."""
         tbl = find_peaks(PEAKDATA, 0.1, box_size=3)
         assert tbl['id'][0] == 1
-        assert_array_equal(tbl['x_peak'], PEAKREF1[:, 1])
-        assert_array_equal(tbl['y_peak'], PEAKREF1[:, 0])
-        assert_array_equal(tbl['peak_value'], [1.0, 1.0])
+        assert_equal(tbl['x_peak'], PEAKREF1[:, 1])
+        assert_equal(tbl['y_peak'], PEAKREF1[:, 0])
+        assert_equal(tbl['peak_value'], [1.0, 1.0])
 
         # test with units
         unit = u.Jy
         tbl2 = find_peaks(PEAKDATA << unit, 0.1 << unit, box_size=3)
         columns = ['id', 'x_peak', 'y_peak']
         for column in columns:
-            assert_array_equal(tbl[column], tbl2[column])
+            assert_equal(tbl[column], tbl2[column])
         col = 'peak_value'
         assert tbl2[col].unit == unit
-        assert_array_equal(tbl[col], tbl2[col].value)
+        assert_equal(tbl[col], tbl2[col].value)
 
     def test_footprint(self):
         """Test with footprint."""
         tbl = find_peaks(PEAKDATA, 0.1, footprint=np.ones((3, 3)))
-        assert_array_equal(tbl['x_peak'], PEAKREF1[:, 1])
-        assert_array_equal(tbl['y_peak'], PEAKREF1[:, 0])
-        assert_array_equal(tbl['peak_value'], [1.0, 1.0])
+        assert_equal(tbl['x_peak'], PEAKREF1[:, 1])
+        assert_equal(tbl['y_peak'], PEAKREF1[:, 0])
+        assert_equal(tbl['peak_value'], [1.0, 1.0])
 
     def test_mask(self):
         """Test with mask."""
@@ -55,9 +55,9 @@ class TestFindPeaks:
         mask[0, 0] = True
         tbl = find_peaks(PEAKDATA, 0.1, box_size=3, mask=mask)
         assert len(tbl) == 1
-        assert_array_equal(tbl['x_peak'], PEAKREF1[1, 0])
-        assert_array_equal(tbl['y_peak'], PEAKREF1[1, 1])
-        assert_array_equal(tbl['peak_value'], 1.0)
+        assert_equal(tbl['x_peak'], PEAKREF1[1, 0])
+        assert_equal(tbl['y_peak'], PEAKREF1[1, 1])
+        assert_equal(tbl['peak_value'], 1.0)
 
     def test_maskshape(self):
         """Test if make shape doesn't match data shape."""
@@ -72,8 +72,8 @@ class TestFindPeaks:
     def test_npeaks(self):
         """Test npeaks."""
         tbl = find_peaks(PEAKDATA, 0.1, box_size=3, npeaks=1)
-        assert_array_equal(tbl['x_peak'], PEAKREF1[1, 1])
-        assert_array_equal(tbl['y_peak'], PEAKREF1[1, 0])
+        assert_equal(tbl['x_peak'], PEAKREF1[1, 1])
+        assert_equal(tbl['y_peak'], PEAKREF1[1, 0])
 
     def test_border_width(self):
         """Test border exclusion."""

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -3,80 +3,129 @@
 Tests for StarFinder.
 """
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
+from astropy.table import Table
+from numpy.testing import assert_equal
 
-from photutils.datasets import make_100gaussians_image
+from photutils.datasets import make_test_psf_data
 from photutils.detection.starfinder import StarFinder
+from photutils.psf import IntegratedGaussianPRF
 from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
-DATA = make_100gaussians_image()
-y, x = np.mgrid[0:25, 0:25]
-g = Gaussian2D(1, 12, 12, 3, 2, theta=np.pi / 6.0)
-PSF = g(x, y)
+
+@pytest.fixture(name='kernel')
+def fixture_kernel():
+    size = 5
+    cen = (size - 1) / 2
+    y, x = np.mgrid[0:size, 0:size]
+    g = Gaussian2D(1, cen, cen, 1.2, 1.2, theta=0)
+    return g(x, y)
+
+
+@pytest.fixture(name='data')
+def fixture_data():
+    shape = (101, 101)
+    psf_shape = (11, 11)
+    psf_model = IntegratedGaussianPRF(flux=1, sigma=1.5)
+    nsources = 25
+    data, _ = make_test_psf_data(shape, psf_model, psf_shape, nsources,
+                                 flux_range=(100, 200),
+                                 min_separation=10,
+                                 seed=0,
+                                 border_size=(10, 10),
+                                 progress_bar=False)
+    return data
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestStarFinder:
-    def test_starfind(self):
-        finder1 = StarFinder(10, PSF)
-        finder2 = StarFinder(30, PSF)
-        tbl1 = finder1(DATA)
-        tbl2 = finder2(DATA)
-        assert len(tbl1) > len(tbl2)
+    def test_starfind(self, data, kernel):
+        finder1 = StarFinder(1, kernel)
+        finder2 = StarFinder(10, kernel)
+        tbl1 = finder1(data)
+        tbl2 = finder2(data)
+        assert isinstance(tbl1, Table)
+        assert len(tbl1) == 25
+        assert len(tbl2) == 7
 
-    def test_inputs(self):
-        with pytest.raises(ValueError):
-            StarFinder(10, PSF, min_separation=-1)
-        with pytest.raises(ValueError):
-            StarFinder(10, PSF, brightest=-1)
-        with pytest.raises(ValueError):
-            StarFinder(10, PSF, brightest=3.1)
+        # test with units
+        unit = u.Jy
+        finder3 = StarFinder(1 * unit, kernel)
+        tbl3 = finder3(data << unit)
+        assert isinstance(tbl3, Table)
+        assert len(tbl3) == 25
+        assert tbl3['flux'].unit == unit
+        assert tbl3['max_value'].unit == unit
+        for col in tbl3.colnames:
+            if col not in ('flux', 'max_value'):
+                assert_equal(tbl3[col], tbl1[col])
 
-    def test_nosources(self):
+    def test_inputs(self, kernel):
+        with pytest.raises(ValueError):
+            StarFinder(1, kernel, min_separation=-1)
+        with pytest.raises(ValueError):
+            StarFinder(1, kernel, brightest=-1)
+        with pytest.raises(ValueError):
+            StarFinder(1, kernel, brightest=3.1)
+
+    def test_nosources(self, data, kernel):
         with pytest.warns(NoDetectionsWarning, match='No sources were found'):
-            finder = StarFinder(100, PSF)
-            tbl = finder(DATA)
+            finder = StarFinder(100, kernel)
+            tbl = finder(data)
             assert tbl is None
 
-    def test_min_separation(self):
-        finder1 = StarFinder(10, PSF, min_separation=0)
-        finder2 = StarFinder(10, PSF, min_separation=50)
-        tbl1 = finder1(DATA)
-        tbl2 = finder2(DATA)
-        assert len(tbl1) > len(tbl2)
+    def test_min_separation(self, data, kernel):
+        finder1 = StarFinder(1, kernel, min_separation=0)
+        finder2 = StarFinder(1, kernel, min_separation=10)
+        tbl1 = finder1(data)
+        tbl2 = finder2(data)
+        assert len(tbl1) == 25
+        assert len(tbl2) == 22
 
-    def test_peakmax(self):
-        finder1 = StarFinder(10, PSF, peakmax=None)
-        finder2 = StarFinder(10, PSF, peakmax=50)
-        tbl1 = finder1(DATA)
-        tbl2 = finder2(DATA)
-        assert len(tbl1) > len(tbl2)
+    def test_peakmax(self, data, kernel):
+        finder1 = StarFinder(1, kernel, peakmax=None)
+        finder2 = StarFinder(1, kernel, peakmax=11)
+        tbl1 = finder1(data)
+        tbl2 = finder2(data)
+        assert len(tbl1) == 25
+        assert len(tbl2) == 17
 
         with pytest.warns(NoDetectionsWarning,
                           match='Sources were found, but none pass'):
-            starfinder = StarFinder(10, PSF, peakmax=5)
-            tbl = starfinder(DATA)
+            starfinder = StarFinder(10, kernel, peakmax=5)
+            tbl = starfinder(data)
             assert tbl is None
 
-    def test_brightest(self):
-        finder = StarFinder(10, PSF, brightest=10)
-        tbl = finder(DATA)
+    def test_brightest(self, data, kernel):
+        finder = StarFinder(1, kernel, brightest=10)
+        tbl = finder(data)
         assert len(tbl) == 10
         fluxes = tbl['flux']
         assert fluxes[0] == np.max(fluxes)
 
-        finder = StarFinder(40, PSF, peakmax=120)
-        tbl = finder(DATA)
+    def test_single_detected_source(self, data, kernel):
+        finder = StarFinder(11, kernel, brightest=1)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0:50] = True
+        tbl = finder(data, mask=mask)
         assert len(tbl) == 1
 
-    def test_mask(self):
-        starfinder = StarFinder(10, PSF)
-        mask = np.zeros(DATA.shape, dtype=bool)
-        mask[0:100] = True
-        tbl1 = starfinder(DATA)
-        tbl2 = starfinder(DATA, mask=mask)
-        assert len(tbl1) > len(tbl2)
-        assert min(tbl2['ycentroid']) > 100
+        # test slicing with scalar catalog to improve coverage
+        cat = finder._get_raw_catalog(data, mask=mask)
+        assert cat.isscalar
+        flux = cat.flux[0]  # evaluate the flux so it can be sliced
+        assert cat[0].flux == flux
+
+    def test_mask(self, data, kernel):
+        starfinder = StarFinder(1, kernel)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0:50] = True
+        tbl1 = starfinder(data)
+        tbl2 = starfinder(data, mask=mask)
+        assert len(tbl1) == 25
+        assert len(tbl2) == 13
+        assert min(tbl2['ycentroid']) > 50

--- a/photutils/utils/_quantity_helpers.py
+++ b/photutils/utils/_quantity_helpers.py
@@ -2,6 +2,8 @@
 """
 This module provides Quantity helper tools.
 """
+import astropy.units as u
+import numpy as np
 
 
 def process_quantities(values, names):
@@ -62,3 +64,28 @@ def process_quantities(values, names):
         values = [val.value if val is not None else val for val in values]
 
     return values, unit
+
+
+def isscalar(value):
+    """
+    Check if a value is a scalar.
+
+    This works for both `~astropy.units.Quantity` and scalars.
+
+    `numpy.isscalar` always returns False for `~astropy.units.Quantity`
+    objects.
+
+    Parameters
+    ----------
+    value : `~astropy.units.Quantity`, scalar, or array-like
+        The value to check.
+
+    Returns
+    -------
+    isscalar : bool
+        `True` if the value is a scalar, `False` otherwise.
+    """
+    if isinstance(value, u.Quantity):
+        return value.isscalar
+    else:
+        return np.isscalar(value)

--- a/photutils/utils/tests/test_quantity_helpers.py
+++ b/photutils/utils/tests/test_quantity_helpers.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
-from photutils.utils._quantity_helpers import process_quantities
+from photutils.utils._quantity_helpers import isscalar, process_quantities
 
 
 @pytest.mark.parametrize('all_units', (False, True))
@@ -60,3 +60,10 @@ def test_inputs():
     match = 'The number of values must match the number of names'
     with pytest.raises(ValueError, match=match):
         _, _ = process_quantities([1, 2, 3], ['a', 'b'])
+
+
+def test_isscalar():
+    assert isscalar(1)
+    assert isscalar(1.0 * u.m)
+    assert not isscalar([1, 2, 3])
+    assert not isscalar([1, 2, 3] * u.m)


### PR DESCRIPTION
With this PR, the `DAOStarFinder`, `IRAFStarFinder`, and `StarFinder` now support input data with units.  In that case, other keyword values like `threshold` must also have the same units as the data.

This PR also refactors the test suite in the detection subpackge.