### PR TITLE
Fix boundary conditions for PSF photometry flag=2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,9 @@ Bug Fixes
     where an error would be raised if the x or y columns in
     ``init_params`` had units. [#2079]
 
+  - Fixed an bug in ``PSFPhotometry`` and ``IterativePSFPhotometry`` for
+    the boundary conditions where flag=2 would be set. [#2080]
+
 - ``photutils.segmentation``
 
   - Fixed an issue where a newly-defined extra property of a

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1379,10 +1379,13 @@ class PSFPhotometry(ModelImageMixin):
         flags[flag1_mask] += 1
 
         # flag=2: the fit x and/or y position lies outside of the input data
+        # Since integer coordinates are at pixel centers, the image
+        # boundaries are -0.5 to ny-0.5 and -0.5 to nx-0.5.
         ny, nx = shape
         x_fit = results_tbl[x_col]
         y_fit = results_tbl[y_col]
-        flag2_mask = ((x_fit < 0) | (y_fit < 0) | (x_fit > nx) | (y_fit > ny))
+        flag2_mask = ((x_fit < -0.5) | (y_fit < -0.5) | (x_fit > nx - 0.5)
+                      | (y_fit > ny - 0.5))
         flags[flag2_mask] += 2
 
         # flag=4: the fit flux is less than or equal to zero

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -1436,3 +1436,20 @@ def test_move_column():
     assert tbl2.colnames == ['a', 'b', 'c']
     tbl3 = psfphot._move_column(tbl, 'b', 'b')
     assert tbl3.colnames == ['a', 'b', 'c']
+
+
+def test_flag2_boundaries():
+    shape = (35, 21)
+    psf_model = CircularGaussianPRF(fwhm=3.0)
+    init_params = QTable()
+    init_params['x_0'] = [-0.4, 20.4, -1.0, 21.0, 5.0, 5.0, 15.0, 15.0]
+    init_params['y_0'] = [10.0, 10.0, 20.0, 20.0, -0.4, 34.4, -1.0, 35.0]
+    init_params['flux'] = 500
+    data = make_model_image(shape, psf_model, init_params)
+
+    fit_shape = (5, 5)
+    psfphot = PSFPhotometry(psf_model, fit_shape)
+    phot = psfphot(data, init_params=init_params)
+    assert len(phot) == 8
+    assert_equal(phot['flags'][[2, 3, 6, 7]], [3, 3, 3, 3])
+    assert_equal(phot['flags'][[0, 1, 4, 5]], [1, 1, 1, 1])


### PR DESCRIPTION
This PR fixes an edge-case bug in ``PSFPhotometry`` and ``IterativePSFPhotometry`` for the boundary conditions where flag=2 would be set.