### PR TITLE
Increase the size of the PSF model bounding boxes

### DIFF
--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -1791,7 +1791,7 @@ class AiryDiskPSF(Fittable2DModel):
         """
         return 2.0 * 1.616339948310703 * self.radius / self._rz / np.pi
 
-    def bounding_box(self, factor=3.0):
+    def bounding_box(self, factor=10.0):
         """
         Return a bounding box defining the limits of the model.
 
@@ -1808,12 +1808,12 @@ class AiryDiskPSF(Fittable2DModel):
         Examples
         --------
         >>> from photutils.psf import AiryDiskPSF
-        >>> model = AiryDiskPSF(x_0=0, y_0=0, radius=10)
+        >>> model = AiryDiskPSF(x_0=0, y_0=0, radius=3)
         >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-25.3099788, upper=25.3099788)
-                y: Interval(lower=-25.3099788, upper=25.3099788)
+                x: Interval(lower=-25.30997880, upper=25.30997880)
+                y: Interval(lower=-25.30997880, upper=25.30997880)
             }
             model=AiryDiskPSF(inputs=('x', 'y'))
             order='C'

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -1565,7 +1565,7 @@ class MoffatPSF(Fittable2DModel):
         """
         return 2.0 * self.alpha * np.sqrt(2 ** (1.0 / self.beta) - 1)
 
-    def bounding_box(self, factor=3.0):
+    def bounding_box(self, factor=10.0):
         """
         Return a bounding box defining the limits of the model.
 
@@ -1586,8 +1586,8 @@ class MoffatPSF(Fittable2DModel):
         >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-6.117894, upper=6.117894)
-                y: Interval(lower=-6.117894, upper=6.117894)
+                x: Interval(lower=-20.3929811, upper=20.3929811)
+                y: Interval(lower=-20.3929811, upper=20.3929811)
             }
             model=MoffatPSF(inputs=('x', 'y'))
             order='C'

--- a/photutils/psf/tests/test_functional_models.py
+++ b/photutils/psf/tests/test_functional_models.py
@@ -217,7 +217,7 @@ def test_moffat_psf_model(use_units):
 
     # test bounding box
     model = MoffatPSF(x_0=0, y_0=0, alpha=1.0, beta=2.0)
-    bbox = 3.861565517
+    bbox = 12.871885058111655
     assert_allclose(model.bounding_box, ((-bbox, bbox), (-bbox, bbox)))
 
 
@@ -251,5 +251,5 @@ def test_airydisk_psf_model(use_units):
 
     # test bounding box
     model = AiryDiskPSF(x_0=0, y_0=0, radius=5)
-    bbox = 12.65498940
+    bbox = 42.18329801081182
     assert_allclose(model.bounding_box, ((-bbox, bbox), (-bbox, bbox)))


### PR DESCRIPTION
This PR increases the size of the `MoffatPSF` and `AiryDiskPSF` model bounding boxes to include more of the integrated flux.  These profiles have broad wings.