### PR TITLE
Fix isophote "mean of empty slice" warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ Bug Fixes
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a
     compilation issue with Cython 3.1.x. [#2260]
 
+  - Fixed spurious NumPy "Mean of empty slice" and related warnings
+    raised during isophote fitting when a trial or failed isophote has
+    an elliptical path that falls entirely (or largely) outside the
+    image. [#2283]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -137,6 +137,30 @@ class Isophote:
 
         if sample.geometry.sma > 0:
             self.intens = sample.mean
+            if sample.actual_points == 0:
+                # No valid sampled points (e.g., a trial geometry that
+                # fell entirely outside the image). Operating on the
+                # empty sample arrays would emit numpy warnings (e.g.,
+                # "Mean of empty slice"), so set non-meaningful values
+                # directly and skip the harmonic computations. Such a
+                # degenerate isophote is transient: it is either
+                # discarded or replaced by `_fix_last_isophote`.
+                self.rms = np.nan
+                self.int_err = np.nan
+                self.pix_stddev = np.nan
+                self.grad = sample.gradient
+                self.gradient_err = sample.gradient_err
+                self.gradient_rel_err = sample.gradient_rel_err
+                self.sarea = sample.sector_area
+                self.n_data = sample.actual_points
+                self.n_flag = sample.total_points - sample.actual_points
+                self.tflux_e = self.tflux_c = 0.0
+                self.npix_e = self.npix_c = 0
+                self.x0_err = self.y0_err = self.pa_err = self.ellip_err = 0.0
+                self.a3 = self.b3 = self.a3_err = self.b3_err = None
+                self.a4 = self.b4 = self.a4_err = self.b4_err = None
+                return
+
             self.rms = np.std(sample.values[2])
             self.int_err = self.rms / np.sqrt(sample.actual_points)
             self.pix_stddev = self.rms * np.sqrt(sample.sector_area)

--- a/photutils/isophote/sample.py
+++ b/photutils/isophote/sample.py
@@ -319,6 +319,20 @@ class EllipseSample:
 
         # Update the mean value first, using extraction from main sample.
         s = self.extract()
+
+        # If the elliptical path falls entirely outside the image (e.g.,
+        # a trial geometry that diverged during the fit), no points are
+        # sampled. Short-circuit here to avoid emitting numpy warnings
+        # (e.g., "Mean of empty slice") from operating on empty arrays.
+        # The fitter detects this condition separately via its own
+        # zero-length check and marks the isophote as invalid.
+        if len(s[2]) == 0:
+            self.mean = np.nan
+            self.gradient = np.nan
+            self.gradient_err = np.nan
+            self.gradient_rel_err = None
+            return
+
         self.mean = np.mean(s[2])
 
         # Get sample with same geometry but at a different distance from
@@ -367,6 +381,16 @@ class EllipseSample:
             integrmode=self.integrmode)
 
         sg = gradient_sample.extract()
+
+        # If the gradient sample (taken at a slightly larger semimajor
+        # axis) falls entirely outside the image, no points are sampled.
+        # Return a non-meaningful gradient without operating on empty
+        # arrays (which would emit numpy warnings). NaN (rather than
+        # None) is returned to match the previous numeric behavior so
+        # that downstream arithmetic continues to work.
+        if len(sg[2]) == 0:
+            return np.nan, np.nan
+
         mean_g = np.mean(sg[2])
         gradient = (mean_g - self.mean) / self.geometry.sma / step
 

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -92,17 +92,10 @@ class TestEllipse:
         # image is off-center by a large offset.
         ellipse = Ellipse(OFFSET_GALAXY)
 
-        match1 = 'Degrees of freedom'
-        match2 = 'Mean of empty slice'
-        match3 = 'invalid value encountered'
-        match4 = 'No meaningful fit was possible'
-        ctx1 = pytest.warns(RuntimeWarning, match=match1)
-        ctx2 = pytest.warns(RuntimeWarning, match=match2)
-        ctx3 = pytest.warns(RuntimeWarning, match=match3)
-        ctx4 = pytest.warns(AstropyUserWarning, match=match4)
-        with ctx1, ctx2, ctx3, ctx4:
+        match = 'No meaningful fit was possible'
+        with pytest.warns(AstropyUserWarning, match=match):
             isophote_list = ellipse.fit_image()
-            assert len(isophote_list) == 0
+        assert len(isophote_list) == 0
 
     def test_offcenter_fit(self):
         # A first guess ellipse that is roughly centered on the

--- a/photutils/isophote/tests/test_harmonics.py
+++ b/photutils/isophote/tests/test_harmonics.py
@@ -205,7 +205,16 @@ def test_upper_harmonics_sign():
     # test image is "disky: disky isophotes have b4 > 0
     # (boxy isophotes have b4 < 0)
     assert np.all(isolist.b4[30:] > 0)
-    assert isolist.a3[-1] < 0
-    assert isolist.a4[-1] < 0
-    assert isolist.b3[-1] > 0
-    assert isolist.b4[-1] > 0
+
+    # Check the sign of the upper harmonics at the outermost
+    # well-sampled isophote. The very last isophote(s) can be
+    # degenerate, with a large fraction of the elliptical path falling
+    # outside the image, in which case the near-zero upper harmonics
+    # are dominated by noise and their signs are not meaningful.
+    n_total = isolist.n_data + isolist.n_flag
+    well_sampled = isolist.n_flag < (0.3 * n_total)
+    idx = np.where(well_sampled)[0][-1]
+    assert isolist.a3[idx] < 0
+    assert isolist.a4[idx] < 0
+    assert isolist.b3[idx] > 0
+    assert isolist.b4[idx] > 0


### PR DESCRIPTION
This PR fixes spurious NumPy "Mean of empty slice" and related warnings raised during isophote fitting when a trial or failed isophote has an elliptical path that falls entirely (or largely) outside the image.

It also fixes a fragile harmonics test.