### PR TITLE
Add fit_params table as PSFPhotometry attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,9 @@ New Features
   - Added a ``make_psf_model_image`` function to generate a simulated
     image from PSF models. [#1785]
 
+  - ``PSFPhotometry`` now has a new ``fit_params`` attribute containing
+    a table of the fit model parameters and errors. [#1789]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -180,6 +183,14 @@ API Changes
   - A ``ValueError`` is now raised if the shape of the ``error`` array
     does not match the ``data`` array when calling the PSF-fitting
     classes. [#1777]
+
+  - The ``fit_param_errs`` key was removed from the ``PSFPhotometry``
+    ``fit_results`` dictionary. The fit parameter errors are now stored
+    in the ``fit_params`` table. [#1789]
+
+  - The ``cfit`` column in the ``PSFPhotometry`` and
+    ``IterativePSFPhotometry`` result table will now be NaN for sources
+    whose initial central pixel is masked. [#1789]
 
 
 1.12.0 (2024-04-12)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -310,7 +310,6 @@ class PSFPhotometry(ModelImageMixin):
         self.init_params = None
         self.fit_params = None
         self._fit_params = None
-        self._fit_models = None
         self.fit_results = defaultdict(list)
         self._group_results = defaultdict(list)
 
@@ -319,7 +318,6 @@ class PSFPhotometry(ModelImageMixin):
         self.init_params = None
         self.fit_params = None
         self._fit_params = None
-        self._fit_models = None
         self.fit_results = defaultdict(list)
         self._group_results = defaultdict(list)
 
@@ -970,7 +968,6 @@ class PSFPhotometry(ModelImageMixin):
         fit_infos = self._order_by_id(fit_infos)
         fit_param_errs = np.array(self._order_by_id(fit_param_errs))
 
-        self._fit_models = fit_models
         self.fit_results['fit_infos'] = fit_infos
         self.fit_results['fit_error_indices'] = self._get_fit_error_indices()
         self.fit_results['fit_param_errs'] = fit_param_errs
@@ -1087,8 +1084,8 @@ class PSFPhotometry(ModelImageMixin):
 
             qfit = []
             cfit = []
-            for index, (model, residual, cen_idx_) in enumerate(
-                    zip(self._fit_models, fit_residuals, cen_idx)):
+            for index, (residual, cen_idx_) in enumerate(
+                    zip(fit_residuals, cen_idx)):
 
                 flux_fit = results_tbl['flux_fit'][index]
                 qfit.append(np.sum(np.abs(residual)) / flux_fit)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -266,8 +266,8 @@ class PSFPhotometry(ModelImageMixin):
 
     If the returned model parameter errors are NaN, then either
     the fit did not converge, the model parameter was fixed, or
-    the input ``fitter`` is not returning parameter errors. For
-    the later case, one can try a different fitter that may return
+    the input ``fitter`` did not return parameter errors. For the
+    later case, one can try a different fitter that may return
     parameter errors (e.g., `astropy.models.fitting.LMLSQFitter
     or `astropy.models.fitting.TRFLSQFitter`). Note that
     these fitters are typically slower than the default
@@ -1470,6 +1470,32 @@ class IterativePSFPhotometry(ModelImageMixin):
 
     Notes
     -----
+    The data that will be fit for each source is defined by the
+    ``fit_shape`` parameter. A cutout will be made around the initial
+    center of each source with a shape defined by ``fit_shape``. The PSF
+    model will be fit to the data in this region. The cutout region that
+    is fit does not shift if the source center shifts during the fit
+    iterations. Therefore, the initial source positions should be close
+    to the true source positions. One way to ensure this is to use a
+    ``finder`` to identify sources in the data.
+
+    If the fitted positions are significantly different from the initial
+    positions, one can re-run the `PSFPhotometry` class using the fit
+    results as the input ``init_params``, which will change the fitted
+    cutout region for each source. After calling `PSFPhotometry` on the
+    data, it will have a ``fit_params`` attribute containing the fitted
+    model parameters. This table can be used as the ``init_params``
+    input in a subsequent call to `PSFPhotometry`.
+
+    If the returned model parameter errors are NaN, then either
+    the fit did not converge, the model parameter was fixed, or
+    the input ``fitter`` did not return parameter errors. For the
+    later case, one can try a different fitter that may return
+    parameter errors (e.g., `astropy.models.fitting.LMLSQFitter
+    or `astropy.models.fitting.TRFLSQFitter`). Note that
+    these fitters are typically slower than the default
+    `astropy.models.fitting.LevMarLSQFitter`.
+
     The local background value around each source is optionally
     estimated using the ``localbkg_estimator`` or obtained from the
     ``local_bkg`` column in the input ``init_params`` table. This local

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -185,7 +185,7 @@ def test_psf_photometry(test_data):
     assert resid_data.shape == data.shape
     assert phot.colnames[:4] == ['id', 'group_id', 'group_size', 'local_bkg']
 
-    keys = ('fit_infos', 'fit_param_errs', 'fit_error_indices')
+    keys = ('fit_infos', 'fit_error_indices')
     for key in keys:
         assert key in psfphot.fit_results
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -403,6 +403,7 @@ def test_psf_photometry_mask(test_data):
     mask[49, 63] = True
     phot = psfphot(data_orig, mask=mask, init_params=init_params)
     assert len(phot) == 1
+    assert np.isnan(phot['cfit'][0])
 
     # this should not raise a warning because the non-finite pixel was
     # explicitly masked


### PR DESCRIPTION
This PR refactor the PSF photometry class to internally store the fitted PSF model parameters instead of the model instances.  This is the first step to parallelizing the fitting code.

This PR also introduces the following changes:

- ``PSFPhotometry`` now has a new ``fit_params`` attribute containing a table of the fit model parameters and errors.
 - The ``fit_param_errs`` key was removed from the ``PSFPhotometry`` ``fit_results`` dictionary. The fit parameter errors are now stored in the new ``fit_params`` table.
- The ``cfit`` column in the ``PSFPhotometry`` and ``IterativePSFPhotometry`` result table will now be NaN for sources whose initial central pixel is masked.