### PR TITLE
Add function to make a simulated image from PSF models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ New Features
     allowed column names in the ``init_params`` table input to the PSF
     photometry objects. [#1765]
 
+  - Added a ``make_psf_model_image`` function to generate a simulated
+    image from PSF models. [#1785]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -97,7 +100,7 @@ API Changes
     values differ. [#1760]
 
   - The ``make_gaussian_prf_sources_image`` function is now
-    deprecated. Use the ``make_psf_test_data`` function or the new
+    deprecated. Use the ``make_model_psf_image`` function or the new
     ``make_model_image`` function instead. [#1762]
 
   - The ``make_gaussian_sources_table`` function now includes an "id"
@@ -109,6 +112,9 @@ API Changes
 
   - The ``make_gaussian_sources_table`` function is now deprecated.
     Use the ``make_model_sources_table`` function instead. [#1764]
+
+  - The ``make_test_psf_data`` function is now deprecated. Use the new
+    ``make_model_psf_image`` function instead. [#1785]
 
 - ``photutils.detection``
 

--- a/docs/grouping.rst
+++ b/docs/grouping.rst
@@ -31,22 +31,22 @@ agglomerative clustering with a distance criterion, calling the
 `scipy.cluster.hierarchy.fclusterdata` function.
 
 First, let's create a simulated image containing 2D Gaussian sources
-using `~photutils.datasets.make_test_psf_data`.
+using `~photutils.psf.make_psf_model_image`.
 
 .. doctest-requires:: scipy
 
-    >>> from photutils.datasets import make_test_psf_data
-    >>> from photutils.psf import IntegratedGaussianPRF
+    >>> from photutils.psf import IntegratedGaussianPRF, make_psf_model_image
     >>> shape = (256, 256)
     >>> sigma = 2.0
     >>> psf_model = IntegratedGaussianPRF(sigma=sigma)
     >>> psf_shape = (11, 11)
-    >>> nsources = 100
+    >>> n_sources = 100
     >>> flux_range = (500, 1000)
     >>> border_size = (7, 7)
-    >>> data, stars = make_test_psf_data(shape, psf_model, psf_shape, nsources,
-    ...                                  flux_range=flux_range,
-    ...                                  border_size=border_size, seed=123)
+    >>> data, stars = make_psf_model_image(shape, psf_model, n_sources,
+    ...                                    model_shape=psf_shape,
+    ...                                    flux_range=flux_range,
+    ...                                    border_size=border_size, seed=123)
 
 Let's display the image:
 
@@ -103,8 +103,8 @@ to find the sources.
 .. doctest-requires:: scipy
 
    >>> import numpy as np
-   >>> x = np.array(stars['x'])
-   >>> y = np.array(stars['y'])
+   >>> x = np.array(stars['x_0'])
+   >>> y = np.array(stars['y_0'])
    >>> groups = grouper(x, y)
 
 The ``groups`` output is an array of integers (ordered the same as the

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -141,15 +141,16 @@ provided by the :ref:`photutils.datasets <datasets>` module:
 .. doctest-requires:: scipy
 
     >>> import numpy as np
-    >>> from photutils.datasets import make_test_psf_data, make_noise_image
-    >>> from photutils.psf import IntegratedGaussianPRF
+    >>> from photutils.datasets import make_noise_image
+    >>> from photutils.psf import IntegratedGaussianPRF, make_psf_model_image
     >>> psf_model = IntegratedGaussianPRF(flux=1, sigma=2.7 / 2.35)
     >>> psf_shape = (9, 9)
-    >>> nsources = 10
+    >>> n_sources = 10
     >>> shape = (101, 101)
-    >>> data, true_params = make_test_psf_data(shape, psf_model, psf_shape,
-    ...                                        nsources, flux_range=(500, 700),
-    ...                                        min_separation=10, seed=0)
+    >>> data, true_params = make_psf_model_image(shape, psf_model, n_sources,
+    ...                                          model_shape=psf_shape,
+    ...                                          flux_range=(500, 700),
+    ...                                          min_separation=10, seed=0)
     >>> noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     >>> data += noise
     >>> error = np.abs(noise)
@@ -159,16 +160,17 @@ Let's plot the image:
 .. plot::
 
     import matplotlib.pyplot as plt
-    from photutils.datasets import make_noise_image, make_test_psf_data
-    from photutils.psf import IntegratedGaussianPRF
+    from photutils.datasets import make_noise_image
+    from photutils.psf import IntegratedGaussianPRF, make_psf_model_image
 
     psf_model = IntegratedGaussianPRF(flux=1, sigma=2.7 / 2.35)
     psf_shape = (9, 9)
-    nsources = 10
+    n_sources = 10
     shape = (101, 101)
-    data, true_params = make_test_psf_data(shape, psf_model, psf_shape,
-                                           nsources, flux_range=(500, 700),
-                                           min_separation=10, seed=0)
+    data, true_params = make_psf_model_image(shape, psf_model, n_sources,
+                                             model_shape=psf_shape,
+                                             flux_range=(500, 700),
+                                             min_separation=10, seed=0)
     noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     data += noise
     plt.imshow(data, origin='lower')
@@ -245,16 +247,16 @@ print the source ID along with the fit x, y, and flux values:
     >>> print(phot[('id', 'x_fit', 'y_fit', 'flux_fit')])  # doctest: +FLOAT_CMP
      id  x_fit   y_fit  flux_fit
     --- ------- ------- --------
-      1 54.5641  7.7650 645.4552
-      2 29.0866 25.6111 553.0376
-      3 79.6285 28.7488 665.8715
-      4 63.2344 48.6406 626.7983
-      5 88.8849 54.1203 681.9908
-      6 79.8762 61.1380 686.3628
-      7 90.9606 72.0860 610.5911
-      8  7.8021 78.5730 509.3270
-      9  5.5349 89.8869 503.9691
-     10 71.8411 90.5841 621.1757
+      1 54.5658  7.7644 514.0129
+      2 29.0865 25.6111 536.5818
+      3 79.6281 28.7487 618.7551
+      4 63.2340 48.6408 563.3426
+      5 88.8848 54.1202 619.8874
+      6 79.8763 61.1380 648.1679
+      7 90.9606 72.0861 601.8609
+      8  7.8038 78.5734 635.6392
+      9  5.5350 89.8870 539.6850
+     10 71.8414 90.5842 692.3331
 
 Let's create the residual image:
 
@@ -269,17 +271,20 @@ and plot it:
     import matplotlib.pyplot as plt
     import numpy as np
     from astropy.visualization import simple_norm
-    from photutils.datasets import make_noise_image, make_test_psf_data
+    from photutils.datasets import make_noise_image
     from photutils.detection import DAOStarFinder
-    from photutils.psf import IntegratedGaussianPRF, PSFPhotometry
+    from photutils.psf import (IntegratedGaussianPRF, PSFPhotometry,
+                               make_psf_model_image)
 
     psf_model = IntegratedGaussianPRF(flux=1, sigma=2.7 / 2.35)
     psf_shape = (9, 9)
-    nsources = 10
+    n_sources = 10
     shape = (101, 101)
-    data, true_params = make_test_psf_data(shape, psf_model, psf_shape,
-                                           nsources, flux_range=(500, 700),
-                                           min_separation=10, seed=0)
+
+    data, true_params = make_psf_model_image(shape, psf_model, n_sources,
+                                             model_shape=psf_shape,
+                                             flux_range=(500, 700),
+                                             min_separation=10, seed=0)
     noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     data += noise
     error = np.abs(noise)
@@ -321,18 +326,18 @@ astropy table):
     >>> psfphot.finder_results['flux'].info.format = '.4f'
     >>> psfphot.finder_results['mag'].info.format = '.4f'
     >>> print(psfphot.finder_results)  # doctest: +FLOAT_CMP
-     id xcentroid ycentroid sharpness ... sky   peak    flux    mag
-    --- --------- --------- --------- ... --- ------- ------- -------
-      1   54.5300    7.7508    0.5996 ... 0.0 67.0314  8.7012 -2.3490
-      2   29.0926   25.5993    0.5952 ... 0.0 58.7504  7.7484 -2.2230
-      3   79.6189   28.7515    0.5956 ... 0.0 70.4621  9.2351 -2.4136
-      4   63.2472   48.6151    0.5817 ... 0.0 64.9101  8.5701 -2.3325
-      5   88.8827   54.1299    0.5954 ... 0.0 75.8880 10.3243 -2.5347
-      6   79.8730   61.1214    0.6204 ... 0.0 78.0913 10.3346 -2.5357
-      7   90.9621   72.0802    0.6162 ... 0.0 69.1417  9.2325 -2.4133
-      8    7.7917   78.5454    0.5971 ... 0.0 52.7325  6.6840 -2.0626
-      9    5.5845   89.8645    0.5721 ... 0.0 50.5544  6.5387 -2.0387
-     10   71.8284   90.5625    0.6038 ... 0.0 65.7975  8.5373 -2.3283
+     id xcentroid ycentroid sharpness ... sky   peak   flux    mag
+    --- --------- --------- --------- ... --- ------- ------ -------
+      1   54.5301    7.7460    0.6002 ... 0.0 53.4082 6.9430 -2.1039
+      2   29.0927   25.5994    0.5950 ... 0.0 56.9892 7.5179 -2.1902
+      3   79.6186   28.7516    0.5953 ... 0.0 65.4845 8.5872 -2.3346
+      4   63.2485   48.6135    0.5797 ... 0.0 58.1835 7.6933 -2.2153
+      5   88.8820   54.1311    0.5943 ... 0.0 68.9214 9.3947 -2.4322
+      6   79.8728   61.1207    0.6212 ... 0.0 73.8172 9.7648 -2.4742
+      7   90.9621   72.0803    0.6163 ... 0.0 68.1552 9.1005 -2.3977
+      8    7.7962   78.5467    0.5975 ... 0.0 65.9807 8.4028 -2.3111
+      9    5.5854   89.8663    0.5737 ... 0.0 54.1899 7.0039 -2.1134
+     10   71.8303   90.5626    0.6034 ... 0.0 73.3127 9.5152 -2.4460
 
 The ``fit_results`` attribute contains a dictionary with detailed
 information returned from the ``fitter`` for each source:
@@ -386,7 +391,7 @@ The output table contains only the fit results for the input source:
     >>> print(phot[('id', 'x_fit', 'y_fit', 'flux_fit')])  # doctest: +FLOAT_CMP
      id  x_fit   y_fit  flux_fit
     --- ------- ------- --------
-      1 63.2344 48.6406 626.7983
+      1 63.2340 48.6408 563.3426
 
 Finally, let's show the residual image. The red circular aperture shows
 the location of the star that was fit and subtracted.
@@ -396,18 +401,22 @@ the location of the star that was fit and subtracted.
     import matplotlib.pyplot as plt
     import numpy as np
     from astropy.table import QTable
+    from astropy.visualization import simple_norm
     from photutils.aperture import CircularAperture
-    from photutils.datasets import make_noise_image, make_test_psf_data
+    from photutils.datasets import make_noise_image
     from photutils.detection import DAOStarFinder
-    from photutils.psf import IntegratedGaussianPRF, PSFPhotometry
+    from photutils.psf import (IntegratedGaussianPRF, PSFPhotometry,
+                               make_psf_model_image)
 
     psf_model = IntegratedGaussianPRF(flux=1, sigma=2.7 / 2.35)
     psf_shape = (9, 9)
-    nsources = 10
+    n_sources = 10
     shape = (101, 101)
-    data, true_params = make_test_psf_data(shape, psf_model, psf_shape,
-                                           nsources, flux_range=(500, 700),
-                                           min_separation=10, seed=0)
+
+    data, true_params = make_psf_model_image(shape, psf_model, n_sources,
+                                             model_shape=psf_shape,
+                                             flux_range=(500, 700),
+                                             min_separation=10, seed=0)
     noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     data += noise
     error = np.abs(noise)
@@ -424,15 +433,20 @@ the location of the star that was fit and subtracted.
     phot = psfphot(data, error=error, init_params=init_params)
 
     resid = psfphot.make_residual_image(data, (9, 9))
-    plt.imshow(resid, origin='lower')
+    aper = CircularAperture(zip(phot['x_fit'], phot['y_fit']), r=4)
 
-    resid = psfphot.make_residual_image(data, (9, 9))
-    aper = CircularAperture(zip(init_params['x'], init_params['y']), r=4)
-    plt.imshow(resid, origin='lower')
-    aper.plot(color='red')
-
-    plt.title('Residual Image')
-    plt.colorbar()
+    fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(15, 5))
+    norm = simple_norm(data, 'sqrt', percent=99)
+    ax[0].imshow(data, origin='lower', norm=norm)
+    ax[1].imshow(data - resid, origin='lower', norm=norm)
+    im = ax[2].imshow(resid, origin='lower')
+    ax[0].set_title('Data')
+    aper.plot(ax=ax[0], color='red')
+    ax[1].set_title('Model')
+    aper.plot(ax=ax[1], color='red')
+    ax[2].set_title('Residual Image')
+    aper.plot(ax=ax[2], color='red')
+    plt.tight_layout()
 
 
 Forced Photometry
@@ -475,7 +489,7 @@ fit:
     ...             'y_fit', 'flux_fit')])  # doctest: +FLOAT_CMP
      id x_init y_init flux_init x_fit y_fit flux_fit
     --- ------ ------ --------- ----- ----- --------
-      1     63     49  619.5049  63.0  49.0 556.8463
+      1     63     49  556.4444  63.0  49.0 500.4789
 
 
 Source Grouping
@@ -551,12 +565,12 @@ The local background values are output in the table:
       1   -0.0840
       2    0.1784
       3    0.2593
-      4   -0.0455
-      5    0.3212
-      6   -0.0836
+      4   -0.0574
+      5    0.2934
+      6   -0.0826
       7   -0.1130
-      8   -0.2482
-      9    0.0315
+      8   -0.2138
+      9    0.0089
      10    0.3926
 
 The local background values can also be input directly using the
@@ -603,16 +617,16 @@ the source was detected:
     >>> print(phot[('id', 'iter_detected', 'x_fit', 'y_fit', 'flux_fit')])  # doctest: +FLOAT_CMP
      id iter_detected  x_fit   y_fit  flux_fit
     --- ------------- ------- ------- --------
-      1             1 54.5646  7.7648 645.7164
-      2             1 29.0884 25.6093 550.5295
-      3             1 79.6278 28.7481 660.1429
-      4             2 63.2344 48.6411 627.4414
-      5             2 88.8859 54.1203 676.3059
-      6             2 79.8764 61.1359 688.1962
-      7             2 90.9631 72.0879 612.4822
-      8             2  7.8259 78.5856 516.4237
-      9             2  5.5348 89.8868 503.4775
-     10             2 71.8491 90.5828 616.2827
+      1             1 54.5665  7.7641 514.2679
+      2             1 29.0883 25.6092 534.0753
+      3             1 79.6273 28.7479 613.0246
+      4             2 63.2340 48.6415 564.1535
+      5             2 88.8857 54.1203 614.6949
+      6             2 79.8765 61.1358 649.9802
+      7             2 90.9631 72.0881 603.7519
+      8             2  7.8202 78.5821 641.7541
+      9             2  5.5350 89.8869 539.5465
+     10             2 71.8485 90.5830 687.4396
 
 
 References

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -453,7 +453,7 @@ def make_gaussian_prf_sources_image(shape, source_table):
     return make_model_image(shape, model, source_table)
 
 
-def _define_psf_shape(psf_model, psf_shape):
+def _define_psf_shape(psf_model, psf_shape):  # pragma: no cover
     """
     Define the shape of the model to evaluate, including the
     oversampling.

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -16,7 +16,6 @@ from astropy.table import QTable, Table
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
-from photutils.psf import IntegratedGaussianPRF
 from photutils.utils._coords import make_random_xycoords
 from photutils.utils._parameters import as_pair
 from photutils.utils._progress_bars import add_progress_bar
@@ -411,7 +410,7 @@ def make_gaussian_sources_image(shape, source_table, oversample=1):
                             y_name='y_mean', discretize_oversample=oversample)
 
 
-@deprecated('1.13.0', alternative='make_test_psf_data')
+@deprecated('1.13.0', alternative='make_psf_model_image')
 def make_gaussian_prf_sources_image(shape, source_table):
     r"""
     Make an image containing 2D Gaussian sources.
@@ -436,6 +435,8 @@ def make_gaussian_prf_sources_image(shape, source_table):
     image : 2D `~numpy.ndarray`
         Image containing 2D Gaussian sources.
     """
+    from photutils.psf import IntegratedGaussianPRF
+
     model = IntegratedGaussianPRF(sigma=1)
 
     if 'sigma' in source_table.colnames:
@@ -456,6 +457,8 @@ def _define_psf_shape(psf_model, psf_shape):
     """
     Define the shape of the model to evaluate, including the
     oversampling.
+
+    Deprecated with make_test_psf_data.
     """
     try:
         model_ndim = psf_model.data.ndim
@@ -504,6 +507,7 @@ def _define_psf_shape(psf_model, psf_shape):
     return psf_shape
 
 
+@deprecated('1.13.0', alternative='make_psf_model_image')
 def make_test_psf_data(shape, psf_model, psf_shape, nsources, *,
                        flux_range=(100, 1000), min_separation=1, seed=0,
                        border_size=None, progress_bar=False):

--- a/photutils/datasets/tests/test_images.py
+++ b/photutils/datasets/tests/test_images.py
@@ -90,23 +90,26 @@ def test_make_gaussian_prf_sources_image(source_params_prf):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_test_psf_data():
-    psf_model = IntegratedGaussianPRF(flux=100, sigma=1.5)
-    psf_shape = (5, 5)
-    nsources = 10
-    shape = (100, 100)
-    data, true_params = make_test_psf_data(shape, psf_model, psf_shape,
-                                           nsources, flux_range=(500, 1000),
-                                           min_separation=10, seed=0)
+    with pytest.warns(AstropyDeprecationWarning):
+        psf_model = IntegratedGaussianPRF(flux=100, sigma=1.5)
+        psf_shape = (5, 5)
+        nsources = 10
+        shape = (100, 100)
+        data, true_params = make_test_psf_data(shape, psf_model, psf_shape,
+                                               nsources,
+                                               flux_range=(500, 1000),
+                                               min_separation=10, seed=0)
 
-    assert isinstance(data, np.ndarray)
-    assert data.shape == shape
-    assert isinstance(true_params, Table)
-    assert len(true_params) == nsources
-    assert true_params['x'].min() >= 0
-    assert true_params['y'].min() >= 0
+        assert isinstance(data, np.ndarray)
+        assert data.shape == shape
+        assert isinstance(true_params, Table)
+        assert len(true_params) == nsources
+        assert true_params['x'].min() >= 0
+        assert true_params['y'].min() >= 0
 
-    match = 'Unable to produce'
-    with pytest.warns(AstropyUserWarning, match=match):
-        nsources = 100
-        make_test_psf_data(shape, psf_model, psf_shape, nsources,
-                           flux_range=(500, 1000), min_separation=100, seed=0)
+        match = 'Unable to produce'
+        with pytest.warns(AstropyUserWarning, match=match):
+            nsources = 100
+            make_test_psf_data(shape, psf_model, psf_shape, nsources,
+                               flux_range=(500, 1000), min_separation=100,
+                               seed=0)

--- a/photutils/datasets/wcs.py
+++ b/photutils/datasets/wcs.py
@@ -165,7 +165,7 @@ def make_gwcs(shape, galactic=False):
 
 
 @deprecated('1.13.0')
-def make_imagehdu(data, wcs=None):
+def make_imagehdu(data, wcs=None):  # pragma: no cover
     """
     Create a FITS `~astropy.io.fits.ImageHDU` containing the input 2D
     image.

--- a/photutils/detection/tests/conftest.py
+++ b/photutils/detection/tests/conftest.py
@@ -7,8 +7,7 @@ import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
 
-from photutils.datasets import make_test_psf_data
-from photutils.psf import IntegratedGaussianPRF
+from photutils.psf import IntegratedGaussianPRF, make_psf_model_image
 
 
 @pytest.fixture(name='kernel')
@@ -23,13 +22,14 @@ def fixture_kernel():
 @pytest.fixture(name='data')
 def fixture_data():
     shape = (101, 101)
-    psf_shape = (11, 11)
+    model_shape = (11, 11)
     psf_model = IntegratedGaussianPRF(flux=1, sigma=1.5)
-    nsources = 25
-    data, _ = make_test_psf_data(shape, psf_model, psf_shape, nsources,
-                                 flux_range=(100, 200),
-                                 min_separation=10,
-                                 seed=0,
-                                 border_size=(10, 10),
-                                 progress_bar=False)
+    n_sources = 25
+    data, _ = make_psf_model_image(shape, psf_model, n_sources,
+                                   model_shape=model_shape,
+                                   flux_range=(100, 200),
+                                   min_separation=10,
+                                   seed=0,
+                                   border_size=(10, 10),
+                                   progress_bar=False)
     return data

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -139,7 +139,7 @@ class TestDAOStarFinder:
                                sharphi=np.inf, brightest=brightest,
                                peakmax=peakmax)
         tbl = finder(data)
-        assert len(tbl) == 7
+        assert len(tbl) == 5
 
     def test_daofind_mask(self, data):
         """Test DAOStarFinder with a mask."""
@@ -174,7 +174,7 @@ class TestDAOStarFinder:
             DAOStarFinder(threshold=10, fwhm=1.5, min_separation=-1.0)
 
     def test_single_detected_source(self, data):
-        finder = DAOStarFinder(8.0, 2, brightest=1)
+        finder = DAOStarFinder(7.9, 2, brightest=1)
         mask = np.zeros(data.shape, dtype=bool)
         mask[0:50] = True
         tbl = finder(data, mask=mask)

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -86,7 +86,7 @@ class TestIRAFStarFinder:
     def test_irafstarfind_sky(self, data):
         with pytest.warns(AstropyDeprecationWarning):
             finder0 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=0.0)
-            finder1 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=5.0)
+            finder1 = IRAFStarFinder(threshold=1.0, fwhm=2.0, sky=2.0)
             tbl0 = finder0(data)
             tbl1 = finder1(data)
             assert np.all(tbl0['flux'] > tbl1['flux'])
@@ -157,7 +157,7 @@ class TestIRAFStarFinder:
             IRAFStarFinder(threshold=10, fwhm=1.5, min_separation=-1.0)
 
     def test_single_detected_source(self, data):
-        finder = IRAFStarFinder(8.0, 2, brightest=1)
+        finder = IRAFStarFinder(8.4, 2, brightest=1)
         mask = np.zeros(data.shape, dtype=bool)
         mask[0:50] = True
         tbl = finder(data, mask=mask)

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -29,7 +29,7 @@ class TestFindPeaks:
         assert np.max(tbl['x_peak']) < 101
         assert np.min(tbl['y_peak']) > 0
         assert np.max(tbl['y_peak']) < 101
-        assert np.max(tbl['peak_value']) < 13.1
+        assert np.max(tbl['peak_value']) < 13.2
 
         # test with units
         unit = u.Jy

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -23,7 +23,7 @@ class TestStarFinder:
         tbl2 = finder2(data)
         assert isinstance(tbl1, Table)
         assert len(tbl1) == 25
-        assert len(tbl2) == 7
+        assert len(tbl2) == 9
 
         # test with units
         unit = u.Jy
@@ -65,7 +65,7 @@ class TestStarFinder:
         tbl1 = finder1(data)
         tbl2 = finder2(data)
         assert len(tbl1) == 25
-        assert len(tbl2) == 22
+        assert len(tbl2) == 20
 
     def test_peakmax(self, data, kernel):
         finder1 = StarFinder(1, kernel, peakmax=None)
@@ -73,7 +73,7 @@ class TestStarFinder:
         tbl1 = finder1(data)
         tbl2 = finder2(data)
         assert len(tbl1) == 25
-        assert len(tbl2) == 17
+        assert len(tbl2) == 16
 
         match = 'Sources were found, but none pass'
         with pytest.warns(NoDetectionsWarning, match=match):
@@ -89,7 +89,7 @@ class TestStarFinder:
         assert fluxes[0] == np.max(fluxes)
 
     def test_single_detected_source(self, data, kernel):
-        finder = StarFinder(11, kernel, brightest=1)
+        finder = StarFinder(11.5, kernel, brightest=1)
         mask = np.zeros(data.shape, dtype=bool)
         mask[0:50] = True
         tbl = finder(data, mask=mask)

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -341,6 +341,7 @@ class TestGridFromEPSFs:
         assert psf_grid.meta['fill_value'] == 0.0
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_image():
     shape = (401, 451)
     n_sources = 100
@@ -357,6 +358,7 @@ def test_make_psf_model_image():
     assert len(params2) == n_sources
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_image_custom():
     shape = (401, 451)
     n_sources = 100
@@ -369,6 +371,7 @@ def test_make_psf_model_image_custom():
     assert len(params) == n_sources
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_image_inputs():
     shape = (50, 50)
     match = 'psf_model must be an Astropy Model subclass'


### PR DESCRIPTION
This PR adds a new `make_psf_model_image` function.  This PR also deprecates the `make_test_psf_data` function in favor of `make_psf_model_image`.