### PR TITLE
Add aperture area to aperture photometry results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ poetry.lock
 .tmp
 .*.sw[op]
 *~
+dev/
 
 # Eclipse editor project files
 .project

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,6 +170,20 @@ API Changes
     ``IterativePSFPhotometry`` output tables, which always include
     ``*_err`` columns (e.g., ``flux_err``). [#2319]
 
+  - ``aperture_photometry`` now always includes an ``'area'`` column
+    (or ``'area_<i>'`` columns for multiple apertures) in the returned
+    table. This is the total unmasked overlap area of the aperture (in
+    ``pix**2``), equivalent to ``PixelAperture.area_overlap`` computed
+    with the same inputs. [#2323]
+
+  - ``PixelAperture.do_photometry`` now returns an ``ApertureResults``
+    object instead of a plain tuple. The result remains backward
+    compatible: it can still be unpacked as a 2-tuple (``aperture_sum,
+    aperture_sum_err = do_photometry(...)``) and supports ``len()`` and
+    integer indexing like the legacy tuple. The new ``area`` attribute
+    provides the total unmasked overlap area of each aperture (in
+    ``pix**2``). [#2323]
+
 
 3.0.0 (2026-04-17)
 ------------------

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -229,6 +229,7 @@ After the aperture object is created, we can then perform the photometry
 using the :func:`~photutils.aperture.aperture_photometry` function. We
 start by defining the aperture (at three positions) as described above::
 
+    >>> from photutils.aperture import CircularAperture
     >>> positions = [(71.4, 23.9), (42.1, 41.7), (54.6, 68.2)]
     >>> aperture = CircularAperture(positions, r=3.1)
 
@@ -243,19 +244,25 @@ here as an array of all ones::
     >>> data = np.ones((100, 100))
     >>> phot_table = aperture_photometry(data, aperture)
     >>> phot_table['aperture_sum'].info.format = '%.8g'  # for consistent table output
+    >>> phot_table['area'].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err
-    --- -------- -------- ------------ ----------------
-      1     71.4     23.9    30.190705              nan
-      2     42.1     41.7    30.190705              nan
-      3     54.6     68.2    30.190705              nan
+     id x_center y_center aperture_sum aperture_sum_err    area
+                                                           pix2
+    --- -------- -------- ------------ ---------------- ---------
+      1     71.4     23.9    30.190705              nan 30.190705
+      2     42.1     41.7    30.190705              nan 30.190705
+      3     54.6     68.2    30.190705              nan 30.190705
 
 This function returns the results of the photometry in an Astropy
-`~astropy.table.QTable`.  In this example, the table has five columns,
-named ``'id'``, ``'x_center'``, ``'y_center'``, ``'aperture_sum'``, and
-``'aperture_sum_err'``. Because no ``error`` was input, the
-``'aperture_sum_err'`` column is filled with NaN values (see
-:ref:`error_estimation`).
+`~astropy.table.QTable`. In this example, the table has six columns,
+named ``'id'``, ``'x_center'``, ``'y_center'``, ``'aperture_sum'``,
+``'aperture_sum_err'``, and ``'area'``. Because no ``error``
+was input, the ``'aperture_sum_err'`` column is filled with NaN
+values (see :ref:`error_estimation`). The ``'area'`` column
+gives the total unmasked overlap area of the aperture with
+the data (in ``pix**2``). It is equivalent to the aperture
+:meth:`~photutils.aperture.PixelAperture.area_overlap` method computed
+with the same inputs.
 
 Since all the data values are 1.0, the aperture sums are equal to the
 area of a circle with a radius of 3.1::
@@ -301,12 +308,15 @@ by a factor of 5 (``subpixels=5``) in each dimension::
 
     >>> phot_table = aperture_photometry(data, aperture, method='subpixel',
     ...                                  subpixels=5)
+    >>> for col in phot_table.colnames:
+    ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center    aperture_sum    aperture_sum_err
-    --- -------- -------- ------------------ ----------------
-      1     71.4     23.9               30.2              nan
-      2     42.1     41.7 29.599999999999998              nan
-      3     54.6     68.2 29.959999999999997              nan
+     id x_center y_center aperture_sum aperture_sum_err  area
+                                                         pix2
+    --- -------- -------- ------------ ---------------- -----
+      1     71.4     23.9         30.2              nan  30.2
+      2     42.1     41.7         29.6              nan  29.6
+      3     54.6     68.2        29.96              nan 29.96
 
 Note that the ``'subpixel'`` sums differ from the exact value of
 30.190705 (see above). They also differ slightly from one another, even
@@ -347,11 +357,12 @@ been calculated and stored in the array ``error``::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err
-    --- -------- -------- ------------ ----------------
-      1     71.4     23.9    28.274334       0.53173616
-      2     42.1     41.7    28.274334       0.53173616
-      3     54.6     68.2    28.274334       0.53173616
+     id x_center y_center aperture_sum aperture_sum_err    area
+                                                           pix2
+    --- -------- -------- ------------ ---------------- ---------
+      1     71.4     23.9    28.274334       0.53173616 28.274334
+      2     42.1     41.7    28.274334       0.53173616 28.274334
+      3     54.6     68.2    28.274334       0.53173616 28.274334
 
 The ``'aperture_sum_err'`` values are calculated as:
 
@@ -382,11 +393,12 @@ units of electrons/s, we use the exposure time as the effective gain::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err
-    --- -------- -------- ------------ ----------------
-      1     71.4     23.9    28.274334       0.58248777
-      2     42.1     41.7    28.274334       0.58248777
-      3     54.6     68.2    28.274334       0.58248777
+     id x_center y_center aperture_sum aperture_sum_err    area
+                                                           pix2
+    --- -------- -------- ------------ ---------------- ---------
+      1     71.4     23.9    28.274334       0.58248777 28.274334
+      2     42.1     41.7    28.274334       0.58248777 28.274334
+      3     54.6     68.2    28.274334       0.58248777 28.274334
 
 Note that the ``'aperture_sum_err'`` values are now larger than in the
 previous example because they include the additional Poisson noise from
@@ -419,11 +431,12 @@ that the ``'aperture_sum_err'`` columns are populated::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum_0 aperture_sum_err_0 aperture_sum_1 aperture_sum_err_1 aperture_sum_2 aperture_sum_err_2
-    --- -------- -------- -------------- ------------------ -------------- ------------------ -------------- ------------------
-      1     71.4     23.9      28.274334         0.58248777      50.265482         0.77665037      78.539816         0.97081296
-      2     42.1     41.7      28.274334         0.58248777      50.265482         0.77665037      78.539816         0.97081296
-      3     54.6     68.2      28.274334         0.58248777      50.265482         0.77665037      78.539816         0.97081296
+     id x_center y_center aperture_sum_0 aperture_sum_err_0   area_0  aperture_sum_1 aperture_sum_err_1   area_1  aperture_sum_2 aperture_sum_err_2   area_2
+                                                               pix2                                        pix2                                        pix2
+    --- -------- -------- -------------- ------------------ --------- -------------- ------------------ --------- -------------- ------------------ ---------
+      1     71.4     23.9      28.274334         0.58248777 28.274334      50.265482         0.77665037 50.265482      78.539816         0.97081296 78.539816
+      2     42.1     41.7      28.274334         0.58248777 28.274334      50.265482         0.77665037 50.265482      78.539816         0.97081296 78.539816
+      3     54.6     68.2      28.274334         0.58248777 28.274334      50.265482         0.77665037 50.265482      78.539816         0.97081296 78.539816
 
 When a list of aperture objects is provided, the output table column
 names are appended with the index of the aperture within the input
@@ -444,11 +457,12 @@ size and orientation. For example, an elliptical aperture requires
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err
-    --- -------- -------- ------------ ----------------
-      1     71.4     23.9     47.12389       0.75198848
-      2     42.1     41.7     47.12389       0.75198848
-      3     54.6     68.2     47.12389       0.75198848
+     id x_center y_center aperture_sum aperture_sum_err   area
+                                                          pix2
+    --- -------- -------- ------------ ---------------- --------
+      1     71.4     23.9     47.12389       0.75198848 47.12389
+      2     42.1     41.7     47.12389       0.75198848 47.12389
+      3     54.6     68.2     47.12389       0.75198848 47.12389
 
 To measure photometry using multiple elliptical apertures, provide a
 list of aperture objects with identical positions, but with different
@@ -463,11 +477,12 @@ list of aperture objects with identical positions, but with different
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum_0 aperture_sum_err_0 aperture_sum_1 aperture_sum_err_1 aperture_sum_2 aperture_sum_err_2
-    --- -------- -------- -------------- ------------------ -------------- ------------------ -------------- ------------------
-      1     71.4     23.9       47.12389         0.75198848      75.398224         0.95119855      109.95574          1.1486814
-      2     42.1     41.7       47.12389         0.75198848      75.398224         0.95119855      109.95574          1.1486814
-      3     54.6     68.2       47.12389         0.75198848      75.398224         0.95119855      109.95574          1.1486814
+     id x_center y_center aperture_sum_0 aperture_sum_err_0  area_0  aperture_sum_1 aperture_sum_err_1   area_1  aperture_sum_2 aperture_sum_err_2   area_2
+                                                              pix2                                        pix2                                        pix2
+    --- -------- -------- -------------- ------------------ -------- -------------- ------------------ --------- -------------- ------------------ ---------
+      1     71.4     23.9       47.12389         0.75198848 47.12389      75.398224         0.95119855 75.398224      109.95574          1.1486814 109.95574
+      2     42.1     41.7       47.12389         0.75198848 47.12389      75.398224         0.95119855 75.398224      109.95574          1.1486814 109.95574
+      3     54.6     68.2       47.12389         0.75198848 47.12389      75.398224         0.95119855 75.398224      109.95574          1.1486814 109.95574
 
 
 Masking Pixels in Aperture Photometry
@@ -485,20 +500,18 @@ by providing a boolean image mask via the ``mask`` keyword::
     >>> data[2, 2] = 100.0  # bad pixel
     >>> mask[2, 2] = True   # mask the bad pixel
     >>> t1 = aperture_photometry(data, aperture, mask=mask)
-    >>> t1['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t1['aperture_sum'])
-    aperture_sum
-    ------------
-       11.566371
+       aperture_sum
+    ------------------
+    11.566370614359172
 
 The result is very different if a ``mask`` image is not provided::
 
     >>> t2 = aperture_photometry(data, aperture)
-    >>> t2['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t2['aperture_sum'])
-    aperture_sum
-    ------------
-       111.56637
+       aperture_sum
+    ------------------
+    111.56637061435919
 
 
 Masking Neighboring Sources with a Segmentation Image
@@ -548,21 +561,19 @@ In this example, a circular aperture centered on the target source
 Without masking, the aperture sum includes the neighbor's flux::
 
     >>> t1 = aperture_photometry(data, aperture)
-    >>> t1['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t1['aperture_sum'])
-    aperture_sum
-    ------------
-       484.67785
+       aperture_sum
+    ------------------
+    484.67784806278354
 
 Masking the neighboring source excludes its flux::
 
     >>> t2 = aperture_photometry(data, aperture, segmentation_image=segm,
     ...                          labels=1, mask_method='mask')
-    >>> t2['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t2['aperture_sum'])
-    aperture_sum
-    ------------
-       124.05299
+       aperture_sum
+    ------------------
+    124.05298520018465
 
 The ``'correct'`` method instead replaces the neighbor's pixels with
 values mirrored across the aperture center, recovering an estimate of
@@ -570,11 +581,10 @@ the obscured flux::
 
     >>> t3 = aperture_photometry(data, aperture, segmentation_image=segm,
     ...                          labels=1, mask_method='correct')
-    >>> t3['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> print(t3['aperture_sum'])
-    aperture_sum
-    ------------
-       131.26548
+       aperture_sum
+    ------------------
+    131.26548245743663
 
 These keywords are also available in
 :class:`~photutils.aperture.ApertureStats`.
@@ -724,6 +734,7 @@ We begin by generating a more realistic example dataset::
 
     >>> from photutils.datasets import make_100gaussians_image
     >>> data = make_100gaussians_image()
+    >>> error = 0.1 * np.ones(data.shape)  # simple background-only error
 
 This artificial image has a known constant background level of 5. In the
 following examples, we'll leave this global background in the image so
@@ -788,31 +799,36 @@ the source fluxes in the circular apertures (the following example uses
 estimation and the aperture photometry)::
 
     >>> from photutils.aperture import aperture_photometry
-    >>> phot_table = aperture_photometry(data, aperture)
+    >>> phot_table = aperture_photometry(data, aperture, error=error)
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err
-    --- -------- -------- ------------ ----------------
-      1    145.1    168.3    1128.1245              nan
-      2     84.5    224.1      735.739              nan
-      3     48.3    200.3    1299.6341              nan
+     id x_center y_center aperture_sum aperture_sum_err    area
+                                                           pix2
+    --- -------- -------- ------------ ---------------- ---------
+      1    145.1    168.3    1128.1245       0.88622693 78.539816
+      2     84.5    224.1      735.739       0.88622693 78.539816
+      3     48.3    200.3    1299.6341       0.88622693 78.539816
 
-The total background within each source aperture is the mean
-background per pixel multiplied by the aperture area. When using the
+The total background within each source aperture is the mean background
+per pixel multiplied by the aperture area. The aperture area is already
+available in the ``'area'`` column of the output table above, which is
+equivalent to the :meth:`~photutils.aperture.PixelAperture.area_overlap`
+method computed with the same photometry inputs. When using the
 default ``'exact'`` overlap method (see :ref:`aperture-mask methods
 <photutils-aperture-overlap>`) and no pixels are masked, the analytical
-aperture area is available from the ``area`` attribute::
+aperture area is also available from the ``area`` attribute::
 
     >>> aperture.area  # doctest: +FLOAT_CMP
     78.53981633974483
 
-In general, however, you should use the
+In general, however, you should use the ``'area'`` column or the
 :meth:`~photutils.aperture.PixelAperture.area_overlap` method to compute
-the aperture area. This method accepts a ``mask`` argument, ensuring
-that the area is computed consistently with the photometry. If using
-a :class:`~photutils.aperture.SkyAperture`, first convert it to a
-:class:`~photutils.aperture.PixelAperture`. In this example, no mask is
+the aperture area. The ``area_overlap`` method accepts a ``mask``
+argument, ensuring that the area is computed consistently with the
+photometry. If using a :class:`~photutils.aperture.SkyAperture`, first
+convert it to a :class:`~photutils.aperture.PixelAperture`. In this
+example, we used the default ``'exact'`` overlap method and no mask is
 used, so ``area_overlap`` returns the same value as ``area``::
 
     >>> aperture_area = aperture.area_overlap(data)
@@ -839,11 +855,13 @@ output table::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum aperture_sum_err total_bkg aperture_sum_bkgsub
-    --- -------- -------- ------------ ---------------- --------- -------------------
-      1    145.1    168.3    1128.1245              nan 392.23708           735.88739
-      2     84.5    224.1      735.739              nan  403.2968           332.44219
-      3     48.3    200.3    1299.6341              nan 382.40618           917.22792
+     id x_center y_center aperture_sum aperture_sum_err    area   total_bkg aperture_sum_bkgsub
+                                                           pix2
+    --- -------- -------- ------------ ---------------- --------- --------- -------------------
+      1    145.1    168.3    1128.1245       0.88622693 78.539816 392.23708           735.88739
+      2     84.5    224.1      735.739       0.88622693 78.539816  403.2968           332.44219
+      3     48.3    200.3    1299.6341       0.88622693 78.539816 382.40618           917.22792
+
 
 Sigma-clipped median within a circular annulus
 """"""""""""""""""""""""""""""""""""""""""""""

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -344,6 +344,27 @@ include ``*_err`` columns (e.g., ``flux_err``)::
     nan
 
 
+Aperture Area Column
+--------------------
+
+`~photutils.aperture.aperture_photometry` now always includes an
+``'area'`` column (or ``'area_<i>'`` columns for multiple apertures)
+in the returned table. This is the total unmasked overlap area of
+the aperture with the data (in ``pix**2``), taking into account the
+aperture mask method, masked data pixels, segmentation masking, and
+partial/no overlap of the aperture with the data. It is equivalent to
+the `~photutils.aperture.PixelAperture.area_overlap` method computed
+with the same photometry inputs.
+
+Relatedly, `photutils.aperture.PixelAperture.do_photometry` now returns
+an ``ApertureResults`` object instead of a plain tuple. The result
+remains backward compatible: it can still be unpacked as a 2-tuple
+(``aperture_sum, aperture_sum_err = do_photometry(...)``) and supports
+``len()`` and integer indexing like the legacy tuple. The new ``area``
+attribute provides the total unmasked overlap area of each aperture (in
+``pix**2``).
+
+
 .. _whatsnew-3.1-deprecations:
 
 New Deprecations

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -9,7 +9,9 @@ import re
 import textwrap
 import warnings
 from copy import deepcopy
+from dataclasses import dataclass
 
+import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
@@ -22,7 +24,7 @@ from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.mask import ApertureMask
 from photutils.utils._deprecation import deprecated_positional_kwargs
 
-__all__ = ['Aperture', 'PixelAperture', 'SkyAperture']
+__all__ = ['Aperture', 'ApertureResults', 'PixelAperture', 'SkyAperture']
 
 
 # Canonical descriptions of the ``method`` and ``subpixels`` parameters
@@ -155,6 +157,43 @@ def _update_method_subpixels_docstring(obj):
 
     obj.__doc__ = _DOC_PLACEHOLDER_RE.sub(replace, docstring)
     return obj
+
+
+@dataclass(frozen=True)
+class ApertureResults:
+    """
+    The results of `PixelAperture.do_photometry`.
+
+    For backward compatibility, this object can still be unpacked as a
+    2-tuple, ``aperture_sum, aperture_sum_err = do_photometry(...)``.
+    Use the named attributes to access ``area``.
+
+    Attributes
+    ----------
+    aperture_sum : `~numpy.ndarray` or `~astropy.units.Quantity`
+        The sum within each aperture.
+
+    aperture_sum_err : `~numpy.ndarray` or `~astropy.units.Quantity`
+        The errors on the sum within each aperture.
+
+    area : `~astropy.units.Quantity`
+        The total unmasked overlap area of each aperture (in pix**2).
+    """
+
+    aperture_sum: np.ndarray
+    aperture_sum_err: np.ndarray
+    area: np.ndarray
+
+    def __iter__(self):
+        # Legacy 2-tuple unpacking only.
+        yield self.aperture_sum
+        yield self.aperture_sum_err
+
+    def __len__(self):
+        return 2
+
+    def __getitem__(self, idx):
+        return (self.aperture_sum, self.aperture_sum_err)[idx]
 
 
 class Aperture(metaclass=abc.ABCMeta):
@@ -615,8 +654,8 @@ class PixelAperture(Aperture):
 
         Returns
         -------
-        aperture_sums, aperture_sum_errs : `~numpy.ndarray`
-            The aperture sums and errors.
+        aperture_sums, aperture_sum_errs, areas : `~numpy.ndarray`
+            The aperture sums, errors, and total unmasked overlap areas.
         """
         apermasks = self.to_mask(method=method, subpixels=subpixels)
         if self.isscalar:
@@ -626,6 +665,7 @@ class PixelAperture(Aperture):
 
         aperture_sums = []
         aperture_sum_errs = []
+        areas = []
         with warnings.catch_warnings():
             # Ignore multiplication with non-finite data values
             warnings.simplefilter('ignore', RuntimeWarning)
@@ -640,6 +680,7 @@ class PixelAperture(Aperture):
                 if slc_large is None:
                     aperture_sums.append(np.nan)
                     aperture_sum_errs.append(np.nan)
+                    areas.append(np.nan)
                     continue
 
                 data_cutout = data[slc_large]
@@ -659,6 +700,7 @@ class PixelAperture(Aperture):
 
                 values = (data_cutout * aper_weights)[pixel_mask]
                 aperture_sums.append(values.sum())
+                areas.append(aper_weights[pixel_mask].sum())
 
                 if error is not None:
                     variance = (error_cutout**2 * aper_weights)[pixel_mask]
@@ -666,7 +708,8 @@ class PixelAperture(Aperture):
                 else:
                     aperture_sum_errs.append(np.nan)
 
-        return np.array(aperture_sums), np.array(aperture_sum_errs)
+        return (np.array(aperture_sums), np.array(aperture_sum_errs),
+                np.array(areas))
 
     def _batch_shape_params(self):
         """
@@ -722,10 +765,10 @@ class PixelAperture(Aperture):
         Returns
         -------
         result : tuple of `~numpy.ndarray` or `None`
-            A ``(aperture_sums, aperture_sum_errs)`` tuple of float64
-            arrays, or `None` if the batch driver does not support this
-            aperture or these inputs (in which case the caller should
-            use the mask-based code path).
+            A ``(aperture_sums, aperture_sum_errs, areas)`` tuple of
+            float64 arrays, or `None` if the batch driver does not
+            support this aperture or these inputs (in which case the
+            caller should use the mask-based code path).
         """
         # Use the batch driver only if the aperture's own class defines
         # the _batch_shape_params hook. Subclasses that do not define
@@ -767,7 +810,7 @@ class PixelAperture(Aperture):
             error = np.ascontiguousarray(error, dtype=np.float64)
         ext_x, ext_y = self._xy_extents
 
-        sums, sum_var, _area, _overlap, *_ = batch_aperture_sums(
+        sums, sum_var, area, _overlap, *_ = batch_aperture_sums(
             np.ascontiguousarray(data, dtype=np.float64), error, mask,
             np.ascontiguousarray(self._positions, dtype=np.float64),
             shape_code, np.array(params, dtype=np.float64),
@@ -782,7 +825,7 @@ class PixelAperture(Aperture):
         else:
             errs = np.sqrt(sum_var)
 
-        return sums, errs
+        return sums, errs, area
 
     @_update_method_subpixels_docstring
     @deprecated_positional_kwargs(since='3.0', until='4.0')
@@ -817,13 +860,32 @@ class PixelAperture(Aperture):
 
         Returns
         -------
-        aperture_sums : `~numpy.ndarray` or `~astropy.units.Quantity`
-            The sum within each aperture. The values are always
-            float64, regardless of the input ``data`` dtype.
+        result : `ApertureResults`
+            The aperture photometry results. For backward
+            compatibility, this object can be unpacked as a 2-tuple,
+            ``aperture_sum, aperture_sum_err = do_photometry(...)``, and
+            supports ``len()`` and integer indexing as if it were a
+            2-tuple. It has the following attributes:
 
-        aperture_sum_errs : `~numpy.ndarray` or `~astropy.units.Quantity`
-            The errors on the sum within each aperture. The values are
-            always float64, regardless of the input ``error`` dtype.
+            - ``aperture_sum`` : `~numpy.ndarray` or \
+              `~astropy.units.Quantity`
+                The sum within each aperture. The values are always
+                float64, regardless of the input ``data`` dtype.
+
+            - ``aperture_sum_err`` : `~numpy.ndarray` or \
+              `~astropy.units.Quantity`
+                The errors on the sum within each aperture. The values
+                are always float64, regardless of the input ``error``
+                dtype.
+
+            - ``area`` : `~astropy.units.Quantity`
+                The total unmasked overlap area of each aperture (in
+                ``pix**2``), taking into account the aperture mask
+                method, masked data pixels, segmentation masking, and
+                partial/no overlap of the aperture with the data. This
+                is equivalent to `area_overlap` computed with the same
+                inputs. The value is ``NaN`` where the aperture does not
+                overlap the data.
         """
         data = np.asanyarray(data)
         if data.ndim != 2:
@@ -863,9 +925,9 @@ class PixelAperture(Aperture):
             mask_method=mask_method)
 
         if result is not None:
-            aperture_sums, aperture_sum_errs = result
+            aperture_sums, aperture_sum_errs, area = result
         else:
-            aperture_sums, aperture_sum_errs = self._do_mask_photometry(
+            aperture_sums, aperture_sum_errs, area = self._do_mask_photometry(
                 data, error=error, mask=mask, method=method,
                 subpixels=subpixels, segmentation=segmentation,
                 labels=labels, mask_method=mask_method)
@@ -875,7 +937,12 @@ class PixelAperture(Aperture):
             aperture_sums <<= unit
             aperture_sum_errs <<= unit
 
-        return aperture_sums, aperture_sum_errs
+        # The area always has units of pix**2, regardless of whether
+        # data/error have units (matches ApertureStats.sum_aper_area).
+        area <<= (u.pix**2)
+
+        return ApertureResults(aperture_sum=aperture_sums,
+                               aperture_sum_err=aperture_sum_errs, area=area)
 
     @staticmethod
     def _make_annulus_path(patch_inner, patch_outer):

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -120,6 +120,21 @@ def aperture_photometry(data, apertures, error=None, mask=None,
           values (always float64). If the input ``error`` is `None`,
           this column is filled with NaN values.
 
+        * ``'area'``:
+          The total unmasked overlap area of the aperture(s)
+          (in ``pix**2``), taking into account the aperture
+          mask method, masked data pixels (``mask`` keyword),
+          segmentation masking, and partial/no overlap of
+          the aperture with the data. This is equivalent to
+          :meth:`~photutils.aperture.PixelAperture.area_overlap`
+          computed with the same inputs. The value is NaN where an
+          aperture does not overlap the data.
+
+        If multiple apertures are input, the ``'aperture_sum'``,
+        ``'aperture_sum_err'``, and ``'area'`` columns will have a
+        ``'_i'`` suffix (e.g., ``'aperture_sum_0'``), where ``i`` is the
+        index of the aperture in the input list.
+
         The table metadata includes the Astropy and Photutils version
         numbers and the `aperture_photometry` calling arguments.
 
@@ -241,19 +256,23 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
     sum_key_main = 'aperture_sum'
     sum_err_key_main = 'aperture_sum_err'
+    area_key_main = 'area'
     for i, aper in enumerate(apertures):
-        aper_sum, aper_sum_err = aper.do_photometry(
+        result = aper.do_photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation_image=segmentation, labels=labels,
             mask_method=mask_method)
 
         sum_key = sum_key_main
         sum_err_key = sum_err_key_main
+        area_key = area_key_main
         if not single_aperture:
             sum_key += f'_{i}'
             sum_err_key += f'_{i}'
+            area_key += f'_{i}'
 
-        tbl[sum_key] = aper_sum
-        tbl[sum_err_key] = aper_sum_err
+        tbl[sum_key] = result.aperture_sum
+        tbl[sum_err_key] = result.aperture_sum_err
+        tbl[area_key] = result.area
 
     return tbl

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -200,14 +200,14 @@ def test_no_overlap_nan_and_err_shape():
     aperture = CircularAperture(POSITIONS, r=5.5)
     n_outside = 3
 
-    sums, errs = aperture._do_batch_photometry(DATA, error=None, mask=None,
-                                               method='exact', subpixels=5)
+    sums, errs, _area = aperture._do_batch_photometry(
+        DATA, error=None, mask=None, method='exact', subpixels=5)
     assert np.isnan(sums).sum() == n_outside
     assert errs.shape == sums.shape
     assert np.all(np.isnan(errs))
 
-    sums, errs = aperture._do_batch_photometry(DATA, error=ERROR, mask=None,
-                                               method='exact', subpixels=5)
+    sums, errs, _area = aperture._do_batch_photometry(
+        DATA, error=ERROR, mask=None, method='exact', subpixels=5)
     assert errs.shape == sums.shape
     assert np.isnan(errs).sum() == n_outside
 

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -185,6 +185,70 @@ class TestPixelApertureDoPhotometry:
         assert len(errs) == len(sums)
         assert_allclose(errs, np.nan)
 
+    def test_do_photometry_result_backward_compatible(self):
+        """
+        Test that the do_photometry result unpacks as a 2-tuple and
+        supports len() and integer indexing like the legacy tuple.
+        """
+        result = self.aper.do_photometry(self.data)
+        assert len(result) == 2
+
+        sums, errs = result
+        assert_allclose(sums, result.aperture_sum)
+        assert_allclose(errs, result.aperture_sum_err, equal_nan=True)
+        assert_allclose(result[0], result.aperture_sum)
+        assert_allclose(result[1], result.aperture_sum_err, equal_nan=True)
+
+    def test_do_photometry_area_matches_area_overlap(self):
+        """
+        Test that the result area matches area_overlap for a simple
+        non-masked, fully-overlapping aperture.
+        """
+        result = self.aper.do_photometry(self.data)
+        expected = self.aper.area_overlap(self.data)
+        assert result.area.unit == u.pix**2
+        assert_allclose(result.area.value, expected)
+
+    def test_do_photometry_area_no_overlap_nan(self):
+        """
+        Test that the result area is NaN for an aperture with no overlap
+        with the data.
+        """
+        aper = CircularAperture((-50, -50), r=3)
+        result = aper.do_photometry(self.data)
+        assert np.isnan(result.area.value).all()
+
+    def test_do_photometry_area_units(self):
+        """
+        Test that the result area always has units of pix**2 regardless
+        of whether the data/error are Quantity or plain arrays.
+        """
+        result = self.aper.do_photometry(self.data)
+        assert result.area.unit == u.pix**2
+
+        result_q = self.aper.do_photometry(self.data * u.Jy,
+                                           error=self.data * u.Jy)
+        assert result_q.area.unit == u.pix**2
+        assert_allclose(result.area.value, result_q.area.value,
+                        equal_nan=True)
+
+    def test_do_photometry_area_batch_vs_mask_path(self):
+        """
+        Test that the batch and mask code paths produce identical area
+        values.
+        """
+        aper = CircularAperture(POSITIONS, r=5.5)
+        mask = np.zeros(self.data.shape, dtype=bool)
+        mask[5, 5] = True
+
+        batch = aper._do_batch_photometry(self.data, error=None, mask=mask,
+                                          method='exact', subpixels=5)
+        assert batch is not None
+        legacy = aper._do_mask_photometry(self.data, error=None, mask=mask,
+                                          method='exact', subpixels=5)
+        # areas are the third element of each result
+        assert_allclose(batch[2], legacy[2], rtol=1e-12, equal_nan=True)
+
 
 class TestApertureReprStr:
     """

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -692,16 +692,36 @@ def test_scalar_aperture():
     ap = CircularAperture((10, 10), r=3.0)
     colnames1 = aperture_photometry(data, ap, error=data).colnames
     assert (colnames1 == ['id', 'x_center', 'y_center', 'aperture_sum',
-                          'aperture_sum_err'])
+                          'aperture_sum_err', 'area'])
 
     colnames2 = aperture_photometry(data, [ap], error=data).colnames
     assert (colnames2 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
-                          'aperture_sum_err_0'])
+                          'aperture_sum_err_0', 'area_0'])
 
     colnames3 = aperture_photometry(data, [ap, ap], error=data).colnames
     assert (colnames3 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
-                          'aperture_sum_err_0', 'aperture_sum_1',
-                          'aperture_sum_err_1'])
+                          'aperture_sum_err_0', 'area_0',
+                          'aperture_sum_1', 'aperture_sum_err_1',
+                          'area_1'])
+
+
+def test_area_column():
+    """
+    Test that the ``'area'`` column matches ``area_overlap`` for
+    representative cases, with and without a mask.
+    """
+    data = np.ones((25, 25), dtype=float)
+    ap = CircularAperture([(10, 10), (15, 15)], r=4.0)
+
+    tbl = aperture_photometry(data, ap)
+    assert tbl['area'].unit == u.pix**2
+    assert_allclose(tbl['area'].value, ap.area_overlap(data))
+
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[10, 10] = True
+    tbl_mask = aperture_photometry(data, ap, mask=mask)
+    assert_allclose(tbl_mask['area'].value,
+                    ap.area_overlap(data, mask=mask))
 
 
 def test_nan_in_bbox():

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -180,7 +180,7 @@ class TestAperturePhotometry:
         batch_sum, batch_err = aper.do_photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
-        mask_sum, mask_err = aper._do_mask_photometry(
+        mask_sum, mask_err, _area = aper._do_mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm.astype(np.intp), labels=labels,
             mask_method='correct')
@@ -459,7 +459,7 @@ class TestBatchDriverSegmentation:
         batch_sum, batch_err = aper.do_photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
-        mask_sum, mask_err = aper._do_mask_photometry(
+        mask_sum, mask_err, _area = aper._do_mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm, labels=labels,
             mask_method='correct')


### PR DESCRIPTION
``aperture_photometry`` now always includes an ``'area'`` column (or ``'area_<i>'`` columns for multiple apertures) in the returned table. This is the total unmasked overlap area of the aperture (in ``pix**2``), equivalent to ``PixelAperture.area_overlap`` computed with the same inputs. [#2323]

`PixelAperture.do_photometry`` now returns an ``ApertureResults`` object instead of a plain tuple. The result remains backward compatible: it can still be unpacked as a 2-tuple (``aperture_sum, aperture_sum_err = do_photometry(...)``) and supports ``len()`` and integer indexing like the legacy tuple. The new ``area`` attribute provides the total unmasked overlap area of each aperture (in ``pix**2``).