### PR TITLE
Fix Background2D when using BkgIDWInterpolator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,17 +1,14 @@
-2.1.0 (unreleased)
+2.0.2 (unreleased)
 ------------------
-
-General
-^^^^^^^
-
-New Features
-^^^^^^^^^^^^
 
 Bug Fixes
 ^^^^^^^^^
 
-API Changes
-^^^^^^^^^^^
+- ``photutils.background``
+
+  - Fixed a bug in ``Background2D`` where an error would be raised when
+    using the ``BkgIDWInterpolator`` and when any mesh was excluded,
+    e.g., due to an input mask. [#1940]
 
 
 2.0.1 (2024-10-16)

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -178,8 +178,11 @@ class BkgIDWInterpolator:
             return np.full(kwargs['shape'], np.min(data),
                            dtype=kwargs['dtype'])
 
+        # we create the interpolator from only the good mesh points
         yxcen = np.column_stack(kwargs['mesh_yxcen'])
-        interp_func = ShepardIDWInterpolator(yxcen, data.ravel(),
+        good_idx = np.where(~kwargs['mesh_nan_mask'])
+        data = data[good_idx]
+        interp_func = ShepardIDWInterpolator(yxcen, data,
                                              leafsize=self.leafsize)
 
         # the position coordinates used when calling the interpolator

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -307,7 +307,8 @@ class TestBackground2D:
         with pytest.warns(AstropyUserWarning, match=match):
             bkg = Background2D(data, (25, 25), filter_size=(1, 1),
                                exclude_percentile=100.0)
-        assert np.count_nonzero(bkg._nan_idx) == 4
+        assert_equal(bkg.npixels_mesh[0:2, 0:2], np.zeros((2, 2)))
+        assert bkg.npixels_mesh[-1, -1] == 625
 
         data = np.ones((111, 121))
         bkg = Background2D(data, box_size=10, exclude_percentile=100)

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -117,6 +117,19 @@ class TestBackground2D:
         assert_allclose(bkg2.background_mesh, bkg_low_res)
         assert bkg2.background.shape == data.shape
 
+        rng = np.random.default_rng(0)
+        data = rng.normal(1.0, 0.1, (121, 289))
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[50:100, 50:100] = True
+        bkg = Background2D(data, (25, 25), mask=mask,
+                           interpolator=interpolator)
+        assert np.mean(bkg.background) < 1.0
+        assert np.mean(bkg.background_rms) < 1.0
+        assert bkg.background_median < 1.0
+        assert bkg.background_rms_median < 0.1
+        assert bkg.npixels_mesh.shape == (5, 12)
+        assert bkg.npixels_map.shape == data.shape
+
     def test_no_sigma_clipping(self):
         data = np.copy(DATA)
         data[10, 10] = 100.0

--- a/photutils/background/tests/test_interpolators.py
+++ b/photutils/background/tests/test_interpolators.py
@@ -63,19 +63,18 @@ def test_zoom_interp_clip():
 
 def test_idw_interp():
     data = np.ones((300, 300))
-    bkg = Background2D(data, 100)
+    interp = BkgIDWInterpolator()
+    bkg = Background2D(data, 100, interpolator=interp)
     mesh = np.array([[0.01, 0.01, 0.02],
                      [0.01, 0.02, 0.03],
                      [0.03, 0.03, 12.9]])
 
-    interp = BkgIDWInterpolator()
     zoom = interp(mesh, **bkg._interp_kwargs)
     assert zoom.shape == (300, 300)
 
     # test with units
     unit = u.nJy
-    bkg = Background2D(data << unit, 100)
-    interp = BkgIDWInterpolator()
+    bkg = Background2D(data << unit, 100, interpolator=interp)
     zoom = interp(mesh << unit, **bkg._interp_kwargs)
     assert zoom.shape == (300, 300)
 


### PR DESCRIPTION
This PR fixes a bug in ``Background2D`` where an error would be raised when using the ``BkgIDWInterpolator`` and when any mesh was excluded, e.g., due to an input mask.