### PR TITLE
Add publishing of developer wheels to anaconda.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,5 +63,12 @@ jobs:
         - cp311*win_amd64
         - cp312*win_amd64
 
+      # Developer wheels
+      upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      anaconda_user: astropy
+      anaconda_package: photutils
+      anaconda_keep_n_latest: 10
+
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
+      anaconda_token: ${{ secrets.anaconda_token }}


### PR DESCRIPTION
This will upload the wheels here: https://anaconda.org/astropy as for reproject and astropy-healpix

I've set up the token in the repository settings under ANACONDA_TOKEN. If there are permission issues when trying to upload a wheel, I can try and update the token scope.