### PR TITLE
Fix SegmentationImage polygons for segments with holes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.segmentation``
+
+  - Fixed an issue where the ``SegmentationImage`` ``polygons``
+    attribute would raise an error if any source segment contained a
+    hole. [#2005]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1331,7 +1331,8 @@ class SegmentationImage:
         from shapely import transform
         from shapely.geometry import shape
 
-        polygons = [shape(geo_poly[0]) for geo_poly in self._geo_polygons]
+        polygons = [shape(geo_poly[0]) for geo_poly in self._geo_polygons
+                    if geo_poly[1] != 0]
 
         # shift the vertices so that the (0, 0) origin is at the
         # center of the lower-left pixel

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -448,6 +448,21 @@ class TestSegmentationImage:
 
     @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
     @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
+    def test_polygon_hole(self):
+
+        data = np.zeros((11, 11), dtype=int)
+        data[3:8, 3:8] = 10
+        data[5, 5] = 0  # hole
+        segm = SegmentationImage(data)
+        polygons = segm.polygons
+        assert len(polygons) == 1
+        verts = np.array(polygons[0].exterior.coords)
+        expected_verts = np.array([[2.5, 2.5], [2.5, 7.5], [7.5, 7.5],
+                                   [7.5, 2.5], [2.5, 2.5]])
+        assert_equal(verts, expected_verts)
+
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_patches(self):
         from matplotlib.patches import Polygon


### PR DESCRIPTION
This PR fixes an issue where the ``SegmentationImage`` ``polygons`` attribute would raise an error if any source segment contained a hole (i.e., multiply-connected polygon).