### PR TITLE
Allow Quantity inputs to centroid_1dg and centroid_2dg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,11 @@ New Features
     convert supported ``regions.Region`` objects to ``Aperture`` objects.
     [#1813, #1852]
 
+- ``photutils.centroids``
+
+  - ``Quantity`` arrays can now be input to ``centroid_1dg`` and
+    ``centroid_2dg``. [#1861]
+
 - ``photutils.psf``
 
   - Added new ``xy_bounds`` keyword to ``PSFPhotometry`` and
@@ -73,6 +78,14 @@ API Changes
 - The ``sklearn`` version information has been removed from the meta
   attribute in output tables. ``sklearn`` was removed as an optional
   dependency in 1.13.0. [#1807]
+
+- ``photutils.centroids``
+
+  - For consistency with other fitting functions (including PSF
+    fitting), the ``centroid_1dg`` and ``centroid_2dg`` functions
+    now fit only a 1D or 2D Gaussian model, respectively, excluding
+    any constant component. The input data are required to be
+    background-subtracted. [#1861]
 
 - ``photutils.isophote``
 

--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -81,7 +81,7 @@ centroiding functions::
 
     >>> x3, y3 = centroid_1dg(data)
     >>> print(np.array((x3, y3)))  # doctest: +FLOAT_CMP
-    [19.96524237 20.04921073]
+    [19.96553246 20.04952841]
 
 .. doctest-requires:: scipy
 
@@ -166,9 +166,13 @@ for each source are then calculated within their cutout images:
     >>> x, y = centroid_sources(data, x_init, y_init, box_size=25,
     ...                         centroid_func=centroid_2dg)
     >>> print(x)  # doctest: +FLOAT_CMP
-    [ 24.9673919   89.98674593 149.96533358 160.18767122]
+    [ 24.96807828  89.98684636 149.96545721 160.18810915]
     >>> print(y)  # doctest: +FLOAT_CMP
-    [40.03744529 60.01821736 24.96773872 69.80462556]
+    [40.03657613 60.01836631 24.96777946 69.80208702]
+
+The measured centroids are all very close to the true centroids of the
+simulated objects in the image, which have ``(x, y)`` values of ``(25,
+40)``, ``(90, 60)``, ``(150, 25)``, and ``(160, 70)``.
 
 Let's plot the results:
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -415,9 +415,9 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
     >>> x, y = centroid_sources(data, x_init, y_init, box_size=25,
     ...                         centroid_func=centroid_2dg)
     >>> print(x)  # doctest: +FLOAT_CMP
-    [ 24.9673919   89.98674593 149.96533358 160.18767122]
+    [ 24.96807828  89.98684636 149.96545721 160.18810915]
     >>> print(y)  # doctest: +FLOAT_CMP
-    [40.03744529 60.01821736 24.96773872 69.80462556]
+    [40.03657613 60.01836631 24.96777946 69.80208702]
 
     .. plot::
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -312,14 +312,15 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
 
     try:
         c = np.linalg.lstsq(coeff_matrix, cutout, rcond=None)[0]
-    except np.linalg.LinAlgError:
+    except np.linalg.LinAlgError:  # pragma: no cover
         warnings.warn('quadratic fit failed', AstropyUserWarning)
         return np.array((np.nan, np.nan))
 
     # analytically find the maximum of the polynomial
     _, c10, c01, c11, c20, c02 = c
     det = 4 * c20 * c02 - c11**2
-    if det <= 0 or ((c20 > 0.0 and c02 >= 0.0) or (c20 >= 0.0 and c02 > 0.0)):
+    if det <= 0 or ((c20 > 0.0 and c02 >= 0.0)
+                    or (c20 >= 0.0 and c02 > 0.0)):  # pragma: no cover
         warnings.warn('quadratic fit does not have a maximum',
                       AstropyUserWarning)
         return np.array((np.nan, np.nan))
@@ -328,7 +329,7 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
     ym = (c10 * c11 - 2.0 * c20 * c01) / det
     if 0.0 < xm < (nx - 1.0) and 0.0 < ym < (ny - 1.0):
         xycen = np.array((xm, ym), dtype=float)
-    else:
+    else:  # pragma: no cover
         warnings.warn('quadratic polynomial maximum value falls outside '
                       'of the image', AstropyUserWarning)
         return np.array((np.nan, np.nan))

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -10,6 +10,8 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import Const1D, Const2D, Gaussian1D, Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 
+from photutils.utils._quantity_helpers import process_quantities
+
 __all__ = ['centroid_1dg', 'centroid_2dg']
 
 __doctest_requires__ = {('centroid_1dg', 'centroid_2dg'): ['scipy']}
@@ -69,6 +71,8 @@ def centroid_1dg(data, error=None, mask=None):
         ax.scatter(*xycen, color='red', marker='+', s=100, label='Centroid')
         ax.legend()
     """
+    (data, error), _ = process_quantities((data, error), ('data', 'error'))
+
     data = np.ma.asanyarray(data)
 
     if mask is not None and mask is not np.ma.nomask:
@@ -218,6 +222,8 @@ def centroid_2dg(data, error=None, mask=None):
     """
     # prevent circular import
     from photutils.morphology import data_properties
+
+    (data, error), _ = process_quantities((data, error), ('data', 'error'))
 
     data = np.ma.asanyarray(data)
 

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -273,6 +273,12 @@ def centroid_2dg(data, error=None, mask=None):
                         theta=props.orientation.value)
     fitter = LevMarLSQFitter()
     y, x = np.indices(data.shape)
-    gfit = fitter(g_init, x, y, data, weights=weights)
+
+    with warnings.catch_warnings(record=True) as fit_warnings:
+        gfit = fitter(g_init, x, y, data, weights=weights)
+
+    if len(fit_warnings) > 0:
+        warnings.warn('The fit may not have converged. Please check your '
+                      'results.', AstropyUserWarning)
 
     return np.array([gfit.x_mean.value, gfit.y_mean.value])

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -36,13 +36,13 @@ def fixture_test_data():
     xsize = 47
     yy, xx = np.mgrid[0:ysize, 0:xsize]
     data = np.zeros((ysize, xsize))
-    xcen = (1, 25, 25, 35, 46)
-    ycen = (1, 25, 12, 35, 49)
-    for xc, yc in zip(xcen, ycen, strict=True):
+    xpos = (1, 25, 25, 35, 46)
+    ypos = (1, 25, 12, 35, 49)
+    for xc, yc in zip(xpos, ypos, strict=True):
         model = Gaussian2D(10.0, xc, yc, x_stddev=2, y_stddev=2,
                            theta=0)
         data += model(xx, yy)
-    return data, xcen, ycen
+    return data, xpos, ypos
 
 
 # NOTE: the fitting routines in astropy use scipy.optimize
@@ -294,11 +294,7 @@ class TestCentroidSources:
         data, xpos, ypos = test_data
         xcen, ycen = centroid_sources(data, xpos, ypos, box_size=3,
                                       centroid_func=centroid_1dg)
-        assert_allclose(xcen, np.full(5, np.nan))
-        assert_allclose(ycen, np.full(5, np.nan))
 
-        xcen, ycen = centroid_sources(data, xpos, ypos, box_size=3,
-                                      centroid_func=centroid_2dg)
         xres = np.copy(xpos).astype(float)
         yres = np.copy(ypos).astype(float)
         xres[-1] = np.nan
@@ -306,10 +302,15 @@ class TestCentroidSources:
         assert_allclose(xcen, xres)
         assert_allclose(ycen, yres)
 
-        xcen, ycen = centroid_sources(data, xpos, ypos, box_size=5,
-                                      centroid_func=centroid_1dg)
+        xcen, ycen = centroid_sources(data, xpos, ypos, box_size=3,
+                                      centroid_func=centroid_2dg)
         assert_allclose(xcen, xres)
         assert_allclose(ycen, yres)
+
+        xcen, ycen = centroid_sources(data, xpos, ypos, box_size=5,
+                                      centroid_func=centroid_1dg)
+        assert_allclose(xcen, xpos)
+        assert_allclose(ycen, ypos)
 
         xcen, ycen = centroid_sources(data, xpos, ypos, box_size=3,
                                       centroid_func=centroid_quadratic)

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -5,6 +5,7 @@ Tests for the core module.
 
 from contextlib import nullcontext
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
@@ -49,8 +50,12 @@ def fixture_test_data():
 @pytest.mark.parametrize('x_std', [3.2, 4.0])
 @pytest.mark.parametrize('y_std', [5.7, 4.1])
 @pytest.mark.parametrize('theta', np.deg2rad([30.0, 45.0]))
-def test_centroid_comquad(test_simple_data, x_std, y_std, theta):
+@pytest.mark.parametrize('units', [True, False])
+def test_centroid_comquad(test_simple_data, x_std, y_std, theta, units):
     data, xcen, ycen = test_simple_data
+
+    if units:
+        data = data * u.nJy
 
     model = Gaussian2D(2.4, xcen, ycen, x_stddev=x_std, y_stddev=y_std,
                        theta=theta)

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -3,7 +3,6 @@
 Tests for the core module.
 """
 
-import itertools
 from contextlib import nullcontext
 
 import numpy as np
@@ -18,45 +17,60 @@ from photutils.centroids.gaussian import centroid_1dg, centroid_2dg
 from photutils.datasets import make_4gaussians_image, make_noise_image
 from photutils.utils._optional_deps import HAS_SCIPY
 
-XCEN = 25.7
-YCEN = 26.2
-XSTDS = [3.2, 4.0]
-YSTDS = [5.7, 4.1]
-THETAS = np.array([30.0, 45.0]) * np.pi / 180.0
 
-DATA = np.zeros((3, 3))
-DATA[0:2, 1] = 1.0
-DATA[1, 0:2] = 1.0
-DATA[1, 1] = 2.0
+@pytest.fixture(name='test_simple_data')
+def fixture_test_simple_data():
+    xcen = 25.7
+    ycen = 26.2
+    data = np.zeros((3, 3))
+    data[0:2, 1] = 1.0
+    data[1, 0:2] = 1.0
+    data[1, 1] = 2.0
+    return data, xcen, ycen
 
-CENTROID_FUNCS = (centroid_com, centroid_quadratic, centroid_1dg,
-                  centroid_2dg)
+
+@pytest.fixture(name='test_data')
+def fixture_test_data():
+    ysize = 50
+    xsize = 47
+    yy, xx = np.mgrid[0:ysize, 0:xsize]
+    data = np.zeros((ysize, xsize))
+    xcen = (1, 25, 25, 35, 46)
+    ycen = (1, 25, 12, 35, 49)
+    for xc, yc in zip(xcen, ycen, strict=True):
+        model = Gaussian2D(10.0, xc, yc, x_stddev=2, y_stddev=2,
+                           theta=0)
+        data += model(xx, yy)
+    return data, xcen, ycen
 
 
 # NOTE: the fitting routines in astropy use scipy.optimize
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.parametrize(('x_std', 'y_std', 'theta'),
-                         list(itertools.product(XSTDS, YSTDS, THETAS)))
-def test_centroid_comquad(x_std, y_std, theta):
-    model = Gaussian2D(2.4, XCEN, YCEN, x_stddev=x_std, y_stddev=y_std,
+@pytest.mark.parametrize('x_std', [3.2, 4.0])
+@pytest.mark.parametrize('y_std', [5.7, 4.1])
+@pytest.mark.parametrize('theta', np.deg2rad([30.0, 45.0]))
+def test_centroid_comquad(test_simple_data, x_std, y_std, theta):
+    data, xcen, ycen = test_simple_data
+
+    model = Gaussian2D(2.4, xcen, ycen, x_stddev=x_std, y_stddev=y_std,
                        theta=theta)
     y, x = np.mgrid[0:50, 0:47]
     data = model(x, y)
     xc, yc = centroid_com(data)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.0e-3)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
 
     xc, yc = centroid_quadratic(data)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=0.015)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=0.015)
 
     # test with mask
     mask = np.zeros(data.shape, dtype=bool)
     data[10, 10] = 1.0e5
     mask[10, 10] = True
     xc, yc = centroid_com(data, mask=mask)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.0e-3)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
 
     xc, yc = centroid_quadratic(data, mask=mask)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=0.015)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=0.015)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -216,25 +230,11 @@ def test_centroid_quadratic_edge():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestCentroidSources:
-    def setup_class(self):
-        ysize = 50
-        xsize = 47
-        yy, xx = np.mgrid[0:ysize, 0:xsize]
-        data = np.zeros((ysize, xsize))
-        xcen = (1, 25, 25, 35, 46)
-        ycen = (1, 25, 12, 35, 49)
-        for xc, yc in zip(xcen, ycen, strict=True):
-            model = Gaussian2D(10.0, xc, yc, x_stddev=2, y_stddev=2,
-                               theta=0)
-            data += model(xx, yy)
-        self.xpos = xcen
-        self.ypos = ycen
-        self.data = data
 
     @staticmethod
     def test_centroid_sources():
         theta = np.pi / 6.0
-        model = Gaussian2D(2.4, XCEN, YCEN, x_stddev=3.2, y_stddev=5.7,
+        model = Gaussian2D(2.4, 25.7, 26.2, x_stddev=3.2, y_stddev=5.7,
                            theta=theta)
         y, x = np.mgrid[0:50, 0:47]
         data = model(x, y)
@@ -275,35 +275,38 @@ class TestCentroidSources:
         with pytest.raises(ValueError, match=match):
             centroid_sources(data, [25], 26, centroid_func=test_func)
 
-    @pytest.mark.parametrize('centroid_func', CENTROID_FUNCS)
-    def test_xypos(self, centroid_func):
+    @pytest.mark.parametrize('centroid_func', [centroid_com,
+                                               centroid_quadratic,
+                                               centroid_1dg, centroid_2dg])
+    def test_xypos(self, test_data, centroid_func):
+        data = test_data[0]
         match = 'xpos, ypos values contains points outside of input data'
         with pytest.raises(ValueError, match=match):
-            centroid_sources(self.data, 47, 50, box_size=5,
+            centroid_sources(data, 47, 50, box_size=5,
                              centroid_func=centroid_func)
 
-    def test_gaussian_fits_npts(self):
-        xcen, ycen = centroid_sources(self.data, self.xpos, self.ypos,
-                                      box_size=3, centroid_func=centroid_1dg)
+    def test_gaussian_fits_npts(self, test_data):
+        data, xpos, ypos = test_data
+        xcen, ycen = centroid_sources(data, xpos, ypos, box_size=3,
+                                      centroid_func=centroid_1dg)
         assert_allclose(xcen, np.full(5, np.nan))
         assert_allclose(ycen, np.full(5, np.nan))
 
-        xcen, ycen = centroid_sources(self.data, self.xpos, self.ypos,
-                                      box_size=3, centroid_func=centroid_2dg)
-        xres = np.copy(self.xpos).astype(float)
-        yres = np.copy(self.ypos).astype(float)
+        xcen, ycen = centroid_sources(data, xpos, ypos, box_size=3,
+                                      centroid_func=centroid_2dg)
+        xres = np.copy(xpos).astype(float)
+        yres = np.copy(ypos).astype(float)
         xres[-1] = np.nan
         yres[-1] = np.nan
         assert_allclose(xcen, xres)
         assert_allclose(ycen, yres)
 
-        xcen, ycen = centroid_sources(self.data, self.xpos, self.ypos,
-                                      box_size=5, centroid_func=centroid_1dg)
+        xcen, ycen = centroid_sources(data, xpos, ypos, box_size=5,
+                                      centroid_func=centroid_1dg)
         assert_allclose(xcen, xres)
         assert_allclose(ycen, yres)
 
-        xcen, ycen = centroid_sources(self.data, self.xpos, self.ypos,
-                                      box_size=3,
+        xcen, ycen = centroid_sources(data, xpos, ypos, box_size=3,
                                       centroid_func=centroid_quadratic)
         assert_allclose(xcen, xres)
         assert_allclose(ycen, yres)
@@ -355,34 +358,37 @@ class TestCentroidSources:
         assert ~np.any(np.isnan(data))
         assert_allclose(xycen, (xc_ref, yc_ref), atol=0.01)
 
-    def test_mask(self):
-        xcen1, ycen1 = centroid_sources(self.data, 25, 23, box_size=(55, 55))
+    def test_mask(self, test_data):
+        data = test_data[0]
+        xcen1, ycen1 = centroid_sources(data, 25, 23, box_size=(55, 55))
 
-        mask = np.zeros(self.data.shape, dtype=bool)
+        mask = np.zeros(data.shape, dtype=bool)
         mask[0, 0] = True
         mask[24, 24] = True
         mask[11, 24] = True
-        xcen2, ycen2 = centroid_sources(self.data, 25, 23,
-                                        box_size=(55, 55), mask=mask)
+        xcen2, ycen2 = centroid_sources(data, 25, 23, box_size=(55, 55),
+                                        mask=mask)
         assert not np.allclose(xcen1, xcen2)
         assert not np.allclose(ycen1, ycen2)
 
-    def test_error_none(self):
-        xycen1 = centroid_sources(self.data, xpos=25, ypos=25, error=None,
+    def test_error_none(self, test_data):
+        data = test_data[0]
+        xycen1 = centroid_sources(data, xpos=25, ypos=25, error=None,
                                   centroid_func=centroid_1dg)
-        xycen2 = centroid_sources(self.data, xpos=25, ypos=25, error=None,
+        xycen2 = centroid_sources(data, xpos=25, ypos=25, error=None,
                                   centroid_func=centroid_2dg)
         assert_allclose(xycen1, ([25], [25]), atol=1.0e-3)
         assert_allclose(xycen2, ([25], [25]), atol=1.0e-3)
 
-    def test_xypeaks_none(self):
-        xycen1 = centroid_sources(self.data, xpos=25, ypos=25, error=None,
+    def test_xypeaks_none(self, test_data):
+        data = test_data[0]
+        xycen1 = centroid_sources(data, xpos=25, ypos=25, error=None,
                                   xpeak=None, ypeak=25,
                                   centroid_func=centroid_quadratic)
-        xycen2 = centroid_sources(self.data, xpos=25, ypos=25, error=None,
+        xycen2 = centroid_sources(data, xpos=25, ypos=25, error=None,
                                   xpeak=25, ypeak=None,
                                   centroid_func=centroid_quadratic)
-        xycen3 = centroid_sources(self.data, xpos=25, ypos=25, error=None,
+        xycen3 = centroid_sources(data, xpos=25, ypos=25, error=None,
                                   xpeak=None, ypeak=None,
                                   centroid_func=centroid_quadratic)
         assert_allclose(xycen1, ([25], [25]), atol=1.0e-3)

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -161,3 +161,14 @@ def test_gaussian1d_moments():
         result = _gaussian1d_moments(data, mask=mask)
         assert_allclose(result, desired, rtol=0, atol=1.0e-6)
         assert len(warnlist) == 1
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+def test_gaussian2d_warning():
+    yy, xx = np.mgrid[:51, :51]
+    model = Gaussian2D(x_mean=24.17, y_mean=25.87, x_stddev=1.7, y_stddev=4.7)
+    data = model(xx, yy)
+
+    match = 'The fit may not have converged'
+    with pytest.warns(AstropyUserWarning, match=match):
+        centroid_2dg(data + 100000)

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -3,7 +3,6 @@
 Tests for the core module.
 """
 
-import itertools
 from contextlib import nullcontext
 
 import numpy as np
@@ -16,47 +15,50 @@ from photutils.centroids.gaussian import (_gaussian1d_moments, centroid_1dg,
                                           centroid_2dg)
 from photutils.utils._optional_deps import HAS_SCIPY
 
-XCEN = 25.7
-YCEN = 26.2
-XSTDS = [3.2, 4.0]
-YSTDS = [5.7, 4.1]
-THETAS = np.array([30.0, 45.0]) * np.pi / 180.0
 
-DATA = np.zeros((3, 3))
-DATA[0:2, 1] = 1.0
-DATA[1, 0:2] = 1.0
-DATA[1, 1] = 2.0
+@pytest.fixture(name='test_data')
+def fixture_test_data():
+    xcen = 25.7
+    ycen = 26.2
+    data = np.zeros((3, 3))
+    data[0:2, 1] = 1.0
+    data[1, 0:2] = 1.0
+    data[1, 1] = 2.0
+    return data, xcen, ycen
 
 
 # NOTE: the fitting routines in astropy use scipy.optimize
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
-@pytest.mark.parametrize(('x_std', 'y_std', 'theta'),
-                         list(itertools.product(XSTDS, YSTDS, THETAS)))
-def test_centroids(x_std, y_std, theta):
-    model = Gaussian2D(2.4, XCEN, YCEN, x_stddev=x_std, y_stddev=y_std,
+@pytest.mark.parametrize('x_std', [3.2, 4.0])
+@pytest.mark.parametrize('y_std', [5.7, 4.1])
+@pytest.mark.parametrize('theta', np.deg2rad([30.0, 45.0]))
+def test_centroids(test_data, x_std, y_std, theta):
+    data, xcen, ycen = test_data
+
+    model = Gaussian2D(2.4, xcen, ycen, x_stddev=x_std, y_stddev=y_std,
                        theta=theta)
     y, x = np.mgrid[0:50, 0:47]
     data = model(x, y)
     xc, yc = centroid_1dg(data)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.0e-3)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
     xc, yc = centroid_2dg(data)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.0e-3)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
 
     # test with errors
     error = np.sqrt(data)
     xc, yc = centroid_1dg(data, error=error)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.0e-3)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
     xc, yc = centroid_2dg(data, error=error)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.0e-3)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
 
     # test with mask
     mask = np.zeros(data.shape, dtype=bool)
     data[10, 10] = 1.0e5
     mask[10, 10] = True
     xc, yc = centroid_1dg(data, mask=mask)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.0e-3)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
     xc, yc = centroid_2dg(data, mask=mask)
-    assert_allclose((xc, yc), (XCEN, YCEN), rtol=0, atol=1.0e-3)
+    assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -132,7 +132,7 @@ def test_invalid_error_shape():
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_centroid_2dg_dof():
     data = np.ones((2, 2))
-    match = 'Input data must have a least 7 unmasked values to fit'
+    match = 'Input data must have a least 6 unmasked values to fit'
     with pytest.raises(ValueError, match=match):
         centroid_2dg(data)
 


### PR DESCRIPTION
With this PR ``Quantity`` arrays can now be input to ``centroid_1dg`` and ``centroid_2dg``.

 For consistency with other fitting functions (including PSF fitting), the ``centroid_1dg`` and ``centroid_2dg`` functions now fit only a 1D or 2D Gaussian model, respectively, excluding any constant component. The input data are required to be background-subtracted (as previously stated in the docs).