### PR TITLE
Add to_polygon method to aperture classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,10 @@ New Features
     for polygon apertures defined by a fixed shape applied at one or
     more positions. [#2297]
 
+  - Added ``to_polygon`` methods to the circular, elliptical, and
+    rectangular apertures (both pixel and sky variants) to convert them
+    to ``PolygonAperture`` or ``SkyPolygonAperture`` objects. [#2298]
+
 - ``photutils.isophote``
 
   - Optimized the ``build_ellipse_model_c`` Cython extension by

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -201,9 +201,13 @@ properties expose the geometric parameters of the shape.
 
 The built-in `~photutils.aperture.CircularAperture`,
 `~photutils.aperture.EllipticalAperture`, and
-`~photutils.aperture.RectangularAperture` classes also provide a
+`~photutils.aperture.RectangularAperture` classes (and their
+sky counterparts `~photutils.aperture.SkyCircularAperture`,
+`~photutils.aperture.SkyEllipticalAperture`, and
+`~photutils.aperture.SkyRectangularAperture`) also provide a
 ``to_polygon`` method to convert them to an approximating (or, for the
-rectangle, exactly equivalent) `~photutils.aperture.PolygonAperture`.
+rectangle, exactly equivalent) `~photutils.aperture.PolygonAperture` or
+`~photutils.aperture.SkyPolygonAperture`.
 
 
 Performing Aperture Photometry

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -185,6 +185,22 @@ transformation of the polygon corners.
 `~regions.PolygonPixelRegion` and `~regions.PolygonSkyRegion`.
 
 
+Converting Apertures to Polygons
+================================
+
+The circular, elliptical, and rectangular apertures (both their pixel
+and sky variants) now have a ``to_polygon`` method that converts
+them to an equivalent `~photutils.aperture.PolygonAperture` or
+`~photutils.aperture.SkyPolygonAperture`. The circular and elliptical
+apertures are approximated by a polygon with a configurable number of
+vertices (``n_vertices``, default 100), while the rectangular aperture
+is converted exactly to a four-vertex polygon::
+
+    >>> from photutils.aperture import CircularAperture
+    >>> aper = CircularAperture((10.0, 20.0), r=5.0)
+    >>> poly = aper.to_polygon(n_vertices=100)
+
+
 .. _whatsnew-3.1-api-changes:
 
 API Changes

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -33,10 +33,10 @@ __all__ = [
 ]
 
 
-def _circular_polygon_offsets(r, n_points):
+def _circular_polygon_offsets(r, n_vertices):
     """
     Compute the vertex offsets that approximate a circle of radius ``r``
-    using ``n_points`` equally spaced vertices.
+    using ``n_vertices`` equally spaced vertices.
 
     ``r`` may be a plain number (pixel offsets) or a
     `~astropy.units.Quantity` (angular offsets); the returned offsets
@@ -47,22 +47,23 @@ def _circular_polygon_offsets(r, n_points):
     r : float or `~astropy.units.Quantity`
         The radius of the circle.
 
-    n_points : int
+    n_vertices : int
         The number of polygon vertices used to approximate the circle.
 
     Returns
     -------
     offsets : 2D `~numpy.ndarray`
         The vertex offsets that approximate the circle. The shape is
-        ``(n_points, 2)``, where the second axis corresponds to the a
+        ``(n_vertices, 2)``, where the second axis corresponds to the
         ``(x, y)`` offsets. The offsets are in the same units as the
         input ``r``.
     """
-    if n_points < 3:
-        msg = f'n_points must be at least 3, got {n_points}'
+    n_vertices = int(n_vertices)
+    if n_vertices < 3:
+        msg = f'n_vertices must be at least 3, got {n_vertices}'
         raise ValueError(msg)
 
-    theta = np.linspace(0.0, 2.0 * np.pi, n_points, endpoint=False)
+    theta = np.linspace(0.0, 2.0 * np.pi, n_vertices, endpoint=False)
     return np.column_stack([np.cos(theta), np.sin(theta)]) * r
 
 
@@ -310,14 +311,14 @@ class CircularAperture(PixelAperture):
         r = Angle(self.r * mean_scale, 'arcsec')
         return SkyCircularAperture(positions=positions, r=r)
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~photutils.aperture.PolygonAperture` that
         approximates this circular aperture.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices used to approximate the
             circle. Must be at least 3. Default is 100.
 
@@ -326,7 +327,7 @@ class CircularAperture(PixelAperture):
         aperture : `~photutils.aperture.PolygonAperture`
             A polygon aperture that approximates the circle.
         """
-        offsets = _circular_polygon_offsets(self.r, n_points)
+        offsets = _circular_polygon_offsets(self.r, n_vertices)
         return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
@@ -586,14 +587,14 @@ class SkyCircularAperture(SkyAperture):
         r = self.r.to_value(u.arcsec) * mean_scale
         return CircularAperture(positions=positions, r=r)
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~photutils.aperture.SkyPolygonAperture` that
         approximates this circular aperture.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices used to approximate the
             circle. Must be at least 3. Default is 100.
 
@@ -602,7 +603,7 @@ class SkyCircularAperture(SkyAperture):
         aperture : `~photutils.aperture.SkyPolygonAperture`
             A sky polygon aperture that approximates the circle.
         """
-        offsets = _circular_polygon_offsets(self.r, n_points)
+        offsets = _circular_polygon_offsets(self.r, n_vertices)
         return SkyPolygonAperture._from_convex_offsets(self.positions,
                                                        offsets)
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -16,7 +16,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            SkyCoordPositions)
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
-from photutils.aperture.polygon import PolygonAperture
+from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
 from photutils.geometry import circular_overlap_grid
 from photutils.geometry._batch_photometry import (SHAPE_CIRCLE,
                                                   SHAPE_CIRCULAR_ANNULUS)
@@ -31,6 +31,39 @@ __all__ = [
     'SkyCircularAnnulus',
     'SkyCircularAperture',
 ]
+
+
+def _circular_polygon_offsets(r, n_points):
+    """
+    Compute the vertex offsets that approximate a circle of radius ``r``
+    using ``n_points`` equally spaced vertices.
+
+    ``r`` may be a plain number (pixel offsets) or a
+    `~astropy.units.Quantity` (angular offsets); the returned offsets
+    carry the same type.
+
+    Parameters
+    ----------
+    r : float or `~astropy.units.Quantity`
+        The radius of the circle.
+
+    n_points : int
+        The number of polygon vertices used to approximate the circle.
+
+    Returns
+    -------
+    offsets : 2D `~numpy.ndarray`
+        The vertex offsets that approximate the circle. The shape is
+        ``(n_points, 2)``, where the second axis corresponds to the a
+        ``(x, y)`` offsets. The offsets are in the same units as the
+        input ``r``.
+    """
+    if n_points < 3:
+        msg = f'n_points must be at least 3, got {n_points}'
+        raise ValueError(msg)
+
+    theta = np.linspace(0.0, 2.0 * np.pi, n_points, endpoint=False)
+    return np.column_stack([np.cos(theta), np.sin(theta)]) * r
 
 
 @deprecated('3.0')
@@ -293,14 +326,7 @@ class CircularAperture(PixelAperture):
         aperture : `~photutils.aperture.PolygonAperture`
             A polygon aperture that approximates the circle.
         """
-        if n_points < 3:
-            msg = f'n_points must be at least 3, got {n_points}'
-            raise ValueError(msg)
-
-        theta = np.linspace(0.0, 2.0 * np.pi, n_points, endpoint=False)
-        offsets = np.column_stack([self.r * np.cos(theta),
-                                   self.r * np.sin(theta)])
-
+        offsets = _circular_polygon_offsets(self.r, n_points)
         return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
@@ -559,6 +585,26 @@ class SkyCircularAperture(SkyAperture):
 
         r = self.r.to_value(u.arcsec) * mean_scale
         return CircularAperture(positions=positions, r=r)
+
+    def to_polygon(self, n_points=100):
+        """
+        Return a `~photutils.aperture.SkyPolygonAperture` that
+        approximates this circular aperture.
+
+        Parameters
+        ----------
+        n_points : int, optional
+            The number of polygon vertices used to approximate the
+            circle. Must be at least 3. Default is 100.
+
+        Returns
+        -------
+        aperture : `~photutils.aperture.SkyPolygonAperture`
+            A sky polygon aperture that approximates the circle.
+        """
+        offsets = _circular_polygon_offsets(self.r, n_points)
+        return SkyPolygonAperture._from_convex_offsets(self.positions,
+                                                       offsets)
 
 
 class SkyCircularAnnulus(SkyAperture):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -16,6 +16,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            SkyCoordPositions)
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
+from photutils.aperture.polygon import PolygonAperture
 from photutils.geometry import circular_overlap_grid
 from photutils.geometry._batch_photometry import (SHAPE_CIRCLE,
                                                   SHAPE_CIRCULAR_ANNULUS)
@@ -275,6 +276,32 @@ class CircularAperture(PixelAperture):
 
         r = Angle(self.r * mean_scale, 'arcsec')
         return SkyCircularAperture(positions=positions, r=r)
+
+    def to_polygon(self, n_points=100):
+        """
+        Return a `~photutils.aperture.PolygonAperture` that
+        approximates this circular aperture.
+
+        Parameters
+        ----------
+        n_points : int, optional
+            The number of polygon vertices used to approximate the
+            circle. Must be at least 3. Default is 100.
+
+        Returns
+        -------
+        aperture : `~photutils.aperture.PolygonAperture`
+            A polygon aperture that approximates the circle.
+        """
+        if n_points < 3:
+            msg = f'n_points must be at least 3, got {n_points}'
+            raise ValueError(msg)
+
+        theta = np.linspace(0.0, 2.0 * np.pi, n_points, endpoint=False)
+        offsets = np.column_stack([self.r * np.cos(theta),
+                                   self.r * np.sin(theta)])
+
+        return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
 class CircularAnnulus(PixelAperture):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -17,6 +17,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            SkyCoordPositions)
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
+from photutils.aperture.polygon import PolygonAperture
 from photutils.geometry import elliptical_overlap_grid
 from photutils.geometry._batch_photometry import (SHAPE_ELLIPSE,
                                                   SHAPE_ELLIPTICAL_ANNULUS)
@@ -333,6 +334,37 @@ class EllipticalAperture(PixelAperture):
         b = Angle(sky_height / 2, 'arcsec')
         return SkyEllipticalAperture(positions=positions, a=a, b=b,
                                      theta=sky_angle)
+
+    def to_polygon(self, n_points=100):
+        """
+        Return a `~photutils.aperture.PolygonAperture` that
+        approximates this elliptical aperture.
+
+        Parameters
+        ----------
+        n_points : int, optional
+            The number of polygon vertices used to approximate the
+            ellipse. Must be at least 3. Default is 100.
+
+        Returns
+        -------
+        aperture : `~photutils.aperture.PolygonAperture`
+            A polygon aperture that approximates the ellipse.
+        """
+        if n_points < 3:
+            msg = f'n_points must be at least 3, got {n_points}'
+            raise ValueError(msg)
+
+        theta = np.linspace(0.0, 2.0 * np.pi, n_points, endpoint=False)
+        x = self.a * np.cos(theta)
+        y = self.b * np.sin(theta)
+        rot = self.theta.to_value(u.radian)
+        cos_t = np.cos(rot)
+        sin_t = np.sin(rot)
+        offsets = np.column_stack([x * cos_t - y * sin_t,
+                                   x * sin_t + y * cos_t])
+
+        return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
 class EllipticalAnnulus(PixelAperture):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -35,11 +35,11 @@ __all__ = [
 ]
 
 
-def _elliptical_polygon_offsets(a, b, theta, n_points, *, swap_axes=False):
+def _elliptical_polygon_offsets(a, b, theta, n_vertices, *, swap_axes=False):
     """
     Compute the vertex offsets that approximate an ellipse with
     semimajor axis ``a``, semiminor axis ``b``, and position angle
-    ``theta`` (in radians) using ``n_points`` equally spaced vertices.
+    ``theta`` (in radians) using ``n_vertices`` equally spaced vertices.
 
     Parameters
     ----------
@@ -50,11 +50,14 @@ def _elliptical_polygon_offsets(a, b, theta, n_points, *, swap_axes=False):
         The semiminor axis of the ellipse.
 
     theta : float
-        The position angle of the ellipse in radians. For a right-handed
-        world coordinate system, the position angle increases
-        counterclockwise from North (PA=0).
+        The rotation angle of the ellipse in radians. With
+        ``swap_axes=False`` (the pixel convention), it is measured
+        counterclockwise from the first (``x``) coordinate axis. With
+        ``swap_axes=True`` (the sky convention), it is the position
+        angle measured counterclockwise from North (+latitude), where
+        PA=0 places the semimajor axis along North.
 
-    n_points : int
+    n_vertices : int
         The number of vertices used to approximate the ellipse. Must be
         at least 3.
 
@@ -69,14 +72,15 @@ def _elliptical_polygon_offsets(a, b, theta, n_points, *, swap_axes=False):
     -------
     offsets : 2D `~numpy.ndarray`
         The vertex offsets that approximate the ellipse. The shape is
-        (n_points, 2) where the columns correspond to the x and y
+        (n_vertices, 2) where the columns correspond to the x and y
         coordinate offsets, respectively.
     """
-    if n_points < 3:
-        msg = f'n_points must be at least 3, got {n_points}'
+    n_vertices = int(n_vertices)
+    if n_vertices < 3:
+        msg = f'n_vertices must be at least 3, got {n_vertices}'
         raise ValueError(msg)
 
-    angles = np.linspace(0.0, 2.0 * np.pi, n_points, endpoint=False)
+    angles = np.linspace(0.0, 2.0 * np.pi, n_vertices, endpoint=False)
     x = a * np.cos(angles)
     y = b * np.sin(angles)
     if swap_axes:
@@ -389,14 +393,14 @@ class EllipticalAperture(PixelAperture):
         return SkyEllipticalAperture(positions=positions, a=a, b=b,
                                      theta=sky_angle)
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~photutils.aperture.PolygonAperture` that approximates
         this elliptical aperture.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices used to approximate the
             ellipse. Must be at least 3. Default is 100.
 
@@ -406,7 +410,7 @@ class EllipticalAperture(PixelAperture):
             A polygon aperture that approximates the ellipse.
         """
         offsets = _elliptical_polygon_offsets(
-            self.a, self.b, self.theta.to_value(u.radian), n_points)
+            self.a, self.b, self.theta.to_value(u.radian), n_vertices)
         return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
@@ -744,14 +748,14 @@ class SkyEllipticalAperture(SkyAperture):
         return EllipticalAperture(positions=positions, a=a, b=b,
                                   theta=pix_angle)
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~photutils.aperture.SkyPolygonAperture` that
         approximates this elliptical aperture.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices used to approximate the
             ellipse. Must be at least 3. Default is 100.
 
@@ -763,7 +767,7 @@ class SkyEllipticalAperture(SkyAperture):
         unit = self.a.unit
         offsets = _elliptical_polygon_offsets(
             self.a.to_value(unit), self.b.to_value(unit),
-            self.theta.to_value(u.radian), n_points, swap_axes=True) * unit
+            self.theta.to_value(u.radian), n_vertices, swap_axes=True) * unit
         return SkyPolygonAperture._from_convex_offsets(self.positions, offsets)
 
 

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -17,7 +17,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            SkyCoordPositions)
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
-from photutils.aperture.polygon import PolygonAperture
+from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
 from photutils.geometry import elliptical_overlap_grid
 from photutils.geometry._batch_photometry import (SHAPE_ELLIPSE,
                                                   SHAPE_ELLIPTICAL_ANNULUS)
@@ -33,6 +33,60 @@ __all__ = [
     'SkyEllipticalAnnulus',
     'SkyEllipticalAperture',
 ]
+
+
+def _elliptical_polygon_offsets(a, b, theta, n_points, *, swap_axes=False):
+    """
+    Compute the vertex offsets that approximate an ellipse with
+    semimajor axis ``a``, semiminor axis ``b``, and position angle
+    ``theta`` (in radians) using ``n_points`` equally spaced vertices.
+
+    Parameters
+    ----------
+    a : float
+        The semimajor axis of the ellipse.
+
+    b : float
+        The semiminor axis of the ellipse.
+
+    theta : float
+        The position angle of the ellipse in radians. For a right-handed
+        world coordinate system, the position angle increases
+        counterclockwise from North (PA=0).
+
+    n_points : int
+        The number of vertices used to approximate the ellipse. Must be
+        at least 3.
+
+    swap_axes : bool, optional
+        If `True`, the unrotated semimajor axis is placed along the
+        second coordinate axis instead of the first. This matches the
+        sky-aperture convention where, at ``theta=0``, the semimajor axis
+        is along +latitude (North) and the semiminor axis is along
+        +longitude.
+
+    Returns
+    -------
+    offsets : 2D `~numpy.ndarray`
+        The vertex offsets that approximate the ellipse. The shape is
+        (n_points, 2) where the columns correspond to the x and y
+        coordinate offsets, respectively.
+    """
+    if n_points < 3:
+        msg = f'n_points must be at least 3, got {n_points}'
+        raise ValueError(msg)
+
+    angles = np.linspace(0.0, 2.0 * np.pi, n_points, endpoint=False)
+    x = a * np.cos(angles)
+    y = b * np.sin(angles)
+    if swap_axes:
+        x, y = y, x
+
+    cos_t = np.cos(theta)
+    sin_t = np.sin(theta)
+
+    return np.column_stack([x * cos_t - y * sin_t,
+                            x * sin_t + y * cos_t])
 
 
 @deprecated('3.0', until='4.0')
@@ -337,8 +391,8 @@ class EllipticalAperture(PixelAperture):
 
     def to_polygon(self, n_points=100):
         """
-        Return a `~photutils.aperture.PolygonAperture` that
-        approximates this elliptical aperture.
+        Return a `~photutils.aperture.PolygonAperture` that approximates
+        this elliptical aperture.
 
         Parameters
         ----------
@@ -351,19 +405,8 @@ class EllipticalAperture(PixelAperture):
         aperture : `~photutils.aperture.PolygonAperture`
             A polygon aperture that approximates the ellipse.
         """
-        if n_points < 3:
-            msg = f'n_points must be at least 3, got {n_points}'
-            raise ValueError(msg)
-
-        theta = np.linspace(0.0, 2.0 * np.pi, n_points, endpoint=False)
-        x = self.a * np.cos(theta)
-        y = self.b * np.sin(theta)
-        rot = self.theta.to_value(u.radian)
-        cos_t = np.cos(rot)
-        sin_t = np.sin(rot)
-        offsets = np.column_stack([x * cos_t - y * sin_t,
-                                   x * sin_t + y * cos_t])
-
+        offsets = _elliptical_polygon_offsets(
+            self.a, self.b, self.theta.to_value(u.radian), n_points)
         return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
@@ -700,6 +743,28 @@ class SkyEllipticalAperture(SkyAperture):
         b = pix_height / 2
         return EllipticalAperture(positions=positions, a=a, b=b,
                                   theta=pix_angle)
+
+    def to_polygon(self, n_points=100):
+        """
+        Return a `~photutils.aperture.SkyPolygonAperture` that
+        approximates this elliptical aperture.
+
+        Parameters
+        ----------
+        n_points : int, optional
+            The number of polygon vertices used to approximate the
+            ellipse. Must be at least 3. Default is 100.
+
+        Returns
+        -------
+        aperture : `~photutils.aperture.SkyPolygonAperture`
+            A sky polygon aperture that approximates the ellipse.
+        """
+        unit = self.a.unit
+        offsets = _elliptical_polygon_offsets(
+            self.a.to_value(unit), self.b.to_value(unit),
+            self.theta.to_value(u.radian), n_points, swap_axes=True) * unit
+        return SkyPolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
 class SkyEllipticalAnnulus(SkyAperture):

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -874,6 +874,43 @@ class SkyPolygonAperture(SkyAperture):
         self.vertex_offsets = vertex_offsets
 
     @classmethod
+    def _from_convex_offsets(cls, positions, offsets):
+        """
+        Construct a `SkyPolygonAperture` from angular vertex offsets
+        that are known to define a simple polygon, skipping the
+        ``O(n^2)`` self-intersection check.
+
+        This is a fast-path internal constructor used by the
+        ``to_polygon`` methods of the built-in sky apertures, where the
+        generated polygon (a discretized circle, ellipse, or rectangle)
+        is guaranteed to be simple by construction. The cheap shape,
+        vertex-count, finiteness, zero-area, and counter-clockwise
+        normalization checks are still applied.
+
+        Parameters
+        ----------
+        positions : `~astropy.coordinates.SkyCoord`
+            The center position(s) in sky coordinates.
+
+        offsets : `~astropy.units.Quantity`
+            The ``(n_vertices, 2)`` angular Quantity of vertex offsets
+            ``(d_lon, d_lat)`` relative to ``positions``.
+
+        Returns
+        -------
+        aperture : `SkyPolygonAperture`
+            The sky polygon aperture.
+        """
+        verts = offsets.to_value(u.arcsec)
+        verts = _validate_simple_polygon(verts, name='vertex_offsets',
+                                         check_simple=False)
+        offsets = (verts * u.arcsec).to(offsets.unit)
+        obj = cls.__new__(cls)
+        obj.positions = positions
+        obj.__dict__['vertex_offsets'] = offsets
+        return obj
+
+    @classmethod
     def from_vertices(cls, vertices):
         """
         Construct a `SkyPolygonAperture` from a single set of absolute

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -17,6 +17,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            SkyCoordPositions)
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
+from photutils.aperture.polygon import PolygonAperture
 from photutils.geometry import rectangular_overlap_grid
 from photutils.geometry._batch_photometry import (SHAPE_RECTANGLE,
                                                   SHAPE_RECTANGULAR_ANNULUS)
@@ -367,6 +368,29 @@ class RectangularAperture(PixelAperture):
         height = Angle(sky_h, 'arcsec')
         return SkyRectangularAperture(positions=positions, w=width, h=height,
                                       theta=sky_angle)
+
+    def to_polygon(self):
+        """
+        Return a `~photutils.aperture.PolygonAperture` with the four
+        corners of this rectangle as its vertices.
+
+        Returns
+        -------
+        aperture : `~photutils.aperture.PolygonAperture`
+            A polygon aperture exactly equivalent to the rectangle.
+        """
+        hw = 0.5 * self.w
+        hh = 0.5 * self.h
+        # Corners ordered counter-clockwise in the unrotated frame.
+        corners = np.array([[-hw, -hh], [hw, -hh],
+                            [hw, hh], [-hw, hh]])
+        rot = self.theta.to_value(u.radian)
+        cos_t = np.cos(rot)
+        sin_t = np.sin(rot)
+        rot_mat = np.array([[cos_t, -sin_t], [sin_t, cos_t]])
+        offsets = corners @ rot_mat.T
+
+        return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
 class RectangularAnnulus(PixelAperture):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -17,7 +17,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            SkyCoordPositions)
 from photutils.aperture.core import PixelAperture, SkyAperture
 from photutils.aperture.mask import ApertureMask
-from photutils.aperture.polygon import PolygonAperture
+from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
 from photutils.geometry import rectangular_overlap_grid
 from photutils.geometry._batch_photometry import (SHAPE_RECTANGLE,
                                                   SHAPE_RECTANGULAR_ANNULUS)
@@ -33,6 +33,41 @@ __all__ = [
     'SkyRectangularAnnulus',
     'SkyRectangularAperture',
 ]
+
+
+def _rectangular_polygon_offsets(half_x, half_y, theta):
+    """
+    Compute the four corner offsets of a rectangle with half-extents
+    ``half_x`` and ``half_y`` along the unrotated first and second
+    coordinate axes, rotated by ``theta`` (in radians).
+
+    The corners are ordered counter-clockwise in the unrotated frame.
+
+    Parameters
+    ----------
+    half_x : float
+        Half of the rectangle width along the unrotated first coordinate
+        axis.
+
+    half_y : float
+        Half of the rectangle height along the unrotated second
+        coordinate axis.
+
+    theta : float
+        The rotation angle in radians from the unrotated first
+        coordinate axis.
+
+    Returns
+    -------
+    offsets : 2D `~numpy.ndarray`
+        The four corner offsets of the rectangle, shape (4, 2).
+    """
+    corners = np.array([[-half_x, -half_y], [half_x, -half_y],
+                        [half_x, half_y], [-half_x, half_y]])
+    cos_t = np.cos(theta)
+    sin_t = np.sin(theta)
+    rot_mat = np.array([[cos_t, -sin_t], [sin_t, cos_t]])
+    return corners @ rot_mat.T
 
 
 @deprecated('3.0', until='4.0')
@@ -379,17 +414,8 @@ class RectangularAperture(PixelAperture):
         aperture : `~photutils.aperture.PolygonAperture`
             A polygon aperture exactly equivalent to the rectangle.
         """
-        hw = 0.5 * self.w
-        hh = 0.5 * self.h
-        # Corners ordered counter-clockwise in the unrotated frame.
-        corners = np.array([[-hw, -hh], [hw, -hh],
-                            [hw, hh], [-hw, hh]])
-        rot = self.theta.to_value(u.radian)
-        cos_t = np.cos(rot)
-        sin_t = np.sin(rot)
-        rot_mat = np.array([[cos_t, -sin_t], [sin_t, cos_t]])
-        offsets = corners @ rot_mat.T
-
+        offsets = _rectangular_polygon_offsets(
+            0.5 * self.w, 0.5 * self.h, self.theta.to_value(u.radian))
         return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
@@ -738,6 +764,25 @@ class SkyRectangularAperture(SkyAperture):
 
         return RectangularAperture(positions=positions, w=pix_w, h=pix_h,
                                    theta=pix_angle)
+
+    def to_polygon(self):
+        """
+        Return a `~photutils.aperture.SkyPolygonAperture` with the four
+        corners of this rectangle as its vertices.
+
+        Returns
+        -------
+        aperture : `~photutils.aperture.SkyPolygonAperture`
+            A sky polygon aperture exactly equivalent to the rectangle.
+        """
+        unit = self.w.unit
+        # At theta=0, the width (w) is along +lat (North) and the height
+        # (h) is along +lon, so the unrotated first axis uses the
+        # half-height and the second axis uses the half-width.
+        offsets = _rectangular_polygon_offsets(
+            0.5 * self.h.to_value(unit), 0.5 * self.w.to_value(unit),
+            self.theta.to_value(u.radian)) * unit
+        return SkyPolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
 class SkyRectangularAnnulus(SkyAperture):

--- a/photutils/aperture/tests/conftest.py
+++ b/photutils/aperture/tests/conftest.py
@@ -1,0 +1,21 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Shared pytest fixtures for the aperture tests.
+"""
+
+import pytest
+from astropy.wcs import WCS
+
+
+@pytest.fixture
+def tan_wcs():
+    """
+    Return a simple gnomonic (TAN) WCS used for aperture round-trip
+    tests.
+    """
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [50.5, 50.5]
+    wcs.wcs.cdelt = [-0.001, 0.001]
+    wcs.wcs.crval = [10.0, 30.0]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    return wcs

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -249,7 +249,7 @@ def test_invalid_positions():
 
 def test_circular_aperture_to_polygon():
     aper = CircularAperture((10.0, 20.0), r=5.0)
-    poly = aper.to_polygon(n_points=200)
+    poly = aper.to_polygon(n_vertices=200)
     assert isinstance(poly, PolygonAperture)
     assert poly.n_vertices == 200
     assert poly.is_regular
@@ -258,21 +258,21 @@ def test_circular_aperture_to_polygon():
 
 def test_circular_aperture_to_polygon_multi_position():
     aper = CircularAperture([(10.0, 20.0), (30.0, 40.0)], r=3.0)
-    poly = aper.to_polygon(n_points=50)
+    poly = aper.to_polygon(n_vertices=50)
     assert poly.vertices.shape == (2, 50, 2)
 
 
-def test_circular_aperture_to_polygon_invalid_n_points():
+def test_circular_aperture_to_polygon_invalid_n_vertices():
     aper = CircularAperture((0.0, 0.0), r=1.0)
-    match = 'n_points must be at least 3'
+    match = 'n_vertices must be at least 3'
     with pytest.raises(ValueError, match=match):
-        aper.to_polygon(n_points=2)
+        aper.to_polygon(n_vertices=2)
 
 
 def test_sky_circular_aperture_to_polygon():
     pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
     aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
-    poly = aper.to_polygon(n_points=200)
+    poly = aper.to_polygon(n_vertices=200)
     assert isinstance(poly, SkyPolygonAperture)
     assert poly.n_vertices == 200
     assert poly.is_regular
@@ -283,16 +283,16 @@ def test_sky_circular_aperture_to_polygon():
 def test_sky_circular_aperture_to_polygon_multi_position():
     pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
     aper = SkyCircularAperture(pos, r=3.0 * u.arcsec)
-    poly = aper.to_polygon(n_points=50)
+    poly = aper.to_polygon(n_vertices=50)
     assert poly.vertices.shape == (2, 50)
 
 
-def test_sky_circular_aperture_to_polygon_invalid_n_points():
+def test_sky_circular_aperture_to_polygon_invalid_n_vertices():
     pos = SkyCoord(ra=0.0, dec=0.0, unit='deg')
     aper = SkyCircularAperture(pos, r=1.0 * u.arcsec)
-    match = 'n_points must be at least 3'
+    match = 'n_vertices must be at least 3'
     with pytest.raises(ValueError, match=match):
-        aper.to_polygon(n_points=2)
+        aper.to_polygon(n_vertices=2)
 
 
 def _make_round_trip_wcs():
@@ -312,8 +312,8 @@ def test_sky_circular_aperture_to_polygon_wcs_round_trip():
     wcs = _make_round_trip_wcs()
     pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
     aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
-    poly_from_sky = aper.to_polygon(n_points=200).to_pixel(wcs)
-    poly_from_pix = aper.to_pixel(wcs).to_polygon(n_points=200)
+    poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(wcs)
+    poly_from_pix = aper.to_pixel(wcs).to_polygon(n_vertices=200)
     assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
     assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
                     rtol=1e-6)
@@ -330,8 +330,8 @@ def test_circular_aperture_to_polygon_to_sky_round_trip():
     # vertex exactly, so only rotation-invariant quantities are compared.
     wcs = _make_round_trip_wcs()
     aper = CircularAperture((50.0, 50.0), r=5.0)
-    sky_from_poly = aper.to_polygon(n_points=200).to_sky(wcs)
-    sky_from_aper = aper.to_sky(wcs).to_polygon(n_points=200)
+    sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(wcs)
+    sky_from_aper = aper.to_sky(wcs).to_polygon(n_vertices=200)
     assert_allclose(sky_from_poly.positions.ra.deg,
                     sky_from_aper.positions.ra.deg)
     assert_allclose(sky_from_poly.positions.dec.deg,

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -7,7 +7,6 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
-from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
 from photutils.aperture import PolygonAperture, SkyPolygonAperture
@@ -255,6 +254,19 @@ def test_circular_aperture_to_polygon():
     assert poly.is_regular
     assert abs(poly.area - aper.area) / aper.area < 1e-3
 
+    # All vertices lie on the circle of radius r
+    radii = np.hypot(*poly.vertex_offsets.T)
+    assert_allclose(radii, 5.0)
+
+
+def test_circular_aperture_to_polygon_float_n_vertices():
+    """
+    Test that a float n_vertices is coerced to an integer.
+    """
+    aper = CircularAperture((10.0, 20.0), r=1.0)
+    poly = aper.to_polygon(n_vertices=50.0)
+    assert poly.n_vertices == 50
+
 
 def test_circular_aperture_to_polygon_multi_position():
     aper = CircularAperture([(10.0, 20.0), (30.0, 40.0)], r=3.0)
@@ -295,31 +307,21 @@ def test_sky_circular_aperture_to_polygon_invalid_n_vertices():
         aper.to_polygon(n_vertices=2)
 
 
-def _make_round_trip_wcs():
-    wcs = WCS(naxis=2)
-    wcs.wcs.crpix = [50.5, 50.5]
-    wcs.wcs.cdelt = [-0.001, 0.001]
-    wcs.wcs.crval = [10.0, 30.0]
-    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
-    return wcs
-
-
-def test_sky_circular_aperture_to_polygon_wcs_round_trip():
+def test_sky_circular_aperture_to_polygon_wcs_round_trip(tan_wcs):
     """
     Test that converting a SkyCircularAperture to a polygon and then to
     pixels is equivalent to converting to pixels and then to a polygon.
     """
-    wcs = _make_round_trip_wcs()
     pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
     aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
-    poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(wcs)
-    poly_from_pix = aper.to_pixel(wcs).to_polygon(n_vertices=200)
+    poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(tan_wcs)
+    poly_from_pix = aper.to_pixel(tan_wcs).to_polygon(n_vertices=200)
     assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
     assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
                     rtol=1e-6)
 
 
-def test_circular_aperture_to_polygon_to_sky_round_trip():
+def test_circular_aperture_to_polygon_to_sky_round_trip(tan_wcs):
     """
     Test that converting a CircularAperture to a polygon and then to sky
     is equivalent to converting to sky and then to a polygon.
@@ -328,15 +330,14 @@ def test_circular_aperture_to_polygon_to_sky_round_trip():
     # the sky shape parameters from ``to_sky`` are derived from a local
     # linear (SVD) approximation, while the polygon ``to_sky`` maps each
     # vertex exactly, so only rotation-invariant quantities are compared.
-    wcs = _make_round_trip_wcs()
     aper = CircularAperture((50.0, 50.0), r=5.0)
-    sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(wcs)
-    sky_from_aper = aper.to_sky(wcs).to_polygon(n_vertices=200)
+    sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(tan_wcs)
+    sky_from_aper = aper.to_sky(tan_wcs).to_polygon(n_vertices=200)
     assert_allclose(sky_from_poly.positions.ra.deg,
                     sky_from_aper.positions.ra.deg)
     assert_allclose(sky_from_poly.positions.dec.deg,
                     sky_from_aper.positions.dec.deg)
     assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
                     sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
-    assert_allclose(sky_from_poly.to_pixel(wcs).area,
-                    sky_from_aper.to_pixel(wcs).area, rtol=1e-6)
+    assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
+                    sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -7,9 +7,10 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
+from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
-from photutils.aperture import PolygonAperture
+from photutils.aperture import PolygonAperture, SkyPolygonAperture
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAnnulus, SkyCircularAperture)
 from photutils.aperture.tests.test_aperture_common import BaseTestAperture
@@ -263,5 +264,79 @@ def test_circular_aperture_to_polygon_multi_position():
 
 def test_circular_aperture_to_polygon_invalid_n_points():
     aper = CircularAperture((0.0, 0.0), r=1.0)
-    with pytest.raises(ValueError, match='n_points must be at least 3'):
+    match = 'n_points must be at least 3'
+    with pytest.raises(ValueError, match=match):
         aper.to_polygon(n_points=2)
+
+
+def test_sky_circular_aperture_to_polygon():
+    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+    aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
+    poly = aper.to_polygon(n_points=200)
+    assert isinstance(poly, SkyPolygonAperture)
+    assert poly.n_vertices == 200
+    assert poly.is_regular
+    assert_allclose(poly.outer_radius.to_value(u.arcsec), 5.0)
+    assert poly.vertices.shape == (200,)
+
+
+def test_sky_circular_aperture_to_polygon_multi_position():
+    pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
+    aper = SkyCircularAperture(pos, r=3.0 * u.arcsec)
+    poly = aper.to_polygon(n_points=50)
+    assert poly.vertices.shape == (2, 50)
+
+
+def test_sky_circular_aperture_to_polygon_invalid_n_points():
+    pos = SkyCoord(ra=0.0, dec=0.0, unit='deg')
+    aper = SkyCircularAperture(pos, r=1.0 * u.arcsec)
+    match = 'n_points must be at least 3'
+    with pytest.raises(ValueError, match=match):
+        aper.to_polygon(n_points=2)
+
+
+def _make_round_trip_wcs():
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [50.5, 50.5]
+    wcs.wcs.cdelt = [-0.001, 0.001]
+    wcs.wcs.crval = [10.0, 30.0]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    return wcs
+
+
+def test_sky_circular_aperture_to_polygon_wcs_round_trip():
+    """
+    Test that converting a SkyCircularAperture to a polygon and then to
+    pixels is equivalent to converting to pixels and then to a polygon.
+    """
+    wcs = _make_round_trip_wcs()
+    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+    aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
+    poly_from_sky = aper.to_polygon(n_points=200).to_pixel(wcs)
+    poly_from_pix = aper.to_pixel(wcs).to_polygon(n_points=200)
+    assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
+    assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
+                    rtol=1e-6)
+
+
+def test_circular_aperture_to_polygon_to_sky_round_trip():
+    """
+    Test that converting a CircularAperture to a polygon and then to sky
+    is equivalent to converting to sky and then to a polygon.
+    """
+    # The bounding-box orientation can differ at the ~1e-5 level because
+    # the sky shape parameters from ``to_sky`` are derived from a local
+    # linear (SVD) approximation, while the polygon ``to_sky`` maps each
+    # vertex exactly, so only rotation-invariant quantities are compared.
+    wcs = _make_round_trip_wcs()
+    aper = CircularAperture((50.0, 50.0), r=5.0)
+    sky_from_poly = aper.to_polygon(n_points=200).to_sky(wcs)
+    sky_from_aper = aper.to_sky(wcs).to_polygon(n_points=200)
+    assert_allclose(sky_from_poly.positions.ra.deg,
+                    sky_from_aper.positions.ra.deg)
+    assert_allclose(sky_from_poly.positions.dec.deg,
+                    sky_from_aper.positions.dec.deg)
+    assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
+                    sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
+    assert_allclose(sky_from_poly.to_pixel(wcs).area,
+                    sky_from_aper.to_pixel(wcs).area, rtol=1e-6)

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -9,6 +9,7 @@ import pytest
 from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
 
+from photutils.aperture import PolygonAperture
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAnnulus, SkyCircularAperture)
 from photutils.aperture.tests.test_aperture_common import BaseTestAperture
@@ -243,3 +244,24 @@ def test_invalid_positions():
     xypos = zip(x, y, strict=True)
     with pytest.raises(TypeError, match=match):
         _ = CircularAperture(xypos, r=3)
+
+
+def test_circular_aperture_to_polygon():
+    aper = CircularAperture((10.0, 20.0), r=5.0)
+    poly = aper.to_polygon(n_points=200)
+    assert isinstance(poly, PolygonAperture)
+    assert poly.n_vertices == 200
+    assert poly.is_regular
+    assert abs(poly.area - aper.area) / aper.area < 1e-3
+
+
+def test_circular_aperture_to_polygon_multi_position():
+    aper = CircularAperture([(10.0, 20.0), (30.0, 40.0)], r=3.0)
+    poly = aper.to_polygon(n_points=50)
+    assert poly.vertices.shape == (2, 50, 2)
+
+
+def test_circular_aperture_to_polygon_invalid_n_points():
+    aper = CircularAperture((0.0, 0.0), r=1.0)
+    with pytest.raises(ValueError, match='n_points must be at least 3'):
+        aper.to_polygon(n_points=2)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -8,8 +8,10 @@ import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.wcs import WCS
+from numpy.testing import assert_allclose
 
-from photutils.aperture import PolygonAperture
+from photutils.aperture import PolygonAperture, SkyPolygonAperture
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus,
                                         SkyEllipticalAperture)
@@ -225,5 +227,90 @@ def test_elliptical_aperture_to_polygon_multi_position():
 
 def test_elliptical_aperture_to_polygon_invalid_n_points():
     aper = EllipticalAperture((0.0, 0.0), a=1.0, b=1.0)
-    with pytest.raises(ValueError, match='n_points must be at least 3'):
+    match = 'n_points must be at least 3'
+    with pytest.raises(ValueError, match=match):
         aper.to_polygon(n_points=2)
+
+
+def test_sky_elliptical_aperture_to_polygon():
+    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+    aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
+                                 theta=30 * u.deg)
+    poly = aper.to_polygon(n_points=200)
+    assert isinstance(poly, SkyPolygonAperture)
+    assert poly.n_vertices == 200
+    assert poly.vertices.shape == (200,)
+    # The maximum and minimum vertex distances equal the semimajor and
+    # semiminor axes, respectively.
+    radii = np.hypot(*poly.vertex_offsets.to_value(u.arcsec).T)
+    assert_allclose(radii.max(), 5.0)
+    assert_allclose(radii.min(), 3.0)
+
+
+def test_sky_elliptical_aperture_to_polygon_multi_position():
+    pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
+    aper = SkyEllipticalAperture(pos, a=4.0 * u.arcsec, b=2.0 * u.arcsec,
+                                 theta=0.5 * u.rad)
+    poly = aper.to_polygon(n_points=50)
+    assert poly.vertices.shape == (2, 50)
+
+
+def test_sky_elliptical_aperture_to_polygon_invalid_n_points():
+    pos = SkyCoord(ra=0.0, dec=0.0, unit='deg')
+    aper = SkyEllipticalAperture(pos, a=1.0 * u.arcsec, b=1.0 * u.arcsec)
+    match = 'n_points must be at least 3'
+    with pytest.raises(ValueError, match=match):
+        aper.to_polygon(n_points=2)
+
+
+def _make_round_trip_wcs():
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [50.5, 50.5]
+    wcs.wcs.cdelt = [-0.001, 0.001]
+    wcs.wcs.crval = [10.0, 30.0]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    return wcs
+
+
+@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+def test_sky_elliptical_aperture_to_polygon_wcs_round_trip(theta_deg):
+    """
+    Test that converting a SkyEllipticalAperture to a polygon and then
+    to pixels is equivalent to converting to pixels and then to a
+    polygon.
+    """
+    wcs = _make_round_trip_wcs()
+    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+    aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
+                                 theta=theta_deg * u.deg)
+    poly_from_sky = aper.to_polygon(n_points=200).to_pixel(wcs)
+    poly_from_pix = aper.to_pixel(wcs).to_polygon(n_points=200)
+    assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
+    assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
+                    rtol=1e-6)
+
+
+@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+def test_elliptical_aperture_to_polygon_to_sky_round_trip(theta_deg):
+    """
+    Test that converting an EllipticalAperture to a polygon and then to
+    sky is equivalent to converting to sky and then to a polygon.
+    """
+    # The bounding-box orientation can differ at the ~1e-5 level because
+    # the sky shape parameters from ``to_sky`` are derived from a local
+    # linear (SVD) approximation, while the polygon ``to_sky`` maps
+    # each vertex exactly, so only rotation-invariant quantities are
+    # compared.
+    wcs = _make_round_trip_wcs()
+    aper = EllipticalAperture((50.0, 50.0), a=5.0, b=3.0,
+                              theta=np.deg2rad(theta_deg))
+    sky_from_poly = aper.to_polygon(n_points=200).to_sky(wcs)
+    sky_from_aper = aper.to_sky(wcs).to_polygon(n_points=200)
+    assert_allclose(sky_from_poly.positions.ra.deg,
+                    sky_from_aper.positions.ra.deg)
+    assert_allclose(sky_from_poly.positions.dec.deg,
+                    sky_from_aper.positions.dec.deg)
+    assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
+                    sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
+    assert_allclose(sky_from_poly.to_pixel(wcs).area,
+                    sky_from_aper.to_pixel(wcs).area, rtol=1e-6)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -9,6 +9,7 @@ import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 
+from photutils.aperture import PolygonAperture
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus,
                                         SkyEllipticalAperture)
@@ -205,3 +206,24 @@ def test_ellipse_annulus_theta_quantity():
 
     assert_quantity_allclose(aper1.theta, aper2.theta)
     assert_quantity_allclose(aper1.theta, aper3.theta)
+
+
+def test_elliptical_aperture_to_polygon():
+    aper = EllipticalAperture((10.0, 20.0), a=5.0, b=3.0, theta=np.pi / 4)
+    poly = aper.to_polygon(n_points=200)
+    assert isinstance(poly, PolygonAperture)
+    assert poly.n_vertices == 200
+    assert abs(poly.area - aper.area) / aper.area < 1e-3
+
+
+def test_elliptical_aperture_to_polygon_multi_position():
+    aper = EllipticalAperture([(10.0, 20.0), (30.0, 40.0)],
+                              a=4.0, b=2.0, theta=0.5)
+    poly = aper.to_polygon(n_points=50)
+    assert poly.vertices.shape == (2, 50, 2)
+
+
+def test_elliptical_aperture_to_polygon_invalid_n_points():
+    aper = EllipticalAperture((0.0, 0.0), a=1.0, b=1.0)
+    with pytest.raises(ValueError, match='n_points must be at least 3'):
+        aper.to_polygon(n_points=2)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
 from photutils.aperture import PolygonAperture, SkyPolygonAperture
@@ -263,35 +262,25 @@ def test_sky_elliptical_aperture_to_polygon_invalid_n_vertices():
         aper.to_polygon(n_vertices=2)
 
 
-def _make_round_trip_wcs():
-    wcs = WCS(naxis=2)
-    wcs.wcs.crpix = [50.5, 50.5]
-    wcs.wcs.cdelt = [-0.001, 0.001]
-    wcs.wcs.crval = [10.0, 30.0]
-    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
-    return wcs
-
-
 @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_sky_elliptical_aperture_to_polygon_wcs_round_trip(theta_deg):
+def test_sky_elliptical_aperture_to_polygon_wcs_round_trip(theta_deg, tan_wcs):
     """
     Test that converting a SkyEllipticalAperture to a polygon and then
     to pixels is equivalent to converting to pixels and then to a
     polygon.
     """
-    wcs = _make_round_trip_wcs()
     pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
     aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
                                  theta=theta_deg * u.deg)
-    poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(wcs)
-    poly_from_pix = aper.to_pixel(wcs).to_polygon(n_vertices=200)
+    poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(tan_wcs)
+    poly_from_pix = aper.to_pixel(tan_wcs).to_polygon(n_vertices=200)
     assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
     assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
                     rtol=1e-6)
 
 
 @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_elliptical_aperture_to_polygon_to_sky_round_trip(theta_deg):
+def test_elliptical_aperture_to_polygon_to_sky_round_trip(theta_deg, tan_wcs):
     """
     Test that converting an EllipticalAperture to a polygon and then to
     sky is equivalent to converting to sky and then to a polygon.
@@ -301,16 +290,15 @@ def test_elliptical_aperture_to_polygon_to_sky_round_trip(theta_deg):
     # linear (SVD) approximation, while the polygon ``to_sky`` maps
     # each vertex exactly, so only rotation-invariant quantities are
     # compared.
-    wcs = _make_round_trip_wcs()
     aper = EllipticalAperture((50.0, 50.0), a=5.0, b=3.0,
                               theta=np.deg2rad(theta_deg))
-    sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(wcs)
-    sky_from_aper = aper.to_sky(wcs).to_polygon(n_vertices=200)
+    sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(tan_wcs)
+    sky_from_aper = aper.to_sky(tan_wcs).to_polygon(n_vertices=200)
     assert_allclose(sky_from_poly.positions.ra.deg,
                     sky_from_aper.positions.ra.deg)
     assert_allclose(sky_from_poly.positions.dec.deg,
                     sky_from_aper.positions.dec.deg)
     assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
                     sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
-    assert_allclose(sky_from_poly.to_pixel(wcs).area,
-                    sky_from_aper.to_pixel(wcs).area, rtol=1e-6)
+    assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
+                    sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -212,7 +212,7 @@ def test_ellipse_annulus_theta_quantity():
 
 def test_elliptical_aperture_to_polygon():
     aper = EllipticalAperture((10.0, 20.0), a=5.0, b=3.0, theta=np.pi / 4)
-    poly = aper.to_polygon(n_points=200)
+    poly = aper.to_polygon(n_vertices=200)
     assert isinstance(poly, PolygonAperture)
     assert poly.n_vertices == 200
     assert abs(poly.area - aper.area) / aper.area < 1e-3
@@ -221,22 +221,22 @@ def test_elliptical_aperture_to_polygon():
 def test_elliptical_aperture_to_polygon_multi_position():
     aper = EllipticalAperture([(10.0, 20.0), (30.0, 40.0)],
                               a=4.0, b=2.0, theta=0.5)
-    poly = aper.to_polygon(n_points=50)
+    poly = aper.to_polygon(n_vertices=50)
     assert poly.vertices.shape == (2, 50, 2)
 
 
-def test_elliptical_aperture_to_polygon_invalid_n_points():
+def test_elliptical_aperture_to_polygon_invalid_n_vertices():
     aper = EllipticalAperture((0.0, 0.0), a=1.0, b=1.0)
-    match = 'n_points must be at least 3'
+    match = 'n_vertices must be at least 3'
     with pytest.raises(ValueError, match=match):
-        aper.to_polygon(n_points=2)
+        aper.to_polygon(n_vertices=2)
 
 
 def test_sky_elliptical_aperture_to_polygon():
     pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
     aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
                                  theta=30 * u.deg)
-    poly = aper.to_polygon(n_points=200)
+    poly = aper.to_polygon(n_vertices=200)
     assert isinstance(poly, SkyPolygonAperture)
     assert poly.n_vertices == 200
     assert poly.vertices.shape == (200,)
@@ -251,16 +251,16 @@ def test_sky_elliptical_aperture_to_polygon_multi_position():
     pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
     aper = SkyEllipticalAperture(pos, a=4.0 * u.arcsec, b=2.0 * u.arcsec,
                                  theta=0.5 * u.rad)
-    poly = aper.to_polygon(n_points=50)
+    poly = aper.to_polygon(n_vertices=50)
     assert poly.vertices.shape == (2, 50)
 
 
-def test_sky_elliptical_aperture_to_polygon_invalid_n_points():
+def test_sky_elliptical_aperture_to_polygon_invalid_n_vertices():
     pos = SkyCoord(ra=0.0, dec=0.0, unit='deg')
     aper = SkyEllipticalAperture(pos, a=1.0 * u.arcsec, b=1.0 * u.arcsec)
-    match = 'n_points must be at least 3'
+    match = 'n_vertices must be at least 3'
     with pytest.raises(ValueError, match=match):
-        aper.to_polygon(n_points=2)
+        aper.to_polygon(n_vertices=2)
 
 
 def _make_round_trip_wcs():
@@ -283,8 +283,8 @@ def test_sky_elliptical_aperture_to_polygon_wcs_round_trip(theta_deg):
     pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
     aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
                                  theta=theta_deg * u.deg)
-    poly_from_sky = aper.to_polygon(n_points=200).to_pixel(wcs)
-    poly_from_pix = aper.to_pixel(wcs).to_polygon(n_points=200)
+    poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(wcs)
+    poly_from_pix = aper.to_pixel(wcs).to_polygon(n_vertices=200)
     assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
     assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
                     rtol=1e-6)
@@ -304,8 +304,8 @@ def test_elliptical_aperture_to_polygon_to_sky_round_trip(theta_deg):
     wcs = _make_round_trip_wcs()
     aper = EllipticalAperture((50.0, 50.0), a=5.0, b=3.0,
                               theta=np.deg2rad(theta_deg))
-    sky_from_poly = aper.to_polygon(n_points=200).to_sky(wcs)
-    sky_from_aper = aper.to_sky(wcs).to_polygon(n_points=200)
+    sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(wcs)
+    sky_from_aper = aper.to_sky(wcs).to_polygon(n_vertices=200)
     assert_allclose(sky_from_poly.positions.ra.deg,
                     sky_from_aper.positions.ra.deg)
     assert_allclose(sky_from_poly.positions.dec.deg,

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -8,9 +8,10 @@ import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
-from photutils.aperture import PolygonAperture
+from photutils.aperture import PolygonAperture, SkyPolygonAperture
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture,
                                           RectangularMaskMixin,
@@ -257,3 +258,94 @@ def test_rectangular_aperture_to_polygon_multi_position():
                                w=4.0, h=3.0, theta=0.5)
     poly = aper.to_polygon()
     assert poly.vertices.shape == (2, 4, 2)
+
+
+def test_sky_rectangular_aperture_to_polygon():
+    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+    aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec)
+    poly = aper.to_polygon()
+    assert isinstance(poly, SkyPolygonAperture)
+    assert poly.n_vertices == 4
+    assert poly.vertices.shape == (4,)
+    # At theta=0, the width (4) is along +lat (d_lat) and the height (2)
+    # is along +lon (d_lon).
+    offsets = poly.vertex_offsets.to_value(u.arcsec)
+    assert_allclose(np.sort(np.abs(offsets[:, 0])), [1.0, 1.0, 1.0, 1.0])
+    assert_allclose(np.sort(np.abs(offsets[:, 1])), [2.0, 2.0, 2.0, 2.0])
+
+
+@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+def test_sky_rectangular_aperture_to_polygon_rotation(theta_deg):
+    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+    aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec,
+                                  theta=theta_deg * u.deg)
+    poly = aper.to_polygon()
+    assert poly.n_vertices == 4
+    # The perimeter and vertex distances are rotation-invariant.
+    assert_allclose(poly.perimeter.to_value(u.arcsec), 2 * (4.0 + 2.0))
+    radii = np.hypot(*poly.vertex_offsets.to_value(u.arcsec).T)
+    assert_allclose(radii, np.hypot(1.0, 2.0))
+
+
+def test_sky_rectangular_aperture_to_polygon_multi_position():
+    pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
+    aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=3.0 * u.arcsec,
+                                  theta=0.5 * u.rad)
+    poly = aper.to_polygon()
+    assert poly.vertices.shape == (2, 4)
+
+
+def _make_round_trip_wcs():
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [50.5, 50.5]
+    wcs.wcs.cdelt = [-0.001, 0.001]
+    wcs.wcs.crval = [10.0, 30.0]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    return wcs
+
+
+@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+def test_sky_rectangular_aperture_to_polygon_wcs_round_trip(theta_deg):
+    """
+    Test that converting a SkyRectangularAperture to a polygon and then
+    to pixels matches converting to pixels and then to a polygon for all
+    rotation angles.
+
+    The two pixel polygons share the same area and bounding-box extents.
+    """
+    wcs = _make_round_trip_wcs()
+    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+    aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec,
+                                  theta=theta_deg * u.deg)
+    poly_from_sky = aper.to_polygon().to_pixel(wcs)
+    poly_from_pix = aper.to_pixel(wcs).to_polygon()
+    assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
+    assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
+                    rtol=1e-6)
+
+
+@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+def test_rectangular_aperture_to_polygon_to_sky_round_trip(theta_deg):
+    """
+    Test that converting a RectangularAperture to a polygon and then to
+    sky matches converting to sky and then to a polygon for all rotation
+    angles.
+    """
+    # The bounding-box orientation can differ at the ~1e-5 level because
+    # the sky shape parameters from ``to_sky`` are derived from a local
+    # linear (SVD) approximation, while the polygon ``to_sky`` maps
+    # each vertex exactly, so only rotation-invariant quantities are
+    # compared.
+    wcs = _make_round_trip_wcs()
+    aper = RectangularAperture((50.0, 50.0), w=4.0, h=2.0,
+                               theta=np.deg2rad(theta_deg))
+    sky_from_poly = aper.to_polygon().to_sky(wcs)
+    sky_from_aper = aper.to_sky(wcs).to_polygon()
+    assert_allclose(sky_from_poly.positions.ra.deg,
+                    sky_from_aper.positions.ra.deg)
+    assert_allclose(sky_from_poly.positions.dec.deg,
+                    sky_from_aper.positions.dec.deg)
+    assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
+                    sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
+    assert_allclose(sky_from_poly.to_pixel(wcs).area,
+                    sky_from_aper.to_pixel(wcs).area, rtol=1e-6)

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -8,7 +8,9 @@ import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
+from numpy.testing import assert_allclose
 
+from photutils.aperture import PolygonAperture
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture,
                                           RectangularMaskMixin,
@@ -223,3 +225,35 @@ def test_deprecated_rectangular_mask_mixin(method, subpixels):
                                         subpixels=subpixels)
     expected = aper.to_mask(method=method, subpixels=subpixels)
     assert_quantity_allclose(mask.data, expected.data)
+
+
+def test_rectangular_aperture_to_polygon():
+    aper = RectangularAperture((10.0, 20.0), w=4.0, h=2.0)
+    poly = aper.to_polygon()
+    assert isinstance(poly, PolygonAperture)
+    assert poly.n_vertices == 4
+    # Area is exact (rectangle is itself a polygon)
+    assert_allclose(poly.area, aper.area)
+
+
+@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+def test_rectangular_aperture_to_polygon_rotation(theta_deg):
+    aper = RectangularAperture((10.0, 20.0), w=4.0, h=2.0,
+                               theta=np.deg2rad(theta_deg))
+    poly = aper.to_polygon()
+    assert poly.n_vertices == 4
+    assert_allclose(poly.area, aper.area, rtol=1e-12)
+    # Bounding-box extents should match the rotated rectangle's.
+    expected_x_extent = (0.5 * abs(aper.w * np.cos(aper.theta.value))
+                         + 0.5 * abs(aper.h * np.sin(aper.theta.value)))
+    expected_y_extent = (0.5 * abs(aper.w * np.sin(aper.theta.value))
+                         + 0.5 * abs(aper.h * np.cos(aper.theta.value)))
+    assert_allclose(poly._xy_extents[0], expected_x_extent, rtol=1e-12)
+    assert_allclose(poly._xy_extents[1], expected_y_extent, rtol=1e-12)
+
+
+def test_rectangular_aperture_to_polygon_multi_position():
+    aper = RectangularAperture([(10.0, 20.0), (30.0, 40.0)],
+                               w=4.0, h=3.0, theta=0.5)
+    poly = aper.to_polygon()
+    assert poly.vertices.shape == (2, 4, 2)

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
 from photutils.aperture import PolygonAperture, SkyPolygonAperture
@@ -295,17 +294,9 @@ def test_sky_rectangular_aperture_to_polygon_multi_position():
     assert poly.vertices.shape == (2, 4)
 
 
-def _make_round_trip_wcs():
-    wcs = WCS(naxis=2)
-    wcs.wcs.crpix = [50.5, 50.5]
-    wcs.wcs.cdelt = [-0.001, 0.001]
-    wcs.wcs.crval = [10.0, 30.0]
-    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
-    return wcs
-
-
 @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_sky_rectangular_aperture_to_polygon_wcs_round_trip(theta_deg):
+def test_sky_rectangular_aperture_to_polygon_wcs_round_trip(
+        theta_deg, tan_wcs):
     """
     Test that converting a SkyRectangularAperture to a polygon and then
     to pixels matches converting to pixels and then to a polygon for all
@@ -313,19 +304,18 @@ def test_sky_rectangular_aperture_to_polygon_wcs_round_trip(theta_deg):
 
     The two pixel polygons share the same area and bounding-box extents.
     """
-    wcs = _make_round_trip_wcs()
     pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
     aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec,
                                   theta=theta_deg * u.deg)
-    poly_from_sky = aper.to_polygon().to_pixel(wcs)
-    poly_from_pix = aper.to_pixel(wcs).to_polygon()
+    poly_from_sky = aper.to_polygon().to_pixel(tan_wcs)
+    poly_from_pix = aper.to_pixel(tan_wcs).to_polygon()
     assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
     assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
                     rtol=1e-6)
 
 
 @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_rectangular_aperture_to_polygon_to_sky_round_trip(theta_deg):
+def test_rectangular_aperture_to_polygon_to_sky_round_trip(theta_deg, tan_wcs):
     """
     Test that converting a RectangularAperture to a polygon and then to
     sky matches converting to sky and then to a polygon for all rotation
@@ -336,16 +326,15 @@ def test_rectangular_aperture_to_polygon_to_sky_round_trip(theta_deg):
     # linear (SVD) approximation, while the polygon ``to_sky`` maps
     # each vertex exactly, so only rotation-invariant quantities are
     # compared.
-    wcs = _make_round_trip_wcs()
     aper = RectangularAperture((50.0, 50.0), w=4.0, h=2.0,
                                theta=np.deg2rad(theta_deg))
-    sky_from_poly = aper.to_polygon().to_sky(wcs)
-    sky_from_aper = aper.to_sky(wcs).to_polygon()
+    sky_from_poly = aper.to_polygon().to_sky(tan_wcs)
+    sky_from_aper = aper.to_sky(tan_wcs).to_polygon()
     assert_allclose(sky_from_poly.positions.ra.deg,
                     sky_from_aper.positions.ra.deg)
     assert_allclose(sky_from_poly.positions.dec.deg,
                     sky_from_aper.positions.dec.deg)
     assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
                     sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
-    assert_allclose(sky_from_poly.to_pixel(wcs).area,
-                    sky_from_aper.to_pixel(wcs).area, rtol=1e-6)
+    assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
+                    sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)


### PR DESCRIPTION
The PR adds ``to_polygon`` methods to the circular, elliptical, and rectangular apertures (both pixel and sky variants) to convert them to ``PolygonAperture`` or ``SkyPolygonAperture`` objects.

Followup to #2297.