### PR TITLE
Fix check of subpixels value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - Fixed a bug checking that the ``subpixels`` keyword is a strictly
+    positive integer. [#1816]
+
 - ``photutils.isophote``
 
   - Fixed a bug in ``build_ellipse_model`` where if

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -190,7 +190,7 @@ class PixelAperture(Aperture):
             mode = 'subpixel'
             subpixels = 32
 
-        if mode == 'subpixels':
+        if mode == 'subpixel':
             if not isinstance(subpixels, int) or subpixels <= 0:
                 raise ValueError('subpixels must be a strictly positive '
                                  'integer')

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -827,3 +827,12 @@ def test_nddata_input():
         if column == 'sky_center':  # cannot test SkyCoord equality
             continue
         assert_allclose(tbl1[column], tbl2[column])
+
+
+def test_invalid_subpixels():
+    data = np.ones((11, 11))
+    aper = CircularAperture((5, 5), r=3)
+    with pytest.raises(ValueError):
+        aperture_photometry(data, aper, method='subpixel', subpixels=0)
+    with pytest.raises(ValueError):
+        aperture_photometry(data, aper, method='subpixel', subpixels=-1)


### PR DESCRIPTION
This PR fixes a bug in the check of the `subpixels` value in aperture photometry.  Many thanks to @havijw for reporting this!