### PR TITLE
[codex] Fix EllipseSample geometry sma cache reset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ Bug Fixes
     an elliptical path that falls entirely (or largely) outside the
     image. [#2283]
 
+  - Fixed ``EllipseSample`` not resetting ``EllipseGeometry`` cached
+    attributes when overriding ``sma``. [#2280]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/isophote/geometry.py
+++ b/photutils/isophote/geometry.py
@@ -143,10 +143,21 @@ class EllipseGeometry:
         self._phi_min = 0.05
         self._phi_max = 0.2
 
+        self._reset_sma_dependent_attributes()
+
+    def _reset_sma_dependent_attributes(self):
+        """
+        Reset attributes derived from the current semimajor axis length.
+        """
         # variables used in the calculation of the sector angular width
         sma1, sma2 = self.bounding_ellipses()
         inner_sma = min((sma2 - sma1), 3.0)
         self._area_factor = (sma2 - sma1) * inner_sma
+
+        for attr in ('sector_angular_width', 'initial_polar_angle',
+                     'initial_polar_radius'):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
         # sma can eventually be zero!
         if self.sma > 0.0:

--- a/photutils/isophote/sample.py
+++ b/photutils/isophote/sample.py
@@ -117,6 +117,7 @@ class EllipseSample:
             # explicitly passed to the constructor.
             self.geometry = copy.deepcopy(geometry)
             self.geometry.sma = sma
+            self.geometry._reset_sma_dependent_attributes()
         else:
             # if no center was specified, assume it's roughly
             # coincident with the image center

--- a/photutils/isophote/tests/test_sample.py
+++ b/photutils/isophote/tests/test_sample.py
@@ -6,6 +6,7 @@ Tests for the sample module.
 import numpy as np
 import pytest
 
+from photutils.isophote.geometry import EllipseGeometry
 from photutils.isophote.integrator import (BILINEAR, MEAN, MEDIAN,
                                            NEAREST_NEIGHBOR)
 from photutils.isophote.isophote import Isophote
@@ -56,3 +57,22 @@ def test_sclip():
 
     assert isinstance(x, np.ndarray)
     assert isinstance(y, np.ndarray)
+
+
+def test_geometry_sma_override_resets_cached_attributes():
+    geometry = EllipseGeometry(25.0, 25.0, 10.0, 0.3, np.pi / 4.0,
+                               astep=0.2)
+    sample = EllipseSample(DATA, 20.0, geometry=geometry)
+    expected_geometry = EllipseGeometry(25.0, 25.0, 20.0, 0.3,
+                                        np.pi / 4.0, astep=0.2)
+
+    assert sample.geometry.sma == 20.0
+    assert geometry.sma == 10.0
+    np.testing.assert_allclose(sample.geometry._area_factor,
+                               expected_geometry._area_factor)
+    np.testing.assert_allclose(sample.geometry.sector_angular_width,
+                               expected_geometry.sector_angular_width)
+    np.testing.assert_allclose(sample.geometry.initial_polar_angle,
+                               expected_geometry.initial_polar_angle)
+    np.testing.assert_allclose(sample.geometry.initial_polar_radius,
+                               expected_geometry.initial_polar_radius)


### PR DESCRIPTION
## Summary

Fixes #2105 by resetting EllipseGeometry attributes that are derived from sma when EllipseSample is constructed from an existing geometry and a new semimajor axis.

The root cause was that EllipseSample deep-copied the input geometry and overwrote geometry.sma, but left cached SMA-dependent values such as _area_factor, sector_angular_width, initial_polar_angle, and initial_polar_radius from the original geometry.

## Changes

- Moved SMA-dependent geometry initialization into a private helper on EllipseGeometry.
- Called that helper after EllipseSample overrides the copied geometry sma.
- Added a regression test that compares the copied-and-overridden geometry against a freshly constructed geometry with the target sma.

## Validation

- python -m pytest photutils/isophote/tests/test_sample.py
- python -m pytest photutils/isophote/tests/test_geometry.py photutils/isophote/tests/test_sample.py
