### PR TITLE
Some refactoring of IterativePSFPhotometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,9 +134,10 @@ API Changes
   - ``IterativePSFPhotometry`` will now only issue warnings after
     all iterations are completed. [#1767]
 
-  - ``PSFPhotometry`` and ``IterativePSFPhotometry`` will now raise
-    a ``ValueError`` for invalid source positions in ``init_params``.
-    [#1770]
+  - The ``IterativePSFPhotometry`` ``psfphot`` attribute has been
+    removed. Instead, use the ``fit_results`` attribute, which contains
+    a list of ``PSFPhotometry`` instances for each fit iteration.
+    [#1771]
 
 
 1.12.0 (2024-04-12)


### PR DESCRIPTION
The ``IterativePSFPhotometry`` ``psfphot`` attribute has also been removed. Instead, use the ``fit_results`` attribute, which contains a list of ``PSFPhotometry`` instances for each fit iteration.