### PR TITLE
Fix failing isophote test for scipy 1.15

### DIFF
--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -54,7 +54,13 @@ def test_model_simulated_data():
 
     g = EllipseGeometry(100.0, 100.0, 5.0, 0.5, np.pi / 3.0)
     ellipse = Ellipse(data, geometry=g, threshold=1.0e5)
-    isophote_list = ellipse.fit_image()
+
+    # Catch warnings that may arise from empty slices. This started
+    # to happen on windows with scipy 1.15.0.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        isophote_list = ellipse.fit_image()
+
     model = build_ellipse_model(data.shape, isophote_list,
                                 fill=np.mean(data[0:50, 0:50]))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = '>=3.11'
 dependencies = [
     'numpy>=1.24',
     'astropy>=5.3',
-    'scipy>=1.10,<1.15',
+    'scipy>=1.10',
 ]
 
 [project.urls]


### PR DESCRIPTION
With the release of scipy 1.15, an isophote test started raising a warning about "RuntimeWarning: Mean of empty slice.", resulting in the test failing (see https://github.com/astropy/photutils/actions/runs/12601676522/job/35123249287).  The test fails only on windows.

The line causing this is
```
isophote\sample.py:299:
    self.mean = np.mean(s[2])
```

This PR catches and filters the warning message.