### PR TITLE
Always return ellipse/rectangle pixel aperture theta as an angular Quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,13 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.aperture``
+
+  - The ``theta`` attribute of ``EllipticalAperture``,
+    ``EllipticalAnnulus``, ``RectangularAperture``, and
+    ``RectangularAnnulus`` is now always returned as an angular
+    ``Quantity``. [#2008]
+
 
 2.1.0 (2025-01-06)
 ------------------

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -175,6 +175,10 @@ class ScalarAngleOrValue(ApertureAttribute):
     Check that value is a scalar angle, either as a
     `~astropy.coordinates.Angle` or `~astropy.units.Quantity` with
     angular units, or a scalar float.
+
+    The value is always output as a `~astropy.units.Quantity` with
+    angular units. If the value is not a `~astropy.units.Quantity`, it
+    is assumed to be in radians.
     """
 
     def __set__(self, instance, value):
@@ -182,13 +186,11 @@ class ScalarAngleOrValue(ApertureAttribute):
         # no need to reset if not already in the instance dict
         if self.name in instance.__dict__:
             self._reset_lazyproperties(instance)
-        instance.__dict__[self.name] = value
 
-        # also store the angle in radians as a float
-        if isinstance(value, u.Quantity):
-            value = value.to(u.radian).value
-        name = f'_{self.name}_radians'
-        instance.__dict__[name] = value
+        # if theta is not a Quantity, it is assumed to be in radians
+        if not isinstance(value, u.Quantity):
+            value <<= u.radian
+        instance.__dict__[self.name] = value
 
     def _validate(self, value):
         if isinstance(value, u.Quantity):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -751,7 +751,7 @@ class PixelAperture(Aperture):
                 # the semimajor axis (i.e., relative to the WCS latitude
                 # axis). region sky angles are defined relative to the WCS
                 # longitude axis.
-                value = (value * u.rad) - angle.to(u.rad)
+                value = value - angle.to(u.rad)
             else:
                 value = (value * u.pix * pixscale).to(u.arcsec)
 
@@ -832,7 +832,7 @@ class SkyAperture(Aperture):
                 # the semimajor axis (i.e., relative to the WCS latitude
                 # axis). region sky angles are defined relative to the WCS
                 # longitude axis.
-                value = (value + angle).to(u.radian).value
+                value = (value + angle).to(u.radian)
             elif value.unit.physical_type == 'angle':
                 value = (value / pixscale).to(u.pixel).value
             else:

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -1555,7 +1555,7 @@ class ApertureStats:
         covar = self._covariance
         orient_radians = 0.5 * np.arctan2(2.0 * covar[:, 0, 1],
                                           (covar[:, 0, 0] - covar[:, 1, 1]))
-        return orient_radians * 180.0 / np.pi * u.deg
+        return np.rad2deg(orient_radians) * u.deg
 
     @lazyproperty
     @as_scalar

--- a/photutils/aperture/tests/test_converters.py
+++ b/photutils/aperture/tests/test_converters.py
@@ -95,7 +95,7 @@ def test_translation_ellipse(image_2d_wcs):
     assert_allclose(aperture.positions, region_shape.center.xy)
     assert_allclose(aperture.a * 2, region_shape.width)
     assert_allclose(aperture.b * 2, region_shape.height)
-    assert_allclose(aperture.theta, region_shape.angle.radian)
+    assert_quantity_allclose(aperture.theta, region_shape.angle)
 
     region_sky = region_shape.to_sky(image_2d_wcs)
     aperture_sky = region_to_aperture(region_sky)
@@ -153,7 +153,7 @@ def test_translation_rectangle(image_2d_wcs):
     assert_allclose(aperture.positions, region_shape.center.xy)
     assert_allclose(aperture.w, region_shape.width)
     assert_allclose(aperture.h, region_shape.height)
-    assert_allclose(aperture.theta, region_shape.angle.radian)
+    assert_quantity_allclose(aperture.theta, region_shape.angle)
 
     region_sky = region_shape.to_sky(image_2d_wcs)
     aperture_sky = region_to_aperture(region_sky)
@@ -259,7 +259,7 @@ def test_translation_ellipse_annulus(image_2d_wcs):
     assert_allclose(aperture.a_out * 2, region_shape.outer_width)
     assert_allclose(aperture.b_in * 2, region_shape.inner_height)
     assert_allclose(aperture.b_out * 2, region_shape.outer_height)
-    assert_allclose(aperture.theta, region_shape.angle.radian)
+    assert_quantity_allclose(aperture.theta, region_shape.angle)
 
     region_sky = region_shape.to_sky(image_2d_wcs)
     aperture_sky = region_to_aperture(region_sky)
@@ -352,7 +352,7 @@ def test_translation_rectangle_annulus(image_2d_wcs):
     assert_allclose(aperture.w_out, region_shape.outer_width)
     assert_allclose(aperture.h_in, region_shape.inner_height)
     assert_allclose(aperture.h_out, region_shape.outer_height)
-    assert_allclose(aperture.theta, region_shape.angle.radian)
+    assert_quantity_allclose(aperture.theta, region_shape.angle)
 
     region_sky = region_shape.to_sky(image_2d_wcs)
     aperture_sky = region_to_aperture(region_sky)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -41,6 +41,10 @@ class TestEllipticalAperture(BaseTestAperture):
         aper.a = 20.0
         assert aper != self.aperture
 
+    def test_theta(self):
+        assert isinstance(self.aperture.theta, u.Quantity)
+        assert self.aperture.theta.unit == u.rad
+
 
 class TestEllipticalAnnulus(BaseTestAperture):
     aperture = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
@@ -74,6 +78,10 @@ class TestEllipticalAnnulus(BaseTestAperture):
         assert aper == self.aperture
         aper.a_in = 2.0
         assert aper != self.aperture
+
+    def test_theta(self):
+        assert isinstance(self.aperture.theta, u.Quantity)
+        assert self.aperture.theta.unit == u.rad
 
 
 class TestSkyEllipticalAperture(BaseTestAperture):

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
 
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus,
@@ -144,8 +145,8 @@ def test_ellipse_theta_quantity():
     theta = Angle(90 * u.deg)
     aper3 = EllipticalAperture(POSITIONS, a=10.0, b=5.0, theta=theta)
 
-    assert aper1._theta_radians == aper2._theta_radians
-    assert aper1._theta_radians == aper3._theta_radians
+    assert_quantity_allclose(aper1.theta, aper2.theta)
+    assert_quantity_allclose(aper1.theta, aper3.theta)
 
 
 def test_ellipse_annulus_theta_quantity():
@@ -158,5 +159,5 @@ def test_ellipse_annulus_theta_quantity():
     aper3 = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
                               theta=theta)
 
-    assert aper1._theta_radians == aper2._theta_radians
-    assert aper1._theta_radians == aper3._theta_radians
+    assert_quantity_allclose(aper1.theta, aper2.theta)
+    assert_quantity_allclose(aper1.theta, aper3.theta)

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -661,7 +661,7 @@ def test_rectangular_bbox():
     assert a.bbox.shape == (height + 1, width + 1)
 
     a = RectangularAperture((50, 50), w=width, h=height,
-                            theta=90.0 * np.pi / 180.0)
+                            theta=np.deg2rad(90.0))
     assert a.bbox.shape == (width, height)
 
     # test even sizes
@@ -674,7 +674,7 @@ def test_rectangular_bbox():
     assert a.bbox.shape == (height, width)
 
     a = RectangularAperture((50.5, 50.5), w=width, h=height,
-                            theta=90.0 * np.pi / 180.0)
+                            theta=np.deg2rad(90.0))
     assert a.bbox.shape == (width, height)
 
 
@@ -688,7 +688,7 @@ def test_elliptical_bbox():
     ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
     assert ap.bbox.shape == (2 * b, 2 * a)
 
-    ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.0 * np.pi / 180.0)
+    ap = EllipticalAperture((50, 50), a=a, b=b, theta=np.deg2rad(90.0))
     assert ap.bbox.shape == (2 * a + 1, 2 * b + 1)
 
     # fractional axes
@@ -700,7 +700,7 @@ def test_elliptical_bbox():
     ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
     assert ap.bbox.shape == (2 * b + 1, 2 * a + 1)
 
-    ap = EllipticalAperture((50, 50), a=a, b=b, theta=90.0 * np.pi / 180.0)
+    ap = EllipticalAperture((50, 50), a=a, b=b, theta=np.deg2rad(90.0))
     assert ap.bbox.shape == (2 * a, 2 * b)
 
 
@@ -727,7 +727,7 @@ def test_to_sky_pixel(wcs_type):
     assert_allclose(ap.r_out, ap2.r_out)
 
     ap = EllipticalAperture(((12.3, 15.7), (48.19, 98.14)), a=3.14, b=5.32,
-                            theta=103.0 * np.pi / 180.0)
+                            theta=np.deg2rad(103.0))
     ap2 = ap.to_sky(wcs).to_pixel(wcs)
     assert_allclose(ap.positions, ap2.positions)
     assert_allclose(ap.a, ap2.a)
@@ -736,7 +736,7 @@ def test_to_sky_pixel(wcs_type):
 
     ap = EllipticalAnnulus(((12.3, 15.7), (48.19, 98.14)), a_in=3.14,
                            a_out=15.32, b_out=4.89,
-                           theta=103.0 * np.pi / 180.0)
+                           theta=np.deg2rad(103.0))
     ap2 = ap.to_sky(wcs).to_pixel(wcs)
     assert_allclose(ap.positions, ap2.positions)
     assert_allclose(ap.a_in, ap2.a_in)
@@ -745,7 +745,7 @@ def test_to_sky_pixel(wcs_type):
     assert_allclose(ap.theta, ap2.theta)
 
     ap = RectangularAperture(((12.3, 15.7), (48.19, 98.14)), w=3.14, h=5.32,
-                             theta=103.0 * np.pi / 180.0)
+                             theta=np.deg2rad(103.0))
     ap2 = ap.to_sky(wcs).to_pixel(wcs)
     assert_allclose(ap.positions, ap2.positions)
     assert_allclose(ap.w, ap2.w)
@@ -754,7 +754,7 @@ def test_to_sky_pixel(wcs_type):
 
     ap = RectangularAnnulus(((12.3, 15.7), (48.19, 98.14)), w_in=3.14,
                             w_out=15.32, h_out=4.89,
-                            theta=103.0 * np.pi / 180.0)
+                            theta=np.deg2rad(103.0))
     ap2 = ap.to_sky(wcs).to_pixel(wcs)
     assert_allclose(ap.positions, ap2.positions)
     assert_allclose(ap.w_in, ap2.w_in)

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -42,6 +42,10 @@ class TestRectangularAperture(BaseTestAperture):
         aper.w = 20.0
         assert aper != self.aperture
 
+    def test_theta(self):
+        assert isinstance(self.aperture.theta, u.Quantity)
+        assert self.aperture.theta.unit == u.rad
+
 
 class TestRectangularAnnulus(BaseTestAperture):
     aperture = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
@@ -75,6 +79,10 @@ class TestRectangularAnnulus(BaseTestAperture):
         assert aper == self.aperture
         aper.w_in = 2.0
         assert aper != self.aperture
+
+    def test_theta(self):
+        assert isinstance(self.aperture.theta, u.Quantity)
+        assert self.aperture.theta.unit == u.rad
 
 
 class TestSkyRectangularAperture(BaseTestAperture):

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
 
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture,
@@ -146,8 +147,8 @@ def test_rectangle_theta_quantity():
     theta = Angle(90 * u.deg)
     aper3 = RectangularAperture(POSITIONS, w=10.0, h=5.0, theta=theta)
 
-    assert aper1._theta_radians == aper2._theta_radians
-    assert aper1._theta_radians == aper3._theta_radians
+    assert_quantity_allclose(aper1.theta, aper2.theta)
+    assert_quantity_allclose(aper1.theta, aper3.theta)
 
 
 def test_rectangle_annulus_theta_quantity():
@@ -160,5 +161,5 @@ def test_rectangle_annulus_theta_quantity():
     aper3 = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
                                theta=theta)
 
-    assert aper1._theta_radians == aper2._theta_radians
-    assert aper1._theta_radians == aper3._theta_radians
+    assert_quantity_allclose(aper1.theta, aper2.theta)
+    assert_quantity_allclose(aper1.theta, aper3.theta)


### PR DESCRIPTION
The ``theta`` attribute of ``EllipticalAperture``, ``EllipticalAnnulus``, ``RectangularAperture``, and ``RectangularAnnulus`` is now always returned as an angular ``Quantity``.