### PR TITLE
Update minimum dependencies

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -41,8 +41,8 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.12'
-            tox_env: 'py312-test-devdeps'
+            python: '3.13'
+            tox_env: 'py313-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'
@@ -56,6 +56,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
     - name: Install base dependencies
       run: python -m pip install --upgrade pip setuptools tox
     - name: Print Python, pip, setuptools, and tox versions

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -99,8 +99,8 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.12'
-            tox_env: 'py312-test-devdeps'
+            python: '3.13'
+            tox_env: 'py313-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'
@@ -114,6 +114,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
     - name: Install base dependencies
       run: python -m pip install --upgrade pip setuptools tox
     - name: Print Python, pip, setuptools, and tox versions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,12 @@ General
 
 - The minimum required SciPy is now 1.10. [#1880]
 
+- The minimum required NumPy is now 1.24. [#1881]
+
+- The minimum required Matplotlib is now 3.7. [#1881]
+
+- The minimum required GWCS is now 0.19. [#1881]
+
 - Importing tools from all subpackages now requires including the
   subpackage name. [#1879]
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Photutils has the following strict requirements:
 
 * `Python <https://www.python.org/>`_ 3.10 or later
 
-* `NumPy <https://numpy.org/>`_ 1.23 or later
+* `NumPy <https://numpy.org/>`_ 1.24 or later
 
 * `Astropy`_ 5.3 or later
 
@@ -18,7 +18,7 @@ Photutils has the following strict requirements:
 
 Photutils also optionally depends on other packages for some features:
 
-* `Matplotlib <https://matplotlib.org/>`_ 3.5 or later: Used to power a
+* `Matplotlib <https://matplotlib.org/>`_ 3.7 or later: Used to power a
   variety of plotting features (e.g., plotting apertures).
 
 * `Regions <https://astropy-regions.readthedocs.io/>`_ 0.9 or
@@ -27,7 +27,7 @@ Photutils also optionally depends on other packages for some features:
 * `scikit-image <https://scikit-image.org/>`_ 0.20 or later: Required
   to deblend segmented sources.
 
-* `GWCS <https://gwcs.readthedocs.io/en/stable/>`_ 0.18 or later:
+* `GWCS <https://gwcs.readthedocs.io/en/stable/>`_ 0.19 or later:
   Required in `~photutils.datasets.make_gwcs` to create a simple celestial
   gwcs object.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = ['version']
 requires-python = '>=3.10'
 dependencies = [
-    'numpy>=1.23',
+    'numpy>=1.24',
     'astropy>=5.3',
     'scipy>=1.10',
 ]
@@ -44,10 +44,10 @@ Documentation = 'https://photutils.readthedocs.io/en/stable/'
 
 [project.optional-dependencies]
 all = [
-    'matplotlib>=3.5',
+    'matplotlib>=3.7',
     'regions>=0.9',
     'scikit-image>=0.20',
-    'gwcs>=0.18',
+    'gwcs>=0.19',
     'bottleneck',
     'tqdm',
     'rasterio',
@@ -67,9 +67,9 @@ docs = [
 requires = [
     'setuptools>=61.2',
     'setuptools_scm>=6.2',
-    'cython>=3.0.0,<3.1.0',
-    'numpy>=2.0.0rc1',
-    'extension-helpers==1.*',
+    'cython>=3.0.0,<4',
+    'numpy>=2.0.0',
+    'extension-helpers>=1',
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{310,311,312}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{310,311,312}-test-numpy{126,200,210}
+    py{310,311,312,313}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
+    py{310,311,312,313}-test-numpy{126,200,210}
     build_docs
     linkcheck
     codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{310,311,312}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{310,311,312}-test-numpy{123,124,125,126}
+    py{310,311,312}-test-numpy{126,200,210}
     build_docs
     linkcheck
     codestyle
@@ -38,27 +38,25 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy123: with numpy 1.23.*
-    numpy124: with numpy 1.24.*
-    numpy125: with numpy 1.25.*
     numpy126: with numpy 1.26.*
+    numpy200: with numpy 2.0.*
+    numpy210: with numpy 2.1.*
 
 # The following provides some specific pinnings for key packages
 deps =
     cov: pytest-cov
 
-    numpy123: numpy==1.23.*
-    numpy124: numpy==1.24.*
-    numpy125: numpy==1.25.*
     numpy126: numpy==1.26.*
+    numpy200: numpy==2.0.*
+    numpy210: numpy==2.1.*
 
-    oldestdeps: numpy==1.23
+    oldestdeps: numpy==1.24
     oldestdeps: astropy==5.3
     oldestdeps: scipy==1.10
-    oldestdeps: matplotlib==3.5
+    oldestdeps: matplotlib==3.7
     oldestdeps: scikit-image==0.20
     oldestdeps: scikit-learn==1.1
-    oldestdeps: gwcs==0.18
+    oldestdeps: gwcs==0.19
     oldestdeps: pytest-astropy==0.11
 
     devdeps: numpy>=0.0.dev0


### PR DESCRIPTION
Following SPEC-0: https://scientific-python.org/specs/spec-0000/

This PR also adds Python 3.13 to the CI tests.