### PR TITLE
Rename EPSFBuildResult to EPSFBuildResults

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,6 +189,13 @@ API Changes
     removed in version 4.0. Note that in the new ``photometry`` method
     all arguments except ``data`` are keyword-only. [#2324]
 
+- ``photutils.psf``
+
+  - The ``EPSFBuildResult`` class returned by ``EPSFBuilder`` has been
+    renamed to ``EPSFBuildResults`` for consistency with the new
+    ``ApertureResults`` class. The old ``EPSFBuildResult`` name is
+    deprecated and will be removed in a future version. [#2326]
+
 
 3.0.0 (2026-04-17)
 ------------------

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -289,7 +289,7 @@ to the instance::
     >>> result = epsf_builder(stars)  # doctest: +REMOTE_DATA
 
 The :class:`~photutils.psf.EPSFBuilder` returns an
-`~photutils.psf.EPSFBuildResult` object containing the constructed ePSF,
+`~photutils.psf.EPSFBuildResults` object containing the constructed ePSF,
 the fitted stars, and detailed information about the build process. This
 result object supports tuple unpacking, so both of the following work::
 
@@ -300,7 +300,7 @@ result object supports tuple unpacking, so both of the following work::
     >>> # Old style: tuple unpacking still works
     >>> epsf, fitted_stars = epsf_builder(stars)  # doctest: +REMOTE_DATA
 
-The `~photutils.psf.EPSFBuildResult` object provides useful diagnostic
+The `~photutils.psf.EPSFBuildResults` object provides useful diagnostic
 information about the build process::
 
     >>> result.converged  # doctest: +REMOTE_DATA

--- a/docs/whats_new/3.0.rst
+++ b/docs/whats_new/3.0.rst
@@ -45,11 +45,11 @@ The ePSF building tools have been significantly refactored for improved
 robustness, better diagnostics, and a cleaner API.
 
 
-New EPSFBuildResult class
--------------------------
+New EPSFBuildResults class
+--------------------------
 
 :class:`~photutils.psf.EPSFBuilder` now returns an
-:class:`~photutils.psf.EPSFBuildResult` dataclass instead of a plain
+:class:`~photutils.psf.EPSFBuildResults` dataclass instead of a plain
 tuple. The result object provides structured access to detailed build
 diagnostics::
 
@@ -75,7 +75,7 @@ Stars that repeatedly fail fitting are now automatically excluded from
 subsequent iterations, with informative warnings indicating the reason
 for exclusion (e.g., fit region extends beyond the cutout, or the fit
 did not converge). The number of excluded stars and their indices are
-reported in the :class:`~photutils.psf.EPSFBuildResult`.
+reported in the :class:`~photutils.psf.EPSFBuildResults`.
 
 
 Improved PSF Matching Tools

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -386,6 +386,15 @@ The old method name is deprecated and will be removed in version
     aperture_sum, aperture_sum_err = aperture.photometry(data, error=error)
 
 
+``EPSFBuildResult`` Renamed to ``EPSFBuildResults``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``EPSFBuildResult`` class returned by `~photutils.psf.EPSFBuilder`
+has been renamed to `~photutils.psf.EPSFBuildResults` for consistency
+with the new ``ApertureResults`` class. The old ``EPSFBuildResult`` name
+is deprecated and will be removed in a future version.
+
+
 Removed Deprecations
 --------------------
 

--- a/photutils/psf/__init__.py
+++ b/photutils/psf/__init__.py
@@ -18,3 +18,21 @@ from .model_plotting import *  # noqa: F401, F403
 from .photometry import *  # noqa: F401, F403
 from .simulation import *  # noqa: F401, F403
 from .utils import *  # noqa: F401, F403
+
+
+def __getattr__(name):
+    # EPSFBuildResult was renamed to EPSFBuildResults in 3.1.
+    if name == 'EPSFBuildResult':
+        import warnings
+
+        from astropy.utils.exceptions import AstropyDeprecationWarning
+
+        from .epsf_builder import EPSFBuildResults
+
+        msg = ('EPSFBuildResult is deprecated and will be removed in a '
+               'future version. Use EPSFBuildResults instead.')
+        warnings.warn(msg, AstropyDeprecationWarning, stacklevel=2)
+        return EPSFBuildResults
+
+    msg = f'module {__name__!r} has no attribute {name!r}'
+    raise AttributeError(msg)

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -28,7 +28,7 @@ from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._round import round_half_away
 from photutils.utils._stats import nanmedian
 
-__all__ = ['EPSFBuildResult', 'EPSFBuilder', 'EPSFFitter']
+__all__ = ['EPSFBuildResults', 'EPSFBuilder', 'EPSFFitter']
 
 SIGMA_CLIP = SigmaClipSentinelDefault(sigma=3.0, maxiters=10)
 
@@ -615,7 +615,7 @@ class _ProgressReporter:
 
 
 @dataclass
-class EPSFBuildResult:
+class EPSFBuildResults:
     """
     Container for ePSF building results.
 
@@ -716,7 +716,7 @@ class EPSFBuildResult:
         if index == 1:
             return self.fitted_stars
 
-        msg = 'EPSFBuildResult index must be 0 (epsf) or 1 (fitted_stars)'
+        msg = 'EPSFBuildResults index must be 0 (epsf) or 1 (fitted_stars)'
         raise IndexError(msg)
 
 
@@ -1123,7 +1123,7 @@ class EPSFBuilder:
 
         Returns
         -------
-        result : `EPSFBuildResult`
+        result : `EPSFBuildResults`
             The result of the ePSF building process.
         """
         return self.build_epsf(stars)
@@ -1941,7 +1941,7 @@ class EPSFBuilder:
 
         Returns
         -------
-        result : `EPSFBuildResult`
+        result : `EPSFBuildResults`
             Structured result containing ePSF, stars, and build
             diagnostics.
         """
@@ -1951,7 +1951,7 @@ class EPSFBuilder:
         progress_reporter.close()
 
         # Create structured result
-        return EPSFBuildResult(
+        return EPSFBuildResults(
             epsf=epsf,
             fitted_stars=stars,
             iterations=iter_num,
@@ -1981,8 +1981,8 @@ class EPSFBuilder:
 
         Returns
         -------
-        result : `EPSFBuildResult` or tuple
-            The ePSF building results. Returns an `EPSFBuildResult` object
+        result : `EPSFBuildResults` or tuple
+            The ePSF building results. Returns an `EPSFBuildResults` object
             with detailed information about the building process. For
             backward compatibility, the result can be unpacked as a tuple:
             ``(epsf, fitted_stars) = epsf_builder(stars)``.
@@ -2049,3 +2049,15 @@ class EPSFBuilder:
                                     iter_num, final_converged,
                                     final_center_accuracy,
                                     excluded_star_indices)
+
+
+def __getattr__(name):
+    # EPSFBuildResult was renamed to EPSFBuildResults in 3.1.
+    if name == 'EPSFBuildResult':
+        msg = ('EPSFBuildResult is deprecated and will be removed in a '
+               'future version. Use EPSFBuildResults instead.')
+        warnings.warn(msg, AstropyDeprecationWarning, stacklevel=2)
+        return EPSFBuildResults
+
+    msg = f'module {__name__!r} has no attribute {name!r}'
+    raise AttributeError(msg)

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -19,7 +19,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from photutils.centroids import (centroid_1dg, centroid_2dg, centroid_com,
                                  centroid_quadratic)
 from photutils.datasets import make_model_image
-from photutils.psf import (CircularGaussianPRF, EPSFBuilder, EPSFBuildResult,
+from photutils.psf import (CircularGaussianPRF, EPSFBuilder, EPSFBuildResults,
                            EPSFFitter, EPSFStar, EPSFStars, ImagePSF,
                            extract_stars, make_psf_model_image)
 from photutils.psf.epsf_builder import (_CoordinateTransformer, _EPSFValidator,
@@ -626,14 +626,14 @@ class TestProgressReporter:
         assert reporter._pbar is None
 
 
-class TestEPSFBuildResult:
+class TestEPSFBuildResults:
     """
-    Tests for the EPSFBuildResult class.
+    Tests for the EPSFBuildResults class.
     """
 
     def test_creation(self):
         """
-        Test EPSFBuildResult creation.
+        Test EPSFBuildResults creation.
         """
         # Create a simple PSF model for testing
         data = np.ones((5, 5))
@@ -642,7 +642,7 @@ class TestEPSFBuildResult:
         # Create stars list (can be empty for this test)
         stars = []
 
-        result = EPSFBuildResult(
+        result = EPSFBuildResults(
             epsf=psf,
             fitted_stars=stars,
             iterations=5,
@@ -658,7 +658,7 @@ class TestEPSFBuildResult:
 
     def test_with_data(self, epsf_test_data):
         """
-        Test EPSFBuildResult with actual data.
+        Test EPSFBuildResults with actual data.
         """
         stars = extract_stars(epsf_test_data['nddata'],
                               epsf_test_data['init_stars'][:5], size=11)
@@ -666,7 +666,7 @@ class TestEPSFBuildResult:
         builder = EPSFBuilder(oversampling=1, maxiters=2, progress_bar=False)
         epsf, fitted_stars = builder(stars)
 
-        result = EPSFBuildResult(
+        result = EPSFBuildResults(
             epsf=epsf,
             fitted_stars=fitted_stars,
             iterations=2,
@@ -682,13 +682,13 @@ class TestEPSFBuildResult:
 
     def test_getitem_invalid_index(self):
         """
-        Test EPSFBuildResult.__getitem__ with invalid index.
+        Test EPSFBuildResults.__getitem__ with invalid index.
         """
         data = np.ones((5, 5))
         psf = ImagePSF(data)
         stars = EPSFStars([])
 
-        result = EPSFBuildResult(
+        result = EPSFBuildResults(
             epsf=psf,
             fitted_stars=stars,
             iterations=5,
@@ -703,7 +703,7 @@ class TestEPSFBuildResult:
         assert result[1] is stars
 
         # Invalid index
-        match = 'EPSFBuildResult index must be 0'
+        match = 'EPSFBuildResults index must be 0'
         with pytest.raises(IndexError, match=match):
             result[2]
 
@@ -712,13 +712,13 @@ class TestEPSFBuildResult:
 
     def test_iteration(self):
         """
-        Test EPSFBuildResult iteration (tuple unpacking).
+        Test EPSFBuildResults iteration (tuple unpacking).
         """
         data = np.ones((5, 5))
         psf = ImagePSF(data)
         stars = EPSFStars([])
 
-        result = EPSFBuildResult(
+        result = EPSFBuildResults(
             epsf=psf,
             fitted_stars=stars,
             iterations=5,
@@ -741,7 +741,7 @@ class TestEPSFBuildResult:
 
     def test_attributes(self, epsf_test_data):
         """
-        Test EPSFBuildResult has all expected attributes.
+        Test EPSFBuildResults has all expected attributes.
         """
         builder = EPSFBuilder(oversampling=1, maxiters=3, progress_bar=False)
 
@@ -758,6 +758,22 @@ class TestEPSFBuildResult:
         assert isinstance(result.final_center_accuracy, (float, np.floating))
         assert isinstance(result.n_excluded_stars, int)
         assert isinstance(result.excluded_star_indices, list)
+
+    def test_deprecated_name(self):
+        """
+        Test that the old EPSFBuildResult name is a deprecated alias.
+        """
+        from photutils import psf
+        from photutils.psf import epsf_builder
+
+        match = 'EPSFBuildResult is deprecated'
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            cls = psf.EPSFBuildResult
+        assert cls is EPSFBuildResults
+
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            cls = epsf_builder.EPSFBuildResult
+        assert cls is EPSFBuildResults
 
 
 class TestEPSFFitter:


### PR DESCRIPTION
The ``EPSFBuildResult`` class returned by ``EPSFBuilder`` has been renamed to ``EPSFBuildResults``.  While technically an API change, this should not impact users as it's a returned helper class.