### PR TITLE
Fix segmentation patches in case of "invalid" shapely polygons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,8 +29,8 @@ New Features
   - An optional ``array`` keyword was added to the ``SourceCatalog``
     ``make_cutouts`` method. [#2023]
 
-  - Added a ``grouped`` keyword to the ``SegmentationImage``
-    ``to_regions`` method. [#2060]
+  - Added a ``group`` keyword to the ``SegmentationImage``
+    ``to_regions`` method. [#2060, #2065]]
 
 
 Bug Fixes

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1605,7 +1605,7 @@ class SegmentationImage:
 
         return patches
 
-    def to_regions(self, *, grouped=False):
+    def to_regions(self, *, group=False):
         """
         Return the `regions.Region` objects representing the source
         segments.
@@ -1614,12 +1614,12 @@ class SegmentationImage:
         of the source segments. Interior holes within the source
         segments are not included.
 
-        See the ``grouped`` keyword below for details about how
+        See the ``group`` keyword below for details about how
         non-contiguous segments for a single label are handled.
 
         Parameters
         ----------
-        grouped : bool, optional
+        group : bool, optional
             If `False` (the default), then a `regions.Regions`
             object will be returned with a flattened list of
             `~regions.PolygonPixelRegion` objects. Note that in this
@@ -1640,12 +1640,12 @@ class SegmentationImage:
         -------
         regions : `~regions.Regions`
             A list of `~regions.Region` objects or a `~regions.Regions`
-            object, depending on the value of ``grouped`` (see above).
+            object, depending on the value of ``group`` (see above).
 
         Notes
         -----
-        If ``grouped=False``, then the number of regions returned may
-        not be equal to the number of unique labels in the segmentation
+        If ``group=False``, then the number of regions returned may not
+        be equal to the number of unique labels in the segmentation
         image. This occurs when the segmentation image contains
         non-contiguous segments for a single label. That can happen as a
         result of slicing the segmentation image where a segment label
@@ -1662,10 +1662,10 @@ class SegmentationImage:
         for label, poly in zip(self.labels, self.polygons, strict=True):
             regions.append(_shapely_polygon_to_region(poly, label=int(label)))
 
-        if grouped:
+        if group:
             return regions
 
-        # If not grouped, return a Regions object with a flattened list
+        # If group=False, return a Regions object with a flattened list
         # of region objects
         flat_regions = []
         for region in regions:

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1415,6 +1415,15 @@ class SegmentationImage:
                 polys = [shape(poly) for poly in geo_polys]
                 polygons.append(MultiPolygon(polys))
 
+        # NOTE: the returned polygons may return False for
+        # is_valid due to ring self-intersections (e.g.,
+        # for corner-only intersections of two pixels). The
+        # shapely.validation.explain_validity function can be
+        # used to explain the validity of the polygons. The
+        # shapely.validation.make_valid function can be used to make the
+        # polygons valid, usually by converting Polygon objects into
+        # MultiPolyon objects.
+
         return polygons
 
     @staticmethod
@@ -1521,7 +1530,7 @@ class SegmentationImage:
 
         return [self._convert_shapely_to_pathpatch(geometry, origin=origin,
                                                    scale=scale, **patch_kwargs)
-                for geometry in self.polygons if geometry.is_valid]
+                for geometry in self.polygons]
 
     def plot_patches(self, *, ax=None, origin=(0, 0), scale=1.0, labels=None,
                      **kwargs):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -474,7 +474,7 @@ class TestSegmentationImage:
 
         segm = self.segm.copy()
         segm.reassign_labels(labels=4, new_label=1)
-        regions = segm.to_regions(grouped=True)
+        regions = segm.to_regions(group=True)
         assert isinstance(regions, list)
         assert isinstance(regions[0], Regions)
         assert isinstance(regions[1], PolygonPixelRegion)
@@ -580,7 +580,7 @@ class TestSegmentationImage:
         for region in regions:
             assert isinstance(region, PolygonPixelRegion)
 
-        regions = segm.to_regions(grouped=True)
+        regions = segm.to_regions(group=True)
         assert len(regions) == 5
         assert isinstance(regions, list)
         for region in regions:
@@ -602,7 +602,7 @@ class TestSegmentationImage:
         assert len(regions) == 7
         assert isinstance(regions, Regions)
         assert isinstance(regions[0], PolygonPixelRegion)
-        regions = segm.to_regions(grouped=True)
+        regions = segm.to_regions(group=True)
         assert len(regions) == 1
         assert isinstance(regions, list)
         assert isinstance(regions[0], Regions)

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -524,6 +524,28 @@ class TestSegmentationImage:
     @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
     @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_patches_corners(self):
+        """
+        Regression test for a bug where patches were not generated for
+        "invalid" Shapely polygons.
+
+        This occurs when two pixels within a segment intersect only at a
+        corner.
+        """
+        data = np.zeros((10, 10), dtype=np.uint32)
+        data[5, 5] = 1
+        data[4, 4] = 1
+        data[3, 3] = 1
+        segm = SegmentationImage(data)
+        assert segm.nlabels == 1
+        assert len(segm.segments) == 1
+        assert len(segm.polygons) == 1
+        assert len(segm.to_patches()) == 1
+        assert len(segm.to_regions()) == 1
+
+    @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_polygons_complex(self):
         """
         Test polygons, patches, and regions for segments that have holes


### PR DESCRIPTION
This PR fixes a bug where patches would not be returned for labels with "invalid" shapely polygons.  This happens when segments have pixels that intersect only at a corner (ring self-intersection).

This PR also renames the `grouped` keyword to `group` in the `to_regions` method (this affects dev only).