### PR TITLE
Prevent table merge conflicts in IterativePSFPhotometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,11 +49,14 @@ Bug Fixes
 
 - ``photutils.psf``
 
-  - Fixed an where ``IterativePSFPhotometry`` would fail if the input
-    data was a ``Quantity`` array. [#1746]
+  - Fixed an issue where ``IterativePSFPhotometry`` would fail if the
+    input data was a ``Quantity`` array. [#1746]
 
   - Fixed the ``IntegratedGaussianPRF`` class ``bounding_box`` limits to
     always be symmetric. [#1754]
+
+  - Fixed an issue where ``IterativePSFPhotometry`` could sometimes fail
+    to merge tables when ``mode='all'``. [#1761]
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1570,6 +1570,7 @@ class IterativePSFPhotometry(ModelImageMixin):
                 orig_sources.rename_column('x_fit', xcol)
                 orig_sources.rename_column('y_fit', ycol)
                 orig_sources.rename_column('flux_fit', fluxcol)
+                new_sources.meta.pop('date', None)  # prevent merge conflicts
                 init_params = vstack([orig_sources, new_sources])
 
                 residual_data = data


### PR DESCRIPTION
This PR prevents possible table merge conflict because of the date in the table metadata.