### PR TITLE
Allow NDData uncertainties in extract_stars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New Features
     ``IterativePSFPhotometry`` to allow one to bound the x and y
     model parameters during the fitting. [#1805]
 
+  - The ``extract_stars`` function can now accept ``NDData`` inputs with
+    uncertainty types other than ``weights``. [#1821]
+
 Bug Fixes
 ^^^^^^^^^
 


### PR DESCRIPTION
With this PR, the ``extract_stars`` function can now accept ``NDData`` inputs with uncertainty types other than ``weights``.  This includes `InverseVariance`, `StdDevUncertainty`, and `VarianceUncertainty`.

Closes: #739