### PR TITLE
Remove sphinx nitpick-exceptions

### DIFF
--- a/docs/nitpick-exceptions.txt
+++ b/docs/nitpick-exceptions.txt
@@ -1,9 +1,0 @@
-# these are needed if photutils.psf automodapi uses ":inherited-members:"
-py:class CompoundModel
-py:class Model
-py:obj CompoundModel
-py:obj Model.evaluate
-py:obj Model.inputs
-py:obj Model.outputs
-py:obj Model.bounding_box
-py:obj custom_model


### PR DESCRIPTION
The warnings from the inherited astropy model classes are no longer emitted.