### PR TITLE
do not build for free-threaded Python

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,14 +43,14 @@ jobs:
       test_command: pytest -p no:warnings --pyargs photutils
       targets: |
         # Linux wheels
-        - cp*-manylinux_x86_64
+        - cp*[!t]-manylinux_x86_64
 
         # MacOS X wheels
-        - cp*-macosx_x86_64
-        - cp*-macosx_arm64
+        - cp*[!t]-macosx_x86_64
+        - cp*[!t]-macosx_arm64
 
         # Windows wheels
-        - cp*-win_amd64
+        - cp*[!t]-win_amd64
 
       # Developer wheels
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}


### PR DESCRIPTION
brought up in https://github.com/spacetelescope/romanisim/issues/354:
> ValueError: `py_limited_api='cp311'` not supported. `Py_LIMITED_API` is currently incompatible with `Py_GIL_DISABLED`. See https://github.com/python/cpython/issues/111506.

this PR needs a milestone, as well as `no-changelog-entry-needed`