### PR TITLE
Remove LevMarLSQFitter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,10 +87,11 @@ New Features
 
   - Added new ``fit_fwhm`` convenience function to estimate the FWHM of
     one or more sources in an image by fitting a circular 2D Gaussian PSF
-    model. [#1859, #1887]
+    model. [#1859, #1887, #1899]
 
-  - Added new ``fit_2dgaussian`` convenience function to fit a circular 2D
-    Gaussian PSF to one or more sources in an image. [#1859, #1887]
+  - Added new ``fit_2dgaussian`` convenience function to fit a circular
+    2D Gaussian PSF to one or more sources in an image. [#1859, #1887,
+    #1899]
 
   - Added new ``ImagePSF`` model class to represent a PSF model as an
     image. [#1890]
@@ -163,6 +164,11 @@ API Changes
     any constant component. The input data are required to be
     background-subtracted. [#1861]
 
+  - The fitter used in ``centroid_1dg`` and ``centroid_2dg`` was changed
+    from ``LevMarLSQFitter`` to ``LMLSQFitter``. ``LevMarLSQFitter`` uses
+    the legacy SciPy function ``scipy.optimize.leastsq``, which is no
+    longer recommended. [#1899]
+
 - ``photutils.datasets``
 
   - The deprecated ``make`` module has been removed. Instead of
@@ -192,6 +198,13 @@ API Changes
 
   - The ``build_ellipse_model`` function now raises a ``ValueError`` if
     the input ``isolist`` is empty. [#1809]
+
+- ``photutils.profiles``
+
+  - The fitter used in ``RadialProfile`` to fit the profile
+    with a Gaussian was changed from ``LevMarLSQFitter`` to
+    ``TRFLSQFitter``. ``LevMarLSQFitter`` uses the legacy SciPy function
+    ``scipy.optimize.leastsq``, which is no longer recommended. [#1899]
 
 - ``photutils.psf``
 
@@ -225,6 +238,12 @@ API Changes
 
   - The ``FittableImageModel`` and ``EPSFModel`` classes have been
     deprecated. Instead, use the new ``ImagePSF`` model class. [#1890]
+
+  - The default fitter for ``PSFPhotometry``,
+    ``IterativePSFPhotometry``, and ``EPSFFitter`` was changed from
+    ``LevMarLSQFitter`` to ``TRFLSQFitter``. ``LevMarLSQFitter`` uses
+    the legacy SciPy function ``scipy.optimize.leastsq``, which is no
+    longer recommended. [#1899]
 
 - ``photutils.segmentation``
 

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -111,7 +111,7 @@ The size of the annulus and the statistic function can be configured in
 
 The next step is to fit the sources and/or groups. This
 task is performed using an astropy fitter, for example
-`~astropy.modeling.fitting.LevMarLSQFitter`, input via the ``fitter``
+`~astropy.modeling.fitting.TRFLSQFitter`, input via the ``fitter``
 keyword. The shape of the region to be fitted can be configured using
 the ``fit_shape`` parameter. In general, ``fit_shape`` should be set
 to a small size (e.g., (5, 5)) that covers the central star region

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -818,7 +818,7 @@ The `photutils.psf` package also provides a convenience function
 called `~photutils.psf.fit_fwhm` to estimate the full width
 at half maximum (FWHM) of one or more sources in an image.
 This function fits the source(s) with a circular 2D Gaussian
-PSF model (`~photutils.psf.CircularGaussianPSF`) using the
+PRF model (`~photutils.psf.CircularGaussianPRF`) using the
 `~photutils.psf.PSFPhotometry` class. If your sources are not
 circular or non-Gaussian, you can fit your sources using the
 `~photutils.psf.PSFPhotometry` class using a different PSF model.
@@ -830,10 +830,10 @@ defined above::
    >>> finder = DAOStarFinder(6.0, 2.0)
    >>> finder_tbl = finder(data)
    >>> xypos = list(zip(finder_tbl['xcentroid'], finder_tbl['ycentroid']))
-   >>> fwhm = fit_fwhm(data, xypos=xypos, error=error, fit_shape=(5, 5))
+   >>> fwhm = fit_fwhm(data, xypos=xypos, error=error, fit_shape=(5, 5), fwhm=2)
    >>> fwhm  # doctest: +FLOAT_CMP
-   array([2.78318472, 2.78836641, 2.77986965, 2.79576313, 2.77475841,
-          2.78849262, 2.78781809, 2.76465783, 2.797418  , 2.79036633])
+   array([2.69735154, 2.70371211, 2.68917219, 2.69310558, 2.68931721,
+          2.69804194, 2.69651045, 2.70423936, 2.71458867, 2.70285813])
 
 
 Convenience Gaussian Fitting Function
@@ -841,7 +841,7 @@ Convenience Gaussian Fitting Function
 
 The `photutils.psf` package also provides a convenience function called
 :func:`~photutils.psf.fit_2dgaussian` for fitting one or more sources
-with a 2D Gaussian PSF model (`~photutils.psf.CircularGaussianPSF`)
+with a 2D Gaussian PRF model (`~photutils.psf.CircularGaussianPRF`)
 using the `~photutils.psf.PSFPhotometry` class. See the function
 documentation for more details and examples.
 

--- a/docs/psf.rst
+++ b/docs/psf.rst
@@ -832,8 +832,8 @@ defined above::
    >>> xypos = list(zip(finder_tbl['xcentroid'], finder_tbl['ycentroid']))
    >>> fwhm = fit_fwhm(data, xypos=xypos, error=error, fit_shape=(5, 5))
    >>> fwhm  # doctest: +FLOAT_CMP
-   array([2.78318472, 2.78834154, 2.77986989, 2.79650315, 2.77475841,
-          2.78849262, 2.78781809, 2.76465724, 2.79742412, 2.79036633])
+   array([2.78318472, 2.78836641, 2.77986965, 2.79576313, 2.77475841,
+          2.78849262, 2.78781809, 2.76465783, 2.797418  , 2.79036633])
 
 
 Convenience Gaussian Fitting Function

--- a/docs/whats_new/2.0.rst
+++ b/docs/whats_new/2.0.rst
@@ -153,10 +153,10 @@ New FWHM estimation tool
 
 A new `~photutils.psf.fit_fwhm` convenience function was added to
 estimate the FWHM of one or more sources in an image by fitting a
-circular 2D Gaussian PSF model using the PSF photometry tools.
+circular 2D Gaussian PRF model using the PSF photometry tools.
 
 Similarly, a new `~photutils.psf.fit_2dgaussian` convenience function
-was added to fit a circular 2D Gaussian PSF to one or more sources in an
+was added to fit a circular 2D Gaussian PRF to one or more sources in an
 image.
 
 

--- a/docs/whats_new/2.0.rst
+++ b/docs/whats_new/2.0.rst
@@ -89,16 +89,6 @@ should be set to `True`, which makes zoom's behavior consistent with
 `False` option was provided only for backwards-compatibility.
 
 
-Bounding model fits in PSF Photometry
-=====================================
-
-A new ``xy_bounds`` keyword was added to `~photutils.psf.PSFPhotometry`
-and `~photutils.psf.IterativePSFPhotometry` to allow one to bound
-the x and y model parameters during the fitting. This can be used to
-prevent the fit values from wandering too far from the initial parameter
-guesses.
-
-
 New PSF Model classes
 ======================
 
@@ -146,6 +136,44 @@ will be removed in a future version. It has been replaced by the
 The existing ``FittableImageModel`` and ``EPSFModel`` classes are now
 deprecated and will be removed in a future version. They have been
 replaced by the new `~photutils.psf.ImagePSF` class.
+
+
+Legacy ``LevMarLSQFitter`` no longer used
+=========================================
+
+The default Astropy fitter for ``PSFPhotometry``,
+``IterativePSFPhotometry``, and ``EPSFFitter`` was changed from
+``LevMarLSQFitter`` to ``TRFLSQFitter``.
+
+``LevMarLSQFitter`` uses the Levenberg-Marquardt algorithm via
+the SciPy legacy function ``scipy.optimize.leastsq``, which is no
+longer recommended. This fitter supports parameter bounds using an
+unsophisticated min/max condition where parameters that are out of
+bounds are simply reset to the min or max of the bounds during each
+step. This can cause parameters to stick to one of the bounds during the
+fitting process if the parameter gets close to the bound. If needed,
+this fitter can still be used by explicitly setting the fitter in the
+``PSFPhotometry``, ``IterativePSFPhotometry``, and ``EPSFFitter``
+classes.
+
+The fitter used in ``RadialProfile`` to fit the profile with a Gaussian
+was also changed from ``LevMarLSQFitter`` to ``TRFLSQFitter``.
+
+The fitter used in ``centroid_1dg`` and ``centroid_2dg`` was changed
+from ``LevMarLSQFitter`` to ``LMLSQFitter``.
+
+For more information about Astropy's non-linear fitters, see
+:ref:`astropy:modeling-getting-started-nonlinear-notes`.
+
+
+Bounding model fits in PSF Photometry
+=====================================
+
+A new ``xy_bounds`` keyword was added to `~photutils.psf.PSFPhotometry`
+and `~photutils.psf.IterativePSFPhotometry` to allow one to bound
+the x and y model parameters during the fitting. This can be used to
+prevent the fit values from wandering too far from the initial parameter
+guesses.
 
 
 New FWHM estimation tool

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -6,7 +6,7 @@ The module contains tools for centroiding sources using Gaussians.
 import warnings
 
 import numpy as np
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import LMLSQFitter
 from astropy.modeling.models import Gaussian1D, Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -105,11 +105,13 @@ def centroid_1dg(data, error=None, mask=None):
 
     xy_data = [np.ma.sum(data, axis=i).data for i in (0, 1)]
 
+    # would need to use a different fitter if parameter bounds are used
+    fitter = LMLSQFitter()
+
     centroid = []
     for (data_i, weights_i) in zip(xy_data, xy_weights, strict=True):
         params_init = _gaussian1d_moments(data_i)
         g_init = Gaussian1D(*params_init)
-        fitter = LevMarLSQFitter()
         x = np.arange(data_i.size)
         g_fit = fitter(g_init, x, data_i, weights=weights_i)
         centroid.append(g_fit.mean.value)
@@ -199,7 +201,7 @@ def centroid_2dg(data, error=None, mask=None):
     >>> data = data[40:80, 70:110]
     >>> x1, y1 = centroid_2dg(data)
     >>> print(np.array((x1, y1)))
-    [19.9851945  20.01490155]
+    [19.98519434 20.01490159]
 
     .. plot::
 
@@ -269,7 +271,10 @@ def centroid_2dg(data, error=None, mask=None):
                         x_stddev=props.semimajor_sigma.value,
                         y_stddev=props.semiminor_sigma.value,
                         theta=props.orientation.value)
-    fitter = LevMarLSQFitter()
+
+    # would need to use a different fitter if parameter bounds are used
+    fitter = LMLSQFitter()
+
     y, x = np.indices(data.shape)
 
     with warnings.catch_warnings(record=True) as fit_warnings:

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -6,7 +6,7 @@ This module provides tools for generating radial profiles.
 import warnings
 
 import numpy as np
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.modeling.models import Gaussian1D
 from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.utils import lazyproperty
@@ -387,7 +387,7 @@ class RadialProfile(ProfileBase):
         std = np.sqrt(abs(np.sum(profile * radius**2) / np.sum(profile)))
         g_init = Gaussian1D(amplitude=amplitude, mean=0.0, stddev=std)
         g_init.mean.fixed = True
-        fitter = LevMarLSQFitter()
+        fitter = TRFLSQFitter()
         return fitter(g_init, radius, profile)
 
     @lazyproperty

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -9,7 +9,7 @@ import copy
 import warnings
 
 import numpy as np
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.nddata.utils import NoOverlapError, PartialOverlapError
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
@@ -53,7 +53,7 @@ class EPSFFitter:
         of the input ``fitter``.
     """
 
-    def __init__(self, *, fitter=LevMarLSQFitter(), fit_boxsize=5,
+    def __init__(self, *, fitter=TRFLSQFitter(), fit_boxsize=5,
                  **fitter_kwargs):
 
         self.fitter = fitter

--- a/photutils/psf/matching/tests/test_fourier.py
+++ b/photutils/psf/matching/tests/test_fourier.py
@@ -5,7 +5,7 @@ Tests for the fourier module.
 
 import numpy as np
 import pytest
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.modeling.models import Gaussian2D
 from numpy.testing import assert_allclose
 
@@ -38,7 +38,7 @@ def test_create_matching_kernel():
     window = SplitCosineBellWindow(0.0, 0.2)
     k = create_matching_kernel(g1, g2, window=window)
 
-    fitter = LevMarLSQFitter()
+    fitter = TRFLSQFitter()
     gfit = fitter(gm1, x, y, k)
     assert_allclose(gfit.x_stddev, gfit.y_stddev)
     assert_allclose(gfit.x_stddev, np.sqrt(std2**2 - std1**2), 0.06)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -12,7 +12,7 @@ from itertools import chain
 
 import astropy.units as u
 import numpy as np
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.nddata import NDData, NoOverlapError, StdDevUncertainty
 from astropy.table import QTable, Table, hstack, join, vstack
 from astropy.utils import lazyproperty
@@ -277,14 +277,12 @@ class PSFPhotometry(ModelImageMixin):
     model parameters. This table can be used as the ``init_params``
     input in a subsequent call to `PSFPhotometry`.
 
-    If the returned model parameter errors are NaN, then either
-    the fit did not converge, the model parameter was fixed, or
-    the input ``fitter`` did not return parameter errors. For the
-    later case, one can try a different fitter that may return
-    parameter errors (e.g., `astropy.modeling.fitting.LMLSQFitter`
-    or `astropy.modeling.fitting.TRFLSQFitter`). Note that
-    these fitters are typically slower than the default
-    `astropy.modeling.fitting.LevMarLSQFitter`.
+    If the returned model parameter errors are NaN, then either the
+    fit did not converge, the model parameter was fixed, or the
+    input ``fitter`` did not return parameter errors. For the later
+    case, one can try a different fitter that may return parameter
+    errors (e.g., `astropy.modeling.fitting.DogBoxLSQFitter` or
+    `astropy.modeling.fitting.LMLSQFitter`).
 
     The local background value around each source is optionally
     estimated using the ``localbkg_estimator`` or obtained from the
@@ -312,7 +310,7 @@ class PSFPhotometry(ModelImageMixin):
                                        alternative='fit_info')
 
     def __init__(self, psf_model, fit_shape, *, finder=None, grouper=None,
-                 fitter=LevMarLSQFitter(), fitter_maxiters=100,
+                 fitter=TRFLSQFitter(), fitter_maxiters=100,
                  xy_bounds=None, localbkg_estimator=None, aperture_radius=None,
                  progress_bar=False):
 
@@ -1581,14 +1579,12 @@ class IterativePSFPhotometry(ModelImageMixin):
     model parameters. This table can be used as the ``init_params``
     input in a subsequent call to `PSFPhotometry`.
 
-    If the returned model parameter errors are NaN, then either
-    the fit did not converge, the model parameter was fixed, or
-    the input ``fitter`` did not return parameter errors. For the
-    later case, one can try a different fitter that may return
-    parameter errors (e.g., `astropy.modeling.fitting.LMLSQFitter`
-    or `astropy.modeling.fitting.TRFLSQFitter`). Note that
-    these fitters are typically slower than the default
-    `astropy.modeling.fitting.LevMarLSQFitter`.
+    If the returned model parameter errors are NaN, then either the
+    fit did not converge, the model parameter was fixed, or the
+    input ``fitter`` did not return parameter errors. For the later
+    case, one can try a different fitter that may return parameter
+    errors (e.g., `astropy.modeling.fitting.DogBoxLSQFitter` or
+    `astropy.modeling.fitting.LMLSQFitter`).
 
     The local background value around each source is optionally
     estimated using the ``localbkg_estimator`` or obtained from the
@@ -1632,7 +1628,7 @@ class IterativePSFPhotometry(ModelImageMixin):
     """
 
     def __init__(self, psf_model, fit_shape, finder, *, grouper=None,
-                 fitter=LevMarLSQFitter(), fitter_maxiters=100,
+                 fitter=TRFLSQFitter(), fitter_maxiters=100,
                  xy_bounds=None, maxiters=3, mode='new',
                  localbkg_estimator=None, aperture_radius=None,
                  sub_shape=None, progress_bar=False):

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1062,19 +1062,10 @@ class PSFPhotometry(ModelImageMixin):
 
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', AstropyUserWarning)
-                try:
-                    fit_model = self.fitter(psf_model, xi, yi, cutout,
-                                            weights=weights, **kwargs)
-                    with contextlib.suppress(AttributeError):
-                        fit_model.clear_cache()
-                except TypeError as exc:
-                    msg = ('For one or more sources, the number of data '
-                           'points available to fit is less than the '
-                           'number of fit parameters. This could be due to '
-                           'a source(s) near the edge of the detector or '
-                           'if it has few unmasked pixels. Please check the '
-                           'input mask or source positions.')
-                    raise ValueError(msg) from exc
+                fit_model = self.fitter(psf_model, xi, yi, cutout,
+                                        weights=weights, **kwargs)
+                with contextlib.suppress(AttributeError):
+                    fit_model.clear_cache()
 
                 fit_info = {}
                 for key in fit_info_keys:

--- a/photutils/psf/tests/test_epsf.py
+++ b/photutils/psf/tests/test_epsf.py
@@ -7,7 +7,7 @@ import itertools
 
 import numpy as np
 import pytest
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.nddata import (InverseVariance, NDData, StdDevUncertainty,
                             VarianceUncertainty)
 from astropy.stats import SigmaClip
@@ -169,10 +169,10 @@ class TestEPSFBuild:
             EPSFBuilder(fitter=EPSFFitter, maxiters=3)
 
         with pytest.raises(TypeError, match=match):
-            EPSFBuilder(fitter=LevMarLSQFitter(), maxiters=3)
+            EPSFBuilder(fitter=TRFLSQFitter(), maxiters=3)
 
         with pytest.raises(TypeError, match=match):
-            EPSFBuilder(fitter=LevMarLSQFitter, maxiters=3)
+            EPSFBuilder(fitter=TRFLSQFitter, maxiters=3)
 
 
 def test_epsfbuilder_inputs():

--- a/photutils/psf/tests/test_functional_models.py
+++ b/photutils/psf/tests/test_functional_models.py
@@ -6,7 +6,7 @@ Tests for the functional_models module.
 import astropy.units as u
 import numpy as np
 import pytest
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.stats import gaussian_fwhm_to_sigma
 from numpy.testing import assert_allclose
 
@@ -106,7 +106,7 @@ def gaussian_tests(name, use_units):
             sigma = sigma.value
         assert_allclose(model.amplitude * (2 * np.pi * sigma**2), model.flux)
 
-    fitter = LevMarLSQFitter()
+    fitter = TRFLSQFitter()
     fit_model = fitter(model_init, xx, yy, data)
     assert_allclose(fit_model.x_0.value, model.x_0.value, rtol=1e-5)
     assert_allclose(fit_model.y_0.value, model.y_0.value, rtol=1e-5)
@@ -204,7 +204,7 @@ def test_moffat_psf_model(use_units):
     fwhm = 2 * model.alpha * np.sqrt(2**(1 / model.beta) - 1)
     assert_allclose(model.fwhm, fwhm)
 
-    fitter = LevMarLSQFitter()
+    fitter = TRFLSQFitter()
     fit_model = fitter(model_init, xx, yy, data)
     assert_allclose(fit_model.x_0.value, model.x_0.value)
     assert_allclose(fit_model.y_0.value, model.y_0.value)
@@ -238,7 +238,7 @@ def test_airydisk_psf_model(use_units):
     fwhm = 0.8436659602162364 * model.radius
     assert_allclose(model.fwhm, fwhm)
 
-    fitter = LevMarLSQFitter()
+    fitter = TRFLSQFitter()
     fit_model = fitter(model_init, xx, yy, data)
     assert_allclose(fit_model.x_0.value, model.x_0.value)
     assert_allclose(fit_model.y_0.value, model.y_0.value)

--- a/photutils/psf/tests/test_functional_models.py
+++ b/photutils/psf/tests/test_functional_models.py
@@ -220,7 +220,7 @@ def test_moffat_psf_model(use_units):
 @pytest.mark.parametrize('use_units', [False, True])
 def test_airydisk_psf_model(use_units):
     model = AiryDiskPSF(flux=71.4, x_0=24.3, y_0=25.2, radius=2.1)
-    model_init = AiryDiskPSF(flux=50, x_0=20, y_0=30, radius=2.5)
+    model_init = AiryDiskPSF(flux=50, x_0=23, y_0=27, radius=2.5)
     model_init.radius.fixed = False
 
     yy, xx = np.mgrid[0:51, 0:51]

--- a/photutils/psf/tests/test_model_helpers.py
+++ b/photutils/psf/tests/test_model_helpers.py
@@ -6,7 +6,7 @@ Tests for the model_helpers module.
 import astropy.units as u
 import numpy as np
 import pytest
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.modeling.models import Const2D, Gaussian2D, Moffat2D
 from astropy.nddata import NDData
 from astropy.table import Table
@@ -78,7 +78,7 @@ def test_moffat_fitting(moffat_source):
     guess_moffat = Moffat2D(x_0=0.1, y_0=-0.05, gamma=1.05,
                             amplitude=model.amplitude * 1.06, alpha=4.75)
 
-    fitter = LevMarLSQFitter()
+    fitter = TRFLSQFitter()
     fit = fitter(guess_moffat, xx, yy, data)
     assert_allclose(fit.parameters, model.parameters, rtol=0.01, atol=0.0005)
 
@@ -113,7 +113,7 @@ def test_make_psf_model(moffat_source, kwargs, tols):
         guess_moffat.y_0 = 0
 
     psf_model = make_psf_model(guess_moffat, **kwargs)
-    fitter = LevMarLSQFitter()
+    fitter = TRFLSQFitter()
     fit_model = fitter(psf_model, xx, yy, data)
     xytol, fluxtol = tols
 

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -89,7 +89,7 @@ def test_fit_fwhm_single():
     # test warning message
     match = 'may not have converged. Please carefully check your results'
     with pytest.warns(AstropyUserWarning, match=match):
-        fwhm = fit_fwhm(data + 100)
+        fwhm = fit_fwhm(np.zeros(data.shape) + 1)
     assert len(fwhm) == 1
 
 

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -11,7 +11,7 @@ from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
 
-from photutils.psf import CircularGaussianPSF, make_psf_model_image
+from photutils.psf import CircularGaussianPRF, make_psf_model_image
 from photutils.psf.utils import (_get_psf_model_params,
                                  _interpolate_missing_data,
                                  _validate_psf_model, fit_2dgaussian, fit_fwhm)
@@ -19,7 +19,7 @@ from photutils.psf.utils import (_get_psf_model_params,
 
 @pytest.fixture(name='test_data')
 def fixture_test_data():
-    psf_model = CircularGaussianPSF()
+    psf_model = CircularGaussianPRF()
     model_shape = (9, 9)
     n_sources = 10
     shape = (101, 101)
@@ -34,7 +34,7 @@ def fixture_test_data():
 def test_fit_2dgaussian_single(fix_fwhm):
     yy, xx = np.mgrid[:51, :51]
     fwhm = 3.123
-    model = CircularGaussianPSF(x_0=22.17, y_0=28.87, fwhm=fwhm)
+    model = CircularGaussianPRF(x_0=22.17, y_0=28.87, fwhm=fwhm)
     data = model(xx, yy)
 
     fit = fit_2dgaussian(data, fwhm=3, fix_fwhm=fix_fwhm)
@@ -78,7 +78,7 @@ def test_fit_2dgaussian_multiple(test_data, fix_fwhm, with_units):
 def test_fit_fwhm_single():
     yy, xx = np.mgrid[:51, :51]
     fwhm0 = 3.123
-    model = CircularGaussianPSF(x_0=22.17, y_0=28.87, fwhm=fwhm0)
+    model = CircularGaussianPRF(x_0=22.17, y_0=28.87, fwhm=fwhm0)
     data = model(xx, yy)
 
     fwhm = fit_fwhm(data, fwhm=3)
@@ -151,7 +151,7 @@ def test_validate_psf_model():
 
 
 def test_get_psf_model_params():
-    model = CircularGaussianPSF(fwhm=1.0)
+    model = CircularGaussianPRF(fwhm=1.0)
     params = _get_psf_model_params(model)
     assert len(params) == 3
     assert params == ('x_0', 'y_0', 'flux')

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -13,7 +13,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from scipy import interpolate
 
 from photutils.centroids import centroid_com
-from photutils.psf.functional_models import CircularGaussianPSF
+from photutils.psf.functional_models import CircularGaussianPRF
 from photutils.utils import CutoutImage
 from photutils.utils._parameters import as_pair
 
@@ -26,7 +26,7 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
     Fit a 2D Gaussian model to one or more sources in an image.
 
     This convenience function uses a
-    `~photutils.psf.CircularGaussianPSF` model to fit the sources using
+    `~photutils.psf.CircularGaussianPRF` model to fit the sources using
     the `~photutils.psf.PSFPhotometry` class.
 
     Non-finite values (e.g., NaN or inf) in the ``data`` array are
@@ -82,7 +82,7 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
 
     Notes
     -----
-    The source(s) are fit with a `~photutils.psf.CircularGaussianPSF`
+    The source(s) are fit with a `~photutils.psf.CircularGaussianPRF`
     model using the `~photutils.psf.PSFPhotometry` class. The initial
     guess for the flux is the sum of the pixel values within the fitting
     region. If ``fwhm`` is `None`, then the initial guess for the FWHM
@@ -94,9 +94,9 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
     a cutout image):
 
     >>> import numpy as np
-    >>> from photutils.psf import CircularGaussianPSF, fit_2dgaussian
+    >>> from photutils.psf import CircularGaussianPRF, fit_2dgaussian
     >>> yy, xx = np.mgrid[:51, :51]
-    >>> model = CircularGaussianPSF(x_0=22.17, y_0=28.87, fwhm=3.123, flux=9.7)
+    >>> model = CircularGaussianPRF(x_0=22.17, y_0=28.87, fwhm=3.123, flux=9.7)
     >>> data = model(xx, yy)
     >>> fit = fit_2dgaussian(data, fix_fwhm=False)
     >>> phot_tbl = fit.results  # doctest: +FLOAT_CMP
@@ -112,9 +112,9 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
 
     >>> import numpy as np
     >>> from photutils.detection import DAOStarFinder
-    >>> from photutils.psf import (CircularGaussianPSF, fit_2dgaussian,
+    >>> from photutils.psf import (CircularGaussianPRF, fit_2dgaussian,
     ...                            make_psf_model_image)
-    >>> model = CircularGaussianPSF()
+    >>> model = CircularGaussianPRF()
     >>> data, sources = make_psf_model_image((100, 100), model, 5,
     ...                                      min_separation=25,
     ...                                      model_shape=(15, 15),
@@ -172,7 +172,7 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
         fwhm = np.mean(fit_shape) / 2.0
     init_params['fwhm'] = fwhm
 
-    model = CircularGaussianPSF(fwhm=fwhm)
+    model = CircularGaussianPRF(fwhm=fwhm)
     model.fwhm.min = 0.0
     if not fix_fwhm:
         model.fwhm.fixed = False
@@ -189,7 +189,7 @@ def fit_fwhm(data, *, xypos=None, fwhm=None, fit_shape=None, mask=None,
     Fit the FWHM of one or more sources in an image.
 
     This convenience function uses a
-    `~photutils.psf.CircularGaussianPSF` model to fit the sources using
+    `~photutils.psf.CircularGaussianPRF` model to fit the sources using
     the `~photutils.psf.PSFPhotometry` class.
 
     Non-finite values (e.g., NaN or inf) in the ``data`` array are
@@ -244,7 +244,7 @@ def fit_fwhm(data, *, xypos=None, fwhm=None, fit_shape=None, mask=None,
     Notes
     -----
     The source(s) are fit using the :func:`fit_2dgaussian` function,
-    which uses a `~photutils.psf.CircularGaussianPSF` model with the
+    which uses a `~photutils.psf.CircularGaussianPRF` model with the
     `~photutils.psf.PSFPhotometry` class. The initial guess for the
     flux is the sum of the pixel values within the fitting region. If
     ``fwhm`` is `None`, then the initial guess for the FWHM is half the
@@ -255,9 +255,9 @@ def fit_fwhm(data, *, xypos=None, fwhm=None, fit_shape=None, mask=None,
     Fit the FWHM of a single source (e.g., a cutout image):
 
     >>> import numpy as np
-    >>> from photutils.psf import CircularGaussianPSF, fit_fwhm
+    >>> from photutils.psf import CircularGaussianPRF, fit_fwhm
     >>> yy, xx = np.mgrid[:51, :51]
-    >>> model = CircularGaussianPSF(x_0=22.17, y_0=28.87, fwhm=3.123, flux=9.7)
+    >>> model = CircularGaussianPRF(x_0=22.17, y_0=28.87, fwhm=3.123, flux=9.7)
     >>> data = model(xx, yy)
     >>> fwhm = fit_fwhm(data)
     >>> fwhm  # doctest: +FLOAT_CMP
@@ -267,9 +267,9 @@ def fit_fwhm(data, *, xypos=None, fwhm=None, fit_shape=None, mask=None,
 
     >>> import numpy as np
     >>> from photutils.detection import DAOStarFinder
-    >>> from photutils.psf import (CircularGaussianPSF, fit_fwhm,
+    >>> from photutils.psf import (CircularGaussianPRF, fit_fwhm,
     ...                            make_psf_model_image)
-    >>> model = CircularGaussianPSF()
+    >>> model = CircularGaussianPRF()
     >>> data, sources = make_psf_model_image((100, 100), model, 5,
     ...                                      min_separation=25,
     ...                                      model_shape=(15, 15),

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -155,10 +155,9 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
         fit_shape = as_pair('fit_shape', fit_shape, lower_bound=(1, 0),
                             check_odd=True)
 
-    yxpos = xypos[:, ::-1]
     flux_init = []
-    for yxpos_ in yxpos:
-        cutout = CutoutImage(data, yxpos_, tuple(fit_shape))
+    for yxpos in xypos[:, ::-1]:
+        cutout = CutoutImage(data, yxpos, tuple(fit_shape))
         flux_init.append(np.sum(cutout.data))
 
     if isinstance(data, Quantity):
@@ -169,13 +168,12 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
     init_params['y'] = xypos[:, 1]
     init_params['flux'] = flux_init
 
-    model = CircularGaussianPSF()
-
     if fwhm is None:
         fwhm = np.mean(fit_shape) / 2.0
     init_params['fwhm'] = fwhm
 
     model = CircularGaussianPSF(fwhm=fwhm)
+    model.fwhm.min = 0.0
     if not fix_fwhm:
         model.fwhm.fixed = False
 


### PR DESCRIPTION
This PR changes the default Astropy fitter for ``PSFPhotometry``, ``IterativePSFPhotometry``, and ``EPSFFitter``  from ``LevMarLSQFitter`` to ``TRFLSQFitter``.

``LevMarLSQFitter`` uses the Levenberg-Marquardt algorithm via the SciPy legacy function ``scipy.optimize.leastsq``, which is no longer recommended. This fitter supports parameter bounds using an unsophisticated min/max condition where parameters that are out of bounds are simply reset to the min or max of the bounds during each step. This can cause parameters to stick to one of the bounds during the fitting process if the parameter gets close to the bound. If needed, this fitter can still be used by explicitly setting the fitter in the ``PSFPhotometry``, ``IterativePSFPhotometry``, and ``EPSFFitter`` classes.

The fitter used in ``RadialProfile`` to fit the profile with a Gaussian was also changed from ``LevMarLSQFitter`` to ``TRFLSQFitter``.

The fitter used in ``centroid_1dg`` and ``centroid_2dg`` was changed from ``LevMarLSQFitter`` to ``LMLSQFitter``.

See https://github.com/astropy/astropy/pull/16983 for more information.

Closes: #1895