### PR TITLE
Add set_bounding_box to models

### DIFF
--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -159,6 +159,7 @@ class GaussianPSF(Fittable2DModel):
                  theta=theta.default, **kwargs):
         super().__init__(flux=flux, x_0=x_0, y_0=y_0, x_fwhm=x_fwhm,
                          y_fwhm=y_fwhm, theta=theta, **kwargs)
+        self.set_bounding_box()
 
     @property
     def amplitude(self):
@@ -181,9 +182,9 @@ class GaussianPSF(Fittable2DModel):
         """
         return self.y_fwhm * GAUSSIAN_FWHM_TO_SIGMA
 
-    def bounding_box(self, factor=5.5):
+    def set_bounding_box(self, factor=5.5):
         """
-        Return a bounding box defining the limits of the model.
+        Set a bounding box defining the limits of the model.
 
         The limits are adjusted for rotation.
 
@@ -193,11 +194,6 @@ class GaussianPSF(Fittable2DModel):
             The multiple of the x and y standard deviations (sigma) used
             to define the limits.
 
-        Returns
-        -------
-        bounding_box : `astropy.modeling.bounding_box.ModelBoundingBox`
-            A bounding box defining the limits of the model.
-
         Examples
         --------
         >>> from photutils.psf import GaussianPSF
@@ -205,8 +201,18 @@ class GaussianPSF(Fittable2DModel):
         >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-4.6712699, upper=4.6712699)
-                y: Interval(lower=-7.0069049, upper=7.0069048)
+                x: Interval(lower=-4.671269901584105, upper=4.671269901584105)
+                y: Interval(lower=-7.006904852376157, upper=7.006904852376157)
+            }
+            model=GaussianPSF(inputs=('x', 'y'))
+            order='C'
+        )
+        >>> model.set_bounding_box(factor=7)
+        >>> model.bounding_box  # doctest: +FLOAT_CMP
+        ModelBoundingBox(
+            intervals={
+                x: Interval(lower=-5.945252602016134, upper=5.945252602016134)
+                y: Interval(lower=-8.9178789030242, upper=8.9178789030242)
             }
             model=GaussianPSF(inputs=('x', 'y'))
             order='C'
@@ -215,9 +221,8 @@ class GaussianPSF(Fittable2DModel):
         a = factor * self.x_sigma
         b = factor * self.y_sigma
         dx, dy = ellipse_extent(a, b, self.theta)
-
-        return ((self.y_0 - dy, self.y_0 + dy),
-                (self.x_0 - dx, self.x_0 + dx))
+        bbox = ((self.y_0 - dy, self.y_0 + dy), (self.x_0 - dx, self.x_0 + dx))
+        self.bounding_box = bbox
 
     def evaluate(self, x, y, flux, x_0, y_0, x_fwhm, y_fwhm, theta):
         """
@@ -489,6 +494,7 @@ class CircularGaussianPSF(Fittable2DModel):
     def __init__(self, *, flux=flux.default, x_0=x_0.default, y_0=y_0.default,
                  fwhm=fwhm.default, **kwargs):
         super().__init__(flux=flux, x_0=x_0, y_0=y_0, fwhm=fwhm, **kwargs)
+        self.set_bounding_box()
 
     @property
     def amplitude(self):
@@ -504,9 +510,9 @@ class CircularGaussianPSF(Fittable2DModel):
         """
         return self.fwhm * GAUSSIAN_FWHM_TO_SIGMA
 
-    def bounding_box(self, factor=5.5):
+    def set_bounding_box(self, factor=5.5):
         """
-        Return a bounding box defining the limits of the model.
+        Set a bounding box defining the limits of the model.
 
         Parameters
         ----------
@@ -526,16 +532,27 @@ class CircularGaussianPSF(Fittable2DModel):
         >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-4.6712699, upper=4.6712699)
-                y: Interval(lower=-4.6712699, upper=4.6712699)
+                x: Interval(lower=-4.671269901584105, upper=4.671269901584105)
+                y: Interval(lower=-4.671269901584105, upper=4.671269901584105)
+            }
+            model=CircularGaussianPSF(inputs=('x', 'y'))
+            order='C'
+        )
+        >>> model.set_bounding_box(factor=7)
+        >>> model.bounding_box  # doctest: +FLOAT_CMP
+        ModelBoundingBox(
+            intervals={
+                x: Interval(lower=-5.945252602016134, upper=5.945252602016134)
+                y: Interval(lower=-5.945252602016134, upper=5.945252602016134)
             }
             model=CircularGaussianPSF(inputs=('x', 'y'))
             order='C'
         )
         """
         delta = factor * self.sigma
-        return ((self.y_0 - delta, self.y_0 + delta),
+        bbox = ((self.y_0 - delta, self.y_0 + delta),
                 (self.x_0 - delta, self.x_0 + delta))
+        self.bounding_box = bbox
 
     def evaluate(self, x, y, flux, x_0, y_0, fwhm):
         """
@@ -763,6 +780,7 @@ class GaussianPRF(Fittable2DModel):
 
         super().__init__(flux=flux, x_0=x_0, y_0=y_0, x_fwhm=x_fwhm,
                          y_fwhm=y_fwhm, theta=theta, **kwargs)
+        self.set_bounding_box()
 
     @property
     def amplitude(self):
@@ -785,9 +803,9 @@ class GaussianPRF(Fittable2DModel):
         """
         return self.y_fwhm * GAUSSIAN_FWHM_TO_SIGMA
 
-    def bounding_box(self, factor=5.5):
+    def set_bounding_box(self, factor=5.5):
         """
-        Return a bounding box defining the limits of the model.
+        Set a bounding box defining the limits of the model.
 
         The limits are adjusted for rotation.
 
@@ -809,8 +827,18 @@ class GaussianPRF(Fittable2DModel):
         >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-4.6712699, upper=4.6712699)
-                y: Interval(lower=-7.0069049, upper=7.0069048)
+                x: Interval(lower=-4.671269901584105, upper=4.671269901584105)
+                y: Interval(lower=-7.006904852376157, upper=7.006904852376157)
+            }
+            model=GaussianPRF(inputs=('x', 'y'))
+            order='C'
+        )
+        >>> model.set_bounding_box(factor=7)
+        >>> model.bounding_box  # doctest: +FLOAT_CMP
+        ModelBoundingBox(
+            intervals={
+                x: Interval(lower=-5.945252602016134, upper=5.945252602016134)
+                y: Interval(lower=-8.9178789030242, upper=8.9178789030242)
             }
             model=GaussianPRF(inputs=('x', 'y'))
             order='C'
@@ -819,9 +847,8 @@ class GaussianPRF(Fittable2DModel):
         a = factor * self.x_fwhm * GAUSSIAN_FWHM_TO_SIGMA
         b = factor * self.y_fwhm * GAUSSIAN_FWHM_TO_SIGMA
         dx, dy = ellipse_extent(a, b, self.theta)
-
-        return ((self.y_0 - dy, self.y_0 + dy),
-                (self.x_0 - dx, self.x_0 + dx))
+        bbox = ((self.y_0 - dy, self.y_0 + dy), (self.x_0 - dx, self.x_0 + dx))
+        self.bounding_box = bbox
 
     def evaluate(self, x, y, flux, x_0, y_0, x_fwhm, y_fwhm, theta):
         """
@@ -1010,6 +1037,7 @@ class CircularGaussianPRF(Fittable2DModel):
                  fwhm=fwhm.default, **kwargs):
 
         super().__init__(flux=flux, x_0=x_0, y_0=y_0, fwhm=fwhm, **kwargs)
+        self.set_bounding_box()
 
     @property
     def amplitude(self):
@@ -1025,9 +1053,9 @@ class CircularGaussianPRF(Fittable2DModel):
         """
         return self.fwhm * GAUSSIAN_FWHM_TO_SIGMA
 
-    def bounding_box(self, factor=5.5):
+    def set_bounding_box(self, factor=5.5):
         """
-        Return a bounding box defining the limits of the model.
+        Set a bounding box defining the limits of the model.
 
         Parameters
         ----------
@@ -1047,16 +1075,27 @@ class CircularGaussianPRF(Fittable2DModel):
         >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-4.6712699, upper=4.6712699)
-                y: Interval(lower=-4.6712699, upper=4.6712699)
+                x: Interval(lower=-4.671269901584105, upper=4.671269901584105)
+                y: Interval(lower=-4.671269901584105, upper=4.671269901584105)
+            }
+            model=CircularGaussianPRF(inputs=('x', 'y'))
+            order='C'
+        )
+        >>> model.set_bounding_box(factor=7)
+        >>> model.bounding_box  # doctest: +FLOAT_CMP
+        ModelBoundingBox(
+            intervals={
+                x: Interval(lower=-5.945252602016134, upper=5.945252602016134)
+                y: Interval(lower=-5.945252602016134, upper=5.945252602016134)
             }
             model=CircularGaussianPRF(inputs=('x', 'y'))
             order='C'
         )
         """
         delta = factor * self.fwhm * GAUSSIAN_FWHM_TO_SIGMA
-        return ((self.y_0 - delta, self.y_0 + delta),
+        bbox = ((self.y_0 - delta, self.y_0 + delta),
                 (self.x_0 - delta, self.x_0 + delta))
+        self.bounding_box = bbox
 
     def evaluate(self, x, y, flux, x_0, y_0, fwhm):
         """
@@ -1225,6 +1264,7 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
                  sigma=sigma.default, **kwargs):
 
         super().__init__(sigma=sigma, x_0=x_0, y_0=y_0, flux=flux, **kwargs)
+        self.set_bounding_box()
 
     @property
     def amplitude(self):
@@ -1240,9 +1280,9 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         """
         return self.sigma / GAUSSIAN_FWHM_TO_SIGMA
 
-    def bounding_box(self, factor=5.5):
+    def set_bounding_box(self, factor=5.5):
         """
-        Return a bounding box defining the limits of the model.
+        Set a bounding box defining the limits of the model.
 
         Parameters
         ----------
@@ -1258,35 +1298,31 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         Examples
         --------
         >>> from photutils.psf import CircularGaussianPRF
-        >>> model = CircularGaussianPRF(x_0=0, y_0=0, sigma=2)
-        >>> model.bounding_box
+        >>> model = CircularGaussianPRF(x_0=0, y_0=0, fwhm=2)
+        >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-11.0, upper=11.0)
-                y: Interval(lower=-11.0, upper=11.0)
+                x: Interval(lower=-4.671269901584105, upper=4.671269901584105)
+                y: Interval(lower=-4.671269901584105, upper=4.671269901584105)
             }
             model=CircularGaussianPRF(inputs=('x', 'y'))
             order='C'
         )
-
-        This range can be set directly (see: `Model.bounding_box
-        <astropy.modeling.Model.bounding_box>`) or by using a different
-        factor, like:
-
-        >>> model.bounding_box = model.bounding_box(factor=2)
-        >>> model.bounding_box
+        >>> model.set_bounding_box(factor=7)
+        >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-4.0, upper=4.0)
-                y: Interval(lower=-4.0, upper=4.0)
+                x: Interval(lower=-5.945252602016134, upper=5.945252602016134)
+                y: Interval(lower=-5.945252602016134, upper=5.945252602016134)
             }
             model=CircularGaussianPRF(inputs=('x', 'y'))
             order='C'
         )
         """
         delta = factor * self.fwhm * GAUSSIAN_FWHM_TO_SIGMA
-        return ((self.y_0 - delta, self.y_0 + delta),
+        bbox = ((self.y_0 - delta, self.y_0 + delta),
                 (self.x_0 - delta, self.x_0 + delta))
+        self.bounding_box = bbox
 
     def evaluate(self, x, y, flux, x_0, y_0, sigma):
         """
@@ -1438,6 +1474,7 @@ class IntegratedGaussianPRF(CircularGaussianSigmaPRF):
                  sigma=sigma.default, **kwargs):
 
         super().__init__(sigma=sigma, x_0=x_0, y_0=y_0, flux=flux, **kwargs)
+        self.set_bounding_box()
 
 
 class MoffatPSF(Fittable2DModel):
@@ -1555,6 +1592,7 @@ class MoffatPSF(Fittable2DModel):
 
         super().__init__(flux=flux, x_0=x_0, y_0=y_0, alpha=alpha, beta=beta,
                          **kwargs)
+        self.set_bounding_box()
 
     @property
     def fwhm(self):
@@ -1563,9 +1601,9 @@ class MoffatPSF(Fittable2DModel):
         """
         return 2.0 * self.alpha * np.sqrt(2 ** (1.0 / self.beta) - 1)
 
-    def bounding_box(self, factor=10.0):
+    def set_bounding_box(self, factor=10.0):
         """
-        Return a bounding box defining the limits of the model.
+        Set a bounding box defining the limits of the model.
 
         Parameters
         ----------
@@ -1584,16 +1622,27 @@ class MoffatPSF(Fittable2DModel):
         >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-20.3929811, upper=20.3929811)
-                y: Interval(lower=-20.3929811, upper=20.3929811)
+                x: Interval(lower=-20.39298114135835, upper=20.39298114135835)
+                y: Interval(lower=-20.39298114135835, upper=20.39298114135835)
+            }
+            model=MoffatPSF(inputs=('x', 'y'))
+            order='C'
+        )
+        >>> model.set_bounding_box(factor=7)
+        >>> model.bounding_box  # doctest: +FLOAT_CMP
+        ModelBoundingBox(
+            intervals={
+                x: Interval(lower=-14.27508679895084, upper=14.27508679895084)
+                y: Interval(lower=-14.27508679895084, upper=14.27508679895084)
             }
             model=MoffatPSF(inputs=('x', 'y'))
             order='C'
         )
         """
         delta = factor * self.fwhm
-        return ((self.y_0 - delta, self.y_0 + delta),
+        bbox = ((self.y_0 - delta, self.y_0 + delta),
                 (self.x_0 - delta, self.x_0 + delta))
+        self.bounding_box = bbox
 
     def evaluate(self, x, y, flux, x_0, y_0, alpha, beta):
         """
@@ -1775,6 +1824,7 @@ class AiryDiskPSF(Fittable2DModel):
                  radius=radius.default, **kwargs):
 
         super().__init__(flux=flux, x_0=x_0, y_0=y_0, radius=radius, **kwargs)
+        self.set_bounding_box()
 
     @property
     def fwhm(self):
@@ -1783,9 +1833,9 @@ class AiryDiskPSF(Fittable2DModel):
         """
         return 2.0 * 1.616339948310703 * self.radius / self._rz / np.pi
 
-    def bounding_box(self, factor=10.0):
+    def set_bounding_box(self, factor=10.0):
         """
-        Return a bounding box defining the limits of the model.
+        Set a bounding box defining the limits of the model.
 
         Parameters
         ----------
@@ -1804,16 +1854,27 @@ class AiryDiskPSF(Fittable2DModel):
         >>> model.bounding_box  # doctest: +FLOAT_CMP
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-25.30997880, upper=25.30997880)
-                y: Interval(lower=-25.30997880, upper=25.30997880)
+                x: Interval(lower=-25.30997880648709, upper=25.30997880648709)
+                y: Interval(lower=-25.30997880648709, upper=25.30997880648709)
+            }
+            model=AiryDiskPSF(inputs=('x', 'y'))
+            order='C'
+        )
+        >>> model.set_bounding_box(factor=7)
+        >>> model.bounding_box  # doctest: +FLOAT_CMP
+        ModelBoundingBox(
+            intervals={
+                x: Interval(lower=-17.71698516454096, upper=17.71698516454096)
+                y: Interval(lower=-17.71698516454096, upper=17.71698516454096)
             }
             model=AiryDiskPSF(inputs=('x', 'y'))
             order='C'
         )
         """
         delta = factor * self.fwhm
-        return ((self.y_0 - delta, self.y_0 + delta),
+        bbox = ((self.y_0 - delta, self.y_0 + delta),
                 (self.x_0 - delta, self.x_0 + delta))
+        self.bounding_box = bbox
 
     def evaluate(self, x, y, flux, x_0, y_0, radius):
         """

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -118,9 +118,9 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
 
         self.data, self.grid_xypos = self._define_grid(nddata)
         self._meta = nddata.meta.copy()  # _meta to avoid the meta descriptor
-        self.oversampling = as_pair('oversampling',
-                                    nddata.meta['oversampling'],
-                                    lower_bound=(0, 1))
+        self._oversampling = as_pair('oversampling',
+                                     nddata.meta['oversampling'],
+                                     lower_bound=(0, 1))
         self.fill_value = fill_value
 
         self._xgrid = np.unique(self.grid_xypos[:, 0])  # sorted
@@ -130,6 +130,7 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
         self._interpolator = {}
 
         super().__init__(flux, x_0, y_0)
+        self.set_bounding_box()
 
     @staticmethod
     def _validate_data(data):
@@ -303,9 +304,36 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
         """
         return copy.deepcopy(self)
 
-    def bounding_box(self):
+    @property
+    def oversampling(self):
         """
-        Return a bounding box defining the limits of the model.
+        The integer oversampling factor(s) of the input ePSF images.
+
+        If ``oversampling`` is a scalar then it will be used for both
+        axes. If ``oversampling`` has two elements, they must be in
+        ``(y, x)`` order.
+        """
+        return self._oversampling
+
+    @oversampling.setter
+    def oversampling(self, value):
+        """
+        Set the oversampling factor(s) of the input ePSF images.
+
+        Parameters
+        ----------
+        value : int or tuple of int
+            The integer oversampling factor(s) of the input ePSF images.
+            If ``oversampling`` is a scalar then it will be used for both
+            axes. If ``oversampling`` has two elements, they must be in
+            ``(y, x)`` order.
+        """
+        self._oversampling = as_pair('oversampling', value, lower_bound=(0, 1))
+        self.set_bounding_box()
+
+    def set_bounding_box(self):
+        """
+        Set a bounding box defining the limits of the model.
 
         Returns
         -------
@@ -343,8 +371,8 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
         )
         """
         dy, dx = np.array(self.data.shape[1:]) / 2 / self.oversampling
-        return ((self.y_0 - dy, self.y_0 + dy),
-                (self.x_0 - dx, self.x_0 + dx))
+        bbox = ((self.y_0 - dy, self.y_0 + dy), (self.x_0 - dx, self.x_0 + dx))
+        self.bounding_box = bbox
 
     @lazyproperty
     def origin(self):

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -134,6 +134,7 @@ class ImagePSF(Fittable2DModel):
         self.fill_value = fill_value
 
         super().__init__(flux, x_0, y_0, **kwargs)
+        self.set_bounding_box()
 
     @staticmethod
     def _validate_data(data):
@@ -253,9 +254,9 @@ class ImagePSF(Fittable2DModel):
         # RectBivariateSpline expects the data to be in (x, y) axis order
         return RectBivariateSpline(x, y, self.data.T, kx=3, ky=3, s=0)
 
-    def bounding_box(self):
+    def set_bounding_box(self):
         """
-        Return a bounding box defining the limits of the model.
+        Set a bounding box defining the limits of the model.
 
         Returns
         -------
@@ -288,8 +289,9 @@ class ImagePSF(Fittable2DModel):
         xshift /= self.oversampling[1]
         yshift /= self.oversampling[0]
 
-        return ((self.y_0 - dy + yshift, self.y_0 + dy + yshift),
+        bbox = ((self.y_0 - dy + yshift, self.y_0 + dy + yshift),
                 (self.x_0 - dx + xshift, self.x_0 + dx + xshift))
+        self.bounding_box = bbox
 
     def evaluate(self, x, y, flux, x_0, y_0):
         """


### PR DESCRIPTION
This PR replaces the `bounding_box` method with `set_bounding_box`.  The base `Model.bounding_box` is a property not a method, and this prevents the `bounding_box` docs from rendering.