### PR TITLE
Cleanup dao- and iraf-starfinder tests. Remove unnecessary abs()

### DIFF
--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -229,6 +229,6 @@ class TestDAOStarFinder:
         tbl = finder.find_stars(data)
 
         assert len(tbl) == 1
-        assert abs(tbl[0]['roundness1']) < 1.e-15
-        assert abs(tbl[0]['roundness2']) == 0.0
-        assert abs(tbl[0]['peak']) == 1.0e20
+        assert tbl[0]['roundness1'] < 1.e-15
+        assert tbl[0]['roundness2'] == 0.0
+        assert tbl[0]['peak'] == 1.0e20

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -221,6 +221,6 @@ class TestIRAFStarFinder:
         tbl = finder.find_stars(data)
 
         assert len(tbl) == 1
-        assert abs(tbl[0]['roundness']) == 0.0
-        assert abs(tbl[0]['pa']) == 0.0
-        assert abs(tbl[0]['peak']) == 0.8
+        assert tbl[0]['roundness'] == 0.0
+        assert tbl[0]['pa'] == 0.0
+        assert tbl[0]['peak'] == 0.8

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -221,6 +221,5 @@ class TestIRAFStarFinder:
         tbl = finder.find_stars(data)
 
         assert len(tbl) == 1
-        assert tbl[0]['roundness'] == 0.0
-        assert tbl[0]['pa'] == 0.0
+        assert tbl[0]['roundness'] < 1.e-15
         assert tbl[0]['peak'] == 0.8


### PR DESCRIPTION
Removes unnecessary `abs()`.