### PR TITLE
Deprecate sky keyword in DAOStarFinder and IRAFStarFinder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,11 @@ API Changes
     functions from ``photutils.datasets.make``, import functions from
     ``photutils.datasets``. [#1726]
 
+- ``photutils.detection``
+
+  - The ``sky`` keyword in ``DAOStarFinder`` and ``IRAFStarFinder`` is
+    now deprecated and will be removed in a future version. [#1747]
+
 - ``photutils.psf``
 
   - ``PSFPhotometry`` and ``IterativePSFPhotometry`` now raise a

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -11,6 +11,7 @@ import numpy as np
 from astropy.nddata import extract_array
 from astropy.table import QTable
 from astropy.utils import lazyproperty
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from photutils.detection.core import (StarFinderBase, _StarFinderKernel,
                                       _validate_brightest)
@@ -69,6 +70,8 @@ class IRAFStarFinder(StarFinderBase):
         The upper bound on roundness for object detection.
 
     sky : float, optional
+        .. deprecated:: 1.13.0
+
         The background sky level of the image. Inputing a ``sky``
         value will override the background sky estimate. Setting
         ``sky`` affects only the output values of the object ``peak``,
@@ -154,6 +157,7 @@ class IRAFStarFinder(StarFinderBase):
     .. _starfind: https://iraf.net/irafhelp.php?val=starfind
     """
 
+    @deprecated_renamed_argument('sky', None, '1.13.0')
     def __init__(self, threshold, fwhm, sigma_radius=1.5, minsep_fwhm=2.5,
                  sharplo=0.5, sharphi=2.0, roundlo=0.0, roundhi=0.2, sky=None,
                  exclude_border=False, brightest=None, peakmax=None,
@@ -234,7 +238,8 @@ class IRAFStarFinder(StarFinderBase):
         Parameters
         ----------
         data : 2D array_like
-            The 2D image array.
+            The 2D image array. The image should be
+            background-subtracted.
 
         mask : 2D bool array, optional
             A boolean mask with the same shape as ``data``, where a
@@ -289,7 +294,7 @@ class _IRAFStarFinderCatalog:
     Parameters
     ----------
     data : 2D `~numpy.ndarray`
-        The 2D image.
+        The 2D image. The image should be background-subtracted.
 
     convolved_data : 2D `~numpy.ndarray`
         The convolved 2D image. If ``data`` is a

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -127,7 +127,8 @@ class StarFinder(StarFinderBase):
         Parameters
         ----------
         data : 2D array_like
-            The 2D image array.
+            The 2D image array. The image should be
+            background-subtracted.
 
         mask : 2D bool array, optional
             A boolean mask with the same shape as ``data``, where a
@@ -174,7 +175,7 @@ class _StarFinderCatalog:
     Parameters
     ----------
     data : 2D `~numpy.ndarray`
-        The 2D image.
+        The 2D image. The image should be background-subtracted.
 
     xypos : Nx2 `numpy.ndarray`
         A Nx2 array of (x, y) pixel coordinates denoting the central

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -25,7 +25,7 @@ class TestDAOStarFinder:
         threshold = 5.0
         fwhm = 1.0
         finder0 = DAOStarFinder(threshold, fwhm)
-        finder1 = DAOStarFinder(threshold * units, fwhm, sky=0 * units)
+        finder1 = DAOStarFinder(threshold * units, fwhm)
 
         tbl0 = finder0(data)
         tbl1 = finder1(data << units)
@@ -101,14 +101,6 @@ class TestDAOStarFinder:
             finder = DAOStarFinder(threshold=1, fwhm=1.0, peakmax=1.0)
             tbl = finder(data)
             assert tbl is None
-
-    def test_daofind_flux_negative(self):
-        """Test handling of negative flux (here created by large sky)."""
-        data = np.ones((5, 5))
-        data[2, 2] = 10.0
-        finder = DAOStarFinder(threshold=0.1, fwhm=1.0, sky=10)
-        tbl = finder(data)
-        assert not np.isfinite(tbl['mag'])
 
     def test_daofind_peakmax_filtering(self, data):
         """

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -5,18 +5,16 @@ Tests for IRAFStarFinder.
 
 import itertools
 import os.path as op
-from contextlib import nullcontext
 
 import astropy.units as u
 import numpy as np
 import pytest
 from astropy.table import Table
-from astropy.utils import minversion
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_array_equal
 
 from photutils.datasets import make_100gaussians_image
 from photutils.detection import IRAFStarFinder
-from photutils.tests.helper import PYTEST_LT_80
 from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
@@ -84,27 +82,12 @@ class TestIRAFStarFinder:
             assert tbl is None
 
     def test_irafstarfind_sky(self, data):
-        finder0 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=0.0)
-        finder1 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=5.0)
-        tbl0 = finder0(data)
-        tbl1 = finder1(data)
-        assert np.all(tbl0['flux'] > tbl1['flux'])
-
-    def test_irafstarfind_largesky(self, data):
-        match1 = 'Sources were found, but none pass'
-        ctx1 = pytest.warns(NoDetectionsWarning, match=match1)
-        if PYTEST_LT_80:
-            ctx2 = nullcontext()
-        else:
-            if not minversion(np, '1.23'):
-                match2 = 'invalid value encountered in true_divide'
-            else:
-                match2 = 'invalid value encountered in divide'
-            ctx2 = pytest.warns(RuntimeWarning, match=match2)
-        with ctx1, ctx2:
-            finder = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=100.0)
-            tbl = finder(data)
-            assert tbl is None
+        with pytest.warns(AstropyDeprecationWarning):
+            finder0 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=0.0)
+            finder1 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=5.0)
+            tbl0 = finder0(data)
+            tbl1 = finder1(data)
+            assert np.all(tbl0['flux'] > tbl1['flux'])
 
     def test_irafstarfind_peakmax_filtering(self, data):
         """


### PR DESCRIPTION
This keyword will be removed in a future version.  The input data array should already be background-subtracted.