### PR TITLE
Preserve SegmentationImage dtype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,6 +162,17 @@ API Changes
     ``FittableImageModel`` derived from the ``discretize_model`` function
     in ``astropy.convolution``. [#1865]
 
+- ``photutils.segmentation``
+
+  - The ``SegmentationImage`` ``relabel_consecutive`` method now keeps
+    the original dtype of segmentation image instead of always changing
+    it to ``int`` (``int64``). [#1878]
+
+  - The ``detect_sources`` and ``deblend_sources`` functions now return
+    a ``SegmentationImage`` instance whose data dtype is ``np.int32``
+    instead of ``int`` (``int64``) unless more than (2**32 - 1) labels
+    are needed. [#1878]
+
 
 1.13.0 (2024-06-28)
 -------------------

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -758,8 +758,9 @@ class SegmentationImage:
             return
 
         old_slices = self.__dict__.get('slices', None)
-        new_labels = np.arange(self.nlabels) + start_label
-        new_label_map = np.zeros(self.max_label + 1, dtype=int)
+        dtype = self.data.dtype  # keep the original dtype
+        new_labels = np.arange(self.nlabels, dtype=dtype) + start_label
+        new_label_map = np.zeros(self.max_label + 1, dtype=dtype)
         new_label_map[self.labels] = new_labels
 
         data_new = new_label_map[self.data]

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -228,11 +228,14 @@ def _detect_sources(data, thresholds, npixels, footprint, inverse_mask, *,
             continue
 
         if not deblend_mode:
-            # relabel the segmentation image with consecutive numbers
+            # relabel the segmentation image with consecutive numbers;
+            # ndimage.label returns segment_img with dtype = np.int32
+            # unless the input array has more than 2**31 - 1 pixels
             nlabels = len(segm_labels)
             if len(labels) != nlabels:
-                label_map = np.zeros(np.max(labels) + 1, dtype=int)
-                labels = np.arange(nlabels) + 1
+                label_map = np.zeros(np.max(labels) + 1,
+                                     dtype=segment_img.dtype)
+                labels = np.arange(nlabels, dtype=segment_img.dtype) + 1
                 label_map[segm_labels] = labels
                 segment_img = label_map[segment_img]
         else:

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -178,12 +178,14 @@ class TestSegmentationImage:
     def test_is_consecutive(self):
         assert not self.segm.is_consecutive
 
-        data = np.array([[2, 2, 0], [0, 3, 3], [0, 0, 4]])
+        data = np.array([[2, 2, 0], [0, 3, 3], [0, 0, 4]], dtype=np.int32)
         segm = SegmentationImage(data)
+        dtype = segm.data.dtype
         assert not segm.is_consecutive  # does not start with label=1
 
         segm.relabel_consecutive(start_label=1)
         assert segm.is_consecutive
+        assert segm.data.dtype == dtype
 
     def test_missing_labels(self):
         assert_allclose(self.segm.missing_labels, [2, 6])

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -36,12 +36,14 @@ class TestDeblendSources:
     def test_deblend_sources(self, mode):
         result = deblend_sources(self.data, self.segm, self.npixels,
                                  mode=mode, progress_bar=False)
+        assert result.data.dtype == self.segm.data.dtype
 
         if mode == 'linear':
             # test multiprocessing
             result2 = deblend_sources(self.data, self.segm, self.npixels,
                                       mode=mode, progress_bar=False, nproc=2)
             assert_equal(result.data, result2.data)
+            assert result2.data.dtype == self.segm.data.dtype
 
         assert result.nlabels == 2
         assert result.nlabels == len(result.slices)

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -181,10 +181,19 @@ class TestDetectSources:
         data[3, 3:] = 2
         data[3:, 3] = 2
 
+        segm = detect_sources(data, 0, npixels=4)
+        assert segm.nlabels == 2
+        assert segm.data.dtype == np.int32
+
+        # removal of labels with size less than npixels
+        # dtype should still be np.int32
         segm = detect_sources(data, 0, npixels=8)
         assert segm.nlabels == 1
+        assert segm.data.dtype == np.int32
+
         segm = detect_sources(data, 0, npixels=9)
         assert segm.nlabels == 1
+        assert segm.data.dtype == np.int32
 
         data = np.zeros((8, 8))
         data[0:4, 0] = 1


### PR DESCRIPTION
With this PR, the ``SegmentationImage`` ``relabel_consecutive`` method now keeps the original dtype of segmentation image instead of always changing it to ``int`` (``int64``).  This change only affects segmentation image that were not already consecutively ordered.

Additionally, the ``detect_sources`` and ``deblend_sources`` functions now return a ``SegmentationImage`` instance whose data dtype is ``np.int32`` instead of ``int`` (``int64``) unless more than (2**32 - 1) labels  are needed.