### PR TITLE
Fix IterativePSFPhotometry no overlap error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,9 @@ Bug Fixes
     table was not used in ``PSFPhotometry`` and
     ``IterativePSFPhotometry``. [#1765]
 
+  - Fixed an issue where ``IterativePSFPhotometry`` could sometimes
+    raise an error about non-overlapping data. [#1778]
+
 API Changes
 ^^^^^^^^^^^
 


### PR DESCRIPTION
This PR fixes an issue where ``IterativePSFPhotometry`` could sometimes raise an error about non-overlapping data.  This was caused by the fitter failing and returning positions well outside of the input image during the iterations.  When those invalid positions then were used an inputs in a subsequent iteration, a `ValueError` was raised.  With this PR, those invalid positions are automatically removed during the iterations.

Fixes #1769.