### PR TITLE
Update CI workflows to use py314

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -40,10 +40,9 @@ jobs:
             allow_failure: false
             prefix: ''
 
-          # no rasterio wheel for 3.14 yet
           - os: ubuntu-latest
-            python: '3.13'
-            tox_env: 'py313-test-devdeps'
+            python: '3.14'
+            tox_env: 'py314-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'
@@ -73,6 +72,6 @@ jobs:
       if: ${{ contains(matrix.tox_env, '-cov') }}
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}  # zizmor: ignore[secrets-outside-env]
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -37,15 +37,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.13'
-            tox_env: 'py313-test-alldeps-devinfra'
+            python: '3.14'
+            tox_env: 'py314-test-alldeps-devinfra'
             allow_failure: false
-
-          # no rasterio wheel for 3.14 yet
-          # - os: ubuntu-latest
-          #   python: '3.14'
-          #   tox_env: 'py314-test-alldeps-devinfra'
-          #   allow_failure: false
 
     steps:
       - name: Check out repository
@@ -86,7 +80,9 @@ jobs:
         include:
           - arch: s390x
           - arch: ppc64le
-          - arch: armv7
+          # isophote.rst fails on armv7 with
+          # "RuntimeWarning: Mean of empty slice."
+          # - arch: armv7
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -69,24 +69,21 @@ jobs:
             allow_failure: false
             prefix: ''
 
-          # cannot use alldeps: rasterio does not have a arm64 wheel
           - os: ubuntu-24.04-arm
-            python: '3.13'
-            tox_env: 'py313-test'
+            python: '3.14'
+            tox_env: 'py314-test'
             allow_failure: false
             prefix: ''
 
-          # no rasterio wheel for 3.14 yet
           - os: macos-latest
-            python: '3.13'
-            tox_env: 'py313-test-alldeps'
+            python: '3.14'
+            tox_env: 'py314-test-alldeps'
             allow_failure: false
             prefix: ''
 
-          # no rasterio wheel for 3.14 yet
           - os: windows-latest
-            python: '3.13'
-            tox_env: 'py313-test-alldeps'
+            python: '3.14'
+            tox_env: 'py314-test-alldeps'
             allow_failure: false
             prefix: ''
 
@@ -108,10 +105,9 @@ jobs:
             allow_failure: false
             prefix: ''
 
-          # no rasterio wheel for 3.14 yet
           - os: ubuntu-latest
-            python: '3.13'
-            tox_env: 'py313-test-devdeps'
+            python: '3.14'
+            tox_env: 'py314-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'
@@ -141,6 +137,6 @@ jobs:
       if: ${{ contains(matrix.tox_env, '-cov') }}
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}  # zizmor: ignore[secrets-outside-env]
         files: ./coverage.xml
         verbose: true


### PR DESCRIPTION
`rasterio` wheels for Python 3.14 are now available.