### PR TITLE
Add missing 'bool' import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``photutils.isophote``
+
+  - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a
+    compilation issue with Cython 3.1.x. [#2260]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/isophote/ellipse_model.pyx
+++ b/photutils/isophote/ellipse_model.pyx
@@ -19,7 +19,6 @@ cdef extern from "math.h":
     double sin(double x)
     double sqrt(double x)
 
-
 DTYPE = np.float64
 ctypedef cnp.float64_t DTYPE_t
 
@@ -83,7 +82,7 @@ def build_ellipse_model_c(
     cdef double r, sma, q, pa, x0, y0, intens0, intens
     cdef int i, j, i_max, j_max
     cdef cython.Py_ssize_t index
-    cdef bool i_ge_zero, i_p1_le_max
+    cdef bint i_ge_zero, i_p1_le_max
 
     # Define output array
     cdef double[:, :] result = np.zeros([n_rows, n_cols], dtype=DTYPE)


### PR DESCRIPTION
When trying to package version 3.0.0 for Debian, I observed the following build failure:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
    ~~~~^^
  File "/usr/lib/python3/dist-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
[…]
  File "/usr/lib/python3/dist-packages/Cython/Build/Dependencies.py", line 1150, in cythonize
    cythonize_one(*args)
    ~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib/python3/dist-packages/Cython/Build/Dependencies.py", line 1294, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: ./photutils/isophote/ellipse_model.pyx

ERROR Backend subprocess exited when trying to invoke build_wheel
```
Invoking cythonize manually gives
```
Error compiling Cython file:
------------------------------------------------------------
...
    cdef double phi, fx, fy, x, y
    cdef double one_m_fx, one_m_fy, one_m_fx_t_one_m_fy, one_m_fy_t_fx, one_m_fx_t_fy, fy_t_fx
    cdef double r, sma, q, pa, x0, y0, intens0, intens
    cdef int i, j, i_max, j_max
    cdef cython.Py_ssize_t index
    cdef bool i_ge_zero, i_p1_le_max
         ^
------------------------------------------------------------

photutils/isophote/ellipse_model.pyx:86:9: 'bool' is not a type identifier
```
While I don't understand why this did not happen in the unit tests, I think the problem is a missing import, which is fixed by this PR.