### PR TITLE
Fix do_photometry flux_err shape when error=None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,11 @@ Bug Fixes
     nonzero ``sum_method`` overlap fractions, the fractional area of
     those pixels is now returned, consistent with ``sum``. [#2314]
 
+  - Fixed ``PixelAperture.do_photometry`` so that the returned flux
+    errors always have the same length as the fluxes when ``error`` is
+    not input. Previously, an all-NaN error array was returned only
+    for sources with no overlap with the data. [#2316]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -661,6 +661,8 @@ class PixelAperture(Aperture):
                 if error is not None:
                     variance = (error_cutout**2 * aper_weights)[pixel_mask]
                     aperture_sum_errs.append(np.sqrt(variance.sum()))
+                else:
+                    aperture_sum_errs.append(np.nan)
 
         return np.array(aperture_sums), np.array(aperture_sum_errs)
 
@@ -763,7 +765,7 @@ class PixelAperture(Aperture):
             error = np.ascontiguousarray(error, dtype=np.float64)
         ext_x, ext_y = self._xy_extents
 
-        sums, sum_var, _area, overlap, *_ = batch_aperture_sums(
+        sums, sum_var, _area, _overlap, *_ = batch_aperture_sums(
             np.ascontiguousarray(data, dtype=np.float64), error, mask,
             np.ascontiguousarray(self._positions, dtype=np.float64),
             shape_code, np.array(params, dtype=np.float64),
@@ -771,9 +773,10 @@ class PixelAperture(Aperture):
             seg_arr, labels_arr, seg_code)
 
         if error is None:
-            # Match the mask-based path, which collects one NaN per
-            # non-overlapping source when error is not input.
-            errs = np.full(np.count_nonzero(~overlap), np.nan)
+            # Match the mask-based path, which returns an all-NaN error
+            # array (with the same length as the fluxes) when error is
+            # not input.
+            errs = np.full(sums.shape, np.nan)
         else:
             errs = np.sqrt(sum_var)
 

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -194,9 +194,8 @@ def test_no_overlap_nan_and_err_shape():
     """
     Test that sources with no overlap with the data give NaN sums.
 
-    Also, test that the error array has the same shape as the sums array
-    and contains NaN values for the non-overlapping sources when error
-    is not input.
+    Also, test that the error array always has the same shape as the
+    sums array, filled with NaN when error is not input.
     """
     aperture = CircularAperture(POSITIONS, r=5.5)
     n_outside = 3
@@ -204,13 +203,33 @@ def test_no_overlap_nan_and_err_shape():
     sums, errs = aperture._do_batch_photometry(DATA, error=None, mask=None,
                                                method='exact', subpixels=5)
     assert np.isnan(sums).sum() == n_outside
-    assert errs.shape == (n_outside,)
+    assert errs.shape == sums.shape
     assert np.all(np.isnan(errs))
 
     sums, errs = aperture._do_batch_photometry(DATA, error=ERROR, mask=None,
                                                method='exact', subpixels=5)
     assert errs.shape == sums.shape
     assert np.isnan(errs).sum() == n_outside
+
+
+@pytest.mark.parametrize('aperture', [
+    CircularAperture(POSITIONS, r=5.5),
+    PolygonAperture.from_regular_polygon(POSITIONS, 6, radius=5.5),
+])
+def test_do_photometry_no_error_flux_err_shape(aperture):
+    """
+    Test that `do_photometry` returns a ``flux_err`` array that always
+    has the same length as ``flux`` and is filled with NaN when
+    ``error`` is not input, both for sources with and without overlap.
+
+    ``CircularAperture`` exercises the batch code path and
+    ``PolygonAperture`` exercises the mask-based code path.
+    """
+    flux, flux_err = aperture.do_photometry(DATA, error=None)
+    assert flux_err.shape == flux.shape
+    assert np.any(np.isnan(flux))
+    assert np.any(~np.isnan(flux))
+    assert np.all(np.isnan(flux_err))
 
 
 def test_fallback_inputs():

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -176,11 +176,14 @@ class TestPixelApertureDoPhotometry:
     def test_do_photometry_basic(self):
         """
         Test that do_photometry returns the expected aperture sum for a
-        uniform data array with no error input.
+        uniform data array with no error input, and that the returned
+        error array has the same length as the flux array, filled with
+        NaN.
         """
         sums, errs = self.aper.do_photometry(self.data)
         assert_allclose(sums[0], np.pi * 9, rtol=1e-3)
-        assert len(errs) == 0
+        assert len(errs) == len(sums)
+        assert_allclose(errs, np.nan)
 
 
 class TestApertureReprStr:


### PR DESCRIPTION
This PR fixes ``PixelAperture.do_photometry`` so that the returned flux errors always have the same length as the fluxes when ``error`` is not input. Previously, an all-NaN error array was returned only for sources with no overlap with the data. 