### PR TITLE
Optimize build_ellipse_model_c Cython extension in isophote package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,16 @@ New Features
     global state, so aperture photometry can now be parallelized across
     threads, including on free-threaded Python builds. [#2292]
 
+- ``photutils.isophote``
+
+  - Optimized the ``build_ellipse_model_c`` Cython extension by
+    adding module-level compiler directives (``boundscheck=False``,
+    ``wraparound=False``, ``cdivision=True``), using C-contiguous memory
+    views, declaring ``math.h`` functions as ``nogil``, and replacing
+    Python function-pointer dispatch with a direct ``if``/``else``
+    branch for harmonic corrections. The module is now also marked as
+    ``freethreading_compatible=True``. [#2293]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/photutils/isophote/ellipse_model.pyx
+++ b/photutils/isophote/ellipse_model.pyx
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: freethreading_compatible=True
 """
 Faster evaluation of ellipses from model.py.
 """
 
-import cython
 import numpy as np
 
 cimport numpy as cnp
@@ -13,26 +13,13 @@ __all__ = ['build_ellipse_model_c']
 
 cnp.import_array()
 
-cdef extern from "math.h":
-
+cdef extern from "math.h" nogil:
     double cos(double x)
     double sin(double x)
     double sqrt(double x)
 
 DTYPE = np.float64
 ctypedef cnp.float64_t DTYPE_t
-
-cdef inline double get_intens_no_harmonics(double intens0, double phi, double a3, double b3, double a4, double b4):
-    return intens0
-
-cdef inline double get_intens_harmonics(double intens0, double phi, double a3, double b3, double a4, double b4):
-    return (
-        intens0
-        + a3 * sin(3.0 * phi)
-        + b3 * cos(3.0 * phi)
-        + a4 * sin(4.0 * phi)
-        + b4 * cos(4.0 * phi)
-    )
 
 
 def build_ellipse_model_c(
@@ -51,18 +38,19 @@ def build_ellipse_model_c(
     double phi_min = 0.,
     double phi_max = 2.0*np.pi,
 ):
-    cdef cython.Py_ssize_t len_sma
+    cdef Py_ssize_t len_sma
     len_sma = len(finely_spaced_sma)
     for array in (intens_array, eps_array, pa_array, x0_array, y0_array):
         if len(array) != len_sma:
-            raise ValueError(f"All input arrays must be same length={len_sma}")
+            msg = f"All input arrays must be same length={len_sma}"
+            raise ValueError(msg)
     harmonic_arrays = (a3_array, b3_array, a4_array, b4_array)
     harmonics_is_none = [array is None for array in harmonic_arrays]
 
     cdef double a3, b3, a4, b4
+    cdef bint do_harmonics
 
     if all(harmonics_is_none):
-        intens_func = get_intens_no_harmonics
         a3 = 0
         b3 = 0
         a4 = 0
@@ -70,43 +58,42 @@ def build_ellipse_model_c(
         do_harmonics = False
     else:
         if any(harmonics_is_none):
-            raise ValueError("Must supply all harmonic arrays if any is not None")
+            msg = "Must supply all harmonic arrays if any is not None"
+            raise ValueError(msg)
         for array in harmonic_arrays:
             if len(array) != len_sma:
-                raise ValueError(f"All input arrays must be same length={len_sma}")
-        intens_func = get_intens_harmonics
+                msg = f"All input arrays must be same length={len_sma}"
+                raise ValueError(msg)
         do_harmonics = True
 
     cdef double phi, fx, fy, x, y
-    cdef double one_m_fx, one_m_fy, one_m_fx_t_one_m_fy, one_m_fy_t_fx, one_m_fx_t_fy, fy_t_fx
+    cdef double one_m_fx, one_m_fy, weight_pix
     cdef double r, sma, q, pa, x0, y0, intens0, intens
     cdef int i, j, i_max, j_max
-    cdef cython.Py_ssize_t index
+    cdef Py_ssize_t index
     cdef bint i_ge_zero, i_p1_le_max
 
     # Define output array
-    cdef double[:, :] result = np.zeros([n_rows, n_cols], dtype=DTYPE)
-    cdef double[:, :] weight = np.zeros([n_rows, n_cols], dtype=DTYPE)
+    cdef double[:, ::1] result = np.zeros([n_rows, n_cols], dtype=DTYPE)
+    cdef double[:, ::1] weight = np.zeros([n_rows, n_cols], dtype=DTYPE)
 
     i_max = n_cols - 1
     j_max = n_rows - 1
 
     for index in range(1, len_sma):
-        with cython.boundscheck(False):
-            sma = finely_spaced_sma[index]
-            q = 1.0 - eps_array[index]
-            pa = pa_array[index]
-            x0 = x0_array[index]
-            y0 = y0_array[index]
-            intens0 = intens_array[index]
+        sma = finely_spaced_sma[index]
+        q = 1.0 - eps_array[index]
+        pa = pa_array[index]
+        x0 = x0_array[index]
+        y0 = y0_array[index]
+        intens0 = intens_array[index]
         phi = phi_min
         r = sma
         if do_harmonics:
-            with cython.boundscheck(False):
-                a3 = a3_array[index]
-                b3 = b3_array[index]
-                a4 = a4_array[index]
-                b4 = b4_array[index]
+            a3 = a3_array[index]
+            b3 = b3_array[index]
+            a4 = a4_array[index]
+            b4 = b4_array[index]
 
         while phi <= phi_max:
             # get image coordinates of (r, phi) pixel
@@ -121,7 +108,12 @@ def build_ellipse_model_c(
                 fx = x - float(i)
                 fy = y - float(j)
 
-                intens = intens_func(intens0, phi, a3, b3, a4, b4)
+                intens = intens0
+                if do_harmonics:
+                    intens += (a3 * sin(3.0 * phi)
+                               + b3 * cos(3.0 * phi)
+                               + a4 * sin(4.0 * phi)
+                               + b4 * cos(4.0 * phi))
 
                 one_m_fx = (1.0 - fx)
                 one_m_fy = (1.0 - fy)
@@ -129,28 +121,28 @@ def build_ellipse_model_c(
                 i_ge_zero = i >= 0
                 i_p1_le_max = (i + 1) <= i_max
 
-                with cython.boundscheck(False):
-                    if j >= 0:
-                        if i_ge_zero:
-                            weight_pix = one_m_fx * one_m_fy
-                            # add up the isophote contribution to the overlapping pixels
-                            result[j, i] += intens * weight_pix
-                            # add up the fractional area contribution to the
-                            # overlapping pixels
-                            weight[j, i] += weight_pix
-                        if i_p1_le_max:
-                            weight_pix = one_m_fy * fx
-                            result[j, i + 1] += intens * weight_pix
-                            weight[j, i + 1] += weight_pix
-                    if (j + 1) <= j_max:
-                        if i_ge_zero:
-                            weight_pix = one_m_fx * fy
-                            result[j + 1, i] += intens * weight_pix
-                            weight[j + 1, i] += weight_pix
-                        if i_p1_le_max:
-                            weight_pix = fy * fx
-                            result[j + 1, i + 1] += intens * weight_pix
-                            weight[j + 1, i + 1] += weight_pix
+                if j >= 0:
+                    if i_ge_zero:
+                        weight_pix = one_m_fx * one_m_fy
+                        # add up the isophote contribution to the
+                        # overlapping pixels
+                        result[j, i] += intens * weight_pix
+                        # add up the fractional area contribution to the
+                        # overlapping pixels
+                        weight[j, i] += weight_pix
+                    if i_p1_le_max:
+                        weight_pix = one_m_fy * fx
+                        result[j, i + 1] += intens * weight_pix
+                        weight[j, i + 1] += weight_pix
+                if (j + 1) <= j_max:
+                    if i_ge_zero:
+                        weight_pix = one_m_fx * fy
+                        result[j + 1, i] += intens * weight_pix
+                        weight[j + 1, i] += weight_pix
+                    if i_p1_le_max:
+                        weight_pix = fy * fx
+                        result[j + 1, i + 1] += intens * weight_pix
+                        weight[j + 1, i + 1] += weight_pix
 
             # step towards next pixel on ellipse
             phi = max((phi + 0.75 / r), phi_min)


### PR DESCRIPTION
This PR pptimizes the ``build_ellipse_model_c`` Cython extension by adding module-level compiler directives, using C-contiguous memory views, and declaring ``math.h`` functions as ``nogil``.