### PR TITLE
Migrate build_ellipse_model_c to const typed memoryviews

### DIFF
--- a/photutils/isophote/_ellipse_model.pyx
+++ b/photutils/isophote/_ellipse_model.pyx
@@ -7,9 +7,6 @@ Faster evaluation of ellipses from model.py.
 
 import numpy as np
 
-cimport numpy as cnp
-
-cnp.import_array()
 
 cdef extern from "math.h" nogil:
     double cos(double x)
@@ -17,22 +14,21 @@ cdef extern from "math.h" nogil:
     double sqrt(double x)
 
 DTYPE = np.float64
-ctypedef cnp.float64_t DTYPE_t
 
 
 def build_ellipse_model_c(
     unsigned int n_rows,
     unsigned int n_cols,
-    cnp.ndarray[DTYPE_t, ndim=1] finely_spaced_sma,
-    cnp.ndarray[DTYPE_t, ndim=1] intens_array,
-    cnp.ndarray[DTYPE_t, ndim=1] eps_array,
-    cnp.ndarray[DTYPE_t, ndim=1] pa_array,
-    cnp.ndarray[DTYPE_t, ndim=1] x0_array,
-    cnp.ndarray[DTYPE_t, ndim=1] y0_array,
-    cnp.ndarray[DTYPE_t, ndim=1] a3_array = None,
-    cnp.ndarray[DTYPE_t, ndim=1] b3_array = None,
-    cnp.ndarray[DTYPE_t, ndim=1] a4_array = None,
-    cnp.ndarray[DTYPE_t, ndim=1] b4_array = None,
+    const double[:] finely_spaced_sma,
+    const double[:] intens_array,
+    const double[:] eps_array,
+    const double[:] pa_array,
+    const double[:] x0_array,
+    const double[:] y0_array,
+    const double[:] a3_array = None,
+    const double[:] b3_array = None,
+    const double[:] a4_array = None,
+    const double[:] b4_array = None,
     double phi_min = 0.,
     double phi_max = 2.0*np.pi,
 ):

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -185,3 +185,63 @@ def test_build_ellipse_model_c_threadsafe():
             result = future.result()
             assert_array_equal(result[0], expected[0])
             assert_array_equal(result[1], expected[1])
+
+
+def test_build_ellipse_model_c_readonly_arrays():
+    """
+    Test that read-only (non-writeable) input arrays are accepted by
+    build_ellipse_model_c and give results identical to writeable
+    arrays.
+    """
+    n = 16
+    sma = np.linspace(0.5, 20.0, n)
+    intens = np.full(n, 1.0)
+    eps = np.full(n, 0.3)
+    pa = np.full(n, 0.5)
+    x0 = np.full(n, 50.0)
+    y0 = np.full(n, 50.0)
+    arrays = (sma, intens, eps, pa, x0, y0)
+    expected = build_ellipse_model_c(100, 100, *arrays)
+
+    arrays_ro = []
+    for arr in arrays:
+        arr_ro = arr.copy()
+        arr_ro.setflags(write=False)
+        arrays_ro.append(arr_ro)
+    result = build_ellipse_model_c(100, 100, *arrays_ro)
+
+    assert_array_equal(result[0], expected[0])
+    assert_array_equal(result[1], expected[1])
+
+
+def test_build_ellipse_model_c_noncontiguous_arrays():
+    """
+    Test that non-contiguous (strided) input arrays are accepted by
+    build_ellipse_model_c and give results identical to contiguous
+    arrays.
+
+    The input arguments are declared as non-contiguous ``double[:]``
+    typed memoryviews. This test guards against a regression if they
+    were ever changed to C-contiguous ``double[::1]`` memoryviews, which
+    would reject strided arrays.
+    """
+    n = 16
+    sma = np.linspace(0.5, 20.0, n)
+    intens = np.full(n, 1.0)
+    eps = np.full(n, 0.3)
+    pa = np.full(n, 0.5)
+    x0 = np.full(n, 50.0)
+    y0 = np.full(n, 50.0)
+    arrays = (sma, intens, eps, pa, x0, y0)
+    expected = build_ellipse_model_c(100, 100, *arrays)
+
+    # Build strided (non-contiguous) views by interleaving and slicing
+    arrays_strided = []
+    for arr in arrays:
+        strided = np.repeat(arr, 2)[::2]
+        assert not strided.flags['C_CONTIGUOUS']
+        arrays_strided.append(strided)
+    result = build_ellipse_model_c(100, 100, *arrays_strided)
+
+    assert_array_equal(result[0], expected[0])
+    assert_array_equal(result[1], expected[1])


### PR DESCRIPTION
This PR replaces the legacy `np.ndarray[DTYPE_t]` buffers with `const` typed memory views in the isophote `build_ellipse_model_c` function.  This PR also updates `build_ellipse_model_c` to allow read-only array inputs.