### PR TITLE
Update progress_bar description in doc strings

### DIFF
--- a/photutils/datasets/images.py
+++ b/photutils/datasets/images.py
@@ -159,8 +159,6 @@ def make_model_image(shape, model, params_table, *, model_shape=None,
         Whether to display a progress bar while adding the sources
         to the image. The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
-        Note that the progress bar does not currently work in the
-        Jupyter console due to limitations in ``tqdm``.
 
     Returns
     -------

--- a/photutils/psf/epsf.py
+++ b/photutils/psf/epsf.py
@@ -276,8 +276,6 @@ class EPSFBuilder:
         Whether to print the progress bar during the build
         iterations. The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
-        Note that the progress bar does not currently work in the
-        Jupyter console due to limitations in ``tqdm``.
 
     norm_radius : float, optional
         The pixel radius over which the ePSF is normalized.

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -265,8 +265,6 @@ class PSFPhotometry(ModelImageMixin):
         Whether to display a progress bar when fitting the sources
         (or groups). The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
-        Note that the progress bar does not currently work in the
-        Jupyter console due to limitations in ``tqdm``.
 
     Notes
     -----
@@ -1565,8 +1563,6 @@ class IterativePSFPhotometry(ModelImageMixin):
         Whether to display a progress bar when fitting the sources
         (or groups). The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
-        Note that the progress bar does not currently work in the
-        Jupyter console due to limitations in ``tqdm``.
 
     Notes
     -----

--- a/photutils/psf/simulation.py
+++ b/photutils/psf/simulation.py
@@ -68,9 +68,7 @@ def make_psf_model_image(shape, psf_model, n_sources, *, model_shape=None,
     progress_bar : bool, optional
         Whether to display a progress bar when creating the sources. The
         progress bar requires that the `tqdm <https://tqdm.github.io/>`_
-        optional dependency be installed. Note that the progress
-        bar does not currently work in the Jupyter console due to
-        limitations in ``tqdm``.
+        optional dependency be installed.
 
     **kwargs
         Keyword arguments are accepted for additional model parameters.

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -240,8 +240,6 @@ class SourceCatalog:
         ``fluxfrac_radius``, ``circular_photometry``, ``centroid_win``,
         ``centroid_quad``). The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
-        Note that the progress bar does not currently work in the
-        Jupyter console due to limitations in ``tqdm``.
 
     Notes
     -----

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -126,9 +126,7 @@ def deblend_sources(data, segment_img, npixels, *, labels=None, nlevels=32,
         deblended. If multiprocessing is used (``nproc > 1``), the ID
         shown is the last source label that was deblended. The progress
         bar requires that the `tqdm <https://tqdm.github.io/>`_ optional
-        dependency be installed. Note that the progress bar does not
-        currently work in the Jupyter console due to limitations in
-        ``tqdm``.
+        dependency be installed.
 
     Returns
     -------

--- a/photutils/segmentation/finder.py
+++ b/photutils/segmentation/finder.py
@@ -98,12 +98,11 @@ class SourceFinder:
     progress_bar : bool, optional
         Whether to display a progress bar. If ``nproc = 1``, then the
         ID shown after the progress bar is the source label being
-        deblended. If multiprocessing is used (``nproc > 1``), the ID
-        shown is the last source label that was deblended. The progress
-        bar requires that the `tqdm <https://tqdm.github.io/>`_ optional
-        dependency be installed. Note that the progress bar does not
-        currently work in the Jupyter console due to limitations in
-        ``tqdm``. This keyword is ignored unless ``deblend=True``.
+        deblended. If multiprocessing is used (``nproc > 1``), the
+        ID shown is the last source label that was deblended. The
+        progress bar requires that the `tqdm <https://tqdm.github.io/>`_
+        optional dependency be installed. This keyword is ignored unless
+        ``deblend=True``.
 
     See Also
     --------

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -80,8 +80,7 @@ class ImageDepth:
     progress_bar : bool, optional
         Whether to display a progress bar. The progress bar requires
         that the `tqdm <https://tqdm.github.io/>`_ optional dependency
-        be installed. Note that the progress bar does not currently work
-        in the Jupyter console due to limitations in ``tqdm``.
+        be installed.
 
     Attributes
     ----------


### PR DESCRIPTION
I've tested that the `tqdm` progress bars now work in a Jupyter console with `tqdm.auto`.