### PR TITLE
Add asdf-astropy to tests extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ all = [
     'tqdm >= 4.67',
 ]
 test = [
+    'asdf-astropy >= 0.10',
     'pytest-asdf-plugin',
     'pytest-astropy >= 0.11',
     'pytest-xdist >= 3.7',


### PR DESCRIPTION
The failing weekly CI tests (https://github.com/astropy/photutils/actions/runs/26017235582) has revealed an issue where the asdf schema tests fail with:

```
pip install photutils[test]
pytest
```
This is because the `test` extra does not install the `asdf-astropy` package and `asdf_schema_tests_enabled` was set to `true`.