### PR TITLE
Add decorator to share method/subpixels param docstrings

### DIFF
--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -16,7 +16,8 @@ from photutils.aperture._batch_photometry import (SHAPE_CIRCLE,
 from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            PositiveScalarAngle,
                                            SkyCoordPositions)
-from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _update_method_subpixels_docstring)
 from photutils.aperture.mask import ApertureMask
 from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
 from photutils.geometry import circular_overlap_grid
@@ -76,37 +77,14 @@ class CircularMaskMixin:  # pragma: no cover
     .. deprecated:: 3.0
     """
 
+    @_update_method_subpixels_docstring
     def to_mask(self, method='exact', subpixels=5):
         """
         Return a mask for the aperture.
 
         Parameters
         ----------
-        method : {'exact', 'center', 'subpixel'}, optional
-            The method used to determine the pixel weights (the fraction
-            of the pixel area covered by the aperture):
-
-            * ``'exact'`` (default):
-              Calculates the exact geometric overlap area. Weights are
-              continuous in the range [0, 1].
-            * ``'center'``:
-              Binary weighting based on the pixel center. Weights are
-              either 0 or 1. A pixel is included only if its center lies
-              strictly inside the aperture; pixel centers lying exactly
-              on the aperture boundary are excluded (weight 0).
-            * ``'subpixel'``:
-              Approximates the overlap by averaging binary samples on a
-              subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1]. A
-              subpixel is included only if its center lies strictly
-              inside the aperture; subpixel centers lying exactly on the
-              aperture boundary are excluded (weight 0).
-
-        subpixels : int, optional
-            The subsampling factor per axis used when
-            ``method='subpixel'``. Each pixel is divided into a grid of
-            ``subpixels**2`` subpixels to approximate the overlap. This
-            parameter is ignored for other methods.
+        <method_subpixels_descriptions>
 
         Returns
         -------

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -26,46 +26,71 @@ __all__ = ['Aperture', 'PixelAperture', 'SkyAperture']
 # shared by many aperture and profile docstrings. The text is stored
 # without leading indentation and is re-indented to match the
 # placeholder by ``_update_method_subpixels_docstring``.
-_METHOD_SUBPIXELS_DOC = """\
+_METHOD_INTRO = """\
 method : {'exact', 'center', 'subpixel'}, optional
     The method used to determine the pixel weights (the fraction
-    of the pixel area covered by the aperture):
+    of the pixel area covered by the aperture):"""
 
-    * ``'exact'`` (default):
-      Calculates the exact geometric overlap area. Weights are
-      continuous in the range [0, 1].
-    * ``'center'``:
-      Binary weighting based on the pixel center. Weights are
-      either 0 or 1. A pixel is included only if its center lies
-      strictly inside the aperture; pixel centers lying exactly
-      on the aperture boundary are excluded (weight 0).
-    * ``'subpixel'``:
-      Approximates the overlap by averaging binary samples on a
-      subgrid. The number of samples is set by the ``subpixels``
-      parameter. Weights are discrete in the range [0, 1]. A
-      subpixel is included only if its center lies strictly
-      inside the aperture; subpixel centers lying exactly on the
-      aperture boundary are excluded (weight 0).
+_METHOD_BULLETS = """\
+* ``'exact'`` (default):
+  Calculates the exact geometric overlap area. Weights are
+  continuous in the range [0, 1].
+* ``'center'``:
+  Binary weighting based on the pixel center. Weights are
+  either 0 or 1. A pixel is included only if its center lies
+  strictly inside the aperture; pixel centers lying exactly
+  on the aperture boundary are excluded (weight 0).
+* ``'subpixel'``:
+  Approximates the overlap by averaging binary samples on a
+  subgrid. The number of samples is set by the ``subpixels``
+  parameter. Weights are discrete in the range [0, 1]. A
+  subpixel is included only if its center lies strictly
+  inside the aperture; subpixel centers lying exactly on the
+  aperture boundary are excluded (weight 0)."""
 
+_SUBPIXELS_DOC = """\
 subpixels : int, optional
     The subsampling factor per axis used when
     ``method='subpixel'``. Each pixel is divided into a grid of
     ``subpixels**2`` subpixels to approximate the overlap. This
     parameter is ignored for other methods."""
 
-_METHOD_SUBPIXELS_PLACEHOLDER = re.compile(
-    r'^([ \t]*)<method_subpixels_descriptions>[ \t]*$', re.MULTILINE)
+_METHOD_SUBPIXELS_DOC = (
+    _METHOD_INTRO + '\n\n'
+    + textwrap.indent(_METHOD_BULLETS, '    ') + '\n\n'
+    + _SUBPIXELS_DOC)
+
+# Mapping of placeholder tags to their replacement text. Each tag must
+# appear alone on its own line in a docstring; the leading indentation
+# of the placeholder is applied to the inserted text.
+_DOC_PLACEHOLDERS = {
+    'method_subpixels_descriptions': _METHOD_SUBPIXELS_DOC,
+    'method_bullets': _METHOD_BULLETS,
+    'subpixels_description': _SUBPIXELS_DOC,
+}
+
+_DOC_PLACEHOLDER_RE = re.compile(
+    r'^([ \t]*)<(' + '|'.join(_DOC_PLACEHOLDERS) + r')>[ \t]*$',
+    re.MULTILINE)
 
 
 def _update_method_subpixels_docstring(obj):
     """
-    Decorator to insert the standard ``method`` and ``subpixels``
+    Decorator to insert standard ``method``, ``subpixels``, and related
     parameter descriptions into a docstring.
 
-    The descriptions replace a ``<method_subpixels_descriptions>``
-    placeholder, which must appear on its own line. The placeholder's
-    indentation is applied to the inserted text, so the same source
-    descriptions can be used at any docstring indentation level.
+    The following placeholders are supported, each of which must appear
+    alone on its own line. The leading indentation of the placeholder is
+    applied to the inserted text, so the same source descriptions can be
+    used at any docstring indentation level.
+
+    * ``<method_subpixels_descriptions>`` : the full ``method`` and
+      ``subpixels`` parameter descriptions.
+    * ``<method_bullets>`` : only the ``'exact'``, ``'center'``, and
+      ``'subpixel'`` bullet list, e.g., for a parameter that uses a
+      custom name and introduction.
+    * ``<subpixels_description>`` : only the ``subpixels`` parameter
+      description.
 
     Parameters
     ----------
@@ -83,9 +108,9 @@ def _update_method_subpixels_docstring(obj):
 
     def replace(match):
         indent = match.group(1)
-        return textwrap.indent(_METHOD_SUBPIXELS_DOC, indent)
+        return textwrap.indent(_DOC_PLACEHOLDERS[match.group(2)], indent)
 
-    obj.__doc__ = _METHOD_SUBPIXELS_PLACEHOLDER.sub(replace, docstring)
+    obj.__doc__ = _DOC_PLACEHOLDER_RE.sub(replace, docstring)
     return obj
 
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -5,6 +5,8 @@ Base aperture classes.
 
 import abc
 import inspect
+import re
+import textwrap
 import warnings
 from copy import deepcopy
 
@@ -18,6 +20,73 @@ from photutils.aperture.mask import ApertureMask
 from photutils.utils._deprecation import deprecated_positional_kwargs
 
 __all__ = ['Aperture', 'PixelAperture', 'SkyAperture']
+
+
+# Canonical descriptions of the ``method`` and ``subpixels`` parameters
+# shared by many aperture and profile docstrings. The text is stored
+# without leading indentation and is re-indented to match the
+# placeholder by ``_update_method_subpixels_docstring``.
+_METHOD_SUBPIXELS_DOC = """\
+method : {'exact', 'center', 'subpixel'}, optional
+    The method used to determine the pixel weights (the fraction
+    of the pixel area covered by the aperture):
+
+    * ``'exact'`` (default):
+      Calculates the exact geometric overlap area. Weights are
+      continuous in the range [0, 1].
+    * ``'center'``:
+      Binary weighting based on the pixel center. Weights are
+      either 0 or 1. A pixel is included only if its center lies
+      strictly inside the aperture; pixel centers lying exactly
+      on the aperture boundary are excluded (weight 0).
+    * ``'subpixel'``:
+      Approximates the overlap by averaging binary samples on a
+      subgrid. The number of samples is set by the ``subpixels``
+      parameter. Weights are discrete in the range [0, 1]. A
+      subpixel is included only if its center lies strictly
+      inside the aperture; subpixel centers lying exactly on the
+      aperture boundary are excluded (weight 0).
+
+subpixels : int, optional
+    The subsampling factor per axis used when
+    ``method='subpixel'``. Each pixel is divided into a grid of
+    ``subpixels**2`` subpixels to approximate the overlap. This
+    parameter is ignored for other methods."""
+
+_METHOD_SUBPIXELS_PLACEHOLDER = re.compile(
+    r'^([ \t]*)<method_subpixels_descriptions>[ \t]*$', re.MULTILINE)
+
+
+def _update_method_subpixels_docstring(obj):
+    """
+    Decorator to insert the standard ``method`` and ``subpixels``
+    parameter descriptions into a docstring.
+
+    The descriptions replace a ``<method_subpixels_descriptions>``
+    placeholder, which must appear on its own line. The placeholder's
+    indentation is applied to the inserted text, so the same source
+    descriptions can be used at any docstring indentation level.
+
+    Parameters
+    ----------
+    obj : function or type
+        The function or class whose docstring will be updated.
+
+    Returns
+    -------
+    obj : function or type
+        The input ``obj`` with its ``__doc__`` updated in place.
+    """
+    docstring = obj.__doc__
+    if docstring is None:
+        return obj
+
+    def replace(match):
+        indent = match.group(1)
+        return textwrap.indent(_METHOD_SUBPIXELS_DOC, indent)
+
+    obj.__doc__ = _METHOD_SUBPIXELS_PLACEHOLDER.sub(replace, docstring)
+    return obj
 
 
 class Aperture(metaclass=abc.ABCMeta):
@@ -323,7 +392,9 @@ class PixelAperture(Aperture):
         area_overlap
         """
 
+    @_update_method_subpixels_docstring
     def area_overlap(self, data, *, mask=None, method='exact', subpixels=5):
+        # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Return the area of overlap between the data and the aperture.
 
@@ -345,31 +416,7 @@ class PixelAperture(Aperture):
             `True` value indicates the corresponding element of ``data``
             is masked. Masked data are excluded from the area overlap.
 
-        method : {'exact', 'center', 'subpixel'}, optional
-            The method used to determine the pixel weights (the fraction
-            of the pixel area covered by the aperture):
-
-            * ``'exact'`` (default):
-              Calculates the exact geometric overlap area. Weights are
-              continuous in the range [0, 1].
-            * ``'center'``:
-              Binary weighting based on the pixel center. Weights are
-              either 0 or 1. A pixel is included only if its center lies
-              strictly inside the aperture; pixel centers lying exactly
-              on the aperture boundary are excluded (weight 0).
-            * ``'subpixel'``:
-              Approximates the overlap by averaging binary samples on a
-              subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1]. A
-              subpixel is included only if its center lies strictly
-              inside the aperture; subpixel centers lying exactly on the
-              aperture boundary are excluded (weight 0).
-
-        subpixels : int, optional
-            The subsampling factor per axis used when
-            ``method='subpixel'``. Each pixel is divided into a grid of
-            ``subpixels**2`` subpixels to approximate the overlap. This
-            parameter is ignored for other methods.
+        <method_subpixels_descriptions>
 
         Returns
         -------
@@ -412,6 +459,7 @@ class PixelAperture(Aperture):
 
         return areas
 
+    @_update_method_subpixels_docstring
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def to_mask(self, method='exact', subpixels=5):
         """
@@ -419,31 +467,7 @@ class PixelAperture(Aperture):
 
         Parameters
         ----------
-        method : {'exact', 'center', 'subpixel'}, optional
-            The method used to determine the pixel weights (the fraction
-            of the pixel area covered by the aperture):
-
-            * ``'exact'`` (default):
-              Calculates the exact geometric overlap area. Weights are
-              continuous in the range [0, 1].
-            * ``'center'``:
-              Binary weighting based on the pixel center. Weights are
-              either 0 or 1. A pixel is included only if its center lies
-              strictly inside the aperture; pixel centers lying exactly
-              on the aperture boundary are excluded (weight 0).
-            * ``'subpixel'``:
-              Approximates the overlap by averaging binary samples on a
-              subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1]. A
-              subpixel is included only if its center lies strictly
-              inside the aperture; subpixel centers lying exactly on the
-              aperture boundary are excluded (weight 0).
-
-        subpixels : int, optional
-            The subsampling factor per axis used when
-            ``method='subpixel'``. Each pixel is divided into a grid of
-            ``subpixels**2`` subpixels to approximate the overlap. This
-            parameter is ignored for other methods.
+        <method_subpixels_descriptions>
 
         Returns
         -------
@@ -645,9 +669,11 @@ class PixelAperture(Aperture):
 
         return sums, errs
 
+    @_update_method_subpixels_docstring
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def do_photometry(self, data, error=None, mask=None, method='exact',
                       subpixels=5):
+        # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Perform aperture photometry on the input data.
 
@@ -669,31 +695,7 @@ class PixelAperture(Aperture):
             `True` value indicates the corresponding element of ``data``
             is masked. Masked data are excluded from all calculations.
 
-        method : {'exact', 'center', 'subpixel'}, optional
-            The method used to determine the pixel weights (the fraction
-            of the pixel area covered by the aperture):
-
-            * ``'exact'`` (default):
-              Calculates the exact geometric overlap area. Weights are
-              continuous in the range [0, 1].
-            * ``'center'``:
-              Binary weighting based on the pixel center. Weights are
-              either 0 or 1. A pixel is included only if its center lies
-              strictly inside the aperture; pixel centers lying exactly
-              on the aperture boundary are excluded (weight 0).
-            * ``'subpixel'``:
-              Approximates the overlap by averaging binary samples on a
-              subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1]. A
-              subpixel is included only if its center lies strictly
-              inside the aperture; subpixel centers lying exactly on the
-              aperture boundary are excluded (weight 0).
-
-        subpixels : int, optional
-            The subsampling factor per axis used when
-            ``method='subpixel'``. Each pixel is divided into a grid of
-            ``subpixels**2`` subpixels to approximate the overlap. This
-            parameter is ignored for other methods.
+        <method_subpixels_descriptions>
 
         Returns
         -------

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -17,7 +17,8 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            PositiveScalarAngle, ScalarAngle,
                                            ScalarAngleOrValue,
                                            SkyCoordPositions)
-from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _update_method_subpixels_docstring)
 from photutils.aperture.mask import ApertureMask
 from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
 from photutils.geometry import elliptical_overlap_grid
@@ -102,37 +103,14 @@ class EllipticalMaskMixin:  # pragma: no cover
     .. deprecated:: 3.0
     """
 
+    @_update_method_subpixels_docstring
     def to_mask(self, method='exact', subpixels=5):
         """
         Return a mask for the aperture.
 
         Parameters
         ----------
-        method : {'exact', 'center', 'subpixel'}, optional
-            The method used to determine the pixel weights (the fraction
-            of the pixel area covered by the aperture):
-
-            * ``'exact'`` (default):
-              Calculates the exact geometric overlap area. Weights are
-              continuous in the range [0, 1].
-            * ``'center'``:
-              Binary weighting based on the pixel center. Weights are
-              either 0 or 1. A pixel is included only if its center lies
-              strictly inside the aperture; pixel centers lying exactly
-              on the aperture boundary are excluded (weight 0).
-            * ``'subpixel'``:
-              Approximates the overlap by averaging binary samples on a
-              subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1]. A
-              subpixel is included only if its center lies strictly
-              inside the aperture; subpixel centers lying exactly on the
-              aperture boundary are excluded (weight 0).
-
-        subpixels : int, optional
-            The subsampling factor per axis used when
-            ``method='subpixel'``. Each pixel is divided into a grid of
-            ``subpixels**2`` subpixels to approximate the overlap. This
-            parameter is ignored for other methods.
+        <method_subpixels_descriptions>
 
         Returns
         -------

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -11,7 +11,8 @@ from astropy.nddata import NDData, StdDevUncertainty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture.converters import region_to_aperture
-from photutils.aperture.core import Aperture, SkyAperture, _aperture_metadata
+from photutils.aperture.core import (Aperture, SkyAperture, _aperture_metadata,
+                                     _update_method_subpixels_docstring)
 from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_positional_kwargs)
 from photutils.utils._misc import _get_meta
@@ -26,9 +27,11 @@ _DEPRECATED_COLUMNS: dict = {
 }
 
 
+@_update_method_subpixels_docstring
 @deprecated_positional_kwargs(since='3.0', until='4.0')
 def aperture_photometry(data, apertures, error=None, mask=None,
                         method='exact', subpixels=5, wcs=None):
+    # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Perform aperture photometry on the input data by summing the flux
     within the given aperture(s).
@@ -73,31 +76,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         value indicates the corresponding element of ``data`` is masked.
         Masked data are excluded from all calculations.
 
-    method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the pixel weights (the fraction of
-        the pixel area covered by the aperture):
-
-        * ``'exact'`` (default):
-          Calculates the exact geometric overlap area. Weights are
-          continuous in the range [0, 1].
-        * ``'center'``:
-          Binary weighting based on the pixel center. Weights are either
-          0 or 1. A pixel is included only if its center lies strictly
-          inside the aperture; pixel centers lying exactly on the
-          aperture boundary are excluded (weight 0).
-        * ``'subpixel'``:
-          Approximates the overlap by averaging binary samples on a
-          subgrid. The number of samples is set by the ``subpixels``
-          parameter. Weights are discrete in the range [0, 1]. A
-          subpixel is included only if its center lies strictly inside
-          the aperture; subpixel centers lying exactly on the aperture
-          boundary are excluded (weight 0).
-
-    subpixels : int, optional
-        The subsampling factor per axis used when ``method='subpixel'``.
-        Each pixel is divided into a grid of ``subpixels**2`` subpixels
-        to approximate the overlap. This parameter is ignored for other
-        methods.
+    <method_subpixels_descriptions>
 
     wcs : WCS object, optional
         A world coordinate system (WCS) transformation that

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -17,7 +17,8 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            PositiveScalarAngle, ScalarAngle,
                                            ScalarAngleOrValue,
                                            SkyCoordPositions)
-from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _update_method_subpixels_docstring)
 from photutils.aperture.mask import ApertureMask
 from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
 from photutils.geometry import rectangular_overlap_grid
@@ -79,37 +80,14 @@ class RectangularMaskMixin:  # pragma: no cover
     .. deprecated:: 3.0
     """
 
+    @_update_method_subpixels_docstring
     def to_mask(self, method='exact', subpixels=5):
         """
         Return a mask for the aperture.
 
         Parameters
         ----------
-        method : {'exact', 'center', 'subpixel'}, optional
-            The method used to determine the pixel weights (the fraction
-            of the pixel area covered by the aperture):
-
-            * ``'exact'`` (default):
-              Calculates the exact geometric overlap area. Weights are
-              continuous in the range [0, 1].
-            * ``'center'``:
-              Binary weighting based on the pixel center. Weights are
-              either 0 or 1. A pixel is included only if its center lies
-              strictly inside the aperture; pixel centers lying exactly
-              on the aperture boundary are excluded (weight 0).
-            * ``'subpixel'``:
-              Approximates the overlap by averaging binary samples on a
-              subgrid. The number of samples is set by the ``subpixels``
-              parameter. Weights are discrete in the range [0, 1]. A
-              subpixel is included only if its center lies strictly
-              inside the aperture; subpixel centers lying exactly on the
-              aperture boundary are excluded (weight 0).
-
-        subpixels : int, optional
-            The subsampling factor per axis used when
-            ``method='subpixel'``. Each pixel is divided into a grid of
-            ``subpixels**2`` subpixels to approximate the overlap. This
-            parameter is ignored for other methods.
+        <method_subpixels_descriptions>
 
         Returns
         -------

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -17,7 +17,8 @@ from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import Aperture, SkyAperture, region_to_aperture
-from photutils.aperture.core import _aperture_metadata
+from photutils.aperture.core import (_aperture_metadata,
+                                     _update_method_subpixels_docstring)
 from photutils.morphology import gini as gini_func
 from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_getattr,
@@ -83,7 +84,8 @@ def as_scalar(method):
     return _decorator
 
 
-class ApertureStats:
+@_update_method_subpixels_docstring
+class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Class to create a catalog of statistics for pixels within an
     aperture.
@@ -153,27 +155,9 @@ class ApertureStats:
         properties. All other properties use the "center" aperture mask
         method. The following methods are available:
 
-        * ``'exact'`` (default):
-          Calculates the exact geometric overlap area. Weights are
-          continuous in the range [0, 1].
-        * ``'center'``:
-          Binary weighting based on the pixel center. Weights are
-          either 0 or 1. A pixel is included only if its center lies
-          strictly inside the aperture; pixel centers lying exactly on
-          the aperture boundary are excluded (weight 0).
-        * ``'subpixel'``:
-          Approximates the overlap by averaging binary samples on a
-          subgrid. The number of samples is set by the ``subpixels``
-          parameter. Weights are discrete in the range [0, 1]. A
-          subpixel is included only if its center lies strictly inside
-          the aperture; subpixel centers lying exactly on the aperture
-          boundary are excluded (weight 0).
+        <method_bullets>
 
-    subpixels : int, optional
-        The subsampling factor per axis used when
-        ``method='subpixel'``. Each pixel is divided into a grid of
-        ``subpixels**2`` subpixels to approximate the overlap. This
-        parameter is ignored for other methods.
+    <subpixels_description>
 
     local_bkg : float, `~numpy.ndarray`, `~astropy.units.Quantity`, or `None`
         The per-pixel local background values to subtract from the data

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -393,3 +393,48 @@ class TestMethodSubpixelsDocstring:
 
         assert '<method_subpixels_descriptions>' not in Example.__doc__
         assert 'subpixels : int, optional' in Example.__doc__
+
+    def test_method_bullets_placeholder(self):
+        """
+        Test that the method-bullets placeholder is replaced by only the
+        method bullet list, without the method header or the subpixels
+        description.
+        """
+        @_update_method_subpixels_docstring
+        def func():
+            """
+            Summary.
+
+            Parameters
+            ----------
+            <method_bullets>
+            """
+
+        doc = func.__doc__
+        assert '<method_bullets>' not in doc
+        assert "* ``'exact'`` (default):" in doc
+        assert "* ``'center'``:" in doc
+        assert "* ``'subpixel'``:" in doc
+        assert "method : {'exact', 'center', 'subpixel'}, optional" not in doc
+        assert 'subpixels : int, optional' not in doc
+
+    def test_subpixels_description_placeholder(self):
+        """
+        Test that the subpixels-description placeholder is replaced by
+        only the subpixels parameter description.
+        """
+        @_update_method_subpixels_docstring
+        def func():
+            """
+            Summary.
+
+            Parameters
+            ----------
+            <subpixels_description>
+            """
+
+        doc = func.__doc__
+        assert '<subpixels_description>' not in doc
+        assert 'subpixels : int, optional' in doc
+        assert "method : {'exact', 'center', 'subpixel'}, optional" not in doc
+        assert "* ``'exact'`` (default):" not in doc

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -11,7 +11,8 @@ from numpy.testing import assert_allclose
 
 from photutils.aperture import (Aperture, CircularAperture, EllipticalAperture,
                                 SkyCircularAperture)
-from photutils.aperture.core import _aperture_metadata
+from photutils.aperture.core import (_aperture_metadata,
+                                     _update_method_subpixels_docstring)
 
 POSITIONS = [(5, 5), (10, 10), (15, 15)]
 SCALAR_POS = (5, 5)
@@ -304,3 +305,91 @@ class TestApertureMetadata:
         assert 'aperture_a' in meta
         assert 'aperture_b' in meta
         assert 'aperture_theta' in meta
+
+
+class TestMethodSubpixelsDocstring:
+    """
+    Tests for the _update_method_subpixels_docstring decorator.
+    """
+
+    def test_insert_descriptions(self):
+        """
+        Test that the placeholder is replaced by the method and
+        subpixels descriptions.
+        """
+        @_update_method_subpixels_docstring
+        def func():
+            """
+            Summary.
+
+            Parameters
+            ----------
+            <method_subpixels_descriptions>
+            """
+
+        doc = func.__doc__
+        assert '<method_subpixels_descriptions>' not in doc
+        assert "method : {'exact', 'center', 'subpixel'}, optional" in doc
+        assert 'subpixels : int, optional' in doc
+
+    def test_indentation_preserved(self):
+        """
+        Test that the inserted text is indented to match the
+        placeholder.
+
+        The docstring is assigned manually to avoid the compile-time
+        docstring dedenting introduced in Python 3.13.
+        """
+        def func():
+            pass
+
+        func.__doc__ = ('Summary.\n\n'
+                        '        Parameters\n'
+                        '        ----------\n'
+                        '        <method_subpixels_descriptions>\n')
+        _update_method_subpixels_docstring(func)
+
+        lines = func.__doc__.splitlines()
+        method_line = next(line for line in lines
+                           if line.lstrip().startswith('method :'))
+        assert method_line.startswith('        method :')
+        subpixels_line = next(line for line in lines
+                              if line.lstrip().startswith('subpixels :'))
+        assert subpixels_line.startswith('        subpixels :')
+
+    def test_no_placeholder_noop(self):
+        """
+        Test that the decorator is a no-op if no placeholder is present.
+        """
+        @_update_method_subpixels_docstring
+        def func():
+            """Summary with no placeholder."""
+
+        assert func.__doc__ == 'Summary with no placeholder.'
+
+    def test_none_docstring_noop(self):
+        """
+        Test that the decorator is a no-op if no docstring exists.
+        """
+        @_update_method_subpixels_docstring
+        def func():
+            pass
+
+        assert func.__doc__ is None
+
+    def test_class_docstring(self):
+        """
+        Test that the decorator also updates a class docstring.
+        """
+        @_update_method_subpixels_docstring
+        class Example:
+            """
+            Summary.
+
+            Parameters
+            ----------
+            <method_subpixels_descriptions>
+            """
+
+        assert '<method_subpixels_descriptions>' not in Example.__doc__
+        assert 'subpixels : int, optional' in Example.__doc__

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
+from photutils.aperture.core import _update_method_subpixels_docstring
 from photutils.utils._deprecation import deprecated_positional_kwargs
 from photutils.utils._quantity_helpers import process_quantities
 from photutils.utils._stats import nanmax, nansum
@@ -17,7 +18,9 @@ from photutils.utils._stats import nanmax, nansum
 __all__ = ['ProfileBase']
 
 
+@_update_method_subpixels_docstring
 class ProfileBase(metaclass=abc.ABCMeta):
+    # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Abstract base class for profile classes.
 
@@ -47,31 +50,7 @@ class ProfileBase(metaclass=abc.ABCMeta):
         value indicates the corresponding element of ``data`` is masked.
         Masked data are excluded from all calculations.
 
-    method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the pixel weights (the fraction of
-        the pixel area covered by the aperture):
-
-        * ``'exact'`` (default):
-          Calculates the exact geometric overlap area. Weights are
-          continuous in the range [0, 1].
-        * ``'center'``:
-          Binary weighting based on the pixel center. Weights are either
-          0 or 1. A pixel is included only if its center lies strictly
-          inside the aperture; pixel centers lying exactly on the
-          aperture boundary are excluded (weight 0).
-        * ``'subpixel'``:
-          Approximates the overlap by averaging binary samples on a
-          subgrid. The number of samples is set by the ``subpixels``
-          parameter. Weights are discrete in the range [0, 1]. A
-          subpixel is included only if its center lies strictly inside
-          the aperture; subpixel centers lying exactly on the aperture
-          boundary are excluded (weight 0).
-
-    subpixels : int, optional
-        The subsampling factor per axis used when ``method='subpixel'``.
-        Each pixel is divided into a grid of ``subpixels**2`` subpixels
-        to approximate the overlap. This parameter is ignored for other
-        methods.
+    <method_subpixels_descriptions>
     """
 
     # Define axis labels used by `~photutils.profiles.ProfileBase.plot`.

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -7,13 +7,16 @@ import numpy as np
 from astropy.utils import lazyproperty
 from scipy.interpolate import PchipInterpolator
 
+from photutils.aperture.core import _update_method_subpixels_docstring
 from photutils.profiles.core import ProfileBase
 
 __all__ = ['CurveOfGrowth', 'EllipticalCurveOfGrowth',
            'EnsquaredCurveOfGrowth']
 
 
+@_update_method_subpixels_docstring
 class CurveOfGrowth(ProfileBase):
+    # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Class to create a curve of growth using concentric circular
     apertures.
@@ -50,31 +53,7 @@ class CurveOfGrowth(ProfileBase):
         value indicates the corresponding element of ``data`` is masked.
         Masked data are excluded from all calculations.
 
-    method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the pixel weights (the fraction of
-        the pixel area covered by the aperture):
-
-        * ``'exact'`` (default):
-          Calculates the exact geometric overlap area. Weights are
-          continuous in the range [0, 1].
-        * ``'center'``:
-          Binary weighting based on the pixel center. Weights are either
-          0 or 1. A pixel is included only if its center lies strictly
-          inside the aperture; pixel centers lying exactly on the
-          aperture boundary are excluded (weight 0).
-        * ``'subpixel'``:
-          Approximates the overlap by averaging binary samples on a
-          subgrid. The number of samples is set by the ``subpixels``
-          parameter. Weights are discrete in the range [0, 1]. A
-          subpixel is included only if its center lies strictly inside
-          the aperture; subpixel centers lying exactly on the aperture
-          boundary are excluded (weight 0).
-
-    subpixels : int, optional
-        The subsampling factor per axis used when ``method='subpixel'``.
-        Each pixel is divided into a grid of ``subpixels**2`` subpixels
-        to approximate the overlap. This parameter is ignored for other
-        methods.
+    <method_subpixels_descriptions>
 
     See Also
     --------
@@ -351,7 +330,9 @@ class CurveOfGrowth(ProfileBase):
         return PchipInterpolator(profile, radius, extrapolate=False)(ee)
 
 
+@_update_method_subpixels_docstring
 class EnsquaredCurveOfGrowth(ProfileBase):
+    # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Class to create a curve of growth using concentric square
     apertures.
@@ -389,37 +370,7 @@ class EnsquaredCurveOfGrowth(ProfileBase):
         value indicates the corresponding element of ``data`` is masked.
         Masked data are excluded from all calculations.
 
-    method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the overlap of the aperture on the
-        pixel grid:
-
-        * ``'exact'`` (default):
-          The exact fractional overlap of the aperture and each pixel is
-          calculated. The aperture weights will contain values between 0
-          and 1.
-
-        * ``'center'``:
-          A pixel is considered to be entirely in or out of the aperture
-          depending on whether its center is in or out of the aperture.
-          The aperture weights will contain values only of 0 (out) and 1
-          (in).
-
-        * ``'subpixel'``:
-          A pixel is divided into subpixels (see the ``subpixels``
-          keyword), each of which are considered to be entirely in or
-          out of the aperture depending on whether its center is in
-          or out of the aperture. If ``subpixels=1``, this method is
-          equivalent to ``'center'``. The aperture weights will contain
-          values between 0 and 1. A subpixel is included only if its
-          center lies strictly inside the aperture; subpixel centers
-          lying exactly on the aperture boundary are excluded (weight
-          0).
-
-    subpixels : int, optional
-        For the ``'subpixel'`` method, resample pixels by this factor
-        in each dimension. That is, each pixel is divided into
-        ``subpixels**2`` subpixels. This keyword is ignored unless
-        ``method='subpixel'``.
+    <method_subpixels_descriptions>
 
     See Also
     --------
@@ -691,7 +642,9 @@ class EnsquaredCurveOfGrowth(ProfileBase):
                                  extrapolate=False)(ee)
 
 
+@_update_method_subpixels_docstring
 class EllipticalCurveOfGrowth(ProfileBase):
+    # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Class to create a curve of growth using concentric elliptical
     apertures with a fixed axis ratio and orientation.
@@ -738,37 +691,7 @@ class EllipticalCurveOfGrowth(ProfileBase):
         value indicates the corresponding element of ``data`` is masked.
         Masked data are excluded from all calculations.
 
-    method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the overlap of the aperture on the
-        pixel grid:
-
-        * ``'exact'`` (default):
-          The exact fractional overlap of the aperture and each pixel is
-          calculated. The aperture weights will contain values between 0
-          and 1.
-
-        * ``'center'``:
-          A pixel is considered to be entirely in or out of the aperture
-          depending on whether its center is in or out of the aperture.
-          The aperture weights will contain values only of 0 (out) and 1
-          (in).
-
-        * ``'subpixel'``:
-          A pixel is divided into subpixels (see the ``subpixels``
-          keyword), each of which are considered to be entirely in or
-          out of the aperture depending on whether its center is in
-          or out of the aperture. If ``subpixels=1``, this method is
-          equivalent to ``'center'``. The aperture weights will contain
-          values between 0 and 1. A subpixel is included only if its
-          center lies strictly inside the aperture; subpixel centers
-          lying exactly on the aperture boundary are excluded (weight
-          0).
-
-    subpixels : int, optional
-        For the ``'subpixel'`` method, resample pixels by this factor
-        in each dimension. That is, each pixel is divided into
-        ``subpixels**2`` subpixels. This keyword is ignored unless
-        ``method='subpixel'``.
+    <method_subpixels_descriptions>
 
     See Also
     --------

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -12,11 +12,13 @@ from astropy.stats import gaussian_sigma_to_fwhm
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
+from photutils.aperture.core import _update_method_subpixels_docstring
 from photutils.profiles.core import ProfileBase
 
 __all__ = ['RadialProfile']
 
 
+@_update_method_subpixels_docstring
 class RadialProfile(ProfileBase):
     """
     Class to create a radial profile using concentric circular annulus
@@ -62,31 +64,7 @@ class RadialProfile(ProfileBase):
         value indicates the corresponding element of ``data`` is masked.
         Masked data are excluded from all calculations.
 
-    method : {'exact', 'center', 'subpixel'}, optional
-        The method used to determine the pixel weights (the fraction of
-        the pixel area covered by the aperture):
-
-        * ``'exact'`` (default):
-          Calculates the exact geometric overlap area. Weights are
-          continuous in the range [0, 1].
-        * ``'center'``:
-          Binary weighting based on the pixel center. Weights are either
-          0 or 1. A pixel is included only if its center lies strictly
-          inside the aperture; pixel centers lying exactly on the
-          aperture boundary are excluded (weight 0).
-        * ``'subpixel'``:
-          Approximates the overlap by averaging binary samples on a
-          subgrid. The number of samples is set by the ``subpixels``
-          parameter. Weights are discrete in the range [0, 1]. A
-          subpixel is included only if its center lies strictly inside
-          the aperture; subpixel centers lying exactly on the aperture
-          boundary are excluded (weight 0).
-
-    subpixels : int, optional
-        The subsampling factor per axis used when ``method='subpixel'``.
-        Each pixel is divided into a grid of ``subpixels**2`` subpixels
-        to approximate the overlap. This parameter is ignored for other
-        methods.
+    <method_subpixels_descriptions>
 
     See Also
     --------

--- a/photutils/psf/flags.py
+++ b/photutils/psf/flags.py
@@ -350,7 +350,7 @@ def _update_decode_docstring(func):
     docstring = func.__doc__
 
     # Look for the placeholder text
-    placeholder = '<flag descriptions>'
+    placeholder = '<flag_descriptions>'
 
     if placeholder in docstring:
         # Generate the flag descriptions
@@ -405,7 +405,7 @@ def decode_psf_flags(flags, return_bit_values=False):
         specific condition that was detected during PSF fitting. If no
         flags are set, an empty list is returned. Possible flag names
         are:
-        <flag descriptions>
+        <flag_descriptions>
 
     Examples
     --------

--- a/photutils/psf/tests/test_flags.py
+++ b/photutils/psf/tests/test_flags.py
@@ -488,7 +488,7 @@ def test_decode_psf_flags_docstring():
     docstring = decode_psf_flags.__doc__
 
     # Should not have placeholder
-    assert '<flag descriptions>' not in docstring
+    assert '<flag_descriptions>' not in docstring
 
     # Should have all expected flag names in the expected format
     expected_flags = [

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -678,7 +678,7 @@ def _create_call_docstring(*, iterative=False):
               no ``error`` array is provided, ``reduced_chi2`` values
               will be NaN.
             * ``flags`` : bitwise flag values
-              <flag descriptions>
+              <flag_descriptions>
 
         Notes
         -----
@@ -710,7 +710,7 @@ def _create_call_docstring(*, iterative=False):
             )
 
         # Apply the flag descriptions replacement
-        placeholder = '<flag descriptions>'
+        placeholder = '<flag_descriptions>'
         if placeholder in customized_docstring:
             # Generate the flag descriptions
             flag_descriptions = []


### PR DESCRIPTION
This PR adds an `_update_method_subpixels_docstring` decorator, which inserts the canonical 'method' and
'subpixels' parameter descriptions in place of a placeholder, e.g., `<method_subpixels_descriptions>`, `<method_bullets>`, or `<subpixels_description>`.

This allows the "method" and "subpixels" descriptions to be defined in a single place.