### PR TITLE
Allow find_peaks border_width to be different along x and y

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.detection``
+
+  - The ``find_peaks`` ``border_width`` keyword can now accept two
+    values, indicating the border width along the the y and x edges,
+    respectively. [#1957]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -19,6 +25,13 @@ Bug Fixes
 
 API Changes
 ^^^^^^^^^^^
+
+- ``photutils.detection``
+
+  - When ``exclude_border`` is set to ``True`` in the ``DAOStarFinder``
+    and ``StarFinder`` classes, the excluded border region can be
+    different along the x and y edges if the kernel shape is rectangular.
+    [#1957]
 
 - ``photutils.psf``
 

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -92,7 +92,7 @@ class StarFinderBase(metaclass=abc.ABCMeta):
             else:
                 yborder = kernel.yradius
                 xborder = kernel.xradius
-            border_width = max(xborder, yborder)
+            border_width = (yborder, xborder)
         else:
             border_width = None
 

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -94,7 +94,7 @@ class StarFinderBase(metaclass=abc.ABCMeta):
                 xborder = kernel.xradius
             border_width = max(xborder, yborder)
         else:
-            border_width = 0
+            border_width = None
 
         # find local peaks in the convolved data
         # suppress any NoDetectionsWarning from find_peaks

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -88,13 +88,25 @@ class TestFindPeaks:
         Test border exclusion.
         """
         tbl0 = find_peaks(data, 0.1, box_size=3)
-        tbl1 = find_peaks(data, 0.1, box_size=3, border_width=25)
-        assert len(tbl1) < len(tbl0)
+        tbl1 = find_peaks(data, 0.1, box_size=3, border_width=0)
+        tbl2 = find_peaks(data, 0.1, box_size=3, border_width=(0, 0))
+        assert len(tbl0) == len(tbl1)
+        assert len(tbl1) == len(tbl2)
 
-        match = 'border_width must be a non-negative integer'
+        tbl3 = find_peaks(data, 0.1, box_size=3, border_width=25)
+        tbl4 = find_peaks(data, 0.1, box_size=3, border_width=(25, 25))
+        assert len(tbl3) == len(tbl4)
+        assert len(tbl3) < len(tbl0)
+
+        tbl0 = find_peaks(data, 0.1, box_size=3, border_width=(34, 0))
+        tbl1 = find_peaks(data, 0.1, box_size=3, border_width=(0, 36))
+        assert np.min(tbl0['y_peak']) >= 34
+        assert np.min(tbl1['x_peak']) >= 36
+
+        match = 'border_width must be >= 0'
         with pytest.raises(ValueError, match=match):
             find_peaks(data, 0.1, box_size=3, border_width=-1)
-        match = 'border_width must be an integer'
+        match = 'border_width must have integer values'
         with pytest.raises(ValueError, match=match):
             find_peaks(data, 0.1, box_size=3, border_width=3.1)
 


### PR DESCRIPTION
The ``find_peaks`` ``border_width`` keyword can now accept two  values, indicating the border width along the the y and x edges, respectively.

When ``exclude_border`` is set to ``True`` in the ``DAOStarFinder``  and ``StarFinder`` classes, the excluded border region can be different along the x and y edges if the kernel shape is rectangular.