### PR TITLE
Upgrade PyPI CI publishing to use Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,6 @@ permissions:
 
 jobs:
   build_and_publish:
-    # This job builds the wheels and publishes them to PyPI for all
-    # tags, except those ending in ".dev". For PRs with the "Build all
-    # wheels" label, wheels are built, but are not uploaded to PyPI.
-
     permissions:
       contents: none
 
@@ -47,15 +43,8 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'Build all wheels')
       )
     with:
-      # We upload to PyPI for all tag pushes, except tags ending in .dev
-      upload_to_pypi: >-
-        ${{ startsWith(github.ref, 'refs/tags/') &&
-            !endsWith(github.ref, '.dev') &&
-            (
-              github.event_name == 'push' ||
-              github.event_name == 'workflow_dispatch'
-            )
-        }}
+      upload_to_pypi: false
+      save_artifacts: true
 
       test_extras: test
       test_command: pytest -p no:warnings --pyargs photutils
@@ -80,5 +69,35 @@ jobs:
       anaconda_keep_n_latest: 10
 
     secrets:
-      pypi_token: ${{ secrets.pypi_token }}
       anaconda_token: ${{ secrets.anaconda_token }}
+
+  upload:
+    # This job builds the wheels and publishes them to PyPI for all
+    # tags, except those ending in ".dev". For PRs with the "Build all
+    # wheels" label, wheels are built, but are not uploaded to PyPI.
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/photutils/
+    # We upload to PyPI for all tag pushes, except tags ending in .dev
+    if: >-
+      ${{ startsWith(github.ref, 'refs/tags/') &&
+          !endsWith(github.ref, '.dev') &&
+          (
+            github.event_name == 'push' ||
+            github.event_name == 'workflow_dispatch'
+          )
+      }}
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [build_and_publish]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
- Background: https://github.com/astropy/specutils/issues/1323

Migrates PyPI publishing from a long-lived API token to [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), motivated by recent supply chain attacks ([litellm](https://blog.pypi.org/posts/2026-04-02-incident-report-litellm-telnyx-supply-chain-attack/), [lightning](https://cybersecuritynews.com/python-package-lightning-hacked/)).

The publishing step uses [a reusable workflow](https://github.com/OpenAstronomy/github-actions-workflows/blob/v2.6.3/.github/workflows/publish.yml) from the OpenAstronomy org, and since you can't pass OIDC tokens across orgs, the workaround (documented [here](https://github-actions-workflows.openastronomy.org/en/latest/trusted_publishing.html)) is to instead set `upload_to_pypi: false` and `save_artifacts: true` then publish the stored artifact with the `pypa/gh-action-pypi` action.

- Adapted from similar PR in regions repo: https://github.com/astropy/regions/pull/661 which followed [this example](https://github.com/astropy/astropy/blob/80447a4334ba617c04d5918b66d80793f202c52e/.github/workflows/publish.yml#L77-L94) from the astropy package repo.

The code changes here require some further (trivial) setup on the PyPI-side. Specifically, the PyPI admin (not just maintainer) needs to register the TP on PyPI at https://pypi.org/manage/project/photutils/settings/publishing/

- Owner: `astropy`
- Repo: `photutils`
- Workflow: `publish.yml`
- Environment: `pypi`

The `pypi_token` secret should be deleted from the repo secrets and can be invalidated on PyPI too.

(Not sure who is the PyPI admin, the maintainers are listed as @larrybradley + @astrofrog)

Closes #2250