### PR TITLE
Remove mutable default arguments

### DIFF
--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -11,10 +11,10 @@ import numpy as np
 from astropy.stats import SigmaClip, mad_std
 
 from photutils.extern.biweight import biweight_location, biweight_scale
+from photutils.utils._parameters import (SigmaClipSentinelDefault,
+                                         create_default_sigmaclip)
 from photutils.utils._repr import make_repr
 from photutils.utils._stats import nanmean, nanmedian, nanstd
-
-SIGMA_CLIP = SigmaClip(sigma=3.0, maxiters=10)
 
 __all__ = [
     'BackgroundBase',
@@ -31,23 +31,30 @@ __all__ = [
 ]
 
 
+SIGMA_CLIP = SigmaClipSentinelDefault(sigma=3.0, maxiters=10)
+
+
 class BackgroundBase(metaclass=abc.ABCMeta):
     """
     Base class for classes that estimate scalar background values.
 
     Parameters
     ----------
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
     """
 
     def __init__(self, sigma_clip=SIGMA_CLIP):
+        if sigma_clip is SIGMA_CLIP:
+            sigma_clip = create_default_sigmaclip(sigma=SIGMA_CLIP.sigma,
+                                                  maxiters=SIGMA_CLIP.maxiters)
+
         if not isinstance(sigma_clip, SigmaClip) and sigma_clip is not None:
             msg = 'sigma_clip must be an astropy SigmaClip instance or None'
             raise TypeError(msg)
+
         self.sigma_clip = sigma_clip
 
     def __repr__(self):
@@ -92,17 +99,21 @@ class BackgroundRMSBase(metaclass=abc.ABCMeta):
 
     Parameters
     ----------
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
     """
 
     def __init__(self, sigma_clip=SIGMA_CLIP):
+        if sigma_clip is SIGMA_CLIP:
+            sigma_clip = create_default_sigmaclip(sigma=SIGMA_CLIP.sigma,
+                                                  maxiters=SIGMA_CLIP.maxiters)
+
         if not isinstance(sigma_clip, SigmaClip) and sigma_clip is not None:
             msg = 'sigma_clip must be an astropy SigmaClip instance or None'
             raise TypeError(msg)
+
         self.sigma_clip = sigma_clip
 
     def __repr__(self):
@@ -148,11 +159,10 @@ class MeanBackground(BackgroundBase):
 
     Parameters
     ----------
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------
@@ -201,11 +211,10 @@ class MedianBackground(BackgroundBase):
 
     Parameters
     ----------
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------
@@ -261,11 +270,10 @@ class ModeEstimatorBackground(BackgroundBase):
     mean_factor : float, optional
         The multiplicative factor for the data mean. Defaults to 2.
 
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------
@@ -330,11 +338,10 @@ class MMMBackground(ModeEstimatorBackground):
 
     Parameters
     ----------
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------
@@ -378,11 +385,10 @@ class SExtractorBackground(BackgroundBase):
 
     Parameters
     ----------
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------
@@ -460,11 +466,10 @@ class BiweightLocationBackground(BackgroundBase):
         Initial guess for the biweight location. Default value is
         `None`.
 
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------
@@ -524,11 +529,10 @@ class StdBackgroundRMS(BackgroundRMSBase):
 
     Parameters
     ----------
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------
@@ -589,11 +593,10 @@ class MADStdBackgroundRMS(BackgroundRMSBase):
 
     Parameters
     ----------
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------
@@ -651,11 +654,10 @@ class BiweightScaleBackgroundRMS(BackgroundRMSBase):
         Initial guess for the biweight location. Default value is
         `None`.
 
-    sigma_clip : `astropy.stats.SigmaClip` object, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters. If `None` then no sigma clipping will
-        be performed. The default is to perform sigma clipping with
-        ``sigma=3.0`` and ``maxiters=10``.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Examples
     --------

--- a/photutils/background/local_background.py
+++ b/photutils/background/local_background.py
@@ -12,8 +12,6 @@ from photutils.utils._repr import make_repr
 
 __all__ = ['LocalBackground']
 
-BKG_ESTIMATOR_DEFAULT = MedianBackground()
-
 
 class LocalBackground:
     """
@@ -38,10 +36,11 @@ class LocalBackground:
         (i.e., sigma-clipped median).
     """
 
-    def __init__(self, inner_radius, outer_radius,
-                 bkg_estimator=BKG_ESTIMATOR_DEFAULT):
+    def __init__(self, inner_radius, outer_radius, bkg_estimator=None):
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
+        if bkg_estimator is None:
+            bkg_estimator = MedianBackground()
         self.bkg_estimator = bkg_estimator
         self._aperture = CircularAnnulus((0, 0), inner_radius, outer_radius)
 

--- a/photutils/psf/iterative.py
+++ b/photutils/psf/iterative.py
@@ -9,7 +9,6 @@ from itertools import chain
 
 import astropy.units as u
 import numpy as np
-from astropy.modeling.fitting import TRFLSQFitter
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable, vstack
 
@@ -19,8 +18,6 @@ from photutils.utils._repr import make_repr
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['IterativePSFPhotometry']
-
-FITTER_DEFAULT = TRFLSQFitter()
 
 
 class IterativePSFPhotometry(ModelImageMixin):
@@ -88,8 +85,9 @@ class IterativePSFPhotometry(ModelImageMixin):
         size is larger than 25 sources.
 
     fitter : `~astropy.modeling.fitting.Fitter`, optional
-        The fitter object used to perform the fit of the model to the
-        data.
+        The fitter object used to perform the fit of the
+        model to the data. If `None`, then the default
+        `~astropy.modeling.fitting.TRFLSQFitter` fitter is used.
 
     fitter_maxiters : int, optional
         The maximum number of iterations in which the ``fitter`` is
@@ -213,7 +211,7 @@ class IterativePSFPhotometry(ModelImageMixin):
     """
 
     def __init__(self, psf_model, fit_shape, finder, *, grouper=None,
-                 fitter=FITTER_DEFAULT, fitter_maxiters=100, xy_bounds=None,
+                 fitter=None, fitter_maxiters=100, xy_bounds=None,
                  maxiters=3, mode='new', localbkg_estimator=None,
                  aperture_radius=None, sub_shape=None, progress_bar=False):
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -31,8 +31,6 @@ from photutils.utils.cutouts import _overlap_slices as overlap_slices
 
 __all__ = ['PSFPhotometry']
 
-FITTER_DEFAULT = TRFLSQFitter()
-
 
 class _PSFParameterManager:
     """
@@ -228,8 +226,9 @@ class PSFPhotometry(ModelImageMixin):
         warning is raised if any group size is larger than 25 sources.
 
     fitter : `~astropy.modeling.fitting.Fitter`, optional
-        The fitter object used to perform the fit of the model to the
-        data.
+        The fitter object used to perform the fit of the
+        model to the data. If `None`, then the default
+        `astropy.modeling.fitting.TRFLSQFitter` is used.
 
     fitter_maxiters : int, optional
         The maximum number of iterations in which the ``fitter`` is
@@ -316,7 +315,7 @@ class PSFPhotometry(ModelImageMixin):
                                        alternative='fit_info')
 
     def __init__(self, psf_model, fit_shape, *, finder=None, grouper=None,
-                 fitter=FITTER_DEFAULT, fitter_maxiters=100, xy_bounds=None,
+                 fitter=None, fitter_maxiters=100, xy_bounds=None,
                  localbkg_estimator=None, aperture_radius=None,
                  progress_bar=False):
 
@@ -327,6 +326,8 @@ class PSFPhotometry(ModelImageMixin):
                                  check_odd=True)
         self.grouper = self._validate_grouper(grouper)
         self.finder = self._validate_callable(finder, 'finder')
+        if fitter is None:
+            fitter = TRFLSQFitter()
         self.fitter = self._validate_callable(fitter, 'fitter')
         self.localbkg_estimator = self._validate_localbkg(
             localbkg_estimator, 'localbkg_estimator')

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -12,17 +12,20 @@ from scipy.ndimage import label as ndi_label
 
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.utils import _make_binary_structure
+from photutils.utils._parameters import (SigmaClipSentinelDefault,
+                                         create_default_sigmaclip)
 from photutils.utils._quantity_helpers import process_quantities
 from photutils.utils._stats import nanmean, nanstd
 from photutils.utils.exceptions import NoDetectionsWarning
 
 __all__ = ['detect_sources', 'detect_threshold']
 
-SIGMA_CLIP_DEFAULT = SigmaClip(sigma=3.0, maxiters=10)
+
+SIGMA_CLIP = SigmaClipSentinelDefault(sigma=3.0, maxiters=10)
 
 
 def detect_threshold(data, nsigma, *, background=None, error=None, mask=None,
-                     sigma_clip=SIGMA_CLIP_DEFAULT):
+                     sigma_clip=SIGMA_CLIP):
     """
     Calculate a pixel-wise threshold image that can be used to detect
     sources.
@@ -65,9 +68,10 @@ def detect_threshold(data, nsigma, *, background=None, error=None, mask=None,
         Masked pixels are ignored when computing the image background
         statistics.
 
-    sigma_clip : `astropy.stats.SigmaClip` instance, optional
+    sigma_clip : `astropy.stats.SigmaClip` or `None`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
-        clipping parameters.
+        clipping parameters. If `None` then no sigma clipping will be
+        performed.
 
     Returns
     -------
@@ -93,6 +97,9 @@ def detect_threshold(data, nsigma, *, background=None, error=None, mask=None,
     inputs, unit = process_quantities(inputs, names)
     (data, background, error) = inputs
 
+    if sigma_clip is SIGMA_CLIP:
+        sigma_clip = create_default_sigmaclip(sigma=SIGMA_CLIP.sigma,
+                                              maxiters=SIGMA_CLIP.maxiters)
     if not isinstance(sigma_clip, SigmaClip):
         msg = 'sigma_clip must be a SigmaClip object'
         raise TypeError(msg)

--- a/photutils/utils/_parameters.py
+++ b/photutils/utils/_parameters.py
@@ -4,6 +4,31 @@ This module provides parameter validation tools.
 """
 
 import numpy as np
+from astropy.stats import SigmaClip
+
+
+class SigmaClipSentinelDefault:
+    """
+    A sentinel object to indicate the default value for sigma_clip.
+    """
+
+    def __init__(self, sigma=3.0, maxiters=10):
+        """
+        Initialize the sentinel with default SigmaClip parameters.
+        """
+        self.sigma = sigma
+        self.maxiters = maxiters
+
+    def __repr__(self):
+        return (f'<default: SigmaClip(sigma={self.sigma}, '
+                f'maxiters={self.maxiters})>')
+
+
+def create_default_sigmaclip(sigma=3.0, maxiters=10):
+    """
+    Return a new, default SigmaClip instance.
+    """
+    return SigmaClip(sigma=sigma, maxiters=maxiters)
 
 
 def as_pair(name, value, lower_bound=None, upper_bound=None, check_odd=False):

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -7,11 +7,12 @@ import warnings
 
 import astropy.units as u
 import numpy as np
-from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
 from scipy.ndimage import binary_dilation
 
 from photutils.utils._coords import apply_separation
+from photutils.utils._parameters import (SigmaClipSentinelDefault,
+                                         create_default_sigmaclip)
 from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._repr import make_repr
 from photutils.utils.footprints import circular_footprint
@@ -20,7 +21,7 @@ __all__ = ['ImageDepth']
 
 __doctest_requires__ = {('ImageDepth', 'ImageDepth.*'): ['skimage']}
 
-SIGMA_CLIP_DEFAULT = SigmaClip(sigma=3.0, maxiters=10)
+SIGMA_CLIP = SigmaClipSentinelDefault(sigma=3.0, maxiters=10)
 
 
 class ImageDepth:
@@ -74,7 +75,7 @@ class ImageDepth:
             m_{\mathrm{lim}} = -2.5 \log_{10} f_{\mathrm{lim}}
                 + \mathrm{zeropoint}
 
-    sigma_clip : `astropy.stats.SigmaClip` instance, optional
+    sigma_clip : `astropy.stats.SigmaClip`, optional
         A `~astropy.stats.SigmaClip` object that defines the sigma
         clipping parameters to use when computing the limiting flux. If
         `None` then no sigma clipping will be performed.
@@ -196,8 +197,7 @@ class ImageDepth:
 
     def __init__(self, aper_radius, *, nsigma=5.0, mask_pad=0, napers=1000,
                  niters=10, overlap=True, overlap_maxiters=100, seed=None,
-                 zeropoint=0.0, sigma_clip=SIGMA_CLIP_DEFAULT,
-                 progress_bar=True):
+                 zeropoint=0.0, sigma_clip=SIGMA_CLIP, progress_bar=True):
 
         if aper_radius <= 0:
             msg = 'aper_radius must be > 0'
@@ -215,6 +215,9 @@ class ImageDepth:
         self.overlap_maxiters = overlap_maxiters
         self.seed = seed
         self.zeropoint = zeropoint
+        if sigma_clip is SIGMA_CLIP:
+            sigma_clip = create_default_sigmaclip(sigma=SIGMA_CLIP.sigma,
+                                                  maxiters=SIGMA_CLIP.maxiters)
         self.sigma_clip = sigma_clip
         self.progress_bar = progress_bar
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,10 @@ exclude = [
     '^test_*',  # test code
     '^conftest.*$',  # pytest configuration
 
+    # PR01: private classes/functions
+    'SigmaClipSentinelDefault$',
+    'create_default_sigmaclip$',
+
     # PR02: subclasses without __init__
     'Background$',
     'BackgroundRMS$',


### PR DESCRIPTION
These default keyword class instances are mutable in principle.  While the risk of changing these is minor, this PR ensures that each function/class gets its own instance.