### PR TITLE
Improve description of normalization for PSF image-based models

### DIFF
--- a/docs/user_guide/psf.rst
+++ b/docs/user_guide/psf.rst
@@ -207,7 +207,7 @@ You can also create your own custom PSF model using the Astropy modeling
 framework. The PSF model must be a 2D model that is a subclass of
 `~astropy.modeling.Fittable2DModel`. It must have parameters called
 ``x_0``, ``y_0``, and ``flux``, specifying the central position and
-total integrated flux, and it should be normalized to unit flux.
+total integrated flux.
 
 
 Analytic PSF Models

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -49,14 +49,8 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
         of ``(N_psf, ePSF_ny, ePSF_nx)``. The length of the x and y axes
         must both be at least 4. All elements of the input image data
         must be finite. The PSF peak is assumed to be located at the
-        center of the input image. The array must be normalized so that
-        the total flux of a source is 1.0. This means that the sum of
-        the values in the input image PSF over an infinite grid is 1.0.
-        In practice, the sum of the data values in the input image may
-        be less than 1.0 if the input image only covers a finite region
-        of the PSF. These correction factors can be estimated from the
-        ensquared or encircled energy of the PSF based on the size of
-        the input image.
+        center of the input image. Please see the Notes section below
+        for details on the normalization of the input image data.
 
         The meta attribute must be dictionary containing the following:
 
@@ -98,6 +92,23 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
 
     Notes
     -----
+    The fitted PSF model flux represents the total flux of the source,
+    assuming the input image was properly normalized. This flux is
+    determined as a multiplicative scale factor applied to the input
+    image PSF, after accounting for any oversampling. Theoretically,
+    the sum of all values in the PSF image over an infinite grid should
+    equal 1.0 (assuming no oversampling). However, when the PSF is
+    represented over a finite region, the sum of the values may be less
+    than 1.0. For oversampled PSF images, the normalization should be
+    adjusted so that the sum of the array values equals the product
+    of the oversampling factors (e.g., oversampling squared if the
+    oversampling is the same along both axes). If the input image only
+    covers a finite region of the PSF, the sum may again be less than
+    the product of the oversampling factors. Correction factors based on
+    the encircled or ensquared energy of the PSF can be used to estimate
+    the proper scaling for the finite region of the input PSF image and
+    ensure correct flux normalization.
+
     Internally, the grid of ePSFs will be arranged and stored such that
     it is sorted first by the y reference pixel coordinate and then by
     the x reference pixel coordinate.

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -39,14 +39,8 @@ class ImagePSF(Fittable2DModel):
         must both be at least 4. All elements of the input image data
         must be finite. By default, the PSF peak is assumed to be
         located at the center of the input image (see the ``origin``
-        keyword). The array must be normalized so that the total flux
-        of a source is 1.0. This means that the sum of the values in
-        the input image PSF over an infinite grid is 1.0. In practice,
-        the sum of the data values in the input image may be less than
-        1.0 if the input image only covers a finite region of the PSF.
-        These correction factors can be estimated from the ensquared
-        or encircled energy of the PSF based on the size of the input
-        image.
+        keyword). Please see the Notes section below for details on the
+        normalization of the input image data.
 
     flux : float, optional
         The total flux of the source, assuming the input image
@@ -91,6 +85,25 @@ class ImagePSF(Fittable2DModel):
     See Also
     --------
     GriddedPSFModel : A model for a grid of ePSF models.
+
+    Notes
+    -----
+    The fitted PSF model flux represents the total flux of the source,
+    assuming the input image was properly normalized. This flux is
+    determined as a multiplicative scale factor applied to the input
+    image PSF, after accounting for any oversampling. Theoretically,
+    the sum of all values in the PSF image over an infinite grid should
+    equal 1.0 (assuming no oversampling). However, when the PSF is
+    represented over a finite region, the sum of the values may be less
+    than 1.0. For oversampled PSF images, the normalization should be
+    adjusted so that the sum of the array values equals the product
+    of the oversampling factors (e.g., oversampling squared if the
+    oversampling is the same along both axes). If the input image only
+    covers a finite region of the PSF, the sum may again be less than
+    the product of the oversampling factors. Correction factors based on
+    the encircled or ensquared energy of the PSF can be used to estimate
+    the proper scaling for the finite region of the input PSF image and
+    ensure correct flux normalization.
 
     Examples
     --------


### PR DESCRIPTION
This PR improves description of normalization for PSF image-based models, including the oversampling factor.

Thanks to @laldoroty for reporting this in #2031.

Closes #2031
Closes #859