### PR TITLE
Add keyword to customize the group warning threshold

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ New Features
     ``'ycentroid'``. The allowed column names are now the same as those
     allowed in the ``init_params`` table. [#2072]
 
+  - Added a ``group_warning_threshold`` keyword to ``PSFPhotometry`` and
+    ``IterativePSFPhotometry``. [#2081]
+
 - ``photutils.segmentation``
 
   - An optional ``array`` keyword was added to the ``SourceCatalog``

--- a/photutils/psf/iterative.py
+++ b/photutils/psf/iterative.py
@@ -128,6 +128,13 @@ class IterativePSFPhotometry(ModelImageMixin):
         ``init_params`` table, they will override this keyword *only for
         the first iteration*.
 
+    group_warning_threshold : int, optional
+        The maximum number of sources in a group before a warning is
+        raised. If the number of sources in a group exceeds this value,
+        a warning is raised to inform the user that fitting such large
+        groups may take a long time and be error-prone. The default is
+        25 sources.
+
     sub_shape : `None`, int, or length-2 array_like
         The rectangular shape around the center of a star that will be
         used when subtracting the fitted PSF models. If ``sub_shape`` is
@@ -213,7 +220,8 @@ class IterativePSFPhotometry(ModelImageMixin):
     def __init__(self, psf_model, fit_shape, finder, *, grouper=None,
                  fitter=None, fitter_maxiters=100, xy_bounds=None,
                  maxiters=3, mode='new', localbkg_estimator=None,
-                 aperture_radius=None, sub_shape=None, progress_bar=False):
+                 aperture_radius=None, group_warning_threshold=25,
+                 sub_shape=None, progress_bar=False):
 
         if finder is None:
             msg = 'finder cannot be None for IterativePSFPhotometry'
@@ -223,12 +231,14 @@ class IterativePSFPhotometry(ModelImageMixin):
             msg = 'aperture_radius cannot be None for IterativePSFPhotometry'
             raise ValueError(msg)
 
+        threshold = group_warning_threshold
         self._psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                                       grouper=grouper, fitter=fitter,
                                       fitter_maxiters=fitter_maxiters,
                                       xy_bounds=xy_bounds,
                                       localbkg_estimator=localbkg_estimator,
                                       aperture_radius=aperture_radius,
+                                      group_warning_threshold=threshold,
                                       progress_bar=progress_bar)
 
         self.maxiters = self._validate_maxiters(maxiters)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -258,6 +258,13 @@ class PSFPhotometry(ModelImageMixin):
         flux of each source. If initial flux values are present in the
         ``init_params`` table, they will override this keyword.
 
+    group_warning_threshold : int, optional
+        The maximum number of sources in a group before a warning is
+        raised. If the number of sources in a group exceeds this value,
+        a warning is raised to inform the user that fitting such large
+        groups may take a long time and be error-prone. The default is
+        25 sources.
+
     progress_bar : bool, optional
         Whether to display a progress bar when fitting the sources
         (or groups). The progress bar requires that the `tqdm
@@ -317,7 +324,7 @@ class PSFPhotometry(ModelImageMixin):
     def __init__(self, psf_model, fit_shape, *, finder=None, grouper=None,
                  fitter=None, fitter_maxiters=100, xy_bounds=None,
                  localbkg_estimator=None, aperture_radius=None,
-                 progress_bar=False):
+                 group_warning_threshold=25, progress_bar=False):
 
         self.psf_model = _validate_psf_model(psf_model)
         self._param_mapper = _PSFParameterManager(self.psf_model)
@@ -336,7 +343,7 @@ class PSFPhotometry(ModelImageMixin):
         self.aperture_radius = self._validate_radius(aperture_radius)
         self.progress_bar = progress_bar
 
-        self.group_warning_threshold = 25
+        self.group_warning_threshold = group_warning_threshold
 
         self._reset_results()
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -1438,6 +1438,24 @@ def test_move_column():
     assert tbl3.colnames == ['a', 'b', 'c']
 
 
+def test_group_warning_threshold(test_data):
+    data, error, sources = test_data
+    sources['group_id'] = [1, 1, 1, 1, 1, 1, 1, 2, 2, 2]
+    psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    fit_shape = (5, 5)
+    finder = DAOStarFinder(6.0, 2.0)
+    psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
+                            aperture_radius=4, group_warning_threshold=6)
+    match = 'Some groups have more than 6 sources'
+    with pytest.warns(AstropyUserWarning, match=match):
+        phot = psfphot(data, error=error, init_params=sources)
+
+    psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
+                            aperture_radius=4, group_warning_threshold=7)
+    phot = psfphot(data, error=error, init_params=sources)
+    assert len(phot) == 10
+
+
 def test_flag2_boundaries():
     shape = (35, 21)
     psf_model = CircularGaussianPRF(fwhm=3.0)


### PR DESCRIPTION
This PR adds a ``group_warning_threshold`` keyword to ``PSFPhotometry`` and ``IterativePSFPhotometry``.

Requested by @keflavich in https://github.com/astropy/photutils/pull/1856#issuecomment-3002013995.