### PR TITLE
Improve aperture photometry performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,13 @@ New Features
   - Rectangular apertures now support the ``method='exact'`` mask mode.
     Previously this fell back to a 32x subpixel approximation. [#2291]
 
+  - Significantly improved the performance of aperture photometry,
+    typically by factors of ~2-25 depending on the aperture shape and
+    overlap method, by computing all sources in a single call into
+    compiled code. The computation also releases the GIL and uses no
+    global state, so aperture photometry can now be parallelized across
+    threads, including on free-threaded Python builds. [#2292]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -73,6 +73,55 @@ algorithm::
     >>> mask = aper.to_mask(method='exact')
 
 
+Faster Aperture Photometry
+==========================
+
+Aperture photometry is now significantly faster for all built-in
+aperture shapes. The photometry for all sources is now computed in a
+single call into compiled code, avoiding the per-source Python overhead
+of creating individual aperture masks and cutouts. Typical speedups
+range from ~2x to more than 25x, depending on the aperture shape and
+overlap method, with the largest gains for fields with many sources. The
+results are identical to those from previous versions.
+
+
+Thread-Safe and Free-Threading-Compatible Aperture Photometry
+==============================================================
+
+The new aperture photometry implementation releases the Python global
+interpreter lock (GIL) during the computation and uses no global state,
+making it safe to call concurrently from multiple threads. The compiled
+extensions are also declared compatible with free-threaded CPython
+builds, so threads can run the computation truly in parallel.
+
+For example, photometry of many apertures on a large image can be
+parallelized across threads by splitting the source positions into
+chunks::
+
+    >>> from concurrent.futures import ThreadPoolExecutor
+    >>> import numpy as np
+    >>> from astropy.table import vstack
+    >>> from photutils.aperture import (CircularAperture,
+    ...                                 aperture_photometry)
+    >>> rng = np.random.default_rng(seed=0)
+    >>> data = rng.random((4096, 4096))
+    >>> positions = rng.uniform(0, 4096, (100_000, 2))
+    >>> n_workers = 10
+    >>> chunks = [CircularAperture(pos, r=5.0)
+    ...           for pos in np.array_split(positions, n_workers)]
+    >>> with ThreadPoolExecutor(max_workers=n_workers) as executor:
+    ...     tables = list(executor.map(
+    ...         lambda aper: aperture_photometry(data, aper), chunks))
+    >>> phot_table = vstack(tables)
+    >>> phot_table['id'] = np.arange(1, len(phot_table) + 1)
+
+Note that the ``id`` column of each chunk's table is numbered starting
+from 1, so the last line renumbers the stacked ``id`` column to match
+the input source order. Because ``executor.map`` returns results in
+input order, the stacked table rows are in the same order as the input
+``positions``.
+
+
 .. _whatsnew-3.1-api-changes:
 
 API Changes

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -525,7 +525,7 @@ class SkyCircularAperture(SkyAperture):
         skypos = self.positions if self.isscalar else self.positions[0]
         _, mean_scale = sky_to_pixel_mean_scale(skypos, wcs)
 
-        r = self.r.to(u.arcsec).value * mean_scale
+        r = self.r.to_value(u.arcsec) * mean_scale
         return CircularAperture(positions=positions, r=r)
 
 
@@ -605,6 +605,6 @@ class SkyCircularAnnulus(SkyAperture):
         skypos = self.positions if self.isscalar else self.positions[0]
         _, mean_scale = sky_to_pixel_mean_scale(skypos, wcs)
 
-        r_in = self.r_in.to(u.arcsec).value * mean_scale
-        r_out = self.r_out.to(u.arcsec).value * mean_scale
+        r_in = self.r_in.to_value(u.arcsec) * mean_scale
+        r_out = self.r_out.to_value(u.arcsec) * mean_scale
         return CircularAnnulus(positions=positions, r_in=r_in, r_out=r_out)

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -17,7 +17,8 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
 from photutils.geometry import circular_overlap_grid
-from photutils.geometry._batch_photometry import SHAPE_CIRCLE
+from photutils.geometry._batch_photometry import (SHAPE_CIRCLE,
+                                                  SHAPE_CIRCULAR_ANNULUS)
 from photutils.utils._deprecation import deprecated
 from photutils.utils._wcs_helpers import (pixel_to_sky_mean_scale,
                                           sky_to_pixel_mean_scale)
@@ -332,6 +333,9 @@ class CircularAnnulus(PixelAperture):
     @lazyproperty
     def _xy_extents(self):
         return self.r_out, self.r_out
+
+    def _batch_shape_params(self):
+        return SHAPE_CIRCULAR_ANNULUS, (self.r_in, self.r_out)
 
     @lazyproperty
     def area(self):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -17,6 +17,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
 from photutils.geometry import circular_overlap_grid
+from photutils.geometry._batch_photometry import SHAPE_CIRCLE
 from photutils.utils._deprecation import deprecated
 from photutils.utils._wcs_helpers import (pixel_to_sky_mean_scale,
                                           sky_to_pixel_mean_scale)
@@ -154,6 +155,9 @@ class CircularAperture(PixelAperture):
     @lazyproperty
     def _xy_extents(self):
         return self.r, self.r
+
+    def _batch_shape_params(self):
+        return SHAPE_CIRCLE, (self.r,)
 
     @lazyproperty
     def area(self):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -683,23 +683,12 @@ class PixelAperture(Aperture):
         Returns
         -------
         aperture_sums : `~numpy.ndarray` or `~astropy.units.Quantity`
-            The sum within each aperture.
+            The sum within each aperture. The values are always
+            float64, regardless of the input ``data`` dtype.
 
         aperture_sum_errs : `~numpy.ndarray` or `~astropy.units.Quantity`
-            The errors on the sum within each aperture.
-
-        Notes
-        -----
-        `RectangularAperture` and `RectangularAnnulus` photometry with
-        the "exact" method uses a subpixel approximation by subdividing
-        each data pixel by a factor of 1024 (``subpixels = 32``). For
-        rectangular aperture widths and heights in the range from
-        2 to 100 pixels, this subpixel approximation gives results
-        typically within 0.001 percent or better of the exact value.
-        The differences can be larger for smaller apertures (e.g.,
-        aperture sizes of one pixel or smaller). For such small sizes,
-        it is recommended to set ``method='subpixel'`` with a larger
-        ``subpixels`` size.
+            The errors on the sum within each aperture. The values are
+            always float64, regardless of the input ``error`` dtype.
         """
         data = np.asanyarray(data)
         if data.ndim != 2:

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -14,6 +14,7 @@ from astropy.utils import lazyproperty
 
 from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.mask import ApertureMask
+from photutils.geometry._batch_photometry import batch_aperture_sums
 from photutils.utils._deprecation import deprecated_positional_kwargs
 
 __all__ = ['Aperture', 'PixelAperture', 'SkyAperture']
@@ -483,6 +484,157 @@ class PixelAperture(Aperture):
             The overlap array.
         """
 
+    def _do_mask_photometry(self, data, *, error, mask, method, subpixels):
+        """
+        Perform aperture photometry using per-source aperture masks.
+
+        This is the fallback code path for apertures or inputs that are
+        not supported by the batch Cython driver.
+
+        Parameters
+        ----------
+        data : `~numpy.ndarray`
+            The 2D array on which to perform photometry, with any units
+            already stripped.
+
+        error, mask, method, subpixels
+            See `do_photometry`. Any units must already be stripped from
+            ``error``.
+
+        Returns
+        -------
+        aperture_sums, aperture_sum_errs : `~numpy.ndarray`
+            The aperture sums and errors.
+        """
+        apermasks = self.to_mask(method=method, subpixels=subpixels)
+        if self.isscalar:
+            apermasks = (apermasks,)
+
+        aperture_sums = []
+        aperture_sum_errs = []
+        with warnings.catch_warnings():
+            # Ignore multiplication with non-finite data values
+            warnings.simplefilter('ignore', RuntimeWarning)
+
+            for apermask in apermasks:
+                (slc_large,
+                 aper_weights,
+                 pixel_mask) = apermask._get_overlap_cutouts(data.shape,
+                                                             mask=mask)
+
+                # No overlap of the aperture with the data
+                if slc_large is None:
+                    aperture_sums.append(np.nan)
+                    aperture_sum_errs.append(np.nan)
+                    continue
+
+                values = (data[slc_large] * aper_weights)[pixel_mask]
+                aperture_sums.append(values.sum())
+
+                if error is not None:
+                    variance = (error[slc_large]**2
+                                * aper_weights)[pixel_mask]
+                    aperture_sum_errs.append(np.sqrt(variance.sum()))
+
+        return np.array(aperture_sums), np.array(aperture_sum_errs)
+
+    def _batch_shape_params(self):
+        """
+        The aperture shape code and parameters for the batch Cython
+        photometry driver.
+
+        Returns
+        -------
+        spec : tuple or `None`
+            A ``(shape_code, params)`` tuple, where
+            ``shape_code`` is one of the shape codes defined in
+            `photutils.geometry._batch_photometry` and ``params``
+            is a tuple of the aperture shape parameters expected by
+            `~photutils.geometry._batch_photometry.batch_aperture_sums`
+            for that shape. `None` is returned if batch photometry is
+            not supported for this aperture, in which case the slower
+            mask-based code path is used.
+
+        Notes
+        -----
+        The batch driver is used only if this hook is defined in the
+        aperture instance's own class (see `_do_batch_photometry`),
+        so subclasses must define this method (e.g., by calling
+        ``super()``) to opt in to the batch code path.
+        """
+        return
+
+    def _do_batch_photometry(self, data, *, error, mask, method, subpixels):
+        """
+        Perform aperture photometry using the batch Cython driver.
+
+        The batch driver computes results identical to the mask-based
+        code path, but without creating per-source mask arrays or making
+        per-source Python calls.
+
+        Parameters
+        ----------
+        data : `~numpy.ndarray`
+            The 2D array on which to perform photometry, with any units
+            already stripped.
+
+        error, mask, method, subpixels
+            See `do_photometry`. Any units must already be stripped from
+            ``error``.
+
+        Returns
+        -------
+        result : tuple of `~numpy.ndarray` or `None`
+            A ``(aperture_sums, aperture_sum_errs)`` tuple of float64
+            arrays, or `None` if the batch driver does not support this
+            aperture or these inputs (in which case the caller should
+            use the mask-based code path).
+        """
+        # Use the batch driver only if the aperture's own class defines
+        # the _batch_shape_params hook. Subclasses that do not define
+        # it may override other behavior (e.g., to_mask) that the batch
+        # driver would not honor, so they use the mask-based code path.
+        if '_batch_shape_params' not in type(self).__dict__:
+            return None
+
+        spec = self._batch_shape_params()
+        if spec is None:
+            return None
+
+        def _supported(arr):
+            return (type(arr) is np.ndarray and arr.dtype.kind in 'fiub'
+                    and arr.dtype.itemsize <= 8)
+
+        if not _supported(data) or (error is not None
+                                    and not _supported(error)):
+            return None
+
+        if mask is not None:
+            if (not isinstance(mask, np.ndarray) or mask.dtype != bool
+                    or mask.shape != data.shape):
+                return None
+            mask = np.ascontiguousarray(mask, dtype=np.uint8)
+
+        use_exact, subpixels = self._translate_mask_method(method, subpixels)
+
+        shape_code, params = spec
+        if error is not None:
+            error = np.ascontiguousarray(error, dtype=np.float64)
+        ext_x, ext_y = self._xy_extents
+
+        sums, errs, overlap = batch_aperture_sums(
+            np.ascontiguousarray(data, dtype=np.float64), error, mask,
+            np.ascontiguousarray(self._positions, dtype=np.float64),
+            shape_code, np.array(params, dtype=np.float64),
+            float(ext_x), float(ext_y), use_exact, subpixels)
+
+        if error is None:
+            # Match the mask-based path, which collects one NaN per
+            # non-overlapping source when error is not input.
+            errs = np.full(np.count_nonzero(~overlap), np.nan)
+
+        return sums, errs
+
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def do_photometry(self, data, error=None, mask=None, method='exact',
                       subpixels=5):
@@ -577,38 +729,16 @@ class PixelAperture(Aperture):
             if error is not None:
                 error = error.value
 
-        apermasks = self.to_mask(method=method, subpixels=subpixels)
-        if self.isscalar:
-            apermasks = (apermasks,)
+        result = self._do_batch_photometry(data, error=error, mask=mask,
+                                           method=method,
+                                           subpixels=subpixels)
 
-        aperture_sums = []
-        aperture_sum_errs = []
-        with warnings.catch_warnings():
-            # Ignore multiplication with non-finite data values
-            warnings.simplefilter('ignore', RuntimeWarning)
-
-            for apermask in apermasks:
-                (slc_large,
-                 aper_weights,
-                 pixel_mask) = apermask._get_overlap_cutouts(data.shape,
-                                                             mask=mask)
-
-                # No overlap of the aperture with the data
-                if slc_large is None:
-                    aperture_sums.append(np.nan)
-                    aperture_sum_errs.append(np.nan)
-                    continue
-
-                values = (data[slc_large] * aper_weights)[pixel_mask]
-                aperture_sums.append(values.sum())
-
-                if error is not None:
-                    variance = (error[slc_large]**2
-                                * aper_weights)[pixel_mask]
-                    aperture_sum_errs.append(np.sqrt(variance.sum()))
-
-        aperture_sums = np.array(aperture_sums)
-        aperture_sum_errs = np.array(aperture_sum_errs)
+        if result is not None:
+            aperture_sums, aperture_sum_errs = result
+        else:
+            aperture_sums, aperture_sum_errs = self._do_mask_photometry(
+                data, error=error, mask=mask, method=method,
+                subpixels=subpixels)
 
         # Apply units
         if unit is not None:

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -18,6 +18,8 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
 from photutils.geometry import elliptical_overlap_grid
+from photutils.geometry._batch_photometry import (SHAPE_ELLIPSE,
+                                                  SHAPE_ELLIPTICAL_ANNULUS)
 from photutils.utils._deprecation import (deprecated,
                                           deprecated_positional_kwargs)
 from photutils.utils._wcs_helpers import (pixel_shape_to_sky_svd,
@@ -207,6 +209,10 @@ class EllipticalAperture(PixelAperture):
         y directions.
         """
         return _calc_ellipse_extents(self.a, self.b, self.theta)
+
+    def _batch_shape_params(self):
+        theta_rad = self.theta.to_value(u.radian)
+        return SHAPE_ELLIPSE, (self.a, self.b, theta_rad)
 
     @lazyproperty
     def area(self):
@@ -429,6 +435,11 @@ class EllipticalAnnulus(PixelAperture):
         x and y directions.
         """
         return _calc_ellipse_extents(self.a_out, self.b_out, self.theta)
+
+    def _batch_shape_params(self):
+        theta_rad = self.theta.to_value(u.radian)
+        return SHAPE_ELLIPTICAL_ANNULUS, (self.a_in, self.b_in, self.a_out,
+                                          self.b_out, theta_rad)
 
     @lazyproperty
     def area(self):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -94,16 +94,16 @@ class EllipticalMaskMixin:  # pragma: no cover
         masks = []
         for bbox, edges in zip(self._bbox, self._centered_edges, strict=True):
             ny, nx = bbox.shape
-            theta_rad = self.theta.to(u.radian).value
             mask = elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                            edges[3], nx, ny, a, b,
-                                           theta_rad, use_exact, subpixels)
+                                           self._theta_rad, use_exact,
+                                           subpixels)
 
             # Subtract the inner ellipse for an annulus
             if hasattr(self, 'a_in'):
                 mask -= elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                                 edges[3], nx, ny, self.a_in,
-                                                self.b_in, theta_rad,
+                                                self.b_in, self._theta_rad,
                                                 use_exact, subpixels)
 
             masks.append(ApertureMask(mask, bbox))
@@ -114,18 +114,17 @@ class EllipticalMaskMixin:  # pragma: no cover
         return masks
 
     @staticmethod
-    def _calc_extents(semimajor_axis, semiminor_axis, theta):
+    def _calc_extents(semimajor_axis, semiminor_axis, theta_rad):
         """
         Calculate half of the bounding box extents of an ellipse.
         """
-        return _calc_ellipse_extents(semimajor_axis, semiminor_axis, theta)
+        return _calc_ellipse_extents(semimajor_axis, semiminor_axis, theta_rad)
 
 
-def _calc_ellipse_extents(semimajor_axis, semiminor_axis, theta):
+def _calc_ellipse_extents(semimajor_axis, semiminor_axis, theta_rad):
     """
     Calculate half of the bounding box extents of an ellipse.
     """
-    theta_rad = theta.to(u.radian).value
     cos_theta = np.cos(theta_rad)
     sin_theta = np.sin(theta_rad)
     semimajor_x = semimajor_axis * cos_theta
@@ -201,6 +200,7 @@ class EllipticalAperture(PixelAperture):
         self.a = a
         self.b = b
         self.theta = theta
+        self._theta_rad = self.theta.to_value(u.radian)
 
     @lazyproperty
     def _xy_extents(self):
@@ -208,11 +208,10 @@ class EllipticalAperture(PixelAperture):
         The half of the bounding box extents of the ellipse in the x and
         y directions.
         """
-        return _calc_ellipse_extents(self.a, self.b, self.theta)
+        return _calc_ellipse_extents(self.a, self.b, self._theta_rad)
 
     def _batch_shape_params(self):
-        theta_rad = self.theta.to_value(u.radian)
-        return SHAPE_ELLIPSE, (self.a, self.b, theta_rad)
+        return SHAPE_ELLIPSE, (self.a, self.b, self._theta_rad)
 
     @lazyproperty
     def area(self):
@@ -248,7 +247,7 @@ class EllipticalAperture(PixelAperture):
         xy_positions, patch_kwargs = self._define_patch_params(origin=origin,
                                                                **kwargs)
 
-        angle = self.theta.to(u.deg).value
+        angle = self.theta.to_value(u.deg)
         patches = [mpatches.Ellipse(xy_position, 2.0 * self.a, 2.0 * self.b,
                                     angle=angle, **patch_kwargs)
                    for xy_position in xy_positions]
@@ -285,10 +284,9 @@ class EllipticalAperture(PixelAperture):
             will be between 0 and 1, where 0 means no overlap and 1
             means full overlap.
         """
-        theta_rad = self.theta.to(u.radian).value
         return elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                        edges[3], nx, ny, self.a, self.b,
-                                       theta_rad, use_exact, subpixels)
+                                       self._theta_rad, use_exact, subpixels)
 
     def to_sky(self, wcs):
         """
@@ -324,7 +322,7 @@ class EllipticalAperture(PixelAperture):
         first_pos = np.atleast_2d(self.positions)[0]
         pixcoord = (float(first_pos[0]), float(first_pos[1]))
         _, sky_width, sky_height, sky_angle = pixel_shape_to_sky_svd(
-            pixcoord, wcs, 2 * self.a, 2 * self.b, self.theta.to(u.rad).value)
+            pixcoord, wcs, 2 * self.a, 2 * self.b, self._theta_rad)
 
         a = Angle(sky_width / 2, 'arcsec')
         b = Angle(sky_height / 2, 'arcsec')
@@ -427,6 +425,7 @@ class EllipticalAnnulus(PixelAperture):
         self.b_in = b_in
 
         self.theta = theta
+        self._theta_rad = self.theta.to_value(u.radian)
 
     @lazyproperty
     def _xy_extents(self):
@@ -434,12 +433,11 @@ class EllipticalAnnulus(PixelAperture):
         The half of the bounding box extents of the outer ellipse in the
         x and y directions.
         """
-        return _calc_ellipse_extents(self.a_out, self.b_out, self.theta)
+        return _calc_ellipse_extents(self.a_out, self.b_out, self._theta_rad)
 
     def _batch_shape_params(self):
-        theta_rad = self.theta.to_value(u.radian)
         return SHAPE_ELLIPTICAL_ANNULUS, (self.a_in, self.b_in, self.a_out,
-                                          self.b_out, theta_rad)
+                                          self.b_out, self._theta_rad)
 
     @lazyproperty
     def area(self):
@@ -476,7 +474,7 @@ class EllipticalAnnulus(PixelAperture):
                                                                **kwargs)
 
         patches = []
-        angle = self.theta.to(u.deg).value
+        angle = self.theta.to_value(u.deg)
         for xy_position in xy_positions:
             patch_inner = mpatches.Ellipse(xy_position, 2.0 * self.a_in,
                                            2.0 * self.b_in, angle=angle)
@@ -517,14 +515,13 @@ class EllipticalAnnulus(PixelAperture):
             will be between 0 and 1, where 0 means no overlap and 1
             means full overlap.
         """
-        theta_rad = self.theta.to(u.radian).value
         overlap = elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                           edges[3], nx, ny, self.a_out,
-                                          self.b_out, theta_rad,
+                                          self.b_out, self._theta_rad,
                                           use_exact, subpixels)
         overlap -= elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                            edges[3], nx, ny, self.a_in,
-                                           self.b_in, theta_rad,
+                                           self.b_in, self._theta_rad,
                                            use_exact, subpixels)
         return overlap
 
@@ -561,12 +558,11 @@ class EllipticalAnnulus(PixelAperture):
 
         first_pos = np.atleast_2d(self.positions)[0]
         pixcoord = (float(first_pos[0]), float(first_pos[1]))
-        theta_rad = self.theta.to(u.rad).value
 
         _, sky_w_out, sky_h_out, sky_angle = pixel_shape_to_sky_svd(
-            pixcoord, wcs, 2 * self.a_out, 2 * self.b_out, theta_rad)
+            pixcoord, wcs, 2 * self.a_out, 2 * self.b_out, self._theta_rad)
         _, sky_w_in, sky_h_in, _ = pixel_shape_to_sky_svd(
-            pixcoord, wcs, 2 * self.a_in, 2 * self.b_in, theta_rad)
+            pixcoord, wcs, 2 * self.a_in, 2 * self.b_in, self._theta_rad)
 
         a_out = Angle(sky_w_out / 2, 'arcsec')
         b_out = Angle(sky_h_out / 2, 'arcsec')
@@ -623,6 +619,7 @@ class SkyEllipticalAperture(SkyAperture):
         self.a = a
         self.b = b
         self.theta = theta
+        self._theta_rad = self.theta.to_value(u.radian)
 
     def to_pixel(self, wcs):
         """
@@ -656,12 +653,11 @@ class SkyEllipticalAperture(SkyAperture):
         positions = np.transpose((xpos, ypos))
 
         skypos = self.positions if self.isscalar else self.positions[0]
-        sky_angle_rad = self.theta.to(u.rad).value
         _, pix_width, pix_height, pix_angle = sky_shape_to_pixel_svd(
             skypos, wcs,
-            2 * self.a.to(u.arcsec).value,
-            2 * self.b.to(u.arcsec).value,
-            sky_angle_rad)
+            2 * self.a.to_value(u.arcsec),
+            2 * self.b.to_value(u.arcsec),
+            self._theta_rad)
 
         a = pix_width / 2
         b = pix_height / 2
@@ -743,6 +739,7 @@ class SkyEllipticalAnnulus(SkyAperture):
         self.b_in = b_in
 
         self.theta = theta
+        self._theta_rad = self.theta.to_value(u.radian)
 
     def to_pixel(self, wcs):
         """
@@ -776,18 +773,17 @@ class SkyEllipticalAnnulus(SkyAperture):
         positions = np.transpose((xpos, ypos))
 
         skypos = self.positions if self.isscalar else self.positions[0]
-        sky_angle_rad = self.theta.to(u.rad).value
 
         _, pix_w_out, pix_h_out, pix_angle = sky_shape_to_pixel_svd(
             skypos, wcs,
-            2 * self.a_out.to(u.arcsec).value,
-            2 * self.b_out.to(u.arcsec).value,
-            sky_angle_rad)
+            2 * self.a_out.to_value(u.arcsec),
+            2 * self.b_out.to_value(u.arcsec),
+            self._theta_rad)
         _, pix_w_in, pix_h_in, _ = sky_shape_to_pixel_svd(
             skypos, wcs,
-            2 * self.a_in.to(u.arcsec).value,
-            2 * self.b_in.to(u.arcsec).value,
-            sky_angle_rad)
+            2 * self.a_in.to_value(u.arcsec),
+            2 * self.b_in.to_value(u.arcsec),
+            self._theta_rad)
 
         a_out = pix_w_out / 2
         b_out = pix_h_out / 2

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -121,11 +121,15 @@ def aperture_photometry(data, apertures, error=None, mask=None,
           if a ``wcs`` is input.
 
         * ``'aperture_sum'``:
-          The sum of the values within the aperture(s).
+          The sum of the values within the aperture(s). The values
+          are always float64, regardless of the input ``data`` dtype
+          (a `~astropy.units.Quantity` with float64 values if ``data``
+          has units).
 
         * ``'aperture_sum_err'``:
           The corresponding uncertainty in the ``'aperture_sum'``
-          values. Returned only if the input ``error`` is not `None`.
+          values (always float64). Returned only if the input ``error``
+          is not `None`.
 
         The table metadata includes the Astropy and Photutils version
         numbers and the `aperture_photometry` calling arguments.
@@ -134,16 +138,6 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     -----
     `~regions.Region` objects are converted to `Aperture` objects using
     the :func:`region_to_aperture` function.
-
-    `RectangularAperture` and `RectangularAnnulus` photometry with the
-    "exact" method uses a subpixel approximation by subdividing each
-    data pixel by a factor of 1024 (``subpixels = 32``). For rectangular
-    aperture widths and heights in the range from 2 to 100 pixels, this
-    subpixel approximation gives results typically within 0.001 percent
-    or better of the exact value. The differences can be larger for
-    smaller apertures (e.g., aperture sizes of one pixel or smaller).
-    For such small sizes, it is recommended to set ``method='subpixel'``
-    with a larger ``subpixels`` size.
 
     If the input ``data`` is a `~astropy.nddata.NDData` instance,
     then the ``error``, ``mask``, and ``wcs`` keyword inputs are

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -18,6 +18,8 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
 from photutils.geometry import rectangular_overlap_grid
+from photutils.geometry._batch_photometry import (SHAPE_RECTANGLE,
+                                                  SHAPE_RECTANGULAR_ANNULUS)
 from photutils.utils._deprecation import (deprecated,
                                           deprecated_positional_kwargs)
 from photutils.utils._wcs_helpers import (pixel_shape_to_sky_svd,
@@ -239,6 +241,10 @@ class RectangularAperture(PixelAperture):
         rectangle.
         """
         return _calc_rectangle_extents(self.w, self.h, self.theta)
+
+    def _batch_shape_params(self):
+        theta_rad = self.theta.to_value(u.radian)
+        return SHAPE_RECTANGLE, (self.w, self.h, theta_rad)
 
     @lazyproperty
     def area(self):
@@ -468,6 +474,11 @@ class RectangularAnnulus(PixelAperture):
         rectangle.
         """
         return _calc_rectangle_extents(self.w_out, self.h_out, self.theta)
+
+    def _batch_shape_params(self):
+        theta_rad = self.theta.to_value(u.radian)
+        return SHAPE_RECTANGULAR_ANNULUS, (self.w_in, self.h_in, self.w_out,
+                                           self.h_out, theta_rad)
 
     @lazyproperty
     def area(self):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -94,16 +94,16 @@ class RectangularMaskMixin:  # pragma: no cover
         masks = []
         for bbox, edges in zip(self._bbox, self._centered_edges, strict=True):
             ny, nx = bbox.shape
-            theta_rad = self.theta.to(u.radian).value
             mask = rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                             edges[3], nx, ny, w, h,
-                                            theta_rad, use_exact, subpixels)
+                                            self._theta_rad, use_exact,
+                                            subpixels)
 
             # Subtract the inner rectangle for an annulus
             if hasattr(self, 'w_in'):
                 mask -= rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                                  edges[3], nx, ny, self.w_in,
-                                                 self.h_in, theta_rad,
+                                                 self.h_in, self._theta_rad,
                                                  use_exact, subpixels)
 
             masks.append(ApertureMask(mask, bbox))
@@ -114,28 +114,27 @@ class RectangularMaskMixin:  # pragma: no cover
         return masks
 
     @staticmethod
-    def _calc_extents(width, height, theta):
+    def _calc_extents(width, height, theta_rad):
         """
         Calculate half of the bounding box extents of a rectangle.
         """
-        return _calc_rectangle_extents(width, height, theta)
+        return _calc_rectangle_extents(width, height, theta_rad)
 
     @staticmethod
-    def _lower_left_positions(positions, width, height, theta):
+    def _lower_left_positions(positions, width, height, theta_rad):
         """
         Calculate lower-left positions from the input center positions.
 
         Used for creating `~matplotlib.patches.Rectangle` patch for the
         aperture.
         """
-        return _calc_lower_left_positions(positions, width, height, theta)
+        return _calc_lower_left_positions(positions, width, height, theta_rad)
 
 
-def _calc_rectangle_extents(width, height, theta):
+def _calc_rectangle_extents(width, height, theta_rad):
     """
     Calculate half of the bounding box extents of a rectangle.
     """
-    theta_rad = theta.to(u.radian).value
     half_width = width / 2.0
     half_height = height / 2.0
     sin_theta = math.sin(theta_rad)
@@ -150,14 +149,13 @@ def _calc_rectangle_extents(width, height, theta):
     return x_extent, y_extent
 
 
-def _calc_lower_left_positions(positions, width, height, theta):
+def _calc_lower_left_positions(positions, width, height, theta_rad):
     """
     Calculate lower-left positions from the input center positions.
 
     Used for creating `~matplotlib.patches.Rectangle` patch for the
     aperture.
     """
-    theta_rad = theta.to(u.radian).value
     half_width = width / 2.0
     half_height = height / 2.0
     sin_theta = math.sin(theta_rad)
@@ -233,6 +231,7 @@ class RectangularAperture(PixelAperture):
         self.w = w
         self.h = h
         self.theta = theta
+        self._theta_rad = self.theta.to_value(u.radian)
 
     @lazyproperty
     def _xy_extents(self):
@@ -240,11 +239,10 @@ class RectangularAperture(PixelAperture):
         The half-width and half-height of the bounding box of the
         rectangle.
         """
-        return _calc_rectangle_extents(self.w, self.h, self.theta)
+        return _calc_rectangle_extents(self.w, self.h, self._theta_rad)
 
     def _batch_shape_params(self):
-        theta_rad = self.theta.to_value(u.radian)
-        return SHAPE_RECTANGLE, (self.w, self.h, theta_rad)
+        return SHAPE_RECTANGLE, (self.w, self.h, self._theta_rad)
 
     @lazyproperty
     def area(self):
@@ -280,9 +278,9 @@ class RectangularAperture(PixelAperture):
         xy_positions, patch_kwargs = self._define_patch_params(origin=origin,
                                                                **kwargs)
         xy_positions = _calc_lower_left_positions(xy_positions, self.w,
-                                                  self.h, self.theta)
+                                                  self.h, self._theta_rad)
 
-        angle = self.theta.to(u.deg).value
+        angle = self.theta.to_value(u.deg)
         patches = [mpatches.Rectangle(xy_position, self.w, self.h,
                                       angle=angle, **patch_kwargs)
                    for xy_position in xy_positions]
@@ -319,10 +317,9 @@ class RectangularAperture(PixelAperture):
             will be between 0 and 1, where 0 means no overlap and 1
             means full overlap.
         """
-        theta_rad = self.theta.to(u.radian).value
         return rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                         edges[3], nx, ny, self.w,
-                                        self.h, theta_rad,
+                                        self.h, self._theta_rad,
                                         use_exact, subpixels)
 
     def to_sky(self, wcs):
@@ -359,7 +356,7 @@ class RectangularAperture(PixelAperture):
         first_pos = np.atleast_2d(self.positions)[0]
         pixcoord = (float(first_pos[0]), float(first_pos[1]))
         _, sky_w, sky_h, sky_angle = pixel_shape_to_sky_svd(
-            pixcoord, wcs, self.w, self.h, self.theta.to(u.rad).value)
+            pixcoord, wcs, self.w, self.h, self._theta_rad)
 
         width = Angle(sky_w, 'arcsec')
         height = Angle(sky_h, 'arcsec')
@@ -466,6 +463,7 @@ class RectangularAnnulus(PixelAperture):
         self.h_in = h_in
 
         self.theta = theta
+        self._theta_rad = self.theta.to_value(u.radian)
 
     @lazyproperty
     def _xy_extents(self):
@@ -473,12 +471,11 @@ class RectangularAnnulus(PixelAperture):
         The half-width and half-height of the bounding box of the
         rectangle.
         """
-        return _calc_rectangle_extents(self.w_out, self.h_out, self.theta)
+        return _calc_rectangle_extents(self.w_out, self.h_out, self._theta_rad)
 
     def _batch_shape_params(self):
-        theta_rad = self.theta.to_value(u.radian)
         return SHAPE_RECTANGULAR_ANNULUS, (self.w_in, self.h_in, self.w_out,
-                                           self.h_out, theta_rad)
+                                           self.h_out, self._theta_rad)
 
     @lazyproperty
     def area(self):
@@ -516,14 +513,14 @@ class RectangularAnnulus(PixelAperture):
         inner_xy_positions = _calc_lower_left_positions(xy_positions,
                                                         self.w_in,
                                                         self.h_in,
-                                                        self.theta)
+                                                        self._theta_rad)
         outer_xy_positions = _calc_lower_left_positions(xy_positions,
                                                         self.w_out,
                                                         self.h_out,
-                                                        self.theta)
+                                                        self._theta_rad)
 
         patches = []
-        angle = self.theta.to(u.deg).value
+        angle = self.theta.to_value(u.deg)
         for xy_in, xy_out in zip(inner_xy_positions, outer_xy_positions,
                                  strict=True):
             patch_inner = mpatches.Rectangle(xy_in, self.w_in, self.h_in,
@@ -565,14 +562,13 @@ class RectangularAnnulus(PixelAperture):
             will be between 0 and 1, where 0 means no overlap and 1
             means full overlap.
         """
-        theta_rad = self.theta.to(u.radian).value
         overlap = rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                            edges[3], nx, ny, self.w_out,
-                                           self.h_out, theta_rad,
+                                           self.h_out, self._theta_rad,
                                            use_exact, subpixels)
         overlap -= rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                             edges[3], nx, ny, self.w_in,
-                                            self.h_in, theta_rad,
+                                            self.h_in, self._theta_rad,
                                             use_exact, subpixels)
         return overlap
 
@@ -609,11 +605,10 @@ class RectangularAnnulus(PixelAperture):
 
         first_pos = np.atleast_2d(self.positions)[0]
         pixcoord = (float(first_pos[0]), float(first_pos[1]))
-        theta_rad = self.theta.to(u.rad).value
         _, sky_w_out, sky_h_out, sky_angle = pixel_shape_to_sky_svd(
-            pixcoord, wcs, self.w_out, self.h_out, theta_rad)
+            pixcoord, wcs, self.w_out, self.h_out, self._theta_rad)
         _, sky_w_in, sky_h_in, _ = pixel_shape_to_sky_svd(
-            pixcoord, wcs, self.w_in, self.h_in, theta_rad)
+            pixcoord, wcs, self.w_in, self.h_in, self._theta_rad)
 
         w_in = Angle(sky_w_in, 'arcsec')
         w_out = Angle(sky_w_out, 'arcsec')
@@ -672,6 +667,7 @@ class SkyRectangularAperture(SkyAperture):
         self.w = w
         self.h = h
         self.theta = theta
+        self._theta_rad = self.theta.to_value(u.radian)
 
     def to_pixel(self, wcs):
         """
@@ -705,12 +701,11 @@ class SkyRectangularAperture(SkyAperture):
         positions = np.transpose((xpos, ypos))
 
         skypos = self.positions if self.isscalar else self.positions[0]
-        sky_angle_rad = self.theta.to(u.rad).value
         _, pix_w, pix_h, pix_angle = sky_shape_to_pixel_svd(
             skypos, wcs,
-            self.w.to(u.arcsec).value,
-            self.h.to(u.arcsec).value,
-            sky_angle_rad)
+            self.w.to_value(u.arcsec),
+            self.h.to_value(u.arcsec),
+            self._theta_rad)
 
         return RectangularAperture(positions=positions, w=pix_w, h=pix_h,
                                    theta=pix_angle)
@@ -797,6 +792,7 @@ class SkyRectangularAnnulus(SkyAperture):
         self.h_in = h_in
 
         self.theta = theta
+        self._theta_rad = self.theta.to_value(u.radian)
 
     def to_pixel(self, wcs):
         """
@@ -830,17 +826,16 @@ class SkyRectangularAnnulus(SkyAperture):
         positions = np.transpose((xpos, ypos))
 
         skypos = self.positions if self.isscalar else self.positions[0]
-        sky_angle_rad = self.theta.to(u.rad).value
         _, pix_w_out, pix_h_out, pix_angle = sky_shape_to_pixel_svd(
             skypos, wcs,
-            self.w_out.to(u.arcsec).value,
-            self.h_out.to(u.arcsec).value,
-            sky_angle_rad)
+            self.w_out.to_value(u.arcsec),
+            self.h_out.to_value(u.arcsec),
+            self._theta_rad)
         _, pix_w_in, pix_h_in, _ = sky_shape_to_pixel_svd(
             skypos, wcs,
-            self.w_in.to(u.arcsec).value,
-            self.h_in.to(u.arcsec).value,
-            sky_angle_rad)
+            self.w_in.to_value(u.arcsec),
+            self.h_in.to_value(u.arcsec),
+            self._theta_rad)
 
         return RectangularAnnulus(positions=positions, w_in=pix_w_in,
                                   w_out=pix_w_out, h_out=pix_h_out,

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -212,6 +212,10 @@ class ApertureStats:
     ``sum_method='exact'``, which produces exact aperture-weighted
     photometry.
 
+    The calculated statistics are always float64, regardless of the
+    input ``data`` dtype (`~astropy.units.Quantity` values with float64
+    dtype if the input ``data`` has units).
+
     .. _SourceExtractor: https://sextractor.readthedocs.io/en/latest/
 
     Examples

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -1,0 +1,269 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the batch Cython aperture photometry driver, which must give
+results identical to the mask-based code path.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from photutils.aperture.circle import CircularAnnulus, CircularAperture
+from photutils.aperture.core import PixelAperture
+from photutils.aperture.ellipse import EllipticalAnnulus, EllipticalAperture
+from photutils.aperture.rectangle import (RectangularAnnulus,
+                                          RectangularAperture)
+
+RNG = np.random.default_rng(0)
+SHAPE = (157, 163)
+DATA = RNG.normal(100.0, 5.0, SHAPE)
+ERROR = RNG.uniform(1.0, 2.0, SHAPE)
+MASK = RNG.uniform(size=SHAPE) < 0.05
+DATA_NAN = DATA.copy()
+DATA_NAN[::11, ::13] = np.nan
+
+# Positions covering interior, subpixel offsets, partial overlap with
+# every data edge, no overlap, and far outside the data
+POSITIONS = np.array([[70.0, 80.0], [50.3, 71.8], [20.49999, 30.50001],
+                      [0.0, 0.0], [162.0, 156.0], [-3.0, 80.0],
+                      [166.0, 80.0], [80.0, -3.0], [80.0, 160.0],
+                      [-50.0, -50.0], [250.0, 250.0], [1e9, -1e9]])
+
+APERTURES = [
+    CircularAperture(POSITIONS, r=5.5),
+    CircularAperture(POSITIONS, r=0.4),
+    CircularAnnulus(POSITIONS, r_in=4.0, r_out=6.0),
+    EllipticalAperture(POSITIONS, a=5.0, b=3.0, theta=0.7),
+    EllipticalAnnulus(POSITIONS, a_in=3.0, a_out=6.0, b_out=4.0, theta=-1.1),
+    RectangularAperture(POSITIONS, w=7.0, h=4.0, theta=0.4),
+    RectangularAnnulus(POSITIONS, w_in=3.0, w_out=8.0, h_out=5.0, theta=2.2),
+]
+
+METHODS = [('exact', 5), ('center', 5), ('subpixel', 1), ('subpixel', 7)]
+
+
+def assert_batch_matches_legacy(aperture, data, *, error=None, mask=None,
+                                method='exact', subpixels=5):
+    """
+    Test that the batch photometry driver gives results identical to the
+    legacy mask-based code path for the given inputs.
+    """
+    batch = aperture._do_batch_photometry(data, error=error, mask=mask,
+                                          method=method, subpixels=subpixels)
+    assert batch is not None
+    legacy = aperture._do_mask_photometry(data, error=error, mask=mask,
+                                          method=method, subpixels=subpixels)
+    for batch_arr, legacy_arr in zip(batch, legacy, strict=True):
+        assert batch_arr.shape == legacy_arr.shape
+        assert_allclose(batch_arr, legacy_arr, rtol=1e-12, atol=0,
+                        equal_nan=True)
+
+
+@pytest.mark.parametrize('aperture', APERTURES)
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_matches_legacy(aperture, method, subpixels):
+    """
+    Test that the batch photometry driver gives results identical to the
+    legacy mask-based code path for the given inputs.
+    """
+    assert_batch_matches_legacy(aperture, DATA, method=method,
+                                subpixels=subpixels)
+
+
+@pytest.mark.parametrize('aperture', APERTURES)
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_matches_legacy_error_mask(aperture, method, subpixels):
+    """
+    Test that the batch photometry driver gives results identical to the
+    legacy mask-based code path for the given inputs, including error
+    and mask.
+    """
+    assert_batch_matches_legacy(aperture, DATA, error=ERROR, mask=MASK,
+                                method=method, subpixels=subpixels)
+
+
+@pytest.mark.parametrize('aperture', APERTURES)
+def test_matches_legacy_nan_data(aperture):
+    """
+    Test that the batch photometry driver gives results identical to the
+    legacy mask-based code path for data containing NaN values.
+    """
+    assert_batch_matches_legacy(aperture, DATA_NAN, error=ERROR)
+
+
+@pytest.mark.parametrize('dtype', ['int32', 'uint16', 'float32', 'bool'])
+def test_data_dtypes(dtype):
+    """
+    Test that the batch photometry driver gives results identical to the
+    legacy mask-based code path for different data dtypes, including
+    bool.
+    """
+    rtol = 1e-5 if dtype == 'float32' else 1e-12
+    aperture = CircularAperture(POSITIONS, r=5.5)
+    data = (DATA > 100.0) if dtype == 'bool' else DATA.astype(dtype)
+    batch = aperture._do_batch_photometry(data, error=None, mask=None,
+                                          method='exact', subpixels=5)
+    legacy = aperture._do_mask_photometry(data, error=None, mask=None,
+                                          method='exact', subpixels=5)
+    assert batch is not None
+    assert_allclose(batch[0], legacy[0], rtol=rtol, equal_nan=True)
+
+
+def test_scalar_position():
+    """
+    Test that the batch photometry driver gives results identical to the
+    legacy mask-based code path for a single scalar position.
+    """
+    aperture = CircularAperture((70.0, 80.0), r=5.5)
+    assert_batch_matches_legacy(aperture, DATA, error=ERROR)
+
+
+def test_units():
+    """
+    Test that the batch photometry driver gives results with the same
+    units as the input data and error, and that the values match the
+    legacy code path.
+    """
+    unit = u.Jy
+    aperture = CircularAperture(POSITIONS, r=5.5)
+    sums, errs = aperture.do_photometry(DATA << unit, error=ERROR << unit)
+    assert sums.unit == unit
+    assert errs.unit == unit
+    sums2, errs2 = aperture.do_photometry(DATA, error=ERROR)
+    assert_allclose(sums.value, sums2, equal_nan=True)
+    assert_allclose(errs.value, errs2, equal_nan=True)
+
+
+def test_no_overlap_nan_and_err_shape():
+    """
+    Test that sources with no overlap with the data give NaN sums.
+
+    Also, test that the error array has the same shape as the sums array
+    and contains NaN values for the non-overlapping sources when error
+    is not input.
+    """
+    aperture = CircularAperture(POSITIONS, r=5.5)
+    n_outside = 3
+
+    sums, errs = aperture._do_batch_photometry(DATA, error=None, mask=None,
+                                               method='exact', subpixels=5)
+    assert np.isnan(sums).sum() == n_outside
+    assert errs.shape == (n_outside,)
+    assert np.all(np.isnan(errs))
+
+    sums, errs = aperture._do_batch_photometry(DATA, error=ERROR, mask=None,
+                                               method='exact', subpixels=5)
+    assert errs.shape == sums.shape
+    assert np.isnan(errs).sum() == n_outside
+
+
+def test_fallback_inputs():
+    """
+    Test that inputs not supported by the batch photometry driver cause
+    it to return None so that the caller falls back to the mask-based
+    code path.
+    """
+    aperture = CircularAperture(POSITIONS, r=5.5)
+
+    # Masked-array data
+    data = np.ma.MaskedArray(DATA, mask=MASK)
+    assert aperture._do_batch_photometry(data, error=None, mask=None,
+                                         method='exact', subpixels=5) is None
+
+    # Non-bool mask
+    assert aperture._do_batch_photometry(DATA, error=None,
+                                         mask=MASK.astype(int),
+                                         method='exact', subpixels=5) is None
+
+    # Mask with mismatched shape
+    assert aperture._do_batch_photometry(DATA, error=None, mask=MASK[1:, :],
+                                         method='exact', subpixels=5) is None
+
+    # Unsupported dtype
+    assert aperture._do_batch_photometry(DATA.astype(complex), error=None,
+                                         mask=None, method='exact',
+                                         subpixels=5) is None
+
+
+def test_fallback_subclass():
+    """
+    Test that aperture subclasses that do not themselves define
+    _batch_shape_params fall back to the mask-based code path in
+    do_photometry, so that any overridden behavior (e.g., to_mask) is
+    honored.
+    """
+
+    class MyAperture(CircularAperture):
+        # Inherits _batch_shape_params, but does not define it in its
+        # own class, so the batch driver must not be used.
+        pass
+
+    aperture = MyAperture(POSITIONS, r=5.5)
+    assert aperture._do_batch_photometry(DATA, error=None, mask=None,
+                                         method='exact', subpixels=5) is None
+    sums, _ = aperture.do_photometry(DATA)
+    sums2, _ = CircularAperture(POSITIONS, r=5.5).do_photometry(DATA)
+    assert_allclose(sums, sums2, rtol=1e-12, equal_nan=True)
+
+
+def test_optin_subclass():
+    """
+    Test that aperture subclasses that define the _batch_shape_params
+    hook in their own class opt in to the batch code path.
+    """
+
+    class MyAperture(CircularAperture):
+        def _batch_shape_params(self):
+            return super()._batch_shape_params()
+
+    aperture = MyAperture(POSITIONS, r=5.5)
+    assert aperture._do_batch_photometry(DATA, error=None, mask=None,
+                                         method='exact', subpixels=5) \
+        is not None
+    assert_batch_matches_legacy(aperture, DATA, error=ERROR, mask=MASK)
+
+
+def test_optin_subclass_base_hook_returns_none():
+    """
+    Test that when a subclass defines _batch_shape_params (opting in)
+    but the method returns None, _do_batch_photometry falls back to
+    None.
+
+    This covers:
+    - PixelAperture._batch_shape_params (the base ``return`` on its own
+      line, which is the hook's default no-op implementation), and
+    - the ``if spec is None: return None`` branch in _do_batch_photometry.
+    """
+
+    class MyAperture(CircularAperture):
+        def _batch_shape_params(self):
+            # Explicitly delegate to the base PixelAperture hook, which
+            # returns None, signalling that the batch driver is not
+            # supported for this subclass.
+            return PixelAperture._batch_shape_params(self)
+
+    aperture = MyAperture(POSITIONS, r=5.5)
+    assert aperture._do_batch_photometry(DATA, error=None, mask=None,
+                                         method='exact', subpixels=5) is None
+
+
+def test_thread_safety():
+    """
+    Test that the batch driver releases the GIL and is therefore
+    thread-safe by running multiple photometry calls in parallel threads
+    and checking that they all give the same results.
+    """
+    aperture = CircularAperture(POSITIONS, r=5.5)
+    expected, _ = aperture.do_photometry(DATA, error=ERROR)
+
+    def run(_):
+        return aperture.do_photometry(DATA, error=ERROR)[0]
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(run, range(8)))
+
+    for result in results:
+        assert_allclose(result, expected, rtol=0, atol=0, equal_nan=True)

--- a/photutils/aperture/tests/test_pixel_sky_conversions.py
+++ b/photutils/aperture/tests/test_pixel_sky_conversions.py
@@ -108,7 +108,7 @@ def _angle_diff_deg(actual, desired):
     """
     Signed angular difference in degrees, wrapped to (-180, 180].
     """
-    diff = (actual.to(u.deg).value - desired.to(u.deg).value + 180) % 360
+    diff = (actual.to_value(u.deg) - desired.to_value(u.deg) + 180) % 360
     return diff - 180
 
 

--- a/photutils/geometry/_batch_photometry.pyx
+++ b/photutils/geometry/_batch_photometry.pyx
@@ -1,0 +1,460 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: freethreading_compatible=True
+"""
+This module provides a batch driver for aperture photometry.
+
+For each source position, the overlap fraction of the aperture with
+each pixel in the aperture bounding box is computed and immediately
+accumulated into the aperture sum, without materializing per-source
+mask arrays or making per-source Python calls. The per-pixel overlap
+fractions are computed with exactly the same arithmetic as the
+``photutils.geometry`` grid functions, so the results agree with the
+mask-based photometry code path.
+
+The main source loop runs without the GIL and uses no global mutable
+state, so this module is safe to use from multiple threads, including on
+free-threaded Python builds.
+"""
+
+import numpy as np
+
+from ._polygon_overlap cimport polygon_pixel_overlap
+from .circular_overlap cimport (circular_overlap_single_exact,
+                                circular_overlap_single_subpixel)
+from .elliptical_overlap cimport (elliptical_overlap_single_exact,
+                                  elliptical_overlap_single_subpixel)
+from .rectangular_overlap cimport rectangular_overlap_single_subpixel
+
+__all__ = ['batch_aperture_sums']
+
+
+cdef extern from "math.h" nogil:
+    double sin(double x)
+    double cos(double x)
+    double sqrt(double x)
+    double fabs(double x)
+    double fmax(double x, double y)
+    double fmin(double x, double y)
+    double floor(double x)
+    double ceil(double x)
+
+# Aperture shape codes. These must stay in sync with the private
+# ``_shape_params`` attributes defined by the aperture classes in
+# ``photutils.aperture``.
+cdef enum:
+    _CIRCLE = 0
+    _CIRCULAR_ANNULUS = 1
+    _ELLIPSE = 2
+    _ELLIPTICAL_ANNULUS = 3
+    _RECTANGLE = 4
+    _RECTANGULAR_ANNULUS = 5
+
+# Python-level aliases of the shape codes
+SHAPE_CIRCLE = _CIRCLE
+SHAPE_CIRCULAR_ANNULUS = _CIRCULAR_ANNULUS
+SHAPE_ELLIPSE = _ELLIPSE
+SHAPE_ELLIPTICAL_ANNULUS = _ELLIPTICAL_ANNULUS
+SHAPE_RECTANGLE = _RECTANGLE
+SHAPE_RECTANGULAR_ANNULUS = _RECTANGULAR_ANNULUS
+
+
+cdef inline double _circle_pixel_frac(double pxmin, double pymin,
+                                      double dx, double dy,
+                                      double pixel_radius, double r,
+                                      int use_exact,
+                                      int subpixels) noexcept nogil:
+    """
+    Fraction of a single pixel that overlaps a circle of radius ``r``
+    centered on the origin.
+
+    This replicates the per-pixel logic of ``circular_overlap_grid``,
+    including the bounding-box and "well inside/outside" shortcuts, so
+    the result is identical to the grid function.
+    """
+    cdef double pxmax = pxmin + dx
+    cdef double pymax = pymin + dy
+    cdef double pxcen, pycen, d
+
+    # Bounding-box check
+    if not (pxmax > -r - 0.5 * dx and pxmin < r + 0.5 * dx
+            and pymax > -r - 0.5 * dy and pymin < r + 0.5 * dy):
+        return 0.0
+
+    # Distance from circle center to pixel center
+    pxcen = pxmin + dx * 0.5
+    pycen = pymin + dy * 0.5
+    d = sqrt(pxcen * pxcen + pycen * pycen)
+
+    if d < r - pixel_radius:  # pixel is well within the circle
+        return 1.0
+
+    if d < r + pixel_radius:  # pixel is close to the circle border
+        if use_exact:
+            return circular_overlap_single_exact(pxmin, pymin, pxmax,
+                                                 pymax, r) / (dx * dy)
+        return circular_overlap_single_subpixel(pxmin, pymin, pxmax,
+                                                pymax, r, subpixels)
+
+    return 0.0  # pixel is fully outside the circle
+
+
+cdef inline double _ellipse_pixel_frac(double pxmin, double pymin,
+                                       double dx, double dy, double norm,
+                                       double rx, double ry, double theta,
+                                       int use_exact,
+                                       int subpixels) noexcept nogil:
+    """
+    Fraction of a single pixel that overlaps an ellipse with semimajor
+    and semiminor axes ``rx`` and ``ry`` and position angle ``theta``
+    centered on the origin.
+
+    This replicates the per-pixel logic of ``elliptical_overlap_grid``,
+    including the bounding-circle shortcut, so the result is identical
+    to the grid function.
+    """
+    cdef double pxmax = pxmin + dx
+    cdef double pymax = pymin + dy
+    cdef double r = fmax(rx, ry)  # bounding circle radius
+
+    # Bounding-box check
+    if not (pxmax > -r - 0.5 * dx and pxmin < r + 0.5 * dx
+            and pymax > -r - 0.5 * dy and pymin < r + 0.5 * dy):
+        return 0.0
+
+    if use_exact:
+        return elliptical_overlap_single_exact(pxmin, pymin, pxmax, pymax,
+                                               rx, ry, theta) * norm
+    return elliptical_overlap_single_subpixel(pxmin, pymin, pxmax, pymax,
+                                              rx, ry, theta, subpixels)
+
+
+cdef inline double _rect_pixel_frac(double pxmin, double pymin,
+                                    double dx, double dy,
+                                    double half_width, double half_height,
+                                    double cos_theta, double sin_theta,
+                                    double bbox_dx, double bbox_dy,
+                                    double *poly_x, double *poly_y,
+                                    double *buf_a_x, double *buf_a_y,
+                                    double *buf_b_x, double *buf_b_y,
+                                    int use_exact,
+                                    int subpixels) noexcept nogil:
+    """
+    Fraction of a single pixel that overlaps a rectangle of full width
+    ``2 * half_width`` and full height ``2 * half_height`` rotated by
+    ``theta`` (given as ``cos_theta``/``sin_theta``) centered on the
+    origin.
+
+    This replicates the per-pixel logic of ``rectangular_overlap_grid``
+    (the exact mode skips pixels outside the axis-aligned bounding box
+    of the rotated rectangle), so the result is identical to the grid
+    function.
+    """
+    cdef double pxmax = pxmin + dx
+    cdef double pymax = pymin + dy
+
+    if use_exact:
+        # Bounding-box check
+        if (pxmax <= -bbox_dx or pxmin >= bbox_dx
+                or pymax <= -bbox_dy or pymin >= bbox_dy):
+            return 0.0
+        return polygon_pixel_overlap(pxmin, pymin, pxmax, pymax,
+                                     poly_x, poly_y, 4,
+                                     buf_a_x, buf_a_y, buf_b_x, buf_b_y,
+                                     32) / (dx * dy)
+
+    return rectangular_overlap_single_subpixel(pxmin, pymin, pxmax, pymax,
+                                               half_width, half_height,
+                                               cos_theta, sin_theta,
+                                               subpixels)
+
+
+cdef inline void _rect_vertices(double half_width, double half_height,
+                                double cos_theta, double sin_theta,
+                                double *poly_x,
+                                double *poly_y) noexcept nogil:
+    """
+    Build the four CCW vertices of a rotated rectangle centered on the
+    origin (same arithmetic as ``rectangular_overlap_grid``).
+    """
+    poly_x[0] = -half_width * cos_theta - (-half_height) * sin_theta
+    poly_y[0] = -half_width * sin_theta + (-half_height) * cos_theta
+    poly_x[1] = half_width * cos_theta - (-half_height) * sin_theta
+    poly_y[1] = half_width * sin_theta + (-half_height) * cos_theta
+    poly_x[2] = half_width * cos_theta - half_height * sin_theta
+    poly_y[2] = half_width * sin_theta + half_height * cos_theta
+    poly_x[3] = -half_width * cos_theta - half_height * sin_theta
+    poly_y[3] = -half_width * sin_theta + half_height * cos_theta
+
+
+def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
+                        const unsigned char[:, ::1] mask,
+                        double[:, ::1] positions, int shape_code,
+                        double[::1] params, double ext_x, double ext_y,
+                        int use_exact, int subpixels):
+    """
+    Compute aperture sums for many source positions in a single call.
+
+    For each position, the aperture bounding box is computed in exactly
+    the same way as `photutils.aperture.BoundingBox.from_float`, and
+    the per-pixel overlap fractions within the bounding box (clipped
+    to the data) are computed with exactly the same arithmetic as the
+    `photutils.geometry` grid functions, so the resulting sums match the
+    mask-based photometry code path.
+
+    Pixels with a non-positive overlap fraction or that are masked are
+    excluded from the sums.
+
+    Parameters
+    ----------
+    data : 2D ndarray of float64 (C-contiguous)
+        The data array.
+
+    error : 2D ndarray of float64 (C-contiguous) or `None`
+        The pixel-wise 1-sigma errors. Must have the same shape as
+        ``data``.
+
+    mask : 2D ndarray of uint8 (C-contiguous) or `None`
+        A mask array where nonzero values indicate masked (excluded)
+        pixels. Must have the same shape as ``data``.
+
+    positions : 2D ndarray of float64 (C-contiguous)
+        The (x, y) source positions with shape ``(n_sources, 2)``.
+
+    shape_code : int
+        The aperture shape code: 0=circle, 1=circular annulus,
+        2=ellipse, 3=elliptical annulus, 4=rectangle, 5=rectangular
+        annulus (see the module-level ``SHAPE_*`` constants).
+
+    params : 1D ndarray of float64 (C-contiguous)
+        The aperture shape parameters:
+
+        * circle: ``(r,)``
+        * circular annulus: ``(r_in, r_out)``
+        * ellipse: ``(a, b, theta)``
+        * elliptical annulus: ``(a_in, b_in, a_out, b_out, theta)``
+        * rectangle: ``(w, h, theta)``
+        * rectangular annulus: ``(w_in, h_in, w_out, h_out, theta)``
+
+        where ``theta`` is in radians.
+
+    ext_x, ext_y : float
+        The half-extents of the aperture minimal bounding box in the x
+        and y directions (i.e., ``Aperture._xy_extents``).
+
+    use_exact : int
+        Whether to compute exact overlap fractions (1) or use subpixel
+        sampling (0).
+
+    subpixels : int
+        The number of subpixels in each dimension when ``use_exact`` is
+        0.
+
+    Returns
+    -------
+    sums : 1D ndarray of float64
+        The aperture sums. NaN where the aperture bounding box does not
+        overlap the data.
+
+    sum_errs : 1D ndarray of float64
+        The quadrature-summed errors. NaN where ``error`` is `None` or
+        the aperture bounding box does not overlap the data.
+
+    overlap : 1D ndarray of bool
+        Whether the aperture bounding box overlaps with the data.
+    """
+    cdef Py_ssize_t n_src = positions.shape[0]
+    cdef Py_ssize_t ny_data = data.shape[0]
+    cdef Py_ssize_t nx_data = data.shape[1]
+
+    sums_arr = np.full(n_src, np.nan)
+    errs_arr = np.full(n_src, np.nan)
+    overlap_arr = np.zeros(n_src, dtype=np.uint8)
+    cdef double[::1] sums = sums_arr
+    cdef double[::1] errs = errs_arr
+    cdef unsigned char[::1] overlap = overlap_arr
+
+    cdef bint has_error = error is not None
+    cdef bint has_mask = mask is not None
+
+    # Aperture shape parameters (constant over all source positions)
+    cdef double r_in = 0.0, r_out = 0.0
+    cdef double rx_in = 0.0, ry_in = 0.0, rx_out = 0.0, ry_out = 0.0
+    cdef double theta = 0.0, cos_theta = 1.0, sin_theta = 0.0
+    cdef double half_width_in = 0.0, half_height_in = 0.0
+    cdef double half_width_out = 0.0, half_height_out = 0.0
+    cdef double bbox_dx_in = 0.0, bbox_dy_in = 0.0
+    cdef double bbox_dx_out = 0.0, bbox_dy_out = 0.0
+    cdef double poly_x_in[4]
+    cdef double poly_y_in[4]
+    cdef double poly_x_out[4]
+    cdef double poly_y_out[4]
+
+    # Scratch buffers for the polygon clipping (rectangular apertures);
+    # these are local to this call, so this function is thread safe.
+    cdef double buf_a_x[32]
+    cdef double buf_a_y[32]
+    cdef double buf_b_x[32]
+    cdef double buf_b_y[32]
+
+    if shape_code == _CIRCLE:
+        r_out = params[0]
+    elif shape_code == _CIRCULAR_ANNULUS:
+        r_in = params[0]
+        r_out = params[1]
+    elif shape_code == _ELLIPSE:
+        rx_out = params[0]
+        ry_out = params[1]
+        theta = params[2]
+    elif shape_code == _ELLIPTICAL_ANNULUS:
+        rx_in = params[0]
+        ry_in = params[1]
+        rx_out = params[2]
+        ry_out = params[3]
+        theta = params[4]
+    elif shape_code == _RECTANGLE or shape_code == _RECTANGULAR_ANNULUS:
+        if shape_code == _RECTANGLE:
+            half_width_out = 0.5 * params[0]
+            half_height_out = 0.5 * params[1]
+            theta = params[2]
+        else:
+            half_width_in = 0.5 * params[0]
+            half_height_in = 0.5 * params[1]
+            half_width_out = 0.5 * params[2]
+            half_height_out = 0.5 * params[3]
+            theta = params[4]
+
+        cos_theta = cos(theta)
+        sin_theta = sin(theta)
+        _rect_vertices(half_width_out, half_height_out, cos_theta,
+                       sin_theta, poly_x_out, poly_y_out)
+        bbox_dx_out = (half_width_out * fabs(cos_theta)
+                       + half_height_out * fabs(sin_theta))
+        bbox_dy_out = (half_width_out * fabs(sin_theta)
+                       + half_height_out * fabs(cos_theta))
+        if shape_code == _RECTANGULAR_ANNULUS:
+            _rect_vertices(half_width_in, half_height_in, cos_theta,
+                           sin_theta, poly_x_in, poly_y_in)
+            bbox_dx_in = (half_width_in * fabs(cos_theta)
+                          + half_height_in * fabs(sin_theta))
+            bbox_dy_in = (half_width_in * fabs(sin_theta)
+                          + half_height_in * fabs(cos_theta))
+    else:
+        msg = f'Invalid shape_code: {shape_code}'
+        raise ValueError(msg)
+
+    cdef Py_ssize_t k, ix, iy, ix0, ix1, iy0, iy1
+    cdef Py_ssize_t ixmin, iymin, grid_nx, grid_ny
+    cdef double cx, cy
+    cdef double ixmin_d, ixmax_d, iymin_d, iymax_d
+    cdef double gxmin, gxmax, gymin, gymax
+    cdef double dx, dy, pixel_radius, norm
+    cdef double pxmin, pymin, frac, err_val, sum_val, var_val
+
+    with nogil:
+        for k in range(n_src):
+            cx = positions[k, 0]
+            cy = positions[k, 1]
+
+            # Replicate BoundingBox.from_float; the values are kept as
+            # (integral) doubles to avoid integer overflow for apertures
+            # far outside the data
+            ixmin_d = floor(cx - ext_x + 0.5)
+            ixmax_d = ceil(cx + ext_x + 0.5)
+            iymin_d = floor(cy - ext_y + 0.5)
+            iymax_d = ceil(cy + ext_y + 0.5)
+
+            # No overlap of the aperture bounding box with the data
+            # (replicates BoundingBox.get_overlap_slices); the sums stay
+            # NaN
+            if (ixmin_d >= <double>nx_data or ixmax_d <= 0.0
+                    or iymin_d >= <double>ny_data or iymax_d <= 0.0):
+                continue
+            overlap[k] = 1
+
+            # Pixel-grid edges relative to the aperture center
+            # (replicates Aperture._centered_edges and the grid setup of
+            # the photutils.geometry grid functions)
+            gxmin = ixmin_d - 0.5 - cx
+            gxmax = ixmax_d - 0.5 - cx
+            gymin = iymin_d - 0.5 - cy
+            gymax = iymax_d - 0.5 - cy
+            grid_nx = <Py_ssize_t>(ixmax_d - ixmin_d)
+            grid_ny = <Py_ssize_t>(iymax_d - iymin_d)
+            dx = (gxmax - gxmin) / grid_nx
+            dy = (gymax - gymin) / grid_ny
+            pixel_radius = 0.5 * sqrt(dx * dx + dy * dy)
+            norm = 1.0 / (dx * dy)
+
+            # Pixel index ranges clipped to the data
+            ixmin = <Py_ssize_t>ixmin_d
+            iymin = <Py_ssize_t>iymin_d
+            ix0 = <Py_ssize_t>fmax(ixmin_d, 0.0)
+            ix1 = <Py_ssize_t>fmin(ixmax_d, <double>nx_data)
+            iy0 = <Py_ssize_t>fmax(iymin_d, 0.0)
+            iy1 = <Py_ssize_t>fmin(iymax_d, <double>ny_data)
+
+            sum_val = 0.0
+            var_val = 0.0
+            for iy in range(iy0, iy1):
+                pymin = gymin + (iy - iymin) * dy
+                for ix in range(ix0, ix1):
+                    if has_mask and mask[iy, ix]:
+                        continue
+                    pxmin = gxmin + (ix - ixmin) * dx
+
+                    if shape_code == _CIRCLE:
+                        frac = _circle_pixel_frac(
+                            pxmin, pymin, dx, dy, pixel_radius, r_out,
+                            use_exact, subpixels)
+                    elif shape_code == _CIRCULAR_ANNULUS:
+                        frac = (_circle_pixel_frac(
+                                    pxmin, pymin, dx, dy, pixel_radius,
+                                    r_out, use_exact, subpixels)
+                                - _circle_pixel_frac(
+                                    pxmin, pymin, dx, dy, pixel_radius,
+                                    r_in, use_exact, subpixels))
+                    elif shape_code == _ELLIPSE:
+                        frac = _ellipse_pixel_frac(
+                            pxmin, pymin, dx, dy, norm, rx_out, ry_out,
+                            theta, use_exact, subpixels)
+                    elif shape_code == _ELLIPTICAL_ANNULUS:
+                        frac = (_ellipse_pixel_frac(
+                                    pxmin, pymin, dx, dy, norm, rx_out,
+                                    ry_out, theta, use_exact, subpixels)
+                                - _ellipse_pixel_frac(
+                                    pxmin, pymin, dx, dy, norm, rx_in,
+                                    ry_in, theta, use_exact, subpixels))
+                    elif shape_code == _RECTANGLE:
+                        frac = _rect_pixel_frac(
+                            pxmin, pymin, dx, dy, half_width_out,
+                            half_height_out, cos_theta, sin_theta,
+                            bbox_dx_out, bbox_dy_out, poly_x_out,
+                            poly_y_out, buf_a_x, buf_a_y, buf_b_x,
+                            buf_b_y, use_exact, subpixels)
+                    else:
+                        frac = (_rect_pixel_frac(
+                                    pxmin, pymin, dx, dy, half_width_out,
+                                    half_height_out, cos_theta, sin_theta,
+                                    bbox_dx_out, bbox_dy_out, poly_x_out,
+                                    poly_y_out, buf_a_x, buf_a_y, buf_b_x,
+                                    buf_b_y, use_exact, subpixels)
+                                - _rect_pixel_frac(
+                                    pxmin, pymin, dx, dy, half_width_in,
+                                    half_height_in, cos_theta, sin_theta,
+                                    bbox_dx_in, bbox_dy_in, poly_x_in,
+                                    poly_y_in, buf_a_x, buf_a_y, buf_b_x,
+                                    buf_b_y, use_exact, subpixels))
+
+                    if frac <= 0.0:
+                        continue
+                    sum_val += data[iy, ix] * frac
+                    if has_error:
+                        err_val = error[iy, ix]
+                        var_val += err_val * err_val * frac
+
+            sums[k] = sum_val
+            if has_error:
+                errs[k] = sqrt(var_val)
+
+    return sums_arr, errs_arr, overlap_arr.view(bool)

--- a/photutils/geometry/_batch_photometry.pyx
+++ b/photutils/geometry/_batch_photometry.pyx
@@ -2,7 +2,7 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # cython: freethreading_compatible=True
 """
-This module provides a batch driver for aperture photometry.
+Tools to provide a batch driver for aperture photometry.
 
 For each source position, the overlap fraction of the aperture with
 each pixel in the aperture bounding box is computed and immediately
@@ -57,134 +57,6 @@ SHAPE_ELLIPSE = _ELLIPSE
 SHAPE_ELLIPTICAL_ANNULUS = _ELLIPTICAL_ANNULUS
 SHAPE_RECTANGLE = _RECTANGLE
 SHAPE_RECTANGULAR_ANNULUS = _RECTANGULAR_ANNULUS
-
-
-cdef inline double _circle_pixel_frac(double pxmin, double pymin,
-                                      double dx, double dy,
-                                      double pixel_radius, double r,
-                                      int use_exact,
-                                      int subpixels) noexcept nogil:
-    """
-    Fraction of a single pixel that overlaps a circle of radius ``r``
-    centered on the origin.
-
-    This replicates the per-pixel logic of ``circular_overlap_grid``,
-    including the bounding-box and "well inside/outside" shortcuts, so
-    the result is identical to the grid function.
-    """
-    cdef double pxmax = pxmin + dx
-    cdef double pymax = pymin + dy
-    cdef double pxcen, pycen, d
-
-    # Bounding-box check
-    if not (pxmax > -r - 0.5 * dx and pxmin < r + 0.5 * dx
-            and pymax > -r - 0.5 * dy and pymin < r + 0.5 * dy):
-        return 0.0
-
-    # Distance from circle center to pixel center
-    pxcen = pxmin + dx * 0.5
-    pycen = pymin + dy * 0.5
-    d = sqrt(pxcen * pxcen + pycen * pycen)
-
-    if d < r - pixel_radius:  # pixel is well within the circle
-        return 1.0
-
-    if d < r + pixel_radius:  # pixel is close to the circle border
-        if use_exact:
-            return circular_overlap_single_exact(pxmin, pymin, pxmax,
-                                                 pymax, r) / (dx * dy)
-        return circular_overlap_single_subpixel(pxmin, pymin, pxmax,
-                                                pymax, r, subpixels)
-
-    return 0.0  # pixel is fully outside the circle
-
-
-cdef inline double _ellipse_pixel_frac(double pxmin, double pymin,
-                                       double dx, double dy, double norm,
-                                       double rx, double ry, double theta,
-                                       int use_exact,
-                                       int subpixels) noexcept nogil:
-    """
-    Fraction of a single pixel that overlaps an ellipse with semimajor
-    and semiminor axes ``rx`` and ``ry`` and position angle ``theta``
-    centered on the origin.
-
-    This replicates the per-pixel logic of ``elliptical_overlap_grid``,
-    including the bounding-circle shortcut, so the result is identical
-    to the grid function.
-    """
-    cdef double pxmax = pxmin + dx
-    cdef double pymax = pymin + dy
-    cdef double r = fmax(rx, ry)  # bounding circle radius
-
-    # Bounding-box check
-    if not (pxmax > -r - 0.5 * dx and pxmin < r + 0.5 * dx
-            and pymax > -r - 0.5 * dy and pymin < r + 0.5 * dy):
-        return 0.0
-
-    if use_exact:
-        return elliptical_overlap_single_exact(pxmin, pymin, pxmax, pymax,
-                                               rx, ry, theta) * norm
-    return elliptical_overlap_single_subpixel(pxmin, pymin, pxmax, pymax,
-                                              rx, ry, theta, subpixels)
-
-
-cdef inline double _rect_pixel_frac(double pxmin, double pymin,
-                                    double dx, double dy,
-                                    double half_width, double half_height,
-                                    double cos_theta, double sin_theta,
-                                    double bbox_dx, double bbox_dy,
-                                    double *poly_x, double *poly_y,
-                                    double *buf_a_x, double *buf_a_y,
-                                    double *buf_b_x, double *buf_b_y,
-                                    int use_exact,
-                                    int subpixels) noexcept nogil:
-    """
-    Fraction of a single pixel that overlaps a rectangle of full width
-    ``2 * half_width`` and full height ``2 * half_height`` rotated by
-    ``theta`` (given as ``cos_theta``/``sin_theta``) centered on the
-    origin.
-
-    This replicates the per-pixel logic of ``rectangular_overlap_grid``
-    (the exact mode skips pixels outside the axis-aligned bounding box
-    of the rotated rectangle), so the result is identical to the grid
-    function.
-    """
-    cdef double pxmax = pxmin + dx
-    cdef double pymax = pymin + dy
-
-    if use_exact:
-        # Bounding-box check
-        if (pxmax <= -bbox_dx or pxmin >= bbox_dx
-                or pymax <= -bbox_dy or pymin >= bbox_dy):
-            return 0.0
-        return polygon_pixel_overlap(pxmin, pymin, pxmax, pymax,
-                                     poly_x, poly_y, 4,
-                                     buf_a_x, buf_a_y, buf_b_x, buf_b_y,
-                                     32) / (dx * dy)
-
-    return rectangular_overlap_single_subpixel(pxmin, pymin, pxmax, pymax,
-                                               half_width, half_height,
-                                               cos_theta, sin_theta,
-                                               subpixels)
-
-
-cdef inline void _rect_vertices(double half_width, double half_height,
-                                double cos_theta, double sin_theta,
-                                double *poly_x,
-                                double *poly_y) noexcept nogil:
-    """
-    Build the four CCW vertices of a rotated rectangle centered on the
-    origin (same arithmetic as ``rectangular_overlap_grid``).
-    """
-    poly_x[0] = -half_width * cos_theta - (-half_height) * sin_theta
-    poly_y[0] = -half_width * sin_theta + (-half_height) * cos_theta
-    poly_x[1] = half_width * cos_theta - (-half_height) * sin_theta
-    poly_y[1] = half_width * sin_theta + (-half_height) * cos_theta
-    poly_x[2] = half_width * cos_theta - half_height * sin_theta
-    poly_y[2] = half_width * sin_theta + half_height * cos_theta
-    poly_x[3] = -half_width * cos_theta - half_height * sin_theta
-    poly_y[3] = -half_width * sin_theta + half_height * cos_theta
 
 
 def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
@@ -458,3 +330,131 @@ def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
                 errs[k] = sqrt(var_val)
 
     return sums_arr, errs_arr, overlap_arr.view(bool)
+
+
+cdef inline double _circle_pixel_frac(double pxmin, double pymin,
+                                      double dx, double dy,
+                                      double pixel_radius, double r,
+                                      int use_exact,
+                                      int subpixels) noexcept nogil:
+    """
+    Fraction of a single pixel that overlaps a circle of radius ``r``
+    centered on the origin.
+
+    This replicates the per-pixel logic of ``circular_overlap_grid``,
+    including the bounding-box and "well inside/outside" shortcuts, so
+    the result is identical to the grid function.
+    """
+    cdef double pxmax = pxmin + dx
+    cdef double pymax = pymin + dy
+    cdef double pxcen, pycen, d
+
+    # Bounding-box check
+    if not (pxmax > -r - 0.5 * dx and pxmin < r + 0.5 * dx
+            and pymax > -r - 0.5 * dy and pymin < r + 0.5 * dy):
+        return 0.0
+
+    # Distance from circle center to pixel center
+    pxcen = pxmin + dx * 0.5
+    pycen = pymin + dy * 0.5
+    d = sqrt(pxcen * pxcen + pycen * pycen)
+
+    if d < r - pixel_radius:  # pixel is well within the circle
+        return 1.0
+
+    if d < r + pixel_radius:  # pixel is close to the circle border
+        if use_exact:
+            return circular_overlap_single_exact(pxmin, pymin, pxmax,
+                                                 pymax, r) / (dx * dy)
+        return circular_overlap_single_subpixel(pxmin, pymin, pxmax,
+                                                pymax, r, subpixels)
+
+    return 0.0  # pixel is fully outside the circle
+
+
+cdef inline double _ellipse_pixel_frac(double pxmin, double pymin,
+                                       double dx, double dy, double norm,
+                                       double rx, double ry, double theta,
+                                       int use_exact,
+                                       int subpixels) noexcept nogil:
+    """
+    Fraction of a single pixel that overlaps an ellipse with semimajor
+    and semiminor axes ``rx`` and ``ry`` and position angle ``theta``
+    centered on the origin.
+
+    This replicates the per-pixel logic of ``elliptical_overlap_grid``,
+    including the bounding-circle shortcut, so the result is identical
+    to the grid function.
+    """
+    cdef double pxmax = pxmin + dx
+    cdef double pymax = pymin + dy
+    cdef double r = fmax(rx, ry)  # bounding circle radius
+
+    # Bounding-box check
+    if not (pxmax > -r - 0.5 * dx and pxmin < r + 0.5 * dx
+            and pymax > -r - 0.5 * dy and pymin < r + 0.5 * dy):
+        return 0.0
+
+    if use_exact:
+        return elliptical_overlap_single_exact(pxmin, pymin, pxmax, pymax,
+                                               rx, ry, theta) * norm
+    return elliptical_overlap_single_subpixel(pxmin, pymin, pxmax, pymax,
+                                              rx, ry, theta, subpixels)
+
+
+cdef inline double _rect_pixel_frac(double pxmin, double pymin,
+                                    double dx, double dy,
+                                    double half_width, double half_height,
+                                    double cos_theta, double sin_theta,
+                                    double bbox_dx, double bbox_dy,
+                                    double *poly_x, double *poly_y,
+                                    double *buf_a_x, double *buf_a_y,
+                                    double *buf_b_x, double *buf_b_y,
+                                    int use_exact,
+                                    int subpixels) noexcept nogil:
+    """
+    Fraction of a single pixel that overlaps a rectangle of full width
+    ``2 * half_width`` and full height ``2 * half_height`` rotated by
+    ``theta`` (given as ``cos_theta``/``sin_theta``) centered on the
+    origin.
+
+    This replicates the per-pixel logic of ``rectangular_overlap_grid``
+    (the exact mode skips pixels outside the axis-aligned bounding box
+    of the rotated rectangle), so the result is identical to the grid
+    function.
+    """
+    cdef double pxmax = pxmin + dx
+    cdef double pymax = pymin + dy
+
+    if use_exact:
+        # Bounding-box check
+        if (pxmax <= -bbox_dx or pxmin >= bbox_dx
+                or pymax <= -bbox_dy or pymin >= bbox_dy):
+            return 0.0
+        return polygon_pixel_overlap(pxmin, pymin, pxmax, pymax,
+                                     poly_x, poly_y, 4,
+                                     buf_a_x, buf_a_y, buf_b_x, buf_b_y,
+                                     32) / (dx * dy)
+
+    return rectangular_overlap_single_subpixel(pxmin, pymin, pxmax, pymax,
+                                               half_width, half_height,
+                                               cos_theta, sin_theta,
+                                               subpixels)
+
+
+cdef inline void _rect_vertices(double half_width, double half_height,
+                                double cos_theta, double sin_theta,
+                                double *poly_x,
+                                double *poly_y) noexcept nogil:
+    """
+    Build the four CCW vertices of a rotated rectangle centered on the
+    origin (same arithmetic as ``rectangular_overlap_grid``).
+    """
+    poly_x[0] = -half_width * cos_theta - (-half_height) * sin_theta
+    poly_y[0] = -half_width * sin_theta + (-half_height) * cos_theta
+    poly_x[1] = half_width * cos_theta - (-half_height) * sin_theta
+    poly_y[1] = half_width * sin_theta + (-half_height) * cos_theta
+    poly_x[2] = half_width * cos_theta - half_height * sin_theta
+    poly_y[2] = half_width * sin_theta + half_height * cos_theta
+    poly_x[3] = -half_width * cos_theta - half_height * sin_theta
+    poly_y[3] = -half_width * sin_theta + half_height * cos_theta

--- a/photutils/geometry/_polygon_overlap.pxd
+++ b/photutils/geometry/_polygon_overlap.pxd
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
-
-# This file is needed in order to be able to cimport functions into
-# other Cython files. These single-pixel functions are pure C math
-# functions that are safe to call without the GIL.
+"""
+Declarations needed to cimport the polygon overlap functions into other
+Cython files. These single-pixel functions are pure C math functions
+that are safe to call without the GIL.
+"""
 
 cdef double polygon_pixel_overlap(double pxmin, double pymin,
                                   double pxmax, double pymax,
@@ -12,7 +13,5 @@ cdef double polygon_pixel_overlap(double pxmin, double pymin,
                                   double *buf_a_x, double *buf_a_y,
                                   double *buf_b_x, double *buf_b_y,
                                   int buf_size) noexcept nogil
-
-
 cdef int point_in_polygon(double x, double y, double *poly_x,
                           double *poly_y, int n_poly) noexcept nogil

--- a/photutils/geometry/_polygon_overlap.pxd
+++ b/photutils/geometry/_polygon_overlap.pxd
@@ -1,6 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
 
+# This file is needed in order to be able to cimport functions into
+# other Cython files. These single-pixel functions are pure C math
+# functions that are safe to call without the GIL.
 
 cdef double polygon_pixel_overlap(double pxmin, double pymin,
                                   double pxmax, double pymax,

--- a/photutils/geometry/_polygon_overlap.pyx
+++ b/photutils/geometry/_polygon_overlap.pyx
@@ -14,7 +14,6 @@ the (always-convex, axis-aligned) pixel rectangle.
 
 import numpy as np
 
-cimport cython
 cimport numpy as np
 
 
@@ -166,14 +165,22 @@ cdef double polygon_pixel_overlap(double pxmin, double pymin,
     n = _clip_against_axis(cur_x, cur_y, n, 0, pxmax, 0, nxt_x, nxt_y)
     if n == 0:
         return 0.0
-    tmp = cur_x; cur_x = nxt_x; nxt_x = tmp
-    tmp = cur_y; cur_y = nxt_y; nxt_y = tmp
+    tmp = cur_x
+    cur_x = nxt_x
+    nxt_x = tmp
+    tmp = cur_y
+    cur_y = nxt_y
+    nxt_y = tmp
 
     n = _clip_against_axis(cur_x, cur_y, n, 1, pymin, 1, nxt_x, nxt_y)
     if n == 0:
         return 0.0
-    tmp = cur_x; cur_x = nxt_x; nxt_x = tmp
-    tmp = cur_y; cur_y = nxt_y; nxt_y = tmp
+    tmp = cur_x
+    cur_x = nxt_x
+    nxt_x = tmp
+    tmp = cur_y
+    cur_y = nxt_y
+    nxt_y = tmp
 
     n = _clip_against_axis(cur_x, cur_y, n, 1, pymax, 0, nxt_x, nxt_y)
     if n == 0:

--- a/photutils/geometry/_polygon_overlap.pyx
+++ b/photutils/geometry/_polygon_overlap.pyx
@@ -10,112 +10,185 @@ aperture whose footprint is a simple polygon (e.g., rotated rectangles,
 regular polygons, or arbitrary user-supplied polygons). Convexity is not
 required: the subject is the aperture polygon and the clip polygon is
 the (always-convex, axis-aligned) pixel rectangle.
+
+The cdef functions are not intended to be called from Python code.
+They are pure C math functions declared ``noexcept nogil`` so they can
+be called without the GIL (e.g., from the batch aperture photometry
+driver), including from multiple threads on free-threaded Python builds.
+Their signatures are exported via _polygon_overlap.pxd.
 """
 
 import numpy as np
 
 cimport numpy as np
 
+__all__ = ['polygon_overlap_grid']
 
-cdef extern from "math.h":
-    double fabs(double x) nogil
-    double fmax(double x, double y) nogil
-    double fmin(double x, double y) nogil
-    double floor(double x) nogil
-    double ceil(double x) nogil
+
+cdef extern from "math.h" nogil:
+    double fabs(double x)
+    double fmax(double x, double y)
+    double fmin(double x, double y)
+    double floor(double x)
+    double ceil(double x)
 
 
 DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
 
 
-cdef inline double _polygon_signed_area(double *xs, double *ys,
-                                        int n) noexcept nogil:
+def polygon_overlap_grid(double xmin, double xmax, double ymin, double ymax,
+                         int nx, int ny,
+                         np.ndarray[DTYPE_t, ndim=1] vertices_x,
+                         np.ndarray[DTYPE_t, ndim=1] vertices_y,
+                         int use_exact, int subpixels):
     """
-    Signed area of a polygon via the shoelace formula.
+    polygon_overlap_grid(xmin, xmax, ymin, ymax, nx, ny, vertices_x,
+                         vertices_y, use_exact, subpixels)
 
-    Positive for counter-clockwise vertices, negative for clockwise
-    vertices. For a Sutherland-Hodgman-clipped polygon the magnitude is
-    the area of the intersection even when the subject was non-convex
-    (any spurious "bridge" edges traverse zero area in pairs).
-    """
-    cdef double area = 0.0
-    cdef int i, j
-    if n < 3:
-        return 0.0
-    for i in range(n):
-        j = i + 1
-        if j == n:
-            j = 0
-        area += xs[i] * ys[j] - xs[j] * ys[i]
-    return 0.5 * area
+    Calculate the fractional overlap between a simple polygon and a
+    pixel grid.
 
-
-cdef inline int _clip_against_axis(double *xs_in, double *ys_in, int n_in,
-                                   int axis, double bound, int keep_greater,
-                                   double *xs_out,
-                                   double *ys_out) noexcept nogil:
-    """
-    Sutherland-Hodgman clip of a polygon (xs_in, ys_in) against an
-    axis-aligned half-plane.
+    The polygon vertices must define a simple polygon (no
+    self-intersections). The polygon may be convex or non-convex. The
+    vertex order may be either clockwise or counter-clockwise; clockwise
+    input is reversed internally.
 
     Parameters
     ----------
-    axis : int
-        0 for an x-aligned bound, 1 for a y-aligned bound.
-    bound : double
-        The coordinate value of the clipping line.
-    keep_greater : int
-        1 to keep points with coordinate >= bound, 0 to keep points
-        with coordinate <= bound.
+    xmin, xmax, ymin, ymax : float
+        The extent of the grid in the x and y direction. The grid is
+        defined by the rectangle with corners (xmin, ymin) and (xmax,
+        ymax).
+
+    nx, ny : int
+        The grid dimensions in the x and y direction. The grid is
+        defined by the rectangle with corners (xmin, ymin) and (xmax,
+        ymax) and is divided into nx and ny pixels in the x and y
+        direction, respectively.
+
+    vertices_x, vertices_y : 1D `~numpy.ndarray`
+        The x and y coordinates of the polygon vertices (in the same
+        coordinate frame as the grid extents). The polygon must have at
+        least 3 vertices.
+
+    use_exact : 0 or 1
+        Set to ``1`` to use an exact method to calculate the overlap
+        between the polygon and each pixel. Set to ``0`` to use a
+        sub-pixel sampling method to calculate the overlap, where each
+        pixel is divided into ``subpixels ** 2`` subpixels and the
+        fraction of subpixels that are within the polygon is used to
+        estimate the overlap.
+
+    subpixels : int
+        The number of subpixels to use in each dimension when using
+        the sub-pixel sampling method. Each pixel is resampled by this
+        factor in each dimension; thus, each pixel is divided into
+        ``subpixels ** 2`` subpixels.
+
+    Returns
+    -------
+    result : `~numpy.ndarray` (float)
+        A 2D array of shape (ny, nx) giving the fraction of each
+        pixel's area that overlaps with the polygon, ranging from 0 to
+        1. The element at index (j, i) corresponds to the pixel with
+        corners at (xmin + i * dx, ymin + j * dy) and (xmin + (i + 1)
+        * dx, ymin + (j + 1) * dy), where dx and dy are the width of
+        each pixel in the x and y direction, respectively.
     """
-    cdef int i, n_out = 0
-    cdef double sx, sy, px, py, sc, pc, t
-    cdef double sign
+    cdef int n_poly = vertices_x.shape[0]
+    if vertices_y.shape[0] != n_poly:
+        msg = 'vertices_x and vertices_y must have the same length'
+        raise ValueError(msg)
+    if n_poly < 3:
+        msg = 'polygon must have at least 3 vertices'
+        raise ValueError(msg)
+    if use_exact != 1 and subpixels < 1:
+        msg = 'subpixels must be a strictly positive integer'
+        raise ValueError(msg)
 
-    if n_in == 0:
-        return 0
+    # Working buffers, allocated once per call (not per pixel) as a
+    # single block. Each Sutherland-Hodgman clip can at most double the
+    # vertex count of a non-convex polygon, so after the four half-plane
+    # clips the vertex count is bounded by 16 * n_poly.
+    cdef int buf_size = 16 * n_poly
+    cdef double[::1] work = np.empty(2 * n_poly + 4 * buf_size, dtype=DTYPE)
+    cdef double *poly_x = &work[0]
+    cdef double *poly_y = &work[n_poly]
+    cdef double *buf_a_x = &work[2 * n_poly]
+    cdef double *buf_a_y = &work[2 * n_poly + buf_size]
+    cdef double *buf_b_x = &work[2 * n_poly + 2 * buf_size]
+    cdef double *buf_b_y = &work[2 * n_poly + 3 * buf_size]
+    cdef double[::1] vx_view = np.ascontiguousarray(vertices_x)
+    cdef double[::1] vy_view = np.ascontiguousarray(vertices_y)
+    _ensure_ccw(vx_view, vy_view, n_poly, poly_x, poly_y)
 
-    if keep_greater == 1:
-        sign = 1.0
+    cdef np.ndarray[DTYPE_t, ndim=2] frac = np.zeros([ny, nx], dtype=DTYPE)
+    cdef double[:, ::1] frac_view = frac
+    cdef double dx = (xmax - xmin) / nx
+    cdef double dy = (ymax - ymin) / ny
+    cdef double pxmin, pxmax, pymin, pymax
+    cdef double bbox_xmin, bbox_xmax, bbox_ymin, bbox_ymax
+    cdef double pixel_area = dx * dy
+    cdef int i, j, ii, jj, k
+    cdef int i_min, i_max, j_min, j_max
+    cdef double sub_dx, sub_dy, sx, sy, hits
+
+    # Polygon bounding box.
+    bbox_xmin = poly_x[0]
+    bbox_xmax = poly_x[0]
+    bbox_ymin = poly_y[0]
+    bbox_ymax = poly_y[0]
+    for k in range(1, n_poly):
+        bbox_xmin = fmin(bbox_xmin, poly_x[k])
+        bbox_xmax = fmax(bbox_xmax, poly_x[k])
+        bbox_ymin = fmin(bbox_ymin, poly_y[k])
+        bbox_ymax = fmax(bbox_ymax, poly_y[k])
+
+    # Restrict the pixel loops to the bounding-box index range (pixels
+    # outside the bounding box have zero overlap). The clamping to
+    # [0, nx] and [0, ny] is done in floating point to avoid integer
+    # overflow for polygons far outside the grid.
+    i_min = <int>fmax(0.0, fmin(<double>nx, floor((bbox_xmin - xmin) / dx)))
+    i_max = <int>fmax(0.0, fmin(<double>nx, ceil((bbox_xmax - xmin) / dx)))
+    j_min = <int>fmax(0.0, fmin(<double>ny, floor((bbox_ymin - ymin) / dy)))
+    j_max = <int>fmax(0.0, fmin(<double>ny, ceil((bbox_ymax - ymin) / dy)))
+
+    if use_exact == 1:
+        with nogil:
+            for i in range(i_min, i_max):
+                pxmin = xmin + i * dx
+                pxmax = pxmin + dx
+                for j in range(j_min, j_max):
+                    pymin = ymin + j * dy
+                    pymax = pymin + dy
+                    frac_view[j, i] = (
+                        polygon_pixel_overlap(pxmin, pymin, pxmax, pymax,
+                                              poly_x, poly_y, n_poly,
+                                              buf_a_x, buf_a_y,
+                                              buf_b_x, buf_b_y, buf_size)
+                        / pixel_area)
     else:
-        sign = -1.0
+        sub_dx = dx / subpixels
+        sub_dy = dy / subpixels
+        with nogil:
+            for i in range(i_min, i_max):
+                pxmin = xmin + i * dx
+                for j in range(j_min, j_max):
+                    pymin = ymin + j * dy
+                    hits = 0.0
+                    sx = pxmin + 0.5 * sub_dx
+                    for ii in range(subpixels):
+                        sy = pymin + 0.5 * sub_dy
+                        for jj in range(subpixels):
+                            if point_in_polygon(sx, sy, poly_x, poly_y,
+                                                n_poly) == 1:
+                                hits += 1.0
+                            sy += sub_dy
+                        sx += sub_dx
+                    frac_view[j, i] = hits / (subpixels * subpixels)
 
-    sx = xs_in[n_in - 1]
-    sy = ys_in[n_in - 1]
-    if axis == 0:
-        sc = sign * (sx - bound)
-    else:
-        sc = sign * (sy - bound)
-
-    for i in range(n_in):
-        px = xs_in[i]
-        py = ys_in[i]
-        if axis == 0:
-            pc = sign * (px - bound)
-        else:
-            pc = sign * (py - bound)
-        if pc >= 0.0:
-            if sc < 0.0:
-                # entering: emit intersection, then point
-                t = sc / (sc - pc)
-                xs_out[n_out] = sx + t * (px - sx)
-                ys_out[n_out] = sy + t * (py - sy)
-                n_out += 1
-            xs_out[n_out] = px
-            ys_out[n_out] = py
-            n_out += 1
-        elif sc >= 0.0:
-            # leaving: emit intersection only
-            t = sc / (sc - pc)
-            xs_out[n_out] = sx + t * (px - sx)
-            ys_out[n_out] = sy + t * (py - sy)
-            n_out += 1
-        sx = px
-        sy = py
-        sc = pc
-
-    return n_out
+    return frac
 
 
 cdef double polygon_pixel_overlap(double pxmin, double pymin,
@@ -218,6 +291,95 @@ cdef int point_in_polygon(double x, double y, double *poly_x,
     return inside
 
 
+cdef inline double _polygon_signed_area(double *xs, double *ys,
+                                        int n) noexcept nogil:
+    """
+    Signed area of a polygon via the shoelace formula.
+
+    Positive for counter-clockwise vertices, negative for clockwise
+    vertices. For a Sutherland-Hodgman-clipped polygon the magnitude is
+    the area of the intersection even when the subject was non-convex
+    (any spurious "bridge" edges traverse zero area in pairs).
+    """
+    cdef double area = 0.0
+    cdef int i, j
+    if n < 3:
+        return 0.0
+    for i in range(n):
+        j = i + 1
+        if j == n:
+            j = 0
+        area += xs[i] * ys[j] - xs[j] * ys[i]
+    return 0.5 * area
+
+
+cdef inline int _clip_against_axis(double *xs_in, double *ys_in, int n_in,
+                                   int axis, double bound, int keep_greater,
+                                   double *xs_out,
+                                   double *ys_out) noexcept nogil:
+    """
+    Sutherland-Hodgman clip of a polygon (xs_in, ys_in) against an
+    axis-aligned half-plane.
+
+    Parameters
+    ----------
+    axis : int
+        0 for an x-aligned bound, 1 for a y-aligned bound.
+    bound : double
+        The coordinate value of the clipping line.
+    keep_greater : int
+        1 to keep points with coordinate >= bound, 0 to keep points
+        with coordinate <= bound.
+    """
+    cdef int i, n_out = 0
+    cdef double sx, sy, px, py, sc, pc, t
+    cdef double sign
+
+    if n_in == 0:
+        return 0
+
+    if keep_greater == 1:
+        sign = 1.0
+    else:
+        sign = -1.0
+
+    sx = xs_in[n_in - 1]
+    sy = ys_in[n_in - 1]
+    if axis == 0:
+        sc = sign * (sx - bound)
+    else:
+        sc = sign * (sy - bound)
+
+    for i in range(n_in):
+        px = xs_in[i]
+        py = ys_in[i]
+        if axis == 0:
+            pc = sign * (px - bound)
+        else:
+            pc = sign * (py - bound)
+        if pc >= 0.0:
+            if sc < 0.0:
+                # entering: emit intersection, then point
+                t = sc / (sc - pc)
+                xs_out[n_out] = sx + t * (px - sx)
+                ys_out[n_out] = sy + t * (py - sy)
+                n_out += 1
+            xs_out[n_out] = px
+            ys_out[n_out] = py
+            n_out += 1
+        elif sc >= 0.0:
+            # leaving: emit intersection only
+            t = sc / (sc - pc)
+            xs_out[n_out] = sx + t * (px - sx)
+            ys_out[n_out] = sy + t * (py - sy)
+            n_out += 1
+        sx = px
+        sy = py
+        sc = pc
+
+    return n_out
+
+
 cdef void _ensure_ccw(double[::1] xs, double[::1] ys, int n,
                       double *out_x, double *out_y) noexcept nogil:
     """
@@ -235,138 +397,3 @@ cdef void _ensure_ccw(double[::1] xs, double[::1] ys, int n,
             k = n - 1 - i
             out_x[i] = xs[k]
             out_y[i] = ys[k]
-
-
-def polygon_overlap_grid(double xmin, double xmax, double ymin, double ymax,
-                         int nx, int ny,
-                         np.ndarray[DTYPE_t, ndim=1] vertices_x,
-                         np.ndarray[DTYPE_t, ndim=1] vertices_y,
-                         int use_exact, int subpixels):
-    """
-    polygon_overlap_grid(xmin, xmax, ymin, ymax, nx, ny, vertices_x,
-                         vertices_y, use_exact, subpixels)
-
-    Area of overlap between a simple polygon and a pixel grid.
-
-    The polygon vertices must define a simple polygon (no
-    self-intersections). The polygon may be convex or non-convex. The
-    vertex order may be either clockwise or counter-clockwise; clockwise
-    input is reversed internally.
-
-    Parameters
-    ----------
-    xmin, xmax, ymin, ymax : float
-        Extent of the grid in the x and y direction.
-    nx, ny : int
-        Grid dimensions.
-    vertices_x, vertices_y : 1-d `~numpy.ndarray`
-        The x and y coordinates of the polygon vertices (in the same
-        coordinate frame as the grid extents). The polygon must have at
-        least 3 vertices.
-    use_exact : 0 or 1
-        If set to 1, calculates the exact overlap, while if set to 0,
-        uses a subpixel sampling method with ``subpixels`` subpixels in
-        each direction.
-    subpixels : int
-        If ``use_exact`` is 0, each pixel is resampled by this factor in
-        each dimension. Each pixel is divided into ``subpixels ** 2``
-        subpixels.
-
-    Returns
-    -------
-    frac : `~numpy.ndarray`
-        2D array giving the fraction of the overlap.
-    """
-    cdef int n_poly = vertices_x.shape[0]
-    if vertices_y.shape[0] != n_poly:
-        msg = 'vertices_x and vertices_y must have the same length'
-        raise ValueError(msg)
-    if n_poly < 3:
-        msg = 'polygon must have at least 3 vertices'
-        raise ValueError(msg)
-    if use_exact != 1 and subpixels < 1:
-        msg = 'subpixels must be a strictly positive integer'
-        raise ValueError(msg)
-
-    # Working buffers, allocated once per call (not per pixel) as a
-    # single block. Each Sutherland-Hodgman clip can at most double the
-    # vertex count of a non-convex polygon, so after the four half-plane
-    # clips the vertex count is bounded by 16 * n_poly.
-    cdef int buf_size = 16 * n_poly
-    cdef double[::1] work = np.empty(2 * n_poly + 4 * buf_size, dtype=DTYPE)
-    cdef double *poly_x = &work[0]
-    cdef double *poly_y = &work[n_poly]
-    cdef double *buf_a_x = &work[2 * n_poly]
-    cdef double *buf_a_y = &work[2 * n_poly + buf_size]
-    cdef double *buf_b_x = &work[2 * n_poly + 2 * buf_size]
-    cdef double *buf_b_y = &work[2 * n_poly + 3 * buf_size]
-    cdef double[::1] vx_view = np.ascontiguousarray(vertices_x)
-    cdef double[::1] vy_view = np.ascontiguousarray(vertices_y)
-    _ensure_ccw(vx_view, vy_view, n_poly, poly_x, poly_y)
-
-    cdef np.ndarray[DTYPE_t, ndim=2] frac = np.zeros([ny, nx], dtype=DTYPE)
-    cdef double[:, ::1] frac_view = frac
-    cdef double dx = (xmax - xmin) / nx
-    cdef double dy = (ymax - ymin) / ny
-    cdef double pxmin, pxmax, pymin, pymax
-    cdef double bbox_xmin, bbox_xmax, bbox_ymin, bbox_ymax
-    cdef double pixel_area = dx * dy
-    cdef int i, j, ii, jj, k
-    cdef int i_min, i_max, j_min, j_max
-    cdef double sub_dx, sub_dy, sx, sy, hits
-
-    # Polygon bounding box.
-    bbox_xmin = poly_x[0]
-    bbox_xmax = poly_x[0]
-    bbox_ymin = poly_y[0]
-    bbox_ymax = poly_y[0]
-    for k in range(1, n_poly):
-        bbox_xmin = fmin(bbox_xmin, poly_x[k])
-        bbox_xmax = fmax(bbox_xmax, poly_x[k])
-        bbox_ymin = fmin(bbox_ymin, poly_y[k])
-        bbox_ymax = fmax(bbox_ymax, poly_y[k])
-
-    # Restrict the pixel loops to the bounding-box index range (pixels
-    # outside the bounding box have zero overlap). The clamping to
-    # [0, nx] and [0, ny] is done in floating point to avoid integer
-    # overflow for polygons far outside the grid.
-    i_min = <int>fmax(0.0, fmin(<double>nx, floor((bbox_xmin - xmin) / dx)))
-    i_max = <int>fmax(0.0, fmin(<double>nx, ceil((bbox_xmax - xmin) / dx)))
-    j_min = <int>fmax(0.0, fmin(<double>ny, floor((bbox_ymin - ymin) / dy)))
-    j_max = <int>fmax(0.0, fmin(<double>ny, ceil((bbox_ymax - ymin) / dy)))
-
-    if use_exact == 1:
-        with nogil:
-            for i in range(i_min, i_max):
-                pxmin = xmin + i * dx
-                pxmax = pxmin + dx
-                for j in range(j_min, j_max):
-                    pymin = ymin + j * dy
-                    pymax = pymin + dy
-                    frac_view[j, i] = (
-                        polygon_pixel_overlap(pxmin, pymin, pxmax, pymax,
-                                              poly_x, poly_y, n_poly,
-                                              buf_a_x, buf_a_y,
-                                              buf_b_x, buf_b_y, buf_size)
-                        / pixel_area)
-    else:
-        sub_dx = dx / subpixels
-        sub_dy = dy / subpixels
-        with nogil:
-            for i in range(i_min, i_max):
-                pxmin = xmin + i * dx
-                for j in range(j_min, j_max):
-                    pymin = ymin + j * dy
-                    hits = 0.0
-                    sx = pxmin + 0.5 * sub_dx
-                    for ii in range(subpixels):
-                        sy = pymin + 0.5 * sub_dy
-                        for jj in range(subpixels):
-                            if point_in_polygon(sx, sy, poly_x, poly_y,
-                                                n_poly) == 1:
-                                hits += 1.0
-                            sy += sub_dy
-                        sx += sub_dx
-                    frac_view[j, i] = hits / (subpixels * subpixels)
-
-    return frac

--- a/photutils/geometry/circular_overlap.pxd
+++ b/photutils/geometry/circular_overlap.pxd
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
-
-# This file is needed in order to be able to cimport functions into
-# other Cython files. These single-pixel functions are pure C math
-# functions that are safe to call without the GIL.
+"""
+Declarations needed to cimport the circular overlap functions into other
+Cython files. These single-pixel functions are pure C math functions
+that are safe to call without the GIL.
+"""
 
 cdef double circular_overlap_single_subpixel(double x0, double y0,
                                              double x1, double y1,

--- a/photutils/geometry/circular_overlap.pxd
+++ b/photutils/geometry/circular_overlap.pxd
@@ -1,0 +1,14 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3
+
+# This file is needed in order to be able to cimport functions into
+# other Cython files. These single-pixel functions are pure C math
+# functions that are safe to call without the GIL.
+
+cdef double circular_overlap_single_subpixel(double x0, double y0,
+                                             double x1, double y1,
+                                             double r,
+                                             int subpixels) noexcept nogil
+cdef double circular_overlap_single_exact(double xmin, double ymin,
+                                          double xmax, double ymax,
+                                          double r) noexcept nogil

--- a/photutils/geometry/circular_overlap.pyx
+++ b/photutils/geometry/circular_overlap.pyx
@@ -1,18 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: freethreading_compatible=True
 """
 The functions defined here allow one to determine the exact area of
-overlap of a rectangle and a circle (written by Thomas Robitaille).
+overlap of a rectangle and a circle.
 """
 
 import numpy as np
+
 cimport numpy as np
+
+from .core cimport area_arc, area_triangle, floor_sqrt
 
 __all__ = ['circular_overlap_grid']
 
 
-cdef extern from "math.h":
-
+cdef extern from "math.h" nogil:
     double asin(double x)
     double sin(double x)
     double sqrt(double x)
@@ -21,21 +24,16 @@ cdef extern from "math.h":
 DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
 
-# NOTE: Here we need to make sure we use cimport to import the C functions from
-# core (since these were defined with cdef). This also requires the core.pxd
-# file to exist with the function signatures.
-from .core cimport area_arc, area_triangle, floor_sqrt
-
 
 def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
                           int nx, int ny, double r, int use_exact,
                           int subpixels):
     """
-    circular_overlap_grid(xmin, xmax, ymin, ymax, nx, ny, r,
-                             use_exact, subpixels)
+    circular_overlap_grid(xmin, xmax, ymin, ymax, nx, ny, r, use_exact,
+                          subpixels)
 
-    Area of overlap between a circle and a pixel grid. The circle is centered
-    on the origin.
+    Area of overlap between a circle and a pixel grid. The circle is
+    centered on the origin.
 
     Parameters
     ----------
@@ -46,8 +44,8 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     r : float
         The radius of the circle.
     use_exact : 0 or 1
-        If ``1`` calculates exact overlap, if ``0`` uses ``subpixel`` number
-        of subpixels to calculate the overlap.
+        If ``1`` calculates exact overlap. If ``0`` uses ``subpixel``
+        number of subpixels to calculate the overlap.
     subpixels : int
         Each pixel resampled by this factor in each dimension, thus each
         pixel is divided into ``subpixels ** 2`` subpixels.
@@ -55,11 +53,10 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     Returns
     -------
     frac : `~numpy.ndarray` (float)
-        2-d array of shape (ny, nx) giving the fraction of the overlap.
+        2D array of shape (ny, nx) giving the fraction of the overlap.
     """
-
     cdef unsigned int i, j
-    cdef double x, y, dx, dy, d, pixel_radius
+    cdef double dx, dy, d, pixel_radius
     cdef double bxmin, bxmax, bymin, bymax
     cdef double pxmin, pxcen, pxmax, pymin, pycen, pymax
 
@@ -89,7 +86,6 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
                 pycen = pymin + dy * 0.5
                 pymax = pymin + dy
                 if pymax > bymin and pymin < bymax:
-
                     # Distance from circle center to pixel center.
                     d = sqrt(pxcen * pxcen + pycen * pycen)
 
@@ -101,7 +97,6 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
                     # If pixel center is "close" to circle border, find
                     # overlap.
                     elif d < r + pixel_radius:
-
                         # Either do exact calculation or use subpixel
                         # sampling:
                         if use_exact:
@@ -117,23 +112,25 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     return frac
 
 
-# NOTE: The following two functions use cdef because they are not
-# intended to be called from the Python code. Using def makes them
-# callable from outside, but also slower. In any case, these aren't useful
-# to call from outside because they only operate on a single pixel.
+# NOTE: The following functions use cdef because they are not intended
+# to be called from Python code. They are pure C math functions declared
+# ``noexcept nogil`` so they can be called without the GIL (e.g., from
+# the batch aperture photometry driver), including from multiple threads
+# on free-threaded Python builds. Their signatures are exported via
+# circular_overlap.pxd.
 
 
 cdef double circular_overlap_single_subpixel(double x0, double y0,
                                              double x1, double y1,
-                                             double r, int subpixels):
+                                             double r,
+                                             int subpixels) noexcept nogil:
     """
     Return the fraction of overlap between a circle and a single pixel
     with given extent, using a sub-pixel sampling method.
     """
-
     cdef unsigned int i, j
     cdef double x, y, dx, dy, r_squared
-    cdef double frac = 0.0  # Accumulator.
+    cdef double frac = 0.0  # accumulator
 
     dx = (x1 - x0) / subpixels
     dy = (y1 - y0) / subpixels
@@ -153,9 +150,9 @@ cdef double circular_overlap_single_subpixel(double x0, double y0,
 
 cdef double circular_overlap_single_exact(double xmin, double ymin,
                                           double xmax, double ymax,
-                                          double r):
+                                          double r) noexcept nogil:
     """
-    Area of overlap of a rectangle and a circle
+    Area of overlap of a rectangle and a circle.
     """
     if 0.0 <= xmin:
         if 0.0 <= ymin:
@@ -187,13 +184,12 @@ cdef double circular_overlap_single_exact(double xmin, double ymin,
                 + circular_overlap_single_exact(0.0, 0.0, xmax, ymax, r)
 
 
-cdef double circular_overlap_core(double xmin, double ymin, double xmax, double ymax,
-                          double r):
+cdef double circular_overlap_core(double xmin, double ymin, double xmax,
+                                  double ymax, double r) noexcept nogil:
     """
-    Assumes that the center of the circle is <= xmin,
-    ymin (can always modify input to conform to this).
+    Assumes that the center of the circle is <= xmin, ymin (can always
+    modify input to conform to this).
     """
-
     cdef double area, d1, d2, x1, x2, y1, y2
 
     if xmin * xmin + ymin * ymin > r * r:

--- a/photutils/geometry/circular_overlap.pyx
+++ b/photutils/geometry/circular_overlap.pyx
@@ -2,8 +2,14 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # cython: freethreading_compatible=True
 """
-The functions defined here allow one to determine the exact area of
-overlap of a rectangle and a circle.
+Tools to calculate the area of overlap between a circle and a pixel
+grid.
+
+The cdef functions are not intended to be called from Python code.
+They are pure C math functions declared ``noexcept nogil`` so they can
+be called without the GIL (e.g., from the batch aperture photometry
+driver), including from multiple threads on free-threaded Python builds.
+Their signatures are exported via circular_overlap.pxd.
 """
 
 import numpy as np
@@ -16,8 +22,6 @@ __all__ = ['circular_overlap_grid']
 
 
 cdef extern from "math.h" nogil:
-    double asin(double x)
-    double sin(double x)
     double sqrt(double x)
 
 
@@ -32,28 +36,49 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     circular_overlap_grid(xmin, xmax, ymin, ymax, nx, ny, r, use_exact,
                           subpixels)
 
-    Area of overlap between a circle and a pixel grid. The circle is
-    centered on the origin.
+    Calculate the fractional overlap between a circle and a pixel grid.
+
+    The circle is centered on the origin.
 
     Parameters
     ----------
     xmin, xmax, ymin, ymax : float
-        Extent of the grid in the x and y direction.
+        The extent of the grid in the x and y direction. The grid is
+        defined by the rectangle with corners (xmin, ymin) and (xmax,
+        ymax).
+
     nx, ny : int
-        Grid dimensions.
+        The grid dimensions in the x and y direction. The grid is
+        defined by the rectangle with corners (xmin, ymin) and (xmax,
+        ymax) and is divided into nx and ny pixels in the x and y
+        direction, respectively.
+
     r : float
         The radius of the circle.
+
     use_exact : 0 or 1
-        If ``1`` calculates exact overlap. If ``0`` uses ``subpixel``
-        number of subpixels to calculate the overlap.
+        Set to ``1`` to use an exact method to calculate the overlap
+        between the circle and each pixel. Set to ``0`` to use a
+        sub-pixel sampling method to calculate the overlap, where each
+        pixel is divided into ``subpixels ** 2`` subpixels and the
+        fraction of subpixels that are within the circle is used to
+        estimate the overlap.
+
     subpixels : int
-        Each pixel resampled by this factor in each dimension, thus each
-        pixel is divided into ``subpixels ** 2`` subpixels.
+        The number of subpixels to use in each dimension when using
+        the sub-pixel sampling method. Each pixel is resampled by this
+        factor in each dimension; thus, each pixel is divided into
+        ``subpixels ** 2`` subpixels.
 
     Returns
     -------
-    frac : `~numpy.ndarray` (float)
-        2D array of shape (ny, nx) giving the fraction of the overlap.
+    result : `~numpy.ndarray` (float)
+        A 2D array of shape (ny, nx) giving the fraction of each
+        pixel's area that overlaps with the circle, ranging from 0 to
+        1. The element at index (j, i) corresponds to the pixel with
+        corners at (xmin + i * dx, ymin + j * dy) and (xmin + (i + 1)
+        * dx, ymin + (j + 1) * dy), where dx and dy are the width of
+        each pixel in the x and y direction, respectively.
     """
     cdef unsigned int i, j
     cdef double dx, dy, d, pixel_radius
@@ -62,6 +87,7 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
 
     # Define output array
     cdef np.ndarray[DTYPE_t, ndim=2] frac = np.zeros([ny, nx], dtype=DTYPE)
+    cdef double[:, ::1] frac_view = frac
 
     # Find the width of each element in x and y
     dx = (xmax - xmin) / nx
@@ -76,48 +102,45 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     bymin = -r - 0.5 * dy
     bymax = +r + 0.5 * dy
 
-    for i in range(nx):
-        pxmin = xmin + i * dx  # lower end of pixel
-        pxcen = pxmin + dx * 0.5
-        pxmax = pxmin + dx  # upper end of pixel
-        if pxmax > bxmin and pxmin < bxmax:
-            for j in range(ny):
-                pymin = ymin + j * dy
-                pycen = pymin + dy * 0.5
-                pymax = pymin + dy
-                if pymax > bymin and pymin < bymax:
-                    # Distance from circle center to pixel center.
-                    d = sqrt(pxcen * pxcen + pycen * pycen)
+    with nogil:
+        for i in range(nx):
+            pxmin = xmin + i * dx  # lower end of pixel
+            pxcen = pxmin + dx * 0.5
+            pxmax = pxmin + dx  # upper end of pixel
+            if pxmax > bxmin and pxmin < bxmax:
+                for j in range(ny):
+                    pymin = ymin + j * dy
+                    pycen = pymin + dy * 0.5
+                    pymax = pymin + dy
+                    if pymax > bymin and pymin < bymax:
+                        # Distance from circle center to pixel center.
+                        d = sqrt(pxcen * pxcen + pycen * pycen)
 
-                    # If pixel center is "well within" circle, count full
-                    # pixel.
-                    if d < r - pixel_radius:
-                        frac[j, i] = 1.0
+                        # If pixel center is "well within" circle,
+                        # count full pixel.
+                        if d < r - pixel_radius:
+                            frac_view[j, i] = 1.0
 
-                    # If pixel center is "close" to circle border, find
-                    # overlap.
-                    elif d < r + pixel_radius:
-                        # Either do exact calculation or use subpixel
-                        # sampling:
-                        if use_exact:
-                            frac[j, i] = circular_overlap_single_exact(
-                                pxmin, pymin, pxmax, pymax, r) / (dx * dy)
-                        else:
-                            frac[j, i] = circular_overlap_single_subpixel(
-                                pxmin, pymin, pxmax, pymax, r, subpixels)
+                        # If pixel center is "close" to circle border,
+                        # find overlap.
+                        elif d < r + pixel_radius:
+                            # Either do exact calculation or use
+                            # subpixel sampling:
+                            if use_exact:
+                                frac_view[j, i] = (
+                                    circular_overlap_single_exact(
+                                        pxmin, pymin, pxmax, pymax, r)
+                                    / (dx * dy))
+                            else:
+                                frac_view[j, i] = (
+                                    circular_overlap_single_subpixel(
+                                        pxmin, pymin, pxmax, pymax, r,
+                                        subpixels))
 
-                    # Otherwise, it is fully outside circle.
-                    # No action needed.
+                        # Otherwise, it is fully outside circle.
+                        # No action needed.
 
     return frac
-
-
-# NOTE: The following functions use cdef because they are not intended
-# to be called from Python code. They are pure C math functions declared
-# ``noexcept nogil`` so they can be called without the GIL (e.g., from
-# the batch aperture photometry driver), including from multiple threads
-# on free-threaded Python builds. Their signatures are exported via
-# circular_overlap.pxd.
 
 
 cdef double circular_overlap_single_subpixel(double x0, double y0,
@@ -152,7 +175,10 @@ cdef double circular_overlap_single_exact(double xmin, double ymin,
                                           double xmax, double ymax,
                                           double r) noexcept nogil:
     """
-    Area of overlap of a rectangle and a circle.
+    Calculate the area of overlap between a circle and a single pixel
+    with given extent, using an exact method.
+
+    The circle is centered on the origin.
     """
     if 0.0 <= xmin:
         if 0.0 <= ymin:
@@ -171,10 +197,7 @@ cdef double circular_overlap_single_exact(double xmin, double ymin,
             return circular_overlap_single_exact(xmin, ymin, xmax, 0.0, r) \
                 + circular_overlap_single_exact(xmin, 0.0, xmax, ymax, r)
     else:
-        if 0.0 <= ymin:
-            return circular_overlap_single_exact(xmin, ymin, 0.0, ymax, r) \
-                + circular_overlap_single_exact(0.0, ymin, xmax, ymax, r)
-        if 0.0 >= ymax:
+        if 0.0 <= ymin or 0.0 >= ymax:
             return circular_overlap_single_exact(xmin, ymin, 0.0, ymax, r) \
                 + circular_overlap_single_exact(0.0, ymin, xmax, ymax, r)
         else:
@@ -187,6 +210,10 @@ cdef double circular_overlap_single_exact(double xmin, double ymin,
 cdef double circular_overlap_core(double xmin, double ymin, double xmax,
                                   double ymax, double r) noexcept nogil:
     """
+    Calculate the area of overlap between a circle and a rectangle,
+    where the rectangle is in the first quadrant and the circle is
+    centered on the origin.
+
     Assumes that the center of the circle is <= xmin, ymin (can always
     modify input to conform to this).
     """

--- a/photutils/geometry/core.pxd
+++ b/photutils/geometry/core.pxd
@@ -1,12 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-#cython: language_level=3
+# cython: language_level=3
 
-# This file is needed in order to be able to cimport functions into other Cython files
+# This file is needed in order to be able to cimport functions into
+# other Cython files. All functions are pure C math functions that are
+# safe to call without the GIL.
 
-cdef double distance(double x1, double y1, double x2, double y2)
-cdef double area_arc(double x1, double y1, double x2, double y2, double R)
-cdef double area_triangle(double x1, double y1, double x2, double y2, double x3, double y3)
-cdef double area_arc_unit(double x1, double y1, double x2, double y2)
-cdef int in_triangle(double x, double y, double x1, double y1, double x2, double y2, double x3, double y3)
-cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, double y2, double x3, double y3)
-cdef double floor_sqrt(double x)
+cdef double distance(double x1, double y1, double x2,
+                     double y2) noexcept nogil
+cdef double area_arc(double x1, double y1, double x2, double y2,
+                     double r) noexcept nogil
+cdef double area_triangle(double x1, double y1, double x2, double y2,
+                          double x3, double y3) noexcept nogil
+cdef double area_arc_unit(double x1, double y1, double x2,
+                          double y2) noexcept nogil
+cdef int in_triangle(double x, double y, double x1, double y1, double x2,
+                     double y2, double x3, double y3) noexcept nogil
+cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2,
+                                              double y2, double x3,
+                                              double y3) noexcept nogil
+cdef double floor_sqrt(double x) noexcept nogil

--- a/photutils/geometry/core.pxd
+++ b/photutils/geometry/core.pxd
@@ -1,10 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
+"""
+Declarations needed to cimport the core geometry functions into other
+Cython files. All functions are pure C math functions that are safe to
+call without the GIL.
+"""
 
-# This file is needed in order to be able to cimport functions into
-# other Cython files. All functions are pure C math functions that are
-# safe to call without the GIL.
-
+cdef double floor_sqrt(double x) noexcept nogil
 cdef double distance(double x1, double y1, double x2,
                      double y2) noexcept nogil
 cdef double area_arc(double x1, double y1, double x2, double y2,
@@ -18,4 +20,3 @@ cdef int in_triangle(double x, double y, double x1, double y1, double x2,
 cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2,
                                               double y2, double x3,
                                               double y3) noexcept nogil
-cdef double floor_sqrt(double x) noexcept nogil

--- a/photutils/geometry/core.pyx
+++ b/photutils/geometry/core.pyx
@@ -1,7 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: freethreading_compatible=True
 """
 The functions here are the core geometry functions.
+
+All ``cdef`` functions in this module are ``noexcept nogil``. They are
+pure C math function that do not interact with Python objects, do not
+raise exceptions, and may safely be called without the GIL (including
+from multiple threads on free-threaded Python builds).
 """
 
 import numpy as np
@@ -9,113 +15,115 @@ import numpy as np
 cimport numpy as np
 
 
-cdef extern from "math.h":
-
+cdef extern from "math.h" nogil:
     double asin(double x)
     double sin(double x)
     double cos(double x)
     double sqrt(double x)
     double fabs(double x)
-
-from cpython cimport bool
+    double M_PI
+    double NAN
 
 DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
 
-cimport cython
-
 ctypedef struct point:
     double x
     double y
-
 
 ctypedef struct intersections:
     point p1
     point p2
 
 
-cdef double floor_sqrt(double x):
+cdef double floor_sqrt(double x) noexcept nogil:
     """
-    In some of the geometrical functions, we have to take the sqrt of a number
-    and we know that the number should be >= 0. However, in some cases the
-    value is e.g. -1e-10, but we want to treat it as zero, which is what
-    this function does.
+    In some of the geometrical functions, we have to take the sqrt of a
+    number and we know that the number should be >= 0. However, in some
+    cases the value is e.g. -1e-10, but we want to treat it as zero,
+    which is what this function does.
 
-    Note that this does **not** check whether negative values are close or not
-    to zero, so this should be used only in cases where the value is expected
-    to be positive on paper.
+    Note that this does **not** check whether negative values are close
+    or not to zero, so this should be used only in cases where the value
+    is expected to be positive.
     """
     if x > 0:
         return sqrt(x)
     else:
         return 0
 
-# NOTE: The following two functions use cdef because they are not intended to be
-# called from the Python code. Using def makes them callable from outside, but
-# also slower. Some functions currently return multiple values, and for those we
-# still use 'def' for now.
 
+# NOTE: The following two functions use cdef because they are not
+# intended to be called from the Python code. Using def makes them
+# callable from outside, but also slower. Some functions currently
+# return multiple values, and for those we still use 'def' for now.
 
-cdef double distance(double x1, double y1, double x2, double y2):
+cdef double distance(double x1, double y1, double x2,
+                     double y2) noexcept nogil:
     """
     Distance between two points in two dimensions.
 
     Parameters
     ----------
     x1, y1 : float
-        The coordinates of the first point
+        The coordinates of the first point.
     x2, y2 : float
-        The coordinates of the second point
+        The coordinates of the second point.
 
     Returns
     -------
     d : float
-        The Euclidean distance between the two points
+        The Euclidean distance between the two points.
     """
-
     return sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
 
 
-cdef double area_arc(double x1, double y1, double x2, double y2, double r):
+cdef double area_arc(double x1, double y1, double x2, double y2,
+                     double r) noexcept nogil:
     """
-    Area of a circle arc with radius r between points (x1, y1) and (x2, y2).
+    Area of a circle arc with radius r between points (x1, y1) and (x2,
+    y2).
 
     References
     ----------
     http://mathworld.wolfram.com/CircularSegment.html
     """
-
     cdef double a, theta
+
     a = distance(x1, y1, x2, y2)
     theta = 2.0 * asin(0.5 * a / r)
     return 0.5 * r * r * (theta - sin(theta))
 
 
-cdef double area_triangle(double x1, double y1, double x2, double y2, double x3,
-                  double y3):
+cdef double area_triangle(double x1, double y1, double x2, double y2,
+                          double x3, double y3) noexcept nogil:
     """
     Area of a triangle defined by three vertices.
     """
     return 0.5 * abs(x1 * (y2 - y3) + x2 * (y3 - y1) + x3 * (y1 - y2))
 
 
-cdef double area_arc_unit(double x1, double y1, double x2, double y2):
+cdef double area_arc_unit(double x1, double y1, double x2,
+                          double y2) noexcept nogil:
     """
-    Area of a circle arc with radius R between points (x1, y1) and (x2, y2)
+    Area of a circle arc with radius R between points (x1, y1) and (x2,
+    y2).
 
     References
     ----------
     http://mathworld.wolfram.com/CircularSegment.html
     """
     cdef double a, theta
+
     a = distance(x1, y1, x2, y2)
     theta = 2.0 * asin(0.5 * a)
     return 0.5 * (theta - sin(theta))
 
 
-cdef int in_triangle(double x, double y, double x1, double y1, double x2, double y2, double x3, double y3):
+cdef int in_triangle(double x, double y, double x1, double y1, double x2,
+                     double y2, double x3, double y3) noexcept nogil:
     """
-    Check if a point (x,y) is inside a triangle
+    Check if a point (x,y) is inside a triangle.
     """
     cdef int c = 0
 
@@ -126,11 +134,11 @@ cdef int in_triangle(double x, double y, double x1, double y1, double x2, double
     return c % 2 == 1
 
 
-cdef intersections circle_line(double x1, double y1, double x2, double y2):
+cdef intersections circle_line(double x1, double y1, double x2,
+                               double y2) noexcept nogil:
     """
     Intersection of a line defined by two points with a unit circle.
     """
-
     cdef double a, b, delta, dx, dy
     cdef double tolerance = 1.e-10
     cdef intersections inter
@@ -145,7 +153,6 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
         inter.p2.y = 2.
 
     elif fabs(dx) > fabs(dy):
-
         # Find the slope and intercept of the line
         a = dy / dx
         b = y1 - a * x1
@@ -153,7 +160,6 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
         # Find the determinant of the quadratic equation
         delta = 1. + a * a - b * b
         if delta > 0.:  # solutions exist
-
             delta = sqrt(delta)
 
             inter.p1.x = (- a * b - delta) / (1. + a * a)
@@ -168,7 +174,6 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
             inter.p2.y = 2.
 
     else:
-
         # Find the slope and intercept of the line
         a = dx / dy
         b = x1 - a * y1
@@ -177,7 +182,6 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
         delta = 1. + a * a - b * b
 
         if delta > 0.:  # solutions exist
-
             delta = sqrt(delta)
 
             inter.p1.y = (- a * b - delta) / (1. + a * a)
@@ -194,12 +198,12 @@ cdef intersections circle_line(double x1, double y1, double x2, double y2):
     return inter
 
 
-cdef point circle_segment_single2(double x1, double y1, double x2, double y2):
+cdef point circle_segment_single2(double x1, double y1, double x2,
+                                  double y2) noexcept nogil:
     """
-    The intersection of a line with the unit circle. The intersection the
-    closest to (x2, y2) is chosen.
+    The intersection of a line with the unit circle. The intersection
+    the closest to (x2, y2) is chosen.
     """
-
     cdef double dx1, dy1, dx2, dy2
     cdef intersections inter
     cdef point pt1, pt2, pt
@@ -229,12 +233,13 @@ cdef point circle_segment_single2(double x1, double y1, double x2, double y2):
     return pt
 
 
-cdef intersections circle_segment(double x1, double y1, double x2, double y2):
+cdef intersections circle_segment(double x1, double y1, double x2,
+                                  double y2) noexcept nogil:
     """
-    Intersection(s) of a segment with the unit circle. Discard any
-    solution not on the segment.
-    """
+    Intersection(s) of a segment with the unit circle.
 
+    Discard any solution not on the segment.
+    """
     cdef intersections inter, inter_new
     cdef point pt1, pt2
 
@@ -243,9 +248,13 @@ cdef intersections circle_segment(double x1, double y1, double x2, double y2):
     pt1 = inter.p1
     pt2 = inter.p2
 
-    if (pt1.x > x1 and pt1.x > x2) or (pt1.x < x1 and pt1.x < x2) or (pt1.y > y1 and pt1.y > y2) or (pt1.y < y1 and pt1.y < y2):
+    if ((pt1.x > x1 and pt1.x > x2) or (pt1.x < x1 and pt1.x < x2)
+            or (pt1.y > y1 and pt1.y > y2)
+            or (pt1.y < y1 and pt1.y < y2)):
         pt1.x, pt1.y = 2., 2.
-    if (pt2.x > x1 and pt2.x > x2) or (pt2.x < x1 and pt2.x < x2) or (pt2.y > y1 and pt2.y > y2) or (pt2.y < y1 and pt2.y < y2):
+    if ((pt2.x > x1 and pt2.x > x2) or (pt2.x < x1 and pt2.x < x2)
+            or (pt2.y > y1 and pt2.y > y2)
+            or (pt2.y < y1 and pt2.y < y2)):
         pt2.x, pt2.y = 2., 2.
 
     if pt1.x > 1. and pt2.x < 2.:
@@ -258,19 +267,21 @@ cdef intersections circle_segment(double x1, double y1, double x2, double y2):
     return inter_new
 
 
-cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, double y2, double x3, double y3):
+cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2,
+                                              double y2, double x3,
+                                              double y3) noexcept nogil:
     """
     Given a triangle defined by three points (x1, y1), (x2, y2), and
     (x3, y3), find the area of overlap with the unit circle.
     """
-
     cdef double d1, d2, d3
-    cdef bool in1, in2, in3
-    cdef bool on1, on2, on3
-    cdef double area
-    cdef double PI = np.pi
+    cdef bint in1, in2, in3
+    cdef bint on1, on2, on3
+    cdef bint intersect13, intersect23
+    cdef bint cond1, cond2
+    cdef double area, xp, yp
     cdef intersections inter
-    cdef point pt1, pt2, pt3, pt4, pt5, pt6, pt_tmp
+    cdef point pt1, pt2, pt3, pt4, pt5, pt6
 
     # Find distance of all vertices to circle center
     d1 = x1 * x1 + y1 * y1
@@ -284,18 +295,23 @@ cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, d
         elif d1 < d3:
             x2, y2, d2, x3, y3, d3 = x3, y3, d3, x2, y2, d2
         else:
-            x1, y1, d1, x2, y2, d2, x3, y3, d3 = x3, y3, d3, x1, y1, d1, x2, y2, d2
+            (x1, y1, d1, x2, y2, d2, x3, y3, d3) = (
+                x3, y3, d3, x1, y1, d1, x2, y2, d2)
 
     else:
         if d1 < d3:
             x1, y1, d1, x2, y2, d2 = x2, y2, d2, x1, y1, d1
         elif d2 < d3:
-            x1, y1, d1, x2, y2, d2, x3, y3, d3 = x2, y2, d2, x3, y3, d3, x1, y1, d1
+            (x1, y1, d1, x2, y2, d2, x3, y3, d3) = (
+                x2, y2, d2, x3, y3, d3, x1, y1, d1)
         else:
-            x1, y1, d1, x2, y2, d2, x3, y3, d3 = x3, y3, d3, x2, y2, d2, x1, y1, d1
+            (x1, y1, d1, x2, y2, d2, x3, y3, d3) = (
+                x3, y3, d3, x2, y2, d2, x1, y1, d1)
 
     if d1 > d2 or d2 > d3 or d1 > d3:
-        raise Exception("ERROR: vertices did not sort correctly")
+        # This should never happen; return NaN to signal an internal
+        # logic error without requiring the GIL to raise an exception.
+        return NAN
 
     # Determine number of vertices inside circle
     in1 = d1 < 1
@@ -308,34 +324,35 @@ cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, d
     on3 = fabs(d3 - 1) < 1.e-10
 
     if on3 or in3:  # triangle is completely in circle
-
         area = area_triangle(x1, y1, x2, y2, x3, y3)
 
     elif in2 or on2:
-        # If vertex 1 or 2 are on the edge of the circle, then we use the dot
-        # product to vertex 3 to determine whether an intersection takes place.
+        # If vertex 1 or 2 are on the edge of the circle, then we
+        # use the dot product to vertex 3 to determine whether an
+        # intersection takes place.
         intersect13 = not on1 or x1 * (x3 - x1) + y1 * (y3 - y1) < 0.
         intersect23 = not on2 or x2 * (x3 - x2) + y2 * (y3 - y2) < 0.
         if intersect13 and intersect23 and not on2:
             pt1 = circle_segment_single2(x1, y1, x3, y3)
             pt2 = circle_segment_single2(x2, y2, x3, y3)
-            area = area_triangle(x1, y1, x2, y2, pt1.x, pt1.y) \
-                 + area_triangle(x2, y2, pt1.x, pt1.y, pt2.x, pt2.y) \
-                 + area_arc_unit(pt1.x, pt1.y, pt2.x, pt2.y)
+            area = (area_triangle(x1, y1, x2, y2, pt1.x, pt1.y)
+                    + area_triangle(x2, y2, pt1.x, pt1.y, pt2.x, pt2.y)
+                    + area_arc_unit(pt1.x, pt1.y, pt2.x, pt2.y))
         elif intersect13:
             pt1 = circle_segment_single2(x1, y1, x3, y3)
-            area = area_triangle(x1, y1, x2, y2, pt1.x, pt1.y) \
-                 + area_arc_unit(x2, y2, pt1.x, pt1.y)
+            area = (area_triangle(x1, y1, x2, y2, pt1.x, pt1.y)
+                    + area_arc_unit(x2, y2, pt1.x, pt1.y))
         elif intersect23:
             pt2 = circle_segment_single2(x2, y2, x3, y3)
-            area = area_triangle(x1, y1, x2, y2, pt2.x, pt2.y) \
-                 + area_arc_unit(x1, y1, pt2.x, pt2.y)
+            area = (area_triangle(x1, y1, x2, y2, pt2.x, pt2.y)
+                    + area_arc_unit(x1, y1, pt2.x, pt2.y))
         else:
             area = area_arc_unit(x1, y1, x2, y2)
 
     elif on1:
         # The triangle is outside the circle
         area = 0.0
+
     elif in1:
         # Check for intersections of far side with circle
         inter = circle_segment(x2, y2, x3, y3)
@@ -343,24 +360,30 @@ cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, d
         pt2 = inter.p2
         pt3 = circle_segment_single2(x1, y1, x2, y2)
         pt4 = circle_segment_single2(x1, y1, x3, y3)
+
         if pt1.x > 1.:  # indicates no intersection
-            # Code taken from `sep.h`.
-            # TODO: use `sep` and get rid of this Cython code.
-            if (((0.-pt3.y) * (pt4.x-pt3.x) > (pt4.y-pt3.y) * (0.-pt3.x)) !=
-                ((y1-pt3.y) * (pt4.x-pt3.x) > (pt4.y-pt3.y) * (x1-pt3.x))):
-                area = area_triangle(x1, y1, pt3.x, pt3.y, pt4.x, pt4.y) \
-                     + (PI - area_arc_unit(pt3.x, pt3.y, pt4.x, pt4.y))
+            # Code from `sep.h`
+            cond1 = ((0. - pt3.y) * (pt4.x - pt3.x)
+                     > (pt4.y - pt3.y) * (0. - pt3.x))
+            cond2 = ((y1 - pt3.y) * (pt4.x - pt3.x)
+                     > (pt4.y - pt3.y) * (x1 - pt3.x))
+            if cond1 != cond2:
+                area = (area_triangle(x1, y1, pt3.x, pt3.y, pt4.x, pt4.y)
+                        + (M_PI - area_arc_unit(pt3.x, pt3.y,
+                                                pt4.x, pt4.y)))
             else:
-                area = area_triangle(x1, y1, pt3.x, pt3.y, pt4.x, pt4.y) \
-                     + area_arc_unit(pt3.x, pt3.y, pt4.x, pt4.y)
+                area = (area_triangle(x1, y1, pt3.x, pt3.y, pt4.x, pt4.y)
+                        + area_arc_unit(pt3.x, pt3.y, pt4.x, pt4.y))
         else:
-            if (pt2.x - x2)**2 + (pt2.y - y2)**2 < (pt1.x - x2)**2 + (pt1.y - y2)**2:
+            if ((pt2.x - x2)**2 + (pt2.y - y2)**2
+                    < (pt1.x - x2)**2 + (pt1.y - y2)**2):
                 pt1, pt2 = pt2, pt1
-            area = area_triangle(x1, y1, pt3.x, pt3.y, pt1.x, pt1.y) \
-                 + area_triangle(x1, y1, pt1.x, pt1.y, pt2.x, pt2.y) \
-                 + area_triangle(x1, y1, pt2.x, pt2.y, pt4.x, pt4.y) \
-                 + area_arc_unit(pt1.x, pt1.y, pt3.x, pt3.y) \
-                 + area_arc_unit(pt2.x, pt2.y, pt4.x, pt4.y)
+            area = (area_triangle(x1, y1, pt3.x, pt3.y, pt1.x, pt1.y)
+                    + area_triangle(x1, y1, pt1.x, pt1.y, pt2.x, pt2.y)
+                    + area_triangle(x1, y1, pt2.x, pt2.y, pt4.x, pt4.y)
+                    + area_arc_unit(pt1.x, pt1.y, pt3.x, pt3.y)
+                    + area_arc_unit(pt2.x, pt2.y, pt4.x, pt4.y))
+
     else:
         inter = circle_segment(x1, y1, x2, y2)
         pt1 = inter.p1
@@ -371,21 +394,25 @@ cdef double overlap_area_triangle_unit_circle(double x1, double y1, double x2, d
         inter = circle_segment(x3, y3, x1, y1)
         pt5 = inter.p1
         pt6 = inter.p2
+
         if pt1.x <= 1.:
             xp, yp = 0.5 * (pt1.x + pt2.x), 0.5 * (pt1.y + pt2.y)
-            area = overlap_area_triangle_unit_circle(x1, y1, x3, y3, xp, yp) \
-                 + overlap_area_triangle_unit_circle(x2, y2, x3, y3, xp, yp)
+            area = (overlap_area_triangle_unit_circle(x1, y1, x3, y3, xp, yp)
+                    + overlap_area_triangle_unit_circle(x2, y2, x3, y3,
+                                                        xp, yp))
         elif pt3.x <= 1.:
             xp, yp = 0.5 * (pt3.x + pt4.x), 0.5 * (pt3.y + pt4.y)
-            area = overlap_area_triangle_unit_circle(x3, y3, x1, y1, xp, yp) \
-                 + overlap_area_triangle_unit_circle(x2, y2, x1, y1, xp, yp)
+            area = (overlap_area_triangle_unit_circle(x3, y3, x1, y1, xp, yp)
+                    + overlap_area_triangle_unit_circle(x2, y2, x1, y1,
+                                                        xp, yp))
         elif pt5.x <= 1.:
             xp, yp = 0.5 * (pt5.x + pt6.x), 0.5 * (pt5.y + pt6.y)
-            area = overlap_area_triangle_unit_circle(x1, y1, x2, y2, xp, yp) \
-                 + overlap_area_triangle_unit_circle(x3, y3, x2, y2, xp, yp)
+            area = (overlap_area_triangle_unit_circle(x1, y1, x2, y2, xp, yp)
+                    + overlap_area_triangle_unit_circle(x3, y3, x2, y2,
+                                                        xp, yp))
         else:  # no intersections
             if in_triangle(0., 0., x1, y1, x2, y2, x3, y3):
-                return PI
+                return M_PI
             else:
                 return 0.
 

--- a/photutils/geometry/core.pyx
+++ b/photutils/geometry/core.pyx
@@ -2,30 +2,22 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # cython: freethreading_compatible=True
 """
-The functions here are the core geometry functions.
+Core geometry functions for computing the overlap of an aperture and a
+pixel grid.
 
-All ``cdef`` functions in this module are ``noexcept nogil``. They are
-pure C math function that do not interact with Python objects, do not
-raise exceptions, and may safely be called without the GIL (including
-from multiple threads on free-threaded Python builds).
+The cdef functions are not intended to be called from Python code. They
+are pure C math functions declared ``noexcept nogil`` so they can be
+called without the GIL, including from multiple threads on free-threaded
+Python builds. Their signatures are exported via core.pxd.
 """
-
-import numpy as np
-
-cimport numpy as np
-
 
 cdef extern from "math.h" nogil:
     double asin(double x)
     double sin(double x)
-    double cos(double x)
     double sqrt(double x)
     double fabs(double x)
     double M_PI
     double NAN
-
-DTYPE = np.float64
-ctypedef np.float64_t DTYPE_t
 
 ctypedef struct point:
     double x
@@ -52,11 +44,6 @@ cdef double floor_sqrt(double x) noexcept nogil:
     else:
         return 0
 
-
-# NOTE: The following two functions use cdef because they are not
-# intended to be called from the Python code. Using def makes them
-# callable from outside, but also slower. Some functions currently
-# return multiple values, and for those we still use 'def' for now.
 
 cdef double distance(double x1, double y1, double x2,
                      double y2) noexcept nogil:
@@ -100,14 +87,14 @@ cdef double area_triangle(double x1, double y1, double x2, double y2,
     """
     Area of a triangle defined by three vertices.
     """
-    return 0.5 * abs(x1 * (y2 - y3) + x2 * (y3 - y1) + x3 * (y1 - y2))
+    return 0.5 * fabs(x1 * (y2 - y3) + x2 * (y3 - y1) + x3 * (y1 - y2))
 
 
 cdef double area_arc_unit(double x1, double y1, double x2,
                           double y2) noexcept nogil:
     """
-    Area of a circle arc with radius R between points (x1, y1) and (x2,
-    y2).
+    Area of a unit circle arc (radius of 1) between points (x1, y1) and
+    (x2, y2).
 
     References
     ----------
@@ -138,6 +125,9 @@ cdef intersections circle_line(double x1, double y1, double x2,
                                double y2) noexcept nogil:
     """
     Intersection of a line defined by two points with a unit circle.
+
+    Coordinates > 1 in the result indicate that there is no
+    intersection.
     """
     cdef double a, b, delta, dx, dy
     cdef double tolerance = 1.e-10
@@ -146,13 +136,16 @@ cdef intersections circle_line(double x1, double y1, double x2,
     dx = x2 - x1
     dy = y2 - y1
 
-    if fabs(dx) < tolerance and fabs(dy) < tolerance:
-        inter.p1.x = 2.
-        inter.p1.y = 2.
-        inter.p2.x = 2.
-        inter.p2.y = 2.
+    # Initialize to values > 1, indicating no intersection
+    inter.p1.x = 2.
+    inter.p1.y = 2.
+    inter.p2.x = 2.
+    inter.p2.y = 2.
 
-    elif fabs(dx) > fabs(dy):
+    if fabs(dx) < tolerance and fabs(dy) < tolerance:
+        return inter
+
+    if fabs(dx) > fabs(dy):
         # Find the slope and intercept of the line
         a = dy / dx
         b = y1 - a * x1
@@ -162,17 +155,10 @@ cdef intersections circle_line(double x1, double y1, double x2,
         if delta > 0.:  # solutions exist
             delta = sqrt(delta)
 
-            inter.p1.x = (- a * b - delta) / (1. + a * a)
+            inter.p1.x = (-a * b - delta) / (1. + a * a)
             inter.p1.y = a * inter.p1.x + b
-            inter.p2.x = (- a * b + delta) / (1. + a * a)
+            inter.p2.x = (-a * b + delta) / (1. + a * a)
             inter.p2.y = a * inter.p2.x + b
-
-        else:  # no solution, return values > 1
-            inter.p1.x = 2.
-            inter.p1.y = 2.
-            inter.p2.x = 2.
-            inter.p2.y = 2.
-
     else:
         # Find the slope and intercept of the line
         a = dx / dy
@@ -180,20 +166,13 @@ cdef intersections circle_line(double x1, double y1, double x2,
 
         # Find the determinant of the quadratic equation
         delta = 1. + a * a - b * b
-
         if delta > 0.:  # solutions exist
             delta = sqrt(delta)
 
-            inter.p1.y = (- a * b - delta) / (1. + a * a)
+            inter.p1.y = (-a * b - delta) / (1. + a * a)
             inter.p1.x = a * inter.p1.y + b
-            inter.p2.y = (- a * b + delta) / (1. + a * a)
+            inter.p2.y = (-a * b + delta) / (1. + a * a)
             inter.p2.x = a * inter.p2.y + b
-
-        else:  # no solution, return values > 1
-            inter.p1.x = 2.
-            inter.p1.y = 2.
-            inter.p2.x = 2.
-            inter.p2.y = 2.
 
     return inter
 
@@ -201,8 +180,9 @@ cdef intersections circle_line(double x1, double y1, double x2,
 cdef point circle_segment_single2(double x1, double y1, double x2,
                                   double y2) noexcept nogil:
     """
-    The intersection of a line with the unit circle. The intersection
-    the closest to (x2, y2) is chosen.
+    The intersection of a line with the unit circle.
+
+    The intersection closest to (x2, y2) is chosen.
     """
     cdef double dx1, dy1, dx2, dy2
     cdef intersections inter

--- a/photutils/geometry/elliptical_overlap.pxd
+++ b/photutils/geometry/elliptical_overlap.pxd
@@ -1,0 +1,16 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3
+
+# This file is needed in order to be able to cimport functions into
+# other Cython files. These single-pixel functions are pure C math
+# functions that are safe to call without the GIL.
+
+cdef double elliptical_overlap_single_subpixel(double x0, double y0,
+                                               double x1, double y1,
+                                               double rx, double ry,
+                                               double theta,
+                                               int subpixels) noexcept nogil
+cdef double elliptical_overlap_single_exact(double xmin, double ymin,
+                                            double xmax, double ymax,
+                                            double rx, double ry,
+                                            double theta) noexcept nogil

--- a/photutils/geometry/elliptical_overlap.pxd
+++ b/photutils/geometry/elliptical_overlap.pxd
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
-
-# This file is needed in order to be able to cimport functions into
-# other Cython files. These single-pixel functions are pure C math
-# functions that are safe to call without the GIL.
+"""
+Declarations needed to cimport the elliptical overlap functions into
+other Cython files. These single-pixel functions are pure C math
+functions that are safe to call without the GIL.
+"""
 
 cdef double elliptical_overlap_single_subpixel(double x0, double y0,
                                                double x1, double y1,

--- a/photutils/geometry/elliptical_overlap.pyx
+++ b/photutils/geometry/elliptical_overlap.pyx
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: freethreading_compatible=True
 """
 The functions defined here allow one to determine the exact area of
 overlap of an ellipse and a triangle (written by Thomas Robitaille).
@@ -12,27 +13,19 @@ import numpy as np
 
 cimport numpy as np
 
+from .core cimport overlap_area_triangle_unit_circle
+
 __all__ = ['elliptical_overlap_grid']
 
 
-cdef extern from "math.h":
-
+cdef extern from "math.h" nogil:
     double asin(double x)
     double sin(double x)
     double cos(double x)
     double sqrt(double x)
 
-from cpython cimport bool
-
 DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
-
-cimport cython
-
-# NOTE: Here we need to make sure we use cimport to import the C functions from
-# core (since these were defined with cdef). This also requires the core.pxd
-# file to exist with the function signatures.
-from .core cimport area_triangle, distance, overlap_area_triangle_unit_circle
 
 
 def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
@@ -40,7 +33,7 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
                             int use_exact, int subpixels):
     """
     elliptical_overlap_grid(xmin, xmax, ymin, ymax, nx, ny, rx, ry,
-                             use_exact, subpixels)
+                            use_exact, subpixels)
 
     Area of overlap between an ellipse and a pixel grid. The ellipse is
     centered on the origin.
@@ -56,23 +49,24 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     ry : float
         The semiminor axis of the ellipse.
     theta : float
-        The position angle of the semimajor axis in radians (counterclockwise).
+        The position angle of the semimajor axis in radians
+        (counterclockwise).
     use_exact : 0 or 1
-        If set to 1, calculates the exact overlap, while if set to 0, uses a
-        subpixel sampling method with ``subpixel`` subpixels in each direction.
+        If set to 1, calculates the exact overlap, while if set to 0,
+        uses a subpixel sampling method with ``subpixel`` subpixels in
+        each direction.
     subpixels : int
-        If ``use_exact`` is 0, each pixel is resampled by this factor in each
-        dimension. Thus, each pixel is divided into ``subpixels ** 2``
-        subpixels.
+        If ``use_exact`` is 0, each pixel is resampled by this factor in
+        each dimension. Thus, each pixel is divided into ``subpixels **
+        2`` subpixels.
 
     Returns
     -------
     frac : `~numpy.ndarray`
-        2-d array giving the fraction of the overlap.
+        2D array giving the fraction of the overlap.
     """
-
     cdef unsigned int i, j
-    cdef double x, y, dx, dy
+    cdef double dx, dy
     cdef double bxmin, bxmax, bymin, bymax
     cdef double pxmin, pxmax, pymin, pymax
     cdef double norm
@@ -86,8 +80,9 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
 
     norm = 1.0 / (dx * dy)
 
-    # For now we use a bounding circle and then use that to find a bounding box
-    # but of course this is inefficient and could be done better.
+    # For now we use a bounding circle and then use that to find a
+    # bounding box but of course this is inefficient and could be done
+    # better.
 
     # Find bounding circle radius
     r = max(rx, ry)
@@ -116,21 +111,23 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     return frac
 
 
-# NOTE: The following two functions use cdef because they are not
-# intended to be called from the Python code. Using def makes them
-# callable from outside, but also slower. In any case, these aren't useful
-# to call from outside because they only operate on a single pixel.
+# NOTE: The following functions use cdef because they are not intended
+# to be called from Python code. They are pure C math functions declared
+# ``noexcept nogil`` so they can be called without the GIL (e.g., from
+# the batch aperture photometry driver), including from multiple threads
+# on free-threaded Python builds. Their signatures are exported via
+# elliptical_overlap.pxd.
 
 
 cdef double elliptical_overlap_single_subpixel(double x0, double y0,
                                                double x1, double y1,
                                                double rx, double ry,
-                                               double theta, int subpixels):
+                                               double theta,
+                                               int subpixels) noexcept nogil:
     """
-    Return the fraction of overlap between a ellipse and a single pixel with
-    given extent, using a sub-pixel sampling method.
+    Return the fraction of overlap between a ellipse and a single pixel
+    with given extent, using a sub-pixel sampling method.
     """
-
     cdef unsigned int i, j
     cdef double x, y
     cdef double frac = 0.0  # Accumulator.
@@ -166,16 +163,16 @@ cdef double elliptical_overlap_single_subpixel(double x0, double y0,
 cdef double elliptical_overlap_single_exact(double xmin, double ymin,
                                             double xmax, double ymax,
                                             double rx, double ry,
-                                            double theta):
+                                            double theta) noexcept nogil:
     """
     Given a rectangle defined by (xmin, ymin, xmax, ymax) and an ellipse
-    with major and minor axes rx and ry respectively, position angle theta,
-    and centered at the origin, find the area of overlap.
+    with major and minor axes rx and ry respectively, position angle
+    theta, and centered at the origin, find the area of overlap.
     """
-
     cdef double cos_m_theta = cos(-theta)
     cdef double sin_m_theta = sin(-theta)
     cdef double scale
+    cdef double x1, y1, x2, y2, x3, y3, x4, y4
 
     # Find scale by which the areas will be shrunk
     scale = rx * ry

--- a/photutils/geometry/elliptical_overlap.pyx
+++ b/photutils/geometry/elliptical_overlap.pyx
@@ -2,11 +2,19 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # cython: freethreading_compatible=True
 """
-The functions defined here allow one to determine the exact area of
-overlap of an ellipse and a triangle (written by Thomas Robitaille).
-The approach is to divide the rectangle into two triangles, and
-reproject these so that the ellipse is a unit circle, then compute the
-intersection of a triangle with a unit circle.
+Tools to calculate the area of overlap between an ellipse and a pixel
+grid.
+
+The method divides the pixel rectangle into two triangles and reprojects
+them into a coordinate system where the ellipse becomes the unit circle.
+It then computes the intersection area between each triangle and the
+unit circle.
+
+The cdef functions are not intended to be called from Python code.
+They are pure C math functions declared ``noexcept nogil`` so they can
+be called without the GIL (e.g., from the batch aperture photometry
+driver), including from multiple threads on free-threaded Python builds.
+Their signatures are exported via elliptical_overlap.pxd.
 """
 
 import numpy as np
@@ -19,10 +27,9 @@ __all__ = ['elliptical_overlap_grid']
 
 
 cdef extern from "math.h" nogil:
-    double asin(double x)
     double sin(double x)
     double cos(double x)
-    double sqrt(double x)
+    double fmax(double x, double y)
 
 DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
@@ -33,46 +40,70 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
                             int use_exact, int subpixels):
     """
     elliptical_overlap_grid(xmin, xmax, ymin, ymax, nx, ny, rx, ry,
-                            use_exact, subpixels)
+                            theta, use_exact, subpixels)
 
-    Area of overlap between an ellipse and a pixel grid. The ellipse is
-    centered on the origin.
+    Calculate the fractional overlap between an ellipse and a pixel
+    grid.
+
+    The ellipse is centered on the origin.
 
     Parameters
     ----------
     xmin, xmax, ymin, ymax : float
-        Extent of the grid in the x and y direction.
+        The extent of the grid in the x and y direction. The grid is
+        defined by the rectangle with corners (xmin, ymin) and (xmax,
+        ymax).
+
     nx, ny : int
-        Grid dimensions.
+        The grid dimensions in the x and y direction. The grid is
+        defined by the rectangle with corners (xmin, ymin) and (xmax,
+        ymax) and is divided into nx and ny pixels in the x and y
+        direction, respectively.
+
     rx : float
         The semimajor axis of the ellipse.
+
     ry : float
         The semiminor axis of the ellipse.
+
     theta : float
         The position angle of the semimajor axis in radians
         (counterclockwise).
+
     use_exact : 0 or 1
-        If set to 1, calculates the exact overlap, while if set to 0,
-        uses a subpixel sampling method with ``subpixel`` subpixels in
-        each direction.
+        Set to ``1`` to use an exact method to calculate the overlap
+        between the ellipse and each pixel. Set to ``0`` to use a
+        sub-pixel sampling method to calculate the overlap, where each
+        pixel is divided into ``subpixels ** 2`` subpixels and the
+        fraction of subpixels that are within the ellipse is used to
+        estimate the overlap.
+
     subpixels : int
-        If ``use_exact`` is 0, each pixel is resampled by this factor in
-        each dimension. Thus, each pixel is divided into ``subpixels **
-        2`` subpixels.
+        The number of subpixels to use in each dimension when using
+        the sub-pixel sampling method. Each pixel is resampled by this
+        factor in each dimension; thus, each pixel is divided into
+        ``subpixels ** 2`` subpixels.
 
     Returns
     -------
-    frac : `~numpy.ndarray`
-        2D array giving the fraction of the overlap.
+    result : `~numpy.ndarray` (float)
+        A 2D array of shape (ny, nx) giving the fraction of each
+        pixel's area that overlaps with the ellipse, ranging from 0 to
+        1. The element at index (j, i) corresponds to the pixel with
+        corners at (xmin + i * dx, ymin + j * dy) and (xmin + (i + 1)
+        * dx, ymin + (j + 1) * dy), where dx and dy are the width of
+        each pixel in the x and y direction, respectively.
     """
     cdef unsigned int i, j
     cdef double dx, dy
+    cdef double r
     cdef double bxmin, bxmax, bymin, bymax
     cdef double pxmin, pxmax, pymin, pymax
     cdef double norm
 
     # Define output array
     cdef np.ndarray[DTYPE_t, ndim=2] frac = np.zeros([ny, nx], dtype=DTYPE)
+    cdef double[:, ::1] frac_view = frac
 
     # Find the width of each element in x and y
     dx = (xmax - xmin) / nx
@@ -85,7 +116,7 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     # better.
 
     # Find bounding circle radius
-    r = max(rx, ry)
+    r = fmax(rx, ry)
 
     # Define bounding box
     bxmin = -r - 0.5 * dx
@@ -93,30 +124,26 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     bymin = -r - 0.5 * dy
     bymax = +r + 0.5 * dy
 
-    for i in range(nx):
-        pxmin = xmin + i * dx  # lower end of pixel
-        pxmax = pxmin + dx  # upper end of pixel
-        if pxmax > bxmin and pxmin < bxmax:
-            for j in range(ny):
-                pymin = ymin + j * dy
-                pymax = pymin + dy
-                if pymax > bymin and pymin < bymax:
-                    if use_exact:
-                        frac[j, i] = elliptical_overlap_single_exact(
-                            pxmin, pymin, pxmax, pymax, rx, ry, theta) * norm
-                    else:
-                        frac[j, i] = elliptical_overlap_single_subpixel(
-                            pxmin, pymin, pxmax, pymax, rx, ry, theta,
-                            subpixels)
+    with nogil:
+        for i in range(nx):
+            pxmin = xmin + i * dx  # lower end of pixel
+            pxmax = pxmin + dx  # upper end of pixel
+            if pxmax > bxmin and pxmin < bxmax:
+                for j in range(ny):
+                    pymin = ymin + j * dy
+                    pymax = pymin + dy
+                    if pymax > bymin and pymin < bymax:
+                        if use_exact:
+                            frac_view[j, i] = (
+                                elliptical_overlap_single_exact(
+                                    pxmin, pymin, pxmax, pymax, rx, ry,
+                                    theta) * norm)
+                        else:
+                            frac_view[j, i] = (
+                                elliptical_overlap_single_subpixel(
+                                    pxmin, pymin, pxmax, pymax, rx, ry,
+                                    theta, subpixels))
     return frac
-
-
-# NOTE: The following functions use cdef because they are not intended
-# to be called from Python code. They are pure C math functions declared
-# ``noexcept nogil`` so they can be called without the GIL (e.g., from
-# the batch aperture photometry driver), including from multiple threads
-# on free-threaded Python builds. Their signatures are exported via
-# elliptical_overlap.pxd.
 
 
 cdef double elliptical_overlap_single_subpixel(double x0, double y0,
@@ -125,8 +152,8 @@ cdef double elliptical_overlap_single_subpixel(double x0, double y0,
                                                double theta,
                                                int subpixels) noexcept nogil:
     """
-    Return the fraction of overlap between a ellipse and a single pixel
-    with given extent, using a sub-pixel sampling method.
+    Return the fraction of overlap between an ellipse and a single
+    pixel with given extent, using a sub-pixel sampling method.
     """
     cdef unsigned int i, j
     cdef double x, y
@@ -165,9 +192,16 @@ cdef double elliptical_overlap_single_exact(double xmin, double ymin,
                                             double rx, double ry,
                                             double theta) noexcept nogil:
     """
-    Given a rectangle defined by (xmin, ymin, xmax, ymax) and an ellipse
-    with major and minor axes rx and ry respectively, position angle
-    theta, and centered at the origin, find the area of overlap.
+    Return the area of overlap between a rectangle and an ellipse.
+
+    The rectangle is defined by (``xmin``, ``ymin``, ``xmax``, ``ymax``)
+    and the ellipse has major and minor axes ``rx`` and ``ry``,
+    respectively, position angle ``theta``, and is centered at the
+    origin. The method divides the pixel rectangle into two triangles
+    and reprojects them into a coordinate system where the ellipse
+    becomes the unit circle. It then computes the intersection area
+    between each triangle and the unit circle, and sums them to get the
+    total area of overlap.
     """
     cdef double cos_m_theta = cos(-theta)
     cdef double sin_m_theta = sin(-theta)

--- a/photutils/geometry/rectangular_overlap.pxd
+++ b/photutils/geometry/rectangular_overlap.pxd
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
-
-# This file is needed in order to be able to cimport functions into
-# other Cython files. This single-pixel function is a pure C math
-# function that is safe to call without the GIL.
+"""
+Declarations needed to cimport the rectangular overlap function into
+other Cython files. This single-pixel function is a pure C math
+function that is safe to call without the GIL.
+"""
 
 cdef double rectangular_overlap_single_subpixel(double x0, double y0,
                                                 double x1, double y1,

--- a/photutils/geometry/rectangular_overlap.pxd
+++ b/photutils/geometry/rectangular_overlap.pxd
@@ -1,0 +1,14 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3
+
+# This file is needed in order to be able to cimport functions into
+# other Cython files. This single-pixel function is a pure C math
+# function that is safe to call without the GIL.
+
+cdef double rectangular_overlap_single_subpixel(double x0, double y0,
+                                                double x1, double y1,
+                                                double half_width,
+                                                double half_height,
+                                                double cos_theta,
+                                                double sin_theta,
+                                                int subpixels) noexcept nogil

--- a/photutils/geometry/rectangular_overlap.pyx
+++ b/photutils/geometry/rectangular_overlap.pyx
@@ -64,7 +64,7 @@ def rectangular_overlap_grid(double xmin, double xmax, double ymin,
     Returns
     -------
     frac : `~numpy.ndarray`
-        2-d array giving the fraction of the overlap.
+        2D array giving the fraction of the overlap.
     """
     cdef unsigned int i, j
     cdef int i_min, i_max, j_min, j_max

--- a/photutils/geometry/rectangular_overlap.pyx
+++ b/photutils/geometry/rectangular_overlap.pyx
@@ -2,8 +2,14 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # cython: freethreading_compatible=True
 """
-This module provides tools to calculate the area of overlap between a
-rectangle and a pixel grid.
+Tools to calculate the area of overlap between a rectangle and a pixel
+grid.
+
+The cdef function is not intended to be called from Python code.
+It is a pure C math function declared ``noexcept nogil`` so it can
+be called without the GIL (e.g., from the batch aperture photometry
+driver), including from multiple threads on free-threaded Python builds.
+Its signature is exported via rectangular_overlap.pxd.
 """
 
 import numpy as np
@@ -15,14 +21,14 @@ from ._polygon_overlap cimport polygon_pixel_overlap
 __all__ = ['rectangular_overlap_grid']
 
 
-cdef extern from "math.h":
-    double sin(double x) nogil
-    double cos(double x) nogil
-    double fabs(double x) nogil
-    double fmax(double x, double y) nogil
-    double fmin(double x, double y) nogil
-    double floor(double x) nogil
-    double ceil(double x) nogil
+cdef extern from "math.h" nogil:
+    double sin(double x)
+    double cos(double x)
+    double fabs(double x)
+    double fmax(double x, double y)
+    double fmin(double x, double y)
+    double floor(double x)
+    double ceil(double x)
 
 
 DTYPE = np.float64
@@ -37,34 +43,57 @@ def rectangular_overlap_grid(double xmin, double xmax, double ymin,
     rectangular_overlap_grid(xmin, xmax, ymin, ymax, nx, ny, width, height,
                              theta, use_exact, subpixels)
 
-    Area of overlap between a rectangle and a pixel grid. The rectangle
-    is centered on the origin.
+    Calculate the fractional overlap between a rectangle and a pixel
+    grid.
+
+    The rectangle is centered on the origin.
 
     Parameters
     ----------
     xmin, xmax, ymin, ymax : float
-        Extent of the grid in the x and y direction.
+        The extent of the grid in the x and y direction. The grid is
+        defined by the rectangle with corners (xmin, ymin) and (xmax,
+        ymax).
+
     nx, ny : int
-        Grid dimensions.
+        The grid dimensions in the x and y direction. The grid is
+        defined by the rectangle with corners (xmin, ymin) and (xmax,
+        ymax) and is divided into nx and ny pixels in the x and y
+        direction, respectively.
+
     width : float
         The width of the rectangle.
+
     height : float
         The height of the rectangle.
+
     theta : float
-        The position angle of the rectangle in radians (counterclockwise).
+        The position angle of the rectangle in radians
+        (counterclockwise).
+
     use_exact : 0 or 1
-        If set to 1, calculates the exact overlap, while if set to 0,
-        uses a subpixel sampling method with ``subpixels`` subpixels in
-        each direction.
+        Set to ``1`` to use an exact method to calculate the overlap
+        between the rectangle and each pixel. Set to ``0`` to use a
+        sub-pixel sampling method to calculate the overlap, where each
+        pixel is divided into ``subpixels ** 2`` subpixels and the
+        fraction of subpixels that are within the rectangle is used to
+        estimate the overlap.
+
     subpixels : int
-        If ``use_exact`` is 0, each pixel is resampled by this factor in
-        each dimension. Each pixel is divided into ``subpixels ** 2``
-        subpixels.
+        The number of subpixels to use in each dimension when using
+        the sub-pixel sampling method. Each pixel is resampled by this
+        factor in each dimension; thus, each pixel is divided into
+        ``subpixels ** 2`` subpixels.
 
     Returns
     -------
-    frac : `~numpy.ndarray`
-        2D array giving the fraction of the overlap.
+    result : `~numpy.ndarray` (float)
+        A 2D array of shape (ny, nx) giving the fraction of each
+        pixel's area that overlaps with the rectangle, ranging from 0
+        to 1. The element at index (j, i) corresponds to the pixel with
+        corners at (xmin + i * dx, ymin + j * dy) and (xmin + (i + 1)
+        * dx, ymin + (j + 1) * dy), where dx and dy are the width of
+        each pixel in the x and y direction, respectively.
     """
     cdef unsigned int i, j
     cdef int i_min, i_max, j_min, j_max


### PR DESCRIPTION
This PR significantly improves the performance of aperture photometry, typically by factors of ~2-25 depending on the aperture shape and overlap method, by computing all sources in a single call into compiled code. The computation also releases the GIL and uses no global state, so aperture photometry can now be parallelized across threads, including on free-threaded Python builds. 