### PR TITLE
Fix circular subpixel overlap to be platform independent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,16 @@ Bug Fixes
     not input. Previously, an all-NaN error array was returned only
     for sources with no overlap with the data. [#2316]
 
+- ``photutils.geometry``
+
+  - Fixed the ``'subpixel'`` overlap method for circular apertures so
+    that it returns identical results across platforms and compilers.
+    Previously, the squared-distance test for each subpixel center could
+    be contracted into a fused multiply-add on platforms with hardware
+    FMA (e.g., Apple silicon), giving slightly different results for
+    subpixel centers lying extremely close to the aperture boundary.
+    [#2320]
+
 - ``photutils.detection``
 
   - Fixed ``DAOStarFinder`` and ``IRAFStarFinder`` ``orientation``

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -284,11 +284,11 @@ by a factor of 5 (``subpixels=5``) in each dimension::
 
     >>> phot_table = aperture_photometry(data, aperture, method='subpixel',
     ...                                  subpixels=5)
-    >>> print(phot_table)  # doctest: +SKIP
-     id x_center y_center aperture_sum
-    --- -------- -------- ------------
-      1     30.0     30.0        27.96
-      2     40.0     40.0        27.96
+    >>> print(phot_table)  # doctest: +FLOAT_CMP
+     id x_center y_center    aperture_sum
+    --- -------- -------- ------------------
+      1     30.0     30.0 27.959999999999997
+      2     40.0     40.0 27.959999999999997
 
 Note that the results differ from the exact value of 28.274333 (see
 above).

--- a/photutils/geometry/circle_overlap.pyx
+++ b/photutils/geometry/circle_overlap.pyx
@@ -161,7 +161,7 @@ cdef double circle_overlap_single_subpixel(double x0, double y0,
         circle.
     """
     cdef unsigned int _i, _j
-    cdef double x, y, dx, dy, r_squared
+    cdef double x, y, xx, yy, dx, dy, r_squared
     cdef double frac = 0.0  # accumulator
 
     dx = (x1 - x0) / subpixels
@@ -174,7 +174,19 @@ cdef double circle_overlap_single_subpixel(double x0, double y0,
         y = y0 - 0.5 * dy
         for _j in range(subpixels):
             y += dy
-            if x * x + y * y < r_squared:
+            # Compute the two squares in separate statements before
+            # adding them. Writing ``x * x + y * y`` as a single
+            # expression allows the C compiler to contract it into a
+            # fused multiply-add (e.g. ``fma(x, x, y * y)``) on
+            # platforms with hardware FMA (such as Apple silicon),
+            # which rounds only once and is asymmetric in x and y. That
+            # produces platform-dependent results for subpixel centers
+            # lying within ~1e-15 of the circle boundary. Adding two
+            # pre-rounded products cannot be fused, so the comparison is
+            # deterministic across compilers and architectures.
+            xx = x * x
+            yy = y * y
+            if xx + yy < r_squared:
                 frac += 1.0
 
     return frac / (subpixels * subpixels)


### PR DESCRIPTION
This PR fixes the ``'subpixel'`` overlap method for circular apertures so that it returns identical results across platforms and compilers. Previously, the squared-distance test for each subpixel center could be contracted into a fused multiply-add on platforms with hardware FMA (e.g., Apple silicon), giving slightly different results for subpixel centers lying extremely close to the aperture boundary.

xref: https://github.com/astropy/photutils/actions/runs/29283366986/job/86929792505?pr=2319