### PR TITLE
Ensure error and data arrays have the same shape

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -158,6 +158,10 @@ API Changes
     ``NonNormalizable`` classes and the ``prepare_psf_model``,
     ``get_grouped_psf_model``, and ``subtract_psf`` functions. [#1774]
 
+  - A ``ValueError`` is now raised if the shape of the ``error`` array
+    does not match the ``data`` array when calling the PSF-fitting
+    classes. [#1777]
+
 
 1.12.0 (2024-04-12)
 -------------------

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1075,6 +1075,7 @@ class PSFPhotometry(ModelImageMixin):
         (data, error), unit = process_quantities((data, error),
                                                  ('data', 'error'))
         data = self._validate_array(data, 'data')
+        error = self._validate_array(error, 'error', data_shape=data.shape)
         mask = self._validate_array(mask, 'mask', data_shape=data.shape)
         mask = self._make_mask(data, mask)
         init_params = self._validate_init_params(init_params, unit)  # copies

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -104,6 +104,12 @@ def test_invalid_inputs():
     with pytest.raises(ValueError, match=match):
         _ = psfphot(np.arange(3))
 
+    match = 'data and error must have the same shape.'
+    with pytest.raises(ValueError, match=match):
+        data = np.ones((11, 11))
+        error = np.ones((3, 3))
+        _ = psfphot(data, error=error)
+
     match = 'data and mask must have the same shape.'
     with pytest.raises(ValueError, match=match):
         data = np.ones((11, 11))


### PR DESCRIPTION
A ``ValueError`` is now raised if the shape of the ``error`` array does not match the ``data`` array when calling the PSF-fitting classes.