### PR TITLE
Deprecate make_gaussian_sources_table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,8 +84,15 @@ API Changes
     deprecated. Use the ``make_psf_test_data`` function or the new
     ``make_model_image`` function instead. [#1762]
 
-  - The ``make_gaussian_sources_table`` function now always returns both
-    ``'flux'`` and ``'amplitude'`` columns. [#1763]
+  - The ``make_gaussian_sources_table`` function now includes an "id"
+    column and always returns both ``'flux'`` and ``'amplitude'`` columns.
+    [#1763]
+
+  - The ``make_model_sources_table`` function now includes an "id"
+    column. [#1764]
+
+  - The ``make_gaussian_sources_table`` function is now deprecated.
+    Use the ``make_model_sources_table`` function instead. [#1764]
 
 - ``photutils.detection``
 

--- a/photutils/datasets/sources.py
+++ b/photutils/datasets/sources.py
@@ -7,6 +7,7 @@ model parameters.
 import numpy as np
 from astropy.modeling.models import Gaussian2D
 from astropy.table import QTable
+from astropy.utils.decorators import deprecated
 
 from photutils.utils._misc import _get_meta
 
@@ -92,6 +93,7 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
     return sources
 
 
+@deprecated('1.13.0', alternative='make_random_models_table')
 def make_random_gaussians_table(n_sources, param_ranges, seed=None):
     """
     Make a `~astropy.table.QTable` containing randomly generated
@@ -148,54 +150,6 @@ def make_random_gaussians_table(n_sources, param_ranges, seed=None):
     To generate identical parameter values from separate function
     calls, ``param_ranges`` must have the same parameter ranges and the
     ``seed`` must be the same.
-
-    Examples
-    --------
-    >>> from photutils.datasets import make_random_gaussians_table
-    >>> n_sources = 5
-    >>> param_ranges = {'amplitude': [500, 1000],
-    ...                 'x_mean': [0, 500],
-    ...                 'y_mean': [0, 300],
-    ...                 'x_stddev': [1, 5],
-    ...                 'y_stddev': [1, 5],
-    ...                 'theta': [0, np.pi]}
-    >>> sources = make_random_gaussians_table(n_sources, param_ranges,
-    ...                                       seed=0)
-    >>> for col in sources.colnames:
-    ...     sources[col].info.format = '%.8g'  # for consistent table output
-    >>> print(sources)
-    amplitude   x_mean    y_mean    x_stddev  y_stddev   theta      flux
-    --------- --------- ---------- --------- --------- --------- ---------
-    818.48084 456.37779  244.75607 1.7026225 1.1132787 1.2053586 9747.8906
-    634.89336 303.31789 0.82155005 4.4527157 1.4971331 3.1328274  26592.92
-    520.48676 364.74828  257.22128 3.1658449 3.6824977 3.0813851 38126.037
-    508.26382  271.8125  10.075673 2.1988476  3.588758 2.1536937 25200.454
-    906.63512 467.53621  218.89663 2.6907489 3.4615404 2.0434781 53058.502
-
-    To specify the flux range instead of the amplitude range:
-
-    >>> param_ranges = {'flux': [500, 1000],
-    ...                 'x_mean': [0, 500],
-    ...                 'y_mean': [0, 300],
-    ...                 'x_stddev': [1, 5],
-    ...                 'y_stddev': [1, 5],
-    ...                 'theta': [0, np.pi]}
-    >>> sources = make_random_gaussians_table(n_sources, param_ranges,
-    ...                                       seed=0)
-    >>> for col in sources.colnames:
-    ...     sources[col].info.format = '%.8g'  # for consistent table output
-    >>> print(sources)
-       flux     x_mean    y_mean    x_stddev  y_stddev   theta   amplitude
-    --------- --------- ---------- --------- --------- --------- ---------
-    818.48084 456.37779  244.75607 1.7026225 1.1132787 1.2053586 68.723678
-    634.89336 303.31789 0.82155005 4.4527157 1.4971331 3.1328274 15.157778
-    520.48676 364.74828  257.22128 3.1658449 3.6824977 3.0813851 7.1055501
-    508.26382  271.8125  10.075673 2.1988476  3.588758 2.1536937 10.251089
-    906.63512 467.53621  218.89663 2.6907489 3.4615404 2.0434781 15.492093
-
-    Note that in this case the output table contains both a flux and
-    amplitude column. The flux column will be ignored when generating an
-    image of the models using :func:`make_gaussian_sources_image`.
     """
     sources = make_random_models_table(n_sources, param_ranges,
                                        seed=seed)

--- a/photutils/datasets/sources.py
+++ b/photutils/datasets/sources.py
@@ -46,7 +46,8 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
         A table of parameters for the randomly generated sources. Each
         row of the table corresponds to a source whose model parameters
         are defined by the column names. The column names will be the
-        keys of the dictionary ``param_ranges``.
+        keys of the dictionary ``param_ranges``. The table will also
+        contain an ``'id'`` column with unique source IDs.
 
     See Also
     --------
@@ -73,18 +74,19 @@ def make_random_models_table(n_sources, param_ranges, seed=None):
     >>> for col in sources.colnames:
     ...     sources[col].info.format = '%.8g'  # for consistent table output
     >>> print(sources)
-    amplitude   x_mean    y_mean    x_stddev  y_stddev   theta
-    --------- --------- ---------- --------- --------- ---------
-    818.48084 456.37779  244.75607 1.7026225 1.1132787 1.2053586
-    634.89336 303.31789 0.82155005 4.4527157 1.4971331 3.1328274
-    520.48676 364.74828  257.22128 3.1658449 3.6824977 3.0813851
-    508.26382  271.8125  10.075673 2.1988476  3.588758 2.1536937
-    906.63512 467.53621  218.89663 2.6907489 3.4615404 2.0434781
+     id amplitude   x_mean    y_mean    x_stddev  y_stddev   theta
+    --- --------- --------- ---------- --------- --------- ---------
+      1 818.48084 456.37779  244.75607 1.7026225 1.1132787 1.2053586
+      2 634.89336 303.31789 0.82155005 4.4527157 1.4971331 3.1328274
+      3 520.48676 364.74828  257.22128 3.1658449 3.6824977 3.0813851
+      4 508.26382  271.8125  10.075673 2.1988476  3.588758 2.1536937
+      5 906.63512 467.53621  218.89663 2.6907489 3.4615404 2.0434781
     """
     rng = np.random.default_rng(seed)
 
     sources = QTable()
     sources.meta.update(_get_meta())  # keep sources.meta type
+    sources['id'] = np.arange(n_sources) + 1
     for param_name, (lower, upper) in param_ranges.items():
         # Generate a column for every item in param_ranges, even if it
         # is not in the model (e.g., flux).

--- a/photutils/datasets/tests/test_noise.py
+++ b/photutils/datasets/tests/test_noise.py
@@ -41,16 +41,14 @@ def test_make_noise_image_poisson():
 
 
 def test_make_noise_image_nomean():
-    """Test if ValueError raises if mean is not input."""
+    """Test invalid inputs."""
+    shape = (100, 100)
+
     with pytest.raises(ValueError):
-        shape = (100, 100)
+        make_noise_image(shape, 'invalid', mean=0, stddev=2.0)
+
+    with pytest.raises(ValueError):
         make_noise_image(shape, 'gaussian', stddev=2.0)
 
-
-def test_make_noise_image_nostddev():
-    """
-    Test if ValueError raises if stddev is not input for Gaussian noise.
-    """
     with pytest.raises(ValueError):
-        shape = (100, 100)
         make_noise_image(shape, 'gaussian', mean=2.0)

--- a/photutils/datasets/tests/test_sources.py
+++ b/photutils/datasets/tests/test_sources.py
@@ -4,6 +4,8 @@ Tests for the sources module.
 """
 
 import numpy as np
+import pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.datasets import (make_random_gaussians_table,
                                 make_random_models_table)
@@ -22,33 +24,36 @@ def test_make_random_models_table():
 
 
 def test_make_random_gaussians_table():
-    n_sources = 5
-    param_ranges = dict([('amplitude', [500, 1000]), ('x_mean', [0, 500]),
-                         ('y_mean', [0, 300]), ('x_stddev', [1, 5]),
-                         ('y_stddev', [1, 5]), ('theta', [0, np.pi])])
+    with pytest.warns(AstropyDeprecationWarning):
+        n_sources = 5
+        param_ranges = dict([('amplitude', [500, 1000]), ('x_mean', [0, 500]),
+                             ('y_mean', [0, 300]), ('x_stddev', [1, 5]),
+                             ('y_stddev', [1, 5]), ('theta', [0, np.pi])])
 
-    table = make_random_gaussians_table(n_sources, param_ranges, seed=0)
-    assert 'flux' in table.colnames
-    assert len(table) == n_sources
+        table = make_random_gaussians_table(n_sources, param_ranges, seed=0)
+        assert 'flux' in table.colnames
+        assert len(table) == n_sources
 
 
 def test_make_random_gaussians_table_no_stddev():
-    n_sources = 5
-    param_ranges = dict([('amplitude', [500, 1000]), ('x_mean', [0, 500]),
-                         ('y_mean', [0, 300])])
+    with pytest.warns(AstropyDeprecationWarning):
+        n_sources = 5
+        param_ranges = dict([('amplitude', [500, 1000]), ('x_mean', [0, 500]),
+                             ('y_mean', [0, 300])])
 
-    table = make_random_gaussians_table(n_sources, param_ranges, seed=0)
-    assert 'flux' in table.colnames
-    assert len(table) == n_sources
-    assert 'x_stddev' not in table.colnames
-    assert 'y_stddev' not in table.colnames
+        table = make_random_gaussians_table(n_sources, param_ranges, seed=0)
+        assert 'flux' in table.colnames
+        assert len(table) == n_sources
+        assert 'x_stddev' not in table.colnames
+        assert 'y_stddev' not in table.colnames
 
 
 def test_make_random_gaussians_table_flux():
-    n_sources = 5
-    param_ranges = dict([('flux', [500, 1000]), ('x_mean', [0, 500]),
-                         ('y_mean', [0, 300]), ('x_stddev', [1, 5]),
-                         ('y_stddev', [1, 5]), ('theta', [0, np.pi])])
-    table = make_random_gaussians_table(n_sources, param_ranges, seed=0)
-    assert 'amplitude' in table.colnames
-    assert len(table) == n_sources
+    with pytest.warns(AstropyDeprecationWarning):
+        n_sources = 5
+        param_ranges = dict([('flux', [500, 1000]), ('x_mean', [0, 500]),
+                             ('y_mean', [0, 300]), ('x_stddev', [1, 5]),
+                             ('y_stddev', [1, 5]), ('theta', [0, np.pi])])
+        table = make_random_gaussians_table(n_sources, param_ranges, seed=0)
+        assert 'amplitude' in table.colnames
+        assert len(table) == n_sources

--- a/photutils/datasets/tests/test_sources.py
+++ b/photutils/datasets/tests/test_sources.py
@@ -16,6 +16,7 @@ def test_make_random_models_table():
                     'gamma': (1, 3), 'alpha': (1.5, 3)}
     source_table = make_random_models_table(10, param_ranges)
     assert len(source_table) == 10
+    assert 'id' in source_table.colnames
     cols = ('x_0', 'y_0', 'gamma', 'alpha')
     for col in cols:
         assert col in source_table.colnames


### PR DESCRIPTION
The ``make_gaussian_sources_table`` function is now deprecated.  Use the more general ``make_model_sources_table`` function instead.

The ``make_model_sources_table`` function now includes an "id" column in the output table.