### PR TITLE
Ensure segment labels match dtype of the segmentation data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -145,7 +145,7 @@ New Features
 
   - Added ``SegmentationImage`` ``get_segment`` and ``get_segments``
     methods to return the ``Segment`` object(s) for a given label or list
-    of labels. [#2228]
+    of labels. [#2228, #2256]
 
   - Added the ability to input ``RegionVisual`` keywords to the
     ``SegmentationImage`` ``to_regions`` method. [#2228]

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -479,7 +479,7 @@ subset of labels is needed:
 
     >>> segments = segment_map.get_segments([1, 5, 10])
     >>> [segment.label for segment in segments]
-    [np.int64(1), np.int64(5), np.int64(10)]
+    [np.int32(1), np.int32(5), np.int32(10)]
 
 A `~photutils.segmentation.Segment` can provide cutout arrays
 of the segment data and of arbitrary data arrays via its

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -537,6 +537,7 @@ class SegmentationImage:
         """
         # _raw_slices is indexed by (label - 1) since it includes all
         # labels up to max_label, even if some are missing
+        label = self._data.dtype.type(label)
         slc = self._raw_slices[label - 1]
         bbox = BoundingBox(ixmin=slc[1].start, ixmax=slc[1].stop,
                            iymin=slc[0].start, iymax=slc[0].stop)
@@ -625,11 +626,11 @@ class SegmentationImage:
         label number.
         """
         if self.n_labels == 0:
-            return np.array([], dtype=int)
+            return np.array([], dtype=self._data.dtype)
         present = np.zeros(self.max_label + 1, dtype=bool)
         present[self.labels] = True
         present[0] = True  # exclude 0 from missing
-        return np.where(~present)[0]
+        return np.where(~present)[0].astype(self._data.dtype)
 
     def copy(self):
         """

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -376,12 +376,25 @@ class TestSegmentationImage:
         """
         assert_allclose(self.segm.missing_labels, [2, 6])
 
+    def test_missing_labels_dtype(self):
+        """
+        Test that missing_labels dtype matches the segmentation image
+        label dtype.
+        """
+        assert self.segm.missing_labels.dtype == self.segm.labels.dtype
+
     def test_missing_labels_empty(self):
         """
-        Test missing_labels with no non-zero labels.
+        Test that missing_labels dtype matches the segmentation image
+        label dtype when there are no labels.
         """
+        segm = SegmentationImage(np.zeros((5, 5), dtype=np.int32))
+        assert_equal(segm.missing_labels, [])
+        assert segm.missing_labels.dtype == segm.data.dtype
+
         segm = SegmentationImage(np.zeros((5, 5), dtype=int))
         assert_equal(segm.missing_labels, [])
+        assert segm.missing_labels.dtype == segm.data.dtype
 
     def test_check_labels(self):
         """
@@ -1340,6 +1353,17 @@ class TestGetSegment:
             assert seg_new.slices == seg_old.slices
             assert seg_new.area == seg_old.area
             assert seg_new.bbox == seg_old.bbox
+
+    def test_get_segments_label_dtype(self):
+        """
+        Test that segment label dtype matches the segmentation image
+        label dtype.
+        """
+        labels = [1, 5]
+        segs = self.segm.get_segments(labels)
+        expected_dtype = self.segm.labels.dtype
+        for seg in segs:
+            assert seg.label.dtype == expected_dtype
 
 
 @pytest.mark.skipif(not HAS_RASTERIO, reason='rasterio is required')


### PR DESCRIPTION
This only affects the `get_segment(s)` methods.