### PR TITLE
Preserve dtype in Background2D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,10 @@ API Changes
     When ``grid_mode`` is eventually removed, the `True` option will
     always be used. [#1870]
 
+  - The ``Background2D`` ``background``, ``background_rms``,
+    ``background_mesh``, and ``background_rms_mesh`` properties now have
+    the same ``dtype`` as the input data. [#1922]
+
 - ``photutils.centroids``
 
   - For consistency with other fitting functions (including PSF

--- a/docs/whats_new/2.0.rst
+++ b/docs/whats_new/2.0.rst
@@ -66,6 +66,10 @@ of the returned ``background`` and ``background_rms`` properties. Assign
 these properties to variables if you need to use them multiple times,
 otherwise they will need to be recomputed.
 
+The ``background``, ``background_rms``, ``background_mesh``, and
+``background_rms_mesh`` properties now have the same ``dtype`` as the
+input data.
+
 Two new properties were also added to the ``Background2D`` class,
 ``npixels_mesh`` and ``npixels_map``, that give a 2D array of the number
 of pixels used to compute the statistics in the low-resolution grid and

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -47,6 +47,26 @@ class TestBackground2D:
         assert bkg.npixels_mesh.shape == (4, 4)
         assert bkg.npixels_map.shape == DATA.shape
 
+    @pytest.mark.parametrize('box_size', [(25, 25), (23, 22)])
+    @pytest.mark.parametrize('dtype', ['int', 'int32', 'float32'])
+    def test_background_dtype(self, box_size, dtype):
+        filter_size = 3
+        interpolator = BkgZoomInterpolator()
+        data2 = DATA.copy().astype(dtype)
+        bkg = Background2D(data2, box_size, filter_size=filter_size,
+                           interpolator=interpolator)
+        assert bkg.background.dtype == data2.dtype
+        assert bkg.background_rms.dtype == data2.dtype
+        assert bkg.background_mesh.dtype == data2.dtype
+        assert bkg.background_rms_mesh.dtype == data2.dtype
+        assert bkg.npixels_map.dtype == int
+        assert bkg.npixels_mesh.dtype == int
+        assert_allclose(bkg.background, data2)
+        assert_allclose(bkg.background_rms, BKG_RMS)
+        assert bkg.background_median == 1.0
+        assert bkg.background_rms_median == 0.0
+        assert bkg.npixels_map.shape == DATA.shape
+
     @pytest.mark.parametrize('data', [DATA1, DATA3, DATA4])
     def test_background_nddata(self, data):
         """


### PR DESCRIPTION
With this PR, the ``Background2D`` ``background``, ``background_rms``, ``background_mesh``, and ``background_rms_mesh`` properties now have the same ``dtype`` as the input data.