### PR TITLE
Deprecate PRFAdapter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,10 @@ API Changes
   - The ``PSFPhotometry`` ``fit_results`` attribute has been renamed to
     ``fit_info``. ``fit_results`` is now deprecated. [#1858]
 
+  - The ``PRFAdapter`` class has been deprecated. Instead, use a
+    ``FittableImageModel`` derived from the ``discretize_model`` function
+    in ``astropy.convolution``. [#1865]
+
 
 1.13.0 (2024-06-28)
 -------------------

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -247,6 +247,13 @@ models are evaluated by sampling the analytic function at the input (x,
 y) coordinates. The PRF models are evaluated by integrating the analytic
 function over the pixel areas.
 
+If one needs a custom PRF model based on an analytical PSF model, an
+efficient option is to first discretize the model on a grid using
+:func:`~astropy.convolution.discretize_model` with the ``'oversample'``
+or ``'integrate'`` ``mode``. The resulting 2D image can then be used as
+the input to ``FittableImageModel`` (see :ref:`psf-image_models` below)
+to create an ePSF model.
+
 Note that the non-circular Gaussian and Moffat models above have
 additional parameters beyond the standard PSF model parameters of
 position and flux (``x_0``, ``y_0``, and ``flux``). By default, these
@@ -255,27 +262,14 @@ process). The user can choose to also vary these parameters by setting
 the ``fixed`` attribute on the model parameter to `False`.
 
 Photutils also provides a convenience function called
-:func:`~photutils.psf.make_psf_model` that creates a PSF model from an
-Astropy fittable 2D model. However, if possible, it is recommended to
-use the PSF models provided by `photutils.psf` as they are optimized for
-PSF photometry. One can also create a custom PSF model using the Astropy
-modeling framework that will provide better performance than using
-:func:`~photutils.psf.make_psf_model`.
+:func:`~photutils.psf.make_psf_model` that creates a PSF model from
+an Astropy fittable 2D model. However, it is recommended that one use
+the PSF models provided by `photutils.psf` (if possible) as they are
+optimized for PSF photometry. If a custom PSF model is needed, one can
+be created using the Astropy modeling framework that will provide better
+performance than using :func:`~photutils.psf.make_psf_model`.
 
-Similarly, Photutils provides a convenience PSF model class called
-`~photutils.psf.PRFAdapter` that adapts a supplied PSF model to act as
-a PRF, i.e., it integrates the PSF model over the pixel areas. This
-class is extremely slow due to its use of numerical integrations for
-each pixel and is only suited for experimentation over small regions. It
-should be used only when absolutely necessary. It is also experimental
-and may be deprecated and removed in the future. If a model class of
-this type is needed, it is strongly recommended that you create a custom
-PRF model instead. If one needs a PRF model from an analytical PSF
-model, a more efficient option is to discretize the model on a grid
-using `astropy.convolution.discretize_model` using the ``'oversample'``
-or ``'integrate'`` ``mode``. The resulting 2D image can then be used as
-the input to ``FittableImageModel`` to create an ePSF model.
-
+.. _psf-image_models:
 
 Image-based PSF Models
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/photutils/psf/model_helpers.py
+++ b/photutils/psf/model_helpers.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.modeling import CompoundModel, Fittable2DModel, Parameter
 from astropy.modeling.models import Const2D, Identity, Shift
 from astropy.nddata import NDData
+from astropy.utils.decorators import deprecated
 
 __all__ = ['make_psf_model', 'grid_from_epsfs', 'PRFAdapter']
 
@@ -460,6 +461,8 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):
     return GriddedPSFModel(data, fill_value=fill_value)
 
 
+@deprecated('1.14.0', alternative='a FittableImageModel derived from the '
+            'discretize_model function in astropy.convolution')
 class PRFAdapter(Fittable2DModel):
     """
     A model that adapts a supplied PSF model to act as a PRF.
@@ -512,18 +515,17 @@ class PRFAdapter(Fittable2DModel):
     -----
     This current implementation of this class (using numerical
     integration for each pixel) is extremely slow, and only suited for
-    experimentation over relatively few small regions. It should be used
-    only when absolutely necessary. It is also experimental and may be
-    deprecated and removed in the future. If a model class of this type
+    experimentation over relatively few small regions. It should be
+    used only when absolutely necessary. If a model class of this type
     is needed, it is strongly recommended that you create a custom PRF
     model instead.
 
-    If one needs a PRF model from an analytical PSF model, a more
-    efficient option is to discretize the model on a grid using
-    `astropy.convolution.discretize_model` using the ``'oversample'`` or
-    ``'integrate'`` ``mode``. The resulting 2D image can then be used as
-    the input to ``FittableImageModel`` to create an ePSF model. This
-    will be *much* faster than using this class.
+    If one needs a PRF model from an analytical PSF model, a
+    more efficient option is to discretize the model on a grid
+    using :func:`~astropy.convolution.discretize_model` using the
+    ``'oversample'`` or ``'integrate'`` ``mode``. The resulting 2D image
+    can then be used as the input to ``FittableImageModel`` to create an
+    ePSF model. This will be *much* faster than using this class.
     """
 
     flux = Parameter(default=1)

--- a/photutils/psf/tests/test_model_helpers.py
+++ b/photutils/psf/tests/test_model_helpers.py
@@ -9,6 +9,7 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.modeling.models import Const2D, Gaussian2D, Moffat2D
 from astropy.nddata import NDData
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils import datasets
@@ -306,7 +307,8 @@ class TestPRFAdapter:
          'renormalize_psf': False}])
     def test_create_eval_prfadapter(self, adapterkwargs):
         mof = Moffat2D(gamma=1, alpha=4.8)
-        prf = PRFAdapter(mof, **adapterkwargs)
+        with pytest.warns(AstropyDeprecationWarning):
+            prf = PRFAdapter(mof, **adapterkwargs)
 
         # test that these work without errors
         prf.x_0 = 0.5
@@ -327,7 +329,8 @@ class TestPRFAdapter:
         mof = Moffat2D(gamma=1.5, alpha=4.8)
         if not adapterkwargs['renormalize_psf']:
             mof = self.normalize_moffat(mof)
-        prf1 = PRFAdapter(mof, **adapterkwargs)
+        with pytest.warns(AstropyDeprecationWarning):
+            prf1 = PRFAdapter(mof, **adapterkwargs)
 
         # first check that the PRF over a central grid ends up summing to the
         # integrand over the whole PSF
@@ -350,12 +353,14 @@ class TestPRFAdapter:
         from scipy.integrate import dblquad
 
         mof1 = self.normalize_moffat(Moffat2D(gamma=1, alpha=4.8))
-        prf1 = PRFAdapter(mof1, **adapterkwargs)
+        with pytest.warns(AstropyDeprecationWarning):
+            prf1 = PRFAdapter(mof1, **adapterkwargs)
 
         # now try integrating over differently-sampled PRFs
         # and check that they match
         mof2 = self.normalize_moffat(Moffat2D(gamma=2, alpha=4.8))
-        prf2 = PRFAdapter(mof2, **adapterkwargs)
+        with pytest.warns(AstropyDeprecationWarning):
+            prf2 = PRFAdapter(mof2, **adapterkwargs)
 
         xg1, yg1 = np.meshgrid(*([(-0.5, 0.5)] * 2))
         xg2, yg2 = np.meshgrid(*([(-1.5, -0.5, 0.5, 1.5)] * 2))


### PR DESCRIPTION
This PR deprecates the `PRFAdapter` class.  This class requires numerical integration of each pixel for every evaluation of the model. This makes it **extremely** slow (too slow to be practical), and only suited for experimentation over relatively few small regions. If a model class of this type is needed, it is strongly recommended that you create a custom PRF model instead.

If one needs a PRF model from an analytical PSF model, a more efficient option is to discretize the model on a grid using `astropy.convolution.discretize_model` using the ``'oversample'`` or ``'integrate'`` ``mode``. The resulting 2D image can then be used as the input to ``FittableImageModel`` to create an ePSF model.  In a test case, the differences between the `PRFAdapater` were on the order of 1e-5.