### PR TITLE
Prevent np.str_ column names in SourceCatalog table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.segmentation``
+
+  - Fixed a bug where the table output from the ``SourceCatalog``
+    ``to_table`` method could have column names with a ``np.str_``
+    representation instead of ``str`` representation when using NumPy
+    2.0+. [#1956]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -967,8 +967,10 @@ class SourceCatalog:
         """
         if columns is None:
             table_columns = self.default_columns
+        elif isinstance(columns, str):
+            table_columns = [columns]
         else:
-            table_columns = np.atleast_1d(columns)
+            table_columns = columns
 
         tbl = QTable()
         tbl.meta.update(self.meta)  # keep tbl.meta type

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -275,6 +275,16 @@ class TestSourceCatalog:
         assert len(tbl) == 7
         assert tbl.colnames == columns
 
+        tbl = self.cat.to_table(self.cat.default_columns)
+        for col in tbl.columns:
+            assert isinstance(col, str)
+            assert not isinstance(col, np.str_)
+
+        tbl = self.cat.to_table('label')
+        for col in tbl.columns:
+            assert isinstance(col, str)
+            assert not isinstance(col, np.str_)
+
     def test_invalid_inputs(self):
         segm = SegmentationImage(np.zeros(self.data.shape, dtype=int))
         match = 'segment_img must have at least one non-zero label'


### PR DESCRIPTION
This PR fixes a bug where the table output from the ``SourceCatalog`` ``to_table`` method could have column names with a ``np.str_`` representation instead of ``str`` representation when using NumPy 2.0+.

Many thanks to @jensmelinder for reporting this in #1952.

Fixes #1952.