### PR TITLE
Improve accuracy of progress bar for multiprocessing source deblending

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,8 +108,12 @@ New Features
 - ``photutils.segmentation``
 
   - Reduced the memory usage and improved the performance of source
-    deblending with ``deblend_sources`` and ``SourceFinder`` when using
-    serial processing. [#1924, #1925]
+    deblending with ``deblend_sources`` and ``SourceFinder``. [#1924,
+    #1925, #1926]
+
+  - Improved the accuracy of the progress bar in ``deblend_sources`` and
+    ``SourceFinder`` when using multiprocessing. Also added the source
+    ID label number to the progress bar. [#1925, 1926]
 
 Bug Fixes
 ^^^^^^^^^

--- a/docs/whats_new/2.0.rst
+++ b/docs/whats_new/2.0.rst
@@ -246,13 +246,18 @@ segmentation image instead of always changing it to ``int`` (``int64``).
 Improved performance for source deblending
 ==========================================
 
-Performance improvements and significant reductions in memory usage
-were made for source deblending when using serial processing,
-especially for large sources and/or large ``nlevels`` values. The
-memory usage will independent of the number of ``nlevels``, and the
-memory usage will be significantly reduced for large sources. This
-affects the `~photutils.segmentation.deblend_sources` function and the
+Performance improvements and significant reductions in memory
+usage were made for source deblending, especially for large
+sources and/or large ``nlevels`` values. The memory usage is now
+independent of the number of ``nlevels``, and the memory usage
+will be significantly reduced for large sources. This affects
+the `~photutils.segmentation.deblend_sources` function and the
 `~photutils.segmentation.SourceFinder` class.
+
+Additionally, the accuracy of the deblending progress bar is now
+improved when using multiprocessing. The progress bar now also displays
+the ID label number of either the current source being deblended
+(serial) or the last source that was deblended (multiprocessing).
 
 
 DAOStarFinder flux and mag changes

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -109,24 +109,26 @@ def deblend_sources(data, segment_img, npixels, *, labels=None, nlevels=32,
         from 1.
 
     nproc : int, optional
+
         The number of processes to use for multiprocessing (if larger
         than 1). If set to 1, then a serial implementation is used
         instead of a parallel one. If `None`, then the number of
         processes will be set to the number of CPUs detected on the
         machine. Please note that due to overheads, multiprocessing may
-        be slower than serial processing. This is especially true if one
-        only has a small number of sources to deblend. The benefits of
-        multiprocessing require ~1000 or more sources to deblend, with
-        larger gains as the number of sources increase.
+        be slower than serial processing if only a small number of
+        sources are to be deblended. The benefits of multiprocessing
+        require ~1000 or more sources to deblend, with larger gains as
+        the number of sources increase.
 
     progress_bar : bool, optional
-        Whether to display a progress bar. Note that if multiprocessing
-        is used (``nproc > 1``), the estimation times (e.g., time per
-        iteration and time remaining, etc) may be unreliable. The
-        progress bar requires that the `tqdm <https://tqdm.github.io/>`_
-        optional dependency be installed. Note that the progress
-        bar does not currently work in the Jupyter console due to
-        limitations in ``tqdm``.
+        Whether to display a progress bar. If ``nproc = 1``, then the
+        ID shown after the progress bar is the source label being
+        deblended. If multiprocessing is used (``nproc > 1``), the ID
+        shown is the last source label that was deblended. The progress
+        bar requires that the `tqdm <https://tqdm.github.io/>`_ optional
+        dependency be installed. Note that the progress bar does not
+        currently work in the Jupyter console due to limitations in
+        ``tqdm``.
 
     Returns
     -------

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -85,26 +85,25 @@ class SourceFinder:
         unless ``deblend=True``.
 
     nproc : int, optional
-        The number of processes to use for source deblending (if
-        larger than 1). If set to 1, then a serial implementation is
-        used instead of a parallel one. If `None`, then the number of
-        processes will be set to the number of CPUs detected on the
-        machine. Please note that due to overheads, multiprocessing may
-        be slower than serial processing. This is especially true if one
-        only has a small number of sources to deblend. The benefits of
-        multiprocessing require ~1000 or more sources to deblend, with
-        larger gains as the number of sources increase. This keyword is
-        ignored unless ``deblend=True``.
+        The number of processes to use for source deblending. If set to
+        1, then a serial implementation is used instead of a parallel
+        one. If `None`, then the number of processes will be set to the
+        number of CPUs detected on the machine. Please note that due to
+        overheads, multiprocessing may be slower than serial processing
+        if only a small number of sources are to be deblended. The
+        benefits of multiprocessing require ~1000 or more sources to
+        deblend, with larger gains as the number of sources increase.
+        This keyword is ignored unless ``deblend=True``.
 
     progress_bar : bool, optional
-        Whether to display a progress bar. Note that if multiprocessing
-        is used (``nproc > 1``), the estimation times (e.g., time per
-        iteration and time remaining, etc) may be unreliable. The
-        progress bar requires that the `tqdm <https://tqdm.github.io/>`_
-        optional dependency be installed. Note that the progress
-        bar does not currently work in the Jupyter console due to
-        limitations in ``tqdm``. This keyword is ignored unless
-        ``deblend=True``.
+        Whether to display a progress bar. If ``nproc = 1``, then the
+        ID shown after the progress bar is the source label being
+        deblended. If multiprocessing is used (``nproc > 1``), the ID
+        shown is the last source label that was deblended. The progress
+        bar requires that the `tqdm <https://tqdm.github.io/>`_ optional
+        dependency be installed. Note that the progress bar does not
+        currently work in the Jupyter console due to limitations in
+        ``tqdm``. This keyword is ignored unless ``deblend=True``.
 
     See Also
     --------

--- a/photutils/utils/_optional_deps.py
+++ b/photutils/utils/_optional_deps.py
@@ -1,10 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Checks for optional dependencies using lazy import from `PEP 562
-<https://www.python.org/dev/peps/pep-0562/>`_.
+This module provides tools for optional dependencies.
 """
 
 import importlib
+
+# Check for optional dependencies using lazy import from `PEP 562
+# <https://www.python.org/dev/peps/pep-0562/>`_.
 
 # This list is a duplicate of the dependencies in pyproject.toml "all".
 # Note that in some cases the package names are different from the
@@ -24,3 +26,25 @@ def __getattr__(name):
         return True
 
     raise AttributeError(f'Module {__name__!r} has no attribute {name!r}.')
+
+
+# Define tqdm as a dummy class if it is not available.
+# This is needed to use tqdm as a context manager with multiprocessing.
+try:
+    from tqdm.auto import tqdm
+except ImportError:
+    class tqdm:  # noqa: N801
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def update(self, *args, **kwargs):
+            pass
+
+        def set_postfix_str(self, *args, **kwargs):
+            pass


### PR DESCRIPTION
This PR also uses `concurrent.futures.ProcessPoolExecutor` and gathers worker tasks as they are completed instead of sequentially.