### PR TITLE
Raise ValueError if Background2D input is all non-finite values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,11 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- ``photutils.background``
+
+  - An explicit ``ValueError`` is now raised in the input ``data`` to
+    ``Background2D`` contains all non-finite values. [#2062]
+
 - ``photutils.psf``
 
   - The ``GriddedPSFModel`` ``data`` and ``grid_xypos`` attributes are


### PR DESCRIPTION
With this PR, an explicit ``ValueError`` is now raised in the input ``data`` to ``Background2D`` contains all non-finite values.