### PR TITLE
Allow array-like shape in CutoutImage

### DIFF
--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -95,7 +95,7 @@ class CutoutImage:
     def __init__(self, data, position, shape, mode='trim', fill_value=np.nan,
                  copy=False):
         self.position = position
-        self.input_shape = shape
+        self.input_shape = tuple(shape)
         self.mode = mode
         self.fill_value = fill_value
         self.copy = copy

--- a/photutils/utils/tests/test_cutouts.py
+++ b/photutils/utils/tests/test_cutouts.py
@@ -35,6 +35,9 @@ def test_cutout():
 
     assert_equal(cutout.xyorigin, np.array((23, 88)))
 
+    cutouts2 = CutoutImage(data, yxpos, np.array(shape))
+    assert cutouts2.input_shape == shape
+
     assert f'Shape: {shape}' in repr(cutout)
     assert f'Shape: {shape}' in str(cutout)
 


### PR DESCRIPTION
This PR ensures the shape is converted to a `tuple` before being input to `extract_array`.