### PR TITLE
Add bitwise quality flags for aperture photometry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,18 @@ New Features
     properties. The default is ``ddof=0`` (population variance), and
     ``ddof=1`` gives the sample (unbiased) variance. [#2314]
 
+  - Added per-source bitwise quality flags to aperture photometry
+    and statistics: ``aperture_photometry`` now includes a ``'flags'``
+    column (or ``'flags_<i>'`` columns for multiple apertures) in the
+    returned table, ``PixelAperture.photometry`` results have a new
+    ``flags`` attribute, and ``ApertureStats`` has new ``flags``
+    and ``decode_flags`` attributes. The flags indicate conditions
+    such as apertures that are partially or fully outside the data,
+    masked or non-finite pixels within the aperture, pixels affected
+    by segmentation masking, sigma-clipped pixels, and too few pixels
+    to compute a statistic. A new ``decode_aperture_flags`` function
+    decodes the flag values into human-readable names. [#2327]
+
 - ``photutils.isophote``
 
   - Optimized the ``build_ellipse_model_c`` Cython extension by
@@ -195,6 +207,11 @@ API Changes
     renamed to ``EPSFBuildResults`` for consistency with the new
     ``ApertureResults`` class. The old ``EPSFBuildResult`` name is
     deprecated and will be removed in a future version. [#2326]
+
+  - ``aperture_photometry`` now always includes a ``'flags'`` column
+    (or ``'flags_<i>'`` columns for multiple apertures) in the
+    returned table, and the default ``ApertureStats.to_table()``
+    columns now include ``'flags'``. [#2327]
 
 
 3.0.0 (2026-04-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,15 +73,19 @@ New Features
 
   - Added per-source bitwise quality flags to aperture photometry
     and statistics: ``aperture_photometry`` now includes a ``'flags'``
-    column (or ``'flags_<i>'`` columns for multiple apertures) in the
-    returned table, ``PixelAperture.photometry`` results have a new
-    ``flags`` attribute, and ``ApertureStats`` has new ``flags``
-    and ``decode_flags`` attributes. The flags indicate conditions
-    such as apertures that are partially or fully outside the data,
-    masked or non-finite pixels within the aperture, pixels affected
-    by segmentation masking, sigma-clipped pixels, and too few pixels
-    to compute a statistic. A new ``decode_aperture_flags`` function
-    decodes the flag values into human-readable names. [#2327]
+    column (or ``'flags_<i>'`` columns for multiple apertures)
+    in the returned table, ``PixelAperture.photometry`` results
+    have a new ``flags`` attribute, and ``ApertureStats`` has new
+    ``flags``, ``sum_flags``, and ``decode_flags`` attributes. In
+    ``ApertureStats``, ``flags`` reports the quality flags for the value
+    statistics (the ``'center'``-method footprint) and ``sum_flags``
+    reports the flags for the sum properties (the ``sum_method``
+    footprint). The flags indicate conditions such as apertures that are
+    partially or fully outside the data, masked or non-finite pixels
+    within the aperture, pixels affected by segmentation masking,
+    sigma-clipped pixels, and too few pixels to compute a statistic. A
+    new ``decode_aperture_flags`` function decodes the flag values into
+    human-readable names. [#2327]
 
 - ``photutils.isophote``
 

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -246,23 +246,25 @@ here as an array of all ones::
     >>> phot_table['aperture_sum'].info.format = '%.8g'  # for consistent table output
     >>> phot_table['area'].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err    area
+     id x_center y_center aperture_sum aperture_sum_err    area   flags
                                                            pix2
-    --- -------- -------- ------------ ---------------- ---------
-      1     71.4     23.9    30.190705              nan 30.190705
-      2     42.1     41.7    30.190705              nan 30.190705
-      3     54.6     68.2    30.190705              nan 30.190705
+    --- -------- -------- ------------ ---------------- --------- -----
+      1     71.4     23.9    30.190705              nan 30.190705     0
+      2     42.1     41.7    30.190705              nan 30.190705     0
+      3     54.6     68.2    30.190705              nan 30.190705     0
 
 This function returns the results of the photometry in an Astropy
-`~astropy.table.QTable`. In this example, the table has six columns,
+`~astropy.table.QTable`. In this example, the table has seven columns,
 named ``'id'``, ``'x_center'``, ``'y_center'``, ``'aperture_sum'``,
-``'aperture_sum_err'``, and ``'area'``. Because no ``error``
-was input, the ``'aperture_sum_err'`` column is filled with NaN
-values (see :ref:`error_estimation`). The ``'area'`` column
-gives the total unmasked overlap area of the aperture with
-the data (in ``pix**2``). It is equivalent to the aperture
+``'aperture_sum_err'``, ``'area'``, and ``'flags'``. Because no
+``error`` was input, the ``'aperture_sum_err'`` column is filled
+with NaN values (see :ref:`error_estimation`). The ``'area'``
+column gives the total unmasked overlap area of the aperture
+with the data (in ``pix**2``). It is equivalent to the aperture
 :meth:`~photutils.aperture.PixelAperture.area_overlap` method computed
-with the same inputs.
+with the same inputs. The ``'flags'`` column contains bitwise quality
+flags for each aperture (see :ref:`aperture_flags`). A value of 0 means
+that no issues were detected.
 
 Since all the data values are 1.0, the aperture sums are equal to the
 area of a circle with a radius of 3.1::
@@ -311,12 +313,12 @@ by a factor of 5 (``subpixels=5``) in each dimension::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err  area
+     id x_center y_center aperture_sum aperture_sum_err  area flags
                                                          pix2
-    --- -------- -------- ------------ ---------------- -----
-      1     71.4     23.9         30.2              nan  30.2
-      2     42.1     41.7         29.6              nan  29.6
-      3     54.6     68.2        29.96              nan 29.96
+    --- -------- -------- ------------ ---------------- ----- -----
+      1     71.4     23.9         30.2              nan  30.2     0
+      2     42.1     41.7         29.6              nan  29.6     0
+      3     54.6     68.2        29.96              nan 29.96     0
 
 Note that the ``'subpixel'`` sums differ from the exact value of
 30.190705 (see above). They also differ slightly from one another, even
@@ -357,12 +359,12 @@ been calculated and stored in the array ``error``::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err    area
+     id x_center y_center aperture_sum aperture_sum_err    area   flags
                                                            pix2
-    --- -------- -------- ------------ ---------------- ---------
-      1     71.4     23.9    28.274334       0.53173616 28.274334
-      2     42.1     41.7    28.274334       0.53173616 28.274334
-      3     54.6     68.2    28.274334       0.53173616 28.274334
+    --- -------- -------- ------------ ---------------- --------- -----
+      1     71.4     23.9    28.274334       0.53173616 28.274334     0
+      2     42.1     41.7    28.274334       0.53173616 28.274334     0
+      3     54.6     68.2    28.274334       0.53173616 28.274334     0
 
 The ``'aperture_sum_err'`` values are calculated as:
 
@@ -393,12 +395,12 @@ units of electrons/s, we use the exposure time as the effective gain::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err    area
+     id x_center y_center aperture_sum aperture_sum_err    area   flags
                                                            pix2
-    --- -------- -------- ------------ ---------------- ---------
-      1     71.4     23.9    28.274334       0.58248777 28.274334
-      2     42.1     41.7    28.274334       0.58248777 28.274334
-      3     54.6     68.2    28.274334       0.58248777 28.274334
+    --- -------- -------- ------------ ---------------- --------- -----
+      1     71.4     23.9    28.274334       0.58248777 28.274334     0
+      2     42.1     41.7    28.274334       0.58248777 28.274334     0
+      3     54.6     68.2    28.274334       0.58248777 28.274334     0
 
 Note that the ``'aperture_sum_err'`` values are now larger than in the
 previous example because they include the additional Poisson noise from
@@ -431,12 +433,12 @@ that the ``'aperture_sum_err'`` columns are populated::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum_0 aperture_sum_err_0   area_0  aperture_sum_1 aperture_sum_err_1   area_1  aperture_sum_2 aperture_sum_err_2   area_2
-                                                               pix2                                        pix2                                        pix2
-    --- -------- -------- -------------- ------------------ --------- -------------- ------------------ --------- -------------- ------------------ ---------
-      1     71.4     23.9      28.274334         0.58248777 28.274334      50.265482         0.77665037 50.265482      78.539816         0.97081296 78.539816
-      2     42.1     41.7      28.274334         0.58248777 28.274334      50.265482         0.77665037 50.265482      78.539816         0.97081296 78.539816
-      3     54.6     68.2      28.274334         0.58248777 28.274334      50.265482         0.77665037 50.265482      78.539816         0.97081296 78.539816
+     id x_center y_center aperture_sum_0 aperture_sum_err_0   area_0  flags_0 aperture_sum_1 aperture_sum_err_1   area_1  flags_1 aperture_sum_2 aperture_sum_err_2   area_2  flags_2
+                                                               pix2                                                pix2                                                pix2
+    --- -------- -------- -------------- ------------------ --------- ------- -------------- ------------------ --------- ------- -------------- ------------------ --------- -------
+      1     71.4     23.9      28.274334         0.58248777 28.274334       0      50.265482         0.77665037 50.265482       0      78.539816         0.97081296 78.539816       0
+      2     42.1     41.7      28.274334         0.58248777 28.274334       0      50.265482         0.77665037 50.265482       0      78.539816         0.97081296 78.539816       0
+      3     54.6     68.2      28.274334         0.58248777 28.274334       0      50.265482         0.77665037 50.265482       0      78.539816         0.97081296 78.539816       0
 
 When a list of aperture objects is provided, the output table column
 names are appended with the index of the aperture within the input
@@ -457,12 +459,12 @@ size and orientation. For example, an elliptical aperture requires
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err   area
+     id x_center y_center aperture_sum aperture_sum_err   area   flags
                                                           pix2
-    --- -------- -------- ------------ ---------------- --------
-      1     71.4     23.9     47.12389       0.75198848 47.12389
-      2     42.1     41.7     47.12389       0.75198848 47.12389
-      3     54.6     68.2     47.12389       0.75198848 47.12389
+    --- -------- -------- ------------ ---------------- -------- -----
+      1     71.4     23.9     47.12389       0.75198848 47.12389     0
+      2     42.1     41.7     47.12389       0.75198848 47.12389     0
+      3     54.6     68.2     47.12389       0.75198848 47.12389     0
 
 To measure photometry using multiple elliptical apertures, provide a
 list of aperture objects with identical positions, but with different
@@ -477,12 +479,12 @@ list of aperture objects with identical positions, but with different
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum_0 aperture_sum_err_0  area_0  aperture_sum_1 aperture_sum_err_1   area_1  aperture_sum_2 aperture_sum_err_2   area_2
-                                                              pix2                                        pix2                                        pix2
-    --- -------- -------- -------------- ------------------ -------- -------------- ------------------ --------- -------------- ------------------ ---------
-      1     71.4     23.9       47.12389         0.75198848 47.12389      75.398224         0.95119855 75.398224      109.95574          1.1486814 109.95574
-      2     42.1     41.7       47.12389         0.75198848 47.12389      75.398224         0.95119855 75.398224      109.95574          1.1486814 109.95574
-      3     54.6     68.2       47.12389         0.75198848 47.12389      75.398224         0.95119855 75.398224      109.95574          1.1486814 109.95574
+     id x_center y_center aperture_sum_0 aperture_sum_err_0  area_0  flags_0 aperture_sum_1 aperture_sum_err_1   area_1  flags_1 aperture_sum_2 aperture_sum_err_2   area_2  flags_2
+                                                              pix2                                                pix2                                                pix2
+    --- -------- -------- -------------- ------------------ -------- ------- -------------- ------------------ --------- ------- -------------- ------------------ --------- -------
+      1     71.4     23.9       47.12389         0.75198848 47.12389       0      75.398224         0.95119855 75.398224       0      109.95574          1.1486814 109.95574       0
+      2     42.1     41.7       47.12389         0.75198848 47.12389       0      75.398224         0.95119855 75.398224       0      109.95574          1.1486814 109.95574       0
+      3     54.6     68.2       47.12389         0.75198848 47.12389       0      75.398224         0.95119855 75.398224       0      109.95574          1.1486814 109.95574       0
 
 
 Masking Pixels in Aperture Photometry
@@ -588,6 +590,76 @@ the obscured flux::
 
 These keywords are also available in
 :class:`~photutils.aperture.ApertureStats`.
+
+
+.. _aperture_flags:
+
+Aperture Quality Flags
+----------------------
+
+The :func:`~photutils.aperture.aperture_photometry` table
+and the :meth:`~photutils.aperture.PixelAperture.photometry`
+results include bitwise quality flags for each source in a
+``'flags'`` column or attribute. A value of 0 means that no
+issues were detected. The flag values can be decoded using the
+:func:`~photutils.aperture.decode_aperture_flags` function. The flags
+are:
+
+* ``'no_overlap'`` (1): the aperture is fully outside the data (no
+  pixel with nonzero aperture weight falls inside the data)
+* ``'partial_overlap'`` (2): the aperture is partially outside the
+  data (one or more pixels with nonzero aperture weight fall outside
+  the data)
+* ``'no_pixels'`` (4): the aperture contains zero pixels with nonzero
+  weight inside the data (e.g., a fully off-image aperture, or a tiny
+  aperture that contains no pixel centers with the ``'center'`` method)
+* ``'masked_pixels'`` (8): one or more input-masked pixels (``mask``
+  keyword) have nonzero aperture weight
+* ``'all_masked'`` (16): the aperture contains pixels, but none are
+  valid (all are masked or excluded)
+* ``'non_finite_data'`` (32): NaN or inf values are present among the
+  unmasked data values within the aperture
+* ``'non_finite_error'`` (64): NaN or inf values are present among the
+  unmasked error values within the aperture
+* ``'neighbor_pixels'`` (128): one or more pixels were excluded,
+  restricted, or corrected due to neighboring sources in the
+  segmentation image (``mask_method`` keyword)
+* ``'uncorrected_pixels'`` (256): with ``mask_method='correct'``, one
+  or more neighbor pixels could not be corrected and were excluded
+  instead
+
+Multiple conditions combine bitwise. For example, an aperture that
+extends beyond the data edge and also contains a masked pixel has
+``flags = 10`` (2 + 8). Note that ``'no_overlap'`` always implies
+``'no_pixels'`` (bits 1 + 4 = 5).
+
+For example::
+
+    >>> import numpy as np
+    >>> from photutils.aperture import (CircularAperture,
+    ...                                 aperture_photometry,
+    ...                                 decode_aperture_flags)
+    >>> data = np.ones((25, 25))
+    >>> mask = np.zeros(data.shape, dtype=bool)
+    >>> mask[12, 12] = True  # bad pixel inside the first aperture
+    >>> positions = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0)]
+    >>> aperture = CircularAperture(positions, r=3.0)
+    >>> phot_table = aperture_photometry(data, aperture, mask=mask)
+    >>> print(phot_table['flags'])
+    flags
+    -----
+        8
+        2
+        5
+
+The flag values can be decoded into human-readable names::
+
+    >>> decoded = decode_aperture_flags(phot_table['flags'])
+    >>> for source_id, names in zip(phot_table['id'], decoded):
+    ...     print(source_id, names)
+    1 ['masked_pixels']
+    2 ['partial_overlap']
+    3 ['no_overlap', 'no_pixels']
 
 
 .. _photutils-aperture-stats:
@@ -802,12 +874,12 @@ estimation and the aperture photometry)::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err    area
+     id x_center y_center aperture_sum aperture_sum_err    area   flags
                                                            pix2
-    --- -------- -------- ------------ ---------------- ---------
-      1    145.1    168.3    1128.1245       0.88622693 78.539816
-      2     84.5    224.1      735.739       0.88622693 78.539816
-      3     48.3    200.3    1299.6341       0.88622693 78.539816
+    --- -------- -------- ------------ ---------------- --------- -----
+      1    145.1    168.3    1128.1245       0.88622693 78.539816     0
+      2     84.5    224.1      735.739       0.88622693 78.539816     0
+      3     48.3    200.3    1299.6341       0.88622693 78.539816     0
 
 The total background within each source aperture is the mean background
 per pixel multiplied by the aperture area. The aperture area is already
@@ -854,12 +926,12 @@ output table::
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum aperture_sum_err    area   total_bkg aperture_sum_bkgsub
+     id x_center y_center aperture_sum aperture_sum_err    area   flags total_bkg aperture_sum_bkgsub
                                                            pix2
-    --- -------- -------- ------------ ---------------- --------- --------- -------------------
-      1    145.1    168.3    1128.1245       0.88622693 78.539816 392.23708           735.88739
-      2     84.5    224.1      735.739       0.88622693 78.539816  403.2968           332.44219
-      3     48.3    200.3    1299.6341       0.88622693 78.539816 382.40618           917.22792
+    --- -------- -------- ------------ ---------------- --------- ----- --------- -------------------
+      1    145.1    168.3    1128.1245       0.88622693 78.539816     0 392.23708           735.88739
+      2     84.5    224.1      735.739       0.88622693 78.539816     0  403.2968           332.44219
+      3     48.3    200.3    1299.6341       0.88622693 78.539816     0 382.40618           917.22792
 
 
 Sigma-clipped median within a circular annulus

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -597,13 +597,13 @@ These keywords are also available in
 Aperture Quality Flags
 ----------------------
 
-The :func:`~photutils.aperture.aperture_photometry` table
-and the :meth:`~photutils.aperture.PixelAperture.photometry`
-results include bitwise quality flags for each source in a
-``'flags'`` column or attribute. A value of 0 means that no
-issues were detected. The flag values can be decoded using the
-:func:`~photutils.aperture.decode_aperture_flags` function. The flags
-are:
+The :func:`~photutils.aperture.aperture_photometry` table, the
+:meth:`~photutils.aperture.PixelAperture.photometry` results, and the
+:class:`~photutils.aperture.ApertureStats` class include bitwise quality
+flags for each source in a ``'flags'`` column or attribute. A value of 0
+means that no issues were detected. The flag values can be decoded using
+the :func:`~photutils.aperture.decode_aperture_flags` function. The
+flags are:
 
 * ``'no_overlap'`` (1): the aperture is fully outside the data (no
   pixel with nonzero aperture weight falls inside the data)
@@ -627,6 +627,15 @@ are:
 * ``'uncorrected_pixels'`` (256): with ``mask_method='correct'``, one
   or more neighbor pixels could not be corrected and were excluded
   instead
+* ``'sigma_clipped'`` (512): one or more pixels within the aperture
+  were rejected by sigma clipping (`~photutils.aperture.ApertureStats`
+  only)
+* ``'all_clipped'`` (1024): all valid pixels within the aperture were
+  rejected by sigma clipping (`~photutils.aperture.ApertureStats` only)
+* ``'too_few_pixels'`` (2048): too few valid pixels to compute a
+  requested statistic, e.g., the variance and standard deviation are
+  undefined when the number of valid pixels is not larger than ``ddof``
+  (`~photutils.aperture.ApertureStats` only)
 
 Multiple conditions combine bitwise. For example, an aperture that
 extends beyond the data edge and also contains a masked pixel has
@@ -660,6 +669,29 @@ The flag values can be decoded into human-readable names::
     1 ['masked_pixels']
     2 ['partial_overlap']
     3 ['no_overlap', 'no_pixels']
+
+The :class:`~photutils.aperture.ApertureStats` class provides the same
+flags in its :attr:`~photutils.aperture.ApertureStats.flags` property
+(also included in the default ``to_table()`` columns), along with a
+:meth:`~photutils.aperture.ApertureStats.decode_flags` convenience
+method::
+
+    >>> from photutils.aperture import ApertureStats
+    >>> aperstats = ApertureStats(data, aperture, mask=mask)
+    >>> print(aperstats.flags)
+    [8 2 5]
+    >>> for names in aperstats.decode_flags():
+    ...     print(names)
+    ['masked_pixels']
+    ['partial_overlap']
+    ['no_overlap', 'no_pixels']
+
+For `~photutils.aperture.ApertureStats`, the flags are evaluated on
+both the ``'center'``-method footprint used by the value statistics and
+the ``sum_method`` footprint used by the sum properties, and combined
+bitwise. Note that in `~photutils.aperture.ApertureStats` non-finite
+data values are automatically masked, so an aperture containing only NaN
+values has ``flags = 48`` (``'non_finite_data'`` + ``'all_masked'``).
 
 
 .. _photutils-aperture-stats:

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -696,12 +696,22 @@ evaluated on the ``'center'``-method footprint, and includes the
 The :attr:`~photutils.aperture.ApertureStats.sum_flags` property
 reports the flags for the sum properties (``sum``, ``sum_err``, and
 ``sum_aper_area``), evaluated on the ``sum_method`` footprint, and
-includes the ``'non_finite_error'`` flag. Both columns are included
-in the default ``to_table()`` output, and either can be decoded by
-passing ``column='flags'`` (the default) or ``column='sum_flags'``
-to :meth:`~photutils.aperture.ApertureStats.decode_flags`. Note that
-in `~photutils.aperture.ApertureStats` non-finite data values are
-automatically masked, so an aperture containing only NaN values has
+includes the ``'non_finite_error'`` flag. When ``sigma_clip`` is used,
+it is applied independently on each footprint, so the pixels clipped
+for the value statistics may differ from those clipped for the sum
+properties. Only ``flags`` reports whether clipping occurred (via
+the ``'sigma_clipped'``, ``'all_clipped'``, and ``'too_few_pixels'``
+bits); ``sum_flags`` never sets those bits, even though the sum-related
+properties are computed from the sigma-clipped ``sum_method`` footprint.
+
+Both columns are included in the default ``to_table()``
+output, and either can be decoded by passing
+``column='flags'`` (the default) or ``column='sum_flags'`` to
+:meth:`~photutils.aperture.ApertureStats.decode_flags`. To check for
+any quality issue across both footprints, combine the two flag columns
+with a bitwise OR, e.g., ``aperstats.flags | aperstats.sum_flags``.
+Note that in `~photutils.aperture.ApertureStats` non-finite data values
+are automatically masked, so an aperture containing only NaN values has
 ``flags = 48`` (``'non_finite_data'`` + ``'all_masked'``).
 
 
@@ -740,10 +750,13 @@ aperture weights of 0 or 1. This avoids the need to compute weighted
 statistics --- the ``data`` pixel values are directly used.
 
 The ``sum_method`` and ``subpixels`` keywords are used to determine
-the aperture-mask method when calculating the sum-related properties:
-``sum``, ``sum_error``, ``sum_aper_area``, ``data_sum_cutout``, and
-``error_sum_cutout``. The default is ``sum_method='exact'``, which
-produces exact aperture-weighted photometry.
+the aperture-mask method only for the sum-related properties:
+``sum``, ``sum_err``, ``sum_aper_area``, ``data_sum_cutout``, and
+``error_sum_cutout``. All other properties, including ``mean``,
+``median``, ``std``, and the morphological properties, always use the
+"center" aperture-mask method regardless of ``sum_method``. The default
+is ``sum_method='exact'``, which produces exact aperture-weighted
+photometry.
 
 The optional ``local_bkg`` keyword can be used to input the per-pixel
 local background of each source, which will be subtracted before
@@ -752,7 +765,11 @@ computing the aperture statistics.
 The optional ``sigma_clip`` keyword can be used to sigma clip the pixel
 values before computing the source properties. This keyword could be
 used, for example, to compute a sigma-clipped median of pixels in an
-annulus aperture to estimate the local background level.
+annulus aperture to estimate the local background level. Sigma clipping
+is applied independently on the "center" and ``sum_method`` footprints
+described above, so the sum-related properties are also computed from
+sigma-clipped data; see :ref:`aperture_flags` for how this affects the
+``flags`` and ``sum_flags`` properties.
 
 Here is a simple example using a circular aperture at one position.
 Note that like :func:`~photutils.aperture.aperture_photometry`,

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -686,12 +686,23 @@ method::
     ['partial_overlap']
     ['no_overlap', 'no_pixels']
 
-For `~photutils.aperture.ApertureStats`, the flags are evaluated on
-both the ``'center'``-method footprint used by the value statistics and
-the ``sum_method`` footprint used by the sum properties, and combined
-bitwise. Note that in `~photutils.aperture.ApertureStats` non-finite
-data values are automatically masked, so an aperture containing only NaN
-values has ``flags = 48`` (``'non_finite_data'`` + ``'all_masked'``).
+For `~photutils.aperture.ApertureStats`, the value statistics
+and the sum properties are measured on two different
+footprints, so they have separate flag columns. The
+:attr:`~photutils.aperture.ApertureStats.flags` property reports the
+flags for the value statistics (e.g., ``mean``, ``median``, ``std``),
+evaluated on the ``'center'``-method footprint, and includes the
+``'sigma_clipped'``, ``'all_clipped'``, and ``'too_few_pixels'`` flags.
+The :attr:`~photutils.aperture.ApertureStats.sum_flags` property
+reports the flags for the sum properties (``sum``, ``sum_err``, and
+``sum_aper_area``), evaluated on the ``sum_method`` footprint, and
+includes the ``'non_finite_error'`` flag. Both columns are included
+in the default ``to_table()`` output, and either can be decoded by
+passing ``column='flags'`` (the default) or ``column='sum_flags'``
+to :meth:`~photutils.aperture.ApertureStats.decode_flags`. Note that
+in `~photutils.aperture.ApertureStats` non-finite data values are
+automatically masked, so an aperture containing only NaN values has
+``flags = 48`` (``'non_finite_data'`` + ``'all_masked'``).
 
 
 .. _photutils-aperture-stats:

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -307,6 +307,60 @@ Example of using the new segmentation-based masking::
     ...                            labels=1, mask_method='mask')
 
 
+.. _whatsnew-3.1-aperture-flags:
+
+Aperture Photometry Quality Flags
+=================================
+
+Aperture photometry and statistics now provide
+per-source bitwise quality flags, unified across
+`~photutils.aperture.aperture_photometry` (a new ``'flags'`` table
+column), `~photutils.aperture.PixelAperture.photometry` (a new ``flags``
+result attribute), and `~photutils.aperture.ApertureStats` (a new
+:attr:`~photutils.aperture.ApertureStats.flags` property, included in
+the default ``to_table()`` columns). A flag value of 0 means that no
+issues were detected. The flags indicate conditions such as:
+
+* the aperture is partially (``'partial_overlap'``) or fully
+  (``'no_overlap'``) outside the data
+* the aperture contains no pixels with nonzero weight
+  (``'no_pixels'``)
+* input-masked pixels within the aperture (``'masked_pixels'``), or
+  no valid pixels at all (``'all_masked'``)
+* non-finite data or error values within the aperture
+  (``'non_finite_data'``, ``'non_finite_error'``)
+* pixels excluded or corrected due to neighboring sources in a
+  segmentation image (``'neighbor_pixels'``, ``'uncorrected_pixels'``)
+* sigma-clipped pixels within the aperture (``'sigma_clipped'``,
+  ``'all_clipped'``) and too few pixels to compute a statistic
+  (``'too_few_pixels'``) in `~photutils.aperture.ApertureStats`
+
+The overlap flags are precise. They are based on the pixels with
+nonzero aperture weight, not simply the aperture bounding box. The new
+:func:`~photutils.aperture.decode_aperture_flags` function and the
+:meth:`~photutils.aperture.ApertureStats.decode_flags` method decode
+flag values into human-readable names::
+
+    >>> import numpy as np
+    >>> from photutils.aperture import (CircularAperture,
+    ...                                 aperture_photometry,
+    ...                                 decode_aperture_flags)
+    >>> data = np.ones((25, 25))
+    >>> mask = np.zeros(data.shape, dtype=bool)
+    >>> mask[12, 12] = True  # bad pixel inside the first aperture
+    >>> positions = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0)]
+    >>> aperture = CircularAperture(positions, r=3.0)
+    >>> phot = aperture_photometry(data, aperture, mask=mask)
+    >>> decoded = decode_aperture_flags(phot['flags'])
+    >>> for source_id, names in zip(phot['id'], decoded):
+    ...     print(source_id, names)
+    1 ['masked_pixels']
+    2 ['partial_overlap']
+    3 ['no_overlap', 'no_pixels']
+
+See :ref:`aperture_flags` for more details.
+
+
 ``GriddedPSFModel`` Performance Improvements
 ============================================
 
@@ -315,8 +369,8 @@ typical performance improvements of approximately 20–25%. The
 optimizations reduce the overhead of PSF interpolation, improving the
 runtime of PSF photometry workflows.
 
-
 .. _whatsnew-3.1-api-changes:
+
 
 API Changes
 ===========
@@ -363,6 +417,16 @@ remains backward compatible: it can still be unpacked as a 2-tuple
 ``len()`` and integer indexing like the legacy tuple. The new ``area``
 attribute provides the total unmasked overlap area of each aperture (in
 ``pix**2``).
+
+
+Aperture Photometry Flags Column
+--------------------------------
+
+`~photutils.aperture.aperture_photometry` now always includes
+a ``'flags'`` column (or ``'flags_<i>'`` columns for
+multiple apertures) in the returned table, and the default
+`photutils.aperture.ApertureStats.to_table` columns now include
+``'flags'``. See :ref:`whatsnew-3.1-aperture-flags` for details.
 
 
 .. _whatsnew-3.1-deprecations:

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -315,11 +315,16 @@ Aperture Photometry Quality Flags
 Aperture photometry and statistics now provide
 per-source bitwise quality flags, unified across
 `~photutils.aperture.aperture_photometry` (a new ``'flags'`` table
-column), `~photutils.aperture.PixelAperture.photometry` (a new ``flags``
-result attribute), and `~photutils.aperture.ApertureStats` (a new
-:attr:`~photutils.aperture.ApertureStats.flags` property, included in
-the default ``to_table()`` columns). A flag value of 0 means that no
-issues were detected. The flags indicate conditions such as:
+column), `~photutils.aperture.PixelAperture.photometry` (a new
+``flags`` result attribute), and `~photutils.aperture.ApertureStats`
+(new :attr:`~photutils.aperture.ApertureStats.flags`
+and :attr:`~photutils.aperture.ApertureStats.sum_flags`
+properties, included in the default ``to_table()`` columns). In
+`~photutils.aperture.ApertureStats`, ``flags`` reports the flags for the
+value statistics (the ``'center'``-method footprint) and ``sum_flags``
+reports the flags for the sum properties (the ``sum_method`` footprint).
+A flag value of 0 means that no issues were detected. The flags indicate
+conditions such as:
 
 * the aperture is partially (``'partial_overlap'``) or fully
   (``'no_overlap'``) outside the data

--- a/photutils/aperture/__init__.py
+++ b/photutils/aperture/__init__.py
@@ -8,6 +8,7 @@ from .circle import *  # noqa: F401, F403
 from .converters import *  # noqa: F401, F403
 from .core import *  # noqa: F401, F403
 from .ellipse import *  # noqa: F401, F403
+from .flags import *  # noqa: F401, F403
 from .mask import *  # noqa: F401, F403
 from .photometry import *  # noqa: F401, F403
 from .polygon import *  # noqa: F401, F403

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -38,6 +38,8 @@ cdef extern from "math.h" nogil:
     double sin(double x)
     double cos(double x)
     double fabs(double x)
+    double ceil(double x)
+    bint isfinite(double x)
 
 # Python-level aliases of the shape codes (the ``cdef enum`` is shared
 # with ``_batch_stats`` via ``_batch_overlap.pxd``)
@@ -48,6 +50,18 @@ SHAPE_ELLIPTICAL_ANNULUS = _ELLIPTICAL_ANNULUS
 SHAPE_RECTANGLE = _RECTANGLE
 SHAPE_RECTANGULAR_ANNULUS = _RECTANGULAR_ANNULUS
 SHAPE_POLYGON = _POLYGON
+
+# Column indices of the per-source ``flag_counts`` arrays returned by
+# the batch drivers (see ``batch_aperture_sums`` and
+# ``photutils.aperture._batch_stats.batch_aperture_gather``)
+FLAG_COL_NPIX = 0
+FLAG_COL_MASKED = 1
+FLAG_COL_NONFINITE_DATA = 2
+FLAG_COL_NONFINITE_ERROR = 3
+FLAG_COL_SEG = 4
+FLAG_COL_UNCORRECTED = 5
+FLAG_COL_VALID = 6
+FLAG_COL_BBOX_CLIPPED = 7
 
 
 def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
@@ -82,7 +96,10 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
     mask : 2D ndarray of uint8 (C-contiguous) or `None`
         A mask array where nonzero values indicate masked (excluded)
-        pixels. Must have the same shape as ``data``.
+        pixels. Must have the same shape as ``data``. For the flag
+        counts, bit 1 (value 1) marks input-masked pixels and bit 2
+        (value 2) marks non-finite data pixels folded into the mask by
+        the caller. Any nonzero value excludes the pixel.
 
     positions : 2D ndarray of float64 (C-contiguous)
         The (x, y) source positions with shape ``(n_sources, 2)``.
@@ -193,6 +210,36 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     sum_counts : 1D ndarray of intp
         The per-source count of packed contributing pixels. Empty
         unless ``emit_sum`` is nonzero.
+
+    flag_counts : 2D ndarray of intp
+        Per-source pixel counts for the quality flags, with one row per
+        source and the columns given by the module-level ``FLAG_COL_*``
+        constants:
+
+        * ``FLAG_COL_NPIX``: the number of nonzero-fraction pixels
+          inside the data
+        * ``FLAG_COL_MASKED``: the number of those pixels that are
+          input-masked
+        * ``FLAG_COL_NONFINITE_DATA``: the number of those pixels that
+          are non-finite in the data (masked or unmasked)
+        * ``FLAG_COL_NONFINITE_ERROR``: the number of those pixels that
+          are non-finite in the error (masked or unmasked)
+        * ``FLAG_COL_SEG``: the number of those pixels that were
+          excluded or corrected by the segmentation masking
+        * ``FLAG_COL_UNCORRECTED``: the number of those pixels that
+          could not be corrected by the segmentation masking
+        * ``FLAG_COL_VALID``: the number of contributing pixels
+          (unmasked, finite, and not excluded by segmentation)
+        * ``FLAG_COL_BBOX_CLIPPED``: a 0/1 indicator of whether the
+          bounding box is clipped by a data edge
+
+        The ``FLAG_COL_NONFINITE_DATA`` and ``FLAG_COL_NONFINITE_ERROR``
+        columns are nonzero when non-finite data or error values
+        contribute to the aperture. Pixels marked non-finite in the mask
+        plane (bit 2) are counted exactly, while unmasked non-finite
+        contributions are detected from the accumulated sums as a 0/1
+        indicator. Rows are all zero where the aperture bounding box
+        does not overlap the data.
     """
     cdef Py_ssize_t n_src = positions.shape[0]
     cdef Py_ssize_t ny_data = data.shape[0]
@@ -203,11 +250,13 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     areas_arr = np.full(n_src, np.nan)
     overlap_arr = np.zeros(n_src, dtype=np.uint8)
     starts_arr = np.zeros(n_src, dtype=np.intp)
+    fcounts_arr = np.zeros((n_src, 8), dtype=np.intp)
     cdef double[::1] sums = sums_arr
     cdef double[::1] sum_vars = vars_arr
     cdef double[::1] areas = areas_arr
     cdef unsigned char[::1] overlap = overlap_arr
     cdef Py_ssize_t[::1] starts = starts_arr
+    cdef Py_ssize_t[:, ::1] fcounts = fcounts_arr
 
     cdef bint has_error = error is not None
     cdef bint has_mask = mask is not None
@@ -338,6 +387,10 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     cdef double pxmin, pymin, frac, err_val, sum_val, var_val, area_val, val
     cdef double errsq = 0.0
     cdef Py_ssize_t total = 0, spos = 0
+    cdef Py_ssize_t n_pix, n_masked, n_nonfin, n_nonfin_err
+    cdef Py_ssize_t n_seg_px, n_uncorr, n_valid, w_out
+    cdef Py_ssize_t ixmax_full, iymax_full
+    cdef unsigned char mbits
 
     # Pass 1 (only when emitting the packed member buffers): size and
     # offset the packed buffers from the per-source clipped bounding-box
@@ -384,38 +437,17 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             sum_val = 0.0
             var_val = 0.0
             area_val = 0.0
+            n_pix = 0
+            n_masked = 0
+            n_nonfin = 0
+            n_nonfin_err = 0
+            n_seg_px = 0
+            n_uncorr = 0
+            n_valid = 0
             spos = starts[k]
             for iy in range(iy0, iy1):
                 pymin = gymin + (iy - iymin) * dy
                 for ix in range(ix0, ix1):
-                    if has_mask and mask[iy, ix]:
-                        continue
-                    six = ix
-                    siy = iy
-                    if has_seg and lbl != 0:
-                        seg_val = segmentation[iy, ix]
-                        if seg_method == 1:
-                            if seg_val != 0 and seg_val != lbl:
-                                continue
-                        elif seg_method == 2:
-                            if seg_val != lbl:
-                                continue
-                        elif seg_method == 3:
-                            if seg_val != 0 and seg_val != lbl:
-                                # Neighbor pixel: replace its value with
-                                # the pixel mirrored across the center.
-                                xm = 2 * ccx - ix
-                                ym = 2 * ccy - iy
-                                if (xm < ix0 or xm >= ix1
-                                        or ym < iy0 or ym >= iy1):
-                                    continue
-                                mseg = segmentation[ym, xm]
-                                if mseg != 0 and mseg != lbl:
-                                    continue
-                                if has_mask and mask[ym, xm]:
-                                    continue
-                                six = xm
-                                siy = ym
                     pxmin = gxmin + (ix - ixmin) * dx
 
                     if shape_code == _CIRCLE:
@@ -465,19 +497,90 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                     # mask-based path (via ``np.maximum``) and the batch
                     # overlap functions clamp such fractions to zero, so
                     # only strictly positive fractions contribute here.
-                    if frac > 0.0:
-                        val = data[siy, six] - lbk
-                        sum_val += val * frac
-                        area_val += frac
-                        if has_error:
-                            err_val = error[siy, six]
-                            errsq = err_val * err_val
-                            var_val += errsq * frac
-                        if emit_sum:
-                            sum_values[spos] = val
-                            sum_fracs[spos] = frac
-                            sum_errsq[spos] = errsq if has_error else 0.0
-                            spos += 1
+                    if frac <= 0.0:
+                        continue
+                    n_pix += 1
+
+                    if has_mask:
+                        mbits = mask[iy, ix]
+                        if mbits & 1:
+                            n_masked += 1
+                            continue
+                        if mbits & 2:
+                            n_nonfin += 1
+                            continue
+                    six = ix
+                    siy = iy
+                    if has_seg and lbl != 0:
+                        seg_val = segmentation[iy, ix]
+                        if seg_method == 1:
+                            if seg_val != 0 and seg_val != lbl:
+                                n_seg_px += 1
+                                continue
+                        elif seg_method == 2:
+                            if seg_val != lbl:
+                                # Only neighbor-source pixels (not
+                                # background pixels) count toward the
+                                # neighbor-pixels flag.
+                                if seg_val != 0:
+                                    n_seg_px += 1
+                                continue
+                        elif seg_method == 3:
+                            if seg_val != 0 and seg_val != lbl:
+                                # Neighbor pixel: replace its value with
+                                # the pixel mirrored across the center.
+                                n_seg_px += 1
+                                xm = 2 * ccx - ix
+                                ym = 2 * ccy - iy
+                                if (xm < ix0 or xm >= ix1
+                                        or ym < iy0 or ym >= iy1):
+                                    n_uncorr += 1
+                                    continue
+                                mseg = segmentation[ym, xm]
+                                if mseg != 0 and mseg != lbl:
+                                    n_uncorr += 1
+                                    continue
+                                if has_mask and mask[ym, xm]:
+                                    n_uncorr += 1
+                                    continue
+                                six = xm
+                                siy = ym
+
+                    val = data[siy, six] - lbk
+                    n_valid += 1
+                    sum_val += val * frac
+                    area_val += frac
+                    if has_error:
+                        err_val = error[siy, six]
+                        errsq = err_val * err_val
+                        var_val += errsq * frac
+                    if emit_sum:
+                        sum_values[spos] = val
+                        sum_fracs[spos] = frac
+                        sum_errsq[spos] = errsq if has_error else 0.0
+                        spos += 1
+
+            # Unmasked non-finite data or error values corrupt the
+            # accumulated sums, so their presence is detected from the
+            # final sums (avoiding per-pixel finiteness tests in the hot
+            # loop). Non-finite pixels folded into the mask plane (bit
+            # 2) are counted exactly in the masked branch above.
+            if not isfinite(sum_val):
+                n_nonfin += 1
+            if has_error and not isfinite(var_val):
+                n_nonfin_err += 1
+
+            # Whether the bounding box is clipped by a data edge. The
+            # caller resolves this to the precise outside-weight test
+            # (nonzero aperture weights outside the data) only for
+            # these sources; unclipped interior sources are exactly 0.
+            ixmax_full = <Py_ssize_t>ceil(cx + ext_x + 0.5)
+            iymax_full = <Py_ssize_t>ceil(cy + ext_y + 0.5)
+            if (ixmin < ix0 or ixmax_full > ix1
+                    or iymin < iy0 or iymax_full > iy1):
+                w_out = 1  # bounding box clipped by data edge
+            else:
+                w_out = 0  # bounding box fully inside data
 
             sums[k] = sum_val
             areas[k] = area_val
@@ -485,7 +588,15 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                 sum_vars[k] = var_val
             if emit_sum:
                 scounts[k] = spos - starts[k]
+            fcounts[k, 0] = n_pix
+            fcounts[k, 1] = n_masked
+            fcounts[k, 2] = n_nonfin
+            fcounts[k, 3] = n_nonfin_err
+            fcounts[k, 4] = n_seg_px
+            fcounts[k, 5] = n_uncorr
+            fcounts[k, 6] = n_valid
+            fcounts[k, 7] = w_out
 
     return (sums_arr, vars_arr, areas_arr, overlap_arr.view(bool),
             starts_arr, sum_values_arr, sum_fracs_arr, sum_errsq_arr,
-            scounts_arr)
+            scounts_arr, fcounts_arr)

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -44,6 +44,7 @@ cdef extern from "math.h" nogil:
     double cos(double x)
     double sqrt(double x)
     double fabs(double x)
+    double ceil(double x)
     const double NAN
 
 cdef extern from "stdlib.h" nogil:
@@ -236,6 +237,9 @@ def batch_aperture_gather(const double[:, ::1] data,
     mask : 2D ndarray of uint8 (C-contiguous) or `None`
         A mask array where nonzero values indicate masked pixels. The
         caller must also fold non-finite ``data`` pixels into this mask.
+        For the flag counts, bit 1 (value 1) marks input-masked pixels
+        and bit 2 (value 2) marks non-finite data pixels. Any nonzero
+        value excludes the pixel.
 
     positions : 2D ndarray of float64 (C-contiguous)
         The ``(x, y)`` source positions with shape ``(n_sources, 2)``.
@@ -284,6 +288,30 @@ def batch_aperture_gather(const double[:, ::1] data,
 
     overlap : 1D ndarray of bool
         Whether the aperture bounding box overlaps with the data.
+
+    flag_counts : 2D ndarray of intp
+        Per-source pixel counts for the quality flags, with one row per
+        source and the columns given by the module-level ``FLAG_COL_*``
+        constants in `photutils.aperture._batch_photometry`:
+
+        * ``FLAG_COL_NPIX``: the number of nonzero-fraction pixels
+          inside the data
+        * ``FLAG_COL_MASKED``: the number of those pixels that are
+          input-masked
+        * ``FLAG_COL_NONFINITE_DATA``: the number of those pixels that
+          are non-finite in the data (masked or unmasked)
+        * ``FLAG_COL_NONFINITE_ERROR``: always zero (this function does
+          not read error values)
+        * ``FLAG_COL_SEG``: the number of those pixels that were
+          excluded or corrected by the segmentation masking
+        * ``FLAG_COL_UNCORRECTED``: the number of those pixels that
+          could not be corrected by the segmentation masking
+        * ``FLAG_COL_VALID``: the number of contributing pixels
+          (unmasked, finite, and not excluded by segmentation)
+        * ``FLAG_COL_BBOX_CLIPPED``: a 0/1 indicator of whether the
+          bounding box is clipped by a data edge
+        Rows are all zero where the aperture bounding box does not
+        overlap the data.
     """
     cdef Py_ssize_t n_src = positions.shape[0]
     cdef Py_ssize_t ny_data = data.shape[0]
@@ -297,9 +325,11 @@ def batch_aperture_gather(const double[:, ::1] data,
     starts_arr = np.zeros(n_src, dtype=np.intp)
     counts_arr = np.zeros(n_src, dtype=np.intp)
     overlap_arr = np.zeros(n_src, dtype=np.uint8)
+    fcounts_arr = np.zeros((n_src, 8), dtype=np.intp)
     cdef Py_ssize_t[::1] starts = starts_arr
     cdef Py_ssize_t[::1] counts = counts_arr
     cdef unsigned char[::1] overlap = overlap_arr
+    cdef Py_ssize_t[:, ::1] fcounts = fcounts_arr
 
     # Aperture shape parameters (constant over all source positions)
     cdef double r_in = 0.0, r_out = 0.0
@@ -408,6 +438,9 @@ def batch_aperture_gather(const double[:, ::1] data,
     cdef double dx, dy, pixel_radius, norm
     cdef double pxmin, pymin, cfrac
     cdef Py_ssize_t total = 0, pos
+    cdef Py_ssize_t n_pix, n_masked, n_nonfin, n_seg_px, n_uncorr, w_out
+    cdef Py_ssize_t ixmax_full, iymax_full
+    cdef unsigned char mbits
 
     # Pass 1: size and offset the packed value buffer from the
     # per-source clipped bounding-box areas (an upper bound on the
@@ -453,37 +486,15 @@ def batch_aperture_gather(const double[:, ::1] data,
             # Non-finite ``data`` pixels are folded into ``mask`` by the
             # caller, so pixel values are loaded lazily (only for pixels
             # that actually contribute).
+            n_pix = 0
+            n_masked = 0
+            n_nonfin = 0
+            n_seg_px = 0
+            n_uncorr = 0
             pos = starts[k]
             for iy in range(iy0, iy1):
                 pymin = gymin + (iy - iymin) * dy
                 for ix in range(ix0, ix1):
-                    if has_mask and mask[iy, ix]:
-                        continue
-                    six = ix
-                    siy = iy
-                    if has_seg and lbl != 0:
-                        seg_val = segmentation[iy, ix]
-                        if seg_method == 1:
-                            if seg_val != 0 and seg_val != lbl:
-                                continue
-                        elif seg_method == 2:
-                            if seg_val != lbl:
-                                continue
-                        elif seg_method == 3:
-                            if seg_val != 0 and seg_val != lbl:
-                                xm = 2 * ccx - ix
-                                ym = 2 * ccy - iy
-                                if (xm < ix0 or xm >= ix1
-                                        or ym < iy0 or ym >= iy1):
-                                    continue
-                                mseg = segmentation[ym, xm]
-                                if mseg != 0 and mseg != lbl:
-                                    continue
-                                if has_mask and mask[ym, xm]:
-                                    continue
-                                six = xm
-                                siy = ym
-
                     pxmin = gxmin + (ix - ixmin) * dx
                     if shape_code == _CIRCLE:
                         cfrac = _circle_pixel_frac(
@@ -521,15 +532,81 @@ def batch_aperture_gather(const double[:, ::1] data,
                             is_poly_convex, pbuf_a_x, pbuf_a_y, pbuf_b_x,
                             pbuf_b_y, poly_buf_size, 0, 1)
 
-                    if cfrac > 0.0:
-                        values[pos] = data[siy, six] - lbk
-                        local_x[pos] = <int>(ix - ix0)
-                        local_y[pos] = <int>(iy - iy0)
-                        pos += 1
+                    if cfrac <= 0.0:
+                        continue
+                    n_pix += 1
+
+                    if has_mask:
+                        mbits = mask[iy, ix]
+                        if mbits & 1:
+                            n_masked += 1
+                            continue
+                        if mbits & 2:
+                            n_nonfin += 1
+                            continue
+                    six = ix
+                    siy = iy
+                    if has_seg and lbl != 0:
+                        seg_val = segmentation[iy, ix]
+                        if seg_method == 1:
+                            if seg_val != 0 and seg_val != lbl:
+                                n_seg_px += 1
+                                continue
+                        elif seg_method == 2:
+                            if seg_val != lbl:
+                                # Only neighbor-source pixels (not
+                                # background pixels) count toward the
+                                # neighbor-pixels flag.
+                                if seg_val != 0:
+                                    n_seg_px += 1
+                                continue
+                        elif seg_method == 3:
+                            if seg_val != 0 and seg_val != lbl:
+                                n_seg_px += 1
+                                xm = 2 * ccx - ix
+                                ym = 2 * ccy - iy
+                                if (xm < ix0 or xm >= ix1
+                                        or ym < iy0 or ym >= iy1):
+                                    n_uncorr += 1
+                                    continue
+                                mseg = segmentation[ym, xm]
+                                if mseg != 0 and mseg != lbl:
+                                    n_uncorr += 1
+                                    continue
+                                if has_mask and mask[ym, xm]:
+                                    n_uncorr += 1
+                                    continue
+                                six = xm
+                                siy = ym
+
+                    values[pos] = data[siy, six] - lbk
+                    local_x[pos] = <int>(ix - ix0)
+                    local_y[pos] = <int>(iy - iy0)
+                    pos += 1
             counts[k] = pos - starts[k]
 
+            # Whether the bounding box is clipped by a data edge. The
+            # caller resolves this to the precise outside-weight test
+            # (nonzero aperture weights outside the data) only for these
+            # sources; unclipped interior sources are exactly 0.
+            ixmax_full = <Py_ssize_t>ceil(cx + ext_x + 0.5)
+            iymax_full = <Py_ssize_t>ceil(cy + ext_y + 0.5)
+            if (ixmin < ix0 or ixmax_full > ix1
+                    or iymin < iy0 or iymax_full > iy1):
+                w_out = 1  # bounding box clipped by a data edge
+            else:
+                w_out = 0  # bounding box fully inside the data
+
+            fcounts[k, 0] = n_pix
+            fcounts[k, 1] = n_masked
+            fcounts[k, 2] = n_nonfin
+            fcounts[k, 4] = n_seg_px
+            fcounts[k, 5] = n_uncorr
+            fcounts[k, 6] = counts[k]
+            fcounts[k, 7] = w_out
+
     return (values_arr, lx_arr, ly_arr, starts_arr, counts_arr,
-            overlap_arr.view(bool))
+            overlap_arr.view(bool), fcounts_arr)
 
 
 def batch_moments(const double[::1] values, const int[::1] local_x,

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -158,27 +158,37 @@ def make_segmentation_exclusion(mask_method, segmentation_cutout,
     exclude : 2D bool `~numpy.ndarray`
         A boolean mask where `True` indicates a pixel to exclude from
         the photometry.
+
+    affected : 2D bool `~numpy.ndarray`
+        A boolean mask where `True` indicates a pixel excluded,
+        replaced, or excluded-instead-of-replaced due to a neighboring
+        source (i.e., a labeled pixel that is not the target source).
+        Background pixels excluded by the ``'source_only'`` method are
+        not marked. For the ``'correct'`` method, ``exclude`` marks
+        exactly the neighbor pixels that could not be corrected.
     """
     exclude = np.zeros(segmentation_cutout.shape, dtype=bool)
 
     if mask_method == 'none' or label == 0:
-        return data, error, exclude
+        return data, error, exclude, exclude
+
+    neighbor = ((segmentation_cutout > 0)
+                & (segmentation_cutout != label))
 
     if mask_method == 'mask':
-        exclude = (segmentation_cutout > 0) & (segmentation_cutout != label)
-        return data, error, exclude
+        return data, error, neighbor, neighbor
 
     if mask_method == 'source_only':
         exclude = segmentation_cutout != label
-        return data, error, exclude
+        return data, error, exclude, neighbor
 
     # The remaining method is the symmetric 'correct' replacement.
-    return _correct_neighbors(segmentation_cutout, label, data, error,
-                              base_mask, cutout_xycen)
+    return _correct_neighbors(segmentation_cutout, neighbor, data,
+                              error, base_mask, cutout_xycen)
 
 
-def _correct_neighbors(segmentation_cutout, label, data, error, base_mask,
-                       cutout_xycen):
+def _correct_neighbors(segmentation_cutout, neighbor, data, error,
+                       base_mask, cutout_xycen):
     """
     Replace neighbor-source pixels with their values mirrored across the
     aperture center.
@@ -188,7 +198,6 @@ def _correct_neighbors(segmentation_cutout, label, data, error, base_mask,
     photometry instead of being replaced.
     """
     ny, nx = segmentation_cutout.shape
-    neighbor = (segmentation_cutout > 0) & (segmentation_cutout != label)
     exclude = np.zeros(segmentation_cutout.shape, dtype=bool)
 
     data = data.copy()
@@ -226,4 +235,4 @@ def _correct_neighbors(segmentation_cutout, label, data, error, base_mask,
     if error is not None:
         error[gy, gx] = error[gmy, gmx]
 
-    return data, error, exclude
+    return data, error, exclude, neighbor

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -16,11 +16,19 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
 
-from photutils.aperture._batch_photometry import batch_aperture_sums
+from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
+                                                  FLAG_COL_MASKED,
+                                                  FLAG_COL_NONFINITE_DATA,
+                                                  FLAG_COL_NONFINITE_ERROR,
+                                                  FLAG_COL_NPIX, FLAG_COL_SEG,
+                                                  FLAG_COL_UNCORRECTED,
+                                                  FLAG_COL_VALID,
+                                                  batch_aperture_sums)
 from photutils.aperture._segmentation import (SEG_METHOD_CODES,
                                               make_segmentation_exclusion,
                                               process_segmentation_inputs)
 from photutils.aperture.bounding_box import BoundingBox
+from photutils.aperture.flags import APERTURE_FLAGS, _counts_to_flag_bits
 from photutils.aperture.mask import ApertureMask
 from photutils.utils._deprecation import (deprecated,
                                           deprecated_positional_kwargs)
@@ -105,6 +113,14 @@ mask_method : {'none', 'mask', 'source_only', 'correct'}, optional
       values of the pixels mirrored across the aperture center. If a
       mirror pixel is unavailable, the pixel is excluded."""
 
+# Bullet list of the aperture quality flags, generated from the central
+# flag registry, used in docstrings via the ``flag_descriptions``
+# placeholder.
+_FLAG_DESCRIPTIONS_DOC = '\n'.join(
+    f"* ``'{flag_def.name}'`` : bit {flag_def.bit_value}, "
+    f'{flag_def.description}'
+    for flag_def in APERTURE_FLAGS.FLAG_DEFINITIONS)
+
 # Mapping of placeholder tags to their replacement text. Each tag must
 # appear alone on its own line in a docstring; the leading indentation
 # of the placeholder is applied to the inserted text.
@@ -113,6 +129,7 @@ _DOC_PLACEHOLDERS = {
     'method_bullets': _METHOD_BULLETS,
     'subpixels_description': _SUBPIXELS_DOC,
     'segmentation_descriptions': _SEGMENTATION_DOC,
+    'flag_descriptions': _FLAG_DESCRIPTIONS_DOC,
 }
 
 _DOC_PLACEHOLDER_RE = re.compile(
@@ -167,7 +184,7 @@ class ApertureResults:
 
     For backward compatibility, this object can still be unpacked as a
     2-tuple, ``aperture_sum, aperture_sum_err = aper.photometry(...)``.
-    Use the named attributes to access ``area``.
+    Use the named attributes to access ``area`` and ``flags``.
 
     Attributes
     ----------
@@ -179,11 +196,16 @@ class ApertureResults:
 
     area : `~astropy.units.Quantity`
         The total unmasked overlap area of each aperture (in pix**2).
+
+    flags : `~numpy.ndarray`
+        The bitwise quality flags for each aperture. See
+        `~photutils.aperture.decode_aperture_flags` for decoding.
     """
 
     aperture_sum: np.ndarray
     aperture_sum_err: np.ndarray
     area: np.ndarray
+    flags: np.ndarray
 
     def __iter__(self):
         # Legacy 2-tuple unpacking only.
@@ -657,6 +679,18 @@ class PixelAperture(Aperture):
         -------
         aperture_sums, aperture_sum_errs, areas : `~numpy.ndarray`
             The aperture sums, errors, and total unmasked overlap areas.
+
+        flag_counts : `~numpy.ndarray`
+            The per-source pixel counts for the quality flags, with one
+            row per source and the columns given by the ``FLAG_COL_*``
+            constants in `photutils.aperture._batch_photometry`,
+            with semantics identical to the batch driver (the
+            ``FLAG_COL_BBOX_CLIPPED`` column is a candidate indicator
+            resolved by the caller, and the non-finite columns are 0/1
+            indicators).
+
+        overlap : `~numpy.ndarray` (bool)
+            Whether the aperture bounding box overlaps the data.
         """
         apermasks = self.to_mask(method=method, subpixels=subpixels)
         if self.isscalar:
@@ -664,9 +698,12 @@ class PixelAperture(Aperture):
 
         positions = np.atleast_2d(self.positions)
 
+        n_src = len(apermasks)
         aperture_sums = []
         aperture_sum_errs = []
         areas = []
+        flag_counts = np.zeros((n_src, 8), dtype=np.intp)
+        overlap = np.zeros(n_src, dtype=bool)
         with warnings.catch_warnings():
             # Ignore multiplication with non-finite data values
             warnings.simplefilter('ignore', RuntimeWarning)
@@ -684,6 +721,16 @@ class PixelAperture(Aperture):
                     areas.append(np.nan)
                     continue
 
+                overlap[idx] = True
+                weighted = aper_weights > 0
+                w_in = np.count_nonzero(weighted)
+                flag_counts[idx, FLAG_COL_NPIX] = w_in
+                flag_counts[idx, FLAG_COL_BBOX_CLIPPED] = (
+                    aper_weights.shape != apermask.data.shape)
+                if mask is not None:
+                    flag_counts[idx, FLAG_COL_MASKED] = np.count_nonzero(
+                        weighted & mask[slc_large])
+
                 data_cutout = data[slc_large]
                 error_cutout = None if error is None else error[slc_large]
 
@@ -692,12 +739,27 @@ class PixelAperture(Aperture):
                     base_mask = None if mask is None else mask[slc_large]
                     cutout_xycen = (positions[idx, 0] - slc_large[1].start,
                                     positions[idx, 1] - slc_large[0].start)
-                    (data_cutout, error_cutout,
-                     exclude) = make_segmentation_exclusion(
+                    (data_cutout, error_cutout, exclude,
+                     affected) = make_segmentation_exclusion(
                         mask_method, segm_cutout, labels[idx],
                         data=data_cutout, error=error_cutout,
                         base_mask=base_mask, cutout_xycen=cutout_xycen)
+                    flag_counts[idx, FLAG_COL_SEG] = np.count_nonzero(
+                        affected & pixel_mask)
+                    if mask_method == 'correct':
+                        # In 'correct' mode, the excluded pixels are
+                        # exactly the uncorrectable neighbor pixels
+                        flag_counts[idx, FLAG_COL_UNCORRECTED] = (
+                            np.count_nonzero(exclude & pixel_mask))
                     pixel_mask = pixel_mask & ~exclude
+
+                flag_counts[idx, FLAG_COL_VALID] = np.count_nonzero(
+                    pixel_mask)
+                flag_counts[idx, FLAG_COL_NONFINITE_DATA] = np.any(
+                    ~np.isfinite(data_cutout) & pixel_mask)
+                if error is not None:
+                    flag_counts[idx, FLAG_COL_NONFINITE_ERROR] = np.any(
+                        ~np.isfinite(error_cutout) & pixel_mask)
 
                 values = (data_cutout * aper_weights)[pixel_mask]
                 aperture_sums.append(values.sum())
@@ -710,7 +772,7 @@ class PixelAperture(Aperture):
                     aperture_sum_errs.append(np.nan)
 
         return (np.array(aperture_sums), np.array(aperture_sum_errs),
-                np.array(areas))
+                np.array(areas), flag_counts, overlap)
 
     def _batch_shape_params(self):
         """
@@ -766,10 +828,16 @@ class PixelAperture(Aperture):
         Returns
         -------
         result : tuple of `~numpy.ndarray` or `None`
-            A ``(aperture_sums, aperture_sum_errs, areas)`` tuple of
-            float64 arrays, or `None` if the batch driver does not
-            support this aperture or these inputs (in which case the
-            caller should use the mask-based code path).
+            A ``(aperture_sums, aperture_sum_errs, areas, flag_counts,
+            overlap)`` tuple, or `None` if the batch driver does not
+            support this aperture or these inputs (in which case
+            the caller should use the mask-based code path). The
+            ``flag_counts`` columns are given by the ``FLAG_COL_*``
+            constants in `photutils.aperture._batch_photometry`; on this
+            code path the ``FLAG_COL_BBOX_CLIPPED`` column is only a
+            candidate indicator (bounding box clipped by a data edge)
+            that the caller must resolve to the precise outside-weight
+            test (see `_resolve_outside_weights`).
         """
         # Use the batch driver only if the aperture's own class defines
         # the _batch_shape_params hook. Subclasses that do not define
@@ -811,7 +879,7 @@ class PixelAperture(Aperture):
             error = np.ascontiguousarray(error, dtype=np.float64)
         ext_x, ext_y = self._xy_extents
 
-        sums, sum_var, area, _overlap, *_ = batch_aperture_sums(
+        sums, sum_var, area, overlap, *_, fcounts = batch_aperture_sums(
             np.ascontiguousarray(data, dtype=np.float64), error, mask,
             np.ascontiguousarray(self._positions, dtype=np.float64),
             shape_code, np.array(params, dtype=np.float64),
@@ -826,7 +894,7 @@ class PixelAperture(Aperture):
         else:
             errs = np.sqrt(sum_var)
 
-        return sums, errs, area
+        return sums, errs, area, fcounts, overlap
 
     @_update_method_subpixels_docstring
     def photometry(self, data, *, error=None, mask=None, method='exact',
@@ -890,6 +958,13 @@ class PixelAperture(Aperture):
                 is equivalent to `area_overlap` computed with the same
                 inputs. The value is ``NaN`` where the aperture does not
                 overlap the data.
+
+            - ``flags`` : `~numpy.ndarray`
+                The bitwise quality flags for each aperture. See
+                `~photutils.aperture.decode_aperture_flags` for decoding
+                flag values. The flags are:
+
+                <flag_descriptions>
         """
         data = np.asanyarray(data)
         if data.ndim != 2:
@@ -929,12 +1004,21 @@ class PixelAperture(Aperture):
             mask_method=mask_method)
 
         if result is not None:
-            aperture_sums, aperture_sum_errs, area = result
+            aperture_sums, aperture_sum_errs, area, fcounts, overlap = result
         else:
-            aperture_sums, aperture_sum_errs, area = self._mask_photometry(
+            (aperture_sums, aperture_sum_errs, area, fcounts,
+             overlap) = self._mask_photometry(
                 data, error=error, mask=mask, method=method,
                 subpixels=subpixels, segmentation=segmentation,
                 labels=labels, mask_method=mask_method)
+
+        # Resolve the precise outside-weight test only for the sources
+        # whose bounding box is clipped by a data edge
+        candidates = fcounts[:, FLAG_COL_BBOX_CLIPPED].astype(bool)
+        w_out = self._resolve_outside_weights(
+            data.shape, method=method, subpixels=subpixels,
+            candidates=candidates)
+        flags = _counts_to_flag_bits(fcounts, overlap, w_out)
 
         # Apply units
         if unit is not None:
@@ -946,7 +1030,8 @@ class PixelAperture(Aperture):
         area <<= (u.pix**2)
 
         return ApertureResults(aperture_sum=aperture_sums,
-                               aperture_sum_err=aperture_sum_errs, area=area)
+                               aperture_sum_err=aperture_sum_errs, area=area,
+                               flags=flags)
 
     @deprecated(since='3.1', alternative='photometry', until='4.0')
     def do_photometry(self, data, error=None, mask=None, method='exact',
@@ -969,6 +1054,55 @@ class PixelAperture(Aperture):
                                subpixels=subpixels,
                                segmentation_image=segmentation_image,
                                labels=labels, mask_method=mask_method)
+
+    def _resolve_outside_weights(self, shape, *, method, subpixels,
+                                 candidates):
+        """
+        Whether each aperture has nonzero mask weights outside the data.
+
+        The precise per-source test is evaluated (via per-source
+        aperture masks) only for the candidate sources, i.e., those
+        whose bounding box is clipped by a data edge; the result is
+        `False` for all other sources. Interior sources are never
+        candidates, so no aperture masks are built for them.
+
+        Parameters
+        ----------
+        shape : tuple of int
+            The shape of the data array.
+
+        method, subpixels
+            See `photometry`.
+
+        candidates : `~numpy.ndarray` (bool)
+            Whether each aperture bounding box is clipped by a data
+            edge.
+
+        Returns
+        -------
+        w_out : `~numpy.ndarray` (bool)
+            Whether each aperture has one or more pixels with nonzero
+            aperture weight outside the data.
+        """
+        w_out = np.zeros(candidates.shape, dtype=bool)
+        idx = np.flatnonzero(candidates)
+        if idx.size == 0:
+            return w_out
+
+        sub = self if self.isscalar else self[idx]
+        apermasks = sub.to_mask(method=method, subpixels=subpixels)
+        if sub.isscalar:
+            apermasks = [apermasks]
+
+        for i, apermask in zip(idx, apermasks, strict=True):
+            n_total = np.count_nonzero(apermask.data)
+            slc_large, slc_small = apermask.get_overlap_slices(shape)
+            if slc_large is None:
+                w_out[i] = n_total > 0
+            else:
+                n_in = np.count_nonzero(apermask.data[slc_small])
+                w_out[i] = n_total > n_in
+        return w_out
 
     @staticmethod
     def _make_annulus_path(patch_inner, patch_outer):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -32,6 +32,7 @@ from photutils.aperture.flags import APERTURE_FLAGS, _counts_to_flag_bits
 from photutils.aperture.mask import ApertureMask
 from photutils.utils._deprecation import (deprecated,
                                           deprecated_positional_kwargs)
+from photutils.utils._flags import define_flag_docstring
 
 __all__ = ['Aperture', 'ApertureResults', 'PixelAperture', 'SkyAperture']
 
@@ -116,10 +117,7 @@ mask_method : {'none', 'mask', 'source_only', 'correct'}, optional
 # Bullet list of the aperture quality flags, generated from the central
 # flag registry, used in docstrings via the ``flag_descriptions``
 # placeholder.
-_FLAG_DESCRIPTIONS_DOC = '\n'.join(
-    f"* ``'{flag_def.name}'`` : bit {flag_def.bit_value}, "
-    f'{flag_def.description}'
-    for flag_def in APERTURE_FLAGS.FLAG_DEFINITIONS)
+_FLAG_DESCRIPTIONS_DOC = '\n'.join(define_flag_docstring(APERTURE_FLAGS))
 
 # Mapping of placeholder tags to their replacement text. Each tag must
 # appear alone on its own line in a docstring; the leading indentation
@@ -199,7 +197,8 @@ class ApertureResults:
 
     flags : `~numpy.ndarray`
         The bitwise quality flags for each aperture. See
-        `~photutils.aperture.decode_aperture_flags` for decoding.
+        `~photutils.aperture.decode_aperture_flags` for decoding flag
+        values.
     """
 
     aperture_sum: np.ndarray

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -1084,6 +1084,15 @@ class PixelAperture(Aperture):
             Whether each aperture has one or more pixels with nonzero
             aperture weight outside the data.
         """
+        # For the 'exact' method the minimal bounding box is tight (the
+        # aperture is tangent to each bbox side), so a bbox that is
+        # clipped by a data edge always leaves a positive-area sliver of
+        # the aperture outside the data. The precise outside-weight test
+        # therefore agrees exactly with the bbox-clipped candidates, and
+        # no per-source aperture masks need to be built.
+        if method == 'exact':
+            return candidates.copy()
+
         w_out = np.zeros(candidates.shape, dtype=bool)
         idx = np.flatnonzero(candidates)
         if idx.size == 0:

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -6,6 +6,8 @@ including centralized flag definitions and decoding utilities.
 
 from typing import ClassVar
 
+import numpy as np
+
 from photutils.utils._flags import (FlagDefinition, FlagRegistry, decode_flags,
                                     update_flag_docstring)
 
@@ -242,3 +244,67 @@ def decode_aperture_flags(flags, *, return_bit_values=False):
     """
     return decode_flags(flags, APERTURE_FLAGS,
                         return_bit_values=return_bit_values)
+
+
+def _counts_to_flag_bits(flag_counts, overlap, w_out):
+    """
+    Map per-source pixel counts to aperture flag bit values.
+
+    Parameters
+    ----------
+    flag_counts : 2D `~numpy.ndarray` (int)
+        The per-source pixel counts, with one row per source and
+        the columns given by the ``FLAG_COL_*`` constants in
+        `photutils.aperture._batch_photometry`. Rows must be all zero
+        for sources whose aperture bounding box does not overlap the
+        data.
+
+    overlap : 1D `~numpy.ndarray` (bool)
+        Whether the aperture bounding box overlaps the data.
+
+    w_out : 1D `~numpy.ndarray` (bool)
+        Whether the aperture has one or more pixels with nonzero
+        aperture weight outside the data.
+
+    Returns
+    -------
+    flags : 1D `~numpy.ndarray` (int)
+        The bitwise quality flags for each source.
+    """
+    # Import here to avoid loading the compiled extension when only the
+    # registry or decoder is needed
+    from photutils.aperture._batch_photometry import (FLAG_COL_MASKED,
+                                                      FLAG_COL_NONFINITE_DATA,
+                                                      FLAG_COL_NONFINITE_ERROR,
+                                                      FLAG_COL_NPIX,
+                                                      FLAG_COL_SEG,
+                                                      FLAG_COL_UNCORRECTED,
+                                                      FLAG_COL_VALID)
+
+    flag_counts = np.atleast_2d(flag_counts)
+    overlap = np.atleast_1d(overlap)
+    w_out = np.atleast_1d(w_out)
+    w_in = flag_counts[:, FLAG_COL_NPIX]
+
+    flags = np.zeros(overlap.shape, dtype=int)
+    no_overlap = ~overlap | ((w_in == 0) & w_out)
+    flags[no_overlap] |= APERTURE_FLAGS.NO_OVERLAP
+    flags[(w_in > 0) & w_out] |= APERTURE_FLAGS.PARTIAL_OVERLAP
+    flags[w_in == 0] |= APERTURE_FLAGS.NO_PIXELS
+
+    # For sources without overlap, the counts are all zero, so the
+    # pixel-membership bits below are never set for them.
+    masked = flag_counts[:, FLAG_COL_MASKED] > 0
+    flags[masked] |= APERTURE_FLAGS.MASKED_PIXELS
+    all_masked = (w_in > 0) & (flag_counts[:, FLAG_COL_VALID] == 0)
+    flags[all_masked] |= APERTURE_FLAGS.ALL_MASKED
+    nonfinite = flag_counts[:, FLAG_COL_NONFINITE_DATA] > 0
+    flags[nonfinite] |= APERTURE_FLAGS.NON_FINITE_DATA
+    nonfinite_err = flag_counts[:, FLAG_COL_NONFINITE_ERROR] > 0
+    flags[nonfinite_err] |= APERTURE_FLAGS.NON_FINITE_ERROR
+    neighbor = flag_counts[:, FLAG_COL_SEG] > 0
+    flags[neighbor] |= APERTURE_FLAGS.NEIGHBOR_PIXELS
+    uncorrected = flag_counts[:, FLAG_COL_UNCORRECTED] > 0
+    flags[uncorrected] |= APERTURE_FLAGS.UNCORRECTED_PIXELS
+
+    return flags

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -1,0 +1,244 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tools for working with aperture photometry and statistics flags,
+including centralized flag definitions and decoding utilities.
+"""
+
+from typing import ClassVar
+
+from photutils.utils._flags import (FlagDefinition, FlagRegistry, decode_flags,
+                                    update_flag_docstring)
+
+__all__ = ['APERTURE_FLAGS', 'decode_aperture_flags']
+
+
+class _ApertureFlags(FlagRegistry):
+    """
+    Centralized definition of aperture photometry and statistics
+    flags.
+
+    This class provides a single source of truth for all
+    aperture flag definitions, including bit values,
+    names, and descriptions. The same flag definitions are
+    used by `~photutils.aperture.aperture_photometry`,
+    `~photutils.aperture.PixelAperture.photometry`, and
+    `~photutils.aperture.ApertureStats`, so a given bit always has the
+    same meaning.
+
+    Examples
+    --------
+    >>> from photutils.aperture.flags import _ApertureFlags
+    >>> flags = _ApertureFlags()
+    >>> flags.NO_OVERLAP
+    1
+    >>> flags.get_name(1)
+    'no_overlap'
+    >>> flags.get_description(8)
+    'masked pixels within the aperture'
+    """
+
+    # Define all aperture flags with their properties
+    FLAG_DEFINITIONS: ClassVar = [
+        FlagDefinition(
+            bit_value=1,
+            name='no_overlap',
+            description='aperture fully outside the data',
+            detailed_description=('The aperture is fully outside the '
+                                  'data array: no pixel with nonzero '
+                                  'aperture weight falls inside the '
+                                  'data'),
+        ),
+        FlagDefinition(
+            bit_value=2,
+            name='partial_overlap',
+            description='aperture partially outside the data',
+            detailed_description=('The aperture is partially outside '
+                                  'the data array: one or more pixels '
+                                  'with nonzero aperture weight fall '
+                                  'outside the data'),
+        ),
+        FlagDefinition(
+            bit_value=4,
+            name='no_pixels',
+            description='no aperture pixels within the data',
+            detailed_description=('The aperture contains zero pixels '
+                                  'with nonzero weight inside the data, '
+                                  'e.g., a fully off-image aperture or '
+                                  'a tiny aperture that contains no '
+                                  'pixel (or subpixel) centers with '
+                                  'the "center" or "subpixel" methods'),
+        ),
+        FlagDefinition(
+            bit_value=8,
+            name='masked_pixels',
+            description='masked pixels within the aperture',
+            detailed_description=('One or more input-masked pixels '
+                                  '(``mask`` keyword) have nonzero '
+                                  'aperture weight'),
+        ),
+        FlagDefinition(
+            bit_value=16,
+            name='all_masked',
+            description='no valid pixels within the aperture',
+            detailed_description=('The aperture contains pixels, but '
+                                  'none are valid: every nonzero-weight '
+                                  'pixel inside the data is masked, '
+                                  'non-finite, or excluded by '
+                                  'segmentation masking'),
+        ),
+        FlagDefinition(
+            bit_value=32,
+            name='non_finite_data',
+            description='non-finite data values within the aperture',
+            detailed_description=('One or more unmasked data values '
+                                  '(NaN or inf) with nonzero aperture '
+                                  'weight are non-finite'),
+        ),
+        FlagDefinition(
+            bit_value=64,
+            name='non_finite_error',
+            description='non-finite error values within the aperture',
+            detailed_description=('One or more unmasked error values '
+                                  '(NaN or inf) with nonzero aperture '
+                                  'weight are non-finite'),
+        ),
+        FlagDefinition(
+            bit_value=128,
+            name='neighbor_pixels',
+            description='segmentation-masked pixels within the aperture',
+            detailed_description=('One or more pixels within the '
+                                  'aperture were excluded, restricted, '
+                                  'or corrected due to neighboring '
+                                  'sources in the segmentation image'),
+        ),
+        FlagDefinition(
+            bit_value=256,
+            name='uncorrected_pixels',
+            description='uncorrectable neighbor pixels within the aperture',
+            detailed_description=('With ``mask_method="correct"``, one '
+                                  'or more neighbor-source pixels could '
+                                  'not be corrected (the mirror pixel '
+                                  'was unavailable) and were excluded '
+                                  'instead'),
+        ),
+        FlagDefinition(
+            bit_value=512,
+            name='sigma_clipped',
+            description='sigma-clipped pixels within the aperture',
+            detailed_description=('One or more pixels within the '
+                                  'aperture were rejected by sigma '
+                                  'clipping'),
+        ),
+        FlagDefinition(
+            bit_value=1024,
+            name='all_clipped',
+            description='all pixels within the aperture were sigma clipped',
+            detailed_description=('All valid pixels within the aperture '
+                                  'were rejected by sigma clipping'),
+        ),
+        FlagDefinition(
+            bit_value=2048,
+            name='too_few_pixels',
+            description='too few pixels to compute a statistic',
+            detailed_description=('There are too few valid pixels '
+                                  'within the aperture to compute a '
+                                  'requested statistic (e.g., the '
+                                  'variance and standard deviation are '
+                                  'undefined when the number of valid '
+                                  'pixels is not larger than ``ddof``)'),
+        ),
+    ]
+
+    domain: ClassVar = 'aperture'
+
+
+# Create a singleton instance for global use
+APERTURE_FLAGS = _ApertureFlags()
+
+
+def _update_decode_docstring(func):
+    """
+    Decorator to update a function docstring with the aperture flag
+    documentation.
+
+    The ``<flag_descriptions>`` placeholder in the function docstring is
+    replaced with a bullet list generated from ``APERTURE_FLAGS`` (see
+    `photutils.utils._flags.update_flag_docstring`).
+
+    Parameters
+    ----------
+    func : function
+        The function to decorate.
+
+    Returns
+    -------
+    func : function
+        The decorated function with updated docstring.
+    """
+    return update_flag_docstring(func, APERTURE_FLAGS)
+
+
+@_update_decode_docstring
+def decode_aperture_flags(flags, *, return_bit_values=False):
+    # numpydoc ignore: RT05
+    """
+    Decode aperture bit flags into individual components.
+
+    This function takes integer flag values from aperture photometry or
+    aperture statistics results and returns a list of human-readable
+    names of the conditions that were detected. This is useful for
+    understanding what problems were encountered without needing to
+    manually perform bitwise operations.
+
+    Parameters
+    ----------
+    flags : int or array-like of int
+        Integer flag value(s) to decode. Each bit in the flag represents
+        a specific condition that was detected when measuring the
+        aperture.
+
+    return_bit_values : bool, optional
+        If `True`, return the decoded bit flags (integers) instead of
+        the flag names (strings). Default is `False`.
+
+    Returns
+    -------
+    decoded : list of str, list of int, list of list of str, or \
+            list of list of int
+        List of active flag names (or bit values), or list of lists
+        if the input is an array. Each string (or integer) represents
+        a specific condition that was detected. If no flags are
+        set, an empty list is returned. Possible flag names are:
+        <flag_descriptions>
+
+    Examples
+    --------
+    Decode a single flag value:
+
+    >>> from photutils.aperture import decode_aperture_flags
+    >>> issues = decode_aperture_flags(10)  # bits 2 and 8 set
+    >>> print(issues)
+    ['partial_overlap', 'masked_pixels']
+    >>> 'partial_overlap' in issues
+    True
+    >>> 'no_overlap' in issues
+    False
+
+    Decode multiple flag values:
+
+    >>> flags = [0, 8, 24]  # 0, bit 8, bits 8+16
+    >>> decoded_list = decode_aperture_flags(flags)
+    >>> decoded_list[0]  # No issues
+    []
+    >>> decoded_list[1]
+    ['masked_pixels']
+    >>> decoded_list[2]
+    ['masked_pixels', 'all_masked']
+
+    Return the bit values instead of the names:
+
+    >>> decode_aperture_flags(10, return_bit_values=True)
+    [2, 8]
+    """
+    return decode_flags(flags, APERTURE_FLAGS,
+                        return_bit_values=return_bit_values)

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -149,6 +149,24 @@ class _ApertureFlags(FlagRegistry):
                                   'undefined when the number of valid '
                                   'pixels is not larger than ``ddof``).'),
         ),
+        FlagDefinition(
+            bit_value=4096,
+            name='singular_covariance',
+            description='singular or nearly singular source covariance',
+            detailed_description=('The source covariance matrix is '
+                                  'singular or nearly singular (the '
+                                  'minor-axis variance is below '
+                                  '``1/12``, the variance of a uniform '
+                                  'distribution across a single pixel), '
+                                  'so covariance-derived shape '
+                                  'properties (e.g., '
+                                  '``semimajor_axis``, ``orientation``, '
+                                  '``eccentricity``) are ill-defined '
+                                  'and have been regularized or set to '
+                                  'NaN. This is a stats-only flag that '
+                                  'is set only when a covariance-derived '
+                                  'property has been computed.'),
+        ),
     ]
 
     domain: ClassVar = 'aperture'

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -48,7 +48,7 @@ class _ApertureFlags(FlagRegistry):
             detailed_description=('The aperture is fully outside the '
                                   'data array: no pixel with nonzero '
                                   'aperture weight falls inside the '
-                                  'data'),
+                                  'data.'),
         ),
         FlagDefinition(
             bit_value=2,
@@ -57,7 +57,7 @@ class _ApertureFlags(FlagRegistry):
             detailed_description=('The aperture is partially outside '
                                   'the data array: one or more pixels '
                                   'with nonzero aperture weight fall '
-                                  'outside the data'),
+                                  'outside the data.'),
         ),
         FlagDefinition(
             bit_value=4,
@@ -68,7 +68,7 @@ class _ApertureFlags(FlagRegistry):
                                   'e.g., a fully off-image aperture or '
                                   'a tiny aperture that contains no '
                                   'pixel (or subpixel) centers with '
-                                  'the "center" or "subpixel" methods'),
+                                  'the "center" or "subpixel" methods.'),
         ),
         FlagDefinition(
             bit_value=8,
@@ -76,7 +76,7 @@ class _ApertureFlags(FlagRegistry):
             description='masked pixels within the aperture',
             detailed_description=('One or more input-masked pixels '
                                   '(``mask`` keyword) have nonzero '
-                                  'aperture weight'),
+                                  'aperture weight.'),
         ),
         FlagDefinition(
             bit_value=16,
@@ -86,7 +86,7 @@ class _ApertureFlags(FlagRegistry):
                                   'none are valid: every nonzero-weight '
                                   'pixel inside the data is masked, '
                                   'non-finite, or excluded by '
-                                  'segmentation masking'),
+                                  'segmentation masking.'),
         ),
         FlagDefinition(
             bit_value=32,
@@ -94,7 +94,7 @@ class _ApertureFlags(FlagRegistry):
             description='non-finite data values within the aperture',
             detailed_description=('One or more unmasked data values '
                                   '(NaN or inf) with nonzero aperture '
-                                  'weight are non-finite'),
+                                  'weight are non-finite.'),
         ),
         FlagDefinition(
             bit_value=64,
@@ -102,7 +102,7 @@ class _ApertureFlags(FlagRegistry):
             description='non-finite error values within the aperture',
             detailed_description=('One or more unmasked error values '
                                   '(NaN or inf) with nonzero aperture '
-                                  'weight are non-finite'),
+                                  'weight are non-finite.'),
         ),
         FlagDefinition(
             bit_value=128,
@@ -111,7 +111,7 @@ class _ApertureFlags(FlagRegistry):
             detailed_description=('One or more pixels within the '
                                   'aperture were excluded, restricted, '
                                   'or corrected due to neighboring '
-                                  'sources in the segmentation image'),
+                                  'sources in the segmentation image.'),
         ),
         FlagDefinition(
             bit_value=256,
@@ -121,7 +121,7 @@ class _ApertureFlags(FlagRegistry):
                                   'or more neighbor-source pixels could '
                                   'not be corrected (the mirror pixel '
                                   'was unavailable) and were excluded '
-                                  'instead'),
+                                  'instead.'),
         ),
         FlagDefinition(
             bit_value=512,
@@ -129,14 +129,14 @@ class _ApertureFlags(FlagRegistry):
             description='sigma-clipped pixels within the aperture',
             detailed_description=('One or more pixels within the '
                                   'aperture were rejected by sigma '
-                                  'clipping'),
+                                  'clipping.'),
         ),
         FlagDefinition(
             bit_value=1024,
             name='all_clipped',
             description='all pixels within the aperture were sigma clipped',
             detailed_description=('All valid pixels within the aperture '
-                                  'were rejected by sigma clipping'),
+                                  'were rejected by sigma clipping.'),
         ),
         FlagDefinition(
             bit_value=2048,
@@ -147,7 +147,7 @@ class _ApertureFlags(FlagRegistry):
                                   'requested statistic (e.g., the '
                                   'variance and standard deviation are '
                                   'undefined when the number of valid '
-                                  'pixels is not larger than ``ddof``)'),
+                                  'pixels is not larger than ``ddof``).'),
         ),
     ]
 
@@ -177,7 +177,7 @@ def _update_decode_docstring(func):
     func : function
         The decorated function with updated docstring.
     """
-    return update_flag_docstring(func, APERTURE_FLAGS)
+    return update_flag_docstring(func, APERTURE_FLAGS, indent=4)
 
 
 @_update_decode_docstring
@@ -210,7 +210,7 @@ def decode_aperture_flags(flags, *, return_bit_values=False):
         List of active flag names (or bit values), or list of lists
         if the input is an array. Each string (or integer) represents
         a specific condition that was detected. If no flags are
-        set, an empty list is returned. Possible flag names are:
+        set, an empty list is returned. Possible flags are:
         <flag_descriptions>
 
     Examples

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -130,10 +130,17 @@ def aperture_photometry(data, apertures, error=None, mask=None,
           computed with the same inputs. The value is NaN where an
           aperture does not overlap the data.
 
+        * ``'flags'``:
+          The bitwise quality flags for the aperture(s). See
+          :func:`~photutils.aperture.decode_aperture_flags` for decoding
+          flag values. The flags are:
+
+          <flag_descriptions>
+
         If multiple apertures are input, the ``'aperture_sum'``,
-        ``'aperture_sum_err'``, and ``'area'`` columns will have a
-        ``'_i'`` suffix (e.g., ``'aperture_sum_0'``), where ``i`` is the
-        index of the aperture in the input list.
+        ``'aperture_sum_err'``, ``'area'``, and ``'flags'`` columns will
+        have a ``'_i'`` suffix (e.g., ``'aperture_sum_0'``), where ``i``
+        is the index of the aperture in the input list.
 
         The table metadata includes the Astropy and Photutils version
         numbers and the `aperture_photometry` calling arguments.
@@ -257,6 +264,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     sum_key_main = 'aperture_sum'
     sum_err_key_main = 'aperture_sum_err'
     area_key_main = 'area'
+    flags_key_main = 'flags'
     for i, aper in enumerate(apertures):
         result = aper.photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
@@ -266,13 +274,18 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         sum_key = sum_key_main
         sum_err_key = sum_err_key_main
         area_key = area_key_main
+        flags_key = flags_key_main
         if not single_aperture:
             sum_key += f'_{i}'
             sum_err_key += f'_{i}'
             area_key += f'_{i}'
+            flags_key += f'_{i}'
 
         tbl[sum_key] = result.aperture_sum
         tbl[sum_err_key] = result.aperture_sum_err
         tbl[area_key] = result.area
+        tbl[flags_key] = result.flags
+        tbl[flags_key].info.description = (
+            'Aperture quality flags; see decode_aperture_flags')
 
     return tbl

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -801,10 +801,11 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         the fast batch driver is unavailable (see `_batch_inputs`).
 
         The result is a tuple ``(values, local_x, local_y, starts,
-        counts, sum_aper, var_aper, sum_area, overlap, ...)`` (a 13-tuple
-        shared with `_fast_sum`). Only the center-value entries (indices
-        0-4) and ``overlap`` (index 8) are populated here; the
-        ``sum_method`` entries are `None`.
+        counts, sum_aper, var_aper, sum_area, overlap, ...)`` (a
+        14-tuple shared with `_fast_sum`, whose last entry is the
+        per-source flag-count array). Only the center-value entries
+        (indices 0-4), ``overlap`` (index 8), and the flag counts (index
+        13) are populated here. The ``sum_method`` entries are `None`.
         """
         inputs = self._batch_inputs
         if inputs is None:
@@ -813,11 +814,12 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
          _sum_use_exact, _sum_subpixels, local_bkg, seg_arr, labels_arr,
          seg_code, clip_spec) = inputs
 
-        values, lx, ly, starts, counts, overlap = batch_aperture_gather(
+        (values, lx, ly, starts, counts, overlap,
+         flag_counts) = batch_aperture_gather(
             data, mask, positions, shape_code, params, ext_x, ext_y,
             local_bkg, seg_arr, labels_arr, seg_code)
         gather = (values, lx, ly, starts, counts, None, None, None, overlap,
-                  None, None, None, None)
+                  None, None, None, None, flag_counts)
 
         if clip_spec is not None:
             gather = self._apply_center_clip(gather, clip_spec)
@@ -856,12 +858,13 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
 
         emit_sum = 1 if clip_spec is not None else 0
         (sums, sum_var, area, overlap, starts, sum_values, sum_fracs,
-         sum_errsq, scounts) = batch_aperture_sums(
+         sum_errsq, scounts, flag_counts) = batch_aperture_sums(
             data, error, mask, positions, shape_code, params, ext_x, ext_y,
             sum_use_exact, sum_subpixels, seg_arr, labels_arr, seg_code,
             local_bkg, emit_sum)
         gather = (None, None, None, starts, None, sums, sum_var, area,
-                  overlap, sum_values, sum_fracs, sum_errsq, scounts)
+                  overlap, sum_values, sum_fracs, sum_errsq, scounts,
+                  flag_counts)
 
         if clip_spec is not None:
             gather = self._apply_sum_clip(gather, clip_spec)
@@ -907,14 +910,14 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         sigma_lower, sigma_upper, maxiters, cenfunc, stdfunc = clip_spec
         (values, local_x, local_y, starts, counts, _sum, _var, _area,
-         overlap, _sv, _sf, _se, _sc) = gather
+         overlap, _sv, _sf, _se, _sc, flag_counts) = gather
 
         (cvalues, clx, cly, cstarts, ccounts) = batch_sigma_clip_center(
             values, local_x, local_y, starts, counts, sigma_lower,
             sigma_upper, maxiters, cenfunc, stdfunc)
 
         return (cvalues, clx, cly, cstarts, ccounts, _sum, _var, _area,
-                overlap, None, None, None, None)
+                overlap, None, None, None, None, flag_counts)
 
     def _apply_sum_clip(self, gather, clip_spec):
         """
@@ -924,7 +927,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         sigma_lower, sigma_upper, maxiters, cenfunc, stdfunc = clip_spec
         (values, local_x, local_y, starts, counts, _sum, _var, _area,
-         overlap, sum_values, sum_fracs, sum_errsq, sum_counts) = gather
+         overlap, sum_values, sum_fracs, sum_errsq, sum_counts,
+         flag_counts) = gather
 
         has_error = 1 if self._error is not None else 0
         (csum, cvar, carea) = batch_sigma_clip_sum(
@@ -932,7 +936,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             sigma_lower, sigma_upper, maxiters, cenfunc, stdfunc, has_error)
 
         return (values, local_x, local_y, starts, counts, csum, cvar, carea,
-                overlap, None, None, None, None)
+                overlap, None, None, None, None, flag_counts)
 
     @lazyproperty
     def _sorted_values(self):

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -1174,8 +1174,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
                     segm_cutout = self._segmentation[slc_large]
                     cutout_xycen = (positions[idx, 0] - slc_large[1].start,
                                     positions[idx, 1] - slc_large[0].start)
-                    (data_cutout, error_cutout,
-                     exclude) = make_segmentation_exclusion(
+                    (data_cutout, error_cutout, exclude,
+                     _seg_affected) = make_segmentation_exclusion(
                         self._mask_method, segm_cutout,
                         self._seg_labels[idx], data=data_cutout,
                         error=error_cutout, base_mask=data_mask,

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -233,17 +233,43 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
     `Aperture` object using the measured centroid and then re-run
     `~photutils.aperture.ApertureStats`.
 
-    Most source properties are calculated using the "center"
-    aperture-mask method, which gives aperture weights of 0 or 1. This
-    avoids the need to compute weighted statistics --- the ``data``
-    pixel values are directly used.
+    All properties other than the sum-related ones described below are
+    calculated using the "center" aperture-mask method, which assigns
+    aperture weights of either 0 or 1, so the ``data`` pixel values
+    are used directly and without weighting. This choice reflects a
+    fundamental limitation because, unlike the mean or variance, order
+    statistics (``min``, ``max``, ``median``) and robust estimators
+    (``mad_std``, ``biweight_location``, ``biweight_midvariance``) have
+    no standard, unambiguous definition for pixels with fractional
+    (partial) aperture weights. Accordingly, these quantities cannot be
+    rigorously computed from a weighted aperture footprint.
 
-    The input ``sum_method`` and ``subpixels`` keywords are used
-    to determine the aperture-mask method when calculating the
-    sum-related properties: ``sum``, ``sum_error``, ``sum_aper_area``,
-    ``data_sum_cutout``, and ``error_sum_cutout``. The default is
-    ``sum_method='exact'``, which produces exact aperture-weighted
-    photometry.
+    All properties other than the sum-related ones described below
+    are calculated using the "center" aperture-mask method, which
+    gives aperture weights of 0 or 1, so the ``data`` pixel values
+    are used directly and unweighted. This is due to fundamental
+    limitation. Unlike the mean or variance, order statistics
+    (``min``, ``max``, ``median``) and robust estimators (``mad_std``,
+    ``biweight_location``, ``biweight_midvariance``) have no standard,
+    unambiguous generalization to pixels with fractional (partial)
+    aperture weights, so they cannot be rigorously computed using a
+    weighted footprint.
+
+    The input ``sum_method`` and ``subpixels`` keywords are
+    used to determine the aperture-mask method only for the
+    sum-related properties: ``sum``, ``sum_err``, ``sum_aper_area``,
+    ``data_sum_cutout``, and ``error_sum_cutout`` (also listed in the
+    ``SUM_FOOTPRINT_PROPERTIES`` class attribute). All other properties,
+    including ``mean``, ``median``, ``std``, and the morphological
+    properties, always use the "center" aperture-mask method regardless
+    of ``sum_method``. The default is ``sum_method='exact'``, which
+    produces exact aperture-weighted photometry.
+
+    The sum-related properties have their own separate `sum_flags`
+    quality flags, distinct from the `flags` property used by all
+    other properties. To check for any quality issue across both
+    footprints, combine the two flag columns with a bitwise OR, e.g.,
+    ``aperstats.flags | aperstats.sum_flags``.
 
     The calculated statistics are always float64, regardless of the
     input ``data`` dtype (`~astropy.units.Quantity` values with float64
@@ -286,6 +312,13 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
     >>> print(aperstats2.sum)
     [10177.62548482 36653.97704059]
     """
+
+    # Properties computed using the ``sum_method`` aperture-mask
+    # footprint (set by the ``sum_method``/``subpixels`` keywords).
+    # All other properties use the "center" aperture-mask method.
+    SUM_FOOTPRINT_PROPERTIES = ('sum', 'sum_err', 'sum_aper_area',
+                                'data_sum_cutout', 'error_sum_cutout',
+                                'sum_flags')
 
     def __init__(self, data, aperture, *, error=None, mask=None, wcs=None,
                  sigma_clip=None, sum_method='exact', subpixels=5, ddof=0,
@@ -1143,7 +1176,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             cutouts.append(cutout)
         return cutouts
 
-    def _make_aperture_cutouts(self, aperture_masks):
+    def _make_aperture_cutouts(self, aperture_masks, *, count_clipped=True):
         """
         Make aperture-weighted cutouts for the data and variance, and
         cutouts for the total mask and aperture mask weights.
@@ -1152,6 +1185,13 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         ----------
         aperture_masks : list of `ApertureMask`
             A list of `ApertureMask` objects.
+
+        count_clipped : bool, optional
+            Whether to count the number of sigma-clipped pixels per
+            source. Only `_footprint_flag_inputs` for the "center"
+            footprint uses this count, so it is skipped (left at 0)
+            for the ``sum_method`` footprint to avoid the wasted
+            computation.
 
         Returns
         -------
@@ -1162,7 +1202,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             flag counts (see the ``FLAG_COL_*`` constants in
             `photutils.aperture._batch_photometry`, with semantics
             identical to the batch drivers), and the number of
-            sigma-clipped pixels.
+            sigma-clipped pixels (always 0 when ``count_clipped`` is
+            `False`).
         """
         data_cutouts = []
         variance_cutouts = []
@@ -1271,7 +1312,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
 
                     # Define a mask of only the sigma-clipped pixels
                     sigclip_mask = data_sigclip.mask & ~mask_cutout
-                    n_clipped_ = np.count_nonzero(sigclip_mask)
+                    if count_clipped:
+                        n_clipped_ = np.count_nonzero(sigclip_mask)
                     weight_cutout *= ~sigclip_mask
 
                     mask_cutout = data_sigclip.mask
@@ -1318,7 +1360,12 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         and aperture weights using the input ``sum_method`` aperture
         mask method.
         """
-        return self._make_aperture_cutouts(self._aperture_masks)
+        # The sigma-clipped pixel count is not tracked for this
+        # footprint: only the "center" footprint's flags use it (see
+        # `_footprint_flag_inputs`), so counting it here would be wasted
+        # computation.
+        return self._make_aperture_cutouts(self._aperture_masks,
+                                           count_clipped=False)
 
     @lazyproperty
     def _mask_cutout_center(self):
@@ -1605,7 +1652,9 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         The sum properties (``sum``, ``sum_err``, and ``sum_aper_area``)
         have their own separate `sum_flags`. The ``'sigma_clipped'``,
         ``'all_clipped'``, and ``'too_few_pixels'`` flags are evaluated
-        on this footprint.
+        on this footprint. To check for any quality issue across both
+        footprints, combine the two flag columns with a bitwise OR
+        (e.g., ``flags | sum_flags``).
 
         See `~photutils.aperture.decode_aperture_flags` for decoding
         flag values. The flags are:
@@ -1647,7 +1696,9 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         `flags`. The ``'non_finite_error'`` flag is evaluated on this
         footprint. The ``'sigma_clipped'``, ``'all_clipped'``, and
         ``'too_few_pixels'`` flags apply only to the value statistics
-        and are never set here.
+        and are never set here. To check for any quality issue across
+        both footprints, combine the two flag columns with a bitwise OR
+        (e.g., ``flags | sum_flags``).
 
         See `~photutils.aperture.decode_aperture_flags` for decoding
         flag values. The flags are:

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -59,9 +59,9 @@ _MAD_STD_SCALE = 1.482602218505602
 
 # Default table columns for `to_table()` output
 DEFAULT_COLUMNS = ['id', 'x_centroid', 'y_centroid', 'sky_centroid',
-                   'sum', 'sum_err', 'sum_aper_area', 'center_aper_area',
-                   'min', 'max', 'mean', 'median', 'mode', 'std',
-                   'mad_std', 'var', 'biweight_location',
+                   'sum', 'sum_err', 'sum_aper_area', 'sum_flags',
+                   'center_aper_area', 'min', 'max', 'mean', 'median',
+                   'mode', 'std', 'mad_std', 'var', 'biweight_location',
                    'biweight_midvariance', 'fwhm', 'semimajor_axis',
                    'semiminor_axis', 'orientation', 'eccentricity',
                    'flags']
@@ -1598,15 +1598,14 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
     def flags(self):
         # numpydoc ignore: RT01
         """
-        The bitwise quality flags for each source.
+        The bitwise quality flags for the value statistics.
 
-        The flags are evaluated on both the "center"-method footprint
-        used by the value statistics and the ``sum_method`` footprint
-        used by the sum properties, and combined bitwise. The
-        ``'non_finite_error'`` flag is evaluated on the ``sum_method``
-        footprint. The ``'sigma_clipped'``, ``'all_clipped'``, and
-        ``'too_few_pixels'`` flags are evaluated on the "center"-method
-        footprint.
+        The flags are evaluated on the "center"-method footprint used
+        by the value statistics (e.g., ``mean``, ``median``, ``std``).
+        The sum properties (``sum``, ``sum_err``, and ``sum_aper_area``)
+        have their own separate `sum_flags`. The ``'sigma_clipped'``,
+        ``'all_clipped'``, and ``'too_few_pixels'`` flags are evaluated
+        on this footprint.
 
         See `~photutils.aperture.decode_aperture_flags` for decoding
         flag values. The flags are:
@@ -1614,11 +1613,10 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         <flag_descriptions>
         """
         # The gather kernel and the center-method cutouts do not
-        # evaluate error values, so the non-finite-error bit is
-        # defined by the sum footprint only
-        center_flags = (self._footprint_flags('center')
-                        & ~APERTURE_FLAGS.NON_FINITE_ERROR)
-        flags = center_flags | self._footprint_flags('sum')
+        # evaluate error values, so the non-finite-error bit is defined
+        # by the sum footprint only (see `sum_flags`).
+        flags = (self._footprint_flags('center')
+                 & ~APERTURE_FLAGS.NON_FINITE_ERROR)
 
         flag_counts, _, n_kept = self._footprint_flag_inputs('center')
         n_valid = flag_counts[:, FLAG_COL_VALID]
@@ -1635,16 +1633,44 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
 
         return flags
 
-    def decode_flags(self, *, return_bit_values=False):
+    @lazyproperty
+    @as_scalar
+    @_update_method_subpixels_docstring
+    def sum_flags(self):
+        # numpydoc ignore: RT01
+        """
+        The bitwise quality flags for the sum properties.
+
+        The flags are evaluated on the ``sum_method`` footprint
+        used by the sum properties (``sum``, ``sum_err``, and
+        ``sum_aper_area``). The value statistics have their own separate
+        `flags`. The ``'non_finite_error'`` flag is evaluated on this
+        footprint. The ``'sigma_clipped'``, ``'all_clipped'``, and
+        ``'too_few_pixels'`` flags apply only to the value statistics
+        and are never set here.
+
+        See `~photutils.aperture.decode_aperture_flags` for decoding
+        flag values. The flags are:
+
+        <flag_descriptions>
+        """
+        return self._footprint_flags('sum')
+
+    def decode_flags(self, *, column='flags', return_bit_values=False):
         """
         Decode the source quality flags into individual components.
 
         This is a convenience method that calls
-        `~photutils.aperture.decode_aperture_flags` with the `flags`
-        property.
+        `~photutils.aperture.decode_aperture_flags` with the `flags` or
+        `sum_flags` property.
 
         Parameters
         ----------
+        column : {'flags', 'sum_flags'}, optional
+            Which quality flags to decode: ``'flags'`` for the value
+            statistics (default) or ``'sum_flags'`` for the sum
+            properties.
+
         return_bit_values : bool, optional
             If `True`, return the decoded bit flags (integers) instead
             of the flag names (strings).
@@ -1673,7 +1699,12 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         ['masked_pixels']
         ['partial_overlap']
         """
-        return decode_aperture_flags(np.atleast_1d(self.flags),
+        if column not in ('flags', 'sum_flags'):
+            msg = "column must be 'flags' or 'sum_flags'"
+            raise ValueError(msg)
+
+        flags = self.flags if column == 'flags' else self.sum_flags
+        return decode_aperture_flags(np.atleast_1d(flags),
                                      return_bit_values=return_bit_values)
 
     def _get_values(self, array):

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -112,6 +112,26 @@ def as_scalar(method):
     return _decorator
 
 
+class _UncachedLazyProperty(lazyproperty):
+    """
+    A property that is discovered as a source property (like
+    `~astropy.utils.lazyproperty`) but is recomputed on every access
+    instead of being cached.
+
+    This is used for `ApertureStats.flags`, whose value can change
+    over the object's lifetime. It reflects whether covariance-derived
+    properties have been computed (see `ApertureStats.flags`). Caching
+    would freeze the first-computed value, so the getter runs on every
+    access. Subclassing `~astropy.utils.lazyproperty` keeps it in the
+    `ApertureStats.properties` list and the ``to_table`` machinery.
+    """
+
+    def __get__(self, obj, owner=None):
+        if obj is None:
+            return self
+        return self.fget(obj)
+
+
 @_update_method_subpixels_docstring
 class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
     """
@@ -274,8 +294,6 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
     The calculated statistics are always float64, regardless of the
     input ``data`` dtype (`~astropy.units.Quantity` values with float64
     dtype if the input ``data`` has units).
-
-    .. _SourceExtractor: https://sextractor.readthedocs.io/en/latest/
 
     Examples
     --------
@@ -709,14 +727,30 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
 
         tbl.meta.update(self.meta)  # keep tbl.meta type
 
-        for column in table_columns:
+        # Evaluate the flag columns last (while preserving the
+        # requested column order in the output table). The ``flags``
+        # column reports the ``'singular_covariance'`` bit only if a
+        # covariance-derived shape property has already been computed
+        # (see `flags`). Evaluating the flag columns after all other
+        # columns ensures that any shape columns present in the same
+        # table are computed first, so the table's ``flags`` column
+        # consistently reflects the other columns it is shown alongside.
+        flag_columns = {'flags', 'sum_flags'}
+        eval_order = ([col for col in table_columns
+                       if col not in flag_columns]
+                      + [col for col in table_columns if col in flag_columns])
+        values_map = {}
+        for column in eval_order:
             values = getattr(self, column)
 
             # Column assignment requires an object with a length
             if self.isscalar:
                 values = (values,)
 
-            tbl[column] = values
+            values_map[column] = values
+
+        for column in table_columns:
+            tbl[column] = values_map[column]
         return tbl
 
     @lazyproperty
@@ -1640,26 +1674,15 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         return _counts_to_flag_bits(flag_counts, overlap, w_out)
 
     @lazyproperty
-    @as_scalar
-    @_update_method_subpixels_docstring
-    def flags(self):
-        # numpydoc ignore: RT01
+    def _base_flags(self):
         """
-        The bitwise quality flags for the value statistics.
+        The count-based value-statistics flag bits (1D int array).
 
-        The flags are evaluated on the "center"-method footprint used
-        by the value statistics (e.g., ``mean``, ``median``, ``std``).
-        The sum properties (``sum``, ``sum_err``, and ``sum_aper_area``)
-        have their own separate `sum_flags`. The ``'sigma_clipped'``,
-        ``'all_clipped'``, and ``'too_few_pixels'`` flags are evaluated
-        on this footprint. To check for any quality issue across both
-        footprints, combine the two flag columns with a bitwise OR
-        (e.g., ``flags | sum_flags``).
-
-        See `~photutils.aperture.decode_aperture_flags` for decoding
-        flag values. The flags are:
-
-        <flag_descriptions>
+        These are the flag bits that do not depend on any lazily
+        computed covariance property: the "center"-method
+        footprint bits plus the sigma-clip and ``ddof`` bits. The
+        ``singular_covariance`` bit is folded in by the `flags` property
+        only if a covariance-derived property has been computed.
         """
         # The gather kernel and the center-method cutouts do not
         # evaluate error values, so the non-finite-error bit is defined
@@ -1680,6 +1703,91 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             flags[(w_in > 0)
                   & (n_kept <= self.ddof)] |= APERTURE_FLAGS.TOO_FEW_PIXELS
 
+        return flags
+
+    @lazyproperty
+    def _singular_covariance_mask(self):
+        """
+        Boolean mask (1D) marking sources with a singular or nearly
+        singular covariance matrix.
+
+        A source is flagged when the minor-axis variance (the smaller
+        eigenvalue of its normalized second-moment covariance matrix)
+        falls below ``1/12``. This flags both unresolved, nearly
+        point-like sources, where the covariance determinant drops below
+        ``(1/12)**2``, and rank-1 degenerate sources, where one axis is
+        unresolved while the other is extended (which the determinant
+        alone would miss). Sources with undefined moments (no overlap or
+        fully masked) have a non-finite determinant and are not flagged
+        here. They are already reported by the overlap and masking bits.
+        """
+        covar = self._raw_covariance
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            covar_det = np.linalg.det(covar)
+            # Smaller eigenvalue (the minor-axis variance) of each 2x2
+            # symmetric covariance matrix, via the closed form
+            # lambda = tr/2 -/+ sqrt((tr/2)**2 - det). The discriminant
+            # ((lambda1 - lambda2)/2)**2 is non-negative for a real
+            # symmetric matrix; clip tiny negative rounding to zero.
+            half_trace = 0.5 * (covar[:, 0, 0] + covar[:, 1, 1])
+            disc = np.maximum(half_trace**2 - covar_det, 0.0)
+            min_eigval = half_trace - np.sqrt(disc)
+        # ``1/12`` is the variance of a uniform distribution across a
+        # single pixel, and hence the smallest second moment a resolved
+        # source can have given finite pixel size. The determinant test
+        # (det < (1/12)**2) flags the isotropic case where both axes are
+        # unresolved; the eigenvalue test (min_eigval < 1/12)
+        # additionally flags rank-1 degeneracy (one unresolved axis) and
+        # covariance matrices that are not positive semidefinite
+        # (det < 0).
+        delta = 1.0 / 12
+        finite = np.isfinite(covar_det) & np.isfinite(min_eigval)
+        return finite & ((covar_det < delta**2) | (min_eigval < delta))
+
+    @_UncachedLazyProperty
+    @as_scalar
+    @_update_method_subpixels_docstring
+    def flags(self):
+        # numpydoc ignore: RT01
+        """
+        The bitwise quality flags for the value statistics.
+
+        The flags are evaluated on the "center"-method footprint used
+        by the value statistics (e.g., ``mean``, ``median``, ``std``).
+        The sum properties (``sum``, ``sum_err``, and ``sum_aper_area``)
+        have their own separate `sum_flags`. The ``'sigma_clipped'``,
+        ``'all_clipped'``, and ``'too_few_pixels'`` flags are evaluated
+        on this footprint. To check for any quality issue across both
+        footprints, combine the two flag columns with a bitwise OR
+        (e.g., ``flags | sum_flags``).
+
+        The ``'singular_covariance'`` bit is special. It reports whether
+        a source's covariance matrix is singular or nearly singular,
+        a condition that is only knowable once a covariance-derived
+        shape property (e.g., ``semimajor_axis``, ``orientation``,
+        ``eccentricity``) has been computed. To avoid forcing that
+        computation, the bit is included only if such a property has
+        already been evaluated on this object; otherwise it is omitted.
+        This means the value of ``flags`` reflects the measurements
+        requested so far, so accessing a shape property and then
+        re-reading ``flags`` may set additional bits. The default
+        `to_table` always evaluates the shape properties, so its
+        ``flags`` column always reflects the ``'singular_covariance'``
+        bit.
+
+        See `~photutils.aperture.decode_aperture_flags` for decoding
+        flag values. The flags are:
+
+        <flag_descriptions>
+        """
+        # A fresh array is returned on every access (never mutating the
+        # cached `_base_flags`), so concurrent readers and previously
+        # returned arrays are never modified in place.
+        flags = self._base_flags.copy()
+        if '_covariance' in self.__dict__:
+            flags[self._singular_covariance_mask] |= (
+                APERTURE_FLAGS.SINGULAR_COVARIANCE)
         return flags
 
     @lazyproperty
@@ -2388,10 +2496,16 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         return tensor.reshape((tensor.shape[0], 2, 2)) * u.pix**2
 
     @lazyproperty
-    def _covariance(self):
+    def _raw_covariance(self):
         """
-        The covariance matrix of the 2D Gaussian function that has the
-        same second-order moments as the source, always as an iterable.
+        The raw ``(N, 2, 2)`` covariance matrix of the 2D Gaussian
+        function that has the same normalized second-order moments as
+        the source, before any regularization.
+
+        This unregularized matrix is shared by `_covariance` (which
+        regularizes a copy) and `_singular_covariance_mask` (which tests
+        it for singularity). Callers that modify the matrix in place
+        must operate on a copy so the cached value is not corrupted.
         """
         moments = self.moments_central
         if self.isscalar:
@@ -2400,31 +2514,51 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
             mu_norm = moments / moments[:, 0, 0][:, np.newaxis, np.newaxis]
-
         covar = np.array([mu_norm[:, 0, 2], mu_norm[:, 1, 1],
                           mu_norm[:, 1, 1], mu_norm[:, 2, 0]]).swapaxes(0, 1)
-        covar = covar.reshape((covar.shape[0], 2, 2))
+        return covar.reshape((covar.shape[0], 2, 2))
 
-        # Modify the covariance matrix in the case of "infinitely" thin
-        # detections. This follows SourceExtractor's prescription of
-        # incrementally increasing the diagonal elements by 1/12.
+    @lazyproperty
+    def _covariance(self):
+        """
+        The covariance matrix of the 2D Gaussian function that has the
+        same second-order moments as the source, always as an iterable.
+        """
+        # Copy so the regularization below does not mutate the cached
+        # raw covariance shared with `_singular_covariance_mask`.
+        covar = self._raw_covariance.copy()
+
+        # Regularize the covariance matrix for "infinitely" thin
+        # detections by incrementally increasing the diagonal elements
+        # by 1/12, the variance of a uniform distribution across a
+        # single pixel (the smallest second moment a resolved source can
+        # have given finite pixel size).
         delta = 1.0 / 12
         delta2 = delta**2
         # Ignore RuntimeWarning from NaN values in covar
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
             covar_det = np.linalg.det(covar)
+            covar_trace = covar[:, 0, 0] + covar[:, 1, 1]
 
-            # Covariance should be positive semidefinite
-            idx = np.where(covar_det < 0)[0]
-            covar[idx] = np.array([[np.nan, np.nan], [np.nan, np.nan]])
+            # A valid covariance is positive semidefinite (det >= 0
+            # and trace >= 0). Any matrix that is not (e.g., from
+            # net-negative flux weighting) has an undefined shape and is
+            # set to NaN.
+            bad = (covar_det < 0) | (covar_trace < 0)
+            covar[bad] = np.nan
 
+            # Regularize "infinitely" thin detections by adding 1/12
+            # (delta) to each diagonal. A single bump is sufficient.
+            # For a positive semidefinite matrix the bumped determinant
+            # exceeds the raw determinant by delta times the trace plus
+            # delta squared. Since the raw determinant and trace are
+            # both non-negative, the result is at least delta squared,
+            # which equals the delta2 threshold, so it clears the
+            # threshold in a single step.
             idx = np.where(covar_det < delta2)[0]
-            while idx.size > 0:
-                covar[idx, 0, 0] += delta
-                covar[idx, 1, 1] += delta
-                covar_det = np.linalg.det(covar)
-                idx = np.where(covar_det < delta2)[0]
+            covar[idx, 0, 0] += delta
+            covar[idx, 1, 1] += delta
         return covar
 
     @lazyproperty
@@ -2619,8 +2753,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         where :math:`R` is a parameter which scales the ellipse (in
         units of the axes lengths).
 
-        `SourceExtractor`_ reports that the isophotal limit of a source
-        is well represented by :math:`R \approx 3`.
+        The isophotal limit of a source is well represented by :math:`R
+        \approx 3`.
         """
         return ((np.cos(self.orientation) / self.semimajor_axis)**2
                 + (np.sin(self.orientation) / self.semiminor_axis)**2)
@@ -2642,8 +2776,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         where :math:`R` is a parameter which scales the ellipse (in
         units of the axes lengths).
 
-        `SourceExtractor`_ reports that the isophotal limit of a source
-        is well represented by :math:`R \approx 3`.
+        That the isophotal limit of a source is well represented by
+        :math:`R \approx 3`.
         """
         return ((np.sin(self.orientation) / self.semimajor_axis)**2
                 + (np.cos(self.orientation) / self.semiminor_axis)**2)
@@ -2665,8 +2799,8 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         where :math:`R` is a parameter which scales the ellipse (in
         units of the axes lengths).
 
-        `SourceExtractor`_ reports that the isophotal limit of a source
-        is well represented by :math:`R \approx 3`.
+        The isophotal limit of a source is well represented by :math:`R
+        \approx 3`.
         """
         return (2.0 * np.cos(self.orientation) * np.sin(self.orientation)
                 * ((1.0 / self.semimajor_axis**2)

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -17,7 +17,14 @@ from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import Aperture, SkyAperture, region_to_aperture
-from photutils.aperture._batch_photometry import batch_aperture_sums
+from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
+                                                  FLAG_COL_MASKED,
+                                                  FLAG_COL_NONFINITE_DATA,
+                                                  FLAG_COL_NONFINITE_ERROR,
+                                                  FLAG_COL_NPIX, FLAG_COL_SEG,
+                                                  FLAG_COL_UNCORRECTED,
+                                                  FLAG_COL_VALID,
+                                                  batch_aperture_sums)
 from photutils.aperture._batch_stats import (batch_aperture_gather,
                                              batch_biweight, batch_gini,
                                              batch_mad, batch_mean_var,
@@ -30,6 +37,8 @@ from photutils.aperture._segmentation import (SEG_METHOD_CODES,
                                               process_segmentation_inputs)
 from photutils.aperture.core import (_aperture_metadata,
                                      _update_method_subpixels_docstring)
+from photutils.aperture.flags import (APERTURE_FLAGS, _counts_to_flag_bits,
+                                      decode_aperture_flags)
 from photutils.morphology import gini as gini_func
 from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_getattr,
@@ -54,7 +63,8 @@ DEFAULT_COLUMNS = ['id', 'x_centroid', 'y_centroid', 'sky_centroid',
                    'min', 'max', 'mean', 'median', 'mode', 'std',
                    'mad_std', 'var', 'biweight_location',
                    'biweight_midvariance', 'fwhm', 'semimajor_axis',
-                   'semiminor_axis', 'orientation', 'eccentricity']
+                   'semiminor_axis', 'orientation', 'eccentricity',
+                   'flags']
 
 # Remove in 4.0
 _DEPRECATED_ATTRIBUTES: dict = {
@@ -744,18 +754,29 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
                                  or mask.shape != data.shape):
             return None
 
-        # Fold non-finite ``data`` values into the mask so the batch
-        # kernel can skip the per-pixel finiteness test (and defer
-        # the pixel-value load to contributing pixels only, like
+        # Fold non-finite ``data`` values into the mask plane so the
+        # batch kernels can skip the per-pixel finiteness test (and
+        # defer the pixel-value load to contributing pixels only, like
         # the ``photometry`` method). This matches the mask-based
         # path, which masks non-finite data before any segmentation
-        # correction.
+        # correction. The plane distinguishes the two causes for the
+        # flag counts: bit 1 (value 1) marks input-masked pixels and bit
+        # 2 (value 2) marks non-finite data pixels. Any nonzero value
+        # excludes the pixel.
+        plane = None
+        if mask is not None:
+            plane = mask.astype(np.uint8)
         if data.dtype.kind == 'f':
             nonfinite = ~np.isfinite(data)
             if nonfinite.any():
-                mask = nonfinite if mask is None else (mask | nonfinite)
+                if plane is None:
+                    plane = np.zeros(data.shape, dtype=np.uint8)
+                    plane[nonfinite] = 2
+                else:
+                    plane[nonfinite & (plane == 0)] = 2
+        mask = plane
         if mask is not None:
-            mask = np.ascontiguousarray(mask, dtype=np.uint8)
+            mask = np.ascontiguousarray(mask)
 
         seg_arr = None
         labels_arr = None
@@ -1134,21 +1155,31 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
 
         Returns
         -------
-        data, variance, mask, weights : list of `~numpy.ndarray`
-            A list of cutout arrays for the data, variance, mask and weight
-            arrays for each source (aperture position).
+        result : list of `~numpy.ndarray`
+            A list of cutout arrays for the data, variance,
+            mask and weight arrays for each source (aperture
+            position), followed by the overlap indicator, per-source
+            flag counts (see the ``FLAG_COL_*`` constants in
+            `photutils.aperture._batch_photometry`, with semantics
+            identical to the batch drivers), and the number of
+            sigma-clipped pixels.
         """
         data_cutouts = []
         variance_cutouts = []
         mask_cutouts = []
         weight_cutouts = []
         overlaps = []
+        flag_counts = []
+        n_clipped = []
 
         positions = np.atleast_2d(self._pixel_aperture.positions)
 
         for idx, (data_cutout, apermask, slices) in enumerate(
                 zip(self._data_cutouts, aperture_masks,
                     self._overlap_slices, strict=True)):
+
+            fc_row = np.zeros(8, dtype=np.intp)
+            n_clipped_ = 0
 
             slc_large, slc_small = slices
             if slc_large is None:  # aperture does not overlap the data
@@ -1160,31 +1191,68 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             else:
                 # Create a mask of non-finite ``data`` values combined
                 # with the input ``mask`` array
-                data_mask = ~np.isfinite(data_cutout)
+                nonfinite_mask = ~np.isfinite(data_cutout)
                 if self._mask is not None:
-                    data_mask |= self._mask[slc_large]
+                    user_mask = self._mask[slc_large]
+                    data_mask = nonfinite_mask | user_mask
+                else:
+                    user_mask = None
+                    data_mask = nonfinite_mask
 
                 error_cutout = (None if self._error is None
                                 else self._error[slc_large])
 
                 # Apply segmentation-based masking and/or symmetric
                 # neighbor correction
+                exclude = None
+                affected = None
                 if (self._segmentation is not None
                         and self._mask_method != 'none'):
                     segm_cutout = self._segmentation[slc_large]
                     cutout_xycen = (positions[idx, 0] - slc_large[1].start,
                                     positions[idx, 1] - slc_large[0].start)
                     (data_cutout, error_cutout, exclude,
-                     _seg_affected) = make_segmentation_exclusion(
+                     affected) = make_segmentation_exclusion(
                         self._mask_method, segm_cutout,
                         self._seg_labels[idx], data=data_cutout,
                         error=error_cutout, base_mask=data_mask,
                         cutout_xycen=cutout_xycen)
+                    pre_seg_mask = data_mask
                     data_mask = data_mask | exclude
 
                 overlap = True
                 aperweight_cutout = apermask.data[slc_small]
                 weight_cutout = aperweight_cutout * ~data_mask
+
+                # Per-source pixel counts for the quality flags,
+                # matching the batch-driver semantics (computed before
+                # any sigma clipping)
+                weighted = aperweight_cutout > 0
+                fc_row[FLAG_COL_NPIX] = np.count_nonzero(weighted)
+                fc_row[FLAG_COL_BBOX_CLIPPED] = (
+                    aperweight_cutout.shape != apermask.data.shape)
+                if user_mask is not None:
+                    fc_row[FLAG_COL_MASKED] = np.count_nonzero(
+                        weighted & user_mask)
+                    fc_row[FLAG_COL_NONFINITE_DATA] = np.count_nonzero(
+                        weighted & nonfinite_mask & ~user_mask)
+                else:
+                    fc_row[FLAG_COL_NONFINITE_DATA] = np.count_nonzero(
+                        weighted & nonfinite_mask)
+                if affected is not None:
+                    pre_valid = weighted & ~pre_seg_mask
+                    fc_row[FLAG_COL_SEG] = np.count_nonzero(
+                        affected & pre_valid)
+                    if self._mask_method == 'correct':
+                        # In 'correct' mode, the excluded pixels are
+                        # exactly the uncorrectable neighbor pixels
+                        fc_row[FLAG_COL_UNCORRECTED] = np.count_nonzero(
+                            exclude & pre_valid)
+                fc_row[FLAG_COL_VALID] = np.count_nonzero(
+                    weighted & ~data_mask)
+                if error_cutout is not None:
+                    fc_row[FLAG_COL_NONFINITE_ERROR] = np.any(
+                        ~np.isfinite(error_cutout) & weighted & ~data_mask)
 
                 # Apply the aperture mask; for "exact" and "subpixel"
                 # this is an expanded boolean mask using the aperture
@@ -1203,6 +1271,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
 
                     # Define a mask of only the sigma-clipped pixels
                     sigclip_mask = data_sigclip.mask & ~mask_cutout
+                    n_clipped_ = np.count_nonzero(sigclip_mask)
                     weight_cutout *= ~sigclip_mask
 
                     mask_cutout = data_sigclip.mask
@@ -1225,11 +1294,14 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             mask_cutouts.append(mask_cutout)
             weight_cutouts.append(weight_cutout)
             overlaps.append(overlap)
+            flag_counts.append(fc_row)
+            n_clipped.append(n_clipped_)
 
         # Use zip (instead of np.transpose) because these may contain
         # arrays that have different shapes
         return list(zip(data_cutouts, variance_cutouts, mask_cutouts,
-                        weight_cutouts, overlaps, strict=True))
+                        weight_cutouts, overlaps, flag_counts, n_clipped,
+                        strict=True))
 
     @lazyproperty
     def _aperture_cutouts_center(self):
@@ -1456,6 +1528,153 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         True if there is no overlap of the aperture with the data.
         """
         return list(zip(*self._aperture_cutouts_center, strict=True))[4]
+
+    def _footprint_flag_inputs(self, footprint):
+        """
+        The per-source flag inputs for the given aperture footprint.
+
+        Parameters
+        ----------
+        footprint : {'center', 'sum'}
+            The aperture footprint: the "center" mask method used by the
+            value statistics, or the ``sum_method`` mask method used by
+            the sum properties.
+
+        Returns
+        -------
+        flag_counts : `~numpy.ndarray`
+            The per-source flag counts (see the ``FLAG_COL_*``
+            constants in `photutils.aperture._batch_photometry`).
+
+        overlap : `~numpy.ndarray` (bool)
+            Whether the aperture bounding box overlaps the data.
+
+        n_kept : `~numpy.ndarray` or `None`
+            For the center footprint, the per-source number of valid
+            pixels remaining after sigma clipping; `None` for the sum
+            footprint.
+        """
+        if footprint == 'center':
+            gather = self._fast_gather
+            if gather is not None:
+                return (gather[13], np.asarray(gather[8]),
+                        np.asarray(gather[4]))
+            cutouts = self._aperture_cutouts_center
+        else:
+            gather = self._fast_sum
+            if gather is not None:
+                return gather[13], np.asarray(gather[8]), None
+            cutouts = self._aperture_cutouts
+
+        flag_counts = np.array([cut[5] for cut in cutouts])
+        overlap = np.array([cut[4] for cut in cutouts])
+        n_kept = None
+        if footprint == 'center':
+            n_clipped = np.array([cut[6] for cut in cutouts])
+            n_kept = flag_counts[:, FLAG_COL_VALID] - n_clipped
+        return flag_counts, overlap, n_kept
+
+    def _footprint_flags(self, footprint):
+        """
+        The per-source flag bits for the given aperture footprint.
+
+        The bounding-box-clipped candidate sources are resolved to the
+        precise outside-weight test using per-source aperture masks.
+        """
+        flag_counts, overlap, _ = self._footprint_flag_inputs(footprint)
+        if footprint == 'center':
+            method, subpixels = 'center', 1
+        else:
+            method, subpixels = self.sum_method, self.subpixels
+        candidates = flag_counts[:, FLAG_COL_BBOX_CLIPPED].astype(bool)
+        w_out = self._pixel_aperture._resolve_outside_weights(
+            self._data.shape, method=method, subpixels=subpixels,
+            candidates=candidates)
+        return _counts_to_flag_bits(flag_counts, overlap, w_out)
+
+    @lazyproperty
+    @as_scalar
+    @_update_method_subpixels_docstring
+    def flags(self):
+        # numpydoc ignore: RT01
+        """
+        The bitwise quality flags for each source.
+
+        The flags are evaluated on both the "center"-method footprint
+        used by the value statistics and the ``sum_method`` footprint
+        used by the sum properties, and combined bitwise. The
+        ``'non_finite_error'`` flag is evaluated on the ``sum_method``
+        footprint. The ``'sigma_clipped'``, ``'all_clipped'``, and
+        ``'too_few_pixels'`` flags are evaluated on the "center"-method
+        footprint.
+
+        See `~photutils.aperture.decode_aperture_flags` for decoding
+        flag values. The flags are:
+
+        <flag_descriptions>
+        """
+        # The gather kernel and the center-method cutouts do not
+        # evaluate error values, so the non-finite-error bit is
+        # defined by the sum footprint only
+        center_flags = (self._footprint_flags('center')
+                        & ~APERTURE_FLAGS.NON_FINITE_ERROR)
+        flags = center_flags | self._footprint_flags('sum')
+
+        flag_counts, _, n_kept = self._footprint_flag_inputs('center')
+        n_valid = flag_counts[:, FLAG_COL_VALID]
+        if self.sigma_clip is not None:
+            n_clipped = n_valid - n_kept
+            flags[n_clipped > 0] |= APERTURE_FLAGS.SIGMA_CLIPPED
+            flags[(n_valid > 0)
+                  & (n_kept == 0)] |= APERTURE_FLAGS.ALL_CLIPPED
+
+        if self.ddof > 0:
+            w_in = flag_counts[:, FLAG_COL_NPIX]
+            flags[(w_in > 0)
+                  & (n_kept <= self.ddof)] |= APERTURE_FLAGS.TOO_FEW_PIXELS
+
+        return flags
+
+    def decode_flags(self, *, return_bit_values=False):
+        """
+        Decode the source quality flags into individual components.
+
+        This is a convenience method that calls
+        `~photutils.aperture.decode_aperture_flags` with the `flags`
+        property.
+
+        Parameters
+        ----------
+        return_bit_values : bool, optional
+            If `True`, return the decoded bit flags (integers) instead
+            of the flag names (strings).
+
+        Returns
+        -------
+        decoded : list of list of str or list of list of int
+            A list of the active flag names (or bit values) for each
+            source.
+
+        See Also
+        --------
+        photutils.aperture.decode_aperture_flags
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from photutils.aperture import ApertureStats, CircularAperture
+        >>> data = np.ones((25, 25))
+        >>> mask = np.zeros(data.shape, dtype=bool)
+        >>> mask[12, 12] = True
+        >>> aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
+        >>> aperstats = ApertureStats(data, aper, mask=mask)
+        >>> for names in aperstats.decode_flags():
+        ...     print(names)
+        ['masked_pixels']
+        ['partial_overlap']
+        """
+        return decode_aperture_flags(np.atleast_1d(self.flags),
+                                     return_bit_values=return_bit_values)
 
     def _get_values(self, array):
         """

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -1,0 +1,288 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the per-source flag counts returned by the batch drivers.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from photutils.aperture import CircularAperture
+from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
+                                                  FLAG_COL_MASKED,
+                                                  FLAG_COL_NONFINITE_DATA,
+                                                  FLAG_COL_NONFINITE_ERROR,
+                                                  FLAG_COL_NPIX, FLAG_COL_SEG,
+                                                  FLAG_COL_UNCORRECTED,
+                                                  FLAG_COL_VALID, SHAPE_CIRCLE,
+                                                  batch_aperture_sums)
+from photutils.aperture._batch_stats import batch_aperture_gather
+
+SHAPE = (25, 25)
+
+
+def _sums_fcounts(data, positions, radius, *, error=None, mask=None,
+                  use_exact=1, subpixels=5, segmentation=None, labels=None,
+                  seg_method=0):
+    """
+    Run ``batch_aperture_sums`` and return the flag-count array.
+    """
+    positions = np.ascontiguousarray(np.atleast_2d(positions),
+                                     dtype=np.float64)
+    params = np.array([radius], dtype=np.float64)
+    result = batch_aperture_sums(
+        np.ascontiguousarray(data, dtype=np.float64), error, mask,
+        positions, SHAPE_CIRCLE, params, radius, radius, use_exact,
+        subpixels, segmentation, labels, seg_method)
+    return result[-1]
+
+
+def _gather_fcounts(data, positions, radius, *, mask=None,
+                    segmentation=None, labels=None, seg_method=0):
+    """
+    Run ``batch_aperture_gather`` and return the flag-count array.
+    """
+    positions = np.ascontiguousarray(np.atleast_2d(positions),
+                                     dtype=np.float64)
+    params = np.array([radius], dtype=np.float64)
+    result = batch_aperture_gather(
+        np.ascontiguousarray(data, dtype=np.float64), mask, positions,
+        SHAPE_CIRCLE, params, radius, radius, None, segmentation,
+        labels, seg_method)
+    return result[-1]
+
+
+def test_interior_source():
+    """
+    Test that a clean interior source has only npix/valid counts.
+    """
+    data = np.ones(SHAPE)
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
+    assert fc[FLAG_COL_NPIX] > 0
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX]
+    assert fc[FLAG_COL_MASKED] == 0
+    assert fc[FLAG_COL_NONFINITE_DATA] == 0
+    assert fc[FLAG_COL_NONFINITE_ERROR] == 0
+    assert fc[FLAG_COL_SEG] == 0
+    assert fc[FLAG_COL_UNCORRECTED] == 0
+    assert fc[FLAG_COL_BBOX_CLIPPED] == 0
+
+
+def test_no_bbox_overlap():
+    """
+    Test that a source with no bounding-box overlap has all-zero counts.
+    """
+    data = np.ones(SHAPE)
+    fc = _sums_fcounts(data, (100.0, 100.0), 3.0)[0]
+    assert_array_equal(fc, 0)
+    fc = _gather_fcounts(data, (100.0, 100.0), 3.0)[0]
+    assert_array_equal(fc, 0)
+
+
+@pytest.mark.parametrize('use_exact', [0, 1])
+def test_masked_pixel_membership(use_exact):
+    """
+    Test that only masked pixels with nonzero overlap fraction are
+    counted.
+    """
+    data = np.ones(SHAPE)
+
+    # Pixel inside the aperture
+    mask = np.zeros(SHAPE, dtype=np.uint8)
+    mask[12, 12] = 1
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
+                       use_exact=use_exact)[0]
+    assert fc[FLAG_COL_MASKED] == 1
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX] - 1
+
+    # Pixel inside the bounding box but outside the aperture (bbox
+    # corner)
+    mask = np.zeros(SHAPE, dtype=np.uint8)
+    mask[9, 9] = 1
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
+                       use_exact=use_exact)[0]
+    assert fc[FLAG_COL_MASKED] == 0
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX]
+
+
+def test_mask_plane_bits():
+    """
+    Test that mask-plane bit 1 counts as masked and bit 2 as non-finite
+    data, with bit 1 taking precedence.
+    """
+    data = np.ones(SHAPE)
+    mask = np.zeros(SHAPE, dtype=np.uint8)
+    mask[12, 12] = 1  # input-masked
+    mask[12, 13] = 2  # non-finite data
+    mask[13, 12] = 3  # both; masked wins
+    for func in (_sums_fcounts, _gather_fcounts):
+        fc = func(data, (12.0, 12.0), 3.0, mask=mask)[0]
+        assert fc[FLAG_COL_MASKED] == 2
+        assert fc[FLAG_COL_NONFINITE_DATA] == 1
+        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX] - 3
+
+
+def test_nonfinite_data_unmasked():
+    """
+    Test that unmasked non-finite data values are detected (and still
+    contribute) in the photometry kernel.
+
+    Unmasked non-finite contributions are detected from the accumulated
+    sums as a 0/1 indicator.
+    """
+    data = np.ones(SHAPE)
+    data[12, 12] = np.nan
+    data[12, 13] = np.inf
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
+    assert fc[FLAG_COL_NONFINITE_DATA] == 1
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX]
+
+
+def test_nonfinite_error():
+    """
+    Test that non-finite error values among contributing pixels are
+    counted.
+    """
+    data = np.ones(SHAPE)
+    error = np.ones(SHAPE)
+    error[12, 12] = np.nan
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error)[0]
+    assert fc[FLAG_COL_NONFINITE_ERROR] == 1
+
+    # A masked pixel with non-finite error is not counted
+    mask = np.zeros(SHAPE, dtype=np.uint8)
+    mask[12, 12] = 1
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error, mask=mask)[0]
+    assert fc[FLAG_COL_NONFINITE_ERROR] == 0
+
+
+@pytest.mark.parametrize('use_exact', [0, 1])
+def test_bbox_clipped_indicator(use_exact):
+    """
+    Test the bbox-clipped indicator for interior and edge sources.
+    """
+    data = np.ones(SHAPE)
+
+    # Interior source
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, use_exact=use_exact)[0]
+    assert fc[FLAG_COL_BBOX_CLIPPED] == 0
+
+    # Aperture straddling the left edge
+    fc = _sums_fcounts(data, (0.0, 12.0), 3.0, use_exact=use_exact)[0]
+    assert fc[FLAG_COL_BBOX_CLIPPED] == 1
+    assert fc[FLAG_COL_NPIX] > 0
+
+    # Clipped bbox whose "center"-method weights are all inside the data
+    # (the caller resolves the precise outside-weight test)
+    fc = _sums_fcounts(data, (0.2, 12.0), 0.8, use_exact=0,
+                       subpixels=1)[0]
+    assert fc[FLAG_COL_BBOX_CLIPPED] == 1
+    assert fc[FLAG_COL_NPIX] > 0
+
+
+def test_bbox_clipped_parity_with_aperture_mask():
+    """
+    Test that npix matches the nonzero in-data aperture-mask weights
+    and that the bbox-clipped indicator matches the overlap slices, for
+    randomized positions including edge and rounding cases.
+    """
+    rng = np.random.default_rng(0)
+    data = np.ones(SHAPE)
+    n_src = 50
+    xy = rng.uniform(-6.0, 30.0, size=(n_src, 2))
+    # Include exact half-integer rounding cases
+    xy[:5] = [(0.5, 0.5), (-0.5, 12.0), (24.5, 24.5), (0.0, 0.0),
+              (12.5, -0.5)]
+    radius = 2.5
+
+    for use_exact, method in ((1, 'exact'), (0, 'center')):
+        fcs = _sums_fcounts(data, xy, radius, use_exact=use_exact,
+                            subpixels=1)
+        apertures = CircularAperture(xy, r=radius)
+        masks = apertures.to_mask(method=method)
+        for fc, apermask in zip(fcs, masks, strict=True):
+            slc_large, slc_small = apermask.get_overlap_slices(SHAPE)
+            if slc_large is None:
+                assert_array_equal(fc, 0)
+                continue
+            n_in = np.count_nonzero(apermask.data[slc_small])
+            assert fc[FLAG_COL_NPIX] == n_in
+            full = (slice(0, apermask.data.shape[0]),
+                    slice(0, apermask.data.shape[1]))
+            assert fc[FLAG_COL_BBOX_CLIPPED] == int(slc_small != full)
+
+
+def test_seg_counts():
+    """
+    Test the segmentation-affected pixel counts for the mask,
+    source_only, and correct methods.
+    """
+    data = np.ones(SHAPE)
+    segm = np.zeros(SHAPE, dtype=np.intp)
+    segm[10:15, 10:15] = 1
+    segm[12, 14] = 2  # neighbor pixel inside the aperture
+    labels = np.array([1], dtype=np.intp)
+
+    # Method 1 ('mask'): neighbor pixels are excluded
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
+                       labels=labels, seg_method=1)[0]
+    assert fc[FLAG_COL_SEG] == 1
+    assert fc[FLAG_COL_UNCORRECTED] == 0
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX] - 1
+
+    # Method 2 ('source_only'): background exclusions are not counted
+    # as neighbor pixels
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
+                       labels=labels, seg_method=2)[0]
+    assert fc[FLAG_COL_SEG] == 1
+
+    # Method 3 ('correct'): the neighbor pixel is corrected (mirror
+    # pixel is valid)
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
+                       labels=labels, seg_method=3)[0]
+    assert fc[FLAG_COL_SEG] == 1
+    assert fc[FLAG_COL_UNCORRECTED] == 0
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX]
+
+    # Method 3 with the mirror pixel also a neighbor: uncorrectable
+    segm2 = segm.copy()
+    segm2[12, 10] = 2  # mirror of (12, 14) across (12, 12)
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm2,
+                       labels=labels, seg_method=3)[0]
+    assert fc[FLAG_COL_SEG] == 2
+    assert fc[FLAG_COL_UNCORRECTED] == 2
+
+    # Method 3 with a masked mirror pixel: uncorrectable
+    mask = np.zeros(SHAPE, dtype=np.uint8)
+    mask[12, 10] = 1
+    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
+                       segmentation=segm, labels=labels, seg_method=3)[0]
+    assert fc[FLAG_COL_SEG] == 1
+    assert fc[FLAG_COL_UNCORRECTED] == 1
+
+
+def test_gather_matches_sums_center():
+    """
+    Test that the gather kernel flag counts match the photometry kernel
+    with the "center" method.
+    """
+    rng = np.random.default_rng(1)
+    data = rng.normal(size=SHAPE)
+    data[11, 12] = np.nan
+    user_mask = np.zeros(SHAPE, dtype=bool)
+    user_mask[12, 13] = True
+
+    xy = np.array([(12.0, 12.0), (0.5, 3.0), (24.0, 24.0)])
+
+    # 2-bit plane: bit 1 = user mask, bit 2 = non-finite data
+    plane = user_mask.astype(np.uint8)
+    plane |= (~np.isfinite(data) & ~user_mask) * np.uint8(2)
+
+    fc_sums = _sums_fcounts(data, xy, 3.0, mask=plane, use_exact=0,
+                            subpixels=1)
+    fc_gather = _gather_fcounts(data, xy, 3.0, mask=plane)
+    # The gather kernel never reads error values
+    cols = [FLAG_COL_NPIX, FLAG_COL_MASKED, FLAG_COL_NONFINITE_DATA,
+            FLAG_COL_SEG, FLAG_COL_UNCORRECTED, FLAG_COL_VALID,
+            FLAG_COL_BBOX_CLIPPED]
+    assert_array_equal(fc_gather[:, cols], fc_sums[:, cols])

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -200,13 +200,13 @@ def test_no_overlap_nan_and_err_shape():
     aperture = CircularAperture(POSITIONS, r=5.5)
     n_outside = 3
 
-    sums, errs, _area = aperture._batch_photometry(
+    sums, errs, _area, *_ = aperture._batch_photometry(
         DATA, error=None, mask=None, method='exact', subpixels=5)
     assert np.isnan(sums).sum() == n_outside
     assert errs.shape == sums.shape
     assert np.all(np.isnan(errs))
 
-    sums, errs, _area = aperture._batch_photometry(
+    sums, errs, _area, *_ = aperture._batch_photometry(
         DATA, error=ERROR, mask=None, method='exact', subpixels=5)
     assert errs.shape == sums.shape
     assert np.isnan(errs).sum() == n_outside

--- a/photutils/aperture/tests/test_batch_thread_safety.py
+++ b/photutils/aperture/tests/test_batch_thread_safety.py
@@ -104,11 +104,13 @@ def _assert_gather_equal(result, expected):
     is meaningful; the trailing entries are uninitialized and must not be
     compared.
     """
-    values, lx, ly, starts, counts, overlap = result
-    e_values, e_lx, e_ly, e_starts, e_counts, e_overlap = expected
+    values, lx, ly, starts, counts, overlap, fcounts = result
+    (e_values, e_lx, e_ly, e_starts, e_counts, e_overlap,
+     e_fcounts) = expected
     assert_array_equal(starts, e_starts)
     assert_array_equal(counts, e_counts)
     assert_array_equal(overlap, e_overlap)
+    assert_array_equal(fcounts, e_fcounts)
     for start, count in zip(starts, counts, strict=True):
         sl = slice(int(start), int(start) + int(count))
         assert_array_equal(values[sl], e_values[sl])

--- a/photutils/aperture/tests/test_flags.py
+++ b/photutils/aperture/tests/test_flags.py
@@ -1,0 +1,214 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the flags module.
+"""
+
+import numpy as np
+import pytest
+
+from photutils.aperture.flags import (APERTURE_FLAGS, _ApertureFlags,
+                                      decode_aperture_flags)
+from photutils.utils._flags import FlagDefinition
+
+EXPECTED_FLAGS = {
+    'no_overlap': 1,
+    'partial_overlap': 2,
+    'no_pixels': 4,
+    'masked_pixels': 8,
+    'all_masked': 16,
+    'non_finite_data': 32,
+    'non_finite_error': 64,
+    'neighbor_pixels': 128,
+    'uncorrected_pixels': 256,
+    'sigma_clipped': 512,
+    'all_clipped': 1024,
+    'too_few_pixels': 2048,
+}
+
+
+def test_decode_aperture_flags():
+    """
+    Test the decode_aperture_flags standalone function.
+    """
+    decoded = decode_aperture_flags(0)
+    assert decoded == []
+    assert isinstance(decoded, list)
+
+    # Test each single flag value
+    for name, bit_value in EXPECTED_FLAGS.items():
+        assert decode_aperture_flags(bit_value) == [name]
+
+    # Test combination of flags
+    decoded = decode_aperture_flags(10)  # bits 2 and 8
+    assert decoded == ['partial_overlap', 'masked_pixels']
+
+    decoded = decode_aperture_flags(5)  # bits 1 and 4
+    assert decoded == ['no_overlap', 'no_pixels']
+
+    # Test with all flags set
+    all_flags = sum(EXPECTED_FLAGS.values())
+    decoded = decode_aperture_flags(all_flags)
+    assert decoded == list(EXPECTED_FLAGS)
+
+    # Test with array input
+    flags_array = [0, 1, 2, 10]
+    decoded_list = decode_aperture_flags(flags_array)
+    assert len(decoded_list) == 4
+    assert decoded_list[0] == []
+    assert decoded_list[1] == ['no_overlap']
+    assert decoded_list[2] == ['partial_overlap']
+    assert decoded_list[3] == ['partial_overlap', 'masked_pixels']
+
+    # Test with numpy array
+    decoded_list = decode_aperture_flags(np.array([8, 16, 32]))
+    assert decoded_list == [['masked_pixels'], ['all_masked'],
+                            ['non_finite_data']]
+
+    # Test with 0D numpy array (scalar array)
+    decoded = decode_aperture_flags(np.array(64))
+    assert decoded == ['non_finite_error']
+
+    # Test with empty array
+    decoded = decode_aperture_flags(np.array([], dtype=int))
+    assert decoded == []
+
+    # Test with 2D array (flattened)
+    decoded = decode_aperture_flags(np.array([[0, 1], [8, 24]]))
+    assert len(decoded) == 4
+    assert decoded[3] == ['masked_pixels', 'all_masked']
+
+
+def test_decode_aperture_flags_return_bit_values():
+    """
+    Test decode_aperture_flags with return_bit_values=True.
+    """
+    assert decode_aperture_flags(0, return_bit_values=True) == []
+    assert decode_aperture_flags(10, return_bit_values=True) == [2, 8]
+
+    decoded_list = decode_aperture_flags([1, 24],
+                                         return_bit_values=True)
+    assert decoded_list == [[1], [8, 16]]
+
+
+def test_decode_aperture_flags_errors():
+    """
+    Test decode_aperture_flags error conditions.
+    """
+    match = 'Flag value must be an integer'
+    with pytest.raises(TypeError, match=match):
+        decode_aperture_flags(3.14)
+    with pytest.raises(TypeError, match=match):
+        decode_aperture_flags('invalid')
+    with pytest.raises(TypeError, match=match):
+        decode_aperture_flags([1, 2.5, 3])
+
+    match = 'Flag value must be a non-negative integer'
+    with pytest.raises(ValueError, match=match):
+        decode_aperture_flags(-2)
+
+
+def test_aperture_flags_singleton():
+    """
+    Test APERTURE_FLAGS singleton behavior.
+    """
+    assert isinstance(APERTURE_FLAGS, _ApertureFlags)
+    assert APERTURE_FLAGS.domain == 'aperture'
+
+    new_flags = _ApertureFlags()
+    assert isinstance(new_flags, _ApertureFlags)
+    assert new_flags is not APERTURE_FLAGS
+
+
+def test_aperture_flags_constants():
+    """
+    Test _ApertureFlags constant access.
+    """
+    for name, bit_value in EXPECTED_FLAGS.items():
+        const_name = name.upper()
+        assert hasattr(APERTURE_FLAGS, const_name)
+        actual_value = getattr(APERTURE_FLAGS, const_name)
+        assert actual_value == bit_value
+        assert isinstance(actual_value, int)
+
+    match = "has no attribute 'INVALID'"
+    with pytest.raises(AttributeError, match=match):
+        _ = APERTURE_FLAGS.INVALID
+
+
+def test_aperture_flags_properties():
+    """
+    Test _ApertureFlags property access methods.
+    """
+    assert APERTURE_FLAGS.bit_values == list(EXPECTED_FLAGS.values())
+    assert APERTURE_FLAGS.names == list(EXPECTED_FLAGS)
+    assert APERTURE_FLAGS.flag_dict == {bit: name for name, bit
+                                        in EXPECTED_FLAGS.items()}
+
+    all_flags = APERTURE_FLAGS.all_flags
+    assert isinstance(all_flags, list)
+    assert len(all_flags) == len(EXPECTED_FLAGS)
+    for flag_def in all_flags:
+        assert isinstance(flag_def, FlagDefinition)
+
+
+def test_aperture_flags_get_methods():
+    """
+    Test _ApertureFlags getter methods.
+    """
+    for name, bit_value in EXPECTED_FLAGS.items():
+        assert APERTURE_FLAGS.get_name(bit_value) == name
+        assert APERTURE_FLAGS.get_bit_value(name) == bit_value
+        assert isinstance(APERTURE_FLAGS.get_description(bit_value), str)
+        detailed = APERTURE_FLAGS.get_detailed_description(bit_value)
+        assert isinstance(detailed, str)
+
+    # Test get_definition by bit value and name
+    def_by_bit = APERTURE_FLAGS.get_definition(1)
+    def_by_name = APERTURE_FLAGS.get_definition('no_overlap')
+    assert def_by_bit is def_by_name
+    assert def_by_bit.name == 'no_overlap'
+
+    # Test error cases
+    match = 'No flag with bit value 999'
+    with pytest.raises(KeyError, match=match):
+        APERTURE_FLAGS.get_definition(999)
+
+    match = "No flag with name 'invalid'"
+    with pytest.raises(KeyError, match=match):
+        APERTURE_FLAGS.get_definition('invalid')
+
+    match = 'identifier must be int'
+    with pytest.raises(TypeError, match=match):
+        APERTURE_FLAGS.get_definition(3.14)
+
+
+def test_aperture_flags_completeness():
+    """
+    Test that _ApertureFlags bit values and names are consistent.
+    """
+    bit_values = APERTURE_FLAGS.bit_values
+    names = APERTURE_FLAGS.names
+
+    # Bit values are unique powers of 2
+    assert len(bit_values) == len(set(bit_values))
+    for bit_val in bit_values:
+        assert bit_val > 0
+        assert (bit_val & (bit_val - 1)) == 0
+
+    # Names are unique, valid snake_case identifiers
+    assert len(names) == len(set(names))
+    for name in names:
+        assert name.isidentifier()
+        assert name == name.lower()
+
+
+def test_decode_aperture_flags_docstring():
+    """
+    Test that decode_aperture_flags has dynamic flag documentation.
+    """
+    docstring = decode_aperture_flags.__doc__
+    assert '<flag_descriptions>' not in docstring
+
+    for name, bit_value in EXPECTED_FLAGS.items():
+        expected = f"``'{name}'`` : bit {bit_value}"
+        assert expected in docstring

--- a/photutils/aperture/tests/test_flags.py
+++ b/photutils/aperture/tests/test_flags.py
@@ -23,6 +23,7 @@ EXPECTED_FLAGS = {
     'sigma_clipped': 512,
     'all_clipped': 1024,
     'too_few_pixels': 2048,
+    'singular_covariance': 4096,
 }
 
 

--- a/photutils/aperture/tests/test_flags.py
+++ b/photutils/aperture/tests/test_flags.py
@@ -210,5 +210,5 @@ def test_decode_aperture_flags_docstring():
     assert '<flag_descriptions>' not in docstring
 
     for name, bit_value in EXPECTED_FLAGS.items():
-        expected = f"``'{name}'`` : bit {bit_value}"
+        expected = f"**{bit_value}** (``'{name}'``)"
         assert expected in docstring

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -692,17 +692,17 @@ def test_scalar_aperture():
     ap = CircularAperture((10, 10), r=3.0)
     colnames1 = aperture_photometry(data, ap, error=data).colnames
     assert (colnames1 == ['id', 'x_center', 'y_center', 'aperture_sum',
-                          'aperture_sum_err', 'area'])
+                          'aperture_sum_err', 'area', 'flags'])
 
     colnames2 = aperture_photometry(data, [ap], error=data).colnames
     assert (colnames2 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
-                          'aperture_sum_err_0', 'area_0'])
+                          'aperture_sum_err_0', 'area_0', 'flags_0'])
 
     colnames3 = aperture_photometry(data, [ap, ap], error=data).colnames
     assert (colnames3 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
-                          'aperture_sum_err_0', 'area_0',
+                          'aperture_sum_err_0', 'area_0', 'flags_0',
                           'aperture_sum_1', 'aperture_sum_err_1',
-                          'area_1'])
+                          'area_1', 'flags_1'])
 
 
 def test_area_column():

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -1,0 +1,391 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the aperture photometry quality flags.
+"""
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from photutils.aperture import (APERTURE_FLAGS, CircularAnnulus,
+                                CircularAperture, EllipticalAperture,
+                                RectangularAperture, aperture_photometry)
+from photutils.aperture.flags import _counts_to_flag_bits
+
+SHAPE = (25, 25)
+
+APERTURE_FACTORIES = [
+    lambda xy: CircularAperture(xy, r=3.0),
+    lambda xy: CircularAnnulus(xy, r_in=2.0, r_out=4.0),
+    lambda xy: EllipticalAperture(xy, a=4.0, b=2.5, theta=0.5),
+    lambda xy: RectangularAperture(xy, w=5.0, h=4.0, theta=0.3),
+]
+
+METHODS = [('exact', 5), ('center', 1), ('subpixel', 4)]
+
+
+class _NoBatchCircularAperture(CircularAperture):
+    """
+    A CircularAperture subclass that does not opt in to the batch
+    Cython driver, forcing the mask-based code path.
+    """
+
+
+def _flags(aperture, data, **kwargs):
+    return aperture.photometry(data, **kwargs).flags
+
+
+def test_no_flags():
+    """
+    Test that a clean interior source has no flags set.
+    """
+    data = np.ones(SHAPE)
+    aper = CircularAperture((12, 12), r=3.0)
+    assert_array_equal(_flags(aper, data), [0])
+
+
+@pytest.mark.parametrize('factory', APERTURE_FACTORIES)
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_no_overlap(factory, method, subpixels):
+    """
+    Test that fully off-image apertures set no_overlap and no_pixels.
+    """
+    data = np.ones(SHAPE)
+    aper = factory([(-50.0, 12.0), (12.0, 12.0)])
+    result = aper.photometry(data, method=method, subpixels=subpixels)
+    expected = APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS
+    assert result.flags[0] == expected
+    assert np.isnan(result.aperture_sum[0])
+    assert result.flags[1] == 0
+
+
+@pytest.mark.parametrize('factory', APERTURE_FACTORIES)
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_partial_overlap(factory, method, subpixels):
+    """
+    Test that apertures straddling an edge set partial_overlap.
+    """
+    data = np.ones(SHAPE)
+    aper = factory([(0.0, 12.0), (12.0, 24.5), (12.0, 12.0)])
+    flags = _flags(aper, data, method=method, subpixels=subpixels)
+    assert flags[0] == APERTURE_FLAGS.PARTIAL_OVERLAP
+    assert flags[1] == APERTURE_FLAGS.PARTIAL_OVERLAP
+    assert flags[2] == 0
+
+
+def test_no_overlap_close_to_edge():
+    """
+    Test an aperture whose bounding box overlaps the data but whose
+    nonzero-weight pixels are all outside (precise no_overlap).
+    """
+    data = np.ones(SHAPE)
+    # bbox column 0 overlaps the data, but with the "center" method
+    # the pixel center at x=0 (distance 1.2) is outside the circle
+    aper = CircularAperture((-1.2, 12.0), r=0.8)
+    result = aper.photometry(data, method='center')
+    assert result.flags[0] == (APERTURE_FLAGS.NO_OVERLAP
+                               | APERTURE_FLAGS.NO_PIXELS)
+    # The sum is 0.0 (not NaN) here: the bounding box overlaps the
+    # data, but no weighted pixel falls inside
+    assert result.aperture_sum[0] == 0.0
+
+    # With the exact method, the aperture area extends into the data
+    result = aper.photometry(data, method='exact')
+    assert result.flags[0] == APERTURE_FLAGS.PARTIAL_OVERLAP
+
+
+def test_partial_overlap_clipped_bbox_only():
+    """
+    Test that a clipped bounding box alone does not set
+    partial_overlap when all nonzero weights are inside the data.
+    """
+    data = np.ones(SHAPE)
+    # bbox extends to column -1, but the pixel center at x=-1
+    # (distance 1.2 > r=0.8) is outside the circle
+    aper = CircularAperture((0.2, 12.0), r=0.8)
+    assert_array_equal(_flags(aper, data, method='center'), [0])
+
+    # The exact-method footprint does extend outside
+    flags = _flags(aper, data, method='exact')
+    assert_array_equal(flags, [APERTURE_FLAGS.PARTIAL_OVERLAP])
+
+
+def test_no_pixels_tiny_aperture():
+    """
+    Test that a tiny aperture with the "center" method sets no_pixels.
+    """
+    data = np.ones(SHAPE)
+    # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
+    aper = CircularAperture((12.5, 12.5), r=0.4)
+    result = aper.photometry(data, method='center')
+    assert result.flags[0] == APERTURE_FLAGS.NO_PIXELS
+    assert result.aperture_sum[0] == 0.0
+
+    # The exact method has a nonzero footprint
+    assert_array_equal(_flags(aper, data, method='exact'), [0])
+
+
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_masked_pixels(method, subpixels):
+    """
+    Test the masked_pixels and all_masked flags.
+    """
+    data = np.ones(SHAPE)
+
+    # One masked pixel inside the aperture
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[12, 12] = True
+    aper = CircularAperture((12, 12), r=3.0)
+    flags = _flags(aper, data, mask=mask, method=method,
+                   subpixels=subpixels)
+    assert flags[0] == APERTURE_FLAGS.MASKED_PIXELS
+
+    # Masked pixel inside the bounding box but outside the aperture
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[9, 9] = True
+    flags = _flags(aper, data, mask=mask, method=method,
+                   subpixels=subpixels)
+    assert flags[0] == 0
+
+    # Fully masked aperture
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[8:17, 8:17] = True
+    flags = _flags(aper, data, mask=mask, method=method,
+                   subpixels=subpixels)
+    assert flags[0] == (APERTURE_FLAGS.MASKED_PIXELS
+                        | APERTURE_FLAGS.ALL_MASKED)
+
+
+def test_non_finite_data():
+    """
+    Test the non_finite_data flag.
+
+    In photometry, unmasked non-finite values contribute to the sum
+    (making it NaN). They do not set all_masked.
+    """
+    data = np.ones(SHAPE)
+    data[12, 12] = np.nan
+    aper = CircularAperture((12, 12), r=3.0)
+    result = aper.photometry(data)
+    assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
+    assert np.isnan(result.aperture_sum[0])
+
+    # An all-NaN aperture is still non_finite_data only (the pixels
+    # contribute, so all_masked is not set)
+    data = np.full(SHAPE, np.nan)
+    result = aper.photometry(data)
+    assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
+
+    # A masked non-finite pixel counts only as masked
+    data = np.ones(SHAPE)
+    data[12, 12] = np.nan
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[12, 12] = True
+    flags = _flags(aper, data, mask=mask)
+    assert flags[0] == APERTURE_FLAGS.MASKED_PIXELS
+
+
+def test_non_finite_error():
+    """
+    Test the non_finite_error flag.
+    """
+    data = np.ones(SHAPE)
+    error = np.ones(SHAPE)
+    error[12, 12] = np.inf
+    aper = CircularAperture((12, 12), r=3.0)
+    flags = _flags(aper, data, error=error)
+    assert flags[0] == APERTURE_FLAGS.NON_FINITE_ERROR
+
+    # Without an error array, the flag is never set
+    assert_array_equal(_flags(aper, data), [0])
+
+
+@pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
+def test_neighbor_pixels(mask_method):
+    """
+    Test the neighbor_pixels flag for all segmentation mask methods.
+    """
+    data = np.ones(SHAPE)
+    segm = np.zeros(SHAPE, dtype=int)
+    segm[10:15, 10:15] = 1
+    segm[12, 14] = 2  # neighbor pixel inside the aperture
+    aper = CircularAperture((12, 12), r=3.0)
+    flags = _flags(aper, data, segmentation_image=segm, labels=1,
+                   mask_method=mask_method)
+    assert flags[0] == APERTURE_FLAGS.NEIGHBOR_PIXELS
+
+    # Without any neighbor pixels inside the aperture, no flag is set
+    segm2 = np.zeros(SHAPE, dtype=int)
+    segm2[10:15, 10:15] = 1
+    flags = _flags(aper, data, segmentation_image=segm2, labels=1,
+                   mask_method=mask_method)
+    assert flags[0] == 0
+
+
+def test_uncorrected_pixels():
+    """
+    Test the uncorrected_pixels flag with mask_method='correct'.
+    """
+    data = np.ones(SHAPE)
+    segm = np.zeros(SHAPE, dtype=int)
+    segm[10:15, 10:15] = 1
+    segm[12, 14] = 2  # neighbor; its mirror (12, 10) is source pixel
+    segm[12, 10] = 2  # make the mirror a neighbor too: uncorrectable
+    aper = CircularAperture((12, 12), r=3.0)
+    flags = _flags(aper, data, segmentation_image=segm, labels=1,
+                   mask_method='correct')
+    assert flags[0] == (APERTURE_FLAGS.NEIGHBOR_PIXELS
+                        | APERTURE_FLAGS.UNCORRECTED_PIXELS)
+
+    # A correctable neighbor does not set uncorrected_pixels
+    segm[12, 10] = 0
+    flags = _flags(aper, data, segmentation_image=segm, labels=1,
+                   mask_method='correct')
+    assert flags[0] == APERTURE_FLAGS.NEIGHBOR_PIXELS
+
+
+def test_flag_combinations():
+    """
+    Test that multiple conditions combine bitwise.
+    """
+    data = np.ones(SHAPE)
+    data[12, 6] = np.nan  # outside the r=3 aperture at (0, 12)
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[10, 1] = True
+    aper = CircularAperture((0.0, 12.0), r=3.0)  # straddles left edge
+    flags = _flags(aper, data, mask=mask)
+    assert flags[0] == (APERTURE_FLAGS.PARTIAL_OVERLAP
+                        | APERTURE_FLAGS.MASKED_PIXELS)
+
+
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_mask_path_parity(method, subpixels):
+    """
+    Test that the mask-based code path produces flags identical to the
+    batch Cython driver.
+    """
+    rng = np.random.default_rng(0)
+    data = rng.normal(1.0, 0.1, size=SHAPE)
+    data[13, 12] = np.nan
+    error = np.ones(SHAPE)
+    error[10, 12] = np.inf
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[12, 12] = True
+
+    xy = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0), (24.5, 24.5),
+          (0.2, 12.0), (-1.2, 12.0)]
+    batch_aper = CircularAperture(xy, r=3.0)
+    nobatch_aper = _NoBatchCircularAperture(xy, r=3.0)
+
+    kwargs = {'error': error, 'mask': mask, 'method': method,
+              'subpixels': subpixels}
+    result_batch = batch_aper.photometry(data, **kwargs)
+    result_nobatch = nobatch_aper.photometry(data, **kwargs)
+    assert_array_equal(result_batch.flags, result_nobatch.flags)
+    assert_allclose(result_batch.aperture_sum,
+                    result_nobatch.aperture_sum, rtol=1e-12,
+                    equal_nan=True)
+
+
+def test_mask_path_parity_segmentation():
+    """
+    Test batch/mask-path flag parity with segmentation masking.
+    """
+    data = np.ones(SHAPE)
+    segm = np.zeros(SHAPE, dtype=int)
+    segm[10:15, 10:15] = 1
+    segm[12, 14] = 2
+    segm[12, 10] = 2
+    segm[3:7, 3:7] = 3
+    xy = [(12.0, 12.0), (5.0, 5.0)]
+    labels = [1, 3]
+
+    for mask_method in ('mask', 'source_only', 'correct'):
+        flags_batch = CircularAperture(xy, r=3.0).photometry(
+            data, segmentation_image=segm, labels=labels,
+            mask_method=mask_method).flags
+        flags_nobatch = _NoBatchCircularAperture(xy, r=3.0).photometry(
+            data, segmentation_image=segm, labels=labels,
+            mask_method=mask_method).flags
+        assert_array_equal(flags_batch, flags_nobatch)
+
+
+def test_aperture_photometry_flags_column():
+    """
+    Test the flags column in the aperture_photometry table.
+    """
+    data = np.ones(SHAPE)
+    xy = [(12.0, 12.0), (-50.0, 12.0), (0.0, 12.0)]
+    aper = CircularAperture(xy, r=3.0)
+    tbl = aperture_photometry(data, aper)
+    expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS,
+                APERTURE_FLAGS.PARTIAL_OVERLAP]
+    assert_array_equal(tbl['flags'], expected)
+    assert 'decode_aperture_flags' in tbl['flags'].info.description
+
+    # Multiple apertures use suffixed column names
+    aper2 = CircularAperture(xy, r=4.0)
+    tbl = aperture_photometry(data, [aper, aper2])
+    assert_array_equal(tbl['flags_0'], expected)
+    assert_array_equal(tbl['flags_1'], expected)
+
+
+def test_flags_with_units():
+    """
+    Test that flags are also set for Quantity inputs.
+    """
+    data = np.ones(SHAPE) * u.Jy
+    data[12, 12] = np.nan * u.Jy
+    aper = CircularAperture((12, 12), r=3.0)
+    result = aper.photometry(data)
+    assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
+    tbl = aperture_photometry(data, aper)
+    assert tbl['flags'][0] == APERTURE_FLAGS.NON_FINITE_DATA
+
+
+def test_legacy_tuple_unpacking():
+    """
+    Test that the legacy 2-tuple unpacking of the photometry results
+    is unchanged by the flags attribute.
+    """
+    data = np.ones(SHAPE)
+    aper = CircularAperture((12, 12), r=3.0)
+    result = aper.photometry(data)
+    aperture_sum, _aperture_sum_err = result
+    assert len(result) == 2
+    assert_array_equal(result[0], aperture_sum)
+    assert result.flags is not None
+
+
+def test_counts_to_flag_bits_scalar_inputs():
+    """
+    Test that _counts_to_flag_bits accepts 1D count rows and scalar
+    overlap/w_out values.
+    """
+    counts = np.zeros(8, dtype=int)
+    flags = _counts_to_flag_bits(counts, np.False_, np.False_)
+    assert flags[0] == (APERTURE_FLAGS.NO_OVERLAP
+                        | APERTURE_FLAGS.NO_PIXELS)
+
+
+def test_resolve_outside_weights_no_mask_overlap():
+    """
+    Test that _resolve_outside_weights returns True for a candidate
+    whose aperture mask does not actually overlap the data.
+
+    In practice, the caller only ever marks a source as a candidate when
+    its aperture mask does overlap the data, so the mask's bounding box
+    is never actually clipped away entirely. This directly exercises
+    that defensive branch.
+    """
+    aper = CircularAperture((-5.0, 12.0), r=3.0)
+    shape = (25, 25)
+    mask = aper.to_mask(method='exact', subpixels=5)
+    assert mask.get_overlap_slices(shape) == (None, None)
+
+    candidates = np.array([True])
+    w_out = aper._resolve_outside_weights(shape, method='exact',
+                                          subpixels=5,
+                                          candidates=candidates)
+    assert w_out[0]

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -374,18 +374,115 @@ def test_resolve_outside_weights_no_mask_overlap():
     Test that _resolve_outside_weights returns True for a candidate
     whose aperture mask does not actually overlap the data.
 
-    In practice, the caller only ever marks a source as a candidate when
-    its aperture mask does overlap the data, so the mask's bounding box
-    is never actually clipped away entirely. This directly exercises
-    that defensive branch.
+    In practice, the caller only ever marks a source as a candidate
+    when its aperture mask does overlap the data, so the mask's
+    bounding box is never actually clipped away entirely. This
+    directly exercises that defensive branch. A non-'exact' method is
+    used because the 'exact' method takes the gated fast path (see
+    ``_resolve_outside_weights``).
     """
     aper = CircularAperture((-5.0, 12.0), r=3.0)
     shape = (25, 25)
-    mask = aper.to_mask(method='exact', subpixels=5)
+    mask = aper.to_mask(method='center')
     assert mask.get_overlap_slices(shape) == (None, None)
 
     candidates = np.array([True])
-    w_out = aper._resolve_outside_weights(shape, method='exact',
+    w_out = aper._resolve_outside_weights(shape, method='center',
                                           subpixels=5,
                                           candidates=candidates)
     assert w_out[0]
+
+
+def _bbox_clipped_candidates(aper, shape):
+    """
+    Per-source indicator of whether the aperture bounding
+    box overlaps the data but is clipped by a data edge (the
+    ``FLAG_COL_BBOX_CLIPPED`` candidate condition, computed from the
+    aperture bounding boxes).
+    """
+    ny, nx = shape
+    candidates = []
+    for bbox in aper._bbox:
+        overlap = (bbox.ixmin < nx and bbox.ixmax > 0
+                   and bbox.iymin < ny and bbox.iymax > 0)
+        clipped = (bbox.ixmin < 0 or bbox.iymin < 0
+                   or bbox.ixmax > nx or bbox.iymax > ny)
+        candidates.append(overlap and clipped)
+    return np.array(candidates, dtype=bool)
+
+
+def _bruteforce_outside_weights(aper, shape, *, method, subpixels, candidates):
+    """
+    Reference (non-gated) per-source outside-weight test, built from
+    explicit aperture masks. This replicates the mask-based branch of
+    ``_resolve_outside_weights``, including its restriction to the
+    candidate (bbox-clipped) sources.
+    """
+    w_out = np.zeros(candidates.shape, dtype=bool)
+    idx = np.flatnonzero(candidates)
+    if idx.size == 0:
+        return w_out
+
+    sub = aper if aper.isscalar else aper[idx]
+    masks = sub.to_mask(method=method, subpixels=subpixels)
+    if sub.isscalar:
+        masks = [masks]
+    for i, mask in zip(idx, masks, strict=True):
+        n_total = np.count_nonzero(mask.data)
+        slc_large, slc_small = mask.get_overlap_slices(shape)
+        if slc_large is None:
+            w_out[i] = n_total > 0
+        else:
+            n_in = np.count_nonzero(mask.data[slc_small])
+            w_out[i] = n_total > n_in
+    return w_out
+
+
+@pytest.mark.parametrize('factory', APERTURE_FACTORIES)
+def test_resolve_outside_weights_exact_gating(factory):
+    """
+    Test that the gated 'exact' fast path in _resolve_outside_weights
+    matches the explicit per-source mask computation.
+
+    For the 'exact' method the minimal bounding box is tight, so a
+    bbox that is clipped by a data edge always leaves a positive-area
+    aperture sliver outside the data. The gated path returns the
+    bbox-clipped candidates unchanged; this must equal the reference
+    mask-based outside-weight test for a mix of interior, edge, corner,
+    and fully off-image positions.
+    """
+    ny, nx = SHAPE
+    xy = [(12.0, 12.0),  # interior (not a candidate)
+          (0.0, 12.0), (nx - 1.0, 12.0),  # left/right edges
+          (12.0, 0.0), (12.0, ny - 1.0),  # bottom/top edges
+          (0.0, 0.0), (nx - 1.0, ny - 1.0),  # corners
+          (0.0, ny - 1.0), (nx - 1.0, 0.0),  # corners
+          (1.5, 12.0), (12.0, ny - 2.0),  # near edges
+          (-50.0, 12.0)]  # fully off-image (not a candidate)
+    aper = factory(xy)
+
+    candidates = _bbox_clipped_candidates(aper, SHAPE)
+    gated = aper._resolve_outside_weights(SHAPE, method='exact',
+                                          subpixels=5,
+                                          candidates=candidates)
+    brute = _bruteforce_outside_weights(aper, SHAPE, method='exact',
+                                        subpixels=5, candidates=candidates)
+
+    # The gated path returns the candidates unchanged.
+    assert_array_equal(gated, candidates)
+    # That exactly matches the explicit mask-based computation.
+    assert_array_equal(gated, brute)
+
+
+def test_resolve_outside_weights_exact_returns_copy():
+    """
+    Test that the gated 'exact' path returns a copy, not the input
+    candidates array.
+    """
+    aper = CircularAperture([(0.0, 12.0), (12.0, 12.0)], r=3.0)
+    candidates = _bbox_clipped_candidates(aper, SHAPE)
+    w_out = aper._resolve_outside_weights(SHAPE, method='exact',
+                                          subpixels=5,
+                                          candidates=candidates)
+    assert w_out is not candidates
+    assert_array_equal(w_out, candidates)

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -180,7 +180,7 @@ class TestAperturePhotometry:
         batch_sum, batch_err = aper.photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
-        mask_sum, mask_err, _area = aper._mask_photometry(
+        mask_sum, mask_err, _area, *_ = aper._mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm.astype(np.intp), labels=labels,
             mask_method='correct')
@@ -293,25 +293,32 @@ class TestApertureStats:
 class TestMakeSegmentationExclusion:
     def test_none_method(self):
         segm = np.array([[0, 1], [2, 1]])
-        _, _, exclude = make_segmentation_exclusion('none', segm, 1)
+        _, _, exclude, affected = make_segmentation_exclusion('none', segm, 1)
         assert not exclude.any()
+        assert not affected.any()
 
     def test_label_zero(self):
         segm = np.array([[0, 1], [2, 1]])
-        _, _, exclude = make_segmentation_exclusion('mask', segm, 0)
+        _, _, exclude, affected = make_segmentation_exclusion('mask', segm, 0)
         assert not exclude.any()
+        assert not affected.any()
 
     def test_mask_method(self):
         segm = np.array([[0, 1], [2, 1]])
-        _, _, exclude = make_segmentation_exclusion('mask', segm, 1)
+        _, _, exclude, affected = make_segmentation_exclusion('mask', segm, 1)
         expected = np.array([[False, False], [True, False]])
         assert_allclose(exclude, expected)
+        assert_allclose(affected, expected)
 
     def test_source_only_method(self):
         segm = np.array([[0, 1], [2, 1]])
-        _, _, exclude = make_segmentation_exclusion('source_only', segm, 1)
+        _, _, exclude, affected = make_segmentation_exclusion(
+            'source_only', segm, 1)
         expected = np.array([[True, False], [True, False]])
         assert_allclose(exclude, expected)
+        # Background exclusions are not marked as affected
+        expected_affected = np.array([[False, False], [True, False]])
+        assert_allclose(affected, expected_affected)
 
     def test_correct_replaces_neighbor(self):
         # 5x5 cutout, center (2, 2). A neighbor pixel at (1, 2) [x=1, y=2]
@@ -320,11 +327,13 @@ class TestMakeSegmentationExclusion:
         segm[2, 2] = 1  # target center
         segm[2, 1] = 2  # neighbor at x=1, y=2
         data = np.arange(25, dtype=float).reshape(5, 5)
-        out_data, _, exclude = make_segmentation_exclusion(
+        out_data, _, exclude, affected = make_segmentation_exclusion(
             'correct', segm, 1, data=data, cutout_xycen=(2, 2))
-        # neighbor replaced, not excluded
+        # Neighbor replaced, not excluded
         assert not exclude[2, 1]
-        # mirror of (x=1, y=2) is (x=3, y=2) -> data[2, 3]
+        # Replaced pixels are marked as affected
+        assert affected[2, 1]
+        # Mirror of (x=1, y=2) is (x=3, y=2) -> data[2, 3]
         assert out_data[2, 1] == data[2, 3]
 
     def test_correct_out_of_bounds_mirror(self):
@@ -334,9 +343,10 @@ class TestMakeSegmentationExclusion:
         segm2[1, 0] = 2  # neighbor x=0,y=1; mirror x=2*1-0=2 in bounds
         segm2[3, 3] = 2  # neighbor x=3,y=3; mirror x=2*1-3=-1 out of bounds
         data = np.ones((5, 5))
-        _, _, exclude = make_segmentation_exclusion(
+        _, _, exclude, affected = make_segmentation_exclusion(
             'correct', segm2, 1, data=data, cutout_xycen=(1, 1))
         assert exclude[3, 3]
+        assert affected[3, 3]
 
     def test_correct_neighbor_mirror(self):
         # A neighbor whose mirror is also a neighbor must be excluded.
@@ -345,7 +355,7 @@ class TestMakeSegmentationExclusion:
         segm[2, 1] = 2  # neighbor x=1,y=2; mirror x=3,y=2
         segm[2, 3] = 2  # neighbor x=3,y=2; mirror x=1,y=2 (both neighbors)
         data = np.ones((5, 5))
-        _, _, exclude = make_segmentation_exclusion(
+        _, _, exclude, _ = make_segmentation_exclusion(
             'correct', segm, 1, data=data, cutout_xycen=(2, 2))
         assert exclude[2, 1]
         assert exclude[2, 3]
@@ -358,7 +368,7 @@ class TestMakeSegmentationExclusion:
         base_mask = np.zeros((5, 5), dtype=bool)
         base_mask[2, 3] = True  # mask the mirror pixel
         data = np.ones((5, 5))
-        _, _, exclude = make_segmentation_exclusion(
+        _, _, exclude, _ = make_segmentation_exclusion(
             'correct', segm, 1, data=data, base_mask=base_mask,
             cutout_xycen=(2, 2))
         assert exclude[2, 1]
@@ -369,7 +379,7 @@ class TestMakeSegmentationExclusion:
         segm[2, 1] = 2
         data = np.arange(25, dtype=float).reshape(5, 5)
         error = np.arange(25, dtype=float).reshape(5, 5) * 0.1
-        _, out_error, _ = make_segmentation_exclusion(
+        _, out_error, _, _ = make_segmentation_exclusion(
             'correct', segm, 1, data=data, error=error, cutout_xycen=(2, 2))
         assert out_error[2, 1] == error[2, 3]
 
@@ -461,7 +471,7 @@ class TestBatchDriverSegmentation:
         batch_sum, batch_err = aper.photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
-        mask_sum, mask_err, _area = aper._mask_photometry(
+        mask_sum, mask_err, _area, *_ = aper._mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm, labels=labels,
             mask_method='correct')

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -163,7 +163,7 @@ class TestApertureStats:
         for prop in apstats1.properties:
             if prop in scalar_props:
                 continue
-            if 'sum' in prop:
+            if 'sum' in prop and prop != 'sum_flags':
                 # Test that these properties are not equal
                 with pytest.raises(AssertionError):
                     assert_equal(getattr(apstats1, prop),
@@ -197,7 +197,7 @@ class TestApertureStats:
         assert apstats[1].sum_err < self.apstats1[1].sum_err
 
         exclude = ('isscalar', 'n_apertures', 'sky_centroid',
-                   'sky_centroid_icrs', 'flags')
+                   'sky_centroid_icrs', 'flags', 'sum_flags')
         apstats1 = apstats[2]
         for prop in apstats1.properties:
             if (prop in exclude or 'bbox' in prop or 'cutout' in prop
@@ -255,7 +255,7 @@ class TestApertureStats:
         assert_equal(apstats._overlap, [True, True, False])
 
         exclude = ('isscalar', 'n_apertures', 'sky_centroid',
-                   'sky_centroid_icrs', 'flags')
+                   'sky_centroid_icrs', 'flags', 'sum_flags')
         apstats1 = apstats[2]
         for prop in apstats1.properties:
             if (prop in exclude or 'bbox' in prop or 'cutout' in prop

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -18,6 +18,7 @@ from numpy.testing import assert_allclose, assert_equal
 from photutils.aperture.circle import CircularAnnulus, CircularAperture
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus)
+from photutils.aperture.flags import APERTURE_FLAGS
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture)
 from photutils.aperture.stats import _MAD_STD_SCALE, ApertureStats
@@ -196,13 +197,18 @@ class TestApertureStats:
         assert apstats[1].sum_err < self.apstats1[1].sum_err
 
         exclude = ('isscalar', 'n_apertures', 'sky_centroid',
-                   'sky_centroid_icrs')
+                   'sky_centroid_icrs', 'flags')
         apstats1 = apstats[2]
         for prop in apstats1.properties:
             if (prop in exclude or 'bbox' in prop or 'cutout' in prop
                     or 'moments' in prop):
                 continue
             assert np.all(np.isnan(getattr(apstats1, prop)))
+
+        # id=2 has masked pixels; id=3 is completely masked
+        assert apstats[1].flags == APERTURE_FLAGS.MASKED_PIXELS
+        assert apstats[2].flags == (APERTURE_FLAGS.MASKED_PIXELS
+                                    | APERTURE_FLAGS.ALL_MASKED)
 
         # Test that mask=None is the same as mask=np.ma.nomask
         apstats1 = ApertureStats(self.data, self.aperture, mask=None)
@@ -249,13 +255,17 @@ class TestApertureStats:
         assert_equal(apstats._overlap, [True, True, False])
 
         exclude = ('isscalar', 'n_apertures', 'sky_centroid',
-                   'sky_centroid_icrs')
+                   'sky_centroid_icrs', 'flags')
         apstats1 = apstats[2]
         for prop in apstats1.properties:
             if (prop in exclude or 'bbox' in prop or 'cutout' in prop
                     or 'moments' in prop):
                 continue
             assert np.all(np.isnan(getattr(apstats1, prop)))
+
+        assert apstats[0].flags == APERTURE_FLAGS.PARTIAL_OVERLAP
+        assert apstats[2].flags == (APERTURE_FLAGS.NO_OVERLAP
+                                    | APERTURE_FLAGS.NO_PIXELS)
 
     def test_to_table(self):
         tbl = self.apstats1.to_table()

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -371,3 +371,213 @@ def test_flags_docstring():
         docstring = prop.__doc__
         assert '<flag_descriptions>' not in docstring
         assert "**1** (``'no_overlap'``)" in docstring
+
+
+def _single_pixel_data():
+    """
+    Return data with a single bright pixel, giving a source whose
+    covariance matrix is singular (zero spatial extent).
+    """
+    data = np.zeros(SHAPE)
+    data[12, 12] = 100.0
+    return data
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_singular_covariance_requires_shape_access():
+    """
+    Test that the singular_covariance bit is not set until a
+    covariance-derived property is accessed.
+    """
+    data = _single_pixel_data()
+    aper = CircularAperture((12.0, 12.0), r=5.0)
+    stats = ApertureStats(data, aper)
+
+    # Not set before any covariance-derived property is accessed
+    assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
+    assert 'singular_covariance' not in stats.decode_flags()[0]
+
+    # Accessing a shape property makes a reread include the bit
+    _ = stats.semimajor_axis
+    assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+    assert 'singular_covariance' in stats.decode_flags()[0]
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_singular_covariance_triggered_by_covariance():
+    """
+    Test that the singular_covariance bit is set when the covariance
+    matrix is computed, even if no shape properties are accessed.
+    """
+    data = _single_pixel_data()
+    aper = CircularAperture((12.0, 12.0), r=5.0)
+    stats = ApertureStats(data, aper)
+    _ = stats.covariance
+    assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_singular_covariance_array_and_guards():
+    """
+    Test that the singular_covariance bit is set for an array of sources
+    and that the covariance computation is guarded against sources with
+    no overlap (undefined moments).
+    """
+    data = _single_pixel_data()
+    data[6, 6] = 100.0
+    yy, xx = np.mgrid[0:25, 0:25]
+    data = data + 50.0 * np.exp(-((xx - 18)**2 + (yy - 18)**2) / (2 * 2.5**2))
+    aper = CircularAperture([(6.0, 6.0), (18.0, 18.0), (-50.0, 12.0)], r=4.0)
+    stats = ApertureStats(data, aper)
+    _ = stats.semimajor_axis  # force the covariance computation
+    flags = stats.flags
+    covar_flag = APERTURE_FLAGS.SINGULAR_COVARIANCE
+    assert (flags[0] & covar_flag) != 0  # singular point source
+    assert (flags[1] & covar_flag) == 0  # extended source
+    assert (flags[2] & covar_flag) == 0  # no-overlap: not flagged singular
+    assert (flags[2] & APERTURE_FLAGS.NO_OVERLAP) != 0
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_singular_covariance_extended_source_not_flagged():
+    """
+    Test that a well-resolved source with a non-singular covariance
+    matrix is not flagged as singular.
+    """
+    yy, xx = np.mgrid[0:25, 0:25]
+    data = 100.0 * np.exp(-((xx - 12)**2 + (yy - 12)**2) / (2 * 3.0**2))
+    aper = CircularAperture((12.0, 12.0), r=6.0)
+    stats = ApertureStats(data, aper)
+    _ = stats.semimajor_axis
+    assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_singular_covariance_in_default_table():
+    """
+    Test that the singular_covariance bit is reflected in the default
+    to_table() output.
+    """
+    data = _single_pixel_data()
+    aper = CircularAperture((12.0, 12.0), r=5.0)
+    stats = ApertureStats(data, aper)
+    tbl = stats.to_table()
+    assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_to_table_evaluates_flags_last():
+    """
+    Test that requesting a shape column before 'flags' still yields a
+    flags column that reflects the singular_covariance bit.
+    """
+    data = _single_pixel_data()
+    aper = CircularAperture((12.0, 12.0), r=5.0)
+    stats = ApertureStats(data, aper)
+    columns = ['flags', 'semimajor_axis']
+    tbl = stats.to_table(columns=columns)
+    assert tbl.colnames == columns  # check order
+    assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_to_table_flags_only_no_singular_bit():
+    """
+    Test that requesting only the 'flags' column does not trigger the
+    covariance computation and so does not set the singular_covariance
+    bit.
+    """
+    data = _single_pixel_data()
+    aper = CircularAperture((12.0, 12.0), r=5.0)
+    stats = ApertureStats(data, aper)
+    tbl = stats.to_table(columns=['flags'])
+    assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_singular_covariance_in_properties():
+    """
+    Test that the singular_covariance bit is reflected in the properties
+    list even if no shape properties are accessed.
+    """
+    data = _single_pixel_data()
+    aper = CircularAperture((12.0, 12.0), r=5.0)
+    stats = ApertureStats(data, aper)
+    assert 'flags' in stats.properties
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_singular_covariance_slicing():
+    """
+    Test that the singular_covariance bit is preserved when slicing an
+    array of ApertureStats objects.
+    """
+    data = _single_pixel_data()
+    data[6, 6] = 100.0
+    aper = CircularAperture([(6.0, 6.0), (12.0, 12.0)], r=4.0)
+    stats = ApertureStats(data, aper)
+    _ = stats.semimajor_axis
+    covar_flag = APERTURE_FLAGS.SINGULAR_COVARIANCE
+    assert (stats[0].flags & covar_flag) != 0
+    assert (stats[1].flags & covar_flag) != 0
+
+
+def _stats_with_injected_covariance(cov_xx, cov_yy, cov_xy):
+    """
+    Return a length-1 array ``ApertureStats`` whose central moments
+    are overridden so that the source covariance matrix has the given
+    entries (with unit total weight).
+
+    This exercises the singular-covariance criterion directly for cases
+    that are awkward to realize from pixel data (rank-1 degeneracy and a
+    covariance matrix that is not positive semidefinite).
+    """
+    data = _single_pixel_data()
+    aper = CircularAperture([(12.0, 12.0)], r=5.0)
+    stats = ApertureStats(data, aper)
+    moments = np.zeros((1, 4, 4))
+    moments[0, 0, 0] = 1.0  # total weight (m00)
+    moments[0, 2, 0] = cov_xx  # normalized -> covariance_xx
+    moments[0, 0, 2] = cov_yy  # normalized -> covariance_yy
+    moments[0, 1, 1] = cov_xy  # normalized -> covariance_xy
+    stats.moments_central = moments
+    return stats
+
+
+def test_singular_covariance_rank1_degeneracy():
+    """
+    Test that a rank-1 degenerate source is flagged as singular.
+
+    A rank-1 degenerate source has one unresolved axis and one extended
+    axis, so its covariance matrix has one tiny eigenvalue. The
+    singularity criterion is that the minor-axis variance is below a
+    floor of ``1/12`` (the variance of a uniform distribution over a
+    unit pixel). This is a more robust criterion than the determinant
+    test, which can be fooled by a rank-1 source with a large major-axis
+    variance.
+    """
+    # Minor-axis variance 0.05 < 1/12, major-axis variance 0.5
+    stats = _stats_with_injected_covariance(cov_xx=0.5, cov_yy=0.05,
+                                            cov_xy=0.0)
+    delta = 1.0 / 12
+    assert delta**2 < 0.5 * 0.05  # determinant test alone would miss it
+    assert delta > 0.05  # minor-axis variance below the floor
+    assert stats._singular_covariance_mask[0]
+
+    # The bit is reflected in flags once a shape property is computed
+    _ = stats.semimajor_axis
+    assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+
+def test_singular_covariance_not_positive_semidefinite():
+    """
+    Test that a covariance matrix that is not positive semidefinite is
+    flagged as singular.
+    """
+    stats = _stats_with_injected_covariance(cov_xx=1.0, cov_yy=1.0,
+                                            cov_xy=2.0)
+    assert (1.0 * 1.0 - 2.0**2) < 0  # negative determinant
+    assert stats._singular_covariance_mask[0]
+
+    _ = stats.semimajor_axis
+    assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -1,0 +1,349 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the ApertureStats quality flags.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from astropy.stats import SigmaClip
+from numpy.testing import assert_array_equal
+
+from photutils.aperture import APERTURE_FLAGS, ApertureStats, CircularAperture
+
+SHAPE = (25, 25)
+
+
+def _stats_flags(data, aperture, **kwargs):
+    return ApertureStats(data, aperture, **kwargs).flags
+
+
+def _force_mask_path():
+    """
+    Return a context manager that disables the fast Cython batch path.
+    """
+    return patch.object(ApertureStats, '_batch_inputs',
+                        property(lambda _self: None))
+
+
+@pytest.fixture(params=[True, False], ids=['fast', 'maskpath'])
+def maybe_mask_path(request):
+    """
+    Run a test with both the fast batch path and the mask-based path.
+    """
+    if request.param:
+        yield
+    else:
+        with _force_mask_path():
+            yield
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_no_flags():
+    """
+    Test that a clean interior source has no flags set.
+    """
+    data = np.ones(SHAPE)
+    aper = CircularAperture((12, 12), r=3.0)
+    stats = ApertureStats(data, aper)
+    assert stats.flags == 0  # scalar aperture gives a scalar flag
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_overlap_flags():
+    """
+    Test the no_overlap, partial_overlap, and no_pixels flags.
+    """
+    data = np.ones(SHAPE)
+    aper = CircularAperture([(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0)],
+                            r=3.0)
+    stats = ApertureStats(data, aper)
+    assert stats.flags[0] == 0
+    assert stats.flags[1] == APERTURE_FLAGS.PARTIAL_OVERLAP
+    assert stats.flags[2] == (APERTURE_FLAGS.NO_OVERLAP
+                              | APERTURE_FLAGS.NO_PIXELS)
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_no_pixels_center_footprint():
+    """
+    Test that an empty "center" footprint sets no_pixels even when the
+    default exact-method sum footprint is populated (the per-footprint
+    flag bits are combined with OR).
+    """
+    data = np.ones(SHAPE)
+    # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
+    aper = CircularAperture((12.5, 12.5), r=0.4)
+    stats = ApertureStats(data, aper)
+    assert stats.flags == APERTURE_FLAGS.NO_PIXELS
+    assert stats.sum > 0.0  # the exact-method sum is finite
+    assert np.isnan(stats.mean)  # center statistics are undefined
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_masked_pixels():
+    """
+    Test the masked_pixels and all_masked flags.
+    """
+    data = np.ones(SHAPE)
+    aper = CircularAperture((12, 12), r=3.0)
+
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[12, 12] = True
+    assert _stats_flags(data, aper,
+                        mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
+
+    # Masked pixel inside the bounding box but outside the aperture
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[9, 9] = True
+    assert _stats_flags(data, aper, mask=mask) == 0
+
+    # Fully masked aperture
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[8:17, 8:17] = True
+    assert _stats_flags(data, aper, mask=mask) == (
+        APERTURE_FLAGS.MASKED_PIXELS | APERTURE_FLAGS.ALL_MASKED)
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_masked_pixels_sum_footprint_only():
+    """
+    Test that a masked boundary pixel touched only by the exact-method
+    sum footprint (its center lies exactly on the aperture boundary)
+    still sets masked_pixels.
+    """
+    data = np.ones(SHAPE)
+    aper = CircularAperture((12, 12), r=3.0)
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[15, 12] = True  # center at distance exactly 3.0 (boundary)
+    assert _stats_flags(data, aper,
+                        mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
+    # The pixel is excluded from the center footprint
+    stats = ApertureStats(data, aper, mask=mask, sum_method='center')
+    assert stats.flags == 0
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_non_finite_data():
+    """
+    Test the non_finite_data flag.
+
+    In ApertureStats, non-finite data values are automatically masked,
+    so they contribute to all_masked (but not to masked_pixels, which
+    reflects only the input mask).
+    """
+    data = np.ones(SHAPE)
+    data[12, 12] = np.nan
+    aper = CircularAperture((12, 12), r=3.0)
+    assert _stats_flags(data, aper) == APERTURE_FLAGS.NON_FINITE_DATA
+
+    # All-NaN aperture: auto-masked, so also all_masked
+    data = np.full(SHAPE, np.nan)
+    assert _stats_flags(data, aper) == (APERTURE_FLAGS.NON_FINITE_DATA
+                                        | APERTURE_FLAGS.ALL_MASKED)
+
+    # A pixel that is both input-masked and non-finite counts only as
+    # masked
+    data = np.ones(SHAPE)
+    data[12, 12] = np.nan
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[12, 12] = True
+    assert _stats_flags(data, aper,
+                        mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_non_finite_error():
+    """
+    Test the non_finite_error flag (evaluated on the sum footprint).
+    """
+    data = np.ones(SHAPE)
+    error = np.ones(SHAPE)
+    error[12, 12] = np.nan
+    aper = CircularAperture((12, 12), r=3.0)
+    assert _stats_flags(data, aper,
+                        error=error) == APERTURE_FLAGS.NON_FINITE_ERROR
+    assert _stats_flags(data, aper) == 0
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_sigma_clipped():
+    """
+    Test the sigma_clipped flag.
+    """
+    rng = np.random.default_rng(0)
+    data = rng.normal(1.0, 0.1, size=SHAPE)
+    data[12, 12] = 1000.0  # outlier
+    aper = CircularAperture((12, 12), r=3.0)
+    sigclip = SigmaClip(sigma=3.0, maxiters=10)
+    flags = _stats_flags(data, aper, sigma_clip=sigclip)
+    assert flags == APERTURE_FLAGS.SIGMA_CLIPPED
+
+    # Without clipping, no flag is set
+    assert _stats_flags(data, aper) == 0
+
+
+def test_all_clipped():
+    """
+    Test the all_clipped flag using a SigmaClip subclass that rejects
+    every pixel (only reachable via the mask-based path).
+    """
+    class _ClipAll(SigmaClip):
+        def __call__(self, data, **kwargs):  # noqa: ARG002
+            return np.ma.masked_array(data,
+                                      mask=np.ones(data.shape, dtype=bool))
+
+    data = np.ones(SHAPE)
+    aper = CircularAperture((12, 12), r=3.0)
+    # A callable cenfunc is not supported by the fast clipping kernel,
+    # forcing the mask-based path
+    sigclip = _ClipAll(cenfunc=np.ma.median)
+    stats = ApertureStats(data, aper, sigma_clip=sigclip)
+    assert stats.flags == (APERTURE_FLAGS.SIGMA_CLIPPED
+                           | APERTURE_FLAGS.ALL_CLIPPED)
+    assert np.isnan(stats.mean)
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_too_few_pixels():
+    """
+    Test the too_few_pixels flag with ddof.
+    """
+    data = np.ones(SHAPE)
+    # The r=1.1 center footprint contains exactly 5 pixels
+    aper = CircularAperture((12, 12), r=1.1)
+
+    stats = ApertureStats(data, aper, ddof=5)
+    assert stats.flags == APERTURE_FLAGS.TOO_FEW_PIXELS
+    assert np.isnan(stats.var)
+    assert np.isnan(stats.std)
+
+    assert _stats_flags(data, aper, ddof=1) == 0
+    assert _stats_flags(data, aper, ddof=0) == 0
+
+
+@pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_neighbor_pixels(mask_method):
+    """
+    Test the neighbor_pixels flag for all segmentation mask methods.
+    """
+    data = np.ones(SHAPE)
+    segm = np.zeros(SHAPE, dtype=int)
+    segm[10:15, 10:15] = 1
+    segm[12, 14] = 2  # neighbor pixel inside the aperture
+    aper = CircularAperture((12, 12), r=3.0)
+    flags = _stats_flags(data, aper, segmentation_image=segm, labels=1,
+                         mask_method=mask_method)
+    assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
+
+
+@pytest.mark.usefixtures('maybe_mask_path')
+def test_uncorrected_pixels():
+    """
+    Test the uncorrected_pixels flag with mask_method='correct'.
+    """
+    data = np.ones(SHAPE)
+    segm = np.zeros(SHAPE, dtype=int)
+    segm[10:15, 10:15] = 1
+    segm[12, 14] = 2
+    segm[12, 10] = 2  # the mirror is also a neighbor: uncorrectable
+    aper = CircularAperture((12, 12), r=3.0)
+    flags = _stats_flags(data, aper, segmentation_image=segm, labels=1,
+                         mask_method='correct')
+    assert flags == (APERTURE_FLAGS.NEIGHBOR_PIXELS
+                     | APERTURE_FLAGS.UNCORRECTED_PIXELS)
+
+
+def test_fast_mask_path_parity():
+    """
+    Test that the fast batch path and the mask-based path produce
+    identical flags for a mix of conditions.
+    """
+    rng = np.random.default_rng(1)
+    data = rng.normal(1.0, 0.1, size=SHAPE)
+    data[13, 12] = np.nan
+    data[5, 5] = 100.0  # sigma-clip outlier
+    error = np.ones(SHAPE)
+    error[10, 12] = np.inf
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[12, 12] = True
+
+    xy = [(12.0, 12.0), (5.0, 5.0), (0.0, 12.0), (-50.0, 12.0),
+          (24.5, 24.5), (0.2, 12.0), (12.5, 3.5)]
+    aper = CircularAperture(xy, r=3.0)
+
+    for kwargs in ({}, {'error': error, 'mask': mask},
+                   {'sigma_clip': SigmaClip(sigma=3.0)},
+                   {'sum_method': 'center'},
+                   {'ddof': 1}):
+        fast = ApertureStats(data, aper, **kwargs)
+        assert fast._batch_inputs is not None
+        with _force_mask_path():
+            slow = ApertureStats(data, aper, **kwargs)
+            assert slow._batch_inputs is None
+            assert_array_equal(fast.flags, slow.flags)
+
+
+def test_flags_in_table_and_properties():
+    """
+    Test that flags appears in the properties list and the default
+    to_table() columns.
+    """
+    data = np.ones(SHAPE)
+    aper = CircularAperture([(12, 12), (-50, 12)], r=3.0)
+    stats = ApertureStats(data, aper)
+    assert 'flags' in stats.properties
+    tbl = stats.to_table()
+    assert 'flags' in tbl.colnames
+    expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS]
+    assert_array_equal(tbl['flags'], expected)
+
+
+def test_flags_slicing():
+    """
+    Test that flags are sliced correctly by __getitem__.
+    """
+    data = np.ones(SHAPE)
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[12, 12] = True
+    aper = CircularAperture([(12, 12), (0.0, 12.0)], r=3.0)
+    stats = ApertureStats(data, aper, mask=mask)
+    flags = stats.flags  # evaluate before slicing
+    assert stats[0].flags == flags[0]
+    assert stats[1].flags == flags[1]
+
+    # Also test slicing before evaluation
+    stats2 = ApertureStats(data, aper, mask=mask)
+    assert stats2[1].flags == flags[1]
+
+
+def test_decode_flags():
+    """
+    Test the decode_flags convenience method.
+    """
+    data = np.ones(SHAPE)
+    mask = np.zeros(SHAPE, dtype=bool)
+    mask[12, 12] = True
+    aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
+    stats = ApertureStats(data, aper, mask=mask)
+    decoded = stats.decode_flags()
+    assert decoded == [['masked_pixels'], ['partial_overlap']]
+
+    decoded = stats.decode_flags(return_bit_values=True)
+    assert decoded == [[APERTURE_FLAGS.MASKED_PIXELS],
+                       [APERTURE_FLAGS.PARTIAL_OVERLAP]]
+
+    # Scalar ApertureStats also returns a list of lists
+    stats = ApertureStats(data, CircularAperture((0.0, 12.0), r=3.0))
+    assert stats.decode_flags() == [['partial_overlap']]
+
+
+def test_flags_docstring():
+    """
+    Test that the flags docstring placeholder was substituted.
+    """
+    docstring = ApertureStats.flags.__doc__
+    assert '<flag_descriptions>' not in docstring
+    assert "``'no_overlap'`` : bit 1" in docstring

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -344,6 +344,7 @@ def test_flags_docstring():
     """
     Test that the flags docstring placeholder was substituted.
     """
-    docstring = ApertureStats.flags.__doc__
-    assert '<flag_descriptions>' not in docstring
-    assert "``'no_overlap'`` : bit 1" in docstring
+    for prop in (ApertureStats.flags,):
+        docstring = prop.__doc__
+        assert '<flag_descriptions>' not in docstring
+        assert "**1** (``'no_overlap'``)" in docstring

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -111,17 +111,20 @@ def test_masked_pixels_sum_footprint_only():
     """
     Test that a masked boundary pixel touched only by the exact-method
     sum footprint (its center lies exactly on the aperture boundary)
-    still sets masked_pixels.
+    sets masked_pixels in sum_flags but not in the value-statistics
+    flags.
     """
     data = np.ones(SHAPE)
     aper = CircularAperture((12, 12), r=3.0)
     mask = np.zeros(SHAPE, dtype=bool)
     mask[15, 12] = True  # center at distance exactly 3.0 (boundary)
-    assert _stats_flags(data, aper,
-                        mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
-    # The pixel is excluded from the center footprint
+    stats = ApertureStats(data, aper, mask=mask)
+    assert stats.sum_flags == APERTURE_FLAGS.MASKED_PIXELS
+    # The pixel is excluded from the center (value-statistics) footprint
+    assert stats.flags == 0
     stats = ApertureStats(data, aper, mask=mask, sum_method='center')
     assert stats.flags == 0
+    assert stats.sum_flags == 0
 
 
 @pytest.mark.usefixtures('maybe_mask_path')
@@ -162,9 +165,12 @@ def test_non_finite_error():
     error = np.ones(SHAPE)
     error[12, 12] = np.nan
     aper = CircularAperture((12, 12), r=3.0)
-    assert _stats_flags(data, aper,
-                        error=error) == APERTURE_FLAGS.NON_FINITE_ERROR
-    assert _stats_flags(data, aper) == 0
+    stats = ApertureStats(data, aper, error=error)
+    # non_finite_error is a sum-footprint flag, not a value-statistics
+    # flag, so it appears in sum_flags but not flags
+    assert stats.sum_flags == APERTURE_FLAGS.NON_FINITE_ERROR
+    assert stats.flags == 0
+    assert ApertureStats(data, aper).sum_flags == 0
 
 
 @pytest.mark.usefixtures('maybe_mask_path')
@@ -179,6 +185,10 @@ def test_sigma_clipped():
     sigclip = SigmaClip(sigma=3.0, maxiters=10)
     flags = _stats_flags(data, aper, sigma_clip=sigclip)
     assert flags == APERTURE_FLAGS.SIGMA_CLIPPED
+
+    # Sigma-clip flags apply only to the value statistics, not sum_flags
+    stats = ApertureStats(data, aper, sigma_clip=sigclip)
+    assert not stats.sum_flags & APERTURE_FLAGS.SIGMA_CLIPPED
 
     # Without clipping, no flag is set
     assert _stats_flags(data, aper) == 0
@@ -284,6 +294,7 @@ def test_fast_mask_path_parity():
             slow = ApertureStats(data, aper, **kwargs)
             assert slow._batch_inputs is None
             assert_array_equal(fast.flags, slow.flags)
+            assert_array_equal(fast.sum_flags, slow.sum_flags)
 
 
 def test_flags_in_table_and_properties():
@@ -295,10 +306,13 @@ def test_flags_in_table_and_properties():
     aper = CircularAperture([(12, 12), (-50, 12)], r=3.0)
     stats = ApertureStats(data, aper)
     assert 'flags' in stats.properties
+    assert 'sum_flags' in stats.properties
     tbl = stats.to_table()
     assert 'flags' in tbl.colnames
+    assert 'sum_flags' in tbl.colnames
     expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS]
     assert_array_equal(tbl['flags'], expected)
+    assert_array_equal(tbl['sum_flags'], expected)
 
 
 def test_flags_slicing():
@@ -335,16 +349,25 @@ def test_decode_flags():
     assert decoded == [[APERTURE_FLAGS.MASKED_PIXELS],
                        [APERTURE_FLAGS.PARTIAL_OVERLAP]]
 
+    # Decode the sum flags via the column keyword
+    decoded = stats.decode_flags(column='sum_flags')
+    assert decoded == [['masked_pixels'], ['partial_overlap']]
+
+    match = "column must be 'flags' or 'sum_flags'"
+    with pytest.raises(ValueError, match=match):
+        stats.decode_flags(column='invalid')
+
     # Scalar ApertureStats also returns a list of lists
     stats = ApertureStats(data, CircularAperture((0.0, 12.0), r=3.0))
     assert stats.decode_flags() == [['partial_overlap']]
+    assert stats.decode_flags(column='sum_flags') == [['partial_overlap']]
 
 
 def test_flags_docstring():
     """
     Test that the flags docstring placeholder was substituted.
     """
-    for prop in (ApertureStats.flags,):
+    for prop in (ApertureStats.flags, ApertureStats.sum_flags):
         docstring = prop.__doc__
         assert '<flag_descriptions>' not in docstring
         assert "**1** (``'no_overlap'``)" in docstring

--- a/photutils/psf/flags.py
+++ b/photutils/psf/flags.py
@@ -4,44 +4,16 @@ Tools for working with PSF photometry flags, including centralized flag
 definitions and decoding utilities.
 """
 
-from dataclasses import dataclass
 from typing import ClassVar
 
-import numpy as np
-
-from photutils.utils._deprecation import (deprecated_getattr,
-                                          deprecated_positional_kwargs)
+from photutils.utils._deprecation import deprecated_positional_kwargs
+from photutils.utils._flags import (FlagDefinition, FlagRegistry, decode_flags,
+                                    update_flag_docstring)
 
 __all__ = ['PSF_FLAGS', 'decode_psf_flags']
 
 
-@dataclass(frozen=True)
-class _PSFFlagDefinition:
-    """
-    A single PSF flag definition.
-
-    Attributes
-    ----------
-    bit_value : int
-        The bit value (power of 2) for this flag.
-
-    name : str
-        Short name for the flag (used in decode_psf_flags).
-
-    description : str
-        Brief description of what this flag indicates.
-
-    detailed_description : str
-        Detailed description for use in docstrings.
-    """
-
-    bit_value: int
-    name: str
-    description: str
-    detailed_description: str
-
-
-class _PSFFlags:
+class _PSFFlags(FlagRegistry):
     """
     Centralized definition of PSF photometry flags.
 
@@ -64,7 +36,7 @@ class _PSFFlags:
 
     # Define all PSF flags with their properties
     FLAG_DEFINITIONS: ClassVar = [
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=1,
             name='n_pixels_fit_partial',
             description=('n_pixels_fit smaller than full fit_shape '
@@ -74,77 +46,77 @@ class _PSFFlags:
                                   'full fit_shape region, indicating '
                                   'partial PSF fitting'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=2,
             name='outside_bounds',
             description='fitted position outside input image bounds',
             detailed_description=('The fitted source position is outside the '
                                   'bounds of the input image'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=4,
             name='negative_flux',
             description='non-positive flux',
             detailed_description=('The fitted flux value is negative or zero, '
                                   'which is non-physical'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=8,
             name='no_convergence',
             description='possible non-convergence',
             detailed_description=('The PSF fitting algorithm may not have '
                                   'converged to a stable solution'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=16,
             name='no_covariance',
             description='missing parameter covariance',
             detailed_description=('Parameter covariance matrix is not '
                                   'available, preventing error estimation'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=32,
             name='near_bound',
             description='fitted parameter near a bound',
             detailed_description=('One or more fitted parameters are very '
                                   'close to their imposed bounds'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=64,
             name='no_overlap',
             description='no overlap with data',
             detailed_description=('The source PSF fitting region has no '
                                   'overlap with valid data pixels'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=128,
             name='fully_masked',
             description='fully masked source',
             detailed_description=('All pixels in the source fitting region '
                                   'are masked'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=256,
             name='too_few_pixels',
             description='too few pixels for fitting',
             detailed_description=('Insufficient unmasked pixels available '
                                   'for reliable PSF fitting'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=512,
             name='non_finite_position',
             description='non-finite fitted position',
             detailed_description=('The fitted x or y position is NaN or inf, '
                                   'indicating an invalid or failed fit'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=1024,
             name='non_finite_flux',
             description='non-finite fitted flux',
             detailed_description=('The fitted flux value is NaN or inf, '
                                   'indicating an invalid or failed fit'),
         ),
-        _PSFFlagDefinition(
+        FlagDefinition(
             bit_value=2048,
             name='non_finite_localbkg',
             description='non-finite local background',
@@ -153,6 +125,8 @@ class _PSFFlags:
                                   'fitting'),
         ),
     ]
+
+    domain: ClassVar = 'psf'
 
     # Remove in 4.0
     _DEPRECATED_FLAG_NAMES: ClassVar = {
@@ -164,162 +138,8 @@ class _PSFFlags:
         'NPIXFIT_PARTIAL': 'N_PIXELS_FIT_PARTIAL',
     }
 
-    def __init__(self):
-        for flag_def in self.FLAG_DEFINITIONS:
-            # Create uppercase constants (e.g., N_PIXELS_FIT_PARTIAL = 1)
-            setattr(self, flag_def.name.upper(), flag_def.bit_value)
-
-        # Create lookup dictionaries for efficient access
-        self._bit_to_def = {fd.bit_value: fd for fd in self.FLAG_DEFINITIONS}
-        self._name_to_def = {fd.name: fd for fd in self.FLAG_DEFINITIONS}
-
-    # Remove in 4.0
-    def __getattr__(self, name):
-        return deprecated_getattr(self, name,
-                                  self._DEPRECATED_CONSTANT_NAMES,
-                                  since='3.0', until='4.0')
-
-    @property
-    def all_flags(self):
-        """
-        Return all flag definitions.
-        """
-        return self.FLAG_DEFINITIONS.copy()
-
-    @property
-    def bit_values(self):
-        """
-        Return all bit values.
-        """
-        return [fd.bit_value for fd in self.FLAG_DEFINITIONS]
-
-    @property
-    def names(self):
-        """
-        Return all flag names.
-        """
-        return [fd.name for fd in self.FLAG_DEFINITIONS]
-
-    @property
-    def flag_dict(self):
-        """
-        Return dictionary mapping bit values to names.
-        """
-        return {fd.bit_value: fd.name for fd in self.FLAG_DEFINITIONS}
-
-    def get_definition(self, identifier):
-        """
-        Get flag definition by bit value or name.
-
-        Parameters
-        ----------
-        identifier : int or str
-            Either the bit value (int) or name (str) of the flag.
-
-        Returns
-        -------
-        definition : `_PSFFlagDefinition`
-            The flag definition.
-
-        Raises
-        ------
-        KeyError
-            If the identifier is not found.
-        """
-        if isinstance(identifier, int):
-            if identifier not in self._bit_to_def:
-                msg = f'No flag with bit value {identifier}'
-                raise KeyError(msg)
-            return self._bit_to_def[identifier]
-
-        if isinstance(identifier, str):
-            # Remove in 4.0
-            if identifier in self._DEPRECATED_FLAG_NAMES:
-                import warnings
-
-                from astropy.utils.exceptions import AstropyDeprecationWarning
-
-                new_name = self._DEPRECATED_FLAG_NAMES[identifier]
-                warnings.warn(
-                    f"The flag name '{identifier}' is deprecated "
-                    f"in version 3.0. Use '{new_name}' instead. "
-                    'It will be removed in version 4.0.',
-                    AstropyDeprecationWarning,
-                    stacklevel=2,
-                )
-                identifier = new_name
-
-            if identifier not in self._name_to_def:
-                msg = f"No flag with name '{identifier}'"
-                raise KeyError(msg)
-            return self._name_to_def[identifier]
-
-        msg = 'identifier must be int (bit value) or str (name)'
-        raise TypeError(msg)
-
-    def get_name(self, bit_value):
-        """
-        Get flag name from bit value.
-
-        Parameters
-        ----------
-        bit_value : int
-            The bit value of the flag.
-
-        Returns
-        -------
-        name : str
-            The name of the flag.
-        """
-        return self.get_definition(bit_value).name
-
-    def get_bit_value(self, name):
-        """
-        Get flag bit value from name.
-
-        Parameters
-        ----------
-        name : str
-            The name of the flag.
-
-        Returns
-        -------
-        bit_value : int
-            The bit value of the flag.
-        """
-        return self.get_definition(name).bit_value
-
-    def get_description(self, bit_value):
-        """
-        Get flag description from bit value.
-
-        Parameters
-        ----------
-        bit_value : int
-            The bit value of the flag.
-
-        Returns
-        -------
-        description : str
-            The brief description of the flag.
-        """
-        return self.get_definition(bit_value).description
-
-    def get_detailed_description(self, bit_value):
-        """
-        Get detailed flag description from bit value.
-
-        Parameters
-        ----------
-        bit_value : int
-            The bit value of the flag.
-
-        Returns
-        -------
-        detailed_description : str
-            The detailed description of the flag.
-        """
-        return self.get_definition(bit_value).detailed_description
+    _DEPRECATED_SINCE: ClassVar = '3.0'
+    _DEPRECATED_UNTIL: ClassVar = '4.0'
 
 
 # Create a singleton instance for global use
@@ -328,11 +148,12 @@ PSF_FLAGS = _PSFFlags()
 
 def _update_decode_docstring(func):
     """
-    Decorator to update function docstring with PSF flag documentation.
+    Decorator to update a function docstring with the PSF flag
+    documentation.
 
-    This decorator can be applied to functions like decode_psf_flags to
-    automatically replace manually defined flag lists with dynamically
-    generated ones.
+    The ``<flag_descriptions>`` placeholder in the function docstring
+    is replaced with a bullet list generated from ``PSF_FLAGS`` (see
+    `photutils.utils._flags.update_flag_docstring`).
 
     Parameters
     ----------
@@ -344,32 +165,7 @@ def _update_decode_docstring(func):
     func : function
         The decorated function with updated docstring.
     """
-    if not hasattr(func, '__doc__') or func.__doc__ is None:
-        return func
-
-    docstring = func.__doc__
-
-    # Look for the placeholder text
-    placeholder = '<flag_descriptions>'
-
-    if placeholder in docstring:
-        # Generate the flag descriptions
-        flag_descriptions = ['']
-
-        indent = ' ' * 4
-        for flag_def in PSF_FLAGS.FLAG_DEFINITIONS:
-            name = flag_def.name
-            bit_val = flag_def.bit_value
-            desc = flag_def.description
-            line = f"{indent}- ``'{name}'`` : bit {bit_val}, {desc}"
-            flag_descriptions.append(line)
-
-        # Replace the placeholder with the flag descriptions
-        flag_text = '\n'.join(flag_descriptions)
-        new_docstring = docstring.replace(placeholder, flag_text)
-        func.__doc__ = new_docstring
-
-    return func
+    return update_flag_docstring(func, PSF_FLAGS)
 
 
 @_update_decode_docstring
@@ -469,39 +265,5 @@ def decode_psf_flags(flags, return_bit_values=False):
     Source 3: n_pixels_fit_partial, no_covariance, too_few_pixels, \
 non_finite_position, non_finite_flux
     """
-    # Get flag definitions from centralized source
-    flag_definitions = PSF_FLAGS.flag_dict
-
-    def _decode_single_flag(flag_value):
-        """
-        Decode a single integer flag value.
-        """
-        if not isinstance(flag_value, (int, np.integer)):
-            msg = 'Flag value must be an integer'
-            raise TypeError(msg)
-
-        if flag_value < 0:
-            msg = 'Flag value must be a non-negative integer'
-            raise ValueError(msg)
-
-        active_flags = []
-        for bit_value, description in flag_definitions.items():
-            if flag_value & bit_value:
-                if return_bit_values:
-                    active_flags.append(bit_value)
-                else:
-                    active_flags.append(description)
-        return active_flags
-
-    # Handle both single values and arrays
-    if np.isscalar(flags):
-        return _decode_single_flag(flags)
-
-    # Convert to numpy array for consistent handling
-    flags_array = np.asarray(flags)
-    if flags_array.ndim == 0:
-        # Handle 0-d arrays (scalar arrays)
-        return _decode_single_flag(flags_array.item())
-
-    # Handle 1-d or higher dimensional arrays
-    return [_decode_single_flag(flag) for flag in flags_array.flat]
+    return decode_flags(flags, PSF_FLAGS,
+                        return_bit_values=return_bit_values)

--- a/photutils/psf/flags.py
+++ b/photutils/psf/flags.py
@@ -39,82 +39,82 @@ class _PSFFlags(FlagRegistry):
         FlagDefinition(
             bit_value=1,
             name='n_pixels_fit_partial',
-            description=('n_pixels_fit smaller than full fit_shape '
-                         'region'),
+            description=("``'n_pixels_fit'`` smaller than full "
+                         "``'fit_shape'`` region"),
             detailed_description=('The number of fitted pixels '
                                   '(n_pixels_fit) is smaller than the '
                                   'full fit_shape region, indicating '
-                                  'partial PSF fitting'),
+                                  'partial PSF fitting.'),
         ),
         FlagDefinition(
             bit_value=2,
             name='outside_bounds',
             description='fitted position outside input image bounds',
             detailed_description=('The fitted source position is outside the '
-                                  'bounds of the input image'),
+                                  'bounds of the input image.'),
         ),
         FlagDefinition(
             bit_value=4,
             name='negative_flux',
             description='non-positive flux',
             detailed_description=('The fitted flux value is negative or zero, '
-                                  'which is non-physical'),
+                                  'which is non-physical.'),
         ),
         FlagDefinition(
             bit_value=8,
             name='no_convergence',
             description='possible non-convergence',
             detailed_description=('The PSF fitting algorithm may not have '
-                                  'converged to a stable solution'),
+                                  'converged to a stable solution.'),
         ),
         FlagDefinition(
             bit_value=16,
             name='no_covariance',
             description='missing parameter covariance',
             detailed_description=('Parameter covariance matrix is not '
-                                  'available, preventing error estimation'),
+                                  'available, preventing error estimation.'),
         ),
         FlagDefinition(
             bit_value=32,
             name='near_bound',
             description='fitted parameter near a bound',
             detailed_description=('One or more fitted parameters are very '
-                                  'close to their imposed bounds'),
+                                  'close to their imposed bounds.'),
         ),
         FlagDefinition(
             bit_value=64,
             name='no_overlap',
             description='no overlap with data',
             detailed_description=('The source PSF fitting region has no '
-                                  'overlap with valid data pixels'),
+                                  'overlap with valid data pixels.'),
         ),
         FlagDefinition(
             bit_value=128,
             name='fully_masked',
             description='fully masked source',
             detailed_description=('All pixels in the source fitting region '
-                                  'are masked'),
+                                  'are masked.'),
         ),
         FlagDefinition(
             bit_value=256,
             name='too_few_pixels',
             description='too few pixels for fitting',
             detailed_description=('Insufficient unmasked pixels available '
-                                  'for reliable PSF fitting'),
+                                  'for reliable PSF fitting.'),
         ),
         FlagDefinition(
             bit_value=512,
             name='non_finite_position',
             description='non-finite fitted position',
             detailed_description=('The fitted x or y position is NaN or inf, '
-                                  'indicating an invalid or failed fit'),
+                                  'indicating an invalid or failed fit.'),
         ),
         FlagDefinition(
             bit_value=1024,
             name='non_finite_flux',
             description='non-finite fitted flux',
             detailed_description=('The fitted flux value is NaN or inf, '
-                                  'indicating an invalid or failed fit'),
+                                  'indicating an invalid or failed fit.'),
         ),
         FlagDefinition(
             bit_value=2048,
@@ -122,7 +122,7 @@ class _PSFFlags(FlagRegistry):
             description='non-finite local background',
             detailed_description=('The local background value is NaN or '
                                   'inf, so it was not subtracted before '
-                                  'fitting'),
+                                  'fitting.'),
         ),
     ]
 
@@ -165,7 +165,7 @@ def _update_decode_docstring(func):
     func : function
         The decorated function with updated docstring.
     """
-    return update_flag_docstring(func, PSF_FLAGS)
+    return update_flag_docstring(func, PSF_FLAGS, indent=4)
 
 
 @_update_decode_docstring
@@ -199,8 +199,7 @@ def decode_psf_flags(flags, return_bit_values=False):
         List of active flag names (or bit values), or list of lists
         if input is an array. Each string (or integer) represents a
         specific condition that was detected during PSF fitting. If no
-        flags are set, an empty list is returned. Possible flag names
-        are:
+        flags are set, an empty list is returned. Possible flags are:
         <flag_descriptions>
 
     Examples

--- a/photutils/psf/tests/test_flags.py
+++ b/photutils/psf/tests/test_flags.py
@@ -5,10 +5,12 @@ Tests for the flags module.
 
 import numpy as np
 import pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.psf import IterativePSFPhotometry, PSFPhotometry
-from photutils.psf.flags import (PSF_FLAGS, _PSFFlagDefinition, _PSFFlags,
+from photutils.psf.flags import (PSF_FLAGS, _PSFFlags,
                                  _update_decode_docstring, decode_psf_flags)
+from photutils.utils._flags import FlagDefinition
 
 
 def test_decode_psf_flags():
@@ -272,7 +274,7 @@ def test_psf_flags_properties():
     assert isinstance(all_flags, list)
     assert len(all_flags) == 12
     for flag_def in all_flags:
-        assert isinstance(flag_def, _PSFFlagDefinition)
+        assert isinstance(flag_def, FlagDefinition)
 
 
 def test_psf_flags_get_methods():
@@ -314,13 +316,13 @@ def test_psf_flags_get_definition():
     """
     # Test get_definition by bit value
     def_by_bit = PSF_FLAGS.get_definition(1)
-    assert isinstance(def_by_bit, _PSFFlagDefinition)
+    assert isinstance(def_by_bit, FlagDefinition)
     assert def_by_bit.bit_value == 1
     assert def_by_bit.name == 'n_pixels_fit_partial'
 
     # Test get_definition by name
     def_by_name = PSF_FLAGS.get_definition('n_pixels_fit_partial')
-    assert isinstance(def_by_name, _PSFFlagDefinition)
+    assert isinstance(def_by_name, FlagDefinition)
     assert def_by_name.bit_value == 1
     assert def_by_name.name == 'n_pixels_fit_partial'
 
@@ -341,12 +343,26 @@ def test_psf_flags_get_definition():
         PSF_FLAGS.get_definition(3.14)
 
 
+def test_psf_flags_get_definition_deprecated_name():
+    """
+    Test that get_definition resolves a deprecated flag name to its
+    current definition and warns.
+    """
+    match = ("The flag name 'npixfit_partial' is deprecated.*Use "
+             "'n_pixels_fit_partial' instead")
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        deprecated_def = PSF_FLAGS.get_definition('npixfit_partial')
+
+    current_def = PSF_FLAGS.get_definition('n_pixels_fit_partial')
+    assert deprecated_def is current_def
+
+
 def test_psf_flag_definition():
     """
-    Test _PSFFlagDefinition dataclass.
+    Test FlagDefinition dataclass.
     """
     # Create a flag definition
-    flag_def = _PSFFlagDefinition(
+    flag_def = FlagDefinition(
         bit_value=1,
         name='test_flag',
         description='test description',
@@ -364,7 +380,7 @@ def test_psf_flag_definition():
         flag_def.bit_value = 2
 
     # Test equality
-    flag_def2 = _PSFFlagDefinition(
+    flag_def2 = FlagDefinition(
         bit_value=1,
         name='test_flag',
         description='test description',
@@ -373,7 +389,7 @@ def test_psf_flag_definition():
     assert flag_def == flag_def2
 
     # Test inequality
-    flag_def3 = _PSFFlagDefinition(
+    flag_def3 = FlagDefinition(
         bit_value=2,
         name='test_flag',
         description='test description',

--- a/photutils/psf/tests/test_flags.py
+++ b/photutils/psf/tests/test_flags.py
@@ -296,7 +296,9 @@ def test_psf_flags_get_methods():
 
     # Test get_description
     desc1 = PSF_FLAGS.get_description(1)
-    assert 'n_pixels_fit smaller than full fit_shape region' in desc1
+    assert 'n_pixels_fit' in desc1
+    assert 'smaller than full' in desc1
+    assert 'fit_shape' in desc1
 
     desc8 = PSF_FLAGS.get_description(8)
     assert 'possible non-convergence' in desc8
@@ -476,19 +478,19 @@ def test_psf_classes_docstrings():
         docstring = cls.__call__.__doc__
 
         # Should have flags section
-        assert '* ``flags`` : bitwise flag values' in docstring
+        assert "* ``'flags'`` : The bitwise quality flags" in docstring
 
         # Should have all dynamic flag descriptions
         dynamic_flags = [
-            'n_pixels_fit smaller than full fit_shape region',
-            'fitted position outside input image bounds',
-            'non-positive flux',
-            'possible non-convergence',
-            'missing parameter covariance',
-            'fitted parameter near a bound',
-            'no overlap with data',
-            'fully masked source',
-            'too few pixels for fitting',
+            'indicating partial PSF fitting',
+            'outside the bounds of the input image',
+            'negative or zero, which is non-physical',
+            'may not have converged to a stable solution',
+            'covariance matrix is not available',
+            'very close to their imposed bounds',
+            'no overlap with valid data pixels',
+            'All pixels in the source fitting region are masked',
+            'Insufficient unmasked pixels available for reliable PSF fitting',
         ]
 
         for flag_desc in dynamic_flags:
@@ -508,15 +510,15 @@ def test_decode_psf_flags_docstring():
 
     # Should have all expected flag names in the expected format
     expected_flags = [
-        "``'n_pixels_fit_partial'`` : bit 1",
-        "``'outside_bounds'`` : bit 2",
-        "``'negative_flux'`` : bit 4",
-        "``'no_convergence'`` : bit 8",
-        "``'no_covariance'`` : bit 16",
-        "``'near_bound'`` : bit 32",
-        "``'no_overlap'`` : bit 64",
-        "``'fully_masked'`` : bit 128",
-        "``'too_few_pixels'`` : bit 256",
+        "``'n_pixels_fit_partial'``",
+        "``'outside_bounds'``",
+        "``'negative_flux'``",
+        "``'no_convergence'``",
+        "``'no_covariance'``",
+        "``'near_bound'``",
+        "``'no_overlap'``",
+        "``'fully_masked'``",
+        "``'too_few_pixels'``",
     ]
 
     for flag_desc in expected_flags:
@@ -525,15 +527,15 @@ def test_decode_psf_flags_docstring():
 
     # Should have flag descriptions
     expected_descriptions = [
-        'n_pixels_fit smaller than full fit_shape region',
-        'fitted position outside input image bounds',
-        'non-positive flux',
-        'possible non-convergence',
-        'missing parameter covariance',
-        'fitted parameter near a bound',
-        'no overlap with data',
-        'fully masked source',
-        'too few pixels for fitting',
+        'indicating partial PSF fitting',
+        'outside the bounds of the input image',
+        'negative or zero, which is non-physical',
+        'may not have converged to a stable solution',
+        'covariance matrix is not available',
+        'very close to their imposed bounds',
+        'no overlap with valid data pixels',
+        'All pixels in the source fitting region are masked',
+        'Insufficient unmasked pixels available for reliable PSF fitting',
     ]
 
     for desc in expected_descriptions:

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -15,6 +15,7 @@ from scipy import interpolate
 from photutils.centroids import centroid_com
 from photutils.psf.functional_models import CircularGaussianPRF
 from photutils.utils import CutoutImage
+from photutils.utils._flags import define_flag_docstring
 from photutils.utils._parameters import as_pair
 
 __all__ = ['fit_2dgaussian', 'fit_fwhm']
@@ -590,11 +591,11 @@ def _create_call_docstring(*, iterative=False):
             a `~astropy.units.Quantity` array with the same units.
 
         init_params : `~astropy.table.Table` or `None`, optional
-            A table containing the initial guesses of the
-            model parameters (e.g., x, y, flux) for each
-            source{init_params_suffix}. If the initial x and y values
-            are not included, then the ``finder`` keyword must be
-            defined. If the initial flux values are not included,
+            A table containing the initial guesses of the model
+            parameters (e.g., x, y, flux) for each
+            source{init_params_suffix}. If the initial x and y
+            values are not included, then the ``finder`` keyword must
+            be defined. If the initial flux values are not included,
             then the ``aperture_radius`` keyword must be defined to
             measure the initial flux values. Note that the initial
             flux values refer to the model flux parameters and are
@@ -602,27 +603,29 @@ def _create_call_docstring(*, iterative=False):
             ``local_bkg_estimator`` or input in a ``local_bkg`` column).
             The allowed column names are:
 
-            * ``x_init``, ``xinit``, ``x``, ``x_0``, ``x0``,
-              ``xcentroid``, ``x_centroid``, ``x_peak``, ``xcen``,
-              ``x_cen``, ``xpos``, ``x_pos``, ``x_fit``, and ``xfit``.
+            * ``'x_init'``, ``'xinit'``, ``'x'``, ``'x_0'``, ``'x0'``,
+              ``'xcentroid'``, ``'x_centroid'``, ``'x_peak'``, ``'xcen'``,
+              ``'x_cen'``, ``'xpos'``, ``'x_pos'``, ``'x_fit'``, and
+              ``'xfit'``.
 
-            * ``y_init``, ``yinit``, ``y``, ``y_0``, ``y0``,
-              ``ycentroid``, ``y_centroid``, ``y_peak``, ``ycen``,
-              ``y_cen``, ``ypos``, ``y_pos``, ``y_fit``, and ``yfit``.
+            * ``'y_init'``, ``'yinit'``, ``'y'``, ``'y_0'``, ``'y0'``,
+              ``'ycentroid'``, ``'y_centroid'``, ``'y_peak'``, ``'ycen'``,
+              ``'y_cen'``, ``'ypos'``, ``'y_pos'``, ``'y_fit'``, and
+              ``'yfit'``.
 
-            * ``flux_init``, ``fluxinit``, ``flux``, ``flux_0``,
-              ``flux0``, ``flux_fit``, ``fluxfit``, ``source_sum``,
-              ``segment_flux``, and ``kron_flux``.
+            * ``'flux_init'``, ``'fluxinit'``, ``'flux'``, ``'flux_0'``,
+              ``'flux0'``, ``'flux_fit'``, ``'fluxfit'``, ``'source_sum'``,
+              ``'segment_flux'``, and ``'kron_flux'``.
 
             * If the PSF model has additional free parameters that are
-              fit, they can be included in the table. The column
-              names must match the parameter names in the PSF model.
-              They can also be suffixed with either the "_init" or
-              "_fit" suffix. The suffix search order is "_init", ""
-              (no suffix), and "_fit". For example, if the PSF model
-              has an additional parameter named "sigma", then the
-              allowed column names are: "sigma_init", "sigma", and
-              "sigma_fit". If the column name is not found in the
+              fit, they can be included in the table. The column names
+              must match the parameter names in the PSF model. They can
+              also be suffixed with either the ``'_init'`` or ``'_fit'``
+              suffix. The suffix search order is ``'_init'``, ``''`` (no
+              suffix), and ``'_fit'``. For example, if the PSF model has
+              an additional parameter named "sigma", then the allowed
+              column names are: ``'sigma_init'``, ``'sigma'``, and
+              ``'sigma_fit'``. If the column name is not found in the
               table, then the default value from the PSF model will be
               used.
 
@@ -633,8 +636,8 @@ def _create_call_docstring(*, iterative=False):
             initial flux values in this table must also must also have
             compatible units.
 
-            The table can also have ``group_id`` and ``local_bkg``
-            columns. If ``group_id`` is input, the values will
+            The table can also have ``'group_id'`` and ``'local_bkg'``
+            columns. If ``'group_id'`` is input, the values will
             be used and ``grouper`` keyword will be ignored. If
             ``local_bkg`` is input, those values will be used and the
             ``local_bkg_estimator`` will be ignored. If ``data`` has
@@ -647,37 +650,39 @@ def _create_call_docstring(*, iterative=False):
             An astropy table with the PSF-fitting results. The table
             will contain the following columns:
 
-            * ``id`` : unique identification number for the source
-            * ``group_id`` : unique identification number for the
+            * ``'id'`` : unique identification number for the source
+            * ``'group_id'`` : unique identification number for the
               source group
-            * ``group_size`` : the total number of sources in the group.
+            * ``'group_size'`` : the total number of sources in the group.
               This number includes sources that are in the group, but were
               not fit due to being masked, having no overlap with the
               input data, or having too few pixels for a fit.
-{iter_detected_column}
-            * ``x_init``, ``x_fit``, ``x_err`` : the initial,
+            {iter_detected_column}
+            * ``'x_init'``, ``'x_fit'``, ``'x_err'`` : the initial,
               fit and error of the source x center
-            * ``y_init``, ``y_fit``, ``y_err`` : the initial, fit,
+            * ``'y_init'``, ``'y_fit'``, ``'y_err'`` : the initial, fit,
               and error of the source y center
-            * ``flux_init``, ``flux_fit``, ``flux_err`` : the initial,
-              fit, and error of the source flux
-            * ``n_pixels_fit`` : the number of unmasked pixels used to
+            * ``'flux_init'``, ``'flux_fit'``, ``'flux_err'`` : the
+              initial, fit, and error of the source flux
+            * ``'n_pixels_fit'`` : the number of unmasked pixels used to
               fit the source
-            * ``qfit`` : a quality-of-fit metric defined as the sum
-              of the absolute value of the fit residuals divided by the
-              fit flux. ``qfit`` is zero for sources that are perfectly
-              fit by the PSF model.
-            * ``cfit`` : a quality-of-fit metric defined as the
+            * ``'qfit'`` : a quality-of-fit metric defined as the sum
+              of the absolute value of the fit residuals divided by
+              the fit flux. ``'qfit'`` is zero for sources that are
+              perfectly fit by the PSF model.
+            * ``'cfit'`` : a quality-of-fit metric defined as the
               fit residual (data - model) in the initial central pixel
               value divided by the fit flux. NaN values indicate that
               the central pixel was masked. Large positive values
               indicate sources that are sharper than the PSF model
               (e.g., cosmic ray, hot pixel, etc.). Large negative values
               indicate sources that are broader than the PSF model
-            * ``reduced_chi2`` : the reduced chi-squared statistic. If
-              no ``error`` array is provided, ``reduced_chi2`` values
+            * ``'reduced_chi2'`` : the reduced chi-squared statistic. If
+              no ``error`` array is provided, ``'reduced_chi2'`` values
               will be NaN.
-            * ``flags`` : bitwise flag values
+            * ``'flags'`` : The bitwise quality flags for the source.
+              See `~photutils.psf.decode_psf_flags` for decoding flag
+              values. The flags are:
               <flag_descriptions>
 
         Notes
@@ -695,12 +700,14 @@ def _create_call_docstring(*, iterative=False):
 
         if iterative:
             # Customizations for IterativePSFPhotometry
+            indent = ' ' * 12
+            suffix = (' *only for the first iteration*')
+            iter_detected_column = ("* ``'iter_detected'`` : the "
+                                    'iteration number in which the\n'
+                                    f"{indent}  source was detected")
             customized_docstring = base_docstring.format(
-                init_params_suffix=(' *only for\n            '
-                                    'the first iteration*'),
-                iter_detected_column=('            * ``iter_detected`` : the '
-                                      'iteration number in which the'
-                                      '\n              source was detected\n'),
+                init_params_suffix=suffix,
+                iter_detected_column=iter_detected_column,
             )
         else:
             # Customizations for PSFPhotometry
@@ -709,18 +716,9 @@ def _create_call_docstring(*, iterative=False):
                 iter_detected_column='',
             )
 
-        # Apply the flag descriptions replacement
         placeholder = '<flag_descriptions>'
         if placeholder in customized_docstring:
-            # Generate the flag descriptions
-            flag_descriptions = []
-            flag_descriptions.append('')
-            flag_descriptions.append('              - 0 : no flags')
-
-            for flag_def in PSF_FLAGS.FLAG_DEFINITIONS:
-                desc = flag_def.description
-                line = f'              - {flag_def.bit_value} : {desc}'
-                flag_descriptions.append(line)
+            flag_descriptions = define_flag_docstring(PSF_FLAGS, indent=14)
 
             # Replace the placeholder with the flag descriptions
             flag_text = '\n'.join(flag_descriptions)

--- a/photutils/utils/_flags.py
+++ b/photutils/utils/_flags.py
@@ -1,0 +1,334 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Generic machinery for defining and decoding bitwise quality flags.
+
+This private module provides the shared building blocks used by the
+public per-package flag registries (e.g., ``photutils.psf.flags`` and
+``photutils.aperture.flags``): a flag-definition dataclass, a registry
+base class, a flag decoder, and a docstring-substitution helper.
+"""
+
+import warnings
+from dataclasses import dataclass
+from typing import ClassVar
+
+import numpy as np
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from photutils.utils._deprecation import deprecated_getattr
+
+__all__ = []
+
+
+@dataclass(frozen=True)
+class FlagDefinition:
+    """
+    A single bitwise flag definition.
+
+    Attributes
+    ----------
+    bit_value : int
+        The bit value (power of 2) for this flag.
+
+    name : str
+        Short name for the flag (used by the flag decoders).
+
+    description : str
+        Brief description of what this flag indicates.
+
+    detailed_description : str
+        Detailed description for use in docstrings.
+    """
+
+    bit_value: int
+    name: str
+    description: str
+    detailed_description: str
+
+
+class FlagRegistry:
+    """
+    Base class for centralized definitions of bitwise quality flags.
+
+    Subclasses define the ``FLAG_DEFINITIONS`` list of `FlagDefinition`
+    objects and a short ``domain`` string identifying the flag source
+    (e.g., ``'psf'`` or ``'aperture'``). The registry provides a single
+    source of truth for the flag bit values, names, and descriptions,
+    enabling consistent flag handling and dynamic docstring generation.
+
+    Uppercase constants (e.g., ``NO_OVERLAP``) are created on the
+    instance for each flag definition.
+    """
+
+    FLAG_DEFINITIONS: ClassVar = []
+    domain: ClassVar = ''
+
+    # Mappings of deprecated flag/constant names to their new names;
+    # subclasses may override these along with the deprecation
+    # versions used in the warning messages.
+    _DEPRECATED_FLAG_NAMES: ClassVar = {}
+    _DEPRECATED_CONSTANT_NAMES: ClassVar = {}
+    _DEPRECATED_SINCE: ClassVar = None
+    _DEPRECATED_UNTIL: ClassVar = None
+
+    def __init__(self):
+        for flag_def in self.FLAG_DEFINITIONS:
+            # Create uppercase constants (e.g., NO_OVERLAP = 1)
+            setattr(self, flag_def.name.upper(), flag_def.bit_value)
+
+        # Create lookup dictionaries for efficient access
+        self._bit_to_def = {fd.bit_value: fd
+                            for fd in self.FLAG_DEFINITIONS}
+        self._name_to_def = {fd.name: fd for fd in self.FLAG_DEFINITIONS}
+
+    def __getattr__(self, name):
+        return deprecated_getattr(self, name,
+                                  self._DEPRECATED_CONSTANT_NAMES,
+                                  since=self._DEPRECATED_SINCE,
+                                  until=self._DEPRECATED_UNTIL)
+
+    @property
+    def all_flags(self):
+        """
+        Return all flag definitions.
+        """
+        return self.FLAG_DEFINITIONS.copy()
+
+    @property
+    def bit_values(self):
+        """
+        Return all bit values.
+        """
+        return [fd.bit_value for fd in self.FLAG_DEFINITIONS]
+
+    @property
+    def names(self):
+        """
+        Return all flag names.
+        """
+        return [fd.name for fd in self.FLAG_DEFINITIONS]
+
+    @property
+    def flag_dict(self):
+        """
+        Return dictionary mapping bit values to names.
+        """
+        return {fd.bit_value: fd.name for fd in self.FLAG_DEFINITIONS}
+
+    def get_definition(self, identifier):
+        """
+        Get flag definition by bit value or name.
+
+        Parameters
+        ----------
+        identifier : int or str
+            Either the bit value (int) or name (str) of the flag.
+
+        Returns
+        -------
+        definition : `FlagDefinition`
+            The flag definition.
+
+        Raises
+        ------
+        KeyError
+            If the identifier is not found.
+        """
+        if isinstance(identifier, int):
+            if identifier not in self._bit_to_def:
+                msg = f'No flag with bit value {identifier}'
+                raise KeyError(msg)
+            return self._bit_to_def[identifier]
+
+        if isinstance(identifier, str):
+            if identifier in self._DEPRECATED_FLAG_NAMES:
+                new_name = self._DEPRECATED_FLAG_NAMES[identifier]
+                warnings.warn(
+                    f"The flag name '{identifier}' is deprecated "
+                    f"in version {self._DEPRECATED_SINCE}. Use "
+                    f"'{new_name}' instead. It will be removed in "
+                    f'version {self._DEPRECATED_UNTIL}.',
+                    AstropyDeprecationWarning,
+                    stacklevel=2,
+                )
+                identifier = new_name
+
+            if identifier not in self._name_to_def:
+                msg = f"No flag with name '{identifier}'"
+                raise KeyError(msg)
+            return self._name_to_def[identifier]
+
+        msg = 'identifier must be int (bit value) or str (name)'
+        raise TypeError(msg)
+
+    def get_name(self, bit_value):
+        """
+        Get flag name from bit value.
+
+        Parameters
+        ----------
+        bit_value : int
+            The bit value of the flag.
+
+        Returns
+        -------
+        name : str
+            The name of the flag.
+        """
+        return self.get_definition(bit_value).name
+
+    def get_bit_value(self, name):
+        """
+        Get flag bit value from name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the flag.
+
+        Returns
+        -------
+        bit_value : int
+            The bit value of the flag.
+        """
+        return self.get_definition(name).bit_value
+
+    def get_description(self, bit_value):
+        """
+        Get flag description from bit value.
+
+        Parameters
+        ----------
+        bit_value : int
+            The bit value of the flag.
+
+        Returns
+        -------
+        description : str
+            The brief description of the flag.
+        """
+        return self.get_definition(bit_value).description
+
+    def get_detailed_description(self, bit_value):
+        """
+        Get detailed flag description from bit value.
+
+        Parameters
+        ----------
+        bit_value : int
+            The bit value of the flag.
+
+        Returns
+        -------
+        detailed_description : str
+            The detailed description of the flag.
+        """
+        return self.get_definition(bit_value).detailed_description
+
+
+def update_flag_docstring(func, registry,
+                          placeholder='<flag_descriptions>'):
+    """
+    Update a function docstring with flag documentation.
+
+    The ``placeholder`` text in the function docstring is replaced with
+    a bullet list of the flag names, bit values, and brief descriptions
+    generated from the ``registry``.
+
+    Parameters
+    ----------
+    func : function
+        The function whose docstring is updated in place.
+
+    registry : `FlagRegistry`
+        The flag registry providing the flag definitions.
+
+    placeholder : str, optional
+        The placeholder text to replace in the docstring.
+
+    Returns
+    -------
+    func : function
+        The function with an updated docstring.
+    """
+    if not hasattr(func, '__doc__') or func.__doc__ is None:
+        return func
+
+    docstring = func.__doc__
+
+    if placeholder in docstring:
+        # Generate the flag descriptions
+        flag_descriptions = ['']
+
+        indent = ' ' * 4
+        for flag_def in registry.FLAG_DEFINITIONS:
+            name = flag_def.name
+            bit_val = flag_def.bit_value
+            desc = flag_def.description
+            line = f"{indent}- ``'{name}'`` : bit {bit_val}, {desc}"
+            flag_descriptions.append(line)
+
+        # Replace the placeholder with the flag descriptions
+        flag_text = '\n'.join(flag_descriptions)
+        func.__doc__ = docstring.replace(placeholder, flag_text)
+
+    return func
+
+
+def decode_flags(flags, registry, *, return_bit_values=False):
+    """
+    Decode bitwise flag values into individual components.
+
+    Parameters
+    ----------
+    flags : int or array-like of int
+        Integer flag value(s) to decode.
+
+    registry : `FlagRegistry`
+        The flag registry providing the flag definitions.
+
+    return_bit_values : bool, optional
+        If `True`, return the decoded bit flags (integers) instead of
+        the flag names (strings).
+
+    Returns
+    -------
+    decoded : list
+        List of active flag names (or bit values), or list of lists
+        if the input is an array.
+    """
+    flag_definitions = registry.flag_dict
+
+    def _decode_single_flag(flag_value):
+        """
+        Decode a single integer flag value.
+        """
+        if not isinstance(flag_value, (int, np.integer)):
+            msg = 'Flag value must be an integer'
+            raise TypeError(msg)
+
+        if flag_value < 0:
+            msg = 'Flag value must be a non-negative integer'
+            raise ValueError(msg)
+
+        active_flags = []
+        for bit_value, name in flag_definitions.items():
+            if flag_value & bit_value:
+                if return_bit_values:
+                    active_flags.append(bit_value)
+                else:
+                    active_flags.append(name)
+        return active_flags
+
+    # Handle both single values and arrays
+    if np.isscalar(flags):
+        return _decode_single_flag(flags)
+
+    # Convert to numpy array for consistent handling
+    flags_array = np.asarray(flags)
+    if flags_array.ndim == 0:
+        # Handle 0D arrays (scalar arrays)
+        return _decode_single_flag(flags_array.item())
+
+    # Handle 1D or higher dimensional arrays
+    return [_decode_single_flag(flag) for flag in flags_array.flat]

--- a/photutils/utils/_flags.py
+++ b/photutils/utils/_flags.py
@@ -226,13 +226,50 @@ class FlagRegistry:
         return self.get_definition(bit_value).detailed_description
 
 
-def update_flag_docstring(func, registry,
+def define_flag_docstring(registry, *, indent=0):
+    """
+    Generate a bullet list of flag names, bit values, and descriptions.
+
+    Parameters
+    ----------
+    registry : `FlagRegistry`
+        The flag registry providing the flag definitions.
+
+    indent : int, optional
+        Number of spaces to indent the bullet list.
+
+    Returns
+    -------
+    flag_descriptions : list of str
+        List of strings representing the bullet list of flag bit values,
+        names, and brief descriptions.
+    """
+    if not isinstance(registry, FlagRegistry):
+        msg = 'registry must be an instance of FlagRegistry'
+        raise TypeError(msg)
+
+    indent_str = ' ' * indent
+
+    # Generate the flag descriptions
+    flag_descriptions = ['', f'{indent_str}* **0** : No flags set.']
+
+    for flag_def in registry.FLAG_DEFINITIONS:
+        name = flag_def.name
+        bit_val = flag_def.bit_value
+        desc = flag_def.detailed_description
+        line = f"{indent_str}* **{bit_val}** (``'{name}'``) : {desc}"
+        flag_descriptions.append(line)
+
+    return flag_descriptions
+
+
+def update_flag_docstring(func, registry, *, indent=0,
                           placeholder='<flag_descriptions>'):
     """
     Update a function docstring with flag documentation.
 
     The ``placeholder`` text in the function docstring is replaced with
-    a bullet list of the flag names, bit values, and brief descriptions
+    a bullet list of the flag bit values, names, and brief descriptions
     generated from the ``registry``.
 
     Parameters
@@ -242,6 +279,9 @@ def update_flag_docstring(func, registry,
 
     registry : `FlagRegistry`
         The flag registry providing the flag definitions.
+
+    indent : int, optional
+        Number of spaces to indent the bullet list.
 
     placeholder : str, optional
         The placeholder text to replace in the docstring.
@@ -257,16 +297,7 @@ def update_flag_docstring(func, registry,
     docstring = func.__doc__
 
     if placeholder in docstring:
-        # Generate the flag descriptions
-        flag_descriptions = ['']
-
-        indent = ' ' * 4
-        for flag_def in registry.FLAG_DEFINITIONS:
-            name = flag_def.name
-            bit_val = flag_def.bit_value
-            desc = flag_def.description
-            line = f"{indent}- ``'{name}'`` : bit {bit_val}, {desc}"
-            flag_descriptions.append(line)
+        flag_descriptions = define_flag_docstring(registry, indent=indent)
 
         # Replace the placeholder with the flag descriptions
         flag_text = '\n'.join(flag_descriptions)


### PR DESCRIPTION
This PR adds per-source bitwise quality flags to aperture photometry and statistics. In ``ApertureStats``, ``flags`` reports the quality flags for the value statistics (the ``'center'``-method footprint) and ``sum_flags`` reports the flags for the sum properties (the ``sum_method`` footprint). The flags indicate conditions such as apertures that are partially or fully outside the data, masked or non-finite pixels within the aperture, pixels affected by segmentation masking, sigma-clipped pixels, and too few pixels to compute a statistic. A new ``decode_aperture_flags`` function decodes the flag values into human-readable names.
