### PR TITLE
Fix initial Gaussian theta units for centroid_2dg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.centroids``
+
+  - Fixed an issue with the initial Gaussian theta units in
+    ``centroid_2dg``. [#2013]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/docs/user_guide/centroids.rst
+++ b/docs/user_guide/centroids.rst
@@ -89,7 +89,7 @@ centroiding functions::
 
     >>> x4, y4 = centroid_2dg(data)
     >>> print(np.array((x4, y4)))  # doctest: +FLOAT_CMP
-    [19.98519436 20.0149016 ]
+    [19.9851944  20.01490157]
 
 The measured centroids are all very close to the true centroid of the object
 in the cutout image of ``(20, 20)``.

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -201,7 +201,7 @@ def centroid_2dg(data, error=None, mask=None):
     >>> data = data[40:80, 70:110]
     >>> x1, y1 = centroid_2dg(data)
     >>> print(np.array((x1, y1)))
-    [19.98519436 20.0149016 ]
+    [19.9851944  20.01490157]
 
     .. plot::
 
@@ -270,7 +270,7 @@ def centroid_2dg(data, error=None, mask=None):
                         y_mean=props.ycentroid,
                         x_stddev=props.semimajor_sigma.value,
                         y_stddev=props.semiminor_sigma.value,
-                        theta=props.orientation.value)
+                        theta=props.orientation)
 
     # Gaussian2D [x/y]_stddev are bounded to be strictly positive
     fitter = TRFLSQFitter()


### PR DESCRIPTION
This PR fixed an issue with the initial Gaussian theta units in ``centroid_2dg``.  The Gaussian was given theta as a unitless value in degrees.  Without units, the Gaussian expects the value to be radians.  This PR updates the initialization to use the Quantity angle value.

Many thanks to @Lyalpha for reporting this issue in #2012.

Fixes #2012.