### PR TITLE
Use consistent max line lengths

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 88
+max-line-length = 79
 exclude = extern

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,7 +2,7 @@ scanner:
     linter: flake8
 
 flake8:
-  max-line-length: 88
+  max-line-length: 79
 
   exclude:
     - version.py

--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,3 +1,3 @@
 [pycodestyle]
-max-line-length = 88
+max-line-length = 79
 exclude = extern

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -65,7 +65,8 @@ class CircularMaskMixin:
 
         Returns
         -------
-        mask : `~photutils.aperture.ApertureMask` or list of `~photutils.aperture.ApertureMask`
+        mask : `~photutils.aperture.ApertureMask` or list of \
+                `~photutils.aperture.ApertureMask`
             A mask for the aperture. If the aperture is scalar then
             a single `~photutils.aperture.ApertureMask` is returned,
             otherwise a list of `~photutils.aperture.ApertureMask` is
@@ -159,7 +160,7 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
     def _to_patch(self, origin=(0, 0), **kwargs):
         """
-        Return a `~matplotlib.patches.patch` for the aperture.
+        Return a `~matplotlib.patches.Patch` for the aperture.
 
         Parameters
         ----------
@@ -173,10 +174,11 @@ class CircularAperture(CircularMaskMixin, PixelAperture):
 
         Returns
         -------
-        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+        patch : `~matplotlib.patches.Patch` or list of \
+                `~matplotlib.patches.Patch`
             A patch for the aperture. If the aperture is scalar then a
-            single `~matplotlib.patches.patch` is returned, otherwise a
-            list of `~matplotlib.patches.patch` is returned.
+            single `~matplotlib.patches.Patch` is returned, otherwise a
+            list of `~matplotlib.patches.Patch` is returned.
         """
         import matplotlib.patches as mpatches
 
@@ -288,7 +290,7 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
 
     def _to_patch(self, origin=(0, 0), **kwargs):
         """
-        Return a `~matplotlib.patches.patch` for the aperture.
+        Return a `~matplotlib.patches.Patch` for the aperture.
 
         Parameters
         ----------
@@ -302,10 +304,11 @@ class CircularAnnulus(CircularMaskMixin, PixelAperture):
 
         Returns
         -------
-        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+        patch : `~matplotlib.patches.Patch` or list of \
+                `~matplotlib.patches.Patch`
             A patch for the aperture. If the aperture is scalar then a
-            single `~matplotlib.patches.patch` is returned, otherwise a
-            list of `~matplotlib.patches.patch` is returned.
+            single `~matplotlib.patches.Patch` is returned, otherwise a
+            list of `~matplotlib.patches.Patch` is returned.
         """
         import matplotlib.patches as mpatches
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -438,7 +438,8 @@ class PixelAperture(Aperture):
 
         Returns
         -------
-        mask : `~photutils.aperture.ApertureMask` or list of `~photutils.aperture.ApertureMask`
+        mask : `~photutils.aperture.ApertureMask` or list of \
+                `~photutils.aperture.ApertureMask`
             A mask for the aperture. If the aperture is scalar then
             a single `~photutils.aperture.ApertureMask` is returned,
             otherwise a list of `~photutils.aperture.ApertureMask` is
@@ -647,7 +648,7 @@ class PixelAperture(Aperture):
     @abc.abstractmethod
     def _to_patch(self, origin=(0, 0), **kwargs):
         """
-        Return a `~matplotlib.patches.patch` for the aperture.
+        Return a `~matplotlib.patches.Patch` for the aperture.
 
         Parameters
         ----------
@@ -661,10 +662,11 @@ class PixelAperture(Aperture):
 
         Returns
         -------
-        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+        patch : `~matplotlib.patches.Patch` or list of \
+                `~matplotlib.patches.Patch`
             A patch for the aperture. If the aperture is scalar then a
-            single `~matplotlib.patches.patch` is returned, otherwise a
-            list of `~matplotlib.patches.patch` is returned.
+            single `~matplotlib.patches.Patch` is returned, otherwise a
+            list of `~matplotlib.patches.Patch` is returned.
         """
         raise NotImplementedError('Needs to be implemented in a subclass.')
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -67,7 +67,8 @@ class EllipticalMaskMixin:
 
         Returns
         -------
-        mask : `~photutils.aperture.ApertureMask` or list of `~photutils.aperture.ApertureMask`
+        mask : `~photutils.aperture.ApertureMask` or list of \
+                `~photutils.aperture.ApertureMask`
             A mask for the aperture. If the aperture is scalar then
             a single `~photutils.aperture.ApertureMask` is returned,
             otherwise a list of `~photutils.aperture.ApertureMask` is
@@ -200,7 +201,7 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
 
     def _to_patch(self, origin=(0, 0), **kwargs):
         """
-        Return a `~matplotlib.patches.patch` for the aperture.
+        Return a `~matplotlib.patches.Patch` for the aperture.
 
         Parameters
         ----------
@@ -214,10 +215,11 @@ class EllipticalAperture(EllipticalMaskMixin, PixelAperture):
 
         Returns
         -------
-        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+        patch : `~matplotlib.patches.Patch` or list of \
+                `~matplotlib.patches.Patch`
             A patch for the aperture. If the aperture is scalar then a
-            single `~matplotlib.patches.patch` is returned, otherwise a
-            list of `~matplotlib.patches.patch` is returned.
+            single `~matplotlib.patches.Patch` is returned, otherwise a
+            list of `~matplotlib.patches.Patch` is returned.
         """
         import matplotlib.patches as mpatches
 
@@ -368,7 +370,7 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
 
     def _to_patch(self, origin=(0, 0), **kwargs):
         """
-        Return a `~matplotlib.patches.patch` for the aperture.
+        Return a `~matplotlib.patches.Patch` for the aperture.
 
         Parameters
         ----------
@@ -382,10 +384,11 @@ class EllipticalAnnulus(EllipticalMaskMixin, PixelAperture):
 
         Returns
         -------
-        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+        patch : `~matplotlib.patches.Patch` or list of \
+                `~matplotlib.patches.Patch`
             A patch for the aperture. If the aperture is scalar then a
-            single `~matplotlib.patches.patch` is returned, otherwise a
-            list of `~matplotlib.patches.patch` is returned.
+            single `~matplotlib.patches.Patch` is returned, otherwise a
+            list of `~matplotlib.patches.Patch` is returned.
         """
         import matplotlib.patches as mpatches
 

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -68,7 +68,8 @@ class RectangularMaskMixin:
 
         Returns
         -------
-        mask : `~photutils.aperture.ApertureMask` or list of `~photutils.aperture.ApertureMask`
+        mask : `~photutils.aperture.ApertureMask` or list of \
+                `~photutils.aperture.ApertureMask`
             A mask for the aperture. If the aperture is scalar then
             a single `~photutils.aperture.ApertureMask` is returned,
             otherwise a list of `~photutils.aperture.ApertureMask` is
@@ -223,7 +224,7 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
 
     def _to_patch(self, origin=(0, 0), **kwargs):
         """
-        Return a `~matplotlib.patches.patch` for the aperture.
+        Return a `~matplotlib.patches.Patch` for the aperture.
 
         Parameters
         ----------
@@ -237,10 +238,11 @@ class RectangularAperture(RectangularMaskMixin, PixelAperture):
 
         Returns
         -------
-        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+        patch : `~matplotlib.patches.Patch` or list of \
+                `~matplotlib.patches.Patch`
             A patch for the aperture. If the aperture is scalar then a
-            single `~matplotlib.patches.patch` is returned, otherwise a
-            list of `~matplotlib.patches.patch` is returned.
+            single `~matplotlib.patches.Patch` is returned, otherwise a
+            list of `~matplotlib.patches.Patch` is returned.
         """
         import matplotlib.patches as mpatches
 
@@ -350,7 +352,8 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
     >>> pos2 = (30.0, 40.0)
     >>> pos3 = (50.0, 60.0)
     >>> aper = RectangularAnnulus([pos1, pos2, pos3], 3.0, 8.0, 5.0)
-    >>> aper = RectangularAnnulus((pos1, pos2, pos3), 3.0, 8.0, 5.0, theta=theta)
+    >>> aper = RectangularAnnulus((pos1, pos2, pos3), 3.0, 8.0, 5.0,
+    ...                           theta=theta)
     """
 
     _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')
@@ -395,7 +398,7 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
     def _to_patch(self, origin=(0, 0), **kwargs):
         """
-        Return a `~matplotlib.patches.patch` for the aperture.
+        Return a `~matplotlib.patches.Patch` for the aperture.
 
         Parameters
         ----------
@@ -409,10 +412,11 @@ class RectangularAnnulus(RectangularMaskMixin, PixelAperture):
 
         Returns
         -------
-        patch : `~matplotlib.patches.patch` or list of `~matplotlib.patches.patch`
+        patch : `~matplotlib.patches.Patch` or list of \
+                `~matplotlib.patches.Patch`
             A patch for the aperture. If the aperture is scalar then a
-            single `~matplotlib.patches.patch` is returned, otherwise a
-            list of `~matplotlib.patches.patch` is returned.
+            single `~matplotlib.patches.Patch` is returned, otherwise a
+            list of `~matplotlib.patches.Patch` is returned.
         """
         import matplotlib.patches as mpatches
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -75,7 +75,8 @@ class ApertureStats:
 
     Parameters
     ----------
-    data : 2D `~numpy.ndarray`, `~astropy.units.Quantity`, `~astropy.nddata.NDData`
+    data : 2D `~numpy.ndarray`, `~astropy.units.Quantity`, \
+            `~astropy.nddata.NDData`
         The 2D array from which to calculate the source properties.
         For accurate source properties, ``data`` should be
         background-subtracted. Non-finite ``data`` values (NaN and inf)
@@ -200,8 +201,11 @@ class ApertureStats:
     >>> print(aperstats.centroid)  # doctest: +FLOAT_CMP
     [149.99080259  24.97484633]
 
-    >>> print(aperstats.mean, aperstats.median, aperstats.std) #  doctest: +FLOAT_CMP
-    47.76300955780609 31.913789514433084 39.193655383492974
+    >>> print(aperstats.mean, aperstats.median)  # doctest: +FLOAT_CMP
+    47.76300955780609 31.913789514433084
+
+    >>> print(aperstats.std)  # doctest: +FLOAT_CMP
+    39.193655383492974
 
     >>> print(aperstats.sum)  # doctest: +FLOAT_CMP
     9286.709206410273

--- a/photutils/aperture/tests/test_converters.py
+++ b/photutils/aperture/tests/test_converters.py
@@ -71,8 +71,9 @@ def test_translation_circle(image_2d_wcs):
     assert aperture_sky.positions == region_sky.center  # SkyCoord
     assert_quantity_allclose(aperture_sky.r, region_sky.radius)
 
-    # NOTE: If these no longer fail, we also have to account for non-scalar inputs.
-    # Assume this is representative for the sky counterpart too.
+    # NOTE: If these no longer fail, we also have to account for
+    # non-scalar inputs. Assume this is representative for the sky
+    # counterpart too.
     with pytest.raises(ValueError, match='must be a scalar PixCoord'):
         CirclePixelRegion(center=PixCoord(x=[0, 42], y=[1, 43]), radius=4.2)
     with pytest.raises(ValueError, match=r'must be .* scalar'):
@@ -84,7 +85,8 @@ def test_translation_ellipse(image_2d_wcs):
     from regions import EllipsePixelRegion, PixCoord
 
     region_shape = EllipsePixelRegion(
-        center=PixCoord(x=42, y=43), width=16, height=10, angle=Angle(30, 'deg')
+        center=PixCoord(x=42, y=43), width=16, height=10,
+        angle=Angle(30, 'deg')
     )
     aperture = region_to_aperture(region_shape)
     assert isinstance(aperture, EllipticalAperture)
@@ -99,10 +101,12 @@ def test_translation_ellipse(image_2d_wcs):
     assert aperture_sky.positions == region_sky.center  # SkyCoord
     assert_quantity_allclose(aperture_sky.a * 2, region_sky.width)
     assert_quantity_allclose(aperture_sky.b * 2, region_sky.height)
-    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg), region_sky.angle)
+    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
+                             region_sky.angle)
 
-    # NOTE: If these no longer fail, we also have to account for non-scalar inputs.
-    # Assume this is representative for the sky counterpart too.
+    # NOTE: If these no longer fail, we also have to account for
+    # non-scalar inputs. Assume this is representative for the sky
+    # counterpart too.
     with pytest.raises(ValueError, match='must be a scalar PixCoord'):
         EllipsePixelRegion(
             center=PixCoord(x=[0, 42], y=[1, 43]),
@@ -138,7 +142,8 @@ def test_translation_rectangle(image_2d_wcs):
     from regions import PixCoord, RectanglePixelRegion
 
     region_shape = RectanglePixelRegion(
-        center=PixCoord(x=42, y=43), width=16, height=10, angle=Angle(30, 'deg')
+        center=PixCoord(x=42, y=43), width=16, height=10,
+        angle=Angle(30, 'deg')
     )
     aperture = region_to_aperture(region_shape)
     assert isinstance(aperture, RectangularAperture)
@@ -153,10 +158,12 @@ def test_translation_rectangle(image_2d_wcs):
     assert aperture_sky.positions == region_sky.center  # SkyCoord
     assert_quantity_allclose(aperture_sky.w, region_sky.width)
     assert_quantity_allclose(aperture_sky.h, region_sky.height)
-    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg), region_sky.angle)
+    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
+                             region_sky.angle)
 
-    # NOTE: If these no longer fail, we also have to account for non-scalar inputs.
-    # Assume this is representative for the sky counterpart too.
+    # NOTE: If these no longer fail, we also have to account for
+    # non-scalar inputs. Assume this is representative for the sky
+    # counterpart too.
     with pytest.raises(ValueError, match='must be a scalar PixCoord'):
         RectanglePixelRegion(
             center=PixCoord(x=[0, 42], y=[1, 43]),
@@ -207,11 +214,13 @@ def test_translation_circle_annulus(image_2d_wcs):
     assert_quantity_allclose(aperture_sky.r_in, region_sky.inner_radius)
     assert_quantity_allclose(aperture_sky.r_out, region_sky.outer_radius)
 
-    # NOTE: If these no longer fail, we also have to account for non-scalar inputs.
-    # Assume this is representative for the sky counterpart too.
+    # NOTE: If these no longer fail, we also have to account for
+    # non-scalar inputs. Assume this is representative for the sky
+    # counterpart too.
     with pytest.raises(ValueError, match='must be a scalar PixCoord'):
         CircleAnnulusPixelRegion(
-            center=PixCoord(x=[0, 42], y=[1, 43]), inner_radius=5, outer_radius=8
+            center=PixCoord(x=[0, 42], y=[1, 43]), inner_radius=5,
+            outer_radius=8
         )
     with pytest.raises(ValueError, match=r'must be .* scalar'):
         CircleAnnulusPixelRegion(
@@ -252,10 +261,12 @@ def test_translation_ellipse_annulus(image_2d_wcs):
     assert_quantity_allclose(aperture_sky.a_out * 2, region_sky.outer_width)
     assert_quantity_allclose(aperture_sky.b_in * 2, region_sky.inner_height)
     assert_quantity_allclose(aperture_sky.b_out * 2, region_sky.outer_height)
-    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg), region_sky.angle)
+    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
+                             region_sky.angle)
 
-    # NOTE: If these no longer fail, we also have to account for non-scalar inputs.
-    # Assume this is representative for the sky counterpart too.
+    # NOTE: If these no longer fail, we also have to account for
+    # non-scalar inputs. Assume this is representative for the sky
+    # counterpart too.
     with pytest.raises(ValueError, match='must be a scalar PixCoord'):
         EllipseAnnulusPixelRegion(
             center=PixCoord(x=[0, 42], y=[1, 43]),
@@ -341,10 +352,12 @@ def test_translation_rectangle_annulus(image_2d_wcs):
     assert_quantity_allclose(aperture_sky.w_out, region_sky.outer_width)
     assert_quantity_allclose(aperture_sky.h_in, region_sky.inner_height)
     assert_quantity_allclose(aperture_sky.h_out, region_sky.outer_height)
-    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg), region_sky.angle)
+    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
+                             region_sky.angle)
 
-    # NOTE: If these no longer fail, we also have to account for non-scalar inputs.
-    # Assume this is representative for the sky counterpart too.
+    # NOTE: If these no longer fail, we also have to account for
+    # non-scalar inputs. Assume this is representative for the sky
+    # counterpart too.
     with pytest.raises(ValueError, match='must be a scalar PixCoord'):
         RectangleAnnulusPixelRegion(
             center=PixCoord(x=[0, 42], y=[1, 43]),
@@ -405,6 +418,7 @@ def test_translation_rectangle_annulus(image_2d_wcs):
 def test_translation_polygon():
     from regions import PixCoord, PolygonPixelRegion
 
-    region_shape = PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 2], y=[1, 1, 2]))
+    region_shape = PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 2],
+                                                        y=[1, 1, 2]))
     with pytest.raises(NotImplementedError, match='is not supported'):
         region_to_aperture(region_shape)

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -433,7 +433,6 @@ def test_aperture_photometry_with_error_units():
     """
     Test aperture_photometry when error has units (see #176).
     """
-
     data1 = np.ones((40, 40), dtype=float)
     data2 = u.Quantity(data1, unit=u.adu)
     error = u.Quantity(data1, unit=u.adu)
@@ -454,7 +453,6 @@ def test_aperture_photometry_inputs_with_mask():
     Test that aperture_photometry does not modify the input data or
     error array when a mask is input.
     """
-
     data = np.ones((5, 5))
     aperture = CircularAperture((2, 2), 2.0)
     mask = np.zeros_like(data, dtype=bool)
@@ -484,7 +482,6 @@ def test_ellipse_exact_grid(x, y, r):
     This is a regression test for the bug discovered in this issue:
     https://github.com/astropy/photutils/issues/198
     """
-
     data = np.ones((10, 10))
 
     aperture = EllipticalAperture((x, y), r, r, 0.0)
@@ -498,7 +495,6 @@ def test_nan_inf_mask(value):
     """
     Test that nans and infs are properly masked [#267].
     """
-
     data = np.ones((9, 9))
     mask = np.zeros_like(data, dtype=bool)
     data[4, 4] = value
@@ -773,7 +769,6 @@ def test_nan_in_bbox():
     Regression test that non-finite data values outside of the aperture
     mask but within the bounding box do not affect the photometry.
     """
-
     data1 = np.ones((101, 101))
     data2 = data1.copy()
     data1[33, 33] = np.nan
@@ -802,7 +797,6 @@ def test_scalar_skycoord():
     Regression test to check that scalar SkyCoords are added to the
     table as a length-1 SkyCoord array.
     """
-
     data = make_4gaussians_image()
     wcs = make_wcs(data.shape)
     skycoord = wcs.pixel_to_world(90, 60)
@@ -850,24 +844,30 @@ class BaseTestRegionPhotometry:
         data = np.ones((40, 40), dtype=float)
         error = np.ones(data.shape, dtype=float)
         region_tables = [
-            aperture_photometry(data, self.region, method='center', error=error),
+            aperture_photometry(data, self.region, method='center',
+                                error=error),
             aperture_photometry(data, self.region,
                                 method='subpixel', subpixels=12,
                                 error=error),
-            aperture_photometry(data, self.region, method='exact', error=error),
+            aperture_photometry(data, self.region, method='exact',
+                                error=error),
         ]
         aperture_tables = [
-            aperture_photometry(data, self.aperture, method='center', error=error),
+            aperture_photometry(data, self.aperture, method='center',
+                                error=error),
             aperture_photometry(data, self.aperture,
                                 method='subpixel', subpixels=12,
                                 error=error),
-            aperture_photometry(data, self.aperture, method='exact', error=error),
+            aperture_photometry(data, self.aperture, method='exact',
+                                error=error),
         ]
 
         for reg_table, ap_table in zip(region_tables, aperture_tables):
-            assert_allclose(reg_table['aperture_sum'], ap_table['aperture_sum'])
+            assert_allclose(reg_table['aperture_sum'],
+                            ap_table['aperture_sum'])
 
-        if isinstance(self.aperture, (RectangularAperture, RectangularAnnulus)):
+        if isinstance(self.aperture, (RectangularAperture,
+                                      RectangularAnnulus)):
             for reg_table, ap_table in zip(region_tables, aperture_tables):
                 assert_allclose(reg_table['aperture_sum_err'],
                                 ap_table['aperture_sum_err'])
@@ -890,7 +890,8 @@ class TestCircleAnnulusRegionPhotometry(BaseTestRegionPhotometry):
         position = (20.0, 20.0)
         r_in = 8.0
         r_out = 10.0
-        self.region = CircleAnnulusPixelRegion(PixCoord(*position), r_in, r_out)
+        self.region = CircleAnnulusPixelRegion(PixCoord(*position), r_in,
+                                               r_out)
         self.aperture = CircularAnnulus(position, r_in, r_out)
 
 
@@ -902,7 +903,8 @@ class TestEllipseRegionPhotometry(BaseTestRegionPhotometry):
         a = 10.0
         b = 5.0
         theta = (-np.pi / 4.0) * u.rad
-        self.region = EllipsePixelRegion(PixCoord(*position), a * 2, b * 2, theta)
+        self.region = EllipsePixelRegion(PixCoord(*position), a * 2, b * 2,
+                                         theta)
         self.aperture = EllipticalAperture(position, a, b, theta=theta)
 
 
@@ -948,8 +950,9 @@ class TestRectangleAnnulusRegionPhotometry(BaseTestRegionPhotometry):
         w_out = 12.0
         h_in = w_in * h_out / w_out
         theta = (np.pi / 8.0) * u.rad
-        self.region = RectangleAnnulusPixelRegion(PixCoord(*position), w_in, w_out,
-                                                  h_in, h_out, theta)
+        self.region = RectangleAnnulusPixelRegion(PixCoord(*position),
+                                                  w_in, w_out, h_in, h_out,
+                                                  theta)
         self.aperture = RectangularAnnulus(position, w_in, w_out,
                                            h_out, h_in, theta)
 

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -112,7 +112,8 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
         position of the sources. This parameter must also be a column
         name in ``params_table``.
 
-    discretize_method : {'center', 'interp', 'oversample', 'integrate'}, optional
+    discretize_method : {'center', 'interp', 'oversample', 'integrate'}, \
+            optional
         One of the following methods for discretizing the model on the
         pixel grid:
 

--- a/photutils/isophote/ellipse.py
+++ b/photutils/isophote/ellipse.py
@@ -21,7 +21,7 @@ __all__ = ['Ellipse']
 
 
 class Ellipse:
-    r"""
+    """
     Class to fit elliptical isophotes to a galaxy image.
 
     The isophotes in the image are measured using an iterative method
@@ -33,7 +33,8 @@ class Ellipse:
     ----------
     image : 2D `~numpy.ndarray`
         The image array.
-    geometry : `~photutils.isophote.EllipseGeometry` instance or `None`, optional
+    geometry : `~photutils.isophote.EllipseGeometry` instance or `None`, \
+            optional
         The optional geometry that describes the first
         ellipse to be fitted. If `None`, a default
         `~photutils.isophote.EllipseGeometry` instance is created
@@ -68,8 +69,8 @@ class Ellipse:
     fitting to the function:
 
     .. math::
-        y  =  y0 + (A1 * \sin(E)) + (B1 * \cos(E)) + (A2 * \sin(2 * E))
-        + (B2 * \cos(2 * E))
+        y  =  y0 + (A1 * \\sin(E)) + (B1 * \\cos(E)) + (A2 * \\sin(2 * E))
+        + (B2 * \\cos(2 * E))
 
     Each one of the harmonic amplitudes (A1, B1, A2, and B2) is related
     to a specific ellipse geometric parameter in the sense that it
@@ -328,7 +329,8 @@ class Ellipse:
             The number of sigma-clip iterations. The default is 0, which
             means sigma-clipping is skipped.
 
-        integrmode : {'bilinear', 'nearest_neighbor', 'mean', 'median'}, optional
+        integrmode : {'bilinear', 'nearest_neighbor', 'mean', 'median'}, \
+                optional
             The area integration mode. The default is 'bilinear'.
 
         linear : bool, optional
@@ -575,7 +577,8 @@ class Ellipse:
             The number of sigma-clip iterations. The default is 0, which
             means sigma-clipping is skipped.
 
-        integrmode : {'bilinear', 'nearest_neighbor', 'mean', 'median'}, optional
+        integrmode : {'bilinear', 'nearest_neighbor', 'mean', 'median'}, \
+                optional
             The area integration mode. The default is 'bilinear'.
 
         linear : bool, optional

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -247,7 +247,8 @@ class ProfileBase(metaclass=abc.ABCMeta):
         calls to `normalize`.
         """
         self.__dict__['profile'] = self.profile * self.normalization_value
-        self.__dict__['profile_error'] = self.profile_error * self.normalization_value
+        self.__dict__['profile_error'] = (self.profile_error
+                                          * self.normalization_value)
         self.normalization_value = 1.0
 
     def plot(self, ax=None, **kwargs):

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -762,7 +762,8 @@ class EPSFBuilder:
         pbar = None
         if self.progress_bar:
             desc = f'EPSFBuilder ({self.maxiters} maxiters)'
-            pbar = add_progress_bar(total=self.maxiters, desc=desc)  # pragma: no cover
+            pbar = add_progress_bar(total=self.maxiters,
+                                    desc=desc)  # pragma: no cover
 
         while (iter_num < self.maxiters and not np.all(fit_failed)
                and np.max(center_dist_sq) >= self.center_accuracy_sq):

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -482,7 +482,8 @@ class LinkedEPSFStar(EPSFStars):
                           'build process.', AstropyUserWarning)
             return
 
-        good_stars = [self._data[i] for i in idx]  # pylint: disable=not-an-iterable
+        good_stars = [self._data[i]
+                      for i in idx]  # pylint: disable=not-an-iterable
 
         coords = []
         for star in good_stars:

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -187,7 +187,8 @@ class PSFPhotometry(ModelImageMixin):
         (e.g., ``(5, 5)``) that covers the region with the highest flux
         signal-to-noise.
 
-    finder : callable or `~photutils.detection.StarFinderBase` or `None`, optional
+    finder : callable or `~photutils.detection.StarFinderBase` or `None`, \
+            optional
         A callable used to identify stars in an image. The
         ``finder`` must accept a 2D image as input and return a
         `~astropy.table.Table` containing the x and y centroid
@@ -234,7 +235,8 @@ class PSFPhotometry(ModelImageMixin):
         then no bounds are applied. Either value can also be `None` to
         indicate no bound in that direction.
 
-    localbkg_estimator : `~photutils.background.LocalBackground` or `None`, optional
+    localbkg_estimator : `~photutils.background.LocalBackground` or `None`, \
+        optional
         The object used to estimate the local background around each
         source. If `None`, then no local background is subtracted. The
         ``local_bkg`` values in ``init_params`` override this keyword.
@@ -1527,7 +1529,8 @@ class IterativePSFPhotometry(ModelImageMixin):
         unsubtracted, data. For the 'all' mode, a source ``grouper``
         must be input. See the Notes section for more details.
 
-    localbkg_estimator : `~photutils.background.LocalBackground` or `None`, optional
+    localbkg_estimator : `~photutils.background.LocalBackground` or `None`, \
+            optional
         The object used to estimate the local background around each
         source. If `None`, then no local background is subtracted. The
         ``local_bkg`` values in ``init_params`` override this keyword.

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -100,7 +100,7 @@ def use_detcat(method):
 
 
 class SourceCatalog:
-    r"""
+    """
     Class to create a catalog of photometry and morphological properties
     for sources defined by a segmentation image.
 
@@ -154,7 +154,8 @@ class SourceCatalog:
         values (NaN and inf) in the input ``data`` are automatically
         masked.
 
-    background : float, 2D `~numpy.ndarray`, or `~astropy.units.Quantity`, optional
+    background : float, 2D `~numpy.ndarray`, or `~astropy.units.Quantity`, \
+            optional
         The background level that was *previously* present in the input
         ``data``. ``background`` may either be a scalar value or a 2D
         image with the same shape as the input ``data``. If ``data``
@@ -279,13 +280,13 @@ class SourceCatalog:
     the quadrature sum of the pixel-wise total errors over the
     unmasked pixels within the source segment:
 
-    .. math:: \Delta F = \sqrt{\sum_{i \in S}
-              \sigma_{\mathrm{tot}, i}^2}
+    .. math:: \\Delta F = \\sqrt{\\sum_{i \\in S}
+              \\sigma_{\\mathrm{tot}, i}^2}
 
-    where :math:`\Delta F` is
+    where :math:`\\Delta F` is
     `~photutils.segmentation.SourceCatalog.segment_fluxerr`,
     :math:`S` are the unmasked pixels in the source segment, and
-    :math:`\sigma_{\mathrm{tot}, i}` is the input ``error`` array.
+    :math:`\\sigma_{\\mathrm{tot}, i}` is the input ``error`` array.
 
     Custom errors for source segments can be calculated using
     the `~photutils.segmentation.SourceCatalog.error_ma` and

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -183,7 +183,8 @@ def deblend_sources(data, segment_img, npixels, *, labels=None, nlevels=32,
     if nproc == 1:
         if progress_bar:
             desc = 'Deblending'
-            all_source_data = add_progress_bar(all_source_data, desc=desc)  # pragma: no cover
+            all_source_data = add_progress_bar(all_source_data,
+                                               desc=desc)  # pragma: no cover
 
         all_source_deblends = []
         for source_data, source_segment in zip(all_source_data,
@@ -202,7 +203,8 @@ def deblend_sources(data, segment_img, npixels, *, labels=None, nlevels=32,
 
         if progress_bar:
             desc = 'Deblending'
-            args_all = add_progress_bar(args_all, total=nlabels, desc=desc)  # pragma: no cover
+            args_all = add_progress_bar(args_all, total=nlabels,
+                                        desc=desc)  # pragma: no cover
 
         with get_context('spawn').Pool(processes=nproc) as executor:
             all_source_deblends = executor.starmap(_deblend_source, args_all)

--- a/photutils/utils/_progress_bars.py
+++ b/photutils/utils/_progress_bars.py
@@ -45,6 +45,7 @@ def add_progress_bar(iterable=None, desc=None, total=None, text=False):
             except ImportError:  # pragma: no cover
                 from tqdm import tqdm
 
-        iterable = tqdm(iterable=iterable, desc=desc, total=total)  # pragma: no cover
+        iterable = tqdm(iterable=iterable, desc=desc,
+                        total=total)  # pragma: no cover
 
     return iterable

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -270,7 +270,8 @@ class ImageDepth:
         iter_range = range(self.niters)
         if self.progress_bar:
             desc = 'Image Depths'
-            iter_range = add_progress_bar(iter_range, desc=desc)  # pragma: no cover
+            iter_range = add_progress_bar(iter_range,
+                                          desc=desc)  # pragma: no cover
 
         fluxes = []
         flux_limits = []

--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ skip_install = true
 changedir = .
 description = check code style with flake8
 deps = flake8
-commands = flake8 photutils --count --max-line-length=100
+commands = flake8 photutils --count --max-line-length=79
 
 [testenv:pep517]
 skip_install = true


### PR DESCRIPTION
Most of the package already uses 79 characters.  That is recommended by [PEP8](https://peps.python.org/pep-0008/#maximum-line-length), and is also what core CPython uses.

Note that for long parameter types, a line-continuation character "\" is recommended.  However, this will not work if the docstring is a raw string.  Here, I've removed the raw strings if a line-continuation character is needed.