### PR TITLE
Fix user-defined group_id in PSFPhotometry init_params

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,9 @@ Bug Fixes
   - Fixed the check in ``GriddedPSFModel`` for rectangular pixel grids.
     [#2035]
 
+  - Fixed a bug in ``PSFPhotometry`` where the ``'group_id'`` would be
+    ignored if included in the ``init_params`` table. [#2070]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where a newly-defined extra property of a

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -680,14 +680,17 @@ class PSFPhotometry(ModelImageMixin):
             init_params[fluxcolname] = flux
 
         if 'group_id' in init_params.colnames:
-            # grouper is ignored if group_id is input in init_params
+            # user-provided group_id takes precedence; disable grouper
             self.grouper = None
-        if self.grouper is not None:
+        elif self.grouper is not None:
+            # no group_id in init_params, but a grouper is provided
             group_id = self.grouper(init_params[xcolname],
                                     init_params[ycolname])
+            init_params['group_id'] = group_id
         else:
-            group_id = init_params['id'].copy()
-        init_params['group_id'] = group_id
+            # no user-provided groups and no grouper; each source is
+            # its own group
+            init_params['group_id'] = init_params['id'].copy()
 
         # add columns for any additional parameters that are fit
         for param_name, colname in self._param_maps['init'].items():


### PR DESCRIPTION
This PR fixes a bug in ``PSFPhotometry`` where the ``'group_id'`` would be ignored if included in the ``init_params`` table.