### PR TITLE
Remove alldeps from ubuntu arm64 CI test

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -74,10 +74,10 @@ jobs:
             allow_failure: false
             prefix: ''
 
+          # cannot use alldeps: rasterio does not have a arm64 wheel
           - os: ubuntu-24.04-arm
             python: '3.12'
-            tox_env: 'py312-test-alldeps'
-            toxposargs: --remote-data=any
+            tox_env: 'py312-test'
             allow_failure: false
             prefix: ''
 


### PR DESCRIPTION
rasterio does not have an ubuntu arm64 wheel and is now having trouble being built from source due to its GDAL dependency