### PR TITLE
Return scalar attributes from AperturePhotometry for scalar aperture position

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -200,6 +200,10 @@ API Changes
     will be removed in version 4.0. Use the new ``AperturePhotometry``
     class instead. [#2324, #2328]
 
+  - The ``ApertureStats.ids`` attribute is now deprecated and will
+    be removed in version 4.0. Use the ``ApertureStats.id`` attribute
+    instead. [#2331]
+
 - ``photutils.psf``
 
   - The ``EPSFBuildResult`` class returned by ``EPSFBuilder`` has been

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ New Features
     recommended tool for aperture photometry. It uses a results-object
     pattern, similar to ``ApertureStats``. The class is immutable after
     construction, so instances are thread-safe and independent frames
-    can be processed concurrently. [#2328]
+    can be processed concurrently. [#2328, #2331]
 
   - Rectangular apertures now support the ``method='exact'`` mask mode.
     Previously this fell back to a 32x subpixel approximation. [#2291]

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -558,8 +558,8 @@ read as many attributes as needed::
     >>> aperture = CircularAperture((25, 25), r=5)
     >>> results = [AperturePhotometry(image, aperture, error=error)
     ...            for image in cube]
-    >>> flux = np.array([phot.flux[0] for phot in results])
-    >>> flux_err = np.array([phot.flux_err[0] for phot in results])
+    >>> flux = np.array([phot.flux for phot in results])
+    >>> flux_err = np.array([phot.flux_err for phot in results])
     >>> print(flux)
     [ 78.53981634 117.80972451 157.07963268 141.37166941  94.24777961]
     >>> print(flux_err)
@@ -568,7 +568,7 @@ read as many attributes as needed::
 Each element of ``flux`` and ``flux_err`` corresponds to one image in
 the cube, together giving the source's light curve and its uncertainty.
 The same pattern extends to multiple sources and to other per-frame
-quantities: index the desired attribute (e.g.,
+quantities: read the desired attribute (e.g.,
 :attr:`~photutils.aperture.AperturePhotometry.flags`) from each results
 object, or build a table per frame with
 :meth:`~photutils.aperture.AperturePhotometry.to_table`.
@@ -590,13 +590,13 @@ by providing a boolean image mask via the ``mask`` keyword::
     >>> mask[2, 2] = True   # mask the bad pixel
     >>> phot1 = AperturePhotometry(data, aperture, mask=mask)
     >>> print(phot1.flux)
-    [11.566370614359172]
+    11.566370614359172
 
 The result is very different if a ``mask`` image is not provided::
 
     >>> phot2 = AperturePhotometry(data, aperture)
     >>> print(phot2.flux)
-    [111.56637061435919]
+    111.56637061435919
 
 For :class:`~photutils.aperture.AperturePhotometry` and
 :class:`~photutils.aperture.ApertureStats`, non-finite values (NaN
@@ -608,7 +608,7 @@ automatically excluded from calculations. For example::
     >>> aperture = CircularAperture((2, 2), r=2.0)
     >>> phot = AperturePhotometry(data, aperture)
     >>> print(phot.flux)
-    [11.566370614359172]
+    11.566370614359172
 
 
 Masking Neighboring Sources with a Segmentation Image
@@ -661,14 +661,14 @@ Without masking, the aperture sum includes the neighbor's flux::
 
     >>> phot1 = AperturePhotometry(data, aperture)
     >>> print(phot1.flux)
-    [484.67784806278354]
+    484.67784806278354
 
 Masking the neighboring source excludes its flux::
 
     >>> phot2 = AperturePhotometry(data, aperture, segmentation_image=segm,
     ...                            labels=1, mask_method='mask')
     >>> print(phot2.flux)
-    [124.05298520018465]
+    124.05298520018465
 
 The ``'correct'`` method instead replaces the neighbor's pixels with
 values mirrored across the aperture center, recovering an estimate of
@@ -677,7 +677,7 @@ the obscured flux::
     >>> phot3 = AperturePhotometry(data, aperture, segmentation_image=segm,
     ...                            labels=1, mask_method='correct')
     >>> print(phot3.flux)
-    [131.26548245743663]
+    131.26548245743663
 
 These keywords are also available in
 :class:`~photutils.aperture.ApertureStats`.

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -106,6 +106,11 @@ threads, and independent frames can be processed concurrently (see
 :ref:`the thread-safety section <whatsnew-3.1-thread-safe-photometry>`
 below).
 
+Like `~photutils.aperture.ApertureStats`, the output attributes
+are scalars when a single scalar aperture position is input (e.g.,
+``CircularAperture((30.0, 30.0), r=5.0)``) and arrays when multiple
+positions are input.
+
 The legacy :func:`~photutils.aperture.aperture_photometry`
 function remains available and is not deprecated, but it is now
 considered a legacy interface. New features are added only to the

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -7,6 +7,7 @@ import warnings
 
 import astropy.units as u
 import numpy as np
+from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable
 from astropy.utils import lazyproperty
@@ -120,10 +121,16 @@ class AperturePhotometry:
     it must be defined in the ``uncertainty`` attribute with a
     `~astropy.nddata.StdDevUncertainty` instance.
 
-    The measured `flux`, `flux_err`, `area`, and `flags` attributes are
-    1D arrays with one element per aperture position when a single
-    aperture is input. If a list of apertures is input, they are 2D
-    arrays with shape ``(n_positions, n_apertures)``.
+    The measured `flux`, `flux_err`, `area`, and `flags` attributes
+    (as well as `id`, `x_center`, `y_center`, and `sky_center`) are
+    scalars if a single scalar aperture position is input (e.g.,
+    ``CircularAperture((10, 20), r=5)``). They are 1D arrays with
+    one element per position if multiple positions are input (e.g.,
+    ``CircularAperture([(10, 20)], r=5)`` or ``CircularAperture([(10,
+    20), (30, 40)], r=5)``). If a list of apertures is input, the
+    `flux`, `flux_err`, `area`, and `flags` attributes gain a trailing
+    aperture axis, giving shape ``(n_apertures,)`` for a single scalar
+    position and ``(n_positions, n_apertures)`` otherwise.
 
     Non-finite ``data`` values (NaN and inf) are automatically masked.
     Such pixels are excluded from the `flux`, `flux_err`, and `area`
@@ -283,6 +290,40 @@ class AperturePhotometry:
 
     def __str__(self):
         return make_repr(self, self._repr_params, long=True)
+
+    def __getattribute__(self, name):
+        # Collapse the leading position axis of the public array-valued
+        # output attributes to a scalar when a single scalar aperture
+        # position is input (e.g., ``CircularAperture((10, 20), r=5)``).
+        # These are the only public array-valued attributes, so the
+        # scalar conversion is applied centrally here instead of being
+        # repeated on each individual property.
+        value = super().__getattribute__(name)
+        if (not name.startswith('_')
+                and name not in ('isscalar', 'n_positions')
+                and isinstance(value, (np.ndarray, SkyCoord))
+                and self.isscalar):
+            return value[0]
+        return value
+
+    def _array(self, name):
+        """
+        Return the full (never scalar-collapsed) array for a public
+        output attribute, regardless of whether the instance is scalar.
+
+        This bypasses the scalar conversion performed in
+        ``__getattribute__`` so that the table-building and
+        flag-decoding machinery always operates on arrays.
+        """
+        return object.__getattribute__(self, name)
+
+    @lazyproperty
+    def isscalar(self):
+        """
+        Whether the instance is scalar (i.e., a single aperture
+        position).
+        """
+        return self._pixel_apertures[0].isscalar
 
     @lazyproperty
     def _photometry_results(self):
@@ -458,13 +499,13 @@ class AperturePhotometry:
 
         per_aperture = ('flux', 'flux_err', 'area', 'flags')
         for column in table_columns:
+            values = self._array(column)
             if column in per_aperture and not self._single_aperture:
-                values = getattr(self, column)
                 for i in range(len(self._pixel_apertures)):
                     name = f'{column}_{i}'
                     tbl[name] = values[:, i]
             else:
-                tbl[column] = getattr(self, column)
+                tbl[column] = values
         return tbl
 
     def decode_flags(self, *, return_bit_values=False):
@@ -494,7 +535,7 @@ class AperturePhotometry:
         --------
         photutils.aperture.decode_aperture_flags
         """
-        return decode_aperture_flags(np.atleast_1d(self.flags),
+        return decode_aperture_flags(self._array('flags'),
                                      return_bit_values=return_bit_values)
 
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -41,7 +41,7 @@ from photutils.aperture.flags import (APERTURE_FLAGS, _counts_to_flag_bits,
                                       decode_aperture_flags)
 from photutils.morphology import gini as gini_func
 from photutils.utils._deprecation import (create_empty_deprecated_qtable,
-                                          deprecated_getattr,
+                                          deprecated, deprecated_getattr,
                                           deprecated_positional_kwargs)
 from photutils.utils._misc import _get_meta
 from photutils.utils._moments import _image_moments
@@ -80,8 +80,8 @@ _DEPRECATED_ATTRIBUTES: dict = {
 # Public attributes that are never collapsed to a scalar for a scalar
 # instance because they describe the whole object rather than a single
 # per-source value (see ``ApertureStats.__getattribute__``).
-_SCALAR_EXCLUDE = frozenset({'default_columns', 'ids', 'isscalar',
-                             'n_apertures', 'properties'})
+_SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'n_apertures',
+                             'properties'})
 
 
 class _UncachedLazyProperty(lazyproperty):
@@ -491,11 +491,12 @@ class ApertureStats:
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
-        # Need to slice _aperture and _ids;
         # aperture determines isscalar (needed below)
-        attrs = ('aperture', '_ids')
-        for attr in attrs:
-            setattr(newcls, attr, getattr(self, attr)[index])
+        newcls.aperture = self.aperture[index]
+
+        # Keep _ids as a 1D array so a scalar instance's id is always
+        # backed by a length-1 iterable (see the id property).
+        newcls._ids = np.atleast_1d(self._ids[index])
 
         # Slice the per-aperture segmentation labels
         if self._seg_labels is None:
@@ -647,15 +648,15 @@ class ApertureStats:
         return self._ids
 
     @property
+    @deprecated('3.1', alternative="the 'id' attribute", until='4.0')
     def ids(self):
         """
-        The aperture identification number(s), always as an iterable
-        `~numpy.ndarray`.
+        The aperture identification number(s).
+
+        .. deprecated:: 3.1
+            Use the `id` attribute instead.
         """
-        _ids = self._ids
-        if self.isscalar:
-            _ids = np.array((_ids,))
-        return _ids
+        return self.id
 
     def select_id(self, id_num):
         """
@@ -692,7 +693,7 @@ class ApertureStats:
             the input ID numbers.
         """
         for id_num in np.atleast_1d(id_nums):
-            if id_num not in self.ids:
+            if id_num not in self._array('id'):
                 msg = f'{id_num} is not a valid source ID number'
                 raise ValueError(msg)
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -3,13 +3,13 @@
 Tools for calculating properties of sources defined by an Aperture.
 """
 
-import functools
 import inspect
 import warnings
 from copy import deepcopy
 
 import astropy.units as u
 import numpy as np
+from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.stats import (SigmaClip, biweight_location, biweight_midvariance,
                            mad_std)
@@ -77,31 +77,11 @@ _DEPRECATED_ATTRIBUTES: dict = {
 }
 
 
-def as_scalar(method):
-    """
-    Return a decorated method where it will always return a scalar value
-    (instead of a length-1 tuple/list/array) if the class is scalar.
-
-    Parameters
-    ----------
-    method : function
-        The method to be decorated.
-
-    Returns
-    -------
-    decorator : function
-        The decorated method.
-    """
-    @functools.wraps(method)
-    def _decorator(*args, **kwargs):
-        result = method(*args, **kwargs)
-        try:
-            return (result[0] if args[0].isscalar and len(result) == 1
-                    else result)
-        except TypeError:  # if result has no len
-            return result
-
-    return _decorator
+# Public attributes that are never collapsed to a scalar for a scalar
+# instance because they describe the whole object rather than a single
+# per-source value (see ``ApertureStats.__getattribute__``).
+_SCALAR_EXCLUDE = frozenset({'default_columns', 'ids', 'isscalar',
+                             'n_apertures', 'properties'})
 
 
 class _UncachedLazyProperty(lazyproperty):
@@ -593,6 +573,37 @@ class ApertureStats:
         return deprecated_getattr(self, name, _DEPRECATED_ATTRIBUTES,
                                   since='3.0', until='4.0')
 
+    def __getattribute__(self, name):
+        # Collapse the leading position axis of the public per-source
+        # output attributes to a scalar when a single scalar aperture
+        # position is input (e.g., ``CircularAperture((10, 20), r=5)``).
+        # The scalar conversion is applied centrally here instead of
+        # being repeated on each individual property (see ``_array`` for
+        # the array-preserving accessor used by the table-building and
+        # flag-decoding machinery).
+        value = super().__getattribute__(name)
+        if (not name.startswith('_')
+                and name not in _SCALAR_EXCLUDE
+                and isinstance(value, (np.ndarray, SkyCoord, list, tuple))
+                and self.isscalar):
+            try:
+                if len(value) == 1:
+                    return value[0]
+            except TypeError:  # value has no len
+                pass
+        return value
+
+    def _array(self, name):
+        """
+        Return the full (never scalar-collapsed) value for a public
+        output attribute, regardless of whether the instance is scalar.
+
+        This bypasses the scalar conversion performed in
+        ``__getattribute__`` so that the table-building and
+        flag-decoding machinery always operates on arrays.
+        """
+        return object.__getattribute__(self, name)
+
     @lazyproperty
     def isscalar(self):
         """
@@ -629,7 +640,6 @@ class ApertureStats:
         return values
 
     @property
-    @as_scalar
     def id(self):
         """
         The aperture identification number(s).
@@ -1454,7 +1464,6 @@ class ApertureStats:
                 for arr, mask in zip(array, self._mask_cutout, strict=True)]
 
     @lazyproperty
-    @as_scalar
     def data_cutout(self):
         """
         A 2D aperture-weighted cutout from the data using the aperture
@@ -1472,7 +1481,6 @@ class ApertureStats:
             list(zip(*self._aperture_cutouts_center, strict=True))[0])
 
     @lazyproperty
-    @as_scalar
     def data_sum_cutout(self):
         """
         A 2D aperture-weighted cutout from the data using the aperture
@@ -1530,7 +1538,6 @@ class ApertureStats:
                                                 strict=True))[1])
 
     @lazyproperty
-    @as_scalar
     def error_sum_cutout(self):
         """
         A 2D aperture-weighted error cutout using the aperture mask with
@@ -1589,9 +1596,7 @@ class ApertureStats:
 
         These arrays are used to derive moment-based properties.
         """
-        data = deepcopy(self.data_cutout)  # self.data_cutout is a list
-        if self.isscalar:
-            data = (data,)
+        data = deepcopy(self._array('data_cutout'))
 
         cutouts = []
         for arr in data:
@@ -1755,7 +1760,6 @@ class ApertureStats:
         return finite & ((covar_det < delta**2) | (min_eigval < delta))
 
     @_UncachedLazyProperty
-    @as_scalar
     @_update_method_subpixels_docstring
     def flags(self):
         # numpydoc ignore: RT01
@@ -1800,7 +1804,6 @@ class ApertureStats:
         return flags
 
     @lazyproperty
-    @as_scalar
     @_update_method_subpixels_docstring
     def sum_flags(self):
         # numpydoc ignore: RT01
@@ -1871,8 +1874,7 @@ class ApertureStats:
             msg = "column must be 'flags' or 'sum_flags'"
             raise ValueError(msg)
 
-        flags = self.flags if column == 'flags' else self.sum_flags
-        return decode_aperture_flags(np.atleast_1d(flags),
+        return decode_aperture_flags(self._array(column),
                                      return_bit_values=return_bit_values)
 
     def _get_values(self, array):
@@ -1900,7 +1902,6 @@ class ApertureStats:
         return self._get_values(self.data_cutout)
 
     @lazyproperty
-    @as_scalar
     def moments(self):
         """
         Spatial moments up to 3rd order of the source.
@@ -1921,15 +1922,12 @@ class ApertureStats:
                          for arr in self._moment_data_cutout])
 
     @lazyproperty
-    @as_scalar
     def moments_central(self):
         """
         Central moments (translation invariant) of the source up to 3rd
         order.
         """
-        cutout_centroid = self.cutout_centroid
-        if self.isscalar:
-            cutout_centroid = cutout_centroid[np.newaxis, :]
+        cutout_centroid = self._array('cutout_centroid')
 
         gather = self._fast_gather
         if gather is not None:
@@ -1949,7 +1947,6 @@ class ApertureStats:
                              cutout_centroid[:, 1], strict=True)])
 
     @lazyproperty
-    @as_scalar
     def cutout_centroid(self):
         """
         The ``(x, y)`` coordinate, relative to the cutout data, of the
@@ -1958,9 +1955,7 @@ class ApertureStats:
         The centroid is computed as the center of mass of the unmasked
         pixels within the aperture.
         """
-        moments = self.moments
-        if self.isscalar:
-            moments = moments[np.newaxis, :]
+        moments = self._array('moments')
 
         # Ignore divide-by-zero RuntimeWarning
         with warnings.catch_warnings():
@@ -1970,7 +1965,6 @@ class ApertureStats:
         return np.transpose((x_centroid, y_centroid))
 
     @lazyproperty
-    @as_scalar
     def centroid(self):
         """
         The ``(x, y)`` coordinate of the centroid.
@@ -1982,17 +1976,6 @@ class ApertureStats:
         return self.cutout_centroid + origin
 
     @lazyproperty
-    def _x_centroid(self):
-        """
-        The ``x`` coordinate of the centroid, always as an iterable.
-        """
-        x_centroid = np.transpose(self.centroid)[0]
-        if self.isscalar:
-            x_centroid = (x_centroid,)
-        return x_centroid
-
-    @lazyproperty
-    @as_scalar
     def x_centroid(self):
         """
         The ``x`` coordinate of the centroid.
@@ -2000,20 +1983,9 @@ class ApertureStats:
         The centroid is computed as the center of mass of the unmasked
         pixels within the aperture.
         """
-        return self._x_centroid
+        return np.transpose(self._array('centroid'))[0]
 
     @lazyproperty
-    def _y_centroid(self):
-        """
-        The ``y`` coordinate of the centroid, always as an iterable.
-        """
-        y_centroid = np.transpose(self.centroid)[1]
-        if self.isscalar:
-            y_centroid = (y_centroid,)
-        return y_centroid
-
-    @lazyproperty
-    @as_scalar
     def y_centroid(self):
         """
         The ``y`` coordinate of the centroid.
@@ -2021,10 +1993,9 @@ class ApertureStats:
         The centroid is computed as the center of mass of the unmasked
         pixels within the aperture.
         """
-        return self._y_centroid
+        return np.transpose(self._array('centroid'))[1]
 
     @lazyproperty
-    @as_scalar
     def sky_centroid(self):
         """
         The sky coordinate of the centroid of the unmasked pixels within
@@ -2040,7 +2011,6 @@ class ApertureStats:
         return self._wcs.pixel_to_world(self.x_centroid, self.y_centroid)
 
     @lazyproperty
-    @as_scalar
     def sky_centroid_icrs(self):
         """
         The sky coordinate in the International Celestial Reference
@@ -2066,7 +2036,6 @@ class ApertureStats:
         return [aperture.bbox for aperture in apertures]
 
     @lazyproperty
-    @as_scalar
     def bbox(self):
         """
         The `~photutils.aperture.BoundingBox` of the aperture.
@@ -2078,20 +2047,16 @@ class ApertureStats:
         return self._bbox
 
     @lazyproperty
-    @as_scalar
     def _bbox_bounds(self):
         """
         The bounding box x and y minimum and maximum bounds.
         """
-        bbox = self.bbox
-        if self.isscalar:
-            bbox = (bbox,)
+        bbox = self._array('bbox')
         return np.array([(bbox_.ixmin, bbox_.ixmax - 1,
                           bbox_.iymin, bbox_.iymax - 1)
                          for bbox_ in bbox])
 
     @lazyproperty
-    @as_scalar
     def bbox_xmin(self):
         """
         The minimum ``x``-pixel index of the bounding box.
@@ -2099,7 +2064,6 @@ class ApertureStats:
         return np.transpose(self._bbox_bounds)[0]
 
     @lazyproperty
-    @as_scalar
     def bbox_xmax(self):
         """
         The maximum ``x``-pixel index of the bounding box.
@@ -2109,7 +2073,6 @@ class ApertureStats:
         return np.transpose(self._bbox_bounds)[1]
 
     @lazyproperty
-    @as_scalar
     def bbox_ymin(self):
         """
         The minimum ``y``-pixel index of the bounding box.
@@ -2117,7 +2080,6 @@ class ApertureStats:
         return np.transpose(self._bbox_bounds)[2]
 
     @lazyproperty
-    @as_scalar
     def bbox_ymax(self):
         """
         The maximum ``y``-pixel index of the bounding box.
@@ -2172,16 +2134,14 @@ class ApertureStats:
         return sem
 
     @lazyproperty
-    @as_scalar
     def center_aper_area(self):
         """
         The total area of the unmasked pixels within the aperture using
         the "center" aperture mask method.
         """
-        return self._center_npixels.copy() << (u.pix**2)
+        return self._center_npixels * (u.pix**2)
 
     @lazyproperty
-    @as_scalar
     def sum_aper_area(self):
         """
         The total area of the unmasked pixels within the aperture using
@@ -2203,7 +2163,6 @@ class ApertureStats:
         return areas << (u.pix**2)
 
     @lazyproperty
-    @as_scalar
     def sum(self):
         r"""
         The sum of the unmasked ``data`` values within the aperture.
@@ -2239,7 +2198,6 @@ class ApertureStats:
         return result
 
     @lazyproperty
-    @as_scalar
     def sum_err(self):
         r"""
         The uncertainty of `sum`, propagated from the input ``error``
@@ -2287,7 +2245,6 @@ class ApertureStats:
         return err
 
     @lazyproperty
-    @as_scalar
     def min(self):
         """
         The minimum of the unmasked pixel values within the aperture.
@@ -2296,7 +2253,6 @@ class ApertureStats:
         return self._finalize_value_stat(fast, np.min)
 
     @lazyproperty
-    @as_scalar
     def max(self):
         """
         The maximum of the unmasked pixel values within the aperture.
@@ -2305,7 +2261,6 @@ class ApertureStats:
         return self._finalize_value_stat(fast, np.max)
 
     @lazyproperty
-    @as_scalar
     def mean(self):
         """
         The mean of the unmasked pixel values within the aperture.
@@ -2314,7 +2269,6 @@ class ApertureStats:
         return self._finalize_value_stat(fast, np.mean)
 
     @lazyproperty
-    @as_scalar
     def mean_err(self):
         r"""
         The standard error of the `mean`.
@@ -2339,7 +2293,6 @@ class ApertureStats:
         return result
 
     @lazyproperty
-    @as_scalar
     def median(self):
         """
         The median of the unmasked pixel values within the aperture.
@@ -2348,7 +2301,6 @@ class ApertureStats:
         return self._finalize_value_stat(fast, np.median)
 
     @lazyproperty
-    @as_scalar
     def median_err(self):
         r"""
         The standard error of the `median`.
@@ -2376,7 +2328,6 @@ class ApertureStats:
         return result
 
     @lazyproperty
-    @as_scalar
     def mode(self):
         """
         The mode of the unmasked pixel values within the aperture.
@@ -2410,7 +2361,6 @@ class ApertureStats:
         return result
 
     @lazyproperty
-    @as_scalar
     def std(self):
         """
         The standard deviation of the unmasked pixel values within the
@@ -2426,7 +2376,6 @@ class ApertureStats:
         return result
 
     @lazyproperty
-    @as_scalar
     def mad_std(self):
         r"""
         The standard deviation calculated using
@@ -2447,7 +2396,6 @@ class ApertureStats:
         return self._finalize_value_stat(fast, mad_std)
 
     @lazyproperty
-    @as_scalar
     def var(self):
         """
         The variance of the unmasked pixel values within the aperture.
@@ -2462,7 +2410,6 @@ class ApertureStats:
         return result
 
     @lazyproperty
-    @as_scalar
     def biweight_location(self):
         """
         The biweight location of the unmasked pixel values within the
@@ -2475,7 +2422,6 @@ class ApertureStats:
         return self._finalize_value_stat(fast, biweight_location)
 
     @lazyproperty
-    @as_scalar
     def biweight_midvariance(self):
         """
         The biweight midvariance of the unmasked pixel values within the
@@ -2489,15 +2435,12 @@ class ApertureStats:
                                          square_unit=True)
 
     @lazyproperty
-    @as_scalar
     def inertia_tensor(self):
         """
         The inertia tensor of the source for the rotation around its
         center of mass.
         """
-        moments = self.moments_central
-        if self.isscalar:
-            moments = moments[np.newaxis, :]
+        moments = self._array('moments_central')
         mu_02 = moments[:, 0, 2]
         mu_11 = -moments[:, 1, 1]
         mu_20 = moments[:, 2, 0]
@@ -2516,9 +2459,7 @@ class ApertureStats:
         it for singularity). Callers that modify the matrix in place
         must operate on a copy so the cached value is not corrupted.
         """
-        moments = self.moments_central
-        if self.isscalar:
-            moments = moments[np.newaxis, :]
+        moments = self._array('moments_central')
         # Ignore divide-by-zero RuntimeWarning
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
@@ -2571,7 +2512,6 @@ class ApertureStats:
         return covar
 
     @lazyproperty
-    @as_scalar
     def covariance(self):
         """
         The covariance matrix of the 2D Gaussian function that has the
@@ -2580,7 +2520,6 @@ class ApertureStats:
         return self._covariance * (u.pix**2)
 
     @lazyproperty
-    @as_scalar
     def covariance_eigvals(self):
         """
         The two eigenvalues of the `covariance` matrix in decreasing
@@ -2604,33 +2543,26 @@ class ApertureStats:
         return eigvals * u.pix**2
 
     @lazyproperty
-    @as_scalar
     def semimajor_axis(self):
         """
         The 1-sigma standard deviation along the semimajor axis of the
         2D Gaussian function that has the same second-order central
         moments as the source.
         """
-        eigvals = self.covariance_eigvals
-        if self.isscalar:
-            eigvals = eigvals[np.newaxis, :]
+        eigvals = self._array('covariance_eigvals')
         return np.sqrt(eigvals[:, 0])
 
     @lazyproperty
-    @as_scalar
     def semiminor_axis(self):
         """
         The 1-sigma standard deviation along the semiminor axis of the
         2D Gaussian function that has the same second-order central
         moments as the source.
         """
-        eigvals = self.covariance_eigvals
-        if self.isscalar:
-            eigvals = eigvals[np.newaxis, :]
+        eigvals = self._array('covariance_eigvals')
         return np.sqrt(eigvals[:, 1])
 
     @lazyproperty
-    @as_scalar
     def fwhm(self):
         r"""
         The circularized full width at half maximum (FWHM) of the 2D
@@ -2651,7 +2583,6 @@ class ApertureStats:
                                             + self.semiminor_axis**2))
 
     @lazyproperty
-    @as_scalar
     def orientation(self):
         """
         The angle between the ``x`` axis and the major axis of the 2D
@@ -2667,7 +2598,6 @@ class ApertureStats:
         return np.rad2deg(orient_radians) * u.deg
 
     @lazyproperty
-    @as_scalar
     def eccentricity(self):
         r"""
         The eccentricity of the 2D Gaussian function that has the same
@@ -2687,7 +2617,6 @@ class ApertureStats:
         return np.sqrt(1.0 - (semiminor_var / semimajor_var))
 
     @lazyproperty
-    @as_scalar
     def elongation(self):
         r"""
         The ratio of the lengths of the semimajor and semiminor axes.
@@ -2702,7 +2631,6 @@ class ApertureStats:
         return self.semimajor_axis / self.semiminor_axis
 
     @lazyproperty
-    @as_scalar
     def ellipticity(self):
         r"""
         1.0 minus the ratio of the lengths of the semimajor and
@@ -2718,7 +2646,6 @@ class ApertureStats:
         return 1.0 - (self.semiminor_axis / self.semimajor_axis)
 
     @lazyproperty
-    @as_scalar
     def covariance_xx(self):
         r"""
         The ``(0, 0)`` element of the `covariance` matrix, representing
@@ -2727,7 +2654,6 @@ class ApertureStats:
         return self._covariance[:, 0, 0] * u.pix**2
 
     @lazyproperty
-    @as_scalar
     def covariance_yy(self):
         r"""
         The ``(1, 1)`` element of the `covariance` matrix, representing
@@ -2736,7 +2662,6 @@ class ApertureStats:
         return self._covariance[:, 1, 1] * u.pix**2
 
     @lazyproperty
-    @as_scalar
     def covariance_xy(self):
         r"""
         The ``(0, 1)`` and ``(1, 0)`` elements of the `covariance`
@@ -2746,7 +2671,6 @@ class ApertureStats:
         return self._covariance[:, 0, 1] * u.pix**2
 
     @lazyproperty
-    @as_scalar
     def ellipse_cxx(self):
         r"""
         Coefficient for ``x**2`` in the generalized ellipse equation in
@@ -2769,7 +2693,6 @@ class ApertureStats:
                 + (np.sin(self.orientation) / self.semiminor_axis)**2)
 
     @lazyproperty
-    @as_scalar
     def ellipse_cyy(self):
         r"""
         Coefficient for ``y**2`` in the generalized ellipse equation in
@@ -2792,7 +2715,6 @@ class ApertureStats:
                 + (np.cos(self.orientation) / self.semiminor_axis)**2)
 
     @lazyproperty
-    @as_scalar
     def ellipse_cxy(self):
         r"""
         Coefficient for ``x * y`` in the generalized ellipse equation in
@@ -2816,7 +2738,6 @@ class ApertureStats:
                    - (1.0 / self.semiminor_axis**2)))
 
     @lazyproperty
-    @as_scalar
     def gini(self):
         r"""
         The `Gini coefficient

--- a/photutils/aperture/tests/conftest.py
+++ b/photutils/aperture/tests/conftest.py
@@ -6,6 +6,19 @@ Shared pytest fixtures for the aperture tests.
 import pytest
 from astropy.wcs import WCS
 
+from photutils.datasets import make_4gaussians_image
+
+
+@pytest.fixture(name='data')
+def fixture_data():
+    """
+    A 2D image containing four Gaussian sources on a noisy background.
+
+    The image is deterministic and must be treated as read-only by
+    tests.
+    """
+    return make_4gaussians_image()
+
 
 @pytest.fixture
 def tan_wcs():

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -22,7 +22,7 @@ from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture,
                                           SkyRectangularAnnulus,
                                           SkyRectangularAperture)
-from photutils.datasets import make_4gaussians_image, make_wcs
+from photutils.datasets import make_wcs
 from photutils.utils._optional_deps import HAS_MATPLOTLIB, HAS_REGIONS
 
 APERTURE_CL = [CircularAperture,
@@ -275,8 +275,7 @@ class TestInputNDData(BaseTestDifferentData):
         self.fluxunit = u.adu
 
 
-def test_input_wcs():
-    data = make_4gaussians_image()
+def test_input_wcs(data):
     wcs = make_wcs(data.shape)
 
     # Hard wired positions in make_4gaussian_image
@@ -294,8 +293,7 @@ def test_input_wcs():
     assert 'sky_center' in phot3.colnames
 
 
-def test_wcs_based_photometry():
-    data = make_4gaussians_image()
+def test_wcs_based_photometry(data):
     wcs = make_wcs(data.shape)
 
     # Hard wired positions in make_4gaussian_image
@@ -732,12 +730,11 @@ def test_nan_in_bbox():
     assert_allclose(tbl3['aperture_sum_err'], tbl4['aperture_sum_err'])
 
 
-def test_scalar_skycoord():
+def test_scalar_skycoord(data):
     """
     Regression test to check that scalar SkyCoords are added to the
     table as a length-1 SkyCoord array.
     """
-    data = make_4gaussians_image()
     wcs = make_wcs(data.shape)
     skycoord = wcs.pixel_to_world(90, 60)
     aper = SkyCircularAperture(skycoord, r=0.1 * u.arcsec)

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -174,7 +174,7 @@ class TestSkyApertures:
         ref = aperture_photometry(data, pix_aper)
         assert_allclose(phot.flux, ref['aperture_sum'])
         assert isinstance(phot.sky_center, SkyCoord)
-        assert phot.sky_center.isscalar is False
+        assert phot.sky_center.isscalar is True
 
     def test_sky_aperture_multiple_positions(self):
         data = make_4gaussians_image()
@@ -361,7 +361,7 @@ class TestFlagsAndArea:
         data = np.ones((25, 25), dtype=float)
         aper = CircularAperture((0, 12), r=5.0)
         phot = AperturePhotometry(data, aper)
-        assert phot.flags[0] != 0
+        assert phot.flags != 0
 
     def test_decode_flags(self):
         data = np.ones((25, 25))
@@ -383,6 +383,131 @@ class TestFlagsAndArea:
         assert decoded[0] == [8]
 
 
+class TestScalarBehavior:
+    """
+    A single scalar aperture position yields scalar output attributes,
+    while array positions yield array outputs.
+    """
+
+    def test_single_scalar_position(self):
+        data = make_4gaussians_image()
+        error = 0.1 * np.ones_like(data)
+        aper = CircularAperture((150, 25), r=8)
+        phot = AperturePhotometry(data, aper, error=error)
+        assert phot.isscalar is True
+        assert phot.n_positions == 1
+        for attr in ('id', 'x_center', 'y_center', 'flux', 'flux_err'):
+            assert np.ndim(getattr(phot, attr)) == 0
+        assert phot.area.isscalar
+        assert np.ndim(phot.flags) == 0
+
+    def test_array_position_single_element(self):
+        # A length-1 list of positions is not scalar.
+        data = make_4gaussians_image()
+        aper = CircularAperture([(150, 25)], r=8)
+        phot = AperturePhotometry(data, aper)
+        assert phot.isscalar is False
+        assert phot.flux.shape == (1,)
+        assert phot.flux_err.shape == (1,)
+        assert phot.area.shape == (1,)
+        assert phot.flags.shape == (1,)
+
+    def test_multiple_positions_not_scalar(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture(((150, 25), (90, 60)), r=8)
+        phot = AperturePhotometry(data, aper)
+        assert phot.isscalar is False
+        assert phot.flux.shape == (2,)
+
+    def test_scalar_matches_array(self):
+        """
+        Test that the scalar output from a single position matches
+        the first element of the array output from a length-1 list of
+        positions.
+        """
+        data = make_4gaussians_image()
+        scalar = AperturePhotometry(data, CircularAperture((150, 25), r=8))
+        array = AperturePhotometry(data, CircularAperture([(150, 25)], r=8))
+        assert_allclose(scalar.flux, array.flux[0])
+        assert scalar.flags == array.flags[0]
+        assert_allclose(scalar.x_center, array.x_center[0])
+
+    def test_list_of_apertures_scalar_position(self):
+        data = make_4gaussians_image()
+        apers = [CircularAperture((150, 25), r=r) for r in (5, 8)]
+        phot = AperturePhotometry(data, apers)
+        assert phot.isscalar is True
+
+        # id/x_center/y_center collapse to scalars
+        assert np.ndim(phot.id) == 0
+        assert np.ndim(phot.x_center) == 0
+        assert np.ndim(phot.y_center) == 0
+
+        # The per-aperture attributes keep only the trailing aperture axis
+        assert phot.flux.shape == (2,)
+        assert phot.flux_err.shape == (2,)
+        assert phot.area.shape == (2,)
+        assert phot.flags.shape == (2,)
+
+    def test_list_of_apertures_array_position(self):
+        data = make_4gaussians_image()
+        pos = ((150, 25), (90, 60))
+        apers = [CircularAperture(pos, r=r) for r in (5, 8)]
+        phot = AperturePhotometry(data, apers)
+        assert phot.isscalar is False
+        assert phot.flux.shape == (2, 2)
+
+    def test_sky_center_scalar(self):
+        data = make_4gaussians_image()
+        wcs = make_wcs(data.shape)
+        phot = AperturePhotometry(data, CircularAperture((150, 25), r=8),
+                                  wcs=wcs)
+        assert isinstance(phot.sky_center, SkyCoord)
+        assert phot.sky_center.isscalar is True
+
+    def test_sky_center_array(self):
+        data = make_4gaussians_image()
+        wcs = make_wcs(data.shape)
+        phot = AperturePhotometry(data, CircularAperture([(150, 25)], r=8),
+                                  wcs=wcs)
+        assert phot.sky_center.isscalar is False
+        assert len(phot.sky_center) == 1
+
+    def test_to_table_scalar_single_aperture(self):
+        data = make_4gaussians_image()
+        aper = CircularAperture((150, 25), r=8)
+        tbl = AperturePhotometry(data, aper).to_table()
+        assert len(tbl) == 1
+        assert tbl.colnames == ['id', 'x_center', 'y_center', 'flux',
+                                'flux_err', 'area', 'flags']
+
+    def test_to_table_scalar_list_of_apertures(self):
+        data = make_4gaussians_image()
+        apers = [CircularAperture((150, 25), r=r) for r in (5, 8)]
+        tbl = AperturePhotometry(data, apers).to_table()
+        assert len(tbl) == 1
+        assert tbl.colnames == ['id', 'x_center', 'y_center', 'flux_0',
+                                'flux_1', 'flux_err_0', 'flux_err_1',
+                                'area_0', 'area_1', 'flags_0', 'flags_1']
+
+    def test_decode_flags_scalar(self):
+        data = np.ones((25, 25))
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[12, 12] = True
+        aper = CircularAperture((12, 12), r=3)
+        phot = AperturePhotometry(data, aper, mask=mask)
+        assert phot.decode_flags() == [['masked_pixels']]
+
+    def test_isscalar_matches_aperture_stats(self):
+        data = make_4gaussians_image()
+        scalar_aper = CircularAperture((150, 25), r=8)
+        array_aper = CircularAperture([(150, 25)], r=8)
+        assert (AperturePhotometry(data, scalar_aper).isscalar
+                == ApertureStats(data, scalar_aper).isscalar)
+        assert (AperturePhotometry(data, array_aper).isscalar
+                == ApertureStats(data, array_aper).isscalar)
+
+
 class TestNonFiniteData:
     """
     Non-finite ``data`` values (NaN and inf) must be automatically
@@ -398,10 +523,10 @@ class TestNonFiniteData:
         phot = AperturePhotometry(data, aper)
         # The two non-finite interior pixels (each of weight 1) are
         # excluded from the flux and area (all other pixels are 1.0).
-        assert np.isfinite(phot.flux[0])
-        assert_allclose(phot.flux[0], aper.area_overlap(data) - 2)
-        assert_allclose(phot.area.value[0], phot.flux[0])
-        assert phot.flags[0] == 32
+        assert np.isfinite(phot.flux)
+        assert_allclose(phot.flux, aper.area_overlap(data) - 2)
+        assert_allclose(phot.area.value, phot.flux)
+        assert phot.flags == 32
         assert phot.decode_flags()[0] == ['non_finite_data']
 
     def test_mask_path_masks_nonfinite(self):
@@ -414,8 +539,8 @@ class TestNonFiniteData:
         with patch.object(CircularAperture, '_batch_shape_params',
                           lambda _self: None):
             phot = AperturePhotometry(data, aper)
-            flux = phot.flux[0]
-            flags = phot.flags[0]
+            flux = phot.flux
+            flags = phot.flags
             decoded = phot.decode_flags()[0]
         assert np.isfinite(flux)
         assert_allclose(flux, aper.area_overlap(data) - 2)
@@ -434,17 +559,17 @@ class TestNonFiniteData:
             aper = PolygonAperture((12, 12), offsets)
         phot = AperturePhotometry(data, aper)
         stats = ApertureStats(data, aper)
-        assert_allclose(phot.flux[0], stats.sum)
-        assert_allclose(phot.area.value[0], stats.sum_aper_area.value)
-        assert phot.flags[0] == stats.flags
+        assert_allclose(phot.flux, stats.sum)
+        assert_allclose(phot.area.value, stats.sum_aper_area.value)
+        assert phot.flags == stats.flags
 
     def test_nonfinite_outside_aperture_not_flagged(self):
         data = np.ones((25, 25))
         data[0, 0] = np.nan  # far outside the aperture
         aper = CircularAperture((12, 12), r=5)
         phot = AperturePhotometry(data, aper)
-        assert phot.flags[0] == 0
-        assert_allclose(phot.flux[0], aper.area_overlap(data))
+        assert phot.flags == 0
+        assert_allclose(phot.flux, aper.area_overlap(data))
 
     def test_combined_mask_and_nonfinite(self):
         data = np.ones((25, 25))
@@ -453,9 +578,9 @@ class TestNonFiniteData:
         mask[11, 12] = True
         aper = CircularAperture((12, 12), r=5)
         phot = AperturePhotometry(data, aper, mask=mask)
-        assert np.isfinite(phot.flux[0])
+        assert np.isfinite(phot.flux)
         # Both masked_pixels (8) and non_finite_data (32) are set.
-        assert phot.flags[0] == 8 | 32
+        assert phot.flags == 8 | 32
         assert set(phot.decode_flags()[0]) == {'masked_pixels',
                                                'non_finite_data'}
 
@@ -468,9 +593,9 @@ class TestNonFiniteData:
         mask[12, 12] = True
         aper = CircularAperture((12, 12), r=5)
         phot = AperturePhotometry(data, aper, mask=mask)
-        assert phot.flags[0] == 8
+        assert phot.flags == 8
         stats = ApertureStats(data, aper, mask=mask)
-        assert phot.flags[0] == stats.flags
+        assert phot.flags == stats.flags
 
     def test_legacy_function_still_corrupts_nonfinite(self):
         """
@@ -558,7 +683,7 @@ class TestReprAndImmutability:
         new_keys = set(vars(phot).keys()) - init_keys
         lazy_names = {'_photometry_results', '_positions', 'n_positions',
                       'id', 'x_center', 'y_center', 'sky_center', 'flux',
-                      'flux_err', 'area', 'flags'}
+                      'flux_err', 'area', 'flags', 'isscalar'}
         assert new_keys.issubset(lazy_names)
 
     def test_concurrent_access(self):

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -19,7 +19,7 @@ from photutils.aperture.photometry import (AperturePhotometry,
                                            aperture_photometry)
 from photutils.aperture.polygon import PolygonAperture
 from photutils.aperture.stats import ApertureStats
-from photutils.datasets import make_4gaussians_image, make_wcs
+from photutils.datasets import make_wcs
 from photutils.segmentation import SegmentationImage
 from photutils.utils._optional_deps import HAS_REGIONS
 
@@ -49,23 +49,20 @@ class TestAperturePhotometryParity:
     ``aperture_photometry`` function for all shared inputs.
     """
 
-    def test_single_aperture(self):
-        data = make_4gaussians_image()
+    def test_single_aperture(self, data):
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper)
         ref = aperture_photometry(data, aper)
         assert_allclose(phot.flux, ref['aperture_sum'])
 
-    def test_multiple_positions(self):
-        data = make_4gaussians_image()
+    def test_multiple_positions(self, data):
         aper = CircularAperture(((150, 25), (90, 60)), 10)
         phot = AperturePhotometry(data, aper)
         ref = aperture_photometry(data, aper)
         assert_allclose(phot.flux, ref['aperture_sum'])
         assert phot.flux.shape == (2,)
 
-    def test_error_propagation(self):
-        data = make_4gaussians_image()
+    def test_error_propagation(self, data):
         error = np.sqrt(np.abs(data))
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper, error=error)
@@ -73,14 +70,12 @@ class TestAperturePhotometryParity:
         assert_allclose(phot.flux, ref['aperture_sum'])
         assert_allclose(phot.flux_err, ref['aperture_sum_err'])
 
-    def test_no_error_is_nan(self):
-        data = make_4gaussians_image()
+    def test_no_error_is_nan(self, data):
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper)
         assert np.all(np.isnan(phot.flux_err))
 
-    def test_mask(self):
-        data = make_4gaussians_image()
+    def test_mask(self, data):
         mask = np.zeros(data.shape, dtype=bool)
         mask[25, 150] = True
         aper = CircularAperture((150, 25), 8)
@@ -88,8 +83,7 @@ class TestAperturePhotometryParity:
         ref = aperture_photometry(data, aper, mask=mask)
         assert_allclose(phot.flux, ref['aperture_sum'])
 
-    def test_nomask(self):
-        data = make_4gaussians_image()
+    def test_nomask(self, data):
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper, mask=np.ma.nomask)
         ref = aperture_photometry(data, aper)
@@ -98,8 +92,7 @@ class TestAperturePhotometryParity:
 
     @pytest.mark.parametrize(('method', 'subpixels'),
                              [('exact', 5), ('center', 5), ('subpixel', 7)])
-    def test_method_variants(self, method, subpixels):
-        data = make_4gaussians_image()
+    def test_method_variants(self, method, subpixels, data):
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper, method=method,
                                   subpixels=subpixels)
@@ -107,8 +100,8 @@ class TestAperturePhotometryParity:
                                   subpixels=subpixels)
         assert_allclose(phot.flux, ref['aperture_sum'])
 
-    def test_units(self):
-        data = make_4gaussians_image() * u.Jy
+    def test_units(self, data):
+        data = data * u.Jy
         error = np.sqrt(np.abs(data.value)) * u.Jy
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper, error=error)
@@ -121,8 +114,7 @@ class TestAperturePhotometryParity:
 
 
 class TestListOfApertures:
-    def test_flux_shape(self):
-        data = make_4gaussians_image()
+    def test_flux_shape(self, data):
         pos = ((150, 25), (90, 60))
         apers = [CircularAperture(pos, r) for r in (5, 8)]
         phot = AperturePhotometry(data, apers)
@@ -130,8 +122,7 @@ class TestListOfApertures:
         assert phot.area.shape == (2, 2)
         assert phot.flags.shape == (2, 2)
 
-    def test_matches_per_aperture(self):
-        data = make_4gaussians_image()
+    def test_matches_per_aperture(self, data):
         pos = ((150, 25), (90, 60))
         apers = [CircularAperture(pos, r) for r in (5, 8)]
         phot = AperturePhotometry(data, apers)
@@ -139,8 +130,7 @@ class TestListOfApertures:
             ref = aperture_photometry(data, aper)
             assert_allclose(phot.flux[:, i], ref['aperture_sum'])
 
-    def test_identical_positions_required(self):
-        data = make_4gaussians_image()
+    def test_identical_positions_required(self, data):
         apers = [CircularAperture((150, 25), 5),
                  CircularAperture((90, 60), 5)]
         match = 'Input apertures must all have identical positions'
@@ -149,23 +139,20 @@ class TestListOfApertures:
 
 
 class TestSkyApertures:
-    def test_sky_center_from_pixel_wcs(self):
-        data = make_4gaussians_image()
+    def test_sky_center_from_pixel_wcs(self, data):
         wcs = make_wcs(data.shape)
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper, wcs=wcs)
         assert isinstance(phot.sky_center, SkyCoord)
         assert 'sky_center' in phot.to_table().colnames
 
-    def test_no_wcs_sky_center_none(self):
-        data = make_4gaussians_image()
+    def test_no_wcs_sky_center_none(self, data):
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper)
         assert phot.sky_center is None
         assert 'sky_center' not in phot.to_table().colnames
 
-    def test_sky_aperture(self):
-        data = make_4gaussians_image()
+    def test_sky_aperture(self, data):
         wcs = make_wcs(data.shape)
         skycoord = wcs.pixel_to_world(150, 25)
         sky_aper = SkyCircularAperture(skycoord, r=0.7 * u.arcsec)
@@ -176,8 +163,7 @@ class TestSkyApertures:
         assert isinstance(phot.sky_center, SkyCoord)
         assert phot.sky_center.isscalar is True
 
-    def test_sky_aperture_multiple_positions(self):
-        data = make_4gaussians_image()
+    def test_sky_aperture_multiple_positions(self, data):
         wcs = make_wcs(data.shape)
         skycoord = wcs.pixel_to_world([150, 90], [25, 60])
         sky_aper = SkyCircularAperture(skycoord, r=0.7 * u.arcsec)
@@ -198,8 +184,7 @@ class TestSkyApertures:
 
 
 class TestNDDataInput:
-    def test_nddata(self):
-        data = make_4gaussians_image()
+    def test_nddata(self, data):
         error = np.sqrt(np.abs(data))
         uncertainty = StdDevUncertainty(error)
         nddata = NDData(data, uncertainty=uncertainty)
@@ -209,8 +194,7 @@ class TestNDDataInput:
         assert_allclose(phot.flux, ref['aperture_sum'])
         assert_allclose(phot.flux_err, ref['aperture_sum_err'])
 
-    def test_nddata_ignored_keywords_warn(self):
-        data = make_4gaussians_image()
+    def test_nddata_ignored_keywords_warn(self, data):
         nddata = NDData(data)
         aper = CircularAperture((150, 25), 8)
         mask = np.zeros(data.shape, dtype=bool)
@@ -218,15 +202,13 @@ class TestNDDataInput:
         with pytest.warns(AstropyUserWarning, match=match):
             AperturePhotometry(nddata, aper, mask=mask)
 
-    def test_nddata_units(self):
-        data = make_4gaussians_image()
+    def test_nddata_units(self, data):
         nddata = NDData(data * u.Jy)
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(nddata, aper)
         assert phot.flux.unit == u.Jy
 
-    def test_nddata_uncertainty_with_unit(self):
-        data = make_4gaussians_image()
+    def test_nddata_uncertainty_with_unit(self, data):
         error = np.sqrt(np.abs(data))
         uncertainty = StdDevUncertainty(error, unit=u.Jy)
         nddata = NDData(data * u.Jy, uncertainty=uncertainty)
@@ -294,35 +276,30 @@ class TestSegmentationMasking:
 
 
 class TestToTable:
-    def test_default_columns(self):
-        data = make_4gaussians_image()
+    def test_default_columns(self, data):
         aper = CircularAperture((150, 25), 8)
         tbl = AperturePhotometry(data, aper).to_table()
         assert tbl.colnames == ['id', 'x_center', 'y_center', 'flux',
                                 'flux_err', 'area', 'flags']
 
-    def test_default_columns_with_wcs(self):
-        data = make_4gaussians_image()
+    def test_default_columns_with_wcs(self, data):
         wcs = make_wcs(data.shape)
         aper = CircularAperture((150, 25), 8)
         tbl = AperturePhotometry(data, aper, wcs=wcs).to_table()
         assert tbl.colnames == ['id', 'x_center', 'y_center', 'sky_center',
                                 'flux', 'flux_err', 'area', 'flags']
 
-    def test_columns_subset(self):
-        data = make_4gaussians_image()
+    def test_columns_subset(self, data):
         aper = CircularAperture((150, 25), 8)
         tbl = AperturePhotometry(data, aper).to_table(columns=['id', 'flux'])
         assert tbl.colnames == ['id', 'flux']
 
-    def test_columns_single_string(self):
-        data = make_4gaussians_image()
+    def test_columns_single_string(self, data):
         aper = CircularAperture((150, 25), 8)
         tbl = AperturePhotometry(data, aper).to_table(columns='flux')
         assert tbl.colnames == ['flux']
 
-    def test_invalid_column(self):
-        data = make_4gaussians_image()
+    def test_invalid_column(self, data):
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper)
         match = 'Invalid column name'
@@ -331,8 +308,7 @@ class TestToTable:
         with pytest.raises(ValueError, match=match):
             phot.to_table(columns=['id', 'subpixels'])
 
-    def test_multi_aperture_suffixes(self):
-        data = make_4gaussians_image()
+    def test_multi_aperture_suffixes(self, data):
         pos = ((150, 25), (90, 60))
         apers = [CircularAperture(pos, r) for r in (5, 8)]
         tbl = AperturePhotometry(data, apers).to_table()
@@ -340,8 +316,7 @@ class TestToTable:
                                 'flux_1', 'flux_err_0', 'flux_err_1',
                                 'area_0', 'area_1', 'flags_0', 'flags_1']
 
-    def test_meta(self):
-        data = make_4gaussians_image()
+    def test_meta(self, data):
         aper = CircularAperture((150, 25), 8)
         tbl = AperturePhotometry(data, aper).to_table()
         assert 'version' in tbl.meta
@@ -389,8 +364,7 @@ class TestScalarBehavior:
     while array positions yield array outputs.
     """
 
-    def test_single_scalar_position(self):
-        data = make_4gaussians_image()
+    def test_single_scalar_position(self, data):
         error = 0.1 * np.ones_like(data)
         aper = CircularAperture((150, 25), r=8)
         phot = AperturePhotometry(data, aper, error=error)
@@ -401,9 +375,8 @@ class TestScalarBehavior:
         assert phot.area.isscalar
         assert np.ndim(phot.flags) == 0
 
-    def test_array_position_single_element(self):
+    def test_array_position_single_element(self, data):
         # A length-1 list of positions is not scalar.
-        data = make_4gaussians_image()
         aper = CircularAperture([(150, 25)], r=8)
         phot = AperturePhotometry(data, aper)
         assert phot.isscalar is False
@@ -412,28 +385,25 @@ class TestScalarBehavior:
         assert phot.area.shape == (1,)
         assert phot.flags.shape == (1,)
 
-    def test_multiple_positions_not_scalar(self):
-        data = make_4gaussians_image()
+    def test_multiple_positions_not_scalar(self, data):
         aper = CircularAperture(((150, 25), (90, 60)), r=8)
         phot = AperturePhotometry(data, aper)
         assert phot.isscalar is False
         assert phot.flux.shape == (2,)
 
-    def test_scalar_matches_array(self):
+    def test_scalar_matches_array(self, data):
         """
         Test that the scalar output from a single position matches
         the first element of the array output from a length-1 list of
         positions.
         """
-        data = make_4gaussians_image()
         scalar = AperturePhotometry(data, CircularAperture((150, 25), r=8))
         array = AperturePhotometry(data, CircularAperture([(150, 25)], r=8))
         assert_allclose(scalar.flux, array.flux[0])
         assert scalar.flags == array.flags[0]
         assert_allclose(scalar.x_center, array.x_center[0])
 
-    def test_list_of_apertures_scalar_position(self):
-        data = make_4gaussians_image()
+    def test_list_of_apertures_scalar_position(self, data):
         apers = [CircularAperture((150, 25), r=r) for r in (5, 8)]
         phot = AperturePhotometry(data, apers)
         assert phot.isscalar is True
@@ -449,40 +419,35 @@ class TestScalarBehavior:
         assert phot.area.shape == (2,)
         assert phot.flags.shape == (2,)
 
-    def test_list_of_apertures_array_position(self):
-        data = make_4gaussians_image()
+    def test_list_of_apertures_array_position(self, data):
         pos = ((150, 25), (90, 60))
         apers = [CircularAperture(pos, r=r) for r in (5, 8)]
         phot = AperturePhotometry(data, apers)
         assert phot.isscalar is False
         assert phot.flux.shape == (2, 2)
 
-    def test_sky_center_scalar(self):
-        data = make_4gaussians_image()
+    def test_sky_center_scalar(self, data):
         wcs = make_wcs(data.shape)
         phot = AperturePhotometry(data, CircularAperture((150, 25), r=8),
                                   wcs=wcs)
         assert isinstance(phot.sky_center, SkyCoord)
         assert phot.sky_center.isscalar is True
 
-    def test_sky_center_array(self):
-        data = make_4gaussians_image()
+    def test_sky_center_array(self, data):
         wcs = make_wcs(data.shape)
         phot = AperturePhotometry(data, CircularAperture([(150, 25)], r=8),
                                   wcs=wcs)
         assert phot.sky_center.isscalar is False
         assert len(phot.sky_center) == 1
 
-    def test_to_table_scalar_single_aperture(self):
-        data = make_4gaussians_image()
+    def test_to_table_scalar_single_aperture(self, data):
         aper = CircularAperture((150, 25), r=8)
         tbl = AperturePhotometry(data, aper).to_table()
         assert len(tbl) == 1
         assert tbl.colnames == ['id', 'x_center', 'y_center', 'flux',
                                 'flux_err', 'area', 'flags']
 
-    def test_to_table_scalar_list_of_apertures(self):
-        data = make_4gaussians_image()
+    def test_to_table_scalar_list_of_apertures(self, data):
         apers = [CircularAperture((150, 25), r=r) for r in (5, 8)]
         tbl = AperturePhotometry(data, apers).to_table()
         assert len(tbl) == 1
@@ -498,8 +463,7 @@ class TestScalarBehavior:
         phot = AperturePhotometry(data, aper, mask=mask)
         assert phot.decode_flags() == [['masked_pixels']]
 
-    def test_isscalar_matches_aperture_stats(self):
-        data = make_4gaussians_image()
+    def test_isscalar_matches_aperture_stats(self, data):
         scalar_aper = CircularAperture((150, 25), r=8)
         array_aper = CircularAperture([(150, 25)], r=8)
         assert (AperturePhotometry(data, scalar_aper).isscalar
@@ -649,25 +613,22 @@ class TestInputValidation:
 
 
 class TestReprAndImmutability:
-    def test_repr(self):
-        data = make_4gaussians_image()
+    def test_repr(self, data):
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper)
         assert 'AperturePhotometry' in repr(phot)
         assert "method='exact'" in repr(phot)
 
-    def test_str(self):
-        data = make_4gaussians_image()
+    def test_str(self, data):
         aper = CircularAperture((150, 25), 8)
         phot = AperturePhotometry(data, aper)
         assert 'AperturePhotometry' in str(phot)
 
-    def test_no_new_attributes_after_init(self):
+    def test_no_new_attributes_after_init(self, data):
         """
         Only lazyproperty cache entries may appear after ``__init__``,
         which is required for the instance to be thread-safe.
         """
-        data = make_4gaussians_image()
         aper = CircularAperture(((150, 25), (90, 60)), 8)
         phot = AperturePhotometry(data, aper, error=np.ones_like(data),
                                   wcs=make_wcs(data.shape))
@@ -686,10 +647,9 @@ class TestReprAndImmutability:
                       'flux_err', 'area', 'flags', 'isscalar'}
         assert new_keys.issubset(lazy_names)
 
-    def test_concurrent_access(self):
+    def test_concurrent_access(self, data):
         from concurrent.futures import ThreadPoolExecutor
 
-        data = make_4gaussians_image()
         aper = CircularAperture(((150, 25), (90, 60)), 8)
         phot = AperturePhotometry(data, aper)
         with ThreadPoolExecutor(max_workers=4) as executor:

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -86,15 +86,15 @@ def test_no_overlap_close_to_edge():
     # the pixel center at x=0 (distance 1.2) is outside the circle
     aper = CircularAperture((-1.2, 12.0), r=0.8)
     result = AperturePhotometry(data, aper, method='center')
-    assert result.flags[0] == (APERTURE_FLAGS.NO_OVERLAP
-                               | APERTURE_FLAGS.NO_PIXELS)
+    assert result.flags == (APERTURE_FLAGS.NO_OVERLAP
+                            | APERTURE_FLAGS.NO_PIXELS)
     # The sum is 0.0 (not NaN) here: the bounding box overlaps the
     # data, but no weighted pixel falls inside
-    assert result.flux[0] == 0.0
+    assert result.flux == 0.0
 
     # With the exact method, the aperture area extends into the data
     result = AperturePhotometry(data, aper, method='exact')
-    assert result.flags[0] == APERTURE_FLAGS.PARTIAL_OVERLAP
+    assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
 
 
 def test_partial_overlap_clipped_bbox_only():
@@ -121,8 +121,8 @@ def test_no_pixels_tiny_aperture():
     # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
     aper = CircularAperture((12.5, 12.5), r=0.4)
     result = AperturePhotometry(data, aper, method='center')
-    assert result.flags[0] == APERTURE_FLAGS.NO_PIXELS
-    assert result.flux[0] == 0.0
+    assert result.flags == APERTURE_FLAGS.NO_PIXELS
+    assert result.flux == 0.0
 
     # The exact method has a nonzero footprint
     assert_array_equal(_flags(aper, data, method='exact'), [0])
@@ -141,22 +141,22 @@ def test_masked_pixels(method, subpixels):
     aper = CircularAperture((12, 12), r=3.0)
     flags = _flags(aper, data, mask=mask, method=method,
                    subpixels=subpixels)
-    assert flags[0] == APERTURE_FLAGS.MASKED_PIXELS
+    assert flags == APERTURE_FLAGS.MASKED_PIXELS
 
     # Masked pixel inside the bounding box but outside the aperture
     mask = np.zeros(SHAPE, dtype=bool)
     mask[9, 9] = True
     flags = _flags(aper, data, mask=mask, method=method,
                    subpixels=subpixels)
-    assert flags[0] == 0
+    assert flags == 0
 
     # Fully masked aperture
     mask = np.zeros(SHAPE, dtype=bool)
     mask[8:17, 8:17] = True
     flags = _flags(aper, data, mask=mask, method=method,
                    subpixels=subpixels)
-    assert flags[0] == (APERTURE_FLAGS.MASKED_PIXELS
-                        | APERTURE_FLAGS.ALL_MASKED)
+    assert flags == (APERTURE_FLAGS.MASKED_PIXELS
+                     | APERTURE_FLAGS.ALL_MASKED)
 
 
 def test_non_finite_data():
@@ -190,7 +190,7 @@ def test_non_finite_data():
     mask = np.zeros(SHAPE, dtype=bool)
     mask[12, 12] = True
     flags = _flags(aper, data, mask=mask)
-    assert flags[0] == APERTURE_FLAGS.MASKED_PIXELS
+    assert flags == APERTURE_FLAGS.MASKED_PIXELS
 
 
 def test_non_finite_error():
@@ -202,7 +202,7 @@ def test_non_finite_error():
     error[12, 12] = np.inf
     aper = CircularAperture((12, 12), r=3.0)
     flags = _flags(aper, data, error=error)
-    assert flags[0] == APERTURE_FLAGS.NON_FINITE_ERROR
+    assert flags == APERTURE_FLAGS.NON_FINITE_ERROR
 
     # Without an error array, the flag is never set
     assert_array_equal(_flags(aper, data), [0])
@@ -220,14 +220,14 @@ def test_neighbor_pixels(mask_method):
     aper = CircularAperture((12, 12), r=3.0)
     flags = _flags(aper, data, segmentation_image=segm, labels=1,
                    mask_method=mask_method)
-    assert flags[0] == APERTURE_FLAGS.NEIGHBOR_PIXELS
+    assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
 
     # Without any neighbor pixels inside the aperture, no flag is set
     segm2 = np.zeros(SHAPE, dtype=int)
     segm2[10:15, 10:15] = 1
     flags = _flags(aper, data, segmentation_image=segm2, labels=1,
                    mask_method=mask_method)
-    assert flags[0] == 0
+    assert flags == 0
 
 
 def test_uncorrected_pixels():
@@ -242,14 +242,14 @@ def test_uncorrected_pixels():
     aper = CircularAperture((12, 12), r=3.0)
     flags = _flags(aper, data, segmentation_image=segm, labels=1,
                    mask_method='correct')
-    assert flags[0] == (APERTURE_FLAGS.NEIGHBOR_PIXELS
-                        | APERTURE_FLAGS.UNCORRECTED_PIXELS)
+    assert flags == (APERTURE_FLAGS.NEIGHBOR_PIXELS
+                     | APERTURE_FLAGS.UNCORRECTED_PIXELS)
 
     # A correctable neighbor does not set uncorrected_pixels
     segm[12, 10] = 0
     flags = _flags(aper, data, segmentation_image=segm, labels=1,
                    mask_method='correct')
-    assert flags[0] == APERTURE_FLAGS.NEIGHBOR_PIXELS
+    assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
 
 
 def test_flag_combinations():
@@ -262,8 +262,8 @@ def test_flag_combinations():
     mask[10, 1] = True
     aper = CircularAperture((0.0, 12.0), r=3.0)  # straddles left edge
     flags = _flags(aper, data, mask=mask)
-    assert flags[0] == (APERTURE_FLAGS.PARTIAL_OVERLAP
-                        | APERTURE_FLAGS.MASKED_PIXELS)
+    assert flags == (APERTURE_FLAGS.PARTIAL_OVERLAP
+                     | APERTURE_FLAGS.MASKED_PIXELS)
 
 
 @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
@@ -350,10 +350,10 @@ def test_mask_path_parity_nonfinite_segmentation(mask_method, nan_pixel):
                     rtol=1e-12)
 
     # The NaN pixel is excluded as non_finite_data in both paths
-    assert result_batch.flags[0] & APERTURE_FLAGS.NON_FINITE_DATA
+    assert result_batch.flags & APERTURE_FLAGS.NON_FINITE_DATA
     stats = ApertureStats(data, batch_aper, **kwargs)
-    assert result_batch.flags[0] == stats.flags
-    assert_allclose(result_batch.flux[0], stats.sum, rtol=1e-12)
+    assert result_batch.flags == stats.flags
+    assert_allclose(result_batch.flux, stats.sum, rtol=1e-12)
 
 
 def test_aperture_photometry_flags():
@@ -383,7 +383,7 @@ def test_flags_with_units():
     data[12, 12] = np.nan * u.Jy
     aper = CircularAperture((12, 12), r=3.0)
     phot = AperturePhotometry(data, aper)
-    assert phot.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
+    assert phot.flags == APERTURE_FLAGS.NON_FINITE_DATA
 
 
 def test_counts_to_flag_bits_scalar_inputs():

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -121,7 +121,7 @@ class TestAperturePhotometry:
             ref = AperturePhotometry(
                 data, CircularAperture(aper.positions[idx], r=6),
                 mask=manual_mask)
-            assert_allclose(result.flux[idx], ref.flux[0])
+            assert_allclose(result.flux[idx], ref.flux)
 
 
 class TestApertureStats:

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -317,7 +317,7 @@ class TestApertureStats:
         _ = apstats.to_table()
         apstat0 = apstats[1]
         assert apstat0.n_apertures == 1
-        assert apstat0.ids == np.array([2])
+        assert apstat0.id == np.array([2])
         apstat1 = apstats.select_id(2)
         assert apstat1.n_apertures == 1
         assert apstat0.sum_aper_area == apstat1.sum_aper_area
@@ -342,18 +342,18 @@ class TestApertureStats:
         apstat0 = apstats[[2, 1, 0]]
         apstat1 = apstats.select_ids([3, 2, 1])
         assert len(apstat0) == len(apstat1) == 3
-        assert_equal(apstat0.ids, [3, 2, 1])
-        assert_equal(apstat1.ids, [3, 2, 1])
+        assert_equal(apstat0.id, [3, 2, 1])
+        assert_equal(apstat1.id, [3, 2, 1])
 
         # Test select_ids when ids are not sorted
         apstat0 = apstats[[2, 1, 0]]
         apstat1 = apstat0.select_ids(2)
-        assert apstat1.ids == 2
+        assert apstat1.id == 2
 
         mask = apstats.id >= 2
         apstat0 = apstats[mask]
         assert len(apstat0) == 2
-        assert_equal(apstat0.ids, [2, 3])
+        assert_equal(apstat0.id, [2, 3])
 
         # Test iter
         for (i, apstat) in enumerate(apstats):
@@ -379,7 +379,7 @@ class TestApertureStats:
     def test_scalar_aperture_stats(self):
         apstats = self.apstats1[0]
         assert apstats.n_apertures == 1
-        assert apstats.ids == np.array([1])
+        assert apstats.id == np.array([1])
         tbl = apstats.to_table()
         assert len(tbl) == 1
 
@@ -412,6 +412,22 @@ class TestApertureStats:
                 old_val = getattr(apstats, old_name)
             new_val = getattr(apstats, new_name)
             assert_equal(old_val, new_val)
+
+    def test_deprecated_ids(self):
+        """
+        Test that the ``ids`` attribute is deprecated and returns the
+        same value as the ``id`` attribute.
+        """
+        apstats = ApertureStats(self.data, self.aperture)
+        match = 'deprecated in version 3.1'
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            old_val = apstats.ids
+        assert_equal(old_val, apstats.id)
+
+        # A scalar instance returns the scalar id
+        scalar = apstats[0]
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            assert scalar.ids == scalar.id
 
     def test_invalid_inputs(self):
         match = 'aperture must be an Aperture or Region object'

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -191,7 +191,7 @@ class ProfileBase(metaclass=abc.ABCMeta):
         areas = []
         for aperture in apertures:
             if aperture is None:
-                flux, flux_err = [0.0], [0.0]
+                flux, flux_err = 0.0, 0.0
                 area = 0.0
             else:
                 result = AperturePhotometry(
@@ -201,9 +201,9 @@ class ProfileBase(metaclass=abc.ABCMeta):
                 area = aperture.area_overlap(self.data, mask=self.mask,
                                              method=self.method,
                                              subpixels=self.subpixels)
-            fluxes.append(flux[0])
+            fluxes.append(flux)
             if self.error is not None:
-                flux_errs.append(flux_err[0])
+                flux_errs.append(flux_err)
             areas.append(area)
 
         fluxes = np.array(fluxes)


### PR DESCRIPTION
This PR also:
* Centralizes the scalar conversions for `ApertureStats`.
* Deprecates the `ApertureStats.ids` attribute in favor of the existing `id` attribute.