### PR TITLE
Add option to exclude negative peaks from residual/model image

### DIFF
--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -164,8 +164,8 @@ class ModelImageMixin:
                 exclude_negative_peaks=exclude_negative_peaks)
         else:
             residual = self.make_model_image(data.shape, psf_shape,
-                                             include_localbkg=include_localbkg,
-                                             exclude_negative_peaks=exclude_negative_peaks)
+                include_localbkg=include_localbkg,
+                exclude_negative_peaks=exclude_negative_peaks)
             np.subtract(data, residual, out=residual)
 
         return residual

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -163,7 +163,8 @@ class ModelImageMixin:
                 data_arr, psf_shape, include_localbkg=include_localbkg,
                 exclude_negative_peaks=exclude_negative_peaks)
         else:
-            residual = self.make_model_image(data.shape, psf_shape,
+            residual = self.make_model_image(
+                data.shape, psf_shape,
                 include_localbkg=include_localbkg,
                 exclude_negative_peaks=exclude_negative_peaks)
             np.subtract(data, residual, out=residual)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -101,7 +101,12 @@ class ModelImageMixin:
         model_params = fit_params
 
         if exclude_negative_peaks:
-            to_include = model_params['flux_fit'] >= 0
+            if 'flux_fit' in model_params:
+                to_include = model_params['flux_fit'] >= 0
+            elif 'flux' in model_params:
+                to_include = model_params['flux'] >= 0
+            else:
+                raise ValueError("No 'flux' or 'flux_fit' column in model parameters.")
             model_params = model_params[to_include]
 
         if include_localbkg:


### PR DESCRIPTION
Solves #1799 by making negative peaks excludable.

It's difficult to impossible for a user to do this now, since the construction of the list of fits for IterativePSFPhotometry is done within `make_model_image`.