### PR TITLE
Add PolygonAperture and SkyPolygonAperture classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,10 @@ New Features
     global state, so aperture photometry can now be parallelized across
     threads, including on free-threaded Python builds. [#2292]
 
+  - Added new ``PolygonAperture`` and ``SkyPolygonAperture`` classes
+    for polygon apertures defined by a fixed shape applied at one or
+    more positions. [#2297]
+
 - ``photutils.isophote``
 
   - Optimized the ``build_ellipse_model_c`` Cython extension by

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -249,16 +249,31 @@ area of a circle with a radius of 3::
 Aperture and Pixel Overlap
 --------------------------
 
-The overlap of the aperture with the data pixels can be handled in
-different ways.  The default method (``method='exact'``) calculates the
-exact intersection of the aperture with each pixel.  The
-other options, ``'center'`` and ``'subpixel'``, are faster, but with
-the expense of less precision.  With ``'center'``, a pixel is
-considered to be entirely in or out of the aperture depending on
-whether its center is in or out of the aperture.  With ``'subpixel'``,
-pixels are divided into a number of subpixels, which are in or out of
-the aperture based on their centers.  For this method, the number of
-subpixels needs to be set with the ``subpixels`` keyword.
+The overlap of the aperture with the data pixels can be handled using one of three methods:
+
+* ``'exact'`` (default):
+  Calculates the exact geometric intersection of the aperture with each
+  pixel. This is the most precise and preferred method.
+
+* ``'center'``:
+  A pixel is assigned a weight of 1 if its center falls within the
+  aperture, and 0 otherwise.
+
+* ``'subpixel'``:
+  Pixels are divided into a sub-grid of :math:`N×N` subpixels (where
+  :math:`N` is set by the ``'subpixels'`` keyword). The pixel weight is
+  the fraction of subpixel centers that fall within the aperture.
+
+.. note::
+
+    For the ``'center'`` and ``'subpixel'`` methods, a pixel (or
+    subpixel) center is considered "inside" the aperture only if it lies
+    *strictly* inside the aperture boundary. A center that lands exactly
+    on the aperture boundary is treated as outside and assigned a weight
+    of 0. This is particularly relevant for the ``'center'`` method
+    when using apertures aligned perfectly with the pixel grid. For the
+    ``'subpixel'`` method it is less relevant, since subpixel centers
+    seldom land exactly on the boundary.
 
 This example uses the ``'subpixel'`` method where pixels are resampled
 by a factor of 5 (``subpixels=5``) in each dimension::
@@ -277,10 +292,9 @@ above).
 For the ``'subpixel'`` method, the default value is ``subpixels=5``,
 meaning that each pixel is equally divided into 25 smaller pixels
 (this is the method and subsampling factor used in `SourceExtractor
-<https://sextractor.readthedocs.io/en/latest/>`_).
-
-The precision can be increased by increasing ``subpixels``, but note
-that computation time will be increased.
+<https://sextractor.readthedocs.io/en/latest/>`_). The precision can
+be improved by increasing ``subpixels``, but the computation time will
+generally increase as a result.
 
 
 Aperture Photometry with Multiple Apertures at Each Position

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -27,6 +27,7 @@ coordinates are:
 * `~photutils.aperture.EllipticalAnnulus`
 * `~photutils.aperture.RectangularAperture`
 * `~photutils.aperture.RectangularAnnulus`
+* `~photutils.aperture.PolygonAperture`
 
 Each of these classes has a corresponding variant defined in sky
 coordinates:
@@ -37,6 +38,7 @@ coordinates:
 * `~photutils.aperture.SkyEllipticalAnnulus`
 * `~photutils.aperture.SkyRectangularAperture`
 * `~photutils.aperture.SkyRectangularAnnulus`
+* `~photutils.aperture.SkyPolygonAperture`
 
 To perform aperture photometry with sky-based apertures, one will need
 to specify a WCS transformation.
@@ -134,13 +136,74 @@ sky apertures, e.g.,::
 
 .. note::
 
-    Aperture objects require scalar shape parameters (e.g., radius,
-    semi-axes, angle), so only a single reference position can be
-    used for computing local WCS properties (pixel scale, rotation
-    angle). For apertures with multiple positions, the first position
-    is used. Apertures with multiple positions used with a WCS that
-    has spatially-varying distortions may produce inaccurate shape
-    conversions for positions far from the first position.
+    A given aperture has a single fixed *shape* that is applied
+    identically at every position (e.g., a pixel circle must remain
+    a pixel circle of the same radius at all positions). Because a
+    WCS can have a spatially-varying scale, rotation, and distortion,
+    the local transformation generally differs from position to
+    position, so the shape cannot be preserved exactly at every
+    position when converting between pixel and sky apertures. To
+    keep the conversion deterministic and the shape well-defined,
+    a single reference position is used to compute the local WCS
+    properties (pixel scale, rotation angle), and by convention
+    this is the **first** position. This applies to all aperture
+    classes, including `~photutils.aperture.PolygonAperture` and
+    `~photutils.aperture.SkyPolygonAperture`, whose vertex offsets are
+    transformed using the WCS sampled at the first position. Apertures
+    with multiple positions used with a WCS that has spatially-varying
+    distortions may therefore produce inaccurate shape conversions for
+    positions far from the first position.
+
+
+Polygon Apertures
+^^^^^^^^^^^^^^^^^
+
+In addition to the built-in circular, elliptical, and
+rectangular shapes, arbitrary polygon apertures are
+supported via the `~photutils.aperture.PolygonAperture` and
+`~photutils.aperture.SkyPolygonAperture` classes. Like the other
+aperture types, a polygon aperture has a single fixed shape (defined by
+its ``vertex_offsets``) that can be applied at one or more positions::
+
+    >>> import numpy as np
+    >>> from photutils.aperture import PolygonAperture
+    >>> positions = [(30.0, 30.0), (40.0, 40.0)]
+    >>> offsets = [(-3.0, -2.0), (3.0, -2.0), (3.0, 2.0), (-3.0, 2.0)]
+    >>> aperture = PolygonAperture(positions, offsets)
+
+The polygon must be simple (non-self-intersecting) with at least three
+vertices, but it does not need to be convex; non-convex shapes such as
+L-shapes or stars are fully supported. The vertices may be input in
+either clockwise or counter-clockwise order; they are normalized to
+counter-clockwise order internally.
+
+A single polygon can also be constructed directly
+from its absolute vertex coordinates using the
+:meth:`~photutils.aperture.PolygonAperture.from_vertices` class method,
+which sets the aperture position to the polygon centroid::
+
+    >>> vertices = [(0.0, 0.0), (4.0, 0.0), (4.0, 3.0)]
+    >>> aperture = PolygonAperture.from_vertices(vertices)
+
+Regular polygons (equal-length sides and equal
+interior angles) can be created with the
+:meth:`~photutils.aperture.PolygonAperture.from_regular_polygon` class
+method by specifying a center, the number of vertices, the circumradius,
+and an optional rotation angle::
+
+    >>> hexagon = PolygonAperture.from_regular_polygon((30.0, 30.0),
+    ...                                                n_vertices=6,
+    ...                                                radius=5.0)
+
+For regular polygons, the ``outer_radius``, ``inner_radius``,
+``side_length``, ``interior_angle``, ``exterior_angle``, and ``theta``
+properties expose the geometric parameters of the shape.
+
+The built-in `~photutils.aperture.CircularAperture`,
+`~photutils.aperture.EllipticalAperture`, and
+`~photutils.aperture.RectangularAperture` classes also provide a
+``to_polygon`` method to convert them to an approximating (or, for the
+rectangle, exactly equivalent) `~photutils.aperture.PolygonAperture`.
 
 
 Performing Aperture Photometry

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -122,6 +122,69 @@ input order, the stacked table rows are in the same order as the input
 ``positions``.
 
 
+Polygon Apertures
+=================
+
+Two new aperture classes have been added:
+`~photutils.aperture.PolygonAperture` and
+`~photutils.aperture.SkyPolygonAperture`. Like the other aperture types,
+they have a single fixed shape (parameterized by ``vertex_offsets``)
+that can be applied at one or more positions::
+
+    >>> import numpy as np
+    >>> from photutils.aperture import PolygonAperture
+    >>> positions = [(10.0, 20.0), (30.0, 40.0)]
+    >>> # A regular hexagon centered on each position
+    >>> outer_radius = 5.0
+    >>> theta = np.linspace(0.0, 2 * np.pi, 6, endpoint=False)
+    >>> offsets = np.column_stack([outer_radius * np.cos(theta),
+    ...                            outer_radius * np.sin(theta)])
+    >>> aper = PolygonAperture(positions, offsets)
+
+The polygon must be simple (non-self-intersecting), but it does not need
+to be convex; non-convex shapes such as L-shapes or stars are fully
+supported.
+
+Regular polygons can be constructed by specifying a center,
+the number of vertices, the `circumradius (outer radius)
+<https://mathworld.wolfram.com/Circumradius.html>`_, and an optional
+rotation angle via the ``from_regular_polygon`` classmethod. The
+``is_regular`` property reports whether a polygon is regular, and the
+``outer_radius``, ``inner_radius``, ``side_length``, ``interior_angle``,
+``exterior_angle``, and ``theta`` properties expose the geometric
+parameters of regular polygons (they raise ``ValueError`` for
+non-regular polygons)::
+
+    >>> hexagon = PolygonAperture.from_regular_polygon((10.0, 20.0),
+    ...                                                n_vertices=6,
+    ...                                                radius=5.0)
+    >>> hexagon.is_regular
+    True
+    >>> hexagon.outer_radius
+    5.0
+    >>> hexagon.interior_angle
+    <Quantity 120. deg>
+
+A ``from_vertices`` classmethod is also provided as a convenience for
+building a single polygon directly from absolute pixel or sky vertex
+coordinates::
+
+    >>> verts = [(0.0, 0.0), (4.0, 0.0), (4.0, 3.0)]
+    >>> aper = PolygonAperture.from_vertices(verts)
+
+Both polygon aperture classes also expose a ``vertices`` attribute
+returning the absolute vertex coordinates at every aperture position.
+
+Conversions between `~photutils.aperture.PolygonAperture` and
+`~photutils.aperture.SkyPolygonAperture` use ``wcs.pixel_to_world`` and
+``wcs.world_to_pixel`` directly on the absolute vertex coordinates,
+so the conversion captures the actual finite-displacement WCS
+transformation of the polygon corners.
+
+``aperture_to_region`` and ``region_to_aperture`` also now support
+`~regions.PolygonPixelRegion` and `~regions.PolygonSkyRegion`.
+
+
 .. _whatsnew-3.1-api-changes:
 
 API Changes

--- a/photutils/aperture/__init__.py
+++ b/photutils/aperture/__init__.py
@@ -10,5 +10,6 @@ from .core import *  # noqa: F401, F403
 from .ellipse import *  # noqa: F401, F403
 from .mask import *  # noqa: F401, F403
 from .photometry import *  # noqa: F401, F403
+from .polygon import *  # noqa: F401, F403
 from .rectangle import *  # noqa: F401, F403
 from .stats import *  # noqa: F401, F403

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -56,7 +56,9 @@ class CircularMaskMixin:  # pragma: no cover
               continuous in the range [0, 1].
             * ``'center'``:
               Binary weighting based on the pixel center. Weights are
-              either 0 or 1.
+              either 0 or 1. A pixel is included only if its center lies
+              strictly inside the aperture; pixel centers lying exactly
+              on the aperture boundary are excluded (weight 0).
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -62,7 +62,10 @@ class CircularMaskMixin:  # pragma: no cover
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1].
+              parameter. Weights are discrete in the range [0, 1]. A
+              subpixel is included only if its center lies strictly
+              inside the aperture; subpixel centers lying exactly on the
+              aperture boundary are excluded (weight 0).
 
         subpixels : int, optional
             The subsampling factor per axis used when

--- a/photutils/aperture/converters.py
+++ b/photutils/aperture/converters.py
@@ -13,6 +13,7 @@ from photutils.aperture.core import Aperture
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus,
                                         SkyEllipticalAperture)
+from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture,
                                           SkyRectangularAnnulus,
@@ -94,6 +95,10 @@ def region_to_aperture(region):
       `~photutils.aperture.RectangularAnnulus`
     * `~regions.RectangleAnnulusSkyRegion` |rarr|
       `~photutils.aperture.SkyRectangularAnnulus`
+    * `~regions.PolygonPixelRegion` |rarr|
+      `~photutils.aperture.PolygonAperture`
+    * `~regions.PolygonSkyRegion` |rarr|
+      `~photutils.aperture.SkyPolygonAperture`
 
     Examples
     --------
@@ -108,6 +113,7 @@ def region_to_aperture(region):
                          CirclePixelRegion, CircleSkyRegion,
                          EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
                          EllipsePixelRegion, EllipseSkyRegion,
+                         PolygonPixelRegion, PolygonSkyRegion,
                          RectangleAnnulusPixelRegion,
                          RectangleAnnulusSkyRegion, RectanglePixelRegion,
                          RectangleSkyRegion, Region)
@@ -177,6 +183,13 @@ def region_to_aperture(region):
             region.inner_width, region.outer_width,
             region.outer_height, h_in=region.inner_height,
             theta=(region.angle - (90 * u.deg)))
+
+    elif isinstance(region, PolygonPixelRegion):
+        verts = np.stack([region.vertices.x, region.vertices.y], axis=1)
+        aperture = PolygonAperture.from_vertices(verts)
+
+    elif isinstance(region, PolygonSkyRegion):
+        aperture = SkyPolygonAperture.from_vertices(region.vertices)
 
     else:
         msg = (f'Cannot convert {region.__class__.__name__!r} to an '
@@ -252,6 +265,10 @@ def aperture_to_region(aperture):
       `~regions.RectangleAnnulusPixelRegion`
     * `~photutils.aperture.SkyRectangularAnnulus` |rarr|
       `~regions.RectangleAnnulusSkyRegion`
+    * `~photutils.aperture.PolygonAperture` |rarr|
+      `~regions.PolygonPixelRegion`
+    * `~photutils.aperture.SkyPolygonAperture` |rarr|
+      `~regions.PolygonSkyRegion`
 
     Examples
     --------
@@ -303,6 +320,7 @@ def _scalar_aperture_to_region(aperture):
                          CirclePixelRegion, CircleSkyRegion,
                          EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
                          EllipsePixelRegion, EllipseSkyRegion, PixCoord,
+                         PolygonPixelRegion, PolygonSkyRegion,
                          RectangleAnnulusPixelRegion,
                          RectangleAnnulusSkyRegion, RectanglePixelRegion,
                          RectangleSkyRegion)
@@ -372,6 +390,14 @@ def _scalar_aperture_to_region(aperture):
             aperture.w_in, aperture.w_out,
             aperture.h_in, aperture.h_out,
             angle=(aperture.theta + (90 * u.deg)))
+
+    elif isinstance(aperture, PolygonAperture):
+        verts = aperture.vertices
+        region = PolygonPixelRegion(
+            PixCoord(x=verts[:, 0], y=verts[:, 1]))
+
+    elif isinstance(aperture, SkyPolygonAperture):
+        region = PolygonSkyRegion(aperture.vertices)
 
     else:
         msg = 'Cannot convert input aperture to a Region object'

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -360,7 +360,10 @@ class PixelAperture(Aperture):
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1].
+              parameter. Weights are discrete in the range [0, 1]. A
+              subpixel is included only if its center lies strictly
+              inside the aperture; subpixel centers lying exactly on the
+              aperture boundary are excluded (weight 0).
 
         subpixels : int, optional
             The subsampling factor per axis used when
@@ -431,7 +434,10 @@ class PixelAperture(Aperture):
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1].
+              parameter. Weights are discrete in the range [0, 1]. A
+              subpixel is included only if its center lies strictly
+              inside the aperture; subpixel centers lying exactly on the
+              aperture boundary are excluded (weight 0).
 
         subpixels : int, optional
             The subsampling factor per axis used when
@@ -678,7 +684,10 @@ class PixelAperture(Aperture):
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1].
+              parameter. Weights are discrete in the range [0, 1]. A
+              subpixel is included only if its center lies strictly
+              inside the aperture; subpixel centers lying exactly on the
+              aperture boundary are excluded (weight 0).
 
         subpixels : int, optional
             The subsampling factor per axis used when

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -354,7 +354,9 @@ class PixelAperture(Aperture):
               continuous in the range [0, 1].
             * ``'center'``:
               Binary weighting based on the pixel center. Weights are
-              either 0 or 1.
+              either 0 or 1. A pixel is included only if its center lies
+              strictly inside the aperture; pixel centers lying exactly
+              on the aperture boundary are excluded (weight 0).
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``
@@ -423,7 +425,9 @@ class PixelAperture(Aperture):
               continuous in the range [0, 1].
             * ``'center'``:
               Binary weighting based on the pixel center. Weights are
-              either 0 or 1.
+              either 0 or 1. A pixel is included only if its center lies
+              strictly inside the aperture; pixel centers lying exactly
+              on the aperture boundary are excluded (weight 0).
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``
@@ -668,7 +672,9 @@ class PixelAperture(Aperture):
               continuous in the range [0, 1].
             * ``'center'``:
               Binary weighting based on the pixel center. Weights are
-              either 0 or 1.
+              either 0 or 1. A pixel is included only if its center lies
+              strictly inside the aperture; pixel centers lying exactly
+              on the aperture boundary are excluded (weight 0).
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -58,7 +58,9 @@ class EllipticalMaskMixin:  # pragma: no cover
               continuous in the range [0, 1].
             * ``'center'``:
               Binary weighting based on the pixel center. Weights are
-              either 0 or 1.
+              either 0 or 1. A pixel is included only if its center lies
+              strictly inside the aperture; pixel centers lying exactly
+              on the aperture boundary are excluded (weight 0).
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -64,7 +64,10 @@ class EllipticalMaskMixin:  # pragma: no cover
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1].
+              parameter. Weights are discrete in the range [0, 1]. A
+              subpixel is included only if its center lies strictly
+              inside the aperture; subpixel centers lying exactly on the
+              aperture boundary are excluded (weight 0).
 
         subpixels : int, optional
             The subsampling factor per axis used when

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -81,8 +81,10 @@ def aperture_photometry(data, apertures, error=None, mask=None,
           Calculates the exact geometric overlap area. Weights are
           continuous in the range [0, 1].
         * ``'center'``:
-          Binary weighting based on the pixel center. Weights are
-          either 0 or 1.
+          Binary weighting based on the pixel center. Weights are either
+          0 or 1. A pixel is included only if its center lies strictly
+          inside the aperture; pixel centers lying exactly on the
+          aperture boundary are excluded (weight 0).
         * ``'subpixel'``:
           Approximates the overlap by averaging binary samples on a
           subgrid. The number of samples is set by the ``subpixels``

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -88,7 +88,10 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         * ``'subpixel'``:
           Approximates the overlap by averaging binary samples on a
           subgrid. The number of samples is set by the ``subpixels``
-          parameter. Weights are discrete in the range [0, 1].
+          parameter. Weights are discrete in the range [0, 1]. A
+          subpixel is included only if its center lies strictly inside
+          the aperture; subpixel centers lying exactly on the aperture
+          boundary are excluded (weight 0).
 
     subpixels : int, optional
         The subsampling factor per axis used when ``method='subpixel'``.

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -1,0 +1,1162 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Polygon apertures in both pixel and sky coordinates.
+"""
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.utils import lazyproperty
+
+from photutils.aperture.attributes import (ApertureAttribute, PixelPositions,
+                                           SkyCoordPositions)
+from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.geometry._polygon_overlap import polygon_overlap_grid
+
+__all__ = [
+    'PolygonAperture',
+    'SkyPolygonAperture',
+]
+
+
+def _signed_polygon_area(verts):
+    """
+    Calculate the signed area of a polygon (positive for
+    counter-clockwise vertices) via the shoelace formula.
+
+    Parameters
+    ----------
+    verts : `~numpy.ndarray`
+        ``(n_vertices, 2)`` array of polygon vertices.
+
+    Returns
+    -------
+    area : float
+        The signed area of the polygon.
+    """
+    x = verts[:, 0]
+    y = verts[:, 1]
+    return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
+
+
+def _orientation(a, b, c):
+    """
+    Return twice the signed area of the triangle ``a``, ``b``, ``c``.
+
+    The result is positive if ``a -> b -> c`` traverses
+    counter-clockwise, negative if clockwise, and zero if the three
+    points are collinear.
+    """
+    return ((b[0] - a[0]) * (c[1] - a[1])
+            - (b[1] - a[1]) * (c[0] - a[0]))
+
+
+def _on_segment(a, b, c):
+    """
+    Return `True` if point ``c``, assumed collinear with ``a`` and
+    ``b``, lies within the closed bounding box of the segment ``a b``.
+    """
+    return (min(a[0], b[0]) <= c[0] <= max(a[0], b[0])
+            and min(a[1], b[1]) <= c[1] <= max(a[1], b[1]))
+
+
+def _segments_intersect(p1, p2, p3, p4):
+    """
+    Return `True` if the closed line segments ``p1 p2`` and ``p3 p4``
+    intersect, including the cases where they merely touch at a point or
+    overlap collinearly.
+    """
+    d1 = _orientation(p3, p4, p1)
+    d2 = _orientation(p3, p4, p2)
+    d3 = _orientation(p1, p2, p3)
+    d4 = _orientation(p1, p2, p4)
+
+    # The segments straddle each other (proper crossing).
+    if (((d1 > 0) and (d2 < 0)) or ((d1 < 0) and (d2 > 0))) and \
+       (((d3 > 0) and (d4 < 0)) or ((d3 < 0) and (d4 > 0))):
+        return True
+
+    # Collinear / touching endpoints.
+    if d1 == 0.0 and _on_segment(p3, p4, p1):
+        return True
+    if d2 == 0.0 and _on_segment(p3, p4, p2):
+        return True
+    if d3 == 0.0 and _on_segment(p1, p2, p3):
+        return True
+    return bool(d4 == 0.0 and _on_segment(p1, p2, p4))
+
+
+def _polygon_is_simple(verts):
+    """
+    Return `True` if the closed polygon defined by ``verts`` is simple
+    (no two non-adjacent edges intersect).
+
+    Every pair of non-adjacent polygon edges is tested for intersection
+    using orientation predicates, including the case where an endpoint
+    of one edge lies on another edge. Adjacent edges (which share a
+    vertex by construction) are not compared with each other, so a
+    polygon that folds straight back onto an adjacent edge is not
+    detected here; such degenerate cases are instead excluded by the
+    zero-area check in `_validate_simple_polygon`.
+
+    The cost is ``O(n^2)`` in the number of vertices ``n``. This is
+    negligible for the polygon sizes used in aperture photometry, and
+    the check is performed only once, when the attribute is set.
+
+    Parameters
+    ----------
+    verts : `~numpy.ndarray`
+        ``(n_vertices, 2)`` array of polygon vertices.
+
+    Returns
+    -------
+    is_simple : bool
+        `True` if the polygon is simple, `False` otherwise.
+    """
+    n = verts.shape[0]
+    for i in range(n):
+        a1 = verts[i]
+        a2 = verts[(i + 1) % n]
+        # Compare edge i only with later, non-adjacent edges. Edges i
+        # and i+1 share a vertex, and (for i == 0) edges 0 and n-1 share
+        # a vertex, so those pairs are skipped.
+        for j in range(i + 2, n):
+            if i == 0 and j == n - 1:
+                continue
+            b1 = verts[j]
+            b2 = verts[(j + 1) % n]
+            if _segments_intersect(a1, a2, b1, b2):
+                return False
+    return True
+
+
+def _validate_simple_polygon(verts, name='vertex_offsets', check_simple=True):
+    """
+    Verify that ``verts`` defines a simple, non-degenerate polygon.
+
+    The polygon is required to be simple (i.e., non-self-intersecting),
+    but it is not required to be convex. Self-intersection is checked
+    explicitly with an ``O(n^2)`` edge-pair test (see
+    `_polygon_is_simple`); this is inexpensive for the polygon sizes
+    used in aperture photometry and runs only once, when the attribute
+    is set.
+
+    Parameters
+    ----------
+    verts : `~numpy.ndarray`
+        ``(n_vertices, 2)`` array of polygon vertices.
+
+    name : str
+        Name to use in error messages.
+
+    check_simple : bool, optional
+        Whether to run the ``O(n^2)`` self-intersection test. Set to
+        `False` only for offsets that are already known to define
+        a simple polygon (e.g., a circle, ellipse, or rectangle
+        discretized into vertices); the cheap shape, vertex-count,
+        finiteness, and zero-area checks are still performed.
+
+    Returns
+    -------
+    verts_ccw : `~numpy.ndarray`
+        The vertices reordered to be counter-clockwise.
+    """
+    if verts.ndim != 2 or verts.shape[1] != 2:
+        msg = (f'{name!r} must have shape (n_vertices, 2), '
+               f'got {verts.shape}')
+        raise ValueError(msg)
+
+    n = verts.shape[0]
+    if n < 3:
+        msg = (f'{name!r} must define a polygon with at least 3 '
+               f'vertices, got {n}')
+        raise ValueError(msg)
+
+    if not np.all(np.isfinite(verts)):
+        msg = f'{name!r} must not contain any non-finite values'
+        raise ValueError(msg)
+
+    signed_area = _signed_polygon_area(verts)
+    if signed_area == 0.0:
+        msg = (f'{name!r} defines a degenerate polygon with zero '
+               'area (vertices are collinear or coincident)')
+        raise ValueError(msg)
+
+    if check_simple and not _polygon_is_simple(verts):
+        msg = (f'{name!r} must define a simple polygon, but its edges '
+               'self-intersect')
+        raise ValueError(msg)
+
+    if signed_area < 0:
+        verts = verts[::-1].copy()
+
+    return verts
+
+
+class PixelVertexOffsets(ApertureAttribute):
+    """
+    Validate and set ``vertex_offsets`` for `PolygonAperture`.
+
+    The value is converted to an ``(n_vertices, 2)`` `~numpy.ndarray` of
+    pixel offsets and reordered into counter-clockwise vertex order.
+    """
+
+    def __set__(self, instance, value):
+        value = self._validate(value)
+        if self.name in instance.__dict__:
+            self._reset_lazyproperties(instance)
+        instance.__dict__[self.name] = value
+
+    def _validate(self, value):
+        if isinstance(value, u.Quantity):
+            msg = f'{self.name!r} must not be a Quantity'
+            raise TypeError(msg)
+
+        try:
+            value = np.asarray(value, dtype=float)
+        except (TypeError, ValueError) as exc:
+            msg = (f'{self.name!r} must be convertible to a numeric '
+                   f'(n_vertices, 2) array')
+            raise TypeError(msg) from exc
+
+        return _validate_simple_polygon(value, name=self.name)
+
+
+class SkyVertexOffsets(ApertureAttribute):
+    """
+    Validate and set ``vertex_offsets`` for `SkyPolygonAperture`.
+
+    The value must be an angular `~astropy.units.Quantity` of shape
+    ``(n_vertices, 2)``. The two columns are the ``(d_lon, d_lat)``
+    offsets relative to the corresponding ``positions`` coordinate.
+    """
+
+    def __set__(self, instance, value):
+        value = self._validate(value)
+        if self.name in instance.__dict__:
+            self._reset_lazyproperties(instance)
+        instance.__dict__[self.name] = value
+
+    def _validate(self, value):
+        if not isinstance(value, u.Quantity):
+            msg = (f'{self.name!r} must be an angular Quantity with '
+                   'shape (n_vertices, 2)')
+            raise TypeError(msg)
+
+        if not value.unit.is_equivalent(u.deg):
+            msg = f'{self.name!r} must have angular units'
+            raise u.UnitsError(msg)
+
+        if value.ndim != 2 or value.shape[1] != 2:
+            msg = (f'{self.name!r} must have shape (n_vertices, 2), '
+                   f'got {value.shape}')
+            raise ValueError(msg)
+
+        # Validate using arcsec values; angular geometry on the local
+        # tangent plane is preserved.
+        verts = value.to_value(u.arcsec)
+        verts = _validate_simple_polygon(verts, name=self.name)
+
+        return (verts * u.arcsec).to(value.unit)
+
+
+def _vertices_centroid(verts):
+    """
+    Return the area-weighted geometric center of a polygon.
+
+    For a polygon with vertices ``v_i`` and area ``A``, the centroid is:
+
+        C_x = (1/(6A)) sum_i (x_i + x_{i+1}) (x_i y_{i+1} - x_{i+1} y_i)
+        C_y = (1/(6A)) sum_i (y_i + y_{i+1}) (x_i y_{i+1} - x_{i+1} y_i)
+    """
+    x = verts[:, 0]
+    y = verts[:, 1]
+    x1 = np.roll(x, -1)
+    y1 = np.roll(y, -1)
+    cross = x * y1 - x1 * y
+    area = 0.5 * float(np.sum(cross))
+    cx = float(np.sum((x + x1) * cross)) / (6.0 * area)
+    cy = float(np.sum((y + y1) * cross)) / (6.0 * area)
+
+    return np.array([cx, cy])
+
+
+def _regular_polygon_offsets(n_vertices, radius, angle_rad):
+    """
+    Return the ``(n_vertices, 2)`` array of vertex offsets for a regular
+    polygon with the given circumradius and rotation angle.
+
+    The first vertex sits at angle ``pi/2 + angle_rad`` (i.e., directly
+    above the center for ``angle_rad == 0``), and subsequent vertices
+    are placed counter-clockwise at uniform angular spacing.
+    """
+    base = np.pi / 2.0 + float(angle_rad)
+    step = 2.0 * np.pi / n_vertices
+    thetas = base + np.arange(n_vertices) * step
+    return np.column_stack([radius * np.cos(thetas),
+                            radius * np.sin(thetas)])
+
+
+def _is_regular_polygon(offsets, rtol=1.0e-7, atol=1.0e-10):
+    """
+    Return `True` if ``offsets`` defines a regular polygon centered at
+    the origin (equal vertex distances and uniform angular spacing).
+    """
+    n = offsets.shape[0]
+    radii = np.hypot(offsets[:, 0], offsets[:, 1])
+
+    if not np.allclose(radii, radii[0], rtol=rtol, atol=atol):
+        return False
+
+    # Sort vertex angles in [0, 2*pi) and check uniform spacing.
+    angles = np.mod(np.arctan2(offsets[:, 1], offsets[:, 0]), 2.0 * np.pi)
+    angles_sorted = np.sort(angles)
+    diffs = np.diff(np.concatenate([angles_sorted,
+                                    angles_sorted[:1] + 2.0 * np.pi]))
+    expected = 2.0 * np.pi / n
+
+    return np.allclose(diffs, expected, rtol=rtol, atol=atol)
+
+
+class _RegularPolygonGeometry:
+    """
+    Compute the geometric properties of a regular polygon from its
+    vertex offsets.
+
+    This small helper centralizes the regular-polygon math shared by
+    `PolygonAperture` and `SkyPolygonAperture`, avoiding duplicated
+    trigonometric formulas in the two classes.
+
+    Parameters
+    ----------
+    offsets : `~numpy.ndarray`
+        The ``(n_vertices, 2)`` array of vertex offsets relative to
+        the polygon center, as plain numbers in the aperture's native
+        length unit (pixels for `PolygonAperture`, arcseconds for
+        `SkyPolygonAperture`).
+
+    Notes
+    -----
+    The length properties (`outer_radius`, `inner_radius`,
+    `side_length`) are returned as plain floats in the same length
+    unit as ``offsets``. The angular properties (`interior_angle`,
+    `exterior_angle`, `theta`) are returned as `~astropy.units.Quantity`
+    in degrees and are independent of the length unit.
+    """
+
+    def __init__(self, offsets):
+        self.offsets = offsets
+        self.n_vertices = offsets.shape[0]
+
+    @property
+    def is_regular(self):
+        return _is_regular_polygon(self.offsets)
+
+    @property
+    def side_length(self):
+        return (2.0 * self.outer_radius
+                * float(np.sin(np.pi / self.n_vertices)))
+
+    @property
+    def outer_radius(self):
+        return float(np.hypot(self.offsets[0, 0], self.offsets[0, 1]))
+
+    @property
+    def inner_radius(self):
+        return self.outer_radius * float(np.cos(np.pi / self.n_vertices))
+
+    @property
+    def interior_angle(self):
+        return ((self.n_vertices - 2) / self.n_vertices) * 180.0 * u.deg
+
+    @property
+    def exterior_angle(self):
+        return (360.0 / self.n_vertices) * u.deg
+
+    @property
+    def theta(self):
+        dx, dy = self.offsets[0]
+        theta_rad = np.arctan2(dy, dx) - np.pi / 2
+        return (np.degrees(theta_rad) % 360.0) * u.deg
+
+
+class PolygonAperture(PixelAperture):
+    """
+    A polygon aperture defined in pixel coordinates.
+
+    The aperture has a single fixed shape, defined by ``vertex_offsets``
+    relative to each ``positions`` entry, but it can have multiple
+    positions.
+
+    Parameters
+    ----------
+    positions : array_like
+        The pixel coordinates of the aperture center(s) in one of the
+        following formats:
+
+        * single ``(x, y)`` pair as a tuple, list, or `~numpy.ndarray`
+        * tuple, list, or `~numpy.ndarray` of ``(x, y)`` pairs
+
+    vertex_offsets : array_like
+        Shape ``(n_vertices, 2)``. The pixel-space offsets ``(dx, dy)``
+        of each polygon vertex relative to ``positions``. The polygon
+        must be simple (non-self-intersecting) with at least 3 vertices.
+        The polygon may be convex or non-convex. Either clockwise or
+        counter-clockwise vertex orderings are accepted; the input is
+        normalized to counter-clockwise internally.
+
+    Raises
+    ------
+    ValueError : `ValueError`
+        If ``vertex_offsets`` is not a valid simple polygon with at
+        least 3 vertices.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from photutils.aperture import PolygonAperture
+    >>> # A regular hexagon centered on (10, 20) with circumradius 5.
+    >>> theta = np.linspace(0.0, 2 * np.pi, 6, endpoint=False)
+    >>> offsets = np.column_stack([5.0 * np.cos(theta),
+    ...                            5.0 * np.sin(theta)])
+    >>> aper = PolygonAperture((10.0, 20.0), offsets)
+
+    Construct a single polygon directly from absolute vertex
+    coordinates::
+
+    >>> verts = [(0.0, 0.0), (4.0, 0.0), (4.0, 3.0)]
+    >>> aper = PolygonAperture.from_vertices(verts)
+    """
+
+    _params = ('positions', 'vertex_offsets')
+    positions = PixelPositions('The center pixel position(s).')
+    vertex_offsets = PixelVertexOffsets(
+        'The (n_vertices, 2) array of pixel offsets of the polygon '
+        'vertices, measured relative to ``positions``.')
+
+    def __init__(self, positions, vertex_offsets):
+        self.positions = positions
+        self.vertex_offsets = vertex_offsets
+
+    @classmethod
+    def _from_convex_offsets(cls, positions, offsets):
+        """
+        Construct a `PolygonAperture` from vertex offsets that are
+        known to define a simple polygon, skipping the ``O(n^2)``
+        self-intersection check.
+
+        This is a fast-path internal constructor used by the
+        ``to_polygon`` methods of the built-in apertures, where the
+        generated polygon (a discretized circle, ellipse, or rectangle)
+        is guaranteed to be simple by construction. The cheap shape,
+        vertex-count, finiteness, zero-area, and counter-clockwise
+        normalization checks are still applied.
+        """
+        offsets = np.asarray(offsets, dtype=float)
+        offsets = _validate_simple_polygon(offsets, name='vertex_offsets',
+                                           check_simple=False)
+        obj = cls.__new__(cls)
+        obj.positions = positions
+        obj.__dict__['vertex_offsets'] = offsets
+        return obj
+
+    @classmethod
+    def from_vertices(cls, vertices):
+        """
+        Construct a `PolygonAperture` from a single set of absolute
+        pixel vertices.
+
+        The aperture's ``positions`` is set to the area-weighted
+        centroid of the input vertices, and ``vertex_offsets`` is set to
+        the vertices minus the centroid.
+
+        Parameters
+        ----------
+        vertices : array_like
+            Shape ``(n_vertices, 2)`` array of absolute pixel ``(x, y)``
+            vertex coordinates.
+
+        Returns
+        -------
+        aperture : `PolygonAperture`
+            A scalar polygon aperture whose ``vertices`` property
+            reproduces the input.
+        """
+        verts = np.asarray(vertices, dtype=float)
+        if verts.ndim != 2 or verts.shape[1] != 2:
+            msg = ('vertices must have shape (n_vertices, 2), '
+                   f'got {verts.shape}')
+            raise ValueError(msg)
+
+        # Validate before computing the centroid: the area-weighted
+        # centroid formula divides by the polygon area, which is zero
+        # for a degenerate (collinear or coincident) polygon.
+        verts = _validate_simple_polygon(verts, name='vertices')
+        center = _vertices_centroid(verts)
+        offsets = verts - center
+
+        return cls(tuple(center), offsets)
+
+    @classmethod
+    def from_regular_polygon(cls, positions, n_vertices, radius, theta=0.0):
+        """
+        Construct a regular `PolygonAperture` from a center, vertex
+        count, circumradius, and rotation angle.
+
+        The first vertex is placed directly above the center (in
+        the ``+y`` direction) for ``theta == 0`` and is rotated
+        counter-clockwise by ``theta``. This convention matches
+        `regions.RegularPolygonPixelRegion`.
+
+        Parameters
+        ----------
+        positions : array_like
+            The pixel coordinates of the aperture center(s) (see
+            `PolygonAperture` for the accepted formats).
+
+        n_vertices : int
+            The number of vertices (must be at least 3).
+
+        radius : float
+            The circumradius (outer radius) of the polygon in pixels
+            (must be positive).
+
+        theta : float or `~astropy.units.Quantity`, optional
+            The rotation angle of the polygon, measured counter-
+            clockwise from the ``+y`` axis. A scalar float is
+            interpreted in radians.
+
+        Returns
+        -------
+        aperture : `PolygonAperture`
+            The regular polygon aperture.
+        """
+        n_vertices = int(n_vertices)
+        if n_vertices < 3:
+            msg = f'n_vertices must be at least 3, got {n_vertices}'
+            raise ValueError(msg)
+
+        radius = float(radius)
+        if not np.isfinite(radius) or radius <= 0.0:
+            msg = f'radius must be a finite positive number, got {radius}'
+            raise ValueError(msg)
+
+        if isinstance(theta, u.Quantity):
+            theta_rad = float(theta.to_value(u.rad))
+        else:
+            theta_rad = float(theta)
+
+        offsets = _regular_polygon_offsets(n_vertices, radius, theta_rad)
+
+        return cls(positions, offsets)
+
+    @lazyproperty
+    def vertices(self):
+        """
+        The absolute pixel ``(x, y)`` vertices of the polygon at each
+        aperture position.
+
+        For a scalar aperture, the returned array has shape
+        ``(n_vertices, 2)``. For an aperture with ``n_positions``
+        positions, the returned array has shape ``(n_positions,
+        n_vertices, 2)``.
+        """
+        # vertex_offsets shape: (n_v, 2); positions shape: (..., 2).
+        # Broadcast position to vertices.
+        offsets = self.vertex_offsets
+        if self.isscalar:
+            pos = np.asarray(self.positions, dtype=float)
+            return pos + offsets
+
+        # positions shape: (n_positions, 2); result: (n_positions, n_v, 2)
+        return self.positions[:, np.newaxis, :] + offsets[np.newaxis, :, :]
+
+    @lazyproperty
+    def _xy_extents(self):
+        """
+        Half the extents of the polygon's axis-aligned bounding box.
+        """
+        x_extent = float(np.max(np.abs(self.vertex_offsets[:, 0])))
+        y_extent = float(np.max(np.abs(self.vertex_offsets[:, 1])))
+        return x_extent, y_extent
+
+    @lazyproperty
+    def area(self):
+        """
+        The exact geometric area of the aperture shape.
+        """
+        return abs(_signed_polygon_area(self.vertex_offsets))
+
+    @lazyproperty
+    def perimeter(self):
+        """
+        The perimeter of the polygon in pixels.
+
+        The perimeter is computed as the sum of the Euclidean distances
+        between consecutive vertices.
+        """
+        offsets = self.vertex_offsets
+        diff = np.roll(offsets, -1, axis=0) - offsets
+        return float(np.sum(np.hypot(diff[:, 0], diff[:, 1])))
+
+    @lazyproperty
+    def n_vertices(self):
+        """
+        The number of vertices of the polygon.
+        """
+        return int(self.vertex_offsets.shape[0])
+
+    @lazyproperty
+    def _regular_geometry(self):
+        """
+        Helper that computes the regular-polygon geometric properties
+        from the pixel vertex offsets.
+        """
+        return _RegularPolygonGeometry(self.vertex_offsets)
+
+    @lazyproperty
+    def is_regular(self):
+        """
+        `True` if the polygon is regular (equal-length sides and equal
+        interior angles, with all vertices at the same distance from
+        ``positions``).
+        """
+        return self._regular_geometry.is_regular
+
+    def _check_regular(self, name):
+        if not self.is_regular:
+            msg = (f'{name!r} is only defined for a regular polygon '
+                   'aperture')
+            raise ValueError(msg)
+
+    @lazyproperty
+    def outer_radius(self):
+        """
+        The outer (circumscribed-circle) radius of the regular polygon
+        in pixels, i.e., the distance from ``positions`` to each vertex.
+
+        This is also called the `circumradius
+        <https://mathworld.wolfram.com/Circumradius.html>`_.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('outer_radius')
+        return self._regular_geometry.outer_radius
+
+    @lazyproperty
+    def inner_radius(self):
+        """
+        The inner (inscribed-circle) radius of the regular polygon in
+        pixels, i.e., the distance from ``positions`` to the midpoint of
+        each side.
+
+        This is also called the `inradius
+        <https://mathworld.wolfram.com/Inradius.html>`_
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('inner_radius')
+        return self._regular_geometry.inner_radius
+
+    @lazyproperty
+    def side_length(self):
+        """
+        The side length of the regular polygon, in pixels.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('side_length')
+        return self._regular_geometry.side_length
+
+    @lazyproperty
+    def interior_angle(self):
+        """
+        The interior angle of the regular polygon as an angular
+        `~astropy.units.Quantity` in degrees.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('interior_angle')
+        return self._regular_geometry.interior_angle
+
+    @lazyproperty
+    def exterior_angle(self):
+        """
+        The exterior angle of the regular polygon as an angular
+        `~astropy.units.Quantity` in degrees.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('exterior_angle')
+        return self._regular_geometry.exterior_angle
+
+    @lazyproperty
+    def theta(self):
+        """
+        The rotation angle of the regular polygon as an angular
+        `~astropy.units.Quantity` in degrees.
+
+        The angle is measured counter-clockwise from the ``+y``
+        axis to the first vertex, in the range ``[0, 360) deg``.
+        This convention matches the ``theta`` parameter of
+        `~PolygonAperture.from_regular_polygon`.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('theta')
+        return self._regular_geometry.theta
+
+    def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
+        """
+        Compute the overlap of the aperture on the pixel grid.
+
+        Parameters
+        ----------
+        edges : list of 4 1D `~numpy.ndarray`
+            The edges of the pixel grid in the form of
+            ``[x_edges, y_edges, x_centers, y_centers]``.
+
+        nx, ny : int
+            The number of pixels in the x and y directions.
+
+        use_exact : bool
+            Whether to use the exact method for calculating the overlap.
+
+        subpixels : int
+            The number of subpixels to use in each dimension for the
+            subpixel method.
+
+        Returns
+        -------
+        overlap : 2D `~numpy.ndarray`
+            The overlap of the aperture on the pixel grid. The values
+            will be between 0 and 1, where 0 means no overlap and 1
+            means full overlap.
+        """
+        verts_x = np.ascontiguousarray(self.vertex_offsets[:, 0])
+        verts_y = np.ascontiguousarray(self.vertex_offsets[:, 1])
+        return polygon_overlap_grid(edges[0], edges[1], edges[2], edges[3],
+                                    nx, ny, verts_x, verts_y,
+                                    use_exact, subpixels)
+
+    def _to_patch(self, *, origin=(0, 0), **kwargs):
+        """
+        Return a `~matplotlib.patches.Polygon` patch (or list of them)
+        for the aperture.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+
+        **kwargs : dict, optional
+            Any keyword arguments accepted by
+            `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.Patch` or list of \
+                `~matplotlib.patches.Patch`
+            A patch for the aperture. If the aperture is scalar then a
+            single `~matplotlib.patches.Patch` is returned, otherwise a
+            list of `~matplotlib.patches.Patch` is returned.
+        """
+        import matplotlib.patches as mpatches
+
+        xy_positions, patch_kwargs = self._define_patch_params(origin=origin,
+                                                               **kwargs)
+        offsets = self.vertex_offsets
+        patches = [mpatches.Polygon(pos + offsets, closed=True,
+                                    **patch_kwargs)
+                   for pos in xy_positions]
+
+        if self.isscalar:
+            return patches[0]
+
+        return patches
+
+    def to_sky(self, wcs):
+        """
+        Convert the aperture to a `SkyPolygonAperture` object defined in
+        celestial coordinates.
+
+        The conversion uses ``wcs.pixel_to_world`` directly on the
+        absolute pixel vertex coordinates, evaluated at the first aperture
+        position.
+
+        Parameters
+        ----------
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that
+            supports the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
+            (e.g., `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
+        Returns
+        -------
+        aperture : `SkyPolygonAperture`
+            The equivalent sky-coordinate polygon aperture.
+        """
+        xpos, ypos = np.transpose(self.positions)
+        positions = wcs.pixel_to_world(xpos, ypos)
+
+        first_pos = np.atleast_2d(self.positions)[0]
+        first_skypos = positions if self.isscalar else positions[0]
+        abs_x = first_pos[0] + self.vertex_offsets[:, 0]
+        abs_y = first_pos[1] + self.vertex_offsets[:, 1]
+        sky_vertices = wcs.pixel_to_world(abs_x, abs_y)
+
+        d_lon, d_lat = first_skypos.spherical_offsets_to(sky_vertices)
+        offsets = u.Quantity([d_lon, d_lat]).T
+
+        return SkyPolygonAperture(positions=positions,
+                                  vertex_offsets=offsets)
+
+
+class SkyPolygonAperture(SkyAperture):
+    """
+    A polygon aperture defined in sky coordinates.
+
+    The aperture has a single fixed shape, defined by angular
+    ``vertex_offsets`` relative to each ``positions`` entry, but it can
+    have multiple positions. The angular offsets are interpreted on the
+    local tangent plane at each position.
+
+    Parameters
+    ----------
+    positions : `~astropy.coordinates.SkyCoord`
+        The celestial coordinates of the aperture center(s). This can be
+        either scalar coordinates or an array of coordinates.
+
+    vertex_offsets : `~astropy.units.Quantity`
+        Shape ``(n_vertices, 2)`` angular Quantity of polygon vertex
+        offsets ``(d_lon, d_lat)`` relative to ``positions``, applied as
+        spherical offsets on the local tangent plane. The polygon must
+        be simple (non-self-intersecting) with at least 3 vertices. The
+        polygon may be convex or non-convex.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> import numpy as np
+    >>> from astropy.coordinates import SkyCoord
+    >>> from photutils.aperture import SkyPolygonAperture
+    >>> positions = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
+    >>> theta = np.linspace(0, 2 * np.pi, 5, endpoint=False)
+    >>> r = 1.0
+    >>> offsets = np.column_stack([r * np.cos(theta),
+    ...                            r * np.sin(theta)]) * u.arcsec
+    >>> aper = SkyPolygonAperture(positions, offsets)
+    """
+
+    _params = ('positions', 'vertex_offsets')
+    positions = SkyCoordPositions('The center position(s) in sky coordinates.')
+    vertex_offsets = SkyVertexOffsets(
+        'The (n_vertices, 2) angular Quantity of polygon vertex offsets '
+        '(d_lon, d_lat) relative to ``positions``.')
+
+    def __init__(self, positions, vertex_offsets):
+        self.positions = positions
+        self.vertex_offsets = vertex_offsets
+
+    @classmethod
+    def from_vertices(cls, vertices):
+        """
+        Construct a `SkyPolygonAperture` from a single set of absolute
+        sky vertices.
+
+        The aperture's ``positions`` is set to an approximate centroid
+        of the input vertices, computed as a single tangent-plane
+        mean of the spherical offsets from the first vertex (i.e.,
+        the vertices' spherical offsets from this centroid average
+        to approximately zero), and ``vertex_offsets`` is set to the
+        spherical offsets of the vertices from this centroid.
+
+        Parameters
+        ----------
+        vertices : `~astropy.coordinates.SkyCoord`
+            A SkyCoord with shape ``(n_vertices,)`` of absolute polygon
+            vertex coordinates.
+
+        Returns
+        -------
+        aperture : `SkyPolygonAperture`
+            A scalar sky polygon aperture whose ``vertices`` property
+            reproduces the input.
+        """
+        if not isinstance(vertices, SkyCoord) or vertices.ndim != 1:
+            msg = ('vertices must be a 1-D SkyCoord with at least 3 '
+                   'vertices')
+            raise TypeError(msg)
+
+        # Provisional centroid: spherical mean approximated via mean of
+        # offsets from the first vertex.
+        ref = vertices[0]
+        d_lon, d_lat = ref.spherical_offsets_to(vertices)
+        center_d_lon = d_lon.mean()
+        center_d_lat = d_lat.mean()
+        center = ref.spherical_offsets_by(center_d_lon, center_d_lat)
+        d_lon, d_lat = center.spherical_offsets_to(vertices)
+        offsets = u.Quantity([d_lon, d_lat]).T
+        return cls(positions=center, vertex_offsets=offsets)
+
+    @classmethod
+    def from_regular_polygon(cls, positions, n_vertices, radius,
+                             theta=0.0 * u.deg):
+        """
+        Construct a regular `SkyPolygonAperture` from a center, vertex
+        count, angular circumradius, and rotation angle.
+
+        The first vertex is placed at the ``+lat`` edge of the local
+        tangent plane (typically northward for standard right-handed
+        celestial coordinates) for ``theta == 0`` and is rotated
+        counter-clockwise by ``theta``.
+
+        Parameters
+        ----------
+        positions : `~astropy.coordinates.SkyCoord`
+            The celestial coordinates of the aperture center(s).
+
+        n_vertices : int
+            The number of vertices (must be at least 3).
+
+        radius : `~astropy.units.Quantity`
+            The angular circumradius (outer radius) of the polygon (must
+            be a positive angular Quantity).
+
+        theta : `~astropy.units.Quantity`, optional
+            The rotation angle of the polygon, measured counter-
+            clockwise from the ``+lat`` axis on the local tangent
+            plane. This assumes a right-handed coordinate system (e.g.,
+            standard celestial coordinates).
+
+        Returns
+        -------
+        aperture : `SkyPolygonAperture`
+            The regular sky polygon aperture.
+        """
+        n_vertices = int(n_vertices)
+        if n_vertices < 3:
+            msg = f'n_vertices must be at least 3, got {n_vertices}'
+            raise ValueError(msg)
+
+        if (not isinstance(radius, u.Quantity)
+                or not radius.unit.is_equivalent(u.deg)):
+            msg = 'radius must be an angular Quantity'
+            raise TypeError(msg)
+
+        radius_arcsec = float(radius.to_value(u.arcsec))
+        if not np.isfinite(radius_arcsec) or radius_arcsec <= 0.0:
+            msg = f'radius must be a finite positive Quantity, got {radius}'
+            raise ValueError(msg)
+
+        if (not isinstance(theta, u.Quantity)
+                or not theta.unit.is_equivalent(u.deg)):
+            msg = 'theta must be an angular Quantity'
+            raise TypeError(msg)
+
+        theta_rad = float(theta.to_value(u.radian))
+        offsets_arcsec = _regular_polygon_offsets(n_vertices, radius_arcsec,
+                                                  theta_rad)
+        offsets = (offsets_arcsec * u.arcsec).to(radius.unit)
+
+        return cls(positions=positions, vertex_offsets=offsets)
+
+    @lazyproperty
+    def n_vertices(self):
+        """
+        The number of vertices of the polygon.
+        """
+        return int(self.vertex_offsets.shape[0])
+
+    @lazyproperty
+    def perimeter(self):
+        """
+        The angular perimeter of the polygon as a
+        `~astropy.units.Quantity`.
+
+        The perimeter is computed as the sum of the angular distances
+        between consecutive vertices on the local tangent plane.
+        """
+        offsets = self.vertex_offsets.to_value(u.arcsec)
+        diff = np.roll(offsets, -1, axis=0) - offsets
+        total = float(np.sum(np.hypot(diff[:, 0], diff[:, 1])))
+        return total * u.arcsec
+
+    @lazyproperty
+    def _regular_geometry(self):
+        """
+        Helper that computes the regular-polygon geometric properties
+        from the angular vertex offsets (in arcseconds).
+        """
+        return _RegularPolygonGeometry(
+            self.vertex_offsets.to_value(u.arcsec))
+
+    @lazyproperty
+    def is_regular(self):
+        """
+        `True` if the polygon is regular (equal-length sides and equal
+        interior angles, with all vertices at the same angular distance
+        from ``positions``).
+        """
+        return self._regular_geometry.is_regular
+
+    def _check_regular(self, name):
+        if not self.is_regular:
+            msg = (f'{name!r} is only defined for a regular polygon '
+                   'aperture')
+            raise ValueError(msg)
+
+    @lazyproperty
+    def outer_radius(self):
+        """
+        The angular outer (circumscribed-circle) radius of the regular
+        polygon as a `~astropy.units.Quantity`, i.e., the distance from
+        ``positions`` to each vertex.
+
+        This is also called the `circumradius
+        <https://mathworld.wolfram.com/Circumradius.html>`_.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('outer_radius')
+        return self._regular_geometry.outer_radius * u.arcsec
+
+    @lazyproperty
+    def inner_radius(self):
+        """
+        The angular inner (inscribed-circle) radius of the regular
+        polygon as a `~astropy.units.Quantity`, i.e., the distance from
+        ``positions`` to the midpoint of each side.
+
+        This is also called the `inradius
+        <https://mathworld.wolfram.com/Inradius.html>`_
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('inner_radius')
+        return self._regular_geometry.inner_radius * u.arcsec
+
+    @lazyproperty
+    def side_length(self):
+        """
+        The angular side length of the regular polygon as a
+        `~astropy.units.Quantity`.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('side_length')
+        return self._regular_geometry.side_length * u.arcsec
+
+    @lazyproperty
+    def interior_angle(self):
+        """
+        The interior angle of the regular polygon as an angular
+        `~astropy.units.Quantity` in degrees.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('interior_angle')
+        return self._regular_geometry.interior_angle
+
+    @lazyproperty
+    def exterior_angle(self):
+        """
+        The exterior angle of the regular polygon as an angular
+        `~astropy.units.Quantity` in degrees.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('exterior_angle')
+        return self._regular_geometry.exterior_angle
+
+    @lazyproperty
+    def theta(self):
+        """
+        The rotation angle of the regular polygon as an angular
+        `~astropy.units.Quantity` in degrees.
+
+        The angle is measured counter-clockwise from the ``+lat``
+        axis on the local tangent plane to the first vertex, in
+        the range ``[0, 360) deg``. This assumes a right-handed
+        coordinate system (e.g., standard celestial coordinates).
+        This convention matches the ``theta`` parameter of
+        `~SkyPolygonAperture.from_regular_polygon`.
+
+        This attribute is only defined for regular polygons. Accessing
+        it for a non-regular polygon raises `ValueError`.
+        """
+        self._check_regular('theta')
+        return self._regular_geometry.theta
+
+    @lazyproperty
+    def vertices(self):
+        """
+        The absolute sky vertices of the polygon at each aperture
+        position, as a `~astropy.coordinates.SkyCoord`.
+
+        For a scalar aperture, the returned SkyCoord has shape
+        ``(n_vertices,)``. For an aperture with ``n_positions``
+        positions, the returned SkyCoord has shape ``(n_positions,
+        n_vertices)``.
+        """
+        d_lon = self.vertex_offsets[:, 0]
+        d_lat = self.vertex_offsets[:, 1]
+
+        if self.isscalar:
+            return self.positions.spherical_offsets_by(d_lon, d_lat)
+
+        # Broadcast to shape (n_positions, n_vertices).
+        positions = self.positions[:, np.newaxis]
+        d_lon_b = d_lon[np.newaxis, :]
+        d_lat_b = d_lat[np.newaxis, :]
+
+        return positions.spherical_offsets_by(d_lon_b, d_lat_b)
+
+    def to_pixel(self, wcs):
+        """
+        Convert the aperture to a `PolygonAperture` object defined in
+        pixel coordinates.
+
+        The conversion uses ``wcs.world_to_pixel`` directly on the
+        absolute sky vertex coordinate, evaluated at the first aperture
+        position.
+
+        Parameters
+        ----------
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that
+            supports the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
+            (e.g., `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
+        Returns
+        -------
+        aperture : `PolygonAperture`
+            The equivalent pixel-coordinate polygon aperture.
+        """
+        xpos, ypos = wcs.world_to_pixel(self.positions)
+        positions = np.transpose((xpos, ypos))
+
+        first_skypos = self.positions if self.isscalar else self.positions[0]
+        first_x = float(np.atleast_1d(xpos)[0])
+        first_y = float(np.atleast_1d(ypos)[0])
+        d_lon = self.vertex_offsets[:, 0]
+        d_lat = self.vertex_offsets[:, 1]
+        abs_sky_vertices = first_skypos.spherical_offsets_by(d_lon, d_lat)
+        vx, vy = wcs.world_to_pixel(abs_sky_vertices)
+        offsets = np.column_stack([vx - first_x, vy - first_y])
+        return PolygonAperture(positions=positions,
+                               vertex_offsets=offsets)

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -11,6 +11,7 @@ from astropy.utils import lazyproperty
 from photutils.aperture.attributes import (ApertureAttribute, PixelPositions,
                                            SkyCoordPositions)
 from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.geometry._batch_photometry import SHAPE_POLYGON
 from photutils.geometry._polygon_overlap import polygon_overlap_grid
 
 __all__ = [
@@ -579,6 +580,12 @@ class PolygonAperture(PixelAperture):
         x_extent = float(np.max(np.abs(self.vertex_offsets[:, 0])))
         y_extent = float(np.max(np.abs(self.vertex_offsets[:, 1])))
         return x_extent, y_extent
+
+    def _batch_shape_params(self):
+        # The vertex offsets are counter-clockwise (normalized when the
+        # attribute is set) and flattened as (x0, y0, x1, y1, ...) for
+        # the batch Cython photometry driver.
+        return SHAPE_POLYGON, tuple(self.vertex_offsets.ravel())
 
     @lazyproperty
     def area(self):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -58,7 +58,9 @@ class RectangularMaskMixin:  # pragma: no cover
               continuous in the range [0, 1].
             * ``'center'``:
               Binary weighting based on the pixel center. Weights are
-              either 0 or 1.
+              either 0 or 1. A pixel is included only if its center lies
+              strictly inside the aperture; pixel centers lying exactly
+              on the aperture boundary are excluded (weight 0).
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -64,7 +64,10 @@ class RectangularMaskMixin:  # pragma: no cover
             * ``'subpixel'``:
               Approximates the overlap by averaging binary samples on a
               subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1].
+              parameter. Weights are discrete in the range [0, 1]. A
+              subpixel is included only if its center lies strictly
+              inside the aperture; subpixel centers lying exactly on the
+              aperture boundary are excluded (weight 0).
 
         subpixels : int, optional
             The subsampling factor per axis used when

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -164,7 +164,10 @@ class ApertureStats:
         * ``'subpixel'``:
           Approximates the overlap by averaging binary samples on a
           subgrid. The number of samples is set by the ``subpixels``
-          parameter. Weights are discrete in the range [0, 1].
+          parameter. Weights are discrete in the range [0, 1]. A
+          subpixel is included only if its center lies strictly inside
+          the aperture; subpixel centers lying exactly on the aperture
+          boundary are excluded (weight 0).
 
     subpixels : int, optional
         The subsampling factor per axis used when

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -158,7 +158,9 @@ class ApertureStats:
           continuous in the range [0, 1].
         * ``'center'``:
           Binary weighting based on the pixel center. Weights are
-          either 0 or 1.
+          either 0 or 1. A pixel is included only if its center lies
+          strictly inside the aperture; pixel centers lying exactly on
+          the aperture boundary are excluded (weight 0).
         * ``'subpixel'``:
           Approximates the overlap by averaging binary samples on a
           subgrid. The number of samples is set by the ``subpixels``

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_allclose
 from photutils.aperture.circle import CircularAnnulus, CircularAperture
 from photutils.aperture.core import PixelAperture
 from photutils.aperture.ellipse import EllipticalAnnulus, EllipticalAperture
+from photutils.aperture.polygon import PolygonAperture
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture)
 
@@ -40,6 +41,12 @@ APERTURES = [
     EllipticalAnnulus(POSITIONS, a_in=3.0, a_out=6.0, b_out=4.0, theta=-1.1),
     RectangularAperture(POSITIONS, w=7.0, h=4.0, theta=0.4),
     RectangularAnnulus(POSITIONS, w_in=3.0, w_out=8.0, h_out=5.0, theta=2.2),
+    PolygonAperture.from_regular_polygon(POSITIONS, 6, radius=5.5),
+    PolygonAperture(POSITIONS, [[-4.0, -3.0], [6.0, -2.0], [3.0, 5.0],
+                                [-5.0, 4.0]]),
+    # A non-convex (concave arrowhead) polygon offset shape
+    PolygonAperture(POSITIONS, [[-5.0, -4.0], [5.0, -4.0], [0.0, 6.0],
+                                [0.0, 0.0]]),
 ]
 
 METHODS = [('exact', 5), ('center', 5), ('subpixel', 1), ('subpixel', 7)]
@@ -118,6 +125,9 @@ def test_scalar_position():
     legacy mask-based code path for a single scalar position.
     """
     aperture = CircularAperture((70.0, 80.0), r=5.5)
+    assert_batch_matches_legacy(aperture, DATA, error=ERROR)
+
+    aperture = EllipticalAperture((70.0, 80.0), 10.124, 5.073)
     assert_batch_matches_legacy(aperture, DATA, error=ERROR)
 
 

--- a/photutils/aperture/tests/test_converters.py
+++ b/photutils/aperture/tests/test_converters.py
@@ -13,9 +13,10 @@ from numpy.testing import assert_allclose
 
 from photutils.aperture import (CircularAnnulus, CircularAperture,
                                 EllipticalAnnulus, EllipticalAperture,
-                                RectangularAnnulus, RectangularAperture,
-                                SkyCircularAnnulus, SkyCircularAperture,
-                                SkyEllipticalAnnulus, SkyEllipticalAperture,
+                                PolygonAperture, RectangularAnnulus,
+                                RectangularAperture, SkyCircularAnnulus,
+                                SkyCircularAperture, SkyEllipticalAnnulus,
+                                SkyEllipticalAperture, SkyPolygonAperture,
                                 SkyRectangularAnnulus, SkyRectangularAperture)
 from photutils.aperture.converters import (_scalar_aperture_to_region,
                                            _shapely_polygon_to_region,
@@ -75,9 +76,7 @@ def test_translation_circle(image_2d_wcs):
     assert aperture_sky.positions == region_sky.center  # SkyCoord
     assert_quantity_allclose(aperture_sky.r, region_sky.radius)
 
-    # NOTE: If these no longer fail, we also have to account for
-    # non-scalar inputs. Assume this is representative for the sky
-    # counterpart too.
+    # Check that non-scalar center and radius raise ValueError
     match = 'must be a scalar PixCoord'
     with pytest.raises(ValueError, match=match):
         CirclePixelRegion(center=PixCoord(x=[0, 42], y=[1, 43]), radius=4.2)
@@ -110,9 +109,8 @@ def test_translation_ellipse(image_2d_wcs):
     assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
                              region_sky.angle)
 
-    # NOTE: If these no longer fail, we also have to account for
-    # non-scalar inputs. Assume this is representative for the sky
-    # counterpart too.
+    # Check that non-scalar center, width, height, and angle raise
+    # ValueError
     match = 'must be a scalar PixCoord'
     with pytest.raises(ValueError, match=match):
         EllipsePixelRegion(
@@ -168,9 +166,8 @@ def test_translation_rectangle(image_2d_wcs):
     assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
                              region_sky.angle)
 
-    # NOTE: If these no longer fail, we also have to account for
-    # non-scalar inputs. Assume this is representative for the sky
-    # counterpart too.
+    # Check that non-scalar center, width, height, and angle raise
+    # ValueError
     match = 'must be a scalar PixCoord'
     with pytest.raises(ValueError, match=match):
         RectanglePixelRegion(
@@ -225,9 +222,8 @@ def test_translation_circle_annulus(image_2d_wcs):
     assert_quantity_allclose(aperture_sky.r_in, region_sky.inner_radius)
     assert_quantity_allclose(aperture_sky.r_out, region_sky.outer_radius)
 
-    # NOTE: If these no longer fail, we also have to account for
-    # non-scalar inputs. Assume this is representative for the sky
-    # counterpart too.
+    # Check that non-scalar center, inner_radius, and outer_radius raise
+    # ValueError
     match = 'must be a scalar PixCoord'
     with pytest.raises(ValueError, match=match):
         CircleAnnulusPixelRegion(
@@ -276,9 +272,8 @@ def test_translation_ellipse_annulus(image_2d_wcs):
     assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
                              region_sky.angle)
 
-    # NOTE: If these no longer fail, we also have to account for
-    # non-scalar inputs. Assume this is representative for the sky
-    # counterpart too.
+    # Check that non-scalar center, inner_width, inner_height,
+    # outer_width, outer_height, and angle raise ValueError
     match = 'must be a scalar PixCoord'
     with pytest.raises(ValueError, match=match):
         EllipseAnnulusPixelRegion(
@@ -369,9 +364,8 @@ def test_translation_rectangle_annulus(image_2d_wcs):
     assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
                              region_sky.angle)
 
-    # NOTE: If these no longer fail, we also have to account for
-    # non-scalar inputs. Assume this is representative for the sky
-    # counterpart too.
+    # Check that non-scalar center, inner_width, inner_height,
+    # outer_width, outer_height, and angle raise ValueError
     match = 'must be a scalar PixCoord'
     with pytest.raises(ValueError, match=match):
         RectangleAnnulusPixelRegion(
@@ -432,14 +426,32 @@ def test_translation_rectangle_annulus(image_2d_wcs):
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_translation_polygon():
+def test_translation_polygon(image_2d_wcs):
     from regions import PixCoord, PolygonPixelRegion
 
-    region_shape = PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 2],
-                                                        y=[1, 1, 2]))
-    match = r'Cannot convert .* to an Aperture object'
-    with pytest.raises(TypeError, match=match):
-        region_to_aperture(region_shape)
+    # Counter-clockwise simple (non-self-intersecting) quadrilateral.
+    x = [42, 50, 47, 40]
+    y = [43, 45, 52, 50]
+    region_shape = PolygonPixelRegion(vertices=PixCoord(x=x, y=y))
+    aperture = region_to_aperture(region_shape)
+    assert isinstance(aperture, PolygonAperture)
+    ref_vertices = np.column_stack((region_shape.vertices.x,
+                                    region_shape.vertices.y))
+    assert_allclose(aperture.vertices, ref_vertices)
+
+    region_sky = region_shape.to_sky(image_2d_wcs)
+    aperture_sky = region_to_aperture(region_sky)
+    assert isinstance(aperture_sky, SkyPolygonAperture)
+    # The inverted RA axis flips the polygon orientation, so the
+    # counter-clockwise normalization reverses the vertex order. Compare
+    # the vertices independently of their ordering.
+    ap_verts = np.column_stack((aperture_sky.vertices.ra.deg,
+                                aperture_sky.vertices.dec.deg))
+    reg_verts = np.column_stack((region_sky.vertices.ra.deg,
+                                 region_sky.vertices.dec.deg))
+    ap_sorted = ap_verts[np.lexsort((ap_verts[:, 1], ap_verts[:, 0]))]
+    reg_sorted = reg_verts[np.lexsort((reg_verts[:, 1], reg_verts[:, 0]))]
+    assert_allclose(ap_sorted, reg_sorted, atol=1e-9)
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
@@ -450,6 +462,14 @@ def test_aperture_to_region():
     ra, dec = np.transpose(xypos)
     skycoord = SkyCoord(ra=ra, dec=dec, unit='deg')
     unit = u.arcsec
+
+    # A square polygon centered on each position (zero-centroid offsets
+    # so the pixel round-trip is exact).
+    poly_offsets = np.array([(-5.0, -5.0), (5.0, -5.0),
+                             (5.0, 5.0), (-5.0, 5.0)])
+    theta = np.linspace(0.0, 2 * np.pi, 5, endpoint=False)
+    sky_poly_offsets = np.column_stack([3.0 * np.cos(theta),
+                                        3.0 * np.sin(theta)]) * unit
 
     apertures = [CircularAperture(xypos, r=3.0),
                  CircularAnnulus(xypos, r_in=3.0, r_out=7.0),
@@ -471,7 +491,10 @@ def test_aperture_to_region():
                                         theta=30 * u.deg),
                  SkyRectangularAnnulus(skycoord, w_in=10.0 * unit,
                                        w_out=20.0 * unit, h_out=17.0 * unit,
-                                       theta=60 * u.deg)]
+                                       theta=60 * u.deg),
+                 PolygonAperture(xypos, poly_offsets),
+                 SkyPolygonAperture(skycoord, sky_poly_offsets),
+                 ]
 
     for aperture in apertures:
         region0 = aperture_to_region(aperture[0])
@@ -482,7 +505,18 @@ def test_aperture_to_region():
         assert len(region) == len(aperture)
 
         aper0 = region_to_aperture(region0)
-        assert aper0 == aperture[0]
+        if isinstance(aperture, SkyPolygonAperture):
+            # The sky polygon round-trip recomputes the centroid from
+            # the vertices, so positions and offsets match only to
+            # within floating-point tolerance.
+            assert isinstance(aper0, SkyPolygonAperture)
+            sep = aper0.positions.separation(aperture[0].positions)
+            assert_quantity_allclose(sep, 0 * u.deg, atol=1e-9 * u.arcsec)
+            assert_quantity_allclose(aper0.vertex_offsets,
+                                     aperture[0].vertex_offsets,
+                                     atol=1e-9 * u.arcsec)
+        else:
+            assert aper0 == aperture[0]
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')

--- a/photutils/aperture/tests/test_exact_area_photometry.py
+++ b/photutils/aperture/tests/test_exact_area_photometry.py
@@ -6,9 +6,9 @@ apertures.
 When the data array is all ones, the photometric sum returned by an
 aperture in exact mode must equal the analytic geometric area of the
 aperture shape (up to floating-point error). These tests verify this
-invariant for circular, elliptical, and rectangular apertures (including
-their annulus counterparts), across a variety of shapes, rotation
-angles, and sub-pixel positions.
+invariant for circular, elliptical, rectangular, and polygon apertures
+(including their annulus counterparts), across a variety of shapes,
+rotation angles, sub-pixel positions, and convex/non-convex polygons.
 """
 
 import numpy as np
@@ -17,8 +17,8 @@ from numpy.testing import assert_allclose
 
 from photutils.aperture import (CircularAnnulus, CircularAperture,
                                 EllipticalAnnulus, EllipticalAperture,
-                                RectangularAnnulus, RectangularAperture,
-                                aperture_photometry)
+                                PolygonAperture, RectangularAnnulus,
+                                RectangularAperture, aperture_photometry)
 
 
 def _phot_sum(aperture, data=None):
@@ -82,3 +82,83 @@ def test_rectangular_annulus_exact_area(w_in, w_out, h_out, theta_deg):
     aper = RectangularAnnulus((50.0, 50.0), w_in=w_in, w_out=w_out,
                               h_out=h_out, theta=np.deg2rad(theta_deg))
     assert_allclose(_phot_sum(aper), aper.area, rtol=1e-12, atol=1e-12)
+
+
+# Polygon shape library: (name, vertex_offsets) - each polygon is
+# centered at the origin so it can be placed at arbitrary positions.
+def _triangle():
+    # Equilateral triangle with circumradius 4.
+    angles = np.pi / 2 + np.arange(3) * 2 * np.pi / 3
+    return np.column_stack([4.0 * np.cos(angles), 4.0 * np.sin(angles)])
+
+
+def _hexagon():
+    angles = np.arange(6) * np.pi / 3
+    return np.column_stack([5.0 * np.cos(angles), 5.0 * np.sin(angles)])
+
+
+def _l_shape():
+    # Non-convex L-shape (centered).
+    return np.array([[-2.0, -2.0], [2.0, -2.0], [2.0, 0.0],
+                     [0.0, 0.0], [0.0, 2.0], [-2.0, 2.0]])
+
+
+def _star_5():
+    # Non-convex 5-pointed star.
+    verts = []
+    for i in range(10):
+        r = 5.0 if i % 2 == 0 else 2.0
+        a = np.pi / 2 + i * np.pi / 5
+        verts.append((r * np.cos(a), r * np.sin(a)))
+    return np.array(verts)
+
+
+def _arrow():
+    # Non-convex arrow shape.
+    return np.array([[-3.0, -1.0], [1.0, -1.0], [1.0, -2.0],
+                     [3.0, 0.0], [1.0, 2.0], [1.0, 1.0],
+                     [-3.0, 1.0]])
+
+
+def _rotate(verts, theta_deg):
+    c = np.cos(np.deg2rad(theta_deg))
+    s = np.sin(np.deg2rad(theta_deg))
+    rot = np.array([[c, -s], [s, c]])
+    return verts @ rot.T
+
+
+POLY_SHAPES = {
+    'triangle': _triangle(),
+    'hexagon': _hexagon(),
+    'l_shape': _l_shape(),
+    'star_5': _star_5(),
+    'arrow': _arrow(),
+}
+
+
+@pytest.mark.parametrize('shape_name', list(POLY_SHAPES))
+@pytest.mark.parametrize('center', [(50.0, 50.0), (50.5, 50.5),
+                                    (50.123, 49.876)])
+@pytest.mark.parametrize('theta_deg', [0.0, 23.5, 60.0])
+def test_polygon_aperture_exact_area(shape_name, center, theta_deg):
+    offsets = _rotate(POLY_SHAPES[shape_name], theta_deg)
+    aper = PolygonAperture(center, offsets)
+    assert_allclose(_phot_sum(aper), aper.area, rtol=1e-12, atol=1e-12)
+
+
+def test_polygon_aperture_exact_area_multiple_positions():
+    """
+    Test that the exact area is returned for multiple positions.
+
+    The photometric sum should equal the area regardless of the
+    position.
+    """
+    offsets = _hexagon()
+    positions = [(30.0, 40.0), (50.5, 50.5), (70.123, 60.876)]
+    aper = PolygonAperture(positions, offsets)
+    shape = (101, 101)
+    data = np.ones(shape, dtype=float)
+    table = aperture_photometry(data, aper, method='exact')
+    expected = aper.area
+    assert_allclose(table['aperture_sum'], expected, rtol=1e-12,
+                    atol=1e-12)

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -17,6 +17,7 @@ from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus,
                                         SkyEllipticalAperture)
 from photutils.aperture.photometry import aperture_photometry
+from photutils.aperture.polygon import PolygonAperture
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture,
                                           SkyRectangularAnnulus,
@@ -221,6 +222,19 @@ class TestRectangularAnnulus(BaseTestAperturePhotometry):
         self.aperture = RectangularAnnulus(position, w_in, w_out, h_out,
                                            theta=theta)
         self.area = h_out * w_out - h_in * w_in
+        self.true_flux = self.area
+
+
+class TestPolygon(BaseTestAperturePhotometry):
+    def setup_class(self):
+        self.data = np.ones((40, 40), dtype=float)
+        position = (20.0, 20.0)
+        n_vertices = 5
+        radius = 6.0
+        theta = 30 * u.deg
+        self.aperture = PolygonAperture.from_regular_polygon(
+            position, n_vertices, radius, theta=theta)
+        self.area = self.aperture.area
         self.true_flux = self.area
 
 
@@ -793,13 +807,8 @@ class BaseTestRegionPhotometry:
                                        strict=True):
             assert_allclose(reg_table['aperture_sum'],
                             ap_table['aperture_sum'])
-
-        if isinstance(self.aperture, (RectangularAperture,
-                                      RectangularAnnulus)):
-            for reg_table, ap_table in zip(region_tables, aperture_tables,
-                                           strict=True):
-                assert_allclose(reg_table['aperture_sum_err'],
-                                ap_table['aperture_sum_err'])
+            assert_allclose(reg_table['aperture_sum_err'],
+                            ap_table['aperture_sum_err'])
 
 
 def test_invalid_inputs():
@@ -918,9 +927,10 @@ class TestRectangleAnnulusRegionPhotometry(BaseTestRegionPhotometry):
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
 def test_unsupported_region_input():
-    from regions import PixCoord, PolygonPixelRegion
+    from regions import LinePixelRegion, PixCoord
 
-    region = PolygonPixelRegion(vertices=PixCoord(x=[1, 2, 3], y=[1, 1, 2]))
+    region = LinePixelRegion(start=PixCoord(x=1, y=1),
+                             end=PixCoord(x=5, y=5))
     data = np.ones((10, 10))
     match = r'Cannot convert .* to an Aperture object'
     with pytest.raises(TypeError, match=match):

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -1,0 +1,996 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the polygon aperture module.
+"""
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.wcs import WCS
+from numpy.testing import assert_allclose
+
+from photutils.aperture.polygon import (PolygonAperture, SkyPolygonAperture,
+                                        _polygon_is_simple,
+                                        _segments_intersect,
+                                        _signed_polygon_area,
+                                        _validate_simple_polygon,
+                                        _vertices_centroid)
+from photutils.aperture.rectangle import RectangularAperture
+from photutils.aperture.tests.test_aperture_common import BaseTestAperture
+from photutils.utils._optional_deps import HAS_MATPLOTLIB
+
+POSITIONS = [(10.0, 20.0), (30.0, 40.0), (50.0, 60.0), (70.0, 80.0)]
+RA, DEC = np.transpose(POSITIONS)
+SKYCOORD = SkyCoord(ra=RA, dec=DEC, unit='deg')
+UNIT = u.arcsec
+SQUARE_OFFSETS = np.array([[-1.0, -1.0], [1.0, -1.0],
+                           [1.0, 1.0], [-1.0, 1.0]])
+TRIANGLE_OFFSETS = np.array([[0.0, -1.0], [1.0, 1.0], [-1.0, 1.0]])
+
+
+def _make_wcs():
+    """
+    Tangent-plane WCS at (180, 0).
+    """
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [50.5, 50.5]
+    wcs.wcs.cdelt = [-0.01, 0.01]
+    wcs.wcs.crval = [180.0, 0.0]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+
+    return wcs
+
+
+def test_signed_polygon_area_ccw_positive():
+    verts = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    assert_allclose(_signed_polygon_area(verts), 1.0)
+
+
+def test_signed_polygon_area_cw_negative():
+    verts = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]])
+    assert_allclose(_signed_polygon_area(verts), -1.0)
+
+
+def test_vertices_centroid_square():
+    verts = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]])
+    assert_allclose(_vertices_centroid(verts), [2.0, 2.0])
+
+
+def test_validate_simple_polygon_reorders_clockwise():
+    cw = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]])
+    out = _validate_simple_polygon(cw)
+    # Expect CCW order
+    assert _signed_polygon_area(out) > 0
+
+
+def test_validate_simple_polygon_rejects_wrong_shape():
+    with pytest.raises(ValueError, match='must have shape'):
+        _validate_simple_polygon(np.array([1.0, 2.0, 3.0]))
+
+
+def test_validate_simple_polygon_rejects_too_few():
+    with pytest.raises(ValueError, match='at least 3 vertices'):
+        _validate_simple_polygon(np.array([[0.0, 0.0], [1.0, 0.0]]))
+
+
+def test_validate_simple_polygon_rejects_nonfinite():
+    bad = np.array([[0.0, 0.0], [np.nan, 0.0], [1.0, 1.0]])
+    with pytest.raises(ValueError, match='non-finite'):
+        _validate_simple_polygon(bad)
+
+
+def test_validate_simple_polygon_rejects_collinear():
+    bad = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
+    with pytest.raises(ValueError, match='degenerate'):
+        _validate_simple_polygon(bad)
+
+
+def test_validate_simple_polygon_accepts_nonconvex():
+    """
+    Test that a non-convex (L-shaped) polygon is accepted.
+    """
+    arrow = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 2.0],
+                      [2.0, 2.0], [2.0, 4.0], [0.0, 4.0]])
+    out = _validate_simple_polygon(arrow)
+    assert out.shape == arrow.shape
+
+
+def _pentagram():
+    """
+    A five-pointed (self-intersecting) star drawn by connecting every
+    other vertex of a regular pentagon.
+
+    Its edges self-intersect, but its signed area is non-zero so it is
+    not caught by the degeneracy check.
+    """
+    ang = np.pi / 2 + np.arange(5) * 2 * np.pi * 2 / 5
+    return np.column_stack([np.cos(ang), np.sin(ang)])
+
+
+def _concave_star():
+    """
+    A ten-pointed star outline (alternating inner/outer radii). It is
+    concave but simple (non-self-intersecting).
+    """
+    ang = np.pi / 2 + np.arange(10) * np.pi / 5
+    radius = np.where(np.arange(10) % 2 == 0, 5.0, 2.0)
+    return np.column_stack([radius * np.cos(ang), radius * np.sin(ang)])
+
+
+def test_polygon_is_simple_true_for_square():
+    assert _polygon_is_simple(SQUARE_OFFSETS)
+
+
+def test_polygon_is_simple_true_for_concave_star():
+    assert _polygon_is_simple(_concave_star())
+
+
+def test_polygon_is_simple_false_for_pentagram():
+    star = _pentagram()
+    # Sanity check: the pentagram has non-zero area, so it is not caught
+    # by the degeneracy check and must be rejected by the simplicity
+    # check.
+    assert _signed_polygon_area(star) != 0.0
+    assert not _polygon_is_simple(star)
+
+
+def test_validate_simple_polygon_rejects_self_intersecting():
+    with pytest.raises(ValueError, match='self-intersect'):
+        _validate_simple_polygon(_pentagram())
+
+
+def test_pixel_polygon_rejects_self_intersecting():
+    with pytest.raises(ValueError, match='self-intersect'):
+        PolygonAperture((0.0, 0.0), _pentagram())
+
+
+def test_sky_polygon_rejects_self_intersecting():
+    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+    with pytest.raises(ValueError, match='self-intersect'):
+        SkyPolygonAperture(pos, _pentagram() * u.arcsec)
+
+
+def test_pixel_polygon_accepts_concave_star():
+    aper = PolygonAperture((0.0, 0.0), _concave_star())
+    assert aper.vertex_offsets.shape == (10, 2)
+
+
+@pytest.mark.parametrize(
+    ('p1', 'p2', 'p3', 'p4', 'expected'),
+    [
+        # Proper crossing (segments straddle each other).
+        ((0.0, 0.0), (2.0, 2.0), (0.0, 2.0), (2.0, 0.0), True),
+        # Disjoint, non-collinear segments.
+        ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0), False),
+        # p1 lies on segment p3-p4 (d1 == 0).
+        ((1.0, 0.0), (1.0, 1.0), (0.0, 0.0), (2.0, 0.0), True),
+        # p2 lies on segment p3-p4 (d2 == 0).
+        ((1.0, 1.0), (1.0, 0.0), (0.0, 0.0), (2.0, 0.0), True),
+        # p3 lies on segment p1-p2 (d3 == 0).
+        ((0.0, 0.0), (2.0, 0.0), (1.0, 0.0), (1.0, 1.0), True),
+        # p4 lies on segment p1-p2 (d4 == 0).
+        ((0.0, 0.0), (2.0, 0.0), (1.0, 1.0), (1.0, 0.0), True),
+        # Collinear but non-overlapping segments.
+        ((0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0), False),
+    ])
+def test_segments_intersect(p1, p2, p3, p4, expected):
+    assert _segments_intersect(p1, p2, p3, p4) is expected
+
+
+class TestPolygonAperture(BaseTestAperture):
+    aperture = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
+
+    def test_index(self):
+        aper = self.aperture[2]
+        assert isinstance(aper, PolygonAperture)
+        assert aper.isscalar
+        assert_allclose(aper.positions, self.aperture.positions[2])
+        assert_allclose(aper.vertex_offsets, self.aperture.vertex_offsets)
+
+    def test_slice(self):
+        aper = self.aperture[0:2]
+        assert isinstance(aper, PolygonAperture)
+        assert len(aper) == 2
+        assert_allclose(aper.positions, self.aperture.positions[0:2])
+        assert_allclose(aper.vertex_offsets, self.aperture.vertex_offsets)
+
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.vertex_offsets = SQUARE_OFFSETS * 2
+        assert aper != self.aperture
+
+    def test_repr(self):
+        assert 'PolygonAperture' in repr(self.aperture)
+        assert 'PolygonAperture' in str(self.aperture)
+
+    def test_perimeter(self):
+        # Unit square (side 2) has perimeter 8.
+        assert_allclose(self.aperture.perimeter, 8.0)
+
+    def test_perimeter_triangle(self):
+        aper = PolygonAperture((0.0, 0.0), TRIANGLE_OFFSETS)
+        expected = 2.0 * np.sqrt(5.0) + 2.0
+        assert_allclose(aper.perimeter, expected, rtol=1e-12)
+
+    def test_perimeter_regular_polygon(self):
+        # Regular hexagon: perimeter = n * 2 * r * sin(pi / n).
+        aper = PolygonAperture.from_regular_polygon((0.0, 0.0), 6, 5.0)
+        expected = 6.0 * 2.0 * 5.0 * np.sin(np.pi / 6)
+        assert_allclose(aper.perimeter, expected, rtol=1e-12)
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_plot(self):
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        self.aperture.plot(ax=ax)
+        plt.close(fig)
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_plot_returns_patches(self):
+        from matplotlib.patches import Patch
+
+        patches = self.aperture._to_patch()
+        assert isinstance(patches, list)
+        for patch in patches:
+            assert isinstance(patch, Patch)
+
+
+def test_construct_scalar():
+    aper = PolygonAperture((10.0, 20.0), SQUARE_OFFSETS)
+    assert aper.isscalar
+    assert aper.shape == ()
+    assert aper.vertex_offsets.shape == (4, 2)
+    assert_allclose(aper.area, 4.0)
+    assert aper._xy_extents == (1.0, 1.0)
+
+
+def test_construct_array_positions():
+    aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
+    assert not aper.isscalar
+    assert aper.shape == (4,)
+    assert len(aper) == 4
+    assert aper.vertices.shape == (4, 4, 2)
+    expected_first = np.asarray(POSITIONS[0]) + SQUARE_OFFSETS
+    assert_allclose(aper.vertices[0], expected_first)
+
+
+def test_vertices_scalar():
+    aper = PolygonAperture((10.0, 20.0), SQUARE_OFFSETS)
+    assert aper.vertices.shape == (4, 2)
+    assert_allclose(aper.vertices, np.array([10.0, 20.0]) + SQUARE_OFFSETS)
+
+
+def test_vertex_offsets_normalized_to_ccw():
+    cw = SQUARE_OFFSETS[::-1].copy()
+    aper = PolygonAperture((0, 0), cw)
+    assert _signed_polygon_area(aper.vertex_offsets) > 0
+
+
+def test_invalid_vertex_offsets_quantity_raises():
+    match = 'must not be a Quantity'
+    with pytest.raises(TypeError, match=match):
+        PolygonAperture((0, 0), SQUARE_OFFSETS * u.pix)
+
+
+def test_invalid_vertex_offsets_nonfinite_raises():
+    bad = np.array([[0.0, 0.0], [np.nan, 1.0], [1.0, 0.0]])
+    with pytest.raises(ValueError, match='non-finite'):
+        PolygonAperture((0, 0), bad)
+
+
+def test_polygon_aperture_accepts_nonconvex():
+    """
+    The aperture supports non-convex (L-shaped) polygons.
+    """
+    l_shape = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 2.0],
+                        [2.0, 2.0], [2.0, 4.0], [0.0, 4.0]])
+    aper = PolygonAperture((0.0, 0.0), l_shape)
+    assert aper.vertex_offsets.shape == (6, 2)
+    assert_allclose(aper.area, 12.0)
+    mask = aper.to_mask(method='exact')
+    assert_allclose(mask.data.sum(), 12.0, atol=1e-12)
+
+
+def test_invalid_vertex_offsets_too_few_raises():
+    match = 'at least 3 vertices'
+    with pytest.raises(ValueError, match=match):
+        PolygonAperture((0, 0), [[0.0, 0.0], [1.0, 1.0]])
+
+
+def test_invalid_vertex_offsets_unparseable():
+    match = 'must be convertible to a numeric'
+    with pytest.raises(TypeError, match=match):
+        PolygonAperture((0, 0), [['a', 'b'], ['c', 'd'], ['e', 'f']])
+
+
+def test_from_vertices_round_trip():
+    verts = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]])
+    aper = PolygonAperture.from_vertices(verts)
+    assert_allclose(aper.vertices, verts)
+
+
+def test_from_vertices_invalid_shape():
+    match = 'vertices must have shape'
+    with pytest.raises(ValueError, match=match):
+        PolygonAperture.from_vertices(np.array([1.0, 2.0]))
+
+
+def test_from_vertices_rejects_degenerate():
+    """
+    Test that ``from_vertices`` rejects collinear vertices.
+
+    The ``from_vertices`` method must raise a clean ValueError
+    rather than a ZeroDivisionError from the area-weighted centroid
+    computation.
+    """
+    match = 'degenerate'
+    with pytest.raises(ValueError, match=match):
+        PolygonAperture.from_vertices([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
+
+
+def test_to_mask_exact_matches_rectangle():
+    """
+    Test that exact polygon mask for a square equals the rectangular
+    result.
+    """
+    poly = PolygonAperture((5.0, 5.0), SQUARE_OFFSETS)
+    rect = RectangularAperture((5.0, 5.0), w=2.0, h=2.0)
+    assert_allclose(poly.to_mask(method='exact').data,
+                    rect.to_mask(method='exact').data)
+
+
+def test_to_mask_subpixel_approximates_exact():
+    poly = PolygonAperture((5.5, 5.5), TRIANGLE_OFFSETS)
+    exact = poly.to_mask(method='exact').data
+    sub = poly.to_mask(method='subpixel', subpixels=32).data
+    assert np.abs(exact - sub).max() < 0.05
+
+
+def test_to_mask_center_method():
+    poly = PolygonAperture((5.0, 5.0), SQUARE_OFFSETS)
+    mask = poly.to_mask(method='center').data
+    assert set(np.unique(mask)).issubset({0.0, 1.0})
+
+
+def test_to_mask_center_matches_rectangle():
+    """
+    Test that the ``center`` mask for a rectangle matches the equivalent
+    polygon.
+
+    A `RectangularAperture` and a `PolygonAperture` built from the same
+    four corners must produce identical ``center`` masks. This includes
+    pixel centers that lie exactly on the aperture boundary, which both
+    apertures must exclude.
+    """
+    shape = (12, 12)
+
+    # Axis-aligned rectangle whose edges fall exactly on pixel centers
+    # (x in [1, 5], y in [2, 4]), so many pixel centers lie on the
+    # boundary and must be excluded by both apertures.
+    rect = RectangularAperture((3.0, 3.0), w=4.0, h=2.0)
+    corners = [(1.0, 2.0), (5.0, 2.0), (5.0, 4.0), (1.0, 4.0)]
+    poly = PolygonAperture.from_vertices(corners)
+    rect_mask = rect.to_mask(method='center').to_image(shape)
+    poly_mask = poly.to_mask(method='center').to_image(shape)
+    assert_allclose(poly_mask, rect_mask)
+
+    # Boundary centers are excluded: only the strictly interior centers
+    # (x in {2, 3, 4}, y = 3) are counted.
+    assert rect_mask.sum() == 3
+
+    # Rotated rectangle, compared against the equivalent polygon.
+    theta = 0.6
+    cos_t, sin_t = np.cos(theta), np.sin(theta)
+    half_w, half_h = 2.5, 1.5
+    local = [(-half_w, -half_h), (half_w, -half_h),
+             (half_w, half_h), (-half_w, half_h)]
+    abs_corners = [(6.0 + x * cos_t - y * sin_t,
+                    6.0 + x * sin_t + y * cos_t) for x, y in local]
+    rect2 = RectangularAperture((6.0, 6.0), w=5.0, h=3.0, theta=theta)
+    poly2 = PolygonAperture.from_vertices(abs_corners)
+    rect2_mask = rect2.to_mask(method='center').to_image(shape)
+    poly2_mask = poly2.to_mask(method='center').to_image(shape)
+    assert_allclose(poly2_mask, rect2_mask)
+
+
+def test_to_mask_array_returns_list():
+    aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
+    masks = aper.to_mask(method='exact')
+    assert isinstance(masks, list)
+    assert len(masks) == len(POSITIONS)
+
+
+def test_indexing_and_iteration():
+    aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
+    one = aper[1]
+    assert one.isscalar
+    assert_allclose(one.positions, POSITIONS[1])
+    assert_allclose(one.vertex_offsets, aper.vertex_offsets)
+    assert list(aper)[0].isscalar
+    sliced = aper[0:2]
+    assert len(sliced) == 2
+
+
+def test_indexing_scalar_raises():
+    aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+    match = 'cannot be indexed'
+    with pytest.raises(TypeError, match=match):
+        aper[0]
+    match = 'no len'
+    with pytest.raises(TypeError, match=match):
+        len(aper)
+
+
+def test_do_photometry():
+    data = np.ones((30, 30))
+    aper = PolygonAperture((10.0, 10.0), SQUARE_OFFSETS)
+    flux, _ = aper.do_photometry(data, method='exact')
+    assert_allclose(flux, [4.0])
+
+
+@pytest.mark.parametrize(('method', 'kwargs'),
+                         [('exact', {}),
+                          ('subpixel', {'subpixels': 7}),
+                          ('center', {})])
+def test_array_photometry_matches_scalar(method, kwargs):
+    """
+    Test that multi-position polygon photometry (batch Cython driver)
+    matches the per-position mask-based (grid) result for the exact,
+    subpixel, and center methods, including for a non-convex polygon.
+
+    This exercises the batch driver's per-position buffer reuse and
+    confirms it is numerically identical to the ``polygon_overlap_grid``
+    code path used by ``to_mask``.
+    """
+    rng = np.random.default_rng(0)
+    data = rng.random((60, 60))
+    positions = [(15.0, 18.0), (30.0, 32.0), (45.0, 22.0)]
+    offsets = _concave_star()
+
+    aper = PolygonAperture(positions, offsets)
+    multi, _ = aper.do_photometry(data, method=method, **kwargs)
+
+    ref = [PolygonAperture(pos, offsets)
+           .to_mask(method=method, **kwargs).multiply(data).sum()
+           for pos in positions]
+    assert_allclose(multi, ref, rtol=1e-12)
+
+
+def test_invalid_mask_method():
+    aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+    match = 'Invalid mask method'
+    with pytest.raises(ValueError, match=match):
+        aper.to_mask(method='nonsense')
+
+
+@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+def test_to_patch_scalar():
+    import matplotlib.patches as mpatches
+    aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+    patch = aper._to_patch()
+    assert isinstance(patch, mpatches.Polygon)
+
+
+class TestSkyPolygonAperture(BaseTestAperture):
+    aperture = SkyPolygonAperture(SKYCOORD, SQUARE_OFFSETS * UNIT)
+
+    def test_index(self):
+        aper = self.aperture[2]
+        assert isinstance(aper, SkyPolygonAperture)
+        assert aper.isscalar
+        assert_quantity_allclose(aper.positions.ra,
+                                 self.aperture.positions[2].ra)
+        assert_quantity_allclose(aper.vertex_offsets,
+                                 self.aperture.vertex_offsets)
+
+    def test_slice(self):
+        aper = self.aperture[0:2]
+        assert isinstance(aper, SkyPolygonAperture)
+        assert len(aper) == 2
+        assert_quantity_allclose(aper.positions.ra,
+                                 self.aperture.positions[0:2].ra)
+        assert_quantity_allclose(aper.vertex_offsets,
+                                 self.aperture.vertex_offsets)
+
+    def test_copy_eq(self):
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        aper.vertex_offsets = SQUARE_OFFSETS * 2 * UNIT
+        assert aper != self.aperture
+
+    def test_perimeter(self):
+        # Unit square (side 2 arcsec): perimeter = 8 arcsec.
+        assert_quantity_allclose(self.aperture.perimeter, 8.0 * u.arcsec)
+
+    def test_perimeter_triangle(self):
+        aper = SkyPolygonAperture(SKYCOORD[0], TRIANGLE_OFFSETS * u.arcsec)
+        expected = (2.0 * np.sqrt(5.0) + 2.0) * u.arcsec
+        assert_quantity_allclose(aper.perimeter, expected, rtol=1e-12)
+
+    def test_perimeter_unit(self):
+        assert self.aperture.perimeter.unit == u.arcsec
+
+    def test_perimeter_regular_polygon(self):
+        # Regular hexagon: perimeter = n * 2 * r * sin(pi / n).
+        aper = SkyPolygonAperture.from_regular_polygon(
+            SKYCOORD[0], 6, 5.0 * u.arcsec)
+        expected = 6.0 * 2.0 * 5.0 * np.sin(np.pi / 6) * u.arcsec
+        assert_quantity_allclose(aper.perimeter, expected, rtol=1e-12)
+
+
+def test_sky_construct():
+    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+    offsets = TRIANGLE_OFFSETS * u.arcsec
+    aper = SkyPolygonAperture(pos, offsets)
+    assert aper.isscalar
+    assert aper.vertex_offsets.unit.is_equivalent(u.arcsec)
+
+
+def test_sky_invalid_offsets_not_quantity():
+    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+    match = 'angular Quantity'
+    with pytest.raises(TypeError, match=match):
+        SkyPolygonAperture(pos, TRIANGLE_OFFSETS)
+
+
+def test_sky_invalid_offsets_wrong_unit():
+    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+    match = 'angular units'
+    with pytest.raises(u.UnitsError, match=match):
+        SkyPolygonAperture(pos, TRIANGLE_OFFSETS * u.m)
+
+
+def test_sky_invalid_offsets_wrong_shape():
+    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+    match = 'shape'
+    with pytest.raises(ValueError, match=match):
+        SkyPolygonAperture(pos, TRIANGLE_OFFSETS.flatten() * u.arcsec)
+
+
+def test_sky_invalid_positions():
+    with pytest.raises(TypeError, match='SkyCoord'):
+        SkyPolygonAperture((1.0, 2.0), TRIANGLE_OFFSETS * u.arcsec)
+
+
+def test_sky_vertices_scalar():
+    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+    offsets = SQUARE_OFFSETS * u.arcsec
+    aper = SkyPolygonAperture(pos, offsets)
+    assert aper.vertices.shape == (4,)
+
+
+def test_sky_vertices_array():
+    pos = SkyCoord(ra=[180.0, 181.0], dec=[0.0, 1.0], unit='deg')
+    offsets = SQUARE_OFFSETS * u.arcsec
+    aper = SkyPolygonAperture(pos, offsets)
+    assert aper.vertices.shape == (2, 4)
+
+
+def test_sky_from_vertices_round_trip():
+    verts = SkyCoord(ra=[180.0, 180.001, 180.0],
+                     dec=[0.0, 0.0, 0.001], unit='deg')
+    aper = SkyPolygonAperture.from_vertices(verts)
+    assert_quantity_allclose(aper.vertices.ra, verts.ra, atol=1e-9 * u.deg)
+    assert_quantity_allclose(aper.vertices.dec, verts.dec, atol=1e-9 * u.deg)
+
+
+def test_sky_from_vertices_requires_skycoord():
+    with pytest.raises(TypeError, match='SkyCoord'):
+        SkyPolygonAperture.from_vertices(np.array([[0.0, 0.0], [1.0, 0.0],
+                                                   [1.0, 1.0]]))
+
+
+def test_pixel_to_sky_to_pixel_round_trip():
+    """
+    Test that round-trip through to_sky / to_pixel reproduces original.
+    """
+    wcs = _make_wcs()
+    aper = PolygonAperture([(50.0, 50.0), (60.0, 60.0)], SQUARE_OFFSETS)
+    sky = aper.to_sky(wcs)
+    back = sky.to_pixel(wcs)
+    assert_allclose(back.positions, aper.positions, atol=1e-9)
+    assert_allclose(back.vertex_offsets, aper.vertex_offsets, atol=1e-9)
+
+
+def test_pixel_to_sky_scalar():
+    wcs = _make_wcs()
+    aper = PolygonAperture((50.0, 50.0), SQUARE_OFFSETS)
+    sky = aper.to_sky(wcs)
+    assert sky.isscalar
+    back = sky.to_pixel(wcs)
+    assert_allclose(back.positions, aper.positions, atol=1e-9)
+
+
+def test_to_sky_vertices_match_pixel_to_world():
+    """
+    For a scalar polygon, the absolute sky vertices from ``to_sky``
+    match feeding the absolute pixel vertices directly to
+    ``wcs.pixel_to_world``.
+
+    The comparison is order-independent. The ``_make_wcs`` WCS flips
+    parity, so the counter-clockwise normalization applied when setting
+    ``vertex_offsets`` may reverse the vertex order relative to the
+    input. The two sets of vertices must still describe the same
+    polygon.
+    """
+    wcs = _make_wcs()
+    aper = PolygonAperture((50.0, 50.0), SQUARE_OFFSETS)
+
+    abs_pix = aper.vertices
+    direct = wcs.pixel_to_world(abs_pix[:, 0], abs_pix[:, 1])
+    got = aper.to_sky(wcs).vertices
+
+    # Each direct vertex must coincide with one of the to_sky vertices
+    nearest = [np.min(coord.separation(got).to_value(u.arcsec))
+               for coord in direct]
+    assert_allclose(nearest, 0.0, atol=1e-9)
+
+
+def test_sky_to_pixel_to_sky_round_trip():
+    """
+    Test that round-trip through to_pixel / to_sky reproduces the
+    original sky aperture.
+    """
+    wcs = _make_wcs()
+    positions = SkyCoord(ra=[180.0, 180.01], dec=[0.0, 0.01], unit='deg')
+    aper = SkyPolygonAperture(positions, SQUARE_OFFSETS * u.arcsec)
+    pixel = aper.to_pixel(wcs)
+    back = pixel.to_sky(wcs)
+    assert_quantity_allclose(back.positions.ra, aper.positions.ra,
+                             atol=1e-9 * u.deg)
+    assert_quantity_allclose(back.positions.dec, aper.positions.dec,
+                             atol=1e-9 * u.deg)
+    assert_quantity_allclose(back.vertex_offsets, aper.vertex_offsets,
+                             atol=1e-6 * u.arcsec)
+
+
+def test_polygon_matches_rotated_rectangle():
+    """
+    Test that the exact polygon mask for a rotated rectangle matches the
+    exact rectangular mask.
+
+    This is a non-trivial test of the polygon masking machinery, since
+    the rectangle vertices are not axis-aligned and thus require the
+    full generality of the polygon code.
+    """
+    rect = RectangularAperture((5.5, 5.5), w=4.0, h=2.0, theta=np.pi / 6)
+    # Build the equivalent polygon from the rotated rectangle vertices.
+    cos_t = np.cos(rect.theta.to_value(u.radian))
+    sin_t = np.sin(rect.theta.to_value(u.radian))
+    hw = rect.w / 2
+    hh = rect.h / 2
+    local = np.array([[-hw, -hh], [hw, -hh], [hw, hh], [-hw, hh]])
+    rot = np.column_stack([local[:, 0] * cos_t - local[:, 1] * sin_t,
+                           local[:, 0] * sin_t + local[:, 1] * cos_t])
+    poly = PolygonAperture((5.5, 5.5), rot)
+    assert_allclose(poly.to_mask(method='exact').data,
+                    rect.to_mask(method='exact').data)
+
+
+def test_sky_indexing():
+    pos = SkyCoord(ra=[180.0, 181.0], dec=[0.0, 1.0], unit='deg')
+    offsets = SQUARE_OFFSETS * u.arcsec
+    aper = SkyPolygonAperture(pos, offsets)
+    one = aper[0]
+    assert one.isscalar
+    assert_quantity_allclose(one.positions.ra, 180.0 * u.deg)
+
+
+def test_sky_vertex_offsets_reset_lazyproperties():
+    """
+    Test that changing vertex_offsets on a SkyPolygonAperture clears the
+    cached vertices, which are stored as a SkyCoord.
+    """
+    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+    aper = SkyPolygonAperture(pos, SQUARE_OFFSETS * u.arcsec)
+    _ = aper.vertices  # cache it
+    aper.vertex_offsets = TRIANGLE_OFFSETS * u.arcsec
+    assert aper.vertices.shape == (3,)
+
+
+def test_pixel_vertex_offsets_reset_lazyproperties():
+    aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+    _ = aper.vertices
+    aper.vertex_offsets = TRIANGLE_OFFSETS
+    assert aper.vertices.shape == (3, 2)
+
+
+@pytest.mark.parametrize('n_vertices', [3, 4, 5, 6, 8, 12])
+def test_pixel_from_regular_polygon_basic(n_vertices):
+    aper = PolygonAperture.from_regular_polygon((10.0, 20.0), n_vertices, 5.0)
+    assert aper.vertex_offsets.shape == (n_vertices, 2)
+    assert aper.n_vertices == n_vertices
+    assert aper.is_regular
+    assert_allclose(aper.outer_radius, 5.0)
+    expected_inner_radius = 5.0 * np.cos(np.pi / n_vertices)
+    assert_allclose(aper.inner_radius, expected_inner_radius)
+    expected_side = 2.0 * 5.0 * np.sin(np.pi / n_vertices)
+    assert_allclose(aper.side_length, expected_side)
+    assert_quantity_allclose(aper.interior_angle,
+                             ((n_vertices - 2) / n_vertices) * 180.0 * u.deg)
+    assert_quantity_allclose(aper.exterior_angle,
+                             (360.0 / n_vertices) * u.deg)
+    assert_allclose(aper.vertices[0], (10.0, 25.0), atol=1e-12)
+
+
+def test_pixel_from_regular_polygon_with_angle_quantity():
+    aper = PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 1.0,
+                                                theta=45.0 * u.deg)
+    assert aper.is_regular
+    expected = np.array([[-np.sqrt(2) / 2, np.sqrt(2) / 2],
+                         [-np.sqrt(2) / 2, -np.sqrt(2) / 2],
+                         [np.sqrt(2) / 2, -np.sqrt(2) / 2],
+                         [np.sqrt(2) / 2, np.sqrt(2) / 2]])
+    assert_allclose(aper.vertex_offsets, expected, atol=1e-12)
+
+
+def test_pixel_from_regular_polygon_with_angle_float():
+    aper = PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 1.0,
+                                                theta=np.pi / 4)
+    assert_allclose(aper.vertex_offsets[0],
+                    (-np.sqrt(2) / 2, np.sqrt(2) / 2), atol=1e-12)
+
+
+def test_pixel_from_regular_polygon_invalid_n_vertices():
+    with pytest.raises(ValueError, match='at least 3'):
+        PolygonAperture.from_regular_polygon((0.0, 0.0), 2, 1.0)
+
+
+def test_pixel_from_regular_polygon_invalid_radius():
+    with pytest.raises(ValueError, match='positive'):
+        PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 0.0)
+    with pytest.raises(ValueError, match='positive'):
+        PolygonAperture.from_regular_polygon((0.0, 0.0), 4, -1.0)
+    with pytest.raises(ValueError, match='positive'):
+        PolygonAperture.from_regular_polygon((0.0, 0.0), 4, np.nan)
+
+
+def test_pixel_is_regular_false_cases():
+    aper = PolygonAperture.from_vertices(
+        np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
+    assert not aper.is_regular
+
+    aper2 = PolygonAperture((0.0, 0.0),
+                            np.array([[1.0, 2.0], [-1.0, 2.0],
+                                      [-1.0, -2.0], [1.0, -2.0]]))
+    assert not aper2.is_regular
+
+    aper3 = PolygonAperture((0.0, 0.0),
+                            np.array([[0.0, 0.0], [4.0, 0.0],
+                                      [4.0, 2.0], [2.0, 2.0],
+                                      [2.0, 4.0], [0.0, 4.0]]))
+    assert not aper3.is_regular
+
+
+def test_pixel_regular_attrs_raise_when_not_regular():
+    aper = PolygonAperture.from_vertices(
+        np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
+    for attr in ('outer_radius', 'inner_radius', 'side_length',
+                 'interior_angle', 'exterior_angle'):
+        with pytest.raises(ValueError, match='regular polygon'):
+            getattr(aper, attr)
+
+
+def test_pixel_n_vertices_works_for_any_polygon():
+    aper = PolygonAperture.from_vertices(
+        np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
+    assert aper.n_vertices == 3
+
+
+@pytest.mark.parametrize('n_vertices', [3, 4, 5, 6])
+def test_sky_from_regular_polygon_basic(n_vertices):
+    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+    aper = SkyPolygonAperture.from_regular_polygon(pos, n_vertices,
+                                                   2.0 * u.arcsec)
+    assert aper.vertex_offsets.shape == (n_vertices, 2)
+    assert aper.n_vertices == n_vertices
+    assert aper.is_regular
+    assert_quantity_allclose(aper.outer_radius, 2.0 * u.arcsec)
+    assert_quantity_allclose(aper.inner_radius,
+                             2.0 * np.cos(np.pi / n_vertices) * u.arcsec)
+    assert_quantity_allclose(aper.side_length,
+                             2.0 * 2.0 * np.sin(np.pi / n_vertices)
+                             * u.arcsec)
+    assert_quantity_allclose(aper.interior_angle,
+                             ((n_vertices - 2) / n_vertices) * 180.0 * u.deg)
+    assert_quantity_allclose(aper.exterior_angle,
+                             (360.0 / n_vertices) * u.deg)
+
+
+def test_sky_from_regular_polygon_with_angle():
+    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+    aper = SkyPolygonAperture.from_regular_polygon(pos, 4,
+                                                   1.0 * u.arcmin,
+                                                   theta=45.0 * u.deg)
+    assert aper.is_regular
+    assert aper.vertex_offsets.unit == u.arcmin
+
+
+def test_sky_from_regular_polygon_invalid_n_vertices():
+    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+    with pytest.raises(ValueError, match='at least 3'):
+        SkyPolygonAperture.from_regular_polygon(pos, 2, 1.0 * u.arcsec)
+
+
+def test_sky_from_regular_polygon_invalid_radius():
+    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+    with pytest.raises(TypeError, match='angular Quantity'):
+        SkyPolygonAperture.from_regular_polygon(pos, 4, 1.0)
+    with pytest.raises(TypeError, match='angular Quantity'):
+        SkyPolygonAperture.from_regular_polygon(pos, 4, 1.0 * u.kg)
+    with pytest.raises(ValueError, match='positive'):
+        SkyPolygonAperture.from_regular_polygon(pos, 4, 0.0 * u.arcsec)
+    with pytest.raises(ValueError, match='positive'):
+        SkyPolygonAperture.from_regular_polygon(pos, 4, -1.0 * u.arcsec)
+
+
+def test_sky_from_regular_polygon_invalid_angle():
+    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+    with pytest.raises(TypeError, match='angular Quantity'):
+        SkyPolygonAperture.from_regular_polygon(pos, 4,
+                                                1.0 * u.arcsec,
+                                                theta=0.5)
+    with pytest.raises(TypeError, match='angular Quantity'):
+        SkyPolygonAperture.from_regular_polygon(pos, 4,
+                                                1.0 * u.arcsec,
+                                                theta=1.0 * u.kg)
+
+
+def test_sky_is_regular_false_and_attrs_raise():
+    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+    aper = SkyPolygonAperture(pos,
+                              np.array([[0.0, 0.0], [4.0, 0.0],
+                                        [4.0, 3.0]]) * u.arcsec)
+    assert not aper.is_regular
+    for attr in ('outer_radius', 'inner_radius', 'side_length',
+                 'interior_angle', 'exterior_angle'):
+        with pytest.raises(ValueError, match='regular polygon'):
+            getattr(aper, attr)
+
+
+def test_sky_n_vertices_works_for_any_polygon():
+    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+    aper = SkyPolygonAperture(pos,
+                              np.array([[0.0, 0.0], [4.0, 0.0],
+                                        [4.0, 3.0]]) * u.arcsec)
+    assert aper.n_vertices == 3
+
+
+def _matches_up_to_cyclic_reversal(a, b, atol=1e-10):
+    n = len(a)
+    if len(b) != n:
+        return False
+    for direction in (b, b[::-1]):
+        for k in range(n):
+            shifted = np.roll(direction, -k, axis=0)
+            if np.allclose(a, shifted, atol=atol):
+                return True
+    return False
+
+
+@pytest.mark.skipif(not pytest.importorskip('regions', minversion='0.11'),
+                    reason='requires regions')
+def test_pixel_from_regular_polygon_matches_regions():
+    from regions import PixCoord, RegularPolygonPixelRegion
+
+    for n in (3, 5, 6, 8):
+        for angle in (0.0, 30.0, 90.0):
+            aper = PolygonAperture.from_regular_polygon(
+                (10.0, 20.0), n, 5.0, theta=angle * u.deg)
+            reg = RegularPolygonPixelRegion(
+                PixCoord(10.0, 20.0), n, 5.0, angle=angle * u.deg)
+            reg_xy = np.column_stack([reg.vertices.x, reg.vertices.y])
+            ours = aper.vertices
+            assert _matches_up_to_cyclic_reversal(ours, reg_xy)
+
+
+class TestPolygonApertureTheta:
+    """
+    Tests for the ``theta`` attribute of `PolygonAperture`.
+    """
+
+    def test_theta_zero(self):
+        aper = PolygonAperture.from_regular_polygon((10, 20), 6, 5.0,
+                                                    theta=0.0)
+        assert isinstance(aper.theta, u.Quantity)
+        assert_quantity_allclose(aper.theta, 0.0 * u.deg, atol=1e-10 * u.deg)
+
+    def test_theta_unit(self):
+        aper = PolygonAperture.from_regular_polygon((10, 20), 5, 3.0,
+                                                    theta=np.pi / 3)
+        assert aper.theta.unit == u.deg
+
+    @pytest.mark.parametrize('theta_rad', [
+        0.0,
+        np.pi / 6,
+        np.pi / 4,
+        np.pi / 2,
+        np.pi,
+        3 * np.pi / 2,
+    ])
+    def test_theta_roundtrip_radians(self, theta_rad):
+        aper = PolygonAperture.from_regular_polygon((10, 20), 6, 5.0,
+                                                    theta=theta_rad)
+        expected = np.degrees(theta_rad) % 360.0
+        assert_quantity_allclose(aper.theta, expected * u.deg,
+                                 atol=1e-10 * u.deg)
+
+    @pytest.mark.parametrize('theta_deg', [0.0, 45.0, 90.0, 135.0, 180.0,
+                                           270.0, 359.0])
+    def test_theta_roundtrip_quantity(self, theta_deg):
+        aper = PolygonAperture.from_regular_polygon((10, 20), 6, 5.0,
+                                                    theta=theta_deg * u.deg)
+        assert_quantity_allclose(aper.theta, theta_deg * u.deg,
+                                 atol=1e-10 * u.deg)
+
+    def test_theta_negative_normalized(self):
+        # Negative theta is normalized to [0, 360) deg.
+        aper = PolygonAperture.from_regular_polygon((10, 20), 6, 5.0,
+                                                    theta=-np.pi / 4)
+        assert_quantity_allclose(aper.theta, 315.0 * u.deg,
+                                 atol=1e-10 * u.deg)
+
+    @pytest.mark.parametrize('n_vertices', [3, 4, 5, 6, 8, 10])
+    def test_theta_different_n_vertices(self, n_vertices):
+        aper = PolygonAperture.from_regular_polygon((0, 0), n_vertices, 1.0,
+                                                    theta=0.0)
+        assert_quantity_allclose(aper.theta, 0.0 * u.deg,
+                                 atol=1e-10 * u.deg)
+
+    def test_theta_nonregular_raises(self):
+        # Non-regular polygon raises ValueError.
+        offsets = [(1.0, 0.0), (2.0, 1.0), (0.0, 2.0)]
+        aper = PolygonAperture((10, 20), offsets)
+        match = "'theta' is only defined for a regular polygon aperture"
+        with pytest.raises(ValueError, match=match):
+            _ = aper.theta
+
+
+class TestSkyPolygonApertureTheta:
+    """
+    Tests for the ``theta`` attribute of `SkyPolygonAperture`.
+    """
+
+    def test_theta_zero(self):
+        aper = SkyPolygonAperture.from_regular_polygon(
+            SKYCOORD[0], 6, 5.0 * u.arcsec, theta=0.0 * u.deg)
+        assert isinstance(aper.theta, u.Quantity)
+        assert_quantity_allclose(aper.theta, 0.0 * u.deg, atol=1e-10 * u.deg)
+
+    def test_theta_unit(self):
+        aper = SkyPolygonAperture.from_regular_polygon(
+            SKYCOORD[0], 5, 3.0 * u.arcsec, theta=60.0 * u.deg)
+        assert aper.theta.unit == u.deg
+
+    @pytest.mark.parametrize('theta_deg', [
+        0.0, 30.0, 45.0, 90.0, 135.0, 180.0, 270.0,
+    ])
+    def test_theta_roundtrip(self, theta_deg):
+        aper = SkyPolygonAperture.from_regular_polygon(
+            SKYCOORD[0], 6, 5.0 * u.arcsec, theta=theta_deg * u.deg)
+        assert_quantity_allclose(aper.theta, theta_deg * u.deg,
+                                 atol=1e-10 * u.deg)
+
+    def test_theta_negative_normalized(self):
+        aper = SkyPolygonAperture.from_regular_polygon(
+            SKYCOORD[0], 6, 5.0 * u.arcsec, theta=-45.0 * u.deg)
+        assert_quantity_allclose(aper.theta, 315.0 * u.deg,
+                                 atol=1e-10 * u.deg)
+
+    def test_theta_nonregular_raises(self):
+        offsets = np.array([(0.5, 0.0), (1.0, 0.5), (0.0, 1.0)]) * u.arcsec
+        aper = SkyPolygonAperture(SKYCOORD[0], offsets)
+        match = "'theta' is only defined for a regular polygon aperture"
+        with pytest.raises(ValueError, match=match):
+            _ = aper.theta
+
+    @pytest.mark.parametrize('n_vertices', [3, 4, 5, 6, 8])
+    def test_theta_different_n_vertices(self, n_vertices):
+        aper = SkyPolygonAperture.from_regular_polygon(
+            SKYCOORD[0], n_vertices, 1.0 * u.arcsec, theta=0.0 * u.deg)
+        assert_quantity_allclose(aper.theta, 0.0 * u.deg,
+                                 atol=1e-10 * u.deg)

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -432,6 +432,71 @@ def test_do_photometry():
     assert_allclose(flux, [4.0])
 
 
+def test_do_photometry_subpixel_on_horizontal_boundary():
+    """
+    Test that ``do_photometry`` excludes subpixel centers landing
+    exactly on a horizontal polygon edge.
+
+    This is the ``do_photometry`` counterpart of
+    ``test_polygon_overlap_subpixel_on_horizontal_boundary`` in
+    ``photutils/geometry/tests/test_polygon_overlap_grid.py``,
+    using the same wide rectangle (half-widths 2 in x, 1 in y) and
+    ``subpixels=3``.
+
+    At an integer position the subpixel centers fall on all multiples
+    of 1/3, so the horizontal edges at y = center +/- 1 coincide with
+    a row of subpixel centers and are excluded. The strictly interior
+    subpixel centers are the 11 x-positions and 5 y-positions inside the
+    open rectangle, giving 55 of every 9 subpixels, i.e., 55/9. Were the
+    on-boundary centers counted instead, the result would be 91/9.
+    """
+    data = np.ones((31, 31))
+    offsets = np.array([[-2.0, -1.0], [2.0, -1.0],
+                        [2.0, 1.0], [-2.0, 1.0]])
+    aper = PolygonAperture((15.0, 15.0), offsets)
+    flux, _ = aper.do_photometry(data, method='subpixel', subpixels=3)
+    assert_allclose(flux, [55.0 / 9.0])
+
+
+def test_do_photometry_subpixel_on_vertical_boundary():
+    """
+    Test that ``do_photometry`` excludes subpixel centers landing
+    exactly on a vertical polygon edge.
+
+    This is the ``do_photometry`` counterpart of
+    ``test_polygon_overlap_subpixel_on_vertical_boundary``, using
+    the same tall rectangle (half-widths 1 in x, 2 in y) and
+    ``subpixels=3``. The vertical edges at x = center +/- 1 coincide
+    with a column of subpixel centers and are excluded, giving 55/9 (the
+    boundary-included value would be 91/9).
+    """
+    data = np.ones((31, 31))
+    offsets = np.array([[-1.0, -2.0], [1.0, -2.0],
+                        [1.0, 2.0], [-1.0, 2.0]])
+    aper = PolygonAperture((15.0, 15.0), offsets)
+    flux, _ = aper.do_photometry(data, method='subpixel', subpixels=3)
+    assert_allclose(flux, [55.0 / 9.0])
+
+
+def test_do_photometry_subpixel_on_all_boundaries():
+    """
+    Test that ``do_photometry`` excludes subpixel centers on horizontal
+    edges, vertical edges, and at corners.
+
+    This is the ``do_photometry`` counterpart of
+    ``test_polygon_overlap_subpixel_on_all_boundaries``, using the same
+    unit square (half-widths 1 in both axes) and ``subpixels=3``. At
+    an integer position the four edges and four corners coincide with
+    subpixel centers and are all excluded, leaving the 5 x-positions
+    and 5 y-positions strictly inside the open square, i.e., 25/9 (the
+    boundary-included value would be 49/9).
+    """
+    data = np.ones((31, 31))
+    aper = PolygonAperture((15.0, 15.0), SQUARE_OFFSETS)
+    flux, _ = aper.do_photometry(data, method='subpixel', subpixels=3)
+    assert_allclose(flux, [25.0 / 9.0])
+
+
 @pytest.mark.parametrize(('method', 'kwargs'),
                          [('exact', {}),
                           ('subpixel', {'subpixels': 7}),

--- a/photutils/geometry/_batch_photometry.pyx
+++ b/photutils/geometry/_batch_photometry.pyx
@@ -19,7 +19,8 @@ free-threaded Python builds.
 
 import numpy as np
 
-from ._polygon_overlap cimport polygon_pixel_overlap
+from ._polygon_overlap cimport (polygon_overlap_single_subpixel,
+                                polygon_pixel_overlap)
 from .circular_overlap cimport (circular_overlap_single_exact,
                                 circular_overlap_single_subpixel)
 from .elliptical_overlap cimport (elliptical_overlap_single_exact,
@@ -49,6 +50,7 @@ cdef enum:
     _ELLIPTICAL_ANNULUS = 3
     _RECTANGLE = 4
     _RECTANGULAR_ANNULUS = 5
+    _POLYGON = 6
 
 # Python-level aliases of the shape codes
 SHAPE_CIRCLE = _CIRCLE
@@ -57,6 +59,7 @@ SHAPE_ELLIPSE = _ELLIPSE
 SHAPE_ELLIPTICAL_ANNULUS = _ELLIPTICAL_ANNULUS
 SHAPE_RECTANGLE = _RECTANGLE
 SHAPE_RECTANGULAR_ANNULUS = _RECTANGULAR_ANNULUS
+SHAPE_POLYGON = _POLYGON
 
 
 def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
@@ -96,7 +99,7 @@ def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
     shape_code : int
         The aperture shape code: 0=circle, 1=circular annulus,
         2=ellipse, 3=elliptical annulus, 4=rectangle, 5=rectangular
-        annulus (see the module-level ``SHAPE_*`` constants).
+        annulus, 6=polygon (see the module-level ``SHAPE_*`` constants).
 
     params : 1D ndarray of float64 (C-contiguous)
         The aperture shape parameters:
@@ -107,6 +110,9 @@ def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
         * elliptical annulus: ``(a_in, b_in, a_out, b_out, theta)``
         * rectangle: ``(w, h, theta)``
         * rectangular annulus: ``(w_in, h_in, w_out, h_out, theta)``
+        * polygon: the flattened counter-clockwise vertex offsets
+          ``(x0, y0, x1, y1, ...)`` relative to each position (at least
+          3 vertices, i.e., 6 values)
 
         where ``theta`` is in radians.
 
@@ -169,6 +175,20 @@ def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
     cdef double buf_b_x[32]
     cdef double buf_b_y[32]
 
+    # Working buffers for arbitrary-polygon apertures. The vertex count
+    # is variable, so these are allocated as a single numpy block (kept
+    # alive by ``poly_work``) and accessed through raw pointers. They
+    # are local to this call, so this function is thread safe.
+    cdef int n_poly = 0, poly_buf_size = 0
+    cdef Py_ssize_t pk
+    cdef double[::1] poly_work
+    cdef double *poly_x = NULL
+    cdef double *poly_y = NULL
+    cdef double *pbuf_a_x = NULL
+    cdef double *pbuf_a_y = NULL
+    cdef double *pbuf_b_x = NULL
+    cdef double *pbuf_b_y = NULL
+
     if shape_code == _CIRCLE:
         r_out = params[0]
     elif shape_code == _CIRCULAR_ANNULUS:
@@ -211,6 +231,30 @@ def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
                           + half_height_in * fabs(sin_theta))
             bbox_dy_in = (half_width_in * fabs(sin_theta)
                           + half_height_in * fabs(cos_theta))
+    elif shape_code == _POLYGON:
+        # ``params`` holds the flattened counter-clockwise vertex
+        # offsets (x0, y0, x1, y1, ...).
+        n_poly = params.shape[0] // 2
+        if n_poly < 3 or 2 * n_poly != params.shape[0]:
+            msg = ('polygon params must be the flattened (x, y) offsets '
+                   'of at least 3 vertices')
+            raise ValueError(msg)
+
+        # Each Sutherland-Hodgman clip can at most double the vertex
+        # count of a non-convex polygon, so 16 * n_poly is a safe bound
+        # (see ``polygon_overlap_grid``).
+        poly_buf_size = 16 * n_poly
+        poly_work = np.empty(2 * n_poly + 4 * poly_buf_size,
+                             dtype=np.float64)
+        poly_x = &poly_work[0]
+        poly_y = &poly_work[n_poly]
+        pbuf_a_x = &poly_work[2 * n_poly]
+        pbuf_a_y = &poly_work[2 * n_poly + poly_buf_size]
+        pbuf_b_x = &poly_work[2 * n_poly + 2 * poly_buf_size]
+        pbuf_b_y = &poly_work[2 * n_poly + 3 * poly_buf_size]
+        for pk in range(n_poly):
+            poly_x[pk] = params[2 * pk]
+            poly_y[pk] = params[2 * pk + 1]
     else:
         msg = f'Invalid shape_code: {shape_code}'
         raise ValueError(msg)
@@ -304,7 +348,7 @@ def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
                             bbox_dx_out, bbox_dy_out, poly_x_out,
                             poly_y_out, buf_a_x, buf_a_y, buf_b_x,
                             buf_b_y, use_exact, subpixels)
-                    else:
+                    elif shape_code == _RECTANGULAR_ANNULUS:
                         frac = (_rect_pixel_frac(
                                     pxmin, pymin, dx, dy, half_width_out,
                                     half_height_out, cos_theta, sin_theta,
@@ -317,6 +361,11 @@ def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
                                     bbox_dx_in, bbox_dy_in, poly_x_in,
                                     poly_y_in, buf_a_x, buf_a_y, buf_b_x,
                                     buf_b_y, use_exact, subpixels))
+                    else:
+                        frac = _polygon_pixel_frac(
+                            pxmin, pymin, dx, dy, poly_x, poly_y, n_poly,
+                            pbuf_a_x, pbuf_a_y, pbuf_b_x, pbuf_b_y,
+                            poly_buf_size, use_exact, subpixels)
 
                     if frac <= 0.0:
                         continue
@@ -440,6 +489,37 @@ cdef inline double _rect_pixel_frac(double pxmin, double pymin,
                                                half_width, half_height,
                                                cos_theta, sin_theta,
                                                subpixels)
+
+
+cdef inline double _polygon_pixel_frac(double pxmin, double pymin,
+                                       double dx, double dy,
+                                       double *poly_x, double *poly_y,
+                                       int n_poly,
+                                       double *buf_a_x, double *buf_a_y,
+                                       double *buf_b_x, double *buf_b_y,
+                                       int buf_size, int use_exact,
+                                       int subpixels) noexcept nogil:
+    """
+    Fraction of a single pixel that overlaps a simple polygon supplied
+    as counter-clockwise vertices centered on the origin.
+
+    This replicates the per-pixel logic of ``polygon_overlap_grid``: the
+    exact mode clips the pixel against the polygon (Sutherland-Hodgman),
+    while the subpixel mode samples pixel centers with point-in-polygon
+    tests, so the result is identical to the grid function.
+    """
+    cdef double pxmax = pxmin + dx
+    cdef double pymax = pymin + dy
+
+    if use_exact:
+        return polygon_pixel_overlap(pxmin, pymin, pxmax, pymax,
+                                     poly_x, poly_y, n_poly,
+                                     buf_a_x, buf_a_y, buf_b_x, buf_b_y,
+                                     buf_size) / (dx * dy)
+
+    return polygon_overlap_single_subpixel(pxmin, pymin, pxmax, pymax,
+                                           poly_x, poly_y, n_poly,
+                                           subpixels)
 
 
 cdef inline void _rect_vertices(double half_width, double half_height,

--- a/photutils/geometry/_batch_photometry.pyx
+++ b/photutils/geometry/_batch_photometry.pyx
@@ -519,7 +519,8 @@ cdef inline double _polygon_pixel_frac(double pxmin, double pymin,
 
     return polygon_overlap_single_subpixel(pxmin, pymin, pxmax, pymax,
                                            poly_x, poly_y, n_poly,
-                                           subpixels)
+                                           subpixels, buf_a_x, buf_a_y,
+                                           buf_b_x)
 
 
 cdef inline void _rect_vertices(double half_width, double half_height,

--- a/photutils/geometry/_polygon_overlap.pxd
+++ b/photutils/geometry/_polygon_overlap.pxd
@@ -16,5 +16,7 @@ cdef double polygon_pixel_overlap(double pxmin, double pymin,
 cdef double polygon_overlap_single_subpixel(double x0, double y0,
                                             double x1, double y1,
                                             double *poly_x, double *poly_y,
-                                            int n_poly,
-                                            int subpixels) noexcept nogil
+                                            int n_poly, int subpixels,
+                                            double *xint_buf,
+                                            double *hxmin_buf,
+                                            double *hxmax_buf) noexcept nogil

--- a/photutils/geometry/_polygon_overlap.pxd
+++ b/photutils/geometry/_polygon_overlap.pxd
@@ -13,5 +13,8 @@ cdef double polygon_pixel_overlap(double pxmin, double pymin,
                                   double *buf_a_x, double *buf_a_y,
                                   double *buf_b_x, double *buf_b_y,
                                   int buf_size) noexcept nogil
-cdef int point_in_polygon(double x, double y, double *poly_x,
-                          double *poly_y, int n_poly) noexcept nogil
+cdef double polygon_overlap_single_subpixel(double x0, double y0,
+                                            double x1, double y1,
+                                            double *poly_x, double *poly_y,
+                                            int n_poly,
+                                            int subpixels) noexcept nogil

--- a/photutils/geometry/_polygon_overlap.pyx
+++ b/photutils/geometry/_polygon_overlap.pyx
@@ -130,9 +130,8 @@ def polygon_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     cdef double pxmin, pxmax, pymin, pymax
     cdef double bbox_xmin, bbox_xmax, bbox_ymin, bbox_ymax
     cdef double pixel_area = dx * dy
-    cdef int i, j, ii, jj, k
+    cdef int i, j, k
     cdef int i_min, i_max, j_min, j_max
-    cdef double sub_dx, sub_dy, sx, sy, hits
 
     # Polygon bounding box.
     bbox_xmin = poly_x[0]
@@ -169,24 +168,14 @@ def polygon_overlap_grid(double xmin, double xmax, double ymin, double ymax,
                                               buf_b_x, buf_b_y, buf_size)
                         / pixel_area)
     else:
-        sub_dx = dx / subpixels
-        sub_dy = dy / subpixels
         with nogil:
             for i in range(i_min, i_max):
                 pxmin = xmin + i * dx
                 for j in range(j_min, j_max):
                     pymin = ymin + j * dy
-                    hits = 0.0
-                    sx = pxmin + 0.5 * sub_dx
-                    for ii in range(subpixels):
-                        sy = pymin + 0.5 * sub_dy
-                        for jj in range(subpixels):
-                            if point_in_polygon(sx, sy, poly_x, poly_y,
-                                                n_poly) == 1:
-                                hits += 1.0
-                            sy += sub_dy
-                        sx += sub_dx
-                    frac_view[j, i] = hits / (subpixels * subpixels)
+                    frac_view[j, i] = polygon_overlap_single_subpixel(
+                        pxmin, pymin, pxmin + dx, pymin + dy,
+                        poly_x, poly_y, n_poly, subpixels)
 
     return frac
 
@@ -289,6 +278,43 @@ cdef int point_in_polygon(double x, double y, double *poly_x,
                 inside = 1 - inside
         j = i
     return inside
+
+
+cdef double polygon_overlap_single_subpixel(double x0, double y0,
+                                            double x1, double y1,
+                                            double *poly_x, double *poly_y,
+                                            int n_poly,
+                                            int subpixels) noexcept nogil:
+    """
+    Return the fraction of overlap between a simple polygon and a single
+    pixel with the given extent, using a sub-pixel sampling method.
+
+    The pixel ``[x0, x1] x [y0, y1]`` is divided into ``subpixels ** 2``
+    subpixels and the fraction of subpixel centers that fall inside the
+    polygon is returned. The polygon may be convex or non-convex.
+
+    This is a pure C math function declared ``noexcept nogil`` so it can
+    be called without the GIL (e.g., from the batch aperture photometry
+    driver), including from multiple threads on free-threaded Python
+    builds.
+    """
+    cdef int i, j
+    cdef double x, y, dx, dy, hits
+
+    dx = (x1 - x0) / subpixels
+    dy = (y1 - y0) / subpixels
+    hits = 0.0
+
+    x = x0 + 0.5 * dx
+    for i in range(subpixels):
+        y = y0 + 0.5 * dy
+        for j in range(subpixels):
+            if point_in_polygon(x, y, poly_x, poly_y, n_poly) == 1:
+                hits += 1.0
+            y += dy
+        x += dx
+
+    return hits / (subpixels * subpixels)
 
 
 cdef inline double _polygon_signed_area(double *xs, double *ys,

--- a/photutils/geometry/_polygon_overlap.pyx
+++ b/photutils/geometry/_polygon_overlap.pyx
@@ -86,6 +86,12 @@ def polygon_overlap_grid(double xmin, double xmax, double ymin, double ymax,
         factor in each dimension; thus, each pixel is divided into
         ``subpixels ** 2`` subpixels.
 
+        With ``subpixels == 1`` (the ``center`` method) a pixel is
+        included only if its center falls strictly inside the polygon.
+        Pixel centers lying exactly on a polygon edge are counted
+        as outside, consistent with the circular, elliptical, and
+        rectangular apertures (see ``point_in_polygon``).
+
     Returns
     -------
     result : `~numpy.ndarray` (float)
@@ -227,6 +233,7 @@ cdef double polygon_pixel_overlap(double pxmin, double pymin,
     n = _clip_against_axis(cur_x, cur_y, n, 0, pxmax, 0, nxt_x, nxt_y)
     if n == 0:
         return 0.0
+
     tmp = cur_x
     cur_x = nxt_x
     nxt_x = tmp
@@ -237,6 +244,7 @@ cdef double polygon_pixel_overlap(double pxmin, double pymin,
     n = _clip_against_axis(cur_x, cur_y, n, 1, pymin, 1, nxt_x, nxt_y)
     if n == 0:
         return 0.0
+
     tmp = cur_x
     cur_x = nxt_x
     nxt_x = tmp
@@ -258,25 +266,60 @@ cdef int point_in_polygon(double x, double y, double *poly_x,
     poly_y)``, 0 otherwise.
 
     Uses the standard ray-casting algorithm so the polygon may be convex
-    or non-convex. Points exactly on an edge may be classified as either
-    inside or outside (the usual half-open behavior of ray casting);
-    this is adequate for subpixel sampling.
+    or non-convex.
+
+    Boundary convention
+    -------------------
+    Points lying exactly on a polygon edge are classified as
+    *outside* (return 0). This matches the ``center`` method
+    of the circular, elliptical, and rectangular apertures,
+    which use a strict inequality (``< r**2``, ``< 1``, and ``<
+    half_width/half_height``, respectively) and therefore also exclude
+    every on-boundary point. In particular, because a rectangle is
+    itself a polygon, a `~photutils.aperture.RectangularAperture` and
+    a `~photutils.aperture.PolygonAperture` with the same four corners
+    produce identical ``center`` masks.
+
+    The on-edge test is performed first: if ``(x, y)`` lies on any edge
+    (within the closed bounding box of that edge and collinear with it),
+    the point is reported as outside. Otherwise the standard ray-casting
+    parity test is applied for strictly interior/exterior points.
+
+    This boundary handling matters mainly for the ``center`` method
+    (``subpixels == 1``), where pixel centers commonly fall exactly
+    on an edge (e.g., for integer-coordinate polygons). For subpixel
+    sampling (``subpixels > 1``) on-edge samples are rare.
     """
     cdef int i, j, inside = 0
     cdef double xi, yi, xj, yj
+    cdef double cross
+
     if n_poly < 3:
         return 0
+
     j = n_poly - 1
     for i in range(n_poly):
         xi = poly_x[i]
         yi = poly_y[i]
         xj = poly_x[j]
         yj = poly_y[j]
+
+        # Reject points exactly on this edge (collinear and within the
+        # edge's closed bounding box), so that all boundary points are
+        # classified as outside, consistent with the other apertures.
+        cross = (xj - xi) * (y - yi) - (yj - yi) * (x - xi)
+        if (cross == 0.0
+                and fmin(xi, xj) <= x <= fmax(xi, xj)
+                and fmin(yi, yj) <= y <= fmax(yi, yj)):
+            return 0
+
         if ((yi > y) != (yj > y)):
             # x of intersection of polygon edge with horizontal line at y
             if x < (xj - xi) * (y - yi) / (yj - yi) + xi:
                 inside = 1 - inside
+
         j = i
+
     return inside
 
 
@@ -329,13 +372,16 @@ cdef inline double _polygon_signed_area(double *xs, double *ys,
     """
     cdef double area = 0.0
     cdef int i, j
+
     if n < 3:
         return 0.0
+
     for i in range(n):
         j = i + 1
         if j == n:
             j = 0
         area += xs[i] * ys[j] - xs[j] * ys[i]
+
     return 0.5 * area
 
 
@@ -414,6 +460,7 @@ cdef void _ensure_ccw(double[::1] xs, double[::1] ys, int n,
     """
     cdef double area = _polygon_signed_area(&xs[0], &ys[0], n)
     cdef int i, k
+
     if area >= 0.0:
         for i in range(n):
             out_x[i] = xs[i]

--- a/photutils/geometry/_polygon_overlap.pyx
+++ b/photutils/geometry/_polygon_overlap.pyx
@@ -92,6 +92,11 @@ def polygon_overlap_grid(double xmin, double xmax, double ymin, double ymax,
         as outside, consistent with the circular, elliptical, and
         rectangular apertures (see ``point_in_polygon``).
 
+        For ``subpixels > 1`` the same convention applies to each
+        subpixel: a subpixel is included only if its center lies
+        strictly inside the polygon; subpixel centers lying exactly on a
+        polygon edge are excluded (weight 0).
+
     Returns
     -------
     result : `~numpy.ndarray` (float)
@@ -181,7 +186,8 @@ def polygon_overlap_grid(double xmin, double xmax, double ymin, double ymax,
                     pymin = ymin + j * dy
                     frac_view[j, i] = polygon_overlap_single_subpixel(
                         pxmin, pymin, pxmin + dx, pymin + dy,
-                        poly_x, poly_y, n_poly, subpixels)
+                        poly_x, poly_y, n_poly, subpixels,
+                        buf_a_x, buf_a_y, buf_b_x)
 
     return frac
 
@@ -326,8 +332,10 @@ cdef int point_in_polygon(double x, double y, double *poly_x,
 cdef double polygon_overlap_single_subpixel(double x0, double y0,
                                             double x1, double y1,
                                             double *poly_x, double *poly_y,
-                                            int n_poly,
-                                            int subpixels) noexcept nogil:
+                                            int n_poly, int subpixels,
+                                            double *xint_buf,
+                                            double *hxmin_buf,
+                                            double *hxmax_buf) noexcept nogil:
     """
     Return the fraction of overlap between a simple polygon and a single
     pixel with the given extent, using a sub-pixel sampling method.
@@ -336,26 +344,129 @@ cdef double polygon_overlap_single_subpixel(double x0, double y0,
     subpixels and the fraction of subpixel centers that fall inside the
     polygon is returned. The polygon may be convex or non-convex.
 
+    For ``subpixels == 1`` (the ``center`` method) the single
+    pixel-center sample is classified with the full `point_in_polygon`
+    test, so that samples lying exactly on a polygon edge are excluded,
+    consistent with the circular, elliptical, and rectangular apertures.
+
+    For ``subpixels > 1`` the samples are classified with a scanline
+    parity fill: for each subpixel row, the polygon boundary restricted
+    to the horizontal line at ``y`` is fully characterized once
+    (``O(n_poly)``) as a set of crossing points (from sloped and
+    vertical edges) plus a set of closed x-intervals (from any
+    horizontal edges lying exactly on that line). The crossings are
+    sorted and the row's samples are then classified by a single
+    monotonic sweep instead of re-testing every edge for every sample.
+    This reduces the per-pixel cost from ``O(subpixels ** 2 * n_poly)``
+    to roughly ``O(subpixels * n_poly + subpixels ** 2)`` while matching
+    the classification of `point_in_polygon`: interior samples are
+    classified by the identical ``x < xint`` parity rule, and every
+    on-boundary sample is excluded (classified as outside). A sample
+    is on the boundary when its x coincides exactly with a crossing (a
+    sloped or vertical edge, including vertices, whose crossing x is
+    computed exactly because the ``y - yi`` term vanishes) or when it
+    lies within the closed x-span of a horizontal edge at that ``y``.
+    This makes the on-boundary exclusion bit-exact for the axis-aligned
+    and integer-coordinate polygons where on-boundary samples actually
+    occur. For samples on the interior of a sloped edge (a rare event
+    for subpixel sampling) the recomputed crossing may differ from the
+    sample x by rounding and the exclusion is not guaranteed.
+
+    ``xint_buf``, ``hxmin_buf``, and ``hxmax_buf`` are caller-supplied
+    scratch buffers, each of which must hold at least ``n_poly``
+    doubles. ``xint_buf`` stores the per-row edge crossings, while
+    ``hxmin_buf`` and ``hxmax_buf`` store the endpoints of the per-row
+    horizontal-edge intervals. They are written only within this call,
+    so the function remains thread safe.
+
     This is a pure C math function declared ``noexcept nogil`` so it can
     be called without the GIL (e.g., from the batch aperture photometry
     driver), including from multiple threads on free-threaded Python
     builds.
     """
-    cdef int i, j
+    cdef int i, j, e, prev, m, a, b, ptr, h, hh
     cdef double x, y, dx, dy, hits
+    cdef double xi, yi, xj, yj, tmp
+    cdef bint inside
 
     dx = (x1 - x0) / subpixels
     dy = (y1 - y0) / subpixels
     hits = 0.0
 
-    x = x0 + 0.5 * dx
+    if subpixels == 1:
+        # Center method: a single sample at the pixel center. Use
+        # the full point-in-polygon test so that on-edge samples are
+        # classified consistently with the other apertures (excluded).
+        if point_in_polygon(x0 + 0.5 * dx, y0 + 0.5 * dy,
+                            poly_x, poly_y, n_poly) == 1:
+            hits = 1.0
+        return hits
+
+    # Subpixel sampling (subpixels > 1): scanline parity fill.
+    y = y0 + 0.5 * dy
     for i in range(subpixels):
-        y = y0 + 0.5 * dy
+        # Characterize the polygon boundary on the horizontal line
+        # at ``y``. Sloped and vertical edges that straddle the line
+        # each contribute one crossing point (``xint_buf``), using
+        # the same edge-straddle test and intersection arithmetic
+        # as the parity step of ``point_in_polygon``. Horizontal
+        # edges lying exactly on the line cannot straddle it,
+        # so they are recorded separately as closed x-intervals
+        # (``hxmin_buf``/``hxmax_buf``). Together these two sets fully
+        # describe the boundary on the line and let every on-boundary
+        # sample be excluded.
+        m = 0
+        h = 0
+        prev = n_poly - 1
+        for e in range(n_poly):
+            yi = poly_y[e]
+            yj = poly_y[prev]
+            if yi == y and yj == y:
+                xi = poly_x[e]
+                xj = poly_x[prev]
+                hxmin_buf[h] = fmin(xi, xj)
+                hxmax_buf[h] = fmax(xi, xj)
+                h += 1
+            elif (yi > y) != (yj > y):
+                xi = poly_x[e]
+                xj = poly_x[prev]
+                xint_buf[m] = (xj - xi) * (y - yi) / (yj - yi) + xi
+                m += 1
+            prev = e
+
+        # Insertion sort the (typically few) crossings in ascending x.
+        for a in range(1, m):
+            tmp = xint_buf[a]
+            b = a - 1
+            while b >= 0 and xint_buf[b] > tmp:
+                xint_buf[b + 1] = xint_buf[b]
+                b -= 1
+            xint_buf[b + 1] = tmp
+
+        # Sweep the row's samples (monotonically increasing in x). A
+        # sample is inside when an odd number of crossings lie strictly
+        # to its right (the ``x < xint`` parity rule), unless it lies
+        # on the boundary. On-boundary samples are excluded (classified
+        # as outside), consistent with ``point_in_polygon``: a sample
+        # whose x coincides exactly with a crossing lies on a sloped or
+        # vertical edge, and a sample within a horizontal edge's closed
+        # x-span lies on that edge.
+        x = x0 + 0.5 * dx
+        ptr = 0
         for j in range(subpixels):
-            if point_in_polygon(x, y, poly_x, poly_y, n_poly) == 1:
+            while ptr < m and xint_buf[ptr] < x:
+                ptr += 1
+            inside = (((m - ptr) & 1) == 1
+                      and not (ptr < m and xint_buf[ptr] == x))
+            if inside:
+                for hh in range(h):
+                    if hxmin_buf[hh] <= x <= hxmax_buf[hh]:
+                        inside = False
+                        break
+            if inside:
                 hits += 1.0
-            y += dy
-        x += dx
+            x += dx
+        y += dy
 
     return hits / (subpixels * subpixels)
 

--- a/photutils/geometry/circular_overlap.pyx
+++ b/photutils/geometry/circular_overlap.pyx
@@ -70,6 +70,10 @@ def circular_overlap_grid(double xmin, double xmax, double ymin, double ymax,
         factor in each dimension; thus, each pixel is divided into
         ``subpixels ** 2`` subpixels.
 
+        A subpixel is included only if its center lies strictly inside
+        the circle; subpixel centers lying exactly on the circle
+        boundary are excluded (weight 0).
+
     Returns
     -------
     result : `~numpy.ndarray` (float)

--- a/photutils/geometry/elliptical_overlap.pyx
+++ b/photutils/geometry/elliptical_overlap.pyx
@@ -84,6 +84,10 @@ def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,
         factor in each dimension; thus, each pixel is divided into
         ``subpixels ** 2`` subpixels.
 
+        A subpixel is included only if its center lies strictly inside
+        the ellipse; subpixel centers lying exactly on the ellipse
+        boundary are excluded (weight 0).
+
     Returns
     -------
     result : `~numpy.ndarray` (float)

--- a/photutils/geometry/rectangular_overlap.pyx
+++ b/photutils/geometry/rectangular_overlap.pyx
@@ -85,6 +85,10 @@ def rectangular_overlap_grid(double xmin, double xmax, double ymin,
         factor in each dimension; thus, each pixel is divided into
         ``subpixels ** 2`` subpixels.
 
+        A subpixel is included only if its center lies strictly inside
+        the rectangle; subpixel centers lying exactly on the rectangle
+        boundary are excluded (weight 0).
+
     Returns
     -------
     result : `~numpy.ndarray` (float)

--- a/photutils/geometry/tests/test_polygon_overlap_grid.py
+++ b/photutils/geometry/tests/test_polygon_overlap_grid.py
@@ -205,3 +205,59 @@ def test_polygon_overlap_many_vertices():
     grid = polygon_overlap_grid(-3.5, 3.5, -3.5, 3.5, n, n, vx, vy, 1, 1)
     pixel_area = (7.0 / n) ** 2
     assert_allclose(grid.sum() * pixel_area, np.pi * radius**2, rtol=1e-6)
+
+
+def test_polygon_overlap_subpixel_on_horizontal_boundary():
+    """
+    Test that subpixel centers landing exactly on a horizontal polygon
+    edge are excluded (classified as outside).
+
+    A wide rectangle spanning y in [-1, 1] is sampled by a single pixel
+    with ``subpixels=3``, so the subpixel-row centers fall exactly at y
+    = -1, 0, +1. The top and bottom rows lie exactly on the rectangle's
+    horizontal edges (with all column centers strictly inside in x), so
+    only the middle row (3 of 9 subpixels) is counted, giving 1/3.
+
+    Before horizontal-edge handling, the bottom edge (lower y, region
+    above) was incorrectly counted, which would give 2/3 instead.
+    """
+    vx = np.array([-2.0, 2.0, 2.0, -2.0])
+    vy = np.array([-1.0, -1.0, 1.0, 1.0])
+    grid = polygon_overlap_grid(-1.5, 1.5, -1.5, 1.5, 1, 1, vx, vy, 0, 3)
+    assert_allclose(grid[0, 0], 1.0 / 3.0)
+
+
+def test_polygon_overlap_subpixel_on_vertical_boundary():
+    """
+    Test that subpixel centers landing exactly on a vertical polygon
+    edge are excluded (classified as outside).
+
+    A tall rectangle spanning x in [-1, 1] is sampled by a single pixel
+    with ``subpixels=3``, so the subpixel-column centers fall exactly
+    at x = -1, 0, +1. The left and right columns lie exactly on the
+    rectangle's vertical edges (with all row centers strictly inside in
+    y), so only the middle column (3 of 9 subpixels) is counted, giving
+    1/3.
+    """
+    vx = np.array([-1.0, 1.0, 1.0, -1.0])
+    vy = np.array([-2.0, -2.0, 2.0, 2.0])
+    grid = polygon_overlap_grid(-1.5, 1.5, -1.5, 1.5, 1, 1, vx, vy, 0, 3)
+    assert_allclose(grid[0, 0], 1.0 / 3.0)
+
+
+def test_polygon_overlap_subpixel_on_all_boundaries():
+    """
+    Test that subpixel centers on horizontal edges, vertical edges, and
+    at corners are all excluded.
+
+    A unit square spanning [-1, 1] in both axes is sampled by a single
+    pixel with ``subpixels=3``, so the 9 subpixel centers fall at every
+    combination of (-1, 0, +1). Of these, only the central center
+    (0, 0) is strictly interior; the four edge-midpoint centers (two
+    horizontal, two vertical) and the four corner centers all lie on the
+    boundary and are excluded, giving 1/9.
+    """
+    vx = np.array([-1.0, 1.0, 1.0, -1.0])
+    vy = np.array([-1.0, -1.0, 1.0, 1.0])
+    grid = polygon_overlap_grid(-1.5, 1.5, -1.5, 1.5, 1, 1, vx, vy, 0, 3)
+    assert_allclose(grid[0, 0], 1.0 / 9.0)

--- a/photutils/geometry/tests/test_thread_safety.py
+++ b/photutils/geometry/tests/test_thread_safety.py
@@ -1,0 +1,201 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Test that the Cython overlap functions return identical results when run
+concurrently from multiple threads.
+
+This catches data races and shared-state issues introduced by ``with
+nogil:`` sections in the functions.
+"""
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from photutils.geometry import (circular_overlap_grid, elliptical_overlap_grid,
+                                rectangular_overlap_grid)
+from photutils.geometry._batch_photometry import (SHAPE_CIRCLE,
+                                                  SHAPE_CIRCULAR_ANNULUS,
+                                                  SHAPE_ELLIPSE,
+                                                  SHAPE_ELLIPTICAL_ANNULUS,
+                                                  SHAPE_RECTANGLE,
+                                                  SHAPE_RECTANGULAR_ANNULUS,
+                                                  batch_aperture_sums)
+from photutils.geometry._polygon_overlap import polygon_overlap_grid
+
+N_THREADS = 8
+N_CALLS_PER_THREAD = 4
+
+
+def _run_concurrent(fn, *, n_threads=N_THREADS,
+                    n_calls=N_CALLS_PER_THREAD):
+    expected = fn()
+    with ThreadPoolExecutor(max_workers=n_threads) as ex:
+        futures = [ex.submit(fn)
+                   for _ in range(n_threads * n_calls)]
+        for fut in futures:
+            np.testing.assert_array_equal(fut.result(), expected)
+
+
+@pytest.mark.parametrize('use_exact', [1, 0])
+def test_circular_overlap_grid_threadsafe(use_exact):
+    def fn():
+        return circular_overlap_grid(-15.0, 15.0, -15.0, 15.0, 200, 200,
+                                     8.0, use_exact, 5)
+    _run_concurrent(fn)
+
+
+@pytest.mark.parametrize('use_exact', [1, 0])
+def test_elliptical_overlap_grid_threadsafe(use_exact):
+    def fn():
+        return elliptical_overlap_grid(-15.0, 15.0, -15.0, 15.0, 200, 200,
+                                       8.0, 5.0, 0.7, use_exact, 5)
+    _run_concurrent(fn)
+
+
+@pytest.mark.parametrize('use_exact', [1, 0])
+def test_rectangular_overlap_grid_threadsafe(use_exact):
+    def fn():
+        return rectangular_overlap_grid(-15.0, 15.0, -15.0, 15.0, 200, 200,
+                                        12.0, 7.0, 0.5, use_exact, 5)
+    _run_concurrent(fn)
+
+
+@pytest.mark.parametrize('use_exact', [1, 0])
+def test_polygon_overlap_grid_threadsafe(use_exact):
+    n_vertices = 32
+    angles = np.linspace(0.0, 2.0 * np.pi, n_vertices, endpoint=False)
+    radii = 8.0 + 2.0 * np.sin(5.0 * angles)
+    vx = np.ascontiguousarray(radii * np.cos(angles))
+    vy = np.ascontiguousarray(radii * np.sin(angles))
+
+    def fn():
+        return polygon_overlap_grid(-15.0, 15.0, -15.0, 15.0, 200, 200,
+                                    vx, vy, use_exact, 8)
+    _run_concurrent(fn)
+
+
+def test_mixed_functions_concurrent():
+    """
+    Run all geometry function types concurrently from many threads.
+
+    This is a more aggressive smoke test that mixes different functions
+    so that if any of them shares mutable state (e.g., a module-level
+    static buffer), interference between calls would surface.
+    """
+    n_vertices = 16
+    angles = np.linspace(0.0, 2.0 * np.pi, n_vertices, endpoint=False)
+    vx = np.ascontiguousarray(7.0 * np.cos(angles))
+    vy = np.ascontiguousarray(5.0 * np.sin(angles))
+
+    expected_circ = circular_overlap_grid(-10.0, 10.0, -10.0, 10.0,
+                                          150, 150, 6.0, 1, 5)
+    expected_ell = elliptical_overlap_grid(-10.0, 10.0, -10.0, 10.0,
+                                           150, 150, 7.0, 4.0, 0.3, 1, 5)
+    expected_rect = rectangular_overlap_grid(-10.0, 10.0, -10.0, 10.0,
+                                             150, 150, 9.0, 5.0, 0.4, 1, 5)
+    expected_poly = polygon_overlap_grid(-10.0, 10.0, -10.0, 10.0,
+                                         150, 150, vx, vy, 1, 5)
+
+    def task(which):
+        if which == 0:
+            return 'c', circular_overlap_grid(
+                -10.0, 10.0, -10.0, 10.0, 150, 150, 6.0, 1, 5)
+        if which == 1:
+            return 'e', elliptical_overlap_grid(
+                -10.0, 10.0, -10.0, 10.0, 150, 150, 7.0, 4.0, 0.3, 1, 5)
+        if which == 2:
+            return 'r', rectangular_overlap_grid(
+                -10.0, 10.0, -10.0, 10.0, 150, 150, 9.0, 5.0, 0.4, 1, 5)
+        return 'p', polygon_overlap_grid(
+            -10.0, 10.0, -10.0, 10.0, 150, 150, vx, vy, 1, 5)
+
+    expected_map = {'c': expected_circ, 'e': expected_ell,
+                    'r': expected_rect, 'p': expected_poly}
+
+    with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+        futures = [ex.submit(task, i % 4)
+                   for i in range(N_THREADS * 8)]
+        for future in futures:
+            tag, result = future.result()
+            assert_array_equal(result, expected_map[tag])
+
+
+def _batch_inputs():
+    """
+    Build deterministic data, error, mask, and source positions for the
+    batch-driver tests.
+    """
+    rng = np.random.default_rng(42)
+    data = rng.random((80, 80))
+    error = rng.random((80, 80)) + 0.1
+    mask = np.zeros((80, 80), dtype=np.uint8)
+    mask[::7, ::5] = 1
+    positions = np.array([[20.0, 25.0], [40.0, 40.0], [55.0, 30.0],
+                          [10.0, 60.0], [70.0, 70.0], [35.0, 15.0]])
+    return data, error, mask, positions
+
+
+# Aperture shape specs: (shape_code, params, ext_x, ext_y).
+# The half-extents need only bound the aperture; they are identical
+# across the baseline and concurrent calls, so the comparison is exact.
+_BATCH_SPECS = [
+    (SHAPE_CIRCLE, [8.0], 8.0, 8.0),
+    (SHAPE_CIRCULAR_ANNULUS, [5.0, 8.0], 8.0, 8.0),
+    (SHAPE_ELLIPSE, [8.0, 5.0, 0.7], 8.0, 8.0),
+    (SHAPE_ELLIPTICAL_ANNULUS, [4.0, 2.0, 8.0, 5.0, 0.7], 8.0, 8.0),
+    (SHAPE_RECTANGLE, [12.0, 7.0, 0.5], 7.0, 7.0),
+    (SHAPE_RECTANGULAR_ANNULUS, [6.0, 4.0, 12.0, 7.0, 0.5], 7.0, 7.0),
+]
+
+
+@pytest.mark.parametrize(('shape_code', 'params', 'ext_x', 'ext_y'),
+                         _BATCH_SPECS)
+@pytest.mark.parametrize('use_exact', [1, 0])
+def test_batch_aperture_sums_threadsafe(shape_code, params, ext_x, ext_y,
+                                        use_exact):
+    data, error, mask, positions = _batch_inputs()
+    params = np.array(params, dtype=np.float64)
+
+    def fn():
+        return batch_aperture_sums(data, error, mask, positions, shape_code,
+                                   params, ext_x, ext_y, use_exact, 8)
+
+    expected = fn()
+    with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+        futures = [ex.submit(fn)
+                   for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
+        for future in futures:
+            sums, errs, overlap = future.result()
+            assert_array_equal(sums, expected[0])
+            assert_array_equal(errs, expected[1])
+            assert_array_equal(overlap, expected[2])
+
+
+def test_batch_aperture_sums_mixed_concurrent():
+    """
+    Run every aperture shape through the batch driver concurrently.
+
+    Mixing shapes within the thread pool surfaces interference between
+    calls if any shared mutable state (e.g., a module-level scratch
+    buffer) were introduced into the ``nogil`` source loop.
+    """
+    data, error, mask, positions = _batch_inputs()
+
+    def task(spec):
+        shape_code, params, ext_x, ext_y = spec
+        params = np.array(params, dtype=np.float64)
+        return batch_aperture_sums(data, error, mask, positions, shape_code,
+                                   params, ext_x, ext_y, 1, 5)
+
+    expected = {spec[0]: task(spec) for spec in _BATCH_SPECS}
+
+    with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+        futures = {ex.submit(task, spec): spec[0]
+                   for spec in _BATCH_SPECS for _ in range(N_THREADS)}
+        for fut, shape_code in futures.items():
+            sums, errs, overlap = fut.result()
+            exp_sums, exp_errs, exp_overlap = expected[shape_code]
+            assert_array_equal(sums, exp_sums)
+            assert_array_equal(errs, exp_errs)
+            assert_array_equal(overlap, exp_overlap)

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -48,33 +48,30 @@ class ProfileBase(metaclass=abc.ABCMeta):
         Masked data are excluded from all calculations.
 
     method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the overlap of the aperture on the
-        pixel grid:
+        The method used to determine the pixel weights (the fraction of
+        the pixel area covered by the aperture):
 
         * ``'exact'`` (default):
-          The exact fractional overlap of the aperture and each pixel is
-          calculated. The aperture weights will contain values between 0
-          and 1.
-
+          Calculates the exact geometric overlap area. Weights are
+          continuous in the range [0, 1].
         * ``'center'``:
-          A pixel is considered to be entirely in or out of the aperture
-          depending on whether its center is in or out of the aperture.
-          The aperture weights will contain values only of 0 (out) and 1
-          (in).
-
+          Binary weighting based on the pixel center. Weights are either
+          0 or 1. A pixel is included only if its center lies strictly
+          inside the aperture; pixel centers lying exactly on the
+          aperture boundary are excluded (weight 0).
         * ``'subpixel'``:
-          A pixel is divided into subpixels (see the ``subpixels``
-          keyword), each of which are considered to be entirely in or
-          out of the aperture depending on whether its center is in
-          or out of the aperture. If ``subpixels=1``, this method is
-          equivalent to ``'center'``. The aperture weights will contain
-          values between 0 and 1.
+          Approximates the overlap by averaging binary samples on a
+          subgrid. The number of samples is set by the ``subpixels``
+          parameter. Weights are discrete in the range [0, 1]. A
+          subpixel is included only if its center lies strictly inside
+          the aperture; subpixel centers lying exactly on the aperture
+          boundary are excluded (weight 0).
 
     subpixels : int, optional
-        For the ``'subpixel'`` method, resample pixels by this factor
-        in each dimension. That is, each pixel is divided into
-        ``subpixels**2`` subpixels. This keyword is ignored unless
-        ``method='subpixel'``.
+        The subsampling factor per axis used when ``method='subpixel'``.
+        Each pixel is divided into a grid of ``subpixels**2`` subpixels
+        to approximate the overlap. This parameter is ignored for other
+        methods.
     """
 
     # Define axis labels used by `~photutils.profiles.ProfileBase.plot`.

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -51,33 +51,30 @@ class CurveOfGrowth(ProfileBase):
         Masked data are excluded from all calculations.
 
     method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the overlap of the aperture on the
-        pixel grid:
+        The method used to determine the pixel weights (the fraction of
+        the pixel area covered by the aperture):
 
         * ``'exact'`` (default):
-          The exact fractional overlap of the aperture and each pixel is
-          calculated. The aperture weights will contain values between 0
-          and 1.
-
+          Calculates the exact geometric overlap area. Weights are
+          continuous in the range [0, 1].
         * ``'center'``:
-          A pixel is considered to be entirely in or out of the aperture
-          depending on whether its center is in or out of the aperture.
-          The aperture weights will contain values only of 0 (out) and 1
-          (in).
-
+          Binary weighting based on the pixel center. Weights are either
+          0 or 1. A pixel is included only if its center lies strictly
+          inside the aperture; pixel centers lying exactly on the
+          aperture boundary are excluded (weight 0).
         * ``'subpixel'``:
-          A pixel is divided into subpixels (see the ``subpixels``
-          keyword), each of which are considered to be entirely in or
-          out of the aperture depending on whether its center is in
-          or out of the aperture. If ``subpixels=1``, this method is
-          equivalent to ``'center'``. The aperture weights will contain
-          values between 0 and 1.
+          Approximates the overlap by averaging binary samples on a
+          subgrid. The number of samples is set by the ``subpixels``
+          parameter. Weights are discrete in the range [0, 1]. A
+          subpixel is included only if its center lies strictly inside
+          the aperture; subpixel centers lying exactly on the aperture
+          boundary are excluded (weight 0).
 
     subpixels : int, optional
-        For the ``'subpixel'`` method, resample pixels by this factor
-        in each dimension. That is, each pixel is divided into
-        ``subpixels**2`` subpixels. This keyword is ignored unless
-        ``method='subpixel'``.
+        The subsampling factor per axis used when ``method='subpixel'``.
+        Each pixel is divided into a grid of ``subpixels**2`` subpixels
+        to approximate the overlap. This parameter is ignored for other
+        methods.
 
     See Also
     --------
@@ -413,7 +410,10 @@ class EnsquaredCurveOfGrowth(ProfileBase):
           out of the aperture depending on whether its center is in
           or out of the aperture. If ``subpixels=1``, this method is
           equivalent to ``'center'``. The aperture weights will contain
-          values between 0 and 1.
+          values between 0 and 1. A subpixel is included only if its
+          center lies strictly inside the aperture; subpixel centers
+          lying exactly on the aperture boundary are excluded (weight
+          0).
 
     subpixels : int, optional
         For the ``'subpixel'`` method, resample pixels by this factor
@@ -759,7 +759,10 @@ class EllipticalCurveOfGrowth(ProfileBase):
           out of the aperture depending on whether its center is in
           or out of the aperture. If ``subpixels=1``, this method is
           equivalent to ``'center'``. The aperture weights will contain
-          values between 0 and 1.
+          values between 0 and 1. A subpixel is included only if its
+          center lies strictly inside the aperture; subpixel centers
+          lying exactly on the aperture boundary are excluded (weight
+          0).
 
     subpixels : int, optional
         For the ``'subpixel'`` method, resample pixels by this factor

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -63,33 +63,30 @@ class RadialProfile(ProfileBase):
         Masked data are excluded from all calculations.
 
     method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the overlap of the aperture on the
-        pixel grid:
+        The method used to determine the pixel weights (the fraction of
+        the pixel area covered by the aperture):
 
         * ``'exact'`` (default):
-          The exact fractional overlap of the aperture and each pixel is
-          calculated. The aperture weights will contain values between 0
-          and 1.
-
+          Calculates the exact geometric overlap area. Weights are
+          continuous in the range [0, 1].
         * ``'center'``:
-          A pixel is considered to be entirely in or out of the aperture
-          depending on whether its center is in or out of the aperture.
-          The aperture weights will contain values only of 0 (out) and 1
-          (in).
-
+          Binary weighting based on the pixel center. Weights are either
+          0 or 1. A pixel is included only if its center lies strictly
+          inside the aperture; pixel centers lying exactly on the
+          aperture boundary are excluded (weight 0).
         * ``'subpixel'``:
-          A pixel is divided into subpixels (see the ``subpixels``
-          keyword), each of which are considered to be entirely in or
-          out of the aperture depending on whether its center is in
-          or out of the aperture. If ``subpixels=1``, this method is
-          equivalent to ``'center'``. The aperture weights will contain
-          values between 0 and 1.
+          Approximates the overlap by averaging binary samples on a
+          subgrid. The number of samples is set by the ``subpixels``
+          parameter. Weights are discrete in the range [0, 1]. A
+          subpixel is included only if its center lies strictly inside
+          the aperture; subpixel centers lying exactly on the aperture
+          boundary are excluded (weight 0).
 
     subpixels : int, optional
-        For the ``'subpixel'`` method, resample pixels by this factor
-        in each dimension. That is, each pixel is divided into
-        ``subpixels**2`` subpixels. This keyword is ignored unless
-        ``method='subpixel'``.
+        The subsampling factor per axis used when ``method='subpixel'``.
+        Each pixel is divided into a grid of ``subpixels**2`` subpixels
+        to approximate the overlap. This parameter is ignored for other
+        methods.
 
     See Also
     --------


### PR DESCRIPTION
This PR adds ``PolygonAperture`` and ``SkyPolygonAperture`` classes for polygon apertures defined by a fixed shape applied at one or more positions.

Closes: #467