### PR TITLE
Add additional allowed columns in PSF photometry init_params

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,10 @@ New Features
   - Added an ``include_localbkg`` keyword to the ``IterativePSFPhotometry``
     ``make_model_image`` and ``make_residual_image`` methods. [#1756]
 
+  - Added "x_fit", "xfit", "y_fit", "yfit", "flux_fit", and "fluxfit" as
+    allowed column names in the ``init_params`` table input to the PSF
+    photometry objects. [#1765]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -57,6 +61,10 @@ Bug Fixes
 
   - Fixed an issue where ``IterativePSFPhotometry`` could sometimes fail
     to merge tables when ``mode='all'``. [#1761]
+
+  - Fixed a bug where the first matching column in the ``init_params``
+    table was not used in ``PSFPhotometry`` and
+    ``IterativePSFPhotometry``. [#1765]
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -426,11 +426,12 @@ class PSFPhotometry(ModelImageMixin):
         A dictionary of column names for the initial x, y, and flux values
         reported in the output table.
         """
+        suffix = '_init'
         init_colnames = {}
-        init_colnames['x'] = 'x_init'
-        init_colnames['y'] = 'y_init'
-        init_colnames['flux'] = 'flux_init'
-        init_colnames['suffix'] = '_init'
+        init_colnames['suffix'] = suffix
+        init_colnames['x'] = f'x{suffix}'
+        init_colnames['y'] = f'y{suffix}'
+        init_colnames['flux'] = f'flux{suffix}'
         return init_colnames
 
     @lazyproperty
@@ -441,25 +442,32 @@ class PSFPhotometry(ModelImageMixin):
 
         These lists are searched in order.
         """
-        xy_suffixes = ('_init', 'init', 'centroid', '_centroid', '_peak', '',
-                       'cen', '_cen', 'pos', '_pos', '_0', '0')
+        xy_suffixes = ('_init', 'init', '', '_0', '0', 'centroid',
+                       '_centroid', '_peak', 'cen', '_cen', 'pos', '_pos')
         x_valid = ['x' + i for i in xy_suffixes]
         y_valid = ['y' + i for i in xy_suffixes]
 
         valid_colnames = {}
         valid_colnames['x'] = x_valid
         valid_colnames['y'] = y_valid
-        valid_colnames['flux'] = ('flux_init', 'flux_0', 'flux0', 'flux',
-                                  'source_sum', 'segment_flux', 'kron_flux')
+        valid_colnames['flux'] = ('flux_init', 'fluxinit', 'flux', 'flux_0',
+                                  'flux0', 'source_sum', 'segment_flux',
+                                  'kron_flux')
 
         return valid_colnames
 
     def _find_column_name(self, key, colnames):
+        """
+        Find the first valid matching column name for x, y, or flux
+        (defined by `_valid_colnames` in the input ``init_params``
+        table).
+        """
         name = ''
         valid_names = self._valid_colnames[key]
         for valid_name in valid_names:
             if valid_name in colnames:
                 name = valid_name
+                break
         return name
 
     def _validate_init_params(self, init_params, flux_unit):

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -200,19 +200,19 @@ class PSFPhotometry(ModelImageMixin):
         A callable used to identify stars in an image. The
         ``finder`` must accept a 2D image as input and return a
         `~astropy.table.Table` containing the x and y centroid
-        positions. These positions are used as the starting points
-        for the PSF fitting. The allowed ``x`` column names are (same
-        suffix for ``y``): ``'x_init'``, ``'xinit'``, ``'xcentroid'``,
-        ``'x_centroid'``, ``'x_peak'``, ``'x'``, ``'xcen'``,
-        ``'x_cen'``, ``'xpos'``, ``'x_pos'``, ``'x_0'``, and ``'x0'``.
-        If `None`, then the initial (x, y) model positions must be
-        input using the ``init_params`` keyword when calling the class.
-        The (x, y) values in ``init_params`` override this keyword.
-        If this class is run on an image that has units (i.e., a
-        `~astropy.units.Quantity` array), then certain ``finder``
-        keywords (e.g., ``threshold``) must have the same units. Please
-        see the the documentation for the specific ``finder`` class for
-        more information.
+        positions. These positions are used as the starting points for
+        the PSF fitting. The allowed ``x`` column names are (same suffix
+        for ``y``): ``'x_init'``, ``'xinit'``, ``'x'``, ``'x_0'``,
+        ``'x0'``, ``'xcentroid'``, ``'x_centroid'``, ``'x_peak'``,
+        ``'xcen'``, ``'x_cen'``, ``'xpos'``, ``'x_pos'``, ``'x_fit'``,
+        and ``'xfit'``. If `None`, then the initial (x, y) model
+        positions must be input using the ``init_params`` keyword
+        when calling the class. The (x, y) values in ``init_params``
+        override this keyword. If this class is run on an image that
+        has units (i.e., a `~astropy.units.Quantity` array), then
+        certain ``finder`` keywords (e.g., ``threshold``) must have the
+        same units. Please see the the documentation for the specific
+        ``finder`` class for more information.
 
     grouper : `~photutils.psf.SourceGrouper` or callable or `None`, optional
         A callable used to group stars. Typically, grouped stars are
@@ -246,7 +246,7 @@ class PSFPhotometry(ModelImageMixin):
 
     aperture_radius : float, optional
         The radius of the circular aperture used to estimate the initial
-        flux of each source. The ``flux_init`` values in ``init_params``
+        flux of each source. The initial flux value in ``init_params``
         override this keyword.
 
     progress_bar : bool, optional
@@ -442,8 +442,8 @@ class PSFPhotometry(ModelImageMixin):
 
         These lists are searched in order.
         """
-        xy_suffixes = ('_init', 'init', '', '_0', '0', 'centroid',
-                       '_centroid', '_peak', 'cen', '_cen', 'pos', '_pos')
+        xy_suffixes = ('_init', 'init', '', '_0', '0', 'centroid', '_centroid',
+                       '_peak', 'cen', '_cen', 'pos', '_pos', '_fit', 'fit')
         x_valid = ['x' + i for i in xy_suffixes]
         y_valid = ['y' + i for i in xy_suffixes]
 
@@ -451,8 +451,8 @@ class PSFPhotometry(ModelImageMixin):
         valid_colnames['x'] = x_valid
         valid_colnames['y'] = y_valid
         valid_colnames['flux'] = ('flux_init', 'fluxinit', 'flux', 'flux_0',
-                                  'flux0', 'source_sum', 'segment_flux',
-                                  'kron_flux')
+                                  'flux0', 'flux_fit', 'fluxfit', 'source_sum',
+                                  'segment_flux', 'kron_flux')
 
         return valid_colnames
 
@@ -1103,15 +1103,16 @@ class PSFPhotometry(ModelImageMixin):
             ``localbkg_estimator`` or input in a ``local_bkg`` column)
             The allowed column names are:
 
-              * ``x_init``, ``xinit``, ``xcentroid``, ``x_centroid``,
-                ``x_peak``, ``x``, ``xcen``, ``x_cen``, ``xpos``,
-                ``x_pos``, ``x_0``, and ``x0``.
+              * ``x_init``, ``xinit``, ``x``, ``x_0``, ``x0``,
+                ``xcentroid``, ``x_centroid``, ``x_peak``, ``xcen``,
+                ``x_cen``, ``xpos``, ``x_pos``, ``x_fit``, and ``xfit``.
 
-              * ``y_init``, ``yinit``, ``ycentroid``, ``y_centroid``,
-                ``y_peak``, ``y``, ``ycen``, ``y_cen``, ``ypos``,
-                ``y_pos``, ``y_0``, and ``y0``.
+              * ``y_init``, ``yinit``, ``y``, ``y_0``, ``y0``,
+                ``ycentroid``, ``y_centroid``, ``y_peak``, ``ycen``,
+                ``y_cen``, ``ypos``, ``y_pos``, ``y_fit``, and ``yfit``.
 
-              * ``flux_init``, ``flux``, ``source_sum``,
+              * ``flux_init``, ``fluxinit``, ``flux``, ``flux_0``,
+                ``flux0``, ``flux_fit``, ``fluxfit``, ``source_sum``,
                 ``segment_flux``, and ``kron_flux``.
 
             The parameter names are searched in the input table in the

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -246,8 +246,8 @@ class PSFPhotometry(ModelImageMixin):
 
     aperture_radius : float, optional
         The radius of the circular aperture used to estimate the initial
-        flux of each source. The initial flux value in ``init_params``
-        override this keyword.
+        flux of each source. If initial flux values are present in the
+        ``init_params`` table, they will override this keyword.
 
     progress_bar : bool, optional
         Whether to display a progress bar when fitting the sources
@@ -1289,19 +1289,20 @@ class IterativePSFPhotometry(ModelImageMixin):
         A callable used to identify stars in an image. The
         ``finder`` must accept a 2D image as input and return a
         `~astropy.table.Table` containing the x and y centroid
-        positions. These positions are used as the starting points
-        for the PSF fitting. The allowed ``x`` column names are (same
-        suffix for ``y``): ``'x_init'``, ``'xinit'``, ``'xcentroid'``,
-        ``'x_centroid'``, ``'x_peak'``, ``'x'``, ``'xcen'``,
-        ``'x_cen'``, ``'xpos'``, ``'x_pos'``, ``'x_0'``, and ``'x0'``.
-        If `None`, then the initial (x, y) model positions must be input
-        using the ``init_params`` keyword when calling the class. The
-        (x, y) values in ``init_params`` override this keyword *only
-        for the first iteration*. If this class is run on an image
-        that has units (i.e., a `~astropy.units.Quantity` array), then
-        certain ``finder`` keywords (e.g., ``threshold``) must have the
-        same units. Please see the the documentation for the specific
-        ``finder`` class for more information.
+        positions. These positions are used as the starting points for
+        the PSF fitting. The allowed ``x`` column names are (same suffix
+        for ``y``): ``'x_init'``, ``'xinit'``, ``'x'``, ``'x_0'``,
+        ``'x0'``, ``'xcentroid'``, ``'x_centroid'``, ``'x_peak'``,
+        ``'xcen'``, ``'x_cen'``, ``'xpos'``, ``'x_pos'``, ``'x_fit'``,
+        and ``'xfit'``. If `None`, then the initial (x, y) model
+        positions must be input using the ``init_params`` keyword
+        when calling the class. The (x, y) values in ``init_params``
+        override this keyword *only for the first iteration*. If
+        this class is run on an image that has units (i.e., a
+        `~astropy.units.Quantity` array), then certain ``finder``
+        keywords (e.g., ``threshold``) must have the same units. Please
+        see the the documentation for the specific ``finder`` class for
+        more information.
 
     grouper : `~photutils.psf.SourceGrouper` or callable or `None`, optional
         A callable used to group stars. Typically, grouped stars are
@@ -1345,8 +1346,9 @@ class IterativePSFPhotometry(ModelImageMixin):
 
     aperture_radius : float, optional
         The radius of the circular aperture used to estimate the initial
-        flux of each source. The ``flux_init`` values in ``init_params``
-        override this keyword *only for the first iteration*.
+        flux of each source. If initial flux values are present in the
+        ``init_params`` table, they will override this keyword *only for
+        the first iteration*.
 
     sub_shape : `None`, int, or length-2 array_like
         The rectangular shape around the center of a star that will be
@@ -1471,19 +1473,23 @@ class IterativePSFPhotometry(ModelImageMixin):
             iteration*. If the x and y values are not input, then the
             ``finder`` will be used for all iterations. If the flux
             values are not input, then the initial fluxes will be
-            measured in using the ``aperture_radius`` keyword. The input
-            flux values will be used for the first iteration only. The
-            allowed column names are:
+            measured using the ``aperture_radius`` keyword. The input
+            flux values will be used for the first iteration only.
+            Note that the initial flux values refer to the model flux
+            parameters and are not corrected for local background
+            values (computed using ``localbkg_estimator`` or input in a
+            ``local_bkg`` column) The allowed column names are:
 
-              * ``x_init``, ``xinit``, ``xcentroid``, ``x_centroid``,
-                ``x_peak``, ``x``, ``xcen``, ``x_cen``, ``xpos``,
-                ``x_pos``, ``x_0``, and ``x0``.
+              * ``x_init``, ``xinit``, ``x``, ``x_0``, ``x0``,
+                ``xcentroid``, ``x_centroid``, ``x_peak``, ``xcen``,
+                ``x_cen``, ``xpos``, ``x_pos``, ``x_fit``, and ``xfit``.
 
-              * ``y_init``, ``yinit``, ``ycentroid``, ``y_centroid``,
-                ``y_peak``, ``y``, ``ycen``, ``y_cen``, ``ypos``,
-                ``y_pos``, and ``y_0``, and ``y0``.
+              * ``y_init``, ``yinit``, ``y``, ``y_0``, ``y0``,
+                ``ycentroid``, ``y_centroid``, ``y_peak``, ``ycen``,
+                ``y_cen``, ``ypos``, ``y_pos``, ``y_fit``, and ``yfit``.
 
-              * ``flux_init``, ``flux``, ``source_sum``,
+              * ``flux_init``, ``fluxinit``, ``flux``, ``flux_0``,
+                ``flux0``, ``flux_fit``, ``fluxfit``, ``source_sum``,
                 ``segment_flux``, and ``kron_flux``.
 
             The parameter names are searched in the input table in the

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -456,6 +456,21 @@ def test_psf_photometry_init_params(test_data):
     with pytest.raises(ValueError, match=match):
         _ = psfphot(data, init_params=init_params)
 
+    # check that the first matching column name is used
+    init_params = QTable()
+    init_params['x'] = [42]
+    init_params['y'] = [36]
+    init_params['flux'] = [680]
+    init_params['x_cen'] = [42.1]
+    init_params['y_cen'] = [36.1]
+    init_params['flux0'] = [680.1]
+    phot = psfphot(data, error=error, init_params=init_params)
+    assert isinstance(phot, QTable)
+    assert len(phot) == 1
+    assert phot['x_init'][0] == 42
+    assert phot['y_init'][0] == 36
+    assert phot['flux_init'][0] == 680
+
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_psf_photometry_init_params_columns(test_data):


### PR DESCRIPTION
This PR adds "x_fit", "xfit", "y_fit", "yfit", "flux_fit", and "fluxfit" as allowed column names in the ``init_params`` table input to the PSF photometry objects.

This PR also fixes a bug where the first matching column in the ``init_params`` table was not used in ``PSFPhotometry`` and ``IterativePSFPhotometry``.