### PR TITLE
Partial revert of limited API builds

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -112,6 +112,18 @@ jobs:
             allow_failure: true
             prefix: '(Allowed failure)'
 
+          - os: macos-latest
+            python: '3.13'
+            tox_env: 'py313-test-alldeps'
+            allow_failure: false
+            prefix: ''
+
+          - os: windows-latest
+            python: '3.13'
+            tox_env: 'py313-test-alldeps'
+            allow_failure: false
+            prefix: ''
+
     steps:
     - name: Check out repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,3 @@ convention = 'numpy'
 ignore-words-list = """
     ned,
 """
-
-[tool.distutils.bdist_wheel]
-py-limited-api = "cp311"


### PR DESCRIPTION
Similarly to https://github.com/astropy/regions/pull/602, this disables limited API builds but keeps the wheel build jobs merged since those changes are fine and not breaking.

I've also added MacOS and Windows CI Python 3.13 builds.

Fixes: #2051 