### PR TITLE
Add optional mask keyword to gini function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,11 @@ New Features
     values, indicating the border width along the the y and x edges,
     respectively. [#1957]
 
+- ``photutils.morphology``
+
+  - An optional ``mask`` keyword was added to the ``gini`` function.
+    [#1979]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -42,6 +47,11 @@ API Changes
     and ``StarFinder`` classes, the excluded border region can be
     different along the x and y edges if the kernel shape is rectangular.
     [#1957]
+
+- ``photutils.morphology``
+
+  - The ``gini`` function now returns zero instead of NaN if the
+    (unmasked) data values sum to zero. [#1979]
 
 - ``photutils.psf``
 

--- a/photutils/morphology/non_parametric.py
+++ b/photutils/morphology/non_parametric.py
@@ -24,8 +24,9 @@ def gini(data, mask=None):
         G = \frac{1}{\left | \bar{x} \right | n (n - 1)}
             \sum^{n}_{i} (2i - n - 1) \left | x_i \right |
 
-    where :math:`\bar{x}` is the mean over all pixel values
-    :math:`x_i`.
+    where :math:`\bar{x}` is the mean over all pixel values :math:`x_i`.
+    If the sum of all pixel values is zero, the Gini coefficient is
+    zero.
 
     The Gini coefficient is a way of measuring the inequality in a given
     set of values. In the context of galaxy morphology, it measures how
@@ -56,10 +57,15 @@ def gini(data, mask=None):
         The Gini coefficient of the input 2D array.
     """
     values = data[~mask] if mask is not None else np.ravel(data)
-    values = np.sort(values)
+    if np.all(np.isnan(values)):
+        return np.nan
 
     npix = np.size(values)
     normalization = np.abs(np.mean(values)) * npix * (npix - 1)
-    kernel = (2.0 * np.arange(1, npix + 1) - npix - 1) * np.abs(values)
+    if normalization == 0:
+        return 0.0
+
+    kernel = ((2.0 * np.arange(1, npix + 1) - npix - 1)
+              * np.abs(np.sort(values)))
 
     return np.sum(kernel) / normalization

--- a/photutils/morphology/non_parametric.py
+++ b/photutils/morphology/non_parametric.py
@@ -9,7 +9,7 @@ import numpy as np
 __all__ = ['gini']
 
 
-def gini(data):
+def gini(data, mask=None):
     r"""
     Calculate the `Gini coefficient
     <https://en.wikipedia.org/wiki/Gini_coefficient>`_ of a 2D array.
@@ -45,14 +45,21 @@ def gini(data):
     data : array_like
         The 2D data array or object that can be converted to an array.
 
+    mask : array_like, optional
+        A boolean mask with the same shape as ``data`` where `True`
+        values indicate masked pixels. Masked pixels are excluded from
+        the calculation.
+
     Returns
     -------
     result : float
         The Gini coefficient of the input 2D array.
     """
-    flattened = np.sort(np.ravel(data))
-    npix = np.size(flattened)
-    normalization = np.abs(np.mean(flattened)) * npix * (npix - 1)
-    kernel = (2.0 * np.arange(1, npix + 1) - npix - 1) * np.abs(flattened)
+    values = data[~mask] if mask is not None else np.ravel(data)
+    values = np.sort(values)
+
+    npix = np.size(values)
+    normalization = np.abs(np.mean(values)) * npix * (npix - 1)
+    kernel = (2.0 * np.arange(1, npix + 1) - npix - 1) * np.abs(values)
 
     return np.sum(kernel) / normalization

--- a/photutils/morphology/tests/test_non_parametric.py
+++ b/photutils/morphology/tests/test_non_parametric.py
@@ -35,3 +35,8 @@ def test_gini_mask():
 
     assert gini(data1, mask=mask1) == 0.0
     assert gini(data2, mask=mask2) == 1.0
+
+
+def test_gini_normalization():
+    data = np.zeros((100, 100))
+    assert gini(data) == 0.0

--- a/photutils/morphology/tests/test_non_parametric.py
+++ b/photutils/morphology/tests/test_non_parametric.py
@@ -18,3 +18,20 @@ def test_gini():
 
     assert gini(data_evenly_distributed) == 0.0
     assert gini(data_point_like) == 1.0
+
+
+def test_gini_mask():
+    shape = (100, 100)
+    data1 = np.ones(shape)
+    data1[50, 50] = 0
+    mask1 = np.zeros(data1.shape, dtype=bool)
+    mask1[50, 50] = True
+
+    data2 = np.zeros(shape)
+    data2[50, 50] = 1
+    data2[0, 0] = 100
+    mask2 = np.zeros(data2.shape, dtype=bool)
+    mask2[0, 0] = True
+
+    assert gini(data1, mask=mask1) == 0.0
+    assert gini(data2, mask=mask2) == 1.0

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -22,6 +22,7 @@ from photutils.aperture import (BoundingBox, CircularAperture,
                                 EllipticalAperture, RectangularAnnulus)
 from photutils.background import SExtractorBackground
 from photutils.centroids import centroid_quadratic
+from photutils.morphology import gini as gini_func
 from photutils.segmentation.core import SegmentationImage
 from photutils.utils._misc import _get_meta
 from photutils.utils._moments import _moments, _moments_central
@@ -2602,7 +2603,8 @@ class SourceCatalog:
                 \sum^{n}_{i} (2i - n - 1) \left | x_i \right |
 
         where :math:`\bar{x}` is the mean over pixel values :math:`x_i`
-        within the source segment.
+        within the source segment. If the sum of all pixel values is
+        zero, the Gini coefficient is zero.
 
         The Gini coefficient is a way of measuring the inequality in a
         given set of values. In the context of galaxy morphology, it
@@ -2612,17 +2614,7 @@ class SourceCatalog:
         while a Gini coefficient value of 1 represents a galaxy image
         with all its light concentrated in just one pixel.
         """
-        gini = []
-        for arr in self._data_values:
-            if np.all(np.isnan(arr)):
-                gini.append(np.nan)
-                continue
-            npix = np.size(arr)
-            normalization = np.abs(np.mean(arr)) * npix * (npix - 1)
-            kernel = ((2.0 * np.arange(1, npix + 1) - npix - 1)
-                      * np.abs(np.sort(arr)))
-            gini.append(np.sum(kernel) / normalization)
-        return np.array(gini)
+        return np.array([gini_func(arr) for arr in self._data_values])
 
     @lazyproperty
     def _local_background_apertures(self):


### PR DESCRIPTION
This PR adds an optional mask keyword to the `gini` function.

The `gini` function also now returns 0 instead of np.nan if the (unmasked) data values sum to zero.

The `SourceCatalog` `gini` property was also updated to use the `gini` function.