### PR TITLE
Fix SExtractorBackground output ndim

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.1.0 (unreleased)
+2.0.1 (unreleased)
 ------------------
 
 General
@@ -9,6 +9,12 @@ New Features
 
 Bug Fixes
 ^^^^^^^^^
+
+- ``photutils.background``
+
+  - Fixed a bug in ``SExtractorBackground`` where the dimensionality of
+    the returned value would not be preserved if the output was a single
+    value. [#1934]
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -105,6 +105,34 @@ def test_sourceextrator_background_skew():
     assert_allclose(bkg.calc_background(data), np.median(data))
 
 
+@pytest.mark.parametrize('bkg_class', BKG_CLASS)
+def test_background_ndim(bkg_class):
+    data1 = np.ones((1, 100, 100))
+    data2 = np.ones((1, 100 * 100))
+    data3 = np.ones((1, 1, 100 * 100))
+    data4 = np.ones((1, 1, 1, 100 * 100))
+
+    bkg = bkg_class(sigma_clip=None)
+    val = bkg(data1, axis=None)
+    assert np.ndim(val) == 0
+    val = bkg(data1, axis=(1, 2))
+    assert val.shape == (1,)
+    val = bkg(data1, axis=-1)
+    assert val.shape == (1, 100)
+    val = bkg(data2, axis=-1)
+    assert val.shape == (1,)
+    val = bkg(data3, axis=-1)
+    assert val.shape == (1, 1)
+    val = bkg(data4, axis=-1)
+    assert val.shape == (1, 1, 1)
+    val = bkg(data4, axis=(2, 3))
+    assert val.shape == (1, 1)
+    val = bkg(data4, axis=(1, 2, 3))
+    assert val.shape == (1,)
+    val = bkg(data4, axis=(0, 1, 2))
+    assert val.shape == (10000,)
+
+
 @pytest.mark.parametrize('rms_class', RMS_CLASS)
 def test_background_rms(rms_class):
     bkgrms = rms_class(sigma_clip=SIGMA_CLIP)

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -133,6 +133,34 @@ def test_background_ndim(bkg_class):
     assert val.shape == (10000,)
 
 
+@pytest.mark.parametrize('bkgrms_class', RMS_CLASS)
+def test_background_rms_ndim(bkgrms_class):
+    data1 = np.ones((1, 100, 100))
+    data2 = np.ones((1, 100 * 100))
+    data3 = np.ones((1, 1, 100 * 100))
+    data4 = np.ones((1, 1, 1, 100 * 100))
+
+    bkgrms = bkgrms_class(sigma_clip=None)
+    val = bkgrms(data1, axis=None)
+    assert np.ndim(val) == 0
+    val = bkgrms(data1, axis=(1, 2))
+    assert val.shape == (1,)
+    val = bkgrms(data1, axis=-1)
+    assert val.shape == (1, 100)
+    val = bkgrms(data2, axis=-1)
+    assert val.shape == (1,)
+    val = bkgrms(data3, axis=-1)
+    assert val.shape == (1, 1)
+    val = bkgrms(data4, axis=-1)
+    assert val.shape == (1, 1, 1)
+    val = bkgrms(data4, axis=(2, 3))
+    assert val.shape == (1, 1)
+    val = bkgrms(data4, axis=(1, 2, 3))
+    assert val.shape == (1,)
+    val = bkgrms(data4, axis=(0, 1, 2))
+    assert val.shape == (10000,)
+
+
 @pytest.mark.parametrize('rms_class', RMS_CLASS)
 def test_background_rms(rms_class):
     bkgrms = rms_class(sigma_clip=SIGMA_CLIP)


### PR DESCRIPTION
This PR fixes `SExtractorBackground` to ensure that dimensionality of the output array is preserved for single-value (array size = 1) output.  Previously, the dimensionality would be removed and a scalar float would be returned.