### PR TITLE
Rename PixelAperture do_photometry method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,7 +121,7 @@ Bug Fixes
     nonzero ``sum_method`` overlap fractions, the fractional area of
     those pixels is now returned, consistent with ``sum``. [#2314]
 
-  - Fixed ``PixelAperture.do_photometry`` so that the returned flux
+  - Fixed ``PixelAperture.photometry`` so that the returned flux
     errors always have the same length as the fluxes when ``error`` is
     not input. Previously, an all-NaN error array was returned only
     for sources with no overlap with the data. [#2316]
@@ -176,13 +176,18 @@ API Changes
     ``pix**2``), equivalent to ``PixelAperture.area_overlap`` computed
     with the same inputs. [#2323]
 
-  - ``PixelAperture.do_photometry`` now returns an ``ApertureResults``
+  - ``PixelAperture.photometry`` now returns an ``ApertureResults``
     object instead of a plain tuple. The result remains backward
     compatible: it can still be unpacked as a 2-tuple (``aperture_sum,
-    aperture_sum_err = do_photometry(...)``) and supports ``len()`` and
-    integer indexing like the legacy tuple. The new ``area`` attribute
-    provides the total unmasked overlap area of each aperture (in
-    ``pix**2``). [#2323]
+    aperture_sum_err = aperture.photometry(...)``) and supports
+    ``len()`` and integer indexing like the legacy tuple. The new
+    ``area`` attribute provides the total unmasked overlap area of each
+    aperture (in ``pix**2``). [#2323]
+
+  - The ``PixelAperture.do_photometry`` method has been renamed to
+    ``photometry``. The old method name is deprecated and will be
+    removed in version 4.0. Note that in the new ``photometry`` method
+    all arguments except ``data`` are keyword-only. [#2324]
 
 
 3.0.0 (2026-04-17)

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -356,10 +356,10 @@ partial/no overlap of the aperture with the data. It is equivalent to
 the `~photutils.aperture.PixelAperture.area_overlap` method computed
 with the same photometry inputs.
 
-Relatedly, `photutils.aperture.PixelAperture.do_photometry` now returns
+Relatedly, `photutils.aperture.PixelAperture.photometry` now returns
 an ``ApertureResults`` object instead of a plain tuple. The result
 remains backward compatible: it can still be unpacked as a 2-tuple
-(``aperture_sum, aperture_sum_err = do_photometry(...)``) and supports
+(``aperture_sum, aperture_sum_err = photometry(...)``) and supports
 ``len()`` and integer indexing like the legacy tuple. The new ``area``
 attribute provides the total unmasked overlap area of each aperture (in
 ``pix**2``).
@@ -369,6 +369,21 @@ attribute provides the total unmasked overlap area of each aperture (in
 
 New Deprecations
 ----------------
+
+Aperture ``do_photometry`` Renamed to ``photometry``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `~photutils.aperture.PixelAperture` ``do_photometry`` method
+has been renamed to `~photutils.aperture.PixelAperture.photometry`.
+The old method name is deprecated and will be removed in version
+4.0. Note that in the new ``photometry`` method all arguments except
+``data`` are keyword-only::
+
+    # Old (deprecated)
+    aperture_sum, aperture_sum_err = aperture.do_photometry(data, error=error)
+
+    # New
+    aperture_sum, aperture_sum_err = aperture.photometry(data, error=error)
 
 
 Removed Deprecations

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -4,7 +4,7 @@ Tools for segmentation-based masking of aperture photometry.
 
 These helpers validate the ``segmentation_image``, ``labels``, and
 ``mask_method`` keywords shared by `aperture_photometry`,
-`~photutils.aperture.PixelAperture.do_photometry`, and
+`~photutils.aperture.PixelAperture.photometry`, and
 `~photutils.aperture.ApertureStats`. They also apply the local masking
 or symmetric-correction behavior to per-aperture cutouts.
 """

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -626,9 +626,9 @@ class PixelAperture(Aperture):
             The overlap array.
         """
 
-    def _do_mask_photometry(self, data, *, error, mask, method, subpixels,
-                            segmentation=None, labels=None,
-                            mask_method='none'):
+    def _mask_photometry(self, data, *, error, mask, method, subpixels,
+                         segmentation=None, labels=None,
+                         mask_method='none'):
         """
         Perform aperture photometry using per-source aperture masks.
 
@@ -732,15 +732,15 @@ class PixelAperture(Aperture):
         Notes
         -----
         The batch driver is used only if this hook is defined in the
-        aperture instance's own class (see `_do_batch_photometry`),
+        aperture instance's own class (see `_batch_photometry`),
         so subclasses must define this method (e.g., by calling
         ``super()``) to opt in to the batch code path.
         """
         return
 
-    def _do_batch_photometry(self, data, *, error, mask, method, subpixels,
-                             segmentation=None, labels=None,
-                             mask_method='none'):
+    def _batch_photometry(self, data, *, error, mask, method, subpixels,
+                          segmentation=None, labels=None,
+                          mask_method='none'):
         """
         Perform aperture photometry using the batch Cython driver.
 
@@ -923,7 +923,7 @@ class PixelAperture(Aperture):
             segmentation_image, labels, mask_method,
             np.atleast_2d(self.positions), data.shape)
 
-        result = self._do_batch_photometry(
+        result = self._batch_photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation=segmentation, labels=labels,
             mask_method=mask_method)
@@ -931,7 +931,7 @@ class PixelAperture(Aperture):
         if result is not None:
             aperture_sums, aperture_sum_errs, area = result
         else:
-            aperture_sums, aperture_sum_errs, area = self._do_mask_photometry(
+            aperture_sums, aperture_sum_errs, area = self._mask_photometry(
                 data, error=error, mask=mask, method=method,
                 subpixels=subpixels, segmentation=segmentation,
                 labels=labels, mask_method=mask_method)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -22,7 +22,8 @@ from photutils.aperture._segmentation import (SEG_METHOD_CODES,
                                               process_segmentation_inputs)
 from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.mask import ApertureMask
-from photutils.utils._deprecation import deprecated_positional_kwargs
+from photutils.utils._deprecation import (deprecated,
+                                          deprecated_positional_kwargs)
 
 __all__ = ['Aperture', 'ApertureResults', 'PixelAperture', 'SkyAperture']
 
@@ -162,10 +163,10 @@ def _update_method_subpixels_docstring(obj):
 @dataclass(frozen=True)
 class ApertureResults:
     """
-    The results of `PixelAperture.do_photometry`.
+    The results of `PixelAperture.photometry`.
 
     For backward compatibility, this object can still be unpacked as a
-    2-tuple, ``aperture_sum, aperture_sum_err = do_photometry(...)``.
+    2-tuple, ``aperture_sum, aperture_sum_err = aper.photometry(...)``.
     Use the named attributes to access ``area``.
 
     Attributes
@@ -644,7 +645,7 @@ class PixelAperture(Aperture):
             already stripped.
 
         error, mask, method, subpixels
-            See `do_photometry`. Any units must already be stripped from
+            See `photometry`. Any units must already be stripped from
             ``error``.
 
         segmentation, labels, mask_method
@@ -754,7 +755,7 @@ class PixelAperture(Aperture):
             already stripped.
 
         error, mask, method, subpixels
-            See `do_photometry`. Any units must already be stripped from
+            See `photometry`. Any units must already be stripped from
             ``error``.
 
         segmentation, labels, mask_method
@@ -828,13 +829,16 @@ class PixelAperture(Aperture):
         return sums, errs, area
 
     @_update_method_subpixels_docstring
-    @deprecated_positional_kwargs(since='3.0', until='4.0')
-    def do_photometry(self, data, error=None, mask=None, method='exact',
-                      subpixels=5, *, segmentation_image=None, labels=None,
-                      mask_method='none'):
+    def photometry(self, data, *, error=None, mask=None, method='exact',
+                   subpixels=5, segmentation_image=None, labels=None,
+                   mask_method='none'):
         # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Perform aperture photometry on the input data.
+
+        .. versionadded:: 3.1
+            This method replaces the deprecated ``do_photometry``
+            method. All arguments except ``data`` are keyword-only.
 
         Parameters
         ----------
@@ -863,7 +867,7 @@ class PixelAperture(Aperture):
         result : `ApertureResults`
             The aperture photometry results. For backward
             compatibility, this object can be unpacked as a 2-tuple,
-            ``aperture_sum, aperture_sum_err = do_photometry(...)``, and
+            ``aperture_sum, aperture_sum_err = photometry(...)``, and
             supports ``len()`` and integer indexing as if it were a
             2-tuple. It has the following attributes:
 
@@ -943,6 +947,28 @@ class PixelAperture(Aperture):
 
         return ApertureResults(aperture_sum=aperture_sums,
                                aperture_sum_err=aperture_sum_errs, area=area)
+
+    @deprecated(since='3.1', alternative='photometry', until='4.0')
+    def do_photometry(self, data, error=None, mask=None, method='exact',
+                      subpixels=5, *, segmentation_image=None, labels=None,
+                      mask_method='none'):
+        # numpydoc ignore: PR01
+        """
+        Perform aperture photometry on the input data.
+
+        .. deprecated:: 3.1
+            Use `photometry` instead. Note that all arguments except
+            ``data`` are keyword-only in ``photometry``.
+
+        Returns
+        -------
+        result : `ApertureResults`
+            The aperture photometry results.
+        """
+        return self.photometry(data, error=error, mask=mask, method=method,
+                               subpixels=subpixels,
+                               segmentation_image=segmentation_image,
+                               labels=labels, mask_method=mask_method)
 
     @staticmethod
     def _make_annulus_path(patch_inner, patch_outer):

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -265,7 +265,7 @@ class ApertureMask:
         This method is separate from ``get_values`` to facilitate
         applying the same slices, aper_weights, and pixel_mask to
         multiple associated arrays (e.g., data and error arrays). It is
-        used in this way by the `PixelAperture.do_photometry` method.
+        used in this way by the `PixelAperture.photometry` method.
         """
         if mask is not None and mask.shape != shape:
             msg = 'mask and data must have the same shape'

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -219,8 +219,8 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
     # Validate the segmentation-masking inputs and resolve the
     # per-aperture source labels once (the resolved labels are passed
-    # explicitly to do_photometry to avoid repeated auto-lookups and
-    # warnings)
+    # explicitly to PixelAperture.photometry to avoid repeated
+    # auto-lookups and warnings).
     segmentation, labels = process_segmentation_inputs(
         segmentation_image, labels, mask_method,
         np.atleast_2d(positions), np.shape(data))
@@ -258,7 +258,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     sum_err_key_main = 'aperture_sum_err'
     area_key_main = 'area'
     for i, aper in enumerate(apertures):
-        result = aper.do_photometry(
+        result = aper.photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation_image=segmentation, labels=labels,
             mask_method=mask_method)

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -745,10 +745,11 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             return None
 
         # Fold non-finite ``data`` values into the mask so the batch
-        # kernel can skip the per-pixel finiteness test (and defer the
-        # pixel-value load to contributing pixels only, like the
-        # ``do_photometry`` kernel). This matches the mask-based path,
-        # which masks non-finite data before any segmentation correction.
+        # kernel can skip the per-pixel finiteness test (and defer
+        # the pixel-value load to contributing pixels only, like
+        # the ``photometry`` method). This matches the mask-based
+        # path, which masks non-finite data before any segmentation
+        # correction.
         if data.dtype.kind == 'f':
             nonfinite = ~np.isfinite(data)
             if nonfinite.any():

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -709,7 +709,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         for example when an unsupported ``sigma_clip`` is used, the
         aperture does not opt in to the batch driver, or the data/mask
         dtypes are not supported. The set of supported inputs matches
-        `~photutils.aperture.PixelAperture._do_batch_photometry`.
+        `~photutils.aperture.PixelAperture._batch_photometry`.
         """
         # A non-None sigma_clip is only supported when it maps to the
         # fast clipping kernel; otherwise fall back to the mask path.
@@ -720,7 +720,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         aper = self._pixel_aperture
 
         # Use the batch driver only if the aperture's own class defines
-        # the _batch_shape_params hook (see _do_batch_photometry).
+        # the _batch_shape_params hook (see _batch_photometry).
         if '_batch_shape_params' not in type(aper).__dict__:
             return None
         spec = aper._batch_shape_params()

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -149,16 +149,16 @@ def test_readonly_arrays(method, subpixels):
                         equal_nan=True)
 
 
-def test_readonly_data_do_photometry():
+def test_readonly_data_photometry():
     """
-    Test that ``do_photometry`` works with read-only data arrays.
+    Test that ``photometry`` works with read-only data arrays.
     """
     data = np.ones((10, 10))
     data.setflags(write=False)
     aperture = CircularAperture((4.5, 4.5), r=4.5)
-    sums, _ = aperture.do_photometry(data, method='exact')
+    sums, _ = aperture.photometry(data, method='exact')
 
-    expected, _ = aperture.do_photometry(np.ones((10, 10)), method='exact')
+    expected, _ = aperture.photometry(np.ones((10, 10)), method='exact')
     assert_allclose(sums, expected, rtol=1e-12)
 
 
@@ -182,10 +182,10 @@ def test_units():
     """
     unit = u.Jy
     aperture = CircularAperture(POSITIONS, r=5.5)
-    sums, errs = aperture.do_photometry(DATA << unit, error=ERROR << unit)
+    sums, errs = aperture.photometry(DATA << unit, error=ERROR << unit)
     assert sums.unit == unit
     assert errs.unit == unit
-    sums2, errs2 = aperture.do_photometry(DATA, error=ERROR)
+    sums2, errs2 = aperture.photometry(DATA, error=ERROR)
     assert_allclose(sums.value, sums2, equal_nan=True)
     assert_allclose(errs.value, errs2, equal_nan=True)
 
@@ -216,16 +216,16 @@ def test_no_overlap_nan_and_err_shape():
     CircularAperture(POSITIONS, r=5.5),
     PolygonAperture.from_regular_polygon(POSITIONS, 6, radius=5.5),
 ])
-def test_do_photometry_no_error_flux_err_shape(aperture):
+def test_photometry_no_error_flux_err_shape(aperture):
     """
-    Test that `do_photometry` returns a ``flux_err`` array that always
+    Test that `photometry` returns a ``flux_err`` array that always
     has the same length as ``flux`` and is filled with NaN when
     ``error`` is not input, both for sources with and without overlap.
 
     ``CircularAperture`` exercises the batch code path and
     ``PolygonAperture`` exercises the mask-based code path.
     """
-    flux, flux_err = aperture.do_photometry(DATA, error=None)
+    flux, flux_err = aperture.photometry(DATA, error=None)
     assert flux_err.shape == flux.shape
     assert np.any(np.isnan(flux))
     assert np.any(~np.isnan(flux))
@@ -264,7 +264,7 @@ def test_fallback_subclass():
     """
     Test that aperture subclasses that do not themselves define
     _batch_shape_params fall back to the mask-based code path in
-    do_photometry, so that any overridden behavior (e.g., to_mask) is
+    photometry, so that any overridden behavior (e.g., to_mask) is
     honored.
     """
 
@@ -276,8 +276,8 @@ def test_fallback_subclass():
     aperture = MyAperture(POSITIONS, r=5.5)
     assert aperture._do_batch_photometry(DATA, error=None, mask=None,
                                          method='exact', subpixels=5) is None
-    sums, _ = aperture.do_photometry(DATA)
-    sums2, _ = CircularAperture(POSITIONS, r=5.5).do_photometry(DATA)
+    sums, _ = aperture.photometry(DATA)
+    sums2, _ = CircularAperture(POSITIONS, r=5.5).photometry(DATA)
     assert_allclose(sums, sums2, rtol=1e-12, equal_nan=True)
 
 
@@ -329,10 +329,10 @@ def test_thread_safety():
     and checking that they all give the same results.
     """
     aperture = CircularAperture(POSITIONS, r=5.5)
-    expected, _ = aperture.do_photometry(DATA, error=ERROR)
+    expected, _ = aperture.photometry(DATA, error=ERROR)
 
     def run(_):
-        return aperture.do_photometry(DATA, error=ERROR)[0]
+        return aperture.photometry(DATA, error=ERROR)[0]
 
     with ThreadPoolExecutor(max_workers=4) as executor:
         results = list(executor.map(run, range(8)))

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -58,11 +58,11 @@ def assert_batch_matches_legacy(aperture, data, *, error=None, mask=None,
     Test that the batch photometry driver gives results identical to the
     legacy mask-based code path for the given inputs.
     """
-    batch = aperture._do_batch_photometry(data, error=error, mask=mask,
-                                          method=method, subpixels=subpixels)
+    batch = aperture._batch_photometry(data, error=error, mask=mask,
+                                       method=method, subpixels=subpixels)
     assert batch is not None
-    legacy = aperture._do_mask_photometry(data, error=error, mask=mask,
-                                          method=method, subpixels=subpixels)
+    legacy = aperture._mask_photometry(data, error=error, mask=mask,
+                                       method=method, subpixels=subpixels)
     for batch_arr, legacy_arr in zip(batch, legacy, strict=True):
         assert batch_arr.shape == legacy_arr.shape
         assert_allclose(batch_arr, legacy_arr, rtol=1e-12, atol=0,
@@ -111,10 +111,10 @@ def test_data_dtypes(dtype):
     rtol = 1e-5 if dtype == 'float32' else 1e-12
     aperture = CircularAperture(POSITIONS, r=5.5)
     data = (DATA > 100.0) if dtype == 'bool' else DATA.astype(dtype)
-    batch = aperture._do_batch_photometry(data, error=None, mask=None,
-                                          method='exact', subpixels=5)
-    legacy = aperture._do_mask_photometry(data, error=None, mask=None,
-                                          method='exact', subpixels=5)
+    batch = aperture._batch_photometry(data, error=None, mask=None,
+                                       method='exact', subpixels=5)
+    legacy = aperture._mask_photometry(data, error=None, mask=None,
+                                       method='exact', subpixels=5)
     assert batch is not None
     assert_allclose(batch[0], legacy[0], rtol=rtol, equal_nan=True)
 
@@ -137,13 +137,13 @@ def test_readonly_arrays(method, subpixels):
     for arr in (data, error, mask):
         arr.setflags(write=False)
 
-    batch = aperture._do_batch_photometry(data, error=error, mask=mask,
-                                          method=method, subpixels=subpixels)
+    batch = aperture._batch_photometry(data, error=error, mask=mask,
+                                       method=method, subpixels=subpixels)
     assert batch is not None
 
-    expected = aperture._do_batch_photometry(DATA, error=ERROR, mask=MASK,
-                                             method=method,
-                                             subpixels=subpixels)
+    expected = aperture._batch_photometry(DATA, error=ERROR, mask=MASK,
+                                          method=method,
+                                          subpixels=subpixels)
     for batch_arr, exp_arr in zip(batch, expected, strict=True):
         assert_allclose(batch_arr, exp_arr, rtol=1e-12, atol=0,
                         equal_nan=True)
@@ -200,13 +200,13 @@ def test_no_overlap_nan_and_err_shape():
     aperture = CircularAperture(POSITIONS, r=5.5)
     n_outside = 3
 
-    sums, errs, _area = aperture._do_batch_photometry(
+    sums, errs, _area = aperture._batch_photometry(
         DATA, error=None, mask=None, method='exact', subpixels=5)
     assert np.isnan(sums).sum() == n_outside
     assert errs.shape == sums.shape
     assert np.all(np.isnan(errs))
 
-    sums, errs, _area = aperture._do_batch_photometry(
+    sums, errs, _area = aperture._batch_photometry(
         DATA, error=ERROR, mask=None, method='exact', subpixels=5)
     assert errs.shape == sums.shape
     assert np.isnan(errs).sum() == n_outside
@@ -242,22 +242,22 @@ def test_fallback_inputs():
 
     # Masked-array data
     data = np.ma.MaskedArray(DATA, mask=MASK)
-    assert aperture._do_batch_photometry(data, error=None, mask=None,
-                                         method='exact', subpixels=5) is None
+    assert aperture._batch_photometry(data, error=None, mask=None,
+                                      method='exact', subpixels=5) is None
 
     # Non-bool mask
-    assert aperture._do_batch_photometry(DATA, error=None,
-                                         mask=MASK.astype(int),
-                                         method='exact', subpixels=5) is None
+    assert aperture._batch_photometry(DATA, error=None,
+                                      mask=MASK.astype(int),
+                                      method='exact', subpixels=5) is None
 
     # Mask with mismatched shape
-    assert aperture._do_batch_photometry(DATA, error=None, mask=MASK[1:, :],
-                                         method='exact', subpixels=5) is None
+    assert aperture._batch_photometry(DATA, error=None, mask=MASK[1:, :],
+                                      method='exact', subpixels=5) is None
 
     # Unsupported dtype
-    assert aperture._do_batch_photometry(DATA.astype(complex), error=None,
-                                         mask=None, method='exact',
-                                         subpixels=5) is None
+    assert aperture._batch_photometry(DATA.astype(complex), error=None,
+                                      mask=None, method='exact',
+                                      subpixels=5) is None
 
 
 def test_fallback_subclass():
@@ -274,8 +274,8 @@ def test_fallback_subclass():
         pass
 
     aperture = MyAperture(POSITIONS, r=5.5)
-    assert aperture._do_batch_photometry(DATA, error=None, mask=None,
-                                         method='exact', subpixels=5) is None
+    assert aperture._batch_photometry(DATA, error=None, mask=None,
+                                      method='exact', subpixels=5) is None
     sums, _ = aperture.photometry(DATA)
     sums2, _ = CircularAperture(POSITIONS, r=5.5).photometry(DATA)
     assert_allclose(sums, sums2, rtol=1e-12, equal_nan=True)
@@ -292,8 +292,8 @@ def test_optin_subclass():
             return super()._batch_shape_params()
 
     aperture = MyAperture(POSITIONS, r=5.5)
-    result = aperture._do_batch_photometry(DATA, error=None, mask=None,
-                                           method='exact', subpixels=5)
+    result = aperture._batch_photometry(DATA, error=None, mask=None,
+                                        method='exact', subpixels=5)
     assert result is not None
     assert_batch_matches_legacy(aperture, DATA, error=ERROR, mask=MASK)
 
@@ -301,13 +301,13 @@ def test_optin_subclass():
 def test_optin_subclass_base_hook_returns_none():
     """
     Test that when a subclass defines _batch_shape_params (opting in)
-    but the method returns None, _do_batch_photometry falls back to
+    but the method returns None, _batch_photometry falls back to
     None.
 
     This covers:
     - PixelAperture._batch_shape_params (the base ``return`` on its own
       line, which is the hook's default no-op implementation), and
-    - the ``if spec is None: return None`` branch in _do_batch_photometry.
+    - the ``if spec is None: return None`` branch in _batch_photometry.
     """
 
     class MyAperture(CircularAperture):
@@ -318,8 +318,8 @@ def test_optin_subclass_base_hook_returns_none():
             return PixelAperture._batch_shape_params(self)
 
     aperture = MyAperture(POSITIONS, r=5.5)
-    assert aperture._do_batch_photometry(DATA, error=None, mask=None,
-                                         method='exact', subpixels=5) is None
+    assert aperture._batch_photometry(DATA, error=None, mask=None,
+                                      method='exact', subpixels=5) is None
 
 
 def test_thread_safety():

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -242,11 +242,11 @@ class TestPixelAperturePhotometry:
         mask = np.zeros(self.data.shape, dtype=bool)
         mask[5, 5] = True
 
-        batch = aper._do_batch_photometry(self.data, error=None, mask=mask,
-                                          method='exact', subpixels=5)
+        batch = aper._batch_photometry(self.data, error=None, mask=mask,
+                                       method='exact', subpixels=5)
         assert batch is not None
-        legacy = aper._do_mask_photometry(self.data, error=None, mask=mask,
-                                          method='exact', subpixels=5)
+        legacy = aper._mask_photometry(self.data, error=None, mask=mask,
+                                       method='exact', subpixels=5)
         # areas are the third element of each result
         assert_allclose(batch[2], legacy[2], rtol=1e-12, equal_nan=True)
 

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 
 from photutils.aperture import (Aperture, CircularAperture, EllipticalAperture,
@@ -129,9 +130,9 @@ class TestPixelAperture:
         assert len(bbox) == len(POSITIONS)
 
 
-class TestPixelApertureDoPhotometry:
+class TestPixelAperturePhotometry:
     """
-    Tests for error-handling branches of PixelAperture.do_photometry.
+    Tests for error-handling branches of PixelAperture.photometry.
     """
 
     def setup_method(self):
@@ -141,56 +142,56 @@ class TestPixelApertureDoPhotometry:
         self.aper = CircularAperture(SCALAR_POS, r=3)
         self.data = np.ones((20, 20))
 
-    def test_do_photometry_1d_data_error(self):
+    def test_photometry_1d_data_error(self):
         """
-        Test that do_photometry raises ValueError when data is not a
+        Test that photometry raises ValueError when data is not a
         2D array.
         """
         match = 'data must be a 2D array'
         with pytest.raises(ValueError, match=match):
-            self.aper.do_photometry(np.ones(20))
+            self.aper.photometry(np.ones(20))
 
-    def test_do_photometry_error_shape_mismatch(self):
+    def test_photometry_error_shape_mismatch(self):
         """
-        Test that do_photometry raises ValueError when the error array
+        Test that photometry raises ValueError when the error array
         does not match the data shape.
         """
         match = 'error and data must have the same shape'
         with pytest.raises(ValueError, match=match):
-            self.aper.do_photometry(self.data, error=np.ones((5, 5)))
+            self.aper.photometry(self.data, error=np.ones((5, 5)))
 
-    def test_do_photometry_unit_mismatch_error(self):
+    def test_photometry_unit_mismatch_error(self):
         """
-        Test that do_photometry raises ValueError when data and error
+        Test that photometry raises ValueError when data and error
         have different units.
         """
         import astropy.units as u
 
         match = 'they both must have the same units'
         with pytest.raises(ValueError, match=match):
-            self.aper.do_photometry(
+            self.aper.photometry(
                 self.data * u.Jy,
                 error=self.data * u.ct,
             )
 
-    def test_do_photometry_basic(self):
+    def test_photometry_basic(self):
         """
-        Test that do_photometry returns the expected aperture sum for a
+        Test that photometry returns the expected aperture sum for a
         uniform data array with no error input, and that the returned
         error array has the same length as the flux array, filled with
         NaN.
         """
-        sums, errs = self.aper.do_photometry(self.data)
+        sums, errs = self.aper.photometry(self.data)
         assert_allclose(sums[0], np.pi * 9, rtol=1e-3)
         assert len(errs) == len(sums)
         assert_allclose(errs, np.nan)
 
-    def test_do_photometry_result_backward_compatible(self):
+    def test_photometry_result_backward_compatible(self):
         """
-        Test that the do_photometry result unpacks as a 2-tuple and
+        Test that the photometry result unpacks as a 2-tuple and
         supports len() and integer indexing like the legacy tuple.
         """
-        result = self.aper.do_photometry(self.data)
+        result = self.aper.photometry(self.data)
         assert len(result) == 2
 
         sums, errs = result
@@ -199,40 +200,40 @@ class TestPixelApertureDoPhotometry:
         assert_allclose(result[0], result.aperture_sum)
         assert_allclose(result[1], result.aperture_sum_err, equal_nan=True)
 
-    def test_do_photometry_area_matches_area_overlap(self):
+    def test_photometry_area_matches_area_overlap(self):
         """
         Test that the result area matches area_overlap for a simple
         non-masked, fully-overlapping aperture.
         """
-        result = self.aper.do_photometry(self.data)
+        result = self.aper.photometry(self.data)
         expected = self.aper.area_overlap(self.data)
         assert result.area.unit == u.pix**2
         assert_allclose(result.area.value, expected)
 
-    def test_do_photometry_area_no_overlap_nan(self):
+    def test_photometry_area_no_overlap_nan(self):
         """
         Test that the result area is NaN for an aperture with no overlap
         with the data.
         """
         aper = CircularAperture((-50, -50), r=3)
-        result = aper.do_photometry(self.data)
+        result = aper.photometry(self.data)
         assert np.isnan(result.area.value).all()
 
-    def test_do_photometry_area_units(self):
+    def test_photometry_area_units(self):
         """
         Test that the result area always has units of pix**2 regardless
         of whether the data/error are Quantity or plain arrays.
         """
-        result = self.aper.do_photometry(self.data)
+        result = self.aper.photometry(self.data)
         assert result.area.unit == u.pix**2
 
-        result_q = self.aper.do_photometry(self.data * u.Jy,
-                                           error=self.data * u.Jy)
+        result_q = self.aper.photometry(self.data * u.Jy,
+                                        error=self.data * u.Jy)
         assert result_q.area.unit == u.pix**2
         assert_allclose(result.area.value, result_q.area.value,
                         equal_nan=True)
 
-    def test_do_photometry_area_batch_vs_mask_path(self):
+    def test_photometry_area_batch_vs_mask_path(self):
         """
         Test that the batch and mask code paths produce identical area
         values.
@@ -248,6 +249,20 @@ class TestPixelApertureDoPhotometry:
                                           method='exact', subpixels=5)
         # areas are the third element of each result
         assert_allclose(batch[2], legacy[2], rtol=1e-12, equal_nan=True)
+
+    def test_do_photometry_deprecated(self):
+        """
+        Test that the deprecated do_photometry method emits a
+        deprecation warning and returns the same results as photometry.
+        """
+        error = np.full(self.data.shape, 0.1)
+        expected = self.aper.photometry(self.data, error=error)
+        match = r'Use photometry instead'
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            result = self.aper.do_photometry(self.data, error=error)
+        assert_allclose(result.aperture_sum, expected.aperture_sum)
+        assert_allclose(result.aperture_sum_err, expected.aperture_sum_err)
+        assert_allclose(result.area.value, expected.area.value)
 
 
 class TestApertureReprStr:

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -197,22 +197,22 @@ def test_pixel_polygon_from_star(n_spikes):
     inner_radius = 2.0
     aper = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
                                       inner_radius)
-    flux, _ = aper.do_photometry(data, method='exact')
+    flux, _ = aper.photometry(data, method='exact')
     assert_allclose(flux, aper.area)
 
     aper1 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
                                        inner_radius, theta=10 * u.deg)
-    flux, _ = aper1.do_photometry(data, method='exact')
+    flux, _ = aper1.photometry(data, method='exact')
     assert_allclose(flux, aper1.area)
 
     aper2 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
                                        optimal_shape=True)
-    flux, _ = aper2.do_photometry(data, method='exact')
+    flux, _ = aper2.photometry(data, method='exact')
     assert_allclose(flux, aper2.area)
 
     aper3 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
                                        collinear_edges=True)
-    flux, _ = aper3.do_photometry(data, method='exact')
+    flux, _ = aper3.photometry(data, method='exact')
     assert_allclose(flux, aper3.area)
 
 
@@ -484,19 +484,19 @@ def test_indexing_scalar_raises():
         len(aper)
 
 
-def test_do_photometry():
+def test_photometry():
     data = np.ones((30, 30))
     aper = PolygonAperture((10.0, 10.0), SQUARE_OFFSETS)
-    flux, _ = aper.do_photometry(data, method='exact')
+    flux, _ = aper.photometry(data, method='exact')
     assert_allclose(flux, [4.0])
 
 
-def test_do_photometry_subpixel_on_horizontal_boundary():
+def test_photometry_subpixel_on_horizontal_boundary():
     """
-    Test that ``do_photometry`` excludes subpixel centers landing
+    Test that ``photometry`` excludes subpixel centers landing
     exactly on a horizontal polygon edge.
 
-    This is the ``do_photometry`` counterpart of
+    This is the ``photometry`` counterpart of
     ``test_polygon_overlap_subpixel_on_horizontal_boundary`` in
     ``photutils/geometry/tests/test_polygon_overlap_grid.py``,
     using the same wide rectangle (half-widths 2 in x, 1 in y) and
@@ -513,16 +513,16 @@ def test_do_photometry_subpixel_on_horizontal_boundary():
     offsets = np.array([[-2.0, -1.0], [2.0, -1.0],
                         [2.0, 1.0], [-2.0, 1.0]])
     aper = PolygonAperture((15.0, 15.0), offsets)
-    flux, _ = aper.do_photometry(data, method='subpixel', subpixels=3)
+    flux, _ = aper.photometry(data, method='subpixel', subpixels=3)
     assert_allclose(flux, [55.0 / 9.0])
 
 
-def test_do_photometry_subpixel_on_vertical_boundary():
+def test_photometry_subpixel_on_vertical_boundary():
     """
-    Test that ``do_photometry`` excludes subpixel centers landing
+    Test that ``photometry`` excludes subpixel centers landing
     exactly on a vertical polygon edge.
 
-    This is the ``do_photometry`` counterpart of
+    This is the ``photometry`` counterpart of
     ``test_polygon_overlap_subpixel_on_vertical_boundary``, using
     the same tall rectangle (half-widths 1 in x, 2 in y) and
     ``subpixels=3``. The vertical edges at x = center +/- 1 coincide
@@ -533,16 +533,16 @@ def test_do_photometry_subpixel_on_vertical_boundary():
     offsets = np.array([[-1.0, -2.0], [1.0, -2.0],
                         [1.0, 2.0], [-1.0, 2.0]])
     aper = PolygonAperture((15.0, 15.0), offsets)
-    flux, _ = aper.do_photometry(data, method='subpixel', subpixels=3)
+    flux, _ = aper.photometry(data, method='subpixel', subpixels=3)
     assert_allclose(flux, [55.0 / 9.0])
 
 
-def test_do_photometry_subpixel_on_all_boundaries():
+def test_photometry_subpixel_on_all_boundaries():
     """
-    Test that ``do_photometry`` excludes subpixel centers on horizontal
+    Test that ``photometry`` excludes subpixel centers on horizontal
     edges, vertical edges, and at corners.
 
-    This is the ``do_photometry`` counterpart of
+    This is the ``photometry`` counterpart of
     ``test_polygon_overlap_subpixel_on_all_boundaries``, using the same
     unit square (half-widths 1 in both axes) and ``subpixels=3``. At
     an integer position the four edges and four corners coincide with
@@ -552,7 +552,7 @@ def test_do_photometry_subpixel_on_all_boundaries():
     """
     data = np.ones((31, 31))
     aper = PolygonAperture((15.0, 15.0), SQUARE_OFFSETS)
-    flux, _ = aper.do_photometry(data, method='subpixel', subpixels=3)
+    flux, _ = aper.photometry(data, method='subpixel', subpixels=3)
     assert_allclose(flux, [25.0 / 9.0])
 
 
@@ -576,7 +576,7 @@ def test_array_photometry_matches_scalar(method, kwargs):
     offsets = _concave_star()
 
     aper = PolygonAperture(positions, offsets)
-    multi, _ = aper.do_photometry(data, method=method, **kwargs)
+    multi, _ = aper.photometry(data, method=method, **kwargs)
 
     ref = [PolygonAperture(pos, offsets)
            .to_mask(method=method, **kwargs).multiply(data).sum()

--- a/photutils/aperture/tests/test_positional_kwargs.py
+++ b/photutils/aperture/tests/test_positional_kwargs.py
@@ -133,21 +133,6 @@ class TestApertureMethodsPositionalKwargs:
         with pytest.warns(AstropyDeprecationWarning, match=match):
             aper.to_mask('exact')
 
-    @pytest.mark.parametrize(('aperture_class', 'params'),
-                             PIXEL_TEST_APERTURES)
-    def test_do_photometry_no_warning(self, aperture_class, params):
-        aper = aperture_class(POSITION, **params)
-        aper.do_photometry(DATA, error=None, mask=None)
-
-    @pytest.mark.parametrize(('aperture_class', 'params'),
-                             PIXEL_TEST_APERTURES)
-    def test_do_photometry_positional_warning(self, aperture_class, params):
-        aper = aperture_class(POSITION, **params)
-        error = np.ones_like(DATA)
-        match = 'do_photometry'
-        with pytest.warns(AstropyDeprecationWarning, match=match):
-            aper.do_photometry(DATA, error)
-
 
 class TestApertureInitPositionalKwargs:
     @pytest.mark.parametrize(('aperture_class', 'params'),

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Tests for segmentation-based masking of aperture photometry, shared
-by `aperture_photometry`, `PixelAperture.do_photometry`, and
+by `aperture_photometry`, `PixelAperture.photometry`, and
 `ApertureStats`.
 """
 
@@ -177,7 +177,7 @@ class TestAperturePhotometry:
                                         mask_method='none')
 
         labels = [1]
-        batch_sum, batch_err = aper.do_photometry(
+        batch_sum, batch_err = aper.photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
         mask_sum, mask_err, _area = aper._do_mask_photometry(
@@ -233,19 +233,21 @@ class TestAperturePhotometry:
                                 mask_method='mask')
 
 
-class TestDoPhotometry:
+class TestPhotometry:
     def test_batch_matches_mask_path(self):
-        # do_photometry uses the batch driver for circular apertures;
-        # compare to the equivalent manual global mask.
+        """
+        Test that the batch driver for circular apertures matches the
+        Python mask code path for segmentation masking.
+        """
         data, segm = make_scene()
         aper = CircularAperture([(21, 21), (28, 22)], r=6)
         labels = [1, 2]
-        sums, _ = aper.do_photometry(data, segmentation_image=segm,
-                                     labels=labels,
-                                     mask_method='mask')
+        sums, _ = aper.photometry(data, segmentation_image=segm,
+                                  labels=labels,
+                                  mask_method='mask')
         for idx, label in enumerate(labels):
             manual_mask = (segm > 0) & (segm != label)
-            ref, _ = CircularAperture(aper.positions[idx], r=6).do_photometry(
+            ref, _ = CircularAperture(aper.positions[idx], r=6).photometry(
                 data, mask=manual_mask)
             assert_allclose(sums[idx], ref[0])
 
@@ -456,7 +458,7 @@ class TestBatchDriverSegmentation:
         aper = CircularAperture(positions, r=8)
         labels = np.array([1], dtype=np.intp)
 
-        batch_sum, batch_err = aper.do_photometry(
+        batch_sum, batch_err = aper.photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
         mask_sum, mask_err, _area = aper._do_mask_photometry(

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -180,7 +180,7 @@ class TestAperturePhotometry:
         batch_sum, batch_err = aper.photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
-        mask_sum, mask_err, _area = aper._do_mask_photometry(
+        mask_sum, mask_err, _area = aper._mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm.astype(np.intp), labels=labels,
             mask_method='correct')
@@ -461,7 +461,7 @@ class TestBatchDriverSegmentation:
         batch_sum, batch_err = aper.photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
-        mask_sum, mask_err, _area = aper._do_mask_photometry(
+        mask_sum, mask_err, _area = aper._mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm, labels=labels,
             mask_method='correct')

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -176,10 +176,10 @@ class TestApertureStats:
             apstats = ApertureStats(self.data, self.aperture,
                                     error=self.error, sum_method=method,
                                     subpixels=subpixels)
-            apsum, apsum_err = self.aperture.do_photometry(self.data,
-                                                           error=self.error,
-                                                           method=method,
-                                                           subpixels=subpixels)
+            apsum, apsum_err = self.aperture.photometry(self.data,
+                                                        error=self.error,
+                                                        method=method,
+                                                        subpixels=subpixels)
             assert_allclose(apstats.sum, apsum)
             assert_allclose(apstats.sum_err, apsum_err)
 

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -193,7 +193,7 @@ class ProfileBase(metaclass=abc.ABCMeta):
                 flux, flux_err = [0.0], [0.0]
                 area = 0.0
             else:
-                flux, flux_err = aperture.do_photometry(
+                flux, flux_err = aperture.photometry(
                     self.data, error=self.error, mask=self.mask,
                     method=self.method, subpixels=self.subpixels)
                 area = aperture.area_overlap(self.data, mask=self.mask,

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -481,7 +481,7 @@ class PSFDataProcessor:
         y_pos = init_params[self.param_mapper.init_colnames['y']]
         apertures = CircularAperture(zip(x_pos, y_pos, strict=True),
                                      r=self.aperture_radius)
-        flux, _ = apertures.do_photometry(data, mask=mask)
+        flux, _ = apertures.photometry(data, mask=mask)
         return flux
 
     def find_sources_if_needed(self, data, mask, init_params):

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -341,7 +341,7 @@ class ImageDepth:
 
             apers = CircularAperture(xycoords, r=self.aper_radius)
             apertures.append(apers)
-            fluxes, _ = apers.do_photometry(data)
+            fluxes, _ = apers.photometry(data)
             if self.sigma_clip is not None:
                 fluxes = self.sigma_clip(fluxes, masked=False)  # ndarray
             self.fluxes.append(fluxes)


### PR DESCRIPTION
The ``PixelAperture.do_photometry`` method has been renamed to ``photometry``. The old method name is deprecated and will be removed in version 4.0. Note that in the new ``photometry`` method all arguments except ``data`` are keyword-only.