### PR TITLE
Require gwcs 0.20+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ General
 
 - The minimum required Python is now 3.11. [#1958]
 
+- The minimum required gwcs is now 0.20. [#1961]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -26,7 +26,7 @@ Photutils also optionally depends on other packages for some features:
 * `scikit-image <https://scikit-image.org/>`_ 0.20 or later: Required
   to deblend segmented sources.
 
-* `GWCS <https://gwcs.readthedocs.io/en/stable/>`_ 0.19 or later:
+* `GWCS <https://gwcs.readthedocs.io/en/stable/>`_ 0.20 or later:
   Required in `~photutils.datasets.make_gwcs` to create a simple celestial
   gwcs object.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ all = [
     'matplotlib>=3.7',
     'regions>=0.9',
     'scikit-image>=0.20',
-    'gwcs>=0.19',
+    'gwcs>=0.20',
     'bottleneck',
     'tqdm',
     'rasterio',

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps =
     oldestdeps: scipy==1.10
     oldestdeps: matplotlib==3.7
     oldestdeps: scikit-image==0.20
-    oldestdeps: gwcs==0.19
+    oldestdeps: gwcs==0.20
     oldestdeps: pytest-astropy==0.11
 
     devdeps: numpy>=0.0.dev0


### PR DESCRIPTION
This PR updates the minimum required version of gwcs to 0.20 to avoid `pkg_resources` deprecation warnings.