### PR TITLE
Add ImagePSF model class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,9 @@ New Features
   - Added new ``fit_2dgaussian`` convenience function to fit a circular 2D
     Gaussian PSF to one or more sources in an image. [#1859, #1887]
 
+  - Added new ``ImagePSF`` model class to represent a PSF model as an
+    image. [#1890]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -205,6 +208,9 @@ API Changes
   - The ``PRFAdapter`` class has been deprecated. Instead, use a
     ``FittableImageModel`` derived from the ``discretize_model`` function
     in ``astropy.convolution``. [#1865]
+
+  - The ``FittableImageModel`` and ``EPSFModel`` classes have been
+    deprecated. Instead, use the new ``ImagePSF`` model class. [#1890]
 
 - ``photutils.segmentation``
 

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -284,11 +284,8 @@ framework. The user must provide the image-based PSF model as an input
 to these classes. The input image(s) can be oversampled to increase the
 accuracy of the PSF model.
 
-- `~photutils.psf.FittableImageModel`: a general class for image-based
-  PSF models that allows for intensity scaling and translations.
-
-- `~photutils.psf.EPSFModel`: similar to
-  `~photutils.psf.FittableImageModel`, but with a different normalization.
+- `~photutils.psf.ImagePSF`: a general class for image-based PSF models
+  that allows for intensity scaling and translations.
 
 - `~photutils.psf.GriddedPSFModel`: a PSF model that contains a grid of
   image-based ePSF models at fiducial detector positions.

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -14,6 +14,7 @@ from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import BoundingBox
+from photutils.psf.image_models import _LegacyEPSFModel
 from photutils.psf.utils import _interpolate_missing_data
 from photutils.utils._parameters import as_pair
 from photutils.utils.cutouts import _overlap_slices as overlap_slices
@@ -183,7 +184,7 @@ class EPSFStar:
 
         Parameters
         ----------
-        epsf : `EPSFModel`
+        epsf : `ImagePSF`
             The ePSF to register.
 
         Returns
@@ -191,11 +192,17 @@ class EPSFStar:
         data : `~numpy.ndarray`
             A 2D array of the registered/scaled ePSF.
         """
+        legacy_epsf = _LegacyEPSFModel(epsf.data, flux=epsf.flux, x_0=epsf.x_0,
+                                       y_0=epsf.y_0,
+                                       oversampling=epsf.oversampling,
+                                       fill_value=epsf.fill_value)
+
         yy, xx = np.indices(self.shape, dtype=float)
         xx = xx - self.cutout_center[0]
         yy = yy - self.cutout_center[1]
 
-        return self.flux * epsf.evaluate(xx, yy, flux=1.0, x_0=0.0, y_0=0.0)
+        return self.flux * legacy_epsf.evaluate(xx, yy, flux=1.0, x_0=0.0,
+                                                y_0=0.0)
 
     def compute_residual_image(self, epsf):
         """
@@ -204,7 +211,7 @@ class EPSFStar:
 
         Parameters
         ----------
-        epsf : `EPSFModel`
+        epsf : `ImagePSF`
             The ePSF to subtract.
 
         Returns

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -418,6 +418,9 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
             raise ValueError('The NDData data attribute must be a 3D numpy '
                              'ndarray')
 
+        if not np.all(np.isfinite(data.data)):
+            raise ValueError('All elements of input data must be finite.')
+
         if 'grid_xypos' not in data.meta:
             raise ValueError('"grid_xypos" must be in the nddata meta '
                              'dictionary.')

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -8,7 +8,7 @@ import warnings
 
 import numpy as np
 from astropy.modeling import Fittable2DModel, Parameter
-from astropy.utils.decorators import lazyproperty
+from astropy.utils.decorators import deprecated, lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from scipy.interpolate import RectBivariateSpline
 
@@ -280,6 +280,7 @@ class ImagePSF(Fittable2DModel):
         return evaluated_model
 
 
+@deprecated('2.0.0', alternative='`ImagePSF`')
 class FittableImageModel(Fittable2DModel):
     r"""
     A fittable image model allowing for intensity scaling and

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -150,6 +150,48 @@ class ImagePSF(Fittable2DModel):
             raise ValueError('The length of the x and y axes must both be at '
                              'least 4.')
 
+    def copy(self):
+        """
+        Return a copy of this model where only the model parameters are
+        copied.
+
+        All other copied model attributes are references to the original
+        model. This prevents copying the image data, which may be a
+        large array.
+
+        This method is useful if one is interested in only changing
+        the model parameters in a model copy. It is used in the PSF
+        photometry classes during model fitting.
+
+        Use the `deepcopy` method if you want to copy all of the model
+        attributes, including the PSF image data.
+
+        Returns
+        -------
+        result : `ImagePSF`
+            A copy of this model with only the model parameters copied.
+        """
+        newcls = object.__new__(self.__class__)
+
+        for key, val in self.__dict__.items():
+            if key in self.param_names:  # copy only the parameter values
+                newcls.__dict__[key] = copy.copy(val)
+            else:
+                newcls.__dict__[key] = val
+
+        return newcls
+
+    def deepcopy(self):
+        """
+        Return a deep copy of this model.
+
+        Returns
+        -------
+        result : `ImagePSF`
+            A deep copy of this model.
+        """
+        return copy.deepcopy(self)
+
     @property
     def origin(self):
         """

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -35,16 +35,18 @@ class ImagePSF(Fittable2DModel):
     Parameters
     ----------
     data : 2D `~numpy.ndarray`
-        Array containing the 2D image. The input image data must be
-        finite. By default, the PSF peak is assumed to be located at
-        the center of the input image (see the ``origin`` keyword). The
-        array must be normalized so that the total flux of a source is
-        1.0. This means that the sum of the values in the input image
-        PSF over an infinite grid is 1.0. In practice, the sum of the
-        data values in the input image may be less than 1.0 if the input
-        image only covers a finite region of the PSF. These correction
-        factors can be estimated from the ensquared or encircled energy
-        of the PSF based on the size of the input image.
+        Array containing the 2D image. The length of the x and y axes
+        must both be at least 4. All elements of the input image data
+        must be finite. By default, the PSF peak is assumed to be
+        located at the center of the input image (see the ``origin``
+        keyword). The array must be normalized so that the total flux
+        of a source is 1.0. This means that the sum of the values in
+        the input image PSF over an infinite grid is 1.0. In practice,
+        the sum of the data values in the input image may be less than
+        1.0 if the input image only covers a finite region of the PSF.
+        These correction factors can be estimated from the ensquared
+        or encircled energy of the PSF based on the size of the input
+        image.
 
     flux : float, optional
         The total flux of the source, assuming the input image
@@ -143,6 +145,10 @@ class ImagePSF(Fittable2DModel):
 
         if not np.all(np.isfinite(data)):
             raise ValueError('All elements of input data must be finite.')
+
+        if np.any(np.array(data.shape) < 4):
+            raise ValueError('The length of the x and y axes must both be at '
+                             'least 4.')
 
     @property
     def origin(self):

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -20,7 +20,6 @@ from photutils.datasets import make_model_image
 from photutils.psf.epsf import EPSFBuilder, EPSFFitter
 from photutils.psf.epsf_stars import EPSFStars, extract_stars
 from photutils.psf.functional_models import CircularGaussianPRF
-from photutils.psf.image_models import EPSFModel
 
 
 class TestEPSFBuild:
@@ -203,54 +202,6 @@ def test_epsfbuilder_inputs():
 
     # valid inputs
     EPSFBuilder(sigma_clip=SigmaClip(sigma=2.5, cenfunc='mean', maxiters=2))
-
-
-def test_epsfmodel_inputs():
-    data = np.array([[], []])
-    match = 'Image data array cannot be zero-sized'
-    with pytest.raises(ValueError, match=match):
-        EPSFModel(data)
-
-    data = np.ones((5, 5), dtype=float)
-    data[2, 2] = np.inf
-    match = 'must be finite'
-    with pytest.raises(ValueError, match=match):
-        EPSFModel(data)
-
-    data[2, 2] = np.nan
-    with pytest.raises(ValueError, match=match):
-        EPSFModel(data, flux=None)
-
-    data[2, 2] = 1
-    match = 'oversampling must be > 0'
-    for oversampling in [-1, [-2, 4]]:
-        with pytest.raises(ValueError, match=match):
-            EPSFModel(data, oversampling=oversampling)
-
-    match = 'oversampling must have 1 or 2 elements'
-    oversampling = (1, 4, 8)
-    with pytest.raises(ValueError, match=match):
-        EPSFModel(data, oversampling=oversampling)
-
-    match = 'oversampling must have integer values'
-    oversampling = 2.1
-    with pytest.raises(ValueError, match=match):
-        EPSFModel(data, oversampling=oversampling)
-
-    match = 'oversampling must be 1D'
-    for oversampling in [((1, 2), (3, 4)), np.ones((2, 2, 2))]:
-        with pytest.raises(ValueError, match=match):
-            EPSFModel(data, oversampling=oversampling)
-
-    match = 'oversampling must be a finite value'
-    for oversampling in [np.nan, (1, np.inf)]:
-        with pytest.raises(ValueError, match=match):
-            EPSFModel(data, oversampling=oversampling)
-
-    origin = (1, 2, 3)
-    match = 'Parameter "origin" must be either None or an iterable with'
-    with pytest.raises(TypeError, match=match):
-        EPSFModel(data, origin=origin)
 
 
 @pytest.mark.parametrize('oversamp', [3, 4])

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_allclose
 
 from photutils.psf.epsf_stars import EPSFStars, extract_stars
 from photutils.psf.functional_models import CircularGaussianPRF
-from photutils.psf.image_models import EPSFModel
+from photutils.psf.image_models import ImagePSF
 
 
 class TestExtractStars:
@@ -66,7 +66,7 @@ def test_epsf_star_residual_image():
     size = 100
     yy, xx, = np.mgrid[0:size + 1, 0:size + 1] / 4
     gmodel = CircularGaussianPRF().evaluate(xx, yy, 1, 12.5, 12.5, 2.5)
-    epsf = EPSFModel(gmodel, oversampling=4, norm_radius=100)
+    epsf = ImagePSF(gmodel, oversampling=4)
     _size = 25
     data = np.zeros((_size, _size))
     _yy, _xx, = np.mgrid[0:_size, 0:_size]

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -98,6 +98,10 @@ class TestImagePSF:
         with pytest.raises(ValueError, match=match):
             ImagePSF(np.ones((10, 10, 10)))
 
+        match = 'The length of the x and y axes must both be at least 4'
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(np.ones((3, 4)))
+
         data = np.ones((10, 10))
         data[0, 0] = np.nan
         match = 'All elements of input data must be finite'

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -6,6 +6,7 @@ Tests for the image_models module.
 import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.psf import CircularGaussianPSF, FittableImageModel, ImagePSF
@@ -161,28 +162,32 @@ class TestFittableImageModel:
 
     def test_fittable_image_model(self, gmodel_old):
         yy, xx = np.mgrid[-2:3, -2:3]
-        model_nonorm = FittableImageModel(gmodel_old(xx, yy))
+        with pytest.warns(AstropyDeprecationWarning):
+            model_nonorm = FittableImageModel(gmodel_old(xx, yy))
 
-        assert_allclose(model_nonorm(0, 0), gmodel_old(0, 0))
-        assert_allclose(model_nonorm(1, 1), gmodel_old(1, 1))
-        assert_allclose(model_nonorm(-2, 1), gmodel_old(-2, 1))
+            assert_allclose(model_nonorm(0, 0), gmodel_old(0, 0))
+            assert_allclose(model_nonorm(1, 1), gmodel_old(1, 1))
+            assert_allclose(model_nonorm(-2, 1), gmodel_old(-2, 1))
 
-        # subpixel should *not* match, but be reasonably close
-        # in this case good to ~0.1% seems to be fine
-        assert_allclose(model_nonorm(0.5, 0.5), gmodel_old(0.5, 0.5),
-                        rtol=.001)
-        assert_allclose(model_nonorm(-0.5, 1.75), gmodel_old(-0.5, 1.75),
-                        rtol=.001)
+            # subpixel should *not* match, but be reasonably close
+            # in this case good to ~0.1% seems to be fine
+            assert_allclose(model_nonorm(0.5, 0.5), gmodel_old(0.5, 0.5),
+                            rtol=.001)
+            assert_allclose(model_nonorm(-0.5, 1.75), gmodel_old(-0.5, 1.75),
+                            rtol=.001)
 
-        model_norm = FittableImageModel(gmodel_old(xx, yy), normalize=True)
-        assert not np.allclose(model_norm(0, 0), gmodel_old(0, 0))
-        assert_allclose(np.sum(model_norm(xx, yy)), 1)
+        with pytest.warns(AstropyDeprecationWarning):
+            model_norm = FittableImageModel(gmodel_old(xx, yy), normalize=True)
+            assert not np.allclose(model_norm(0, 0), gmodel_old(0, 0))
+            assert_allclose(np.sum(model_norm(xx, yy)), 1)
 
-        model_norm2 = FittableImageModel(gmodel_old(xx, yy), normalize=True,
-                                         normalization_correction=2)
-        assert not np.allclose(model_norm2(0, 0), gmodel_old(0, 0))
-        assert_allclose(model_norm(0, 0), model_norm2(0, 0) * 2)
-        assert_allclose(np.sum(model_norm2(xx, yy)), 0.5)
+        with pytest.warns(AstropyDeprecationWarning):
+            model_norm2 = FittableImageModel(gmodel_old(xx, yy),
+                                             normalize=True,
+                                             normalization_correction=2)
+            assert not np.allclose(model_norm2(0, 0), gmodel_old(0, 0))
+            assert_allclose(model_norm(0, 0), model_norm2(0, 0) * 2)
+            assert_allclose(np.sum(model_norm2(xx, yy)), 0.5)
 
     def test_fittable_image_model_oversampling(self, gmodel_old):
         oversamp = 3  # oversampling factor
@@ -191,50 +196,55 @@ class TestFittableImageModel:
         im = gmodel_old(xx, yy)
         assert im.shape[0] > 7
 
-        model_oversampled = FittableImageModel(im, oversampling=oversamp)
-        assert_allclose(model_oversampled(0, 0), gmodel_old(0, 0))
-        assert_allclose(model_oversampled(1, 1), gmodel_old(1, 1))
-        assert_allclose(model_oversampled(-2, 1), gmodel_old(-2, 1))
-        assert_allclose(model_oversampled(0.5, 0.5), gmodel_old(0.5, 0.5),
-                        rtol=.001)
-        assert_allclose(model_oversampled(-0.5, 1.75), gmodel_old(-0.5, 1.75),
-                        rtol=.001)
+        with pytest.warns(AstropyDeprecationWarning):
+            model_oversampled = FittableImageModel(im, oversampling=oversamp)
+            assert_allclose(model_oversampled(0, 0), gmodel_old(0, 0))
+            assert_allclose(model_oversampled(1, 1), gmodel_old(1, 1))
+            assert_allclose(model_oversampled(-2, 1), gmodel_old(-2, 1))
+            assert_allclose(model_oversampled(0.5, 0.5), gmodel_old(0.5, 0.5),
+                            rtol=.001)
+            assert_allclose(model_oversampled(-0.5, 1.75),
+                            gmodel_old(-0.5, 1.75), rtol=.001)
 
         # without oversampling the same tests should fail except for at
         # the origin
-        model_wrongsampled = FittableImageModel(im)
-        assert_allclose(model_wrongsampled(0, 0), gmodel_old(0, 0))
-        assert not np.allclose(model_wrongsampled(1, 1), gmodel_old(1, 1))
-        assert not np.allclose(model_wrongsampled(-2, 1), gmodel_old(-2, 1))
-        assert not np.allclose(model_wrongsampled(0.5, 0.5),
-                               gmodel_old(0.5, 0.5), rtol=.001)
-        assert not np.allclose(model_wrongsampled(-0.5, 1.75),
-                               gmodel_old(-0.5, 1.75), rtol=.001)
+        with pytest.warns(AstropyDeprecationWarning):
+            model_wrongsampled = FittableImageModel(im)
+            assert_allclose(model_wrongsampled(0, 0), gmodel_old(0, 0))
+            assert not np.allclose(model_wrongsampled(1, 1), gmodel_old(1, 1))
+            assert not np.allclose(model_wrongsampled(-2, 1),
+                                   gmodel_old(-2, 1))
+            assert not np.allclose(model_wrongsampled(0.5, 0.5),
+                                   gmodel_old(0.5, 0.5), rtol=.001)
+            assert not np.allclose(model_wrongsampled(-0.5, 1.75),
+                                   gmodel_old(-0.5, 1.75), rtol=.001)
 
     def test_centering_oversampled(self, gmodel_old):
         oversamp = 3
         yy, xx = np.mgrid[-3:3.00001:(1 / oversamp), -3:3.00001:(1 / oversamp)]
 
-        model_oversampled = FittableImageModel(gmodel_old(xx, yy),
-                                               oversampling=oversamp)
+        with pytest.warns(AstropyDeprecationWarning):
+            model_oversampled = FittableImageModel(gmodel_old(xx, yy),
+                                                   oversampling=oversamp)
 
-        valcen = gmodel_old(0, 0)
-        val36 = gmodel_old(0.66, 0.66)
+            valcen = gmodel_old(0, 0)
+            val36 = gmodel_old(0.66, 0.66)
 
-        assert_allclose(valcen, model_oversampled(0, 0))
-        assert_allclose(val36, model_oversampled(0.66, 0.66), rtol=1.0e-6)
+            assert_allclose(valcen, model_oversampled(0, 0))
+            assert_allclose(val36, model_oversampled(0.66, 0.66), rtol=1.0e-6)
 
-        model_oversampled.x_0 = 2.5
-        model_oversampled.y_0 = -3.5
+            model_oversampled.x_0 = 2.5
+            model_oversampled.y_0 = -3.5
 
-        assert_allclose(valcen, model_oversampled(2.5, -3.5))
-        assert_allclose(val36, model_oversampled(2.5 + 0.66, -3.5 + 0.66),
-                        rtol=1.0e-6)
+            assert_allclose(valcen, model_oversampled(2.5, -3.5))
+            assert_allclose(val36, model_oversampled(2.5 + 0.66, -3.5 + 0.66),
+                            rtol=1.0e-6)
 
     def test_oversampling_inputs(self):
         data = np.arange(30).reshape(5, 6)
         for oversampling in [4, (3, 3), (3, 4)]:
-            fim = FittableImageModel(data, oversampling=oversampling)
+            with pytest.warns(AstropyDeprecationWarning):
+                fim = FittableImageModel(data, oversampling=oversampling)
             if not hasattr(oversampling, '__len__'):
                 _oversamp = float(oversampling)
             else:
@@ -243,24 +253,29 @@ class TestFittableImageModel:
 
         match = 'oversampling must be > 0'
         for oversampling in [-1, [-2, 4]]:
-            with pytest.raises(ValueError, match=match):
+            with (pytest.raises(ValueError, match=match),
+                  pytest.warns(AstropyDeprecationWarning)):
                 FittableImageModel(data, oversampling=oversampling)
 
         match = 'oversampling must have 1 or 2 elements'
         oversampling = (1, 4, 8)
-        with pytest.raises(ValueError, match=match):
+        with (pytest.raises(ValueError, match=match),
+              pytest.warns(AstropyDeprecationWarning)):
             FittableImageModel(data, oversampling=oversampling)
 
         match = 'oversampling must be 1D'
         for oversampling in [((1, 2), (3, 4)), np.ones((2, 2, 2))]:
-            with pytest.raises(ValueError, match=match):
+            with (pytest.raises(ValueError, match=match),
+                  pytest.warns(AstropyDeprecationWarning)):
                 FittableImageModel(data, oversampling=oversampling)
 
         match = 'oversampling must have integer values'
-        with pytest.raises(ValueError, match=match):
+        with (pytest.raises(ValueError, match=match),
+              pytest.warns(AstropyDeprecationWarning)):
             FittableImageModel(data, oversampling=2.1)
 
         match = 'oversampling must be a finite value'
         for oversampling in [np.nan, (1, np.inf)]:
-            with pytest.raises(ValueError, match=match):
+            with (pytest.raises(ValueError, match=match),
+                  pytest.warns(AstropyDeprecationWarning)):
                 FittableImageModel(data, oversampling=oversampling)

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -155,6 +155,34 @@ class TestImagePSF:
         with pytest.raises(ValueError, match=match):
             ImagePSF(np.ones((10, 10)), origin=(np.nan, 1))
 
+    @pytest.mark.parametrize('deepcopy', [False, True])
+    def test_copy(self, deepcopy):
+        data = np.arange(30).reshape(5, 6)
+        model = ImagePSF(data, flux=1, x_0=0, y_0=0)
+        model_copy = model.deepcopy() if deepcopy else model.copy()
+
+        assert_equal(model.data, model_copy.data)
+        assert_equal(model.flux, model_copy.flux)
+        assert_equal(model.x_0, model_copy.x_0)
+        assert_equal(model.y_0, model_copy.y_0)
+        assert_equal(model.oversampling, model_copy.oversampling)
+        assert_equal(model.origin, model_copy.origin)
+
+        model_copy.data[0, 0] = 42
+        if deepcopy:
+            assert model.data[0, 0] != model_copy.data[0, 0]
+        else:
+            assert model.data[0, 0] == model_copy.data[0, 0]
+
+        model_copy.flux = 2
+        assert model.flux != model_copy.flux
+
+        model_copy.x_0.fixed = True
+        model_copy.y_0.fixed = True
+        model_copy2 = model_copy.copy()
+        assert model_copy2.x_0.fixed
+        assert model_copy2.fixed == model_copy.fixed
+
 
 class TestFittableImageModel:
     """

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -6,14 +6,148 @@ Tests for the image_models module.
 import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
-from photutils.psf import FittableImageModel
+from photutils.psf import CircularGaussianPSF, FittableImageModel, ImagePSF
 
 
-@pytest.fixture(name='gmodel')
-def fixture_gmodel():
+@pytest.fixture(name='gmodel_old')
+def fixture_gmodel_old():
+    # remove when FittableImageModel is removed
     return Gaussian2D(x_stddev=3, y_stddev=3)
+
+
+@pytest.fixture(name='gaussian_psf')
+def fixture_gaussian_psf():
+    return CircularGaussianPSF(fwhm=2.1)
+
+
+class TestImagePSF:
+
+    def test_imagepsf(self, gaussian_psf):
+        yy, xx = np.mgrid[-10:11, -10:11]
+        psf_data = gaussian_psf(xx, yy)
+        psf_data /= np.sum(psf_data)
+        model = ImagePSF(psf_data)
+
+        assert_allclose(model(xx, yy), gaussian_psf(xx, yy), atol=1e-6)
+
+        # subpixel should not match, but be reasonably close
+        for x, y in [(0.5, 0.5), (-0.5, 1.75)]:
+            assert_allclose(model(x, y), gaussian_psf(x, y), atol=4e-3)
+
+    def test_imagepsf_oversampling(self, gaussian_psf):
+        oversamp = 3
+        yy, xx = np.mgrid[-3:3.00001:(1 / oversamp), -3:3.00001:(1 / oversamp)]
+        psf_data = gaussian_psf(xx, yy)
+
+        model = ImagePSF(psf_data, oversampling=oversamp)
+        for x, y in [(0, 0), (1, 1), (-2, 1)]:
+            assert_allclose(model(x, y), gaussian_psf(x, y))
+        for x, y in [(0.5, 0.5), (-0.5, 1.75)]:  # subpixel values
+            assert_allclose(model(x, y), gaussian_psf(x, y), rtol=0.001)
+        for x, y in [(0.33, 0.33), (0.66, 0.66)]:
+            assert_allclose(model(x, y), gaussian_psf(x, y), rtol=2.0e-5)
+
+        x_0 = 2.5
+        y_0 = -3.5
+        model.x_0 = x_0
+        model.y_0 = y_0
+        for x, y in [(0, 0), (0.66, 0.66)]:
+            assert_allclose(model(x, y), gaussian_psf(x + x_0, y + y_0),
+                            atol=3.0e-6)
+
+        # without oversampling the same tests should fail except for at
+        # the origin
+        model = ImagePSF(psf_data)
+        assert_allclose(model(0, 0), gaussian_psf(0, 0))
+        for x, y in [(1, 1), (-2, 1)]:  # integer values
+            assert not np.allclose(model(x, y), gaussian_psf(x, y))
+        for x, y in [(0.5, 0.5), (-0.5, 1.75)]:
+            assert not np.allclose(model(x, y), gaussian_psf(x, y), rtol=0.001)
+
+    def test_origin(self):
+        yy, xx = np.mgrid[:5, :5]
+        gaussian_psf = CircularGaussianPSF(x_0=2, y_0=2, fwhm=2.1)
+        psf_data = gaussian_psf(xx, yy)
+        origin = (0, 0)
+        model = ImagePSF(psf_data, x_0=2, y_0=2, origin=origin)
+        assert_equal(model.origin, origin)
+        for x, y in [(0, 0), (1, 1), (-2, 1)]:
+            assert_allclose(model(x + 2, y + 2), gaussian_psf(x, y), atol=5e-6)
+
+    def test_bounding_box(self, gaussian_psf):
+        psf_data = np.arange(30, dtype=float).reshape(5, 6)
+        psf_data /= np.sum(psf_data)
+        model = ImagePSF(psf_data, flux=1, x_0=0, y_0=0)
+        assert_equal(model.bounding_box.bounding_box(), ((-2.5, 2.5),
+                                                         (-3.0, 3.0)))
+
+        model = ImagePSF(psf_data, flux=1, x_0=0, y_0=0, oversampling=2)
+        assert_equal(model.bounding_box.bounding_box(), ((-1.25, 1.25),
+                                                         (-1.5, 1.5)))
+
+    def test_data_inputs(self):
+        match = 'Input data must be a 2D numpy array'
+        with pytest.raises(TypeError, match=match):
+            ImagePSF(42)
+
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(np.ones(10))
+
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(np.ones((10, 10, 10)))
+
+        data = np.ones((10, 10))
+        data[0, 0] = np.nan
+        match = 'All elements of input data must be finite'
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(data)
+
+    def test_oversampling_inputs(self):
+        data = np.arange(30).reshape(5, 6)
+
+        for oversampling in [4, (3, 3), (3, 4)]:
+            model = ImagePSF(data, oversampling=oversampling)
+            if np.ndim(oversampling) == 0:
+                assert_equal(model.oversampling, (oversampling, oversampling))
+            else:
+                assert_equal(model.oversampling, oversampling)
+
+        match = 'oversampling must be > 0'
+        for oversampling in [-1, [-2, 4]]:
+            with pytest.raises(ValueError, match=match):
+                ImagePSF(data, oversampling=oversampling)
+
+        match = 'oversampling must have 1 or 2 elements'
+        oversampling = (1, 4, 8)
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(data, oversampling=oversampling)
+
+        match = 'oversampling must be 1D'
+        for oversampling in [((1, 2), (3, 4)), np.ones((2, 2, 2))]:
+            with pytest.raises(ValueError, match=match):
+                ImagePSF(data, oversampling=oversampling)
+
+        match = 'oversampling must have integer values'
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(data, oversampling=2.1)
+
+        match = 'oversampling must be a finite value'
+        for oversampling in [np.nan, (1, np.inf)]:
+            with pytest.raises(ValueError, match=match):
+                ImagePSF(data, oversampling=oversampling)
+
+    def test_origin_inputs(self):
+        match = 'origin must be 1D and have 2-elements'
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(np.ones((10, 10)), origin=(1, 2, 3))
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(np.ones((10, 10)), origin=np.ones((2, 2)))
+
+        match = 'All elements of origin must be finite'
+        with pytest.raises(ValueError, match=match):
+            ImagePSF(np.ones((10, 10)), origin=(np.nan, 1))
 
 
 class TestFittableImageModel:
@@ -21,66 +155,67 @@ class TestFittableImageModel:
     Tests for FittableImageModel.
     """
 
-    def test_fittable_image_model(self, gmodel):
+    def test_fittable_image_model(self, gmodel_old):
         yy, xx = np.mgrid[-2:3, -2:3]
-        model_nonorm = FittableImageModel(gmodel(xx, yy))
+        model_nonorm = FittableImageModel(gmodel_old(xx, yy))
 
-        assert_allclose(model_nonorm(0, 0), gmodel(0, 0))
-        assert_allclose(model_nonorm(1, 1), gmodel(1, 1))
-        assert_allclose(model_nonorm(-2, 1), gmodel(-2, 1))
+        assert_allclose(model_nonorm(0, 0), gmodel_old(0, 0))
+        assert_allclose(model_nonorm(1, 1), gmodel_old(1, 1))
+        assert_allclose(model_nonorm(-2, 1), gmodel_old(-2, 1))
 
         # subpixel should *not* match, but be reasonably close
         # in this case good to ~0.1% seems to be fine
-        assert_allclose(model_nonorm(0.5, 0.5), gmodel(0.5, 0.5), rtol=.001)
-        assert_allclose(model_nonorm(-0.5, 1.75), gmodel(-0.5, 1.75),
+        assert_allclose(model_nonorm(0.5, 0.5), gmodel_old(0.5, 0.5),
+                        rtol=.001)
+        assert_allclose(model_nonorm(-0.5, 1.75), gmodel_old(-0.5, 1.75),
                         rtol=.001)
 
-        model_norm = FittableImageModel(gmodel(xx, yy), normalize=True)
-        assert not np.allclose(model_norm(0, 0), gmodel(0, 0))
+        model_norm = FittableImageModel(gmodel_old(xx, yy), normalize=True)
+        assert not np.allclose(model_norm(0, 0), gmodel_old(0, 0))
         assert_allclose(np.sum(model_norm(xx, yy)), 1)
 
-        model_norm2 = FittableImageModel(gmodel(xx, yy), normalize=True,
+        model_norm2 = FittableImageModel(gmodel_old(xx, yy), normalize=True,
                                          normalization_correction=2)
-        assert not np.allclose(model_norm2(0, 0), gmodel(0, 0))
+        assert not np.allclose(model_norm2(0, 0), gmodel_old(0, 0))
         assert_allclose(model_norm(0, 0), model_norm2(0, 0) * 2)
         assert_allclose(np.sum(model_norm2(xx, yy)), 0.5)
 
-    def test_fittable_image_model_oversampling(self, gmodel):
+    def test_fittable_image_model_oversampling(self, gmodel_old):
         oversamp = 3  # oversampling factor
         yy, xx = np.mgrid[-3:3.00001:(1 / oversamp), -3:3.00001:(1 / oversamp)]
 
-        im = gmodel(xx, yy)
+        im = gmodel_old(xx, yy)
         assert im.shape[0] > 7
 
         model_oversampled = FittableImageModel(im, oversampling=oversamp)
-        assert_allclose(model_oversampled(0, 0), gmodel(0, 0))
-        assert_allclose(model_oversampled(1, 1), gmodel(1, 1))
-        assert_allclose(model_oversampled(-2, 1), gmodel(-2, 1))
-        assert_allclose(model_oversampled(0.5, 0.5), gmodel(0.5, 0.5),
+        assert_allclose(model_oversampled(0, 0), gmodel_old(0, 0))
+        assert_allclose(model_oversampled(1, 1), gmodel_old(1, 1))
+        assert_allclose(model_oversampled(-2, 1), gmodel_old(-2, 1))
+        assert_allclose(model_oversampled(0.5, 0.5), gmodel_old(0.5, 0.5),
                         rtol=.001)
-        assert_allclose(model_oversampled(-0.5, 1.75), gmodel(-0.5, 1.75),
+        assert_allclose(model_oversampled(-0.5, 1.75), gmodel_old(-0.5, 1.75),
                         rtol=.001)
 
         # without oversampling the same tests should fail except for at
         # the origin
         model_wrongsampled = FittableImageModel(im)
-        assert_allclose(model_wrongsampled(0, 0), gmodel(0, 0))
-        assert not np.allclose(model_wrongsampled(1, 1), gmodel(1, 1))
-        assert not np.allclose(model_wrongsampled(-2, 1), gmodel(-2, 1))
-        assert not np.allclose(model_wrongsampled(0.5, 0.5), gmodel(0.5, 0.5),
-                               rtol=.001)
+        assert_allclose(model_wrongsampled(0, 0), gmodel_old(0, 0))
+        assert not np.allclose(model_wrongsampled(1, 1), gmodel_old(1, 1))
+        assert not np.allclose(model_wrongsampled(-2, 1), gmodel_old(-2, 1))
+        assert not np.allclose(model_wrongsampled(0.5, 0.5),
+                               gmodel_old(0.5, 0.5), rtol=.001)
         assert not np.allclose(model_wrongsampled(-0.5, 1.75),
-                               gmodel(-0.5, 1.75), rtol=.001)
+                               gmodel_old(-0.5, 1.75), rtol=.001)
 
-    def test_centering_oversampled(self, gmodel):
+    def test_centering_oversampled(self, gmodel_old):
         oversamp = 3
         yy, xx = np.mgrid[-3:3.00001:(1 / oversamp), -3:3.00001:(1 / oversamp)]
 
-        model_oversampled = FittableImageModel(gmodel(xx, yy),
+        model_oversampled = FittableImageModel(gmodel_old(xx, yy),
                                                oversampling=oversamp)
 
-        valcen = gmodel(0, 0)
-        val36 = gmodel(0.66, 0.66)
+        valcen = gmodel_old(0, 0)
+        val36 = gmodel_old(0.66, 0.66)
 
         assert_allclose(valcen, model_oversampled(0, 0))
         assert_allclose(val36, model_oversampled(0.66, 0.66), rtol=1.0e-6)

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -325,7 +325,7 @@ def _interpolate_missing_data(data, mask, method='cubic'):
     data_interp : 2D `~numpy.ndarray`
         The interpolated 2D image.
     """
-    data_interp = np.array(data, copy=True)
+    data_interp = np.copy(data)
 
     if len(data_interp.shape) != 2:
         raise ValueError("'data' must be a 2D array.")
@@ -333,10 +333,12 @@ def _interpolate_missing_data(data, mask, method='cubic'):
     if mask.shape != data.shape:
         raise ValueError("'mask' and 'data' must have the same shape.")
 
+    # initialize the interpolator
     y, x = np.indices(data_interp.shape)
     xy = np.dstack((x[~mask].ravel(), y[~mask].ravel()))[0]
     z = data_interp[~mask].ravel()
 
+    # interpolate the missing data
     if method == 'nearest':
         interpol = interpolate.NearestNDInterpolator(xy, z)
     elif method == 'cubic':


### PR DESCRIPTION
This PR consolidates the `FittableImageMode` and `EPSFModel` into a new `ImagePSF` model.

The `FittableImageMode` and `EPSFModel` classes are now deprecated.