### PR TITLE
Fix issues with exclude_border option in star finders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,14 @@ Bug Fixes
     using the ``BkgIDWInterpolator`` and when any mesh was excluded,
     e.g., due to an input mask. [#1940]
 
+- ``photutils.detection``
+
+  - Fixed a bug in the star finders (``DAOStarFinder``,
+    ``IRAFStarFinder``, and ``StarFinder``) when
+    ``exclude_border=True``. Also, fixed an issue with
+    ``exclude_border=True`` where if all sources were in the border
+    region then an error would be raised. [#1943]
+
 
 2.0.1 (2024-10-16)
 ------------------

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -416,7 +416,7 @@ class _IRAFStarFinderCatalog:
         skymask = ~self.kernel.mask.astype(bool)  # 1=sky, 0=obj
         nsky = np.count_nonzero(skymask)
         axis = (1, 2)
-        if nsky == 0.0:
+        if nsky == 0.0:  # pragma: no cover
             sky = (np.max(self.cutout_data_nosub, axis=axis)
                    - np.max(self.cutout_convdata, axis=axis))
         else:
@@ -452,7 +452,7 @@ class _IRAFStarFinderCatalog:
         return data
 
     @lazyproperty
-    def cutout_convdata(self):
+    def cutout_convdata(self):  # pragma: no cover
         return self.make_cutouts(self.convolved_data)
 
     @lazyproperty

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -19,7 +19,7 @@ __all__ = ['find_peaks']
 
 
 def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
-               border_width=None, npeaks=np.inf, centroid_func=None,
+               border_width=0, npeaks=np.inf, centroid_func=None,
                error=None, wcs=None):
     """
     Find local peaks in an image that are above a specified threshold
@@ -74,9 +74,9 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
         A boolean mask with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
 
-    border_width : bool, optional
+    border_width : int, optional
         The width in pixels to exclude around the border of the
-        ``data``.
+        ``data``. Must be an non-negative integer.
 
     npeaks : int, optional
         The maximum number of peaks to return. When the number of
@@ -126,7 +126,6 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
     arrays, unit = process_quantities((data, threshold, error),
                                       ('data', 'threshold', 'error'))
     data, threshold, error = arrays
-
     data = np.asanyarray(data)
 
     if np.all(data == data.flat[0]):
@@ -139,6 +138,11 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
         if data.shape != threshold.shape:
             raise ValueError('A threshold array must have the same shape as '
                              'the input data.')
+
+    if border_width < 0:
+        raise ValueError('border_width must be a non-negative integer.')
+    if int(border_width) != border_width:
+        raise ValueError('border_width must be an integer.')
 
     # remove NaN values to avoid runtime warnings
     nan_mask = np.isnan(data)
@@ -161,7 +165,7 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
             raise ValueError('data and mask must have the same shape')
         peak_goodmask = np.logical_and(peak_goodmask, ~mask)
 
-    if border_width is not None:
+    if border_width > 0:
         for i in range(peak_goodmask.ndim):
             peak_goodmask = peak_goodmask.swapaxes(0, i)
             peak_goodmask[:border_width] = False

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -96,7 +96,8 @@ class StarFinder(StarFinderBase):
         kernel = self.kernel
         kernel /= np.max(kernel)  # normalize max value to 1.0
         denom = np.sum(kernel**2) - (np.sum(kernel)**2 / kernel.size)
-        kernel = (kernel - np.sum(kernel) / kernel.size) / denom
+        if denom > 0:
+            kernel = (kernel - np.sum(kernel) / kernel.size) / denom
 
         convolved_data = _filter_data(data, kernel, mode='constant',
                                       fill_value=0.0,

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -9,6 +9,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from photutils.detection import IRAFStarFinder
+from photutils.psf import CircularGaussianPRF
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
@@ -171,3 +172,30 @@ class TestIRAFStarFinder:
         assert cat.isscalar
         flux = cat.flux[0]  # evaluate the flux so it can be sliced
         assert cat[0].flux == flux
+
+    def test_all_border_sources(self):
+        model1 = CircularGaussianPRF(flux=100, x_0=1, y_0=1, fwhm=2)
+        model2 = CircularGaussianPRF(flux=100, x_0=50, y_0=50, fwhm=2)
+        model3 = CircularGaussianPRF(flux=100, x_0=30, y_0=30, fwhm=2)
+
+        threshold = 1
+        yy, xx = np.mgrid[:51, :51]
+        data = model1(xx, yy)
+
+        # test single source within the border region
+        finder = IRAFStarFinder(threshold=threshold, fwhm=2.0, roundlo=-0.1,
+                                exclude_border=True)
+        with pytest.warns(NoDetectionsWarning):
+            tbl = finder(data)
+        assert tbl is None
+
+        # test multiple sources all within the border region
+        data += model2(xx, yy)
+        with pytest.warns(NoDetectionsWarning):
+            tbl = finder(data)
+        assert tbl is None
+
+        # test multiple sources with some within the border region
+        data += model3(xx, yy)
+        tbl = finder(data)
+        assert len(tbl) == 1

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -91,6 +91,13 @@ class TestFindPeaks:
         tbl1 = find_peaks(data, 0.1, box_size=3, border_width=25)
         assert len(tbl1) < len(tbl0)
 
+        match = 'border_width must be a non-negative integer'
+        with pytest.raises(ValueError, match=match):
+            find_peaks(data, 0.1, box_size=3, border_width=-1)
+        match = 'border_width must be an integer'
+        with pytest.raises(ValueError, match=match):
+            find_peaks(data, 0.1, box_size=3, border_width=3.1)
+
     def test_box_size_int(self, data):
         """
         Test non-integer box_size.

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -46,6 +46,18 @@ class TestStarFinder:
         with pytest.raises(ValueError, match=match):
             StarFinder(1, kernel, brightest=3.1)
 
+    def test_exclude_border(self, data, kernel):
+        data = np.zeros((12, 12))
+        data[0:2, 0:2] = 1
+        data[9:12, 9:12] = 1
+        kernel = np.ones((3, 3))
+
+        finder0 = StarFinder(1, kernel, exclude_border=False)
+        finder1 = StarFinder(1, kernel, exclude_border=True)
+        tbl0 = finder0(data)
+        tbl1 = finder1(data)
+        assert len(tbl0) > len(tbl1)
+
     def test_nosources(self, data, kernel):
         match = 'No sources were found'
         with pytest.warns(NoDetectionsWarning, match=match):


### PR DESCRIPTION
This PR fixes a bug in the star finders (``DAOStarFinder``, ``IRAFStarFinder``, and ``StarFinder``) when
``exclude_border=True``. It also fixes an issue reported by @lapeer in #1936 with``exclude_border=True`` where if all sources were in the border region then an error would be raised.

Fixes #1936.