### PR TITLE
Refactor Background2D to reduce memory usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,16 @@ New Features
     convert supported ``regions.Region`` objects to ``Aperture`` objects.
     [#1813, #1852]
 
+- ``photutils.background``
+
+  - The ``Background2D`` class has been refactored to significantly
+    reduce its memory usage. In some cases, it is also significantly
+    faster. [#1870]
+
+  - A new ``npixels_mesh`` property was added to ``Background2D``
+    that gives a 2D array of the number of pixels used to compute the
+    statistics in the low-resolution grid. [#1870]
+
 - ``photutils.centroids``
 
   - ``Quantity`` arrays can now be input to ``centroid_1dg`` and
@@ -78,6 +88,31 @@ API Changes
 - The ``sklearn`` version information has been removed from the meta
   attribute in output tables. ``sklearn`` was removed as an optional
   dependency in 1.13.0. [#1807]
+
+- ``photutils.background``
+
+  - The ``Background2D`` ``background_mesh`` and ``background_rms_mesh``
+    properties will have units if the input data has units. [#1870]
+
+  - The ``Background2D`` ``edge_method`` keyword is now deprecated.
+    When ``edge_method`` is eventually removed, the ``'pad'`` option
+    will always be used. [#1870]
+
+  - The ``Background2D`` ``background_mesh_masked``,
+    ``background_rms_mesh_masked``, and ``mesh_nmasked`` properties are
+    now deprecated. [#1870]
+
+  - To reduce memory usage, ``Background2D`` no longer keeps a cached
+    copy of the returned ``background`` and ``background_rms`` properties.
+    [#1870]
+
+  - The ``Background2D`` ``data``, ``mask``, ``total_mask``, ``nboxes``,
+    ``box_npixels``, and ``nboxes_tot`` attributes have been removed.
+    [#1870]
+
+  - The ``BkgZoomInterpolator`` ``grid_mode`` keyword is now deprecated.
+    When ``grid_mode`` is eventually removed, the `True` option will
+    always be used. [#1870]
 
 - ``photutils.centroids``
 

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -381,7 +381,7 @@ this example requires `scipy`_):
     from astropy.visualization import SqrtStretch
     from astropy.visualization.mpl_normalize import ImageNormalize
     from photutils.datasets import make_100gaussians_image
-    from scipy.ndimage.interpolation import rotate
+    from scipy.ndimage import rotate
 
     data = make_100gaussians_image()
     ny, nx = data.shape
@@ -427,7 +427,7 @@ image (values assigned to ``fill_value``):
     from astropy.visualization.mpl_normalize import ImageNormalize
     from photutils.background import Background2D
     from photutils.datasets import make_100gaussians_image
-    from scipy.ndimage.interpolation import rotate
+    from scipy.ndimage import rotate
 
     data = make_100gaussians_image()
     ny, nx = data.shape
@@ -461,7 +461,7 @@ Finally, let's subtract the background from the image and plot it:
     from astropy.visualization.mpl_normalize import ImageNormalize
     from photutils.background import Background2D
     from photutils.datasets import make_100gaussians_image
-    from scipy.ndimage.interpolation import rotate
+    from scipy.ndimage import rotate
 
     data = make_100gaussians_image()
     ny, nx = data.shape
@@ -508,7 +508,7 @@ Meshes without a center marker were excluded.
     from astropy.visualization.mpl_normalize import ImageNormalize
     from photutils.background import Background2D
     from photutils.datasets import make_100gaussians_image
-    from scipy.ndimage.interpolation import rotate
+    from scipy.ndimage import rotate
 
     data = make_100gaussians_image()
     ny, nx = data.shape

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -19,7 +19,7 @@ from photutils.background.interpolators import BkgZoomInterpolator
 from photutils.utils import ShepardIDWInterpolator
 from photutils.utils._parameters import as_pair
 from photutils.utils._repr import make_repr
-from photutils.utils._stats import _nanmedian
+from photutils.utils._stats import nanmedian
 
 __all__ = ['Background2D']
 
@@ -543,7 +543,7 @@ class Background2D:
         if self.filter_threshold is None:
             # filter the entire array
             from scipy.ndimage import generic_filter
-            filtdata = generic_filter(data, _nanmedian, size=self.filter_size,
+            filtdata = generic_filter(data, nanmedian, size=self.filter_size,
                                       mode='constant', cval=np.nan)
         else:
             # selectively filter the array

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -248,7 +248,7 @@ class Background2D:
         self._min_bkg_stats = np.nanmin(self._bkg_stats)
 
         # update the interpolator keyword arguments
-        self._interp_kwargs['mesh_yxcen'] = self._mesh_yxcen
+        self._interp_kwargs['mesh_yxcen'] = self._calculate_mesh_yxcen()
 
     def __repr__(self):
         ellipsis = ('coverage_mask',)
@@ -656,12 +656,11 @@ class Background2D:
 
         return filtdata
 
-    @lazyproperty
-    def _mesh_yxcen(self):
+    def _calculate_mesh_yxcen(self):
         """
-        The y and x positions of the centers of the low-resolution
-        background and background RMS meshes with respect to the input
-        data array.
+        Calculate the y and x positions of the centers of the low-
+        resolution background and background RMS meshes with respect to
+        the input data array.
 
         This is used by the interpolator to expand the low-resolution
         mesh to the full-size image. It is also used to plot the mesh
@@ -821,7 +820,7 @@ class Background2D:
         if ax is None:
             ax = plt.gca()
 
-        mesh_xycen = np.flipud(self._mesh_yxcen)
+        mesh_xycen = np.flipud(self._interp_kwargs['mesh_yxcen'])
         ax.scatter(*mesh_xycen, s=markersize, marker=marker, color=color,
                    alpha=alpha)
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -121,10 +121,11 @@ class Background2D:
           of boxes is only slightly larger than the ``data`` size to
           minimize the amount of padding.
         * ``'crop'``: crop the image along the top and/or right edges.
-          This method should be used sparingly. Best results will occur
-          when ``box_size`` is chosen such that an integer number of
-          boxes is only slightly smaller than the ``data`` size to
-          minimize the amount of cropping.
+          This method should be used sparingly, and it may be deprecated
+          in the future. Best results will occur when ``box_size`` is
+          chosen such that an integer number of boxes is only slightly
+          smaller than the ``data`` size to minimize the amount of
+          cropping.
 
     sigma_clip : `astropy.stats.SigmaClip` instance, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -240,6 +240,7 @@ class Background2D:
         # perform the initial calculations to avoid storing large data
         # arrays and keep the memory usage minimal
         self._prepare_data()
+
         (self._bkg_stats,
          self._bkgrms_stats,
          self._ngood) = self._calculate_stats()
@@ -525,7 +526,7 @@ class Background2D:
         # we no longer need the copy of the input array
         del self._data
 
-        # TEMP: remove when background_mesh_masked,
+        # TEMP: can probably remove this when background_mesh_masked,
         # background_rms_mesh_masked, and mesh_nmasked are removed
         self._nan_idx = np.where(np.isnan(bkg))
 
@@ -679,7 +680,8 @@ class Background2D:
         background map check image in SourceExtractor.
         """
         data = self._interpolate_grid(self._bkg_stats)
-        if self.filter_threshold is None:
+        if ('background_rms_mesh' in self.__dict__
+                or self.filter_threshold is None):
             self._bkg_stats = None  # delete to save memory
         return self._apply_units(self._filter_grid(data))
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -795,6 +795,10 @@ class Background2D:
     def background(self):
         """
         A 2D `~numpy.ndarray` containing the background image.
+
+        Note that the returned value is re-calculated each time this
+        property is accessed. If you need to access the background image
+        multiple times, you should store the result in a variable.
         """
         return self._calculate_image(self.background_mesh)
 
@@ -802,6 +806,10 @@ class Background2D:
     def background_rms(self):
         """
         A 2D `~numpy.ndarray` containing the background RMS image.
+
+        Note that the returned value is re-calculated each time this
+        property is accessed. If you need to access the background rms
+        image multiple times, you should store the result in a variable.
         """
         return self._calculate_image(self.background_rms_mesh)
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -740,7 +740,7 @@ class Background2D:
         return data
 
     @property
-    @deprecated('1.14.0')
+    @deprecated('1.14.0', alternative='npixels_mesh')
     def mesh_nmasked(self):
         """
         A 2D array of the number of masked pixels in each mesh.
@@ -750,6 +750,14 @@ class Background2D:
         data = (np.prod(self.box_size) - self._ngood).astype(float)
         data[self._nan_idx] = np.nan
         return data
+
+    @property
+    def npixels_mesh(self):
+        """
+        A 2D array of the number pixels used to compute the statistics
+        in each mesh.
+        """
+        return self._ngood
 
     @lazyproperty
     def background_median(self):

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -11,6 +11,7 @@ import numpy as np
 from astropy.nddata import NDData, reshape_as_blocks
 from astropy.stats import SigmaClip
 from astropy.utils import lazyproperty
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import RectangularAperture
@@ -706,6 +707,7 @@ class Background2D:
         return self._apply_units(self._filter_grid(data))
 
     @property
+    @deprecated('1.14.0')
     def background_mesh_masked(self):
         """
         The low-resolution background image prior to any interpolation
@@ -718,6 +720,7 @@ class Background2D:
         return data
 
     @property
+    @deprecated('1.14.0')
     def background_rms_mesh_masked(self):
         """
         The low-resolution background RMS image prior to any
@@ -730,6 +733,7 @@ class Background2D:
         return data
 
     @property
+    @deprecated('1.14.0')
     def mesh_nmasked(self):
         """
         A 2D array of the number of masked pixels in each mesh.

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy.nddata import NDData, reshape_as_blocks
 from astropy.stats import SigmaClip
 from astropy.utils import lazyproperty
-from astropy.utils.decorators import deprecated
+from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import RectangularAperture
@@ -110,6 +110,12 @@ class Background2D:
         (default).
 
     edge_method : {'pad', 'crop'}, optional
+        This keyword will be removed in a future version and the default
+        version of ``'pad'`` will always be used. The ``'crop'`` option
+        has been strongly discouraged for some time now. Its usage
+        creates a undesirable scaling of the low-resolution maps that
+        leads to incorrect results.
+
         The method used to determine how to handle the case where the
         image size is not an integer multiple of the ``box_size``
         in either dimension. Both options will resize the image for
@@ -181,6 +187,7 @@ class Background2D:
     .. _bottleneck:  https://github.com/pydata/bottleneck
     """
 
+    @deprecated_renamed_argument('edge_method', None, '1.14.0')
     def __init__(self, data, box_size, *, mask=None, coverage_mask=None,
                  fill_value=0.0, exclude_percentile=10.0, filter_size=(3, 3),
                  filter_threshold=None, edge_method='pad',

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy.stats import SigmaClip, biweight_location, biweight_scale, mad_std
 
 from photutils.utils._repr import make_repr
-from photutils.utils._stats import _nanmean, _nanmedian, _nanstd
+from photutils.utils._stats import nanmean, nanmedian, nanstd
 
 SIGMA_CLIP = SigmaClip(sigma=3.0, maxiters=10)
 
@@ -177,7 +177,7 @@ class MeanBackground(BackgroundBase):
         # ignore RuntimeWarning where axis is all NaN
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            result = _nanmean(data, axis=axis)
+            result = nanmean(data, axis=axis)
 
         if masked and isinstance(result, np.ndarray):
             result = np.ma.masked_where(np.isnan(result), result)
@@ -231,7 +231,7 @@ class MedianBackground(BackgroundBase):
         # ignore RuntimeWarning where axis is all NaN
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            result = _nanmedian(data, axis=axis)
+            result = nanmedian(data, axis=axis)
 
         if masked and isinstance(result, np.ndarray):
             result = np.ma.masked_where(np.isnan(result), result)
@@ -302,8 +302,8 @@ class ModeEstimatorBackground(BackgroundBase):
         # ignore RuntimeWarning where axis is all NaN
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            result = ((self.median_factor * _nanmedian(data, axis=axis))
-                      - (self.mean_factor * _nanmean(data, axis=axis)))
+            result = ((self.median_factor * nanmedian(data, axis=axis))
+                      - (self.mean_factor * nanmean(data, axis=axis)))
 
         if masked and isinstance(result, np.ndarray):
             result = np.ma.masked_where(np.isnan(result), result)
@@ -409,9 +409,9 @@ class SExtractorBackground(BackgroundBase):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
 
-            _median = np.atleast_1d(_nanmedian(data, axis=axis))
-            _mean = np.atleast_1d(_nanmean(data, axis=axis))
-            _std = np.atleast_1d(_nanstd(data, axis=axis))
+            _median = np.atleast_1d(nanmedian(data, axis=axis))
+            _mean = np.atleast_1d(nanmean(data, axis=axis))
+            _std = np.atleast_1d(nanstd(data, axis=axis))
             bkg = np.atleast_1d((2.5 * _median) - (1.5 * _mean))
 
             bkg = np.where(_std == 0, _mean, bkg)
@@ -547,7 +547,7 @@ class StdBackgroundRMS(BackgroundRMSBase):
         # ignore RuntimeWarning where axis is all NaN
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            result = _nanstd(data, axis=axis)
+            result = nanstd(data, axis=axis)
 
         if masked and isinstance(result, np.ndarray):
             result = np.ma.masked_where(np.isnan(result), result)

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -8,8 +8,9 @@ import abc
 import warnings
 
 import numpy as np
-from astropy.stats import SigmaClip, biweight_location, biweight_scale, mad_std
+from astropy.stats import SigmaClip, mad_std
 
+from photutils.extern.biweight import biweight_location, biweight_scale
 from photutils.utils._repr import make_repr
 from photutils.utils._stats import nanmean, nanmedian, nanstd
 

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -5,6 +5,7 @@ This module defines interpolator classes for Background2D.
 
 import numpy as np
 from astropy.units import Quantity
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from photutils.utils import ShepardIDWInterpolator
 from photutils.utils._repr import make_repr
@@ -38,6 +39,11 @@ class BkgZoomInterpolator:
         The value used for points outside the boundaries of the input if
         ``mode='constant'``. Default is 0.0.
 
+    clip : bool, optional
+        Whether to clip the output to the range of values in the
+        input image. This is enabled by default, since higher order
+        interpolation may produce values outside the given input range.
+
     grid_mode : bool, optional
         If `True` (default), the samples are considered as the centers
         of regularly-spaced grid elements. If `False`, the samples
@@ -47,14 +53,14 @@ class BkgZoomInterpolator:
         `skimage.transform.resize`. The `False` option is provided only
         for backwards-compatibility.
 
-    clip : bool, optional
-        Whether to clip the output to the range of values in the
-        input image. This is enabled by default, since higher order
-        interpolation may produce values outside the given input range.
+        .. deprecated:: 1.14.0
+           When this keyword is removed, the behavior will be
+           ``grid_mode=True``.
     """
 
-    def __init__(self, *, order=3, mode='reflect', cval=0.0, grid_mode=True,
-                 clip=True):
+    @deprecated_renamed_argument('grid_mode', None, '1.14.0')
+    def __init__(self, *, order=3, mode='reflect', cval=0.0, clip=True,
+                 grid_mode=True):
         self.order = order
         self.mode = mode
         self.cval = cval
@@ -62,7 +68,7 @@ class BkgZoomInterpolator:
         self.clip = clip
 
     def __repr__(self):
-        params = ('order', 'mode', 'cval', 'grid_mode', 'clip')
+        params = ('order', 'mode', 'cval', 'clip', 'grid_mode')
         return make_repr(self, params)
 
     def __call__(self, data, **kwargs):

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -4,6 +4,7 @@ This module defines interpolator classes for Background2D.
 """
 
 import numpy as np
+from astropy.units import Quantity
 
 from photutils.utils import ShepardIDWInterpolator
 from photutils.utils._repr import make_repr
@@ -64,47 +65,49 @@ class BkgZoomInterpolator:
         params = ('order', 'mode', 'cval', 'grid_mode', 'clip')
         return make_repr(self, params)
 
-    def __call__(self, mesh, bkg2d_obj):
+    def __call__(self, data, **kwargs):
         """
         Resize the 2D mesh array.
 
         Parameters
         ----------
-        mesh : 2D `~numpy.ndarray`
+        data : 2D `~numpy.ndarray`
             The low-resolution 2D mesh array.
 
-        bkg2d_obj : `Background2D` object
-            The `Background2D` object that prepared the ``mesh`` array.
+        **kwargs : dict
+            Additional keyword arguments passed to the interpolator.
 
         Returns
         -------
         result : 2D `~numpy.ndarray`
             The resized background or background RMS image.
         """
-        mesh = np.asanyarray(mesh)
-        if np.ptp(mesh) == 0:
-            return np.zeros_like(bkg2d_obj.data) + np.min(mesh)
+        data = np.asanyarray(data)
+        if isinstance(data, Quantity):
+            data = data.value
+        if np.ptp(data) == 0:
+            return np.full(kwargs['shape'], np.min(data),
+                           dtype=kwargs['dtype'])
 
         from scipy.ndimage import zoom
 
-        if bkg2d_obj.edge_method == 'pad':
+        if kwargs['edge_method'] == 'pad':
             # The mesh is first resized to the larger padded-data size
             # (i.e., zoom_factor should be an integer) and then cropped
             # back to the final data size.
-            zoom_factor = bkg2d_obj.box_size
-            result = zoom(mesh, zoom_factor, order=self.order, mode=self.mode,
+            zoom_factor = kwargs['box_size']
+            result = zoom(data, zoom_factor, order=self.order, mode=self.mode,
                           cval=self.cval, grid_mode=self.grid_mode)
-            result = result[0:bkg2d_obj.data.shape[0],
-                            0:bkg2d_obj.data.shape[1]]
+            result = result[0:kwargs['shape'][0], 0:kwargs['shape'][1]]
         else:
             # The mesh is resized directly to the final data size.
-            zoom_factor = np.array(bkg2d_obj.data.shape) / mesh.shape
-            result = zoom(mesh, zoom_factor, order=self.order, mode=self.mode,
+            zoom_factor = np.array(kwargs['shape']) / data.shape
+            result = zoom(data, zoom_factor, order=self.order, mode=self.mode,
                           cval=self.cval)
 
         if self.clip:
-            minval = np.min(mesh)
-            maxval = np.max(mesh)
+            minval = np.min(data)
+            maxval = np.max(data)
             np.clip(result, minval, maxval, out=result)  # clip in place
 
         return result
@@ -148,38 +151,38 @@ class BkgIDWInterpolator:
         params = ('leafsize', 'n_neighbors', 'power', 'reg')
         return make_repr(self, params)
 
-    def __call__(self, mesh, bkg2d_obj):
+    def __call__(self, data, **kwargs):
         """
         Resize the 2D mesh array.
 
         Parameters
         ----------
-        mesh : 2D `~numpy.ndarray`
+        data : 2D `~numpy.ndarray`
             The low-resolution 2D mesh array.
 
-        bkg2d_obj : `Background2D` object
-            The `Background2D` object that prepared the ``mesh`` array.
+        **kwargs : dict
+            Additional keyword arguments passed to the interpolator.
 
         Returns
         -------
         result : 2D `~numpy.ndarray`
             The resized background or background RMS image.
         """
-        mesh = np.asanyarray(mesh)
-        if np.ptp(mesh) == 0:
-            return np.zeros_like(bkg2d_obj.data) + np.min(mesh)
+        data = np.asanyarray(data)
+        if isinstance(data, Quantity):
+            data = data.value
+        if np.ptp(data) == 0:
+            return np.full(kwargs['shape'], np.min(data),
+                           dtype=kwargs['dtype'])
 
-        yxpos = np.column_stack(bkg2d_obj._mesh_yxpos)
-        mesh1d = mesh[bkg2d_obj._mesh_idx]
-        interp_func = ShepardIDWInterpolator(yxpos, mesh1d,
+        yxcen = np.column_stack(kwargs['mesh_yxcen'])
+        interp_func = ShepardIDWInterpolator(yxcen, data.ravel(),
                                              leafsize=self.leafsize)
 
         # the position coordinates used when calling the interpolator
-        ny, nx = bkg2d_obj.data.shape
-        yi, xi = np.mgrid[0:ny, 0:nx]
+        yi, xi = np.mgrid[0:kwargs['shape'][0], 0:kwargs['shape'][1]]
         yx_indices = np.column_stack((yi.ravel(), xi.ravel()))
-        data = interp_func(yx_indices,
-                           n_neighbors=self.n_neighbors, power=self.power,
-                           reg=self.reg)
+        data = interp_func(yx_indices, n_neighbors=self.n_neighbors,
+                           power=self.power, reg=self.reg)
 
-        return data.reshape(bkg2d_obj.data.shape)
+        return data.reshape(kwargs['shape'])

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -92,7 +92,7 @@ class TestBackground2D:
         assert_allclose(bkg1.background_mesh, bkg_low_res)
         assert bkg1.background.shape == data.shape
         bkg2 = Background2D(data, (25, 25), filter_size=(1, 1),
-                            edge_method='pad', interpolator=interpolator)
+                            interpolator=interpolator)
         assert_allclose(bkg2.background_mesh, bkg_low_res)
         assert bkg2.background.shape == data.shape
 
@@ -108,10 +108,12 @@ class TestBackground2D:
 
     @pytest.mark.parametrize('filter_size', FILTER_SIZES)
     def test_resizing(self, filter_size):
-        bkg1 = Background2D(DATA, (23, 22), filter_size=filter_size,
-                            bkg_estimator=MeanBackground(), edge_method='crop')
+        with pytest.warns(AstropyDeprecationWarning):
+            bkg1 = Background2D(DATA, (23, 22), filter_size=filter_size,
+                                bkg_estimator=MeanBackground(),
+                                edge_method='crop')
         bkg2 = Background2D(DATA, (23, 22), filter_size=filter_size,
-                            bkg_estimator=MeanBackground(), edge_method='pad')
+                            bkg_estimator=MeanBackground())
         assert_allclose(bkg1.background, bkg2.background, rtol=2e-6)
         assert_allclose(bkg1.background_rms, bkg2.background_rms)
 
@@ -145,8 +147,10 @@ class TestBackground2D:
         assert_allclose(bkg.background_rms, BKG_RMS)
 
         # test edge crop with mask
-        bkg2 = Background2D(data, box_size, filter_size=(1, 1), mask=mask,
-                            bkg_estimator=MeanBackground(), edge_method='crop')
+        with pytest.warns(AstropyDeprecationWarning):
+            bkg2 = Background2D(data, box_size, filter_size=(1, 1), mask=mask,
+                                bkg_estimator=MeanBackground(),
+                                edge_method='crop')
         assert_allclose(bkg2.background, DATA, rtol=2.0e-5)
 
     def test_mask(self):
@@ -372,7 +376,8 @@ class TestBackground2D:
 
     def test_invalid_edge_method(self):
         match = 'edge_method must be "pad" or "crop"'
-        with pytest.raises(ValueError, match=match):
+        with (pytest.warns(AstropyDeprecationWarning),
+              pytest.raises(ValueError, match=match)):
             Background2D(DATA, (23, 22), filter_size=(1, 1),
                          edge_method='not_valid')
 
@@ -387,20 +392,21 @@ class TestBackground2D:
 
     def test_crop(self):
         data = np.ones((300, 500))
-        bkg = Background2D(data, (74, 99), edge_method='crop')
+        with pytest.warns(AstropyDeprecationWarning):
+            bkg = Background2D(data, (74, 99), edge_method='crop')
         assert_allclose(bkg.background_median, 1.0)
         assert_allclose(bkg.background_rms_median, 0.0)
         assert_allclose(bkg.background_mesh.shape, (4, 5))
 
     def test_repr(self):
         data = np.ones((300, 500))
-        bkg = Background2D(data, (74, 99), edge_method='crop')
+        bkg = Background2D(data, (74, 99))
         cls_repr = repr(bkg)
         assert cls_repr.startswith(f'{bkg.__class__.__name__}')
 
     def test_str(self):
         data = np.ones((300, 500))
-        bkg = Background2D(data, (74, 99), edge_method='crop')
+        bkg = Background2D(data, (74, 99))
         cls_str = str(bkg)
         cls_name = bkg.__class__.__name__
         cls_name = f'{bkg.__class__.__module__}.{cls_name}'

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -7,7 +7,8 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.nddata import CCDData, NDData
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.background.background_2d import Background2D
@@ -156,19 +157,26 @@ class TestBackground2D:
         bkg1 = Background2D(data, (25, 25), filter_size=(1, 1), mask=None,
                             bkg_estimator=MeanBackground())
 
-        assert_equal(bkg1.background_mesh, bkg1.background_mesh_masked)
-        assert_equal(bkg1.background_rms_mesh, bkg1.background_rms_mesh_masked)
-        assert np.count_nonzero(np.isnan(bkg1.mesh_nmasked)) == 0
+        with pytest.warns(AstropyDeprecationWarning):
+            assert_equal(bkg1.background_mesh, bkg1.background_mesh_masked)
+        with pytest.warns(AstropyDeprecationWarning):
+            assert_equal(bkg1.background_rms_mesh,
+                         bkg1.background_rms_mesh_masked)
+        with pytest.warns(AstropyDeprecationWarning):
+            assert np.count_nonzero(np.isnan(bkg1.mesh_nmasked)) == 0
 
         bkg2 = Background2D(data, (25, 25), filter_size=(1, 1), mask=mask,
                             bkg_estimator=MeanBackground())
 
         nboxes_tot = 25 * 25
-        assert (np.count_nonzero(~np.isnan(bkg2.background_mesh_masked))
-                < nboxes_tot)
-        assert (np.count_nonzero(~np.isnan(bkg2.background_rms_mesh_masked))
-                < nboxes_tot)
-        assert np.count_nonzero(np.isnan(bkg2.mesh_nmasked)) == 1
+        with pytest.warns(AstropyDeprecationWarning):
+            assert (np.count_nonzero(~np.isnan(bkg2.background_mesh_masked))
+                    < nboxes_tot)
+        with pytest.warns(AstropyDeprecationWarning):
+            assert (np.count_nonzero(~np.isnan(
+                bkg2.background_rms_mesh_masked)) < nboxes_tot)
+        with pytest.warns(AstropyDeprecationWarning):
+            assert np.count_nonzero(np.isnan(bkg2.mesh_nmasked)) == 1
 
     @pytest.mark.parametrize('fill_value', [0.0, np.nan, -1.0])
     def test_coverage_mask(self, fill_value):

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -389,3 +389,11 @@ class TestBackground2D:
         bkg = Background2D(data, (74, 99), edge_method='crop')
         cls_repr = repr(bkg)
         assert cls_repr.startswith(f'{bkg.__class__.__name__}')
+
+    def test_str(self):
+        data = np.ones((300, 500))
+        bkg = Background2D(data, (74, 99), edge_method='crop')
+        cls_str = str(bkg)
+        cls_name = bkg.__class__.__name__
+        cls_name = f'{bkg.__class__.__module__}.{cls_name}'
+        assert cls_str.startswith(f'<{cls_name}>')

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -45,6 +45,7 @@ class TestBackground2D:
         assert_allclose(bkg.background_rms_mesh, BKG_RMS_MESH)
         assert bkg.background_median == 1.0
         assert bkg.background_rms_median == 0.0
+        assert bkg.npixels_mesh.shape == (4, 4)
 
     @pytest.mark.parametrize('data', [DATA1, DATA3, DATA4])
     def test_background_nddata(self, data):
@@ -270,6 +271,12 @@ class TestBackground2D:
         assert bkg.background_median == 1.0
         assert bkg.background_rms_median == 0.0
 
+        bkg = Background2D(DATA, (22, 25), filter_size=(1, 1))
+        assert_allclose(bkg.background, DATA, rtol=1e-5)
+        assert_allclose(bkg.background_rms, BKG_RMS)
+        assert bkg.background_median == 1.0
+        assert bkg.background_rms_median == 0.0
+
     def test_exclude_percentile(self):
         """
         Only meshes greater than filter_threshold are filtered.
@@ -281,6 +288,10 @@ class TestBackground2D:
             bkg = Background2D(data, (25, 25), filter_size=(1, 1),
                                exclude_percentile=100.0)
         assert np.count_nonzero(bkg._nan_idx) == 4
+
+        data = np.ones((111, 121))
+        bkg = Background2D(data, box_size=10, exclude_percentile=100)
+        assert_equal(bkg.background_mesh, np.ones((12, 13)))
 
     def test_filter_threshold(self):
         """

--- a/photutils/background/tests/test_interpolators.py
+++ b/photutils/background/tests/test_interpolators.py
@@ -20,11 +20,32 @@ def test_zoom_interp():
                      [0.03, 0.03, 12.9]])
 
     interp = BkgZoomInterpolator(clip=False)
-    zoom = interp(mesh, bkg)
+    zoom = interp(mesh, **bkg._interp_kwargs)
     assert zoom.shape == (300, 300)
 
     cls_repr = repr(interp)
     assert cls_repr.startswith(f'{interp.__class__.__name__}')
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
+def test_zoom_interp_clip():
+    bkg = Background2D(np.ones((300, 300)), 100)
+    mesh = np.array([[0.01, 0.01, 0.02],
+                     [0.01, 0.02, 0.03],
+                     [0.03, 0.03, 12.9]])
+
+    interp1 = BkgZoomInterpolator(clip=False)
+    zoom1 = interp1(mesh, **bkg._interp_kwargs)
+
+    interp2 = BkgZoomInterpolator(clip=True)
+    zoom2 = interp2(mesh, **bkg._interp_kwargs)
+
+    minval = np.min(mesh)
+    maxval = np.max(mesh)
+    assert np.min(zoom1) < minval
+    assert np.max(zoom1) > maxval
+    assert np.min(zoom2) == minval
+    assert np.max(zoom2) == maxval
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
@@ -35,7 +56,7 @@ def test_idw_interp():
                      [0.03, 0.03, 12.9]])
 
     interp = BkgIDWInterpolator()
-    zoom = interp(mesh, bkg)
+    zoom = interp(mesh, **bkg._interp_kwargs)
     assert zoom.shape == (300, 300)
 
     cls_repr = repr(interp)

--- a/photutils/extern/biweight.py
+++ b/photutils/extern/biweight.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from photutils.utils._stats import _nanmedian, _nansum
+from photutils.utils._stats import nanmedian, nansum
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -34,8 +34,8 @@ def _stat_functions(
         median_func = np.ma.median
         sum_func = np.ma.sum
     elif ignore_nan:
-        median_func = _nanmedian
-        sum_func = _nansum
+        median_func = nanmedian
+        sum_func = nansum
     else:
         median_func = np.median
         sum_func = np.sum
@@ -549,7 +549,7 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
                 data = np.ma.masked_where(np.isnan(data), data, copy=True)
         elif ignore_nan:
             is_masked = False
-            func = _nanmedian
+            func = nanmedian
         else:
             is_masked = False
             func = np.median  # drops units if result is NaN

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -11,7 +11,7 @@ from astropy.stats import SigmaClip
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.utils import _make_binary_structure
 from photutils.utils._quantity_helpers import process_quantities
-from photutils.utils._stats import _nanmean, _nanstd
+from photutils.utils._stats import nanmean, nanstd
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['detect_threshold', 'detect_sources']
@@ -100,14 +100,14 @@ def detect_threshold(data, nsigma, *, background=None, error=None, mask=None,
                                   copy=True)
 
     if background is None:
-        background = _nanmean(clipped_data)
+        background = nanmean(clipped_data)
 
     if not np.isscalar(background) and background.shape != data.shape:
         raise ValueError('If input background is 2D, then it must have the '
                          'same shape as the input data.')
 
     if error is None:
-        error = _nanstd(clipped_data)
+        error = nanstd(clipped_data)
     if not np.isscalar(error) and error.shape != data.shape:
         raise ValueError('If input error is 2D, then it must have the same '
                          'shape as the input data.')

--- a/photutils/utils/_stats.py
+++ b/photutils/utils/_stats.py
@@ -99,19 +99,19 @@ if HAS_BOTTLENECK:
 
         return result
 
-    _nansum = partial(_apply_bottleneck, bn.nansum)
-    _nanmean = partial(_apply_bottleneck, bn.nanmean)
-    _nanmedian = partial(_apply_bottleneck, bn.nanmedian)
-    _nanstd = partial(_apply_bottleneck, bn.nanstd)
-    _nanvar = partial(_apply_bottleneck, bn.nanvar)
-    _nanmin = partial(_apply_bottleneck, bn.nanmin)
-    _nanmax = partial(_apply_bottleneck, bn.nanmax)
+    nansum = partial(_apply_bottleneck, bn.nansum)
+    nanmean = partial(_apply_bottleneck, bn.nanmean)
+    nanmedian = partial(_apply_bottleneck, bn.nanmedian)
+    nanstd = partial(_apply_bottleneck, bn.nanstd)
+    nanvar = partial(_apply_bottleneck, bn.nanvar)
+    nanmin = partial(_apply_bottleneck, bn.nanmin)
+    nanmax = partial(_apply_bottleneck, bn.nanmax)
 
 else:
-    _nansum = np.nansum
-    _nanmean = np.nanmean
-    _nanmedian = np.nanmedian
-    _nanstd = np.nanstd
-    _nanvar = np.nanvar
-    _nanmin = np.nanmin
-    _nanmax = np.nanmax
+    nansum = np.nansum
+    nanmean = np.nanmean
+    nanmedian = np.nanmedian
+    nanstd = np.nanstd
+    nanvar = np.nanvar
+    nanmin = np.nanmin
+    nanmax = np.nanmax

--- a/photutils/utils/tests/test_stats.py
+++ b/photutils/utils/tests/test_stats.py
@@ -9,12 +9,12 @@ import pytest
 from numpy.testing import assert_equal
 
 from photutils.utils._optional_deps import HAS_BOTTLENECK
-from photutils.utils._stats import (_nanmax, _nanmean, _nanmedian, _nanmin,
-                                    _nanstd, _nansum, _nanvar)
+from photutils.utils._stats import (nanmax, nanmean, nanmedian, nanmin, nanstd,
+                                    nansum, nanvar)
 
-funcs = [(_nansum, np.nansum), (_nanmean, np.nanmean),
-         (_nanmedian, np.nanmedian), (_nanstd, np.nanstd),
-         (_nanvar, np.nanvar), (_nanmin, np.nanmin), (_nanmax, np.nanmax)]
+funcs = [(nansum, np.nansum), (nanmean, np.nanmean),
+         (nanmedian, np.nanmedian), (nanstd, np.nanstd),
+         (nanvar, np.nanvar), (nanmin, np.nanmin), (nanmax, np.nanmax)]
 
 
 @pytest.mark.skipif(not HAS_BOTTLENECK, reason='bottleneck is required')
@@ -22,7 +22,7 @@ funcs = [(_nansum, np.nansum), (_nanmean, np.nanmean),
 @pytest.mark.parametrize('axis', [None, 0, 1, (0, 1), (1, 2), (2, 1),
                                   (0, 1, 2), (3, 1), (0, 3), (2, 0)])
 @pytest.mark.parametrize('use_units', [False, True])
-def test_nanmean(func, axis, use_units):
+def testnanmean(func, axis, use_units):
     arr = np.ones((5, 3, 8, 9))
     if use_units:
         arr <<= u.m


### PR DESCRIPTION
This PR refactors the ``Background2D`` class to significantly reduce its memory usage. In some cases, it is also significantly faster.

With this PR, the ``background_mesh`` and ``background_rms_mesh``  properties will have units if the input data has units.  Also, a new `npixels_mesh` property was added.

This PR also includes a number of API changes/deprecations:
* the ``edge_method`` keyword is now deprecated. When ``edge_method`` is eventually removed, the ``'pad'`` option will always be used.
* the ``background_mesh_masked``, ``background_rms_mesh_masked``, and ``mesh_nmasked`` properties are now deprecated.
* to reduce memory usage, ``Background2D`` no longer keeps a cached copy of the returned ``background`` and ``background_rms`` properties.
* the ``data``, ``mask``, ``total_mask``, ``nboxes``, ``box_npixels``, and ``nboxes_tot`` attributes have been removed.
* the ``BkgZoomInterpolator`` ``grid_mode`` keyword is now deprecated. When ``grid_mode`` is eventually removed, the `True` option will always be used.
