### PR TITLE
Make SciPy a required dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ General
 
 - The minimum required Astropy is now 5.3. [#1839]
 
+- SciPy is now a required dependency. [#1880]
+
+- The minimum required SciPy is now 1.10. [#1880]
+
 - Importing tools from all subpackages now requires including the
   subpackage name. [#1879]
 

--- a/docs/background.rst
+++ b/docs/background.rst
@@ -129,9 +129,7 @@ rough estimate of the threshold at the 2-sigma background noise level.
 Then we use the `~photutils.segmentation.detect_sources` function to
 generate a `~photutils.segmentation.SegmentationImage`. Finally, we use
 the :meth:`~photutils.segmentation.SegmentationImage.make_source_mask`
-method with a circular dilation footprint to create the source mask:
-
-.. doctest-requires:: scipy
+method with a circular dilation footprint to create the source mask::
 
     >>> from astropy.stats import sigma_clipped_stats, SigmaClip
     >>> from photutils.segmentation import detect_threshold, detect_sources
@@ -148,8 +146,6 @@ method with a circular dilation footprint to create the source mask:
 The source detection and masking procedure can be iterated further. Even
 with one iteration we are within 0.2% of the true background value and
 1.5% of the true background RMS.
-
-.. _scipy: https://scipy.org/
 
 
 2D Background and Noise Estimation
@@ -260,9 +256,7 @@ background gradient to the image defined above::
 We start by creating a `~photutils.background.Background2D` object
 using a box size of 50x50 and a 3x3 median filter.  We will estimate
 the background level in each mesh as the sigma-clipped median using an
-instance of :class:`~photutils.background.MedianBackground`.
-
-.. doctest-requires:: scipy
+instance of :class:`~photutils.background.MedianBackground`::
 
     >>> from astropy.stats import SigmaClip
     >>> from photutils.background import Background2D, MedianBackground
@@ -278,9 +272,7 @@ returned object. The low-resolution versions of these images are stored
 in the ``background_mesh`` and ``background_rms_mesh`` attributes,
 respectively. The global median value of the low-resolution background
 and background RMS image can be accessed with the ``background_median``
-and ``background_rms_median`` attributes, respectively:
-
-.. doctest-requires:: scipy
+and ``background_rms_median`` attributes, respectively::
 
     >>> print(bkg.background_median)  # doctest: +FLOAT_CMP
     10.852487630351824
@@ -363,10 +355,7 @@ background and background RMS maps. The ``fill_value`` keyword defines
 the value assigned in the output background and background RMS maps
 where the input ``coverage_mask`` is `True`.
 
-Let's create a rotated image that has blank areas and plot it (NOTE:
-this example requires `scipy`_):
-
-.. doctest-requires:: scipy
+Let's create a rotated image that has blank areas and plot it::
 
     >>> from scipy.ndimage import rotate
     >>> data3 = rotate(data2, -45.0)
@@ -401,9 +390,7 @@ real data, one can usually create a coverage mask from a weight or noise
 image. In this example we also use a smaller box size to help capture
 the strong gradient in the background. We also increase the value of the
 ``exclude_percentile`` keyword to include more boxes around the edge of
-the rotated image:
-
-.. doctest-requires:: scipy
+the rotated image::
 
     >>> coverage_mask = (data3 == 0)
     >>> bkg3 = Background2D(data3, (15, 15), filter_size=(3, 3),
@@ -411,9 +398,7 @@ the rotated image:
     ...                     exclude_percentile=50.0)
 
 Note that the ``coverage_mask`` is applied to the output background
-image (values assigned to ``fill_value``):
-
-.. doctest-requires:: scipy
+image (values assigned to ``fill_value``)::
 
     >>> norm = ImageNormalize(stretch=SqrtStretch())  # doctest: +SKIP
     >>> plt.imshow(bkg3.background, origin='lower', cmap='Greys_r', norm=norm,

--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -153,7 +153,6 @@ position of size ``box_size``. Optionally, a non-rectangular local
 ``footprint`` mask can be input instead of ``box_size``. The centroids
 for each source are then calculated within their cutout images::
 
-    >>> import matplotlib.pyplot as plt
     >>> import numpy as np
     >>> from photutils.centroids import centroid_2dg, centroid_sources
     >>> from photutils.datasets import make_4gaussians_image

--- a/docs/centroids.rst
+++ b/docs/centroids.rst
@@ -77,13 +77,13 @@ centroiding functions::
     >>> print(np.array((x2, y2)))  # doctest: +FLOAT_CMP
     [19.94009505 20.06884997]
 
-.. doctest-requires:: scipy
+::
 
     >>> x3, y3 = centroid_1dg(data)
     >>> print(np.array((x3, y3)))  # doctest: +FLOAT_CMP
     [19.96553246 20.04952841]
 
-.. doctest-requires:: scipy
+::
 
     >>> x4, y4 = centroid_2dg(data)
     >>> print(np.array((x4, y4)))  # doctest: +FLOAT_CMP
@@ -151,9 +151,7 @@ centroiding function.
 For each source, a cutout image is made that is centered at each initial
 position of size ``box_size``. Optionally, a non-rectangular local
 ``footprint`` mask can be input instead of ``box_size``. The centroids
-for each source are then calculated within their cutout images:
-
-.. doctest-requires:: scipy
+for each source are then calculated within their cutout images::
 
     >>> import matplotlib.pyplot as plt
     >>> import numpy as np

--- a/docs/detection.rst
+++ b/docs/detection.rst
@@ -66,9 +66,7 @@ Now we will subtract the background and use an instance of
 image that have FWHMs of around 3 pixels and have peaks approximately
 5-sigma above the background. Running this class on the data yields an
 astropy `~astropy.table.Table` containing the results of the star
-finder:
-
-.. doctest-requires:: scipy
+finder::
 
     >>> from photutils.detection import DAOStarFinder
     >>> daofind = DAOStarFinder(fwhm=3.0, threshold=5.*std)  # doctest: +REMOTE_DATA
@@ -199,9 +197,7 @@ keyword to :func:`~photutils.detection.find_peaks` to also compute
 centroid coordinates with subpixel precision.
 
 As a simple example, let's find the local peaks in an image that are 5
-sigma above the background and a separated by at least 5 pixels:
-
-.. doctest-requires:: scipy
+sigma above the background and a separated by at least 5 pixels::
 
     >>> from astropy.stats import sigma_clipped_stats
     >>> from photutils.datasets import make_100gaussians_image

--- a/docs/epsf.rst
+++ b/docs/epsf.rst
@@ -79,9 +79,7 @@ not use the centroiding option in
 :func:`~photutils.detection.find_peaks` to simulate the effect of
 having imperfect initial guesses for the positions of the stars.  Here we
 set the detection threshold value to 500.0 to select only the brightest
-stars:
-
-.. doctest-requires:: scipy
+stars::
 
     >>> from photutils.detection import find_peaks
     >>> peaks_tbl = find_peaks(data, threshold=500.0)  # doctest: +REMOTE_DATA
@@ -114,9 +112,7 @@ table columns called simply ``x`` and ``y``.
 
 We plan to extract 25 x 25 pixel cutouts of our selected stars, so
 let's explicitly exclude stars that are too close to the image
-boundaries (because they cannot be extracted):
-
-.. doctest-requires:: scipy
+boundaries (because they cannot be extracted)::
 
     >>> size = 25
     >>> hsize = (size - 1) / 2
@@ -125,9 +121,7 @@ boundaries (because they cannot be extracted):
     >>> mask = ((x > hsize) & (x < (data.shape[1] -1 - hsize)) &
     ...         (y > hsize) & (y < (data.shape[0] -1 - hsize)))  # doctest: +REMOTE_DATA
 
-Now let's create the table of good star positions:
-
-.. doctest-requires:: scipy
+Now let's create the table of good star positions::
 
     >>> from astropy.table import Table
     >>> stars_tbl = Table()
@@ -167,9 +161,7 @@ objects) and the `~astropy.nddata.NDData` objects must contain valid
 will be "linked" across images, meaning it will be constrained to have
 the same sky coordinate in each input image.
 
-Let's extract the 25 x 25 pixel cutouts of our selected stars:
-
-.. doctest-requires:: scipy
+Let's extract the 25 x 25 pixel cutouts of our selected stars::
 
     >>> from photutils.psf import extract_stars
     >>> stars = extract_stars(nddata, stars_tbl, size=25)  # doctest: +REMOTE_DATA
@@ -249,9 +241,7 @@ documentation for further details.
 
 We first initialize an :class:`~photutils.psf.EPSFBuilder` instance
 with our desired parameters and then input the cutouts of our selected
-stars to the instance:
-
-.. doctest-requires:: scipy
+stars to the instance::
 
     >>> from photutils.psf import EPSFBuilder
     >>> epsf_builder = EPSFBuilder(oversampling=4, maxiters=3,

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,9 +26,7 @@ example, we use :class:`~photutils.detection.DAOStarFinder` to detect
 the stars in the image.  We set the detection threshold at the 3-sigma
 noise level, estimated using the median absolute deviation
 (`~astropy.stats.mad_std`) of the image. The parameters of the
-detected sources are returned as an Astropy `~astropy.table.Table`:
-
-.. doctest-requires:: scipy
+detected sources are returned as an Astropy `~astropy.table.Table`::
 
     >>> from photutils.detection import DAOStarFinder
     >>> from astropy.stats import mad_std
@@ -59,9 +57,7 @@ columns), we now define circular apertures centered at these positions
 with a radius of 4 pixels and compute the sum of the pixel values
 within the apertures.  The
 :func:`~photutils.aperture.aperture_photometry` function returns an
-Astropy `~astropy.table.QTable` with the results of the photometry:
-
-.. doctest-requires:: scipy
+Astropy `~astropy.table.QTable` with the results of the photometry::
 
     >>> from photutils.aperture import aperture_photometry, CircularAperture
     >>> positions = np.transpose((sources['xcentroid'], sources['ycentroid']))  # doctest: +REMOTE_DATA

--- a/docs/grouping.rst
+++ b/docs/grouping.rst
@@ -32,9 +32,7 @@ agglomerative clustering with a distance criterion, calling the
 `scipy.cluster.hierarchy.fclusterdata` function.
 
 First, let's create a simulated image containing 2D Gaussian sources
-using `~photutils.psf.make_psf_model_image`.
-
-.. doctest-requires:: scipy
+using `~photutils.psf.make_psf_model_image`::
 
     >>> from photutils.psf import CircularGaussianPRF, make_psf_model_image
     >>> shape = (256, 256)
@@ -86,9 +84,7 @@ Now, let's find the stellar groups. We start by creating
 a `~photutils.psf.SourceGrouper` object. Here we set the
 ``min_separation`` parameter ``2.5 * fwhm``, where the ``fwhm`` is taken
 from the 2D Gaussian PSF model used to generate the stars. In general,
-one will need to measure the FWHM of the stellar profiles.
-
-.. doctest-requires:: scipy
+one will need to measure the FWHM of the stellar profiles::
 
     >>> from photutils.psf import SourceGrouper
     >>> fwhm = 4.7
@@ -98,9 +94,7 @@ one will need to measure the FWHM of the stellar profiles.
 We then call the class instance on arrays of the star ``(x, y)``
 positions. Here will use the known positions of the stars when
 we generated the image. In general, one can use a star finder
-(:ref:`source_detection`) to find the sources.
-
-.. doctest-requires:: scipy
+(:ref:`source_detection`) to find the sources::
 
    >>> import numpy as np
    >>> x = np.array(stars['x_0'])
@@ -111,9 +105,7 @@ The ``groups`` output is an array of integers (ordered the same as the
 ``(x, y)`` inputs) containing the group indices. Stars with the same
 group index are in the same group.
 
-For example, to find all the stars in group 3:
-
-.. doctest-requires:: scipy
+For example, to find all the stars in group 3::
 
    >>> mask = groups == 3
    >>> x[mask], y[mask]

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,10 +13,10 @@ Photutils has the following strict requirements:
 
 * `Astropy`_ 5.3 or later
 
-Photutils also optionally depends on other packages for some features:
-
-* `SciPy <https://scipy.org/>`_ 1.8 or later: Used to power a variety of
+* `SciPy <https://scipy.org/>`_ 1.10 or later: Used to power a variety of
   features in several modules (strongly recommended).
+
+Photutils also optionally depends on other packages for some features:
 
 * `Matplotlib <https://matplotlib.org/>`_ 3.5 or later: Used to power a
   variety of plotting features (e.g., plotting apertures).

--- a/docs/isophote.rst
+++ b/docs/isophote.rst
@@ -96,9 +96,7 @@ geometry object::
     >>> ellipse = Ellipse(data, geometry)
 
 To perform the elliptical isophote fit, we run the
-:meth:`~photutils.isophote.Ellipse.fit_image` method:
-
-.. doctest-requires:: scipy
+:meth:`~photutils.isophote.Ellipse.fit_image` method::
 
     >>> isolist = ellipse.fit_image()
 
@@ -106,9 +104,7 @@ The result is a list of isophotes as an
 `~photutils.isophote.IsophoteList` object, whose attributes are the
 fit values for each `~photutils.isophote.Isophote` sorted by the
 semimajor axis length.  Let's print the fit position angles
-(radians):
-
-.. doctest-requires:: scipy
+(radians)::
 
     >>> print(isolist.pa)  # doctest: +SKIP
     [ 0.          0.16838914  0.18453378  0.20310945  0.22534975  0.25007781
@@ -122,9 +118,7 @@ semimajor axis length.  Let's print the fit position angles
       0.68614488  0.7177538   0.7177538   0.7029571   0.7029571   0.7029571 ]
 
 We can also show the isophote values as a table, which is again sorted
-by the semimajor axis length (``sma``):
-
-.. doctest-requires:: scipy
+by the semimajor axis length (``sma``)::
 
     >>> print(isolist.to_table())  # doctest: +SKIP
          sma            intens        intens_err   ... flag niter stop_code
@@ -194,10 +188,7 @@ position as a function of the semimajor axis length:
 
 We can build an elliptical model image from the
 `~photutils.isophote.IsophoteList` object using the
-:func:`~photutils.isophote.build_ellipse_model` function (NOTE: this
-function requires `scipy <https://scipy.org/>`_):
-
-.. doctest-requires:: scipy
+:func:`~photutils.isophote.build_ellipse_model` function::
 
     >>> from photutils.isophote import build_ellipse_model
     >>> model_image = build_ellipse_model(data.shape, isolist)

--- a/docs/morphology.rst
+++ b/docs/morphology.rst
@@ -34,9 +34,7 @@ First, we create the source image and subtract its background::
     >>> mean, median, std = sigma_clipped_stats(data, sigma=3.0)
     >>> data -= median  # subtract background
 
-Then, calculate its properties:
-
-.. doctest-requires:: scipy
+Then, calculate its properties::
 
     >>> from photutils.morphology import data_properties
     >>> cat = data_properties(data)

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -203,17 +203,13 @@ Fitting the profile with a 1D Gaussian
 Now let's fit a 1D Gaussian to the radial profile and return the
 `~astropy.modeling.functional_models.Gaussian1D` model using the
 `~photutils.profiles.RadialProfile.gaussian_fit` attribute. The returned
-value is a 1D Gaussian model fit to the radial profile:
-
-.. doctest-requires:: scipy
+value is a 1D Gaussian model fit to the radial profile::
 
     >>> rp.gaussian_fit  # doctest: +FLOAT_CMP
     <Gaussian1D(amplitude=41.54880743, mean=0., stddev=4.71059406)>
 
 The FWHM of the fitted 1D Gaussian model is stored in the
-`~photutils.profiles.RadialProfile.gaussian_fwhm` attribute:
-
-.. doctest-requires:: scipy
+`~photutils.profiles.RadialProfile.gaussian_fwhm` attribute::
 
     >>> print(rp.gaussian_fwhm)  # doctest: +FLOAT_CMP
     11.09260130738712
@@ -415,16 +411,12 @@ respectively. They are implemented as interpolation functions using the
 calculated curve-of-growth profile. The performance of these methods
 is dependent on the quality of the curve-of-growth profile (e.g., it's
 generally better to have a curve-of-growth profile with more radial
-bins):
-
-.. doctest-requires:: scipy
+bins)::
 
     >>> cog.normalize(method='max')
     >>> ee_vals = cog.calc_ee_at_radius([5, 10, 15])  # doctest: +FLOAT_CMP
     >>> ee_vals
     array([0.41923785, 0.87160376, 0.96902919])
-
-.. doctest-requires:: scipy
 
     >>> cog.calc_radius_at_ee(ee_vals)  # doctest: +FLOAT_CMP
     array([ 5., 10., 15.])

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -301,9 +301,7 @@ PSF Photometry Examples
 
 Let's start with a simple example using simulated stars whose PSF is
 assumed to be Gaussian. We'll create a synthetic image using tools
-provided by the :ref:`photutils.datasets <datasets>` module:
-
-.. doctest-requires:: scipy
+provided by the :ref:`photutils.datasets <datasets>` module::
 
     >>> import numpy as np
     >>> from photutils.datasets import make_noise_image
@@ -358,9 +356,7 @@ source detection. We'll estimate the initial fluxes of each
 source using a circular aperture with a radius 4 pixels. The
 central 5x5 pixel region of each star will be fit using an
 `~photutils.psf.CircularGaussianPRF` PSF model. First, let's create an
-instance of the `~photutils.psf.PSFPhotometry` class:
-
-.. doctest-requires:: scipy
+instance of the `~photutils.psf.PSFPhotometry` class::
 
     >>> from photutils.detection import DAOStarFinder
     >>> from photutils.psf import PSFPhotometry
@@ -375,9 +371,7 @@ on the data array, and optionally an error and mask array. A
 `~astropy.nddata.NDData` object holding the data, error, and mask arrays
 can also be input into the ``data`` parameter. Note that all non-finite
 (e.g., NaN or inf) data values are automatically masked. Here we input
-the data and error arrays:
-
-.. doctest-requires:: scipy
+the data and error arrays::
 
     >>> phot = psfphot(data, error=error)
 
@@ -402,9 +396,7 @@ fit, the group size, quality-of-fit metrics, and flags. See the
 output columns.
 
 The full table cannot be shown here as it has many columns, but let's
-print the source ID along with the fit x, y, and flux values:
-
-.. doctest-requires:: scipy
+print the source ID along with the fit x, y, and flux values::
 
     >>> phot['x_fit'].info.format = '.4f'  # optional format
     >>> phot['y_fit'].info.format = '.4f'
@@ -423,9 +415,7 @@ print the source ID along with the fit x, y, and flux values:
       9  5.5350 89.8870 539.6831
      10 71.8414 90.5842 692.3373
 
-Let's create the residual image:
-
-.. doctest-requires:: scipy
+Let's create the residual image::
 
     >>> resid = psfphot.make_residual_image(data, (9, 9))
 
@@ -480,9 +470,7 @@ Further details about the PSF fitting can be obtained from attributes on
 the `~photutils.psf.PSFPhotometry` instance. For example, the results
 from the ``finder`` instance called during PSF fitting can be accessed
 using the ``finder_results`` attribute (the ``finder`` returns an
-astropy table):
-
-.. doctest-requires:: scipy
+astropy table)::
 
     >>> psfphot.finder_results['xcentroid'].info.format = '.4f'  # optional format
     >>> psfphot.finder_results['ycentroid'].info.format = '.4f'  # optional format
@@ -505,9 +493,7 @@ astropy table):
      10   71.8303   90.5624    0.6038 ... 0.0 73.5747 9.5639 -2.4516
 
 The ``fit_info`` attribute contains a dictionary with detailed
-information returned from the ``fitter`` for each source:
-
-.. doctest-requires:: scipy
+information returned from the ``fitter`` for each source::
 
     >>> psfphot.fit_info.keys()
     dict_keys(['fit_infos', 'fit_error_indices'])
@@ -535,9 +521,7 @@ in an image. We can do that by defining a table of the sources that
 we want to fit. For this example, let's fit the single star at ``(x,
 y) = (63, 49)``. We first define a table with this position and then
 pass that table into the ``init_params`` keyword when calling the PSF
-photometry class on the data:
-
-.. doctest-requires:: scipy
+photometry class on the data::
 
     >>> from astropy.table import QTable
     >>> init_params = QTable()
@@ -549,9 +533,7 @@ The PSF photometry class allows for flexible input column names
 using a heuristic to identify the x, y, and flux columns. See
 `~photutils.psf.PSFPhotometry` for more details.
 
-The output table contains only the fit results for the input source:
-
-.. doctest-requires:: scipy
+The output table contains only the fit results for the input source::
 
     >>> phot['x_fit'].info.format = '.4f'  # optional format
     >>> phot['y_fit'].info.format = '.4f'
@@ -627,9 +609,7 @@ y positions and the flux. However, the astropy modeling and fitting
 framework allows any of these parameters to be fixed during the fitting.
 
 Let's say you want to fix the (x, y) position for each source. You can
-do that by setting the ``fixed`` attribute on the model parameters:
-
-.. doctest-requires:: scipy
+do that by setting the ``fixed`` attribute on the model parameters::
 
     >>> psf_model2 = CircularGaussianPRF(flux=1, fwhm=2.7)
     >>> psf_model2.x_0.fixed = True
@@ -639,9 +619,7 @@ do that by setting the ``fixed`` attribute on the model parameters:
 
 Now when the model is fit, the flux will be varied but, the (x, y)
 position will be fixed at its initial position for every source. Let's
-just fit a single source (defined in ``init_params``):
-
-.. doctest-requires:: scipy
+just fit a single source (defined in ``init_params``)::
 
     >>> psfphot = PSFPhotometry(psf_model2, fit_shape, finder=finder,
     ...                         aperture_radius=4)
@@ -649,9 +627,7 @@ just fit a single source (defined in ``init_params``):
 
 The output table shows that the (x, y) position was unchanged, with the
 fit values being identical to the initial values. However, the flux was
-fit:
-
-.. doctest-requires:: scipy
+fit::
 
     >>> phot['flux_init'].info.format = '.4f'  # optional format
     >>> phot['flux_fit'].info.format = '.4f'
@@ -685,9 +661,8 @@ can be from its initial (x, y) position.
 For example, you may want to constrain the flux of a source to be
 between certain values or ensure that it is a non-negative value. This
 can be done by setting the ``bounds`` attribute on the input PSF model
-parameters. Here we constrain the flux to be greater than or equal to 0:
-
-.. doctest-requires:: scipy
+parameters. Here we constrain the flux to be greater than or equal to
+0::
 
     >>> psf_model3 = CircularGaussianPRF(flux=1, fwhm=2.7)
     >>> psf_model3.flux.bounds = (0, None)
@@ -695,18 +670,14 @@ parameters. Here we constrain the flux to be greater than or equal to 0:
     {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (None, None)}
 
 The model parameter ``bounds`` can also be set using the ``min`` and/or
-``max`` attributes. Here we set the minimum flux to be 0:
-
-.. doctest-requires:: scipy
+``max`` attributes. Here we set the minimum flux to be 0::
 
     >>> psf_model3.flux.min = 0
     >>> psf_model3.bounds
     {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (None, None)}
 
 For this example, let's constrain the flux value to be between between
-400 and 600:
-
-.. doctest-requires:: scipy
+400 and 600::
 
     >>> psf_model3 = CircularGaussianPRF(flux=1, fwhm=2.7)
     >>> psf_model3.flux.bounds = (400, 600)
@@ -720,9 +691,7 @@ Source Grouping
 Source grouping is an optional feature. To turn it on, create a
 `~photutils.psf.SourceGrouper` instance and input it via the ``grouper``
 keyword. Here we'll group stars that are within 20 pixels of each
-other:
-
-.. doctest-requires:: scipy
+other::
 
     >>> from photutils.psf import SourceGrouper
     >>> grouper = SourceGrouper(min_separation=20)
@@ -731,9 +700,7 @@ other:
     >>> phot = psfphot(data, error=error)
 
 The ``group_id`` column shows that seven groups were identified. The
-stars in each group were simultaneously fit.
-
-.. doctest-requires:: scipy
+stars in each group were simultaneously fit::
 
     >>> print(phot[('id', 'group_id', 'group_size')])
      id group_id group_size
@@ -766,9 +733,7 @@ To subtract a local background from each source, define a
 the ``localbkg_estimator`` keyword. Here we'll use an annulus with
 an inner and outer radius of 5 and 10 pixels, respectively, with the
 `~photutils.background.MMMBackground` statistic (with its default sigma
-clipping):
-
-.. doctest-requires:: scipy
+clipping)::
 
     >>> from photutils.background import LocalBackground, MMMBackground
     >>> bkgstat = MMMBackground()
@@ -779,9 +744,7 @@ clipping):
     ...                         localbkg_estimator=localbkg_estimator)
     >>> phot = psfphot(data, error=error)
 
-The local background values are output in the table:
-
-.. doctest-requires:: scipy
+The local background values are output in the table::
 
     >>> phot['local_bkg'].info.format = '.4f'  # optional format
     >>> print(phot[('id', 'local_bkg')])  # doctest: +FLOAT_CMP
@@ -812,9 +775,7 @@ may not be detected until after the bright stars are subtracted.
 
 For this simple example, let's input a table of three stars for the
 first fit iteration. Subsequent iterations will use the ``finder`` to
-find additional stars:
-
-.. doctest-requires:: scipy
+find additional stars::
 
     >>> from photutils.background import LocalBackground, MMMBackground
     >>> from photutils.psf import IterativePSFPhotometry
@@ -832,9 +793,7 @@ find additional stars:
 
 The table output from `~photutils.psf.IterativePSFPhotometry` contains a
 column called ``iter_detected`` that returns the fit iteration in which
-the source was detected:
-
-.. doctest-requires:: scipy
+the source was detected::
 
     >>> phot['x_fit'].info.format = '.4f'  # optional format
     >>> phot['y_fit'].info.format = '.4f'
@@ -867,9 +826,7 @@ circular or non-Gaussian, you can fit your sources using the
 `~photutils.psf.PSFPhotometry` class using a different PSF model.
 
 For example, let's estimate the FWHM of the sources in our example image
-defined above:
-
-.. doctest-requires:: scipy
+defined above::
 
    >>> from photutils.psf import fit_fwhm
    >>> finder = DAOStarFinder(6.0, 2.0)

--- a/docs/segmentation.rst
+++ b/docs/segmentation.rst
@@ -32,9 +32,7 @@ Let's start by making a synthetic image provided by the
 
 Next, we need to subtract the background from the image. In this
 example, we'll use the :class:`~photutils.background.Background2D` class
-to produce a background and background noise image:
-
-.. doctest-requires:: scipy
+to produce a background and background noise image::
 
     >>> from photutils.background import Background2D, MedianBackground
     >>> bkg_estimator = MedianBackground()
@@ -45,9 +43,7 @@ to produce a background and background noise image:
 After subtracting the background, we need to define the detection
 threshold. In this example, we'll define a 2D detection threshold image
 using the background RMS image. We set the threshold at the 1.5-sigma (per
-pixel) noise level:
-
-.. doctest-requires:: scipy
+pixel) noise level::
 
     >>> threshold = 1.5 * bkg.background_rms
 
@@ -67,9 +63,7 @@ defined above (i.e., 1.5 sigma per pixel above the background noise).
 Note that by default "connected pixels" means "8-connected" pixels,
 where pixels touch along their edges or corners. One can also use
 "4-connected" pixels that touch only along their edges by setting
-``connectivity=4``:
-
-.. doctest-requires:: scipy
+``connectivity=4``::
 
     >>> from photutils.segmentation import detect_sources
     >>> segment_map = detect_sources(convolved_data, threshold, npixels=10)
@@ -157,7 +151,7 @@ peak must have to be considered as a separate object.
 
 Here's a simple example of source deblending:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: skimage
 
     >>> from photutils.segmentation import deblend_sources
     >>> segm_deblend = deblend_sources(convolved_data, segment_map,
@@ -263,7 +257,7 @@ of `~photutils.segmentation.detect_sources` and
 with the desired detection and deblending parameters, you call it with
 the background-subtracted (convolved) image and threshold:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: skimage
 
     >>> from photutils.segmentation import SourceFinder
     >>> finder = SourceFinder(npixels=10, progress_bar=False)
@@ -315,7 +309,7 @@ measured (if not input, the unconvolved image is used instead).
 Let's continue our example from above and measure the properties of the
 detected sources:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: skimage
 
     >>> from photutils.segmentation import SourceCatalog
     >>> cat = SourceCatalog(data, segm_deblend, convolved_data=convolved_data)
@@ -340,7 +334,7 @@ properties. The ``label`` column corresponds to the label value in the
 input segmentation image. Note that only a small subset of the source
 properties are shown below:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: skimage
 
     >>> tbl = cat.to_table()
     >>> tbl['xcentroid'].info.format = '.2f'  # optional format
@@ -427,7 +421,7 @@ We can also create a `~photutils.segmentation.SourceCatalog` object
 containing only a specific subset of sources, defined by their
 label numbers in the segmentation image:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: skimage
 
     >>> cat = SourceCatalog(data, segm_deblend, convolved_data=convolved_data)
     >>> labels = [1, 5, 20, 50, 75, 80]
@@ -452,7 +446,7 @@ includes only a small subset of source properties. The output table
 properties can be customized in the `~astropy.table.QTable` using the
 ``columns`` keyword:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: skimage
 
     >>> cat = SourceCatalog(data, segm_deblend, convolved_data=convolved_data)
     >>> labels = [1, 5, 20, 50, 75, 80]
@@ -488,7 +482,7 @@ that was subtracted from the data into the ``background`` keyword
 of :class:`~photutils.segmentation.SourceCatalog`, the background
 properties for each source will also be calculated:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: skimage
 
     >>> cat = SourceCatalog(data, segm_deblend, background=bkg.background)
     >>> labels = [1, 5, 20, 50, 75, 80]
@@ -541,7 +535,7 @@ calculated. `~photutils.segmentation.SourceCatalog.segment_flux`
 and `~photutils.segmentation.SourceCatalog.segment_fluxerr` are the
 instrumental flux and propagated flux error within the source segments:
 
-.. doctest-requires:: scipy, skimage
+.. doctest-requires:: skimage
 
     >>> from photutils.utils import calc_total_error
     >>> effective_gain = 500.0

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -24,8 +24,6 @@ from photutils.utils._stats import nanmedian, nanmin
 
 __all__ = ['Background2D']
 
-__doctest_requires__ = {'Background2D': ['scipy']}
-
 COPY_IF_NEEDED = False if not minversion(np, '2.0.0') else None
 
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -13,6 +13,7 @@ from astropy.stats import SigmaClip
 from astropy.utils import lazyproperty, minversion
 from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.ndimage import generic_filter
 
 from photutils.aperture import RectangularAperture
 from photutils.background.core import SExtractorBackground, StdBackgroundRMS
@@ -667,7 +668,6 @@ class Background2D:
         if (self.filter_threshold is None
                 or self.filter_threshold < self._min_bkg_stats):
             # filter the entire array
-            from scipy.ndimage import generic_filter
             filtdata = generic_filter(data, nanmedian, size=self.filter_size,
                                       mode='constant', cval=np.nan)
         else:

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -12,8 +12,6 @@ from photutils.utils._repr import make_repr
 
 __all__ = ['BkgZoomInterpolator', 'BkgIDWInterpolator']
 
-__doctest_requires__ = {'BkgZoomInterpolator': ['scipy']}
-
 
 class BkgZoomInterpolator:
     """

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -6,6 +6,7 @@ This module defines interpolator classes for Background2D.
 import numpy as np
 from astropy.units import Quantity
 from astropy.utils.decorators import deprecated_renamed_argument
+from scipy.ndimage import zoom
 
 from photutils.utils import ShepardIDWInterpolator
 from photutils.utils._repr import make_repr
@@ -92,8 +93,6 @@ class BkgZoomInterpolator:
         if np.ptp(data) == 0:
             return np.full(kwargs['shape'], np.min(data),
                            dtype=kwargs['dtype'])
-
-        from scipy.ndimage import zoom
 
         if kwargs['edge_method'] == 'pad':
             # The mesh is first resized to the larger padded-data size

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -15,7 +15,7 @@ from photutils.background.background_2d import Background2D
 from photutils.background.core import MeanBackground
 from photutils.background.interpolators import (BkgIDWInterpolator,
                                                 BkgZoomInterpolator)
-from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY
+from photutils.utils._optional_deps import HAS_MATPLOTLIB
 
 DATA = np.ones((100, 100))
 BKG_RMS = np.zeros((100, 100))
@@ -32,7 +32,6 @@ DATA3 = NDData(DATA, unit=u.ct)
 DATA4 = CCDData(DATA, unit=u.ct)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestBackground2D:
     @pytest.mark.parametrize('filter_size', FILTER_SIZES)
     @pytest.mark.parametrize('interpolator', INTERPOLATORS)

--- a/photutils/background/tests/test_interpolators.py
+++ b/photutils/background/tests/test_interpolators.py
@@ -11,10 +11,8 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from photutils.background.background_2d import Background2D
 from photutils.background.interpolators import (BkgIDWInterpolator,
                                                 BkgZoomInterpolator)
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_zoom_interp():
     data = np.ones((300, 300))
     bkg = Background2D(data, 100)
@@ -43,7 +41,6 @@ def test_zoom_interp():
     assert cls_repr.startswith(f'{interp.__class__.__name__}')
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_zoom_interp_clip():
     bkg = Background2D(np.ones((300, 300)), 100)
     mesh = np.array([[0.01, 0.01, 0.02],
@@ -64,7 +61,6 @@ def test_zoom_interp_clip():
     assert np.max(zoom2) == maxval
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_idw_interp():
     data = np.ones((300, 300))
     bkg = Background2D(data, 100)

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -15,8 +15,6 @@ from photutils.utils.cutouts import _overlap_slices as overlap_slices
 
 __all__ = ['centroid_com', 'centroid_quadratic', 'centroid_sources']
 
-__doctest_requires__ = {('centroid_quadratic', 'centroid_sources'): ['scipy']}
-
 
 def centroid_com(data, mask=None):
     """
@@ -404,7 +402,6 @@ def centroid_sources(data, xpos, ypos, box_size=11, footprint=None, mask=None,
 
     Examples
     --------
-    >>> import matplotlib.pyplot as plt
     >>> import numpy as np
     >>> from photutils.centroids import centroid_2dg, centroid_sources
     >>> from photutils.datasets import make_4gaussians_image

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -14,8 +14,6 @@ from photutils.utils._quantity_helpers import process_quantities
 
 __all__ = ['centroid_1dg', 'centroid_2dg']
 
-__doctest_requires__ = {('centroid_1dg', 'centroid_2dg'): ['scipy']}
-
 
 def centroid_1dg(data, error=None, mask=None):
     """

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -16,7 +16,6 @@ from photutils.centroids.core import (centroid_com, centroid_quadratic,
                                       centroid_sources)
 from photutils.centroids.gaussian import centroid_1dg, centroid_2dg
 from photutils.datasets import make_4gaussians_image, make_noise_image
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 @pytest.fixture(name='test_simple_data')
@@ -46,7 +45,6 @@ def fixture_test_data():
 
 
 # NOTE: the fitting routines in astropy use scipy.optimize
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('x_std', [3.2, 4.0])
 @pytest.mark.parametrize('y_std', [5.7, 4.1])
 @pytest.mark.parametrize('theta', np.deg2rad([30.0, 45.0]))
@@ -78,7 +76,6 @@ def test_centroid_comquad(test_simple_data, x_std, y_std, theta, units):
     assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=0.015)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('use_mask', [True, False])
 def test_centroid_comquad_nan_withmask(use_mask):
     xc_ref = 24.7
@@ -137,7 +134,6 @@ def test_centroid_com_invalid_inputs():
         centroid_com(data, mask=mask)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_centroid_quadratic_xypeak():
     data = np.zeros((11, 11))
     data[5, 5] = 100
@@ -165,7 +161,6 @@ def test_centroid_quadratic_xypeak():
         centroid_quadratic(data, xpeak=15, ypeak=15)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_centroid_quadratic_nan():
     gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     yy, xx = np.mgrid[0:100, 0:100]
@@ -179,7 +174,6 @@ def test_centroid_quadratic_nan():
     assert_allclose(xycen, [47.58324, 51.827182])
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_centroid_quadratic_npts():
     data = np.zeros((3, 3))
     data[1, 1] = 1
@@ -191,7 +185,6 @@ def test_centroid_quadratic_npts():
         centroid_quadratic(data, mask=mask)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_centroid_quadratic_invalid_inputs():
     data = np.zeros((4, 4))
     mask = np.zeros((2, 2), dtype=bool)
@@ -213,7 +206,6 @@ def test_centroid_quadratic_invalid_inputs():
         centroid_quadratic(data, mask=mask)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_centroid_quadratic_edge():
     data = np.zeros((11, 11))
     data[1, 1] = 100
@@ -233,7 +225,6 @@ def test_centroid_quadratic_edge():
     assert_allclose(xycen, (0, 0))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestCentroidSources:
 
     @staticmethod

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -14,7 +14,6 @@ from numpy.testing import assert_allclose
 
 from photutils.centroids.gaussian import (_gaussian1d_moments, centroid_1dg,
                                           centroid_2dg)
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 @pytest.fixture(name='test_data')
@@ -29,7 +28,6 @@ def fixture_test_data():
 
 
 # NOTE: the fitting routines in astropy use scipy.optimize
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('x_std', [3.2, 4.0])
 @pytest.mark.parametrize('y_std', [5.7, 4.1])
 @pytest.mark.parametrize('theta', np.deg2rad([30.0, 45.0]))
@@ -72,7 +70,6 @@ def test_centroids(x_std, y_std, theta, units):
     assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=1.0e-3)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('use_mask', [True, False])
 def test_centroids_nan_withmask(use_mask):
     xc_ref = 24.7
@@ -105,7 +102,6 @@ def test_centroids_nan_withmask(use_mask):
             assert len(warnlist) == nwarn
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_invalid_mask_shape():
     data = np.zeros((4, 4))
     mask = np.zeros((2, 2), dtype=bool)
@@ -119,7 +115,6 @@ def test_invalid_mask_shape():
         _gaussian1d_moments(data, mask=mask)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_invalid_error_shape():
     error = np.zeros((2, 2), dtype=bool)
     match = 'data and error must have the same shape'
@@ -129,7 +124,6 @@ def test_invalid_error_shape():
         centroid_2dg(np.zeros((4, 4)), error=error)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_centroid_2dg_dof():
     data = np.ones((2, 2))
     match = 'Input data must have a least 6 unmasked values to fit'
@@ -163,7 +157,6 @@ def test_gaussian1d_moments():
         assert len(warnlist) == 1
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_gaussian2d_warning():
     yy, xx = np.mgrid[:51, :51]
     model = Gaussian2D(x_mean=24.17, y_mean=25.87, x_stddev=1.7, y_stddev=4.7)

--- a/photutils/datasets/sources.py
+++ b/photutils/datasets/sources.py
@@ -16,8 +16,6 @@ from photutils.utils._parameters import as_pair
 __all__ = ['make_model_params', 'make_random_models_table',
            'make_random_gaussians_table']
 
-__doctest_requires__ = {'make_model_params': ['scipy']}
-
 
 def make_model_params(shape, n_sources, *, x_name='x_0', y_name='y_0',
                       min_separation=1, border_size=(0, 0), seed=0, **kwargs):

--- a/photutils/datasets/tests/test_images.py
+++ b/photutils/datasets/tests/test_images.py
@@ -16,7 +16,6 @@ from photutils.datasets import (make_gaussian_prf_sources_image,
                                 make_gaussian_sources_image, make_model_image,
                                 make_model_sources_image, make_test_psf_data)
 from photutils.psf import CircularGaussianSigmaPRF
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 @pytest.fixture(name='source_params')
@@ -68,7 +67,6 @@ def test_make_model_image():
     assert image.sum() > 1
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_model_image_units():
     unit = u.Jy
     params = QTable()
@@ -219,7 +217,6 @@ def test_make_gaussian_sources_image_desc_oversample(source_params):
         assert_allclose(image.sum(), source_params['flux'].sum())
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_gaussian_prf_sources_image(source_params_prf):
     with pytest.warns(AstropyDeprecationWarning):
         shape = (100, 100)
@@ -229,7 +226,6 @@ def test_make_gaussian_prf_sources_image(source_params_prf):
         assert_allclose(image.sum(), flux.sum(), rtol=1.0e-6)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_test_psf_data():
     with pytest.warns(AstropyDeprecationWarning):
         psf_model = CircularGaussianSigmaPRF(flux=100, sigma=1.5)

--- a/photutils/datasets/tests/test_sources.py
+++ b/photutils/datasets/tests/test_sources.py
@@ -11,10 +11,8 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
 
 from photutils.datasets import (make_model_params, make_random_gaussians_table,
                                 make_random_models_table)
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_model_params():
     shape = (100, 100)
     n_sources = 10
@@ -55,7 +53,6 @@ def test_make_model_params():
         make_model_params(shape, n_sources, flux=(1, 2), alpha=(1, 2, 3))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_model_params_nsources():
     """
     Test case when the number of the possible sources is less than
@@ -71,7 +68,6 @@ def test_make_model_params_nsources():
         assert len(params) < 100
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_model_params_border_size():
     shape = (10, 10)
     n_sources = 10

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -8,6 +8,7 @@ import warnings
 
 import numpy as np
 from astropy.table import QTable
+from scipy.ndimage import maximum_filter
 
 from photutils.utils._misc import _get_meta
 from photutils.utils._quantity_helpers import process_quantities
@@ -122,8 +123,6 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
     to compute centroid coordinates with subpixel precision within the
     input ``box_size`` or ``footprint``.
     """
-    from scipy.ndimage import maximum_filter
-
     arrays, unit = process_quantities((data, threshold, error),
                                       ('data', 'threshold', 'error'))
     data, threshold, error = arrays

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -9,11 +9,9 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from photutils.detection.daofinder import DAOStarFinder
-from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestDAOStarFinder:
     def test_daostarfind(self, data):
         units = u.Jy

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -10,11 +10,9 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_array_equal
 
 from photutils.detection import IRAFStarFinder
-from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestIRAFStarFinder:
     def test_irafstarfind(self, data):
         units = u.Jy

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -12,11 +12,10 @@ from numpy.testing import assert_array_equal, assert_equal
 from photutils.centroids import centroid_com
 from photutils.datasets import make_gwcs, make_wcs
 from photutils.detection import find_peaks
-from photutils.utils._optional_deps import HAS_GWCS, HAS_SCIPY
+from photutils.utils._optional_deps import HAS_GWCS
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestFindPeaks:
     def test_box_size(self, data):
         """

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -10,11 +10,9 @@ from astropy.table import Table
 from numpy.testing import assert_equal
 
 from photutils.detection import StarFinder
-from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestStarFinder:
     def test_starfind(self, data, kernel):
         finder1 = StarFinder(1, kernel)

--- a/photutils/isophote/harmonics.py
+++ b/photutils/isophote/harmonics.py
@@ -4,6 +4,7 @@ This module provides tools for computing and fitting harmonic functions.
 """
 
 import numpy as np
+from scipy.optimize import leastsq
 
 __all__ = ['first_and_second_harmonic_function',
            'fit_first_and_second_harmonics', 'fit_upper_harmonic']
@@ -12,7 +13,6 @@ __all__ = ['first_and_second_harmonic_function',
 def _least_squares_fit(optimize_func, parameters):
     # call the least squares fitting
     # function and handle the result.
-    from scipy.optimize import leastsq
 
     solution = leastsq(optimize_func, parameters, full_output=True)
 

--- a/photutils/isophote/model.py
+++ b/photutils/isophote/model.py
@@ -5,6 +5,7 @@ from a list of isophotes.
 """
 
 import numpy as np
+from scipy.interpolate import LSQUnivariateSpline
 
 from photutils.isophote.geometry import EllipseGeometry
 
@@ -51,8 +52,6 @@ def build_ellipse_model(shape, isolist, fill=0.0, high_harmonics=False):
     """
     if len(isolist) == 0:
         raise ValueError('isolist must not be empty')
-
-    from scipy.interpolate import LSQUnivariateSpline
 
     # the target grid is spaced in 0.1 pixel intervals so as
     # to ensure no gaps will result on the output array.

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -18,7 +18,6 @@ from photutils.isophote.geometry import EllipseGeometry
 from photutils.isophote.isophote import Isophote, IsophoteList
 from photutils.isophote.tests.make_test_data import make_test_image
 from photutils.tests.helper import PYTEST_LT_80
-from photutils.utils._optional_deps import HAS_SCIPY
 
 # define an off-center position and a tilted sma
 POS = 384
@@ -32,7 +31,6 @@ OFFSET_GALAXY = make_test_image(x0=POS, y0=POS, pa=PA, noise=1.0e-12,
                                 seed=0)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestEllipse:
     def setup_class(self):
         # centered, tilted galaxy

--- a/photutils/isophote/tests/test_fitter.py
+++ b/photutils/isophote/tests/test_fitter.py
@@ -16,7 +16,6 @@ from photutils.isophote.integrator import MEAN
 from photutils.isophote.isophote import Isophote
 from photutils.isophote.sample import CentralEllipseSample, EllipseSample
 from photutils.isophote.tests.make_test_data import make_test_image
-from photutils.utils._optional_deps import HAS_SCIPY
 
 DATA = make_test_image(seed=0)
 DEFAULT_POS = 256
@@ -35,7 +34,6 @@ def test_gradient():
     assert_allclose(sample.sector_area, 2.00, atol=0.01)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fitting_raw():
     """
     This test performs a raw (no EllipseFitter), 1-step correction in
@@ -63,7 +61,6 @@ def test_fitting_raw():
     assert_allclose(new_eps, 0.21, atol=0.01)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fitting_small_radii():
     sample = EllipseSample(DATA, 2.0)
     fitter = EllipseFitter(sample)
@@ -73,7 +70,6 @@ def test_fitting_small_radii():
     assert isophote.ndata == 13
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fitting_eps():
     # initial guess is off in the eps parameter
     sample = EllipseSample(DATA, 40.0, eps=2 * 0.2)
@@ -86,7 +82,6 @@ def test_fitting_eps():
     assert g.eps <= 0.21
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fitting_pa():
     data = make_test_image(pa=np.pi / 4, noise=0.01, seed=0)
 
@@ -100,7 +95,6 @@ def test_fitting_pa():
     assert g.pa <= (np.pi / 4 + 0.05)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fitting_xy():
     pos = DEFAULT_POS - 5
     data = make_test_image(x0=pos, y0=pos, seed=0)
@@ -117,7 +111,6 @@ def test_fitting_xy():
     assert g.y0 <= (pos + 1)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fitting_all():
     # build test image that is off from the defaults
     # assumed by the EllipseSample constructor.
@@ -155,7 +148,6 @@ def test_fitting_all():
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestM51:
     def setup_class(self):
         path = get_path('isophote/M51.fits', location='photutils-datasets',

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -6,6 +6,7 @@ Tests for the harmonics module.
 import numpy as np
 from astropy.modeling.models import Gaussian2D
 from numpy.testing import assert_allclose
+from scipy.optimize import leastsq
 
 from photutils.isophote.ellipse import Ellipse
 from photutils.isophote.fitter import EllipseFitter
@@ -18,8 +19,6 @@ from photutils.isophote.tests.make_test_data import make_test_image
 
 
 def test_harmonics_1():
-    from scipy.optimize import leastsq
-
     # this is an almost as-is example taken from stackoverflow
     npts = 100  # number of data points
     theta = np.linspace(0, 4 * np.pi, npts)

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -4,7 +4,6 @@ Tests for the harmonics module.
 """
 
 import numpy as np
-import pytest
 from astropy.modeling.models import Gaussian2D
 from numpy.testing import assert_allclose
 
@@ -16,10 +15,8 @@ from photutils.isophote.harmonics import (first_and_second_harmonic_function,
                                           fit_upper_harmonic)
 from photutils.isophote.sample import EllipseSample
 from photutils.isophote.tests.make_test_data import make_test_image
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_harmonics_1():
     from scipy.optimize import leastsq
 
@@ -53,7 +50,6 @@ def test_harmonics_1():
     assert_allclose(np.std(residual), 0.01, atol=0.01)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_harmonics_2():
     # this uses the actual functional form used for fitting ellipses
     npts = 100
@@ -80,7 +76,6 @@ def test_harmonics_2():
     assert_allclose(np.std(residual), 0.015, atol=0.01)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_harmonics_3():
     """
     Tests an upper harmonic fit.
@@ -106,7 +101,6 @@ def test_harmonics_3():
     assert_allclose(np.std(residual), 0.015, atol=0.014)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestFitEllipseSamples:
     def setup_class(self):
         # major axis parallel to X image axis
@@ -194,7 +188,6 @@ class TestFitEllipseSamples:
         assert_allclose(iso.b4_err, 7.473e-6, atol=1.0e-7)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_upper_harmonics_sign():
     """
     Regression test for #1486/#1501.

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -15,13 +15,11 @@ from photutils.isophote.geometry import EllipseGeometry
 from photutils.isophote.isophote import CentralPixel, Isophote, IsophoteList
 from photutils.isophote.sample import EllipseSample
 from photutils.isophote.tests.make_test_data import make_test_image
-from photutils.utils._optional_deps import HAS_SCIPY
 
 DEFAULT_FIX = np.array([False, False, False, False])
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestIsophote:
     def setup_class(self):
         path = get_path('isophote/M51.fits', location='photutils-datasets',
@@ -288,7 +286,6 @@ class TestIsophoteList:
         result.sort()
         assert result[-1].sma > result[0].sma
 
-    @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_to_table(self):
         test_img = make_test_image(nx=55, ny=55, x0=27, y0=27,
                                    background=100.0, noise=1.0e-6, i0=100.0,

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -19,11 +19,9 @@ from photutils.isophote.isophote import IsophoteList
 from photutils.isophote.model import build_ellipse_model
 from photutils.isophote.tests.make_test_data import make_test_image
 from photutils.tests.helper import PYTEST_LT_80
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_model():
     path = get_path('isophote/M105-S001-RGB.fits',
                     location='photutils-datasets', cache=True)
@@ -50,7 +48,6 @@ def test_model():
     assert np.mean(residual) >= -5.0
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_model_simulated_data():
     data = make_test_image(nx=200, ny=200, i0=10.0, sma=5.0, eps=0.5,
                            pa=np.pi / 3.0, noise=0.05, seed=0)
@@ -68,7 +65,6 @@ def test_model_simulated_data():
     assert np.mean(residual) >= -5.0
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_model_minimum_radius():
     # This test requires a "defective" image that drives the
     # model building algorithm into a corner, where it fails.
@@ -109,7 +105,6 @@ def test_model_inputs():
         build_ellipse_model((10, 10), IsophoteList([]))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_model_harmonics():
     """
     Test that high harmonics are included in build_ellipse_model.

--- a/photutils/isophote/tests/test_regression.py
+++ b/photutils/isophote/tests/test_regression.py
@@ -57,10 +57,8 @@ from astropy.table import Table
 from photutils.datasets import get_path
 from photutils.isophote.ellipse import Ellipse
 from photutils.isophote.integrator import BILINEAR
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 # @pytest.mark.parametrize('name', ['M51', 'synth', 'synth_lowsnr',
 #                                   'synth_highsnr'])
 @pytest.mark.parametrize('name', ['synth_highsnr'])

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -4,6 +4,7 @@ This module provides tools for generating curves of growth.
 """
 import numpy as np
 from astropy.utils import lazyproperty
+from scipy.interpolate import PchipInterpolator
 
 from photutils.profiles.core import ProfileBase
 
@@ -294,8 +295,6 @@ class CurveOfGrowth(ProfileBase):
             The encircled energy at each radius/radii. Returns NaN for
             radii outside the range of the profile data.
         """
-        from scipy.interpolate import PchipInterpolator
-
         return PchipInterpolator(self.radius, self.profile,
                                  extrapolate=False)(radius)
 
@@ -324,8 +323,6 @@ class CurveOfGrowth(ProfileBase):
             The radius at each encircled energy. Returns NaN for
             encircled energies outside the range of the profile data.
         """
-        from scipy.interpolate import PchipInterpolator
-
         # restrict the profile to the monotonically increasing region;
         # this is necessary for the interpolator
         radius = self.radius

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -15,8 +15,6 @@ from photutils.profiles.core import ProfileBase
 
 __all__ = ['RadialProfile']
 
-__doctest_requires__ = {'RadialProfile': ['scipy']}
-
 
 class RadialProfile(ProfileBase):
     """

--- a/photutils/profiles/tests/test_curve_of_growth.py
+++ b/photutils/profiles/tests/test_curve_of_growth.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture import CircularAperture
 from photutils.profiles import CurveOfGrowth
-from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY
+from photutils.utils._optional_deps import HAS_MATPLOTLIB
 
 
 @pytest.fixture(name='profile_data')
@@ -137,7 +137,6 @@ def test_curve_of_growth_normalize(profile_data):
         cg1.normalize(method='max')
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_curve_of_growth_interp(profile_data):
     xycen, data, error, _ = profile_data
     radii = np.arange(1, 36)

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -12,7 +12,6 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture import CircularAnnulus, CircularAperture
 from photutils.profiles import RadialProfile
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 @pytest.fixture(name='profile_data')
@@ -90,7 +89,6 @@ def test_radial_profile_inputs(profile_data):
         RadialProfile(data, xycen, edge_radii, error=None, mask=mask)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_radial_profile_gaussian(profile_data):
     xycen, data, _, _ = profile_data
 

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -13,6 +13,7 @@ from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.nddata.utils import NoOverlapError, PartialOverlapError
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.ndimage import convolve
 
 from photutils.centroids import centroid_com
 from photutils.psf.epsf_stars import EPSFStar, EPSFStars, LinkedEPSFStar
@@ -504,8 +505,6 @@ class EPSFBuilder:
         result : 2D `~numpy.ndarray`
             The smoothed (convolved) ePSF data.
         """
-        from scipy.ndimage import convolve
-
         if self.smoothing_kernel is None:
             return epsf_data
 

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -14,8 +14,6 @@ __all__ = ['GaussianPSF', 'CircularGaussianPSF', 'GaussianPRF',
            'CircularGaussianPRF', 'CircularGaussianSigmaPRF',
            'IntegratedGaussianPRF', 'MoffatPSF', 'AiryDiskPSF']
 
-__doctest_requires__ = {'*': ['scipy']}
-
 GAUSSIAN_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 
 

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -18,6 +18,7 @@ from astropy.modeling import Fittable2DModel, Parameter
 from astropy.nddata import NDData, reshape_as_blocks
 from astropy.utils import minversion
 from astropy.visualization import simple_norm
+from scipy.interpolate import RectBivariateSpline
 
 from photutils.utils._parameters import as_pair
 
@@ -645,8 +646,6 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
         Note that the interpolator will be cached by _calc_interpolator.
         It can be cleared by calling the clear_cache method.
         """
-        from scipy.interpolate import RectBivariateSpline
-
         if (x_0 < self._xgrid[0] or x_0 > self._xgrid[-1]
                 or y_0 < self._ygrid[0] or y_0 > self._ygrid[-1]):
             # position is outside of the grid, so simply use the

--- a/photutils/psf/groupers.py
+++ b/photutils/psf/groupers.py
@@ -6,6 +6,7 @@ This module provides classes to perform grouping of stars.
 from collections import defaultdict
 
 import numpy as np
+from scipy.cluster.hierarchy import fclusterdata
 
 __all__ = ['SourceGrouper']
 
@@ -66,8 +67,6 @@ class SourceGrouper:
             A 1D array of the groups, in the same order as the input x
             and y coordinates.
         """
-        from scipy.cluster.hierarchy import fclusterdata
-
         x = np.atleast_1d(x)
         y = np.atleast_1d(y)
         if x.shape != y.shape:

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 from astropy.modeling import Fittable2DModel, Parameter
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.interpolate import RectBivariateSpline
 
 from photutils.aperture import CircularAperture
 from photutils.utils._parameters import as_pair
@@ -433,8 +434,6 @@ class FittableImageModel(Fittable2DModel):
           decrease code performance due to the need to recompute
           interpolator.
         """
-        from scipy.interpolate import RectBivariateSpline
-
         if 'degree' in kwargs:
             degree = kwargs['degree']
             if hasattr(degree, '__iter__') and len(degree) == 2:
@@ -695,8 +694,6 @@ class EPSFModel(FittableImageModel):
           decrease code performance due to the need to recompute
           interpolator.
         """
-        from scipy.interpolate import RectBivariateSpline
-
         if 'degree' in kwargs:
             degree = kwargs['degree']
             if hasattr(degree, '__iter__') and len(degree) == 2:

--- a/photutils/psf/matching/fourier.py
+++ b/photutils/psf/matching/fourier.py
@@ -5,6 +5,7 @@ This module provides tools for matching PSFs using Fourier methods.
 
 import numpy as np
 from numpy.fft import fft2, fftshift, ifft2, ifftshift
+from scipy.ndimage import zoom
 
 __all__ = ['resize_psf', 'create_matching_kernel']
 
@@ -34,8 +35,6 @@ def resize_psf(psf, input_pixel_scale, output_pixel_scale, *, order=3):
     result : 2D `~numpy.ndarray`
         The resampled/interpolated 2D data array.
     """
-    from scipy.ndimage import zoom
-
     ratio = input_pixel_scale / output_pixel_scale
     return zoom(psf, ratio, order=order) / ratio**2
 

--- a/photutils/psf/matching/tests/test_fourier.py
+++ b/photutils/psf/matching/tests/test_fourier.py
@@ -11,17 +11,14 @@ from numpy.testing import assert_allclose
 
 from photutils.psf.matching.fourier import create_matching_kernel, resize_psf
 from photutils.psf.matching.windows import SplitCosineBellWindow
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_resize_psf():
     psf1 = np.ones((5, 5))
     psf2 = resize_psf(psf1, 0.1, 0.05)
     assert psf2.shape == (10, 10)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_create_matching_kernel():
     """
     Test with noiseless 2D Gaussians.

--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -10,7 +10,6 @@ from numpy.testing import assert_allclose
 from photutils.psf.matching.windows import (CosineBellWindow, HanningWindow,
                                             SplitCosineBellWindow,
                                             TopHatWindow, TukeyWindow)
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 def test_hanning():
@@ -40,7 +39,6 @@ def test_tukey():
     assert_allclose(data[1, :], ref)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_tukey_scipy():
     """
     Test Tukey window against 1D scipy version.

--- a/photutils/psf/matching/tests/test_windows.py
+++ b/photutils/psf/matching/tests/test_windows.py
@@ -6,6 +6,7 @@ Tests for the windows module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from scipy.signal.windows import tukey
 
 from photutils.psf.matching.windows import (CosineBellWindow, HanningWindow,
                                             SplitCosineBellWindow,
@@ -43,8 +44,6 @@ def test_tukey_scipy():
     """
     Test Tukey window against 1D scipy version.
     """
-    from scipy.signal.windows import tukey
-
     size = 101
     cen = (size - 1) // 2
     shape = (size, size)

--- a/photutils/psf/model_helpers.py
+++ b/photutils/psf/model_helpers.py
@@ -14,8 +14,6 @@ from astropy.utils.decorators import deprecated
 
 __all__ = ['make_psf_model', 'grid_from_epsfs', 'PRFAdapter']
 
-__doctest_requires__ = {'make_psf_model': ['scipy']}
-
 
 def make_psf_model(model, *, x_name=None, y_name=None, flux_name=None,
                    normalize=True, dx=50, dy=50, subsample=100,

--- a/photutils/psf/model_helpers.py
+++ b/photutils/psf/model_helpers.py
@@ -11,6 +11,7 @@ from astropy.modeling import CompoundModel, Fittable2DModel, Parameter
 from astropy.modeling.models import Const2D, Identity, Shift
 from astropy.nddata import NDData
 from astropy.utils.decorators import deprecated
+from scipy.integrate import dblquad, trapezoid
 
 __all__ = ['make_psf_model', 'grid_from_epsfs', 'PRFAdapter']
 
@@ -273,11 +274,7 @@ def _integrate_model(model, x_name=None, y_name=None, dx=50, dy=50,
         The integral of the model over the 2D grid.
     """
     if use_dblquad:
-        from scipy.integrate import dblquad
-
         return dblquad(model, -np.inf, np.inf, -np.inf, np.inf)[0]
-
-    from scipy.integrate import trapezoid
 
     if dx <= 0 or dy <= 0:
         raise ValueError('dx and dy must be > 0')
@@ -537,7 +534,6 @@ class PRFAdapter(Fittable2DModel):
         self.psfmodel = psfmodel.copy()
 
         if renormalize_psf:
-            from scipy.integrate import dblquad
             self._psf_scale_factor = 1.0 / dblquad(self.psfmodel,
                                                    -np.inf, np.inf,
                                                    lambda x: -np.inf,
@@ -602,8 +598,6 @@ class PRFAdapter(Fittable2DModel):
         return self._integrated_psfmodel(dx, dy)
 
     def _integrated_psfmodel(self, dx, dy):
-        from scipy.integrate import dblquad
-
         # infer type/shape from the PSF model. Seems wasteful, but the
         # integration step is a *lot* more expensive so its just peanuts
         out = np.empty_like(self.psfmodel(dx, dy))

--- a/photutils/psf/simulation.py
+++ b/photutils/psf/simulation.py
@@ -12,8 +12,6 @@ from photutils.utils._parameters import as_pair
 
 __all__ = ['make_psf_model_image']
 
-__doctest_requires__ = {'make_psf_model_image': ['scipy']}
-
 
 def make_psf_model_image(shape, psf_model, n_sources, *, model_shape=None,
                          min_separation=1, border_size=None, seed=0,

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -14,6 +14,7 @@ from astropy.stats import SigmaClip
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_almost_equal
+from scipy.spatial import cKDTree
 
 from photutils.datasets import make_model_image
 from photutils.psf.epsf import EPSFBuilder, EPSFFitter
@@ -27,8 +28,6 @@ class TestEPSFBuild:
         """
         Create a simulated image for testing.
         """
-        from scipy.spatial import cKDTree
-
         shape = (750, 750)
 
         # define random star positions

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -20,10 +20,8 @@ from photutils.psf.epsf import EPSFBuilder, EPSFFitter
 from photutils.psf.epsf_stars import EPSFStars, extract_stars
 from photutils.psf.functional_models import CircularGaussianPRF
 from photutils.psf.image_models import EPSFModel
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestEPSFBuild:
     def setup_class(self):
         """
@@ -256,7 +254,6 @@ def test_epsfmodel_inputs():
         EPSFModel(data, origin=origin)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('oversamp', [3, 4])
 def test_epsf_build_oversampling(oversamp):
     offsets = (np.arange(oversamp) * 1.0 / oversamp - 0.5 + 1.0

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -13,10 +13,8 @@ from numpy.testing import assert_allclose
 from photutils.psf.epsf_stars import EPSFStars, extract_stars
 from photutils.psf.functional_models import CircularGaussianPRF
 from photutils.psf.image_models import EPSFModel
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestExtractStars:
     def setup_class(self):
         stars_tbl = Table()
@@ -61,7 +59,6 @@ class TestExtractStars:
             extract_stars([self.nddata, self.nddata], self.stars_tbl)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_epsf_star_residual_image():
     """
     Test to ensure ``compute_residual_image`` gives correct residuals.

--- a/photutils/psf/tests/test_functional_models.py
+++ b/photutils/psf/tests/test_functional_models.py
@@ -13,7 +13,6 @@ from numpy.testing import assert_allclose
 from photutils.psf import (AiryDiskPSF, CircularGaussianPRF,
                            CircularGaussianPSF, CircularGaussianSigmaPRF,
                            GaussianPRF, GaussianPSF, MoffatPSF)
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 def make_gaussian_models(name):
@@ -140,14 +139,12 @@ def gaussian_tests(name, use_units):
             fitter(model_init, xx, yy, data)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('name', ['GaussianPSF', 'CircularGaussianPSF'])
 @pytest.mark.parametrize('use_units', [False, True])
 def test_gaussian_psfs(name, use_units):
     gaussian_tests(name, use_units)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('name', ['GaussianPRF', 'CircularGaussianPRF',
                                   'CircularGaussianSigmaPRF'])
 @pytest.mark.parametrize('use_units', [False, True])
@@ -155,7 +152,6 @@ def test_gaussian_prfs(name, use_units):
     gaussian_tests(name, use_units)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_gaussian_prf_sums():
     """
     Test that subpixel accuracy of Gaussian PRFs by checking the sum of
@@ -169,7 +165,6 @@ def test_gaussian_prf_sums():
         assert_allclose(model(xx, yy).sum(), 1.0)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_gaussian_bounding_boxes():
     model1 = GaussianPSF(x_0=0, y_0=0, x_fwhm=2, y_fwhm=3)
     model2 = GaussianPRF(x_0=0, y_0=0, x_fwhm=2, y_fwhm=3)
@@ -187,7 +182,6 @@ def test_gaussian_bounding_boxes():
     assert_allclose(model5.bounding_box, ((-11, 11), (-11, 11)))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('use_units', [False, True])
 def test_moffat_psf_model(use_units):
     model = MoffatPSF(flux=71.4, x_0=24.3, y_0=25.2, alpha=8.1, beta=7.2)
@@ -223,7 +217,6 @@ def test_moffat_psf_model(use_units):
     assert_allclose(model.bounding_box, ((-bbox, bbox), (-bbox, bbox)))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('use_units', [False, True])
 def test_airydisk_psf_model(use_units):
     model = AiryDiskPSF(flux=71.4, x_0=24.3, y_0=25.2, radius=2.1)

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.psf import GriddedPSFModel, STDPSFGrid
 from photutils.segmentation import SourceCatalog, detect_sources
-from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_SCIPY
+from photutils.utils._optional_deps import HAS_MATPLOTLIB
 
 # the first file has a single detector, the rest have multiple detectors
 STDPSF_FILENAMES = ('STDPSF_NRCA1_F150W_mock.fits',
@@ -70,7 +70,6 @@ class TestGriddedPSFModel:
         xypos = grid_xypos[idx]
         assert_allclose(xypos, grid_xypos)
 
-    @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_gridded_psf_model_basic_eval(self, psfmodel):
         y, x = np.mgrid[0:100, 0:100]
         psf = psfmodel.evaluate(x=x, y=y, flux=100, x_0=40, y_0=60)
@@ -81,7 +80,6 @@ class TestGriddedPSFModel:
         with pytest.raises(ValueError, match=match):
             psfmodel.evaluate(x=x2, y=y2, flux=100, x_0=40, y_0=60)
 
-    @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_gridded_psf_model_eval_outside_grid(self, psfmodel):
         y, x = np.mgrid[-50:50, -50:50]
         psf1 = psfmodel.evaluate(x=x, y=y, flux=100, x_0=0, y_0=0)
@@ -95,7 +93,6 @@ class TestGriddedPSFModel:
         psf4 = psfmodel.evaluate(x=x, y=y, flux=100, x_0=220, y_0=220)
         assert_allclose(psf3, psf4)
 
-    @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_gridded_psf_model_interp(self, psfmodel):
         # test xyref length
         match = 'object is not iterable'
@@ -168,7 +165,6 @@ class TestGriddedPSFModel:
         with pytest.raises(ValueError, match=match):
             GriddedPSFModel(nddata)
 
-    @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_gridded_psf_model_eval(self, psfmodel):
         """
         Create a simulated image using GriddedPSFModel and test the
@@ -229,7 +225,6 @@ class TestGriddedPSFModel:
         new_model.flux = 100
         assert new_model.flux.value != flux
 
-    @pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
     def test_cache(self, psfmodel):
         for x, y in psfmodel.grid_xypos:
             psfmodel.x_0 = x

--- a/photutils/psf/tests/test_groupers.py
+++ b/photutils/psf/tests/test_groupers.py
@@ -8,10 +8,8 @@ import pytest
 from numpy.testing import assert_equal
 
 from photutils.psf.groupers import SourceGrouper
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_empty():
     """
     Test case when there are no sources.
@@ -24,7 +22,6 @@ def test_grouper_empty():
         grouper(xx, yy)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_one_source():
     """
     Test case when there is only one source.
@@ -37,7 +34,6 @@ def test_grouper_one_source():
     assert_equal(groups, gg)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_inputs():
     xx = np.array([1, 2, 3, 4])
     yy = np.array([1, 2])
@@ -47,7 +43,6 @@ def test_grouper_inputs():
         grouper(xx, yy)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_isolated_sources():
     """
     Test case when all sources are isolated.
@@ -62,7 +57,6 @@ def test_isolated_sources():
     assert_equal(groups, gg)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_one():
     #      +---------+--------+---------+---------+--------+---------+
     #      |  *            *                        *             *  |
@@ -101,7 +95,6 @@ def test_grouper_one():
     assert_equal(groups, gg)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_two():
     #      +--------------+--------------+-------------+--------------+
     #    3 +                             *                            +
@@ -135,7 +128,6 @@ def test_grouper_two():
     assert_equal(groups, gg)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_three():
     #     1 +--+-------+--------+--------+--------+-------+--------+--+
     #       |                                                         |
@@ -169,7 +161,6 @@ def test_grouper_three():
     assert_equal(groups, gg)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_four():
     #       +-+---------+---------+---------+---------+-+
     #     1 +                     *                     +
@@ -202,7 +193,6 @@ def test_grouper_four():
     assert_equal(groups, gg)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_five():
     #      +--+--------+--------+-------+--------+--------+--------+--+
     #    3 +                            *                             +
@@ -246,7 +236,6 @@ def test_grouper_five():
     assert_equal(groups, gg)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper_six():
     #       +------+----------+----------+----------+----------+------+
     #       |  *       *             *       *             *       *  |

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -9,7 +9,6 @@ from astropy.modeling.models import Gaussian2D
 from numpy.testing import assert_allclose
 
 from photutils.psf import FittableImageModel
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 @pytest.fixture(name='gmodel')
@@ -17,7 +16,6 @@ def fixture_gmodel():
     return Gaussian2D(x_stddev=3, y_stddev=3)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestFittableImageModel:
     """
     Tests for FittableImageModel.

--- a/photutils/psf/tests/test_model_helpers.py
+++ b/photutils/psf/tests/test_model_helpers.py
@@ -11,6 +11,7 @@ from astropy.nddata import NDData
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_equal
+from scipy.integrate import dblquad
 
 from photutils import datasets
 from photutils.detection import find_peaks
@@ -316,8 +317,6 @@ class TestPRFAdapter:
         {'xname': None, 'yname': None, 'fluxname': None,
          'renormalize_psf': False}])
     def test_prfadapter_integrates(self, adapterkwargs):
-        from scipy.integrate import dblquad
-
         mof = Moffat2D(gamma=1.5, alpha=4.8)
         if not adapterkwargs['renormalize_psf']:
             mof = self.normalize_moffat(mof)
@@ -342,8 +341,6 @@ class TestPRFAdapter:
         {'xname': None, 'yname': None, 'fluxname': None,
          'renormalize_psf': False}])
     def test_prfadapter_sizematch(self, adapterkwargs):
-        from scipy.integrate import dblquad
-
         mof1 = self.normalize_moffat(Moffat2D(gamma=1, alpha=4.8))
         with pytest.warns(AstropyDeprecationWarning):
             prf1 = PRFAdapter(mof1, **adapterkwargs)

--- a/photutils/psf/tests/test_model_helpers.py
+++ b/photutils/psf/tests/test_model_helpers.py
@@ -17,7 +17,6 @@ from photutils.detection import find_peaks
 from photutils.psf import (EPSFBuilder, PRFAdapter, extract_stars,
                            grid_from_epsfs, make_psf_model)
 from photutils.psf.model_helpers import _integrate_model, _InverseShift
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 def test_inverse_shift():
@@ -27,7 +26,6 @@ def test_inverse_shift():
     assert model.fit_deriv(10, 1)[0] == -1.0
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_integrate_model():
     model = Gaussian2D(1, 5, 5, 1, 1) * Const2D(0.0)
     integral = _integrate_model(model, x_name='x_mean_0', y_name='y_mean_0')
@@ -68,7 +66,6 @@ def fixture_moffat_source():
     return model, (xx, yy, model(xx, yy))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_moffat_fitting(moffat_source):
     """
     Test fitting with a Moffat2D model.
@@ -97,7 +94,6 @@ def test_moffat_fitting(moffat_source):
                           ({'x_name': 'x_0', 'y_name': 'y_0',
                             'flux_name': 'amplitude', 'normalize': False},
                            (1e-3, None))])
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model(moffat_source, kwargs, tols):
     model, (xx, yy, data) = moffat_source
 
@@ -132,7 +128,6 @@ def test_make_psf_model(moffat_source, kwargs, tols):
         assert fit_model[2].amplitude == guess_moffat.amplitude
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_compound():
     model = (Const2D(0.0) + Const2D(1.0) + Gaussian2D(1, 5, 5, 1, 1)
              * Const2D(1.0) * Const2D(1.0))
@@ -152,7 +147,6 @@ def test_make_psf_model_inputs():
         make_psf_model(model, x_name='x_mean', y_name='y_mean_10')
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_integral():
     model = Gaussian2D(1, 5, 5, 1, 1) * Const2D(0.0)
     match = 'Cannot normalize the model because the integrated flux is zero'
@@ -177,7 +171,6 @@ def test_make_psf_model_offset():
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestGridFromEPSFs:
     """
     Tests for `photutils.psf.utils.grid_from_epsfs`.
@@ -286,7 +279,6 @@ class TestGridFromEPSFs:
         assert psf_grid.meta['fill_value'] == 0.0
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestPRFAdapter:
     """
     Tests for PRFAdapter.

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -19,7 +19,6 @@ from photutils.detection import DAOStarFinder
 from photutils.psf import (CircularGaussianPRF, IterativePSFPhotometry,
                            PSFPhotometry, SourceGrouper, make_psf_model,
                            make_psf_model_image)
-from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
@@ -40,7 +39,6 @@ def fixture_test_data():
     return data, error, true_params
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_invalid_inputs():
     model = CircularGaussianPRF(fwhm=1.0)
 
@@ -164,7 +162,6 @@ def test_invalid_inputs():
         _ = psfphot(data, init_params=init_params)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_psf_photometry(test_data):
     data, error, sources = test_data
 
@@ -212,7 +209,6 @@ def test_psf_photometry(test_data):
         assert not isinstance(col, u.Quantity)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('fit_fwhm', [False, True])
 def test_psf_photometry_forced(test_data, fit_fwhm):
     data, error, sources = test_data
@@ -245,7 +241,6 @@ def test_psf_photometry_forced(test_data, fit_fwhm):
             assert colname in phot.colnames
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_psf_photometry_nddata(test_data):
     data, error, _ = test_data
 
@@ -284,7 +279,6 @@ def test_psf_photometry_nddata(test_data):
     assert resid_data3.unit == unit
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_model_residual_image(test_data):
     data, error, _ = test_data
 
@@ -322,7 +316,6 @@ def test_model_residual_image(test_data):
     assert resid2[y, x] < -9
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('fit_stddev', [False, True])
 def test_psf_photometry_compound_psfmodel(test_data, fit_stddev):
     """
@@ -396,7 +389,6 @@ def test_psf_photometry_compound_psfmodel(test_data, fit_stddev):
             assert np.all(np.isnan(phot[column]))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('mode', ['new', 'all'])
 def test_iterative_psf_photometry_compound(mode):
     x_stddev = y_stddev = 1.7
@@ -468,7 +460,6 @@ def test_iterative_psf_photometry_compound(mode):
         assert colname in phot.colnames
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_psf_photometry_mask(test_data):
     data, error, sources = test_data
 
@@ -558,7 +549,6 @@ def test_psf_photometry_mask(test_data):
     psfphot(data, mask=mask, init_params=init_params)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_psf_photometry_init_params(test_data):
     data, error, _ = test_data
     data = data.copy()
@@ -638,7 +628,6 @@ def test_psf_photometry_init_params(test_data):
     assert phot['flux_init'][0] == flux
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_psf_photometry_init_params_units(test_data):
     data, error, _ = test_data
     data2 = data.copy()
@@ -694,7 +683,6 @@ def test_psf_photometry_init_params_units(test_data):
             _ = psfphot(data << u.Jy, init_params=init_params2)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_psf_photometry_init_params_columns(test_data):
     data, error, _ = test_data
     data = data.copy()
@@ -731,7 +719,6 @@ def test_psf_photometry_init_params_columns(test_data):
         assert_allclose(phot['flux_fit'], phots[0]['flux_fit'])
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_grouper(test_data):
     data, error, sources = test_data
 
@@ -748,7 +735,6 @@ def test_grouper(test_data):
     assert_equal(phot['group_size'], (1, 1, 1, 1, 3, 3, 3, 2, 2, 1))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_large_group_warning():
     psf_model = CircularGaussianPRF(flux=1, fwhm=2)
     grouper = SourceGrouper(min_separation=50)
@@ -766,7 +752,6 @@ def test_large_group_warning():
         psfphot(data, init_params=true_params)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_local_bkg(test_data):
     data, error, sources = test_data
 
@@ -785,7 +770,6 @@ def test_local_bkg(test_data):
     assert np.count_nonzero(phot['local_bkg']) == len(sources)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fixed_params(test_data):
     data, error, _ = test_data
 
@@ -806,7 +790,6 @@ def test_fixed_params(test_data):
         assert np.all(np.isnan(phot['flux_err']))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fit_warning(test_data):
     data, _, _ = test_data
 
@@ -826,7 +809,6 @@ def test_fit_warning(test_data):
         assert len(psfphot.fit_info['fit_error_indices']) > 0
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fitter_no_maxiters_no_metrics(test_data):
     """
     Test with a fitter that does not have a maxiters parameter and does
@@ -848,7 +830,6 @@ def test_fitter_no_maxiters_no_metrics(test_data):
         assert np.all(np.isnan(phot['cfit']))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_xy_bounds(test_data):
     data, error, _ = test_data
 
@@ -909,7 +890,6 @@ def test_xy_bounds(test_data):
         PSFPhotometry(psf_model, fit_shape, xy_bounds=(-1, 2))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_iterative_psf_photometry_mode_new(test_data):
     data, error, sources = test_data
 
@@ -997,7 +977,6 @@ def test_iterative_psf_photometry_mode_new(test_data):
         assert phot is None
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_iterative_psf_photometry_mode_all():
     sources = QTable()
     sources['x_0'] = [50, 45, 55, 27, 22, 77, 82]
@@ -1069,7 +1048,6 @@ def test_iterative_psf_photometry_mode_all():
     assert resid_nddata.unit == unit
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_iterative_psf_photometry_overlap():
     """
     Regression test for #1769.
@@ -1100,7 +1078,6 @@ def test_iterative_psf_photometry_overlap():
         assert len(phot) == 49
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_iterative_psf_photometry_inputs():
     psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
     fit_shape = (5, 5)
@@ -1130,7 +1107,6 @@ def test_iterative_psf_photometry_inputs():
                                    aperture_radius=4, maxiters=3.14)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_negative_xy():
     sources = Table()
     sources['id'] = np.arange(3) + 1
@@ -1148,7 +1124,6 @@ def test_negative_xy():
     assert_equal(phot['y_init'], sources['y_0'])
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_out_of_bounds_centroids():
     sources = Table()
     sources['id'] = np.arange(8) + 1
@@ -1171,7 +1146,6 @@ def test_out_of_bounds_centroids():
     assert np.any(np.isnan(phot['cfit']))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model():
     normalize = False
     sigma = 3.0
@@ -1218,7 +1192,6 @@ def test_make_psf_model():
                      tbl4['flux_fit'][0]), (xval, yval, flux))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_move_column():
     psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
     fit_shape = (5, 5)

--- a/photutils/psf/tests/test_simulation.py
+++ b/photutils/psf/tests/test_simulation.py
@@ -11,10 +11,8 @@ from numpy.testing import assert_equal
 
 from photutils.psf import (CircularGaussianPRF, make_psf_model,
                            make_psf_model_image)
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_image():
     shape = (401, 451)
     n_sources = 100
@@ -48,7 +46,6 @@ def test_make_psf_model_image():
     assert np.max(params['fwhm']) <= fwhm[1]
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_image_custom():
     shape = (401, 451)
     n_sources = 100
@@ -61,7 +58,6 @@ def test_make_psf_model_image_custom():
     assert len(params) == n_sources
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_psf_model_image_inputs():
     shape = (50, 50)
     match = 'psf_model must be an Astropy Model subclass'

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -15,7 +15,6 @@ from photutils.psf import CircularGaussianPSF, make_psf_model_image
 from photutils.psf.utils import (_get_psf_model_params,
                                  _interpolate_missing_data,
                                  _validate_psf_model, fit_2dgaussian, fit_fwhm)
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 @pytest.fixture(name='test_data')
@@ -31,7 +30,6 @@ def fixture_test_data():
     return data, true_params
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('fix_fwhm', [False, True])
 def test_fit_2dgaussian_single(fix_fwhm):
     yy, xx = np.mgrid[:51, :51]
@@ -50,7 +48,6 @@ def test_fit_2dgaussian_single(fix_fwhm):
         assert_allclose(fit_tbl['fwhm_fit'], fwhm)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize(('fix_fwhm', 'with_units'),
                          [(False, True), (True, False)])
 def test_fit_2dgaussian_multiple(test_data, fix_fwhm, with_units):
@@ -78,7 +75,6 @@ def test_fit_2dgaussian_multiple(test_data, fix_fwhm, with_units):
                 assert fit_tbl['flux_fit'].unit == unit
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_fit_fwhm_single():
     yy, xx = np.mgrid[:51, :51]
     fwhm0 = 3.123
@@ -97,7 +93,6 @@ def test_fit_fwhm_single():
     assert len(fwhm) == 1
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.parametrize('with_units', [False, True])
 def test_fit_fwhm_multiple(test_data, with_units):
     data, sources = test_data
@@ -113,7 +108,6 @@ def test_fit_fwhm_multiple(test_data, with_units):
     assert_allclose(fwhms, sources['fwhm'])
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_interpolate_missing_data():
     data = np.arange(100).reshape(10, 10)
     mask = np.zeros_like(data, dtype=bool)

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -17,8 +17,6 @@ from photutils.utils._parameters import as_pair
 
 __all__ = ['fit_2dgaussian', 'fit_fwhm']
 
-__doctest_requires__ = {('fit_2dgaussian', 'fit_fwhm'): ['scipy']}
-
 
 def fit_2dgaussian(data, *, xypos=None, fit_shape=None, mask=None, error=None,
                    fix_fwhm=True):

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -2,6 +2,7 @@
 """
 This module provides utilities for PSF-fitting photometry.
 """
+
 import warnings
 
 import numpy as np
@@ -9,6 +10,7 @@ from astropy.modeling import Model
 from astropy.table import QTable
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy import interpolate
 
 from photutils.centroids import centroid_com
 from photutils.psf.functional_models import CircularGaussianPSF
@@ -309,8 +311,6 @@ def _interpolate_missing_data(data, mask, method='cubic'):
     data_interp : 2D `~numpy.ndarray`
         The interpolated 2D image.
     """
-    from scipy import interpolate
-
     data_interp = np.array(data, copy=True)
 
     if len(data_interp.shape) != 2:

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -15,6 +15,8 @@ from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
 from astropy.table import QTable
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.ndimage import binary_erosion, convolve, map_coordinates
+from scipy.optimize import root_scalar
 
 from photutils.aperture import (BoundingBox, CircularAperture,
                                 EllipticalAperture, RectangularAnnulus)
@@ -2146,8 +2148,6 @@ class SourceCatalog:
         if self._background is None:
             bkg = self._null_values
         else:
-            from scipy.ndimage import map_coordinates
-
             xcen = self._xcentroid
             ycen = self._ycentroid
             bkg = map_coordinates(self._background, (xcen, ycen), order=1,
@@ -2222,8 +2222,6 @@ class SourceCatalog:
                the Irish Machine Vision and Image Processing Conference,
                pp. 51-57 (2000).
         """
-        from scipy.ndimage import binary_erosion, convolve
-
         footprint = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
         kernel = np.array([[10, 2, 10], [2, 1, 2], [10, 2, 10]])
         size = 34
@@ -3583,8 +3581,6 @@ class SourceCatalog:
         """
         if fluxfrac <= 0 or fluxfrac > 1:
             raise ValueError('fluxfrac must be > 0 and <= 1')
-
-        from scipy.optimize import root_scalar
 
         args = self._fluxfrac_optimizer_args
         if self.progress_bar:  # pragma: no cover

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -29,8 +29,6 @@ from photutils.utils.cutouts import CutoutImage
 
 __all__ = ['SourceCatalog']
 
-__doctest_requires__ = {('SourceCatalog', 'SourceCatalog.*'): ['scipy']}
-
 
 # default table columns for `to_table()` output
 DEFAULT_COLUMNS = ['label', 'xcentroid', 'ycentroid', 'sky_centroid',

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -19,9 +19,6 @@ from photutils.utils.colormaps import make_random_cmap
 
 __all__ = ['SegmentationImage', 'Segment']
 
-__doctest_requires__ = {('SegmentationImage', 'SegmentationImage.*'):
-                        ['scipy']}
-
 
 class SegmentationImage:
     """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -11,6 +11,8 @@ from copy import copy, deepcopy
 import numpy as np
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.ndimage import find_objects, grey_dilation
+from scipy.signal import fftconvolve
 
 from photutils.aperture import BoundingBox
 from photutils.utils._optional_deps import HAS_RASTERIO, HAS_SHAPELY
@@ -277,7 +279,6 @@ class SegmentationImage:
 
     @lazyproperty
     def _raw_slices(self):
-        from scipy.ndimage import find_objects
         return find_objects(self.data)
 
     @lazyproperty
@@ -1220,11 +1221,10 @@ class SegmentationImage:
         footprint = footprint.astype(bool)
 
         if np.all(footprint):
-            # With a rectangular footprint, scipy grey_dilation is
+            # With a rectangular footprint, scipy's grey_dilation is
             # currently much faster than binary_dilation (separable
             # footprint). grey_dilation and binary_dilation are identical
             # for binary inputs (equivalent to a 2D maximum filter).
-            from scipy.ndimage import grey_dilation
             return grey_dilation(mask, footprint=footprint)
 
         # Binary dilation is very slow, especially for large
@@ -1234,7 +1234,6 @@ class SegmentationImage:
         # "Dilation and Erosion of Gray Images with Spherical
         # Masks", J. Kukal, D. Majerova, A. Prochazka (Jan 2007).
         # https://www.researchgate.net/publication/238778666_DILATION_AND_EROSION_OF_GRAY_IMAGES_WITH_SPHERICAL_MASKS
-        from scipy.signal import fftconvolve
         return fftconvolve(mask, footprint, 'same') > 0.5
 
     @lazyproperty

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -10,6 +10,8 @@ from multiprocessing import cpu_count, get_context
 import numpy as np
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.ndimage import label as ndi_label
+from scipy.ndimage import sum_labels
 
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.detect import _detect_sources
@@ -401,8 +403,6 @@ class _Deblender:
             as markers. The last list element contains all of the
             potential source markers.
         """
-        from scipy.ndimage import label as ndi_label
-
         for i in range(len(segments) - 1):
             segm_lower = segments[i].data
             segm_upper = segments[i + 1].data
@@ -450,7 +450,6 @@ class _Deblender:
             A 2D int array containing the deblended source labels. Note
             that the source labels may not be consecutive.
         """
-        from scipy.ndimage import sum_labels
         from skimage.segmentation import watershed
 
         # all markers are at the top level

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -7,6 +7,8 @@ import warnings
 
 import numpy as np
 from astropy.stats import SigmaClip
+from scipy.ndimage import find_objects
+from scipy.ndimage import label as ndi_label
 
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.utils import _make_binary_structure
@@ -181,9 +183,6 @@ def _detect_sources(data, thresholds, npixels, footprint, inverse_mask, *,
         threshold, then the output list will contain `None` for that
         threshold. Also see the ``deblend_mode`` keyword.
     """
-    from scipy.ndimage import find_objects
-    from scipy.ndimage import label as ndi_label
-
     segms = []
     for threshold in thresholds:
         # RuntimeWarning caused by > comparison when data contains NaNs

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -25,11 +25,10 @@ from photutils.segmentation.detect import detect_sources
 from photutils.segmentation.finder import SourceFinder
 from photutils.segmentation.utils import make_2dgaussian_kernel
 from photutils.utils._optional_deps import (HAS_GWCS, HAS_MATPLOTLIB,
-                                            HAS_SCIPY, HAS_SKIMAGE)
+                                            HAS_SKIMAGE)
 from photutils.utils.cutouts import CutoutImage
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestSourceCatalog:
     def setup_class(self):
         xcen = 51.0
@@ -883,7 +882,6 @@ class TestSourceCatalog:
         assert_allclose(cat.fwhm, [0.67977799, np.nan] * u.pix)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_kron_params():
     data = make_100gaussians_image()
@@ -938,7 +936,6 @@ def test_kron_params():
     assert isinstance(cat.kron_aperture[0], CircularAperture)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_centroid_win():
     g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
@@ -966,7 +963,6 @@ def test_centroid_win():
     assert cat.ycentroid[1] == cat.ycentroid_win[1]
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_centroid_win_migrate():
     """
     Test that when the windowed centroid moves the aperture completely

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -12,10 +12,9 @@ from numpy.testing import assert_allclose, assert_equal
 from photutils.segmentation.core import Segment, SegmentationImage
 from photutils.utils import circular_footprint
 from photutils.utils._optional_deps import (HAS_MATPLOTLIB, HAS_RASTERIO,
-                                            HAS_SCIPY, HAS_SHAPELY)
+                                            HAS_SHAPELY)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestSegmentationImage:
     def setup_class(self):
         self.data = np.array([[1, 1, 0, 0, 4, 4],
@@ -479,7 +478,6 @@ class CustomSegm(SegmentationImage):
         return np.median(self.data)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_subclass():
     """
     Test that cached properties are reset in SegmentationImage

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -12,10 +12,9 @@ from numpy.testing import assert_allclose, assert_equal
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.deblend import deblend_sources
 from photutils.segmentation.detect import detect_sources
-from photutils.utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE
+from photutils.utils._optional_deps import HAS_SKIMAGE
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 class TestDeblendSources:
     def setup_class(self):
@@ -334,7 +333,6 @@ class TestDeblendSources:
         assert result.nlabels == 2
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_nmarkers_fallback():
     """

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -11,14 +11,12 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.segmentation.detect import detect_sources, detect_threshold
 from photutils.segmentation.utils import make_2dgaussian_kernel
-from photutils.utils._optional_deps import HAS_SCIPY
 from photutils.utils.exceptions import NoDetectionsWarning
 
 DATA = np.array([[0, 1, 0], [0, 2, 0], [0, 0, 0]]).astype(float)
 REF1 = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestDetectThreshold:
     def test_nsigma(self):
         """
@@ -132,7 +130,6 @@ class TestDetectThreshold:
             detect_threshold(DATA, 1.0, sigma_clip=10)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestDetectSources:
     def setup_class(self):
         self.data = np.array([[0, 1, 0], [0, 2, 0],

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -12,11 +12,10 @@ from astropy.modeling.models import Gaussian2D
 from photutils.datasets import make_100gaussians_image
 from photutils.segmentation.finder import SourceFinder
 from photutils.segmentation.utils import make_2dgaussian_kernel
-from photutils.utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE
+from photutils.utils._optional_deps import HAS_SKIMAGE
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestSourceFinder:
     data = make_100gaussians_image() - 5.0  # subtract background
     kernel = make_2dgaussian_kernel(3.0, size=5)

--- a/photutils/segmentation/tests/test_utils.py
+++ b/photutils/segmentation/tests/test_utils.py
@@ -4,13 +4,11 @@ Tests for the _utils module.
 """
 
 import numpy as np
-import pytest
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.segmentation.utils import (_make_binary_structure,
                                           _mask_to_mirrored_value,
                                           make_2dgaussian_kernel)
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
 def test_make_2dgaussian_kernel():
@@ -22,7 +20,6 @@ def test_make_2dgaussian_kernel():
     assert_allclose(kernel.array.sum(), 1.0)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_2dgaussian_kernel_modes():
     kernel = make_2dgaussian_kernel(3.0, 5)
     assert_allclose(kernel.array.sum(), 1.0)
@@ -37,7 +34,6 @@ def test_make_2dgaussian_kernel_modes():
     assert_allclose(kernel.array.sum(), 1.0)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 def test_make_binary_structure():
     footprint = _make_binary_structure(1, 4)
     assert_allclose(footprint, np.array([1, 1, 1]))

--- a/photutils/segmentation/utils.py
+++ b/photutils/segmentation/utils.py
@@ -6,6 +6,7 @@ This module provides utility functions for image segmentation.
 import numpy as np
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
+from scipy.ndimage import generate_binary_structure
 
 from photutils.utils._parameters import as_pair
 
@@ -96,8 +97,6 @@ def _make_binary_structure(ndim, connectivity):
             raise ValueError(f'Invalid connectivity={connectivity}. '
                              'Options are 4 or 8.')
     else:
-        from scipy.ndimage import generate_binary_structure
-
         footprint = generate_binary_structure(ndim, 1)
 
     return footprint

--- a/photutils/utils/_convolution.py
+++ b/photutils/utils/_convolution.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.convolution import Kernel2D
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.ndimage import convolve as ndi_convolve
 
 
 def _filter_data(data, kernel, mode='constant', fill_value=0.0,
@@ -50,8 +51,6 @@ def _filter_data(data, kernel, mode='constant', fill_value=0.0,
     if kernel is None:
         return data
 
-    from scipy import ndimage
-
     kernel_array = kernel.array if isinstance(kernel, Kernel2D) else kernel
 
     if check_normalization and not np.allclose(np.sum(kernel_array), 1.0):
@@ -72,7 +71,7 @@ def _filter_data(data, kernel, mode='constant', fill_value=0.0,
 
     # NOTE: astropy.convolution.convolve fails with zero-sum kernels
     # (used in findstars) (cf. astropy #1647)
-    result = ndimage.convolve(data, kernel_array, mode=mode, cval=fill_value)
+    result = ndi_convolve(data, kernel_array, mode=mode, cval=fill_value)
 
     # reapply the input unit
     if unit is not None:

--- a/photutils/utils/_coords.py
+++ b/photutils/utils/_coords.py
@@ -2,11 +2,13 @@
 """
 This module provides tools for generating random (x, y) coordinates.
 """
+
 import warnings
 from collections import defaultdict
 
 import numpy as np
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.spatial import KDTree
 
 
 def apply_separation(xycoords, min_separation):
@@ -29,8 +31,6 @@ def apply_separation(xycoords, min_separation):
         The (x, y) coordinates with shape ``(N, 2)`` after excluding
         points closer than the minimum separation.
     """
-    from scipy.spatial import KDTree
-
     tree = KDTree(xycoords)
     pairs = tree.query_pairs(min_separation, output_type='ndarray')
 

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -9,7 +9,7 @@ import importlib
 # This list is a duplicate of the dependencies in pyproject.toml "all".
 # Note that in some cases the package names are different from the
 # pip-install name (e.g.k scikit-image -> skimage).
-optional_deps = ['scipy', 'matplotlib', 'regions', 'skimage', 'gwcs',
+optional_deps = ['matplotlib', 'regions', 'skimage', 'gwcs',
                  'bottleneck', 'tqdm', 'rasterio', 'shapely']
 deps = {key.upper(): key for key in optional_deps}
 __all__ = [f'HAS_{pkg}' for pkg in deps]

--- a/photutils/utils/_quantity_helpers.py
+++ b/photutils/utils/_quantity_helpers.py
@@ -2,6 +2,7 @@
 """
 This module provides Quantity helper tools.
 """
+
 import astropy.units as u
 import numpy as np
 

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -9,6 +9,7 @@ import astropy.units as u
 import numpy as np
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
+from scipy.ndimage import binary_dilation
 
 from photutils.utils._coords import apply_separation
 from photutils.utils._progress_bars import add_progress_bar
@@ -424,8 +425,6 @@ class ImageDepth:
         mask : 2D bool `~numpy.ndarray`
             Dilated boolean mask array.
         """
-        from scipy.ndimage import binary_dilation
-
         if np.any(mask):
             mask = binary_dilation(mask, structure=self.dilate_footprint)
 

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -17,7 +17,7 @@ from photutils.utils.footprints import circular_footprint
 
 __all__ = ['ImageDepth']
 
-__doctest_requires__ = {('ImageDepth', 'ImageDepth.*'): ['scipy', 'skimage']}
+__doctest_requires__ = {('ImageDepth', 'ImageDepth.*'): ['skimage']}
 
 
 class ImageDepth:

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -4,6 +4,7 @@ This module provides tools for interpolating data.
 """
 
 import numpy as np
+from scipy.spatial import cKDTree
 
 __all__ = ['ShepardIDWInterpolator']
 
@@ -115,8 +116,6 @@ class ShepardIDWInterpolator:
     """
 
     def __init__(self, coordinates, values, weights=None, leafsize=10):
-        from scipy.spatial import cKDTree
-
         coordinates = np.asarray(coordinates)
         if coordinates.ndim == 0:  # scalar coordinate
             coordinates = np.atleast_2d(coordinates)

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -7,8 +7,6 @@ import numpy as np
 
 __all__ = ['ShepardIDWInterpolator']
 
-__doctest_requires__ = {'ShepardIDWInterpolator': ['scipy']}
-
 
 class ShepardIDWInterpolator:
     """

--- a/photutils/utils/tests/test_convolution.py
+++ b/photutils/utils/tests/test_convolution.py
@@ -4,16 +4,13 @@ Tests for the convolution module.
 """
 
 import astropy.units as u
-import pytest
 from astropy.convolution import Gaussian2DKernel
 from numpy.testing import assert_allclose
 
 from photutils.datasets import make_100gaussians_image
 from photutils.utils._convolution import _filter_data
-from photutils.utils._optional_deps import HAS_SCIPY
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestFilterData:
     def setup_class(self):
         self.data = make_100gaussians_image()

--- a/photutils/utils/tests/test_depths.py
+++ b/photutils/utils/tests/test_depths.py
@@ -13,13 +13,12 @@ from numpy.testing import assert_allclose
 
 from photutils.datasets import make_100gaussians_image
 from photutils.segmentation import SourceFinder, make_2dgaussian_kernel
-from photutils.utils._optional_deps import HAS_SCIPY, HAS_SKIMAGE
+from photutils.utils._optional_deps import HAS_SKIMAGE
 from photutils.utils.depths import ImageDepth
 
 bool_vals = (True, False)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 class TestImageDepth:
     def setup_class(self):

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -2,13 +2,11 @@
 """
 Tests for the interpolation module.
 """
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
 from photutils.utils import ShepardIDWInterpolator as IDWInterp
-from photutils.utils._optional_deps import HAS_SCIPY
 
 SHAPE = (5, 5)
 DATA = np.ones(SHAPE) * 2.0
@@ -19,7 +17,6 @@ BACKGROUND = np.ones(SHAPE)
 WRONG_SHAPE = np.ones((2, 2))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason='scipy is required')
 class TestShepardIDWInterpolator:
     def setup_class(self):
         self.rng = np.random.default_rng(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ requires-python = '>=3.10'
 dependencies = [
     'numpy>=1.23',
     'astropy>=5.3',
+    'scipy>=1.10',
 ]
 
 [project.urls]
@@ -43,7 +44,6 @@ Documentation = 'https://photutils.readthedocs.io/en/stable/'
 
 [project.optional-dependencies]
 all = [
-    'scipy>=1.8',
     'matplotlib>=3.5',
     'regions>=0.9',
     'scikit-image>=0.20',

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps =
 
     oldestdeps: numpy==1.23
     oldestdeps: astropy==5.3
-    oldestdeps: scipy==1.8
+    oldestdeps: scipy==1.10
     oldestdeps: matplotlib==3.5
     oldestdeps: scikit-image==0.20
     oldestdeps: scikit-learn==1.1


### PR DESCRIPTION
With this PR, `SciPy` is now a *required* dependency, instead of an optional dependency.  The reality is that most of the subpackages in photutils require scipy for functionality (as this large PR attests!).  Version 2.0 is a good time to make it a required dependency.

This PR also bumps the minimum required scipy version to 1.10.0 following SPEC-0 (https://scientific-python.org/specs/spec-0000/).