### PR TITLE
Add a check for invalid source positions in PSF photometry init_params

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,6 +134,10 @@ API Changes
   - ``IterativePSFPhotometry`` will now only issue warnings after
     all iterations are completed. [#1767]
 
+  - ``PSFPhotometry`` and ``IterativePSFPhotometry`` will now raise
+    a ``ValueError`` for invalid source positions in ``init_params``.
+    [#1770]
+
 
 1.12.0 (2024-04-12)
 -------------------

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -865,10 +865,12 @@ class PSFPhotometry(ModelImageMixin):
                     except AttributeError:
                         pass
                 except TypeError as exc:
-                    msg = ('The number of data points is less than the '
-                           'number of fit parameters. This is likely due '
-                           'to overmasked data. Please check the input '
-                           'mask.')
+                    msg = ('For one or more sources, the number of data '
+                           'points available to fit is less than the '
+                           'number of fit parameters. This could be due to '
+                           'a source(s) near the edge of the detector or '
+                           'if it has few unmasked pixels. Please check the '
+                           'input mask or source positions.')
                     raise ValueError(msg) from exc
 
                 fit_info = {}

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -453,7 +453,7 @@ def test_psf_photometry_init_params(test_data):
     init_params['x'] = [-42]
     init_params['y'] = [-36]
     init_params['flux'] = [100]
-    match = 'does not overlap with the input data'
+    match = 'Some of the sources have no overlap with the data'
     with pytest.raises(ValueError, match=match):
         _ = psfphot(data, init_params=init_params)
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -376,8 +376,8 @@ def test_psf_photometry_mask(test_data):
         _ = psfphot(data, mask=mask, init_params=init_params)
 
     # completely masked source
-    match = ('The number of data points is less than the number of fit '
-             'parameters.')
+    match = ('the number of data points available to fit is less than the '
+             'number of fit parameters')
     with pytest.raises(ValueError, match=match):
         init_params = QTable()
         init_params['x'] = [42]


### PR DESCRIPTION
With this PR, ``PSFPhotometry`` and ``IterativePSFPhotometry`` will now raise a ``ValueError`` for invalid source positions in ``init_params``.