### PR TITLE
Add hooks to pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,10 @@ version: 2
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"  # checks files in .github/workflows
+    directory: ".github/workflows/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "actions/checkout"
-        versions: ["1"]
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,6 +100,13 @@ repos:
     hooks:
       - id: numpydoc-validation
 
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: [--in-place, --config, ./pyproject.toml]
+
   # - repo: https://github.com/MarcoGorelli/absolufy-imports
   #   rev: v0.3.1
   #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,11 @@ repos:
         args: ["--py310-plus"]
         exclude: ".*(extern.*)$"
 
+  - repo: https://github.com/scientific-python/cookie
+    rev: 2024.04.23
+    hooks:
+      - id: sp-repo-review
+
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     rev: v3.17.0
     hooks:
       - id: pyupgrade
-        args: ["--py39-plus"]
+        args: ["--py310-plus"]
         exclude: ".*(extern.*)$"
 
   - repo: https://github.com/pycqa/isort

--- a/photutils/__init__.py
+++ b/photutils/__init__.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Photutils is an Astropy affiliated package to provide tools for
-detecting and performing photometry of astronomical sources. It also has
-tools for background estimation, ePSF building, PSF matching, radial
-profiles, centroiding, and morphological measurements.
+detecting and performing photometry of astronomical sources.
 
+It also has tools for background estimation, ePSF building, PSF
+matching, radial profiles, centroiding, and morphological measurements.
 """
 
 import warnings

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -206,9 +206,8 @@ class BoundingBox:
     def extent(self):
         """
         The extent of the mask, defined as the ``(xmin, xmax, ymin,
-        ymax)`` bounding box from the bottom-left corner of the
-        lower-left pixel to the upper-right corner of the upper-right
-        pixel.
+        ymax)`` bounding box from the bottom-left corner of the lower-
+        left pixel to the upper-right corner of the upper-right pixel.
 
         The upper edges here are the actual pixel positions of the
         edges, i.e., they are not "exclusive" indices used for python

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -447,8 +447,8 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
     def to_sky(self, wcs):
         """
-        Convert the aperture to a `SkyRectangularAnnulus` object
-        defined in celestial coordinates.
+        Convert the aperture to a `SkyRectangularAnnulus` object defined
+        in celestial coordinates.
 
         Parameters
         ----------

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -411,7 +411,8 @@ class ApertureStats:
     @lazyproperty
     def isscalar(self):
         """
-        Whether the instance is scalar (e.g., a single aperture position).
+        Whether the instance is scalar (e.g., a single aperture
+        position).
         """
         return self._pixel_aperture.isscalar
 
@@ -705,17 +706,17 @@ class ApertureStats:
     @lazyproperty
     def _aperture_cutouts_center(self):
         """
-        Aperture-weighted cutouts for the data, variance, total mask, and
-        aperture weights using the "center" aperture mask method.
+        Aperture-weighted cutouts for the data, variance, total mask,
+        and aperture weights using the "center" aperture mask method.
         """
         return self._make_aperture_cutouts(self._aperture_masks_center)
 
     @lazyproperty
     def _aperture_cutouts(self):
         """
-        Aperture-weighted cutouts for the data, variance, total mask, and
-        aperture weights using the input ``sum_method`` aperture mask
-        method.
+        Aperture-weighted cutouts for the data, variance, total mask,
+        and aperture weights using the input ``sum_method`` aperture
+        mask method.
         """
         return self._make_aperture_cutouts(self._aperture_masks)
 
@@ -783,8 +784,8 @@ class ApertureStats:
     @as_scalar
     def data_sumcutout(self):
         """
-        A 2D aperture-weighted cutout from the data using the
-        aperture mask with the input ``sum_method`` method as a
+        A 2D aperture-weighted cutout from the data using the aperture
+        mask with the input ``sum_method`` method as a
         `~numpy.ma.MaskedArray`.
 
         The cutout does not have units due to current limitations of
@@ -819,8 +820,8 @@ class ApertureStats:
     @lazyproperty
     def _variance_cutout(self):
         """
-        A 2D aperture-weighted variance cutout using the
-        aperture mask with the input ``sum_method`` method as a
+        A 2D aperture-weighted variance cutout using the aperture mask
+        with the input ``sum_method`` method as a
         `~numpy.ma.MaskedArray`.
 
         The cutout does not have units due to current limitations of
@@ -976,8 +977,8 @@ class ApertureStats:
     @as_scalar
     def cutout_centroid(self):
         """
-        The ``(x, y)`` coordinate, relative to the cutout data, of
-        the centroid within the aperture.
+        The ``(x, y)`` coordinate, relative to the cutout data, of the
+        centroid within the aperture.
 
         The centroid is computed as the center of mass of the unmasked
         pixels within the aperture.
@@ -1067,9 +1068,9 @@ class ApertureStats:
     @as_scalar
     def sky_centroid_icrs(self):
         """
-        The sky coordinate in the International Celestial
-        Reference System (ICRS) frame of the centroid of the
-        unmasked pixels within the aperture, returned as a
+        The sky coordinate in the International Celestial Reference
+        System (ICRS) frame of the centroid of the unmasked pixels
+        within the aperture, returned as a
         `~astropy.coordinates.SkyCoord` object.
 
         `None` if ``wcs`` is not input.
@@ -1598,8 +1599,8 @@ class ApertureStats:
     @as_scalar
     def cxx(self):
         r"""
-        Coefficient for ``x**2`` in the generalized ellipse equation.
-        in units of pixel**(-2).
+        Coefficient for ``x**2`` in the generalized ellipse equation in
+        units of pixel**(-2).
 
         The ellipse is defined as
 
@@ -1620,8 +1621,8 @@ class ApertureStats:
     @as_scalar
     def cyy(self):
         r"""
-        Coefficient for ``y**2`` in the generalized ellipse equation.
-        in units of pixel**(-2).
+        Coefficient for ``y**2`` in the generalized ellipse equation in
+        units of pixel**(-2).
 
         The ellipse is defined as
 
@@ -1642,8 +1643,8 @@ class ApertureStats:
     @as_scalar
     def cxy(self):
         r"""
-        Coefficient for ``x * y`` in the generalized ellipse equation.
-        in units of pixel**(-2).
+        Coefficient for ``x * y`` in the generalized ellipse equation in
+        units of pixel**(-2).
 
         The ellipse is defined as
 

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -430,7 +430,9 @@ def test_basic_circular_aperture_photometry_unit():
 
 
 def test_aperture_photometry_with_error_units():
-    """Test aperture_photometry when error has units (see #176)."""
+    """
+    Test aperture_photometry when error has units (see #176).
+    """
 
     data1 = np.ones((40, 40), dtype=float)
     data2 = u.Quantity(data1, unit=u.adu)
@@ -449,8 +451,8 @@ def test_aperture_photometry_with_error_units():
 
 def test_aperture_photometry_inputs_with_mask():
     """
-    Test that aperture_photometry does not modify the input
-    data or error array when a mask is input.
+    Test that aperture_photometry does not modify the input data or
+    error array when a mask is input.
     """
 
     data = np.ones((5, 5))
@@ -476,7 +478,8 @@ TEST_ELLIPSE_EXACT_APERTURES = [(3.469906, 3.923861394, 3.0),
 @pytest.mark.parametrize('x,y,r', TEST_ELLIPSE_EXACT_APERTURES)
 def test_ellipse_exact_grid(x, y, r):
     """
-    Test elliptical exact aperture photometry on a grid of pixel positions.
+    Test elliptical exact aperture photometry on a grid of pixel
+    positions.
 
     This is a regression test for the bug discovered in this issue:
     https://github.com/astropy/photutils/issues/198
@@ -492,7 +495,9 @@ def test_ellipse_exact_grid(x, y, r):
 
 @pytest.mark.parametrize('value', [np.nan, np.inf])
 def test_nan_inf_mask(value):
-    """Test that nans and infs are properly masked [267]."""
+    """
+    Test that nans and infs are properly masked [#267].
+    """
 
     data = np.ones((9, 9))
     mask = np.zeros_like(data, dtype=bool)
@@ -794,8 +799,8 @@ def test_nan_in_bbox():
 
 def test_scalar_skycoord():
     """
-    Regression test to check that scalar SkyCoords are added to the table
-    as a length-1 SkyCoord array.
+    Regression test to check that scalar SkyCoords are added to the
+    table as a length-1 SkyCoord array.
     """
 
     data = make_4gaussians_image()

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -440,8 +440,8 @@ class Background2D:
     def _interpolate_meshes(self, data, n_neighbors=10, eps=0.0, power=1.0,
                             reg=0.0):
         """
-        Use IDW interpolation to fill in any masked pixels in the
-        low-resolution 2D mesh background and background RMS images.
+        Use IDW interpolation to fill in any masked pixels in the low-
+        resolution 2D mesh background and background RMS images.
 
         This is required to use a regular-grid interpolator to expand
         the low-resolution image to the full size image.
@@ -590,8 +590,9 @@ class Background2D:
     def background_mesh_masked(self):
         """
         The background 2D (masked) array mesh prior to any
-        interpolation. The array has NaN values where meshes were
-        excluded.
+        interpolation.
+
+        The array has NaN values where meshes were excluded.
         """
         data = np.full(self.background_mesh.shape, np.nan)
         data[self._mesh_idx] = self.background_mesh[self._mesh_idx]
@@ -601,8 +602,9 @@ class Background2D:
     def background_rms_mesh_masked(self):
         """
         The background RMS 2D (masked) array mesh prior to any
-        interpolation. The array has NaN values where meshes were
-        excluded.
+        interpolation.
+
+        The array has NaN values where meshes were excluded.
         """
         data = np.full(self.background_rms_mesh.shape, np.nan)
         data[self._mesh_idx] = self.background_rms_mesh[self._mesh_idx]
@@ -620,8 +622,9 @@ class Background2D:
     @lazyproperty
     def mesh_nmasked(self):
         """
-        A 2D array of the number of masked pixels in each mesh. NaN
-        values indicate where meshes were excluded.
+        A 2D array of the number of masked pixels in each mesh.
+
+        NaN values indicate where meshes were excluded.
         """
         return self._make_2d_array(
             np.count_nonzero(np.isnan(self._box_data), axis=1))
@@ -654,7 +657,9 @@ class Background2D:
 
     @lazyproperty
     def background(self):
-        """A 2D `~numpy.ndarray` containing the background image."""
+        """
+        A 2D `~numpy.ndarray` containing the background image.
+        """
         bkg = self.interpolator(self.background_mesh, self)
         if self.coverage_mask is not None:
             bkg[self.coverage_mask] = self.fill_value
@@ -664,7 +669,9 @@ class Background2D:
 
     @lazyproperty
     def background_rms(self):
-        """A 2D `~numpy.ndarray` containing the background RMS image."""
+        """
+        A 2D `~numpy.ndarray` containing the background RMS image.
+        """
         bkg_rms = self.interpolator(self.background_rms_mesh, self)
         if self.coverage_mask is not None:
             bkg_rms[self.coverage_mask] = self.fill_value

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -362,8 +362,8 @@ class MMMBackground(ModeEstimatorBackground):
 
 class SExtractorBackground(BackgroundBase):
     """
-    Class to calculate the background in an array using the
-    Source Extractor algorithm.
+    Class to calculate the background in an array using the Source
+    Extractor algorithm.
 
     The background is calculated using a mode estimator of the form
     ``(2.5 * median) - (1.5 * mean)``. If ``(mean - median) / std >
@@ -509,8 +509,8 @@ class BiweightLocationBackground(BackgroundBase):
 
 class StdBackgroundRMS(BackgroundRMSBase):
     """
-    Class to calculate the background RMS in an array as the
-    (sigma-clipped) standard deviation.
+    Class to calculate the background RMS in an array as the (sigma-
+    clipped) standard deviation.
 
     Parameters
     ----------
@@ -630,8 +630,8 @@ class MADStdBackgroundRMS(BackgroundRMSBase):
 
 class BiweightScaleBackgroundRMS(BackgroundRMSBase):
     """
-    Class to calculate the background RMS in an array as the
-    (sigma-clipped) biweight scale.
+    Class to calculate the background RMS in an array as the (sigma-
+    clipped) biweight scale.
 
     Parameters
     ----------

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -50,7 +50,9 @@ class TestBackground2D:
 
     @pytest.mark.parametrize('data', [DATA1, DATA3, DATA4])
     def test_background_nddata(self, data):
-        """Test with NDData and CCDData, and also test units."""
+        """
+        Test with NDData and CCDData, and also test units.
+        """
         bkg = Background2D(data, (25, 25), filter_size=3)
         assert isinstance(bkg.background, u.Quantity)
         assert isinstance(bkg.background_rms, u.Quantity)
@@ -130,8 +132,10 @@ class TestBackground2D:
     @pytest.mark.parametrize('box_size', ([(25, 25), (23, 22)]))
     def test_background_mask(self, box_size):
         """
-        Test with an input mask. Note that box_size=(23, 22) tests the
-        resizing of the image and mask.
+        Test with an input mask.
+
+        Note that box_size=(23, 22) tests the resizing of the image and
+        mask.
         """
         data = np.copy(DATA)
         data[25:50, 25:50] = 100.0
@@ -204,6 +208,7 @@ class TestBackground2D:
     def test_mask_with_already_masked_nans(self):
         """
         Test masked invalid values.
+
         These tests should not issue a warning.
         """
         data = DATA.copy()
@@ -246,7 +251,9 @@ class TestBackground2D:
             Background2D(DATA, (25, 25), mask=mask)
 
     def test_zero_padding(self):
-        """Test case where padding is added only on one axis."""
+        """
+        Test case where padding is added only on one axis.
+        """
         bkg = Background2D(DATA, (25, 22), filter_size=(1, 1))
         assert_allclose(bkg.background, DATA, rtol=1e-5)
         assert_allclose(bkg.background_rms, BKG_RMS)
@@ -254,7 +261,9 @@ class TestBackground2D:
         assert bkg.background_rms_median == 0.0
 
     def test_exclude_percentile(self):
-        """Only meshes greater than filter_threshold are filtered."""
+        """
+        Only meshes greater than filter_threshold are filtered.
+        """
         data = np.copy(DATA)
         data[0:50, 0:50] = np.nan
         with pytest.warns(AstropyUserWarning,
@@ -264,7 +273,9 @@ class TestBackground2D:
         assert len(bkg._box_idx) == 12
 
     def test_filter_threshold(self):
-        """Only meshes greater than filter_threshold are filtered."""
+        """
+        Only meshes greater than filter_threshold are filtered.
+        """
         data = np.copy(DATA)
         data[25:50, 50:75] = 10.0
         bkg = Background2D(data, (25, 25), filter_size=(3, 3),
@@ -276,7 +287,9 @@ class TestBackground2D:
         assert bkg2.background_mesh[1, 2] == 10
 
     def test_filter_threshold_high(self):
-        """No filtering because filter_threshold is too large."""
+        """
+        No filtering because filter_threshold is too large.
+        """
         data = np.copy(DATA)
         data[25:50, 50:75] = 10.0
         ref_data = np.copy(BKG_MESH)
@@ -286,7 +299,9 @@ class TestBackground2D:
         assert_allclose(b.background_mesh, ref_data)
 
     def test_filter_threshold_nofilter(self):
-        """No filtering because filter_size is (1, 1)."""
+        """
+        No filtering because filter_size is (1, 1).
+        """
         data = np.copy(DATA)
         data[25:50, 50:75] = 10.0
         ref_data = np.copy(BKG_MESH)

--- a/photutils/datasets/tests/test_noise.py
+++ b/photutils/datasets/tests/test_noise.py
@@ -19,7 +19,9 @@ def test_apply_poisson_noise():
 
 
 def test_apply_poisson_noise_negative():
-    """Test if negative image values raises ValueError."""
+    """
+    Test if negative image values raises ValueError.
+    """
     with pytest.raises(ValueError):
         shape = (100, 100)
         data = np.zeros(shape) - 1.0
@@ -41,7 +43,9 @@ def test_make_noise_image_poisson():
 
 
 def test_make_noise_image_nomean():
-    """Test invalid inputs."""
+    """
+    Test invalid inputs.
+    """
     shape = (100, 100)
 
     with pytest.raises(ValueError):

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -1,8 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This module implements the base class and star finder kernel for
-detecting stars in an astronomical image. Each star-finding class should
-define a method called ``find_stars`` that finds stars in an image.
+detecting stars in an astronomical image.
+
+Each star-finding class should define a method called ``find_stars``
+that finds stars in an image.
 """
 
 import abc

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -287,7 +287,9 @@ class _StarFinderCatalog:
                                                  predicate=islazyproperty)]
 
     def reset_ids(self):
-        """Reset the ID column to be consecutive integers."""
+        """
+        Reset the ID column to be consecutive integers.
+        """
         self.id = np.arange(len(self)) + 1
 
     @lazyproperty
@@ -410,7 +412,9 @@ class _StarFinderCatalog:
         return pa
 
     def apply_filters(self):
-        """Filter the catalog."""
+        """
+        Filter the catalog.
+        """
         # remove all non-finite values - consider these non-detections
         attrs = ('xcentroid', 'ycentroid', 'fwhm', 'roundness', 'pa',
                  'max_value', 'flux')
@@ -437,8 +441,8 @@ class _StarFinderCatalog:
 
     def select_brightest(self):
         """
-        Sort the catalog by the brightest fluxes and select the
-        top brightest sources.
+        Sort the catalog by the brightest fluxes and select the top
+        brightest sources.
         """
         newcat = self
         if self.brightest is not None:

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -78,7 +78,9 @@ class TestDAOStarFinder:
         assert len(tbl0) > len(tbl1)
 
     def test_daofind_sharpness(self, data):
-        """Sources found, but none pass the sharpness criteria."""
+        """
+        Sources found, but none pass the sharpness criteria.
+        """
         match = 'Sources were found, but none pass'
 
         with pytest.warns(NoDetectionsWarning, match=match):
@@ -87,7 +89,9 @@ class TestDAOStarFinder:
             assert tbl is None
 
     def test_daofind_roundness(self, data):
-        """Sources found, but none pass the roundness criteria."""
+        """
+        Sources found, but none pass the roundness criteria.
+        """
         match = 'Sources were found, but none pass'
         with pytest.warns(NoDetectionsWarning, match=match):
             finder = DAOStarFinder(threshold=1, fwhm=1.0, roundlo=1.0)
@@ -95,7 +99,9 @@ class TestDAOStarFinder:
             assert tbl is None
 
     def test_daofind_peakmax(self, data):
-        """Sources found, but none pass the peakmax criteria."""
+        """
+        Sources found, but none pass the peakmax criteria.
+        """
         match = 'Sources were found, but none pass'
         with pytest.warns(NoDetectionsWarning, match=match):
             finder = DAOStarFinder(threshold=1, fwhm=1.0, peakmax=1.0)
@@ -142,7 +148,9 @@ class TestDAOStarFinder:
         assert len(tbl) == 5
 
     def test_daofind_mask(self, data):
-        """Test DAOStarFinder with a mask."""
+        """
+        Test DAOStarFinder with a mask.
+        """
         finder = DAOStarFinder(threshold=1.0, fwhm=1.5)
         mask = np.zeros(data.shape, dtype=bool)
         mask[0:50, :] = True

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -60,7 +60,9 @@ class TestIRAFStarFinder:
             assert tbl is None
 
     def test_irafstarfind_sharpness(self, data):
-        """Sources found, but none pass the sharpness criteria."""
+        """
+        Sources found, but none pass the sharpness criteria.
+        """
         match = 'Sources were found, but none pass'
         with pytest.warns(NoDetectionsWarning, match=match):
             finder = IRAFStarFinder(threshold=1, fwhm=1.0, sharplo=2.0)
@@ -68,7 +70,9 @@ class TestIRAFStarFinder:
             assert tbl is None
 
     def test_irafstarfind_roundness(self, data):
-        """Sources found, but none pass the roundness criteria."""
+        """
+        Sources found, but none pass the roundness criteria.
+        """
         match = 'Sources were found, but none pass'
         with pytest.warns(NoDetectionsWarning, match=match):
             finder = IRAFStarFinder(threshold=1, fwhm=1.0, roundlo=1.0)
@@ -76,7 +80,9 @@ class TestIRAFStarFinder:
             assert tbl is None
 
     def test_irafstarfind_peakmax(self, data):
-        """Sources found, but none pass the peakmax criteria."""
+        """
+        Sources found, but none pass the peakmax criteria.
+        """
         match = 'Sources were found, but none pass'
         with pytest.warns(NoDetectionsWarning, match=match):
             finder = IRAFStarFinder(threshold=1, fwhm=1.0, peakmax=1.0)
@@ -111,7 +117,8 @@ class TestIRAFStarFinder:
 
     def test_irafstarfind_brightest_filtering(self, data):
         """
-        Regression test that only top ``brightest`` objects are selected.
+        Regression test that only top ``brightest`` objects are
+        selected.
         """
         brightest = 10
         finder = IRAFStarFinder(threshold=1.0, fwhm=2, roundlo=-np.inf,
@@ -121,7 +128,9 @@ class TestIRAFStarFinder:
         assert len(tbl) == brightest
 
     def test_irafstarfind_mask(self, data):
-        """Test IRAFStarFinder with a mask."""
+        """
+        Test IRAFStarFinder with a mask.
+        """
         finder = IRAFStarFinder(threshold=1.0, fwhm=1.5)
         mask = np.zeros(data.shape, dtype=bool)
         mask[0:50, :] = True

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -19,7 +19,9 @@ from photutils.utils.exceptions import NoDetectionsWarning
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestFindPeaks:
     def test_box_size(self, data):
-        """Test with box_size."""
+        """
+        Test with box_size.
+        """
         tbl = find_peaks(data, 0.1, box_size=3)
         assert tbl['id'][0] == 1
         assert len(tbl) == 25
@@ -42,13 +44,17 @@ class TestFindPeaks:
         assert_equal(tbl[col], tbl2[col].value)
 
     def test_footprint(self, data):
-        """Test with footprint."""
+        """
+        Test with footprint.
+        """
         tbl0 = find_peaks(data, 0.1, box_size=3)
         tbl1 = find_peaks(data, 0.1, footprint=np.ones((3, 3)))
         assert_array_equal(tbl0, tbl1)
 
     def test_mask(self, data):
-        """Test with mask."""
+        """
+        Test with mask.
+        """
         mask = np.zeros(data.shape, dtype=bool)
         mask[0:50, :] = True
         tbl0 = find_peaks(data, 0.1, box_size=3)
@@ -56,39 +62,53 @@ class TestFindPeaks:
         assert len(tbl1) < len(tbl0)
 
     def test_maskshape(self, data):
-        """Test if make shape doesn't match data shape."""
+        """
+        Test if make shape doesn't match data shape.
+        """
         with pytest.raises(ValueError):
             find_peaks(data, 0.1, mask=np.ones((5, 5)))
 
     def test_thresholdshape(self, data):
-        """Test if threshold shape doesn't match data shape."""
+        """
+        Test if threshold shape doesn't match data shape.
+        """
         with pytest.raises(ValueError):
             find_peaks(data, np.ones((2, 2)))
 
     def test_npeaks(self, data):
-        """Test npeaks."""
+        """
+        Test npeaks.
+        """
         tbl = find_peaks(data, 0.1, box_size=3, npeaks=1)
         assert len(tbl) == 1
 
     def test_border_width(self, data):
-        """Test border exclusion."""
+        """
+        Test border exclusion.
+        """
         tbl0 = find_peaks(data, 0.1, box_size=3)
         tbl1 = find_peaks(data, 0.1, box_size=3, border_width=25)
         assert len(tbl1) < len(tbl0)
 
     def test_box_size_int(self, data):
-        """Test non-integer box_size."""
+        """
+        Test non-integer box_size.
+        """
         tbl1 = find_peaks(data, 0.1, box_size=5.0)
         tbl2 = find_peaks(data, 0.1, box_size=5.5)
         assert_array_equal(tbl1, tbl2)
 
     def test_centroid_func_callable(self, data):
-        """Test that centroid_func is callable."""
+        """
+        Test that centroid_func is callable.
+        """
         with pytest.raises(TypeError):
             find_peaks(data, 0.1, box_size=2, centroid_func=True)
 
     def test_wcs(self, data):
-        """Test with astropy WCS."""
+        """
+        Test with astropy WCS.
+        """
         columns = ['skycoord_peak', 'skycoord_centroid']
 
         fits_wcs = make_wcs(data.shape)
@@ -101,7 +121,9 @@ class TestFindPeaks:
 
     @pytest.mark.skipif(not HAS_GWCS, reason='gwcs is required')
     def test_gwcs(self, data):
-        """Test with gwcs."""
+        """
+        Test with gwcs.
+        """
         columns = ['skycoord_peak', 'skycoord_centroid']
 
         gwcs_obj = make_gwcs(data.shape)
@@ -121,7 +143,9 @@ class TestFindPeaks:
             assert_quantity_allclose(tbl1[column].dec, tbl2[column].dec)
 
     def test_constant_array(self):
-        """Test for empty output table when data is constant."""
+        """
+        Test for empty output table when data is constant.
+        """
         data = np.ones((10, 10))
         match = 'Input data is constant'
         with pytest.warns(NoDetectionsWarning, match=match):
@@ -153,7 +177,9 @@ class TestFindPeaks:
             assert tbl is None
 
     def test_data_nans(self, data):
-        """Test that data with NaNs does not issue Runtime warning."""
+        """
+        Test that data with NaNs does not issue Runtime warning.
+        """
         data = np.copy(data)
         data[50:, :] = np.nan
         find_peaks(data, 0.1)

--- a/photutils/isophote/integrator.py
+++ b/photutils/isophote/integrator.py
@@ -19,7 +19,8 @@ MEDIAN = 'median'
 
 class _Integrator:
     """
-    Base class that supports different kinds of pixel integration methods.
+    Base class that supports different kinds of pixel integration
+    methods.
 
     Parameters
     ----------
@@ -57,9 +58,9 @@ class _Integrator:
 
     def integrate(self, radius, phi):
         """
-        The three input lists (angles, radii, intensities) are
-        appended with one sample point taken from the image by
-        a chosen integration method.
+        The three input lists (angles, radii, intensities) are appended
+        with one sample point taken from the image by a chosen
+        integration method.
 
         Sub classes should implement the actual integration method.
 
@@ -77,8 +78,8 @@ class _Integrator:
         """
         Reset the lists containing results.
 
-        This method is for internal use and shouldn't
-        be used by external callers.
+        This method is for internal use and shouldn't be used by
+        external callers.
         """
         self._angles = []
         self._radii = []

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -192,27 +192,37 @@ class Isophote:
 
     @property
     def sma(self):
-        """The semimajor axis length (pixels)."""
+        """
+        The semimajor axis length (pixels).
+        """
         return self.sample.geometry.sma
 
     @property
     def eps(self):
-        """The ellipticity of the ellipse."""
+        """
+        The ellipticity of the ellipse.
+        """
         return self.sample.geometry.eps
 
     @property
     def pa(self):
-        """The position angle (radians) of the ellipse."""
+        """
+        The position angle (radians) of the ellipse.
+        """
         return self.sample.geometry.pa
 
     @property
     def x0(self):
-        """The center x coordinate (pixel)."""
+        """
+        The center x coordinate (pixel).
+        """
         return self.sample.geometry.x0
 
     @property
     def y0(self):
-        """The center y coordinate (pixel)."""
+        """
+        The center y coordinate (pixel).
+        """
         return self.sample.geometry.y0
 
     def _compute_fluxes(self):
@@ -264,8 +274,10 @@ class Isophote:
     def _compute_deviations(self, sample, n):
         """
         Compute deviations from a perfect ellipse, based on the
-        amplitudes and errors for harmonic "n". Note that we first
-        subtract the first and second harmonics from the raw data.
+        amplitudes and errors for harmonic "n".
+
+        Note that we first subtract the first and second harmonics from
+        the raw data.
         """
         try:
             # upper (third and fourth) harmonics
@@ -436,12 +448,16 @@ class CentralPixel(Isophote):
 
     @property
     def eps(self):
-        """The ellipticity of the ellipse."""
+        """
+        The ellipticity of the ellipse.
+        """
         return 0.0
 
     @property
     def pa(self):
-        """The position angle (radians) of the ellipse."""
+        """
+        The position angle (radians) of the ellipse.
+        """
         return 0.0
 
 
@@ -569,57 +585,79 @@ class IsophoteList:
 
     @property
     def sma(self):
-        """The semimajor axis length (pixels)."""
+        """
+        The semimajor axis length (pixels).
+        """
         return self._collect_as_array('sma')
 
     @property
     def intens(self):
-        """The mean intensity value along the elliptical path."""
+        """
+        The mean intensity value along the elliptical path.
+        """
         return self._collect_as_array('intens')
 
     @property
     def int_err(self):
-        """The error of the mean intensity (rms / sqrt(# data points))."""
+        """
+        The error of the mean intensity (rms / sqrt(# data points)).
+        """
         return self._collect_as_array('int_err')
 
     @property
     def eps(self):
-        """The ellipticity of the ellipse."""
+        """
+        The ellipticity of the ellipse.
+        """
         return self._collect_as_array('eps')
 
     @property
     def ellip_err(self):
-        """The ellipticity error."""
+        """
+        The ellipticity error.
+        """
         return self._collect_as_array('ellip_err')
 
     @property
     def pa(self):
-        """The position angle (radians) of the ellipse."""
+        """
+        The position angle (radians) of the ellipse.
+        """
         return self._collect_as_array('pa')
 
     @property
     def pa_err(self):
-        """The position angle error (radians)."""
+        """
+        The position angle error (radians).
+        """
         return self._collect_as_array('pa_err')
 
     @property
     def x0(self):
-        """The center x coordinate (pixel)."""
+        """
+        The center x coordinate (pixel).
+        """
         return self._collect_as_array('x0')
 
     @property
     def x0_err(self):
-        """The error associated with the center x coordinate."""
+        """
+        The error associated with the center x coordinate.
+        """
         return self._collect_as_array('x0_err')
 
     @property
     def y0(self):
-        """The center y coordinate (pixel)."""
+        """
+        The center y coordinate (pixel).
+        """
         return self._collect_as_array('y0')
 
     @property
     def y0_err(self):
-        """The error associated with the center y coordinate."""
+        """
+        The error associated with the center y coordinate.
+        """
         return self._collect_as_array('y0_err')
 
     @property
@@ -640,14 +678,15 @@ class IsophoteList:
 
     @property
     def grad(self):
-        """The local radial intensity gradient."""
+        """
+        The local radial intensity gradient.
+        """
         return self._collect_as_array('grad')
 
     @property
     def grad_error(self):
         """
-        The measurement error of the local radial intensity
-        gradient.
+        The measurement error of the local radial intensity gradient.
         """
         return self._collect_as_array('grad_error')
 
@@ -660,42 +699,55 @@ class IsophoteList:
 
     @property
     def sarea(self):
-        """The average sector area on the isophote (pixel**2)."""
+        """
+        The average sector area on the isophote (pixel**2).
+        """
         return self._collect_as_array('sarea')
 
     @property
     def ndata(self):
-        """The number of extracted data points."""
+        """
+        The number of extracted data points.
+        """
         return self._collect_as_array('ndata')
 
     @property
     def nflag(self):
         """
-        The number of discarded data points. Data points can be
-        discarded either because they are physically outside the image
-        frame boundaries, because they were rejected by sigma-clipping,
-        or they are masked.
+        The number of discarded data points.
+
+        Data points can be discarded either because they are physically
+        outside the image frame boundaries, because they were rejected
+        by sigma-clipping, or they are masked.
         """
         return self._collect_as_array('nflag')
 
     @property
     def niter(self):
-        """The number of iterations used to fit the isophote."""
+        """
+        The number of iterations used to fit the isophote.
+        """
         return self._collect_as_array('niter')
 
     @property
     def valid(self):
-        """The status of the fitting operation."""
+        """
+        The status of the fitting operation.
+        """
         return self._collect_as_array('valid')
 
     @property
     def stop_code(self):
-        """The fitting stop code."""
+        """
+        The fitting stop code.
+        """
         return self._collect_as_array('stop_code')
 
     @property
     def tflux_e(self):
-        """The sum of all pixels inside the ellipse."""
+        """
+        The sum of all pixels inside the ellipse.
+        """
         return self._collect_as_array('tflux_e')
 
     @property
@@ -708,7 +760,9 @@ class IsophoteList:
 
     @property
     def npix_e(self):
-        """The total number of valid pixels inside the ellipse."""
+        """
+        The total number of valid pixels inside the ellipse.
+        """
         return self._collect_as_array('npix_e')
 
     @property
@@ -722,7 +776,9 @@ class IsophoteList:
     @property
     def a3(self):
         """
-        A third-order harmonic coefficient. See the
+        A third-order harmonic coefficient.
+
+        See the
         :func:`~photutils.isophote.fit_upper_harmonic` function for
         details.
         """
@@ -731,7 +787,9 @@ class IsophoteList:
     @property
     def b3(self):
         """
-        A third-order harmonic coefficient. See the
+        A third-order harmonic coefficient.
+
+        See the
         :func:`~photutils.isophote.fit_upper_harmonic` function for
         details.
         """
@@ -740,7 +798,9 @@ class IsophoteList:
     @property
     def a4(self):
         """
-        A fourth-order harmonic coefficient. See the
+        A fourth-order harmonic coefficient.
+
+        See the
         :func:`~photutils.isophote.fit_upper_harmonic` function for
         details.
         """
@@ -749,7 +809,9 @@ class IsophoteList:
     @property
     def b4(self):
         """
-        A fourth-order harmonic coefficient. See the
+        A fourth-order harmonic coefficient.
+
+        See the
         :func:`~photutils.isophote.fit_upper_harmonic` function for
         details.
         """
@@ -842,8 +904,8 @@ def _get_properties(isophote_list):
 
 def _isophote_list_to_table(isophote_list, columns='main'):
     """
-    Convert an `~photutils.isophote.IsophoteList` instance to
-    a `~astropy.table.QTable`.
+    Convert an `~photutils.isophote.IsophoteList` instance to a
+    `~astropy.table.QTable`.
 
     Parameters
     ----------

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -141,7 +141,9 @@ class TestEllipse:
             assert not np.any(iso.sample.values[2] == 0)
 
     def test_ellipse_shape(self):
-        """Regression test for #670/673."""
+        """
+        Regression test for #670/673.
+        """
 
         ny = 500
         nx = 150

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -81,7 +81,9 @@ def test_harmonics_2():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_harmonics_3():
-    """Tests an upper harmonic fit."""
+    """
+    Tests an upper harmonic fit.
+    """
 
     N = 100
     E = np.linspace(0, 4 * np.pi, N)

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -20,8 +20,8 @@ __doctest_requires__ = {'RadialProfile': ['scipy']}
 
 class RadialProfile(ProfileBase):
     """
-    Class to create a radial profile using concentric circular
-    annulus apertures.
+    Class to create a radial profile using concentric circular annulus
+    apertures.
 
     The radial profile represents the azimuthally-averaged flux in
     circular annuli apertures as a function of radius.
@@ -379,8 +379,8 @@ class RadialProfile(ProfileBase):
     @lazyproperty
     def gaussian_fit(self):
         """
-        The fitted 1D Gaussian to the radial profile as
-        a `~astropy.modeling.functional_models.Gaussian1D` model.
+        The fitted 1D Gaussian to the radial profile as a
+        `~astropy.modeling.functional_models.Gaussian1D` model.
         """
         profile = self.profile[self._profile_nanmask]
         radius = self.radius[self._profile_nanmask]

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -139,8 +139,8 @@ def test_radial_profile_error(profile_data):
 
 def test_radial_profile_normalize_nan(profile_data):
     """
-    If the profile has NaNs (e.g., aperture outside of the image),
-    make sure the normalization ignores them.
+    If the profile has NaNs (e.g., aperture outside of the image), make
+    sure the normalization ignores them.
     """
     xycen, data, _, _ = profile_data
 

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -102,7 +102,9 @@ class EPSFStar:
 
     @property
     def data(self):
-        """The 2D cutout image."""
+        """
+        The 2D cutout image.
+        """
         return self._data
 
     @property
@@ -256,7 +258,9 @@ class EPSFStar:
 
     @lazyproperty
     def _data_values(self):
-        """1D array of unmasked cutout data values."""
+        """
+        1D array of unmasked cutout data values.
+        """
         return self.data[~self.mask].ravel()
 
     @lazyproperty
@@ -337,10 +341,9 @@ class EPSFStars:
     @property
     def cutout_center_flat(self):
         """
-        A `~numpy.ndarray` of the ``(x, y)`` position of all the
-        stars' centers (including linked stars) with respect to the
-        input cutout ``data`` array, as a 2D array (``n_all_stars`` x
-        2).
+        A `~numpy.ndarray` of the ``(x, y)`` position of all the stars'
+        centers (including linked stars) with respect to the input
+        cutout ``data`` array, as a 2D array (``n_all_stars`` x 2).
 
         Note that when `EPSFStars` contains any `LinkedEPSFStar`, the
         ``cutout_center`` attribute will be a nested 3D array.
@@ -404,8 +407,9 @@ class EPSFStars:
     def n_all_stars(self):
         """
         The total number of `EPSFStar` objects, including all the linked
-        stars within `LinkedEPSFStar`. Each linked star is included in
-        the count.
+        stars within `LinkedEPSFStar`.
+
+        Each linked star is included in the count.
         """
         return len(self.all_stars)
 
@@ -414,7 +418,9 @@ class EPSFStars:
         """
         The total number of `EPSFStar` objects, including all the linked
         stars within `LinkedEPSFStar`, that have not been excluded from
-        fitting. Each non-excluded linked star is included in the count.
+        fitting.
+
+        Each non-excluded linked star is included in the count.
         """
         return len(self.all_good_stars)
 

--- a/photutils/psf/griddedpsfmodel.py
+++ b/photutils/psf/griddedpsfmodel.py
@@ -557,8 +557,8 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
 
     def _find_bounding_points(self, x, y):
         """
-        Find the indices of the grid points that bound the input
-        ``(x, y)`` position.
+        Find the indices of the grid points that bound the input ``(x,
+        y)`` position.
 
         Parameters
         ----------
@@ -957,8 +957,8 @@ def _get_metadata(filename, detector_id):
 
 def stdpsf_reader(filename, detector_id=None):
     """
-    Generate a `~photutils.psf.GriddedPSFModel` from a STScI
-    standard-format ePSF (STDPSF) FITS file.
+    Generate a `~photutils.psf.GriddedPSFModel` from a STScI standard-
+    format ePSF (STDPSF) FITS file.
 
     .. note::
         Instead of being used directly, this function is intended to be
@@ -1047,8 +1047,8 @@ def stdpsf_reader(filename, detector_id=None):
 
 def webbpsf_reader(filename):
     """
-    Generate a `~photutils.psf.GriddedPSFModel` from a WebbPSF
-    FITS file containing a PSF grid.
+    Generate a `~photutils.psf.GriddedPSFModel` from a WebbPSF FITS file
+    containing a PSF grid.
 
     .. note::
         Instead of being used directly, this function is intended to be

--- a/photutils/psf/matching/tests/test_fourier.py
+++ b/photutils/psf/matching/tests/test_fourier.py
@@ -23,7 +23,9 @@ def test_resize_psf():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_create_matching_kernel():
-    """Test with noiseless 2D Gaussians."""
+    """
+    Test with noiseless 2D Gaussians.
+    """
 
     size = 25
     cen = (size - 1) / 2.0
@@ -47,7 +49,9 @@ def test_create_matching_kernel():
 
 
 def test_create_matching_kernel_shapes():
-    """Test with wrong PSF shapes."""
+    """
+    Test with wrong PSF shapes.
+    """
     with pytest.raises(ValueError):
         psf1 = np.ones((5, 5))
         psf2 = np.ones((3, 3))

--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -21,7 +21,9 @@ def test_hanning():
 
 
 def test_hanning_numpy():
-    """Test Hanning window against 1D numpy version."""
+    """
+    Test Hanning window against 1D numpy version.
+    """
 
     size = 101
     cen = (size - 1) // 2
@@ -41,7 +43,9 @@ def test_tukey():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_tukey_scipy():
-    """Test Tukey window against 1D scipy version."""
+    """
+    Test Tukey window against 1D scipy version.
+    """
 
     from scipy.signal.windows import tukey
 

--- a/photutils/psf/models.py
+++ b/photutils/psf/models.py
@@ -244,17 +244,23 @@ class FittableImageModel(Fittable2DModel):
 
     @property
     def data(self):
-        """Get original image data."""
+        """
+        Get original image data.
+        """
         return self._data
 
     @property
     def normalized_data(self):
-        """Get normalized and/or intensity-corrected image data."""
+        """
+        Get normalized and/or intensity-corrected image data.
+        """
         return self._normalization_constant * self._data
 
     @property
     def normalization_constant(self):
-        """Get normalization constant."""
+        """
+        Get normalization constant.
+        """
         return self._normalization_constant
 
     @property
@@ -304,12 +310,16 @@ class FittableImageModel(Fittable2DModel):
 
     @property
     def nx(self):
-        """Number of columns in the data array."""
+        """
+        Number of columns in the data array.
+        """
         return self._nx
 
     @property
     def ny(self):
-        """Number of rows in the data array."""
+        """
+        Number of rows in the data array.
+        """
         return self._ny
 
     @property
@@ -342,21 +352,26 @@ class FittableImageModel(Fittable2DModel):
 
     @property
     def x_origin(self):
-        """X-coordinate of the origin of the coordinate system."""
+        """
+        X-coordinate of the origin of the coordinate system.
+        """
         return self._x_origin
 
     @property
     def y_origin(self):
-        """Y-coordinate of the origin of the coordinate system."""
+        """
+        Y-coordinate of the origin of the coordinate system.
+        """
         return self._y_origin
 
     @property
     def fill_value(self):
         """
         Fill value to be returned for coordinates outside of the domain
-        of definition of the interpolator. If ``fill_value`` is `None`,
-        then values outside of the domain of definition are the ones
-        returned by the interpolator.
+        of definition of the interpolator.
+
+        If ``fill_value`` is `None`, then values outside of the domain
+        of definition are the ones returned by the interpolator.
         """
         return self._fill_value
 
@@ -583,8 +598,8 @@ class EPSFModel(FittableImageModel):
 
     def _compute_raw_image_norm(self):
         """
-        Compute the normalization of input image data as the flux
-        within a given radius.
+        Compute the normalization of input image data as the flux within
+        a given radius.
         """
         xypos = (self._nx / 2.0, self._ny / 2.0)
         # TODO: generalize "radius" (ellipse?) is oversampling is
@@ -597,9 +612,11 @@ class EPSFModel(FittableImageModel):
     def _compute_normalization(self, normalize=True):
         """
         Helper function that computes (corrected) normalization factor
-        of the original image data. For the ePSF this is defined as the
-        sum over the inner N (default=5.5) pixels of the non-oversampled
-        image. Will re-normalize the data to the value calculated.
+        of the original image data.
+
+        For the ePSF this is defined as the sum over the inner N
+        (default=5.5) pixels of the non-oversampled image. Will re-
+        normalize the data to the value calculated.
         """
         if normalize:
             if self._img_norm is None:

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -372,7 +372,8 @@ class PSFPhotometry(ModelImageMixin):
 
     def _define_param_maps(self, psf_model):
         """
-        Map x, y, and flux column names to the PSF model parameter names.
+        Map x, y, and flux column names to the PSF model parameter
+        names.
 
         Also include any extra PSF model parameters that are fit, but do
         not correspond to x, y, or flux.
@@ -716,8 +717,8 @@ class PSFPhotometry(ModelImageMixin):
 
     def _make_psf_model(self, sources):
         """
-        Make a PSF model to fit a single source or several sources within
-        a group.
+        Make a PSF model to fit a single source or several sources
+        within a group.
         """
         init_param_map = self._param_maps['init']
 
@@ -1701,8 +1702,8 @@ class IterativePSFPhotometry(ModelImageMixin):
 
     def _measure_init_fluxes(self, data, mask, sources):
         """
-        Measure initial fluxes for the new sources from the
-        residual data.
+        Measure initial fluxes for the new sources from the residual
+        data.
 
         The fluxes are added in place to the input ``sources`` table.
 

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -84,8 +84,8 @@ def test_epsf_star_residual_image():
 
 def test_stars_pickleable():
     """
-    Verify that EPSFStars can be successfully
-    pickled/unpickled for use multiprocessing
+    Verify that EPSFStars can be successfully pickled/unpickled for use
+    multiprocessing.
     """
     from multiprocessing.reduction import ForkingPickler
 

--- a/photutils/psf/tests/test_griddedpsfmodel.py
+++ b/photutils/psf/tests/test_griddedpsfmodel.py
@@ -164,8 +164,8 @@ class TestGriddedPSFModel:
     @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_gridded_psf_model_eval(self, psfmodel):
         """
-        Create a simulated image using GriddedPSFModel and test
-        the properties of the generated sources.
+        Create a simulated image using GriddedPSFModel and test the
+        properties of the generated sources.
         """
         shape = (200, 200)
         data = np.zeros(shape)

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -87,7 +87,8 @@ class _InverseShift(Shift):
     @staticmethod
     def fit_deriv(x, *params):
         """
-        One dimensional Shift model derivative with respect to parameter.
+        One dimensional Shift model derivative with respect to
+        parameter.
         """
         d_offset = -np.ones_like(x)
         return [d_offset]
@@ -563,8 +564,8 @@ def _validate_psf_model(psf_model):
 
 def _get_psf_model_params(psf_model):
     """
-    Get the names of the PSF model parameters corresponding to
-    x, y, and flux.
+    Get the names of the PSF model parameters corresponding to x, y, and
+    flux.
 
     The PSF model must have parameters called 'x_0', 'y_0', and
     'flux' or it must have 'x_name', 'y_name', and 'flux_name'

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -748,8 +748,8 @@ class SourceCatalog:
     @lazyproperty
     def _segment_img_cutouts(self):
         """
-        A list of segmentation image cutouts using the segmentation image
-        slices.
+        A list of segmentation image cutouts using the segmentation
+        image slices.
         """
         return [self._segment_img.data[slc] for slc in self._slices_iter]
 
@@ -1244,8 +1244,8 @@ class SourceCatalog:
     @as_scalar
     def cutout_centroid(self):
         """
-        The ``(x, y)`` coordinate, relative to the cutout data, of
-        the centroid within the isophotal source segment.
+        The ``(x, y)`` coordinate, relative to the cutout data, of the
+        centroid within the isophotal source segment.
 
         The centroid is computed as the center of mass of the unmasked
         pixels within the source segment.
@@ -1660,8 +1660,8 @@ class SourceCatalog:
     @as_scalar
     def sky_centroid_win(self):
         """
-        The sky coordinate of the "windowed" centroid
-        (`centroid_win`) within the source segment, returned as a
+        The sky coordinate of the "windowed" centroid (`centroid_win`)
+        within the source segment, returned as a
         `~astropy.coordinates.SkyCoord` object.
 
         The output coordinate frame is the same as the input ``wcs``.
@@ -2047,7 +2047,8 @@ class SourceCatalog:
     @as_scalar
     def segment_flux(self):
         r"""
-        The sum of the unmasked ``data`` values within the source segment.
+        The sum of the unmasked ``data`` values within the source
+        segment.
 
         .. math:: F = \sum_{i \in S} I_i
 
@@ -2408,7 +2409,9 @@ class SourceCatalog:
         """
         The angle between the ``x`` axis and the major axis of the 2D
         Gaussian function that has the same second-order moments as the
-        source. The angle increases in the counter-clockwise direction.
+        source.
+
+        The angle increases in the counter-clockwise direction.
         """
         covar = self._covariance
         orient_radians = 0.5 * np.arctan2(2.0 * covar[:, 0, 1],
@@ -2499,8 +2502,8 @@ class SourceCatalog:
     @as_scalar
     def cxx(self):
         r"""
-        Coefficient for ``x**2`` in the generalized ellipse equation.
-        in units of pixel**(-2).
+        Coefficient for ``x**2`` in the generalized ellipse equation in
+        units of pixel**(-2).
 
         The ellipse is defined as
 
@@ -2522,8 +2525,8 @@ class SourceCatalog:
     @as_scalar
     def cyy(self):
         r"""
-        Coefficient for ``y**2`` in the generalized ellipse equation.
-        in units of pixel**(-2).
+        Coefficient for ``y**2`` in the generalized ellipse equation in
+        units of pixel**(-2).
 
         The ellipse is defined as
 
@@ -2545,8 +2548,8 @@ class SourceCatalog:
     @as_scalar
     def cxy(self):
         r"""
-        Coefficient for ``x * y`` in the generalized ellipse equation.
-        in units of pixel**(-2).
+        Coefficient for ``x * y`` in the generalized ellipse equation in
+        units of pixel**(-2).
 
         The ellipse is defined as
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -139,7 +139,9 @@ class SegmentationImage:
 
     @property
     def data(self):
-        """The segmentation array."""
+        """
+        The segmentation array.
+        """
         return self._data
 
     @property
@@ -184,17 +186,23 @@ class SegmentationImage:
 
     @lazyproperty
     def shape(self):
-        """The shape of the segmentation array."""
+        """
+        The shape of the segmentation array.
+        """
         return self._data.shape
 
     @lazyproperty
     def _ndim(self):
-        """The number of array dimensions of the segmentation array."""
+        """
+        The number of array dimensions of the segmentation array.
+        """
         return self._data.ndim
 
     @lazyproperty
     def labels(self):
-        """The sorted non-zero labels in the segmentation array."""
+        """
+        The sorted non-zero labels in the segmentation array.
+        """
         if '_raw_slices' in self.__dict__:
             labels_all = np.arange(len(self._raw_slices)) + 1
             labels = []
@@ -208,12 +216,16 @@ class SegmentationImage:
 
     @lazyproperty
     def nlabels(self):
-        """The number of non-zero labels in the segmentation array."""
+        """
+        The number of non-zero labels in the segmentation array.
+        """
         return len(self.labels)
 
     @lazyproperty
     def max_label(self):
-        """The maximum label in the segmentation array."""
+        """
+        The maximum label in the segmentation array.
+        """
         if self.nlabels == 0:
             return 0
         return np.max(self.labels)
@@ -299,7 +311,9 @@ class SegmentationImage:
 
     @lazyproperty
     def background_area(self):
-        """The area (in pixel**2) of the background (label=0) region."""
+        """
+        The area (in pixel**2) of the background (label=0) region.
+        """
         return self._data.size - np.count_nonzero(self._data)
 
     @lazyproperty

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -257,7 +257,9 @@ class TestDeblendSources:
             assert segm.info['warnings']['nonposmin']['input_labels'] == 1
 
     def test_connectivity(self):
-        """Regression test for #341."""
+        """
+        Regression test for #341.
+        """
         data = np.zeros((3, 3))
         data[0, 0] = 2
         data[1, 1] = 2
@@ -276,7 +278,9 @@ class TestDeblendSources:
     def test_data_nan(self):
         """
         Test that deblending occurs even if the data within a segment
-        contains one or more NaNs. Regression test for #658.
+        contains one or more NaNs.
+
+        Regression test for #658.
         """
 
         data = self.data.copy()

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -21,7 +21,9 @@ REF1 = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestDetectThreshold:
     def test_nsigma(self):
-        """Test basic nsigma."""
+        """
+        Test basic nsigma.
+        """
         threshold = detect_threshold(DATA, nsigma=0.1)
         ref = 0.4 * np.ones((3, 3))
         assert_allclose(threshold, ref)
@@ -31,7 +33,9 @@ class TestDetectThreshold:
         assert_allclose(threshold.value, ref)
 
     def test_nsigma_zero(self):
-        """Test nsigma=0."""
+        """
+        Test nsigma=0.
+        """
         threshold = detect_threshold(DATA, nsigma=0.0)
         ref = (1.0 / 3.0) * np.ones((3, 3))
         assert_allclose(threshold, ref)
@@ -108,6 +112,7 @@ class TestDetectThreshold:
     def test_image_mask(self):
         """
         Test detection with image_mask.
+
         Set sigma=10 and iters=1 to prevent sigma clipping after
         applying the mask.
         """
@@ -134,7 +139,9 @@ class TestDetectSources:
         self.kernel = kernel
 
     def test_detection(self):
-        """Test basic detection."""
+        """
+        Test basic detection.
+        """
         segm = detect_sources(self.data, threshold=0.9, npixels=2)
         assert_equal(segm.data, self.refdata)
 
@@ -150,13 +157,16 @@ class TestDetectSources:
             detect_sources(self.data << u.uJy, threshold=0.9 * u.m, npixels=2)
 
     def test_small_sources(self):
-        """Test detection where sources are smaller than npixels size."""
+        """
+        Test detection where sources are smaller than npixels size.
+        """
         with pytest.warns(NoDetectionsWarning, match='No sources were found'):
             detect_sources(self.data, threshold=0.9, npixels=5)
 
     def test_npixels(self):
         """
         Test removal of sources whose size is less than npixels.
+
         Regression tests for #663.
         """
         data = np.zeros((8, 8))
@@ -187,40 +197,54 @@ class TestDetectSources:
             detect_sources(data, 0, npixels=14)
 
     def test_zerothresh(self):
-        """Test detection with zero threshold."""
+        """
+        Test detection with zero threshold.
+        """
         segm = detect_sources(self.data, threshold=0.0, npixels=2)
         assert_equal(segm.data, self.refdata)
 
     def test_zerodet(self):
-        """Test detection with large threshold giving no detections."""
+        """
+        Test detection with large threshold giving no detections.
+        """
         with pytest.warns(NoDetectionsWarning, match='No sources were found'):
             detect_sources(self.data, threshold=7, npixels=2)
 
     def test_8connectivity(self):
-        """Test detection with connectivity=8."""
+        """
+        Test detection with connectivity=8.
+        """
         data = np.eye(3)
         segm = detect_sources(data, threshold=0.9, npixels=1, connectivity=8)
         assert_equal(segm.data, data)
 
     def test_4connectivity(self):
-        """Test detection with connectivity=4."""
+        """
+        Test detection with connectivity=4.
+        """
         data = np.eye(3)
         ref = np.diag([1, 2, 3])
         segm = detect_sources(data, threshold=0.9, npixels=1, connectivity=4)
         assert_equal(segm.data, ref)
 
     def test_npixels_nonint(self):
-        """Test if error raises if npixel is non-integer."""
+        """
+        Test if error raises if npixel is non-integer.
+        """
         with pytest.raises(ValueError):
             detect_sources(self.data, threshold=1, npixels=0.1)
 
     def test_npixels_negative(self):
-        """Test if error raises if npixel is negative."""
+        """
+        Test if error raises if npixel is negative.
+        """
         with pytest.raises(ValueError):
             detect_sources(self.data, threshold=1, npixels=-1)
 
     def test_connectivity_invalid(self):
-        """Test if error raises if connectivity is invalid."""
+        """
+        Test if error raises if connectivity is invalid.
+        """
         with pytest.raises(ValueError):
             detect_sources(self.data, threshold=1, npixels=1, connectivity=10)
 

--- a/photutils/utils/_wcs_helpers.py
+++ b/photutils/utils/_wcs_helpers.py
@@ -9,8 +9,8 @@ import numpy as np
 
 def _pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1 * u.arcsec):
     """
-    Calculate the pixel coordinate scale and WCS rotation angle at
-    the position of a SkyCoord coordinate.
+    Calculate the pixel coordinate scale and WCS rotation angle at the
+    position of a SkyCoord coordinate.
 
     Parameters
     ----------

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -363,8 +363,8 @@ class ImageDepth:
 
     def _find_slices(self, data):
         """
-        Calculate a tuple slice for the minimal bounding box for
-        the `True` values of a 2D boolean array.
+        Calculate a tuple slice for the minimal bounding box for the
+        `True` values of a 2D boolean array.
 
         Parameters
         ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,19 @@ exclude_lines = [
     'def _ipython_key_completions_',
 ]
 
+[tool.repo-review]
+ignore = [
+    'MY',  # ignore MyPy
+    'RF',  # ignore Ruff
+    'PC110',
+    'PC111',
+    'PC140',
+    'PC180',
+    'PC190',
+    'PC191',
+    'PC901',
+]
+
 [tool.isort]
 skip_glob = [
     'photutils/*__init__.py*',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,14 @@ norecursedirs = [
 astropy_header = true
 doctest_plus = 'enabled'
 text_file_format = 'rst'
-addopts = '--color=yes --doctest-rst'
+addopts = [
+    '-ra',
+    '--color=yes',
+    '--doctest-rst',
+    '--strict-config',
+    '--strict-markers',
+]
+log_cli_level = 'INFO'
 xfail_strict = true
 remote_data_strict = true
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,3 +240,8 @@ exclude = [
     # GL08: inner function
     '\.optimize_func$',
 ]
+
+[tool.docformatter]
+    wrap-summaries = 72
+    pre-summary-newline = true
+    make-summary-multi-line = true


### PR DESCRIPTION
This PR adds the scientific-python `sp-repo-review` and the PyCQA `docformatter` hooks to `pre-commit`.  It also included changes (mainly in docstrings and `pyproject.toml`) to pass these new tests.