### PR TITLE
Deprecate functions in datasets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,10 @@ API Changes
     slightly different. The noise sigma is the same, but the pixel
     values differ. [#1760]
 
+  - The ``make_gaussian_prf_sources_image`` function is now
+    deprecated. Use the ``make_psf_test_data`` function or the new
+    ``make_model_image`` function instead. [#1762]
+
 - ``photutils.detection``
 
   - The ``sky`` keyword in ``DAOStarFinder`` and ``IRAFStarFinder`` is

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -355,6 +355,7 @@ def make_model_sources_image(shape, model, source_table, oversample=1):
     return image
 
 
+@deprecated('1.13.0', alternative='make_model_image')
 def make_gaussian_sources_image(shape, source_table, oversample=1):
     r"""
     Make an image containing 2D Gaussian sources.

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -322,10 +322,6 @@ def make_model_sources_image(shape, model, source_table, oversample=1):
     -------
     image : 2D `~numpy.ndarray`
         Image containing model sources.
-
-    See Also
-    --------
-    make_random_models_table, make_gaussian_sources_image
     """
     image = np.zeros(shape, dtype=float)
     yidx, xidx = np.indices(shape)
@@ -391,10 +387,6 @@ def make_gaussian_sources_image(shape, source_table, oversample=1):
     -------
     image : 2D `~numpy.ndarray`
         Image containing 2D Gaussian sources.
-
-    See Also
-    --------
-    make_random_gaussians_table
 
     Examples
     --------
@@ -480,10 +472,6 @@ def make_gaussian_prf_sources_image(shape, source_table):
     -------
     image : 2D `~numpy.ndarray`
         Image containing 2D Gaussian sources.
-
-    See Also
-    --------
-    make_random_gaussians_table
 
     Examples
     --------

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -456,6 +456,7 @@ def make_gaussian_sources_image(shape, source_table, oversample=1):
                             yname='y_mean', discretize_oversample=oversample)
 
 
+@deprecated('1.13.0', alternative='make_test_psf_data')
 def make_gaussian_prf_sources_image(shape, source_table):
     r"""
     Make an image containing 2D Gaussian sources.

--- a/photutils/datasets/sources.py
+++ b/photutils/datasets/sources.py
@@ -136,7 +136,7 @@ def make_random_gaussians_table(n_sources, param_ranges, seed=None):
 
     See Also
     --------
-    make_random_models_table, make_gaussian_sources_image
+    make_random_models_table
 
     Notes
     -----

--- a/photutils/datasets/tests/test_images.py
+++ b/photutils/datasets/tests/test_images.py
@@ -52,26 +52,30 @@ def test_make_model_sources_image():
 
 
 def test_make_gaussian_sources_image(source_params):
-    shape = (100, 100)
-    image = make_gaussian_sources_image(shape, source_params)
-    assert image.shape == shape
-    assert_allclose(image.sum(), source_params['flux'].sum())
+    with pytest.warns(AstropyDeprecationWarning):
+        shape = (100, 100)
+        image = make_gaussian_sources_image(shape, source_params)
+        assert image.shape == shape
+        assert_allclose(image.sum(), source_params['flux'].sum())
 
 
 def test_make_gaussian_sources_image_amplitude(source_params):
-    params = source_params.copy()
-    params.remove_column('flux')
-    params['amplitude'] = [1, 2, 3]
-    shape = (100, 100)
-    image = make_gaussian_sources_image(shape, params)
-    assert image.shape == shape
+    with pytest.warns(AstropyDeprecationWarning):
+        params = source_params.copy()
+        params.remove_column('flux')
+        params['amplitude'] = [1, 2, 3]
+        shape = (100, 100)
+        image = make_gaussian_sources_image(shape, params)
+        assert image.shape == shape
 
 
 def test_make_gaussian_sources_image_desc_oversample(source_params):
-    shape = (100, 100)
-    image = make_gaussian_sources_image(shape, source_params, oversample=10)
-    assert image.shape == shape
-    assert_allclose(image.sum(), source_params['flux'].sum())
+    with pytest.warns(AstropyDeprecationWarning):
+        shape = (100, 100)
+        image = make_gaussian_sources_image(shape, source_params,
+                                            oversample=10)
+        assert image.shape == shape
+        assert_allclose(image.sum(), source_params['flux'].sum())
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')

--- a/photutils/datasets/tests/test_images.py
+++ b/photutils/datasets/tests/test_images.py
@@ -76,11 +76,12 @@ def test_make_gaussian_sources_image_desc_oversample(source_params):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_gaussian_prf_sources_image(source_params_prf):
-    shape = (100, 100)
-    image = make_gaussian_prf_sources_image(shape, source_params_prf)
-    assert image.shape == shape
-    flux = source_params_prf['amplitude'] * (2 * np.pi)  # sigma = 1
-    assert_allclose(image.sum(), flux.sum(), rtol=1.0e-6)
+    with pytest.warns(AstropyDeprecationWarning):
+        shape = (100, 100)
+        image = make_gaussian_prf_sources_image(shape, source_params_prf)
+        assert image.shape == shape
+        flux = source_params_prf['amplitude'] * (2 * np.pi)  # sigma = 1
+        assert_allclose(image.sum(), flux.sum(), rtol=1.0e-6)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')

--- a/photutils/datasets/wcs.py
+++ b/photutils/datasets/wcs.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy import coordinates as coord
 from astropy.io import fits
 from astropy.modeling import models
+from astropy.utils.decorators import deprecated
 from astropy.wcs import WCS
 
 __all__ = ['make_wcs', 'make_gwcs', 'make_imagehdu']
@@ -155,6 +156,7 @@ def make_gwcs(shape, galactic=False):
     return gwcs_wcs.WCS(pipeline)
 
 
+@deprecated('1.13.0')
 def make_imagehdu(data, wcs=None):
     """
     Create a FITS `~astropy.io.fits.ImageHDU` containing the input 2D
@@ -173,20 +175,6 @@ def make_imagehdu(data, wcs=None):
     -------
     image_hdu : `~astropy.io.fits.ImageHDU`
         The FITS `~astropy.io.fits.ImageHDU`.
-
-    See Also
-    --------
-    make_wcs
-
-    Examples
-    --------
-    >>> from photutils.datasets import make_imagehdu, make_wcs
-    >>> shape = (100, 100)
-    >>> data = np.ones(shape)
-    >>> wcs = make_wcs(shape)
-    >>> hdu = make_imagehdu(data, wcs=wcs)
-    >>> print(hdu.data.shape)
-    (100, 100)
     """
     data = np.asanyarray(data)
     if data.ndim != 2:

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -14,7 +14,7 @@ from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_almost_equal
 
-from photutils.datasets import make_gaussian_prf_sources_image
+from photutils.datasets import make_model_image
 from photutils.psf.epsf import EPSFBuilder, EPSFFitter
 from photutils.psf.epsf_stars import EPSFStars, extract_stars
 from photutils.psf.models import EPSFModel, IntegratedGaussianPRF
@@ -58,7 +58,8 @@ class TestEPSFBuild:
         sources['sigma'] = np.zeros(len(xx)) + self.stddev
         sources['theta'] = 0.0
 
-        self.data = make_gaussian_prf_sources_image(shape, sources)
+        psf_model = IntegratedGaussianPRF(sigma=self.stddev)
+        self.data = make_model_image(shape, psf_model, sources)
         self.nddata = NDData(self.data)
 
         init_stars = Table()
@@ -203,7 +204,9 @@ def test_epsf_build_oversampling(oversamp):
     sources['y_0'] = y.ravel() + ydithers
     sources['sigma'] = np.full((nstars,), sigma)
 
-    data = make_gaussian_prf_sources_image((size, size), sources)
+    psf_model = IntegratedGaussianPRF(sigma=sigma)
+    shape = (size, size)
+    data = make_model_image(shape, psf_model, sources)
     nddata = NDData(data=data)
     stars_tbl = Table()
     stars_tbl['x'] = sources['x_0']

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -15,8 +15,8 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.background import LocalBackground, MMMBackground
-from photutils.datasets import (make_gaussian_prf_sources_image,
-                                make_noise_image, make_test_psf_data)
+from photutils.datasets import (make_model_image, make_noise_image,
+                                make_test_psf_data)
 from photutils.detection import DAOStarFinder
 from photutils.psf import (IntegratedGaussianPRF, IterativePSFPhotometry,
                            PSFPhotometry, SourceGrouper, make_psf_model)
@@ -769,11 +769,10 @@ def test_negative_xy():
     sources['y_0'] = [-0.3, -0.4, 18.7]
     sources['sigma'] = 3.1
     shape = (31, 31)
-    data = make_gaussian_prf_sources_image(shape, sources)
     psf_model = IntegratedGaussianPRF(flux=1, sigma=3.1)
+    data = make_model_image(shape, psf_model, sources)
     fit_shape = (11, 11)
-    psfphot = PSFPhotometry(psf_model, fit_shape,
-                            aperture_radius=10)
+    psfphot = PSFPhotometry(psf_model, fit_shape, aperture_radius=10)
     phot = psfphot(data, init_params=sources)
     assert_equal(phot['x_init'], sources['x_0'])
     assert_equal(phot['y_init'], sources['y_0'])
@@ -789,12 +788,10 @@ def test_out_of_bounds_centroids():
     sources['sigma'] = 3.1
 
     shape = (51, 51)
-    data = make_gaussian_prf_sources_image(shape, sources)
-
     psf_model = IntegratedGaussianPRF(flux=1, sigma=3.1)
+    data = make_model_image(shape, psf_model, sources)
     fit_shape = (11, 11)
-    psfphot = PSFPhotometry(psf_model, fit_shape,
-                            aperture_radius=10)
+    psfphot = PSFPhotometry(psf_model, fit_shape, aperture_radius=10)
 
     phot = psfphot(data, init_params=sources)
 


### PR DESCRIPTION
The ``make_gaussian_sources_image``, ``make_gaussian_prf_sources_image``, and `make_imagehdu` functions are now deprecated. 

For the Gaussian functions, use the more flexible ``make_psf_test_data`` or the new ``make_model_image`` functions instead. 