### PR TITLE
Update bottleneck stat functions

### DIFF
--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -19,7 +19,7 @@ from photutils.background.interpolators import BkgZoomInterpolator
 from photutils.utils import ShepardIDWInterpolator
 from photutils.utils._parameters import as_pair
 from photutils.utils._repr import make_repr
-from photutils.utils._stats import nanmedian
+from photutils.utils._stats import _nanmedian
 
 __all__ = ['Background2D']
 
@@ -543,7 +543,7 @@ class Background2D:
         if self.filter_threshold is None:
             # filter the entire array
             from scipy.ndimage import generic_filter
-            filtdata = generic_filter(data, nanmedian, size=self.filter_size,
+            filtdata = generic_filter(data, _nanmedian, size=self.filter_size,
                                       mode='constant', cval=np.nan)
         else:
             # selectively filter the array

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy.stats import SigmaClip, biweight_location, biweight_scale, mad_std
 
 from photutils.utils._repr import make_repr
-from photutils.utils._stats import nanmean, nanmedian, nanstd
+from photutils.utils._stats import _nanmean, _nanmedian, _nanstd
 
 SIGMA_CLIP = SigmaClip(sigma=3.0, maxiters=10)
 
@@ -177,7 +177,7 @@ class MeanBackground(BackgroundBase):
         # ignore RuntimeWarning where axis is all NaN
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            result = nanmean(data, axis=axis)
+            result = _nanmean(data, axis=axis)
 
         if masked and isinstance(result, np.ndarray):
             result = np.ma.masked_where(np.isnan(result), result)
@@ -231,7 +231,7 @@ class MedianBackground(BackgroundBase):
         # ignore RuntimeWarning where axis is all NaN
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            result = nanmedian(data, axis=axis)
+            result = _nanmedian(data, axis=axis)
 
         if masked and isinstance(result, np.ndarray):
             result = np.ma.masked_where(np.isnan(result), result)
@@ -302,8 +302,8 @@ class ModeEstimatorBackground(BackgroundBase):
         # ignore RuntimeWarning where axis is all NaN
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            result = ((self.median_factor * nanmedian(data, axis=axis))
-                      - (self.mean_factor * nanmean(data, axis=axis)))
+            result = ((self.median_factor * _nanmedian(data, axis=axis))
+                      - (self.mean_factor * _nanmean(data, axis=axis)))
 
         if masked and isinstance(result, np.ndarray):
             result = np.ma.masked_where(np.isnan(result), result)
@@ -409,9 +409,9 @@ class SExtractorBackground(BackgroundBase):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
 
-            _median = np.atleast_1d(nanmedian(data, axis=axis))
-            _mean = np.atleast_1d(nanmean(data, axis=axis))
-            _std = np.atleast_1d(nanstd(data, axis=axis))
+            _median = np.atleast_1d(_nanmedian(data, axis=axis))
+            _mean = np.atleast_1d(_nanmean(data, axis=axis))
+            _std = np.atleast_1d(_nanstd(data, axis=axis))
             bkg = np.atleast_1d((2.5 * _median) - (1.5 * _mean))
 
             bkg = np.where(_std == 0, _mean, bkg)
@@ -547,7 +547,7 @@ class StdBackgroundRMS(BackgroundRMSBase):
         # ignore RuntimeWarning where axis is all NaN
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            result = nanstd(data, axis=axis)
+            result = _nanstd(data, axis=axis)
 
         if masked and isinstance(result, np.ndarray):
             result = np.ma.masked_where(np.isnan(result), result)

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -11,7 +11,7 @@ from astropy.stats import SigmaClip
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.utils import _make_binary_structure
 from photutils.utils._quantity_helpers import process_quantities
-from photutils.utils._stats import nanmean, nanstd
+from photutils.utils._stats import _nanmean, _nanstd
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['detect_threshold', 'detect_sources']
@@ -100,14 +100,14 @@ def detect_threshold(data, nsigma, *, background=None, error=None, mask=None,
                                   copy=True)
 
     if background is None:
-        background = nanmean(clipped_data)
+        background = _nanmean(clipped_data)
 
     if not np.isscalar(background) and background.shape != data.shape:
         raise ValueError('If input background is 2D, then it must have the '
                          'same shape as the input data.')
 
     if error is None:
-        error = nanstd(clipped_data)
+        error = _nanstd(clipped_data)
     if not np.isscalar(error) and error.shape != data.shape:
         raise ValueError('If input error is 2D, then it must have the same '
                          'shape as the input data.')

--- a/photutils/utils/_stats.py
+++ b/photutils/utils/_stats.py
@@ -99,19 +99,19 @@ if HAS_BOTTLENECK:
 
         return result
 
-    nansum = partial(_apply_bottleneck, bn.nansum)
-    nanmean = partial(_apply_bottleneck, bn.nanmean)
-    nanmedian = partial(_apply_bottleneck, bn.nanmedian)
-    nanstd = partial(_apply_bottleneck, bn.nanstd)
-    nanvar = partial(_apply_bottleneck, bn.nanvar)
-    nanmin = partial(_apply_bottleneck, bn.nanmin)
-    nanmax = partial(_apply_bottleneck, bn.nanmax)
+    _nansum = partial(_apply_bottleneck, bn.nansum)
+    _nanmean = partial(_apply_bottleneck, bn.nanmean)
+    _nanmedian = partial(_apply_bottleneck, bn.nanmedian)
+    _nanstd = partial(_apply_bottleneck, bn.nanstd)
+    _nanvar = partial(_apply_bottleneck, bn.nanvar)
+    _nanmin = partial(_apply_bottleneck, bn.nanmin)
+    _nanmax = partial(_apply_bottleneck, bn.nanmax)
 
 else:
-    nansum = np.nansum
-    nanmean = np.nanmean
-    nanmedian = np.nanmedian
-    nanstd = np.nanstd
-    nanvar = np.nanvar
-    nanmin = np.nanmin
-    nanmax = np.nanmax
+    _nansum = np.nansum
+    _nanmean = np.nanmean
+    _nanmedian = np.nanmedian
+    _nanstd = np.nanstd
+    _nanvar = np.nanvar
+    _nanmin = np.nanmin
+    _nanmax = np.nanmax

--- a/photutils/utils/_stats.py
+++ b/photutils/utils/_stats.py
@@ -14,13 +14,15 @@ from photutils.utils._optional_deps import HAS_BOTTLENECK
 if HAS_BOTTLENECK:
     import bottleneck as bn
 
-    def move_tuple_axes_first(array, axis):
+    def _move_tuple_axes_last(array, axis):
         """
-        Move the axes in a tuple to the beginning of the array.
+        Move the specified axes of a NumPy array to the last positions
+        and combine them.
 
-        Bottleneck can only take integer axis, not tuple, so this function
-        takes all the axes to be operated on and combines them into the
-        first dimension of the array so that we can then use axis=0.
+        Bottleneck can only take integer axis, not tuple, so this
+        function takes all the axes to be operated on and combines them
+        into the last dimension of the array so that we can then use
+        axis=-1.
 
         Parameters
         ----------
@@ -28,32 +30,23 @@ if HAS_BOTTLENECK:
             The input array.
 
         axis : tuple of int
-            The axes on which to operate.
+            The axes on which to move and combine.
 
         Returns
         -------
         array_new : `~numpy.ndarray`
-            Array with the axes being operated on moved into the first
+            Array with the axes being operated on moved into the last
             dimension.
         """
-        # Figure out how many axes we are operating over
-        naxis = len(axis)
+        other_axes = tuple(i for i in range(array.ndim) if i not in axis)
 
-        # Add remaining axes to the axis tuple
-        axis += tuple(i for i in range(array.ndim) if i not in axis)
+        # Move the specified axes to the last positions
+        array_new = np.transpose(array, other_axes + axis)
 
-        # The new position of each axis is just in order
-        destination = tuple(range(array.ndim))
+        # Reshape the array by combining the moved axes
+        return array_new.reshape(array_new.shape[:len(other_axes)] + (-1,))
 
-        # Reorder the array so that the axes being operated on are at the
-        # beginning
-        array_new = np.moveaxis(array, axis, destination)
-
-        # Collapse the dimensions being operated on into a single dimension
-        # so that we can then use axis=0 with the bottleneck functions
-        return array_new.reshape((-1,) + array_new.shape[naxis:])
-
-    def apply_bottleneck(function, array, axis=None, **kwargs):
+    def _apply_bottleneck(function, array, axis=None, **kwargs):
         """
         Wrap a bottleneck function to handle tuple axis.
 
@@ -82,12 +75,23 @@ if HAS_BOTTLENECK:
             ``array``, ``axis``, and ``kwargs``.
         """
         if isinstance(axis, tuple):
-            array = move_tuple_axes_first(array, axis=axis)
-            axis = 0
+            array = _move_tuple_axes_last(array, axis=axis)
+            axis = -1
 
-        result = function(array, axis=axis, **kwargs)
+        # The only keyword argument that bottleneck functions that
+        # reduce the input array along the specified axis accept besides
+        # "axis" is "ddof". We filter out any other keyword arguments
+        # that the np.nan* functions accept (e.g., dtype, out, keepdims,
+        # overwrite_input)
+        kwargs_filtered = {key: value for key, value in kwargs.items()
+                           if key == 'ddof'}
+
+        result = function(array, axis=axis, **kwargs_filtered)
         if isinstance(array, Quantity):
-            return array.__array_wrap__(result)
+            if function == bn.nanvar:
+                result <<= array.unit ** 2
+            else:
+                result = array.__array_wrap__(result)
 
         if isinstance(result, float):
             # For compatibility with numpy, always return a numpy scalar
@@ -95,11 +99,19 @@ if HAS_BOTTLENECK:
 
         return result
 
-    nanmean = partial(apply_bottleneck, bn.nanmean)
-    nanmedian = partial(apply_bottleneck, bn.nanmedian)
-    nanstd = partial(apply_bottleneck, bn.nanstd)
+    nansum = partial(_apply_bottleneck, bn.nansum)
+    nanmean = partial(_apply_bottleneck, bn.nanmean)
+    nanmedian = partial(_apply_bottleneck, bn.nanmedian)
+    nanstd = partial(_apply_bottleneck, bn.nanstd)
+    nanvar = partial(_apply_bottleneck, bn.nanvar)
+    nanmin = partial(_apply_bottleneck, bn.nanmin)
+    nanmax = partial(_apply_bottleneck, bn.nanmax)
 
 else:
+    nansum = np.nansum
     nanmean = np.nanmean
     nanmedian = np.nanmedian
     nanstd = np.nanstd
+    nanvar = np.nanvar
+    nanmin = np.nanmin
+    nanmax = np.nanmax

--- a/photutils/utils/tests/test_stats.py
+++ b/photutils/utils/tests/test_stats.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the _stats module.
+"""
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_equal
+
+from photutils.utils._optional_deps import HAS_BOTTLENECK
+from photutils.utils._stats import (nanmax, nanmean, nanmedian, nanmin, nanstd,
+                                    nansum, nanvar)
+
+funcs = [(nansum, np.nansum), (nanmean, np.nanmean), (nanmedian, np.nanmedian),
+         (nanstd, np.nanstd), (nanvar, np.nanvar), (nanmin, np.nanmin),
+         (nanmax, np.nanmax)]
+
+
+@pytest.mark.skipif(not HAS_BOTTLENECK, reason='bottleneck is required')
+@pytest.mark.parametrize('func', funcs)
+@pytest.mark.parametrize('axis', [None, 0, 1, (0, 1), (1, 2), (2, 1),
+                                  (0, 1, 2), (3, 1), (0, 3), (2, 0)])
+@pytest.mark.parametrize('use_units', [False, True])
+def test_nanmean(func, axis, use_units):
+    arr = np.ones((5, 3, 8, 9))
+    if use_units:
+        arr <<= u.m
+
+    result1 = func[0](arr, axis=axis)
+    result2 = func[1](arr, axis=axis)
+    assert_equal(result1, result2)

--- a/photutils/utils/tests/test_stats.py
+++ b/photutils/utils/tests/test_stats.py
@@ -9,12 +9,12 @@ import pytest
 from numpy.testing import assert_equal
 
 from photutils.utils._optional_deps import HAS_BOTTLENECK
-from photutils.utils._stats import (nanmax, nanmean, nanmedian, nanmin, nanstd,
-                                    nansum, nanvar)
+from photutils.utils._stats import (_nanmax, _nanmean, _nanmedian, _nanmin,
+                                    _nanstd, _nansum, _nanvar)
 
-funcs = [(nansum, np.nansum), (nanmean, np.nanmean), (nanmedian, np.nanmedian),
-         (nanstd, np.nanstd), (nanvar, np.nanvar), (nanmin, np.nanmin),
-         (nanmax, np.nanmax)]
+funcs = [(_nansum, np.nansum), (_nanmean, np.nanmean),
+         (_nanmedian, np.nanmedian), (_nanstd, np.nanstd),
+         (_nanvar, np.nanvar), (_nanmin, np.nanmin), (_nanmax, np.nanmax)]
 
 
 @pytest.mark.skipif(not HAS_BOTTLENECK, reason='bottleneck is required')


### PR DESCRIPTION
The PR changes the bottleneck stat functions when a tuple axis is used by moving the axis keywords to the last axis and then combining them so they can be operated on using axis=-1. The current implementation moves the axes to the first axis and then uses axis=0, but that operation is slower because the memory is non-contiguous (for the default C-like order).

Note the tuple axis reordering is necessary because bottleneck only allows integer axis values.

This PR also adds `_nansum, `_nanvar`, `_nanmin`, `_nanmax`.

