### PR TITLE
Temporarily disable docformatter pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,13 +96,15 @@ repos:
       - id: numpydoc-validation
         exclude: "extern/"
 
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
-    hooks:
-      - id: docformatter
-        additional_dependencies: [tomli]
-        args: [--in-place, --config, ./pyproject.toml]
-        exclude: "extern/"
+  # temporarily disabled
+  # see https://github.com/PyCQA/docformatter/pull/287
+  # - repo: https://github.com/PyCQA/docformatter
+  #   rev: v1.7.5
+  #   hooks:
+  #     - id: docformatter
+  #       additional_dependencies: [tomli]
+  #       args: [--in-place, --config, ./pyproject.toml]
+  #       exclude: "extern/"
 
   # - repo: https://github.com/MarcoGorelli/absolufy-imports
   #   rev: v0.3.1


### PR DESCRIPTION
`pre-commit` 4.0.0 removed `language: python_venv`, which breaks the `docformatter` hook.  See https://github.com/PyCQA/docformatter/pull/287