### PR TITLE
Add use_future_column_names context manager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -169,6 +169,11 @@ New Features
   - Significantly improved the performance (by factors of 3 or more) of
     ``ShepardIDWInterpolator`` [#2187].
 
+  - Added a ``use_future_column_names`` context manager for temporarily
+    enabling future column names in a scoped, thread-safe,
+    and async-safe way without modifying the global
+    ``photutils.future_column_names`` flag. [#2258]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/docs/whats_new/3.0.rst
+++ b/docs/whats_new/3.0.rst
@@ -595,6 +595,30 @@ with 4.0 before the release.
     column names will always be returned.
 
 
+Scoped Override for Libraries
+"""""""""""""""""""""""""""""
+
+Libraries that build on photutils can use the
+``photutils.use_future_column_names`` context manager to opt into 4.0
+behavior for a limited scope without changing the global flag. This is
+thread-safe and async-safe::
+
+    >>> from photutils import use_future_column_names
+    >>> with use_future_column_names():
+    ...     table = cat.to_table()  # returns a plain QTable
+    >>> # outside the block, behavior is unchanged
+
+The context-local override takes precedence over the global
+``photutils.future_column_names`` flag and nests correctly::
+
+    >>> with use_future_column_names():
+    ...     # new names only
+    ...     with use_future_column_names(enabled=False):
+    ...         # deprecated mapping is active again
+    ...         pass
+    ...     # back to new names only
+
+
 Aperture Package
 ^^^^^^^^^^^^^^^^
 

--- a/photutils/__init__.py
+++ b/photutils/__init__.py
@@ -12,6 +12,8 @@ try:
 except ImportError:
     __version__ = ''
 
+from .utils._deprecation import use_future_column_names  # noqa: F401
+
 
 future_column_names = False
 """
@@ -20,4 +22,10 @@ If `True`, all photutils functions return standard
 new column names instead of deprecated-column subclasses. Set this to
 `True` after updating your code to use the new column names to verify
 compatibility with the 4.0 behavior.
+
+For a scoped override that does not affect the global flag, use
+`photutils.use_future_column_names` as a context manager::
+
+    with photutils.use_future_column_names():
+        table = cat.to_table()  # returns a plain QTable
 """

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -24,7 +24,8 @@ from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
 from photutils.morphology import gini as gini_func
 from photutils.segmentation.core import SegmentationImage
 from photutils.segmentation.utils import _mask_to_mirrored_value
-from photutils.utils._deprecation import (create_empty_deprecated_qtable,
+from photutils.utils._deprecation import (_get_future_column_names,
+                                          create_empty_deprecated_qtable,
                                           deprecated_getattr,
                                           deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
@@ -517,15 +518,12 @@ class SourceCatalog:
         return detection_catalog
 
     def _update_meta(self):
-        import photutils
-
         meta_values = {}
-        attrs = ('local_bkg_width', 'aperture_mask_method',
-                 'kron_params')
+        attrs = ('local_bkg_width', 'aperture_mask_method', 'kron_params')
         for attr in attrs:
             meta_values[attr] = getattr(self, attr)
 
-        if not photutils.future_column_names:
+        if not _get_future_column_names():
             for old_name, new_name in _DEPRECATED_META_KEYS.items():
                 if new_name in meta_values:
                     meta_values[old_name] = meta_values[new_name]

--- a/photutils/utils/_deprecation.py
+++ b/photutils/utils/_deprecation.py
@@ -16,6 +16,8 @@ must use the new column names when calling such functions.
 
 import inspect
 import warnings
+from contextlib import contextmanager
+from contextvars import ContextVar
 from functools import wraps
 
 from astropy.table import QTable, Table
@@ -23,6 +25,66 @@ from astropy.utils.decorators import deprecated as astropy_deprecated
 from astropy.utils.decorators import (
     deprecated_renamed_argument as astropy_deprecated_renamed_argument)
 from astropy.utils.exceptions import AstropyDeprecationWarning
+
+_SENTINEL = object()
+_future_column_names_var = ContextVar(
+    'photutils_future_column_names', default=_SENTINEL,
+)
+
+
+def _get_future_column_names():
+    """
+    Return the effective value of ``future_column_names``.
+
+    A context-local override (set via `use_future_column_names`) takes
+    precedence over the global ``photutils.future_column_names`` flag.
+
+    Returns
+    -------
+    result : bool
+        Whether future column names are enabled.
+    """
+    import photutils
+
+    val = _future_column_names_var.get()
+    if val is not _SENTINEL:
+        return val
+    return photutils.future_column_names
+
+
+@contextmanager
+def use_future_column_names(enabled=True):
+    """
+    Context manager to temporarily override ``future_column_names``.
+
+    Within the ``with`` block, photutils functions will behave as
+    though ``photutils.future_column_names`` is set to enabled,
+    without modifying the global flag. This is safe to use in
+    multi-threaded and async code because the override is stored in a
+    `~contextvars.ContextVar`.
+
+    Parameters
+    ----------
+    enabled : bool, optional
+        The value to use inside the block. The default is `True`.
+
+    Examples
+    --------
+    >>> import photutils
+    >>> from photutils import use_future_column_names
+    >>> photutils.future_column_names  # global default
+    False
+    >>> with use_future_column_names():
+    ...     # inside here, tables use new column names only
+    ...     pass
+    >>> photutils.future_column_names  # unchanged
+    False
+    """
+    token = _future_column_names_var.set(enabled)
+    try:
+        yield
+    finally:
+        _future_column_names_var.reset(token)
 
 
 def deprecated(since, *, alternative=None, until=None):
@@ -620,9 +682,7 @@ def create_empty_deprecated_qtable(deprecation_map, *, since=None,
     >>> float(col[0])
     1.0
     """
-    import photutils
-
-    if photutils.future_column_names:
+    if _get_future_column_names():
         return QTable(**kwargs)
 
     table = DeprecatedColumnQTable(**kwargs)
@@ -713,14 +773,12 @@ def create_deprecated_table_from_data(data, deprecation_map, *,
     >>> type(qtable).__name__
     'DeprecatedColumnQTable'
     """
-    import photutils
-
     # Rename the keys in the data dictionary before creation
     renamed_data = {
         deprecation_map.get(k, k): v for k, v in data.items()
     }
 
-    if photutils.future_column_names:
+    if _get_future_column_names():
         table_class = QTable if use_qtable else Table
         return table_class(renamed_data, **kwargs)
 

--- a/photutils/utils/tests/test_deprecation.py
+++ b/photutils/utils/tests/test_deprecation.py
@@ -12,11 +12,13 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.utils._deprecation import (DeprecatedColumnQTable,
                                           DeprecatedColumnTable,
+                                          _future_column_names_var,
                                           create_deprecated_table_from_data,
                                           create_empty_deprecated_qtable,
                                           deprecated, deprecated_getattr,
                                           deprecated_positional_kwargs,
-                                          deprecated_renamed_argument)
+                                          deprecated_renamed_argument,
+                                          use_future_column_names)
 
 DEPRECATION_MAP = {'old': 'new', 'old_b': 'new_b'}
 
@@ -410,6 +412,118 @@ class TestFutureColumnNames:
         table = create_empty_deprecated_qtable(DEPRECATION_MAP)
         assert type(table) is QTable
         assert len(table) == 0
+
+
+class TestUseFutureColumnNames:
+    """
+    Tests for the ``use_future_column_names`` context manager.
+    """
+
+    def test_context_manager_returns_plain_table(self, raw_data):
+        """
+        Test that the context manager makes
+        create_deprecated_table_from_data return a plain Table.
+        """
+        with use_future_column_names():
+            table = create_deprecated_table_from_data(
+                raw_data, DEPRECATION_MAP)
+        assert type(table) is Table
+        assert set(table.colnames) == {'new', 'new_b', 'stable'}
+
+    def test_context_manager_returns_plain_qtable(self, raw_data):
+        """
+        Test that the context manager makes
+        create_deprecated_table_from_data return a plain QTable.
+        """
+        with use_future_column_names():
+            table = create_deprecated_table_from_data(
+                raw_data, DEPRECATION_MAP, use_qtable=True)
+        assert type(table) is QTable
+
+    def test_context_manager_empty_qtable(self):
+        """
+        Test that the context manager makes
+        create_empty_deprecated_qtable return a plain QTable.
+        """
+        with use_future_column_names():
+            table = create_empty_deprecated_qtable(DEPRECATION_MAP)
+        assert type(table) is QTable
+        assert len(table) == 0
+
+    def test_global_unchanged_after_context(self):
+        """
+        Test that the global flag is unchanged after the context
+        manager exits.
+        """
+        import photutils
+
+        original = photutils.future_column_names
+        with use_future_column_names():
+            pass
+        assert photutils.future_column_names == original
+
+    def test_outside_context_uses_global(self, raw_data):
+        """
+        Test that outside the context manager, the global flag is
+        respected and deprecated table behavior is used.
+        """
+        import photutils
+
+        assert not photutils.future_column_names
+        with use_future_column_names():
+            pass
+        # Outside the context, should use the deprecated table
+        table = create_deprecated_table_from_data(
+            raw_data, DEPRECATION_MAP)
+        assert type(table) is DeprecatedColumnTable
+
+    def test_nested_context_managers(self, raw_data):
+        """
+        Test that nested context managers work correctly with different
+        values.
+        """
+        with use_future_column_names(enabled=True):
+            table1 = create_deprecated_table_from_data(
+                raw_data, DEPRECATION_MAP)
+            assert type(table1) is Table
+
+            with use_future_column_names(enabled=False):
+                table2 = create_deprecated_table_from_data(
+                    raw_data, DEPRECATION_MAP)
+                assert type(table2) is DeprecatedColumnTable
+
+            # Back to the outer context
+            table3 = create_deprecated_table_from_data(
+                raw_data, DEPRECATION_MAP)
+            assert type(table3) is Table
+
+    def test_context_manager_disabled(self, raw_data):
+        """
+        Test that use_future_column_names(enabled=False) forces the
+        deprecated table behavior even if the global flag is True.
+        """
+        import photutils
+
+        original = photutils.future_column_names
+        try:
+            photutils.future_column_names = True
+            with use_future_column_names(enabled=False):
+                table = create_deprecated_table_from_data(
+                    raw_data, DEPRECATION_MAP)
+                assert type(table) is DeprecatedColumnTable
+        finally:
+            photutils.future_column_names = original
+
+    def test_restores_on_exception(self):
+        """
+        Test that the context manager restores state even if an
+        exception occurs.
+        """
+        sentinel_before = _future_column_names_var.get()
+        msg = 'test error'
+        with use_future_column_names(), pytest.raises(ValueError, match=msg):
+            raise ValueError(msg)
+        assert _future_column_names_var.get() == sentinel_before
 
 
 @deprecated_positional_kwargs('1.0', until='2.0')


### PR DESCRIPTION
 This PR adds a ``use_future_column_names`` context manager for temporarily enabling future column names in a scoped, thread-safe, and async-safe way without modifying the global ``photutils.future_column_names`` flag.