### PR TITLE
Include interval ends for sharpless, roundness, and peakmax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,11 @@ API Changes
     different along the x and y edges if the kernel shape is rectangular.
     [#1957]
 
+  - Detected sources that match interval ends for sharpness, roundness, and
+    maximum peak values (``sharplo``, ``sharphi``, ``roundlo``, ``roundhi``,
+    and ``peakmax``) are now included in the returned table of detected
+    sources by ``DAOStarFinder`` and ``IRAFStarFinder``. [#1978]
+
 - ``photutils.morphology``
 
   - The ``gini`` function now returns zero instead of NaN if the

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -740,13 +740,13 @@ class _DAOStarFinderCatalog:
 
         # filter based on sharpness, roundness, and peakmax
         mask = ((newcat.sharpness > newcat.sharplo)
-                & (newcat.sharpness < newcat.sharphi)
-                & (newcat.roundness1 > newcat.roundlo)
-                & (newcat.roundness1 < newcat.roundhi)
-                & (newcat.roundness2 > newcat.roundlo)
-                & (newcat.roundness2 < newcat.roundhi))
+                & (newcat.sharpness <= newcat.sharphi)
+                & (newcat.roundness1 >= newcat.roundlo)
+                & (newcat.roundness1 <= newcat.roundhi)
+                & (newcat.roundness2 >= newcat.roundlo)
+                & (newcat.roundness2 <= newcat.roundhi))
         if newcat.peakmax is not None:
-            mask &= (newcat.peak < newcat.peakmax)
+            mask &= (newcat.peak <= newcat.peakmax)
         newcat = newcat[mask]
 
         if len(newcat) == 0:

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -739,7 +739,7 @@ class _DAOStarFinderCatalog:
             return None
 
         # filter based on sharpness, roundness, and peakmax
-        mask = ((newcat.sharpness > newcat.sharplo)
+        mask = ((newcat.sharpness >= newcat.sharplo)
                 & (newcat.sharpness <= newcat.sharphi)
                 & (newcat.roundness1 >= newcat.roundlo)
                 & (newcat.roundness1 <= newcat.roundhi)

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -577,12 +577,12 @@ class _IRAFStarFinderCatalog:
             return None
 
         # filter based on sharpness, roundness, and peakmax
-        mask = ((newcat.sharpness > newcat.sharplo)
-                & (newcat.sharpness < newcat.sharphi)
-                & (newcat.roundness > newcat.roundlo)
-                & (newcat.roundness < newcat.roundhi))
+        mask = ((newcat.sharpness >= newcat.sharplo)
+                & (newcat.sharpness <= newcat.sharphi)
+                & (newcat.roundness >= newcat.roundlo)
+                & (newcat.roundness <= newcat.roundhi))
         if newcat.peakmax is not None:
-            mask &= (newcat.peak < newcat.peakmax)
+            mask &= (newcat.peak <= newcat.peakmax)
         newcat = newcat[mask]
 
         if len(newcat) == 0:

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -205,3 +205,30 @@ class TestDAOStarFinder:
         assert cat.isscalar
         flux = cat.flux[0]  # evaluate the flux so it can be sliced
         assert cat[0].flux == flux
+
+    def test_interval_ends_included(self):
+        # https://github.com/astropy/photutils/issues/1977
+        data = np.zeros((46, 64))
+
+        x = 33
+        y = 21
+
+        data[y - 1: y + 2, x - 1: x + 2] = [
+            [1.0, 2.0, 1.0],
+            [2.0, 1.0e20, 2.0],
+            [1.0, 2.0, 1.0],
+        ]
+
+        finder = DAOStarFinder(
+            threshold=0,
+            fwhm=2.5,
+            roundlo=0,
+            sharphi=1.407913491884342,
+            peakmax=1.0e20
+        )
+        tbl = finder.find_stars(data)
+
+        assert len(tbl) == 1
+        assert abs(tbl[0]['roundness1']) == 0.0
+        assert abs(tbl[0]['roundness2']) == 0.0
+        assert abs(tbl[0]['peak']) == 1.0e20

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -229,6 +229,6 @@ class TestDAOStarFinder:
         tbl = finder.find_stars(data)
 
         assert len(tbl) == 1
-        assert abs(tbl[0]['roundness1']) == 0.0
+        assert abs(tbl[0]['roundness1']) < 1.e-15
         assert abs(tbl[0]['roundness2']) == 0.0
         assert abs(tbl[0]['peak']) == 1.0e20

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -212,7 +212,12 @@ class TestIRAFStarFinder:
             [0.1, 0.6, 0.1],
         ]
 
-        finder = IRAFStarFinder(0, 2.5, roundlo=0, peakmax=0.8)
+        finder = IRAFStarFinder(
+            threshold=0,
+            fwhm=2.5,
+            roundlo=0,
+            peakmax=0.8
+        )
         tbl = finder.find_stars(data)
 
         assert len(tbl) == 1

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -206,15 +206,16 @@ class TestIRAFStarFinder:
 
         x = 33
         y = 21
-        data[y-1:y+2, x-1:x+2] = [
+        data[y - 1: y + 2, x - 1: x + 2] = [
             [0.1, 0.6, 0.1],
             [0.6, 0.8, 0.6],
             [0.1, 0.6, 0.1],
         ]
 
-        finder = IRAFStarFinder(0, 2.5, roundlo=0)
+        finder = IRAFStarFinder(0, 2.5, roundlo=0, peakmax=0.8)
         tbl = finder.find_stars(data)
 
         assert len(tbl) == 1
-        assert abs(tbl[0]["roundness"]) == 0.0
-        assert abs(tbl[0]["pa"]) == 0.0
+        assert abs(tbl[0]['roundness']) == 0.0
+        assert abs(tbl[0]['pa']) == 0.0
+        assert abs(tbl[0]['peak']) == 0.8

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -199,3 +199,22 @@ class TestIRAFStarFinder:
         data += model3(xx, yy)
         tbl = finder(data)
         assert len(tbl) == 1
+
+    def test_interval_ends_included(self):
+        # https://github.com/astropy/photutils/issues/1977
+        data = np.zeros((46, 64))
+
+        x = 33
+        y = 21
+        data[y-1:y+2, x-1:x+2] = [
+            [0.1, 0.6, 0.1],
+            [0.6, 0.8, 0.6],
+            [0.1, 0.6, 0.1],
+        ]
+
+        finder = IRAFStarFinder(0, 2.5, roundlo=0)
+        tbl = finder.find_stars(data)
+
+        assert len(tbl) == 1
+        assert abs(tbl[0]["roundness"]) == 0.0
+        assert abs(tbl[0]["pa"]) == 0.0


### PR DESCRIPTION
Closes #1977

This PR modifies selection of sources by shapness, roundness, and peakmax to include the interval ends, i.e., that sources that have roundness 0.0 are selected instead of being rejected when `sharplo=0.0`.