### PR TITLE
Fix bug in fit_2dgaussian and fit_fwhm when the input data contains NaN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,11 @@ Bug Fixes
   - Fixed an issue with the initial Gaussian theta units in
     ``centroid_2dg``. [#2013]
 
+- ``photutils.psf``
+
+  - Fixed a bug in ``fit_2dgaussian`` and ``fit_fwhm`` where the fit
+    would fail if there were NaN values in the input data. [#2030]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -47,6 +47,24 @@ def test_fit_2dgaussian_single(fix_fwhm):
         assert 'fwhm_fit' in fit_tbl.colnames
         assert_allclose(fit_tbl['fwhm_fit'], fwhm)
 
+    # test with NaNs
+    data[22, 29] = np.nan
+    match = 'Input data contains non-finite values'
+    match = 'Input data contains unmasked non-finite values'
+    with pytest.warns(AstropyUserWarning, match=match):
+        fit = fit_2dgaussian(data, fwhm=3, fix_fwhm=fix_fwhm)
+    fit_tbl = fit.results
+    assert isinstance(fit_tbl, QTable)
+    assert len(fit_tbl) == 1
+
+    # test with NaNs and mask
+    data[22, 29] = np.nan
+    mask = np.isnan(data)
+    fit = fit_2dgaussian(data, fwhm=3, fix_fwhm=fix_fwhm, mask=mask)
+    fit_tbl = fit.results
+    assert isinstance(fit_tbl, QTable)
+    assert len(fit_tbl) == 1
+
 
 @pytest.mark.parametrize(('fix_fwhm', 'with_units'),
                          [(False, True), (True, False)])

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -191,8 +191,11 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
     # prevent circular import
     from photutils.psf.photometry import PSFPhotometry
 
+    # mask non-finite values
+    mask = _make_mask(data, mask)
+
     if xypos is None:
-        xypos = centroid_com(data)
+        xypos = centroid_com(data, mask=mask)
     xypos = np.atleast_2d(xypos)
 
     if fit_shape is None:
@@ -204,7 +207,8 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
     flux_init = []
     for yxpos in xypos[:, ::-1]:
         cutout = CutoutImage(data, yxpos, tuple(fit_shape))
-        flux_init.append(np.sum(cutout.data))
+        cutout = cutout.data[np.isfinite(cutout.data)]
+        flux_init.append(np.nansum(cutout))
 
     if isinstance(data, Quantity):
         flux_init <<= data.unit


### PR DESCRIPTION
The PR fixes a bug in ``fit_2dgaussian`` and ``fit_fwhm`` where the fit would fail if there were NaN values in the input data.

Many thanks to @mwcraig for reporting this in #2029!

Fixes #2029.