### PR TITLE
Fix make_model_image and make_residual_image signatures

### DIFF
--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -40,8 +40,7 @@ class ModelImageMixin:
     residuals.
     """
 
-    def make_model_image(self, shape, *, psf_shape=None,
-                         include_localbkg=False):
+    def make_model_image(self, shape, psf_shape=None, include_localbkg=False):
         """
         Create a 2D image from the fit PSF models and optional local
         background.
@@ -120,7 +119,7 @@ class ModelImageMixin:
                                  x_name=x_name, y_name=y_name,
                                  progress_bar=progress_bar)
 
-    def make_residual_image(self, data, *, psf_shape=None,
+    def make_residual_image(self, data, psf_shape=None,
                             include_localbkg=False):
         """
         Create a 2D residual image from the fit PSF models and local


### PR DESCRIPTION
This PR fixes `make_model_image` and `make_residual_image` to not require keyword-only arguments. That was unintentionally added in v2.0.