### PR TITLE
Fixes to IntegratedGaussianPRF bounding box

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Bug Fixes
   - Fixed an where ``IterativePSFPhotometry`` would fail if the input
     data was a ``Quantity`` array. [#1746]
 
+  - Fixed the ``IntegratedGaussianPRF`` class ``bounding_box`` limits to
+    always be symmetric. [#1754]
+
 API Changes
 ^^^^^^^^^^^
 
@@ -67,6 +70,11 @@ API Changes
   - ``PSFPhotometry`` and ``IterativePSFPhotometry`` now raise a
     ``ValueError`` if the input ``psf_model`` is not two-dimensional
     with ``n_inputs=2`` and ``n_outputs=1``. [#1741]
+
+  - The ``IntegratedGaussianPRF`` class ``bounding_box`` is now a method
+    instead of an attribute for consistency with Astropy models. The
+    method has a ``factor`` keyword to scale the bounding box. The
+    default scale factor is 5.5 times ``sigma``. [#1754]
 
 
 1.12.0 (2024-04-12)

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -746,11 +746,52 @@ class IntegratedGaussianPRF(Fittable2DModel):
 
     _erf = None
 
-    @property
-    def bounding_box(self):
-        halfwidth = 4 * self.sigma
-        return ((int(self.y_0 - halfwidth), int(self.y_0 + halfwidth)),
-                (int(self.x_0 - halfwidth), int(self.x_0 + halfwidth)))
+    def bounding_box(self, factor=5.5):
+        """
+        Tuple defining the default ``bounding_box`` limits, ``(x_low,
+        x_high)``.
+
+        Parameters
+        ----------
+        factor : float
+            The multiple of `sigma` used to define the limits. The
+            default is 5.5, corresponding to a relative flux error less
+            than 5e-9.
+
+        Examples
+        --------
+        >>> from photutils.psf import IntegratedGaussianPRF
+        >>> model = IntegratedGaussianPRF(x_0=0, y_0=0, sigma=2)
+        >>> model.bounding_box
+        ModelBoundingBox(
+            intervals={
+                x: Interval(lower=-11.0, upper=11.0)
+                y: Interval(lower=-11.0, upper=11.0)
+            }
+            model=IntegratedGaussianPRF(inputs=('x', 'y'))
+            order='C'
+        )
+
+        This range can be set directly (see: `Model.bounding_box
+        <astropy.modeling.Model.bounding_box>`) or by using a different
+        factor, like:
+
+        >>> model.bounding_box = model.bounding_box(factor=2)
+        >>> model.bounding_box
+        ModelBoundingBox(
+            intervals={
+                x: Interval(lower=-4.0, upper=4.0)
+                y: Interval(lower=-4.0, upper=4.0)
+            }
+            model=IntegratedGaussianPRF(inputs=('x', 'y'))
+            order='C'
+        )
+        """
+        delta = factor * self.sigma
+        return (
+            (self.y_0 - delta, self.y_0 + delta),
+            (self.x_0 - delta, self.x_0 + delta),
+        )
 
     def __init__(self, sigma=sigma.default,
                  x_0=x_0.default, y_0=y_0.default, flux=flux.default,

--- a/photutils/psf/tests/test_models.py
+++ b/photutils/psf/tests/test_models.py
@@ -125,7 +125,6 @@ class TestIntegratedGaussianPRF:
         Test subpixel accuracy of IntegratedGaussianPRF by checking the
         sum of pixels.
         """
-
         gauss_psf = IntegratedGaussianPRF(width)
         y, x = np.mgrid[-10:11, -10:11]
         assert_allclose(gauss_psf(x, y).sum(), 1)
@@ -136,10 +135,23 @@ class TestIntegratedGaussianPRF:
         Test if IntegratedGaussianPRF integrates to unity on larger
         scales.
         """
-
         psf = IntegratedGaussianPRF(sigma=sigma)
         y, x = np.mgrid[-100:101, -100:101]
         assert_allclose(psf(y, x).sum(), 1)
+
+    def test_gaussian_psf_bbox(self):
+        """
+        Test bounding_box.
+        """
+        psf = IntegratedGaussianPRF(sigma=2.0)
+        assert psf.bounding_box.bounding_box() == ((-11, 11), (-11, 11))
+
+        psf = IntegratedGaussianPRF(sigma=2.2)
+        assert_allclose(psf.bounding_box, ((-12.1, 12.1), (-12.1, 12.1)))
+
+        psf = IntegratedGaussianPRF(sigma=2.0)
+        psf.bounding_box = psf.bounding_box(factor=2)
+        assert psf.bounding_box.bounding_box() == ((-4, 4), (-4, 4))
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')


### PR DESCRIPTION
 This PR fixes the ``IntegratedGaussianPRF`` class ``bounding_box`` limits to always be symmetric. 

The ``bounding_box`` is also now a method instead of an attribute for consistency with Astropy models.  The method has a ``factor`` keyword to scale the bounding box.  The default scale factor is 5.5 times ``sigma``.