### PR TITLE
Add segmentation masking to aperture_photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,11 @@ New Features
     rectangular apertures (both pixel and sky variants) to convert them
     to ``PolygonAperture`` or ``SkyPolygonAperture`` objects. [#2298]
 
+  - Added ``segmentation_image``, ``labels``, and ``mask_method``
+    keywords to ``aperture_photometry`` and ``ApertureStats`` to mask or
+    correct the flux from neighboring sources within an aperture using a
+    segmentation map. [#2309]
+
 - ``photutils.isophote``
 
   - Optimized the ``build_ellipse_model_c`` Cython extension by

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -755,6 +755,85 @@ The result is very different if a ``mask`` image is not provided::
        111.56637
 
 
+Masking Neighboring Sources with a Segmentation Image
+-----------------------------------------------------
+
+When apertures contain flux from neighboring sources, that
+contamination can be masked or corrected using a segmentation image
+(see :ref:`image_segmentation`). A segmentation image is an integer
+image with the same shape as the data, where background pixels have a
+value of 0 and sources are labeled with positive integers.
+
+The behavior is controlled by the ``aperture_mask_method`` keyword,
+which accepts one of four values:
+
+* ``'none'`` (default):
+  The segmentation image is ignored and all pixels within the aperture
+  are included.
+* ``'mask'``:
+  Pixels belonging to neighboring sources (labeled, but not the target
+  source) are excluded.
+* ``'source_only'``:
+  Only pixels belonging to the target source are included; both
+  neighboring sources and background pixels are excluded.
+* ``'correct'``:
+  Pixels belonging to neighboring sources are replaced by the values of
+  the pixels mirrored across the aperture center. If a mirror pixel is
+  unavailable, the pixel is excluded.
+
+By default, the source label for each aperture is determined
+automatically by sampling the segmentation image at the aperture center.
+The labels may also be provided explicitly via the ``labels`` keyword.
+
+In this example, a circular aperture centered on the target source
+(label 1) also overlaps a bright neighboring source (label 2)::
+
+    >>> import numpy as np
+    >>> from photutils.aperture import CircularAperture, aperture_photometry
+    >>> data = np.ones((11, 11))
+    >>> data[4:7, 4:7] = 10.0  # target source
+    >>> data[4:7, 7:10] = 50.0  # bright neighbor
+    >>> segm = np.zeros((11, 11), dtype=int)
+    >>> segm[4:7, 4:7] = 1
+    >>> segm[4:7, 7:10] = 2
+    >>> aperture = CircularAperture((5, 5), r=4)
+
+Without masking, the aperture sum includes the neighbor's flux::
+
+    >>> t1 = aperture_photometry(data, aperture)
+    >>> t1['aperture_sum'].info.format = '%.8g'  # for consistent table output
+    >>> print(t1['aperture_sum'])
+    aperture_sum
+    ------------
+       484.67785
+
+Masking the neighboring source excludes its flux::
+
+    >>> t2 = aperture_photometry(data, aperture, segmentation_image=segm,
+    ...                          aperture_mask_method='mask')
+    >>> t2['aperture_sum'].info.format = '%.8g'  # for consistent table output
+    >>> print(t2['aperture_sum'])
+    aperture_sum
+    ------------
+       124.05299
+
+The ``'correct'`` method instead replaces the neighbor's pixels with
+values mirrored across the aperture center, recovering an estimate of
+the obscured flux::
+
+    >>> t3 = aperture_photometry(data, aperture, segmentation_image=segm,
+    ...                          aperture_mask_method='correct')
+    >>> t3['aperture_sum'].info.format = '%.8g'  # for consistent table output
+    >>> print(t3['aperture_sum'])
+    aperture_sum
+    ------------
+       131.26548
+
+These keywords are also available in
+:meth:`~photutils.aperture.PixelAperture.do_photometry` and
+:class:`~photutils.aperture.ApertureStats`.
+
+
 Aperture Masks
 --------------
 

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -758,14 +758,14 @@ The result is very different if a ``mask`` image is not provided::
 Masking Neighboring Sources with a Segmentation Image
 -----------------------------------------------------
 
-When apertures contain flux from neighboring sources, that
-contamination can be masked or corrected using a segmentation image
-(see :ref:`image_segmentation`). A segmentation image is an integer
+When apertures contain flux from neighboring sources, that contamination
+can be masked or corrected using a segmentation image (see :ref:`Image
+Segmentation <image_segmentation>`). A segmentation image is an integer
 image with the same shape as the data, where background pixels have a
 value of 0 and sources are labeled with positive integers.
 
-The behavior is controlled by the ``aperture_mask_method`` keyword,
-which accepts one of four values:
+The behavior is controlled by the ``mask_method`` keyword, which accepts
+one of four values:
 
 * ``'none'`` (default):
   The segmentation image is ignored and all pixels within the aperture
@@ -810,7 +810,7 @@ Without masking, the aperture sum includes the neighbor's flux::
 Masking the neighboring source excludes its flux::
 
     >>> t2 = aperture_photometry(data, aperture, segmentation_image=segm,
-    ...                          aperture_mask_method='mask')
+    ...                          mask_method='mask')
     >>> t2['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t2['aperture_sum'])
     aperture_sum
@@ -822,7 +822,7 @@ values mirrored across the aperture center, recovering an estimate of
 the obscured flux::
 
     >>> t3 = aperture_photometry(data, aperture, segmentation_image=segm,
-    ...                          aperture_mask_method='correct')
+    ...                          mask_method='correct')
     >>> t3['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t3['aperture_sum'])
     aperture_sum
@@ -830,7 +830,6 @@ the obscured flux::
        131.26548
 
 These keywords are also available in
-:meth:`~photutils.aperture.PixelAperture.do_photometry` and
 :class:`~photutils.aperture.ApertureStats`.
 
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -201,6 +201,42 @@ is converted exactly to a four-vertex polygon::
     >>> poly = aper.to_polygon(n_vertices=100)
 
 
+Segmentation-Based Masking in Aperture Photometry
+=================================================
+
+`~photutils.aperture.aperture_photometry` and
+`~photutils.aperture.ApertureStats` now accept ``segmentation_image``,
+``labels``, and ``mask_method`` keywords to mask or correct
+the flux from neighboring sources that overlap an aperture.
+The ``segmentation_image`` (see :ref:`Image Segmentation
+<image_segmentation>`) labels each source with a positive integer, and
+the ``mask_method`` keyword selects how neighboring sources are handled:
+
+* ``'none'`` (default): the segmentation image is ignored.
+* ``'mask'``: pixels belonging to neighboring sources are excluded.
+* ``'source_only'``: only pixels belonging to the target source are
+  included.
+* ``'correct'``: neighboring-source pixels are replaced by the values
+  mirrored across the aperture center (excluded if the mirror pixel is
+  unavailable).
+
+By default, the source label for each aperture is determined
+automatically by sampling the segmentation image at the aperture center;
+labels may also be provided explicitly via the ``labels`` keyword::
+
+    >>> import numpy as np
+    >>> from photutils.aperture import CircularAperture, aperture_photometry
+    >>> data = np.ones((11, 11))
+    >>> data[4:7, 4:7] = 10.0  # target source
+    >>> data[4:7, 7:10] = 50.0  # bright neighbor
+    >>> segm = np.zeros((11, 11), dtype=int)
+    >>> segm[4:7, 4:7] = 1
+    >>> segm[4:7, 7:10] = 2
+    >>> aperture = CircularAperture((5, 5), r=4)
+    >>> phot = aperture_photometry(data, aperture, segmentation_image=segm,
+    ...                            mask_method='mask')
+
+
 ``GriddedPSFModel`` Performance Improvements
 ============================================
 

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -67,7 +67,9 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                         const unsigned char[:, ::1] mask,
                         const double[:, ::1] positions, int shape_code,
                         const double[::1] params, double ext_x, double ext_y,
-                        int use_exact, int subpixels):
+                        int use_exact, int subpixels,
+                        const Py_ssize_t[:, ::1] segmentation=None,
+                        const Py_ssize_t[::1] labels=None, int seg_method=0):
     """
     Compute aperture sums for many source positions in a single call.
 
@@ -129,6 +131,25 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
         The number of subpixels in each dimension when ``use_exact`` is
         0.
 
+    segmentation : 2D ndarray of intp (C-contiguous) or `None`
+        A segmentation array where background pixels are zero and
+        sources have positive integer labels. Must have the same shape
+        as ``data``. If `None`, no segmentation masking is applied.
+
+    labels : 1D ndarray of intp (C-contiguous) or `None`
+        The target source label for each position with shape
+        ``(n_sources,)``. A label of 0 disables segmentation masking for
+        that source. Required (not `None`) if ``segmentation`` is input.
+
+    seg_method : int
+        The segmentation masking method:
+
+        * 0: disables masking
+        * 1: excludes neighbor-source pixels
+             (``(seg > 0) & (seg != label)``)
+        * 2: excludes all pixels not assigned to the target source
+             (``seg != label``).
+
     Returns
     -------
     sums : 1D ndarray of float64
@@ -155,6 +176,8 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
     cdef bint has_error = error is not None
     cdef bint has_mask = mask is not None
+    cdef bint has_seg = segmentation is not None
+    cdef Py_ssize_t lbl = 0, seg_val
 
     # Aperture shape parameters (constant over all source positions)
     cdef double r_in = 0.0, r_out = 0.0
@@ -272,6 +295,8 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
         for k in range(n_src):
             cx = positions[k, 0]
             cy = positions[k, 1]
+            if has_seg:
+                lbl = labels[k]
 
             # Replicate BoundingBox.from_float; the values are kept as
             # (integral) doubles to avoid integer overflow for apertures
@@ -318,6 +343,14 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                 for ix in range(ix0, ix1):
                     if has_mask and mask[iy, ix]:
                         continue
+                    if has_seg and lbl != 0:
+                        seg_val = segmentation[iy, ix]
+                        if seg_method == 1:
+                            if seg_val != 0 and seg_val != lbl:
+                                continue
+                        elif seg_method == 2:
+                            if seg_val != lbl:
+                                continue
                     pxmin = gxmin + (ix - ixmin) * dx
 
                     if shape_code == _CIRCLE:

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -149,6 +149,11 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
              (``(seg > 0) & (seg != label)``)
         * 2: excludes all pixels not assigned to the target source
              (``seg != label``).
+        * 3: replaces neighbor-source pixels with the values mirrored
+             across the (rounded) aperture center (the symmetric
+             ``'correct'`` method). For method 3, a neighbor pixel whose
+             mirror falls outside the aperture bounding box, is itself a
+             neighbor, or is masked is excluded instead of replaced.
 
     Returns
     -------
@@ -285,6 +290,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
     cdef Py_ssize_t k, ix, iy, ix0, ix1, iy0, iy1
     cdef Py_ssize_t ixmin, iymin, grid_nx, grid_ny
+    cdef Py_ssize_t six, siy, xm, ym, ccx = 0, ccy = 0, mseg
     cdef double cx, cy
     cdef double ixmin_d, ixmax_d, iymin_d, iymax_d
     cdef double gxmin, gxmax, gymin, gymax
@@ -297,6 +303,17 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             cy = positions[k, 1]
             if has_seg:
                 lbl = labels[k]
+                if seg_method == 3:
+                    # Center pixel for the symmetric 'correct' mirror,
+                    # rounded half away from zero (round_half_away)
+                    if cx >= 0.0:
+                        ccx = <Py_ssize_t>floor(cx + 0.5)
+                    else:
+                        ccx = <Py_ssize_t>ceil(cx - 0.5)
+                    if cy >= 0.0:
+                        ccy = <Py_ssize_t>floor(cy + 0.5)
+                    else:
+                        ccy = <Py_ssize_t>ceil(cy - 0.5)
 
             # Replicate BoundingBox.from_float; the values are kept as
             # (integral) doubles to avoid integer overflow for apertures
@@ -343,6 +360,8 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                 for ix in range(ix0, ix1):
                     if has_mask and mask[iy, ix]:
                         continue
+                    six = ix
+                    siy = iy
                     if has_seg and lbl != 0:
                         seg_val = segmentation[iy, ix]
                         if seg_method == 1:
@@ -351,6 +370,22 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                         elif seg_method == 2:
                             if seg_val != lbl:
                                 continue
+                        elif seg_method == 3:
+                            if seg_val != 0 and seg_val != lbl:
+                                # Neighbor pixel: replace its value with
+                                # the pixel mirrored across the center.
+                                xm = 2 * ccx - ix
+                                ym = 2 * ccy - iy
+                                if (xm < ix0 or xm >= ix1
+                                        or ym < iy0 or ym >= iy1):
+                                    continue
+                                mseg = segmentation[ym, xm]
+                                if mseg != 0 and mseg != lbl:
+                                    continue
+                                if has_mask and mask[ym, xm]:
+                                    continue
+                                six = xm
+                                siy = ym
                     pxmin = gxmin + (ix - ixmin) * dx
 
                     if shape_code == _CIRCLE:
@@ -403,9 +438,9 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
                     if frac <= 0.0:
                         continue
-                    sum_val += data[iy, ix] * frac
+                    sum_val += data[siy, six] * frac
                     if has_error:
-                        err_val = error[iy, ix]
+                        err_val = error[siy, six]
                         var_val += err_val * err_val * frac
 
             sums[k] = sum_val

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -119,9 +119,10 @@ def _auto_lookup_labels(segmentation, positions):
     Look up the source label at each aperture center.
 
     The aperture center is rounded to the nearest pixel (rounding half
-    away from zero). Apertures whose centers fall outside the image or
-    on a background pixel (label 0) are assigned a label of 0, and an
-    `~astropy.utils.exceptions.AstropyUserWarning` is emitted.
+    away from zero). Apertures whose centers fall outside the image
+    or on a background pixel (label 0) are assigned a label of 0. A
+    single `~astropy.utils.exceptions.AstropyUserWarning` summarizing
+    the number of affected apertures is emitted.
     """
     ny, nx = segmentation.shape
     xpos = np.atleast_1d(positions[:, 0])
@@ -137,10 +138,11 @@ def _auto_lookup_labels(segmentation, positions):
         labels[in_bounds] = segmentation[yi[in_bounds].astype(np.intp),
                                          xi[in_bounds].astype(np.intp)]
 
-    for idx in np.nonzero(labels == 0)[0]:
-        msg = (f'Aperture at (x, y) = ({xpos[idx]}, {ypos[idx]}) centers '
-               'on a background pixel (label 0) in the segmentation map. '
-               'Masking behavior is disabled for this aperture. Use the '
+    n_background = np.count_nonzero(labels == 0)
+    if n_background > 0:
+        msg = (f'{n_background} aperture center(s) were on a background '
+               'pixel (label 0) in the segmentation image. Masking '
+               'behavior is disabled for these apertures. Use the '
                "'labels' argument to explicitly define source IDs.")
         warnings.warn(msg, AstropyUserWarning)
 

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -1,0 +1,264 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tools for segmentation-based masking of aperture photometry.
+
+These helpers validate the ``segmentation_image``, ``labels``, and
+``aperture_mask_method`` keywords shared by `aperture_photometry`,
+`~photutils.aperture.PixelAperture.do_photometry`, and
+`~photutils.aperture.ApertureStats`. They also apply the local masking
+or symmetric-correction behavior to per-aperture cutouts.
+"""
+
+import warnings
+
+import numpy as np
+from astropy.utils.exceptions import AstropyUserWarning
+
+from photutils.utils._round import round_half_away
+
+__all__ = []
+
+# The valid ``aperture_mask_method`` values and their integer codes
+# used by the batch Cython driver (see ``_batch_photometry.pyx``). The
+# ``'correct'`` method is not supported by the batch driver and falls
+# back to the mask-based code path.
+APERTURE_MASK_METHODS = ('none', 'mask', 'source_only', 'correct')
+SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'source_only': 2}
+
+
+def process_segmentation_inputs(segmentation_image, labels,
+                                aperture_mask_method, positions, data_shape):
+    """
+    Validate the segmentation-masking inputs and resolve the
+    per-aperture source labels.
+
+    Parameters
+    ----------
+    segmentation_image : `~photutils.segmentation.SegmentationImage`, \
+            2D `~numpy.ndarray`, or `None`
+        The segmentation image, where background pixels are zero and
+        sources have positive integer labels.
+
+    labels : int, 1D array_like, or `None`
+        The source label(s) associated with the aperture ``positions``.
+        If `None`, the labels are looked up automatically by sampling
+        ``segmentation_image`` at the (rounded) aperture centers.
+
+    aperture_mask_method : {'none', 'mask', 'source_only', 'correct'}
+        The segmentation masking method.
+
+    positions : 2D array_like
+        The ``(x, y)`` aperture positions with shape ``(n_positions, 2)``.
+
+    data_shape : tuple of int
+        The shape of the data array.
+
+    Returns
+    -------
+    segmentation : 2D `~numpy.ndarray` (intp) or `None`
+        The validated segmentation array, or `None` if
+        ``aperture_mask_method`` is ``'none'``.
+
+    labels : 1D `~numpy.ndarray` (intp) or `None`
+        The resolved per-aperture source labels, or `None` if
+        ``aperture_mask_method`` is ``'none'``.
+    """
+    if aperture_mask_method not in APERTURE_MASK_METHODS:
+        msg = f'aperture_mask_method must be one of {APERTURE_MASK_METHODS}'
+        raise ValueError(msg)
+
+    if aperture_mask_method == 'none':
+        return None, None
+
+    if segmentation_image is None:
+        msg = ('segmentation_image must be input when aperture_mask_method '
+               "is not 'none'")
+        raise ValueError(msg)
+
+    # Local import to avoid a circular import with photutils.segmentation
+    from photutils.segmentation import SegmentationImage
+
+    if isinstance(segmentation_image, SegmentationImage):
+        segm = segmentation_image.data
+    else:
+        segm = np.asarray(segmentation_image)
+
+    if segm.ndim != 2:
+        msg = 'segmentation_image must be a 2D array'
+        raise ValueError(msg)
+
+    if segm.shape != tuple(data_shape):
+        msg = 'segmentation_image must have the same shape as the data'
+        raise ValueError(msg)
+
+    if segm.dtype.kind not in ('i', 'u'):
+        msg = 'segmentation_image must have an integer data type'
+        raise ValueError(msg)
+
+    segm = np.ascontiguousarray(segm, dtype=np.intp)
+
+    positions = np.atleast_2d(positions)
+    n_positions = positions.shape[0]
+
+    if labels is not None:
+        labels = np.atleast_1d(labels)
+        if labels.shape[0] != n_positions:
+            msg = ('labels must have the same length as the number of '
+                   'aperture positions')
+            raise ValueError(msg)
+        labels = np.ascontiguousarray(labels, dtype=np.intp)
+    else:
+        labels = _auto_lookup_labels(segm, positions)
+
+    return segm, labels
+
+
+def _auto_lookup_labels(segmentation, positions):
+    """
+    Look up the source label at each aperture center.
+
+    The aperture center is rounded to the nearest pixel (rounding half
+    away from zero). Apertures whose centers fall outside the image or
+    on a background pixel (label 0) are assigned a label of 0, and an
+    `~astropy.utils.exceptions.AstropyUserWarning` is emitted.
+    """
+    ny, nx = segmentation.shape
+    xpos = np.atleast_1d(positions[:, 0])
+    ypos = np.atleast_1d(positions[:, 1])
+
+    xi = np.atleast_1d(np.asarray(round_half_away(xpos)))
+    yi = np.atleast_1d(np.asarray(round_half_away(ypos)))
+
+    labels = np.zeros(positions.shape[0], dtype=np.intp)
+    in_bounds = (np.isfinite(xpos) & np.isfinite(ypos)
+                 & (xi >= 0) & (xi < nx) & (yi >= 0) & (yi < ny))
+    if np.any(in_bounds):
+        labels[in_bounds] = segmentation[yi[in_bounds].astype(np.intp),
+                                         xi[in_bounds].astype(np.intp)]
+
+    for idx in np.nonzero(labels == 0)[0]:
+        msg = (f'Aperture at (x, y) = ({xpos[idx]}, {ypos[idx]}) centers '
+               'on a background pixel (label 0) in the segmentation map. '
+               'Masking behavior is disabled for this aperture. Use the '
+               "'labels' argument to explicitly define source IDs.")
+        warnings.warn(msg, AstropyUserWarning)
+
+    return labels
+
+
+def make_segmentation_exclusion(aperture_mask_method, segmentation_cutout,
+                                label, *, data=None, error=None,
+                                base_mask=None, cutout_xycen=None):
+    """
+    Build the segmentation-based pixel exclusion mask for a single
+    aperture cutout, optionally applying the symmetric ``'correct'``
+    replacement to the ``data`` and ``error`` cutouts.
+
+    Parameters
+    ----------
+    aperture_mask_method : {'none', 'mask', 'source_only', 'correct'}
+        The segmentation masking method.
+
+    segmentation_cutout : 2D `~numpy.ndarray`
+        The segmentation cutout for the aperture, aligned with ``data``.
+
+    label : int
+        The target source label for this aperture. If ``label`` is 0,
+        masking is disabled and no pixels are excluded.
+
+    data : 2D `~numpy.ndarray`, optional
+        The data cutout, required for the ``'correct'`` method.
+
+    error : 2D `~numpy.ndarray`, optional
+        The error cutout, mirror-corrected alongside ``data`` for the
+        ``'correct'`` method.
+
+    base_mask : 2D bool `~numpy.ndarray`, optional
+        Pixels that are already masked (e.g., the global ``mask`` or
+        non-finite values). Used by the ``'correct'`` method to avoid
+        mirroring from masked pixels.
+
+    cutout_xycen : tuple of float, optional
+        The ``(x, y)`` aperture center relative to the cutout origin,
+        required for the ``'correct'`` method.
+
+    Returns
+    -------
+    data : 2D `~numpy.ndarray`
+        The (possibly mirror-corrected) data cutout.
+
+    error : 2D `~numpy.ndarray` or `None`
+        The (possibly mirror-corrected) error cutout.
+
+    exclude : 2D bool `~numpy.ndarray`
+        A boolean mask where `True` indicates a pixel to exclude from
+        the photometry.
+    """
+    exclude = np.zeros(segmentation_cutout.shape, dtype=bool)
+
+    if aperture_mask_method == 'none' or label == 0:
+        return data, error, exclude
+
+    if aperture_mask_method == 'mask':
+        exclude = (segmentation_cutout > 0) & (segmentation_cutout != label)
+        return data, error, exclude
+
+    if aperture_mask_method == 'source_only':
+        exclude = segmentation_cutout != label
+        return data, error, exclude
+
+    # The remaining method is the symmetric 'correct' replacement.
+    return _correct_neighbors(segmentation_cutout, label, data, error,
+                              base_mask, cutout_xycen)
+
+
+def _correct_neighbors(segmentation_cutout, label, data, error, base_mask,
+                       cutout_xycen):
+    """
+    Replace neighbor-source pixels with their values mirrored across the
+    aperture center.
+
+    A neighbor pixel whose mirror pixel is unavailable (outside the
+    cutout, itself a neighbor, or in ``base_mask``) is excluded from the
+    photometry instead of being replaced.
+    """
+    ny, nx = segmentation_cutout.shape
+    neighbor = (segmentation_cutout > 0) & (segmentation_cutout != label)
+    exclude = np.zeros(segmentation_cutout.shape, dtype=bool)
+
+    data = data.copy()
+    if error is not None:
+        error = error.copy()
+
+    cx = int(round_half_away(cutout_xycen[0]))
+    cy = int(round_half_away(cutout_xycen[1]))
+
+    yidx, xidx = np.nonzero(neighbor)
+    xmirror = 2 * cx - xidx
+    ymirror = 2 * cy - yidx
+
+    out_of_bounds = ((xmirror < 0) | (ymirror < 0)
+                     | (xmirror >= nx) | (ymirror >= ny))
+    exclude[yidx[out_of_bounds], xidx[out_of_bounds]] = True
+
+    keep = ~out_of_bounds
+    yidx = yidx[keep]
+    xidx = xidx[keep]
+    xmirror = xmirror[keep]
+    ymirror = ymirror[keep]
+
+    bad_mirror = neighbor[ymirror, xmirror]
+    if base_mask is not None:
+        bad_mirror |= base_mask[ymirror, xmirror]
+    exclude[yidx[bad_mirror], xidx[bad_mirror]] = True
+
+    good = ~bad_mirror
+    gy = yidx[good]
+    gx = xidx[good]
+    gmy = ymirror[good]
+    gmx = xmirror[good]
+    data[gy, gx] = data[gmy, gmx]
+    if error is not None:
+        error[gy, gx] = error[gmy, gmx]
+
+    return data, error, exclude

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -3,7 +3,7 @@
 Tools for segmentation-based masking of aperture photometry.
 
 These helpers validate the ``segmentation_image``, ``labels``, and
-``aperture_mask_method`` keywords shared by `aperture_photometry`,
+``mask_method`` keywords shared by `aperture_photometry`,
 `~photutils.aperture.PixelAperture.do_photometry`, and
 `~photutils.aperture.ApertureStats`. They also apply the local masking
 or symmetric-correction behavior to per-aperture cutouts.
@@ -18,14 +18,14 @@ from photutils.utils._round import round_half_away
 
 __all__ = []
 
-# The valid ``aperture_mask_method`` values and their integer codes used
+# The valid ``mask_method`` values and their integer codes used
 # by the batch Cython driver (see ``_batch_photometry.pyx``).
-APERTURE_MASK_METHODS = ('none', 'mask', 'source_only', 'correct')
+MASK_METHODS = ('none', 'mask', 'source_only', 'correct')
 SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'source_only': 2, 'correct': 3}
 
 
 def process_segmentation_inputs(segmentation_image, labels,
-                                aperture_mask_method, positions, data_shape):
+                                mask_method, positions, data_shape):
     """
     Validate the segmentation-masking inputs and resolve the
     per-aperture source labels.
@@ -42,7 +42,7 @@ def process_segmentation_inputs(segmentation_image, labels,
         If `None`, the labels are looked up automatically by sampling
         ``segmentation_image`` at the (rounded) aperture centers.
 
-    aperture_mask_method : {'none', 'mask', 'source_only', 'correct'}
+    mask_method : {'none', 'mask', 'source_only', 'correct'}
         The segmentation masking method.
 
     positions : 2D array_like
@@ -55,21 +55,24 @@ def process_segmentation_inputs(segmentation_image, labels,
     -------
     segmentation : 2D `~numpy.ndarray` (intp) or `None`
         The validated segmentation array, or `None` if
-        ``aperture_mask_method`` is ``'none'``.
+        ``mask_method`` is ``'none'``.
 
     labels : 1D `~numpy.ndarray` (intp) or `None`
         The resolved per-aperture source labels, or `None` if
-        ``aperture_mask_method`` is ``'none'``.
+        ``mask_method`` is ``'none'``.
     """
-    if aperture_mask_method not in APERTURE_MASK_METHODS:
-        msg = f'aperture_mask_method must be one of {APERTURE_MASK_METHODS}'
+    if mask_method not in MASK_METHODS:
+        msg = f'aperture_mask_method must be one of {MASK_METHODS}'
+
+    if mask_method not in MASK_METHODS:
+        msg = f'mask_method must be one of {MASK_METHODS}'
         raise ValueError(msg)
 
-    if aperture_mask_method == 'none':
+    if mask_method == 'none':
         return None, None
 
     if segmentation_image is None:
-        msg = ('segmentation_image must be input when aperture_mask_method '
+        msg = ('segmentation_image must be input when mask_method '
                "is not 'none'")
         raise ValueError(msg)
 
@@ -144,7 +147,7 @@ def _auto_lookup_labels(segmentation, positions):
     return labels
 
 
-def make_segmentation_exclusion(aperture_mask_method, segmentation_cutout,
+def make_segmentation_exclusion(mask_method, segmentation_cutout,
                                 label, *, data=None, error=None,
                                 base_mask=None, cutout_xycen=None):
     """
@@ -154,7 +157,7 @@ def make_segmentation_exclusion(aperture_mask_method, segmentation_cutout,
 
     Parameters
     ----------
-    aperture_mask_method : {'none', 'mask', 'source_only', 'correct'}
+    mask_method : {'none', 'mask', 'source_only', 'correct'}
         The segmentation masking method.
 
     segmentation_cutout : 2D `~numpy.ndarray`
@@ -194,14 +197,14 @@ def make_segmentation_exclusion(aperture_mask_method, segmentation_cutout,
     """
     exclude = np.zeros(segmentation_cutout.shape, dtype=bool)
 
-    if aperture_mask_method == 'none' or label == 0:
+    if mask_method == 'none' or label == 0:
         return data, error, exclude
 
-    if aperture_mask_method == 'mask':
+    if mask_method == 'mask':
         exclude = (segmentation_cutout > 0) & (segmentation_cutout != label)
         return data, error, exclude
 
-    if aperture_mask_method == 'source_only':
+    if mask_method == 'source_only':
         exclude = segmentation_cutout != label
         return data, error, exclude
 

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -18,12 +18,10 @@ from photutils.utils._round import round_half_away
 
 __all__ = []
 
-# The valid ``aperture_mask_method`` values and their integer codes
-# used by the batch Cython driver (see ``_batch_photometry.pyx``). The
-# ``'correct'`` method is not supported by the batch driver and falls
-# back to the mask-based code path.
+# The valid ``aperture_mask_method`` values and their integer codes used
+# by the batch Cython driver (see ``_batch_photometry.pyx``).
 APERTURE_MASK_METHODS = ('none', 'mask', 'source_only', 'correct')
-SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'source_only': 2}
+SEG_METHOD_CODES = {'none': 0, 'mask': 1, 'source_only': 2, 'correct': 3}
 
 
 def process_segmentation_inputs(segmentation_image, labels,

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -780,7 +780,7 @@ class PixelAperture(Aperture):
     @_update_method_subpixels_docstring
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def do_photometry(self, data, error=None, mask=None, method='exact',
-                      subpixels=5, segmentation_image=None, labels=None,
+                      subpixels=5, *, segmentation_image=None, labels=None,
                       mask_method='none'):
         # numpydoc ignore: PR01,PR02,PR04,PR07
         """

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -592,8 +592,9 @@ class PixelAperture(Aperture):
 
         This is the fallback code path for apertures or inputs that are
         not supported by the batch Cython driver. It also handles the
-        ``aperture_mask_method='correct'`` segmentation masking, which
-        is not supported by the batch driver.
+        ``aperture_mask_method='correct'`` segmentation masking for
+        apertures (e.g., `PolygonAperture`) or statistics (e.g.,
+        `ApertureStats`) that do not use the batch driver.
 
         Parameters
         ----------
@@ -713,8 +714,6 @@ class PixelAperture(Aperture):
             The validated segmentation array, per-aperture source
             labels, and masking method (see
             `~photutils.aperture._segmentation.process_segmentation_inputs`).
-            The ``'correct'`` method is not supported by the batch
-            driver, so `None` is returned in that case.
 
         Returns
         -------
@@ -724,11 +723,6 @@ class PixelAperture(Aperture):
             aperture or these inputs (in which case the caller should
             use the mask-based code path).
         """
-        # The symmetric 'correct' method modifies the data array and is
-        # only implemented in the mask-based code path.
-        if aperture_mask_method == 'correct':
-            return None
-
         # Use the batch driver only if the aperture's own class defines
         # the _batch_shape_params hook. Subclasses that do not define
         # it may override other behavior (e.g., to_mask) that the batch

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -15,6 +15,9 @@ from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
 
 from photutils.aperture._batch_photometry import batch_aperture_sums
+from photutils.aperture._segmentation import (SEG_METHOD_CODES,
+                                              make_segmentation_exclusion,
+                                              process_segmentation_inputs)
 from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.mask import ApertureMask
 from photutils.utils._deprecation import deprecated_positional_kwargs
@@ -60,6 +63,43 @@ _METHOD_SUBPIXELS_DOC = (
     + textwrap.indent(_METHOD_BULLETS, '    ') + '\n\n'
     + _SUBPIXELS_DOC)
 
+_SEGMENTATION_DOC = """\
+segmentation_image : `~photutils.segmentation.SegmentationImage`, 2D \
+array_like, or `None`, optional
+    A 2D segmentation image with the same shape as ``data``, where
+    background pixels have a value of 0 and sources are labeled with
+    positive integers. If input, neighboring sources can be masked or
+    corrected within each aperture according to the
+    ``aperture_mask_method`` keyword. This keyword is required if
+    ``aperture_mask_method`` is not ``'none'``.
+
+labels : int, 1D array_like, or `None`, optional
+    The source label(s) in ``segmentation_image`` associated with the
+    aperture position(s). If input, ``labels`` must have the same
+    length as the number of aperture positions. If `None` (default),
+    the label for each aperture is determined by sampling
+    ``segmentation_image`` at the aperture center (rounded to the
+    nearest pixel). An aperture whose center falls on a background
+    pixel (label 0) has its masking behavior disabled.
+
+aperture_mask_method : {'none', 'mask', 'source_only', 'correct'}, optional
+    The method used to handle neighboring sources within each aperture
+    using the ``segmentation_image``:
+
+    * ``'none'`` (default):
+      The ``segmentation_image`` is ignored and all pixels within the
+      aperture are included.
+    * ``'mask'``:
+      Pixels belonging to neighboring sources (i.e., labeled but not
+      the target source) are excluded.
+    * ``'source_only'``:
+      Only pixels belonging to the target source are included; both
+      neighboring sources and background pixels are excluded.
+    * ``'correct'``:
+      Pixels belonging to neighboring sources are replaced by the
+      values of the pixels mirrored across the aperture center. If a
+      mirror pixel is unavailable, the pixel is excluded."""
+
 # Mapping of placeholder tags to their replacement text. Each tag must
 # appear alone on its own line in a docstring; the leading indentation
 # of the placeholder is applied to the inserted text.
@@ -67,6 +107,7 @@ _DOC_PLACEHOLDERS = {
     'method_subpixels_descriptions': _METHOD_SUBPIXELS_DOC,
     'method_bullets': _METHOD_BULLETS,
     'subpixels_description': _SUBPIXELS_DOC,
+    'segmentation_descriptions': _SEGMENTATION_DOC,
 }
 
 _DOC_PLACEHOLDER_RE = re.compile(
@@ -543,12 +584,16 @@ class PixelAperture(Aperture):
             The overlap array.
         """
 
-    def _do_mask_photometry(self, data, *, error, mask, method, subpixels):
+    def _do_mask_photometry(self, data, *, error, mask, method, subpixels,
+                            segmentation=None, labels=None,
+                            aperture_mask_method='none'):
         """
         Perform aperture photometry using per-source aperture masks.
 
         This is the fallback code path for apertures or inputs that are
-        not supported by the batch Cython driver.
+        not supported by the batch Cython driver. It also handles the
+        ``aperture_mask_method='correct'`` segmentation masking, which
+        is not supported by the batch driver.
 
         Parameters
         ----------
@@ -560,6 +605,11 @@ class PixelAperture(Aperture):
             See `do_photometry`. Any units must already be stripped from
             ``error``.
 
+        segmentation, labels, aperture_mask_method
+            The validated segmentation array, per-aperture source
+            labels, and masking method (see
+            `~photutils.aperture._segmentation.process_segmentation_inputs`).
+
         Returns
         -------
         aperture_sums, aperture_sum_errs : `~numpy.ndarray`
@@ -569,13 +619,15 @@ class PixelAperture(Aperture):
         if self.isscalar:
             apermasks = (apermasks,)
 
+        positions = np.atleast_2d(self.positions)
+
         aperture_sums = []
         aperture_sum_errs = []
         with warnings.catch_warnings():
             # Ignore multiplication with non-finite data values
             warnings.simplefilter('ignore', RuntimeWarning)
 
-            for apermask in apermasks:
+            for idx, apermask in enumerate(apermasks):
                 (slc_large,
                  aper_weights,
                  pixel_mask) = apermask._get_overlap_cutouts(data.shape,
@@ -587,12 +639,26 @@ class PixelAperture(Aperture):
                     aperture_sum_errs.append(np.nan)
                     continue
 
-                values = (data[slc_large] * aper_weights)[pixel_mask]
+                data_cutout = data[slc_large]
+                error_cutout = None if error is None else error[slc_large]
+
+                if segmentation is not None and aperture_mask_method != 'none':
+                    segm_cutout = segmentation[slc_large]
+                    base_mask = None if mask is None else mask[slc_large]
+                    cutout_xycen = (positions[idx, 0] - slc_large[1].start,
+                                    positions[idx, 1] - slc_large[0].start)
+                    (data_cutout, error_cutout,
+                     exclude) = make_segmentation_exclusion(
+                        aperture_mask_method, segm_cutout, labels[idx],
+                        data=data_cutout, error=error_cutout,
+                        base_mask=base_mask, cutout_xycen=cutout_xycen)
+                    pixel_mask = pixel_mask & ~exclude
+
+                values = (data_cutout * aper_weights)[pixel_mask]
                 aperture_sums.append(values.sum())
 
                 if error is not None:
-                    variance = (error[slc_large]**2
-                                * aper_weights)[pixel_mask]
+                    variance = (error_cutout**2 * aper_weights)[pixel_mask]
                     aperture_sum_errs.append(np.sqrt(variance.sum()))
 
         return np.array(aperture_sums), np.array(aperture_sum_errs)
@@ -623,7 +689,9 @@ class PixelAperture(Aperture):
         """
         return
 
-    def _do_batch_photometry(self, data, *, error, mask, method, subpixels):
+    def _do_batch_photometry(self, data, *, error, mask, method, subpixels,
+                             segmentation=None, labels=None,
+                             aperture_mask_method='none'):
         """
         Perform aperture photometry using the batch Cython driver.
 
@@ -641,6 +709,13 @@ class PixelAperture(Aperture):
             See `do_photometry`. Any units must already be stripped from
             ``error``.
 
+        segmentation, labels, aperture_mask_method
+            The validated segmentation array, per-aperture source
+            labels, and masking method (see
+            `~photutils.aperture._segmentation.process_segmentation_inputs`).
+            The ``'correct'`` method is not supported by the batch
+            driver, so `None` is returned in that case.
+
         Returns
         -------
         result : tuple of `~numpy.ndarray` or `None`
@@ -649,6 +724,11 @@ class PixelAperture(Aperture):
             aperture or these inputs (in which case the caller should
             use the mask-based code path).
         """
+        # The symmetric 'correct' method modifies the data array and is
+        # only implemented in the mask-based code path.
+        if aperture_mask_method == 'correct':
+            return None
+
         # Use the batch driver only if the aperture's own class defines
         # the _batch_shape_params hook. Subclasses that do not define
         # it may override other behavior (e.g., to_mask) that the batch
@@ -674,6 +754,14 @@ class PixelAperture(Aperture):
                 return None
             mask = np.ascontiguousarray(mask, dtype=np.uint8)
 
+        seg_arr = None
+        labels_arr = None
+        seg_code = 0
+        if segmentation is not None and aperture_mask_method != 'none':
+            seg_arr = np.ascontiguousarray(segmentation, dtype=np.intp)
+            labels_arr = np.ascontiguousarray(labels, dtype=np.intp)
+            seg_code = SEG_METHOD_CODES[aperture_mask_method]
+
         use_exact, subpixels = self._translate_mask_method(method, subpixels)
 
         shape_code, params = spec
@@ -685,7 +773,8 @@ class PixelAperture(Aperture):
             np.ascontiguousarray(data, dtype=np.float64), error, mask,
             np.ascontiguousarray(self._positions, dtype=np.float64),
             shape_code, np.array(params, dtype=np.float64),
-            float(ext_x), float(ext_y), use_exact, subpixels)
+            float(ext_x), float(ext_y), use_exact, subpixels,
+            seg_arr, labels_arr, seg_code)
 
         if error is None:
             # Match the mask-based path, which collects one NaN per
@@ -697,7 +786,8 @@ class PixelAperture(Aperture):
     @_update_method_subpixels_docstring
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def do_photometry(self, data, error=None, mask=None, method='exact',
-                      subpixels=5):
+                      subpixels=5, segmentation_image=None, labels=None,
+                      aperture_mask_method='none'):
         # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Perform aperture photometry on the input data.
@@ -721,6 +811,8 @@ class PixelAperture(Aperture):
             is masked. Masked data are excluded from all calculations.
 
         <method_subpixels_descriptions>
+
+        <segmentation_descriptions>
 
         Returns
         -------
@@ -760,16 +852,22 @@ class PixelAperture(Aperture):
             if error is not None:
                 error = error.value
 
-        result = self._do_batch_photometry(data, error=error, mask=mask,
-                                           method=method,
-                                           subpixels=subpixels)
+        segmentation, labels = process_segmentation_inputs(
+            segmentation_image, labels, aperture_mask_method,
+            np.atleast_2d(self.positions), data.shape)
+
+        result = self._do_batch_photometry(
+            data, error=error, mask=mask, method=method, subpixels=subpixels,
+            segmentation=segmentation, labels=labels,
+            aperture_mask_method=aperture_mask_method)
 
         if result is not None:
             aperture_sums, aperture_sum_errs = result
         else:
             aperture_sums, aperture_sum_errs = self._do_mask_photometry(
                 data, error=error, mask=mask, method=method,
-                subpixels=subpixels)
+                subpixels=subpixels, segmentation=segmentation,
+                labels=labels, aperture_mask_method=aperture_mask_method)
 
         # Apply units
         if unit is not None:

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -69,20 +69,20 @@ array_like, or `None`, optional
     A 2D segmentation image with the same shape as ``data``, where
     background pixels have a value of 0 and sources are labeled with
     positive integers. If input, neighboring sources can be masked or
-    corrected within each aperture according to the
-    ``aperture_mask_method`` keyword. This keyword is required if
-    ``aperture_mask_method`` is not ``'none'``.
+    corrected within each aperture according to the ``mask_method``
+    keyword. This keyword is required if ``mask_method`` is not
+    ``'none'``.
 
 labels : int, 1D array_like, or `None`, optional
     The source label(s) in ``segmentation_image`` associated with the
-    aperture position(s). If input, ``labels`` must have the same
-    length as the number of aperture positions. If `None` (default),
-    the label for each aperture is determined by sampling
-    ``segmentation_image`` at the aperture center (rounded to the
-    nearest pixel). An aperture whose center falls on a background
-    pixel (label 0) has its masking behavior disabled.
+    aperture position(s). If input, ``labels`` must have the same length
+    as the number of aperture positions. If `None` (default), the label
+    for each aperture is determined by sampling ``segmentation_image``
+    at the aperture center (rounded to the nearest pixel). An aperture
+    whose center falls on a background pixel (label 0) has its masking
+    behavior disabled.
 
-aperture_mask_method : {'none', 'mask', 'source_only', 'correct'}, optional
+mask_method : {'none', 'mask', 'source_only', 'correct'}, optional
     The method used to handle neighboring sources within each aperture
     using the ``segmentation_image``:
 
@@ -586,15 +586,15 @@ class PixelAperture(Aperture):
 
     def _do_mask_photometry(self, data, *, error, mask, method, subpixels,
                             segmentation=None, labels=None,
-                            aperture_mask_method='none'):
+                            mask_method='none'):
         """
         Perform aperture photometry using per-source aperture masks.
 
         This is the fallback code path for apertures or inputs that are
         not supported by the batch Cython driver. It also handles the
-        ``aperture_mask_method='correct'`` segmentation masking for
-        apertures (e.g., `PolygonAperture`) or statistics (e.g.,
-        `ApertureStats`) that do not use the batch driver.
+        ``mask_method='correct'`` segmentation masking for apertures
+        (e.g., `PolygonAperture`) or statistics (e.g., `ApertureStats`)
+        that do not use the batch driver.
 
         Parameters
         ----------
@@ -606,7 +606,7 @@ class PixelAperture(Aperture):
             See `do_photometry`. Any units must already be stripped from
             ``error``.
 
-        segmentation, labels, aperture_mask_method
+        segmentation, labels, mask_method
             The validated segmentation array, per-aperture source
             labels, and masking method (see
             `~photutils.aperture._segmentation.process_segmentation_inputs`).
@@ -643,14 +643,14 @@ class PixelAperture(Aperture):
                 data_cutout = data[slc_large]
                 error_cutout = None if error is None else error[slc_large]
 
-                if segmentation is not None and aperture_mask_method != 'none':
+                if segmentation is not None and mask_method != 'none':
                     segm_cutout = segmentation[slc_large]
                     base_mask = None if mask is None else mask[slc_large]
                     cutout_xycen = (positions[idx, 0] - slc_large[1].start,
                                     positions[idx, 1] - slc_large[0].start)
                     (data_cutout, error_cutout,
                      exclude) = make_segmentation_exclusion(
-                        aperture_mask_method, segm_cutout, labels[idx],
+                        mask_method, segm_cutout, labels[idx],
                         data=data_cutout, error=error_cutout,
                         base_mask=base_mask, cutout_xycen=cutout_xycen)
                     pixel_mask = pixel_mask & ~exclude
@@ -692,7 +692,7 @@ class PixelAperture(Aperture):
 
     def _do_batch_photometry(self, data, *, error, mask, method, subpixels,
                              segmentation=None, labels=None,
-                             aperture_mask_method='none'):
+                             mask_method='none'):
         """
         Perform aperture photometry using the batch Cython driver.
 
@@ -710,7 +710,7 @@ class PixelAperture(Aperture):
             See `do_photometry`. Any units must already be stripped from
             ``error``.
 
-        segmentation, labels, aperture_mask_method
+        segmentation, labels, mask_method
             The validated segmentation array, per-aperture source
             labels, and masking method (see
             `~photutils.aperture._segmentation.process_segmentation_inputs`).
@@ -751,10 +751,10 @@ class PixelAperture(Aperture):
         seg_arr = None
         labels_arr = None
         seg_code = 0
-        if segmentation is not None and aperture_mask_method != 'none':
+        if segmentation is not None and mask_method != 'none':
             seg_arr = np.ascontiguousarray(segmentation, dtype=np.intp)
             labels_arr = np.ascontiguousarray(labels, dtype=np.intp)
-            seg_code = SEG_METHOD_CODES[aperture_mask_method]
+            seg_code = SEG_METHOD_CODES[mask_method]
 
         use_exact, subpixels = self._translate_mask_method(method, subpixels)
 
@@ -781,7 +781,7 @@ class PixelAperture(Aperture):
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def do_photometry(self, data, error=None, mask=None, method='exact',
                       subpixels=5, segmentation_image=None, labels=None,
-                      aperture_mask_method='none'):
+                      mask_method='none'):
         # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Perform aperture photometry on the input data.
@@ -847,13 +847,13 @@ class PixelAperture(Aperture):
                 error = error.value
 
         segmentation, labels = process_segmentation_inputs(
-            segmentation_image, labels, aperture_mask_method,
+            segmentation_image, labels, mask_method,
             np.atleast_2d(self.positions), data.shape)
 
         result = self._do_batch_photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation=segmentation, labels=labels,
-            aperture_mask_method=aperture_mask_method)
+            mask_method=mask_method)
 
         if result is not None:
             aperture_sums, aperture_sum_errs = result
@@ -861,7 +861,7 @@ class PixelAperture(Aperture):
             aperture_sums, aperture_sum_errs = self._do_mask_photometry(
                 data, error=error, mask=mask, method=method,
                 subpixels=subpixels, segmentation=segmentation,
-                labels=labels, aperture_mask_method=aperture_mask_method)
+                labels=labels, mask_method=mask_method)
 
         # Apply units
         if unit is not None:

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.utils.exceptions import AstropyUserWarning
 
+from photutils.aperture._segmentation import process_segmentation_inputs
 from photutils.aperture.converters import region_to_aperture
 from photutils.aperture.core import (Aperture, SkyAperture, _aperture_metadata,
                                      _update_method_subpixels_docstring)
@@ -30,7 +31,9 @@ _DEPRECATED_COLUMNS: dict = {
 @_update_method_subpixels_docstring
 @deprecated_positional_kwargs(since='3.0', until='4.0')
 def aperture_photometry(data, apertures, error=None, mask=None,
-                        method='exact', subpixels=5, wcs=None):
+                        method='exact', subpixels=5, wcs=None,
+                        segmentation_image=None, labels=None,
+                        aperture_mask_method='none'):
     # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Perform aperture photometry on the input data by summing the flux
@@ -87,6 +90,8 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         coordinates of the input aperture center(s). This keyword is
         required if the input ``apertures`` contains a `SkyAperture` or
         `~regions.SkyRegion`.
+
+    <segmentation_descriptions>
 
     Returns
     -------
@@ -154,7 +159,10 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
         return aperture_photometry(data, apertures, error=error, mask=mask,
                                    method=method, subpixels=subpixels,
-                                   wcs=wcs)
+                                   wcs=wcs,
+                                   segmentation_image=segmentation_image,
+                                   labels=labels,
+                                   aperture_mask_method=aperture_mask_method)
 
     single_aperture = False
     if not isinstance(apertures, (list, tuple, np.ndarray)):
@@ -194,6 +202,14 @@ def aperture_photometry(data, apertures, error=None, mask=None,
             msg = 'Input apertures must all have identical positions'
             raise ValueError(msg)
 
+    # Validate the segmentation-masking inputs and resolve the
+    # per-aperture source labels once (the resolved labels are passed
+    # explicitly to do_photometry to avoid repeated auto-lookups and
+    # warnings)
+    segmentation, labels = process_segmentation_inputs(
+        segmentation_image, labels, aperture_mask_method,
+        np.atleast_2d(positions), np.shape(data))
+
     # Define output table meta data
     meta = _get_meta()
     calling_args = f"method='{method}', subpixels={subpixels}"
@@ -226,9 +242,10 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     sum_key_main = 'aperture_sum'
     sum_err_key_main = 'aperture_sum_err'
     for i, aper in enumerate(apertures):
-        aper_sum, aper_sum_err = aper.do_photometry(data, error=error,
-                                                    mask=mask, method=method,
-                                                    subpixels=subpixels)
+        aper_sum, aper_sum_err = aper.do_photometry(
+            data, error=error, mask=mask, method=method, subpixels=subpixels,
+            segmentation_image=segmentation, labels=labels,
+            aperture_mask_method=aperture_mask_method)
 
         sum_key = sum_key_main
         sum_err_key = sum_err_key_main

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -31,7 +31,7 @@ _DEPRECATED_COLUMNS: dict = {
 @_update_method_subpixels_docstring
 @deprecated_positional_kwargs(since='3.0', until='4.0')
 def aperture_photometry(data, apertures, error=None, mask=None,
-                        method='exact', subpixels=5, wcs=None,
+                        method='exact', subpixels=5, wcs=None, *,
                         segmentation_image=None, labels=None,
                         mask_method='none'):
     # numpydoc ignore: PR01,PR02,PR04,PR07

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -33,7 +33,7 @@ _DEPRECATED_COLUMNS: dict = {
 def aperture_photometry(data, apertures, error=None, mask=None,
                         method='exact', subpixels=5, wcs=None,
                         segmentation_image=None, labels=None,
-                        aperture_mask_method='none'):
+                        mask_method='none'):
     # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Perform aperture photometry on the input data by summing the flux
@@ -162,7 +162,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
                                    wcs=wcs,
                                    segmentation_image=segmentation_image,
                                    labels=labels,
-                                   aperture_mask_method=aperture_mask_method)
+                                   mask_method=mask_method)
 
     single_aperture = False
     if not isinstance(apertures, (list, tuple, np.ndarray)):
@@ -207,7 +207,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     # explicitly to do_photometry to avoid repeated auto-lookups and
     # warnings)
     segmentation, labels = process_segmentation_inputs(
-        segmentation_image, labels, aperture_mask_method,
+        segmentation_image, labels, mask_method,
         np.atleast_2d(positions), np.shape(data))
 
     # Define output table meta data
@@ -245,7 +245,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         aper_sum, aper_sum_err = aper.do_photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation_image=segmentation, labels=labels,
-            aperture_mask_method=aperture_mask_method)
+            mask_method=mask_method)
 
         sum_key = sum_key_main
         sum_err_key = sum_err_key_main

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -250,7 +250,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
     def __init__(self, data, aperture, *, error=None, mask=None, wcs=None,
                  sigma_clip=None, sum_method='exact', subpixels=5,
                  local_bkg=None, segmentation_image=None, labels=None,
-                 aperture_mask_method='none'):
+                 mask_method='none'):
 
         if isinstance(data, NDData):
             data, error, mask, wcs = self._unpack_nddata(data, error, mask,
@@ -314,11 +314,11 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
 
         # Validate the segmentation-masking inputs and resolve the
         # per-aperture source labels
-        self._aperture_mask_method = aperture_mask_method
+        self._mask_method = mask_method
         seg_positions = np.atleast_2d(self._pixel_aperture.positions)
         (self._segmentation,
          self._seg_labels) = process_segmentation_inputs(
-            segmentation_image, labels, aperture_mask_method,
+            segmentation_image, labels, mask_method,
             seg_positions, self._data.shape)
 
     @staticmethod
@@ -415,7 +415,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         init_attr = ('_data', '_data_unit', '_error', '_mask', '_wcs',
                      'sigma_clip', 'sum_method', 'subpixels',
                      'default_columns', 'meta', '_segmentation',
-                     '_aperture_mask_method')
+                     '_mask_method')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
@@ -751,13 +751,13 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
                 # Apply segmentation-based masking and/or symmetric
                 # neighbor correction
                 if (self._segmentation is not None
-                        and self._aperture_mask_method != 'none'):
+                        and self._mask_method != 'none'):
                     segm_cutout = self._segmentation[slc_large]
                     cutout_xycen = (positions[idx, 0] - slc_large[1].start,
                                     positions[idx, 1] - slc_large[0].start)
                     (data_cutout, error_cutout,
                      exclude) = make_segmentation_exclusion(
-                        self._aperture_mask_method, segm_cutout,
+                        self._mask_method, segm_cutout,
                         self._seg_labels[idx], data=data_cutout,
                         error=error_cutout, base_mask=data_mask,
                         cutout_xycen=cutout_xycen)

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -17,6 +17,8 @@ from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import Aperture, SkyAperture, region_to_aperture
+from photutils.aperture._segmentation import (make_segmentation_exclusion,
+                                              process_segmentation_inputs)
 from photutils.aperture.core import (_aperture_metadata,
                                      _update_method_subpixels_docstring)
 from photutils.morphology import gini as gini_func
@@ -170,6 +172,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         units, then ``local_bkg`` must be a `~astropy.units.Quantity`
         with the same units.
 
+    <segmentation_descriptions>
+
     Notes
     -----
     ``data`` should be background-subtracted for accurate source
@@ -245,7 +249,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
 
     def __init__(self, data, aperture, *, error=None, mask=None, wcs=None,
                  sigma_clip=None, sum_method='exact', subpixels=5,
-                 local_bkg=None):
+                 local_bkg=None, segmentation_image=None, labels=None,
+                 aperture_mask_method='none'):
 
         if isinstance(data, NDData):
             data, error, mask, wcs = self._unpack_nddata(data, error, mask,
@@ -306,6 +311,15 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         self.default_columns = DEFAULT_COLUMNS
         self.meta = _get_meta()
         self.meta.update(aperture_meta)
+
+        # Validate the segmentation-masking inputs and resolve the
+        # per-aperture source labels
+        self._aperture_mask_method = aperture_mask_method
+        seg_positions = np.atleast_2d(self._pixel_aperture.positions)
+        (self._segmentation,
+         self._seg_labels) = process_segmentation_inputs(
+            segmentation_image, labels, aperture_mask_method,
+            seg_positions, self._data.shape)
 
     @staticmethod
     def _unpack_nddata(data, error, mask, wcs):
@@ -400,7 +414,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         # new class
         init_attr = ('_data', '_data_unit', '_error', '_mask', '_wcs',
                      'sigma_clip', 'sum_method', 'subpixels',
-                     'default_columns', 'meta')
+                     'default_columns', 'meta', '_segmentation',
+                     '_aperture_mask_method')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
@@ -409,6 +424,12 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         attrs = ('aperture', '_ids')
         for attr in attrs:
             setattr(newcls, attr, getattr(self, attr)[index])
+
+        # Slice the per-aperture segmentation labels
+        if self._seg_labels is None:
+            newcls._seg_labels = None
+        else:
+            newcls._seg_labels = np.atleast_1d(self._seg_labels[index])
 
         # Slice evaluated lazyproperty objects
         keys = set(self.__dict__.keys()) & set(self._lazyproperties)
@@ -704,10 +725,11 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         weight_cutouts = []
         overlaps = []
 
-        for (data_cutout, apermask, slices) in zip(self._data_cutouts,
-                                                   aperture_masks,
-                                                   self._overlap_slices,
-                                                   strict=True):
+        positions = np.atleast_2d(self._pixel_aperture.positions)
+
+        for idx, (data_cutout, apermask, slices) in enumerate(
+                zip(self._data_cutouts, aperture_masks,
+                    self._overlap_slices, strict=True)):
 
             slc_large, slc_small = slices
             if slc_large is None:  # aperture does not overlap the data
@@ -722,6 +744,24 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
                 data_mask = ~np.isfinite(data_cutout)
                 if self._mask is not None:
                     data_mask |= self._mask[slc_large]
+
+                error_cutout = (None if self._error is None
+                                else self._error[slc_large])
+
+                # Apply segmentation-based masking and/or symmetric
+                # neighbor correction
+                if (self._segmentation is not None
+                        and self._aperture_mask_method != 'none'):
+                    segm_cutout = self._segmentation[slc_large]
+                    cutout_xycen = (positions[idx, 0] - slc_large[1].start,
+                                    positions[idx, 1] - slc_large[0].start)
+                    (data_cutout, error_cutout,
+                     exclude) = make_segmentation_exclusion(
+                        self._aperture_mask_method, segm_cutout,
+                        self._seg_labels[idx], data=data_cutout,
+                        error=error_cutout, base_mask=data_mask,
+                        cutout_xycen=cutout_xycen)
+                    data_mask = data_mask | exclude
 
                 overlap = True
                 aperweight_cutout = apermask.data[slc_small]
@@ -757,7 +797,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
                 else:
                     # Apply the exact weights and total mask;
                     # error_cutout will have zeros where mask_cutout is True
-                    variance = self._error[slc_large]**2
+                    variance = error_cutout**2
                     variance_cutout = (variance * aperweight_cutout
                                        * ~mask_cutout)
 

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -1,0 +1,449 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for segmentation-based masking of aperture photometry, shared
+by `aperture_photometry`, `PixelAperture.do_photometry`, and
+`ApertureStats`.
+"""
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.utils.exceptions import AstropyUserWarning
+from numpy.testing import assert_allclose
+
+from photutils.aperture._batch_photometry import (SHAPE_CIRCLE,
+                                                  batch_aperture_sums)
+from photutils.aperture._segmentation import (make_segmentation_exclusion,
+                                              process_segmentation_inputs)
+from photutils.aperture.circle import CircularAperture
+from photutils.aperture.photometry import aperture_photometry
+from photutils.aperture.polygon import PolygonAperture
+from photutils.aperture.stats import ApertureStats
+from photutils.segmentation import SegmentationImage
+
+
+def make_scene():
+    """
+    Build a deterministic scene with a target source (label 1) and a
+    bright neighbor source (label 2), on a nonzero background.
+    """
+    data = np.ones((50, 50))
+    segm = np.zeros((50, 50), dtype=int)
+
+    # Target source (label 1)
+    data[18:25, 18:25] = 10.0
+    segm[18:25, 18:25] = 1
+
+    # Bright neighbor source (label 2)
+    data[20:25, 26:32] = 100.0
+    segm[20:25, 26:32] = 2
+
+    return data, segm
+
+
+class TestProcessSegmentationInputs:
+    def test_method_none_returns_none(self):
+        data, segm = make_scene()
+        positions = [(21, 21)]
+        result = process_segmentation_inputs(segm, None, 'none', positions,
+                                             data.shape)
+        assert result == (None, None)
+
+    def test_invalid_method(self):
+        data, segm = make_scene()
+        match = 'aperture_mask_method must be one of'
+        with pytest.raises(ValueError, match=match):
+            process_segmentation_inputs(segm, None, 'invalid', [(21, 21)],
+                                        data.shape)
+
+    def test_missing_segmentation(self):
+        match = 'segmentation_image must be input'
+        with pytest.raises(ValueError, match=match):
+            process_segmentation_inputs(None, None, 'mask', [(21, 21)],
+                                        (50, 50))
+
+    def test_segmentation_image_object(self):
+        data, segm = make_scene()
+        segm_obj = SegmentationImage(segm)
+        out_segm, out_labels = process_segmentation_inputs(
+            segm_obj, [1], 'mask', [(21, 21)], data.shape)
+        assert out_segm.dtype == np.intp
+        assert_allclose(out_labels, [1])
+
+    def test_ndarray_input(self):
+        data, segm = make_scene()
+        out_segm, _ = process_segmentation_inputs(
+            segm, [1], 'mask', [(21, 21)], data.shape)
+        assert out_segm.dtype == np.intp
+
+    def test_not_2d(self):
+        match = 'segmentation_image must be a 2D array'
+        with pytest.raises(ValueError, match=match):
+            process_segmentation_inputs(np.zeros((3, 3, 3), dtype=int), [1],
+                                        'mask', [(1, 1)], (3, 3))
+
+    def test_wrong_shape(self):
+        match = 'same shape as the data'
+        with pytest.raises(ValueError, match=match):
+            process_segmentation_inputs(np.zeros((10, 10), dtype=int), [1],
+                                        'mask', [(1, 1)], (50, 50))
+
+    def test_non_integer_dtype(self):
+        match = 'integer data type'
+        with pytest.raises(ValueError, match=match):
+            process_segmentation_inputs(np.zeros((50, 50), dtype=float), [1],
+                                        'mask', [(21, 21)], (50, 50))
+
+    def test_labels_length_mismatch(self):
+        data, segm = make_scene()
+        match = 'labels must have the same length'
+        with pytest.raises(ValueError, match=match):
+            process_segmentation_inputs(segm, [1, 2], 'mask', [(21, 21)],
+                                        data.shape)
+
+    def test_auto_lookup(self):
+        data, segm = make_scene()
+        _, labels = process_segmentation_inputs(segm, None, 'mask',
+                                                [(21, 21), (28, 22)],
+                                                data.shape)
+        assert_allclose(labels, [1, 2])
+
+    def test_auto_lookup_background_warning(self):
+        data, segm = make_scene()
+        match = 'centers on a background pixel'
+        with pytest.warns(AstropyUserWarning, match=match):
+            _, labels = process_segmentation_inputs(segm, None, 'mask',
+                                                    [(5, 5)], data.shape)
+        assert_allclose(labels, [0])
+
+    def test_auto_lookup_out_of_bounds_warning(self):
+        data, segm = make_scene()
+        match = 'centers on a background pixel'
+        with pytest.warns(AstropyUserWarning, match=match):
+            _, labels = process_segmentation_inputs(segm, None, 'mask',
+                                                    [(100, 100)], data.shape)
+        assert_allclose(labels, [0])
+
+
+class TestAperturePhotometry:
+    @pytest.mark.parametrize('use_segm_obj', [True, False])
+    def test_mask_method_matches_manual(self, use_segm_obj):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        segm_in = SegmentationImage(segm) if use_segm_obj else segm
+
+        phot = aperture_photometry(data, aper, segmentation_image=segm_in,
+                                   labels=[1], aperture_mask_method='mask')
+        manual_mask = (segm > 0) & (segm != 1)
+        ref = aperture_photometry(data, aper, mask=manual_mask)
+        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
+
+    def test_source_only_matches_manual(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        phot = aperture_photometry(data, aper, segmentation_image=segm,
+                                   labels=[1],
+                                   aperture_mask_method='source_only')
+        manual_mask = segm != 1
+        ref = aperture_photometry(data, aper, mask=manual_mask)
+        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
+
+    def test_none_method_ignores_segmentation(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        phot = aperture_photometry(data, aper, segmentation_image=segm,
+                                   aperture_mask_method='none')
+        ref = aperture_photometry(data, aper)
+        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
+
+    def test_missing_segmentation_raises(self):
+        data, _ = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        match = 'segmentation_image must be input'
+        with pytest.raises(ValueError, match=match):
+            aperture_photometry(data, aper, aperture_mask_method='mask')
+
+    def test_mask_excludes_neighbor_flux(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=10)
+        none_phot = aperture_photometry(data, aper,
+                                        aperture_mask_method='none')
+        mask_phot = aperture_photometry(data, aper, segmentation_image=segm,
+                                        labels=[1],
+                                        aperture_mask_method='mask')
+        # Masking the bright neighbor reduces the sum
+        assert mask_phot['aperture_sum'][0] < none_phot['aperture_sum'][0]
+
+    def test_label0_disables_masking(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        phot = aperture_photometry(data, aper, segmentation_image=segm,
+                                   labels=[0], aperture_mask_method='mask')
+        ref = aperture_photometry(data, aper)
+        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
+
+    def test_correct_matches_mask_path(self):
+        # The 'correct' method uses the Python mask path. Verify it runs
+        # and differs from 'none' for a scene with a neighbor.
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=10)
+        none_phot = aperture_photometry(data, aper,
+                                        aperture_mask_method='none')
+        corr_phot = aperture_photometry(data, aper, segmentation_image=segm,
+                                        labels=[1],
+                                        aperture_mask_method='correct')
+        assert corr_phot['aperture_sum'][0] != none_phot['aperture_sum'][0]
+
+    def test_polygon_mask_path(self):
+        # Polygon apertures have no batch driver, exercising the mask
+        # code path for segmentation masking.
+        data, segm = make_scene()
+        offsets = np.array([[-7, -7], [9, -7], [9, 9], [-7, 9]])
+        aper = PolygonAperture((21, 21), offsets)
+        phot = aperture_photometry(data, aper, segmentation_image=segm,
+                                   labels=[1], aperture_mask_method='mask')
+        manual_mask = (segm > 0) & (segm != 1)
+        ref = aperture_photometry(data, aper, mask=manual_mask)
+        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
+
+    def test_with_error(self):
+        data, segm = make_scene()
+        error = np.ones_like(data) * 2.0
+        aper = CircularAperture([(21, 21)], r=8)
+        phot = aperture_photometry(data, aper, error=error,
+                                   segmentation_image=segm, labels=[1],
+                                   aperture_mask_method='mask')
+        manual_mask = (segm > 0) & (segm != 1)
+        ref = aperture_photometry(data, aper, error=error, mask=manual_mask)
+        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
+        assert_allclose(phot['aperture_sum_err'], ref['aperture_sum_err'])
+
+    def test_with_units(self):
+        data, segm = make_scene()
+        unit = u.Jy
+        aper = CircularAperture([(21, 21)], r=8)
+        phot = aperture_photometry(data * unit, aper,
+                                   segmentation_image=segm, labels=[1],
+                                   aperture_mask_method='mask')
+        manual_mask = (segm > 0) & (segm != 1)
+        ref = aperture_photometry(data * unit, aper, mask=manual_mask)
+        assert_allclose(phot['aperture_sum'].value, ref['aperture_sum'].value)
+        assert phot['aperture_sum'].unit == unit
+
+    def test_auto_lookup_warning(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(5, 5)], r=8)
+        match = 'centers on a background pixel'
+        with pytest.warns(AstropyUserWarning, match=match):
+            aperture_photometry(data, aper, segmentation_image=segm,
+                                aperture_mask_method='mask')
+
+
+class TestDoPhotometry:
+    def test_batch_matches_mask_path(self):
+        # do_photometry uses the batch driver for circular apertures;
+        # compare to the equivalent manual global mask.
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21), (28, 22)], r=6)
+        _, labels = process_segmentation_inputs(segm, None, 'mask',
+                                                [(21, 21), (28, 22)],
+                                                data.shape)
+        sums, _ = aper.do_photometry(data, segmentation_image=segm,
+                                     labels=labels,
+                                     aperture_mask_method='mask')
+        for idx, label in enumerate(labels):
+            manual_mask = (segm > 0) & (segm != label)
+            ref, _ = CircularAperture(aper.positions[idx], r=6).do_photometry(
+                data, mask=manual_mask)
+            assert_allclose(sums[idx], ref[0])
+
+
+class TestApertureStats:
+    @pytest.mark.parametrize('method',
+                             ['none', 'mask', 'source_only', 'correct'])
+    def test_matches_aperture_photometry(self, method):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21), (28, 22)], r=6)
+        kwargs = {}
+        if method != 'none':
+            kwargs = {'segmentation_image': segm, 'labels': [1, 2],
+                      'aperture_mask_method': method}
+        phot = aperture_photometry(data, aper, **kwargs)
+        stats = ApertureStats(data, aper, **kwargs)
+        assert_allclose(stats.sum, phot['aperture_sum'], rtol=1e-10)
+
+    def test_slicing_preserves_labels(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21), (28, 22)], r=6)
+        stats = ApertureStats(data, aper, segmentation_image=segm,
+                              labels=[1, 2], aperture_mask_method='mask')
+        sub = stats[1]
+        assert_allclose(sub.sum, stats.sum[1])
+
+    def test_copy_preserves_masking(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=6)
+        stats = ApertureStats(data, aper, segmentation_image=segm,
+                              labels=[1], aperture_mask_method='mask')
+        copied = stats.copy()
+        assert_allclose(copied.sum, stats.sum)
+
+    def test_no_segmentation_slicing(self):
+        data, _ = make_scene()
+        aper = CircularAperture([(21, 21), (28, 22)], r=6)
+        stats = ApertureStats(data, aper)
+        sub = stats[0]
+        assert sub._seg_labels is None
+
+
+class TestMakeSegmentationExclusion:
+    def test_none_method(self):
+        segm = np.array([[0, 1], [2, 1]])
+        _, _, exclude = make_segmentation_exclusion('none', segm, 1)
+        assert not exclude.any()
+
+    def test_label_zero(self):
+        segm = np.array([[0, 1], [2, 1]])
+        _, _, exclude = make_segmentation_exclusion('mask', segm, 0)
+        assert not exclude.any()
+
+    def test_mask_method(self):
+        segm = np.array([[0, 1], [2, 1]])
+        _, _, exclude = make_segmentation_exclusion('mask', segm, 1)
+        expected = np.array([[False, False], [True, False]])
+        assert_allclose(exclude, expected)
+
+    def test_source_only_method(self):
+        segm = np.array([[0, 1], [2, 1]])
+        _, _, exclude = make_segmentation_exclusion('source_only', segm, 1)
+        expected = np.array([[True, False], [True, False]])
+        assert_allclose(exclude, expected)
+
+    def test_correct_replaces_neighbor(self):
+        # 5x5 cutout, center (2, 2). A neighbor pixel at (1, 2) [x=1, y=2]
+        # is mirrored from (3, 2) [x=3, y=2], a good background pixel.
+        segm = np.zeros((5, 5), dtype=int)
+        segm[2, 2] = 1  # target center
+        segm[2, 1] = 2  # neighbor at x=1, y=2
+        data = np.arange(25, dtype=float).reshape(5, 5)
+        out_data, _, exclude = make_segmentation_exclusion(
+            'correct', segm, 1, data=data, cutout_xycen=(2, 2))
+        # neighbor replaced, not excluded
+        assert not exclude[2, 1]
+        # mirror of (x=1, y=2) is (x=3, y=2) -> data[2, 3]
+        assert out_data[2, 1] == data[2, 3]
+
+    def test_correct_out_of_bounds_mirror(self):
+        # Neighbor whose mirror falls outside the cutout is excluded.
+        segm2 = np.zeros((5, 5), dtype=int)
+        segm2[1, 1] = 1
+        segm2[1, 0] = 2  # neighbor x=0,y=1; mirror x=2*1-0=2 in bounds
+        segm2[3, 3] = 2  # neighbor x=3,y=3; mirror x=2*1-3=-1 out of bounds
+        data = np.ones((5, 5))
+        _, _, exclude = make_segmentation_exclusion(
+            'correct', segm2, 1, data=data, cutout_xycen=(1, 1))
+        assert exclude[3, 3]
+
+    def test_correct_neighbor_mirror(self):
+        # A neighbor whose mirror is also a neighbor must be excluded.
+        segm = np.zeros((5, 5), dtype=int)
+        segm[2, 2] = 1
+        segm[2, 1] = 2  # neighbor x=1,y=2; mirror x=3,y=2
+        segm[2, 3] = 2  # neighbor x=3,y=2; mirror x=1,y=2 (both neighbors)
+        data = np.ones((5, 5))
+        _, _, exclude = make_segmentation_exclusion(
+            'correct', segm, 1, data=data, cutout_xycen=(2, 2))
+        assert exclude[2, 1]
+        assert exclude[2, 3]
+
+    def test_correct_masked_mirror(self):
+        # A neighbor whose mirror is in base_mask must be excluded.
+        segm = np.zeros((5, 5), dtype=int)
+        segm[2, 2] = 1
+        segm[2, 1] = 2  # neighbor x=1,y=2; mirror x=3,y=2
+        base_mask = np.zeros((5, 5), dtype=bool)
+        base_mask[2, 3] = True  # mask the mirror pixel
+        data = np.ones((5, 5))
+        _, _, exclude = make_segmentation_exclusion(
+            'correct', segm, 1, data=data, base_mask=base_mask,
+            cutout_xycen=(2, 2))
+        assert exclude[2, 1]
+
+    def test_correct_with_error(self):
+        segm = np.zeros((5, 5), dtype=int)
+        segm[2, 2] = 1
+        segm[2, 1] = 2
+        data = np.arange(25, dtype=float).reshape(5, 5)
+        error = np.arange(25, dtype=float).reshape(5, 5) * 0.1
+        _, out_error, _ = make_segmentation_exclusion(
+            'correct', segm, 1, data=data, error=error, cutout_xycen=(2, 2))
+        assert out_error[2, 1] == error[2, 3]
+
+
+class TestBatchDriverSegmentation:
+    def test_mask_method(self):
+        rng = np.random.default_rng(0)
+        data = rng.random((40, 40))
+        error = rng.random((40, 40)) + 0.1
+        mask = np.zeros((40, 40), dtype=np.uint8)
+        positions = np.array([[20.0, 20.0]])
+        params = np.array([8.0])
+
+        segm = np.zeros((40, 40), dtype=np.intp)
+        segm[18:23, 18:23] = 1
+        segm[18:23, 23:28] = 2
+        labels = np.array([1], dtype=np.intp)
+
+        sums, _, _ = batch_aperture_sums(
+            data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
+            1, 8, segm, labels, 1)
+
+        # Reference via global mask
+        manual_mask = ((segm > 0) & (segm != 1)).astype(np.uint8)
+        ref, _, _ = batch_aperture_sums(
+            data, error, manual_mask, positions, SHAPE_CIRCLE, params,
+            8.0, 8.0, 1, 8)
+        assert_allclose(sums, ref)
+
+    def test_source_only_method(self):
+        rng = np.random.default_rng(1)
+        data = rng.random((40, 40))
+        error = rng.random((40, 40)) + 0.1
+        mask = np.zeros((40, 40), dtype=np.uint8)
+        positions = np.array([[20.0, 20.0]])
+        params = np.array([8.0])
+
+        segm = np.zeros((40, 40), dtype=np.intp)
+        segm[18:23, 18:23] = 1
+        labels = np.array([1], dtype=np.intp)
+
+        sums, _, _ = batch_aperture_sums(
+            data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
+            1, 8, segm, labels, 2)
+
+        manual_mask = (segm != 1).astype(np.uint8)
+        ref, _, _ = batch_aperture_sums(
+            data, error, manual_mask, positions, SHAPE_CIRCLE, params,
+            8.0, 8.0, 1, 8)
+        assert_allclose(sums, ref)
+
+    def test_label0_disables(self):
+        rng = np.random.default_rng(2)
+        data = rng.random((40, 40))
+        error = rng.random((40, 40)) + 0.1
+        mask = np.zeros((40, 40), dtype=np.uint8)
+        positions = np.array([[20.0, 20.0]])
+        params = np.array([8.0])
+
+        segm = np.zeros((40, 40), dtype=np.intp)
+        segm[18:23, 18:23] = 1
+        segm[18:23, 23:28] = 2
+        labels = np.array([0], dtype=np.intp)
+
+        sums, _, _ = batch_aperture_sums(
+            data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
+            1, 8, segm, labels, 1)
+        ref, _, _ = batch_aperture_sums(
+            data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
+            1, 8)
+        assert_allclose(sums, ref)

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -110,7 +110,7 @@ class TestProcessSegmentationInputs:
 
     def test_auto_lookup_background_warning(self):
         data, segm = make_scene()
-        match = 'centers on a background pixel'
+        match = 'on a background pixel'
         with pytest.warns(AstropyUserWarning, match=match):
             _, labels = process_segmentation_inputs(segm, None, 'mask',
                                                     [(5, 5)], data.shape)
@@ -118,7 +118,7 @@ class TestProcessSegmentationInputs:
 
     def test_auto_lookup_out_of_bounds_warning(self):
         data, segm = make_scene()
-        match = 'centers on a background pixel'
+        match = 'on a background pixel'
         with pytest.warns(AstropyUserWarning, match=match):
             _, labels = process_segmentation_inputs(segm, None, 'mask',
                                                     [(100, 100)], data.shape)
@@ -245,7 +245,7 @@ class TestAperturePhotometry:
     def test_auto_lookup_warning(self):
         data, segm = make_scene()
         aper = CircularAperture([(5, 5)], r=8)
-        match = 'centers on a background pixel'
+        match = 'on a background pixel'
         with pytest.warns(AstropyUserWarning, match=match):
             aperture_photometry(data, aper, segmentation_image=segm,
                                 mask_method='mask')

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -183,16 +183,29 @@ class TestAperturePhotometry:
         assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
 
     def test_correct_matches_mask_path(self):
-        # The 'correct' method uses the Python mask path. Verify it runs
+        # The 'correct' method uses the Cython batch driver for circular
+        # apertures. Verify it exactly matches the Python mask code path
         # and differs from 'none' for a scene with a neighbor.
         data, segm = make_scene()
+        error = np.ones_like(data) * 2.0
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[22, 30] = True
         aper = CircularAperture([(21, 21)], r=10)
         none_phot = aperture_photometry(data, aper,
                                         aperture_mask_method='none')
-        corr_phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                        labels=[1],
-                                        aperture_mask_method='correct')
-        assert corr_phot['aperture_sum'][0] != none_phot['aperture_sum'][0]
+
+        _, labels = process_segmentation_inputs(segm, None, 'correct',
+                                                [(21, 21)], data.shape)
+        batch_sum, batch_err = aper.do_photometry(
+            data, error=error, mask=mask, segmentation_image=segm,
+            labels=labels, aperture_mask_method='correct')
+        mask_sum, mask_err = aper._do_mask_photometry(
+            data, error=error, mask=mask, method='exact', subpixels=5,
+            segmentation=segm.astype(np.intp), labels=labels,
+            aperture_mask_method='correct')
+        assert_allclose(batch_sum, mask_sum, rtol=1e-12)
+        assert_allclose(batch_err, mask_err, rtol=1e-12)
+        assert batch_sum[0] != none_phot['aperture_sum'][0]
 
     def test_polygon_mask_path(self):
         # Polygon apertures have no batch driver, exercising the mask
@@ -447,3 +460,29 @@ class TestBatchDriverSegmentation:
             data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
             1, 8)
         assert_allclose(sums, ref)
+
+    def test_correct_method_matches_mask_path(self):
+        # The batch 'correct' kernel (seg_method=3) must exactly match
+        # the Python mask-path 'correct' implementation.
+        rng = np.random.default_rng(3)
+        data = rng.normal(10.0, 1.0, (60, 60))
+        error = rng.random((60, 60)) + 0.5
+        mask = np.zeros((60, 60), dtype=bool)
+        mask[22, 30] = True
+        segm = np.zeros((60, 60), dtype=np.intp)
+        segm[18:25, 18:25] = 1  # target
+        segm[18:25, 25:31] = 2  # bright neighbor
+        data[18:25, 25:31] += 200.0
+        positions = [(21.0, 21.0)]
+        aper = CircularAperture(positions, r=8)
+        labels = np.array([1], dtype=np.intp)
+
+        batch_sum, batch_err = aper.do_photometry(
+            data, error=error, mask=mask, segmentation_image=segm,
+            labels=labels, aperture_mask_method='correct')
+        mask_sum, mask_err = aper._do_mask_photometry(
+            data, error=error, mask=mask, method='exact', subpixels=5,
+            segmentation=segm, labels=labels,
+            aperture_mask_method='correct')
+        assert_allclose(batch_sum, mask_sum, rtol=1e-12)
+        assert_allclose(batch_err, mask_err, rtol=1e-12)

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -51,7 +51,7 @@ class TestProcessSegmentationInputs:
 
     def test_invalid_method(self):
         data, segm = make_scene()
-        match = 'aperture_mask_method must be one of'
+        match = 'mask_method must be one of'
         with pytest.raises(ValueError, match=match):
             process_segmentation_inputs(segm, None, 'invalid', [(21, 21)],
                                         data.shape)
@@ -133,7 +133,7 @@ class TestAperturePhotometry:
         segm_in = SegmentationImage(segm) if use_segm_obj else segm
 
         phot = aperture_photometry(data, aper, segmentation_image=segm_in,
-                                   labels=[1], aperture_mask_method='mask')
+                                   labels=[1], mask_method='mask')
         manual_mask = (segm > 0) & (segm != 1)
         ref = aperture_photometry(data, aper, mask=manual_mask)
         assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
@@ -143,7 +143,7 @@ class TestAperturePhotometry:
         aper = CircularAperture([(21, 21)], r=8)
         phot = aperture_photometry(data, aper, segmentation_image=segm,
                                    labels=[1],
-                                   aperture_mask_method='source_only')
+                                   mask_method='source_only')
         manual_mask = segm != 1
         ref = aperture_photometry(data, aper, mask=manual_mask)
         assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
@@ -152,7 +152,7 @@ class TestAperturePhotometry:
         data, segm = make_scene()
         aper = CircularAperture([(21, 21)], r=8)
         phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                   aperture_mask_method='none')
+                                   mask_method='none')
         ref = aperture_photometry(data, aper)
         assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
 
@@ -161,16 +161,15 @@ class TestAperturePhotometry:
         aper = CircularAperture([(21, 21)], r=8)
         match = 'segmentation_image must be input'
         with pytest.raises(ValueError, match=match):
-            aperture_photometry(data, aper, aperture_mask_method='mask')
+            aperture_photometry(data, aper, mask_method='mask')
 
     def test_mask_excludes_neighbor_flux(self):
         data, segm = make_scene()
         aper = CircularAperture([(21, 21)], r=10)
         none_phot = aperture_photometry(data, aper,
-                                        aperture_mask_method='none')
+                                        mask_method='none')
         mask_phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                        labels=[1],
-                                        aperture_mask_method='mask')
+                                        labels=[1], mask_method='mask')
         # Masking the bright neighbor reduces the sum
         assert mask_phot['aperture_sum'][0] < none_phot['aperture_sum'][0]
 
@@ -178,7 +177,7 @@ class TestAperturePhotometry:
         data, segm = make_scene()
         aper = CircularAperture([(21, 21)], r=8)
         phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                   labels=[0], aperture_mask_method='mask')
+                                   labels=[0], mask_method='mask')
         ref = aperture_photometry(data, aper)
         assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
 
@@ -192,17 +191,17 @@ class TestAperturePhotometry:
         mask[22, 30] = True
         aper = CircularAperture([(21, 21)], r=10)
         none_phot = aperture_photometry(data, aper,
-                                        aperture_mask_method='none')
+                                        mask_method='none')
 
         _, labels = process_segmentation_inputs(segm, None, 'correct',
                                                 [(21, 21)], data.shape)
         batch_sum, batch_err = aper.do_photometry(
             data, error=error, mask=mask, segmentation_image=segm,
-            labels=labels, aperture_mask_method='correct')
+            labels=labels, mask_method='correct')
         mask_sum, mask_err = aper._do_mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm.astype(np.intp), labels=labels,
-            aperture_mask_method='correct')
+            mask_method='correct')
         assert_allclose(batch_sum, mask_sum, rtol=1e-12)
         assert_allclose(batch_err, mask_err, rtol=1e-12)
         assert batch_sum[0] != none_phot['aperture_sum'][0]
@@ -214,7 +213,7 @@ class TestAperturePhotometry:
         offsets = np.array([[-7, -7], [9, -7], [9, 9], [-7, 9]])
         aper = PolygonAperture((21, 21), offsets)
         phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                   labels=[1], aperture_mask_method='mask')
+                                   labels=[1], mask_method='mask')
         manual_mask = (segm > 0) & (segm != 1)
         ref = aperture_photometry(data, aper, mask=manual_mask)
         assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
@@ -225,7 +224,7 @@ class TestAperturePhotometry:
         aper = CircularAperture([(21, 21)], r=8)
         phot = aperture_photometry(data, aper, error=error,
                                    segmentation_image=segm, labels=[1],
-                                   aperture_mask_method='mask')
+                                   mask_method='mask')
         manual_mask = (segm > 0) & (segm != 1)
         ref = aperture_photometry(data, aper, error=error, mask=manual_mask)
         assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
@@ -237,7 +236,7 @@ class TestAperturePhotometry:
         aper = CircularAperture([(21, 21)], r=8)
         phot = aperture_photometry(data * unit, aper,
                                    segmentation_image=segm, labels=[1],
-                                   aperture_mask_method='mask')
+                                   mask_method='mask')
         manual_mask = (segm > 0) & (segm != 1)
         ref = aperture_photometry(data * unit, aper, mask=manual_mask)
         assert_allclose(phot['aperture_sum'].value, ref['aperture_sum'].value)
@@ -249,7 +248,7 @@ class TestAperturePhotometry:
         match = 'centers on a background pixel'
         with pytest.warns(AstropyUserWarning, match=match):
             aperture_photometry(data, aper, segmentation_image=segm,
-                                aperture_mask_method='mask')
+                                mask_method='mask')
 
 
 class TestDoPhotometry:
@@ -263,7 +262,7 @@ class TestDoPhotometry:
                                                 data.shape)
         sums, _ = aper.do_photometry(data, segmentation_image=segm,
                                      labels=labels,
-                                     aperture_mask_method='mask')
+                                     mask_method='mask')
         for idx, label in enumerate(labels):
             manual_mask = (segm > 0) & (segm != label)
             ref, _ = CircularAperture(aper.positions[idx], r=6).do_photometry(
@@ -280,7 +279,7 @@ class TestApertureStats:
         kwargs = {}
         if method != 'none':
             kwargs = {'segmentation_image': segm, 'labels': [1, 2],
-                      'aperture_mask_method': method}
+                      'mask_method': method}
         phot = aperture_photometry(data, aper, **kwargs)
         stats = ApertureStats(data, aper, **kwargs)
         assert_allclose(stats.sum, phot['aperture_sum'], rtol=1e-10)
@@ -289,7 +288,7 @@ class TestApertureStats:
         data, segm = make_scene()
         aper = CircularAperture([(21, 21), (28, 22)], r=6)
         stats = ApertureStats(data, aper, segmentation_image=segm,
-                              labels=[1, 2], aperture_mask_method='mask')
+                              labels=[1, 2], mask_method='mask')
         sub = stats[1]
         assert_allclose(sub.sum, stats.sum[1])
 
@@ -297,7 +296,7 @@ class TestApertureStats:
         data, segm = make_scene()
         aper = CircularAperture([(21, 21)], r=6)
         stats = ApertureStats(data, aper, segmentation_image=segm,
-                              labels=[1], aperture_mask_method='mask')
+                              labels=[1], mask_method='mask')
         copied = stats.copy()
         assert_allclose(copied.sum, stats.sum)
 
@@ -479,10 +478,10 @@ class TestBatchDriverSegmentation:
 
         batch_sum, batch_err = aper.do_photometry(
             data, error=error, mask=mask, segmentation_image=segm,
-            labels=labels, aperture_mask_method='correct')
+            labels=labels, mask_method='correct')
         mask_sum, mask_err = aper._do_mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm, labels=labels,
-            aperture_mask_method='correct')
+            mask_method='correct')
         assert_allclose(batch_sum, mask_sum, rtol=1e-12)
         assert_allclose(batch_err, mask_err, rtol=1e-12)


### PR DESCRIPTION
This PR adds ``segmentation_image``, ``labels``, and ``mask_method`` keywords to ``aperture_photometry`` and ``ApertureStats`` to mask or correct the flux from neighboring sources within an aperture using a segmentation map.