### PR TITLE
Fix aperture photometry for read-only arrays

### DIFF
--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -119,6 +119,49 @@ def test_data_dtypes(dtype):
     assert_allclose(batch[0], legacy[0], rtol=rtol, equal_nan=True)
 
 
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_readonly_arrays(method, subpixels):
+    """
+    Test that read-only (non-writeable) data, error, and mask arrays are
+    accepted by the batch photometry driver and give results identical
+    to writeable arrays.
+
+    The batch Cython driver buffers the data, error, and positions into
+    ``const`` typed memoryviews so that read-only arrays do not raise a
+    ``ValueError``.
+    """
+    aperture = CircularAperture(POSITIONS, r=5.5)
+    data = DATA.copy()
+    error = ERROR.copy()
+    mask = MASK.copy()
+    for arr in (data, error, mask):
+        arr.setflags(write=False)
+
+    batch = aperture._do_batch_photometry(data, error=error, mask=mask,
+                                          method=method, subpixels=subpixels)
+    assert batch is not None
+
+    expected = aperture._do_batch_photometry(DATA, error=ERROR, mask=MASK,
+                                             method=method,
+                                             subpixels=subpixels)
+    for batch_arr, exp_arr in zip(batch, expected, strict=True):
+        assert_allclose(batch_arr, exp_arr, rtol=1e-12, atol=0,
+                        equal_nan=True)
+
+
+def test_readonly_data_do_photometry():
+    """
+    Test that ``do_photometry`` works with read-only data arrays.
+    """
+    data = np.ones((10, 10))
+    data.setflags(write=False)
+    aperture = CircularAperture((4.5, 4.5), r=4.5)
+    sums, _ = aperture.do_photometry(data, method='exact')
+
+    expected, _ = aperture.do_photometry(np.ones((10, 10)), method='exact')
+    assert_allclose(sums, expected, rtol=1e-12)
+
+
 def test_scalar_position():
     """
     Test that the batch photometry driver gives results identical to the

--- a/photutils/geometry/_batch_photometry.pyx
+++ b/photutils/geometry/_batch_photometry.pyx
@@ -62,10 +62,10 @@ SHAPE_RECTANGULAR_ANNULUS = _RECTANGULAR_ANNULUS
 SHAPE_POLYGON = _POLYGON
 
 
-def batch_aperture_sums(double[:, ::1] data, double[:, ::1] error,
+def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                         const unsigned char[:, ::1] mask,
-                        double[:, ::1] positions, int shape_code,
-                        double[::1] params, double ext_x, double ext_y,
+                        const double[:, ::1] positions, int shape_code,
+                        const double[::1] params, double ext_x, double ext_y,
                         int use_exact, int subpixels):
     """
     Compute aperture sums for many source positions in a single call.

--- a/photutils/geometry/_polygon_overlap.pyx
+++ b/photutils/geometry/_polygon_overlap.pyx
@@ -130,8 +130,8 @@ def polygon_overlap_grid(double xmin, double xmax, double ymin, double ymax,
     cdef double *buf_a_y = &work[2 * n_poly + buf_size]
     cdef double *buf_b_x = &work[2 * n_poly + 2 * buf_size]
     cdef double *buf_b_y = &work[2 * n_poly + 3 * buf_size]
-    cdef double[::1] vx_view = np.ascontiguousarray(vertices_x)
-    cdef double[::1] vy_view = np.ascontiguousarray(vertices_y)
+    cdef const double[::1] vx_view = np.ascontiguousarray(vertices_x)
+    cdef const double[::1] vy_view = np.ascontiguousarray(vertices_y)
     _ensure_ccw(vx_view, vy_view, n_poly, poly_x, poly_y)
 
     cdef np.ndarray[DTYPE_t, ndim=2] frac = np.zeros([ny, nx], dtype=DTYPE)
@@ -471,7 +471,7 @@ cdef double polygon_overlap_single_subpixel(double x0, double y0,
     return hits / (subpixels * subpixels)
 
 
-cdef inline double _polygon_signed_area(double *xs, double *ys,
+cdef inline double _polygon_signed_area(const double *xs, const double *ys,
                                         int n) noexcept nogil:
     """
     Signed area of a polygon via the shoelace formula.
@@ -563,7 +563,7 @@ cdef inline int _clip_against_axis(double *xs_in, double *ys_in, int n_in,
     return n_out
 
 
-cdef void _ensure_ccw(double[::1] xs, double[::1] ys, int n,
+cdef void _ensure_ccw(const double[::1] xs, const double[::1] ys, int n,
                       double *out_x, double *out_y) noexcept nogil:
     """
     Copy ``(xs, ys)`` into ``(out_x, out_y)`` ensuring counter-clockwise

--- a/photutils/geometry/tests/test_batch_photometry.py
+++ b/photutils/geometry/tests/test_batch_photometry.py
@@ -1,0 +1,52 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the low-level batch Cython aperture photometry driver.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from photutils.geometry._batch_photometry import (SHAPE_CIRCLE,
+                                                  batch_aperture_sums)
+
+
+def _batch_inputs():
+    """
+    Build deterministic data, error, mask, and source positions for the
+    batch-driver tests.
+    """
+    rng = np.random.default_rng(42)
+    data = rng.random((80, 80))
+    error = rng.random((80, 80)) + 0.1
+    mask = np.zeros((80, 80), dtype=np.uint8)
+    mask[::7, ::5] = 1
+    positions = np.array([[20.0, 25.0], [40.0, 40.0], [55.0, 30.0],
+                          [10.0, 60.0], [70.0, 70.0], [35.0, 15.0]])
+    return data, error, mask, positions
+
+
+@pytest.mark.parametrize('use_exact', [1, 0])
+def test_readonly_arrays(use_exact):
+    """
+    Test that the batch driver accepts read-only (non-writeable) data,
+    error, positions, and params arrays and returns results identical to
+    writeable arrays.
+
+    The data, error, positions, and params arguments are declared as
+    ``const`` typed memoryviews so that read-only arrays do not raise a
+    ``ValueError``.
+    """
+    data, error, mask, positions = _batch_inputs()
+    params = np.array([8.0], dtype=np.float64)
+
+    expected = batch_aperture_sums(data, error, mask, positions, SHAPE_CIRCLE,
+                                   params, 8.0, 8.0, use_exact, 8)
+
+    for arr in (data, error, positions, params):
+        arr.setflags(write=False)
+    result = batch_aperture_sums(data, error, mask, positions, SHAPE_CIRCLE,
+                                 params, 8.0, 8.0, use_exact, 8)
+
+    for res_arr, exp_arr in zip(result, expected, strict=True):
+        assert_array_equal(res_arr, exp_arr)

--- a/photutils/geometry/tests/test_circular_overlap_grid.py
+++ b/photutils/geometry/tests/test_circular_overlap_grid.py
@@ -26,3 +26,15 @@ def test_circular_overlap_grid(grid_size, circ_size, use_exact, subsample):
     g = circular_overlap_grid(-1.0, 1.0, -1.0, 1.0, grid_size, grid_size,
                               circ_size, use_exact, subsample)
     assert_allclose(g.max(), 1.0)
+
+
+@pytest.mark.parametrize('use_exact', use_exacts)
+def test_circular_overlap_grid_no_readonly_inputs(use_exact):
+    """
+    Test that the scalar-input overlap grid function takes no array
+    inputs (so read-only input arrays cannot occur) and returns a
+    freshly allocated, writeable output array of shape (ny, nx).
+    """
+    g = circular_overlap_grid(-5.0, 5.0, -5.0, 5.0, 10, 12, 3.0, use_exact, 5)
+    assert g.shape == (12, 10)
+    assert g.flags.writeable

--- a/photutils/geometry/tests/test_elliptical_overlap_grid.py
+++ b/photutils/geometry/tests/test_elliptical_overlap_grid.py
@@ -32,3 +32,16 @@ def test_elliptical_overlap_grid(grid_size, maj_size, min_size, angle,
                                 maj_size, min_size, angle, use_exact,
                                 subsample)
     assert_allclose(g.max(), 1.0)
+
+
+@pytest.mark.parametrize('use_exact', use_exacts)
+def test_elliptical_overlap_grid_no_readonly_inputs(use_exact):
+    """
+    Test that the scalar-input overlap grid function takes no array
+    inputs (so read-only input arrays cannot occur) and returns a
+    freshly allocated, writeable output array of shape (ny, nx).
+    """
+    g = elliptical_overlap_grid(-5.0, 5.0, -5.0, 5.0, 10, 12, 4.0, 2.0,
+                                0.5, use_exact, 5)
+    assert g.shape == (12, 10)
+    assert g.flags.writeable

--- a/photutils/geometry/tests/test_polygon_overlap_grid.py
+++ b/photutils/geometry/tests/test_polygon_overlap_grid.py
@@ -26,6 +26,29 @@ def test_polygon_overlap_clockwise_input():
     assert_allclose(grid_cw, grid_ccw)
 
 
+@pytest.mark.parametrize('use_exact', [1, 0])
+def test_polygon_overlap_readonly_vertices(use_exact):
+    """
+    Regression test that read-only (non-writeable) vertex arrays are
+    accepted and give results identical to writeable arrays.
+
+    The vertex arrays are buffered into ``const`` typed memoryviews so
+    that read-only arrays do not raise a ``ValueError``.
+    """
+    vx = np.array([-4.0, 6.0, 3.0, -5.0])
+    vy = np.array([-3.0, -2.0, 5.0, 4.0])
+    expected = polygon_overlap_grid(-10.0, 10.0, -10.0, 10.0, 40, 40,
+                                    vx, vy, use_exact, 5)
+
+    vx_ro = vx.copy()
+    vy_ro = vy.copy()
+    vx_ro.setflags(write=False)
+    vy_ro.setflags(write=False)
+    result = polygon_overlap_grid(-10.0, 10.0, -10.0, 10.0, 40, 40,
+                                  vx_ro, vy_ro, use_exact, 5)
+    assert_allclose(result, expected, rtol=1e-12)
+
+
 @pytest.mark.parametrize(('leg', 'dx', 'dy'), [
     (3.0, 0.0, 0.0),  # base case
     (1.0, 0.0, 0.0),  # small triangle

--- a/photutils/geometry/tests/test_rectangular_overlap_grid.py
+++ b/photutils/geometry/tests/test_rectangular_overlap_grid.py
@@ -93,3 +93,16 @@ def test_rectangle_exact_no_overlap():
     grid = rectangular_overlap_grid(10.0, 12.0, 10.0, 12.0, 4, 4,
                                     1.0, 1.0, 0.0, 1, 1)
     assert_allclose(grid, 0.0)
+
+
+@pytest.mark.parametrize('use_exact', [0, 1])
+def test_rectangular_overlap_grid_no_readonly_inputs(use_exact):
+    """
+    Test that the scalar-input overlap grid function takes no array
+    inputs (so read-only input arrays cannot occur) and returns a
+    freshly allocated, writeable output array of shape (ny, nx).
+    """
+    g = rectangular_overlap_grid(-5.0, 5.0, -5.0, 5.0, 10, 12, 4.0, 2.0,
+                                 0.5, use_exact, 5)
+    assert g.shape == (12, 10)
+    assert g.flags.writeable


### PR DESCRIPTION
This PR fixes an issue where the new batch aperture photometry would fail with read-only (non-writeable) `data`, `error`, and `mask` arrays.  The typed memory views are now declared as `const`, so read-only arrays are accepted.