### PR TITLE
Fix for overlap bug

### DIFF
--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -7,11 +7,11 @@ import inspect
 import warnings
 
 import numpy as np
-from astropy.nddata.utils import overlap_slices
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.utils._parameters import as_pair
 from photutils.utils._round import py2intround
+from photutils.utils.cutouts import _overlap_slices as overlap_slices
 
 __all__ = ['centroid_com', 'centroid_quadratic', 'centroid_sources']
 

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -11,7 +11,6 @@ import numpy as np
 from astropy.convolution import discretize_model
 from astropy.modeling import Model
 from astropy.modeling.models import Gaussian2D
-from astropy.nddata import overlap_slices
 from astropy.nddata.utils import NoOverlapError
 from astropy.table import QTable, Table
 from astropy.utils.decorators import deprecated
@@ -21,6 +20,7 @@ from photutils.psf import IntegratedGaussianPRF
 from photutils.utils._coords import make_random_xycoords
 from photutils.utils._parameters import as_pair
 from photutils.utils._progress_bars import add_progress_bar
+from photutils.utils.cutouts import _overlap_slices as overlap_slices
 
 __all__ = ['make_model_image', 'make_model_sources_image',
            'make_gaussian_sources_image', 'make_gaussian_prf_sources_image',

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -8,7 +8,6 @@ import warnings
 
 import astropy.units as u
 import numpy as np
-from astropy.nddata import overlap_slices
 from astropy.table import QTable
 from astropy.utils import lazyproperty
 
@@ -17,6 +16,7 @@ from photutils.utils._convolution import _filter_data
 from photutils.utils._misc import _get_meta
 from photutils.utils._moments import _moments, _moments_central
 from photutils.utils._quantity_helpers import process_quantities
+from photutils.utils.cutouts import _overlap_slices as overlap_slices
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['StarFinder']

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -10,8 +10,7 @@ import warnings
 
 import numpy as np
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.nddata.utils import (NoOverlapError, PartialOverlapError,
-                                  overlap_slices)
+from astropy.nddata.utils import NoOverlapError, PartialOverlapError
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -23,6 +22,7 @@ from photutils.utils._optional_deps import HAS_BOTTLENECK
 from photutils.utils._parameters import as_pair
 from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._round import py2intround
+from photutils.utils.cutouts import _overlap_slices as overlap_slices
 
 __all__ = ['EPSFFitter', 'EPSFBuilder']
 

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -8,8 +8,7 @@ import warnings
 
 import numpy as np
 from astropy.nddata import NDData
-from astropy.nddata.utils import (NoOverlapError, PartialOverlapError,
-                                  overlap_slices)
+from astropy.nddata.utils import NoOverlapError, PartialOverlapError
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
@@ -17,6 +16,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from photutils.aperture import BoundingBox
 from photutils.psf.utils import _interpolate_missing_data
 from photutils.utils._parameters import as_pair
+from photutils.utils.cutouts import _overlap_slices as overlap_slices
 
 __all__ = ['EPSFStar', 'EPSFStars', 'LinkedEPSFStar', 'extract_stars']
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -13,8 +13,7 @@ import astropy.units as u
 import numpy as np
 from astropy.modeling import Model
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.nddata import (NDData, NoOverlapError, StdDevUncertainty,
-                            overlap_slices)
+from astropy.nddata import NDData, NoOverlapError, StdDevUncertainty
 from astropy.table import QTable, Table, hstack, vstack
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
@@ -27,6 +26,7 @@ from photutils.utils._parameters import as_pair
 from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._quantity_helpers import process_quantities
 from photutils.utils._round import py2intround
+from photutils.utils.cutouts import _overlap_slices as overlap_slices
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['ModelImageMixin', 'PSFPhotometry', 'IterativePSFPhotometry']

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from astropy.modeling.fitting import LMLSQFitter, SimplexLSQFitter
 from astropy.modeling.models import Gaussian1D, Gaussian2D, custom_model
-from astropy.nddata import NDData, StdDevUncertainty, overlap_slices
+from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable, Table
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
@@ -22,6 +22,7 @@ from photutils.psf import (IntegratedGaussianPRF, IterativePSFPhotometry,
                            PSFPhotometry, SourceGrouper, make_psf_model)
 from photutils.psf.photometry_depr import DAOGroup
 from photutils.utils._optional_deps import HAS_SCIPY
+from photutils.utils.cutouts import _overlap_slices as overlap_slices
 from photutils.utils.exceptions import NoDetectionsWarning
 
 

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -101,8 +101,8 @@ class CutoutImage:
         self.copy = copy
 
         data = np.asanyarray(data)
-        self._overlap_slices = overlap_slices(data.shape, shape, position,
-                                              mode=mode)
+        self._overlap_slices = _overlap_slices(data.shape, shape, position,
+                                               mode=mode)
         self.data = self._make_cutout(data)
         self.shape = self.data.shape
 

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -4,12 +4,26 @@ This module provides tools for generating 2D image cutouts.
 """
 
 import numpy as np
-from astropy.nddata import extract_array, overlap_slices
+from astropy.nddata import NoOverlapError, extract_array, overlap_slices
 from astropy.utils import lazyproperty
 
 from photutils.aperture import BoundingBox
 
 __all__ = ['CutoutImage']
+
+
+def _overlap_slices(large_array_shape, small_array_shape, position,
+                    mode='partial'):
+    slc_lg, slc_sm = overlap_slices(large_array_shape, small_array_shape,
+                                    position, mode=mode)
+
+    # TEMP: remove when required Astropy >= 6.1.1
+    # fix for https://github.com/astropy/astropy/pull/16544
+    for i in (0, 1):
+        if slc_lg[i].stop - slc_lg[i].start == 0:
+            raise NoOverlapError('Arrays do not overlap.')
+
+    return slc_lg, slc_sm
 
 
 class CutoutImage:


### PR DESCRIPTION
This PR provides a temporary fix to an upstream corner-case bug in Astropy `overlap_slices`.  This fix can be removed when the minimum required astropy >= 6.1.1.