### PR TITLE
Imports from psf.matching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,8 @@ General
 - The minimum required GWCS is now 0.19. [#1881]
 
 - Importing tools from all subpackages now requires including the
-  subpackage name. [#1879]
+  subpackage name. Also, PSF matching tools must now be imported from
+  ``photutils.psf.matching`` instead of ``photutils.psf``. [#1879, #1904]
 
 New Features
 ^^^^^^^^^^^^
@@ -248,6 +249,11 @@ API Changes
     ``LevMarLSQFitter`` to ``TRFLSQFitter``. ``LevMarLSQFitter`` uses
     the legacy SciPy function ``scipy.optimize.leastsq``, which is no
     longer recommended. [#1899]
+
+- ``photutils.psf.matching``
+
+  - PSF matching tools must now be imported from
+    ``photutils.psf.matching`` instead of ``photutils.psf``. [#1904]
 
 - ``photutils.segmentation``
 

--- a/docs/psf_matching.rst
+++ b/docs/psf_matching.rst
@@ -38,7 +38,7 @@ with :math:`\sigma=4` (``sqrt(5**2 - 3**2)``).  Let's create the
 matching kernel using a Fourier ratio method.  Note that the input
 source and target PSFs must have the same shape and pixel scale::
 
-    >>> from photutils.psf import create_matching_kernel
+    >>> from photutils.psf.matching import create_matching_kernel
     >>> kernel = create_matching_kernel(g1, g2)
 
 Let's plot the result:
@@ -48,7 +48,7 @@ Let's plot the result:
     import matplotlib.pyplot as plt
     import numpy as np
     from astropy.modeling.models import Gaussian2D
-    from photutils.psf import create_matching_kernel
+    from photutils.psf.matching import create_matching_kernel
 
     y, x = np.mgrid[0:51, 0:51]
     gm1 = Gaussian2D(100, 25, 25, 3, 3)
@@ -86,9 +86,9 @@ functions:
 .. plot::
 
     import matplotlib.pyplot as plt
-    from photutils.psf import (CosineBellWindow, HanningWindow,
-                               SplitCosineBellWindow, TopHatWindow,
-                               TukeyWindow)
+    from photutils.psf.matching import (CosineBellWindow, HanningWindow,
+                                        SplitCosineBellWindow, TopHatWindow,
+                                        TukeyWindow)
 
     w1 = HanningWindow()
     w2 = TukeyWindow(alpha=0.5)
@@ -138,7 +138,7 @@ generate a custom window function.
 In this example, because these are noiseless PSFs, we will use a
 `~photutils.psf.matching.TopHatWindow` object as the low-pass filter::
 
-    >>> from photutils.psf import TopHatWindow
+    >>> from photutils.psf.matching import TopHatWindow
     >>> window = TopHatWindow(0.35)
     >>> kernel = create_matching_kernel(g1, g2, window=window)
 
@@ -156,7 +156,7 @@ Let's display the new matching kernel:
     import matplotlib.pyplot as plt
     import numpy as np
     from astropy.modeling.models import Gaussian2D
-    from photutils.psf import TopHatWindow, create_matching_kernel
+    from photutils.psf.matching import TopHatWindow, create_matching_kernel
 
     y, x = np.mgrid[0:51, 0:51]
     gm1 = Gaussian2D(100, 25, 25, 3, 3)
@@ -180,7 +180,7 @@ kernel images:
     import matplotlib.pyplot as plt
     import numpy as np
     from astropy.modeling.models import Gaussian2D
-    from photutils.psf import TopHatWindow, create_matching_kernel
+    from photutils.psf.matching import TopHatWindow, create_matching_kernel
 
     y, x = np.mgrid[0:51, 0:51]
     gm1 = Gaussian2D(100, 25, 25, 3, 3)
@@ -253,7 +253,8 @@ lower-resolution PSF to the same size as the higher-resolution PSF.
 
 .. doctest-skip::
 
-    >>> from photutils.psf import CosineBellWindow, create_matching_kernel
+    >>> from photutils.psf.matching import (CosineBellWindow,
+    ...                                     create_matching_kernel)
     >>> window = CosineBellWindow(alpha=0.35)
     >>> kernel = create_matching_kernel(ch1, ch4, window=window)
 
@@ -265,7 +266,7 @@ Let's display the matching kernel result:
     from astropy.visualization import LogStretch
     from astropy.visualization.mpl_normalize import ImageNormalize
     from photutils.datasets import load_irac_psf
-    from photutils.psf import CosineBellWindow, create_matching_kernel
+    from photutils.psf.matching import CosineBellWindow, create_matching_kernel
 
     ch1_hdu = load_irac_psf(channel=1)
     ch4_hdu = load_irac_psf(channel=4)

--- a/docs/whats_new/2.0.rst
+++ b/docs/whats_new/2.0.rst
@@ -15,7 +15,8 @@ Imports
 
 Importing tools from all subpackages now requires including the
 subpackage name. These deprecations were introduced in version 1.6.0
-(2022-12-09).
+(2022-12-09). Also, PSF matching tools must now be imported from
+``photutils.psf.matching`` instead of ``photutils.psf``
 
 For example, this is no longer allowed: ``from photutils import
 CircularAperture``. Instead use this: ``from photutils.aperture import

--- a/photutils/psf/__init__.py
+++ b/photutils/psf/__init__.py
@@ -4,34 +4,15 @@ This subpackage contains tools to perform point-spread-function (PSF)
 photometry.
 """
 
-from . import (epsf, epsf_stars, functional_models, gridded_models, groupers,
-               image_models, photometry, model_helpers, model_io,
-               model_plotting, simulation, utils)
 from .epsf import *  # noqa: F401, F403
 from .epsf_stars import *  # noqa: F401, F403
 from .functional_models import *  # noqa: F401, F403
 from .gridded_models import *  # noqa: F401, F403
 from .groupers import *  # noqa: F401, F403
 from .image_models import *  # noqa: F401, F403
-from .matching import *  # noqa: F401, F403
-from .photometry import *  # noqa: F401, F403
 from .model_helpers import *  # noqa: F401, F403
 from .model_io import *  # noqa: F401, F403
 from .model_plotting import *  # noqa: F401, F403
+from .photometry import *  # noqa: F401, F403
 from .simulation import *  # noqa: F401, F403
 from .utils import *  # noqa: F401, F403
-
-# exclude matching from this list to avoid sphinx warnings
-__all__ = []
-__all__ += epsf.__all__
-__all__ += epsf_stars.__all__
-__all__ += functional_models.__all__
-__all__ += gridded_models.__all__
-__all__ += groupers.__all__
-__all__ += image_models.__all__
-__all__ += photometry.__all__
-__all__ += model_helpers.__all__
-__all__ += model_io.__all__
-__all__ += model_plotting.__all__
-__all__ += simulation.__all__
-__all__ += utils.__all__

--- a/photutils/psf/matching/windows.py
+++ b/photutils/psf/matching/windows.py
@@ -54,7 +54,7 @@ class SplitCosineBellWindow:
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import SplitCosineBellWindow
+        from photutils.psf.matching import SplitCosineBellWindow
 
         taper = SplitCosineBellWindow(alpha=0.4, beta=0.3)
         data = taper((101, 101))
@@ -67,7 +67,7 @@ class SplitCosineBellWindow:
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import SplitCosineBellWindow
+        from photutils.psf.matching import SplitCosineBellWindow
 
         taper = SplitCosineBellWindow(alpha=0.4, beta=0.3)
         data = taper((101, 101))
@@ -125,7 +125,7 @@ class HanningWindow(SplitCosineBellWindow):
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import HanningWindow
+        from photutils.psf.matching import HanningWindow
 
         taper = HanningWindow()
         data = taper((101, 101))
@@ -138,7 +138,7 @@ class HanningWindow(SplitCosineBellWindow):
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import HanningWindow
+        from photutils.psf.matching import HanningWindow
 
         taper = HanningWindow()
         data = taper((101, 101))
@@ -169,7 +169,7 @@ class TukeyWindow(SplitCosineBellWindow):
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import TukeyWindow
+        from photutils.psf.matching import TukeyWindow
 
         taper = TukeyWindow(alpha=0.4)
         data = taper((101, 101))
@@ -182,7 +182,7 @@ class TukeyWindow(SplitCosineBellWindow):
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import TukeyWindow
+        from photutils.psf.matching import TukeyWindow
 
         taper = TukeyWindow(alpha=0.4)
         data = taper((101, 101))
@@ -208,7 +208,7 @@ class CosineBellWindow(SplitCosineBellWindow):
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import CosineBellWindow
+        from photutils.psf.matching import CosineBellWindow
 
         taper = CosineBellWindow(alpha=0.3)
         data = taper((101, 101))
@@ -221,7 +221,7 @@ class CosineBellWindow(SplitCosineBellWindow):
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import CosineBellWindow
+        from photutils.psf.matching import CosineBellWindow
 
         taper = CosineBellWindow(alpha=0.3)
         data = taper((101, 101))
@@ -248,7 +248,7 @@ class TopHatWindow(SplitCosineBellWindow):
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import TopHatWindow
+        from photutils.psf.matching import TopHatWindow
 
         taper = TopHatWindow(beta=0.4)
         data = taper((101, 101))
@@ -262,7 +262,7 @@ class TopHatWindow(SplitCosineBellWindow):
         :include-source:
 
         import matplotlib.pyplot as plt
-        from photutils.psf import TopHatWindow
+        from photutils.psf.matching import TopHatWindow
 
         taper = TopHatWindow(beta=0.4)
         data = taper((101, 101))


### PR DESCRIPTION
PSF matching tools must now be imported from ``photutils.psf.matching`` instead of ``photutils.psf``.