### PR TITLE
Add parameter bounds to PSF models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,11 +75,12 @@ New Features
 
   - Added new ``GaussianPSF``, ``CircularGaussianPSF``, ``GaussianPRF``,
     ``CircularGaussianPRF``, and ``MoffatPSF`` PSF model classes.
-    [#1838, #1898]
+    [#1838, #1898, #1918]
 
-  - Added new ``AiryDiskPSF`` PSF model class. [#1843]
+  - Added new ``AiryDiskPSF`` PSF model class. [#1843, #1918]
 
-  - Added new ``CircularGaussianSigmaPRF`` PSF model class. [#1845]
+  - Added new ``CircularGaussianSigmaPRF`` PSF model class. [#1845,
+    #1918]
 
   - The ``IntegratedGaussianPRF`` model now supports units. [#1838]
 
@@ -88,7 +89,7 @@ New Features
 
   - Added new ``fit_fwhm`` convenience function to estimate the FWHM of
     one or more sources in an image by fitting a circular 2D Gaussian PSF
-    model. [#1859, #1887, #1899]
+    model. [#1859, #1887, #1899, #1918]
 
   - Added new ``fit_2dgaussian`` convenience function to fit a circular
     2D Gaussian PSF to one or more sources in an image. [#1859, #1887,

--- a/docs/user_guide/psf.rst
+++ b/docs/user_guide/psf.rst
@@ -664,23 +664,23 @@ parameters. Here we constrain the flux to be greater than or equal to
 
     >>> psf_model3 = CircularGaussianPRF(flux=1, fwhm=2.7)
     >>> psf_model3.flux.bounds = (0, None)
-    >>> psf_model3.bounds
-    {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (None, None)}
+    >>> psf_model3.bounds  # doctest: +FLOAT_CMP
+    {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (0.0, None)}
 
 The model parameter ``bounds`` can also be set using the ``min`` and/or
 ``max`` attributes. Here we set the minimum flux to be 0::
 
     >>> psf_model3.flux.min = 0
-    >>> psf_model3.bounds
-    {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (None, None)}
+    >>> psf_model3.bounds  # doctest: +FLOAT_CMP
+    {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (0.0, None)}
 
 For this example, let's constrain the flux value to be between between
 400 and 600::
 
     >>> psf_model3 = CircularGaussianPRF(flux=1, fwhm=2.7)
     >>> psf_model3.flux.bounds = (400, 600)
-    >>> psf_model3.bounds
-    {'flux': (400.0, 600.0), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (None, None)}
+    >>> psf_model3.bounds  # doctest: +FLOAT_CMP
+    {'flux': (400.0, 600.0), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (0.0, None)}
 
 
 Source Grouping

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -15,6 +15,7 @@ __all__ = ['GaussianPSF', 'CircularGaussianPSF', 'GaussianPRF',
            'CircularGaussianPRF', 'CircularGaussianSigmaPRF',
            'IntegratedGaussianPRF', 'MoffatPSF', 'AiryDiskPSF']
 
+FLOAT_EPSILON = float(np.finfo(np.float32).tiny)
 GAUSSIAN_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 
 
@@ -122,6 +123,9 @@ class GaussianPSF(Fittable2DModel):
         >>> model.y_fwhm.fixed = False
         >>> model.theta.fixed = False
 
+    By default, the ``x_fwhm`` and ``y_fwhm`` parameters are bounded to
+    be strictly positive.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Gaussian_function
@@ -148,11 +152,15 @@ class GaussianPSF(Fittable2DModel):
     y_0 = Parameter(
         default=0, description='Position of the peak along the y axis')
     x_fwhm = Parameter(
-        default=1, description='FWHM of the Gaussian along the x axis',
-        fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='FWHM of the Gaussian along the x axis')
     y_fwhm = Parameter(
-        default=1, description='FWHM of the Gaussian along the y axis',
-        fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='FWHM of the Gaussian along the y axis')
     theta = Parameter(
         default=0.0, description=('CCW rotation angle either as a float (in '
                                   'degrees) or a Quantity angle (optional)'),
@@ -484,6 +492,9 @@ class CircularGaussianPSF(Fittable2DModel):
         >>> model = CircularGaussianPSF()
         >>> model.fwhm.fixed = False
 
+    By default, the ``fwhm`` parameter is bounded to be strictly
+    positive.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Gaussian_function
@@ -509,7 +520,10 @@ class CircularGaussianPSF(Fittable2DModel):
     y_0 = Parameter(
         default=0, description='Position of the peak along the y axis')
     fwhm = Parameter(
-        default=1, description='FWHM of the Gaussian', fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='FWHM of the Gaussian')
 
     def __init__(self, *, flux=flux.default, x_0=x_0.default, y_0=y_0.default,
                  fwhm=fwhm.default, bbox_factor=5.5, **kwargs):
@@ -769,6 +783,9 @@ class GaussianPRF(Fittable2DModel):
         >>> model.y_fwhm.fixed = False
         >>> model.theta.fixed = False
 
+    By default, the ``x_fwhm`` and ``y_fwhm`` parameters are bounded to
+    be strictly positive.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Gaussian_function
@@ -795,11 +812,15 @@ class GaussianPRF(Fittable2DModel):
     y_0 = Parameter(
         default=0, description='Position of the peak along the y axis')
     x_fwhm = Parameter(
-        default=1, description='FWHM of the Gaussian along the x axis',
-        fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='FWHM of the Gaussian along the x axis')
     y_fwhm = Parameter(
-        default=1, description='FWHM of the Gaussian along the y axis',
-        fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='FWHM of the Gaussian along the y axis')
     theta = Parameter(
         default=0.0, description=('CCW rotation angle either as a float (in '
                                   'degrees) or a Quantity angle (optional)'),
@@ -1047,6 +1068,9 @@ class CircularGaussianPRF(Fittable2DModel):
         >>> model = CircularGaussianPRF()
         >>> model.fwhm.fixed = False
 
+    By default, the ``fwhm`` parameter is bounded to be strictly
+    positive.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Gaussian_function
@@ -1072,7 +1096,10 @@ class CircularGaussianPRF(Fittable2DModel):
     y_0 = Parameter(
         default=0, description='Position of the peak along the y axis')
     fwhm = Parameter(
-        default=1, description='FWHM of the Gaussian', fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='FWHM of the Gaussian')
 
     def __init__(self, *, flux=flux.default, x_0=x_0.default, y_0=y_0.default,
                  fwhm=fwhm.default, bbox_factor=5.5, **kwargs):
@@ -1282,6 +1309,9 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         >>> model = CircularGaussianSigmaPRF()
         >>> model.sigma.fixed = False
 
+    By default, the ``sigma`` parameter is bounded to be strictly
+    positive.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Gaussian_function
@@ -1308,8 +1338,10 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
     y_0 = Parameter(
         default=0, description='Position of the peak along the y axis')
     sigma = Parameter(
-        default=1, description='Sigma (standard deviation) of the Gaussian',
-        fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='Sigma (standard deviation) of the Gaussian')
 
     def __init__(self, *, flux=flux.default, x_0=x_0.default, y_0=y_0.default,
                  sigma=sigma.default, bbox_factor=5.5, **kwargs):
@@ -1528,8 +1560,10 @@ class IntegratedGaussianPRF(CircularGaussianSigmaPRF):
     y_0 = Parameter(
         default=0, description='Position of the peak along the y axis')
     sigma = Parameter(
-        default=1, description='Sigma (standard deviation) of the Gaussian',
-        fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='Sigma (standard deviation) of the Gaussian')
 
     def __init__(self, *, flux=flux.default, x_0=x_0.default, y_0=y_0.default,
                  sigma=sigma.default, bbox_factor=5.5, **kwargs):
@@ -1615,6 +1649,9 @@ class MoffatPSF(Fittable2DModel):
         >>> model.alpha.fixed = False
         >>> model.beta.fixed = False
 
+    By default, the ``alpha`` parameter is bounded to be strictly
+    positive and the ``beta`` parameter is bounded to be greater than 1.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Moffat_distribution
@@ -1644,11 +1681,15 @@ class MoffatPSF(Fittable2DModel):
     y_0 = Parameter(
         default=0, description='Position of the peak along the y axis')
     alpha = Parameter(
-        default=1, description='Characteristic radius of the Moffat profile',
-        fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='Characteristic radius of the Moffat profile')
     beta = Parameter(
-        default=1, description='Power-law index of the Moffat profile',
-        fixed=True)
+        default=2,
+        bounds=(1.0 + FLOAT_EPSILON, None),
+        fixed=True,
+        description='Power-law index of the Moffat profile')
 
     def __init__(self, *, flux=flux.default, x_0=x_0.default, y_0=y_0.default,
                  alpha=alpha.default, beta=beta.default, bbox_factor=10.0,
@@ -1861,6 +1902,9 @@ class AiryDiskPSF(Fittable2DModel):
         >>> model = AiryDiskPSF()
         >>> model.radius.fixed = False
 
+    By default, the ``radius`` parameter is bounded to be strictly
+    positive.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Airy_disk
@@ -1888,8 +1932,10 @@ class AiryDiskPSF(Fittable2DModel):
     y_0 = Parameter(
         default=0, description='Position of the peak along the y axis')
     radius = Parameter(
-        default=1, description='Radius of the Airy disk at the first zero',
-        fixed=True)
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        fixed=True,
+        description='Radius of the Airy disk at the first zero')
 
     _rz = jn_zeros(1, 1)[0] / np.pi
 

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -291,7 +291,7 @@ def fit_fwhm(data, *, xypos=None, fwhm=None, fit_shape=None, mask=None,
                       'the input "xypos" and "fit_shape" parameters.',
                       AstropyUserWarning)
 
-    return np.abs(np.array(phot.results['fwhm_fit']))
+    return np.array(phot.results['fwhm_fit'])
 
 
 def _interpolate_missing_data(data, mask, method='cubic'):


### PR DESCRIPTION
All `*fwhm` and "radius" parameters are strictly positive by default.  The `MoffatPSF` `gamma` parameter is required to be > 1.