### PR TITLE
Preserve Segmentation dtype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,9 +274,11 @@ API Changes
 
 - ``photutils.segmentation``
 
-  - The ``SegmentationImage`` ``relabel_consecutive`` method now keeps
-    the original dtype of the segmentation image instead of always
-    changing it to ``int`` (``int64``). [#1878]
+  - The ``SegmentationImage`` ``relabel_consecutive``,
+    ``resassign_label(s)``, ``keep_label(s)``, ``remove_label(s)``,
+    ``remove_border_labels``, and ``remove_masked_labels`` methods now
+    keep the original dtype of the segmentation image instead of always
+    changing it to ``int`` (``int64``). [#1878, #1923]
 
   - The ``detect_sources`` and ``deblend_sources`` functions now return
     a ``SegmentationImage`` instance whose data dtype is ``np.int32``

--- a/docs/whats_new/2.0.rst
+++ b/docs/whats_new/2.0.rst
@@ -236,6 +236,11 @@ The `~photutils.segmentation.detect_sources` and
 ``SegmentationImage`` instance whose data dtype is ``np.int32`` instead
 of ``int`` (``int64``) unless more than (2**32 - 1) labels are needed.
 
+Also, the ``relabel_consecutive``, ``resassign_label(s)``,
+``keep_label(s)``, ``remove_label(s)``, ``remove_border_labels``, and
+``remove_masked_labels`` methods now keep the original dtype of the
+segmentation image instead of always changing it to ``int`` (``int64``).
+
 
 DAOStarFinder flux and mag changes
 ==================================

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -698,14 +698,14 @@ class SegmentationImage:
         if labels.size == 0:
             return
 
-        idx = np.zeros(self.max_label + 1, dtype=int)
+        idx = np.zeros(self.max_label + 1, dtype=self.data.dtype)
         idx[self.labels] = self.labels
         idx[labels] = new_label  # reassign labels
 
         if relabel:
             labels = np.unique(idx[idx != 0])
             if len(labels) != 0:
-                idx2 = np.zeros(max(labels) + 1, dtype=int)
+                idx2 = np.zeros(max(labels) + 1, dtype=self.data.dtype)
                 idx2[labels] = np.arange(len(labels)) + 1
                 idx = idx2[idx]
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -309,6 +309,12 @@ class TestSegmentationImage:
         segm.remove_labels(labels=[5, 3])
         assert_allclose(segm.data, ref_data)
 
+        dtype = np.int32
+        data2 = ref_data.copy().astype(dtype)
+        segm2 = SegmentationImage(data2)
+        segm2.remove_label(1)
+        assert segm2.data.dtype == dtype
+
     def test_remove_labels_relabel(self):
         ref_data = np.array([[1, 1, 0, 0, 2, 2],
                              [0, 0, 0, 0, 0, 2],


### PR DESCRIPTION
The ``SegmentationImage`` ``resassign_label(s)``, ``keep_label(s)``, ``remove_label(s)``, ``remove_border_labels``, and ``remove_masked_labels`` methods now keep the original dtype of the segmentation image instead of always changing it to ``int`` (``int64``).