### PR TITLE
Add make_model_params function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New Features
     and is significantly faster than the now-deprecated
     ``make_model_sources_image`` function. [#1759]
 
+  - Added a ``make_model_params`` function to make a table of randomly
+    generated model positions and fluxes for simulated sources. [#1766]
+
 - ``photutils.detection``
 
   - The ``find_peaks`` function now supports input arrays with units.

--- a/photutils/datasets/examples.py
+++ b/photutils/datasets/examples.py
@@ -59,8 +59,8 @@ def make_4gaussians_image(noise=True):
     model = Gaussian2D()
     params = QTable.read(_DATASETS_DATA_DIR / '4gaussians_params.ecsv',
                          format='ascii.ecsv')
-    data = make_model_image(shape, model, params, xname='x_mean',
-                            yname='y_mean')
+    data = make_model_image(shape, model, params, x_name='x_mean',
+                            y_name='y_mean')
     data += 5.0  # background
 
     if noise:
@@ -111,7 +111,7 @@ def make_100gaussians_image(noise=True):
     params = QTable.read(_DATASETS_DATA_DIR / '100gaussians_params.ecsv',
                          format='ascii.ecsv')
     data = make_model_image(shape, model, params, bbox_factor=6.0,
-                            xname='x_mean', yname='y_mean')
+                            x_name='x_mean', y_name='y_mean')
     data += 5.0  # background
 
     if noise:

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -28,7 +28,7 @@ __all__ = ['make_model_image', 'make_model_sources_image',
 
 
 def make_model_image(shape, model, params_table, *, model_shape=None,
-                     bbox_factor=None, xname='x_0', yname='y_0',
+                     bbox_factor=None, x_name='x_0', y_name='y_0',
                      discretize_method='center', discretize_oversample=10,
                      progress_bar=False):
     """
@@ -49,7 +49,7 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
         has 1 output. The model must have parameters for the x and y
         positions of the sources. Typically, these parameters are named
         'x_0' and 'y_0', but the parameter names can be specified using
-        the ``xname`` and ``yname`` keywords.
+        the ``x_name`` and ``y_name`` keywords.
 
     params_table : `~astropy.table.Table`
         A table containing the model parameters for each source. Each
@@ -57,7 +57,7 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
         are defined by the column names, which must match the model
         parameter names. The table must contain columns for the x and
         y positions of the sources. The column names for the x and y
-        positions can be specified using the ``xname`` and ``yname``
+        positions can be specified using the ``x_name`` and ``y_name``
         keywords. Model parameters not defined in the table will be set
         to the ``model`` default value. Any units in the table will be
         ignored.
@@ -98,12 +98,12 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
         ``model_shape`` is specified or if the ``params_table`` contains
         a ``'model_shape'`` column.
 
-    xname : str, optional
+    x_name : str, optional
         The name of the ``model`` parameter that corresponds to the x
         position of the sources. This parameter must also be a column
         name in ``params_table``.
 
-    yname : str, optional
+    y_name : str, optional
         The name of the ``model`` parameter that corresponds to the y
         position of the sources. This parameter must also be a column
         name in ``params_table``.
@@ -193,17 +193,17 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
         raise ValueError('model must be a Model instance')
     if model.n_inputs != 2 or model.n_outputs != 1:
         raise ValueError('model must be a 2D model')
-    if xname not in model.param_names:
-        raise ValueError(f'xname "{xname}" not in model parameter names')
-    if yname not in model.param_names:
-        raise ValueError(f'yname "{yname}" not in model parameter names')
+    if x_name not in model.param_names:
+        raise ValueError(f'x_name "{x_name}" not in model parameter names')
+    if y_name not in model.param_names:
+        raise ValueError(f'y_name "{y_name}" not in model parameter names')
 
     if not isinstance(params_table, Table):
         raise ValueError('params_table must be an astropy Table')
-    if xname not in params_table.colnames:
-        raise ValueError(f'xname "{xname}" not in psf_params column names')
-    if yname not in params_table.colnames:
-        raise ValueError(f'yname "{yname}" not in psf_params column names')
+    if x_name not in params_table.colnames:
+        raise ValueError(f'x_name "{x_name}" not in psf_params column names')
+    if y_name not in params_table.colnames:
+        raise ValueError(f'y_name "{y_name}" not in psf_params column names')
 
     if model_shape is not None:
         model_shape = as_pair('model_shape', model_shape, lower_bound=(0, 1))
@@ -243,8 +243,8 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
         for param in params_to_set:
             setattr(model, param, source[param])
 
-        x0 = getattr(model, xname).value
-        y0 = getattr(model, yname).value
+        x0 = getattr(model, x_name).value
+        y0 = getattr(model, y_name).value
 
         if variable_shape:
             mod_shape = model_shape[i]
@@ -446,8 +446,8 @@ def make_gaussian_sources_image(shape, source_table, oversample=1):
         source_table['amplitude'] = (source_table['flux']
                                      / (2.0 * np.pi * xstd * ystd))
 
-    return make_model_image(shape, model, source_table, xname='x_mean',
-                            yname='y_mean', discretize_oversample=oversample)
+    return make_model_image(shape, model, source_table, x_name='x_mean',
+                            y_name='y_mean', discretize_oversample=oversample)
 
 
 @deprecated('1.13.0', alternative='make_test_psf_data')

--- a/photutils/datasets/sources.py
+++ b/photutils/datasets/sources.py
@@ -72,13 +72,13 @@ def make_model_params(shape, n_sources, flux_range, *, min_separation=1,
     if xrange[0] >= xrange[1] or yrange[0] >= yrange[1]:
         raise ValueError('border_size is too large for the given shape')
 
+    rng = np.random.default_rng(seed)
     xycoords = make_random_xycoords(n_sources, xrange, yrange,
                                     min_separation=min_separation,
-                                    seed=seed)
+                                    seed=rng)
     x, y = np.transpose(xycoords)
 
-    rng = np.random.default_rng(seed)
-    flux = rng.uniform(flux_range[0], flux_range[1], len(x))
+    flux = rng.uniform(flux_range[0], flux_range[1], size=len(x))
 
     params = QTable()
     params['id'] = np.arange(len(x)) + 1

--- a/photutils/datasets/sources.py
+++ b/photutils/datasets/sources.py
@@ -37,7 +37,7 @@ def make_model_params(shape, n_sources, flux_range, *, min_separation=1,
         given ``shape`` and therefore the number of sources generated
         may be less than ``n_sources``.
 
-    flux_range : tuple
+    flux_range : 2-tuple
         The lower and upper bounds of the flux range. The fluxes will be
         uniformly distributed between these bounds.
 

--- a/photutils/datasets/tests/test_sources.py
+++ b/photutils/datasets/tests/test_sources.py
@@ -5,10 +5,37 @@ Tests for the sources module.
 
 import numpy as np
 import pytest
+from astropy.table import Table
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-from photutils.datasets import (make_random_gaussians_table,
+from photutils.datasets import (make_model_params, make_random_gaussians_table,
                                 make_random_models_table)
+from photutils.utils._optional_deps import HAS_SCIPY
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+def test_make_model_params():
+    shape = (100, 100)
+    n_sources = 10
+    flux_range = (100, 1000)
+    params = make_model_params(shape, n_sources, flux_range)
+    assert isinstance(params, Table)
+    assert len(params) == 10
+    cols = ('id', 'x_0', 'y_0', 'flux')
+    for col in cols:
+        assert col in params.colnames
+        assert np.min(params[col]) >= 0
+    assert np.min(params['flux']) >= flux_range[0]
+    assert np.max(params['flux']) <= flux_range[1]
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+def test_make_model_params_border_size():
+    shape = (10, 10)
+    n_sources = 10
+    flux_range = (100, 1000)
+    with pytest.raises(ValueError):
+        make_model_params(shape, n_sources, flux_range, border_size=20)
 
 
 def test_make_random_models_table():

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -182,7 +182,7 @@ class PSFPhotometry(ModelImageMixin):
         named ``x_0``, ``y_0``, and ``flux``, corresponding to the
         center (x, y) position and flux, or it must have 'x_name',
         'y_name', and 'flux_name' attributes that map to the x, y, and
-        flux parameters (i.e., a model output from `prepare_psf_model`).
+        flux parameters (i.e., a model output from `make_psf_model`).
         The model must be two-dimensional such that it accepts 2 inputs
         (e.g., x and y) and provides 1 output.
 
@@ -367,7 +367,7 @@ class PSFPhotometry(ModelImageMixin):
 
         The PSF model must have parameters called 'x_0', 'y_0', and
         'flux' or it must have 'x_name', 'y_name', and 'flux_name'
-        attributes (i.e., output from `prepare_psf_model`). Otherwise, a
+        attributes (i.e., output from `make_psf_model`). Otherwise, a
         `ValueError` is raised.
         """
         if not isinstance(self.psf_model, Model):
@@ -1271,7 +1271,7 @@ class IterativePSFPhotometry(ModelImageMixin):
         named ``x_0``, ``y_0``, and ``flux``, corresponding to the
         center (x, y) position and flux, or it must have 'x_name',
         'y_name', and 'flux_name' attributes that map to the x, y, and
-        flux parameters (i.e., a model output from `prepare_psf_model`).
+        flux parameters (i.e., a model output from `make_psf_model`).
         The model must be two-dimensional such that it accepts 2 inputs
         (e.g., x and y) and provides 1 output.
 

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -201,13 +201,14 @@ def make_psf_model(model, *, x_name=None, y_name=None, flux_name=None,
     fittable 2D model.
 
     If the ``x_name``, ``y_name``, or ``flux_name`` keywords are input,
-    this function will map the those ``model`` parameter names to
-    ``x_0``, ``y_0``, or ``flux``, respectively.
+    this function will map those ``model`` parameter names to ``x_0``,
+    ``y_0``, or ``flux``, respectively.
 
-    If any of these keywords are `None`, then a new parameter will be
-    added to the model corresponding to the missing parameter. The new
-    position parameters will be set to 0, and the new flux parameter
-    will be set to 1.
+    If any of the ``x_name``, ``y_name``, or ``flux_name`` keywords
+    are `None`, then a new parameter will be added to the model
+    corresponding to the missing parameter. Any new position parameters
+    will be set to a default value of 0, and any new flux parameter will
+    be set to a default value of 1.
 
     The output PSF model will have ``x_name``, ``y_name``, and
     ``flux_name`` attributes that contain the name of the corresponding

--- a/photutils/utils/_coords.py
+++ b/photutils/utils/_coords.py
@@ -75,7 +75,9 @@ def make_random_xycoords(size, x_range, y_range, min_separation=0.0,
     xycoords = xycoords[:size]
 
     if len(xycoords) < size:
-        warnings.warn(f'Unable to produce {size!r} coordinates.',
+        warnings.warn(f'Unable to produce {size!r} coordinates within the '
+                      'given shape and minimum separation. Only '
+                      f'{len(xycoords)!r} coordinates were generated.',
                       AstropyUserWarning)
 
     return xycoords


### PR DESCRIPTION
This PR adds a `make_model_params` function to make a table of randomly generated model positions and fluxes for simulated sources.

This PR also changes the new `make_model_image` keyword names to `x_name` and `y_name` for consistency with other existing functions.