### PR TITLE
Do not indent psf.matching in API docs index

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -30,7 +30,7 @@ how to import these tools.
 
 * :doc:`photutils.psf <psf_api>`
 
-  - :doc:`photutils.psf.matching <psf_matching_api>`
+* :doc:`photutils.psf.matching <psf_matching_api>`
 
 * :doc:`photutils.segmentation <segmentation_api>`
 


### PR DESCRIPTION
Followup to #2087 