### PR TITLE
Add ability to calculate the raw radial profile of data points

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.profiles``
+
+  - Added ``data_radius`` and ``data_profile`` attributes to the
+    ``RadialProfile`` class for calculating the raw radial profile.
+    [#2001]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/docs/user_guide/profiles.rst
+++ b/docs/user_guide/profiles.rst
@@ -45,9 +45,9 @@ data before creating a radial profile or curve of growth.
     data += noise
     error = np.zeros_like(data) + bkg_sig
 
+    fig, ax = plt.subplots(figsize=(5, 5))
     norm = simple_norm(data, 'sqrt')
-    plt.figure(figsize=(5, 5))
-    plt.imshow(data, norm=norm)
+    ax.imshow(data, norm=norm)
 
 
 Creating a Radial Profile
@@ -163,9 +163,10 @@ to set the plot label.
     rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
     # plot the radial profile
-    rp.plot(label='Radial Profile')
-    rp.plot_error()
-    plt.legend()
+    fig, ax = plt.subplots(figsize=(8, 6))
+    rp.plot(ax=ax, label='Radial Profile')
+    rp.plot_error(ax=ax)
+    ax.legend()
 
 The `~photutils.profiles.RadialProfile.apertures` attribute contains a
 list of the apertures. Let's plot a few of the annulus apertures (the
@@ -199,11 +200,11 @@ instance on the data:
     rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
     norm = simple_norm(data, 'sqrt')
-    plt.figure(figsize=(5, 5))
-    plt.imshow(data, norm=norm)
-    rp.apertures[5].plot(color='C0', lw=2)
-    rp.apertures[10].plot(color='C1', lw=2)
-    rp.apertures[15].plot(color='C3', lw=2)
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.imshow(data, norm=norm)
+    rp.apertures[5].plot(ax=ax, color='C0', lw=2)
+    rp.apertures[10].plot(ax=ax, color='C1', lw=2)
+    rp.apertures[15].plot(ax=ax, color='C3', lw=2)
 
 Fitting the profile with a 1D Gaussian
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -251,10 +252,11 @@ class:`~photutils.profiles.RadialProfile` radial profile:
     rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
     # plot the radial profile
-    rp.plot(label='Radial Profile')
-    rp.plot_error()
-    plt.plot(rp.radius, rp.gaussian_profile, label='Gaussian Fit')
-    plt.legend()
+    fig, ax = plt.subplots(figsize=(8, 6))
+    rp.plot(ax=ax, label='Radial Profile')
+    rp.plot_error(ax=ax)
+    ax.plot(rp.radius, rp.gaussian_profile, label='Gaussian Fit')
+    ax.legend()
 
 
 Creating a Curve of Growth
@@ -356,9 +358,10 @@ to set the plot label.
     cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
     # plot the radial profile
-    cog.plot(label='Curve of Growth')
-    cog.plot_error()
-    plt.legend()
+    fig, ax = plt.subplots(figsize=(8, 6))
+    cog.plot(ax=ax, label='Curve of Growth')
+    cog.plot_error(ax=ax)
+    ax.legend()
 
 The `~photutils.profiles.CurveOfGrowth.apertures` attribute contains a
 list of the apertures. Let's plot a few of the circular apertures (the
@@ -391,11 +394,11 @@ list of the apertures. Let's plot a few of the circular apertures (the
     cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
     norm = simple_norm(data, 'sqrt')
-    plt.figure(figsize=(5, 5))
-    plt.imshow(data, norm=norm)
-    cog.apertures[5].plot(color='C0', lw=2)
-    cog.apertures[10].plot(color='C1', lw=2)
-    cog.apertures[15].plot(color='C3', lw=2)
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.imshow(data, norm=norm)
+    cog.apertures[5].plot(ax=ax, color='C0', lw=2)
+    cog.apertures[10].plot(ax=ax, color='C1', lw=2)
+    cog.apertures[15].plot(ax=ax, color='C3', lw=2)
 
 
 Encircled Energy

--- a/docs/user_guide/profiles.rst
+++ b/docs/user_guide/profiles.rst
@@ -23,8 +23,10 @@ data before creating a radial profile or curve of growth.
     >>> gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     >>> yy, xx = np.mgrid[0:100, 0:100]
     >>> data = gmodel(xx, yy)
-    >>> error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    >>> data += error
+    >>> bkg_sig = 2.4
+    >>> noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    >>> data += noise
+    >>> error = np.zeros_like(data) + bkg_sig
 
 .. plot::
 
@@ -38,8 +40,10 @@ data before creating a radial profile or curve of growth.
     gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     yy, xx = np.mgrid[0:100, 0:100]
     data = gmodel(xx, yy)
-    error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    data += error
+    bkg_sig = 2.4
+    noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    data += noise
+    error = np.zeros_like(data) + bkg_sig
 
     norm = simple_norm(data, 'sqrt')
     plt.figure(figsize=(5, 5))
@@ -98,10 +102,10 @@ propagated errors::
       4.03348112e-01  1.43482678e-01 -2.62777461e-01  7.30653622e-02]
 
     >>> print(rp.profile_error)  # doctest: +FLOAT_CMP
-    [1.69588246 0.81797694 0.61132694 0.44670831 0.49499835 0.38025361
-     0.40844702 0.32906672 0.36466713 0.33059274 0.29661894 0.27314739
-     0.25551933 0.27675376 0.25553986 0.23421017 0.22966813 0.21747036
-     0.23654884 0.22760386 0.23941711 0.20661313 0.18999134 0.17469024]
+    [1.354055   0.78176402 0.60555181 0.51178468 0.45135167 0.40826294
+     0.37554729 0.3496155  0.32840658 0.31064152 0.29547903 0.28233999
+     0.270811   0.26058801 0.2514417  0.24319546 0.23571072 0.22887707
+     0.22260527 0.21682233 0.21146786 0.20649145 0.2018506  0.19750922]
 
 Normalization
 ^^^^^^^^^^^^^
@@ -146,8 +150,10 @@ to set the plot label.
     gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     yy, xx = np.mgrid[0:100, 0:100]
     data = gmodel(xx, yy)
-    error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    data += error
+    bkg_sig = 2.4
+    noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    data += noise
+    error = np.zeros_like(data) + bkg_sig
 
     # find the source centroid
     xycen = centroid_quadratic(data, xpeak=47, ypeak=52)
@@ -180,8 +186,10 @@ instance on the data:
     gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     yy, xx = np.mgrid[0:100, 0:100]
     data = gmodel(xx, yy)
-    error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    data += error
+    bkg_sig = 2.4
+    noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    data += noise
+    error = np.zeros_like(data) + bkg_sig
 
     # find the source centroid
     xycen = centroid_quadratic(data, xpeak=47, ypeak=52)
@@ -230,8 +238,10 @@ class:`~photutils.profiles.RadialProfile` radial profile:
     gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     yy, xx = np.mgrid[0:100, 0:100]
     data = gmodel(xx, yy)
-    error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    data += error
+    bkg_sig = 2.4
+    noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    data += noise
+    error = np.zeros_like(data) + bkg_sig
 
     # find the source centroid
     xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
@@ -284,11 +294,11 @@ profile and propagated errors::
      5948.92254787 5968.30540534 5931.15611704 5941.94457249 5942.06535486]
 
     >>> print(cog.profile_error)  # doctest: +FLOAT_CMP
-    [  5.32777186   9.37111012  13.41750992  16.62928904  21.7350922
-      25.39862532  30.3867526   34.11478867  39.28263973  43.96047829
-      48.11931395  52.00967328  55.7471834   60.48824739  64.81392778
-      68.71042311  72.71899201  76.54959872  81.33806741  85.98568713
-      91.34841248  95.5173253   99.22190499 102.51980185 106.83601366]
+    [  4.25388924   8.50777848  12.76166773  17.01555697  21.26944621
+      25.52333545  29.7772247   34.03111394  38.28500318  42.53889242
+      46.79278166  51.04667091  55.30056015  59.55444939  63.80833863
+      68.06222787  72.31611712  76.57000636  80.8238956   85.07778484
+      89.33167409  93.58556333  97.83945257 102.09334181 106.34723105]
 
 Normalization
 ^^^^^^^^^^^^^
@@ -333,8 +343,10 @@ to set the plot label.
     gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     yy, xx = np.mgrid[0:100, 0:100]
     data = gmodel(xx, yy)
-    error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    data += error
+    bkg_sig = 2.4
+    noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    data += noise
+    error = np.zeros_like(data) + bkg_sig
 
     # find the source centroid
     xycen = centroid_quadratic(data, xpeak=47, ypeak=52)
@@ -366,8 +378,10 @@ list of the apertures. Let's plot a few of the circular apertures (the
     gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     yy, xx = np.mgrid[0:100, 0:100]
     data = gmodel(xx, yy)
-    error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    data += error
+    bkg_sig = 2.4
+    noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    data += noise
+    error = np.zeros_like(data) + bkg_sig
 
     # find the source centroid
     xycen = centroid_quadratic(data, xpeak=47, ypeak=52)
@@ -408,7 +422,7 @@ to the given encircled energy (or energies). These methods are
 :meth:`~photutils.profiles.CurveOfGrowth.calc_ee_at_radius` and
 :meth:`~photutils.profiles.CurveOfGrowth.calc_radius_at_ee`,
 respectively. They are implemented as interpolation functions using the
-calculated curve-of-growth profile. The performance of these methods
+calculated curve-of-growth profile. The accuracy of these methods
 is dependent on the quality of the curve-of-growth profile (e.g., it's
 generally better to have a curve-of-growth profile with more radial
 bins)::

--- a/docs/user_guide/profiles.rst
+++ b/docs/user_guide/profiles.rst
@@ -223,10 +223,22 @@ The FWHM of the fitted 1D Gaussian model is stored in the
     >>> print(rp.gaussian_fwhm)  # doctest: +FLOAT_CMP
     11.09260130738712
 
+The 1D Gaussian model evaluated at the profile radius values is stored
+in the `~photutils.profiles.RadialProfile.gaussian_profile` attribute::
+
+    >>> print(rp.gaussian_profile)  # doctest: +FLOAT_CMP
+    [4.13154108e+01 3.94948235e+01 3.60907893e+01 3.15268576e+01
+     2.63264980e+01 2.10152035e+01 1.60362275e+01 1.16976580e+01
+     8.15687363e+00 5.43721678e+00 3.46463641e+00 2.11040974e+00
+     1.22886451e+00 6.84020824e-01 3.63967618e-01 1.85133184e-01
+     9.00189404e-02 4.18419219e-02 1.85916294e-02 7.89680446e-03
+     3.20636838e-03 1.24452479e-03 4.61765823e-04 1.63782737e-04]
+
 Finally, let's plot the fitted 1D Gaussian model for the
 class:`~photutils.profiles.RadialProfile` radial profile:
 
 .. plot::
+   :include-source:
 
     import matplotlib.pyplot as plt
     import numpy as np

--- a/docs/user_guide/profiles.rst
+++ b/docs/user_guide/profiles.rst
@@ -107,6 +107,52 @@ propagated errors::
      0.270811   0.26058801 0.2514417  0.24319546 0.23571072 0.22887707
      0.22260527 0.21682233 0.21146786 0.20649145 0.2018506  0.19750922]
 
+
+Raw Data Profile
+^^^^^^^^^^^^^^^^
+
+The `~photutils.profiles.RadialProfile` class also includes
+:attr:`~photutils.profiles.RadialProfile.data_radius` and
+:attr:`~photutils.profiles.RadialProfile.data_profile` attributes that
+that can be used to plot the raw data profile. These methods return the
+radii and values of the data points within the maximum radius defined by
+the input radii.
+
+Let's plot the raw data profile along with the radial profile and its
+error bars:
+
+.. plot::
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from astropy.modeling.models import Gaussian2D
+
+    from photutils.centroids import centroid_quadratic
+    from photutils.datasets import make_noise_image
+    from photutils.profiles import RadialProfile
+
+    # create an artificial single source
+    gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
+    yy, xx = np.mgrid[0:100, 0:100]
+    data = gmodel(xx, yy)
+    bkg_sig = 2.4
+    noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    data += noise
+    error = np.zeros_like(data) + bkg_sig
+
+    # find the source centroid
+    xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
+
+    # create the radial profile
+    edge_radii = np.arange(26)
+    rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
+
+    # plot the radial profile
+    fig, ax = plt.subplots(figsize=(8, 6))
+    rp.plot(ax=ax, color='C0')
+    rp.plot_error(ax=ax)
+    ax.scatter(rp.data_radius, rp.data_profile, s=1, color='C1')
+
 Normalization
 ^^^^^^^^^^^^^
 

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -231,6 +231,7 @@ class ProfileBase(metaclass=abc.ABCMeta):
         else:
             raise ValueError('invalid method, must be "max" or "sum"')
 
+        # NOTE: max and sum will never be NaN (automatically masked)
         if normalization == 0:
             warnings.warn('The profile cannot be normalized because the '
                           'max or sum is zero.', AstropyUserWarning)
@@ -242,6 +243,9 @@ class ProfileBase(metaclass=abc.ABCMeta):
             # need to use __dict__ as these are lazy properties
             self.__dict__['profile'] = self.profile / normalization
             self.__dict__['profile_error'] = self.profile_error / normalization
+            if 'data_profile' in self.__dict__:
+                self.__dict__['data_profile'] = (self.data_profile
+                                                 / normalization)
 
     def unnormalize(self):
         """
@@ -251,6 +255,9 @@ class ProfileBase(metaclass=abc.ABCMeta):
         self.__dict__['profile'] = self.profile * self.normalization_value
         self.__dict__['profile_error'] = (self.profile_error
                                           * self.normalization_value)
+        if 'data_profile' in self.__dict__:
+            self.__dict__['data_profile'] = (self.data_profile
+                                             * self.normalization_value)
         self.normalization_value = 1.0
 
     def plot(self, ax=None, **kwargs):

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -125,6 +125,7 @@ class CurveOfGrowth(ProfileBase):
 
     .. plot::
 
+        import matplotlib.pyplot as plt
         import numpy as np
         from astropy.modeling.models import Gaussian2D
 
@@ -149,13 +150,15 @@ class CurveOfGrowth(ProfileBase):
         cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
         # plot the curve of growth
-        cog.plot()
-        cog.plot_error()
+        fig, ax = plt.subplots(figsize=(8, 6))
+        cog.plot(ax=ax)
+        cog.plot_error(ax=ax)
 
     Normalize the profile and plot the normalized curve of growth.
 
     .. plot::
 
+        import matplotlib.pyplot as plt
         import numpy as np
         from astropy.modeling.models import Gaussian2D
 
@@ -181,8 +184,9 @@ class CurveOfGrowth(ProfileBase):
 
         # plot the curve of growth
         cog.normalize()
-        cog.plot()
-        cog.plot_error()
+        fig, ax = plt.subplots(figsize=(8, 6))
+        cog.plot(ax=ax)
+        cog.plot_error(ax=ax)
 
     Plot a couple of the apertures on the data.
 
@@ -214,11 +218,11 @@ class CurveOfGrowth(ProfileBase):
         cog = CurveOfGrowth(data, xycen, radii, error=error, mask=None)
 
         norm = simple_norm(data, 'sqrt')
-        plt.figure(figsize=(5, 5))
-        plt.imshow(data, norm=norm, origin='lower')
-        cog.apertures[5].plot(color='C0', lw=2)
-        cog.apertures[10].plot(color='C1', lw=2)
-        cog.apertures[15].plot(color='C3', lw=2)
+        fig, ax = plt.subplots(figsize=(5, 5))
+        ax.imshow(data, norm=norm, origin='lower')
+        cog.apertures[5].plot(ax=ax, color='C0', lw=2)
+        cog.apertures[10].plot(ax=ax, color='C1', lw=2)
+        cog.apertures[15].plot(ax=ax, color='C3', lw=2)
     """
 
     def __init__(self, data, xycen, radii, *, error=None, mask=None,

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -92,8 +92,10 @@ class CurveOfGrowth(ProfileBase):
     >>> gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     >>> yy, xx = np.mgrid[0:100, 0:100]
     >>> data = gmodel(xx, yy)
-    >>> error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    >>> data += error
+    >>> bkg_sig = 2.4
+    >>> noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    >>> data += noise
+    >>> error = np.zeros_like(data) + bkg_sig
 
     Create the curve of growth.
 
@@ -113,11 +115,11 @@ class CurveOfGrowth(ProfileBase):
      5948.92254787 5968.30540534 5931.15611704 5941.94457249 5942.06535486]
 
     >>> print(cog.profile_error)  # doctest: +FLOAT_CMP
-    [  5.32777186   9.37111012  13.41750992  16.62928904  21.7350922
-      25.39862532  30.3867526   34.11478867  39.28263973  43.96047829
-      48.11931395  52.00967328  55.7471834   60.48824739  64.81392778
-      68.71042311  72.71899201  76.54959872  81.33806741  85.98568713
-      91.34841248  95.5173253   99.22190499 102.51980185 106.83601366]
+    [  4.25388924   8.50777848  12.76166773  17.01555697  21.26944621
+      25.52333545  29.7772247   34.03111394  38.28500318  42.53889242
+      46.79278166  51.04667091  55.30056015  59.55444939  63.80833863
+      68.06222787  72.31611712  76.57000636  80.8238956   85.07778484
+      89.33167409  93.58556333  97.83945257 102.09334181 106.34723105]
 
     Plot the curve of growth.
 
@@ -134,8 +136,10 @@ class CurveOfGrowth(ProfileBase):
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
         yy, xx = np.mgrid[0:100, 0:100]
         data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
+        bkg_sig = 2.4
+        noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+        data += noise
+        error = np.zeros_like(data) + bkg_sig
 
         # find the source centroid
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
@@ -163,8 +167,10 @@ class CurveOfGrowth(ProfileBase):
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
         yy, xx = np.mgrid[0:100, 0:100]
         data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
+        bkg_sig = 2.4
+        noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+        data += noise
+        error = np.zeros_like(data) + bkg_sig
 
         # find the source centroid
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
@@ -195,8 +201,10 @@ class CurveOfGrowth(ProfileBase):
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
         yy, xx = np.mgrid[0:100, 0:100]
         data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
+        bkg_sig = 2.4
+        noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+        data += noise
+        error = np.zeros_like(data) + bkg_sig
 
         # find the source centroid
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -388,6 +388,9 @@ class RadialProfile(ProfileBase):
         """
         The fitted 1D Gaussian to the radial profile as a
         `~astropy.modeling.functional_models.Gaussian1D` model.
+
+        The Gaussian fit will not change if the profile normalization is
+        changed after performing the fit.
         """
         profile = self.profile[self._profile_nanmask]
         radius = self.radius[self._profile_nanmask]
@@ -404,6 +407,9 @@ class RadialProfile(ProfileBase):
         """
         The fitted 1D Gaussian profile to the radial profile as a 1D
         `~numpy.ndarray`.
+
+        The Gaussian profile will not change if the profile
+        normalization is changed after performing the fit.
         """
         return self.gaussian_fit(self.radius)
 
@@ -422,8 +428,7 @@ class RadialProfile(ProfileBase):
         of radii and data values.
 
         This method returns the radii and values of the data points
-        within the maximum radius defined by the input radii. These
-        values are not normalized.
+        within the maximum radius defined by the input radii.
         """
         shape = self.data.shape
         max_radius = np.max(self.radii)

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -177,6 +177,40 @@ class RadialProfile(ProfileBase):
         rp.plot(ax=ax)
         rp.plot_error(ax=ax)
 
+    Plot the radial profile, including the raw data profile.
+
+    .. plot::
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        from astropy.modeling.models import Gaussian2D
+
+        from photutils.centroids import centroid_quadratic
+        from photutils.datasets import make_noise_image
+        from photutils.profiles import RadialProfile
+
+        # create an artificial single source
+        gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
+        yy, xx = np.mgrid[0:100, 0:100]
+        data = gmodel(xx, yy)
+        bkg_sig = 2.4
+        noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+        data += noise
+        error = np.zeros_like(data) + bkg_sig
+
+        # find the source centroid
+        xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
+
+        # create the radial profile
+        edge_radii = np.arange(26)
+        rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
+
+        # plot the radial profile
+        fig, ax = plt.subplots(figsize=(8, 6))
+        rp.plot(ax=ax, color='C0')
+        rp.plot_error(ax=ax)
+        ax.scatter(rp.data_radius, rp.data_profile, s=1, color='C1')
+
     Normalize the profile and plot the normalized radial profile.
 
     .. plot::

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -113,8 +113,10 @@ class RadialProfile(ProfileBase):
     >>> gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
     >>> yy, xx = np.mgrid[0:100, 0:100]
     >>> data = gmodel(xx, yy)
-    >>> error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-    >>> data += error
+    >>> bkg_sig = 2.4
+    >>> noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+    >>> data += noise
+    >>> error = np.zeros_like(data) + bkg_sig
 
     Create the radial profile.
 
@@ -136,11 +138,11 @@ class RadialProfile(ProfileBase):
       7.84616804e-04]
 
     >>> print(rp.profile_error)  # doctest: +FLOAT_CMP
-    [1.69588246 0.81797694 0.61132694 0.44670831 0.49499835 0.38025361
-     0.40844702 0.32906672 0.36466713 0.33059274 0.29661894 0.27314739
-     0.25551933 0.27675376 0.25553986 0.23421017 0.22966813 0.21747036
-     0.23654884 0.22760386 0.23941711 0.20661313 0.18999134 0.17469024
-     0.19527558]
+    [1.354055   0.78176402 0.60555181 0.51178468 0.45135167 0.40826294
+     0.37554729 0.3496155  0.32840658 0.31064152 0.29547903 0.28233999
+     0.270811   0.26058801 0.2514417  0.24319546 0.23571072 0.22887707
+     0.22260527 0.21682233 0.21146786 0.20649145 0.2018506  0.19750922
+     0.19343643]
 
     Plot the radial profile.
 
@@ -157,8 +159,10 @@ class RadialProfile(ProfileBase):
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
         yy, xx = np.mgrid[0:100, 0:100]
         data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
+        bkg_sig = 2.4
+        noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+        data += noise
+        error = np.zeros_like(data) + bkg_sig
 
         # find the source centroid
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
@@ -186,8 +190,10 @@ class RadialProfile(ProfileBase):
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
         yy, xx = np.mgrid[0:100, 0:100]
         data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
+        bkg_sig = 2.4
+        noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+        data += noise
+        error = np.zeros_like(data) + bkg_sig
 
         # find the source centroid
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
@@ -218,8 +224,10 @@ class RadialProfile(ProfileBase):
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
         yy, xx = np.mgrid[0:100, 0:100]
         data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
+        bkg_sig = 2.4
+        noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+        data += noise
+        error = np.zeros_like(data) + bkg_sig
 
         # find the source centroid
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)
@@ -260,8 +268,10 @@ class RadialProfile(ProfileBase):
         gmodel = Gaussian2D(42.1, 47.8, 52.4, 4.7, 4.7, 0)
         yy, xx = np.mgrid[0:100, 0:100]
         data = gmodel(xx, yy)
-        error = make_noise_image(data.shape, mean=0., stddev=2.4, seed=123)
-        data += error
+        bkg_sig = 2.4
+        noise = make_noise_image(data.shape, mean=0., stddev=bkg_sig, seed=123)
+        data += noise
+        error = np.zeros_like(data) + bkg_sig
 
         # find the source centroid
         xycen = centroid_quadratic(data, xpeak=48, ypeak=52)

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -148,6 +148,7 @@ class RadialProfile(ProfileBase):
 
     .. plot::
 
+        import matplotlib.pyplot as plt
         import numpy as np
         from astropy.modeling.models import Gaussian2D
 
@@ -172,13 +173,15 @@ class RadialProfile(ProfileBase):
         rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
         # plot the radial profile
-        rp.plot()
-        rp.plot_error()
+        fig, ax = plt.subplots(figsize=(8, 6))
+        rp.plot(ax=ax)
+        rp.plot_error(ax=ax)
 
     Normalize the profile and plot the normalized radial profile.
 
     .. plot::
 
+        import matplotlib.pyplot as plt
         import numpy as np
         from astropy.modeling.models import Gaussian2D
 
@@ -204,8 +207,9 @@ class RadialProfile(ProfileBase):
 
         # plot the radial profile
         rp.normalize()
-        rp.plot()
-        rp.plot_error()
+        fig, ax = plt.subplots(figsize=(8, 6))
+        rp.plot(ax=ax)
+        rp.plot_error(ax=ax)
 
     Plot three of the annulus apertures on the data.
 
@@ -237,11 +241,11 @@ class RadialProfile(ProfileBase):
         rp = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
 
         norm = simple_norm(data, 'sqrt')
-        plt.figure(figsize=(5, 5))
-        plt.imshow(data, norm=norm, origin='lower')
-        rp.apertures[5].plot(color='C0', lw=2)
-        rp.apertures[10].plot(color='C1', lw=2)
-        rp.apertures[15].plot(color='C3', lw=2)
+        fig, ax = plt.subplots(figsize=(5, 5))
+        ax.imshow(data, norm=norm, origin='lower')
+        rp.apertures[5].plot(ax=ax, color='C0', lw=2)
+        rp.apertures[10].plot(ax=ax, color='C1', lw=2)
+        rp.apertures[15].plot(ax=ax, color='C3', lw=2)
 
     Fit a 1D Gaussian to the radial profile and return the Gaussian
     model.
@@ -282,10 +286,11 @@ class RadialProfile(ProfileBase):
 
         # plot the radial profile
         rp.normalize()
-        rp.plot(label='Radial Profile')
-        rp.plot_error()
-        plt.plot(rp.radius, rp.gaussian_profile, label='Gaussian Fit')
-        plt.legend()
+        fig, ax = plt.subplots(figsize=(8, 6))
+        rp.plot(ax=ax, label='Radial Profile')
+        rp.plot_error(ax=ax)
+        ax.plot(rp.radius, rp.gaussian_profile, label='Gaussian Fit')
+        ax.legend()
     """
 
     @lazyproperty

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -414,3 +414,43 @@ class RadialProfile(ProfileBase):
         Gaussian fitted to the radial profile.
         """
         return self.gaussian_fit.stddev.value * gaussian_sigma_to_fwhm
+
+    @lazyproperty
+    def _data_profile(self):
+        """
+        The raw data profile returned as a 1D arrays (`~numpy.ndarray`)
+        of radii and data values.
+
+        This method returns the radii and values of the data points
+        within the maximum radius defined by the input radii. These
+        values are not normalized.
+        """
+        shape = self.data.shape
+        max_radius = np.max(self.radii)
+        x_min = int(max(np.floor(self.xycen[0] - max_radius), 0))
+        x_max = int(min(np.ceil(self.xycen[0] + max_radius), shape[1]))
+        y_min = int(max(np.floor(self.xycen[1] - max_radius), 0))
+        y_max = int(min(np.ceil(self.xycen[1] + max_radius), shape[0]))
+        yidx, xidx = np.indices((y_max - y_min, x_max - x_min))
+        xidx += x_min
+        yidx += y_min
+        radii = np.hypot(xidx - self.xycen[0], yidx - self.xycen[1])
+        mask = radii <= max_radius
+        radii = radii[mask]
+        data_values = self.data[yidx[mask], xidx[mask]]
+
+        return radii, data_values
+
+    @lazyproperty
+    def data_radius(self):
+        """
+        The radii of the raw data profile as a 1D `~numpy.ndarray`.
+        """
+        return self._data_profile[0]
+
+    @lazyproperty
+    def data_profile(self):
+        """
+        The raw data profile as a 1D `~numpy.ndarray`.
+        """
+        return self._data_profile[1]

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -55,6 +55,20 @@ def test_radial_profile(profile_data):
     assert isinstance(rp2.apertures[0], CircularAnnulus)
 
 
+def test_radial_profile_data(profile_data):
+    xycen, data, _, _ = profile_data
+
+    edge_radii = np.arange(36)
+    rp1 = RadialProfile(data, xycen, edge_radii, error=None, mask=None)
+
+    data_radius = rp1.data_radius
+    data_profile = rp1.data_profile
+    assert np.max(data_radius) <= np.max(edge_radii)
+    assert data_radius.shape == data_profile.shape
+    assert np.min(data_profile) >= np.min(data)
+    assert np.max(data_profile) <= np.max(data)
+
+
 def test_radial_profile_inputs(profile_data):
     xycen, data, _, _ = profile_data
 

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -55,6 +55,26 @@ def test_radial_profile(profile_data):
     assert isinstance(rp2.apertures[0], CircularAnnulus)
 
 
+def test_radial_profile_normalization(profile_data):
+    xycen, data, error, _ = profile_data
+
+    edge_radii = np.arange(36)
+    rp1 = RadialProfile(data, xycen, edge_radii, error=error, mask=None)
+
+    profile = rp1.profile
+    profile_error = rp1.profile_error
+    data_profile = rp1.data_profile
+    rp1.normalize()
+    assert np.max(rp1.profile) == 1.0
+    assert np.max(rp1.profile_error) <= np.max(profile_error)
+    assert np.max(rp1.data_profile) <= np.max(data_profile)
+
+    rp1.unnormalize()
+    assert_allclose(rp1.profile, profile)
+    assert_allclose(rp1.profile_error, profile_error)
+    assert_allclose(rp1.data_profile, data_profile)
+
+
 def test_radial_profile_data(profile_data):
     xycen, data, _, _ = profile_data
 


### PR DESCRIPTION
This PR adds ``data_radius`` and ``data_profile`` attributes to the ``RadialProfile`` class for calculating the raw radial profile.

It also expands and improves the `profiles` narrative docs.