### PR TITLE
Deprecate grid_from_epsfs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ API Changes
   - Removed the deprecated ``IntegratedGaussianPRF`` and ``PRFAdapter``
     classes. [#2103]
 
+  - The ``grid_from_epsfs`` helper function is now deprecated. Instead,
+    use ``GriddedPSFModel`` directly. [#2111]
+
 
 2.3.0 (2025-09-15)
 ------------------

--- a/docs/whats_new/3.0.rst
+++ b/docs/whats_new/3.0.rst
@@ -31,6 +31,10 @@ well-suited for resizing images on a regular grid to larger sizes. It
 is also significantly slower than the default interpolator based on
 ``scipy.ndimage.zoom``.
 
+The ``grid_from_epsfs`` helper function is now deprecated. This function
+creates a ``GriddedPSFModel`` from a list of ePSFs. Instead, use the
+``GriddedPSFModel`` class directly.
+
 
 Removed Deprecations
 ====================

--- a/photutils/psf/model_helpers.py
+++ b/photutils/psf/model_helpers.py
@@ -11,6 +11,7 @@ from astropy.modeling import CompoundModel
 from astropy.modeling.models import Const2D, Identity, Shift
 from astropy.nddata import NDData
 from astropy.units import Quantity
+from astropy.utils.decorators import deprecated
 from scipy.integrate import dblquad, trapezoid
 
 __all__ = ['grid_from_epsfs', 'make_psf_model']
@@ -322,6 +323,7 @@ def _shift_model_param(model, param_name, shift=2):
     return new_name
 
 
+@deprecated(since='3.0', alternative='`GriddedPSFModel`')
 def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):
     """
     Create a GriddedPSFModel from a list of ImagePSF models.

--- a/photutils/psf/tests/test_model_helpers.py
+++ b/photutils/psf/tests/test_model_helpers.py
@@ -10,6 +10,7 @@ from astropy.modeling.fitting import TRFLSQFitter
 from astropy.modeling.models import Const2D, Gaussian2D, Moffat2D
 from astropy.nddata import NDData
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils import datasets
@@ -247,7 +248,8 @@ class TestGridFromEPSFs:
         self.grid_xypos = [val['fiducial'] for val in quad_stars.values()]
 
     def test_basic_test_grid_from_epsfs(self):
-        psf_grid = grid_from_epsfs(self.epsfs)
+        with pytest.warns(AstropyDeprecationWarning):
+            psf_grid = grid_from_epsfs(self.epsfs)
 
         assert np.all(psf_grid.oversampling == self.epsfs[0].oversampling)
         assert psf_grid.data.shape == (4, psf_grid.oversampling[0] * 25 + 1,
@@ -258,7 +260,8 @@ class TestGridFromEPSFs:
         Test both options for setting PSF locations.
         """
         # default option x_0 and y_0s on input EPSFs
-        psf_grid = grid_from_epsfs(self.epsfs)
+        with pytest.warns(AstropyDeprecationWarning):
+            psf_grid = grid_from_epsfs(self.epsfs)
 
         assert psf_grid.meta['grid_xypos'] == [(0.0, 0.0), (1000.0, 1000.0),
                                                (0.0, 1000.0), (1000.0, 0.0)]
@@ -267,7 +270,8 @@ class TestGridFromEPSFs:
         grid_xypos = [(250.0, 250.0), (750.0, 750.0),
                       (250.0, 750.0), (750.0, 250.0)]
 
-        psf_grid = grid_from_epsfs(self.epsfs, grid_xypos=grid_xypos)
+        with pytest.warns(AstropyDeprecationWarning):
+            psf_grid = grid_from_epsfs(self.epsfs, grid_xypos=grid_xypos)
         assert psf_grid.meta['grid_xypos'] == grid_xypos
 
     def test_meta(self):
@@ -277,7 +281,8 @@ class TestGridFromEPSFs:
         keys = ['grid_xypos', 'oversampling', 'fill_value']
 
         # when 'meta' isn't provided, there should be just three keys
-        psf_grid = grid_from_epsfs(self.epsfs)
+        with pytest.warns(AstropyDeprecationWarning):
+            psf_grid = grid_from_epsfs(self.epsfs)
         for key in keys:
             assert key in psf_grid.meta
 
@@ -285,7 +290,8 @@ class TestGridFromEPSFs:
         # in the list above should be overwritten
         meta = {'grid_xypos': 0.0, 'oversampling': 0.0,
                 'fill_value': -999, 'extra_key': 'extra'}
-        psf_grid = grid_from_epsfs(self.epsfs, meta=meta)
+        with pytest.warns(AstropyDeprecationWarning):
+            psf_grid = grid_from_epsfs(self.epsfs, meta=meta)
         for key in [*keys, 'extra_key']:
             assert key in psf_grid.meta
         assert psf_grid.meta['grid_xypos'].sort() == self.grid_xypos.sort()


### PR DESCRIPTION
This PR deprecates the ``grid_from_epsfs`` helper function. Instead, use ``GriddedPSFModel`` directly.