### PR TITLE
Improved GriddedPSFModel evaluation performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,10 +58,9 @@ New Features
 
 - ``photutils.psf``
 
-  - Improved ``GriddedPSFModel`` evaluation performance by ~15% by
-    replacing the per-call grid lookup with a precomputed grid-cell
-    lookup table and implementing a scalar fast path for the bilinear
-    interpolation weights. [#2289]
+  - Improved ``GriddedPSFModel`` evaluation performance by ~20-25%
+    through optimizations that reduce per-evaluation overhead and
+    streamline interpolation calculations. [#2289, #2307]
 
 
 Bug Fixes

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -201,6 +201,15 @@ is converted exactly to a four-vertex polygon::
     >>> poly = aper.to_polygon(n_vertices=100)
 
 
+``GriddedPSFModel`` Performance Improvements
+============================================
+
+``GriddedPSFModel`` evaluations are now significantly faster, with
+typical performance improvements of approximately 20–25%. The
+optimizations reduce the overhead of PSF interpolation, improving the
+runtime of PSF photometry workflows.
+
+
 .. _whatsnew-3.1-api-changes:
 
 API Changes

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -671,16 +671,17 @@ class GriddedPSFModel(Fittable2DModel):
             coordinate.
         """
         grid_idx, grid_xy = self._find_bounding_points(x_0, y_0)
-        interpolators = np.array([self._calc_interpolator(gidx)
-                                  for gidx in grid_idx])
         weights = self._calc_bilinear_weights(x_0, y_0, grid_xy)
 
-        idx = np.where(weights != 0)
-        interpolators = interpolators[idx]
-        weights = weights[idx]
-
-        result = 0
-        for interp, weight in zip(interpolators, weights, strict=True):
+        # Accumulate the weighted interpolator evaluations using a plain
+        # Python loop. This avoids the overhead of building intermediate
+        # arrays and fancy-indexing (np.array, np.where), which is
+        # called once per model evaluation during fitting.
+        result = 0.0
+        for gidx, weight in zip(grid_idx, weights, strict=True):
+            if weight == 0.0:
+                continue
+            interp = self._calc_interpolator(int(gidx))
             result += interp(xi, yi, grid=False) * weight
 
         return result


### PR DESCRIPTION
This PR reduces the per-evaluation overhead of ``GriddedPSFModel`` by removing intermediate array allocations and fancy indexing from the bilinear interpolation hot path.  This results in modest, but measurable (~4-5%) improvement.

Followup to #2289 
