### PR TITLE
Re-enable limited api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
 requires = [
     'setuptools >= 77.0',
     'setuptools_scm >= 8.0',
-    'cython >= 3.1.0,<4',
+    'cython >= 3.1.2,<4',
     'numpy >= 2.0.0',
     'extension-helpers >= 1.3,<2',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,3 +309,6 @@ convention = 'numpy'
 ignore-words-list = """
     ned,
 """
+
+[tool.distutils.bdist_wheel]
+py-limited-api = "cp311"


### PR DESCRIPTION
This re-enables the limited API now that Cython 3.1.2 is out.

Since last time, we also have Python 3.13 builds on MacOS X and Windows, but @larrybradley feel free to also check locally that everything works fine.
