### PR TITLE
Make the GriddedPSFModel data and grid_xypos attributes read-only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,11 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.psf``
+
+  - The ``GriddedPSFModel`` ``data`` and ``grid_xypos`` attributes are
+    now read-only. [#2036]
+
 
 2.2.0 (2025-02-18)
 ------------------

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -131,7 +131,7 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
     def __init__(self, nddata, *, flux=flux.default, x_0=x_0.default,
                  y_0=y_0.default, fill_value=0.0):
 
-        self.data, self.grid_xypos = self._define_grid(nddata)
+        self._data, self._grid_xypos = self._define_grid(nddata)
         self._meta = nddata.meta.copy()  # _meta to avoid the meta descriptor
         self._oversampling = as_pair('oversampling',
                                      nddata.meta['oversampling'],
@@ -289,6 +289,28 @@ class GriddedPSFModel(ModelGridPlotMixin, Fittable2DModel):
 
     def __str__(self):
         return self._format_str(keywords=self._cls_info())
+
+    @property
+    def data(self):
+        """
+        The 3D array of ePSFs.
+
+        The shape is ``(N_psf, ePSF_ny, ePSF_nx)``.
+        """
+        return self._data
+
+    @property
+    def grid_xypos(self):
+        """
+        The (x, y) positions of the ePSFs.
+
+        The order of positions should match the first axis of the 3D
+        `~numpy.ndarray` of ePSFs. In other words, ``grid_xypos[i]``
+        should be the (x, y) position of the reference ePSF defined in
+        ``nddata.data[i]``. The grid positions must form a rectangular
+        grid.
+        """
+        return self._grid_xypos
 
     def copy(self):
         """

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -69,6 +69,13 @@ class TestGriddedPSFModel:
         xypos = grid_xypos[idx]
         assert_allclose(xypos, grid_xypos)
 
+        # check that data and grid_xypos attributes are read-only
+        match = 'object has no setter'
+        with pytest.raises(AttributeError, match=match):
+            psfmodel.data = np.ones((4, 5, 5))
+        with pytest.raises(AttributeError, match=match):
+            psfmodel.grid_xypos = [[0, 0], [1, 1]]
+
     def test_gridded_psf_model_basic_eval(self, psfmodel):
         assert psfmodel(0, 0) == 1
         assert psfmodel(100, 100) == 0
@@ -85,7 +92,7 @@ class TestGriddedPSFModel:
 
     def test_gridded_psf_model_single_psf(self, psfmodel):
         psfmodel = psfmodel.copy()
-        psfmodel.data = psfmodel.data[0:1, :, :]
+        psfmodel._data = psfmodel.data[0:1, :, :]
         assert psfmodel(0, 0) == 1
         assert psfmodel(100, 100) == 0
         assert_allclose(psfmodel([0, 100], [0, 100]), [1, 0])


### PR DESCRIPTION
With this PR, the `GriddedPSFModel``data` and `grid_xypos` attributes are now read-only.  These two attributes are closely coupled and making them read-only prevents them from becoming unsynced.  Instead, one can create a new `GriddedPSFModel`.