### PR TITLE
Allow single ePSF in GriddedPSFModel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New Features
     if the input ``error`` array contains non-finite or zero values.
     [#2022]
 
+  - ``GriddedPSFModel`` can now be used with a single input ePSF model,
+    which will be equivalent to ``ImagePSF``. [#2034]
+
 - ``photutils.segmentation``
 
   - An optional ``array`` keyword was added to the ``SourceCatalog``

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -52,6 +52,10 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
         center of the input image. Please see the Notes section below
         for details on the normalization of the input image data.
 
+        If the N_psf is 1, the model will be evaluated using the single
+        ePSF image at every (x, y) position. This is equivalent to using
+        the `~photutils.psf.ImagePSF` model with the single ePSF.
+
         The meta attribute must be dictionary containing the following:
 
         * ``'grid_xypos'``: A list of the (x, y) grid positions of
@@ -581,7 +585,13 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
         xi += self.origin[0]
         yi += self.origin[1]
 
-        evaluated_model = flux * self._calc_model_values(x_0, y_0, xi, yi)
+        if self.data.shape[0] == 1:
+            # if there is only one ePSF, we do not need to perform
+            # the bilinear interpolation
+            evaluated_model = flux * self._calc_interpolator(0)(xi, yi,
+                                                                grid=False)
+        else:
+            evaluated_model = flux * self._calc_model_values(x_0, y_0, xi, yi)
 
         if self.fill_value is not None:
             # set pixels that are outside the input pixel grid to the

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -419,16 +419,29 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
 
         The resulting interpolator is cached in the `_interpolator`
         dictionary for reuse.
+
+        Parameters
+        ----------
+        grid_idx : int
+            The index of the ePSF image in the reference grid.
+
+        Returns
+        -------
+        interp : `~scipy.interpolate.RectBivariateSpline`
+            The interpolator for the input ePSF image.
         """
-        xypos = tuple(self.grid_xypos[grid_idx])
-        if xypos in self._interpolator:
-            return self._interpolator[xypos]
+        # check if the interpolator is already cached
+        if grid_idx in self._interpolator:
+            return self._interpolator[grid_idx]
 
         # RectBivariateSpline expects the data to be in (x, y) axis order
         data = self.data[grid_idx]
         interp = RectBivariateSpline(*self._interp_xyidx, data.T, kx=3, ky=3,
                                      s=0)
-        self._interpolator[xypos] = interp
+
+        # cache the interpolator for reuse
+        self._interpolator[grid_idx] = interp
+
         return interp
 
     def _find_bounding_points(self, x, y):

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -83,6 +83,22 @@ class TestGriddedPSFModel:
         with pytest.raises(ValueError, match=match):
             psfmodel.evaluate(x=x2, y=y2, flux=100, x_0=40, y_0=60)
 
+    def test_gridded_psf_model_single_psf(self, psfmodel):
+        psfmodel = psfmodel.copy()
+        psfmodel.data = psfmodel.data[0:1, :, :]
+        assert psfmodel(0, 0) == 1
+        assert psfmodel(100, 100) == 0
+        assert_allclose(psfmodel([0, 100], [0, 100]), [1, 0])
+
+        y, x = np.mgrid[0:100, 0:100]
+        psf = psfmodel.evaluate(x=x, y=y, flux=100, x_0=40, y_0=60)
+        assert psf.shape == (100, 100)
+
+        _, y2, x2 = np.mgrid[0:100, 0:100, 0:100]
+        match = 'x and y must be 1D or 2D'
+        with pytest.raises(ValueError, match=match):
+            psfmodel.evaluate(x=x2, y=y2, flux=100, x_0=40, y_0=60)
+
     def test_gridded_psf_model_eval_outside_grid(self, psfmodel):
         y, x = np.mgrid[-50:50, -50:50]
         psf1 = psfmodel.evaluate(x=x, y=y, flux=100, x_0=0, y_0=0)


### PR DESCRIPTION
With the PR, ``GriddedPSFModel`` can now be used with a single input ePSF model, which will be equivalent to ``ImagePSF``.