### PR TITLE
Do not average upper harmonics in build_ellipse_model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.isophote``
+
+  - Fixed a bug in ``build_ellipse_model`` where if
+    ``high_harmonics=True``, the harmonics were not correctly added to
+    the model. [#1810]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/isophote/model.py
+++ b/photutils/isophote/model.py
@@ -124,7 +124,7 @@ def build_ellipse_model(shape, isolist, fill=0.0, high_harmonics=False):
                 harm = (a3_array[index] * np.sin(3.0 * phi)
                         + b3_array[index] * np.cos(3.0 * phi)
                         + a4_array[index] * np.sin(4.0 * phi)
-                        + b4_array[index] * np.cos(4.0 * phi)) / 4.0
+                        + b4_array[index] * np.cos(4.0 * phi))
 
             # get image coordinates of (r, phi) pixel
             x = r * np.cos(phi + pa) + x0


### PR DESCRIPTION
This PR fixes the issues reported in #1776 and #1722 where the high-order harmonics were not properly being added to the ellipse model in `build_ellipse_model` when `high_harmonics=True`. 

Fixes: #1776, #1722