### PR TITLE
Add map of deblended labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,12 @@ New Features
   - An optional ``mask`` keyword was added to the ``gini`` function.
     [#1979]
 
+- ``photutils.segmentation``
+
+  - Added ``deblended_labels``, ``deblended_labels_map``, and
+    ``deblended_labels_inverse_map`` properties to ``SegmentationImage``
+    to identify and map any deblended labels. [#1988]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -40,6 +46,9 @@ Bug Fixes
 
   - Fixed a bug to ensure that the dtype of the ``SegmentationImage``
     ``labels`` always matches the image dtype. [#1986]
+
+  - Fixed a issue with the source labels after source deblending when
+    using ``relabel=False``. [#1988]
 
 API Changes
 ^^^^^^^^^^^

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -140,12 +140,14 @@ class SegmentationImage:
     @lazyproperty
     def deblended_labels(self):
         """
-        A 1D array of deblended label numbers.
+        A sorted 1D array of deblended label numbers.
 
         The list will be empty if deblending has not been performed or
         if no sources were deblended.
         """
-        return np.concatenate(list(self._deblend_label_map.values()))
+        if len(self._deblend_label_map) == 0:
+            return np.array([], dtype=self._data.dtype)
+        return np.sort(np.concatenate(list(self._deblend_label_map.values())))
 
     @lazyproperty
     def deblended_labels_map(self):
@@ -589,6 +591,20 @@ class SegmentationImage:
         """
         return self.make_cmap(background_color='#000000ff', seed=0)
 
+    def _update_deblend_label_map(self, relabel_map):
+        """
+        Update the deblended label map based on a relabel map.
+
+        Parameters
+        ----------
+        relabel_map : `~numpy.ndarray`
+            An array mapping the original label numbers to the new label
+            numbers.
+        """
+        # child_labels are the deblended labels
+        for parent_label, child_labels in self._deblend_label_map.items():
+            self._deblend_label_map[parent_label] = relabel_map[child_labels]
+
     def reassign_label(self, label, new_label, relabel=False):
         """
         Reassign a label number to a new number.
@@ -744,20 +760,22 @@ class SegmentationImage:
         if labels.size == 0:
             return
 
-        idx = np.zeros(self.max_label + 1, dtype=self.data.dtype)
-        idx[self.labels] = self.labels
-        idx[labels] = new_label  # reassign labels
+        dtype = self.data.dtype  # keep the original dtype
+        relabel_map = np.zeros(self.max_label + 1, dtype=dtype)
+        relabel_map[self.labels] = self.labels
+        relabel_map[labels] = new_label  # reassign labels
 
         if relabel:
-            labels = np.unique(idx[idx != 0])
+            labels = np.unique(relabel_map[relabel_map != 0])
             if len(labels) != 0:
-                idx2 = np.zeros(max(labels) + 1, dtype=self.data.dtype)
-                idx2[labels] = np.arange(len(labels)) + 1
-                idx = idx2[idx]
+                map2 = np.zeros(max(labels) + 1, dtype=dtype)
+                map2[labels] = np.arange(len(labels), dtype=dtype) + 1
+                relabel_map = map2[relabel_map]
 
-        data_new = idx[self.data]
+        data_new = relabel_map[self.data]
         self._reset_lazyproperties()  # reset all cached properties
         self._data = data_new  # use _data to avoid validation
+        self._update_deblend_label_map(relabel_map)
 
     def relabel_consecutive(self, start_label=1):
         """
@@ -813,6 +831,7 @@ class SegmentationImage:
         self.__dict__['labels'] = new_labels
         if old_slices is not None:
             self.__dict__['slices'] = old_slices  # slice order is unchanged
+        self._update_deblend_label_map(new_label_map)
 
     def keep_label(self, label, relabel=False):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -47,6 +47,7 @@ class SegmentationImage:
         if not isinstance(data, np.ndarray):
             raise TypeError('Input data must be a numpy array')
         self.data = data
+        self._deblend_label_map = {}
 
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
@@ -135,6 +136,50 @@ class SegmentationImage:
                 segments.append(Segment(self.data, label, slc, bbox, area))
 
         return segments
+
+    @lazyproperty
+    def deblended_labels(self):
+        """
+        A 1D array of deblended label numbers.
+
+        The list will be empty if deblending has not been performed or
+        if no sources were deblended.
+        """
+        return np.concatenate(list(self._deblend_label_map.values()))
+
+    @lazyproperty
+    def deblended_labels_map(self):
+        """
+        A dictionary mapping deblended label numbers to the original
+        parent label numbers.
+
+        The keys are the deblended label numbers and the values are the
+        original parent label numbers. Only deblended sources are
+        included in the dictionary.
+
+        The dictionary will be empty if deblending has not been
+        performed or if no sources were deblended.
+        """
+        inverse_map = {}
+        for key, values in self._deblend_label_map.items():
+            for value in values:
+                inverse_map[value] = key
+        return inverse_map
+
+    @lazyproperty
+    def deblended_labels_inverse_map(self):
+        """
+        A dictionary mapping the original parent label numbers to the
+        deblended label numbers.
+
+        The keys are the original parent label numbers and the values
+        are the deblended label numbers. Only deblended sources are
+        included in the dictionary.
+
+        The dictionary will be empty if deblending has not been
+        performed or if no sources were deblended.
+        """
+        return self._deblend_label_map
 
     @property
     def data(self):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -47,7 +47,7 @@ class SegmentationImage:
         if not isinstance(data, np.ndarray):
             raise TypeError('Input data must be a numpy array')
         self.data = data
-        self._deblend_label_map = {}
+        self._deblend_label_map = {}  # set by source deblender
 
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
@@ -219,6 +219,7 @@ class SegmentationImage:
 
         self._data = value  # pylint: disable=attribute-defined-outside-init
         self.__dict__['labels'] = labels
+        self.__dict__['_deblend_label_map'] = {}  # reset deblended labels
 
     @lazyproperty
     def data_ma(self):

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -743,7 +743,7 @@ def _update_deblend_label_map(deblend_label_map, relabel_map):
         A dictionary mapping the original labels to the new deblended
         labels.
 
-    relabel_map : 2D `~numpy.ndarray`
+    relabel_map : 1D `~numpy.ndarray`
         The array mapping the original labels to the new labels.
 
     Returns

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -186,12 +186,12 @@ def deblend_sources(data, segment_img, npixels, *, labels=None, nlevels=32,
     if nproc is None:
         nproc = cpu_count()  # pragma: no cover
 
+    max_label = segment_img.max_label
     if nproc == 1:
         if progress_bar:  # pragma: no cover
             desc = 'Deblending'
             label_indices = add_progress_bar(label_indices, desc=desc)
 
-        max_label = segment_img.max_label + 1
         nonposmin_labels = []
         nmarkers_labels = []
         for label, label_idx in zip(labels, label_indices, strict=True):
@@ -263,7 +263,6 @@ def deblend_sources(data, segment_img, npixels, *, labels=None, nlevels=32,
                     results[idx] = future.result()
 
         # Process the results
-        max_label = segment_img.max_label + 1
         nonposmin_labels = []
         nmarkers_labels = []
         for label, source_slice, source_deblended in zip(labels,

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -242,6 +242,7 @@ def _detect_sources(data, threshold, npixels, footprint, inverse_mask, *,
         segm._data = segment_img
         segm.__dict__['labels'] = labels
         segm.__dict__['slices'] = segm_slices
+        segm.__dict__['_deblend_label_map'] = {}
         return segm
 
     # this is used by deblend_sources

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -503,5 +503,5 @@ def test_subclass():
                       [70, 70, 0, 0],
                       [70, 70, 0, 1]])
     segm.data = data2
-    assert len(segm.__dict__) == 2
+    assert len(segm.__dict__) == 3
     assert_equal(segm.areas, [1, 2, 2, 4])

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -193,6 +193,7 @@ class TestDeblendSources:
         result = deblend_sources(self.data, self.segm, self.npixels,
                                  mode=mode, relabel=False, progress_bar=False)
         assert result.nlabels == 2
+        assert_equal(result.labels, [2, 3])
         assert len(result.slices) <= result.max_label
         assert len(result.slices) == result.nlabels
         assert_allclose(np.nonzero(self.segm), np.nonzero(result))

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -52,6 +52,7 @@ class TestDeblendSources:
         assert_allclose(len(result.data[mask1]), len(result.data[mask2]))
         assert_allclose(np.sum(self.data[mask1]), np.sum(self.data[mask2]))
         assert_allclose(np.nonzero(self.segm), np.nonzero(result))
+        assert_equal(result._deblend_label_map, {1: [1, 2]})
 
     def test_deblend_multiple_sources(self):
         g4 = Gaussian2D(100, 50, 15, 5, 5)
@@ -194,6 +195,7 @@ class TestDeblendSources:
                                  mode=mode, relabel=False, progress_bar=False)
         assert result.nlabels == 2
         assert_equal(result.labels, [2, 3])
+        assert_equal(result._deblend_label_map, {1: [2, 3]})
         assert len(result.slices) <= result.max_label
         assert len(result.slices) == result.nlabels
         assert_allclose(np.nonzero(self.segm), np.nonzero(result))

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -52,7 +52,7 @@ class TestDeblendSources:
         assert_allclose(len(result.data[mask1]), len(result.data[mask2]))
         assert_allclose(np.sum(self.data[mask1]), np.sum(self.data[mask2]))
         assert_allclose(np.nonzero(self.segm), np.nonzero(result))
-        assert_equal(result._deblend_label_map, {1: [1, 2]})
+        assert_equal(result.deblended_labels_inverse_map, {1: [1, 2]})
 
     def test_deblend_multiple_sources(self):
         g4 = Gaussian2D(100, 50, 15, 5, 5)
@@ -195,7 +195,7 @@ class TestDeblendSources:
                                  mode=mode, relabel=False, progress_bar=False)
         assert result.nlabels == 2
         assert_equal(result.labels, [2, 3])
-        assert_equal(result._deblend_label_map, {1: [2, 3]})
+        assert_equal(result.deblended_labels_inverse_map, {1: [2, 3]})
         assert len(result.slices) <= result.max_label
         assert len(result.slices) == result.nlabels
         assert_allclose(np.nonzero(self.segm), np.nonzero(result))


### PR DESCRIPTION
This PR adds  ``deblended_labels``, ``deblended_labels_map``, and ``deblended_labels_inverse_map`` properties to ``SegmentationImage`` to identify and map any deblended labels to the original parent segmentation image.

It also fixes a small bug in deblended labels if `relabel=False` (which is not the default).