### PR TITLE
Require explicit labels for segmentation-based aperture masking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ New Features
   - Added ``segmentation_image``, ``labels``, and ``mask_method``
     keywords to ``aperture_photometry`` and ``ApertureStats`` to mask or
     correct the flux from neighboring sources within an aperture using a
-    segmentation map. [#2309]
+    segmentation map. [#2309, #2321]
 
   - Significantly improved the performance of elliptical, rectangular,
     and convex polygon aperture photometry, typically by a factor of ~2.

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -784,9 +784,10 @@ one of four values:
   the pixels mirrored across the aperture center. If a mirror pixel is
   unavailable, the pixel is excluded.
 
-By default, the source label for each aperture is determined
-automatically by sampling the segmentation image at the aperture center.
-The labels may also be provided explicitly via the ``labels`` keyword.
+When a segmentation image is used (i.e., ``mask_method`` is not
+``'none'``), the source ``labels`` keyword must be provided explicitly.
+The ``labels`` keyword gives the target source label for each aperture
+and must have the same length as the number of aperture positions.
 
 In this example, a circular aperture centered on the target source
 (label 1) also overlaps a bright neighboring source (label 2)::
@@ -813,7 +814,7 @@ Without masking, the aperture sum includes the neighbor's flux::
 Masking the neighboring source excludes its flux::
 
     >>> t2 = aperture_photometry(data, aperture, segmentation_image=segm,
-    ...                          mask_method='mask')
+    ...                          labels=1, mask_method='mask')
     >>> t2['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t2['aperture_sum'])
     aperture_sum
@@ -825,7 +826,7 @@ values mirrored across the aperture center, recovering an estimate of
 the obscured flux::
 
     >>> t3 = aperture_photometry(data, aperture, segmentation_image=segm,
-    ...                          mask_method='correct')
+    ...                          labels=1, mask_method='correct')
     >>> t3['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t3['aperture_sum'])
     aperture_sum

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -282,9 +282,16 @@ the ``mask_method`` keyword selects how neighboring sources are handled:
   mirrored across the aperture center (excluded if the mirror pixel is
   unavailable).
 
-By default, the source label for each aperture is determined
-automatically by sampling the segmentation image at the aperture center;
-labels may also be provided explicitly via the ``labels`` keyword::
+It is required to explicitly provide the source ``labels`` for each
+aperture when a ``segmentation_image`` is input and ``mask_method`` is
+not ``'none'``. The ``labels`` keyword must have the same length as
+the number of aperture positions and identifies the target source for
+each aperture. Requiring explicit labels ensures the correct target
+source is used for each aperture, which is especially important for
+irregularly shaped source segmentation footprints or for apertures
+that are not centered on a source.
+
+Example of using the new segmentation-based masking::
 
     >>> import numpy as np
     >>> from photutils.aperture import CircularAperture, aperture_photometry
@@ -294,9 +301,10 @@ labels may also be provided explicitly via the ``labels`` keyword::
     >>> segm = np.zeros((11, 11), dtype=int)
     >>> segm[4:7, 4:7] = 1
     >>> segm[4:7, 7:10] = 2
+    >>> labels = 1
     >>> aperture = CircularAperture((5, 5), r=4)
     >>> phot = aperture_photometry(data, aperture, segmentation_image=segm,
-    ...                            mask_method='mask')
+    ...                            labels=1, mask_method='mask')
 
 
 ``GriddedPSFModel`` Performance Improvements
@@ -320,8 +328,8 @@ Aperture Photometry Error Column
 ``'aperture_sum_err'`` column in the returned table. When the ``error``
 keyword is not provided, the column is filled with ``NaN`` values.
 Previously, the column was omitted entirely in that case. This makes the
-behavior consistent with `~photutils.aperture.ApertureStats.to_table`,
-`~photutils.segmentation.SourceCatalog.to_table`,
+behavior consistent with `photutils.aperture.ApertureStats.to_table`,
+`photutils.segmentation.SourceCatalog.to_table`,
 and the `~photutils.psf.PSFPhotometry` and
 `~photutils.psf.IterativePSFPhotometry` output tables, which always
 include ``*_err`` columns (e.g., ``flux_err``)::

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -62,9 +62,6 @@ def process_segmentation_inputs(segmentation_image, labels,
         ``mask_method`` is ``'none'``.
     """
     if mask_method not in MASK_METHODS:
-        msg = f'aperture_mask_method must be one of {MASK_METHODS}'
-
-    if mask_method not in MASK_METHODS:
         msg = f'mask_method must be one of {MASK_METHODS}'
         raise ValueError(msg)
 

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -9,10 +9,7 @@ These helpers validate the ``segmentation_image``, ``labels``, and
 or symmetric-correction behavior to per-aperture cutouts.
 """
 
-import warnings
-
 import numpy as np
-from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.utils._round import round_half_away
 
@@ -39,8 +36,9 @@ def process_segmentation_inputs(segmentation_image, labels,
 
     labels : int, 1D array_like, or `None`
         The source label(s) associated with the aperture ``positions``.
-        If `None`, the labels are looked up automatically by sampling
-        ``segmentation_image`` at the (rounded) aperture centers.
+        ``labels`` is required (must not be `None`) when
+        ``segmentation_image`` is input and ``mask_method`` is not
+        ``'none'``.
 
     mask_method : {'none', 'mask', 'source_only', 'correct'}
         The segmentation masking method.
@@ -98,52 +96,19 @@ def process_segmentation_inputs(segmentation_image, labels,
     positions = np.atleast_2d(positions)
     n_positions = positions.shape[0]
 
-    if labels is not None:
-        labels = np.atleast_1d(labels)
-        if labels.shape[0] != n_positions:
-            msg = ('labels must have the same length as the number of '
-                   'aperture positions')
-            raise ValueError(msg)
-        labels = np.ascontiguousarray(labels, dtype=np.intp)
-    else:
-        labels = _auto_lookup_labels(segm, positions)
+    if labels is None:
+        msg = ('labels must be input when segmentation_image is input '
+               "and mask_method is not 'none'")
+        raise ValueError(msg)
+
+    labels = np.atleast_1d(labels)
+    if labels.shape[0] != n_positions:
+        msg = ('labels must have the same length as the number of '
+               'aperture positions')
+        raise ValueError(msg)
+    labels = np.ascontiguousarray(labels, dtype=np.intp)
 
     return segm, labels
-
-
-def _auto_lookup_labels(segmentation, positions):
-    """
-    Look up the source label at each aperture center.
-
-    The aperture center is rounded to the nearest pixel (rounding half
-    away from zero). Apertures whose centers fall outside the image
-    or on a background pixel (label 0) are assigned a label of 0. A
-    single `~astropy.utils.exceptions.AstropyUserWarning` summarizing
-    the number of affected apertures is emitted.
-    """
-    ny, nx = segmentation.shape
-    xpos = np.atleast_1d(positions[:, 0])
-    ypos = np.atleast_1d(positions[:, 1])
-
-    xi = np.atleast_1d(np.asarray(round_half_away(xpos)))
-    yi = np.atleast_1d(np.asarray(round_half_away(ypos)))
-
-    labels = np.zeros(positions.shape[0], dtype=np.intp)
-    in_bounds = (np.isfinite(xpos) & np.isfinite(ypos)
-                 & (xi >= 0) & (xi < nx) & (yi >= 0) & (yi < ny))
-    if np.any(in_bounds):
-        labels[in_bounds] = segmentation[yi[in_bounds].astype(np.intp),
-                                         xi[in_bounds].astype(np.intp)]
-
-    n_background = np.count_nonzero(labels == 0)
-    if n_background > 0:
-        msg = (f'{n_background} aperture center(s) were on a background '
-               'pixel (label 0) in the segmentation image. Masking '
-               'behavior is disabled for these apertures. Use the '
-               "'labels' argument to explicitly define source IDs.")
-        warnings.warn(msg, AstropyUserWarning)
-
-    return labels
 
 
 def make_segmentation_exclusion(mask_method, segmentation_cutout,

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -71,16 +71,18 @@ array_like, or `None`, optional
     positive integers. If input, neighboring sources can be masked or
     corrected within each aperture according to the ``mask_method``
     keyword. This keyword is required if ``mask_method`` is not
-    ``'none'``.
+    ``'none'``. When ``segmentation_image`` is input, the ``labels``
+    keyword must also be provided to ensure the correct target source is
+    used for each aperture. If ``segmentation_image`` is `None`, then
+    the ``mask_method` keyword is ignored and no neighboring source
+    masking or correction is performed.
 
 labels : int, 1D array_like, or `None`, optional
-    The source label(s) in ``segmentation_image`` associated with the
-    aperture position(s). If input, ``labels`` must have the same length
-    as the number of aperture positions. If `None` (default), the label
-    for each aperture is determined by sampling ``segmentation_image``
-    at the aperture center (rounded to the nearest pixel). An aperture
-    whose center falls on a background pixel (label 0) has its masking
-    behavior disabled.
+    The source label(s) in ``segmentation_image`` associated
+    with the aperture position(s). ``labels`` is required if
+    ``segmentation_image`` is input and ``mask_method`` is not
+    ``'none'``. ``labels`` must have the same length as the number of
+    aperture positions.
 
 mask_method : {'none', 'mask', 'source_only', 'correct'}, optional
     The method used to handle neighboring sources within each aperture

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -8,7 +8,6 @@ by `aperture_photometry`, `PixelAperture.do_photometry`, and
 import astropy.units as u
 import numpy as np
 import pytest
-from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
 
 from photutils.aperture._batch_photometry import (SHAPE_CIRCLE,
@@ -101,28 +100,12 @@ class TestProcessSegmentationInputs:
             process_segmentation_inputs(segm, [1, 2], 'mask', [(21, 21)],
                                         data.shape)
 
-    def test_auto_lookup(self):
+    def test_labels_required(self):
         data, segm = make_scene()
-        _, labels = process_segmentation_inputs(segm, None, 'mask',
-                                                [(21, 21), (28, 22)],
-                                                data.shape)
-        assert_allclose(labels, [1, 2])
-
-    def test_auto_lookup_background_warning(self):
-        data, segm = make_scene()
-        match = 'on a background pixel'
-        with pytest.warns(AstropyUserWarning, match=match):
-            _, labels = process_segmentation_inputs(segm, None, 'mask',
-                                                    [(5, 5)], data.shape)
-        assert_allclose(labels, [0])
-
-    def test_auto_lookup_out_of_bounds_warning(self):
-        data, segm = make_scene()
-        match = 'on a background pixel'
-        with pytest.warns(AstropyUserWarning, match=match):
-            _, labels = process_segmentation_inputs(segm, None, 'mask',
-                                                    [(100, 100)], data.shape)
-        assert_allclose(labels, [0])
+        match = 'labels must be input when segmentation_image is input'
+        with pytest.raises(ValueError, match=match):
+            process_segmentation_inputs(segm, None, 'mask',
+                                        [(21, 21), (28, 22)], data.shape)
 
 
 class TestAperturePhotometry:
@@ -193,8 +176,7 @@ class TestAperturePhotometry:
         none_phot = aperture_photometry(data, aper,
                                         mask_method='none')
 
-        _, labels = process_segmentation_inputs(segm, None, 'correct',
-                                                [(21, 21)], data.shape)
+        labels = [1]
         batch_sum, batch_err = aper.do_photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
@@ -242,11 +224,11 @@ class TestAperturePhotometry:
         assert_allclose(phot['aperture_sum'].value, ref['aperture_sum'].value)
         assert phot['aperture_sum'].unit == unit
 
-    def test_auto_lookup_warning(self):
+    def test_labels_required(self):
         data, segm = make_scene()
-        aper = CircularAperture([(5, 5)], r=8)
-        match = 'on a background pixel'
-        with pytest.warns(AstropyUserWarning, match=match):
+        aper = CircularAperture([(21, 21)], r=8)
+        match = 'labels must be input when segmentation_image is input'
+        with pytest.raises(ValueError, match=match):
             aperture_photometry(data, aper, segmentation_image=segm,
                                 mask_method='mask')
 
@@ -257,9 +239,7 @@ class TestDoPhotometry:
         # compare to the equivalent manual global mask.
         data, segm = make_scene()
         aper = CircularAperture([(21, 21), (28, 22)], r=6)
-        _, labels = process_segmentation_inputs(segm, None, 'mask',
-                                                [(21, 21), (28, 22)],
-                                                data.shape)
+        labels = [1, 2]
         sums, _ = aper.do_photometry(data, segmentation_image=segm,
                                      labels=labels,
                                      mask_method='mask')


### PR DESCRIPTION
With this PR, when a segmentation image is used for aperture masking (i.e., ``mask_method`` is not ``'none'``), the source ``labels`` keyword must be provided explicitly.