### PR TITLE
Add CI test for oldest supported Cython version

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -32,6 +32,12 @@ jobs:
         include:
           - os: ubuntu-latest
             python: '3.11'
+            tox_env: 'py311-cython-oldestdeps'
+            allow_failure: false
+            prefix: ''
+
+          - os: ubuntu-latest
+            python: '3.11'
             tox_env: 'py311-test-oldestdeps'
             allow_failure: false
             prefix: ''

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,0 @@
-rules:
-  secrets-outside-env:
-    ignore:
-      # CODECOV_TOKEN is a low-risk CI-only token; no GitHub Environment is
-      # needed. This rule will be demoted to --persona=auditor only in
-      # zizmor v1.24.0, at which point this ignore block can be removed.
-      - ci_cron_daily.yml:76
-      - ci_tests.yml:144

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.a
 *.o
 *.so
+*.whl
 __pycache__
 
 # Ignore .c files by default to avoid including generated code. If you want to
@@ -13,6 +14,9 @@ __pycache__
 */version.py
 */cython_version.py
 MANIFEST
+build-oldest-constraints.txt
+install-oldest-constraints.txt
+requirements-min.txt
 htmlcov
 .coverage*
 .ipynb_checkpoints

--- a/_build_oldest_pins.py
+++ b/_build_oldest_pins.py
@@ -1,0 +1,66 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Generate a pip requirements file pinning build and runtime dependencies
+to their minimum supported versions, as declared in pyproject.toml.
+
+This script reads [build-system].requires and [project].dependencies
+from pyproject.toml and writes a requirements file that pins each
+dependency with a >= specifier to its minimum version (using ==).
+"""
+
+import sys
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+pyproject = Path(__file__).parent / 'pyproject.toml'
+data = tomllib.loads(pyproject.read_text())
+
+
+def pin_minimum(req_str_sections):
+    """
+    Return a list of pinned requirement strings with the minimum
+    versions for each package.
+
+    Parameters
+    ----------
+    req_str_sections : list of list of str
+        A list of sections, where each section is a list of
+        requirement strings (e.g. from [build-system].requires or
+        [project].dependencies).
+
+    Returns
+    -------
+    result : list of str
+        A list of requirement strings with minimum versions pinned (e.g.
+        'package==1.2.3').
+    """
+    mins = {}
+    for section in req_str_sections:
+        for req_str in section:
+            req = Requirement(req_str)
+            name = req.name.lower()
+            for spec in req.specifier:
+                if spec.operator == '>=':
+                    ver = Version(spec.version)
+                    if name not in mins or ver > mins[name][1]:
+                        mins[name] = (req.name, ver)
+                    break
+    return [f'{name}=={ver}' for name, ver in mins.values()]
+
+
+build_pins = pin_minimum([data['build-system']['requires']])
+all_pins = pin_minimum([data['build-system']['requires'],
+                        data['project']['dependencies']])
+
+for filename, pins in (
+    ('build-oldest-constraints.txt', build_pins),
+    ('install-oldest-constraints.txt', all_pins),
+):
+    output = pyproject.parent / filename
+    output.write_text('\n'.join(pins) + '\n')
+    sys.stdout.write(f'Wrote {output}:\n')
+    for p in pins:
+        sys.stdout.write(f'  {p}\n')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = [
     'cython >= 3.1.2, < 4',
     'extension-helpers >= 1.3, < 2',
     'numpy >= 2.0',
-    'setuptools >= 77.0',
+    'setuptools >= 77.0.1',
     'setuptools_scm >= 8.1',
 ]
 build-backend = 'setuptools.build_meta'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist =
     py{311,312}-test-oldestdeps
+    py{311,312}-cython-oldestdeps
+    py{311,312}-build-oldestdeps
+    py{311,312}-install-oldestdeps
     py{311,312,313,314}-test{,-alldeps,-devdeps,-devinfra}{,-cov}
     build_docs
     linkcheck
@@ -117,6 +120,48 @@ deps =
 commands =
     python -m build --sdist .
     twine check dist/* --strict
+
+[testenv:{py311,py312}-cython-oldestdeps]
+skip_install = true
+changedir = .
+description = check Cython compilation with oldest supported Cython version
+deps =
+    packaging
+commands_pre =
+    python -c "import sys; assert (3,11) <= sys.version_info < (3,13), 'Requires Python 3.11 or 3.12'"
+    python {toxinidir}/_build_oldest_pins.py
+    pip install -r {toxinidir}/build-oldest-constraints.txt
+commands =
+    pip freeze --all
+    python -c "from Cython.Build import cythonize; cythonize('photutils/**/*.pyx', force=True, language_level='3')"
+
+[testenv:{py311,py312}-build-oldestdeps]
+skip_install = true
+changedir = .
+description = check building the package with oldest supported build dependencies
+deps =
+    packaging
+commands_pre =
+    python -c "import sys; assert (3,11) <= sys.version_info < (3,13), 'Requires Python 3.11 or 3.12'"
+    python {toxinidir}/_build_oldest_pins.py
+    pip install -r {toxinidir}/build-oldest-constraints.txt
+commands =
+    pip freeze --all
+    pip wheel --no-build-isolation --no-deps .
+
+[testenv:{py311,py312}-install-oldestdeps]
+skip_install = true
+changedir = .
+description = check building and installing the package with oldest supported dependencies
+deps =
+    packaging
+commands_pre =
+    python -c "import sys; assert (3,11) <= sys.version_info < (3,13), 'Requires Python 3.11 or 3.12'"
+    python {toxinidir}/_build_oldest_pins.py
+    pip install -r {toxinidir}/install-oldest-constraints.txt
+commands =
+    pip freeze --all
+    pip install --no-build-isolation .
 
 [testenv:bandit]
 skip_install = true


### PR DESCRIPTION
#2260 revealed a build issue that occurs only when using Cython 3.1.x.  CI tests have been passing because they were always using Cython 3.2.x, where `bool` is a recognized type.

This PR adds a CI test to test Cythonizing with the oldest-supported Cython version (based on `pyproject.toml`).

The `py311-cython-oldestdeps` should fail until #2260 is resolved.