### PR TITLE
Fix aperture to_sky/to_pixel for flipped-parity WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,12 @@ Bug Fixes
     ``to_pixel`` conversions so that they round-trip correctly with a
     sheared WCS. [#2286]
 
+  - Fixed the aperture ``to_sky`` and ``to_pixel`` conversions for
+    elliptical and rectangular apertures (and their annulus variants)
+    so that the orientation is correct for a WCS with a flipped parity
+    (e.g., North down, East left). Previously, such apertures were
+    mirrored about the x-axis. [#2288]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/photutils/aperture/tests/test_pixel_sky_conversions.py
+++ b/photutils/aperture/tests/test_pixel_sky_conversions.py
@@ -215,6 +215,25 @@ def sip_wcs():
     return _make_sip_wcs()
 
 
+@pytest.fixture
+def flipped_wcs():
+    """
+    A flipped-parity TAN WCS (North down, East left).
+
+    Both CDELT values are negative, so the pixel scale matrix has
+    a positive determinant (parity = +1), opposite the standard
+    astronomical convention. North (increasing Dec) points along -y and
+    East (increasing RA) points along -x.
+    """
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [10.5, 10.5]
+    wcs.wcs.crval = [CENTER.ra.deg, CENTER.dec.deg]
+    wcs.wcs.cdelt = [-0.1 / 3600, -0.1 / 3600]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+
+    return wcs
+
+
 class TestApertureSkyToPixel:
     """
     Converting a sky aperture to a pixel aperture must return the
@@ -530,3 +549,80 @@ class TestCircularInputAnglePreserved:
         pix_rt = pix.to_sky(rotated_wcs).to_pixel(rotated_wcs)
         diff = _angle_diff_deg(pix_rt.theta, theta_deg * u.deg)
         assert abs(diff) < 1e-6
+
+
+class TestFlippedParityWCS:
+    """
+    Regression tests for a flipped-parity WCS (North down, East left;
+    positive-determinant pixel scale matrix).
+
+    Such a WCS previously produced apertures that were mirrored about
+    the x-axis. For the flipped axis-aligned WCS, North = -y and East =
+    -x, so the sky/pixel angle relation is ``pixel.theta == 270 deg -
+    sky.theta`` (mod 360).
+    """
+
+    def test_flipped_wcs_has_positive_parity(self, flipped_wcs):
+        """
+        The flipped WCS fixture must have a positive-determinant pixel
+        scale matrix (parity = +1).
+        """
+        assert np.linalg.det(flipped_wcs.pixel_scale_matrix) > 0
+
+    def test_north_is_minus_y(self, flipped_wcs):
+        """
+        A sky aperture at PA=0 (North) maps to a pixel aperture pointing
+        along -y (down), i.e., pixel theta = 270 deg.
+        """
+        sky = SkyEllipticalAperture(CENTER, a=2 * u.arcsec, b=1 * u.arcsec,
+                                    theta=0 * u.deg)
+        pix = sky.to_pixel(flipped_wcs)
+        diff = _angle_diff_deg(pix.theta, 270 * u.deg)
+        assert abs(diff) < 2e-5
+
+    def test_east_is_minus_x(self, flipped_wcs):
+        """
+        A sky aperture at PA=90 deg (East) maps to a pixel aperture
+        pointing along -x (left), i.e., pixel theta = 180 deg.
+        """
+        sky = SkyEllipticalAperture(CENTER, a=2 * u.arcsec, b=1 * u.arcsec,
+                                    theta=90 * u.deg)
+        pix = sky.to_pixel(flipped_wcs)
+        diff = _angle_diff_deg(pix.theta, 180 * u.deg)
+        assert abs(diff) < 2e-5
+
+    @pytest.mark.parametrize('case', DIRECTED_CASES)
+    @pytest.mark.parametrize('theta_deg', ANGLES_DEG)
+    def test_sky_to_pixel_theta(self, flipped_wcs, case, theta_deg):
+        """
+        Verify ``sky.to_pixel`` returns ``270 deg - theta`` (mod 360)
+        for the flipped-parity WCS (not the mirrored value).
+        """
+        sky, _ = _build_pair(case, theta_deg * u.deg)
+        pix = sky.to_pixel(flipped_wcs)
+        diff = _angle_diff_deg(pix.theta, (270 - theta_deg) * u.deg)
+        assert abs(diff) < 2e-5
+
+    @pytest.mark.parametrize('case', DIRECTED_CASES)
+    @pytest.mark.parametrize('theta_deg', ANGLES_DEG)
+    def test_pixel_to_sky_theta(self, flipped_wcs, case, theta_deg):
+        """
+        Verify ``pixel.to_sky`` returns ``270 deg - theta`` (mod 360)
+        for the flipped-parity WCS (the inverse of the above relation).
+        """
+        _, pix = _build_pair(case, theta_deg * u.deg)
+        sky = pix.to_sky(flipped_wcs)
+        diff = _angle_diff_deg(sky.theta, (270 - theta_deg) * u.deg)
+        assert abs(diff) < 2e-5
+
+    @pytest.mark.parametrize('case', DIRECTED_CASES)
+    @pytest.mark.parametrize('theta_deg', ANGLES_DEG)
+    def test_sky_pixel_sky_roundtrip_theta(self, flipped_wcs, case, theta_deg):
+        """
+        Verify ``sky -> pixel -> sky`` preserves the original theta for
+        the flipped-parity WCS.
+        """
+        sky, _ = _build_pair(case, theta_deg * u.deg)
+        sky_rt = sky.to_pixel(flipped_wcs).to_sky(flipped_wcs)
+        diff = _angle_diff_deg(sky_rt.theta, theta_deg * u.deg)
+        assert abs(diff) < 2e-5

--- a/photutils/utils/_wcs_helpers.py
+++ b/photutils/utils/_wcs_helpers.py
@@ -90,8 +90,7 @@ def _pixel_to_sky_jacobian(pixcoord, wcs):
     return center, jacobian, jacobian_inv, parity
 
 
-def _svd_ellipse_from_composite(m_comp, width_col_idx=0,
-                                use_parity_for_angle=False, parity=1,
+def _svd_ellipse_from_composite(m_comp, width_col_idx=0, sky_angle=False,
                                 input_circular=False):
     """
     Extract ellipse width, height, and angle from a composite matrix
@@ -111,13 +110,13 @@ def _svd_ellipse_from_composite(m_comp, width_col_idx=0,
         The column index (0 or 1) of ``m_comp`` that corresponds to the
         width semi-axis. Default is 0.
 
-    use_parity_for_angle : bool, optional
-        If True, apply ``parity`` to the RA (x) component when computing
-        the sky rotation angle. Default is False (for pixel angles).
-
-    parity : float, optional
-        The WCS parity (+1 or -1). Only used if ``use_parity_for_angle``
-        is True.
+    sky_angle : bool, optional
+        If True, the composite matrix columns are tangent-plane (``xi``
+        = East, ``eta`` = North) vectors, so the returned angle is a sky
+        position angle (PA) measured from North toward East. If False
+        (the default), the columns are pixel (``x``, ``y``) vectors
+        and the returned angle is measured counterclockwise from the
+        positive x-axis.
 
     input_circular : bool, optional
         If True, the input ellipse is known to be circular (width ==
@@ -173,13 +172,15 @@ def _svd_ellipse_from_composite(m_comp, width_col_idx=0,
             angle_col = width_col / width_norm
 
     # Compute the rotation angle
-    if use_parity_for_angle:
+    if sky_angle:
         # Sky position angle (PA) measured from North (eta/Dec) toward
-        # East. The xi (RA) component in the composite matrix has
-        # -parity baked in, so we multiply by -parity to recover the
-        # physical East direction.
+        # East. The composite-matrix columns are tangent-plane vectors
+        # with components (xi=East, eta=North), so the PA is simply
+        # arctan2(xi, eta). The local Jacobian (or its inverse) used to
+        # build the composite matrix already encodes the WCS parity, so
+        # no additional parity correction is needed here.
         angle = Angle(
-            np.rad2deg(np.arctan2(-parity * angle_col[0],
+            np.rad2deg(np.arctan2(angle_col[0],
                                   angle_col[1])) * u.deg,
         ).wrap_at(360 * u.deg)
     else:
@@ -506,7 +507,7 @@ def pixel_shape_to_sky_svd(pixcoord, wcs, width, height, pixel_angle_rad):
         counterclockwise from North (the latitude/Dec axis), wrapped to
         [0, 360) degrees.
     """
-    center, _, jacobian_inv, parity = _pixel_to_sky_jacobian(pixcoord, wcs)
+    center, _, jacobian_inv, _ = _pixel_to_sky_jacobian(pixcoord, wcs)
 
     # Build M_pix: columns are pixel semi-axis vectors
     cos_a = np.cos(pixel_angle_rad)
@@ -520,7 +521,7 @@ def pixel_shape_to_sky_svd(pixcoord, wcs, width, height, pixel_angle_rad):
     m_sky = jacobian_inv @ m_pix
 
     sky_width, sky_height, sky_angle = _svd_ellipse_from_composite(
-        m_sky, use_parity_for_angle=True, parity=parity,
+        m_sky, sky_angle=True,
         input_circular=np.isclose(width, height))
 
     return center, sky_width, sky_height, sky_angle
@@ -579,17 +580,19 @@ def sky_shape_to_pixel_svd(skycoord, wcs, width_arcsec, height_arcsec,
         counterclockwise from the positive x-axis, wrapped to [0, 360)
         degrees.
     """
-    center, jacobian, parity = _sky_to_pixel_jacobian(skycoord, wcs)
+    center, jacobian, _ = _sky_to_pixel_jacobian(skycoord, wcs)
 
     # Build M_sky: columns are sky semi-axis vectors in tangent-plane
-    # coordinates (xi=RA, eta=Dec). The width axis is at the given PA
-    # from North. Apply parity to the RA (xi) component.
+    # coordinates (xi=East, eta=North). The width axis is at the given
+    # PA from North (toward East), so its tangent-plane components are
+    # (sin(PA), cos(PA)); the height axis is perpendicular, at PA+90.
+    # The local Jacobian already encodes the WCS parity, so no manual
+    # parity factor is applied here.
     cos_pa = np.cos(sky_angle_rad)
     sin_pa = np.sin(sky_angle_rad)
     half_w = 0.5 * width_arcsec
     half_h = 0.5 * height_arcsec
-    m_sky = np.array([[-parity * half_w * sin_pa,
-                       -parity * half_h * cos_pa],
+    m_sky = np.array([[half_w * sin_pa, half_h * cos_pa],
                       [half_w * cos_pa, -half_h * sin_pa]])
 
     # M_pix = J @ M_sky: columns are pixel semi-axis vectors

--- a/photutils/utils/tests/conftest.py
+++ b/photutils/utils/tests/conftest.py
@@ -142,6 +142,24 @@ def nonsquare_wcs():
 
 
 @pytest.fixture
+def flipped_wcs():
+    """
+    Non-distorted TAN WCS with a flipped parity (North down, East left).
+
+    Both CDELT values are negative, so the determinant of the pixel
+    scale matrix is positive (parity = +1). This is the opposite parity
+    from the standard astronomical convention (North up, East left) and
+    reproduces the mirrored-aperture bug reported for such WCS.
+    """
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [10.5, 10.5]
+    wcs.wcs.crval = [WCS_CENTER.ra.deg, WCS_CENTER.dec.deg]
+    wcs.wcs.cdelt = [-WCS_CDELT_ARCSEC / 3600, -WCS_CDELT_ARCSEC / 3600]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    return wcs
+
+
+@pytest.fixture
 def center_xy_coord(simple_wcs):
     """
     Return the center (x, y) tuple at CRPIX of the simple WCS.

--- a/photutils/utils/tests/test_wcs_helpers.py
+++ b/photutils/utils/tests/test_wcs_helpers.py
@@ -605,3 +605,114 @@ class TestSVDShapeConversions:
             center, wcs, pw, ph, pa.to(u.rad).value)
         assert_allclose(sw, 2.0, rtol=1e-3)
         assert_allclose(sh, 1.0, rtol=1e-3)
+
+
+def _project_sky_ellipse_boundary(skycoord, wcs, a_arcsec, b_arcsec,
+                                  pa_rad, npts=720):
+    """
+    Project the boundary of a sky ellipse to pixel coordinates.
+
+    The boundary points are computed in the tangent plane (``xi``
+    = East, ``eta`` = North) and offset from ``skycoord`` using
+    great-circle geometry, then converted to pixel coordinates with
+    ``wcs.world_to_pixel``. This is an independent ground truth for the
+    pixel image of a sky ellipse.
+    """
+    theta = np.linspace(0, 2 * np.pi, npts, endpoint=False)
+    xi = (a_arcsec * np.cos(theta) * np.sin(pa_rad)
+          + b_arcsec * np.sin(theta) * np.cos(pa_rad))
+    eta = (a_arcsec * np.cos(theta) * np.cos(pa_rad)
+           - b_arcsec * np.sin(theta) * np.sin(pa_rad))
+    sep = np.hypot(xi, eta) * u.arcsec
+    posang = np.arctan2(xi, eta) * u.rad
+    pts = skycoord.directional_offset_by(posang, sep)
+    x, y = wcs.world_to_pixel(pts)
+    return np.asarray(x, dtype=float), np.asarray(y, dtype=float)
+
+
+def _ellipse_implicit_residual(x, y, center, width, height, angle_rad):
+    """
+    Evaluate the implicit ellipse equation for points ``(x, y)``.
+
+    Returns ``(u / a)**2 + (v / b)**2`` where ``(u, v)`` are the point
+    offsets from ``center`` rotated into the ellipse frame and ``a``,
+    ``b`` are the semi-axes. Points exactly on the ellipse boundary
+    yield 1.
+    """
+    cx, cy = center
+    dx = x - cx
+    dy = y - cy
+    cos_a = np.cos(angle_rad)
+    sin_a = np.sin(angle_rad)
+    u_axis = dx * cos_a + dy * sin_a
+    v_axis = -dx * sin_a + dy * cos_a
+    return (u_axis / (width / 2)) ** 2 + (v_axis / (height / 2)) ** 2
+
+
+class TestFlippedParityWCS:
+    """
+    Regression tests for sky <-> pixel shape conversions with a
+    flipped-parity WCS (North down, East left; positive determinant).
+
+    Such a WCS previously produced apertures that were mirrored about
+    the x-axis relative to the correct orientation.
+    """
+
+    PA_DEGS = (0.0, 30.0, 75.0, 130.0, 228.0, 310.0)
+
+    def test_flipped_wcs_has_positive_parity(self, flipped_wcs):
+        """
+        The flipped WCS fixture must have a positive-determinant pixel
+        scale matrix (parity = +1), opposite the standard convention.
+        """
+        assert np.linalg.det(flipped_wcs.pixel_scale_matrix) > 0
+
+    @pytest.mark.parametrize('pa_deg', PA_DEGS)
+    def test_sky_to_pixel_matches_projection(self, flipped_wcs, pa_deg):
+        """
+        The pixel ellipse from ``sky_shape_to_pixel_svd`` must match
+        the true projection of the sky ellipse boundary (not its mirror
+        image) for a flipped-parity WCS.
+        """
+        a_arcsec, b_arcsec = 3.0, 1.5
+        pa_rad = np.deg2rad(pa_deg)
+        center, pw, ph, pangle = sky_shape_to_pixel_svd(
+            WCS_CENTER, flipped_wcs, 2 * a_arcsec, 2 * b_arcsec, pa_rad)
+
+        x, y = _project_sky_ellipse_boundary(
+            WCS_CENTER, flipped_wcs, a_arcsec, b_arcsec, pa_rad)
+        resid = _ellipse_implicit_residual(
+            x, y, center, pw, ph, pangle.rad)
+        # All projected boundary points must lie on the pixel ellipse.
+        assert_allclose(resid, 1.0, atol=1e-3)
+
+    @pytest.mark.parametrize('pa_deg', PA_DEGS)
+    def test_normal_wcs_matches_projection(self, simple_wcs, pa_deg):
+        """
+        The same check for a standard-parity WCS (a control case that
+        already worked before the fix).
+        """
+        a_arcsec, b_arcsec = 3.0, 1.5
+        pa_rad = np.deg2rad(pa_deg)
+        center, pw, ph, pangle = sky_shape_to_pixel_svd(
+            WCS_CENTER, simple_wcs, 2 * a_arcsec, 2 * b_arcsec, pa_rad)
+
+        x, y = _project_sky_ellipse_boundary(
+            WCS_CENTER, simple_wcs, a_arcsec, b_arcsec, pa_rad)
+        resid = _ellipse_implicit_residual(
+            x, y, center, pw, ph, pangle.rad)
+        assert_allclose(resid, 1.0, atol=1e-3)
+
+    def test_roundtrip_sky_pixel_sky(self, flipped_wcs):
+        """
+        Sky -> pixel -> sky should recover the original ellipse for a
+        flipped-parity WCS.
+        """
+        sky_w, sky_h, sky_a = 6.0, 3.0, np.deg2rad(228.0)
+        center_pix, pw, ph, pa = sky_shape_to_pixel_svd(
+            WCS_CENTER, flipped_wcs, sky_w, sky_h, sky_a)
+        _, rw, rh, ra = pixel_shape_to_sky_svd(
+            center_pix, flipped_wcs, pw, ph, pa.rad)
+        assert_allclose(rw, sky_w, rtol=1e-6)
+        assert_allclose(rh, sky_h, rtol=1e-6)
+        assert_allclose(ra.rad, sky_a, rtol=1e-4)


### PR DESCRIPTION
This PR fixes the aperture ``to_sky`` and ``to_pixel`` conversions for elliptical and rectangular apertures (and their annulus variants) so that the orientation is correct for a WCS with a flipped parity (e.g., North down, East left). Previously, such apertures were mirrored about the x-axis.

Many thanks to @djones1040 for reporting this.


Fixes #2287 