### PR TITLE
Exclude sources with non-finite properties in star finders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,10 @@ API Changes
   - The ``sky`` keyword in ``DAOStarFinder`` and ``IRAFStarFinder`` is
     now deprecated and will be removed in a future version. [#1747]
 
+  - Sources that have non-finite properties (e.g., centroid, roundness,
+    sharpness, etc.) are automatically excluded from the output table in
+    ``DAOStarFinder``, ``IRAFStarFinder``, and ``StarFinder``. [#1750]
+
 - ``photutils.psf``
 
   - ``PSFPhotometry`` and ``IterativePSFPhotometry`` now raise a

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -64,6 +64,11 @@ class TestDAOStarFinder:
             tbl = finder(data)
             assert tbl is None
 
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = DAOStarFinder(threshold=1, fwhm=2)
+            tbl = finder(-data)
+            assert tbl is None
+
     def test_daofind_exclude_border(self):
         data = np.zeros((9, 9))
         data[0, 0] = 1

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -57,6 +57,13 @@ class TestIRAFStarFinder:
             tbl = finder(data)
             assert tbl is None
 
+        data = np.ones((5, 5))
+        data[2, 2] = 10.0
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = IRAFStarFinder(threshold=0.1, fwhm=0.1)
+            tbl = finder(-data)
+            assert tbl is None
+
     def test_irafstarfind_sharpness(self, data):
         """Sources found, but none pass the sharpness criteria."""
         match = 'Sources were found, but none pass'

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -52,6 +52,13 @@ class TestStarFinder:
             tbl = finder(data)
             assert tbl is None
 
+        data = np.ones((5, 5))
+        data[2, 2] = 10.0
+        with pytest.warns(NoDetectionsWarning, match=match):
+            finder = StarFinder(1, kernel)
+            tbl = finder(-data)
+            assert tbl is None
+
     def test_min_separation(self, data, kernel):
         finder1 = StarFinder(1, kernel, min_separation=0)
         finder2 = StarFinder(1, kernel, min_separation=10)


### PR DESCRIPTION
With this PR, sources that have non-finite properties (e.g., centroid, roundness, sharpness, etc.) are automatically excluded from the output table in ``DAOStarFinder``, ``IRAFStarFinder``, and ``StarFinder``.