### PR TITLE
Add utility function to decode PSF photometry flags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ New Features
   - Added a ``group`` keyword to the ``SegmentationImage``
     ``to_regions`` method. [#2060, #2065]]
 
+  - Added a ``decode_psf_flags`` utility function for decoding PSF
+    photometry bit flags. [#2090]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/psf/__init__.py
+++ b/photutils/psf/__init__.py
@@ -6,6 +6,7 @@ photometry.
 
 from .epsf import *  # noqa: F401, F403
 from .epsf_stars import *  # noqa: F401, F403
+from .flags import *  # noqa: F401, F403
 from .functional_models import *  # noqa: F401, F403
 from .gridded_models import *  # noqa: F401, F403
 from .groupers import *  # noqa: F401, F403

--- a/photutils/psf/flags.py
+++ b/photutils/psf/flags.py
@@ -44,6 +44,67 @@ def decode_psf_flags(flags):
         - ``'no_overlap'`` : bit 64, no overlap with data
         - ``'fully_masked'`` : bit 128, fully masked source
         - ``'too_few_pixels'`` : bit 256, too few pixels for fitting
+
+    Examples
+    --------
+    Decode a single flag value:
+
+    >>> from photutils.psf import decode_psf_flags
+    >>> issues = decode_psf_flags(5)  # bits 1 and 4 set
+    >>> print(issues)
+    ['npixfit_partial', 'negative_flux']
+    >>> 'npixfit_partial' in issues
+    True
+    >>> 'no_convergence' in issues
+    False
+
+    Decode multiple flag values:
+
+    >>> flags = [0, 8, 136]  # 0, bit 8, bits 8+128
+    >>> decoded_list = decode_psf_flags(flags)
+    >>> len(decoded_list)
+    3
+    >>> decoded_list[0]  # No issues
+    []
+    >>> decoded_list[1]  # Convergence issue
+    ['no_convergence']
+    >>> decoded_list[2]  # Multiple issues
+    ['no_convergence', 'fully_masked']
+
+    Check for specific issues:
+
+    >>> issues = decode_psf_flags(136)
+    >>> if 'no_convergence' in issues:
+    ...     print("Fit may not have converged")
+    Fit may not have converged
+    >>> if issues:  # Any issues present
+    ...     print(f"Found {len(issues)} issues: {', '.join(issues)}")
+    Found 2 issues: no_convergence, fully_masked
+
+    Working with PSF photometry results:
+
+    >>> import numpy as np
+    >>> from astropy.modeling import models
+    >>> from astropy.table import Table
+    >>> from photutils.psf import (CircularGaussianPRF, PSFPhotometry,
+    ...                            decode_psf_flags)
+    >>> # Create minimal test data
+    >>> yy, xx = np.mgrid[:21, :21]
+    >>> m1 = CircularGaussianPRF(flux=-10, x_0=10, y_0=10, fwhm=2)
+    >>> m2 = CircularGaussianPRF(flux=10, x_0=3, y_0=3, fwhm=2)
+    >>> m3 = CircularGaussianPRF(flux=10, x_0=21, y_0=21, fwhm=2)
+    >>> data = m1(xx, yy) + m2(xx, yy) + m3(xx, yy)
+    >>> psf_model = CircularGaussianPRF(flux=1, x_0=10, y_0=10, fwhm=2)
+    >>> init_params = Table({'x': (10, 3, 21), 'y': (10, 3, 21),
+    ...                      'flux': (1, 10, 10)})
+    >>> photometry = PSFPhotometry(psf_model, (3, 3))
+    >>> results = photometry(data, init_params=init_params)
+    >>> issues_list = decode_psf_flags(results['flags'])
+    >>> for i, issues in enumerate(issues_list):
+    ...     if issues:
+    ...         print(f"Source {i+1}: {', '.join(issues)}")
+    Source 1: negative_flux
+    Source 3: npixfit_partial, no_covariance, too_few_pixels
     """
     # Flag definitions with descriptive names
     flag_definitions = {

--- a/photutils/psf/flags.py
+++ b/photutils/psf/flags.py
@@ -1,0 +1,86 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Utilities for decoding PSF photometry bit flags.
+"""
+
+import numpy as np
+
+__all__ = ['decode_psf_flags']
+
+
+def decode_psf_flags(flags):
+    """
+    Decode PSF photometry bit flags into individual components.
+
+    This function takes integer flag values from PSF photometry results
+    and returns a list of human-readable descriptions of the issues
+    that occurred during fitting. This is useful for understanding
+    what problems were encountered without needing to manually perform
+    bitwise operations.
+
+    Parameters
+    ----------
+    flags : int or array-like of int
+        Integer flag value(s) to decode. Each bit in the flag
+        represents a specific condition that occurred during
+        PSF fitting.
+
+    Returns
+    -------
+    decoded : list of str or list of list of str
+        List of active flag names, or list of lists if input is
+        an array. Each string represents a specific condition
+        that was detected during PSF fitting. If no flags are
+        set, returns an empty list. Possible flag names are:
+
+        - ``'npixfit_partial'`` : bit 1, npixfit smaller than
+          full fit_shape region
+        - ``'outside_bounds'`` : bit 2, fitted position outside
+          input image bounds
+        - ``'negative_flux'`` : bit 4, non-positive flux
+        - ``'no_convergence'`` : bit 8, possible non-convergence
+        - ``'no_covariance'`` : bit 16, missing parameter covariance
+        - ``'near_bound'`` : bit 32, fitted parameter near a bound
+        - ``'no_overlap'`` : bit 64, no overlap with data
+        - ``'fully_masked'`` : bit 128, fully masked source
+        - ``'too_few_pixels'`` : bit 256, too few pixels for fitting
+    """
+    # Flag definitions with descriptive names
+    flag_definitions = {
+        1: 'npixfit_partial',   # npixfit smaller than full fit_shape
+        2: 'outside_bounds',    # fitted position outside image bounds
+        4: 'negative_flux',     # non-positive flux
+        8: 'no_convergence',    # possible non-convergence
+        16: 'no_covariance',    # missing parameter covariance
+        32: 'near_bound',       # near a positional bound
+        64: 'no_overlap',       # no overlap with data
+        128: 'fully_masked',    # fully masked source
+        256: 'too_few_pixels',  # too few pixels for fitting
+    }
+
+    def _decode_single_flag(flag_value):
+        """
+        Decode a single integer flag value.
+        """
+        if not isinstance(flag_value, (int, np.integer)):
+            msg = 'Flag value must be an integer'
+            raise TypeError(msg)
+
+        active_flags = []
+        for bit_value, description in flag_definitions.items():
+            if flag_value & bit_value:
+                active_flags.append(description)
+        return active_flags
+
+    # Handle both single values and arrays
+    if np.isscalar(flags):
+        return _decode_single_flag(flags)
+
+    # Convert to numpy array for consistent handling
+    flags_array = np.asarray(flags)
+    if flags_array.ndim == 0:
+        # Handle 0-d arrays (scalar arrays)
+        return _decode_single_flag(flags_array.item())
+
+    # Handle 1-d or higher dimensional arrays
+    return [_decode_single_flag(flag) for flag in flags_array.flat]

--- a/photutils/psf/tests/test_flags.py
+++ b/photutils/psf/tests/test_flags.py
@@ -1,0 +1,179 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the flags module.
+"""
+
+import numpy as np
+import pytest
+
+from photutils.psf import decode_psf_flags
+
+
+def test_decode_psf_flags():
+    """
+    Test the decode_psf_flags standalone function.
+    """
+    # Test single flag value with no flags set
+    decoded = decode_psf_flags(0)
+    assert decoded == []
+    assert isinstance(decoded, list)
+
+    # Test single flag value with one bit set
+    decoded = decode_psf_flags(1)
+    assert decoded == ['npixfit_partial']
+
+    decoded = decode_psf_flags(2)
+    assert decoded == ['outside_bounds']
+
+    decoded = decode_psf_flags(4)
+    assert decoded == ['negative_flux']
+
+    decoded = decode_psf_flags(8)
+    assert decoded == ['no_convergence']
+
+    decoded = decode_psf_flags(16)
+    assert decoded == ['no_covariance']
+
+    decoded = decode_psf_flags(32)
+    assert decoded == ['near_bound']
+
+    decoded = decode_psf_flags(64)
+    assert decoded == ['no_overlap']
+
+    decoded = decode_psf_flags(128)
+    assert decoded == ['fully_masked']
+
+    decoded = decode_psf_flags(256)
+    assert decoded == ['too_few_pixels']
+
+    # Test combination of flags
+    decoded = decode_psf_flags(5)  # bits 1 and 4
+    assert set(decoded) == {'npixfit_partial', 'negative_flux'}
+    assert len(decoded) == 2
+
+    decoded = decode_psf_flags(136)  # bits 8 and 128
+    assert set(decoded) == {'no_convergence', 'fully_masked'}
+    assert len(decoded) == 2
+
+    # Test with all flags set
+    all_flags = 1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256  # 511
+    decoded = decode_psf_flags(all_flags)
+    expected_all = ['npixfit_partial', 'outside_bounds', 'negative_flux',
+                    'no_convergence', 'no_covariance', 'near_bound',
+                    'no_overlap', 'fully_masked', 'too_few_pixels']
+    assert set(decoded) == set(expected_all)
+    assert len(decoded) == 9
+
+    # Test with array input
+    flags_array = [0, 1, 2, 5]
+    decoded_list = decode_psf_flags(flags_array)
+    assert len(decoded_list) == 4
+    assert isinstance(decoded_list, list)
+
+    # Check individual results
+    assert decoded_list[0] == []
+    assert decoded_list[1] == ['npixfit_partial']
+    assert decoded_list[2] == ['outside_bounds']
+    assert set(decoded_list[3]) == {'npixfit_partial', 'negative_flux'}
+
+    # Test with numpy array
+    flags_np = np.array([8, 16, 32])
+    decoded_list = decode_psf_flags(flags_np)
+    assert len(decoded_list) == 3
+    assert decoded_list[0] == ['no_convergence']
+    assert decoded_list[1] == ['no_covariance']
+    assert decoded_list[2] == ['near_bound']
+
+    # Test with 0-d numpy array (scalar array)
+    flag_scalar = np.array(64)
+    decoded = decode_psf_flags(flag_scalar)
+    assert isinstance(decoded, list)
+    assert decoded == ['no_overlap']
+
+    # Test membership operations (common usage pattern)
+    issues = decode_psf_flags(136)
+    assert 'no_convergence' in issues
+    assert 'fully_masked' in issues
+    assert 'negative_flux' not in issues
+
+    # Test error conditions
+    with pytest.raises(TypeError, match='Flag value must be an integer'):
+        decode_psf_flags(3.14)
+
+    with pytest.raises(TypeError, match='Flag value must be an integer'):
+        decode_psf_flags('invalid')
+
+    with pytest.raises(TypeError, match='Flag value must be an integer'):
+        decode_psf_flags([1, 2.5, 3])
+
+
+def test_decode_psf_flags_practical_usage():
+    """
+    Test practical usage patterns for decode_psf_flags.
+    """
+    # Simulate some typical flag values
+    typical_flags = [0, 1, 8, 64, 136, 256]
+
+    # Test batch processing
+    all_issues = decode_psf_flags(typical_flags)
+    assert len(all_issues) == len(typical_flags)
+
+    # Test filtering for specific conditions
+    convergence_issues = [i for i, issues in enumerate(all_issues)
+                          if 'no_convergence' in issues]
+    expected_conv_indices = [2, 4]  # flags 8 and 136 have convergence issues
+    assert convergence_issues == expected_conv_indices
+
+    # Test counting issues
+    issue_counts = {}
+    for issues in all_issues:
+        for issue in issues:
+            issue_counts[issue] = issue_counts.get(issue, 0) + 1
+
+    # Verify expected counts
+    assert issue_counts.get('no_convergence', 0) == 2  # flags 8 and 136
+    assert issue_counts.get('fully_masked', 0) == 1  # flag 136
+    assert issue_counts.get('npixfit_partial', 0) == 1  # flag 1
+
+    # Test boolean context (empty list is falsy)
+    clean_sources = [i for i, issues in enumerate(all_issues) if not issues]
+    assert 0 in clean_sources  # flag 0 should have no issues
+
+    # Test string formatting for reporting
+    for i, issues in enumerate(all_issues):
+        if issues:
+            report = f"Source {i}: {', '.join(issues)}"
+            assert isinstance(report, str)
+            assert str(i) in report
+
+
+def test_decode_psf_flags_edge_cases():
+    """
+    Test edge cases for decode_psf_flags.
+    """
+    # Test with very large flag value (all bits set + extra)
+    large_flag = 2**16 - 1  # Much larger than our defined flags
+    decoded = decode_psf_flags(large_flag)
+    expected_all = ['npixfit_partial', 'outside_bounds', 'negative_flux',
+                    'no_convergence', 'no_covariance', 'near_bound',
+                    'no_overlap', 'fully_masked', 'too_few_pixels']
+    assert set(decoded) == set(expected_all)
+
+    # Test with negative flag (should still work)
+    # Note: This is technically invalid input but numpy ints can be negative
+    negative_flag = -1  # All bits set in two's complement
+    decoded = decode_psf_flags(negative_flag)
+    assert len(decoded) == 9  # All our flags should be detected
+    # Test with empty array
+    empty_array = np.array([], dtype=int)
+    decoded = decode_psf_flags(empty_array)
+    assert decoded == []
+
+    # Test with 2D array (should flatten)
+    flag_2d = np.array([[0, 1], [8, 136]])
+    decoded = decode_psf_flags(flag_2d)
+    assert len(decoded) == 4  # Flattened to 4 elements
+    assert decoded[0] == []
+    assert decoded[1] == ['npixfit_partial']
+    assert decoded[2] == ['no_convergence']
+    assert set(decoded[3]) == {'no_convergence', 'fully_masked'}


### PR DESCRIPTION
This PR adds a ``decode_psf_flags`` utility function for decoding PSF photometry bit flags. 