### PR TITLE
Require n_vertices to be keyword-only

### DIFF
--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -311,7 +311,7 @@ class CircularAperture(PixelAperture):
         r = Angle(self.r * mean_scale, 'arcsec')
         return SkyCircularAperture(positions=positions, r=r)
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~photutils.aperture.PolygonAperture` that
         approximates this circular aperture.
@@ -587,7 +587,7 @@ class SkyCircularAperture(SkyAperture):
         r = self.r.to_value(u.arcsec) * mean_scale
         return CircularAperture(positions=positions, r=r)
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~photutils.aperture.SkyPolygonAperture` that
         approximates this circular aperture.

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -393,7 +393,7 @@ class EllipticalAperture(PixelAperture):
         return SkyEllipticalAperture(positions=positions, a=a, b=b,
                                      theta=sky_angle)
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~photutils.aperture.PolygonAperture` that approximates
         this elliptical aperture.
@@ -748,7 +748,7 @@ class SkyEllipticalAperture(SkyAperture):
         return EllipticalAperture(positions=positions, a=a, b=b,
                                   theta=pix_angle)
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~photutils.aperture.SkyPolygonAperture` that
         approximates this elliptical aperture.

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -131,7 +131,8 @@ def _polygon_is_simple(verts):
     return True
 
 
-def _validate_simple_polygon(verts, name='vertex_offsets', check_simple=True):
+def _validate_simple_polygon(verts, *, name='vertex_offsets',
+                             check_simple=True):
     """
     Verify that ``verts`` defines a simple, non-degenerate polygon.
 
@@ -298,7 +299,7 @@ def _regular_polygon_offsets(n_vertices, radius, angle_rad):
                             radius * np.sin(thetas)])
 
 
-def _is_regular_polygon(offsets, rtol=1.0e-7, atol=1.0e-10):
+def _is_regular_polygon(offsets, *, rtol=1.0e-7, atol=1.0e-10):
     """
     Return `True` if ``offsets`` defines a regular polygon centered at
     the origin (equal vertex distances and uniform angular spacing).
@@ -499,7 +500,7 @@ class PolygonAperture(PixelAperture):
         return cls(tuple(center), offsets)
 
     @classmethod
-    def from_regular_polygon(cls, positions, n_vertices, radius, theta=0.0):
+    def from_regular_polygon(cls, positions, n_vertices, radius, *, theta=0.0):
         """
         Construct a regular `PolygonAperture` from a center, vertex
         count, circumradius, and rotation angle.
@@ -952,7 +953,7 @@ class SkyPolygonAperture(SkyAperture):
         return cls(positions=center, vertex_offsets=offsets)
 
     @classmethod
-    def from_regular_polygon(cls, positions, n_vertices, radius,
+    def from_regular_polygon(cls, positions, n_vertices, radius, *,
                              theta=0.0 * u.deg):
         """
         Construct a regular `SkyPolygonAperture` from a center, vertex

--- a/photutils/aperture/tests/test_exact_area_photometry.py
+++ b/photutils/aperture/tests/test_exact_area_photometry.py
@@ -21,7 +21,7 @@ from photutils.aperture import (CircularAnnulus, CircularAperture,
                                 RectangularAperture, aperture_photometry)
 
 
-def _phot_sum(aperture, data=None):
+def _phot_sum(aperture, *, data=None):
     if data is None:
         shape = (101, 101)
         data = np.ones(shape, dtype=float)

--- a/photutils/aperture/tests/test_pixel_sky_conversions.py
+++ b/photutils/aperture/tests/test_pixel_sky_conversions.py
@@ -122,7 +122,7 @@ def _build_pair(case, theta):
     return sky, pix
 
 
-def _make_sip_wcs(ra_deg=100.0, dec_deg=30.0):
+def _make_sip_wcs(*, ra_deg=100.0, dec_deg=30.0):
     """
     Build a small TAN-SIP WCS centered at the given (RA, Dec).
 

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -925,7 +925,7 @@ def test_sky_n_vertices_works_for_any_polygon():
     assert aper.n_vertices == 3
 
 
-def _matches_up_to_cyclic_reversal(a, b, atol=1e-10):
+def _matches_up_to_cyclic_reversal(a, b, *, atol=1e-10):
     n = len(a)
     if len(b) != n:
         return False

--- a/photutils/datasets/load.py
+++ b/photutils/datasets/load.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-def _get_path(filename, location='local', cache=True, show_progress=False):
+def _get_path(filename, *, location='local', cache=True, show_progress=False):
     """
     Get the local path for a given file.
 

--- a/photutils/utils/_deprecation.py
+++ b/photutils/utils/_deprecation.py
@@ -326,7 +326,7 @@ class DeprecatedColumnMixin:
     _deprecation_since = None
     _deprecation_until = None
 
-    def _warn_deprecated(self, name, new_name, stacklevel=4):
+    def _warn_deprecated(self, name, new_name, *, stacklevel=4):
         """
         Issue a deprecation warning for a column name.
 
@@ -357,7 +357,7 @@ class DeprecatedColumnMixin:
         warnings.warn(msg, AstropyDeprecationWarning,
                       stacklevel=stacklevel)
 
-    def _translate_name(self, name, stacklevel=4):
+    def _translate_name(self, name, *, stacklevel=4):
         """
         Translate a single name, issue a warning, and return the new
         name.
@@ -382,7 +382,7 @@ class DeprecatedColumnMixin:
             return new_name
         return name
 
-    def _translate_names(self, names, stacklevel=4):
+    def _translate_names(self, names, *, stacklevel=4):
         """
         Translate a single name or a list/tuple of names.
 
@@ -596,6 +596,9 @@ class DeprecatedColumnMixin:
         ----------
         copy_data : bool, optional
             Whether to copy the data. The default is `True`.
+            ``copy_data`` cannot be forced to be kwarg-only because
+            astropy table ``deepcopy()`` calls ``copy`` with a
+            positional argument.
 
         Returns
         -------

--- a/photutils/utils/_stats.py
+++ b/photutils/utils/_stats.py
@@ -55,7 +55,7 @@ if HAS_BOTTLENECK:
         # Reshape the array by combining the moved axes
         return array_new.reshape((*array_new.shape[:len(other_axes)], -1))
 
-    def _apply_bottleneck(function, array, axis=None, **kwargs):
+    def _apply_bottleneck(function, array, *, axis=None, **kwargs):
         """
         Wrap a bottleneck function to handle tuple axis.
 

--- a/photutils/utils/_wcs_helpers.py
+++ b/photutils/utils/_wcs_helpers.py
@@ -90,7 +90,7 @@ def _pixel_to_sky_jacobian(pixcoord, wcs):
     return center, jacobian, jacobian_inv, parity
 
 
-def _svd_ellipse_from_composite(m_comp, width_col_idx=0, sky_angle=False,
+def _svd_ellipse_from_composite(m_comp, *, width_col_idx=0, sky_angle=False,
                                 input_circular=False):
     """
     Extract ellipse width, height, and angle from a composite matrix

--- a/photutils/utils/tests/conftest.py
+++ b/photutils/utils/tests/conftest.py
@@ -14,7 +14,7 @@ WCS_CENTER = SkyCoord(100 * u.deg, 30 * u.deg)
 WCS_CDELT_ARCSEC = 0.1
 
 
-def _make_simple_wcs(skycoord, resolution, size, rotation_deg=0.0):
+def _make_simple_wcs(skycoord, resolution, size, *, rotation_deg=0.0):
     """
     Create a simple TAN WCS with optional rotation.
 

--- a/photutils/utils/tests/test_deprecation.py
+++ b/photutils/utils/tests/test_deprecation.py
@@ -694,7 +694,7 @@ class TestDeprecatedPositionalKwargs:
 
 
 @deprecated_renamed_argument('b', 'new', '1.0', until='2.0')
-def _example_func2(a, new, c=20):
+def _example_func2(a, new, *, c=20):
     """
     Example function for testing deprecated_renamed_argument.
     """
@@ -702,7 +702,7 @@ def _example_func2(a, new, c=20):
 
 
 @deprecated_renamed_argument('b', 'new', '1.0', until=None)
-def _example_func3(a, new, c=20):
+def _example_func3(a, new, *, c=20):
     """
     Example function for testing deprecated_renamed_argument
     with no "until" version specified.

--- a/photutils/utils/tests/test_wcs_helpers.py
+++ b/photutils/utils/tests/test_wcs_helpers.py
@@ -608,7 +608,7 @@ class TestSVDShapeConversions:
 
 
 def _project_sky_ellipse_boundary(skycoord, wcs, a_arcsec, b_arcsec,
-                                  pa_rad, npts=720):
+                                  pa_rad, *, npts=720):
     """
     Project the boundary of a sky ellipse to pixel coordinates.
 


### PR DESCRIPTION
Followup to #2298 .

This PR also requires kwarg-only arguments in tests and private functions.