### PR TITLE
Fix unit support in make_model_image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New Features
   - Added a ``make_model_image`` function for generating simulated images
     with model sources. This function has more options
     and is significantly faster than the now-deprecated
-    ``make_model_sources_image`` function. [#1759]
+    ``make_model_sources_image`` function. [#1759, #1790]
 
   - Added a ``make_model_params`` function to make a table of randomly
     generated model positions and fluxes for simulated sources. [#1766]

--- a/photutils/datasets/tests/test_images.py
+++ b/photutils/datasets/tests/test_images.py
@@ -68,6 +68,7 @@ def test_make_model_image():
     assert image.sum() > 1
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_model_image_units():
     unit = u.Jy
     params = QTable()


### PR DESCRIPTION
This PR fixes unit support in `make_model_image`.  To use units, one must input the model `params_table` as a `QTable` (not `Table`) with `Quantity` columns.