### PR TITLE
Add npixels_map property to Background2D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ New Features
     that gives a 2D array of the number of pixels used to compute the
     statistics in the low-resolution grid. [#1870]
 
+  - A new ``npixels_map`` property was added to ``Background2D``
+    that gives a 2D array of the number of pixels used to compute the
+    statistics in each mesh, resized to the shape of the input data.
+    [#1871]
+
 - ``photutils.centroids``
 
   - ``Quantity`` arrays can now be input to ``centroid_1dg`` and

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -8,7 +8,7 @@ import warnings
 
 import astropy.units as u
 import numpy as np
-from astropy.nddata import NDData, reshape_as_blocks
+from astropy.nddata import NDData, block_replicate, reshape_as_blocks
 from astropy.stats import SigmaClip
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated, deprecated_renamed_argument
@@ -758,6 +758,22 @@ class Background2D:
         in each mesh.
         """
         return self._ngood
+
+    @property
+    def npixels_map(self):
+        """
+        A 2D map of the number of pixels used to compute the statistics
+        in each mesh, resized to the shape of the input image.
+
+        Note that the returned value is re-calculated each time this
+        property is accessed. If you need to access the returned image
+        multiple times, you should store the result in a variable.
+        """
+        npixels_map = block_replicate(self.npixels_mesh,
+                                      self._interp_kwargs['box_size'],
+                                      conserve_sum=False)
+        return npixels_map[:self._interp_kwargs['shape'][0],
+                           :self._interp_kwargs['shape'][1]]
 
     @lazyproperty
     def background_median(self):

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -46,6 +46,7 @@ class TestBackground2D:
         assert bkg.background_median == 1.0
         assert bkg.background_rms_median == 0.0
         assert bkg.npixels_mesh.shape == (4, 4)
+        assert bkg.npixels_map.shape == DATA.shape
 
     @pytest.mark.parametrize('data', [DATA1, DATA3, DATA4])
     def test_background_nddata(self, data):


### PR DESCRIPTION
This new property gives a 2D array of the number of pixels used to compute the statistics in each mesh, resized to the shape of the input data.