### PR TITLE
Add fit_fwhm and fit_2dgaussian functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,13 @@ New Features
   - A new ``results`` attribute was added to ``PSFPhotometry`` to store
     the returned table of fit results. [#1858]
 
+  - Added new ``fit_fwhm`` convenience function to estimate the FWHM of
+    one or more sources in an image by fitting a circular 2D Gaussian PSF
+    model. [#1859]
+
+  - Added new ``fit_2dgaussian`` convenience function to fit a circular 2D
+    Gaussian PSF to one or more sources in an image. [#1859]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -855,6 +855,43 @@ the source was detected:
      10             2 71.8485 90.5830 687.4573
 
 
+Estimating the FWHM of sources
+------------------------------
+
+The `photutils.psf` package also provides a convenience function
+called `~photutils.psf.fit_fwhm` to estimate the full width
+at half maximum (FWHM) of one or more sources in an image.
+This function fits the source(s) with a circular 2D Gaussian
+PSF model (`~photutils.psf.CircularGaussianPSF`) using the
+`~photutils.psf.PSFPhotometry` class. If your sources are not
+circular or non-Gaussian, you can fit your sources using the
+`~photutils.psf.PSFPhotometry` class using a different PSF model.
+
+For example, let's estimate the FWHM of the sources in our example image
+defined above:
+
+.. doctest-requires:: scipy
+
+   >>> from photutils.psf import fit_fwhm
+   >>> finder = DAOStarFinder(6.0, 2.0)
+   >>> finder_tbl = finder(data)
+   >>> xypos = list(zip(finder_tbl['xcentroid'], finder_tbl['ycentroid']))
+   >>> fwhm = fit_fwhm(data, xypos=xypos, error=error, fit_shape=(5, 5))
+   >>> fwhm  # doctest: +FLOAT_CMP
+   array([2.78318472, 2.78834154, 2.77986989, 2.79650315, 2.77475841,
+          2.78849262, 2.78781809, 2.76465724, 2.79742412, 2.79036633])
+
+
+Convenience Gaussian Fitting Function
+-------------------------------------
+
+The `photutils.psf` package also provides a convenience function called
+:func:`~photutils.psf.fit_2dgaussian` for fitting one or more sources
+with a 2D Gaussian PSF model (`~photutils.psf.CircularGaussianPSF`)
+using the `~photutils.psf.PSFPhotometry` class. See the function
+documentation for more details and examples.
+
+
 Reference/API
 -------------
 

--- a/photutils/psf/__init__.py
+++ b/photutils/psf/__init__.py
@@ -5,7 +5,7 @@ photometry.
 """
 
 from . import (epsf, epsf_stars, functional_models, gridded_models, groupers,
-               image_models, photometry, model_helpers, simulation)
+               image_models, photometry, model_helpers, simulation, utils)
 from .epsf import *  # noqa: F401, F403
 from .epsf_stars import *  # noqa: F401, F403
 from .functional_models import *  # noqa: F401, F403
@@ -16,6 +16,7 @@ from .matching import *  # noqa: F401, F403
 from .photometry import *  # noqa: F401, F403
 from .model_helpers import *  # noqa: F401, F403
 from .simulation import *  # noqa: F401, F403
+from .utils import *  # noqa: F401, F403
 
 # exclude matching from this list to avoid sphinx warnings
 __all__ = []
@@ -28,3 +29,4 @@ __all__ += image_models.__all__
 __all__ += photometry.__all__
 __all__ += model_helpers.__all__
 __all__ += simulation.__all__
+__all__ += utils.__all__

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -3,15 +3,78 @@
 Tests for the utils module.
 """
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian1D, Gaussian2D
+from astropy.table import QTable
+from numpy.testing import assert_allclose
 
-from photutils.psf import CircularGaussianPSF
+from photutils.psf import CircularGaussianPSF, make_psf_model_image
 from photutils.psf.utils import (_get_psf_model_params,
                                  _interpolate_missing_data,
-                                 _validate_psf_model)
+                                 _validate_psf_model, fit_2dgaussian)
 from photutils.utils._optional_deps import HAS_SCIPY
+
+
+@pytest.fixture(name='test_data')
+def fixture_test_data():
+    psf_model = CircularGaussianPSF()
+    model_shape = (9, 9)
+    n_sources = 10
+    shape = (101, 101)
+    data, true_params = make_psf_model_image(shape, psf_model, n_sources,
+                                             model_shape=model_shape,
+                                             flux=(500, 700), fwhm=(2.7, 2.7),
+                                             min_separation=10, seed=0)
+    return data, true_params
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+@pytest.mark.parametrize('fix_fwhm', [False, True])
+def test_fit_2dgaussian_single(fix_fwhm):
+    yy, xx = np.mgrid[:51, :51]
+    fwhm = 3.123
+    model = CircularGaussianPSF(x_0=22.17, y_0=28.87, fwhm=fwhm)
+    data = model(xx, yy)
+
+    fit = fit_2dgaussian(data, fix_fwhm=fix_fwhm)
+    fit_tbl = fit.results
+    assert isinstance(fit_tbl, QTable)
+    assert len(fit_tbl) == 1
+    if fix_fwhm:
+        assert 'fwhm_fit' not in fit_tbl.colnames
+    else:
+        assert 'fwhm_fit' in fit_tbl.colnames
+        assert_allclose(fit_tbl['fwhm_fit'], fwhm)
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+@pytest.mark.parametrize(('fix_fwhm', 'with_units'),
+                         [(False, True), (True, False)])
+def test_fit_2dgaussian_multiple(test_data, fix_fwhm, with_units):
+    data, sources = test_data
+
+    unit = u.nJy
+    if with_units:
+        data = data * unit
+
+    xypos = list(zip(sources['x_0'], sources['y_0'], strict=True))
+    fit = fit_2dgaussian(data, xypos=xypos, fit_shape=(5, 5),
+                         fix_fwhm=fix_fwhm)
+    fit_tbl = fit.results
+    assert isinstance(fit_tbl, QTable)
+    assert len(fit_tbl) == len(sources)
+    if fix_fwhm:
+        assert 'fwhm_fit' not in fit_tbl.colnames
+    else:
+        assert 'fwhm_fit' in fit_tbl.colnames
+        assert_allclose(fit_tbl['fwhm_fit'], sources['fwhm'])
+
+    if with_units:
+        for column in fit_tbl.colnames:
+            if 'flux' in column:
+                assert fit_tbl['flux_fit'].unit == unit
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -8,12 +8,13 @@ import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian1D, Gaussian2D
 from astropy.table import QTable
+from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
 
 from photutils.psf import CircularGaussianPSF, make_psf_model_image
 from photutils.psf.utils import (_get_psf_model_params,
                                  _interpolate_missing_data,
-                                 _validate_psf_model, fit_2dgaussian)
+                                 _validate_psf_model, fit_2dgaussian, fit_fwhm)
 from photutils.utils._optional_deps import HAS_SCIPY
 
 
@@ -75,6 +76,41 @@ def test_fit_2dgaussian_multiple(test_data, fix_fwhm, with_units):
         for column in fit_tbl.colnames:
             if 'flux' in column:
                 assert fit_tbl['flux_fit'].unit == unit
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+def test_fit_fwhm_single():
+    yy, xx = np.mgrid[:51, :51]
+    fwhm0 = 3.123
+    model = CircularGaussianPSF(x_0=22.17, y_0=28.87, fwhm=fwhm0)
+    data = model(xx, yy)
+
+    fwhm = fit_fwhm(data)
+    assert isinstance(fwhm, np.ndarray)
+    assert len(fwhm) == 1
+    assert_allclose(fwhm, fwhm0)
+
+    # test warning message
+    match = 'may not have converged. Please carefully check your results'
+    with pytest.warns(AstropyUserWarning, match=match):
+        fwhm = fit_fwhm(data + 100)
+    assert len(fwhm) == 1
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+@pytest.mark.parametrize('with_units', [False, True])
+def test_fit_fwhm_multiple(test_data, with_units):
+    data, sources = test_data
+
+    unit = u.nJy
+    if with_units:
+        data = data * unit
+
+    xypos = list(zip(sources['x_0'], sources['y_0'], strict=True))
+    fwhms = fit_fwhm(data, xypos=xypos, fit_shape=(5, 5))
+    assert isinstance(fwhms, np.ndarray)
+    assert len(fwhms) == len(sources)
+    assert_allclose(fwhms, sources['fwhm'])
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -78,6 +78,60 @@ def fit_2dgaussian(data, *, xypos=None, fit_shape=None, mask=None, error=None,
     guess for the flux is the sum of the pixel values within the fitting
     region. The initial guess for the FWHM is half the mean of the x and
     y sizes of the ``fit_shape`` values.
+
+    Examples
+    --------
+    Fit a 2D Gaussian model to a image containing only one source (e.g.,
+    a cutout image):
+
+    >>> import numpy as np
+    >>> from photutils.psf import CircularGaussianPSF, fit_2dgaussian
+    >>> yy, xx = np.mgrid[:51, :51]
+    >>> model = CircularGaussianPSF(x_0=22.17, y_0=28.87, fwhm=3.123, flux=9.7)
+    >>> data = model(xx, yy)
+    >>> fit = fit_2dgaussian(data, fix_fwhm=False)
+    >>> phot_tbl = fit.results  # doctest: +FLOAT_CMP
+    >>> cols = ['x_fit', 'y_fit', 'fwhm_fit', 'flux_fit']
+    >>> for col in cols:
+    ...     phot_tbl[col].info.format = '.4f'  # optional format
+    >>> print(phot_tbl[['id'] + cols])
+     id  x_fit   y_fit  fwhm_fit flux_fit
+    --- ------- ------- -------- --------
+      1 22.1700 28.8700   3.1230   9.7000
+
+    Fit a 2D Gaussian model to multiple sources in an image:
+
+    >>> import numpy as np
+    >>> from photutils.detection import DAOStarFinder
+    >>> from photutils.psf import (CircularGaussianPSF, fit_2dgaussian,
+    ...                            make_psf_model_image)
+    >>> model = CircularGaussianPSF()
+    >>> data, sources = make_psf_model_image((100, 100), model, 5,
+    ...                                      min_separation=25,
+    ...                                      model_shape=(15, 15),
+    ...                                      flux=(100, 200), fwhm=[3, 8])
+    >>> finder = DAOStarFinder(0.1, 5)
+    >>> finder_tbl = finder(data)
+    >>> xypos = list(zip(sources['x_0'], sources['y_0']))
+    >>> psfphot = fit_2dgaussian(data, xypos=xypos, fit_shape=7,
+    ...                          fix_fwhm=False)
+    >>> phot_tbl = psfphot.results
+    >>> len(phot_tbl)
+    5
+
+    Here we show only a few columns of the photometry table:
+
+    >>> cols = ['x_fit', 'y_fit', 'fwhm_fit', 'flux_fit']
+    >>> for col in cols:
+    ...     phot_tbl[col].info.format = '.4f'  # optional format
+    >>> print(phot_tbl[['id'] + cols])
+     id  x_fit   y_fit  fwhm_fit flux_fit
+    --- ------- ------- -------- --------
+      1 61.7787 74.6905   5.6947 147.9988
+      2 30.2017 27.5858   5.2138 123.2373
+      3 10.5237 82.3776   7.6551 180.1881
+      4  8.4214 12.0369   3.2026 192.3530
+      5 76.9412 35.9061   6.6600 126.6130
     """
     # prevent circular import
     from photutils.psf.photometry import PSFPhotometry

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -2,11 +2,13 @@
 """
 This module provides utilities for PSF-fitting photometry.
 """
+import warnings
 
 import numpy as np
 from astropy.modeling import Model
 from astropy.table import QTable
 from astropy.units import Quantity
+from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.centroids import centroid_com
 from photutils.psf.functional_models import CircularGaussianPSF
@@ -171,8 +173,16 @@ def fit_fwhm(data, *, xypos=None, fit_shape=None, mask=None, error=None):
     initial guess for the FWHM is half the mean of the x and y sizes of
     the ``fit_shape`` values.
     """
-    phot = fit_2dgaussian(data, xypos=xypos, fit_shape=fit_shape, mask=mask,
-                          error=error, fix_fwhm=False)
+    with warnings.catch_warnings(record=True) as fit_warnings:
+        phot = fit_2dgaussian(data, xypos=xypos, fit_shape=fit_shape,
+                              mask=mask, error=error, fix_fwhm=False)
+
+    if len(fit_warnings) > 0:
+        warnings.warn('One or more fit(s) may not have converged. Please '
+                      'carefully check your results. You may need to change '
+                      'the input "xypos" and "fit_shape" parameters.',
+                      AstropyUserWarning)
+
     return np.abs(np.array(phot.results['fwhm_fit']))
 
 

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -71,6 +71,10 @@ def fit_2dgaussian(data, *, xypos=None, fit_shape=None, mask=None, error=None,
     result : `~photutils.psf.PSFPhotometry`
         The PSF-fitting photometry results.
 
+    See Also
+    --------
+    fit_fwhm : Fit the FWHM of one or more sources in an image.
+
     Notes
     -----
     The source(s) are fit with a `~photutils.psf.CircularGaussianPSF`
@@ -218,6 +222,11 @@ def fit_fwhm(data, *, xypos=None, fit_shape=None, mask=None, error=None):
         The FWHM of the sources. Note that the returned FWHM values are
         always positive.
 
+    See Also
+    --------
+    fit_2dgaussian : Fit a 2D Gaussian model to one or more sources in an
+                     image.
+
     Notes
     -----
     The source(s) are fit using the :func:`fit_2dgaussian` function,
@@ -226,6 +235,37 @@ def fit_fwhm(data, *, xypos=None, fit_shape=None, mask=None, error=None):
     flux is the sum of the pixel values within the fitting region. The
     initial guess for the FWHM is half the mean of the x and y sizes of
     the ``fit_shape`` values.
+
+    Examples
+    --------
+    Fit the FWHM of a single source (e.g., a cutout image):
+
+    >>> import numpy as np
+    >>> from photutils.psf import CircularGaussianPSF, fit_fwhm
+    >>> yy, xx = np.mgrid[:51, :51]
+    >>> model = CircularGaussianPSF(x_0=22.17, y_0=28.87, fwhm=3.123, flux=9.7)
+    >>> data = model(xx, yy)
+    >>> fwhm = fit_fwhm(data)
+    >>> fwhm  # doctest: +FLOAT_CMP
+    array([3.123])
+
+    Fit the FWHMs of multiple sources in an image:
+
+    >>> import numpy as np
+    >>> from photutils.detection import DAOStarFinder
+    >>> from photutils.psf import (CircularGaussianPSF, fit_fwhm,
+    ...                            make_psf_model_image)
+    >>> model = CircularGaussianPSF()
+    >>> data, sources = make_psf_model_image((100, 100), model, 5,
+    ...                                      min_separation=25,
+    ...                                      model_shape=(15, 15),
+    ...                                      flux=(100, 200), fwhm=[3, 8])
+    >>> finder = DAOStarFinder(0.1, 5)
+    >>> finder_tbl = finder(data)
+    >>> xypos = list(zip(sources['x_0'], sources['y_0']))
+    >>> fwhms = fit_fwhm(data, xypos=xypos, fit_shape=7)
+    >>> fwhms  # doctest: +FLOAT_CMP
+    array([5.69467204, 5.21376414, 7.65508658, 3.20255356, 6.66003098])
     """
     with warnings.catch_warnings(record=True) as fit_warnings:
         phot = fit_2dgaussian(data, xypos=xypos, fit_shape=fit_shape,


### PR DESCRIPTION
This PR adds two convenience functions based on fitting one or more sources in an image
using a circular 2D Gaussian PSF model:

* `fit_fwhm`: estimate the FWHM of one or more sources
*  `fit_2dgaussian`: fit one or more sources with `CircularGaussianPSF' model