### PR TITLE
Add validation of columns in to_table methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3442,10 +3442,6 @@ New Features
   - Significantly improved the performance of calculating the
     ``background_at_centroid`` property in ``SourceCatalog``. [#863]
 
-  - The default output table columns (source properties) are defined
-    in a publicly-accessible variable called
-    ``photutils.segmentation.properties.DEFAULT_COLUMNS``. [#863]
-
   - Added the ``gini`` source property representing the Gini
     coefficient. [#864]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,17 @@ New Features
     ``decode_aperture_flags`` function decodes the flag values into
     human-readable names. [#2327, #2328]
 
+  - Added validation of the ``ApertureStats.to_table()`` ``columns``
+    keyword. [#2329]
+
+- ``photutils.detection``
+
+  - Added validation of the ``StarFinderCatalogBase.to_table()``
+    ``columns`` keyword. This is the base class used by the
+    ``DAOStarFinder``, ``IRAFStarFinder``, and ``StarFinder`` catalogs.
+    The ``columns`` keyword now accepts a single string in addition to a
+    list of column names. [#2329]
+
 - ``photutils.isophote``
 
   - Optimized the ``build_ellipse_model_c`` Cython extension by
@@ -96,11 +107,20 @@ New Features
     branch for harmonic corrections. The module is now also marked as
     ``freethreading_compatible=True``. [#2293]
 
+  - Added validation of the ``IsophoteList.to_table()`` ``columns``
+    keyword. Also restored the ``npix_e`` and ``npix_c`` properties to
+    the ``columns='all'`` output. [#2329]
+
 - ``photutils.psf``
 
   - Improved ``GriddedPSFModel`` evaluation performance by ~20-25%
     through optimizations that reduce per-evaluation overhead and
     streamline interpolation calculations. [#2289, #2307]
+
+- ``photutils.segmentation``
+
+  - Added validation of the ``SourceCatalog.to_table()`` ``columns``
+    keyword. [#2329]
 
 
 Bug Fixes

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -20,6 +20,7 @@ from photutils.aperture.flags import decode_aperture_flags
 from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_positional_kwargs)
 from photutils.utils._misc import _get_meta
+from photutils.utils._parameters import validate_table_columns
 from photutils.utils._quantity_helpers import process_quantities
 from photutils.utils._repr import make_repr
 
@@ -439,22 +440,18 @@ class AperturePhotometry:
         table : `~astropy.table.QTable`
             A table of the aperture photometry results with one row per
             aperture position.
-        """
-        if columns is None:
-            table_columns = self.default_columns
-        elif isinstance(columns, str):
-            table_columns = [columns]
-        else:
-            table_columns = columns
 
+        Raises
+        ------
+        ValueError
+            If any name in ``columns`` is not a valid column name.
+        """
         allowed_columns = ('id', 'x_center', 'y_center', 'sky_center',
                            'flux', 'flux_err', 'area', 'flags')
-        invalid = [col for col in table_columns
-                   if col not in allowed_columns]
-        if invalid:
-            msg = (f'Invalid column name(s): {invalid!r}. The allowed '
-                   f'column names are: {", ".join(allowed_columns)}')
-            raise ValueError(msg)
+        if columns is None:
+            table_columns = self.default_columns
+        else:
+            table_columns = validate_table_columns(columns, allowed_columns)
 
         tbl = QTable()
         tbl.meta.update(self.meta)

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -45,6 +45,7 @@ from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_positional_kwargs)
 from photutils.utils._misc import _get_meta
 from photutils.utils._moments import _image_moments
+from photutils.utils._parameters import validate_table_columns
 from photutils.utils._quantity_helpers import process_quantities
 
 __all__ = ['ApertureStats']
@@ -485,6 +486,11 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         lazyproperties = [name for name in self._lazyproperties if not
                           name.startswith('_')]
+        # isscalar and n_apertures are scalar values for the whole
+        # object, not per-source values, so they are not valid table
+        # columns
+        lazyproperties.remove('isscalar')
+        lazyproperties.remove('n_apertures')
         lazyproperties.sort()
         return lazyproperties
 
@@ -702,13 +708,22 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
         -------
         table : `~astropy.table.QTable`
             A table of sources properties with one row per source.
+
+        Raises
+        ------
+        ValueError
+            If any name in ``columns`` is not a valid (or deprecated)
+            column name.
         """
         if columns is None:
             table_columns = self.default_columns
-        elif isinstance(columns, str):
-            table_columns = [columns]
         else:
-            table_columns = columns
+            # id is not included in self.properties because it is not
+            # a lazyproperty
+            allowed_columns = set(self.properties) | set(self.default_columns)
+            table_columns = validate_table_columns(
+                columns, allowed_columns,
+                deprecated_names=_DEPRECATED_ATTRIBUTES)
 
         # Replace with QTable in 4.0
         tbl = create_empty_deprecated_qtable(
@@ -739,7 +754,12 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             values_map[column] = values
 
         for column in table_columns:
-            tbl[column] = values_map[column]
+            # Use the canonical (non-deprecated) column name so that
+            # assigning into ``tbl`` does not trigger a second,
+            # redundant deprecation warning (the deprecated attribute
+            # access above already warned once).
+            canonical_column = _DEPRECATED_ATTRIBUTES.get(column, column)
+            tbl[canonical_column] = values_map[column]
         return tbl
 
     @lazyproperty

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -58,15 +58,6 @@ __all__ = ['ApertureStats']
 _MAD_STD_SCALE = 1.482602218505602
 
 
-# Default table columns for `to_table()` output
-DEFAULT_COLUMNS = ['id', 'x_centroid', 'y_centroid', 'sky_centroid',
-                   'sum', 'sum_err', 'sum_aper_area', 'sum_flags',
-                   'center_aper_area', 'min', 'max', 'mean', 'median',
-                   'mode', 'std', 'mad_std', 'var', 'biweight_location',
-                   'biweight_midvariance', 'fwhm', 'semimajor_axis',
-                   'semiminor_axis', 'orientation', 'eccentricity',
-                   'flags']
-
 # Remove in 4.0
 _DEPRECATED_ATTRIBUTES: dict = {
     'covar_sigx2': 'covariance_xx',
@@ -134,7 +125,8 @@ class _UncachedLazyProperty(lazyproperty):
 
 
 @_update_method_subpixels_docstring
-class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
+class ApertureStats:
+    # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Class to create a catalog of statistics for pixels within an
     aperture.
@@ -395,7 +387,15 @@ class ApertureStats:  # numpydoc ignore: PR01,PR02,PR04,PR07
             self._local_bkg = local_bkg  # always an iterable
 
         self._ids = np.arange(self.n_apertures) + 1
-        self.default_columns = DEFAULT_COLUMNS
+        self.default_columns = ['id', 'x_centroid', 'y_centroid',
+                                'sky_centroid', 'sum', 'sum_err',
+                                'sum_aper_area', 'sum_flags',
+                                'center_aper_area', 'min', 'max', 'mean',
+                                'median', 'mode', 'std', 'mad_std', 'var',
+                                'biweight_location', 'biweight_midvariance',
+                                'fwhm', 'semimajor_axis', 'semiminor_axis',
+                                'orientation', 'eccentricity', 'flags']
+
         self.meta = _get_meta()
         self.meta.update(aperture_meta)
 

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -281,6 +281,37 @@ class TestApertureStats:
         assert tbl.colnames == ['sum']
         assert len(tbl) == len(self.apstats1) == 3
 
+    @pytest.mark.parametrize('columns', ['invalid',
+                                         'sum_method',
+                                         'isscalar',
+                                         'n_apertures',
+                                         ['id', 'subpixels']])
+    def test_invalid_column(self, columns):
+        match = 'Invalid column name'
+        with pytest.raises(ValueError, match=match):
+            self.apstats1.to_table(columns=columns)
+
+    def test_properties_excludes_scalar_attrs(self):
+        """
+        Regression test to ensure that ``isscalar`` and ``n_apertures``
+        (scalar values for the whole object, not per-source values) are
+        not included in ``properties`` and so are not valid ``to_table``
+        columns.
+        """
+        assert 'isscalar' not in self.apstats1.properties
+        assert 'n_apertures' not in self.apstats1.properties
+
+    def test_deprecated_column(self):
+        """
+        Regression test to ensure that deprecated column names are still
+        accepted by ``to_table``, not rejected by the new column-name
+        validation.
+        """
+        match = "'xcentroid' attribute was deprecated"
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            tbl = self.apstats1.to_table(columns='xcentroid')
+        assert tbl.colnames == ['x_centroid']
+
     def test_slicing(self):
         apstats = self.apstats1
         _ = apstats.to_table()

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -24,6 +24,7 @@ from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
 from photutils.utils._misc import _get_meta
+from photutils.utils._parameters import validate_table_columns
 from photutils.utils._quantity_helpers import check_units
 from photutils.utils._repr import make_repr
 from photutils.utils.cutouts import _make_cutouts
@@ -340,6 +341,19 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
                     [i[0] for i in inspect.getmembers(
                         cls, predicate=islazyproperty)])
         return getattr(cls, attr)
+
+    @property
+    def _properties(self):
+        """
+        A sorted list of the built-in source properties.
+        """
+        lazyproperties = [name for name in self._lazyproperties if not
+                          name.startswith('_')]
+        # isscalar is a scalar value for the whole object, not a
+        # per-source value, so it is not a valid table column
+        lazyproperties.remove('isscalar')
+        lazyproperties.sort()
+        return lazyproperties
 
     @lazyproperty
     def isscalar(self):
@@ -685,14 +699,20 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        columns : list of str, optional
-            List of column names to include in the table. If `None`,
+        columns : str or list of str, optional
+            Names of column(s) to include in the table. If `None`,
             uses ``self.default_columns``.
 
         Returns
         -------
         table : `~astropy.table.QTable`
             A table of the catalog properties.
+
+        Raises
+        ------
+        ValueError
+            If any name in ``columns`` is not a valid (or deprecated)
+            column name.
         """
         # Replace with QTable in 4.0
         table = create_empty_deprecated_qtable(
@@ -705,9 +725,25 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
                        'pass explicit column names or set '
                        'default_columns in the subclass __init__')
                 raise AttributeError(msg)
-            columns = self.default_columns
-        for column in columns:
-            table[column] = getattr(self, column)
+            table_columns = list(self.default_columns)
+        else:
+            # id is not included in self._properties because it is
+            # not a lazyproperty
+            allowed_columns = (set(self._properties) | {'id'}
+                               | set(self.default_columns))
+            table_columns = validate_table_columns(
+                columns, allowed_columns,
+                deprecated_names=_DEPRECATED_ATTRIBUTES)
+
+        for column in table_columns:
+            values = getattr(self, column)
+
+            # Use the canonical (non-deprecated) column name so that
+            # assigning into ``table`` does not trigger a second,
+            # redundant deprecation warning (the deprecated attribute
+            # access above already warned once).
+            canonical_column = _DEPRECATED_ATTRIBUTES.get(column, column)
+            table[canonical_column] = values
         return table
 
 

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -5,6 +5,7 @@ Tests for the photutils.detection.core module.
 
 import numpy as np
 import pytest
+from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.detection import DAOStarFinder
@@ -189,11 +190,11 @@ def _make_minimal_catalog_class():
 
     class _MinimalCatalog(StarFinderCatalogBase):
 
-        @property
+        @lazyproperty
         def x_centroid(self):
             return self.cutout_x_centroid
 
-        @property
+        @lazyproperty
         def y_centroid(self):
             return self.cutout_y_centroid
 
@@ -271,6 +272,81 @@ class TestStarFinderCatalogBase:
         tbl = cat.to_table(columns=columns)
         assert len(tbl) == 1
         assert tbl.colnames == list(columns)
+
+    def test_to_table_invalid_column(self, minimal_catalog_cls):
+        """
+        Regression test for invalid column names not being validated
+        in to_table (e.g., ``data`` is an attribute, but not a valid
+        column name).
+        """
+        data = np.zeros((11, 11))
+        data[5, 5] = 10.0
+        kernel = np.ones((3, 3))
+        xypos = np.array([[5, 5]])
+        cat = minimal_catalog_cls(data, xypos, kernel)
+        match = 'Invalid column name'
+        with pytest.raises(ValueError, match=match):
+            cat.to_table(columns=('id', 'data'))
+
+    def test_to_table_scalar_column(self, minimal_catalog_cls):
+        """
+        Regression test to ensure that ``isscalar`` (a scalar value
+        for the whole object, not a per-source value) is not a valid
+        ``to_table`` column.
+        """
+        data = np.zeros((11, 11))
+        data[5, 5] = 10.0
+        kernel = np.ones((3, 3))
+        xypos = np.array([[5, 5]])
+        cat = minimal_catalog_cls(data, xypos, kernel)
+        match = 'Invalid column name'
+        with pytest.raises(ValueError, match=match):
+            cat.to_table(columns='isscalar')
+
+    def test_to_table_deprecated_column(self, minimal_catalog_cls):
+        """
+        Regression test to ensure that deprecated column names are still
+        accepted by ``to_table``, not rejected by the new column-name
+        validation.
+        """
+        data = np.zeros((11, 11))
+        data[5, 5] = 10.0
+        kernel = np.ones((3, 3))
+        xypos = np.array([[5, 5]])
+        cat = minimal_catalog_cls(data, xypos, kernel)
+        match = "'xcentroid' attribute was deprecated"
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            tbl = cat.to_table(columns='xcentroid')
+        assert tbl.colnames == ['x_centroid']
+
+    def test_to_table_str_column(self, minimal_catalog_cls):
+        """
+        Regression test to ensure that a single string column name (not
+        wrapped in a list) is accepted by ``to_table``.
+        """
+        data = np.zeros((11, 11))
+        data[5, 5] = 10.0
+        kernel = np.ones((3, 3))
+        xypos = np.array([[5, 5]])
+        cat = minimal_catalog_cls(data, xypos, kernel)
+        tbl = cat.to_table(columns='id')
+        assert tbl.colnames == ['id']
+
+    def test_properties(self, minimal_catalog_cls):
+        """
+        Test that the _properties attribute returns a sorted list of
+        lazyproperty names.
+        """
+        data = np.zeros((11, 11))
+        data[5, 5] = 10.0
+        kernel = np.ones((3, 3))
+        xypos = np.array([[5, 5]])
+        cat = minimal_catalog_cls(data, xypos, kernel)
+        assert cat._properties == sorted(cat._properties)
+        assert 'x_centroid' in cat._properties
+        assert 'y_centroid' in cat._properties
+        assert 'data' not in cat._properties
+        assert 'isscalar' not in cat._properties
 
     def test_getitem_integer_index(self, minimal_catalog_cls):
         """

--- a/photutils/isophote/isophote.py
+++ b/photutils/isophote/isophote.py
@@ -13,6 +13,7 @@ from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_getattr,
                                           deprecated_positional_kwargs)
 from photutils.utils._misc import _get_meta
+from photutils.utils._parameters import validate_table_columns
 
 __all__ = ['Isophote', 'IsophoteList']
 
@@ -943,17 +944,45 @@ def _get_properties(isophote_list):
     result : dict
         An dictionary with the list of the isophote_list properties.
     """
-    # deprecated IsophoteList property names to exclude
-    _deprecated_props = {'npix_e', 'npix_c'}
-
     properties = {}
     for an_item in isophote_list.__class__.__dict__:
         p_type = isophote_list.__class__.__dict__[an_item]
-        # Exclude the sample property and deprecated properties
-        if (isinstance(p_type, property) and 'sample' not in an_item
-                and an_item not in _deprecated_props):
+        # Exclude the sample property
+        if isinstance(p_type, property) and 'sample' not in an_item:
             properties[str(an_item)] = str(an_item)
     return properties
+
+
+# The "main" isophote_list properties included in to_table() by default.
+_MAIN_PROPERTIES = ('sma', 'intens', 'int_err', 'eps', 'ellip_err',
+                    'pa', 'pa_err', 'grad', 'gradient_err',
+                    'gradient_rel_err', 'x0', 'x0_err', 'y0', 'y0_err',
+                    'n_data', 'n_flag', 'n_iter', 'stop_code')
+
+# Isophote_list property names renamed for their to_table() column names.
+_RENAME_MAP = {
+    'int_err': 'intens_err',
+    'eps': 'ellipticity',
+    'ellip_err': 'ellipticity_err',
+}
+
+
+def _rename_properties(names):
+    """
+    Map isophote_list property names to their to_table() column names.
+
+    Parameters
+    ----------
+    names : iterable of str
+        The isophote_list property names.
+
+    Returns
+    -------
+    properties : dict
+        A dictionary mapping each property name to its (possibly
+        renamed) table column name.
+    """
+    return {name: _RENAME_MAP.get(name, name) for name in names}
 
 
 def _isophote_list_to_table(isophote_list, *, columns='main'):
@@ -976,14 +1005,19 @@ def _isophote_list_to_table(isophote_list, *, columns='main'):
     -------
     result : `~astropy.table.QTable`
         An astropy QTable with the selected or all isophote parameters.
-    """
-    properties = {}
 
-    # Remove in 4.0
-    _deprecation_map = {
-        'grad_error': 'gradient_err',
-        'grad_rerror': 'gradient_rel_err',
-    }
+    Raises
+    ------
+    ValueError
+        If any name in ``columns`` is not a valid (or deprecated)
+        column name.
+    """
+    _deprecation_map = _DEPRECATED_ATTRIBUTES.copy()
+    all_names = _get_properties(isophote_list).keys()
+
+    allowed_columns = {*all_names, 'main', 'all'}
+    table_columns = validate_table_columns(
+        columns, allowed_columns, deprecated_names=_deprecation_map)
 
     # Replace with QTable in 4.0
     isotable = create_empty_deprecated_qtable(
@@ -991,58 +1025,17 @@ def _isophote_list_to_table(isophote_list, *, columns='main'):
 
     isotable.meta.update(_get_meta())  # keep isotable.meta type
 
-    # main_properties: `List`
-    # A list of main parameters matching the original names of
-    # the isophote_list parameters
-
-    def __rename_properties(properties, *,
-                            orig_names=('int_err', 'eps', 'ellip_err',
-                                        'n_flag'),
-                            new_names=('intens_err', 'ellipticity',
-                                       'ellipticity_err', 'n_flag')):
-        """
-        Simple renaming for some of the isophote_list parameters.
-
-        Parameters
-        ----------
-        properties : dict
-            A dictionary with the list of the isophote_list parameters.
-
-        orig_names : list
-            A list of original names in the isophote_list parameters to
-            be renamed.
-
-        new_names : list
-            A list of new names matching in length of the orig_names.
-
-        Returns
-        -------
-        properties : dict
-            A dictionary with the list of the renamed isophote_list
-            parameters.
-        """
-        main_properties = ['sma', 'intens', 'int_err', 'eps', 'ellip_err',
-                           'pa', 'pa_err', 'grad', 'gradient_err',
-                           'gradient_rel_err', 'x0', 'x0_err', 'y0',
-                           'y0_err', 'n_data', 'n_flag', 'n_iter',
-                           'stop_code']
-
-        for an_item in main_properties:
-            if an_item in orig_names:
-                properties[an_item] = new_names[orig_names.index(an_item)]
-            else:
-                properties[an_item] = an_item
-        return properties
-
-    if columns == 'all':
-        properties = _get_properties(isophote_list)
-        properties = __rename_properties(properties)
-
-    elif columns == 'main':
-        properties = __rename_properties(properties)
+    if table_columns == ['all']:
+        properties = _rename_properties(all_names)
+    elif table_columns == ['main']:
+        properties = _rename_properties(_MAIN_PROPERTIES)
     else:
-        for an_item in columns:
-            properties[an_item] = an_item
+        # Use the canonical (non-deprecated) column name so that
+        # assigning into ``isotable`` does not trigger a second,
+        # redundant deprecation warning (the deprecated attribute access
+        # below already warns once).
+        properties = {name: _deprecation_map.get(name, name)
+                      for name in table_columns}
 
     for k, v in properties.items():
         isotable[v] = np.array([getattr(iso, k) for iso in isophote_list])

--- a/photutils/isophote/tests/test_isophote.py
+++ b/photutils/isophote/tests/test_isophote.py
@@ -6,6 +6,7 @@ Tests for the isophote module.
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 
 from photutils.datasets.load import _get_path
@@ -311,3 +312,33 @@ class TestIsophoteList:
         tbl = isolist.to_table(columns=['tflux_e', 'tflux_c', 'npix_e',
                                         'npix_c'])
         assert len(tbl.colnames) == 4
+
+    @pytest.mark.parametrize('columns', ['invalid', 'append',
+                                         ['id', 'n_iter']])
+    def test_invalid_column(self, columns):
+        test_img = make_test_image(nx=55, ny=55, x0=27, y0=27,
+                                   background=100.0, noise=1.0e-6, i0=100.0,
+                                   sma=10.0, eps=0.2, pa=0.0, seed=1)
+        g = EllipseGeometry(27, 27, 5, 0.2, 0)
+        ellipse = Ellipse(test_img, geometry=g, threshold=0.1)
+        isolist = ellipse.fit_image(maxsma=27)
+        match = 'Invalid column name'
+        with pytest.raises(ValueError, match=match):
+            isolist.to_table(columns=columns)
+
+    def test_deprecated_column(self):
+        """
+        Regression test to ensure that deprecated column names are still
+        accepted by ``to_table``, not rejected by the new column-name
+        validation.
+        """
+        test_img = make_test_image(nx=55, ny=55, x0=27, y0=27,
+                                   background=100.0, noise=1.0e-6, i0=100.0,
+                                   sma=10.0, eps=0.2, pa=0.0, seed=1)
+        g = EllipseGeometry(27, 27, 5, 0.2, 0)
+        ellipse = Ellipse(test_img, geometry=g, threshold=0.1)
+        isolist = ellipse.fit_image(maxsma=27)
+        match = "'grad_error' attribute was deprecated"
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            tbl = isolist.to_table(columns=['grad_error'])
+        assert tbl.colnames == ['gradient_err']

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -37,13 +37,6 @@ from photutils.utils.cutouts import CutoutImage
 __all__ = ['SourceCatalog']
 
 
-# Default table columns for `to_table()` output
-DEFAULT_COLUMNS = ['label', 'x_centroid', 'y_centroid', 'sky_centroid',
-                   'bbox_xmin', 'bbox_xmax', 'bbox_ymin', 'bbox_ymax',
-                   'area', 'semimajor_axis', 'semiminor_axis', 'orientation',
-                   'eccentricity', 'min_value', 'max_value', 'segment_flux',
-                   'segment_flux_err', 'kron_flux', 'kron_flux_err']
-
 # Remove in 4.0
 _DEPRECATED_ATTRIBUTES = {
     'add_extra_property': 'add_property',
@@ -435,7 +428,15 @@ class SourceCatalog:
             'cen_win': {'method': 'center'},
         }
 
-        self.default_columns = DEFAULT_COLUMNS
+        self.default_columns = ['label', 'x_centroid', 'y_centroid',
+                                'sky_centroid', 'bbox_xmin', 'bbox_xmax',
+                                'bbox_ymin', 'bbox_ymax', 'area',
+                                'semimajor_axis', 'semiminor_axis',
+                                'orientation', 'eccentricity', 'min_value',
+                                'max_value', 'segment_flux',
+                                'segment_flux_err', 'kron_flux',
+                                'kron_flux_err']
+
         self._custom_properties = []
         self._flux_radius_cache = {}
         self.meta = _get_meta()

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -30,6 +30,7 @@ from photutils.utils._deprecation import (_get_future_column_names,
                                           deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
 from photutils.utils._misc import _get_meta
+from photutils.utils._parameters import validate_table_columns
 from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._quantity_helpers import process_quantities
 from photutils.utils.cutouts import CutoutImage
@@ -1142,13 +1143,21 @@ class SourceCatalog:
         -------
         table : `~astropy.table.QTable`
             A table of sources properties with one row per source.
+
+        Raises
+        ------
+        ValueError
+            If any name in ``columns`` is not a valid (or deprecated)
+            column name.
         """
         if columns is None:
             table_columns = self.default_columns
-        elif isinstance(columns, str):
-            table_columns = [columns]
         else:
-            table_columns = columns
+            allowed_columns = (set(self.properties)
+                               | set(self.custom_properties))
+            table_columns = validate_table_columns(
+                columns, allowed_columns,
+                deprecated_names=_DEPRECATED_ATTRIBUTES)
 
         # Replace with QTable() in 4.0
         tbl = create_empty_deprecated_qtable(
@@ -1162,7 +1171,12 @@ class SourceCatalog:
             if self.isscalar:
                 values = (values,)
 
-            tbl[column] = values
+            # Use the canonical (non-deprecated) column name so that
+            # assigning into ``tbl`` does not trigger a second,
+            # redundant deprecation warning (the deprecated attribute
+            # access above already warned once).
+            canonical_column = _DEPRECATED_ATTRIBUTES.get(column, column)
+            tbl[canonical_column] = values
         return tbl
 
     @lazyproperty

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -385,6 +385,25 @@ class TestSourceCatalog:
             assert isinstance(col, str)
             assert not isinstance(col, np.str_)
 
+    @pytest.mark.parametrize('columns', ['invalid',
+                                         'kron_params',
+                                         ['_mask', '_slices']])
+    def test_invalid_column(self, columns):
+        match = 'Invalid column name'
+        with pytest.raises(ValueError, match=match):
+            self.cat.to_table(columns=columns)
+
+    def test_deprecated_column(self):
+        """
+        Regression test to ensure that deprecated column names are still
+        accepted by ``to_table``, not rejected by the new column-name
+        validation.
+        """
+        match = "'xcentroid' attribute was deprecated"
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            tbl = self.cat.to_table(columns='xcentroid')
+        assert tbl.colnames == ['x_centroid']
+
     def test_invalid_inputs(self):
         """
         Test invalid inputs.

--- a/photutils/utils/_parameters.py
+++ b/photutils/utils/_parameters.py
@@ -143,3 +143,52 @@ def as_pair(name, value, *, lower_bound=None, upper_bound=None,
                           min(value[1], upper_bound[1])))
 
     return value
+
+
+def validate_table_columns(columns, allowed_columns, *,
+                           deprecated_names=None):
+    """
+    Validate requested ``to_table()`` column names.
+
+    This is a helper function for ``to_table`` methods that accept a
+    ``columns`` keyword. It normalizes ``columns`` to a list and raises
+    a `ValueError` if any requested name is not in ``allowed_columns``
+    or ``deprecated_names``.
+
+    Parameters
+    ----------
+    columns : str or list of str
+        The requested column name(s).
+
+    allowed_columns : iterable of str
+        The allowed column names.
+
+    deprecated_names : iterable of str, optional
+        Deprecated column names (e.g., the keys of a class's
+        ``_DEPRECATED_ATTRIBUTES`` mapping) that should still be
+        accepted in addition to ``allowed_columns``.
+
+    Returns
+    -------
+    table_columns : list of str
+        ``columns`` normalized to a list of strings.
+
+    Raises
+    ------
+    ValueError
+        If any name in ``columns`` is not an allowed or deprecated
+        column name.
+    """
+    table_columns = [columns] if isinstance(columns, str) else list(columns)
+
+    allowed = set(allowed_columns)
+    if deprecated_names is not None:
+        allowed |= set(deprecated_names)
+
+    invalid = [col for col in table_columns if col not in allowed]
+    if invalid:
+        msg = (f'Invalid column name(s): {invalid!r}. The allowed '
+               f'column names are: {", ".join(sorted(allowed))}.')
+        raise ValueError(msg)
+
+    return table_columns

--- a/photutils/utils/tests/test_parameters.py
+++ b/photutils/utils/tests/test_parameters.py
@@ -10,7 +10,8 @@ from astropy.stats import SigmaClip
 from numpy.testing import assert_equal
 
 from photutils.utils._parameters import (SigmaClipSentinelDefault, as_pair,
-                                         create_default_sigmaclip)
+                                         create_default_sigmaclip,
+                                         validate_table_columns)
 
 
 class TestAsPairBasic:
@@ -145,3 +146,41 @@ class TestCreateDefaultSigmaClip:
         assert isinstance(sc, SigmaClip)
         assert sc.sigma == 2.5
         assert sc.maxiters == 5
+
+
+class TestValidateTableColumns:
+    """
+    Tests for the ``validate_table_columns`` helper function.
+    """
+
+    def test_str_column(self):
+        result = validate_table_columns('a', ['a', 'b', 'c'])
+        assert result == ['a']
+
+    def test_list_column(self):
+        result = validate_table_columns(['a', 'c'], ['a', 'b', 'c'])
+        assert result == ['a', 'c']
+
+    def test_tuple_column(self):
+        result = validate_table_columns(('a', 'c'), ['a', 'b', 'c'])
+        assert result == ['a', 'c']
+
+    def test_invalid_column(self):
+        match = "Invalid column name\\(s\\): \\['invalid'\\]"
+        with pytest.raises(ValueError, match=match):
+            validate_table_columns(['a', 'invalid'], ['a', 'b', 'c'])
+
+    def test_deprecated_column_allowed(self):
+        result = validate_table_columns(
+            'old_name', ['new_name'], deprecated_names=['old_name'])
+        assert result == ['old_name']
+
+    def test_deprecated_column_not_allowed_without_map(self):
+        match = "Invalid column name\\(s\\): \\['old_name'\\]"
+        with pytest.raises(ValueError, match=match):
+            validate_table_columns('old_name', ['new_name'])
+
+    def test_error_message_lists_allowed_columns(self):
+        match = 'The allowed column names are: a, b, c'
+        with pytest.raises(ValueError, match=match):
+            validate_table_columns(['invalid'], ['c', 'a', 'b'])


### PR DESCRIPTION
This PR adds validation of the `columns` keyword in several `to_table` methods (`ApertureStats`, `IsophoteList`, `SourceCatalog`, and `StarFinderCatalogBase`.