### PR TITLE
Add PSFPhotometry results attribute to store table results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ New Features
 
   - The ``IntegratedGaussianPRF`` model now supports units. [#1838]
 
+  - A new ``results`` attribute was added to ``PSFPhotometry`` to store
+    the returned table of fit results. [#1858]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -91,6 +94,9 @@ API Changes
     ``simulations`` module. It is recommended that all of these tools be
     imported from ``photutils.psf`` without using the submodule name.
     [#1854]
+
+  - The ``PSFPhotometry`` ``fit_results`` attribute has been renamed to
+    ``fit_info``. ``fit_results`` is now deprecated. [#1858]
 
 
 1.13.0 (2024-06-28)

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -505,12 +505,12 @@ astropy table):
       9    5.5858   89.8664    0.5741 ... 0.0 54.3786 7.0389 -2.1188
      10   71.8303   90.5624    0.6038 ... 0.0 73.5747 9.5639 -2.4516
 
-The ``fit_results`` attribute contains a dictionary with detailed
+The ``fit_info`` attribute contains a dictionary with detailed
 information returned from the ``fitter`` for each source:
 
 .. doctest-requires:: scipy
 
-    >>> psfphot.fit_results.keys()
+    >>> psfphot.fit_info.keys()
     dict_keys(['fit_infos', 'fit_error_indices'])
 
 The ``fit_error_indices`` key contains the indices of sources for which
@@ -522,7 +522,7 @@ covariance matrix):
 
 .. doctest-skip::
 
-    >>> psfphot.fit_results['fit_infos'][0]['param_cov']  # doctest: +FLOAT_CMP
+    >>> psfphot.fit_info['fit_infos'][0]['param_cov']  # doctest: +FLOAT_CMP
     array([[ 7.27034774e-01,  8.86845334e-04,  3.98593038e-03],
            [ 8.86845334e-04,  2.92871525e-06, -6.36805464e-07],
            [ 3.98593038e-03, -6.36805464e-07,  4.29520185e-05]])

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -338,6 +338,7 @@ class PSFPhotometry(ModelImageMixin):
         self.init_params = None
         self.fit_params = None
         self._fit_model_params = None
+        self.results = None
         self.fit_info = defaultdict(list)
         self._group_results = defaultdict(list)
 
@@ -350,6 +351,7 @@ class PSFPhotometry(ModelImageMixin):
         self.init_params = None
         self.fit_params = None
         self._fit_model_params = None
+        self.results = None
         self.fit_info = defaultdict(list)
         self._group_results = defaultdict(list)
 
@@ -1425,6 +1427,7 @@ class PSFPhotometry(ModelImageMixin):
 
         # convert results from defaultdict to dict
         self.fit_info = dict(self.fit_info)
+        self.results = results_tbl
 
         return results_tbl
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -178,6 +178,7 @@ def test_psf_photometry(test_data):
 
     assert isinstance(psfphot.finder_results, QTable)
     assert isinstance(phot, QTable)
+    assert isinstance(psfphot.results, QTable)
     assert len(phot) == len(sources)
     assert isinstance(resid_data, np.ndarray)
     assert resid_data.shape == data.shape

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -189,11 +189,11 @@ def test_psf_photometry(test_data):
 
     keys = ('fit_infos', 'fit_error_indices')
     for key in keys:
-        assert key in psfphot.fit_results
+        assert key in psfphot.fit_info
 
     # test that repeated calls reset the results
     phot = psfphot(data, error=error)
-    assert len(psfphot.fit_results['fit_infos']) == len(phot)
+    assert len(psfphot.fit_info['fit_infos']) == len(phot)
 
     # test units
     unit = u.Jy
@@ -822,7 +822,7 @@ def test_fit_warning(test_data):
     match = r'One or more fit\(s\) may not have converged.'
     with pytest.warns(AstropyUserWarning, match=match):
         _ = psfphot(data)
-        assert len(psfphot.fit_results['fit_error_indices']) > 0
+        assert len(psfphot.fit_info['fit_error_indices']) > 0
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')


### PR DESCRIPTION
A new ``results`` attribute was added to ``PSFPhotometry`` to store the returned table of fit results.  Also, the ``PSFPhotometry`` ``fit_results`` attribute has been renamed to ``fit_info``. ``fit_results`` is now deprecated.