### PR TITLE
Raise error for non-finite errors in PSF fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- ``photutils.psf``
+
+  - ``PSFPhotometry`` and ``IterativePSFPhotometry`` now raise an error
+    if the input ``error`` array contains non-finite or zero values.
+    [#2022]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1073,7 +1073,14 @@ class PSFPhotometry(ModelImageMixin):
             psf_model = self._make_psf_model(sources_)
             yi, xi, cutout = self._define_fit_data(sources_, data, mask)
 
-            weights = 1.0 / error[yi, xi] if error is not None else None
+            if error is not None:
+                weights = 1.0 / error[yi, xi]
+                if np.any(~np.isfinite(weights)):
+                    raise ValueError('Fit weights contain a non-finite '
+                                     'value. Check the input error array '
+                                     'for any zeros or non-finite values.')
+            else:
+                weights = None
 
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', AstropyUserWarning)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -281,6 +281,22 @@ def test_psf_photometry_nddata(test_data):
     assert resid_data3.unit == unit
 
 
+def test_psf_photometry_finite_weights(test_data):
+    data, _, sources = test_data
+    error = np.zeros_like(data)
+
+    psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    fit_shape = (5, 5)
+    finder = DAOStarFinder(6.0, 2.0)
+    psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
+                            aperture_radius=4)
+    match1 = 'divide by zero'
+    match2 = 'Fit weights contain a non-finite value'
+    with (pytest.warns(RuntimeWarning, match=match1),
+          pytest.raises(ValueError, match=match2)):
+        _ = psfphot(data, error=error)
+
+
 def test_model_residual_image(test_data):
     data, error, _ = test_data
 


### PR DESCRIPTION
With this PR ``PSFPhotometry`` and ``IterativePSFPhotometry`` now raise an error if the input ``error`` array contains non-finite or zero values.  Such values cause the fit weights to be non-finite, resulting in an error from the astropy fitter.