### PR TITLE
Fix DAOStarFinder if threshold=0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,12 @@ Bug Fixes
   - Fixed a bug checking that the ``subpixels`` keyword is a strictly
     positive integer. [#1816]
 
+- ``photutils.detection``
+
+  - Fixed an issue where ``DAOStarFinder`` would not return any sources
+    if the input ``threshold`` was set to zero due to the ``flux`` being
+    non-finite. [#1882]
+
 - ``photutils.isophote``
 
   - Fixed a bug in ``build_ellipse_model`` where if

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -279,7 +279,7 @@ class DAOStarFinder(StarFinderBase):
               array.
             * ``sky``: the input ``sky`` parameter.
             * ``peak``: the peak, sky-subtracted, pixel value of the object.
-            * ``flux``: the object DAOFind "flux" calculated as the peak
+            * ``flux``: the object DAOFIND "flux" calculated as the peak
               density in the convolved image divided by the detection
               threshold. This derivation matches that of DAOFIND if
               ``sky`` is 0.0.
@@ -288,6 +288,18 @@ class DAOStarFinder(StarFinderBase):
               DAOFIND if ``sky`` is 0.0.
 
             `None` is returned if no stars are found.
+
+            .. warning::
+                The ``flux`` parameter returned by the DAOFIND algorithm
+                is a bit of a misnomer. It is not a typical integrated
+                source flux, and its value critically depends on the
+                input ``threshold`` parameter. The ``flux`` parameter is
+                calculated as the peak density in the convolved image
+                divided by the effective detection threshold. ``flux``
+                and the corresponding ``mag`` parameter are reported
+                in the output table for comparison to the IRAF DAOFIND
+                output only. They are not intended to be used as a
+                measure of source flux.
         """
         # here we validate the units, but do not strip them
         # since sky is deprecated, we do not include it in the

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -24,6 +24,13 @@ class TestDAOStarFinder:
         tbl1 = finder1(data << units)
         assert_array_equal(tbl0, tbl1)
 
+        # test that sources are returned with threshold = 0
+        finder = DAOStarFinder(0, fwhm)
+        tbl = finder(data)
+        assert len(tbl) == 25
+        assert np.all(~np.isfinite(tbl['flux']))
+        assert np.all(~np.isfinite(tbl['mag']))
+
     def test_daofind_inputs(self):
         match = 'threshold must be a scalar value'
         with pytest.raises(ValueError, match=match):


### PR DESCRIPTION
This PR fixes an issue (introduced in version 1.13.0) where `DAOStarFinder` would not return any sources if the input `threshold = 0`.  This is due to the `flux` being non-finite when `threshold = 0`, as defined by the original DAOFIND algorithm.  With this PR, the source parameters are returned, with the `flux` and `mag` columns being all infinite values.

Thanks to @mdlpstsci for reporting this issue.