### PR TITLE
Make psf_shape an optional keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,6 +113,12 @@ Bug Fixes
   - Fixed a bug checking that the ``subpixels`` keyword is a strictly
     positive integer. [#1816]
 
+- ``photutils.datasets``
+
+  - Fixed an issue in ``make_model_image`` where if the ``bbox_factor``
+    was input and the model bounding box did not have a ``factor`` keyword
+    then an error would be raised. [#1921]
+
 - ``photutils.detection``
 
   - Fixed an issue where ``DAOStarFinder`` would not return any sources
@@ -250,6 +256,12 @@ API Changes
     ``LevMarLSQFitter`` to ``TRFLSQFitter``. ``LevMarLSQFitter`` uses
     the legacy SciPy function ``scipy.optimize.leastsq``, which is no
     longer recommended. [#1899]
+
+  - ``psf_shape`` is now an optional keyword in the ``make_model_image``
+    and ``make_residual_image`` methods of ``PSFPhotometry`` and
+    ``IterativePSFPhotometry``. The value defaults to using the model
+    bounding box to define the shape and is required only if the PSF
+    model does not have a bounding box attribute. [#1921]
 
 - ``photutils.psf.matching``
 

--- a/docs/user_guide/psf.rst
+++ b/docs/user_guide/psf.rst
@@ -414,7 +414,7 @@ print the source ID along with the fit x, y, and flux values::
 
 Let's create the residual image::
 
-    >>> resid = psfphot.make_residual_image(data, (9, 9))
+    >>> resid = psfphot.make_residual_image(data)
 
 and plot it:
 
@@ -448,7 +448,7 @@ and plot it:
                             aperture_radius=4)
     phot = psfphot(data, error=error)
 
-    resid = psfphot.make_residual_image(data, (9, 9))
+    resid = psfphot.make_residual_image(data)
 
     fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(15, 5))
     norm = simple_norm(data, 'sqrt', percent=99)
@@ -580,7 +580,7 @@ the location of the star that was fit and subtracted.
     init_params['y'] = [49]
     phot = psfphot(data, error=error, init_params=init_params)
 
-    resid = psfphot.make_residual_image(data, (9, 9))
+    resid = psfphot.make_residual_image(data)
     aper = CircularAperture(zip(phot['x_fit'], phot['y_fit']), r=4)
 
     fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(15, 5))

--- a/docs/whats_new/2.0.rst
+++ b/docs/whats_new/2.0.rst
@@ -178,6 +178,30 @@ For more information about Astropy's non-linear fitters, see
 :ref:`astropy:modeling-getting-started-nonlinear-notes`.
 
 
+Breaking API Change for PSF Photometry residual/model images
+============================================================
+
+The ``sub_shape`` keyword in `~photutils.psf.IterativePSFPhotometry`
+now defaults to using the model bounding box to define the shape. This
+is a change from the previous behavior where the default shape was set
+to ``fit_shape``. In general, one should want the subtraction shape to
+cover a large portion of the model image, which the bounding box does.
+If one wants to use a different shape, then the ``sub_shape`` keyword
+can be explicitly set. If the PSF model does not have a bounding box
+attribute, then the ``sub_shape`` keyword must be set to define the
+subtraction shape.
+
+Similarly, ``psf_shape`` is now an optional keyword in
+the ``make_model_image`` and ``make_residual_image``
+methods of `~photutils.psf.PSFPhotometry` and
+`~photutils.psf.IterativePSFPhotometry`. The value defaults to using the
+model bounding box to define the shape and is required only if the PSF
+model does not have a bounding box attribute. In general, one should
+want the model and residual images to be constructed using the a large
+portion of model image, which the bounding box does. If one wants to use
+a different shape, then the ``psf_shape`` keyword can be explicitly set.
+
+
 Bounding model fits in PSF Photometry
 =====================================
 

--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -273,16 +273,7 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
         elif model_shape is None:
             # the bounding box size generally depends on model parameters,
             # so needs to be calculated for each source
-            if bbox_factor is not None:
-                try:
-                    bbox = model.bounding_box(factor=bbox_factor)
-                except NotImplementedError:
-                    bbox = model.bounding_box.bounding_box()
-            else:
-                bbox = model.bounding_box.bounding_box()
-
-            mod_shape = (int(np.ceil(bbox[0][1] - bbox[0][0])),
-                         int(np.ceil(bbox[1][1] - bbox[1][0])))
+            mod_shape = _model_shape_from_bbox(model, bbox_factor=bbox_factor)
         else:
             mod_shape = model_shape
 
@@ -314,3 +305,48 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
             continue
 
     return image
+
+
+def _model_shape_from_bbox(model, bbox_factor=None):
+    """
+    Calculate the model shape from the model bounding box.
+
+    Parameters
+    ----------
+    model : 2D `astropy.modeling.Model`
+        The 2D model to be used to render the sources.
+
+    bbox_factor : `None` or float, optional
+        The multiplicative factor to pass to the model ``bounding_box``
+        method to determine the model shape. If the model
+        ``bounding_box`` method does not accept a ``factor`` keyword,
+        then this keyword is ignored. If `None`, the default model
+        bounding box will be used.
+
+    Returns
+    -------
+    model_shape : 2-tuple of int
+        The shape around the (x, y) center of the model that will used
+        to evaluate the model.
+
+    Raises
+    ------
+    ValueError
+        If the model does not have a bounding_box attribute.
+    """
+    try:
+        hasattr(model, 'bounding_box')
+    except NotImplementedError as exc:
+        msg = 'model does not have a bounding_box attribute'
+        raise ValueError(msg) from exc
+
+    if bbox_factor is not None:
+        try:
+            bbox = model.bounding_box(factor=bbox_factor)
+        except NotImplementedError:
+            bbox = model.bounding_box.bounding_box()
+    else:
+        bbox = model.bounding_box.bounding_box()
+
+    return (int(np.ceil(bbox[0][1] - bbox[0][0])),
+            int(np.ceil(bbox[1][1] - bbox[1][0])))

--- a/photutils/datasets/tests/test_images.py
+++ b/photutils/datasets/tests/test_images.py
@@ -2,15 +2,16 @@
 """
 Tests for the images module.
 """
-
 import astropy.units as u
 import numpy as np
 import pytest
 from astropy.modeling.models import Moffat2D
 from astropy.table import QTable
+from numpy.testing import assert_allclose
 
 from photutils.datasets import make_model_image
-from photutils.psf import CircularGaussianSigmaPRF
+from photutils.psf import (CircularGaussianPSF, CircularGaussianSigmaPRF,
+                           ImagePSF)
 
 
 def test_make_model_image():
@@ -148,3 +149,26 @@ def test_make_model_image_inputs():
     shape = (100, 100)
     with pytest.raises(ValueError, match=match):
         make_model_image(shape, model, params)
+
+
+def test_make_model_image_bbox():
+    model1 = CircularGaussianPSF(x_0=50, y_0=50, fwhm=10)
+    yy, xx = np.mgrid[:101, :101]
+    model2 = ImagePSF(model1(xx, yy), x_0=50, y_0=50)
+
+    params = QTable()
+    params['x_0'] = [50, 70, 90]
+    params['y_0'] = [50, 50, 50]
+    shape = (100, 151)
+    image1 = make_model_image(shape, model2, params, bbox_factor=10)
+    image2 = make_model_image(shape, model2, params, bbox_factor=None)
+    assert_allclose(image1, image2)
+
+    image3 = make_model_image(shape, model1, params, bbox_factor=10)
+    image4 = make_model_image(shape, model1, params, bbox_factor=None)
+    assert_allclose(image3, image4)
+
+    model1.bbox_factor = 10
+    image5 = make_model_image(shape, model1, params)
+    assert np.sum(image5) > np.sum(image4)
+    assert_allclose(image3, image4)

--- a/photutils/datasets/tests/test_images.py
+++ b/photutils/datasets/tests/test_images.py
@@ -2,6 +2,7 @@
 """
 Tests for the images module.
 """
+
 import astropy.units as u
 import numpy as np
 import pytest

--- a/photutils/psf/simulation.py
+++ b/photutils/psf/simulation.py
@@ -7,6 +7,7 @@ models.
 import numpy as np
 
 from photutils.datasets import make_model_image, make_model_params
+from photutils.datasets.images import _model_shape_from_bbox
 from photutils.psf.utils import _get_psf_model_params
 from photutils.utils._parameters import as_pair
 
@@ -106,16 +107,16 @@ def make_psf_model_image(shape, psf_model, n_sources, *, model_shape=None,
     >>> print(params)  # doctest: +FLOAT_CMP
      id   x_0      y_0      flux
     --- -------- -------- --------
-      1 125.4749  72.2784 147.9522
-      2  57.1803  38.6027 128.1262
-      3  14.6211 116.0558 200.8790
-      4  10.0741 132.6001 129.2661
-      5 158.2683  43.1937 186.6532
-      6 176.7725  80.2951 190.3359
-      7 142.6864 133.6184 244.3635
-      8 108.1142  12.5095 110.8398
-      9 180.9235 106.5528 174.9959
-     10 158.7488  90.5548 211.6146
+      1 125.2010  72.3184 147.9522
+      2  57.6408  39.1380 128.1262
+      3  15.5391 115.4520 200.8790
+      4  11.0411 131.7530 129.2661
+      5 157.6417  43.6615 186.6532
+      6 175.9470  80.2172 190.3359
+      7 142.2274 132.7563 244.3635
+      8 108.0270  13.4284 110.8398
+      9 180.0533 106.0888 174.9959
+     10 158.1171  90.3260 211.6146
 
     .. plot::
         :include-source:
@@ -151,11 +152,8 @@ def make_psf_model_image(shape, psf_model, n_sources, *, model_shape=None,
         model_shape = as_pair('model_shape', model_shape, lower_bound=(0, 1))
     else:
         try:
-            bbox = psf_model.bounding_box.bounding_box()
-            model_shape = (int(np.round(bbox[0][1] - bbox[0][0])),
-                           int(np.round(bbox[1][1] - bbox[1][0])))
-
-        except NotImplementedError as exc:
+            model_shape = _model_shape_from_bbox(psf_model)
+        except ValueError as exc:
             raise ValueError('model_shape must be specified if the model '
                              'does not have a bounding_box attribute') from exc
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -172,7 +172,7 @@ def test_psf_photometry(test_data):
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                             aperture_radius=4)
     phot = psfphot(data, error=error)
-    resid_data = psfphot.make_residual_image(data, fit_shape)
+    resid_data = psfphot.make_residual_image(data, psf_shape=fit_shape)
 
     assert isinstance(psfphot.finder_results, QTable)
     assert isinstance(phot, QTable)
@@ -203,7 +203,8 @@ def test_psf_photometry(test_data):
     colnames = ('flux_init', 'flux_fit', 'flux_err', 'local_bkg')
     for col in colnames:
         assert photu[col].unit == unit
-    resid_datau = psfphotu.make_residual_image(data << unit, fit_shape)
+    resid_datau = psfphotu.make_residual_image(data << unit,
+                                               psf_shape=fit_shape)
     assert resid_datau.unit == unit
     colnames = ('qfit', 'cfit')
     for col in colnames:
@@ -224,7 +225,7 @@ def test_psf_photometry_forced(test_data, fit_fwhm):
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                             aperture_radius=4)
     phot = psfphot(data, error=error)
-    resid_data = psfphot.make_residual_image(data, fit_shape)
+    resid_data = psfphot.make_residual_image(data, psf_shape=fit_shape)
 
     assert isinstance(psfphot.finder_results, QTable)
     assert isinstance(phot, QTable)
@@ -256,8 +257,8 @@ def test_psf_photometry_nddata(test_data):
                             aperture_radius=4)
     phot1 = psfphot(data, error=error)
     phot2 = psfphot(nddata)
-    resid_data1 = psfphot.make_residual_image(data, fit_shape)
-    resid_data2 = psfphot.make_residual_image(nddata, fit_shape)
+    resid_data1 = psfphot.make_residual_image(data, psf_shape=fit_shape)
+    resid_data2 = psfphot.make_residual_image(nddata, psf_shape=fit_shape)
 
     assert np.all(phot1 == phot2)
     assert isinstance(resid_data2, NDData)
@@ -276,7 +277,7 @@ def test_psf_photometry_nddata(test_data):
     assert photu['flux_init'].unit == unit
     assert photu['flux_fit'].unit == unit
     assert photu['flux_err'].unit == unit
-    resid_data3 = psfphotu.make_residual_image(nddata, fit_shape)
+    resid_data3 = psfphotu.make_residual_image(nddata, psf_shape=fit_shape)
     assert resid_data3.unit == unit
 
 
@@ -295,13 +296,13 @@ def test_model_residual_image(test_data):
     psfphot(data, error=error)
 
     psf_shape = (25, 25)
-    model1 = psfphot.make_model_image(data.shape, psf_shape,
+    model1 = psfphot.make_model_image(data.shape, psf_shape=psf_shape,
                                       include_localbkg=False)
-    model2 = psfphot.make_model_image(data.shape, psf_shape,
+    model2 = psfphot.make_model_image(data.shape, psf_shape=psf_shape,
                                       include_localbkg=True)
-    resid1 = psfphot.make_residual_image(data, psf_shape,
+    resid1 = psfphot.make_residual_image(data, psf_shape=psf_shape,
                                          include_localbkg=False)
-    resid2 = psfphot.make_residual_image(data, psf_shape,
+    resid2 = psfphot.make_residual_image(data, psf_shape=psf_shape,
                                          include_localbkg=True)
 
     x, y = 0, 100
@@ -349,13 +350,13 @@ def test_psf_photometry_compound_psfmodel(test_data, fit_stddev):
 
     # test model and residual images
     psf_shape = (9, 9)
-    model1 = psfphot.make_model_image(data.shape, psf_shape,
+    model1 = psfphot.make_model_image(data.shape, psf_shape=psf_shape,
                                       include_localbkg=False)
-    resid1 = psfphot.make_residual_image(data, psf_shape,
+    resid1 = psfphot.make_residual_image(data, psf_shape=psf_shape,
                                          include_localbkg=False)
-    model2 = psfphot.make_model_image(data.shape, psf_shape,
+    model2 = psfphot.make_model_image(data.shape, psf_shape=psf_shape,
                                       include_localbkg=True)
-    resid2 = psfphot.make_residual_image(data, psf_shape,
+    resid2 = psfphot.make_residual_image(data, psf_shape=psf_shape,
                                          include_localbkg=True)
     assert model1.shape == data.shape
     assert model2.shape == data.shape
@@ -414,8 +415,10 @@ def test_iterative_psf_photometry_compound(mode):
     fit_shape = (5, 5)
     finder = DAOStarFinder(6.0, 3.0)
     grouper = SourceGrouper(min_separation=2)
+
     psfphot = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
                                      grouper=grouper, aperture_radius=4,
+                                     sub_shape=fit_shape,
                                      mode=mode, maxiters=2)
     phot = psfphot(data, error=error, init_params=init_params)
     assert isinstance(phot, QTable)
@@ -429,13 +432,13 @@ def test_iterative_psf_photometry_compound(mode):
 
     # test model and residual images
     psf_shape = (9, 9)
-    model1 = psfphot.make_model_image(data.shape, psf_shape,
+    model1 = psfphot.make_model_image(data.shape, psf_shape=psf_shape,
                                       include_localbkg=False)
-    resid1 = psfphot.make_residual_image(data, psf_shape,
+    resid1 = psfphot.make_residual_image(data, psf_shape=psf_shape,
                                          include_localbkg=False)
-    model2 = psfphot.make_model_image(data.shape, psf_shape,
+    model2 = psfphot.make_model_image(data.shape, psf_shape=psf_shape,
                                       include_localbkg=True)
-    resid2 = psfphot.make_residual_image(data, psf_shape,
+    resid2 = psfphot.make_residual_image(data, psf_shape=psf_shape,
                                          include_localbkg=True)
     assert model1.shape == data.shape
     assert model2.shape == data.shape
@@ -635,11 +638,11 @@ def test_psf_photometry_init_params_units(test_data):
     assert len(phot) == 1
 
     for val in (True, False):
-        im = psfphot.make_model_image(data2.shape, fit_shape,
+        im = psfphot.make_model_image(data2.shape, psf_shape=fit_shape,
                                       include_localbkg=val)
         assert isinstance(im, u.Quantity)
         assert im.unit == unit
-        resid = psfphot.make_residual_image(data2, fit_shape,
+        resid = psfphot.make_residual_image(data2, psf_shape=fit_shape,
                                             include_localbkg=val)
         assert isinstance(resid, u.Quantity)
         assert resid.unit == unit
@@ -893,12 +896,12 @@ def test_iterative_psf_photometry_mode_new(test_data):
     assert 'iter_detected' in phot.colnames
     assert len(phot) == len(sources)
 
-    resid_data = psfphot.make_residual_image(data, fit_shape)
+    resid_data = psfphot.make_residual_image(data, psf_shape=fit_shape)
     assert isinstance(resid_data, np.ndarray)
     assert resid_data.shape == data.shape
 
     nddata = NDData(data)
-    resid_nddata = psfphot.make_residual_image(nddata, fit_shape)
+    resid_nddata = psfphot.make_residual_image(nddata, psf_shape=fit_shape)
     assert isinstance(resid_nddata, NDData)
     assert resid_nddata.data.shape == data.shape
 
@@ -913,7 +916,7 @@ def test_iterative_psf_photometry_mode_new(test_data):
     colnames = ('flux_init', 'flux_fit', 'flux_err', 'local_bkg')
     for col in colnames:
         assert_allclose(phot0[col], phot[col])
-    resid_nddata = psfphot.make_residual_image(nddata, fit_shape)
+    resid_nddata = psfphot.make_residual_image(nddata, psf_shape=fit_shape)
     assert isinstance(resid_nddata, NDData)
     assert_equal(resid_nddata.data, resid_data)
 
@@ -940,7 +943,7 @@ def test_iterative_psf_photometry_mode_new(test_data):
     for col in colnames:
         assert phot3[col].unit == unit
         assert_allclose(phot3[col].value, phot2[col].value)
-    resid_nddata = psfphot.make_residual_image(nddata, fit_shape)
+    resid_nddata = psfphot.make_residual_image(nddata, psf_shape=fit_shape)
     assert isinstance(resid_nddata, NDData)
     assert resid_nddata.unit == unit
 
@@ -984,7 +987,7 @@ def test_iterative_psf_photometry_mode_all():
     assert_equal(phot['iter_detected'], [1, 1, 1, 2, 2, 2, 2])
     assert_allclose(phot['flux_fit'], [1000, 1000, 1000, 100, 50, 100, 100])
 
-    resid = psfphot.make_residual_image(data, sub_shape)
+    resid = psfphot.make_residual_image(data, psf_shape=sub_shape)
     assert_allclose(resid, 0, atol=1e-6)
 
     match = 'mode must be "new" or "all".'
@@ -1022,7 +1025,7 @@ def test_iterative_psf_photometry_mode_all():
     for col in colnames:
         assert phot3[col].unit == unit
         assert_allclose(phot3[col].value, phot[col])
-    resid_nddata = psfphotu.make_residual_image(nddata, fit_shape)
+    resid_nddata = psfphotu.make_residual_image(nddata, psf_shape=fit_shape)
     assert isinstance(resid_nddata, NDData)
     assert resid_nddata.unit == unit
 
@@ -1048,14 +1051,44 @@ def test_iterative_psf_photometry_overlap():
     daofinder = DAOStarFinder(threshold=0.5, fwhm=fwhm)
     grouper = SourceGrouper(min_separation=1.3 * fwhm)
     fitter = TRFLSQFitter()
-    psfphot = IterativePSFPhotometry(psf_model, fit_shape=(5, 5),
+    fit_shape = (5, 5)
+    sub_shape = fit_shape
+    psfphot = IterativePSFPhotometry(psf_model, fit_shape=fit_shape,
                                      finder=daofinder, mode='all',
                                      grouper=grouper, maxiters=2,
+                                     sub_shape=sub_shape,
                                      aperture_radius=3, fitter=fitter)
     match = r'One or more .* may not have converged'
     with pytest.warns(AstropyUserWarning, match=match):
         phot = psfphot(data, error=error)
         assert len(phot) == 38
+
+
+def test_iterative_psf_photometry_subshape():
+    """
+    A ValueError should not be raised if sub_shape=None and
+    the model does not have a bounding box.
+    """
+    fwhm = 3.5
+    psf_model = CircularGaussianPRF(flux=1, fwhm=fwhm)
+    data, _ = make_psf_model_image((150, 150), psf_model, n_sources=30,
+                                   model_shape=(11, 11), flux=(50, 100),
+                                   min_separation=1, seed=0)
+
+    daofinder = DAOStarFinder(threshold=0.5, fwhm=fwhm)
+    grouper = SourceGrouper(min_separation=1.3 * fwhm)
+    fitter = TRFLSQFitter()
+    fit_shape = (5, 5)
+    sub_shape = None
+    psf_model.bounding_box = None
+    psfphot = IterativePSFPhotometry(psf_model, fit_shape=fit_shape,
+                                     finder=daofinder, mode='all',
+                                     grouper=grouper, maxiters=2,
+                                     sub_shape=sub_shape,
+                                     aperture_radius=3, fitter=fitter)
+    match = r'model_shape must be specified .* does not have a bounding_box'
+    with pytest.raises(ValueError, match=match):
+        psfphot(data)
 
 
 def test_iterative_psf_photometry_inputs():


### PR DESCRIPTION
With this PR, ``psf_shape`` is now an optional keyword in the ``make_model_image`` and ``make_residual_image`` methods of ``PSFPhotometry`` and ``IterativePSFPhotometry``. The value defaults to using the model bounding box to define the shape and is required only if the PSF model does not have a bounding box attribute.

This PR also fixes an issue in ``make_model_image`` where if the ``bbox_factor`` was input and the model bounding box did not have a ``factor`` keyword then an error would be raised. 