### PR TITLE
Aperture photometry class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,12 @@ New Features
 
 - ``photutils.aperture``
 
+  - Added a new ``AperturePhotometry`` class, which is now the
+    recommended tool for aperture photometry. It uses a results-object
+    pattern, similar to ``ApertureStats``. The class is immutable after
+    construction, so instances are thread-safe and independent frames
+    can be processed concurrently. [#2328]
+
   - Rectangular apertures now support the ``method='exact'`` mask mode.
     Previously this fell back to a 32x subpixel approximation. [#2291]
 
@@ -47,9 +53,9 @@ New Features
     to ``PolygonAperture`` or ``SkyPolygonAperture`` objects. [#2298]
 
   - Added ``segmentation_image``, ``labels``, and ``mask_method``
-    keywords to ``aperture_photometry`` and ``ApertureStats`` to mask or
+    keywords to ``AperturePhotometry`` and ``ApertureStats`` to mask or
     correct the flux from neighboring sources within an aperture using a
-    segmentation map. [#2309, #2321]
+    segmentation map. [#2309, #2321, #2328]
 
   - Significantly improved the performance of elliptical, rectangular,
     and convex polygon aperture photometry, typically by a factor of ~2.
@@ -71,21 +77,14 @@ New Features
     properties. The default is ``ddof=0`` (population variance), and
     ``ddof=1`` gives the sample (unbiased) variance. [#2314]
 
-  - Added per-source bitwise quality flags to aperture photometry
-    and statistics: ``aperture_photometry`` now includes a ``'flags'``
-    column (or ``'flags_<i>'`` columns for multiple apertures)
-    in the returned table, ``PixelAperture.photometry`` results
-    have a new ``flags`` attribute, and ``ApertureStats`` has new
-    ``flags``, ``sum_flags``, and ``decode_flags`` attributes. In
-    ``ApertureStats``, ``flags`` reports the quality flags for the value
-    statistics (the ``'center'``-method footprint) and ``sum_flags``
-    reports the flags for the sum properties (the ``sum_method``
-    footprint). The flags indicate conditions such as apertures that are
-    partially or fully outside the data, masked or non-finite pixels
-    within the aperture, pixels affected by segmentation masking,
-    sigma-clipped pixels, and too few pixels to compute a statistic. A
-    new ``decode_aperture_flags`` function decodes the flag values into
-    human-readable names. [#2327]
+  - Added per-source bitwise quality flags to aperture photometry and
+    statistics. The ``AperturePhotometry`` and ``ApertureStats``
+    classes provide a ``flags`` attribute (and a ``'flags'`` column,
+    or ``'flags_<i>'`` columns for multiple apertures, in their
+    default ``to_table()`` output), and ``ApertureStats`` also
+    provides a ``sum_flags`` attribute for the sum properties. A new
+    ``decode_aperture_flags`` function decodes the flag values into
+    human-readable names. [#2327, #2328]
 
 - ``photutils.isophote``
 
@@ -137,8 +136,8 @@ Bug Fixes
     nonzero ``sum_method`` overlap fractions, the fractional area of
     those pixels is now returned, consistent with ``sum``. [#2314]
 
-  - Fixed ``PixelAperture.photometry`` so that the returned flux
-    errors always have the same length as the fluxes when ``error`` is
+  - Fixed the aperture photometry so that the returned flux errors
+    always have the same length as the fluxes when ``error`` is
     not input. Previously, an all-NaN error array was returned only
     for sources with no overlap with the data. [#2316]
 
@@ -177,45 +176,19 @@ API Changes
 
 - ``photutils.aperture``
 
-  - ``aperture_photometry`` now always includes an
-    ``'aperture_sum_err'`` column in the returned table, filled with
-    NaN values if the ``error`` keyword is not input. Previously,
-    the column was omitted entirely in that case. This makes
-    the behavior consistent with ``ApertureStats.to_table()``,
-    ``SourceCatalog.to_table()``, and the ``PSFPhotometry`` and
-    ``IterativePSFPhotometry`` output tables, which always include
-    ``*_err`` columns (e.g., ``flux_err``). [#2319]
-
-  - ``aperture_photometry`` now always includes an ``'area'`` column
-    (or ``'area_<i>'`` columns for multiple apertures) in the returned
-    table. This is the total unmasked overlap area of the aperture (in
-    ``pix**2``), equivalent to ``PixelAperture.area_overlap`` computed
-    with the same inputs. [#2323]
-
-  - ``PixelAperture.photometry`` now returns an ``ApertureResults``
-    object instead of a plain tuple. The result remains backward
-    compatible: it can still be unpacked as a 2-tuple (``aperture_sum,
-    aperture_sum_err = aperture.photometry(...)``) and supports
-    ``len()`` and integer indexing like the legacy tuple. The new
-    ``area`` attribute provides the total unmasked overlap area of each
-    aperture (in ``pix**2``). [#2323]
-
-  - The ``PixelAperture.do_photometry`` method has been renamed to
-    ``photometry``. The old method name is deprecated and will be
-    removed in version 4.0. Note that in the new ``photometry`` method
-    all arguments except ``data`` are keyword-only. [#2324]
+  - The ``PixelAperture.do_photometry`` method is now deprecated and
+    will be removed in version 4.0. Use the new ``AperturePhotometry``
+    class instead. [#2324, #2328]
 
 - ``photutils.psf``
 
   - The ``EPSFBuildResult`` class returned by ``EPSFBuilder`` has been
-    renamed to ``EPSFBuildResults`` for consistency with the new
-    ``ApertureResults`` class. The old ``EPSFBuildResult`` name is
-    deprecated and will be removed in a future version. [#2326]
+    renamed to ``EPSFBuildResults`` for consistency with the plural
+    naming of the other results classes. The old ``EPSFBuildResult``
+    name is deprecated and will be removed in a future version. [#2326]
 
-  - ``aperture_photometry`` now always includes a ``'flags'`` column
-    (or ``'flags_<i>'`` columns for multiple apertures) in the
-    returned table, and the default ``ApertureStats.to_table()``
-    columns now include ``'flags'``. [#2327]
+  - The default ``ApertureStats.to_table()`` columns now include a
+    ``'flags'`` column. [#2327]
 
 
 3.0.0 (2026-04-17)

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -536,6 +536,38 @@ list of aperture objects with identical positions, but with different
       3     54.6     68.2 47.12389 75.398224 109.95574 0.75198848 0.95119855  1.1486814 47.12389 75.398224 109.95574       0       0       0
 
 
+Aperture Photometry on a 3D Data Cube
+-------------------------------------
+
+:class:`~photutils.aperture.AperturePhotometry` operates on a single
+2D image. To measure a source in a 3D data cube -- for example, a time
+series of images of the same field -- apply the same aperture to each 2D
+image in the stack and collect the results into a light curve.
+
+Here we create a small stack of five images in which a single source
+varies in brightness from frame to frame, and measure its flux in each
+frame using the same circular aperture::
+
+    >>> import numpy as np
+    >>> from photutils.aperture import AperturePhotometry, CircularAperture
+    >>> scales = np.array([1.0, 1.5, 2.0, 1.8, 1.2])
+    >>> cube = scales[:, None, None] * np.ones((5, 50, 50))
+    >>> aperture = CircularAperture((25, 25), r=5)
+    >>> flux = np.array([AperturePhotometry(image, aperture).flux[0]
+    ...                  for image in cube])
+    >>> print(flux)  # doctest: +FLOAT_CMP
+    [ 78.53981634 117.80972451 157.07963268 141.37166941  94.24777961]
+
+Each element of ``flux`` corresponds to one image in the cube, giving
+the source's light curve. The same pattern extends to multiple sources
+and to per-frame uncertainties or quality flags: keep each results
+object and index the desired attribute (e.g.,
+:attr:`~photutils.aperture.AperturePhotometry.flux_err` or
+:attr:`~photutils.aperture.AperturePhotometry.flags`) for every frame,
+or build a table per frame with
+:meth:`~photutils.aperture.AperturePhotometry.to_table`.
+
+
 Masking Pixels in Aperture Photometry
 --------------------------------------
 
@@ -975,35 +1007,19 @@ the source fluxes in the circular apertures::
       3     48.3    200.3 1299.6341 0.88622693 78.539816     0
 
 The total background within each source aperture is the mean background
-per pixel multiplied by the aperture area. The aperture area is already
-available in the ``'area'`` column of the output table above, which is
-equivalent to the :meth:`~photutils.aperture.PixelAperture.area_overlap`
-method computed with the same photometry inputs. When using the
-default ``'exact'`` overlap method (see :ref:`aperture-mask methods
-<aperture-mask-methods>`) and no pixels are masked, the analytical
-aperture area is also available from the ``area`` attribute::
+per pixel multiplied by the aperture area. Rather than the analytical
+aperture area, use the unmasked overlap area that was actually used for
+the photometry, which is available in the ``'area'`` column of the
+output table above (equivalent to the
+:meth:`~photutils.aperture.PixelAperture.area_overlap` method computed
+with the same photometry inputs). Using this computed area ensures the
+background is scaled consistently with the photometry, correctly
+accounting for the overlap method and any masked pixels::
 
-    >>> aperture.area
-    78.53981633974483
-
-In general, however, you should use the ``'area'`` column or the
-:meth:`~photutils.aperture.PixelAperture.area_overlap` method to compute
-the aperture area. The ``area_overlap`` method accepts a ``mask``
-argument, ensuring that the area is computed consistently with the
-photometry. If using a :class:`~photutils.aperture.SkyAperture`, first
-convert it to a :class:`~photutils.aperture.PixelAperture`. In this
-example, we used the default ``'exact'`` overlap method and no mask is
-used, so ``area_overlap`` returns the same value as ``area``::
-
-    >>> aperture_area = aperture.area_overlap(data)
-    >>> print(aperture_area)
-    [78.53981634 78.53981634 78.53981634]
-
-The total background within the circular aperture is then::
-
+    >>> aperture_area = phot_table['area'].value
     >>> total_bkg = bkg_mean * aperture_area
     >>> print(total_bkg)
-    [392.23708187 403.29680431 382.40617574]
+    [392.23708187 403.29680431 382.40617607]
 
 Subtracting this background estimate from the measured aperture sums
 gives the background-subtracted photometry::

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -6,10 +6,40 @@ Aperture Photometry (`photutils.aperture`)
 Introduction
 ------------
 
-The :func:`~photutils.aperture.aperture_photometry` function and the
+The :class:`~photutils.aperture.AperturePhotometry` class and the
 :class:`~photutils.aperture.ApertureStats` class are the primary tools
 for performing aperture photometry. They work in conjunction with the
 aperture classes.
+
+The :class:`~photutils.aperture.AperturePhotometry` class sums the
+(weighted) data values within one or more apertures and reports the
+aperture fluxes, uncertainties, unmasked overlap areas, and bitwise
+quality flags. The :class:`~photutils.aperture.ApertureStats`
+class computes per-source statistics (e.g., mean, median,
+standard deviation, sigma-clipped values, and morphological
+properties) for the pixels within an aperture. The legacy
+:func:`~photutils.aperture.aperture_photometry` function
+performs basic aperture photometry, returning only the aperture
+sums and (optionally) their uncertainties. It is retained
+for backwards compatibility, but new features are added only
+to the :class:`~photutils.aperture.AperturePhotometry` and
+:class:`~photutils.aperture.ApertureStats` classes.
+
+.. tip::
+
+    Which tool should I use?
+
+    * Use :class:`~photutils.aperture.AperturePhotometry` for aperture
+      fluxes (sums), errors, areas and quality flags. The calculated
+      values can be accessed as class attributes or output as an Astropy
+      `~astropy.table.QTable`. For aperture photometry, it is faster
+      than :class:`~photutils.aperture.ApertureStats`.
+    * Use :class:`~photutils.aperture.ApertureStats` for per-source
+      statistics such as the median, standard deviation, sigma-clipped
+      values, and morphological properties.
+    * Use the legacy
+      :func:`~photutils.aperture.aperture_photometry` function only if
+      you need its original output columns for backwards compatibility.
 
 .. _photutils-apertures:
 
@@ -39,14 +69,14 @@ coordinates.
    * - `~photutils.aperture.PolygonAperture`
      - `~photutils.aperture.SkyPolygonAperture`
 
-The :func:`~photutils.aperture.aperture_photometry` function and
+The :class:`~photutils.aperture.AperturePhotometry` class and
 the :class:`~photutils.aperture.ApertureStats` class both accept
 :class:`~photutils.aperture.Aperture` objects. When using sky-based
 apertures, a WCS transformation must also be provided.
 
 They also accept supported `regions.Region` objects, i.e., region
 classes that correspond to the aperture classes listed above. The
-:func:`~photutils.aperture.aperture_photometry` function additionally
+:class:`~photutils.aperture.AperturePhotometry` class additionally
 accepts a list of :class:`~photutils.aperture.Aperture` and/or
 `regions.Region` objects, provided they all have identical positions.
 
@@ -226,38 +256,52 @@ Performing Aperture Photometry
 ------------------------------
 
 After the aperture object is created, we can then perform the photometry
-using the :func:`~photutils.aperture.aperture_photometry` function. We
+using the :class:`~photutils.aperture.AperturePhotometry` class. We
 start by defining the aperture (at three positions) as described above::
 
     >>> from photutils.aperture import CircularAperture
     >>> positions = [(71.4, 23.9), (42.1, 41.7), (54.6, 68.2)]
     >>> aperture = CircularAperture(positions, r=3.1)
 
-We then call the :func:`~photutils.aperture.aperture_photometry`
-function with the data and the apertures. Note that
-:func:`~photutils.aperture.aperture_photometry` assumes that the input
+We then create an :class:`~photutils.aperture.AperturePhotometry`
+instance with the data and the apertures. Note that
+:class:`~photutils.aperture.AperturePhotometry` assumes that the input
 data have been background subtracted. For simplicity, we define the data
 here as an array of all ones::
 
     >>> import numpy as np
-    >>> from photutils.aperture import aperture_photometry
+    >>> from photutils.aperture import AperturePhotometry
     >>> data = np.ones((100, 100))
-    >>> phot_table = aperture_photometry(data, aperture)
-    >>> phot_table['aperture_sum'].info.format = '%.8g'  # for consistent table output
-    >>> phot_table['area'].info.format = '%.8g'  # for consistent table output
-    >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err    area   flags
-                                                           pix2
-    --- -------- -------- ------------ ---------------- --------- -----
-      1     71.4     23.9    30.190705              nan 30.190705     0
-      2     42.1     41.7    30.190705              nan 30.190705     0
-      3     54.6     68.2    30.190705              nan 30.190705     0
+    >>> phot = AperturePhotometry(data, aperture)
 
-This function returns the results of the photometry in an Astropy
-`~astropy.table.QTable`. In this example, the table has seven columns,
-named ``'id'``, ``'x_center'``, ``'y_center'``, ``'aperture_sum'``,
-``'aperture_sum_err'``, ``'area'``, and ``'flags'``. Because no
-``error`` was input, the ``'aperture_sum_err'`` column is filled
+The aperture fluxes, uncertainties, unmasked overlap areas, and
+quality flags are available as lazily-computed attributes (see
+:attr:`~photutils.aperture.AperturePhotometry.flux`,
+:attr:`~photutils.aperture.AperturePhotometry.flux_err`,
+:attr:`~photutils.aperture.AperturePhotometry.area`, and
+:attr:`~photutils.aperture.AperturePhotometry.flags`)::
+
+    >>> print(phot.flux)  # doctest: +FLOAT_CMP
+    [30.1907054 30.1907054 30.1907054]
+
+The results can also be output as an Astropy `~astropy.table.QTable`
+using the :meth:`~photutils.aperture.AperturePhotometry.to_table`
+method::
+
+    >>> phot_table = phot.to_table()
+    >>> phot_table['flux'].info.format = '%.8g'  # for consistent table output
+    >>> phot_table['area'].info.format = '%.8g'  # for consistent table output
+    >>> phot_table.pprint(max_width=-1)
+     id x_center y_center    flux   flux_err    area   flags
+                                                pix2
+    --- -------- -------- --------- -------- --------- -----
+      1     71.4     23.9 30.190705      nan 30.190705     0
+      2     42.1     41.7 30.190705      nan 30.190705     0
+      3     54.6     68.2 30.190705      nan 30.190705     0
+
+The default table has seven columns, named ``'id'``, ``'x_center'``,
+``'y_center'``, ``'flux'``, ``'flux_err'``, ``'area'``, and ``'flags'``.
+Because no ``error`` was input, the ``'flux_err'`` column is filled
 with NaN values (see :ref:`error_estimation`). The ``'area'``
 column gives the total unmasked overlap area of the aperture
 with the data (in ``pix**2``). It is equivalent to the aperture
@@ -273,7 +317,7 @@ area of a circle with a radius of 3.1::
     30.190705401
 
 
-.. _photutils-aperture-overlap:
+.. _aperture-mask-methods:
 
 Aperture and Pixel Overlap
 --------------------------
@@ -308,17 +352,18 @@ one of three methods:
 This example uses the ``'subpixel'`` method where pixels are resampled
 by a factor of 5 (``subpixels=5``) in each dimension::
 
-    >>> phot_table = aperture_photometry(data, aperture, method='subpixel',
-    ...                                  subpixels=5)
+    >>> phot = AperturePhotometry(data, aperture, method='subpixel',
+    ...                           subpixels=5)
+    >>> phot_table = phot.to_table()
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
-    >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err  area flags
-                                                         pix2
-    --- -------- -------- ------------ ---------------- ----- -----
-      1     71.4     23.9         30.2              nan  30.2     0
-      2     42.1     41.7         29.6              nan  29.6     0
-      3     54.6     68.2        29.96              nan 29.96     0
+    >>> phot_table.pprint(max_width=-1)
+     id x_center y_center  flux flux_err  area flags
+                                          pix2
+    --- -------- -------- ----- -------- ----- -----
+      1     71.4     23.9  30.2      nan  30.2     0
+      2     42.1     41.7  29.6      nan  29.6     0
+      3     54.6     68.2 29.96      nan 29.96     0
 
 Note that the ``'subpixel'`` sums differ from the exact value of
 30.190705 (see above). They also differ slightly from one another, even
@@ -342,10 +387,9 @@ Aperture Photometry Error Estimation
 ------------------------------------
 
 If the ``error`` keyword is provided to
-:func:`~photutils.aperture.aperture_photometry`, the
-``'aperture_sum_err'`` column contains the propagated uncertainty
-of ``'aperture_sum'``. If ``error`` is not provided, the
-``'aperture_sum_err'`` column is filled with NaN values.
+:class:`~photutils.aperture.AperturePhotometry`, the ``'flux_err'``
+column contains the propagated uncertainty of ``'flux'``. If ``error``
+is not provided, the ``'flux_err'`` column is filled with NaN values.
 
 For example, suppose the uncertainty of each pixel value has already
 been calculated and stored in the array ``error``::
@@ -355,18 +399,19 @@ been calculated and stored in the array ``error``::
     >>> data = np.ones((100, 100))
     >>> error = 0.1 * data
 
-    >>> phot_table = aperture_photometry(data, aperture, error=error)
+    >>> phot = AperturePhotometry(data, aperture, error=error)
+    >>> phot_table = phot.to_table()
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
-    >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err    area   flags
-                                                           pix2
-    --- -------- -------- ------------ ---------------- --------- -----
-      1     71.4     23.9    28.274334       0.53173616 28.274334     0
-      2     42.1     41.7    28.274334       0.53173616 28.274334     0
-      3     54.6     68.2    28.274334       0.53173616 28.274334     0
+    >>> phot_table.pprint(max_width=-1)
+     id x_center y_center    flux    flux_err     area   flags
+                                                  pix2
+    --- -------- -------- --------- ---------- --------- -----
+      1     71.4     23.9 28.274334 0.53173616 28.274334     0
+      2     42.1     41.7 28.274334 0.53173616 28.274334     0
+      3     54.6     68.2 28.274334 0.53173616 28.274334     0
 
-The ``'aperture_sum_err'`` values are calculated as:
+The ``'flux_err'`` values are calculated as:
 
 .. math:: \Delta F = \sqrt{\sum_{i \in A} \sigma_{\mathrm{tot}, i}^2}
 
@@ -391,18 +436,19 @@ units of electrons/s, we use the exposure time as the effective gain::
     >>> bkg_error = 0.1 * data  # background-only error
     >>> effective_gain = 500  # seconds
     >>> error = calc_total_error(data, bkg_error, effective_gain)
-    >>> phot_table = aperture_photometry(data, aperture, error=error)
+    >>> phot = AperturePhotometry(data, aperture, error=error)
+    >>> phot_table = phot.to_table()
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
-    >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err    area   flags
-                                                           pix2
-    --- -------- -------- ------------ ---------------- --------- -----
-      1     71.4     23.9    28.274334       0.58248777 28.274334     0
-      2     42.1     41.7    28.274334       0.58248777 28.274334     0
-      3     54.6     68.2    28.274334       0.58248777 28.274334     0
+    >>> phot_table.pprint(max_width=-1)
+     id x_center y_center    flux    flux_err     area   flags
+                                                  pix2
+    --- -------- -------- --------- ---------- --------- -----
+      1     71.4     23.9 28.274334 0.58248777 28.274334     0
+      2     42.1     41.7 28.274334 0.58248777 28.274334     0
+      3     54.6     68.2 28.274334 0.58248777 28.274334     0
 
-Note that the ``'aperture_sum_err'`` values are now larger than in the
+Note that the ``'flux_err'`` values are now larger than in the
 previous example because they include the additional Poisson noise from
 the source. Refer to the :func:`~photutils.utils.calc_total_error`
 documentation for more details on the calculation of the total error.
@@ -417,33 +463,34 @@ at every position (e.g., the same radius and orientation).
 
 To perform photometry using multiple aperture sizes or shapes at each
 position, pass a list of aperture objects to the
-:func:`~photutils.aperture.aperture_photometry` function. In this case,
+:class:`~photutils.aperture.AperturePhotometry` class. In this case,
 all aperture objects in the list must have identical position(s).
 
 For example, suppose we want to measure three circular apertures with
 radii of 3, 4, and 5 pixels at each source position. We therefore create
 a list of aperture objects, where each object has the same positions but
 a different radius. We also pass the ``error`` array defined above so
-that the ``'aperture_sum_err'`` columns are populated::
+that the ``'flux_err'`` columns are populated::
 
     >>> positions = [(71.4, 23.9), (42.1, 41.7), (54.6, 68.2)]
     >>> radii = [3.0, 4.0, 5.0]
     >>> apertures = [CircularAperture(positions, r=r) for r in radii]
-    >>> phot_table = aperture_photometry(data, apertures, error=error)
+    >>> phot = AperturePhotometry(data, apertures, error=error)
+    >>> phot_table = phot.to_table()
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum_0 aperture_sum_err_0   area_0  flags_0 aperture_sum_1 aperture_sum_err_1   area_1  flags_1 aperture_sum_2 aperture_sum_err_2   area_2  flags_2
-                                                               pix2                                                pix2                                                pix2
-    --- -------- -------- -------------- ------------------ --------- ------- -------------- ------------------ --------- ------- -------------- ------------------ --------- -------
-      1     71.4     23.9      28.274334         0.58248777 28.274334       0      50.265482         0.77665037 50.265482       0      78.539816         0.97081296 78.539816       0
-      2     42.1     41.7      28.274334         0.58248777 28.274334       0      50.265482         0.77665037 50.265482       0      78.539816         0.97081296 78.539816       0
-      3     54.6     68.2      28.274334         0.58248777 28.274334       0      50.265482         0.77665037 50.265482       0      78.539816         0.97081296 78.539816       0
+     id x_center y_center   flux_0    flux_1    flux_2  flux_err_0 flux_err_1 flux_err_2   area_0    area_1    area_2  flags_0 flags_1 flags_2
+                                                                                            pix2      pix2      pix2
+    --- -------- -------- --------- --------- --------- ---------- ---------- ---------- --------- --------- --------- ------- ------- -------
+      1     71.4     23.9 28.274334 50.265482 78.539816 0.58248777 0.77665037 0.97081296 28.274334 50.265482 78.539816       0       0       0
+      2     42.1     41.7 28.274334 50.265482 78.539816 0.58248777 0.77665037 0.97081296 28.274334 50.265482 78.539816       0       0       0
+      3     54.6     68.2 28.274334 50.265482 78.539816 0.58248777 0.77665037 0.97081296 28.274334 50.265482 78.539816       0       0       0
 
 When a list of aperture objects is provided, the output table column
 names are appended with the index of the aperture within the input
-list (e.g., ``aperture_sum_0`` for the first aperture,
-``aperture_sum_1`` for the second, and so on).
+list (e.g., ``flux_0`` for the first aperture, ``flux_1`` for the
+second, and so on).
 
 Other aperture classes have additional parameters that define their
 size and orientation. For example, an elliptical aperture requires
@@ -455,16 +502,17 @@ size and orientation. For example, an elliptical aperture requires
     >>> b = 3.0
     >>> theta = Angle(45, 'deg')
     >>> apertures = EllipticalAperture(positions, a, b, theta=theta)
-    >>> phot_table = aperture_photometry(data, apertures, error=error)
+    >>> phot = AperturePhotometry(data, apertures, error=error)
+    >>> phot_table = phot.to_table()
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
-    >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err   area   flags
-                                                          pix2
-    --- -------- -------- ------------ ---------------- -------- -----
-      1     71.4     23.9     47.12389       0.75198848 47.12389     0
-      2     42.1     41.7     47.12389       0.75198848 47.12389     0
-      3     54.6     68.2     47.12389       0.75198848 47.12389     0
+    >>> phot_table.pprint(max_width=-1)
+     id x_center y_center   flux    flux_err    area   flags
+                                                pix2
+    --- -------- -------- -------- ---------- -------- -----
+      1     71.4     23.9 47.12389 0.75198848 47.12389     0
+      2     42.1     41.7 47.12389 0.75198848 47.12389     0
+      3     54.6     68.2 47.12389 0.75198848 47.12389     0
 
 To measure photometry using multiple elliptical apertures, provide a
 list of aperture objects with identical positions, but with different
@@ -475,16 +523,17 @@ list of aperture objects with identical positions, but with different
     >>> theta = Angle(45, 'deg')
     >>> apertures = [EllipticalAperture(positions, a=ai, b=bi, theta=theta)
     ...              for (ai, bi) in zip(a, b)]
-    >>> phot_table = aperture_photometry(data, apertures, error=error)
+    >>> phot = AperturePhotometry(data, apertures, error=error)
+    >>> phot_table = phot.to_table()
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum_0 aperture_sum_err_0  area_0  flags_0 aperture_sum_1 aperture_sum_err_1   area_1  flags_1 aperture_sum_2 aperture_sum_err_2   area_2  flags_2
-                                                              pix2                                                pix2                                                pix2
-    --- -------- -------- -------------- ------------------ -------- ------- -------------- ------------------ --------- ------- -------------- ------------------ --------- -------
-      1     71.4     23.9       47.12389         0.75198848 47.12389       0      75.398224         0.95119855 75.398224       0      109.95574          1.1486814 109.95574       0
-      2     42.1     41.7       47.12389         0.75198848 47.12389       0      75.398224         0.95119855 75.398224       0      109.95574          1.1486814 109.95574       0
-      3     54.6     68.2       47.12389         0.75198848 47.12389       0      75.398224         0.95119855 75.398224       0      109.95574          1.1486814 109.95574       0
+     id x_center y_center  flux_0    flux_1    flux_2  flux_err_0 flux_err_1 flux_err_2  area_0    area_1    area_2  flags_0 flags_1 flags_2
+                                                                                          pix2      pix2      pix2
+    --- -------- -------- -------- --------- --------- ---------- ---------- ---------- -------- --------- --------- ------- ------- -------
+      1     71.4     23.9 47.12389 75.398224 109.95574 0.75198848 0.95119855  1.1486814 47.12389 75.398224 109.95574       0       0       0
+      2     42.1     41.7 47.12389 75.398224 109.95574 0.75198848 0.95119855  1.1486814 47.12389 75.398224 109.95574       0       0       0
+      3     54.6     68.2 47.12389 75.398224 109.95574 0.75198848 0.95119855  1.1486814 47.12389 75.398224 109.95574       0       0       0
 
 
 Masking Pixels in Aperture Photometry
@@ -501,29 +550,39 @@ by providing a boolean image mask via the ``mask`` keyword::
     >>> mask = np.zeros(data.shape, dtype=bool)
     >>> data[2, 2] = 100.0  # bad pixel
     >>> mask[2, 2] = True   # mask the bad pixel
-    >>> t1 = aperture_photometry(data, aperture, mask=mask)
-    >>> print(t1['aperture_sum'])
-       aperture_sum
-    ------------------
-    11.566370614359172
+    >>> phot1 = AperturePhotometry(data, aperture, mask=mask)
+    >>> print(phot1.flux)
+    [11.566370614359172]
 
 The result is very different if a ``mask`` image is not provided::
 
-    >>> t2 = aperture_photometry(data, aperture)
-    >>> print(t2['aperture_sum'])
-       aperture_sum
-    ------------------
-    111.56637061435919
+    >>> phot2 = AperturePhotometry(data, aperture)
+    >>> print(phot2.flux)
+    [111.56637061435919]
+
+For :class:`~photutils.aperture.AperturePhotometry` and
+:class:`~photutils.aperture.ApertureStats`, non-finite values (NaN
+or Inf) in the input ``data`` are automatically masked, so they are
+automatically excluded from calculations. For example::
+
+    >>> data = np.ones((5, 5))
+    >>> data[2, 2] = np.nan
+    >>> aperture = CircularAperture((2, 2), r=2.0)
+    >>> phot = AperturePhotometry(data, aperture)
+    >>> print(phot.flux)
+    [11.566370614359172]
 
 
 Masking Neighboring Sources with a Segmentation Image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When apertures contain flux from neighboring sources, that contamination
-can be masked or corrected using a segmentation image (see :ref:`Image
-Segmentation <image_segmentation>`). A segmentation image is an integer
-image with the same shape as the data, where background pixels have a
-value of 0 and sources are labeled with positive integers.
+:class:`~photutils.aperture.AperturePhotometry` and
+:class:`~photutils.aperture.ApertureStats` support masking or correcting
+flux contamination from neighboring sources using a segmentation image
+(see :ref:`Image Segmentation <image_segmentation>`). A segmentation
+image is an integer image with the same shape as the data, where
+background pixels have a value of 0 and sources are labeled with
+positive integers.
 
 The behavior is controlled by the ``mask_method`` keyword, which accepts
 one of four values:
@@ -551,7 +610,7 @@ In this example, a circular aperture centered on the target source
 (label 1) also overlaps a bright neighboring source (label 2)::
 
     >>> import numpy as np
-    >>> from photutils.aperture import CircularAperture, aperture_photometry
+    >>> from photutils.aperture import AperturePhotometry, CircularAperture
     >>> data = np.ones((11, 11))
     >>> data[4:7, 4:7] = 10.0  # target source
     >>> data[4:7, 7:10] = 50.0  # bright neighbor
@@ -562,31 +621,25 @@ In this example, a circular aperture centered on the target source
 
 Without masking, the aperture sum includes the neighbor's flux::
 
-    >>> t1 = aperture_photometry(data, aperture)
-    >>> print(t1['aperture_sum'])
-       aperture_sum
-    ------------------
-    484.67784806278354
+    >>> phot1 = AperturePhotometry(data, aperture)
+    >>> print(phot1.flux)
+    [484.67784806278354]
 
 Masking the neighboring source excludes its flux::
 
-    >>> t2 = aperture_photometry(data, aperture, segmentation_image=segm,
-    ...                          labels=1, mask_method='mask')
-    >>> print(t2['aperture_sum'])
-       aperture_sum
-    ------------------
-    124.05298520018465
+    >>> phot2 = AperturePhotometry(data, aperture, segmentation_image=segm,
+    ...                            labels=1, mask_method='mask')
+    >>> print(phot2.flux)
+    [124.05298520018465]
 
 The ``'correct'`` method instead replaces the neighbor's pixels with
 values mirrored across the aperture center, recovering an estimate of
 the obscured flux::
 
-    >>> t3 = aperture_photometry(data, aperture, segmentation_image=segm,
-    ...                          labels=1, mask_method='correct')
-    >>> print(t3['aperture_sum'])
-       aperture_sum
-    ------------------
-    131.26548245743663
+    >>> phot3 = AperturePhotometry(data, aperture, segmentation_image=segm,
+    ...                            labels=1, mask_method='correct')
+    >>> print(phot3.flux)
+    [131.26548245743663]
 
 These keywords are also available in
 :class:`~photutils.aperture.ApertureStats`.
@@ -621,21 +674,23 @@ For example::
     >>> aperture = CircularAperture(positions, r=3.0)
     >>> phot = AperturePhotometry(data, aperture, mask=mask)
     >>> print(phot.flags)
-    [8, 2, 5]
+    [8 2 5]
 
-The flag values can be decoded into human-readable names::
+The flag values can be decoded into human-readable names using the the
+:meth:`~photutils.aperture.AperturePhotometry.decode_flags` convenience
+method::
 
-    >>> decoded = decode_aperture_flags(phot.flags])
-    >>> for source_id, names in zip(phot.id, decoded):
+    >>> for source_id, names in zip(phot.id, phot.decode_flags()):
     ...     print(source_id, names)
     1 ['masked_pixels']
     2 ['partial_overlap']
     3 ['no_overlap', 'no_pixels']
 
-or using the :meth:`~photutils.aperture.AperturePhotometry.decode_flags`
-convenience method::
+or using the :func:`~photutils.aperture.decode_aperture_flags`
+function::
 
-    >>> for source_id, names in zip(phot.id, phot.decode_flags()):
+    >>> decoded = decode_aperture_flags(phot.flags)
+    >>> for source_id, names in zip(phot.id, decoded):
     ...     print(source_id, names)
     1 ['masked_pixels']
     2 ['partial_overlap']
@@ -667,13 +722,11 @@ evaluated on the ``'center'``-method footprint, and includes the
 The :attr:`~photutils.aperture.ApertureStats.sum_flags` property
 reports the flags for the sum properties (``sum``, ``sum_err``, and
 ``sum_aper_area``), evaluated on the ``sum_method`` footprint, and
-includes the ``'non_finite_error'`` flag. When ``sigma_clip`` is used,
-it is applied independently on each footprint, so the pixels clipped
-for the value statistics may differ from those clipped for the sum
-properties. Only ``flags`` reports whether clipping occurred (via
-the ``'sigma_clipped'``, ``'all_clipped'``, and ``'too_few_pixels'``
-bits); ``sum_flags`` never sets those bits, even though the sum-related
-properties are computed from the sigma-clipped ``sum_method`` footprint.
+includes the ``'non_finite_error'`` flag. Only ``flags`` reports whether
+clipping occurred (via the ``'sigma_clipped'``, ``'all_clipped'``, and
+``'too_few_pixels'`` bits). ``sum_flags`` never sets those bits, even
+though the sum-related properties are computed from the sigma-clipped
+``sum_method`` footprint.
 
 Both columns are included in the default ``to_table()``
 output, and either can be decoded by passing
@@ -681,9 +734,12 @@ output, and either can be decoded by passing
 :meth:`~photutils.aperture.ApertureStats.decode_flags`. To check for
 any quality issue across both footprints, combine the two flag columns
 with a bitwise OR, e.g., ``aperstats.flags | aperstats.sum_flags``.
-Note that in `~photutils.aperture.ApertureStats` non-finite data values
-are automatically masked, so an aperture containing only NaN values has
-``flags = 48`` (``'non_finite_data'`` + ``'all_masked'``).
+
+Because non-finite values are automatically masked in
+both :class:`~photutils.aperture.AperturePhotometry` and
+:class:`~photutils.aperture.ApertureStats`, an aperture that contains
+only non-finite values will have ``flags = 48`` (``'non_finite_data'`` +
+``all_masked'``).
 
 
 .. _photutils-aperture-stats:
@@ -702,7 +758,7 @@ like :attr:`~photutils.aperture.ApertureStats.min`,
 :attr:`~photutils.aperture.ApertureStats.std`,
 :attr:`~photutils.aperture.ApertureStats.sum_aper_area`,
 and :attr:`~photutils.aperture.ApertureStats.sum`. It
-also can be used to calculate morphological properties
+also can be used to calculate shape properties
 like :attr:`~photutils.aperture.ApertureStats.centroid`,
 :attr:`~photutils.aperture.ApertureStats.fwhm`,
 :attr:`~photutils.aperture.ApertureStats.semimajor_axis`,
@@ -715,13 +771,20 @@ accessed using `~photutils.aperture.ApertureStats` attributes
 or output to an Astropy `~astropy.table.QTable` using the
 :meth:`~photutils.aperture.ApertureStats.to_table` method.
 
-Most of the source properties are calculated using the "center"
-:ref:`aperture-mask method <photutils-aperture-overlap>`, which gives
-aperture weights of 0 or 1. This avoids the need to compute weighted
-statistics --- the ``data`` pixel values are directly used.
+All properties other than the sum-related ones described below
+are calculated using the "center" :ref:`aperture-mask method
+<aperture-mask-methods>`, which assigns aperture weights of either
+0 or 1, so the ``data`` pixel values are used directly and without
+weighting. This choice reflects a fundamental limitation because,
+unlike the mean or variance, order statistics (``min``, ``max``,
+``median``) and robust estimators (``mad_std``, ``biweight_location``,
+``biweight_midvariance``) have no standard, unambiguous definition for
+pixels with fractional (partial) aperture weights. Accordingly, these
+quantities cannot be rigorously computed from a weighted aperture
+footprint.
 
-The ``sum_method`` and ``subpixels`` keywords are used to determine
-the aperture-mask method only for the sum-related properties:
+The input ``sum_method`` and ``subpixels`` keywords are used to
+determine the aperture-mask method only for the sum-related properties:
 ``sum``, ``sum_err``, ``sum_aper_area``, ``data_sum_cutout``, and
 ``error_sum_cutout``. All other properties, including ``mean``,
 ``median``, ``std``, and the morphological properties, always use the
@@ -743,7 +806,7 @@ sigma-clipped data; see :ref:`aperture_flags` for how this affects the
 ``flags`` and ``sum_flags`` properties.
 
 Here is a simple example using a circular aperture at one position.
-Note that like :func:`~photutils.aperture.aperture_photometry`,
+Note that like :class:`~photutils.aperture.AperturePhotometry`,
 :class:`~photutils.aperture.ApertureStats` expects the input data to
 be background subtracted. For simplicity, here we roughly estimate the
 background as the sigma-clipped median value::
@@ -770,7 +833,7 @@ background as the sigma-clipped median value::
     >>> print(aperstats.sum)
     8487.061886925028
 
-Similar to `~photutils.aperture.aperture_photometry`, the input aperture
+Similar to `~photutils.aperture.AperturePhotometry`, the input aperture
 can have multiple positions (but the same shape and size at each
 position). In this case, the :class:`~photutils.aperture.ApertureStats`
 class will calculate the statistics for each position and return the
@@ -804,14 +867,14 @@ Background Subtraction
 Global Background Subtraction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:func:`~photutils.aperture.aperture_photometry` and
+:class:`~photutils.aperture.AperturePhotometry` and
 :class:`~photutils.aperture.ApertureStats` both assume that the input
 data have already been background-subtracted. If ``bkg`` is a scalar or
 an array representing the background of the data (e.g., estimated by
 `~photutils.background.Background2D` or another method), subtract it
 from the data before performing aperture photometry::
 
-    >>> phot_table = aperture_photometry(data - bkg, aperture)  # doctest: +SKIP
+    >>> phot = AperturePhotometry(data - bkg, aperture)  # doctest: +SKIP
 
 For :class:`~photutils.aperture.ApertureStats`, a constant background
 can instead be specified using the ``local_bkg`` keyword. This avoids
@@ -895,22 +958,21 @@ position::
     >>> print(bkg_mean)
     [4.99411764 5.1349344  4.86894665]
 
-Next, we use :func:`~photutils.aperture.aperture_photometry` to measure
-the source fluxes in the circular apertures (the following example uses
-:class:`~photutils.aperture.ApertureStats` for both the background
-estimation and the aperture photometry)::
+Next, we use :class:`~photutils.aperture.AperturePhotometry` to measure
+the source fluxes in the circular apertures::
 
-    >>> from photutils.aperture import aperture_photometry
-    >>> phot_table = aperture_photometry(data, aperture, error=error)
+    >>> from photutils.aperture import AperturePhotometry
+    >>> phot = AperturePhotometry(data, aperture, error=error)
+    >>> phot_table = phot.to_table()
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
-    >>> print(phot_table)
-     id x_center y_center aperture_sum aperture_sum_err    area   flags
-                                                           pix2
-    --- -------- -------- ------------ ---------------- --------- -----
-      1    145.1    168.3    1128.1245       0.88622693 78.539816     0
-      2     84.5    224.1      735.739       0.88622693 78.539816     0
-      3     48.3    200.3    1299.6341       0.88622693 78.539816     0
+    >>> phot_table.pprint(max_width=-1)
+     id x_center y_center    flux    flux_err     area   flags
+                                                  pix2
+    --- -------- -------- --------- ---------- --------- -----
+      1    145.1    168.3 1128.1245 0.88622693 78.539816     0
+      2     84.5    224.1   735.739 0.88622693 78.539816     0
+      3     48.3    200.3 1299.6341 0.88622693 78.539816     0
 
 The total background within each source aperture is the mean background
 per pixel multiplied by the aperture area. The aperture area is already
@@ -918,7 +980,7 @@ available in the ``'area'`` column of the output table above, which is
 equivalent to the :meth:`~photutils.aperture.PixelAperture.area_overlap`
 method computed with the same photometry inputs. When using the
 default ``'exact'`` overlap method (see :ref:`aperture-mask methods
-<photutils-aperture-overlap>`) and no pixels are masked, the analytical
+<aperture-mask-methods>`) and no pixels are masked, the analytical
 aperture area is also available from the ``area`` attribute::
 
     >>> aperture.area
@@ -946,23 +1008,23 @@ The total background within the circular aperture is then::
 Subtracting this background estimate from the measured aperture sums
 gives the background-subtracted photometry::
 
-    >>> phot_bkgsub = phot_table['aperture_sum'] - total_bkg
+    >>> phot_bkgsub = phot_table['flux'] - total_bkg
 
 Finally, we add the local background estimate, the total background
 within the aperture, and the background-subtracted photometry to the
 output table::
 
     >>> phot_table['total_bkg'] = total_bkg
-    >>> phot_table['aperture_sum_bkgsub'] = phot_bkgsub
+    >>> phot_table['flux_bkgsub'] = phot_bkgsub
     >>> for col in phot_table.colnames:
     ...     phot_table[col].info.format = '%.8g'  # for consistent table output
     >>> phot_table.pprint(max_width=-1)
-     id x_center y_center aperture_sum aperture_sum_err    area   flags total_bkg aperture_sum_bkgsub
-                                                           pix2
-    --- -------- -------- ------------ ---------------- --------- ----- --------- -------------------
-      1    145.1    168.3    1128.1245       0.88622693 78.539816     0 392.23708           735.88739
-      2     84.5    224.1      735.739       0.88622693 78.539816     0  403.2968           332.44219
-      3     48.3    200.3    1299.6341       0.88622693 78.539816     0 382.40618           917.22792
+     id x_center y_center    flux    flux_err     area   flags total_bkg flux_bkgsub
+                                                  pix2
+    --- -------- -------- --------- ---------- --------- ----- --------- -----------
+      1    145.1    168.3 1128.1245 0.88622693 78.539816     0 392.23708   735.88739
+      2     84.5    224.1   735.739 0.88622693 78.539816     0  403.2968   332.44219
+      3     48.3    200.3 1299.6341 0.88622693 78.539816     0 382.40618   917.22792
 
 
 Sigma-clipped median within a circular annulus

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -597,45 +597,12 @@ These keywords are also available in
 Aperture Quality Flags
 ----------------------
 
-The :func:`~photutils.aperture.aperture_photometry` table, the
-:meth:`~photutils.aperture.PixelAperture.photometry` results, and the
-:class:`~photutils.aperture.ApertureStats` class include bitwise quality
-flags for each source in a ``'flags'`` column or attribute. A value of 0
-means that no issues were detected. The flag values can be decoded using
-the :func:`~photutils.aperture.decode_aperture_flags` function. The
-flags are:
-
-* ``'no_overlap'`` (1): the aperture is fully outside the data (no
-  pixel with nonzero aperture weight falls inside the data)
-* ``'partial_overlap'`` (2): the aperture is partially outside the
-  data (one or more pixels with nonzero aperture weight fall outside
-  the data)
-* ``'no_pixels'`` (4): the aperture contains zero pixels with nonzero
-  weight inside the data (e.g., a fully off-image aperture, or a tiny
-  aperture that contains no pixel centers with the ``'center'`` method)
-* ``'masked_pixels'`` (8): one or more input-masked pixels (``mask``
-  keyword) have nonzero aperture weight
-* ``'all_masked'`` (16): the aperture contains pixels, but none are
-  valid (all are masked or excluded)
-* ``'non_finite_data'`` (32): NaN or inf values are present among the
-  unmasked data values within the aperture
-* ``'non_finite_error'`` (64): NaN or inf values are present among the
-  unmasked error values within the aperture
-* ``'neighbor_pixels'`` (128): one or more pixels were excluded,
-  restricted, or corrected due to neighboring sources in the
-  segmentation image (``mask_method`` keyword)
-* ``'uncorrected_pixels'`` (256): with ``mask_method='correct'``, one
-  or more neighbor pixels could not be corrected and were excluded
-  instead
-* ``'sigma_clipped'`` (512): one or more pixels within the aperture
-  were rejected by sigma clipping (`~photutils.aperture.ApertureStats`
-  only)
-* ``'all_clipped'`` (1024): all valid pixels within the aperture were
-  rejected by sigma clipping (`~photutils.aperture.ApertureStats` only)
-* ``'too_few_pixels'`` (2048): too few valid pixels to compute a
-  requested statistic, e.g., the variance and standard deviation are
-  undefined when the number of valid pixels is not larger than ``ddof``
-  (`~photutils.aperture.ApertureStats` only)
+The :class:`~photutils.aperture.AperturePhotometry` and
+:class:`~photutils.aperture.ApertureStats` classes include bitwise
+quality flags for each source in a ``'flags'`` column or attribute. See
+the :func:`~photutils.aperture.decode_aperture_flags` function for a a
+definition of the flags. This convenience method can be used to decode
+the flags into human-readable names.
 
 Multiple conditions combine bitwise. For example, an aperture that
 extends beyond the data edge and also contains a masked pixel has
@@ -645,26 +612,30 @@ extends beyond the data edge and also contains a masked pixel has
 For example::
 
     >>> import numpy as np
-    >>> from photutils.aperture import (CircularAperture,
-    ...                                 aperture_photometry,
+    >>> from photutils.aperture import (AperturePhotometry,
     ...                                 decode_aperture_flags)
     >>> data = np.ones((25, 25))
     >>> mask = np.zeros(data.shape, dtype=bool)
     >>> mask[12, 12] = True  # bad pixel inside the first aperture
     >>> positions = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0)]
     >>> aperture = CircularAperture(positions, r=3.0)
-    >>> phot_table = aperture_photometry(data, aperture, mask=mask)
-    >>> print(phot_table['flags'])
-    flags
-    -----
-        8
-        2
-        5
+    >>> phot = AperturePhotometry(data, aperture, mask=mask)
+    >>> print(phot.flags)
+    [8, 2, 5]
 
 The flag values can be decoded into human-readable names::
 
-    >>> decoded = decode_aperture_flags(phot_table['flags'])
-    >>> for source_id, names in zip(phot_table['id'], decoded):
+    >>> decoded = decode_aperture_flags(phot.flags])
+    >>> for source_id, names in zip(phot.id, decoded):
+    ...     print(source_id, names)
+    1 ['masked_pixels']
+    2 ['partial_overlap']
+    3 ['no_overlap', 'no_pixels']
+
+or using the :meth:`~photutils.aperture.AperturePhotometry.decode_flags`
+convenience method::
+
+    >>> for source_id, names in zip(phot.id, phot.decode_flags()):
     ...     print(source_id, names)
     1 ['masked_pixels']
     2 ['partial_overlap']

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -281,7 +281,7 @@ quality flags are available as lazily-computed attributes (see
 :attr:`~photutils.aperture.AperturePhotometry.area`, and
 :attr:`~photutils.aperture.AperturePhotometry.flags`)::
 
-    >>> print(phot.flux)  # doctest: +FLOAT_CMP
+    >>> print(phot.flux)
     [30.1907054 30.1907054 30.1907054]
 
 The results can also be output as an Astropy `~astropy.table.QTable`
@@ -539,32 +539,38 @@ list of aperture objects with identical positions, but with different
 Aperture Photometry on a 3D Data Cube
 -------------------------------------
 
-:class:`~photutils.aperture.AperturePhotometry` operates on a single
-2D image. To measure a source in a 3D data cube -- for example, a time
-series of images of the same field -- apply the same aperture to each 2D
-image in the stack and collect the results into a light curve.
+:class:`~photutils.aperture.AperturePhotometry` operates on a single 2D
+image. To measure a source in a 3D data cube --- for example, a time
+series of images of the same field --- apply the same aperture to each
+2D image in the stack and collect the results into a light curve.
 
 Here we create a small stack of five images in which a single source
-varies in brightness from frame to frame, and measure its flux in each
-frame using the same circular aperture::
+varies in brightness from frame to frame, and measure its flux and
+uncertainty in each frame using the same circular aperture. Build the
+list of results objects first (a single photometry pass per frame), then
+read as many attributes as needed::
 
     >>> import numpy as np
     >>> from photutils.aperture import AperturePhotometry, CircularAperture
     >>> scales = np.array([1.0, 1.5, 2.0, 1.8, 1.2])
     >>> cube = scales[:, None, None] * np.ones((5, 50, 50))
+    >>> error = 0.1 * np.ones((50, 50))
     >>> aperture = CircularAperture((25, 25), r=5)
-    >>> flux = np.array([AperturePhotometry(image, aperture).flux[0]
-    ...                  for image in cube])
-    >>> print(flux)  # doctest: +FLOAT_CMP
+    >>> results = [AperturePhotometry(image, aperture, error=error)
+    ...            for image in cube]
+    >>> flux = np.array([phot.flux[0] for phot in results])
+    >>> flux_err = np.array([phot.flux_err[0] for phot in results])
+    >>> print(flux)
     [ 78.53981634 117.80972451 157.07963268 141.37166941  94.24777961]
+    >>> print(flux_err)
+    [0.88622693 0.88622693 0.88622693 0.88622693 0.88622693]
 
-Each element of ``flux`` corresponds to one image in the cube, giving
-the source's light curve. The same pattern extends to multiple sources
-and to per-frame uncertainties or quality flags: keep each results
-object and index the desired attribute (e.g.,
-:attr:`~photutils.aperture.AperturePhotometry.flux_err` or
-:attr:`~photutils.aperture.AperturePhotometry.flags`) for every frame,
-or build a table per frame with
+Each element of ``flux`` and ``flux_err`` corresponds to one image in
+the cube, together giving the source's light curve and its uncertainty.
+The same pattern extends to multiple sources and to other per-frame
+quantities: index the desired attribute (e.g.,
+:attr:`~photutils.aperture.AperturePhotometry.flags`) from each results
+object, or build a table per frame with
 :meth:`~photutils.aperture.AperturePhotometry.to_table`.
 
 
@@ -684,9 +690,9 @@ Aperture Quality Flags
 
 The :class:`~photutils.aperture.AperturePhotometry` and
 :class:`~photutils.aperture.ApertureStats` classes include bitwise
-quality flags for each source in a ``'flags'`` column or attribute. See
-the :func:`~photutils.aperture.decode_aperture_flags` function for a a
-definition of the flags. This convenience method can be used to decode
+quality flags for each source in a ``'flags'`` column or attribute.
+See the :func:`~photutils.aperture.decode_aperture_flags` function
+for a definition of the flags. This function can be used to decode
 the flags into human-readable names.
 
 Multiple conditions combine bitwise. For example, an aperture that
@@ -708,7 +714,7 @@ For example::
     >>> print(phot.flags)
     [8 2 5]
 
-The flag values can be decoded into human-readable names using the the
+The flag values can be decoded into human-readable names using the
 :meth:`~photutils.aperture.AperturePhotometry.decode_flags` convenience
 method::
 
@@ -771,7 +777,7 @@ Because non-finite values are automatically masked in
 both :class:`~photutils.aperture.AperturePhotometry` and
 :class:`~photutils.aperture.ApertureStats`, an aperture that contains
 only non-finite values will have ``flags = 48`` (``'non_finite_data'`` +
-``all_masked'``).
+``'all_masked'``).
 
 
 .. _photutils-aperture-stats:
@@ -1055,22 +1061,7 @@ photometry and the local background::
     >>> sigclip = SigmaClip(sigma=3.0, maxiters=10)
     >>> aper_stats = ApertureStats(data, aperture, sigma_clip=None)
     >>> bkg_stats = ApertureStats(data, annulus_aperture, sigma_clip=sigclip)
-
-The sigma-clipped median background values are::
-
-    >>> print(bkg_stats.median)
-    [4.89374178 5.05655328 4.83268958]
-
-The total background within each source aperture is the per-pixel
-background multiplied by the aperture area::
-
     >>> total_bkg = bkg_stats.median * aper_stats.sum_aper_area.value
-    >>> print(total_bkg)
-    [384.35358069 397.14076611 379.5585524 ]
-
-Subtracting this background estimate from the measured aperture sums
-gives the local background-subtracted photometry::
-
     >>> apersum_bkgsub = aper_stats.sum - total_bkg
     >>> print(apersum_bkgsub)
     [743.77088731 338.59823118 920.07553956]

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -73,6 +73,49 @@ algorithm::
     >>> mask = aper.to_mask(method='exact')
 
 
+New ``AperturePhotometry`` Class
+================================
+
+Photutils 3.1 introduces a new `~photutils.aperture.AperturePhotometry`
+class, which is now the recommended tool for aperture photometry. Like
+`~photutils.aperture.ApertureStats`, it uses a results-object pattern:
+the data, apertures, and options are supplied to the constructor, and
+the results are exposed as lazily-computed attributes or as an Astropy
+`~astropy.table.QTable` via the ``to_table`` method::
+
+    >>> import numpy as np
+    >>> from photutils.aperture import AperturePhotometry, CircularAperture
+    >>> data = np.ones((100, 100))
+    >>> aperture = CircularAperture([(30.0, 30.0), (40.0, 40.0)], r=5.0)
+    >>> phot = AperturePhotometry(data, aperture)
+    >>> fluxes = phot.flux  # lazily computed
+    >>> phot_table = phot.to_table()
+
+The class reports the aperture
+:attr:`~photutils.aperture.AperturePhotometry.flux`,
+:attr:`~photutils.aperture.AperturePhotometry.flux_err`, unmasked
+overlap :attr:`~photutils.aperture.AperturePhotometry.area`, and
+bitwise quality :attr:`~photutils.aperture.AperturePhotometry.flags`
+as attributes, all of which are included in the
+default ``to_table()`` output. Compared to the legacy
+:func:`~photutils.aperture.aperture_photometry` function, it adds
+the aperture areas and quality flags and supports segmentation-based
+neighbor masking (see below). The flux columns use the names
+``'flux'`` and ``'flux_err'`` (rather than ``'aperture_sum'`` and
+``'aperture_sum_err'``).
+
+The class is immutable after construction (aside from the internal
+lazy-attribute cache), so a single instance is safe to share across
+threads, and independent frames can be processed concurrently (see
+:ref:`the thread-safety section <whatsnew-3.1-thread-safe-photometry>`
+below).
+
+The legacy :func:`~photutils.aperture.aperture_photometry`
+function remains available and is not deprecated, but it is now
+considered a legacy interface. New features are added only to the
+`~photutils.aperture.AperturePhotometry` class.
+
+
 Faster Aperture Photometry
 ==========================
 
@@ -147,6 +190,8 @@ All other properties are unaffected, including the ``mean_err`` and
 sample standard deviation regardless of the value of ``ddof``.
 
 
+.. _whatsnew-3.1-thread-safe-photometry:
+
 Thread-Safe and Free-Threading-Compatible Aperture Photometry
 ==============================================================
 
@@ -205,7 +250,7 @@ that can be applied at one or more positions::
     >>> aper = PolygonAperture(positions, offsets)
 
 The polygon must be simple (non-self-intersecting), but it does not need
-to be convex; non-convex shapes such as L-shapes or stars are fully
+to be convex. Non-convex shapes such as L-shapes or stars are fully
 supported.
 
 Regular polygons can be constructed by specifying a center,
@@ -385,6 +430,13 @@ API Changes
 
 New Deprecations
 ----------------
+
+``PixelAperture.do_photometry`` Deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``PixelAperture.do_photometry`` method is now deprecated
+and will be removed in a future version. Use the new
+`~photutils.aperture.AperturePhotometry` class instead.
 
 ``EPSFBuildResult`` Renamed to ``EPSFBuildResults``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -163,8 +163,8 @@ chunks::
     >>> from concurrent.futures import ThreadPoolExecutor
     >>> import numpy as np
     >>> from astropy.table import vstack
-    >>> from photutils.aperture import (CircularAperture,
-    ...                                 aperture_photometry)
+    >>> from photutils.aperture import (AperturePhotometry,
+    ...                                 CircularAperture)
     >>> rng = np.random.default_rng(seed=0)
     >>> data = rng.random((4096, 4096))
     >>> positions = rng.uniform(0, 4096, (100_000, 2))
@@ -172,8 +172,9 @@ chunks::
     >>> chunks = [CircularAperture(pos, r=5.0)
     ...           for pos in np.array_split(positions, n_workers)]
     >>> with ThreadPoolExecutor(max_workers=n_workers) as executor:
-    ...     tables = list(executor.map(
-    ...         lambda aper: aperture_photometry(data, aper), chunks))
+    ...     results = list(executor.map(
+    ...         lambda aper: AperturePhotometry(data, aper), chunks))
+    >>> tables = [result.to_table() for result in results]
     >>> phot_table = vstack(tables)
     >>> phot_table['id'] = np.arange(1, len(phot_table) + 1)
 
@@ -266,7 +267,7 @@ is converted exactly to a four-vertex polygon::
 Segmentation-Based Masking in Aperture Photometry
 =================================================
 
-`~photutils.aperture.aperture_photometry` and
+`~photutils.aperture.AperturePhotometry` and
 `~photutils.aperture.ApertureStats` now accept ``segmentation_image``,
 ``labels``, and ``mask_method`` keywords to mask or correct
 the flux from neighboring sources that overlap an aperture.
@@ -294,7 +295,7 @@ that are not centered on a source.
 Example of using the new segmentation-based masking::
 
     >>> import numpy as np
-    >>> from photutils.aperture import CircularAperture, aperture_photometry
+    >>> from photutils.aperture import AperturePhotometry, CircularAperture
     >>> data = np.ones((11, 11))
     >>> data[4:7, 4:7] = 10.0  # target source
     >>> data[4:7, 7:10] = 50.0  # bright neighbor
@@ -303,8 +304,8 @@ Example of using the new segmentation-based masking::
     >>> segm[4:7, 7:10] = 2
     >>> labels = 1
     >>> aperture = CircularAperture((5, 5), r=4)
-    >>> phot = aperture_photometry(data, aperture, segmentation_image=segm,
-    ...                            labels=1, mask_method='mask')
+    >>> phot = AperturePhotometry(data, aperture, segmentation_image=segm,
+    ...                           labels=1, mask_method='mask')
 
 
 .. _whatsnew-3.1-aperture-flags:
@@ -314,12 +315,11 @@ Aperture Photometry Quality Flags
 
 Aperture photometry and statistics now provide
 per-source bitwise quality flags, unified across
-`~photutils.aperture.aperture_photometry` (a new ``'flags'`` table
-column), `~photutils.aperture.PixelAperture.photometry` (a new
-``flags`` result attribute), and `~photutils.aperture.ApertureStats`
-(new :attr:`~photutils.aperture.ApertureStats.flags`
-and :attr:`~photutils.aperture.ApertureStats.sum_flags`
-properties, included in the default ``to_table()`` columns). In
+the `~photutils.aperture.AperturePhotometry` and
+`~photutils.aperture.ApertureStats` classes. (e.g., new
+:attr:`~photutils.aperture.ApertureStats.flags` and
+:attr:`~photutils.aperture.ApertureStats.sum_flags` properties,
+included in the default ``to_table()`` columns). In
 `~photutils.aperture.ApertureStats`, ``flags`` reports the flags for the
 value statistics (the ``'center'``-method footprint) and ``sum_flags``
 reports the flags for the sum properties (the ``sum_method`` footprint).
@@ -341,23 +341,24 @@ conditions such as:
   (``'too_few_pixels'``) in `~photutils.aperture.ApertureStats`
 
 The overlap flags are precise. They are based on the pixels with
-nonzero aperture weight, not simply the aperture bounding box. The new
-:func:`~photutils.aperture.decode_aperture_flags` function and the
-:meth:`~photutils.aperture.ApertureStats.decode_flags` method decode
+nonzero aperture weight, not simply the aperture bounding box. The
+new :func:`~photutils.aperture.decode_aperture_flags` function and
+the :meth:`~photutils.aperture.AperturePhotometry.decode_flags` and
+:meth:`~photutils.aperture.ApertureStats.decode_flags` methods decode
 flag values into human-readable names::
 
     >>> import numpy as np
-    >>> from photutils.aperture import (CircularAperture,
-    ...                                 aperture_photometry,
+    >>> from photutils.aperture import (AperturePhotometry,
+    ...                                 CircularAperture,
     ...                                 decode_aperture_flags)
     >>> data = np.ones((25, 25))
     >>> mask = np.zeros(data.shape, dtype=bool)
     >>> mask[12, 12] = True  # bad pixel inside the first aperture
     >>> positions = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0)]
     >>> aperture = CircularAperture(positions, r=3.0)
-    >>> phot = aperture_photometry(data, aperture, mask=mask)
-    >>> decoded = decode_aperture_flags(phot['flags'])
-    >>> for source_id, names in zip(phot['id'], decoded):
+    >>> phot = AperturePhotometry(data, aperture, mask=mask)
+    >>> decoded = decode_aperture_flags(phot.flags)
+    >>> for source_id, names in zip(phot.id, decoded):
     ...     print(source_id, names)
     1 ['masked_pixels']
     2 ['partial_overlap']
@@ -380,88 +381,18 @@ runtime of PSF photometry workflows.
 API Changes
 ===========
 
-Aperture Photometry Error Column
---------------------------------
-
-`~photutils.aperture.aperture_photometry` now always includes an
-``'aperture_sum_err'`` column in the returned table. When the ``error``
-keyword is not provided, the column is filled with ``NaN`` values.
-Previously, the column was omitted entirely in that case. This makes the
-behavior consistent with `photutils.aperture.ApertureStats.to_table`,
-`photutils.segmentation.SourceCatalog.to_table`,
-and the `~photutils.psf.PSFPhotometry` and
-`~photutils.psf.IterativePSFPhotometry` output tables, which always
-include ``*_err`` columns (e.g., ``flux_err``)::
-
-    >>> import numpy as np
-    >>> from photutils.aperture import CircularAperture, aperture_photometry
-    >>> data = np.ones((11, 11))
-    >>> aperture = CircularAperture((5, 5), r=3)
-    >>> phot = aperture_photometry(data, aperture)
-    >>> phot['aperture_sum_err']
-    <Column name='aperture_sum_err' dtype='float64' length=1>
-    nan
-
-
-Aperture Area Column
---------------------
-
-`~photutils.aperture.aperture_photometry` now always includes an
-``'area'`` column (or ``'area_<i>'`` columns for multiple apertures)
-in the returned table. This is the total unmasked overlap area of
-the aperture with the data (in ``pix**2``), taking into account the
-aperture mask method, masked data pixels, segmentation masking, and
-partial/no overlap of the aperture with the data. It is equivalent to
-the `~photutils.aperture.PixelAperture.area_overlap` method computed
-with the same photometry inputs.
-
-Relatedly, `photutils.aperture.PixelAperture.photometry` now returns
-an ``ApertureResults`` object instead of a plain tuple. The result
-remains backward compatible: it can still be unpacked as a 2-tuple
-(``aperture_sum, aperture_sum_err = photometry(...)``) and supports
-``len()`` and integer indexing like the legacy tuple. The new ``area``
-attribute provides the total unmasked overlap area of each aperture (in
-``pix**2``).
-
-
-Aperture Photometry Flags Column
---------------------------------
-
-`~photutils.aperture.aperture_photometry` now always includes
-a ``'flags'`` column (or ``'flags_<i>'`` columns for
-multiple apertures) in the returned table, and the default
-`photutils.aperture.ApertureStats.to_table` columns now include
-``'flags'``. See :ref:`whatsnew-3.1-aperture-flags` for details.
-
-
 .. _whatsnew-3.1-deprecations:
 
 New Deprecations
 ----------------
 
-Aperture ``do_photometry`` Renamed to ``photometry``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The `~photutils.aperture.PixelAperture` ``do_photometry`` method
-has been renamed to `~photutils.aperture.PixelAperture.photometry`.
-The old method name is deprecated and will be removed in version
-4.0. Note that in the new ``photometry`` method all arguments except
-``data`` are keyword-only::
-
-    # Old (deprecated)
-    aperture_sum, aperture_sum_err = aperture.do_photometry(data, error=error)
-
-    # New
-    aperture_sum, aperture_sum_err = aperture.photometry(data, error=error)
-
-
 ``EPSFBuildResult`` Renamed to ``EPSFBuildResults``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``EPSFBuildResult`` class returned by `~photutils.psf.EPSFBuilder`
-has been renamed to `~photutils.psf.EPSFBuildResults` for consistency
-with the new ``ApertureResults`` class. The old ``EPSFBuildResult`` name
-is deprecated and will be removed in a future version.
+has been renamed to `~photutils.psf.EPSFBuildResults`. The old
+``EPSFBuildResult`` name is deprecated and will be removed in a future
+version.
 
 
 Removed Deprecations

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -2,9 +2,10 @@
 """
 Tools for segmentation-based masking of aperture photometry.
 
-These helpers validate the ``segmentation_image``, ``labels``, and
-``mask_method`` keywords shared by `aperture_photometry`,
-`~photutils.aperture.PixelAperture.photometry`, and
+These helpers validate the ``segmentation_image``,
+``labels``, and ``mask_method`` keywords shared by
+`~photutils.aperture.PixelAperture._photometry`,
+`~photutils.aperture.AperturePhotometry`, and
 `~photutils.aperture.ApertureStats`. They also apply the local masking
 or symmetric-correction behavior to per-aperture cutouts.
 """

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -725,9 +725,30 @@ class PixelAperture(Aperture):
                 data_cutout = data[slc_large]
                 error_cutout = None if error is None else error[slc_large]
 
+                # Non-finite ``data`` masking (used by the class
+                # path). Flag the contributing non-finite pixels, then
+                # exclude them *before* the segmentation handling so
+                # the segmentation counts and the 'correct' mirror
+                # replacement never use non-finite pixels, matching the
+                # batch kernel (mask plane bit 2) and `ApertureStats`.
+                # When ``mask_nonfinite`` is `False` (the legacy
+                # function), the non-finite pixels are left in the
+                # computation so they corrupt the sum.
+                nonfinite_data = ~np.isfinite(data_cutout)
+                if mask_nonfinite:
+                    flag_counts[idx, FLAG_COL_NONFINITE_DATA] = np.any(
+                        nonfinite_data & pixel_mask)
+                    pixel_mask = pixel_mask & ~nonfinite_data
+
                 if segmentation is not None and mask_method != 'none':
                     segm_cutout = segmentation[slc_large]
                     base_mask = None if mask is None else mask[slc_large]
+                    if mask_nonfinite:
+                        # Fold the non-finite pixels into the base mask
+                        # so that non-finite mirror pixels are treated
+                        # as uncorrectable by the 'correct' method.
+                        base_mask = (nonfinite_data if base_mask is None
+                                     else base_mask | nonfinite_data)
                     cutout_xycen = (positions[idx, 0] - slc_large[1].start,
                                     positions[idx, 1] - slc_large[0].start)
                     (data_cutout, error_cutout, exclude,
@@ -743,20 +764,6 @@ class PixelAperture(Aperture):
                         flag_counts[idx, FLAG_COL_UNCORRECTED] = (
                             np.count_nonzero(exclude & pixel_mask))
                     pixel_mask = pixel_mask & ~exclude
-
-                # Non-finite ``data`` masking (used by the class
-                # path). Flag the contributing non-finite pixels, then
-                # exclude them from the sum, area, and valid-pixel
-                # count so they do not corrupt the result (matching
-                # `ApertureStats`). When ``mask_nonfinite`` is `False`
-                # (the legacy function), the non-finite pixels are left
-                # in the computation so they corrupt the sum (the 3.0.0
-                # behavior).
-                nonfinite_data = ~np.isfinite(data_cutout)
-                if mask_nonfinite:
-                    flag_counts[idx, FLAG_COL_NONFINITE_DATA] = np.any(
-                        nonfinite_data & pixel_mask)
-                    pixel_mask = pixel_mask & ~nonfinite_data
 
                 flag_counts[idx, FLAG_COL_VALID] = np.count_nonzero(
                     pixel_mask)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -34,7 +34,7 @@ from photutils.utils._deprecation import (deprecated,
                                           deprecated_positional_kwargs)
 from photutils.utils._flags import define_flag_docstring
 
-__all__ = ['Aperture', 'ApertureResults', 'PixelAperture', 'SkyAperture']
+__all__ = ['Aperture', 'PixelAperture', 'SkyAperture']
 
 
 # Canonical descriptions of the ``method`` and ``subpixels`` parameters
@@ -176,21 +176,17 @@ def _update_method_subpixels_docstring(obj):
 
 
 @dataclass(frozen=True)
-class ApertureResults:
+class _ApertureResults:
     """
-    The results of `PixelAperture.photometry`.
-
-    For backward compatibility, this object can still be unpacked as a
-    2-tuple, ``aperture_sum, aperture_sum_err = aper.photometry(...)``.
-    Use the named attributes to access ``area`` and ``flags``.
+    The results of `PixelAperture._photometry`.
 
     Attributes
     ----------
-    aperture_sum : `~numpy.ndarray` or `~astropy.units.Quantity`
-        The sum within each aperture.
+    flux : `~numpy.ndarray` or `~astropy.units.Quantity`
+        The sum of the data within each aperture.
 
-    aperture_sum_err : `~numpy.ndarray` or `~astropy.units.Quantity`
-        The errors on the sum within each aperture.
+    flux_err : `~numpy.ndarray` or `~astropy.units.Quantity`
+        The uncertainty in the sum of the data within each aperture.
 
     area : `~astropy.units.Quantity`
         The total unmasked overlap area of each aperture (in pix**2).
@@ -201,21 +197,10 @@ class ApertureResults:
         values.
     """
 
-    aperture_sum: np.ndarray
-    aperture_sum_err: np.ndarray
+    flux: np.ndarray
+    flux_err: np.ndarray
     area: np.ndarray
     flags: np.ndarray
-
-    def __iter__(self):
-        # Legacy 2-tuple unpacking only.
-        yield self.aperture_sum
-        yield self.aperture_sum_err
-
-    def __len__(self):
-        return 2
-
-    def __getitem__(self, idx):
-        return (self.aperture_sum, self.aperture_sum_err)[idx]
 
 
 class Aperture(metaclass=abc.ABCMeta):
@@ -649,7 +634,7 @@ class PixelAperture(Aperture):
 
     def _mask_photometry(self, data, *, error, mask, method, subpixels,
                          segmentation=None, labels=None,
-                         mask_method='none', _mask_nonfinite=False):
+                         mask_method='none', mask_nonfinite=False):
         """
         Perform aperture photometry using per-source aperture masks.
 
@@ -673,6 +658,13 @@ class PixelAperture(Aperture):
             The validated segmentation array, per-aperture source
             labels, and masking method (see
             `~photutils.aperture._segmentation.process_segmentation_inputs`).
+
+        mask_nonfinite : bool, optional
+            Whether to mask non-finite ``data`` values (matching
+            `ApertureStats`) instead of leaving them in the computation,
+            where they corrupt the sum (the 3.0.0 behavior, used by the
+            legacy `aperture_photometry` function). In both cases, the
+            non-finite pixels are flagged as ``non_finite_data``.
 
         Returns
         -------
@@ -752,23 +744,23 @@ class PixelAperture(Aperture):
                             np.count_nonzero(exclude & pixel_mask))
                     pixel_mask = pixel_mask & ~exclude
 
-                # Non-finite ``data`` masking (used by the class path).
-                # Flag the contributing non-finite pixels, then exclude
-                # them from the sum, area, and valid-pixel count so they
-                # do not poison the result (matching `ApertureStats`).
-                # When ``_mask_nonfinite`` is `False` (the legacy
-                # function), the non-finite pixels are left in the
-                # computation so they poison the sum (the 3.0.0
+                # Non-finite ``data`` masking (used by the class
+                # path). Flag the contributing non-finite pixels, then
+                # exclude them from the sum, area, and valid-pixel
+                # count so they do not corrupt the result (matching
+                # `ApertureStats`). When ``mask_nonfinite`` is `False`
+                # (the legacy function), the non-finite pixels are left
+                # in the computation so they corrupt the sum (the 3.0.0
                 # behavior).
                 nonfinite_data = ~np.isfinite(data_cutout)
-                if _mask_nonfinite:
+                if mask_nonfinite:
                     flag_counts[idx, FLAG_COL_NONFINITE_DATA] = np.any(
                         nonfinite_data & pixel_mask)
                     pixel_mask = pixel_mask & ~nonfinite_data
 
                 flag_counts[idx, FLAG_COL_VALID] = np.count_nonzero(
                     pixel_mask)
-                if not _mask_nonfinite:
+                if not mask_nonfinite:
                     flag_counts[idx, FLAG_COL_NONFINITE_DATA] = np.any(
                         nonfinite_data & pixel_mask)
                 if error is not None:
@@ -816,7 +808,7 @@ class PixelAperture(Aperture):
 
     def _batch_photometry(self, data, *, error, mask, method, subpixels,
                           segmentation=None, labels=None,
-                          mask_method='none', _mask_nonfinite=False):
+                          mask_method='none', mask_nonfinite=False):
         """
         Perform aperture photometry using the batch Cython driver.
 
@@ -838,6 +830,13 @@ class PixelAperture(Aperture):
             The validated segmentation array, per-aperture source
             labels, and masking method (see
             `~photutils.aperture._segmentation.process_segmentation_inputs`).
+
+        mask_nonfinite : bool, optional
+            Whether to mask non-finite ``data`` values (matching
+            `ApertureStats`) instead of leaving them in the computation,
+            where they corrupt the sum (the 3.0.0 behavior, used by the
+            legacy `aperture_photometry` function). In both cases, the
+            non-finite pixels are flagged as ``non_finite_data``.
 
         Returns
         -------
@@ -877,20 +876,20 @@ class PixelAperture(Aperture):
                                  or mask.shape != data.shape):
             return None
 
-        # Build a uint8 mask plane for the batch kernels. Bit 1
-        # (value 1) marks input-masked pixels and bit 2 (value 2) marks
+        # Build a uint8 mask plane for the batch kernels. Bit 1 (value
+        # 1) marks input-masked pixels and bit 2 (value 2) marks
         # non-finite ``data`` pixels; any nonzero value excludes the
-        # pixel. Folding the non-finite pixels into the plane lets the
-        # class exclude them from the sum, area, and valid-pixel count
-        # while still flagging them as ``non_finite_data`` (not
-        # ``masked_pixels``), matching `ApertureStats`. When
-        # ``_mask_nonfinite`` is `False` (the legacy function), the
-        # non-finite pixels are left in the data so they poison the sum
+        # pixel. Folding the non-finite pixels into the plane lets
+        # the class exclude them from the sum, area, and valid-pixel
+        # count while still flagging them as ``non_finite_data``
+        # (not ``masked_pixels``), matching `ApertureStats`. When
+        # ``mask_nonfinite`` is `False` (the legacy function), the
+        # non-finite pixels are left in the data so they corrupt the sum
         # (the 3.0.0 behavior).
         plane = None
         if mask is not None:
             plane = mask.astype(np.uint8)
-        if _mask_nonfinite and data.dtype.kind == 'f':
+        if mask_nonfinite and data.dtype.kind == 'f':
             nonfinite = ~np.isfinite(data)
             if nonfinite.any():
                 if plane is None:
@@ -933,16 +932,12 @@ class PixelAperture(Aperture):
         return sums, errs, area, fcounts, overlap
 
     @_update_method_subpixels_docstring
-    def photometry(self, data, *, error=None, mask=None, method='exact',
-                   subpixels=5, segmentation_image=None, labels=None,
-                   mask_method='none', _mask_nonfinite=False):
+    def _photometry(self, data, *, error=None, mask=None, method='exact',
+                    subpixels=5, segmentation_image=None, labels=None,
+                    mask_method='none', mask_nonfinite=False):
         # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Perform aperture photometry on the input data.
-
-        .. versionadded:: 3.1
-            This method replaces the deprecated ``do_photometry``
-            method. All arguments except ``data`` are keyword-only.
 
         Parameters
         ----------
@@ -966,41 +961,43 @@ class PixelAperture(Aperture):
 
         <segmentation_descriptions>
 
+        mask_nonfinite : bool, optional
+            Whether to mask non-finite ``data`` values (matching
+            `ApertureStats`) instead of leaving them in the computation,
+            where they corrupt the sum (the 3.0.0 behavior, used by the
+            legacy `aperture_photometry` function). In both cases, the
+            non-finite pixels are flagged as ``non_finite_data``.
+
         Returns
         -------
-        result : `ApertureResults`
-            The aperture photometry results. For backward
-            compatibility, this object can be unpacked as a 2-tuple,
-            ``aperture_sum, aperture_sum_err = photometry(...)``, and
-            supports ``len()`` and integer indexing as if it were a
-            2-tuple. It has the following attributes:
+        result : `_ApertureResults`
+            The aperture photometry results. It has the following
+            attributes:
 
-            - ``aperture_sum`` : `~numpy.ndarray` or \
-              `~astropy.units.Quantity`
-                The sum within each aperture. The values are always
-                float64, regardless of the input ``data`` dtype.
+            - ``flux`` : `~numpy.ndarray` or `~astropy.units.Quantity`
+              The sum within each aperture. The values are always
+              float64, regardless of the input ``data`` dtype.
 
-            - ``aperture_sum_err`` : `~numpy.ndarray` or \
-              `~astropy.units.Quantity`
-                The errors on the sum within each aperture. The values
-                are always float64, regardless of the input ``error``
-                dtype.
+            - ``flux_err`` : `~numpy.ndarray` or `~astropy.units.Quantity`
+              The errors on the sum within each aperture. The values
+              are always float64, regardless of the input ``error``
+              dtype.
 
             - ``area`` : `~astropy.units.Quantity`
-                The total unmasked overlap area of each aperture (in
-                ``pix**2``), taking into account the aperture mask
-                method, masked data pixels, segmentation masking, and
-                partial/no overlap of the aperture with the data. This
-                is equivalent to `area_overlap` computed with the same
-                inputs. The value is ``NaN`` where the aperture does not
-                overlap the data.
+              The total unmasked overlap area of each aperture (in
+              ``pix**2``), taking into account the aperture mask
+              method, masked data pixels, segmentation masking, and
+              partial/no overlap of the aperture with the data. This
+              is equivalent to `area_overlap` computed with the same
+              inputs. The value is ``NaN`` where the aperture does not
+              overlap the data.
 
             - ``flags`` : `~numpy.ndarray`
-                The bitwise quality flags for each aperture. See
-                `~photutils.aperture.decode_aperture_flags` for decoding
-                flag values. The flags are:
+              The bitwise quality flags for each aperture. See
+              `~photutils.aperture.decode_aperture_flags` for decoding
+              flag values. The flags are:
 
-                <flag_descriptions>
+              <flag_descriptions>
         """
         data = np.asanyarray(data)
         if data.ndim != 2:
@@ -1037,17 +1034,16 @@ class PixelAperture(Aperture):
         result = self._batch_photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation=segmentation, labels=labels,
-            mask_method=mask_method, _mask_nonfinite=_mask_nonfinite)
+            mask_method=mask_method, mask_nonfinite=mask_nonfinite)
 
         if result is not None:
-            aperture_sums, aperture_sum_errs, area, fcounts, overlap = result
+            flux, flux_err, area, fcounts, overlap = result
         else:
-            (aperture_sums, aperture_sum_errs, area, fcounts,
-             overlap) = self._mask_photometry(
+            (flux, flux_err, area, fcounts, overlap) = self._mask_photometry(
                 data, error=error, mask=mask, method=method,
                 subpixels=subpixels, segmentation=segmentation,
                 labels=labels, mask_method=mask_method,
-                _mask_nonfinite=_mask_nonfinite)
+                mask_nonfinite=mask_nonfinite)
 
         # Resolve the precise outside-weight test only for the sources
         # whose bounding box is clipped by a data edge
@@ -1059,38 +1055,58 @@ class PixelAperture(Aperture):
 
         # Apply units
         if unit is not None:
-            aperture_sums <<= unit
-            aperture_sum_errs <<= unit
+            flux <<= unit
+            flux_err <<= unit
 
         # The area always has units of pix**2, regardless of whether
         # data/error have units (matches ApertureStats.sum_aper_area).
         area <<= (u.pix**2)
 
-        return ApertureResults(aperture_sum=aperture_sums,
-                               aperture_sum_err=aperture_sum_errs, area=area,
-                               flags=flags)
+        return _ApertureResults(flux=flux, flux_err=flux_err, area=area,
+                                flags=flags)
 
-    @deprecated(since='3.1', alternative='photometry', until='4.0')
+    @_update_method_subpixels_docstring
+    @deprecated(since='3.1', alternative='AperturePhotometry', until='4.0')
     def do_photometry(self, data, error=None, mask=None, method='exact',
-                      subpixels=5, *, segmentation_image=None, labels=None,
-                      mask_method='none'):
-        # numpydoc ignore: PR01
+                      subpixels=5):
+        # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Perform aperture photometry on the input data.
 
         .. deprecated:: 3.1
-            Use `photometry` instead. Note that all arguments except
-            ``data`` are keyword-only in ``photometry``.
+            Use `~photutils.aperture.AperturePhotometry` instead.
+
+        Parameters
+        ----------
+        data : array_like or `~astropy.units.Quantity` instance
+            The 2D array on which to perform photometry. ``data`` should
+            be background subtracted.
+
+        error : array_like or `~astropy.units.Quantity`, optional
+            The pixel-wise Gaussian 1-sigma errors of the input
+            ``data``. ``error`` is assumed to include *all* sources
+            of error, including the Poisson error of the sources (see
+            `~photutils.utils.calc_total_error`). ``error`` must have
+            the same shape as the input ``data``.
+
+        mask : array_like (bool), optional
+            A boolean mask with the same shape as ``data`` where a
+            `True` value indicates the corresponding element of ``data``
+            is masked. Masked data are excluded from all calculations.
+
+        <method_subpixels_descriptions>
 
         Returns
         -------
-        result : `ApertureResults`
-            The aperture photometry results.
+        aperture_sums : `~numpy.ndarray` or `~astropy.units.Quantity`
+            The sum within each aperture.
+
+        aperture_sum_errs : `~numpy.ndarray` or `~astropy.units.Quantity`
+            The errors on the sum within each aperture.
         """
-        return self.photometry(data, error=error, mask=mask, method=method,
-                               subpixels=subpixels,
-                               segmentation_image=segmentation_image,
-                               labels=labels, mask_method=mask_method)
+        result = self._photometry(data, error=error, mask=mask,
+                                  method=method, subpixels=subpixels)
+        return result.flux, result.flux_err
 
     def _resolve_outside_weights(self, shape, *, method, subpixels,
                                  candidates):

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -649,7 +649,7 @@ class PixelAperture(Aperture):
 
     def _mask_photometry(self, data, *, error, mask, method, subpixels,
                          segmentation=None, labels=None,
-                         mask_method='none'):
+                         mask_method='none', _mask_nonfinite=False):
         """
         Perform aperture photometry using per-source aperture masks.
 
@@ -752,10 +752,25 @@ class PixelAperture(Aperture):
                             np.count_nonzero(exclude & pixel_mask))
                     pixel_mask = pixel_mask & ~exclude
 
+                # Non-finite ``data`` masking (used by the class path).
+                # Flag the contributing non-finite pixels, then exclude
+                # them from the sum, area, and valid-pixel count so they
+                # do not poison the result (matching `ApertureStats`).
+                # When ``_mask_nonfinite`` is `False` (the legacy
+                # function), the non-finite pixels are left in the
+                # computation so they poison the sum (the 3.0.0
+                # behavior).
+                nonfinite_data = ~np.isfinite(data_cutout)
+                if _mask_nonfinite:
+                    flag_counts[idx, FLAG_COL_NONFINITE_DATA] = np.any(
+                        nonfinite_data & pixel_mask)
+                    pixel_mask = pixel_mask & ~nonfinite_data
+
                 flag_counts[idx, FLAG_COL_VALID] = np.count_nonzero(
                     pixel_mask)
-                flag_counts[idx, FLAG_COL_NONFINITE_DATA] = np.any(
-                    ~np.isfinite(data_cutout) & pixel_mask)
+                if not _mask_nonfinite:
+                    flag_counts[idx, FLAG_COL_NONFINITE_DATA] = np.any(
+                        nonfinite_data & pixel_mask)
                 if error is not None:
                     flag_counts[idx, FLAG_COL_NONFINITE_ERROR] = np.any(
                         ~np.isfinite(error_cutout) & pixel_mask)
@@ -801,7 +816,7 @@ class PixelAperture(Aperture):
 
     def _batch_photometry(self, data, *, error, mask, method, subpixels,
                           segmentation=None, labels=None,
-                          mask_method='none'):
+                          mask_method='none', _mask_nonfinite=False):
         """
         Perform aperture photometry using the batch Cython driver.
 
@@ -857,11 +872,33 @@ class PixelAperture(Aperture):
                                     and not _supported(error)):
             return None
 
+        if mask is not None and (not isinstance(mask, np.ndarray)
+                                 or mask.dtype != bool
+                                 or mask.shape != data.shape):
+            return None
+
+        # Build a uint8 mask plane for the batch kernels. Bit 1
+        # (value 1) marks input-masked pixels and bit 2 (value 2) marks
+        # non-finite ``data`` pixels; any nonzero value excludes the
+        # pixel. Folding the non-finite pixels into the plane lets the
+        # class exclude them from the sum, area, and valid-pixel count
+        # while still flagging them as ``non_finite_data`` (not
+        # ``masked_pixels``), matching `ApertureStats`. When
+        # ``_mask_nonfinite`` is `False` (the legacy function), the
+        # non-finite pixels are left in the data so they poison the sum
+        # (the 3.0.0 behavior).
+        plane = None
         if mask is not None:
-            if (not isinstance(mask, np.ndarray) or mask.dtype != bool
-                    or mask.shape != data.shape):
-                return None
-            mask = np.ascontiguousarray(mask, dtype=np.uint8)
+            plane = mask.astype(np.uint8)
+        if _mask_nonfinite and data.dtype.kind == 'f':
+            nonfinite = ~np.isfinite(data)
+            if nonfinite.any():
+                if plane is None:
+                    plane = np.zeros(data.shape, dtype=np.uint8)
+                    plane[nonfinite] = 2
+                else:
+                    plane[nonfinite & (plane == 0)] = 2
+        mask = None if plane is None else np.ascontiguousarray(plane)
 
         seg_arr = None
         labels_arr = None
@@ -898,7 +935,7 @@ class PixelAperture(Aperture):
     @_update_method_subpixels_docstring
     def photometry(self, data, *, error=None, mask=None, method='exact',
                    subpixels=5, segmentation_image=None, labels=None,
-                   mask_method='none'):
+                   mask_method='none', _mask_nonfinite=False):
         # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Perform aperture photometry on the input data.
@@ -1000,7 +1037,7 @@ class PixelAperture(Aperture):
         result = self._batch_photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation=segmentation, labels=labels,
-            mask_method=mask_method)
+            mask_method=mask_method, _mask_nonfinite=_mask_nonfinite)
 
         if result is not None:
             aperture_sums, aperture_sum_errs, area, fcounts, overlap = result
@@ -1009,7 +1046,8 @@ class PixelAperture(Aperture):
              overlap) = self._mask_photometry(
                 data, error=error, mask=mask, method=method,
                 subpixels=subpixels, segmentation=segmentation,
-                labels=labels, mask_method=mask_method)
+                labels=labels, mask_method=mask_method,
+                _mask_nonfinite=_mask_nonfinite)
 
         # Resolve the precise outside-weight test only for the sources
         # whose bounding box is clipped by a data edge

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -20,10 +20,10 @@ class _ApertureFlags(FlagRegistry):
     flags.
 
     This class provides a single source of truth for all
-    aperture flag definitions, including bit values,
-    names, and descriptions. The same flag definitions are
-    used by `~photutils.aperture.aperture_photometry`,
-    `~photutils.aperture.PixelAperture.photometry`, and
+    aperture flag definitions, including bit values, names,
+    and descriptions. The same flag definitions are used
+    by `~photutils.aperture.PixelAperture._photometry`,
+    `~photutils.aperture.AperturePhotometry`, and
     `~photutils.aperture.ApertureStats`, so a given bit always has the
     same meaning.
 

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -223,12 +223,12 @@ def decode_aperture_flags(flags, *, return_bit_values=False):
 
     Returns
     -------
-    decoded : list of str, list of int, list of list of str, or \
-            list of list of int
-        List of active flag names (or bit values), or list of lists
-        if the input is an array. Each string (or integer) represents
-        a specific condition that was detected. If no flags are
-        set, an empty list is returned. Possible flags are:
+    decoded : list of str, list of int, or nested list
+        List of active flag names (or bit values) for a scalar input.
+        For an array input, a nested list with the same shape as the
+        input is returned, where each innermost element is the list of
+        active flag names (or bit values) for the corresponding flag. If
+        no flags are set, an empty list is returned. Possible flags are:
         <flag_descriptions>
 
     Examples

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -264,8 +264,7 @@ class ApertureMask:
         -----
         This method is separate from ``get_values`` to facilitate
         applying the same slices, aper_weights, and pixel_mask to
-        multiple associated arrays (e.g., data and error arrays). It is
-        used in this way by the `PixelAperture.photometry` method.
+        multiple associated arrays (e.g., data and error arrays).
         """
         if mask is not None and mask.shape != shape:
             msg = 'mask and data must have the same shape'

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -129,12 +129,15 @@ class AperturePhotometry:
     calculations and are indicated by the ``non_finite_data`` quality
     flag (see `~photutils.aperture.decode_aperture_flags`).
 
-    This class is immutable after initialization (its cached attributes
-    use compute-once `~astropy.utils.decorators.lazyproperty` caching),
-    so a single instance can be safely shared across threads.
+    This class should be treated as immutable after
+    initialization (aside from the internal compute-once
+    `~astropy.utils.decorators.lazyproperty` cache), so a single
+    instance can be safely shared across threads. Do not reassign its
+    attributes after construction.
 
     Examples
     --------
+    >>> import numpy as np
     >>> from photutils.datasets import make_4gaussians_image
     >>> from photutils.aperture import AperturePhotometry, CircularAperture
     >>> data = make_4gaussians_image()
@@ -147,7 +150,7 @@ class AperturePhotometry:
     [1.41796308 1.41796308 1.41796308]
     >>> phot.to_table(columns=['id', 'flux', 'flux_err'])
     <QTable length=3>
-    id         flux             flux_err
+      id         flux             flux_err
     int64      float64            float64
     ----- ------------------ -----------------
         1  5853.596272924398 1.417963080724414
@@ -444,6 +447,15 @@ class AperturePhotometry:
         else:
             table_columns = columns
 
+        allowed_columns = ('id', 'x_center', 'y_center', 'sky_center',
+                           'flux', 'flux_err', 'area', 'flags')
+        invalid = [col for col in table_columns
+                   if col not in allowed_columns]
+        if invalid:
+            msg = (f'Invalid column name(s): {invalid!r}. The allowed '
+                   f'column names are: {", ".join(allowed_columns)}')
+            raise ValueError(msg)
+
         tbl = QTable()
         tbl.meta.update(self.meta)
 
@@ -476,7 +488,10 @@ class AperturePhotometry:
         -------
         decoded : list of list of str or list of list of int
             A list of the active flag names (or bit values) for each
-            aperture.
+            aperture. If a list of apertures was input (2D `flags`),
+            the result is a nested list with the same ``(n_positions,
+            n_apertures)`` shape as `flags`, so ``decoded[i][j]`` gives
+            the active flags for position ``i`` and aperture ``j``.
 
         See Also
         --------
@@ -695,19 +710,13 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     if wcs is not None and not skyaper:
         tbl['sky_center'] = wcs.pixel_to_world(*np.transpose(positions))
 
-    sum_key_main = 'flux'
-    sum_err_key_main = 'flux_err'
-    column_map = {
-        sum_key_main: 'aperture_sum',
-        sum_err_key_main: 'aperture_sum_err',
-    }
     for i, aper in enumerate(apertures):
         result = aper._photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels)
 
-        # Apply column name mapping for legacy column names
-        sum_key = column_map.get(sum_key_main, sum_key_main)
-        sum_err_key = column_map.get(sum_err_key_main, sum_err_key_main)
+        # Legacy column names
+        sum_key = 'aperture_sum'
+        sum_err_key = 'aperture_sum_err'
 
         if not single_aperture:
             sum_key += f'_{i}'

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -582,10 +582,10 @@ def aperture_photometry(data, apertures, error=None, mask=None,
           (always float64). Returned only if the input ``error`` is not
           `None`.
 
-        If multiple apertures are input, the ``'aperture_sum'``, and
-        ``'aperture_sumx_err'`` columns will have a ``'_i'`` suffix
-        (e.g., ``'flux_0'``), where ``i`` is the index of the aperture
-        in the input list.
+        If multiple apertures are input, the ``'aperture_sum'`` and
+        ``'aperture_sum_err'`` columns will have a ``'_i'`` suffix
+        (e.g., ``'aperture_sum_0'``), where ``i`` is the index of the
+        aperture in the input list.
 
         The table metadata includes the Astropy and Photutils version
         numbers and the `aperture_photometry` calling arguments.

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -283,15 +283,15 @@ class AperturePhotometry:
     @lazyproperty
     def _photometry_results(self):
         """
-        The per-aperture `~photutils.aperture.ApertureResults`, one for
-        each input aperture.
+        The per-aperture photometry result objects, one for each input
+        aperture.
         """
-        return [aper.photometry(
+        return [aper._photometry(
             self._data, error=self._error, mask=self._mask,
             method=self.method, subpixels=self.subpixels,
             segmentation_image=self._segmentation,
             labels=self._seg_labels, mask_method=self.mask_method,
-            _mask_nonfinite=True)
+            mask_nonfinite=True)
             for aper in self._pixel_apertures]
 
     @lazyproperty
@@ -365,7 +365,7 @@ class AperturePhotometry:
         The values are always float64, regardless of the input ``data``
         dtype (a `~astropy.units.Quantity` if ``data`` has units).
         """
-        values = self._stack('aperture_sum')
+        values = self._stack('flux')
         if self._data_unit is not None:
             values <<= self._data_unit
         return values
@@ -379,7 +379,7 @@ class AperturePhotometry:
         dtype (a `~astropy.units.Quantity` if ``data`` has units). If the
         input ``error`` is `None`, this is filled with NaN values.
         """
-        values = self._stack('aperture_sum_err')
+        values = self._stack('flux_err')
         if self._data_unit is not None:
             values <<= self._data_unit
         return values
@@ -567,16 +567,16 @@ def aperture_photometry(data, apertures, error=None, mask=None,
           The sky coordinates of the input aperture center(s). Returned
           if a ``wcs`` is input.
 
-        * ``'aperture_sum'``:
+        * ``'flux'``:
           The sum of the values within the aperture(s). The values
           are always float64, regardless of the input ``data`` dtype
           (a `~astropy.units.Quantity` with float64 values if ``data``
           has units).
 
-        * ``'aperture_sum_err'``:
-          The corresponding uncertainty in the ``'aperture_sum'``
-          values (always float64). If the input ``error`` is `None`,
-          this column is filled with NaN values.
+        * ``'flux_err'``:
+          The corresponding uncertainty in the ``'flux'`` values (always
+          float64). If the input ``error`` is `None`, this column is
+          filled with NaN values.
 
         * ``'area'``:
           The total unmasked overlap area of the aperture(s)
@@ -595,10 +595,10 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
           <flag_descriptions>
 
-        If multiple apertures are input, the ``'aperture_sum'``,
-        ``'aperture_sum_err'``, ``'area'``, and ``'flags'`` columns will
-        have a ``'_i'`` suffix (e.g., ``'aperture_sum_0'``), where ``i``
-        is the index of the aperture in the input list.
+        If multiple apertures are input, the ``'flux'``, ``'flux_err'``,
+        ``'area'``, and ``'flags'`` columns will have a ``'_i'`` suffix
+        (e.g., ``'flux_0'``), where ``i`` is the index of the aperture
+        in the input list.
 
         The table metadata includes the Astropy and Photutils version
         numbers and the `aperture_photometry` calling arguments.
@@ -682,10 +682,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
             msg = 'Input apertures must all have identical positions'
             raise ValueError(msg)
 
-    # Validate the segmentation-masking inputs and resolve the
-    # per-aperture source labels once (the resolved labels are passed
-    # explicitly to PixelAperture.photometry to avoid repeated
-    # auto-lookups and warnings).
+    # Validate the segmentation-masking inputs
     segmentation, labels = process_segmentation_inputs(
         segmentation_image, labels, mask_method,
         np.atleast_2d(positions), np.shape(data))
@@ -719,28 +716,34 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     if wcs is not None and not skyaper:
         tbl['sky_center'] = wcs.pixel_to_world(*np.transpose(positions))
 
-    sum_key_main = 'aperture_sum'
-    sum_err_key_main = 'aperture_sum_err'
+    flux_key_main = 'flux'
+    flux_err_key_main = 'flux_err'
     area_key_main = 'area'
     flags_key_main = 'flags'
+    column_map = {
+        flux_key_main: 'aperture_sum',
+        flux_err_key_main: 'aperture_sum_err',
+    }
     for i, aper in enumerate(apertures):
-        result = aper.photometry(
+        result = aper._photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation_image=segmentation, labels=labels,
             mask_method=mask_method)
 
-        sum_key = sum_key_main
-        sum_err_key = sum_err_key_main
+        # Apply column name mapping for legacy column names
+        flux_key = column_map.get(flux_key_main, flux_key_main)
+        flux_err_key = column_map.get(flux_err_key_main, flux_err_key_main)
+
         area_key = area_key_main
         flags_key = flags_key_main
         if not single_aperture:
-            sum_key += f'_{i}'
-            sum_err_key += f'_{i}'
+            flux_key += f'_{i}'
+            flux_err_key += f'_{i}'
             area_key += f'_{i}'
             flags_key += f'_{i}'
 
-        tbl[sum_key] = result.aperture_sum
-        tbl[sum_err_key] = result.aperture_sum_err
+        tbl[flux_key] = result.flux
+        tbl[flux_err_key] = result.flux_err
         tbl[area_key] = result.area
         tbl[flags_key] = result.flags
         tbl[flags_key].info.description = (

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -489,17 +489,23 @@ class AperturePhotometry:
 @_update_method_subpixels_docstring
 @deprecated_positional_kwargs(since='3.0', until='4.0')
 def aperture_photometry(data, apertures, error=None, mask=None,
-                        method='exact', subpixels=5, wcs=None, *,
-                        segmentation_image=None, labels=None,
-                        mask_method='none'):
+                        method='exact', subpixels=5, wcs=None):
     # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Perform aperture photometry on the input data by summing the flux
     within the given aperture(s).
 
-    Note that this function returns the sum of the (weighted) input
-    ``data`` values within the aperture. It does not convert data
-    in surface brightness units to flux or counts. Conversion from
+    .. note::
+        This is a legacy function. It is not deprecated,
+        but new features are no longer added to it. The
+        :class:`~photutils.aperture.AperturePhotometry` class is the
+        recommended tool for aperture photometry. It provides additional
+        outputs (e.g., aperture areas, quality flags) and options (e.g.,
+        segmentation-based neighbor masking).
+
+    This function returns the sum of the (weighted) input ``data``
+    values within the aperture. It does not convert data in
+    surface brightness units to flux or counts. Conversion from
     surface-brightness units should be performed before using this
     function.
 
@@ -549,8 +555,6 @@ def aperture_photometry(data, apertures, error=None, mask=None,
         required if the input ``apertures`` contains a `SkyAperture` or
         `~regions.SkyRegion`.
 
-    <segmentation_descriptions>
-
     Returns
     -------
     table : `~astropy.table.QTable`
@@ -567,36 +571,19 @@ def aperture_photometry(data, apertures, error=None, mask=None,
           The sky coordinates of the input aperture center(s). Returned
           if a ``wcs`` is input.
 
-        * ``'flux'``:
+        * ``'aperture_sum'``:
           The sum of the values within the aperture(s). The values
           are always float64, regardless of the input ``data`` dtype
           (a `~astropy.units.Quantity` with float64 values if ``data``
           has units).
 
-        * ``'flux_err'``:
-          The corresponding uncertainty in the ``'flux'`` values (always
-          float64). If the input ``error`` is `None`, this column is
-          filled with NaN values.
+        * ``'aperture_sum_err'``:
+          The corresponding uncertainty in the ``'aperture_sum'`` values
+          (always float64). Returned only if the input ``error`` is not
+          `None`.
 
-        * ``'area'``:
-          The total unmasked overlap area of the aperture(s)
-          (in ``pix**2``), taking into account the aperture
-          mask method, masked data pixels (``mask`` keyword),
-          segmentation masking, and partial/no overlap of
-          the aperture with the data. This is equivalent to
-          :meth:`~photutils.aperture.PixelAperture.area_overlap`
-          computed with the same inputs. The value is NaN where an
-          aperture does not overlap the data.
-
-        * ``'flags'``:
-          The bitwise quality flags for the aperture(s). See
-          :func:`~photutils.aperture.decode_aperture_flags` for decoding
-          flag values. The flags are:
-
-          <flag_descriptions>
-
-        If multiple apertures are input, the ``'flux'``, ``'flux_err'``,
-        ``'area'``, and ``'flags'`` columns will have a ``'_i'`` suffix
+        If multiple apertures are input, the ``'aperture_sum'``, and
+        ``'aperture_sumx_err'`` columns will have a ``'_i'`` suffix
         (e.g., ``'flux_0'``), where ``i`` is the index of the aperture
         in the input list.
 
@@ -639,10 +626,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
 
         return aperture_photometry(data, apertures, error=error, mask=mask,
                                    method=method, subpixels=subpixels,
-                                   wcs=wcs,
-                                   segmentation_image=segmentation_image,
-                                   labels=labels,
-                                   mask_method=mask_method)
+                                   wcs=wcs)
 
     single_aperture = False
     if not isinstance(apertures, (list, tuple, np.ndarray)):
@@ -682,11 +666,6 @@ def aperture_photometry(data, apertures, error=None, mask=None,
             msg = 'Input apertures must all have identical positions'
             raise ValueError(msg)
 
-    # Validate the segmentation-masking inputs
-    segmentation, labels = process_segmentation_inputs(
-        segmentation_image, labels, mask_method,
-        np.atleast_2d(positions), np.shape(data))
-
     # Define output table meta data
     meta = _get_meta()
     calling_args = f"method='{method}', subpixels={subpixels}"
@@ -716,37 +695,26 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     if wcs is not None and not skyaper:
         tbl['sky_center'] = wcs.pixel_to_world(*np.transpose(positions))
 
-    flux_key_main = 'flux'
-    flux_err_key_main = 'flux_err'
-    area_key_main = 'area'
-    flags_key_main = 'flags'
+    sum_key_main = 'flux'
+    sum_err_key_main = 'flux_err'
     column_map = {
-        flux_key_main: 'aperture_sum',
-        flux_err_key_main: 'aperture_sum_err',
+        sum_key_main: 'aperture_sum',
+        sum_err_key_main: 'aperture_sum_err',
     }
     for i, aper in enumerate(apertures):
         result = aper._photometry(
-            data, error=error, mask=mask, method=method, subpixels=subpixels,
-            segmentation_image=segmentation, labels=labels,
-            mask_method=mask_method)
+            data, error=error, mask=mask, method=method, subpixels=subpixels)
 
         # Apply column name mapping for legacy column names
-        flux_key = column_map.get(flux_key_main, flux_key_main)
-        flux_err_key = column_map.get(flux_err_key_main, flux_err_key_main)
+        sum_key = column_map.get(sum_key_main, sum_key_main)
+        sum_err_key = column_map.get(sum_err_key_main, sum_err_key_main)
 
-        area_key = area_key_main
-        flags_key = flags_key_main
         if not single_aperture:
-            flux_key += f'_{i}'
-            flux_err_key += f'_{i}'
-            area_key += f'_{i}'
-            flags_key += f'_{i}'
+            sum_key += f'_{i}'
+            sum_err_key += f'_{i}'
 
-        tbl[flux_key] = result.flux
-        tbl[flux_err_key] = result.flux_err
-        tbl[area_key] = result.area
-        tbl[flags_key] = result.flags
-        tbl[flags_key].info.description = (
-            'Aperture quality flags; see decode_aperture_flags')
+        tbl[sum_key] = result.flux
+        if error is not None:
+            tbl[sum_err_key] = result.flux_err
 
     return tbl

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -57,7 +57,8 @@ class AperturePhotometry:
         The 2D array on which to perform photometry. ``data`` should be
         background-subtracted. If ``data`` is a `~astropy.units.Quantity`
         array, then ``error`` (if input) must also be a
-        `~astropy.units.Quantity` array with the same units. See the
+        `~astropy.units.Quantity` array with the same units. Non-finite
+        ``data`` values (NaN and inf) are automatically masked. See the
         Notes section below for more information about
         `~astropy.nddata.NDData` input.
 
@@ -82,7 +83,9 @@ class AperturePhotometry:
     mask : array_like (bool), optional
         A boolean mask with the same shape as ``data`` where a `True`
         value indicates the corresponding element of ``data`` is masked.
-        Masked data are excluded from all calculations.
+        Masked data are excluded from all calculations. Non-finite
+        values (NaN and inf) in the input ``data`` are automatically
+        masked.
 
     wcs : WCS object, optional
         A world coordinate system (WCS) transformation that
@@ -120,6 +123,11 @@ class AperturePhotometry:
     1D arrays with one element per aperture position when a single
     aperture is input. If a list of apertures is input, they are 2D
     arrays with shape ``(n_positions, n_apertures)``.
+
+    Non-finite ``data`` values (NaN and inf) are automatically masked.
+    Such pixels are excluded from the `flux`, `flux_err`, and `area`
+    calculations and are indicated by the ``non_finite_data`` quality
+    flag (see `~photutils.aperture.decode_aperture_flags`).
 
     This class is immutable after initialization (its cached attributes
     use compute-once `~astropy.utils.decorators.lazyproperty` caching),
@@ -282,7 +290,8 @@ class AperturePhotometry:
             self._data, error=self._error, mask=self._mask,
             method=self.method, subpixels=self.subpixels,
             segmentation_image=self._segmentation,
-            labels=self._seg_labels, mask_method=self.mask_method)
+            labels=self._seg_labels, mask_method=self.mask_method,
+            _mask_nonfinite=True)
             for aper in self._pixel_apertures]
 
     @lazyproperty

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -8,17 +8,22 @@ import warnings
 import astropy.units as u
 import numpy as np
 from astropy.nddata import NDData, StdDevUncertainty
+from astropy.table import QTable
+from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture._segmentation import process_segmentation_inputs
 from photutils.aperture.converters import region_to_aperture
 from photutils.aperture.core import (Aperture, SkyAperture, _aperture_metadata,
                                      _update_method_subpixels_docstring)
+from photutils.aperture.flags import decode_aperture_flags
 from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_positional_kwargs)
 from photutils.utils._misc import _get_meta
+from photutils.utils._quantity_helpers import process_quantities
+from photutils.utils._repr import make_repr
 
-__all__ = ['aperture_photometry']
+__all__ = ['AperturePhotometry', 'aperture_photometry']
 
 
 # Remove in 4.0
@@ -26,6 +31,450 @@ _DEPRECATED_COLUMNS: dict = {
     'xcenter': 'x_center',
     'ycenter': 'y_center',
 }
+
+
+@_update_method_subpixels_docstring
+class AperturePhotometry:
+    # numpydoc ignore: PR01,PR02,PR04,PR07
+    """
+    Class to perform aperture photometry on 2D data.
+
+    This class sums the (weighted) input ``data`` values within the
+    given aperture(s) and provides the aperture fluxes, uncertainties,
+    unmasked overlap areas, and bitwise quality flags as lazily-computed
+    attributes. Use `to_table` to obtain the results as an
+    `~astropy.table.QTable`.
+
+    Note that this class returns the sum of the (weighted) input
+    ``data`` values within the aperture. It does not convert data in
+    surface brightness units to flux or counts. Conversion from
+    surface-brightness units should be performed before using this
+    class.
+
+    Parameters
+    ----------
+    data : array_like, `~astropy.units.Quantity`, `~astropy.nddata.NDData`
+        The 2D array on which to perform photometry. ``data`` should be
+        background-subtracted. If ``data`` is a `~astropy.units.Quantity`
+        array, then ``error`` (if input) must also be a
+        `~astropy.units.Quantity` array with the same units. See the
+        Notes section below for more information about
+        `~astropy.nddata.NDData` input.
+
+    apertures : `~photutils.aperture.Aperture`, supported `regions.Region`, \
+        list of `~photutils.aperture.Aperture` or `regions.Region`
+        The aperture(s) to use for the photometry. If ``apertures`` is
+        a list of `~photutils.aperture.Aperture` or `regions.Region`,
+        then they all must have the same position(s). If ``apertures``
+        contains a `~photutils.aperture.SkyAperture` or `~regions.SkyRegion`
+        object, then a WCS must be input using the ``wcs`` keyword.
+        Region objects are converted to aperture objects.
+
+    error : array_like or `~astropy.units.Quantity`, optional
+        The pixel-wise Gaussian 1-sigma errors of the input
+        ``data``. ``error`` is assumed to include *all* sources
+        of error, including the Poisson error of the sources (see
+        `~photutils.utils.calc_total_error`). ``error`` must have the
+        same shape as the input ``data``. If a `~astropy.units.Quantity`
+        array, then ``data`` must also be a `~astropy.units.Quantity`
+        array with the same units.
+
+    mask : array_like (bool), optional
+        A boolean mask with the same shape as ``data`` where a `True`
+        value indicates the corresponding element of ``data`` is masked.
+        Masked data are excluded from all calculations.
+
+    wcs : WCS object, optional
+        A world coordinate system (WCS) transformation that
+        supports the `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`). If provided, the `sky_center`
+        attribute and the ``'sky_center'`` column of `to_table` will
+        contain the sky coordinates of the input aperture center(s).
+        This keyword is required if the input ``apertures`` contains a
+        `SkyAperture` or `~regions.SkyRegion`.
+
+    <method_subpixels_descriptions>
+
+    <segmentation_descriptions>
+
+    See Also
+    --------
+    photutils.aperture.ApertureStats : Per-source statistics (e.g.,
+        centroid, min, max, median, standard deviation, and
+        morphological properties) of the pixels within an aperture.
+
+    Notes
+    -----
+    `~regions.Region` objects are converted to `Aperture` objects using
+    the :func:`region_to_aperture` function.
+
+    If the input ``data`` is a `~astropy.nddata.NDData` instance,
+    then the ``error``, ``mask``, and ``wcs`` keyword inputs are
+    ignored. Instead, these values should be defined as attributes in
+    the `~astropy.nddata.NDData` object. In the case of ``error``,
+    it must be defined in the ``uncertainty`` attribute with a
+    `~astropy.nddata.StdDevUncertainty` instance.
+
+    The measured `flux`, `flux_err`, `area`, and `flags` attributes are
+    1D arrays with one element per aperture position when a single
+    aperture is input. If a list of apertures is input, they are 2D
+    arrays with shape ``(n_positions, n_apertures)``.
+
+    This class is immutable after initialization (its cached attributes
+    use compute-once `~astropy.utils.decorators.lazyproperty` caching),
+    so a single instance can be safely shared across threads.
+
+    Examples
+    --------
+    >>> from photutils.datasets import make_4gaussians_image
+    >>> from photutils.aperture import AperturePhotometry, CircularAperture
+    >>> data = make_4gaussians_image()
+    >>> error = 0.1 * np.ones(data.shape)  # simple background-only error
+    >>> aper = CircularAperture([(25, 40), (90, 60), (150, 25)], r=8)
+    >>> phot = AperturePhotometry(data, aper, error=error)
+    >>> print(phot.flux)
+    [ 5853.59627292 28440.27461471  9286.70920641]
+    >>> print(phot.flux_err)
+    [1.41796308 1.41796308 1.41796308]
+    >>> phot.to_table(columns=['id', 'flux', 'flux_err'])
+    <QTable length=3>
+    id         flux             flux_err
+    int64      float64            float64
+    ----- ------------------ -----------------
+        1  5853.596272924398 1.417963080724414
+        2 28440.274614708058 1.417963080724414
+        3  9286.709206410273 1.417963080724414
+    """
+
+    _repr_params = ('method', 'subpixels', 'mask_method')
+
+    def __init__(self, data, apertures, *, error=None, mask=None, wcs=None,
+                 method='exact', subpixels=5, segmentation_image=None,
+                 labels=None, mask_method='none'):
+
+        if isinstance(data, NDData):
+            data, error, mask, wcs = self._unpack_nddata(data, error, mask,
+                                                         wcs)
+
+        (data, error), unit = process_quantities(
+            (data, error), ('data', 'error'))
+        self._data = self._validate_array(data, 'data', shape=False)
+        self._data_unit = unit
+        self._error = self._validate_array(error, 'error')
+        self._mask = self._validate_array(mask, 'mask')
+        self._wcs = wcs
+        self.method = method
+        self.subpixels = subpixels
+        self.mask_method = mask_method
+
+        single_aperture = False
+        if not isinstance(apertures, (list, tuple, np.ndarray)):
+            single_aperture = True
+            apertures = (apertures,)
+        self._single_aperture = single_aperture
+
+        # Create table metadata using the input apertures, not the
+        # converted ones
+        aper_meta = {}
+        for i, aperture in enumerate(apertures):
+            idx = '' if single_aperture else i
+            aper_meta.update(_aperture_metadata(aperture, index=idx))
+
+        # Convert regions to apertures if necessary
+        apertures = [region_to_aperture(aper)
+                     if not isinstance(aper, Aperture) else aper
+                     for aper in apertures]
+
+        # Convert sky to pixel apertures
+        self._skyaper = False
+        self._sky_positions = None
+        if isinstance(apertures[0], SkyAperture):
+            if wcs is None:
+                msg = ('A WCS transform must be defined by the input data '
+                       'or the wcs keyword when using a SkyAperture object.')
+                raise ValueError(msg)
+            self._skyaper = True
+            self._sky_positions = apertures[0].positions
+            apertures = [aper.to_pixel(wcs) for aper in apertures]
+
+        # Compare positions in pixels to avoid comparing SkyCoord objects
+        positions = apertures[0].positions
+        for aper in apertures[1:]:
+            if not np.array_equal(aper.positions, positions):
+                msg = 'Input apertures must all have identical positions'
+                raise ValueError(msg)
+        self._pixel_apertures = apertures
+
+        # Validate the segmentation-masking inputs and resolve the
+        # per-aperture source labels once
+        self.segmentation_image = segmentation_image
+        self.labels = labels
+        seg_positions = np.atleast_2d(apertures[0].positions)
+        (self._segmentation,
+         self._seg_labels) = process_segmentation_inputs(
+            segmentation_image, labels, mask_method, seg_positions,
+            self._data.shape)
+
+        # Define output table metadata
+        self.meta = _get_meta()
+        calling_args = f"method='{method}', subpixels={subpixels}"
+        self.meta['aperture_photometry_args'] = calling_args
+        self.meta.update(aper_meta)
+
+        default_columns = ['id', 'x_center', 'y_center']
+        if self._wcs is not None or self._skyaper:
+            default_columns.append('sky_center')
+        default_columns += ['flux', 'flux_err', 'area', 'flags']
+        self.default_columns = default_columns
+
+    @staticmethod
+    def _unpack_nddata(data, error, mask, wcs):
+        nddata_attr = {'error': error, 'mask': mask, 'wcs': wcs}
+        for key, value in nddata_attr.items():
+            if value is not None:
+                msg = (f'The {key!r} keyword is ignored. Its value '
+                       'is obtained from the input NDData object.')
+                warnings.warn(msg, AstropyUserWarning)
+
+        mask = data.mask
+        wcs = data.wcs
+
+        if isinstance(data.uncertainty, StdDevUncertainty):
+            if data.uncertainty.unit is None:
+                error = data.uncertainty.array
+            else:
+                error = data.uncertainty.array * data.uncertainty.unit
+
+        if data.unit is not None:
+            data = u.Quantity(data.data, unit=data.unit)
+        else:
+            data = data.data
+
+        return data, error, mask, wcs
+
+    def _validate_array(self, array, name, *, ndim=2, shape=True):
+        if name == 'mask' and array is np.ma.nomask:
+            array = None
+        if array is not None:
+            array = np.asanyarray(array)
+            if array.ndim != ndim:
+                msg = f'{name} must be a {ndim}D array'
+                raise ValueError(msg)
+            if shape and array.shape != self._data.shape:
+                msg = f'data and {name} must have the same shape'
+                raise ValueError(msg)
+        return array
+
+    def __repr__(self):
+        return make_repr(self, self._repr_params)
+
+    def __str__(self):
+        return make_repr(self, self._repr_params, long=True)
+
+    @lazyproperty
+    def _photometry_results(self):
+        """
+        The per-aperture `~photutils.aperture.ApertureResults`, one for
+        each input aperture.
+        """
+        return [aper.photometry(
+            self._data, error=self._error, mask=self._mask,
+            method=self.method, subpixels=self.subpixels,
+            segmentation_image=self._segmentation,
+            labels=self._seg_labels, mask_method=self.mask_method)
+            for aper in self._pixel_apertures]
+
+    @lazyproperty
+    def _positions(self):
+        """
+        The aperture positions in pixels, always as a 2D array.
+        """
+        return np.atleast_2d(self._pixel_apertures[0].positions)
+
+    @lazyproperty
+    def n_positions(self):
+        """
+        The number of aperture positions.
+        """
+        return self._positions.shape[0]
+
+    @lazyproperty
+    def id(self):
+        """
+        The aperture identification number(s).
+        """
+        return np.arange(self.n_positions) + 1
+
+    @lazyproperty
+    def x_center(self):
+        """
+        The ``x`` pixel coordinate(s) of the aperture center(s).
+        """
+        return self._positions[:, 0]
+
+    @lazyproperty
+    def y_center(self):
+        """
+        The ``y`` pixel coordinate(s) of the aperture center(s).
+        """
+        return self._positions[:, 1]
+
+    @lazyproperty
+    def sky_center(self):
+        """
+        The sky coordinates of the aperture center(s), or `None` if no
+        ``wcs`` was input.
+        """
+        if self._skyaper:
+            pos = self._sky_positions
+            if pos.isscalar:
+                # Return a length-1 SkyCoord array
+                return pos.reshape((-1,))
+            return pos
+        if self._wcs is not None:
+            return self._wcs.pixel_to_world(*np.transpose(self._positions))
+        return None
+
+    def _stack(self, attr):
+        """
+        Stack a per-aperture result attribute into a 1D array (single
+        aperture) or a 2D ``(n_positions, n_apertures)`` array (list of
+        apertures).
+        """
+        values = [getattr(result, attr)
+                  for result in self._photometry_results]
+        if self._single_aperture:
+            return values[0]
+        return np.stack(values, axis=1)
+
+    @lazyproperty
+    def flux(self):
+        """
+        The sum of the (weighted) values within the aperture(s).
+
+        The values are always float64, regardless of the input ``data``
+        dtype (a `~astropy.units.Quantity` if ``data`` has units).
+        """
+        values = self._stack('aperture_sum')
+        if self._data_unit is not None:
+            values <<= self._data_unit
+        return values
+
+    @lazyproperty
+    def flux_err(self):
+        """
+        The uncertainty in the `flux` values.
+
+        The values are always float64, regardless of the input ``error``
+        dtype (a `~astropy.units.Quantity` if ``data`` has units). If the
+        input ``error`` is `None`, this is filled with NaN values.
+        """
+        values = self._stack('aperture_sum_err')
+        if self._data_unit is not None:
+            values <<= self._data_unit
+        return values
+
+    @lazyproperty
+    def area(self):
+        """
+        The total unmasked overlap area of the aperture(s) (in
+        ``pix**2``).
+
+        This takes into account the aperture mask method, masked
+        data pixels (``mask`` keyword), segmentation masking, and
+        partial/no overlap of the aperture with the data. The value is
+        NaN where an aperture does not overlap the data.
+        """
+        values = [result.area for result in self._photometry_results]
+        if self._single_aperture:
+            return values[0]
+        stacked = np.stack([value.value for value in values], axis=1)
+        return u.Quantity(stacked, u.pix**2)
+
+    @lazyproperty
+    def flags(self):
+        """
+        The bitwise quality flags for the aperture(s).
+
+        See `~photutils.aperture.decode_aperture_flags` for decoding
+        flag values.
+        """
+        return self._stack('flags')
+
+    @deprecated_positional_kwargs(since='3.1', until='4.0')
+    def to_table(self, *, columns=None):
+        """
+        Create a `~astropy.table.QTable` of the aperture photometry
+        results.
+
+        Parameters
+        ----------
+        columns : str, list of str, `None`, optional
+            Names of columns, in order, to include in the output
+            `~astropy.table.QTable`. The allowed column names are
+            ``'id'``, ``'x_center'``, ``'y_center'``, ``'sky_center'``,
+            ``'flux'``, ``'flux_err'``, ``'area'``, and ``'flags'``. If
+            ``columns`` is `None`, then a default list of columns will
+            be used (the ``default_columns`` attribute). If a list of
+            apertures was input, then the ``'flux'``, ``'flux_err'``,
+            ``'area'``, and ``'flags'`` columns will have a ``'_i'``
+            suffix (e.g., ``'flux_0'``), where ``i`` is the index of the
+            aperture in the input list.
+
+        Returns
+        -------
+        table : `~astropy.table.QTable`
+            A table of the aperture photometry results with one row per
+            aperture position.
+        """
+        if columns is None:
+            table_columns = self.default_columns
+        elif isinstance(columns, str):
+            table_columns = [columns]
+        else:
+            table_columns = columns
+
+        tbl = QTable()
+        tbl.meta.update(self.meta)
+
+        per_aperture = ('flux', 'flux_err', 'area', 'flags')
+        for column in table_columns:
+            if column in per_aperture and not self._single_aperture:
+                values = getattr(self, column)
+                for i in range(len(self._pixel_apertures)):
+                    name = f'{column}_{i}'
+                    tbl[name] = values[:, i]
+            else:
+                tbl[column] = getattr(self, column)
+        return tbl
+
+    def decode_flags(self, *, return_bit_values=False):
+        """
+        Decode the aperture quality flags into individual components.
+
+        This is a convenience method that calls
+        `~photutils.aperture.decode_aperture_flags` with the `flags`
+        attribute.
+
+        Parameters
+        ----------
+        return_bit_values : bool, optional
+            If `True`, return the decoded bit flags (integers) instead
+            of the flag names (strings).
+
+        Returns
+        -------
+        decoded : list of list of str or list of list of int
+            A list of the active flag names (or bit values) for each
+            aperture.
+
+        See Also
+        --------
+        photutils.aperture.decode_aperture_flags
+        """
+        return decode_aperture_flags(np.atleast_1d(self.flags),
+                                     return_bit_values=return_bit_values)
 
 
 @_update_method_subpixels_docstring

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -2765,7 +2765,7 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         where :math:`R` is a parameter which scales the ellipse (in
         units of the axes lengths).
 
-        That the isophotal limit of a source is well represented by
+        The isophotal limit of a source is well represented by
         :math:`R \approx 3`.
         """
         return ((np.sin(self.orientation) / self.semimajor_axis)**2

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -264,17 +264,6 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
     (partial) aperture weights. Accordingly, these quantities cannot be
     rigorously computed from a weighted aperture footprint.
 
-    All properties other than the sum-related ones described below
-    are calculated using the "center" aperture-mask method, which
-    gives aperture weights of 0 or 1, so the ``data`` pixel values
-    are used directly and unweighted. This is due to fundamental
-    limitation. Unlike the mean or variance, order statistics
-    (``min``, ``max``, ``median``) and robust estimators (``mad_std``,
-    ``biweight_location``, ``biweight_midvariance``) have no standard,
-    unambiguous generalization to pixels with fractional (partial)
-    aperture weights, so they cannot be rigorously computed using a
-    weighted footprint.
-
     The input ``sum_method`` and ``subpixels`` keywords are
     used to determine the aperture-mask method only for the
     sum-related properties: ``sum``, ``sum_err``, ``sum_aper_area``,

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -151,15 +151,15 @@ def test_readonly_arrays(method, subpixels):
 
 def test_readonly_data_photometry():
     """
-    Test that ``photometry`` works with read-only data arrays.
+    Test that ``_photometry`` works with read-only data arrays.
     """
     data = np.ones((10, 10))
     data.setflags(write=False)
     aperture = CircularAperture((4.5, 4.5), r=4.5)
-    sums, _ = aperture.photometry(data, method='exact')
+    results = aperture._photometry(data, method='exact')
 
-    expected, _ = aperture.photometry(np.ones((10, 10)), method='exact')
-    assert_allclose(sums, expected, rtol=1e-12)
+    expected = aperture._photometry(np.ones((10, 10)), method='exact')
+    assert_allclose(results.flux, expected.flux, rtol=1e-12)
 
 
 def test_scalar_position():
@@ -182,12 +182,12 @@ def test_units():
     """
     unit = u.Jy
     aperture = CircularAperture(POSITIONS, r=5.5)
-    sums, errs = aperture.photometry(DATA << unit, error=ERROR << unit)
-    assert sums.unit == unit
-    assert errs.unit == unit
-    sums2, errs2 = aperture.photometry(DATA, error=ERROR)
-    assert_allclose(sums.value, sums2, equal_nan=True)
-    assert_allclose(errs.value, errs2, equal_nan=True)
+    results = aperture._photometry(DATA << unit, error=ERROR << unit)
+    assert results.flux.unit == unit
+    assert results.flux_err.unit == unit
+    results2 = aperture._photometry(DATA, error=ERROR)
+    assert_allclose(results.flux.value, results2.flux, equal_nan=True)
+    assert_allclose(results.flux_err.value, results2.flux_err, equal_nan=True)
 
 
 def test_no_overlap_nan_and_err_shape():
@@ -225,11 +225,11 @@ def test_photometry_no_error_flux_err_shape(aperture):
     ``CircularAperture`` exercises the batch code path and
     ``PolygonAperture`` exercises the mask-based code path.
     """
-    flux, flux_err = aperture.photometry(DATA, error=None)
-    assert flux_err.shape == flux.shape
-    assert np.any(np.isnan(flux))
-    assert np.any(~np.isnan(flux))
-    assert np.all(np.isnan(flux_err))
+    result = aperture._photometry(DATA, error=None)
+    assert result.flux_err.shape == result.flux.shape
+    assert np.any(np.isnan(result.flux))
+    assert np.any(~np.isnan(result.flux))
+    assert np.all(np.isnan(result.flux_err))
 
 
 def test_fallback_inputs():
@@ -276,9 +276,9 @@ def test_fallback_subclass():
     aperture = MyAperture(POSITIONS, r=5.5)
     assert aperture._batch_photometry(DATA, error=None, mask=None,
                                       method='exact', subpixels=5) is None
-    sums, _ = aperture.photometry(DATA)
-    sums2, _ = CircularAperture(POSITIONS, r=5.5).photometry(DATA)
-    assert_allclose(sums, sums2, rtol=1e-12, equal_nan=True)
+    result = aperture._photometry(DATA)
+    result2 = CircularAperture(POSITIONS, r=5.5)._photometry(DATA)
+    assert_allclose(result.flux, result2.flux, rtol=1e-12, equal_nan=True)
 
 
 def test_optin_subclass():
@@ -329,13 +329,14 @@ def test_thread_safety():
     and checking that they all give the same results.
     """
     aperture = CircularAperture(POSITIONS, r=5.5)
-    expected, _ = aperture.photometry(DATA, error=ERROR)
+    expected = aperture._photometry(DATA, error=ERROR)
 
     def run(_):
-        return aperture.photometry(DATA, error=ERROR)[0]
+        return aperture._photometry(DATA, error=ERROR)
 
     with ThreadPoolExecutor(max_workers=4) as executor:
         results = list(executor.map(run, range(8)))
 
     for result in results:
-        assert_allclose(result, expected, rtol=0, atol=0, equal_nan=True)
+        assert_allclose(result.flux, expected.flux, rtol=0, atol=0,
+                        equal_nan=True)

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -132,7 +132,7 @@ class TestPixelAperture:
 
 class TestPixelAperturePhotometry:
     """
-    Tests for error-handling branches of PixelAperture.photometry.
+    Tests for error-handling branches of PixelAperture._photometry.
     """
 
     def setup_method(self):
@@ -149,7 +149,7 @@ class TestPixelAperturePhotometry:
         """
         match = 'data must be a 2D array'
         with pytest.raises(ValueError, match=match):
-            self.aper.photometry(np.ones(20))
+            self.aper._photometry(np.ones(20))
 
     def test_photometry_error_shape_mismatch(self):
         """
@@ -158,7 +158,7 @@ class TestPixelAperturePhotometry:
         """
         match = 'error and data must have the same shape'
         with pytest.raises(ValueError, match=match):
-            self.aper.photometry(self.data, error=np.ones((5, 5)))
+            self.aper._photometry(self.data, error=np.ones((5, 5)))
 
     def test_photometry_unit_mismatch_error(self):
         """
@@ -169,43 +169,28 @@ class TestPixelAperturePhotometry:
 
         match = 'they both must have the same units'
         with pytest.raises(ValueError, match=match):
-            self.aper.photometry(
+            self.aper._photometry(
                 self.data * u.Jy,
                 error=self.data * u.ct,
             )
 
     def test_photometry_basic(self):
         """
-        Test that photometry returns the expected aperture sum for a
-        uniform data array with no error input, and that the returned
-        error array has the same length as the flux array, filled with
-        NaN.
+        Test that photometry returns the expected flux for a uniform
+        data array with no error input, and that the returned error
+        array has the same length as the flux array, filled with NaN.
         """
-        sums, errs = self.aper.photometry(self.data)
-        assert_allclose(sums[0], np.pi * 9, rtol=1e-3)
-        assert len(errs) == len(sums)
-        assert_allclose(errs, np.nan)
-
-    def test_photometry_result_backward_compatible(self):
-        """
-        Test that the photometry result unpacks as a 2-tuple and
-        supports len() and integer indexing like the legacy tuple.
-        """
-        result = self.aper.photometry(self.data)
-        assert len(result) == 2
-
-        sums, errs = result
-        assert_allclose(sums, result.aperture_sum)
-        assert_allclose(errs, result.aperture_sum_err, equal_nan=True)
-        assert_allclose(result[0], result.aperture_sum)
-        assert_allclose(result[1], result.aperture_sum_err, equal_nan=True)
+        result = self.aper._photometry(self.data)
+        assert_allclose(result.flux, np.pi * 9, rtol=1e-3)
+        assert len(result.flux_err) == len(result.flux)
+        assert_allclose(result.flux_err, np.nan)
 
     def test_photometry_area_matches_area_overlap(self):
         """
         Test that the result area matches area_overlap for a simple
         non-masked, fully-overlapping aperture.
         """
-        result = self.aper.photometry(self.data)
+        result = self.aper._photometry(self.data)
         expected = self.aper.area_overlap(self.data)
         assert result.area.unit == u.pix**2
         assert_allclose(result.area.value, expected)
@@ -216,7 +201,7 @@ class TestPixelAperturePhotometry:
         with the data.
         """
         aper = CircularAperture((-50, -50), r=3)
-        result = aper.photometry(self.data)
+        result = aper._photometry(self.data)
         assert np.isnan(result.area.value).all()
 
     def test_photometry_area_units(self):
@@ -224,11 +209,11 @@ class TestPixelAperturePhotometry:
         Test that the result area always has units of pix**2 regardless
         of whether the data/error are Quantity or plain arrays.
         """
-        result = self.aper.photometry(self.data)
+        result = self.aper._photometry(self.data)
         assert result.area.unit == u.pix**2
 
-        result_q = self.aper.photometry(self.data * u.Jy,
-                                        error=self.data * u.Jy)
+        result_q = self.aper._photometry(self.data * u.Jy,
+                                         error=self.data * u.Jy)
         assert result_q.area.unit == u.pix**2
         assert_allclose(result.area.value, result_q.area.value,
                         equal_nan=True)
@@ -253,16 +238,18 @@ class TestPixelAperturePhotometry:
     def test_do_photometry_deprecated(self):
         """
         Test that the deprecated do_photometry method emits a
-        deprecation warning and returns the same results as photometry.
+        deprecation warning and returns a plain (flux, flux_err)
+        2-tuple matching the private photometry engine.
         """
         error = np.full(self.data.shape, 0.1)
-        expected = self.aper.photometry(self.data, error=error)
-        match = r'Use photometry instead'
+        expected = self.aper._photometry(self.data, error=error)
+        match = r'Use AperturePhotometry instead'
         with pytest.warns(AstropyDeprecationWarning, match=match):
             result = self.aper.do_photometry(self.data, error=error)
-        assert_allclose(result.aperture_sum, expected.aperture_sum)
-        assert_allclose(result.aperture_sum_err, expected.aperture_sum_err)
-        assert_allclose(result.area.value, expected.area.value)
+        assert len(result) == 2
+        flux, flux_err = result
+        assert_allclose(flux, expected.flux)
+        assert_allclose(flux_err, expected.flux_err)
 
 
 class TestApertureReprStr:

--- a/photutils/aperture/tests/test_flags.py
+++ b/photutils/aperture/tests/test_flags.py
@@ -8,7 +8,7 @@ import pytest
 
 from photutils.aperture.flags import (APERTURE_FLAGS, _ApertureFlags,
                                       decode_aperture_flags)
-from photutils.utils._flags import FlagDefinition
+from photutils.utils._flags import FlagDefinition, define_flag_docstring
 
 EXPECTED_FLAGS = {
     'no_overlap': 1,
@@ -73,10 +73,12 @@ def test_decode_aperture_flags():
     decoded = decode_aperture_flags(np.array([], dtype=int))
     assert decoded == []
 
-    # Test with 2D array (flattened)
+    # Test with 2D array (shape preserved as nested lists)
     decoded = decode_aperture_flags(np.array([[0, 1], [8, 24]]))
-    assert len(decoded) == 4
-    assert decoded[3] == ['masked_pixels', 'all_masked']
+    assert len(decoded) == 2
+    assert decoded == [[[], ['no_overlap']],
+                       [['masked_pixels'],
+                        ['masked_pixels', 'all_masked']]]
 
 
 def test_decode_aperture_flags_return_bit_values():
@@ -169,6 +171,11 @@ def test_aperture_flags_get_methods():
     assert def_by_bit is def_by_name
     assert def_by_bit.name == 'no_overlap'
 
+    # NumPy integers (e.g., values from a flags table column) are
+    # accepted as bit values
+    assert APERTURE_FLAGS.get_name(np.int64(8)) == 'masked_pixels'
+    assert APERTURE_FLAGS.get_definition(np.int32(1)) is def_by_bit
+
     # Test error cases
     match = 'No flag with bit value 999'
     with pytest.raises(KeyError, match=match):
@@ -201,6 +208,15 @@ def test_aperture_flags_completeness():
     for name in names:
         assert name.isidentifier()
         assert name == name.lower()
+
+
+def test_define_flag_docstring_invalid_registry():
+    """
+    Test that define_flag_docstring rejects a non-FlagRegistry input.
+    """
+    match = 'registry must be an instance of FlagRegistry'
+    with pytest.raises(TypeError, match=match):
+        define_flag_docstring('invalid')
 
 
 def test_decode_aperture_flags_docstring():

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -692,36 +692,16 @@ def test_scalar_aperture():
     ap = CircularAperture((10, 10), r=3.0)
     colnames1 = aperture_photometry(data, ap, error=data).colnames
     assert (colnames1 == ['id', 'x_center', 'y_center', 'aperture_sum',
-                          'aperture_sum_err', 'area', 'flags'])
+                          'aperture_sum_err'])
 
     colnames2 = aperture_photometry(data, [ap], error=data).colnames
     assert (colnames2 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
-                          'aperture_sum_err_0', 'area_0', 'flags_0'])
+                          'aperture_sum_err_0'])
 
     colnames3 = aperture_photometry(data, [ap, ap], error=data).colnames
     assert (colnames3 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
-                          'aperture_sum_err_0', 'area_0', 'flags_0',
-                          'aperture_sum_1', 'aperture_sum_err_1',
-                          'area_1', 'flags_1'])
-
-
-def test_area_column():
-    """
-    Test that the ``'area'`` column matches ``area_overlap`` for
-    representative cases, with and without a mask.
-    """
-    data = np.ones((25, 25), dtype=float)
-    ap = CircularAperture([(10, 10), (15, 15)], r=4.0)
-
-    tbl = aperture_photometry(data, ap)
-    assert tbl['area'].unit == u.pix**2
-    assert_allclose(tbl['area'].value, ap.area_overlap(data))
-
-    mask = np.zeros(data.shape, dtype=bool)
-    mask[10, 10] = True
-    tbl_mask = aperture_photometry(data, ap, mask=mask)
-    assert_allclose(tbl_mask['area'].value,
-                    ap.area_overlap(data, mask=mask))
+                          'aperture_sum_err_0', 'aperture_sum_1',
+                          'aperture_sum_err_1'])
 
 
 def test_nan_in_bbox():

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -1,0 +1,478 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the AperturePhotometry class.
+"""
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
+from astropy.nddata import NDData, StdDevUncertainty
+from astropy.utils.exceptions import AstropyUserWarning
+from numpy.testing import assert_allclose, assert_equal
+
+from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
+                                       SkyCircularAperture)
+from photutils.aperture.photometry import (AperturePhotometry,
+                                           aperture_photometry)
+from photutils.aperture.polygon import PolygonAperture
+from photutils.datasets import make_4gaussians_image, make_wcs
+from photutils.segmentation import SegmentationImage
+from photutils.utils._optional_deps import HAS_REGIONS
+
+
+def make_scene():
+    """
+    Build a deterministic scene with a target source (label 1) and a
+    bright neighbor source (label 2), on a nonzero background.
+    """
+    data = np.ones((50, 50))
+    segm = np.zeros((50, 50), dtype=int)
+
+    # Target source (label 1)
+    data[18:25, 18:25] = 10.0
+    segm[18:25, 18:25] = 1
+
+    # Bright neighbor source (label 2)
+    data[20:25, 26:32] = 100.0
+    segm[20:25, 26:32] = 2
+
+    return data, segm
+
+
+class TestAperturePhotometryParity:
+    """
+    The class must return results identical to the legacy
+    ``aperture_photometry`` function for all shared inputs.
+    """
+
+    def test_single_aperture(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper)
+        ref = aperture_photometry(data, aper)
+        assert_allclose(phot.flux, ref['aperture_sum'])
+        assert_allclose(phot.area.value, ref['area'].value)
+        assert_equal(phot.flags, ref['flags'])
+
+    def test_multiple_positions(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture(((150, 25), (90, 60)), 10)
+        phot = AperturePhotometry(data, aper)
+        ref = aperture_photometry(data, aper)
+        assert_allclose(phot.flux, ref['aperture_sum'])
+        assert phot.flux.shape == (2,)
+
+    def test_error_propagation(self):
+        data = make_4gaussians_image()
+        error = np.sqrt(np.abs(data))
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper, error=error)
+        ref = aperture_photometry(data, aper, error=error)
+        assert_allclose(phot.flux, ref['aperture_sum'])
+        assert_allclose(phot.flux_err, ref['aperture_sum_err'])
+
+    def test_no_error_is_nan(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper)
+        assert np.all(np.isnan(phot.flux_err))
+
+    def test_mask(self):
+        data = make_4gaussians_image()
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[25, 150] = True
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper, mask=mask)
+        ref = aperture_photometry(data, aper, mask=mask)
+        assert_allclose(phot.flux, ref['aperture_sum'])
+
+    def test_nomask(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper, mask=np.ma.nomask)
+        ref = aperture_photometry(data, aper)
+        assert phot._mask is None
+        assert_allclose(phot.flux, ref['aperture_sum'])
+
+    @pytest.mark.parametrize(('method', 'subpixels'),
+                             [('exact', 5), ('center', 5), ('subpixel', 7)])
+    def test_method_variants(self, method, subpixels):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper, method=method,
+                                  subpixels=subpixels)
+        ref = aperture_photometry(data, aper, method=method,
+                                  subpixels=subpixels)
+        assert_allclose(phot.flux, ref['aperture_sum'])
+
+    def test_units(self):
+        data = make_4gaussians_image() * u.Jy
+        error = np.sqrt(np.abs(data.value)) * u.Jy
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper, error=error)
+        ref = aperture_photometry(data, aper, error=error)
+        assert phot.flux.unit == u.Jy
+        assert phot.flux_err.unit == u.Jy
+        assert phot.area.unit == u.pix**2
+        assert_allclose(phot.flux.value, ref['aperture_sum'].value)
+        assert_allclose(phot.flux_err.value, ref['aperture_sum_err'].value)
+
+
+class TestListOfApertures:
+    def test_flux_shape(self):
+        data = make_4gaussians_image()
+        pos = ((150, 25), (90, 60))
+        apers = [CircularAperture(pos, r) for r in (5, 8)]
+        phot = AperturePhotometry(data, apers)
+        assert phot.flux.shape == (2, 2)
+        assert phot.area.shape == (2, 2)
+        assert phot.flags.shape == (2, 2)
+
+    def test_matches_per_aperture(self):
+        data = make_4gaussians_image()
+        pos = ((150, 25), (90, 60))
+        apers = [CircularAperture(pos, r) for r in (5, 8)]
+        phot = AperturePhotometry(data, apers)
+        for i, aper in enumerate(apers):
+            ref = aperture_photometry(data, aper)
+            assert_allclose(phot.flux[:, i], ref['aperture_sum'])
+
+    def test_identical_positions_required(self):
+        data = make_4gaussians_image()
+        apers = [CircularAperture((150, 25), 5),
+                 CircularAperture((90, 60), 5)]
+        match = 'Input apertures must all have identical positions'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, apers)
+
+
+class TestSkyApertures:
+    def test_sky_center_from_pixel_wcs(self):
+        data = make_4gaussians_image()
+        wcs = make_wcs(data.shape)
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper, wcs=wcs)
+        assert isinstance(phot.sky_center, SkyCoord)
+        assert 'sky_center' in phot.to_table().colnames
+
+    def test_no_wcs_sky_center_none(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper)
+        assert phot.sky_center is None
+        assert 'sky_center' not in phot.to_table().colnames
+
+    def test_sky_aperture(self):
+        data = make_4gaussians_image()
+        wcs = make_wcs(data.shape)
+        skycoord = wcs.pixel_to_world(150, 25)
+        sky_aper = SkyCircularAperture(skycoord, r=0.7 * u.arcsec)
+        pix_aper = sky_aper.to_pixel(wcs)
+        phot = AperturePhotometry(data, sky_aper, wcs=wcs)
+        ref = aperture_photometry(data, pix_aper)
+        assert_allclose(phot.flux, ref['aperture_sum'])
+        assert isinstance(phot.sky_center, SkyCoord)
+        assert phot.sky_center.isscalar is False
+
+    def test_sky_aperture_multiple_positions(self):
+        data = make_4gaussians_image()
+        wcs = make_wcs(data.shape)
+        skycoord = wcs.pixel_to_world([150, 90], [25, 60])
+        sky_aper = SkyCircularAperture(skycoord, r=0.7 * u.arcsec)
+        pix_aper = sky_aper.to_pixel(wcs)
+        phot = AperturePhotometry(data, sky_aper, wcs=wcs)
+        ref = aperture_photometry(data, pix_aper)
+        assert_allclose(phot.flux, ref['aperture_sum'])
+        assert phot.sky_center.isscalar is False
+        assert len(phot.sky_center) == 2
+
+    def test_sky_aperture_requires_wcs(self):
+        data = np.ones((11, 11))
+        wcs = make_wcs(data.shape)
+        sky_aper = CircularAperture((5, 5), r=3).to_sky(wcs=wcs)
+        match = 'A WCS transform must be defined'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, sky_aper)
+
+
+class TestNDDataInput:
+    def test_nddata(self):
+        data = make_4gaussians_image()
+        error = np.sqrt(np.abs(data))
+        uncertainty = StdDevUncertainty(error)
+        nddata = NDData(data, uncertainty=uncertainty)
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(nddata, aper)
+        ref = aperture_photometry(data, aper, error=error)
+        assert_allclose(phot.flux, ref['aperture_sum'])
+        assert_allclose(phot.flux_err, ref['aperture_sum_err'])
+
+    def test_nddata_ignored_keywords_warn(self):
+        data = make_4gaussians_image()
+        nddata = NDData(data)
+        aper = CircularAperture((150, 25), 8)
+        mask = np.zeros(data.shape, dtype=bool)
+        match = 'is obtained from the input NDData object'
+        with pytest.warns(AstropyUserWarning, match=match):
+            AperturePhotometry(nddata, aper, mask=mask)
+
+    def test_nddata_units(self):
+        data = make_4gaussians_image()
+        nddata = NDData(data * u.Jy)
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(nddata, aper)
+        assert phot.flux.unit == u.Jy
+
+    def test_nddata_uncertainty_with_unit(self):
+        data = make_4gaussians_image()
+        error = np.sqrt(np.abs(data))
+        uncertainty = StdDevUncertainty(error, unit=u.Jy)
+        nddata = NDData(data * u.Jy, uncertainty=uncertainty)
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(nddata, aper)
+        ref = aperture_photometry(data * u.Jy, aper, error=error * u.Jy)
+        assert phot.flux_err.unit == u.Jy
+        assert_allclose(phot.flux_err.value, ref['aperture_sum_err'].value)
+
+
+class TestSegmentationMasking:
+    @pytest.mark.parametrize('use_segm_obj', [True, False])
+    def test_mask_method_matches_manual(self, use_segm_obj):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        segm_in = SegmentationImage(segm) if use_segm_obj else segm
+        phot = AperturePhotometry(data, aper, segmentation_image=segm_in,
+                                  labels=[1], mask_method='mask')
+        manual_mask = (segm > 0) & (segm != 1)
+        ref = AperturePhotometry(data, aper, mask=manual_mask)
+        assert_allclose(phot.flux, ref.flux)
+
+    def test_source_only_matches_manual(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        phot = AperturePhotometry(data, aper, segmentation_image=segm,
+                                  labels=[1], mask_method='source_only')
+        manual_mask = segm != 1
+        ref = AperturePhotometry(data, aper, mask=manual_mask)
+        assert_allclose(phot.flux, ref.flux)
+
+    def test_none_method_ignores_segmentation(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        phot = AperturePhotometry(data, aper, segmentation_image=segm,
+                                  mask_method='none')
+        ref = AperturePhotometry(data, aper)
+        assert_allclose(phot.flux, ref.flux)
+
+    def test_correct_matches_neighbor(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=10)
+        none_phot = AperturePhotometry(data, aper, mask_method='none')
+        corr_phot = AperturePhotometry(data, aper, segmentation_image=segm,
+                                       labels=[1], mask_method='correct')
+        assert corr_phot.flux[0] != none_phot.flux[0]
+
+    def test_polygon_mask_path(self):
+        data, segm = make_scene()
+        offsets = np.array([[-7, -7], [9, -7], [9, 9], [-7, 9]])
+        aper = PolygonAperture((21, 21), offsets)
+        phot = AperturePhotometry(data, aper, segmentation_image=segm,
+                                  labels=[1], mask_method='mask')
+        manual_mask = (segm > 0) & (segm != 1)
+        ref = AperturePhotometry(data, aper, mask=manual_mask)
+        assert_allclose(phot.flux, ref.flux)
+
+    def test_labels_required(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        match = 'labels must be input when segmentation_image is input'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, aper, segmentation_image=segm,
+                               mask_method='mask')
+
+
+class TestToTable:
+    def test_default_columns(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        tbl = AperturePhotometry(data, aper).to_table()
+        assert tbl.colnames == ['id', 'x_center', 'y_center', 'flux',
+                                'flux_err', 'area', 'flags']
+
+    def test_default_columns_with_wcs(self):
+        data = make_4gaussians_image()
+        wcs = make_wcs(data.shape)
+        aper = CircularAperture((150, 25), 8)
+        tbl = AperturePhotometry(data, aper, wcs=wcs).to_table()
+        assert tbl.colnames == ['id', 'x_center', 'y_center', 'sky_center',
+                                'flux', 'flux_err', 'area', 'flags']
+
+    def test_columns_subset(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        tbl = AperturePhotometry(data, aper).to_table(columns=['id', 'flux'])
+        assert tbl.colnames == ['id', 'flux']
+
+    def test_columns_single_string(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        tbl = AperturePhotometry(data, aper).to_table(columns='flux')
+        assert tbl.colnames == ['flux']
+
+    def test_multi_aperture_suffixes(self):
+        data = make_4gaussians_image()
+        pos = ((150, 25), (90, 60))
+        apers = [CircularAperture(pos, r) for r in (5, 8)]
+        tbl = AperturePhotometry(data, apers).to_table()
+        assert tbl.colnames == ['id', 'x_center', 'y_center', 'flux_0',
+                                'flux_1', 'flux_err_0', 'flux_err_1',
+                                'area_0', 'area_1', 'flags_0', 'flags_1']
+
+    def test_meta(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        tbl = AperturePhotometry(data, aper).to_table()
+        assert 'version' in tbl.meta
+        assert 'aperture_photometry_args' in tbl.meta
+        assert tbl.meta['aperture'] == 'CircularAperture'
+
+
+class TestFlagsAndArea:
+    def test_area_matches_area_overlap(self):
+        data = np.ones((25, 25), dtype=float)
+        aper = CircularAperture([(10, 10), (15, 15)], r=4.0)
+        phot = AperturePhotometry(data, aper)
+        assert phot.area.unit == u.pix**2
+        assert_allclose(phot.area.value, aper.area_overlap(data))
+
+    def test_partial_overlap_flag(self):
+        data = np.ones((25, 25), dtype=float)
+        aper = CircularAperture((0, 12), r=5.0)
+        phot = AperturePhotometry(data, aper)
+        assert phot.flags[0] != 0
+
+    def test_decode_flags(self):
+        data = np.ones((25, 25))
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[12, 12] = True
+        aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
+        phot = AperturePhotometry(data, aper, mask=mask)
+        decoded = phot.decode_flags()
+        assert decoded[0] == ['masked_pixels']
+        assert decoded[1] == ['partial_overlap']
+
+    def test_decode_flags_bit_values(self):
+        data = np.ones((25, 25))
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[12, 12] = True
+        aper = CircularAperture([(12.0, 12.0)], r=3.0)
+        phot = AperturePhotometry(data, aper, mask=mask)
+        decoded = phot.decode_flags(return_bit_values=True)
+        assert decoded[0] == [8]
+
+
+class TestInputValidation:
+    def test_data_not_2d(self):
+        aper = CircularAperture((5, 5), r=3)
+        match = 'data must be a 2D array'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(np.ones((5, 5, 5)), aper)
+
+    def test_error_shape_mismatch(self):
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+        match = 'data and error must have the same shape'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, aper, error=np.ones((5, 5)))
+
+    def test_mask_shape_mismatch(self):
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+        match = 'data and mask must have the same shape'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, aper, mask=np.zeros((5, 5), dtype=bool))
+
+    def test_unit_mismatch(self):
+        data = np.ones((11, 11)) * u.Jy
+        aper = CircularAperture((5, 5), r=3)
+        with pytest.raises(ValueError, match='must all have the same units'):
+            AperturePhotometry(data, aper, error=np.ones((11, 11)))
+
+
+class TestReprAndImmutability:
+    def test_repr(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper)
+        assert 'AperturePhotometry' in repr(phot)
+        assert "method='exact'" in repr(phot)
+
+    def test_str(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper)
+        assert 'AperturePhotometry' in str(phot)
+
+    def test_no_new_attributes_after_init(self):
+        """
+        Only lazyproperty cache entries may appear after ``__init__``,
+        which is required for the instance to be thread-safe.
+        """
+        data = make_4gaussians_image()
+        aper = CircularAperture(((150, 25), (90, 60)), 8)
+        phot = AperturePhotometry(data, aper, error=np.ones_like(data),
+                                  wcs=make_wcs(data.shape))
+        init_keys = set(vars(phot).keys())
+
+        # Touch every public and private lazy property/attribute
+        for name in ('id', 'x_center', 'y_center', 'sky_center', 'flux',
+                     'flux_err', 'area', 'flags', 'n_positions'):
+            getattr(phot, name)
+        phot.to_table()
+        phot.decode_flags()
+
+        new_keys = set(vars(phot).keys()) - init_keys
+        lazy_names = {'_photometry_results', '_positions', 'n_positions',
+                      'id', 'x_center', 'y_center', 'sky_center', 'flux',
+                      'flux_err', 'area', 'flags'}
+        assert new_keys.issubset(lazy_names)
+
+    def test_concurrent_access(self):
+        from concurrent.futures import ThreadPoolExecutor
+
+        data = make_4gaussians_image()
+        aper = CircularAperture(((150, 25), (90, 60)), 8)
+        phot = AperturePhotometry(data, aper)
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(lambda _: phot.flux, range(8)))
+        for result in results:
+            assert_allclose(result, results[0])
+
+
+@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+class TestRegionInput:
+    def test_region_matches_aperture(self):
+        from regions import CirclePixelRegion, PixCoord
+
+        data = np.ones((40, 40), dtype=float)
+        error = np.ones(data.shape, dtype=float)
+        position = (20.0, 20.0)
+        r = 10.0
+        region = CirclePixelRegion(PixCoord(*position), r)
+        aper = CircularAperture(position, r)
+        phot = AperturePhotometry(data, region, error=error)
+        ref = AperturePhotometry(data, aper, error=error)
+        assert_allclose(phot.flux, ref.flux)
+        assert_allclose(phot.flux_err, ref.flux_err)
+
+    def test_annulus_region(self):
+        from regions import CircleAnnulusPixelRegion, PixCoord
+
+        data = np.ones((40, 40), dtype=float)
+        position = (20.0, 20.0)
+        region = CircleAnnulusPixelRegion(PixCoord(*position), 8.0, 10.0)
+        aper = CircularAnnulus(position, 8.0, 10.0)
+        phot = AperturePhotometry(data, region)
+        ref = AperturePhotometry(data, aper)
+        assert_allclose(phot.flux, ref.flux)

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -11,7 +11,7 @@ import pytest
 from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.utils.exceptions import AstropyUserWarning
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose
 
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAperture)
@@ -55,8 +55,6 @@ class TestAperturePhotometryParity:
         phot = AperturePhotometry(data, aper)
         ref = aperture_photometry(data, aper)
         assert_allclose(phot.flux, ref['aperture_sum'])
-        assert_allclose(phot.area.value, ref['area'].value)
-        assert_equal(phot.flags, ref['flags'])
 
     def test_multiple_positions(self):
         data = make_4gaussians_image()

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -321,6 +321,16 @@ class TestToTable:
         tbl = AperturePhotometry(data, aper).to_table(columns='flux')
         assert tbl.colnames == ['flux']
 
+    def test_invalid_column(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper)
+        match = 'Invalid column name'
+        with pytest.raises(ValueError, match=match):
+            phot.to_table(columns='invalid')
+        with pytest.raises(ValueError, match=match):
+            phot.to_table(columns=['id', 'subpixels'])
+
     def test_multi_aperture_suffixes(self):
         data = make_4gaussians_image()
         pos = ((150, 25), (90, 60))

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -464,16 +464,23 @@ class TestNonFiniteData:
         stats = ApertureStats(data, aper, mask=mask)
         assert phot.flags[0] == stats.flags
 
-    def test_legacy_function_still_poisons_nonfinite(self):
-        # The legacy aperture_photometry function keeps the 3.0.0
-        # behavior: non-finite data poison the sum (not masked).
+    def test_legacy_function_still_corrupts_nonfinite(self):
+        """
+        Test that the legacy aperture_photometry function still returns
+        NaN for the aperture sum when there are non-finite values in the
+        aperture, even though the new AperturePhotometry class masks
+        them and returns a finite sum.
+
+        This is to ensure backward compatibility with existing code that
+        relies on the old behavior.
+        """
         data = np.ones((25, 25))
         data[12, 12] = np.nan
+
         aper = CircularAperture((12, 12), r=5)
         tbl = aperture_photometry(data, aper)
         assert np.isnan(tbl['aperture_sum'][0])
 
-        # The mask-based path (PolygonAperture) also poisons.
         offsets = np.array([[-5, -5], [5, -5], [5, 5], [-5, 5]])
         poly = PolygonAperture((12, 12), offsets)
         tbl = aperture_photometry(data, poly)

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -3,6 +3,8 @@
 Tests for the AperturePhotometry class.
 """
 
+from unittest.mock import patch
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -16,6 +18,7 @@ from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
 from photutils.aperture.photometry import (AperturePhotometry,
                                            aperture_photometry)
 from photutils.aperture.polygon import PolygonAperture
+from photutils.aperture.stats import ApertureStats
 from photutils.datasets import make_4gaussians_image, make_wcs
 from photutils.segmentation import SegmentationImage
 from photutils.utils._optional_deps import HAS_REGIONS
@@ -370,6 +373,111 @@ class TestFlagsAndArea:
         phot = AperturePhotometry(data, aper, mask=mask)
         decoded = phot.decode_flags(return_bit_values=True)
         assert decoded[0] == [8]
+
+
+class TestNonFiniteData:
+    """
+    Non-finite ``data`` values (NaN and inf) must be automatically
+    masked (excluded from flux, flux_err, and area) and reported via the
+    ``non_finite_data`` flag, mirroring ``ApertureStats``.
+    """
+
+    def test_batch_path_masks_nonfinite(self):
+        data = np.ones((25, 25))
+        data[12, 12] = np.nan
+        data[11, 11] = np.inf
+        aper = CircularAperture((12, 12), r=5)
+        phot = AperturePhotometry(data, aper)
+        # The two non-finite interior pixels (each of weight 1) are
+        # excluded from the flux and area (all other pixels are 1.0).
+        assert np.isfinite(phot.flux[0])
+        assert_allclose(phot.flux[0], aper.area_overlap(data) - 2)
+        assert_allclose(phot.area.value[0], phot.flux[0])
+        assert phot.flags[0] == 32
+        assert phot.decode_flags()[0] == ['non_finite_data']
+
+    def test_mask_path_masks_nonfinite(self):
+        # Disable the batch Cython driver to exercise the slower
+        # mask-based code path (via a spec of None).
+        aper = CircularAperture((12, 12), r=5)
+        data = np.ones((25, 25))
+        data[12, 12] = np.nan
+        data[11, 11] = np.inf
+        with patch.object(CircularAperture, '_batch_shape_params',
+                          lambda _self: None):
+            phot = AperturePhotometry(data, aper)
+            flux = phot.flux[0]
+            flags = phot.flags[0]
+            decoded = phot.decode_flags()[0]
+        assert np.isfinite(flux)
+        assert_allclose(flux, aper.area_overlap(data) - 2)
+        assert flags == 32
+        assert decoded == ['non_finite_data']
+
+    @pytest.mark.parametrize('aperture_type', ['circle', 'polygon'])
+    def test_parity_with_aperture_stats(self, aperture_type):
+        data = np.ones((25, 25))
+        data[12, 12] = np.nan
+        data[11, 11] = np.inf
+        if aperture_type == 'circle':
+            aper = CircularAperture((12, 12), r=5)
+        else:
+            offsets = np.array([[-5, -5], [5, -5], [5, 5], [-5, 5]])
+            aper = PolygonAperture((12, 12), offsets)
+        phot = AperturePhotometry(data, aper)
+        stats = ApertureStats(data, aper)
+        assert_allclose(phot.flux[0], stats.sum)
+        assert_allclose(phot.area.value[0], stats.sum_aper_area.value)
+        assert phot.flags[0] == stats.flags
+
+    def test_nonfinite_outside_aperture_not_flagged(self):
+        data = np.ones((25, 25))
+        data[0, 0] = np.nan  # far outside the aperture
+        aper = CircularAperture((12, 12), r=5)
+        phot = AperturePhotometry(data, aper)
+        assert phot.flags[0] == 0
+        assert_allclose(phot.flux[0], aper.area_overlap(data))
+
+    def test_combined_mask_and_nonfinite(self):
+        data = np.ones((25, 25))
+        data[12, 12] = np.nan
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[11, 12] = True
+        aper = CircularAperture((12, 12), r=5)
+        phot = AperturePhotometry(data, aper, mask=mask)
+        assert np.isfinite(phot.flux[0])
+        # Both masked_pixels (8) and non_finite_data (32) are set.
+        assert phot.flags[0] == 8 | 32
+        assert set(phot.decode_flags()[0]) == {'masked_pixels',
+                                               'non_finite_data'}
+
+    def test_nonfinite_at_masked_pixel_counts_as_masked(self):
+        # A non-finite pixel that is also input-masked is reported as
+        # masked_pixels, not non_finite_data (matching ApertureStats).
+        data = np.ones((25, 25))
+        data[12, 12] = np.nan
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[12, 12] = True
+        aper = CircularAperture((12, 12), r=5)
+        phot = AperturePhotometry(data, aper, mask=mask)
+        assert phot.flags[0] == 8
+        stats = ApertureStats(data, aper, mask=mask)
+        assert phot.flags[0] == stats.flags
+
+    def test_legacy_function_still_poisons_nonfinite(self):
+        # The legacy aperture_photometry function keeps the 3.0.0
+        # behavior: non-finite data poison the sum (not masked).
+        data = np.ones((25, 25))
+        data[12, 12] = np.nan
+        aper = CircularAperture((12, 12), r=5)
+        tbl = aperture_photometry(data, aper)
+        assert np.isnan(tbl['aperture_sum'][0])
+
+        # The mask-based path (PolygonAperture) also poisons.
+        offsets = np.array([[-5, -5], [5, -5], [5, 5], [-5, 5]])
+        poly = PolygonAperture((12, 12), offsets)
+        tbl = aperture_photometry(data, poly)
+        assert np.isnan(tbl['aperture_sum'][0])
 
 
 class TestInputValidation:

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -8,11 +8,10 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
-from photutils.aperture import (APERTURE_FLAGS, CircularAnnulus,
-                                CircularAperture, EllipticalAperture,
-                                RectangularAperture, aperture_photometry)
+from photutils.aperture import (APERTURE_FLAGS, AperturePhotometry,
+                                CircularAnnulus, CircularAperture,
+                                EllipticalAperture, RectangularAperture)
 from photutils.aperture.flags import _counts_to_flag_bits
-from photutils.aperture.photometry import AperturePhotometry
 
 SHAPE = (25, 25)
 
@@ -318,24 +317,23 @@ def test_mask_path_parity_segmentation():
         assert_array_equal(flags_batch, flags_nobatch)
 
 
-def test_aperture_photometry_flags_column():
+def test_aperture_photometry_flags():
     """
-    Test the flags column in the aperture_photometry table.
+    Test the AperturePhotometry flags.
     """
     data = np.ones(SHAPE)
     xy = [(12.0, 12.0), (-50.0, 12.0), (0.0, 12.0)]
     aper = CircularAperture(xy, r=3.0)
-    tbl = aperture_photometry(data, aper)
+    phot = AperturePhotometry(data, aper)
     expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS,
                 APERTURE_FLAGS.PARTIAL_OVERLAP]
-    assert_array_equal(tbl['flags'], expected)
-    assert 'decode_aperture_flags' in tbl['flags'].info.description
+    assert_array_equal(phot.flags, expected)
 
-    # Multiple apertures use suffixed column names
+    # The flags are multi-dimensional for multiple apertures
     aper2 = CircularAperture(xy, r=4.0)
-    tbl = aperture_photometry(data, [aper, aper2])
-    assert_array_equal(tbl['flags_0'], expected)
-    assert_array_equal(tbl['flags_1'], expected)
+    phot = AperturePhotometry(data, [aper, aper2])
+    assert_array_equal(phot.flags[:, 0], expected)
+    assert_array_equal(phot.flags[:, 1], expected)
 
 
 def test_flags_with_units():
@@ -347,8 +345,8 @@ def test_flags_with_units():
     aper = CircularAperture((12, 12), r=3.0)
     result = AperturePhotometry(data, aper)
     assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
-    tbl = aperture_photometry(data, aper)
-    assert tbl['flags'][0] == APERTURE_FLAGS.NON_FINITE_DATA
+    phot = AperturePhotometry(data, aper)
+    assert phot.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
 
 
 def test_counts_to_flag_bits_scalar_inputs():

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -12,6 +12,7 @@ from photutils.aperture import (APERTURE_FLAGS, CircularAnnulus,
                                 CircularAperture, EllipticalAperture,
                                 RectangularAperture, aperture_photometry)
 from photutils.aperture.flags import _counts_to_flag_bits
+from photutils.aperture.photometry import AperturePhotometry
 
 SHAPE = (25, 25)
 
@@ -33,7 +34,7 @@ class _NoBatchCircularAperture(CircularAperture):
 
 
 def _flags(aperture, data, **kwargs):
-    return aperture.photometry(data, **kwargs).flags
+    return AperturePhotometry(data, aperture, **kwargs).flags
 
 
 def test_no_flags():
@@ -53,10 +54,11 @@ def test_no_overlap(factory, method, subpixels):
     """
     data = np.ones(SHAPE)
     aper = factory([(-50.0, 12.0), (12.0, 12.0)])
-    result = aper.photometry(data, method=method, subpixels=subpixels)
+    result = AperturePhotometry(data, aper, method=method,
+                                subpixels=subpixels)
     expected = APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS
     assert result.flags[0] == expected
-    assert np.isnan(result.aperture_sum[0])
+    assert np.isnan(result.flux[0])
     assert result.flags[1] == 0
 
 
@@ -83,15 +85,15 @@ def test_no_overlap_close_to_edge():
     # bbox column 0 overlaps the data, but with the "center" method
     # the pixel center at x=0 (distance 1.2) is outside the circle
     aper = CircularAperture((-1.2, 12.0), r=0.8)
-    result = aper.photometry(data, method='center')
+    result = AperturePhotometry(data, aper, method='center')
     assert result.flags[0] == (APERTURE_FLAGS.NO_OVERLAP
                                | APERTURE_FLAGS.NO_PIXELS)
     # The sum is 0.0 (not NaN) here: the bounding box overlaps the
     # data, but no weighted pixel falls inside
-    assert result.aperture_sum[0] == 0.0
+    assert result.flux[0] == 0.0
 
     # With the exact method, the aperture area extends into the data
-    result = aper.photometry(data, method='exact')
+    result = AperturePhotometry(data, aper, method='exact')
     assert result.flags[0] == APERTURE_FLAGS.PARTIAL_OVERLAP
 
 
@@ -118,9 +120,9 @@ def test_no_pixels_tiny_aperture():
     data = np.ones(SHAPE)
     # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
     aper = CircularAperture((12.5, 12.5), r=0.4)
-    result = aper.photometry(data, method='center')
+    result = AperturePhotometry(data, aper, method='center')
     assert result.flags[0] == APERTURE_FLAGS.NO_PIXELS
-    assert result.aperture_sum[0] == 0.0
+    assert result.flux[0] == 0.0
 
     # The exact method has a nonzero footprint
     assert_array_equal(_flags(aper, data, method='exact'), [0])
@@ -163,18 +165,23 @@ def test_non_finite_data():
 
     In photometry, unmasked non-finite values contribute to the sum
     (making it NaN). They do not set all_masked.
+
+    This tests the legacy (non-class) engine call directly
+    (``mask_nonfinite=False``, the default), which corrupts the sum
+    with the non-finite value instead of masking it out, unlike
+    `AperturePhotometry`.
     """
     data = np.ones(SHAPE)
     data[12, 12] = np.nan
     aper = CircularAperture((12, 12), r=3.0)
-    result = aper.photometry(data)
+    result = aper._photometry(data)
     assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
-    assert np.isnan(result.aperture_sum[0])
+    assert np.isnan(result.flux[0])
 
     # An all-NaN aperture is still non_finite_data only (the pixels
     # contribute, so all_masked is not set)
     data = np.full(SHAPE, np.nan)
-    result = aper.photometry(data)
+    result = aper._photometry(data)
     assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
 
     # A masked non-finite pixel counts only as masked
@@ -280,11 +287,11 @@ def test_mask_path_parity(method, subpixels):
 
     kwargs = {'error': error, 'mask': mask, 'method': method,
               'subpixels': subpixels}
-    result_batch = batch_aper.photometry(data, **kwargs)
-    result_nobatch = nobatch_aper.photometry(data, **kwargs)
+    result_batch = batch_aper._photometry(data, **kwargs)
+    result_nobatch = nobatch_aper._photometry(data, **kwargs)
     assert_array_equal(result_batch.flags, result_nobatch.flags)
-    assert_allclose(result_batch.aperture_sum,
-                    result_nobatch.aperture_sum, rtol=1e-12,
+    assert_allclose(result_batch.flux,
+                    result_nobatch.flux, rtol=1e-12,
                     equal_nan=True)
 
 
@@ -302,10 +309,10 @@ def test_mask_path_parity_segmentation():
     labels = [1, 3]
 
     for mask_method in ('mask', 'source_only', 'correct'):
-        flags_batch = CircularAperture(xy, r=3.0).photometry(
+        flags_batch = CircularAperture(xy, r=3.0)._photometry(
             data, segmentation_image=segm, labels=labels,
             mask_method=mask_method).flags
-        flags_nobatch = _NoBatchCircularAperture(xy, r=3.0).photometry(
+        flags_nobatch = _NoBatchCircularAperture(xy, r=3.0)._photometry(
             data, segmentation_image=segm, labels=labels,
             mask_method=mask_method).flags
         assert_array_equal(flags_batch, flags_nobatch)
@@ -338,24 +345,10 @@ def test_flags_with_units():
     data = np.ones(SHAPE) * u.Jy
     data[12, 12] = np.nan * u.Jy
     aper = CircularAperture((12, 12), r=3.0)
-    result = aper.photometry(data)
+    result = AperturePhotometry(data, aper)
     assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
     tbl = aperture_photometry(data, aper)
     assert tbl['flags'][0] == APERTURE_FLAGS.NON_FINITE_DATA
-
-
-def test_legacy_tuple_unpacking():
-    """
-    Test that the legacy 2-tuple unpacking of the photometry results
-    is unchanged by the flags attribute.
-    """
-    data = np.ones(SHAPE)
-    aper = CircularAperture((12, 12), r=3.0)
-    result = aper.photometry(data)
-    aperture_sum, _aperture_sum_err = result
-    assert len(result) == 2
-    assert_array_equal(result[0], aperture_sum)
-    assert result.flags is not None
 
 
 def test_counts_to_flag_bits_scalar_inputs():

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -9,8 +9,9 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 from photutils.aperture import (APERTURE_FLAGS, AperturePhotometry,
-                                CircularAnnulus, CircularAperture,
-                                EllipticalAperture, RectangularAperture)
+                                ApertureStats, CircularAnnulus,
+                                CircularAperture, EllipticalAperture,
+                                RectangularAperture)
 from photutils.aperture.flags import _counts_to_flag_bits
 
 SHAPE = (25, 25)
@@ -317,6 +318,44 @@ def test_mask_path_parity_segmentation():
         assert_array_equal(flags_batch, flags_nobatch)
 
 
+@pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
+@pytest.mark.parametrize('nan_pixel', [(12, 14), (12, 10)],
+                         ids=['nan_neighbor', 'nan_mirror'])
+def test_mask_path_parity_nonfinite_segmentation(mask_method, nan_pixel):
+    """
+    Test batch/mask-path parity when non-finite masking (the
+    AperturePhotometry path) combines with segmentation masking.
+
+    Non-finite pixels must be masked before the segmentation handling,
+    so a NaN neighbor pixel is excluded as non-finite (not counted as
+    a neighbor pixel or mirror-corrected) and a NaN mirror pixel makes
+    its neighbor uncorrectable with mask_method='correct', matching the
+    batch kernel and ApertureStats.
+    """
+    data = np.ones(SHAPE)
+    data[nan_pixel] = np.nan
+    segm = np.zeros(SHAPE, dtype=int)
+    segm[10:15, 10:15] = 1
+    segm[12, 14] = 2  # neighbor pixel; its mirror is (12, 10)
+
+    kwargs = {'segmentation_image': segm, 'labels': [1],
+              'mask_method': mask_method}
+    batch_aper = CircularAperture((12.0, 12.0), r=3.0)
+    nobatch_aper = _NoBatchCircularAperture((12.0, 12.0), r=3.0)
+    result_batch = AperturePhotometry(data, batch_aper, **kwargs)
+    result_nobatch = AperturePhotometry(data, nobatch_aper, **kwargs)
+    assert_array_equal(result_batch.flags, result_nobatch.flags)
+    assert_allclose(result_batch.flux, result_nobatch.flux, rtol=1e-12)
+    assert_allclose(result_batch.area.value, result_nobatch.area.value,
+                    rtol=1e-12)
+
+    # The NaN pixel is excluded as non_finite_data in both paths
+    assert result_batch.flags[0] & APERTURE_FLAGS.NON_FINITE_DATA
+    stats = ApertureStats(data, batch_aper, **kwargs)
+    assert result_batch.flags[0] == stats.flags
+    assert_allclose(result_batch.flux[0], stats.sum, rtol=1e-12)
+
+
 def test_aperture_photometry_flags():
     """
     Test the AperturePhotometry flags.
@@ -343,8 +382,6 @@ def test_flags_with_units():
     data = np.ones(SHAPE) * u.Jy
     data[12, 12] = np.nan * u.Jy
     aper = CircularAperture((12, 12), r=3.0)
-    result = AperturePhotometry(data, aper)
-    assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
     phot = AperturePhotometry(data, aper)
     assert phot.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
 

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -11,6 +11,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
+from photutils.aperture.photometry import AperturePhotometry
 from photutils.aperture.polygon import (PolygonAperture, SkyPolygonAperture,
                                         _polygon_is_simple,
                                         _segments_intersect,
@@ -197,23 +198,23 @@ def test_pixel_polygon_from_star(n_spikes):
     inner_radius = 2.0
     aper = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
                                       inner_radius)
-    flux, _ = aper.photometry(data, method='exact')
-    assert_allclose(flux, aper.area)
+    phot = AperturePhotometry(data, aper, method='exact')
+    assert_allclose(phot.flux, aper.area)
 
     aper1 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
                                        inner_radius, theta=10 * u.deg)
-    flux, _ = aper1.photometry(data, method='exact')
-    assert_allclose(flux, aper1.area)
+    phot = AperturePhotometry(data, aper1, method='exact')
+    assert_allclose(phot.flux, aper1.area)
 
     aper2 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
                                        optimal_shape=True)
-    flux, _ = aper2.photometry(data, method='exact')
-    assert_allclose(flux, aper2.area)
+    phot = AperturePhotometry(data, aper2, method='exact')
+    assert_allclose(phot.flux, aper2.area)
 
     aper3 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
                                        collinear_edges=True)
-    flux, _ = aper3.photometry(data, method='exact')
-    assert_allclose(flux, aper3.area)
+    phot = AperturePhotometry(data, aper3, method='exact')
+    assert_allclose(phot.flux, aper3.area)
 
 
 @pytest.mark.parametrize(
@@ -487,8 +488,8 @@ def test_indexing_scalar_raises():
 def test_photometry():
     data = np.ones((30, 30))
     aper = PolygonAperture((10.0, 10.0), SQUARE_OFFSETS)
-    flux, _ = aper.photometry(data, method='exact')
-    assert_allclose(flux, [4.0])
+    phot = AperturePhotometry(data, aper, method='exact')
+    assert_allclose(phot.flux, [4.0])
 
 
 def test_photometry_subpixel_on_horizontal_boundary():
@@ -513,8 +514,8 @@ def test_photometry_subpixel_on_horizontal_boundary():
     offsets = np.array([[-2.0, -1.0], [2.0, -1.0],
                         [2.0, 1.0], [-2.0, 1.0]])
     aper = PolygonAperture((15.0, 15.0), offsets)
-    flux, _ = aper.photometry(data, method='subpixel', subpixels=3)
-    assert_allclose(flux, [55.0 / 9.0])
+    phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
+    assert_allclose(phot.flux, [55.0 / 9.0])
 
 
 def test_photometry_subpixel_on_vertical_boundary():
@@ -533,8 +534,8 @@ def test_photometry_subpixel_on_vertical_boundary():
     offsets = np.array([[-1.0, -2.0], [1.0, -2.0],
                         [1.0, 2.0], [-1.0, 2.0]])
     aper = PolygonAperture((15.0, 15.0), offsets)
-    flux, _ = aper.photometry(data, method='subpixel', subpixels=3)
-    assert_allclose(flux, [55.0 / 9.0])
+    phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
+    assert_allclose(phot.flux, [55.0 / 9.0])
 
 
 def test_photometry_subpixel_on_all_boundaries():
@@ -552,8 +553,8 @@ def test_photometry_subpixel_on_all_boundaries():
     """
     data = np.ones((31, 31))
     aper = PolygonAperture((15.0, 15.0), SQUARE_OFFSETS)
-    flux, _ = aper.photometry(data, method='subpixel', subpixels=3)
-    assert_allclose(flux, [25.0 / 9.0])
+    phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
+    assert_allclose(phot.flux, [25.0 / 9.0])
 
 
 @pytest.mark.parametrize(('method', 'kwargs'),
@@ -576,12 +577,12 @@ def test_array_photometry_matches_scalar(method, kwargs):
     offsets = _concave_star()
 
     aper = PolygonAperture(positions, offsets)
-    multi, _ = aper.photometry(data, method=method, **kwargs)
+    phot = AperturePhotometry(data, aper, method=method, **kwargs)
 
     ref = [PolygonAperture(pos, offsets)
            .to_mask(method=method, **kwargs).multiply(data).sum()
            for pos in positions]
-    assert_allclose(multi, ref, rtol=1e-12)
+    assert_allclose(phot.flux, ref, rtol=1e-12)
 
 
 def test_invalid_mask_method():

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Tests for segmentation-based masking of aperture photometry, shared
-by `aperture_photometry`, `PixelAperture._photometry`, and
-`ApertureStats`.
+Tests for segmentation-based masking of aperture photometry, shared by
+`AperturePhotometry` and `ApertureStats`.
 """
 
-import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -15,9 +13,7 @@ from photutils.aperture._batch_photometry import (SHAPE_CIRCLE,
 from photutils.aperture._segmentation import (make_segmentation_exclusion,
                                               process_segmentation_inputs)
 from photutils.aperture.circle import CircularAperture
-from photutils.aperture.photometry import (AperturePhotometry,
-                                           aperture_photometry)
-from photutils.aperture.polygon import PolygonAperture
+from photutils.aperture.photometry import AperturePhotometry
 from photutils.aperture.stats import ApertureStats
 from photutils.segmentation import SegmentationImage
 
@@ -110,131 +106,6 @@ class TestProcessSegmentationInputs:
 
 
 class TestAperturePhotometry:
-    @pytest.mark.parametrize('use_segm_obj', [True, False])
-    def test_mask_method_matches_manual(self, use_segm_obj):
-        data, segm = make_scene()
-        aper = CircularAperture([(21, 21)], r=8)
-        segm_in = SegmentationImage(segm) if use_segm_obj else segm
-
-        phot = aperture_photometry(data, aper, segmentation_image=segm_in,
-                                   labels=[1], mask_method='mask')
-        manual_mask = (segm > 0) & (segm != 1)
-        ref = aperture_photometry(data, aper, mask=manual_mask)
-        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
-
-    def test_source_only_matches_manual(self):
-        data, segm = make_scene()
-        aper = CircularAperture([(21, 21)], r=8)
-        phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                   labels=[1],
-                                   mask_method='source_only')
-        manual_mask = segm != 1
-        ref = aperture_photometry(data, aper, mask=manual_mask)
-        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
-
-    def test_none_method_ignores_segmentation(self):
-        data, segm = make_scene()
-        aper = CircularAperture([(21, 21)], r=8)
-        phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                   mask_method='none')
-        ref = aperture_photometry(data, aper)
-        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
-
-    def test_missing_segmentation_raises(self):
-        data, _ = make_scene()
-        aper = CircularAperture([(21, 21)], r=8)
-        match = 'segmentation_image must be input'
-        with pytest.raises(ValueError, match=match):
-            aperture_photometry(data, aper, mask_method='mask')
-
-    def test_mask_excludes_neighbor_flux(self):
-        data, segm = make_scene()
-        aper = CircularAperture([(21, 21)], r=10)
-        none_phot = aperture_photometry(data, aper,
-                                        mask_method='none')
-        mask_phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                        labels=[1], mask_method='mask')
-        # Masking the bright neighbor reduces the sum
-        assert mask_phot['aperture_sum'][0] < none_phot['aperture_sum'][0]
-
-    def test_label0_disables_masking(self):
-        data, segm = make_scene()
-        aper = CircularAperture([(21, 21)], r=8)
-        phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                   labels=[0], mask_method='mask')
-        ref = aperture_photometry(data, aper)
-        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
-
-    def test_correct_matches_mask_path(self):
-        # The 'correct' method uses the Cython batch driver for circular
-        # apertures. Verify it exactly matches the Python mask code path
-        # and differs from 'none' for a scene with a neighbor.
-        data, segm = make_scene()
-        error = np.ones_like(data) * 2.0
-        mask = np.zeros(data.shape, dtype=bool)
-        mask[22, 30] = True
-        aper = CircularAperture([(21, 21)], r=10)
-        none_phot = aperture_photometry(data, aper,
-                                        mask_method='none')
-
-        labels = [1]
-        batch = aper._photometry(
-            data, error=error, mask=mask, segmentation_image=segm,
-            labels=labels, mask_method='correct')
-        mask_sum, mask_err, _area, *_ = aper._mask_photometry(
-            data, error=error, mask=mask, method='exact', subpixels=5,
-            segmentation=segm.astype(np.intp), labels=labels,
-            mask_method='correct')
-        assert_allclose(batch.flux, mask_sum, rtol=1e-12)
-        assert_allclose(batch.flux_err, mask_err, rtol=1e-12)
-        assert batch.flux[0] != none_phot['aperture_sum'][0]
-
-    def test_polygon_mask_path(self):
-        # Polygon apertures have no batch driver, exercising the mask
-        # code path for segmentation masking.
-        data, segm = make_scene()
-        offsets = np.array([[-7, -7], [9, -7], [9, 9], [-7, 9]])
-        aper = PolygonAperture((21, 21), offsets)
-        phot = aperture_photometry(data, aper, segmentation_image=segm,
-                                   labels=[1], mask_method='mask')
-        manual_mask = (segm > 0) & (segm != 1)
-        ref = aperture_photometry(data, aper, mask=manual_mask)
-        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
-
-    def test_with_error(self):
-        data, segm = make_scene()
-        error = np.ones_like(data) * 2.0
-        aper = CircularAperture([(21, 21)], r=8)
-        phot = aperture_photometry(data, aper, error=error,
-                                   segmentation_image=segm, labels=[1],
-                                   mask_method='mask')
-        manual_mask = (segm > 0) & (segm != 1)
-        ref = aperture_photometry(data, aper, error=error, mask=manual_mask)
-        assert_allclose(phot['aperture_sum'], ref['aperture_sum'])
-        assert_allclose(phot['aperture_sum_err'], ref['aperture_sum_err'])
-
-    def test_with_units(self):
-        data, segm = make_scene()
-        unit = u.Jy
-        aper = CircularAperture([(21, 21)], r=8)
-        phot = aperture_photometry(data * unit, aper,
-                                   segmentation_image=segm, labels=[1],
-                                   mask_method='mask')
-        manual_mask = (segm > 0) & (segm != 1)
-        ref = aperture_photometry(data * unit, aper, mask=manual_mask)
-        assert_allclose(phot['aperture_sum'].value, ref['aperture_sum'].value)
-        assert phot['aperture_sum'].unit == unit
-
-    def test_labels_required(self):
-        data, segm = make_scene()
-        aper = CircularAperture([(21, 21)], r=8)
-        match = 'labels must be input when segmentation_image is input'
-        with pytest.raises(ValueError, match=match):
-            aperture_photometry(data, aper, segmentation_image=segm,
-                                mask_method='mask')
-
-
-class TestPhotometry:
     def test_batch_matches_mask_path(self):
         """
         Test that the batch driver for circular apertures matches the
@@ -263,9 +134,9 @@ class TestApertureStats:
         if method != 'none':
             kwargs = {'segmentation_image': segm, 'labels': [1, 2],
                       'mask_method': method}
-        phot = aperture_photometry(data, aper, **kwargs)
+        phot = AperturePhotometry(data, aper, **kwargs)
         stats = ApertureStats(data, aper, **kwargs)
-        assert_allclose(stats.sum, phot['aperture_sum'], rtol=1e-10)
+        assert_allclose(stats.sum, phot.flux, rtol=1e-10)
 
     def test_slicing_preserves_labels(self):
         data, segm = make_scene()

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Tests for segmentation-based masking of aperture photometry, shared
-by `aperture_photometry`, `PixelAperture.photometry`, and
+by `aperture_photometry`, `PixelAperture._photometry`, and
 `ApertureStats`.
 """
 
@@ -15,7 +15,8 @@ from photutils.aperture._batch_photometry import (SHAPE_CIRCLE,
 from photutils.aperture._segmentation import (make_segmentation_exclusion,
                                               process_segmentation_inputs)
 from photutils.aperture.circle import CircularAperture
-from photutils.aperture.photometry import aperture_photometry
+from photutils.aperture.photometry import (AperturePhotometry,
+                                           aperture_photometry)
 from photutils.aperture.polygon import PolygonAperture
 from photutils.aperture.stats import ApertureStats
 from photutils.segmentation import SegmentationImage
@@ -177,16 +178,16 @@ class TestAperturePhotometry:
                                         mask_method='none')
 
         labels = [1]
-        batch_sum, batch_err = aper.photometry(
+        batch = aper._photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
         mask_sum, mask_err, _area, *_ = aper._mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm.astype(np.intp), labels=labels,
             mask_method='correct')
-        assert_allclose(batch_sum, mask_sum, rtol=1e-12)
-        assert_allclose(batch_err, mask_err, rtol=1e-12)
-        assert batch_sum[0] != none_phot['aperture_sum'][0]
+        assert_allclose(batch.flux, mask_sum, rtol=1e-12)
+        assert_allclose(batch.flux_err, mask_err, rtol=1e-12)
+        assert batch.flux[0] != none_phot['aperture_sum'][0]
 
     def test_polygon_mask_path(self):
         # Polygon apertures have no batch driver, exercising the mask
@@ -242,14 +243,14 @@ class TestPhotometry:
         data, segm = make_scene()
         aper = CircularAperture([(21, 21), (28, 22)], r=6)
         labels = [1, 2]
-        sums, _ = aper.photometry(data, segmentation_image=segm,
-                                  labels=labels,
-                                  mask_method='mask')
+        result = AperturePhotometry(data, aper, segmentation_image=segm,
+                                    labels=labels, mask_method='mask')
         for idx, label in enumerate(labels):
             manual_mask = (segm > 0) & (segm != label)
-            ref, _ = CircularAperture(aper.positions[idx], r=6).photometry(
-                data, mask=manual_mask)
-            assert_allclose(sums[idx], ref[0])
+            ref = AperturePhotometry(
+                data, CircularAperture(aper.positions[idx], r=6),
+                mask=manual_mask)
+            assert_allclose(result.flux[idx], ref.flux[0])
 
 
 class TestApertureStats:
@@ -468,12 +469,12 @@ class TestBatchDriverSegmentation:
         aper = CircularAperture(positions, r=8)
         labels = np.array([1], dtype=np.intp)
 
-        batch_sum, batch_err = aper.photometry(
+        batch = aper._photometry(
             data, error=error, mask=mask, segmentation_image=segm,
             labels=labels, mask_method='correct')
         mask_sum, mask_err, _area, *_ = aper._mask_photometry(
             data, error=error, mask=mask, method='exact', subpixels=5,
             segmentation=segm, labels=labels,
             mask_method='correct')
-        assert_allclose(batch_sum, mask_sum, rtol=1e-12)
-        assert_allclose(batch_err, mask_err, rtol=1e-12)
+        assert_allclose(batch.flux, mask_sum, rtol=1e-12)
+        assert_allclose(batch.flux_err, mask_err, rtol=1e-12)

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -19,6 +19,7 @@ from photutils.aperture.circle import CircularAnnulus, CircularAperture
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus)
 from photutils.aperture.flags import APERTURE_FLAGS
+from photutils.aperture.photometry import AperturePhotometry
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture)
 from photutils.aperture.stats import _MAD_STD_SCALE, ApertureStats
@@ -177,12 +178,11 @@ class TestApertureStats:
             apstats = ApertureStats(self.data, self.aperture,
                                     error=self.error, sum_method=method,
                                     subpixels=subpixels)
-            apsum, apsum_err = self.aperture.photometry(self.data,
-                                                        error=self.error,
-                                                        method=method,
-                                                        subpixels=subpixels)
-            assert_allclose(apstats.sum, apsum)
-            assert_allclose(apstats.sum_err, apsum_err)
+            phot = AperturePhotometry(self.data, self.aperture,
+                                      error=self.error, method=method,
+                                      subpixels=subpixels)
+            assert_allclose(apstats.sum, phot.flux)
+            assert_allclose(apstats.sum_err, phot.flux_err)
 
     def test_mask(self):
         mask = np.zeros(self.data.shape, dtype=bool)

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -11,6 +11,7 @@ from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture.core import _update_method_subpixels_docstring
+from photutils.aperture.photometry import AperturePhotometry
 from photutils.utils._deprecation import deprecated_positional_kwargs
 from photutils.utils._quantity_helpers import process_quantities
 from photutils.utils._stats import nanmax, nansum
@@ -193,9 +194,10 @@ class ProfileBase(metaclass=abc.ABCMeta):
                 flux, flux_err = [0.0], [0.0]
                 area = 0.0
             else:
-                flux, flux_err = aperture.photometry(
-                    self.data, error=self.error, mask=self.mask,
+                result = AperturePhotometry(
+                    self.data, aperture, error=self.error, mask=self.mask,
                     method=self.method, subpixels=self.subpixels)
+                flux, flux_err = result.flux, result.flux_err
                 area = aperture.area_overlap(self.data, mask=self.mask,
                                              method=self.method,
                                              subpixels=self.subpixels)

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -21,7 +21,7 @@ from astropy.table import QTable, Table, hstack, join
 from astropy.utils import minversion
 from astropy.utils.exceptions import AstropyUserWarning
 
-from photutils.aperture import CircularAperture
+from photutils.aperture import AperturePhotometry, CircularAperture
 from photutils.datasets import make_model_image as _make_model_image
 from photutils.utils._deprecation import DeprecatedColumnQTable
 from photutils.utils._misc import _get_meta
@@ -481,8 +481,7 @@ class PSFDataProcessor:
         y_pos = init_params[self.param_mapper.init_colnames['y']]
         apertures = CircularAperture(zip(x_pos, y_pos, strict=True),
                                      r=self.aperture_radius)
-        flux, _ = apertures.photometry(data, mask=mask)
-        return flux
+        return AperturePhotometry(data, apertures, mask=mask).flux
 
     def find_sources_if_needed(self, data, mask, init_params):
         """

--- a/photutils/psf/flags.py
+++ b/photutils/psf/flags.py
@@ -194,12 +194,14 @@ def decode_psf_flags(flags, return_bit_values=False):
 
     Returns
     -------
-    decoded : list of str, list of int, list of list of str, or \
-            list of list of int
-        List of active flag names (or bit values), or list of lists
-        if input is an array. Each string (or integer) represents a
-        specific condition that was detected during PSF fitting. If no
-        flags are set, an empty list is returned. Possible flags are:
+    decoded : list of str, list of int, or nested list
+        List of active flag names (or bit values) for a scalar input.
+        For an array input, a nested list with the same shape as the
+        input is returned, where each innermost element is the list of
+        active flag names (or bit values) for the corresponding flag.
+        Each string (or integer) represents a specific condition that
+        was detected during PSF fitting. If no flags are set, an empty
+        list is returned. Possible flags are:
         <flag_descriptions>
 
     Examples

--- a/photutils/psf/tests/test_flags.py
+++ b/photutils/psf/tests/test_flags.py
@@ -185,14 +185,14 @@ def test_decode_psf_flags_edge_cases():
     decoded = decode_psf_flags(empty_array)
     assert decoded == []
 
-    # Test with 2D array (should flatten)
+    # Test with 2D array (shape preserved as nested lists)
     flag_2d = np.array([[0, 1], [8, 136]])
     decoded = decode_psf_flags(flag_2d)
-    assert len(decoded) == 4  # Flattened to 4 elements
-    assert decoded[0] == []
-    assert decoded[1] == ['n_pixels_fit_partial']
-    assert decoded[2] == ['no_convergence']
-    assert set(decoded[3]) == {'no_convergence', 'fully_masked'}
+    assert len(decoded) == 2  # Shape preserved
+    assert decoded[0][0] == []
+    assert decoded[0][1] == ['n_pixels_fit_partial']
+    assert decoded[1][0] == ['no_convergence']
+    assert set(decoded[1][1]) == {'no_convergence', 'fully_masked'}
 
 
 def test_psf_flags_singleton():

--- a/photutils/utils/_flags.py
+++ b/photutils/utils/_flags.py
@@ -134,7 +134,9 @@ class FlagRegistry:
         KeyError
             If the identifier is not found.
         """
-        if isinstance(identifier, int):
+        if isinstance(identifier, (int, np.integer)) and not isinstance(
+                identifier, bool):
+            identifier = int(identifier)
             if identifier not in self._bit_to_def:
                 msg = f'No flag with bit value {identifier}'
                 raise KeyError(msg)
@@ -325,8 +327,10 @@ def decode_flags(flags, registry, *, return_bit_values=False):
     Returns
     -------
     decoded : list
-        List of active flag names (or bit values), or list of lists
-        if the input is an array.
+        List of active flag names (or bit values) for a scalar input.
+        For an array input, a nested list with the same shape as the
+        input is returned, where each innermost element is the list of
+        active flag names (or bit values) for the corresponding flag.
     """
     flag_definitions = registry.flag_dict
 
@@ -351,6 +355,15 @@ def decode_flags(flags, registry, *, return_bit_values=False):
                     active_flags.append(name)
         return active_flags
 
+    def _decode_array(arr):
+        """
+        Recursively decode an array, preserving its shape as nested
+        lists.
+        """
+        if arr.ndim == 1:
+            return [_decode_single_flag(flag) for flag in arr]
+        return [_decode_array(sub) for sub in arr]
+
     # Handle both single values and arrays
     if np.isscalar(flags):
         return _decode_single_flag(flags)
@@ -361,5 +374,5 @@ def decode_flags(flags, registry, *, return_bit_values=False):
         # Handle 0D arrays (scalar arrays)
         return _decode_single_flag(flags_array.item())
 
-    # Handle 1D or higher dimensional arrays
-    return [_decode_single_flag(flag) for flag in flags_array.flat]
+    # Handle 1D or higher dimensional arrays, preserving shape
+    return _decode_array(flags_array)

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -302,7 +302,7 @@ class ImageDepth:
             calculated from the flux limit and the input ``zeropoint``.
         """
         # Prevent circular import
-        from photutils.aperture import CircularAperture
+        from photutils.aperture import AperturePhotometry, CircularAperture
 
         if mask is None or not np.any(mask):
             all_xycoords = self._make_all_coords_no_mask(data.shape)
@@ -341,7 +341,7 @@ class ImageDepth:
 
             apers = CircularAperture(xycoords, r=self.aper_radius)
             apertures.append(apers)
-            fluxes, _ = apers.photometry(data)
+            fluxes = AperturePhotometry(data, apers).flux
             if self.sigma_clip is not None:
                 fluxes = self.sigma_clip(fluxes, masked=False)  # ndarray
             self.fluxes.append(fluxes)


### PR DESCRIPTION
This PR adds a new ``AperturePhotometry`` class, which is now the recommended tool for aperture photometry. It uses a results-object pattern, similar to ``ApertureStats``.  This class includes calculating the unmasked aperture area, bitwise quality flags, and enables segmentation masking.

The `aperture_photometry` class is unchanged and is now considered a legacy function. It is not deprecated.