### PR TITLE
Add array keyword to SourceCatalog make_cutouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ New Features
     if the input ``error`` array contains non-finite or zero values.
     [#2022]
 
+- ``photutils.segmentation``
+
+  - An optional ``array`` keyword was added to the ``SourceCatalog``
+    ``make_cutouts`` method. [#2023]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -3660,7 +3660,8 @@ class SourceCatalog:
         return result
 
     @as_scalar
-    def make_cutouts(self, shape, mode='partial', fill_value=np.nan):
+    def make_cutouts(self, shape, *, array=None, mode='partial',
+                     fill_value=np.nan):
         """
         Make cutout arrays for each source.
 
@@ -3672,6 +3673,14 @@ class SourceCatalog:
         ----------
         shape : 2-tuple
             The cutout shape along each axis in ``(ny, nx)`` order.
+
+        array : `None` or 2D `~numpy.ndarray`
+            A 2D array with the same shape as the ``data`` array input
+            to `~photutils.segmentation.SourceCatalog`. If `None` then
+            the ``data`` array will be used. If any cutout arrays
+            are not fully contained within the ``array`` array and
+            ``mode='partial'`` with ``fill_value=np.nan``, then the
+            input ``array`` must have a float data type.
 
         mode : {'partial', 'trim'}, optional
             The mode used for extracting the cutout array. In
@@ -3698,6 +3707,11 @@ class SourceCatalog:
             cutout will be `None` where the source `centroid` position
             is not finite or where the source is completely masked.
         """
+        if array is None:
+            array = self._data
+        elif array.shape != self._data.shape:
+            raise ValueError('array must have the same shape as data')
+
         if mode not in ('partial', 'trim'):
             raise ValueError('mode must be "partial" or "trim"')
 
@@ -3710,7 +3724,7 @@ class SourceCatalog:
                 cutouts.append(None)
                 continue
 
-            cutouts.append(CutoutImage(self._data, (ycen, xcen), shape,
+            cutouts.append(CutoutImage(array, (ycen, xcen), shape,
                                        mode=mode, fill_value=fill_value))
 
         return cutouts

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -844,7 +844,19 @@ class TestSourceCatalog:
 
         assert len(cutouts) == len(cat)
         assert isinstance(cutouts[1], CutoutImage)
-        assert cutouts[1].data.shape == shape
+        for cutout in cutouts:
+            assert cutout.data.shape == shape
+
+        # test making cutouts from an input image
+        image = np.ones(data.shape)
+        cutouts = cat.make_cutouts(shape, array=image, mode='partial')
+        for cutout in cutouts:
+            assert np.all(cutout.data[np.isfinite(cutout.data)] == 1)
+            assert cutout.data.shape == shape
+
+        match = 'array must have the same shape as data'
+        with pytest.raises(ValueError, match=match):
+            cat.make_cutouts(shape, array=np.ones((3, 3)), mode='partial')
 
         obj = cat[1]
         cut = obj.make_cutouts(shape)

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -74,6 +74,12 @@ class CutoutImage:
         the original ``data`` array. If `True`, then the cutout data
         will hold a copy of the original ``data`` array.
 
+    Notes
+    -----
+    If the cutout array is not fully contained within the input ``data``
+    array and ``mode='partial'`` with ``fill_value=np.nan``, then the
+    input ``data`` must have a float data type.
+
     Examples
     --------
     >>> import numpy as np


### PR DESCRIPTION
This PR adds an optional ``array`` keyword to the ``SourceCatalog`` ``make_cutouts`` method to allow making cutouts from other arrays than the input science array to `SourceCatalog`.