### PR TITLE
Remove stray references to sklearn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- The ``sklearn`` version information has been removed from the meta
+  attribute in output tables. ``sklearn`` was removed as an optional
+  dependency in 1.13.0. [#1807]
+
 
 1.13.0 (2024-06-28)
 -------------------

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -553,7 +553,7 @@ Source grouping is an optional feature. To turn it on, create a
 keyword. Here we'll group stars that are within 20 pixels of each
 other:
 
-.. doctest-requires:: scipy, sklearn
+.. doctest-requires:: scipy
 
     >>> from photutils.psf import SourceGrouper
     >>> grouper = SourceGrouper(min_separation=20)
@@ -564,7 +564,7 @@ other:
 The ``group_id`` column shows that six groups were identified (each with
 two stars). The stars in each group were simultaneously fit.
 
-.. doctest-requires:: scipy, sklearn
+.. doctest-requires:: scipy
 
     >>> print(phot[('id', 'group_id', 'group_size')])
      id group_id group_size
@@ -596,7 +596,7 @@ an inner and outer radius of 5 and 10 pixels, respectively, with the
 `~photutils.background.MMMBackground` statistic (with its default sigma
 clipping):
 
-.. doctest-requires:: scipy, sklearn
+.. doctest-requires:: scipy
 
     >>> from photutils.background import LocalBackground, MMMBackground
     >>> bkgstat = MMMBackground()
@@ -609,7 +609,7 @@ clipping):
 
 The local background values are output in the table:
 
-.. doctest-requires:: scipy, sklearn
+.. doctest-requires:: scipy
 
     >>> phot['local_bkg'].info.format = '.4f'  # optional format
     >>> print(phot[('id', 'local_bkg')])  # doctest: +FLOAT_CMP

--- a/photutils/conftest.py
+++ b/photutils/conftest.py
@@ -20,8 +20,7 @@ def pytest_configure(config):
         # running the tests.
         PYTEST_HEADER_MODULES.clear()
         deps = ['NumPy', 'SciPy', 'Matplotlib', 'Astropy', 'skimage',
-                'sklearn', 'GWCS', 'Bottleneck', 'tqdm', 'Rasterio',
-                'Shapely']
+                'GWCS', 'Bottleneck', 'tqdm', 'Rasterio', 'Shapely']
         for dep in deps:
             PYTEST_HEADER_MODULES[dep] = dep.lower()
 

--- a/photutils/utils/_misc.py
+++ b/photutils/utils/_misc.py
@@ -22,7 +22,7 @@ def _get_version_info():
     versions = {'Python': sys.version.split()[0]}
 
     packages = ('photutils', 'astropy', 'numpy', 'scipy', 'skimage',
-                'sklearn', 'matplotlib', 'gwcs', 'bottleneck')
+                'matplotlib', 'gwcs', 'bottleneck')
     for package in packages:
         try:
             pkg = __import__(package)

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -9,8 +9,8 @@ import importlib
 # This list is a duplicate of the dependencies in pyproject.toml "all".
 # Note that in some cases the package names are different from the
 # pip-install name (e.g.k scikit-image -> skimage).
-optional_deps = ['scipy', 'matplotlib', 'skimage', 'sklearn', 'gwcs',
-                 'bottleneck', 'tqdm', 'rasterio', 'shapely']
+optional_deps = ['scipy', 'matplotlib', 'skimage', 'gwcs', 'bottleneck',
+                 'tqdm', 'rasterio', 'shapely']
 deps = {key.upper(): key for key in optional_deps}
 __all__ = [f'HAS_{pkg}' for pkg in deps]
 

--- a/photutils/utils/tests/test_misc.py
+++ b/photutils/utils/tests/test_misc.py
@@ -18,6 +18,6 @@ def test_get_meta(utc):
     versions = meta['version']
     assert isinstance(versions, dict)
     keys = ('Python', 'photutils', 'astropy', 'numpy', 'scipy', 'skimage',
-            'sklearn', 'matplotlib', 'gwcs', 'bottleneck')
+            'matplotlib', 'gwcs', 'bottleneck')
     for key in keys:
         assert key in versions


### PR DESCRIPTION
`sklearn` was removed as an optional dependency in 1.13.0.

As part of this removal, the ``sklearn`` version information has been removed from the meta attribute in output tables.

