### PR TITLE
Fix centroid_com corner-case bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,10 @@ Bug Fixes
   - Fixed an issue with the initial Gaussian theta units in
     ``centroid_2dg``. [#2013]
 
+  - Fixed a corner-case issue where zero-sum arrays with ndim > 2 input
+    to ``centroid_com`` would return only two np.nan coordinates instead
+    of matching the dimensionality of the input array. [#2045]
+
 - ``photutils.psf``
 
   - Fixed a bug in ``fit_2dgaussian`` and ``fit_fwhm`` where the fit

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -87,7 +87,7 @@ def centroid_com(data, mask=None):
 
     total = np.sum(data)
     if total == 0:
-        return np.array((np.nan, np.nan))
+        return np.full(data.ndim, np.nan)
 
     indices = np.ogrid[tuple(slice(0, i) for i in data.shape)]
 

--- a/photutils/centroids/core.py
+++ b/photutils/centroids/core.py
@@ -222,6 +222,8 @@ def centroid_quadratic(data, xpeak=None, ypeak=None, fit_boxsize=5,
 
     # preserve input data - which should be a small cutout image
     data = np.asanyarray(data, dtype=float).copy()
+    if data.ndim != 2:
+        raise ValueError('data must be a 2D array')
     ny, nx = data.shape
 
     badmask = ~np.isfinite(data)

--- a/photutils/centroids/gaussian.py
+++ b/photutils/centroids/gaussian.py
@@ -72,6 +72,8 @@ def centroid_1dg(data, error=None, mask=None):
     (data, error), _ = process_quantities((data, error), ('data', 'error'))
 
     data = np.ma.asanyarray(data)
+    if data.ndim != 2:
+        raise ValueError('data must be a 2D array')
 
     if mask is not None and mask is not np.ma.nomask:
         mask = np.asanyarray(mask)
@@ -225,6 +227,8 @@ def centroid_2dg(data, error=None, mask=None):
     (data, error), _ = process_quantities((data, error), ('data', 'error'))
 
     data = np.ma.asanyarray(data)
+    if data.ndim != 2:
+        raise ValueError('data must be a 2D array')
 
     if mask is not None and mask is not np.ma.nomask:
         mask = np.asanyarray(mask)

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -76,6 +76,15 @@ def test_centroid_comquad(test_simple_data, x_std, y_std, theta, units):
     assert_allclose((xc, yc), (xcen, ycen), rtol=0, atol=0.015)
 
 
+@pytest.mark.parametrize('ndim', [1, 2, 3, 4, 5])
+def test_centroid_com_zero_sum(ndim):
+    data = np.zeros([10] * ndim)
+    cen = centroid_com(data)
+    assert cen.shape == (ndim,)
+    for cen_ in cen:
+        assert np.isnan(cen_)
+
+
 @pytest.mark.parametrize('use_mask', [True, False])
 def test_centroid_comquad_nan_withmask(use_mask):
     xc_ref = 24.7

--- a/photutils/centroids/tests/test_core.py
+++ b/photutils/centroids/tests/test_core.py
@@ -195,6 +195,11 @@ def test_centroid_quadratic_npts():
 
 
 def test_centroid_quadratic_invalid_inputs():
+    data = np.zeros((4, 4, 4))
+    match = 'data must be a 2D array'
+    with pytest.raises(ValueError, match=match):
+        centroid_quadratic(data)
+
     data = np.zeros((4, 4))
     mask = np.zeros((2, 2), dtype=bool)
     match = 'xpeak and ypeak must both be input or "None"'
@@ -202,14 +207,17 @@ def test_centroid_quadratic_invalid_inputs():
         centroid_quadratic(data, xpeak=3, ypeak=None)
     with pytest.raises(ValueError, match=match):
         centroid_quadratic(data, xpeak=None, ypeak=3)
+
     match = 'fit_boxsize must have 1 or 2 elements'
     with pytest.raises(ValueError, match=match):
         centroid_quadratic(data, fit_boxsize=(2, 2, 2))
+
     match = 'fit_boxsize must have an odd value for both axes'
     with pytest.raises(ValueError, match=match):
         centroid_quadratic(data, fit_boxsize=(-2, 2))
     with pytest.raises(ValueError, match=match):
         centroid_quadratic(data, fit_boxsize=(2, 2))
+
     match = 'data and mask must have the same shape'
     with pytest.raises(ValueError, match=match):
         centroid_quadratic(data, mask=mask)

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -102,10 +102,16 @@ def test_centroids_nan_withmask(use_mask):
             assert len(warnlist) == nwarn
 
 
-def test_invalid_mask_shape():
+def test_invalid_shapes():
+    data = np.zeros((4, 4, 4))
+    match = 'data must be a 2D array'
+    with pytest.raises(ValueError, match=match):
+        centroid_1dg(data)
+    with pytest.raises(ValueError, match=match):
+        centroid_2dg(data)
+
     data = np.zeros((4, 4))
     mask = np.zeros((2, 2), dtype=bool)
-
     match = 'data and mask must have the same shape'
     with pytest.raises(ValueError, match=match):
         centroid_1dg(data, mask=mask)


### PR DESCRIPTION
This PR fixes a corner-case issue where zero-sum arrays with ndim > 2 input to ``centroid_com`` would return only two np.nan coordinates instead of matching the dimensionality of the input array.