### PR TITLE
Require astropy 5.3+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ General
 
 - The ``regions`` package is now an optional dependency. [#1813]
 
+- The minimum required Astropy is now 5.3. [#1839]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,7 +11,7 @@ Photutils has the following strict requirements:
 
 * `NumPy <https://numpy.org/>`_ 1.23 or later
 
-* `Astropy`_ 5.1 or later
+* `Astropy`_ 5.3 or later
 
 Photutils also optionally depends on other packages for some features:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = ['version']
 requires-python = '>=3.10'
 dependencies = [
     'numpy>=1.23',
-    'astropy>=5.1',
+    'astropy>=5.3',
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     numpy126: numpy==1.26.*
 
     oldestdeps: numpy==1.23
-    oldestdeps: astropy==5.1
+    oldestdeps: astropy==5.3
     oldestdeps: scipy==1.8
     oldestdeps: matplotlib==3.5
     oldestdeps: scikit-image==0.20


### PR DESCRIPTION
This is need to support fitting PSF models with units (#1838).