### PR TITLE
DOC: Mention nightly wheel in dev install

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -141,7 +141,7 @@ the "-e" option::
 Alternatively, `pip`_ can be used to retrieve and install the
 latest development pre-built wheel::
 
-    pip install --upgrade --index-url https://pypi.anaconda.org/astropy/simple photutils[all] --pre
+    pip install --upgrade --extra-index-url https://pypi.anaconda.org/astropy/simple photutils[all] --pre
 
 Testing an installed Photutils
 ==============================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -138,11 +138,10 @@ the "-e" option::
 
     pip install -e ".[all]"
 
-Alternatively, `pip`_ can be used to retrieve, build, and install the
-latest development version from `GitHub`_::
+Alternatively, `pip`_ can be used to retrieve and install the
+latest development pre-built wheel::
 
-    pip install "photutils[all] @ git+https://github.com/astropy/photutils.git"
-
+    pip install --upgrade --index-url https://pypi.anaconda.org/astropy/simple photutils[all] --pre
 
 Testing an installed Photutils
 ==============================


### PR DESCRIPTION
Follow-up of #1834

p.s. The `[all]` actually does not work right now because of `bottleneck` but fixing that is out of scope here.