### PR TITLE
add catalog option to make_model_image

### DIFF
--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -42,10 +42,10 @@ class ModelImageMixin:
     residuals.
     """
 
-    def make_model_image(self, shape, psf_shape=None, include_localbkg=False):
+    def make_model_image(self, shape, psf_shape=None, include_localbkg=False, model_params=None):
         """
-        Create a 2D image from the fit PSF models and optional local
-        background.
+        Create a 2D image from the fit PSF models or a provided catalog 
+        and optional local background.
 
         Parameters
         ----------
@@ -67,6 +67,12 @@ class ModelImageMixin:
             ``psf_shape``. Thus, regions where the ``psf_shape`` of
             sources overlap will have the local background added
             multiple times.
+
+        model_params : `~astropy.table.Table`, optional
+            A table of objects to simulate using the PSF model.
+            The table must contain columns that match those output
+            of fitting, typically `x_0`, `y_0`, and `flux`.
+            If `None`, the most recent fit will be used.
 
         Returns
         -------
@@ -102,7 +108,8 @@ class ModelImageMixin:
                 fit_params = self.fit_results[-1]._fit_model_params
                 local_bkgs = self.fit_results[-1].init_params['local_bkg']
 
-        model_params = fit_params
+        if model_params is None:
+            model_params = fit_params
 
         if include_localbkg:
             # add local_bkg


### PR DESCRIPTION
This PR does something quite simple: it adds a `model_params` option to `make_model_image`.  It still requires several thinks to be ready to be un-drafted:

- [ ] Add the option to the subclass' use of `make_model_image`
- [ ] Tests
- [ ] Asimple example in the docs?

Before I do any of these though, a key question for @larrybradley : do you like this idea or do you think there's a better way to do this?

The context is that I was talking to a photutils user who wanted to add simulated stars to an image, and they naturally came to the `psf` machinery and expected to find a way to do it here. A couple of alternatives are available though: 1) just tell people to use `datasets.make_model_image`. I could modify this in that case to just be a documentation change that shows how to do this starting from a PSF. 2) add something to the PSF base classes instead of expecting them to build a photometry object even though they aren't necessarily planning to do photometry.