### PR TITLE
Fix not appending to extra_properties when overwrite=True in SourceCatalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,12 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.segmentation``
+
+  - Fixed an issue where a newly-defined extra property of a
+    ``SourceCatalog`` with ``overwrite=True`` would not be added to
+    the ``extra_properties`` attribute.
+
 - ``photutils.centroids``
 
   - Fixed an issue with the initial Gaussian theta units in

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -659,7 +659,7 @@ class SourceCatalog:
                              'property.')
 
         setattr(self, name, value)
-        if not overwrite:
+        if name not in self._extra_properties:
             self._extra_properties.append(name)
 
     def remove_extra_property(self, name):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -737,6 +737,9 @@ class TestSourceCatalog:
         assert cat._has_len([1, 2, 3])
         assert not cat._has_len('test_string')
 
+        cat.add_extra_property('segment_snr4', segment_snr, overwrite=True)
+        cat.add_extra_property('segment_snr4', segment_snr, overwrite=True)
+
     def test_extra_properties_invalid(self):
         cat = SourceCatalog(self.data, self.segm)
         match = 'value must have the same number of elements as the catalog'


### PR DESCRIPTION
When adding a new property to an existing `SourceCatalog` instance with `add_extra_property(..., overwrite=True`), it is not appended to the `_extra_properties` attribute, even if it doesn't already exist, due to: https://github.com/astropy/photutils/blob/0977e52be71ce0c30db8a575ae6ae46efa8f1ab4/photutils/segmentation/catalog.py#L662-L663

If one tries to then overwrite this new property, an unexpected error message occurs as this condition is triggered: https://github.com/astropy/photutils/blob/0977e52be71ce0c30db8a575ae6ae46efa8f1ab4/photutils/segmentation/catalog.py#L628-L630

This update will always append the new property to the `_extra_properties` attribute if it doesn't exist, regardless of `overwrite`, which would be the behaviour at least I was expecting. Apologies if I've misread the intent of this.

This alleviates the use case where one wants to perform an "update or create" action for property that may be called again. Currently this requires checking if the property already exists.

