### PR TITLE
Use bottleneck nanfunctions only for float64 arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@
 Bug Fixes
 ^^^^^^^^^
 
+- Due to an upstream bug in ``bottleneck`` with ``float32`` arrays,
+  ``bottleneck`` nan-functions are now used internally only for
+  ``float64`` arrays. Performance may be impacted for computations
+  involving arrays with dtype other than ``float64``. Affected functions
+  are used in the ``aperture``, ``background``, ``detection``,
+  ``profiles``, ``psf``, and ``segmentation`` subpackages. This change
+  has no impact if ``bottleneck`` is not installed.
+
 - ``photutils.background``
 
   - Fixed a bug in ``Background2D`` where an error would be raised when

--- a/photutils/extern/biweight.py
+++ b/photutils/extern/biweight.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from photutils.utils._optional_deps import HAS_BOTTLENECK
 from photutils.utils._stats import nanmedian, nansum
 
 if TYPE_CHECKING:
@@ -45,7 +46,7 @@ def _stat_functions(
 
 def biweight_location(
     data: ArrayLike,
-    c: float | None = 6.0,
+    c: float = 6.0,
     M: float | ArrayLike | None = None,
     axis: int | tuple[int, ...] | None = None,
     *,
@@ -183,7 +184,7 @@ def biweight_location(
 
 def biweight_scale(
     data: ArrayLike,
-    c: float | None = 9.0,
+    c: float = 9.0,
     M: float | ArrayLike | None = None,
     axis: int | tuple[int, ...] | None = None,
     modify_sample_size: bool | None = False,
@@ -309,7 +310,7 @@ def biweight_scale(
 
 def biweight_midvariance(
     data: ArrayLike,
-    c: float | None = 9.0,
+    c: float = 9.0,
     M: float | ArrayLike | None = None,
     axis: int | tuple[int, ...] | None = None,
     modify_sample_size: bool | None = False,
@@ -565,7 +566,11 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
     if axis is not None:
         data_median = np.expand_dims(data_median, axis=axis)
 
-    result = func(np.abs(data - data_median), axis=axis, overwrite_input=True)
+    if HAS_BOTTLENECK:
+        result = func(np.abs(data - data_median), axis=axis)
+    else:
+        result = func(np.abs(data - data_median), axis=axis,
+                      overwrite_input=True)
 
     if axis is None and np.ma.isMaskedArray(result):
         # return scalar version

--- a/photutils/utils/tests/test_stats.py
+++ b/photutils/utils/tests/test_stats.py
@@ -22,7 +22,7 @@ funcs = [(nansum, np.nansum), (nanmean, np.nanmean),
 @pytest.mark.parametrize('axis', [None, 0, 1, (0, 1), (1, 2), (2, 1),
                                   (0, 1, 2), (3, 1), (0, 3), (2, 0)])
 @pytest.mark.parametrize('use_units', [False, True])
-def testnanmean(func, axis, use_units):
+def test_nan_funcs(func, axis, use_units):
     arr = np.ones((5, 3, 8, 9))
     if use_units:
         arr <<= u.m


### PR DESCRIPTION
Due to an upstream bug in bottleneck with float32 arrays, bottleneck nan-functions are now used internally only for float64 arrays.  Using bottleneck with large float32 arrays gives incorrect results.  In this case, slower/correct is much better than faster/wrong.  Performance may be impacted for computations involving arrays with dtype other than float64. Affected functions are used in the aperture, background, detection, profiles, psf, and segmentation subpackages. This change has no impact if bottleneck is not installed.