### PR TITLE
Fix error raised due to naming scheme for NIRCam SW STDPSFs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ Bug Fixes
   - Fixed an issue with the initial Gaussian theta units in
     ``centroid_2dg``. [#2013]
 
+- ``photutils.psf``
+
+  - Adapt ``psf.GriddedPSFModel.read()`` to the changed STDPSF file name
+    convention for NIRCam's short wavelength channel. [#2017]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -373,6 +373,10 @@ def _get_metadata(filename, detector_id):
         return None  # filename from astropy download_file
 
     detector, filter_name = parts[1:3]
+    if (inst_det[1] == 'NRCSW') and ('~jayander' in filename.split('/')): 
+        #Fix bug with the Jay Anderson NIRCam short wavelength STDPSFs
+        filter_name, detector = parts[1:3]
+        
     meta = {'STDPSF': filename,
             'detector': detector,
             'filter': filter_name}

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -374,7 +374,7 @@ def _get_metadata(filename, detector_id):
 
     detector, filter_name = parts[1:3]
     if ('SWC' in filename.split('/')) and ('~jayander' in filename.split('/')):
-        #Fix bug with the Jay Anderson NIRCam short wavelength STDPSFs
+        # Fix bug with the Jay Anderson NIRCam short wavelength STDPSFs
         filter_name, detector = parts[1:3]
         
     meta = {'STDPSF': filename,

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -373,7 +373,7 @@ def _get_metadata(filename, detector_id):
         return None  # filename from astropy download_file
 
     detector, filter_name = parts[1:3]
-    if (inst_det[1] == 'NRCSW') and ('~jayander' in filename.split('/')): 
+    if ('SWC' in filename.split('/')) and ('~jayander' in filename.split('/')):
         #Fix bug with the Jay Anderson NIRCam short wavelength STDPSFs
         filter_name, detector = parts[1:3]
         


### PR DESCRIPTION
The filter name and detector ID are swapped in Jay Anderson's short wavelength NIRCam STDPSFs. This is a quick bug fix to swap the order of the arguments after checking that the STDPSFs are being pulled from the STScI site and are for the NIRCam short wavelength channel.

As a test, the following code, which previously would have raised an error (`ValueError: Unknown detector F115W.`) should now work:

```
from photutils.psf import GriddedPSFModel
url = 'https://www.stsci.edu/~jayander/JWST1PASS/LIB/PSFs/STDPSFs/NIRCam/SWC/F115W/STDPSF_F115W_NRCA2.fits'
det = 2
model = GriddedPSFModel.read(filename = url, detector_id = det, format= 'stdpsf')
```

I will note that this fix is limited to users who provide the filename via URL, not those who provide a path to a locally downloaded STDPSF file. This was an explicit condition on swapping the detector and filter values to prevent causing issues for users who are providing files with the traditional naming scheme.