### PR TITLE
Raise ValueError if isolist is empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,11 @@ API Changes
   attribute in output tables. ``sklearn`` was removed as an optional
   dependency in 1.13.0. [#1807]
 
+- ``photutils.isophote``
+
+  - The ``build_ellipse_model`` function now raises a ``ValueError`` if
+    the input ``isolist`` is empty. [#1809]
+
 
 1.13.0 (2024-06-28)
 -------------------

--- a/photutils/isophote/model.py
+++ b/photutils/isophote/model.py
@@ -49,6 +49,9 @@ def build_ellipse_model(shape, isolist, fill=0.0, high_harmonics=False):
     result : 2D `~numpy.ndarray`
         The image with the model galaxy.
     """
+    if len(isolist) == 0:
+        raise ValueError('isolist must not be empty')
+
     from scipy.interpolate import LSQUnivariateSpline
 
     # the target grid is spaced in 0.1 pixel intervals so as

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -14,6 +14,7 @@ from astropy.utils.data import get_pkg_data_filename
 from photutils.datasets import get_path
 from photutils.isophote.ellipse import Ellipse
 from photutils.isophote.geometry import EllipseGeometry
+from photutils.isophote.isophote import IsophoteList
 from photutils.isophote.model import build_ellipse_model
 from photutils.isophote.tests.make_test_data import make_test_image
 from photutils.tests.helper import PYTEST_LT_80
@@ -99,3 +100,9 @@ def test_model_minimum_radius():
         # It's enough that the algorithm reached this point. The
         # actual accuracy of the modelling is being tested elsewhere.
         assert data.shape == model.shape
+
+
+def test_model_inputs():
+    match = 'isolist must not be empty'
+    with pytest.raises(ValueError, match=match):
+        build_ellipse_model((10, 10), IsophoteList([]))


### PR DESCRIPTION
With this PR, the ``build_ellipse_model`` function now raises a ``ValueError`` if the input ``isolist`` is empty.