### PR TITLE
Fix orientation output to return a value in the range (-90, 90]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,23 @@ Bug Fixes
     not input. Previously, an all-NaN error array was returned only
     for sources with no overlap with the data. [#2316]
 
+- ``photutils.detection``
+
+  - Fixed ``DAOStarFinder`` and ``IRAFStarFinder`` ``orientation``
+    output to return a value in the range (-90, 90] degrees instead
+    of incorrectly wrapping it to [0, 360) degrees (which only ever
+    produced values in the disjoint ranges [0, 90] and (270, 360)). This
+    also makes it consistent with ``ApertureStats.orientation`` and
+    ``SourceCatalog.orientation``. [#2317]
+
+- ``photutils.segmentation``
+
+  - Fixed ``SourceCatalog.orientation`` to return a value in the range
+    (-90, 90] degrees instead of incorrectly wrapping it to [0, 360)
+    degrees (which only ever produced values in the disjoint ranges
+    [0, 90] and (270, 360)). This also makes it consistent with
+    ``ApertureStats.orientation``. [#2317]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -2207,7 +2207,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         Gaussian function that has the same second-order moments as the
         source.
 
-        The angle increases in the counter-clockwise direction.
+        The angle increases in the counter-clockwise direction and is
+        in the range (-90, 90] degrees.
         """
         covar = self._covariance
         orient_radians = 0.5 * np.arctan2(2.0 * covar[:, 0, 1],

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -509,12 +509,12 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         Gaussian function that has the same second-order moments as the
         source.
 
-        The angle increases in the counter-clockwise direction and
-        will be in the range [0, 360) degrees.
+        The angle increases in the counter-clockwise direction and is
+        in the range (-90, 90] degrees.
         """
         angle = 0.5 * np.arctan2(2.0 * self.moments_central[:, 1, 1],
                                  self.mu_diff)
-        return (np.rad2deg(angle) % 360) << u.deg
+        return np.rad2deg(angle) * u.deg
 
     @lazyproperty
     def roundness(self):

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -352,7 +352,7 @@ class IRAFStarFinder(StarFinderBase):
             * ``roundness``: object roundness.
             * ``orientation``: the angle between the ``x`` axis and the
               major axis source measured counter-clockwise in the range
-              [0, 360) degrees.
+              (-90, 90] degrees.
             * ``n_pixels``: the total number of (positive) unmasked
               pixels.
             * ``peak``: the peak, sky-subtracted, pixel value of the object.

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -199,7 +199,7 @@ class StarFinder(StarFinderBase):
             * ``roundness``: object roundness.
             * ``orientation``: the angle between the ``x`` axis and the
               major axis source measured counter-clockwise in the range
-              [0, 360) degrees.
+              (-90, 90] degrees.
             * ``max_value``: the maximum pixel value in the source
             * ``flux``: the source instrumental flux.
             * ``mag``: the source instrumental magnitude calculated as

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -385,7 +385,7 @@ class TestGriddedPSFModel:
         cat = SourceCatalog(data, segm)
         orients = cat.orientation.value
         assert_allclose(orients[1], 50.0, rtol=1.0e-5)
-        assert_allclose(orients[2], 280.0, rtol=1.0e-5)
+        assert_allclose(orients[2], -80.0, rtol=1.0e-5)
         assert 88.3 < orients[0] < 88.4
         assert 64.0 < orients[3] < 64.2
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2841,13 +2841,13 @@ class SourceCatalog:
         Gaussian function that has the same second-order moments as the
         source.
 
-        The angle increases in the counter-clockwise direction and
-        will be in the range [0, 360) degrees.
+        The angle increases in the counter-clockwise direction and is
+        in the range (-90, 90] degrees.
         """
         covar = self._covariance
         orient_radians = 0.5 * np.arctan2(2.0 * covar[:, 0, 1],
                                           (covar[:, 0, 0] - covar[:, 1, 1]))
-        return (np.rad2deg(orient_radians) % 360) << u.deg
+        return np.rad2deg(orient_radians) * u.deg
 
     @lazyproperty
     @use_detcat


### PR DESCRIPTION
This PR reverts/fixes ``SourceCatalog.orientation``, and ``DAOStarFinder`` and ``IRAFStarFinder`` ``orientation`` output to return a value in the range (-90, 90] degrees instead of incorrectly wrapping it to [0, 360) degrees (which only ever produced values in the disjoint ranges [0, 90] and (270, 360)). This also makes it consistent with ``ApertureStats.orientation``.