### PR TITLE
Fix issue with covariance matrix in ApertureStats and SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Fixed an issue in ``ApertureStats`` where in very rare cases the
+    ``covariance`` calculation could take a long time. [#1788]
+
 - ``photutils.background``
 
   - No longer warn about NaNs in the data if those NaNs are masked in
@@ -76,6 +81,11 @@ Bug Fixes
 
   - Fixed an issue where ``IterativePSFPhotometry`` could sometimes
     raise an error about non-overlapping data. [#1778]
+
+- ``photutils.segmentation``
+
+  - Fixed an issue in ``SourceCatalog`` where in very rare cases the
+    ``covariance`` calculation could take a long time. [#1788]
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -1397,8 +1397,13 @@ class ApertureStats:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
             covar_det = np.linalg.det(covar)
+
+            # covariance should be positive semidefinite
+            idx = np.where(covar_det < 0)[0]
+            covar[idx] = np.array([[np.nan, np.nan], [np.nan, np.nan]])
+
             idx = np.where(covar_det < delta2)[0]
-            while idx.size > 0:  # pragma: no cover
+            while idx.size > 0:
                 covar[idx, 0, 0] += delta
                 covar[idx, 1, 1] += delta
                 covar_det = np.linalg.det(covar)
@@ -1428,7 +1433,7 @@ class ApertureStats:
         eigvals[idx] = np.linalg.eigvals(self._covariance[idx])
 
         # check for negative variance
-        # (just in case covariance matrix is not positive (semi)definite)
+        # (just in case covariance matrix is not positive semidefinite)
         idx2 = np.unique(np.where(eigvals < 0)[0])  # pragma: no cover
         eigvals[idx2] = (np.nan, np.nan)  # pragma: no cover
 

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -340,3 +340,15 @@ class TestApertureStats:
 
         if with_units:
             assert apstats1.sum.unit == unit
+
+    def test_tiny_source(self):
+        data = np.zeros((21, 21))
+        data[5, 5] = 1.0
+        aperture = CircularAperture(((5, 5), (15, 15)), r=1)
+        apstats = ApertureStats(data, aperture)
+        assert_allclose(apstats.sum, (1.0, 0.0))
+        assert_allclose(apstats[0].covariance,
+                        [(1 / 12, 0), (0, 1 / 12)] * u.pix**2)
+        assert_allclose(apstats[1].covariance,
+                        [(np.nan, np.nan), (np.nan, np.nan)] * u.pix**2)
+        assert_allclose(apstats.fwhm, [0.67977799, np.nan] * u.pix)

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2278,8 +2278,13 @@ class SourceCatalog:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
             covar_det = np.linalg.det(covar)
+
+            # covariance should be positive semidefinite
+            idx = np.where(covar_det < 0)[0]
+            covar[idx] = np.array([[np.nan, np.nan], [np.nan, np.nan]])
+
             idx = np.where(covar_det < delta2)[0]
-            while idx.size > 0:  # pragma: no cover
+            while idx.size > 0:
                 covar[idx, 0, 0] += delta
                 covar[idx, 1, 1] += delta
                 covar_det = np.linalg.det(covar)
@@ -2311,7 +2316,7 @@ class SourceCatalog:
         eigvals[idx] = np.linalg.eigvals(self._covariance[idx])
 
         # check for negative variance
-        # (just in case covariance matrix is not positive (semi)definite)
+        # (just in case covariance matrix is not positive semidefinite)
         idx2 = np.unique(np.where(eigvals < 0)[0])  # pragma: no cover
         eigvals[idx2] = (np.nan, np.nan)  # pragma: no cover
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1338,9 +1338,9 @@ class SourceCatalog:
         kwargs = self._apermask_kwargs['cen_win']
 
         labels = self.labels
-        if self.progress_bar:
+        if self.progress_bar:  # pragma: no cover
             desc = 'centroid_win'
-            labels = add_progress_bar(labels, desc=desc)  # pragma: no cover
+            labels = add_progress_bar(labels, desc=desc)
 
         xcen_win = []
         ycen_win = []
@@ -1519,9 +1519,9 @@ class SourceCatalog:
             warnings.simplefilter('ignore', AstropyUserWarning)
 
             cutouts = self._data_cutouts
-            if self.progress_bar:
+            if self.progress_bar:  # pragma: no cover
                 desc = 'centroid_quad'
-                cutouts = add_progress_bar(cutouts, desc=desc)  # pragma: no cover
+                cutouts = add_progress_bar(cutouts, desc=desc)
 
             for data, mask in zip(cutouts, self._cutout_total_masks):
                 try:
@@ -2974,9 +2974,9 @@ class SourceCatalog:
             cyy = (cyy,)
 
         labels = self.labels
-        if self.progress_bar:
+        if self.progress_bar:  # pragma: no cover
             desc = 'kron_radius'
-            labels = add_progress_bar(labels, desc=desc)  # pragma: no cover
+            labels = add_progress_bar(labels, desc=desc)
 
         kron_radius = []
         for (label, aperture, cxx_, cxy_, cyy_) in zip(labels, apertures,
@@ -3278,8 +3278,8 @@ class SourceCatalog:
             The flux and flux error arrays.
         """
         labels = self.labels
-        if self.progress_bar:
-            labels = add_progress_bar(labels, desc=desc)  # pragma: no cover
+        if self.progress_bar:  # pragma: no cover
+            labels = add_progress_bar(labels, desc=desc)
 
         flux = []
         fluxerr = []
@@ -3509,9 +3509,9 @@ class SourceCatalog:
         kwargs = self._apermask_kwargs['fluxfrac']
 
         labels = self.labels
-        if self.progress_bar:
+        if self.progress_bar:  # pragma: no cover
             desc = 'fluxfrac_radius prep'
-            labels = add_progress_bar(labels, desc=desc)  # pragma: no cover
+            labels = add_progress_bar(labels, desc=desc)
 
         args = []
         for label, xcen, ycen, kronflux, bkg, max_radius_ in zip(
@@ -3572,9 +3572,9 @@ class SourceCatalog:
         from scipy.optimize import root_scalar
 
         args = self._fluxfrac_optimizer_args
-        if self.progress_bar:
+        if self.progress_bar:  # pragma: no cover
             desc = 'fluxfrac_radius'
-            args = add_progress_bar(args, desc=desc)  # pragma: no cover
+            args = add_progress_bar(args, desc=desc)
 
         radius = []
         for fluxfrac_args in args:

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -833,6 +833,19 @@ class TestSourceCatalog:
         tbl = self.cat.to_table()
         assert len(tbl) == 7
 
+    def test_tiny_sources(self):
+        data = np.zeros((11, 11))
+        data[5, 5] = 1.0
+        data[8, 8] = 1.0
+        segm = detect_sources(data, 0.1, 1)
+        data[8, 8] = 0
+        cat = SourceCatalog(data, segm)
+        assert_allclose(cat[0].covariance,
+                        [(1 / 12, 0), (0, 1 / 12)] * u.pix**2)
+        assert_allclose(cat[1].covariance,
+                        [(np.nan, np.nan), (np.nan, np.nan)] * u.pix**2)
+        assert_allclose(cat.fwhm, [0.67977799, np.nan] * u.pix)
+
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')


### PR DESCRIPTION
This PR fixes an issue in ``ApertureStats`` and `SourceCatalog` where in very rare cases the ``covariance`` calculation could take a long time.

Fixes #1775 