### PR TITLE
Fix x/y units of PSF photometry init_params table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,10 @@ Bug Fixes
     column would not have units if the input data had units and the flux
     model parameter was fixed in value. [#2072]
 
+  - Fixed a bug in ``PSFPhotometry`` and ``IterativePSFPhotometry``
+    where an error would be raised if the x or y columns in
+    ``init_params`` had units. [#2079]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where a newly-defined extra property of a

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -409,7 +409,7 @@ class PSFPhotometry(ModelImageMixin):
     @staticmethod
     def _validate_radius(radius):
         if radius is not None and (not np.isscalar(radius)
-                                   or radius <= 0 or ~np.isfinite(radius)):
+                                   or radius <= 0 or not np.isfinite(radius)):
             msg = 'aperture_radius must be a strictly-positive scalar'
             raise ValueError(msg)
         return radius

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -615,6 +615,12 @@ class PSFPhotometry(ModelImageMixin):
         if init_params is None:
             return None
 
+        # strip any units from the x/y position columns
+        for axis in ('x', 'y'):
+            colname = self._param_mapper.init_colnames[axis]
+            if isinstance(init_params[colname], u.Quantity):
+                init_params[colname] = init_params[colname].value
+
         init_params = self._estimate_flux_and_bkg_if_needed(data, mask,
                                                             init_params)
         init_params = self._group_sources(init_params)


### PR DESCRIPTION
This PR fixes a bug in ``PSFPhotometry`` and ``IterativePSFPhotometry`` where an error would be raised if the x or y columns in the ``init_params`` table had units.