### PR TITLE
Drop Support for Python 3.10

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps'
+            python: '3.11'
+            tox_env: 'py311-test-oldestdeps'
             allow_failure: false
             prefix: ''
 
@@ -93,8 +93,8 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-oldestdeps'
+            python: '3.13'
+            tox_env: 'py313-test-alldeps'
             allow_failure: false
             prefix: ''
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,24 +43,20 @@ jobs:
       test_command: pytest -p no:warnings --pyargs photutils
       targets: |
         # Linux wheels
-        - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
         - cp312-manylinux_x86_64
         - cp313-manylinux_x86_64
 
         # MacOS X wheels
-        - cp310*macosx_x86_64
         - cp311*macosx_x86_64
         - cp312*macosx_x86_64
         - cp313*macosx_x86_64
 
-        - cp310*macosx_arm64
         - cp311*macosx_arm64
         - cp312*macosx_arm64
         - cp313*macosx_arm64
 
         # Windows wheels
-        - cp310*win_amd64
         - cp311*win_amd64
         - cp312*win_amd64
         - cp313*win_amd64

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     post_checkout:
       - git fetch --shallow-since=2023-05-01 || true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 General
 ^^^^^^^
 
+- The minimum required Python is now 3.11. [#1958]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,16 +15,12 @@ See astropy.sphinx.conf for which values are set there.
 
 import os
 import sys
-from datetime import datetime, timezone
+import tomllib
+from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
 
 from sphinx.util import logging
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +85,7 @@ rst_epilog = """
 # -- Project information ------------------------------------------------------
 project = project_meta['name']
 author = project_meta['authors'][0]['name']
-project_copyright = f'2011-{datetime.now(tz=timezone.utc).year}, {author}'
+project_copyright = f'2011-{datetime.now(tz=UTC).year}, {author}'
 github_project = 'astropy/photutils'
 
 # The version info for the project you're documenting, acts as

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -7,7 +7,7 @@ Requirements
 
 Photutils has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.10 or later
+* `Python <https://www.python.org/>`_ 3.11 or later
 
 * `NumPy <https://numpy.org/>`_ 1.24 or later
 

--- a/photutils/utils/_misc.py
+++ b/photutils/utils/_misc.py
@@ -5,7 +5,7 @@ versions.
 """
 
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def _get_version_info():
@@ -49,11 +49,7 @@ def _get_date(utc=False):
     result : str
         The current date/time.
     """
-    if not utc:
-        now = datetime.now().astimezone()
-    else:
-        now = datetime.now(timezone.utc)
-
+    now = datetime.now().astimezone() if not utc else datetime.now(UTC)
     return now.strftime('%Y-%m-%d %H:%M:%S %Z')
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Astronomy',
 ]
 dynamic = ['version']
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 dependencies = [
     'numpy>=1.24',
     'astropy>=5.3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ docs = [
     'sphinx',
     'sphinx_design',
     'sphinx-astropy[confv2]>=1.9.1',
-    'tomli; python_version < "3.11"',
 ]
 
 [build-system]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{310,311,312,313}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{310,311,312,313}-test-numpy{126,200,210}
+    py{311,312,313}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
+    py{311,312,313}-test-numpy{126,200,210}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
Following [SPEC-0](https://scientific-python.org/specs/spec-0000/) and Astropy 7.0 release (https://github.com/astropy/astropy/pull/16903).