### PR TITLE
Replace LMLSQFitter with TRFLSQFitter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,9 +170,9 @@ API Changes
     background-subtracted. [#1861]
 
   - The fitter used in ``centroid_1dg`` and ``centroid_2dg`` was changed
-    from ``LevMarLSQFitter`` to ``LMLSQFitter``. ``LevMarLSQFitter`` uses
+    from ``LevMarLSQFitter`` to ``TRFLSQFitter``. ``LevMarLSQFitter`` uses
     the legacy SciPy function ``scipy.optimize.leastsq``, which is no
-    longer recommended. [#1899]
+    longer recommended. [#1917]
 
 - ``photutils.datasets``
 

--- a/docs/user_guide/centroids.rst
+++ b/docs/user_guide/centroids.rst
@@ -87,7 +87,7 @@ centroiding functions::
 
     >>> x4, y4 = centroid_2dg(data)
     >>> print(np.array((x4, y4)))  # doctest: +FLOAT_CMP
-    [19.9850329  20.01484321]
+    [19.98519436 20.0149016 ]
 
 The measured centroids are all very close to the true centroid of the object
 in the cutout image of ``(20, 20)``.

--- a/docs/whats_new/2.0.rst
+++ b/docs/whats_new/2.0.rst
@@ -171,8 +171,8 @@ classes.
 The fitter used in ``RadialProfile`` to fit the profile with a Gaussian
 was also changed from ``LevMarLSQFitter`` to ``TRFLSQFitter``.
 
-The fitter used in ``centroid_1dg`` and ``centroid_2dg`` was changed
-from ``LevMarLSQFitter`` to ``LMLSQFitter``.
+The fitter used in ``centroid_1dg`` and ``centroid_2dg`` was also
+changed from ``LevMarLSQFitter`` to ``TRFLSQFitter``.
 
 For more information about Astropy's non-linear fitters, see
 :ref:`astropy:modeling-getting-started-nonlinear-notes`.

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -6,7 +6,7 @@ The module contains tools for centroiding sources using Gaussians.
 import warnings
 
 import numpy as np
-from astropy.modeling.fitting import LMLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.modeling.models import Gaussian1D, Gaussian2D
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -105,8 +105,8 @@ def centroid_1dg(data, error=None, mask=None):
 
     xy_data = [np.ma.sum(data, axis=i).data for i in (0, 1)]
 
-    # would need to use a different fitter if parameter bounds are used
-    fitter = LMLSQFitter()
+    # Gaussian1D stddev is bounded to be strictly positive
+    fitter = TRFLSQFitter()
 
     centroid = []
     for (data_i, weights_i) in zip(xy_data, xy_weights, strict=True):
@@ -272,8 +272,8 @@ def centroid_2dg(data, error=None, mask=None):
                         y_stddev=props.semiminor_sigma.value,
                         theta=props.orientation.value)
 
-    # would need to use a different fitter if parameter bounds are used
-    fitter = LMLSQFitter()
+    # Gaussian2D [x/y]_stddev are bounded to be strictly positive
+    fitter = TRFLSQFitter()
 
     y, x = np.indices(data.shape)
 

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -201,7 +201,7 @@ def centroid_2dg(data, error=None, mask=None):
     >>> data = data[40:80, 70:110]
     >>> x1, y1 = centroid_2dg(data)
     >>> print(np.array((x1, y1)))
-    [19.98519434 20.01490159]
+    [19.98519436 20.0149016 ]
 
     .. plot::
 

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -288,13 +288,15 @@ class TestCentroidSources:
 
         xres = np.copy(xpos).astype(float)
         yres = np.copy(ypos).astype(float)
-        xres[-1] = np.nan
-        yres[-1] = np.nan
+        xres[-1] = 46.689208
+        yres[-1] = 49.689208
         assert_allclose(xcen, xres)
         assert_allclose(ycen, yres)
 
         xcen, ycen = centroid_sources(data, xpos, ypos, box_size=3,
                                       centroid_func=centroid_2dg)
+        xres[-1] = np.nan
+        yres[-1] = np.nan
         assert_allclose(xcen, xres)
         assert_allclose(ycen, yres)
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -6,7 +6,8 @@ Tests for the photometry module.
 import astropy.units as u
 import numpy as np
 import pytest
-from astropy.modeling.fitting import LMLSQFitter, SimplexLSQFitter
+from astropy.modeling.fitting import (LMLSQFitter, SimplexLSQFitter,
+                                      TRFLSQFitter)
 from astropy.modeling.models import Gaussian1D, Gaussian2D
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable, Table
@@ -1046,7 +1047,7 @@ def test_iterative_psf_photometry_overlap():
 
     daofinder = DAOStarFinder(threshold=0.5, fwhm=fwhm)
     grouper = SourceGrouper(min_separation=1.3 * fwhm)
-    fitter = LMLSQFitter()
+    fitter = TRFLSQFitter()
     psfphot = IterativePSFPhotometry(psf_model, fit_shape=(5, 5),
                                      finder=daofinder, mode='all',
                                      grouper=grouper, maxiters=2,


### PR DESCRIPTION
The default `stddev` of Astropy's `Gaussian1D` model is bounded to be strictly positive, so the `TRFLSQFitter` should be used.  Followup to https://github.com/astropy/photutils/pull/1899

I've opened a PR for `Gaussian2D` to have the same default bounds:  https://github.com/astropy/astropy/pull/17137

Many thanks to @astrofrog for pointing this out!