### PR TITLE
Fix Background2D if box_size equals image shape

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Bug Fixes
     the returned value would not be preserved if the output was a single
     value. [#1934]
 
+  - Fixed an issue in ``Background2D`` where if the ``box_size`` equals
+    the input array shape the input data array could be modified. [#1935]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -500,9 +500,11 @@ class Background2D:
         # another for the reshape). Only one copy of the data and mask
         # array is made (except for the extra corner). The boolean mask
         # copy is much smaller than the data array.
-        core = reshape_as_blocks(self._data[:y1, :x1], self.box_size)
+        # An explicit copy of the data array is needed to avoid
+        # modifying the original data array if the shape of the data
+        # array is (y1, x1) (i.e., box_size = data.shape).
+        core = reshape_as_blocks(self._data[:y1, :x1].copy(), self.box_size)
         core_mask = reshape_as_blocks(mask[:y1, :x1], self.box_size)
-        # these rehape operations need to make a temporary copy
         core = core.reshape((*nboxes, -1))
         core_mask = core_mask.reshape((*nboxes, -1))
         core[core_mask] = np.nan


### PR DESCRIPTION
This PR fixes an issue in ``Background2D`` where if the ``box_size`` equals the input array shape the input data array could be modified.

Fixes #1933