### PR TITLE
Serialize PSF models to ASDF files

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -3,7 +3,7 @@ name: CI Tests
 on:
   push:
     branches:
-      - '*'
+      - main
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -3,7 +3,7 @@ name: CI Tests
 on:
   push:
     branches:
-      - main
+      - '*'
     tags:
       - '*'
   pull_request:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ General
 
 - The ``asdf-astropy`` package is now an optional dependency. [#2211]
 
--  Added serialization to ASDF for all PSF models. [#2335]
+- Added serialization to ASDF for all PSF models. [#2335]
 
 New Features
 ^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ General
 
 - The ``asdf-astropy`` package is now an optional dependency. [#2211]
 
+-  Added serialization to ASDF for all PSF models. [#2335]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -54,12 +54,15 @@ So far, the following classes can be serialized to and deserialized from
 ASDF files:
 
 * `~photutils.psf.AiryDiskPSF`
-* `photutils.psf.CircularGaussianPRF`
-* `photutils.psf.CircularGaussianPSF`
-* `photutils.psf.CircularGaussianSigmaPRF`
-* `photutils.psf.GaussianPRF`
-* `photutils.psf.GaussianPSF`
-* `photutils.psf.MoffatPSF`
+* `~photutils.psf.CircularGaussianPRF`
+* `~photutils.psf.CircularGaussianPSF`
+* `~photutils.psf.CircularGaussianSigmaPRF`
+* `~photutils.psf.GaussianPRF`
+* `~photutils.psf.GaussianPSF`
+* `~photutils.psf.MoffatPSF`
+* `~photutils.psf.GriddedPSFModel`
+* `~photutils.psf.ImagePSFModel`
+* `~photutils.psf.STDPSFGrid.`
 * `~photutils.aperture.CircularAperture`
 
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -54,6 +54,12 @@ So far, the following classes can be serialized to and deserialized from
 ASDF files:
 
 * `~photutils.psf.AiryDiskPSF`
+* `photutils.psf.CircularGaussianPRF`
+* `photutils.psf.CircularGaussianPSF`
+* `photutils.psf.CircularGaussianSigmaPRF`
+* `photutils.psf.GaussianPRF`
+* `photutils.psf.GaussianPSF`
+* `photutils.psf.MoffatPSF`
 * `~photutils.aperture.CircularAperture`
 
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -61,8 +61,8 @@ ASDF files:
 * `~photutils.psf.GaussianPSF`
 * `~photutils.psf.MoffatPSF`
 * `~photutils.psf.GriddedPSFModel`
-* `~photutils.psf.ImagePSFModel`
-* `~photutils.psf.STDPSFGrid.`
+* `~photutils.psf.ImagePSF`
+* `~photutils.psf.STDPSFGrid`
 * `~photutils.aperture.CircularAperture`
 
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -50,7 +50,7 @@ installing the ``asdf`` package. For some classes, the new optional
     >>> with asdf.open('aperture.asdf') as af:
     ...     aperture = af['aperture']
 
-So far, the following classes can be serialized to and deserialized from
+The following classes can be serialized to and deserialized from
 ASDF files:
 
 * `~photutils.psf.AiryDiskPSF`

--- a/photutils/converters/__init__.py
+++ b/photutils/converters/__init__.py
@@ -24,7 +24,6 @@ if _ASDF_ASTROPY_INSTALLED:
     from .image_models import GriddedPSFConverter, ImagePSFConverter
 
 
-
 __all__ = [
     'AiryDiskPSFConverter',
     'CircularApertureConverter',

--- a/photutils/converters/__init__.py
+++ b/photutils/converters/__init__.py
@@ -12,9 +12,28 @@ except ImportError:
 
 if _ASDF_ASTROPY_INSTALLED:
     from .apertures import CircularApertureConverter
-    from .functional_models import AiryDiskPSFConverter
+    from .functional_models import (
+        AiryDiskPSFConverter,
+        CircularGaussianPRFConverter,
+        CircularGaussianPSFConverter,
+        CircularGaussianSigmaPRFConverter,
+        GaussianPRFConverter,
+        GaussianPSFConverter,
+        MoffatPSFConverter,
+    )
+    from .image_models import GriddedPSFConverter, ImagePSFConverter
+
+
 
 __all__ = [
     'AiryDiskPSFConverter',
     'CircularApertureConverter',
+    'CircularGaussianPRFConverter',
+    'CircularGaussianPSFConverter',
+    'CircularGaussianSigmaPRFConverter',
+    'GaussianPRFConverter',
+    'GaussianPSFConverter',
+    'GriddedPSFConverter',
+    'ImagePSFConverter',
+    'MoffatPSFConverter',
 ]

--- a/photutils/converters/__init__.py
+++ b/photutils/converters/__init__.py
@@ -21,7 +21,11 @@ if _ASDF_ASTROPY_INSTALLED:
         GaussianPSFConverter,
         MoffatPSFConverter,
     )
-    from .image_models import GriddedPSFConverter, ImagePSFConverter
+    from .image_models import (
+        GriddedPSFConverter,
+        ImagePSFConverter,
+        STDPSFGridConverter,
+    )
 
 
 __all__ = [
@@ -35,4 +39,5 @@ __all__ = [
     'GriddedPSFConverter',
     'ImagePSFConverter',
     'MoffatPSFConverter',
+    'STDPSFGridConverter',
 ]

--- a/photutils/converters/functional_models.py
+++ b/photutils/converters/functional_models.py
@@ -11,7 +11,14 @@ if _ASDF_ASTROPY_INSTALLED:
 else:
     TransformConverterBase = object
 
-__all__ = ['AiryDiskPSFConverter']
+__all__ = ['AiryDiskPSFConverter',
+           'CircularGaussianPRFConverter',
+           'CircularGaussianPSFConverter',
+           'CircularGaussianSigmaPRFConverter',
+           'GaussianPRFConverter',
+           'GaussianPSFConverter',
+           'MoffatPSFConverter',
+           ]
 
 
 class AiryDiskPSFConverter(TransformConverterBase):
@@ -39,5 +46,189 @@ class AiryDiskPSFConverter(TransformConverterBase):
             x_0=node['x_0'],
             y_0=node['y_0'],
             radius=node['radius'],
+            bbox_factor=node['bbox_factor'],
+        )
+
+
+class CircularGaussianPRFConverter(TransformConverterBase):
+    """
+    ASDF converter for CircularGaussianPRF model.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/circular_gaussian_prf-*',)
+    types = ('photutils.psf.CircularGaussianPRF',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'flux': parameter_to_value(model.flux),
+            'x_0': parameter_to_value(model.x_0),
+            'y_0': parameter_to_value(model.y_0),
+            'fwhm': parameter_to_value(model.fwhm),
+            'bbox_factor': model.bbox_factor,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from photutils.psf import CircularGaussianPRF
+
+        return CircularGaussianPRF(
+            flux=node['flux'],
+            x_0=node['x_0'],
+            y_0=node['y_0'],
+            fwhm=node['fwhm'],
+            bbox_factor=node['bbox_factor'],
+        )
+
+
+class CircularGaussianPSFConverter(TransformConverterBase):
+    """
+    ASDF converter for CircularGaussianPSF model.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/circular_gaussian_psf-*',)
+    types = ('photutils.psf.CircularGaussianPSF',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'flux': parameter_to_value(model.flux),
+            'x_0': parameter_to_value(model.x_0),
+            'y_0': parameter_to_value(model.y_0),
+            'fwhm': parameter_to_value(model.fwhm),
+            'bbox_factor': model.bbox_factor,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from photutils.psf import CircularGaussianPSF
+
+        return CircularGaussianPSF(
+            flux=node['flux'],
+            x_0=node['x_0'],
+            y_0=node['y_0'],
+            fwhm=node['fwhm'],
+            bbox_factor=node['bbox_factor'],
+        )
+
+
+class CircularGaussianSigmaPRFConverter(TransformConverterBase):
+    """
+    ASDF converter for CircularGaussianSigmaPRF model.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-*',)
+    types = ('photutils.psf.CircularGaussianSigmaPRF',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'flux': parameter_to_value(model.flux),
+            'x_0': parameter_to_value(model.x_0),
+            'y_0': parameter_to_value(model.y_0),
+            'sigma': parameter_to_value(model.sigma),
+            'bbox_factor': model.bbox_factor,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from photutils.psf import CircularGaussianSigmaPRF
+
+        return CircularGaussianSigmaPRF(
+            flux=node['flux'],
+            x_0=node['x_0'],
+            y_0=node['y_0'],
+            sigma=node['sigma'],
+            bbox_factor=node['bbox_factor'],
+        )
+
+
+class GaussianPRFConverter(TransformConverterBase):
+    """
+    ASDF converter for GaussianPRF model.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/gaussian_prf-*',)
+    types = ('photutils.psf.GaussianPRF',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'flux': parameter_to_value(model.flux),
+            'x_0': parameter_to_value(model.x_0),
+            'y_0': parameter_to_value(model.y_0),
+            'x_fwhm': parameter_to_value(model.x_fwhm),
+            'y_fwhm': parameter_to_value(model.y_fwhm),
+            'theta': parameter_to_value(model.theta),
+            'bbox_factor': model.bbox_factor,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from photutils.psf import GaussianPRF
+
+        return GaussianPRF(
+            flux=node['flux'],
+            x_0=node['x_0'],
+            y_0=node['y_0'],
+            x_fwhm=node['x_fwhm'],
+            y_fwhm=node['y_fwhm'],
+            theta=node['theta'],
+            bbox_factor=node['bbox_factor'],
+        )
+
+
+class GaussianPSFConverter(TransformConverterBase):
+    """
+    ASDF converter for GaussianPSF model.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/gaussian_psf-*',)
+    types = ('photutils.psf.GaussianPSF',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'flux': parameter_to_value(model.flux),
+            'x_0': parameter_to_value(model.x_0),
+            'y_0': parameter_to_value(model.y_0),
+            'x_fwhm': parameter_to_value(model.x_fwhm),
+            'y_fwhm': parameter_to_value(model.y_fwhm),
+            'theta': parameter_to_value(model.theta),
+            'bbox_factor': model.bbox_factor,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from photutils.psf import GaussianPSF
+
+        return GaussianPSF(
+            flux=node['flux'],
+            x_0=node['x_0'],
+            y_0=node['y_0'],
+            x_fwhm=node['x_fwhm'],
+            y_fwhm=node['y_fwhm'],
+            theta=node['theta'],
+            bbox_factor=node['bbox_factor'],
+        )
+
+
+class MoffatPSFConverter(TransformConverterBase):
+    """
+    ASDF converter for MoffatPSF model.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/moffat_psf-*',)
+    types = ('photutils.psf.MoffatPSF',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'flux': parameter_to_value(model.flux),
+            'x_0': parameter_to_value(model.x_0),
+            'y_0': parameter_to_value(model.y_0),
+            'alpha': parameter_to_value(model.alpha),
+            'beta': parameter_to_value(model.beta),
+            'bbox_factor': model.bbox_factor,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from photutils.psf import MoffatPSF
+
+        return MoffatPSF(
+            flux=node['flux'],
+            x_0=node['x_0'],
+            y_0=node['y_0'],
+            alpha=node['alpha'],
+            beta=node['beta'],
             bbox_factor=node['bbox_factor'],
         )

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -112,6 +112,8 @@ class STDPSFGridConverter(Converter):
         xypos = np.array(model.grid_xypos)
         xgrid = np.array(list(set(xypos[:, 0])))
         ygrid = np.array(list(set(xypos[:, 1])))
+        xgrid.sort()
+        ygrid.sort()
         meta = {'STDPSF': model.meta.get('STDPSF', None),
                 'oversampling': model.meta['oversampling'],
                 'detector': model.meta['detector'],
@@ -121,12 +123,12 @@ class STDPSFGridConverter(Converter):
 
                 }
         return {
-            'data': model.data.copy(),
+            'data': model.data,
             'npsfs': shape[0],
             'nxpsfs': shape[-2],
             'nypsfs': shape[-1],
-            'xgrid': xgrid.copy(),
-            'ygrid': ygrid.copy(),
+            'xgrid': xgrid,
+            'ygrid': ygrid,
             'meta': meta,
         }
 

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -114,14 +114,17 @@ class STDPSFGridConverter(Converter):
         ygrid = np.array(list(set(xypos[:, 1])))
         xgrid.sort()
         ygrid.sort()
-        meta = {'STDPSF': model.meta.get('STDPSF', None),
-                'oversampling': model.meta['oversampling'],
-                'detector': model.meta['detector'],
-                'filter': model.meta['filter'],
-                'grid_shape': model.meta['grid_shape'],
-                'grid_xypos': xypos.copy(),
-
-                }
+        meta = {
+            'oversampling': model.meta['oversampling'],
+            'grid_shape': model.meta['grid_shape'],
+            'grid_xypos': xypos.copy(),
+        }
+        if 'filter' in model.meta:
+            meta['filter'] = model.meta['filter']
+        if 'detector' in model.meta:
+            meta['detector'] = model.meta['detector']
+        if 'STDPSF' in model.meta:
+            meta['STDPSF'] = model.meta['STDPSF']
         return {
             'data': model.data,
             'npsfs': shape[0],
@@ -135,4 +138,6 @@ class STDPSFGridConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
         from photutils.psf import STDPSFGrid
 
+        # Touch the array to load it into memory
+        node['meta']['grid_xypos'][0]
         return STDPSFGrid(**node)

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -15,7 +15,10 @@ else:
     TransformConverterBase = object
 
 
-__all__ = ['GriddedPSFConverter', 'ImagePSFConverter']
+__all__ = ['GriddedPSFConverter',
+           'ImagePSFConverter',
+           'STDPSFGridConverter',
+           ]
 
 
 class ImagePSFConverter(TransformConverterBase):
@@ -92,3 +95,27 @@ class GriddedPSFConverter(TransformConverterBase):
             y_0=node['y_0'],
             fill_value=node['fill_value'],
         )
+
+
+class STDPSFGridConverter(TransformConverterBase):
+    """
+    ASDF converter for STDPSFModel.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/stdpsf-*',)
+    types = ('photutils.psf.STDPSFGrid',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'data': model.data,
+            'npsfs': model.npsfs,
+            'nxpsfs': model.nxpsfs,
+            'nypsfs': model.nypsfs,
+            'xgrid': model.xgrid,
+            'ygrid': model.ygrid,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from photutils.psf import STDPSFGrid
+
+        return STDPSFGrid(node)

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -9,10 +9,12 @@ import numpy as np
 from . import _ASDF_ASTROPY_INSTALLED
 
 if _ASDF_ASTROPY_INSTALLED:
+    from asdf.extension import Converter
     from asdf_astropy.converters.transform.core import (TransformConverterBase,
                                                         parameter_to_value)
 else:
     TransformConverterBase = object
+    Converter = object
 
 
 __all__ = ['GriddedPSFConverter',
@@ -97,7 +99,7 @@ class GriddedPSFConverter(TransformConverterBase):
         )
 
 
-class STDPSFGridConverter(TransformConverterBase):
+class STDPSFGridConverter(Converter):
     """
     ASDF converter for STDPSFModel.
     """
@@ -105,17 +107,30 @@ class STDPSFGridConverter(TransformConverterBase):
     tags = ('tag:astropy.org:photutils/psf/stdpsf-*',)
     types = ('photutils.psf.STDPSFGrid',)
 
-    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+    def to_yaml_tree(self, model, tag, ctx):  # noqa: ARG002
+        shape = model.data.shape
+        xypos = np.array(model.grid_xypos)
+        xgrid = np.array(list(set(xypos[:, 0])))
+        ygrid = np.array(list(set(xypos[:, 1])))
+        meta = {'STDPSF': model.meta.get('STDPSF', None),
+                'oversampling': model.meta['oversampling'],
+                'detector': model.meta['detector'],
+                'filter': model.meta['filter'],
+                'grid_shape': model.meta['grid_shape'],
+                'grid_xypos': xypos.copy(),
+
+                }
         return {
-            'data': model.data,
-            'npsfs': model.npsfs,
-            'nxpsfs': model.nxpsfs,
-            'nypsfs': model.nypsfs,
-            'xgrid': model.xgrid,
-            'ygrid': model.ygrid,
+            'data': model.data.copy(),
+            'npsfs': shape[0],
+            'nxpsfs': shape[-2],
+            'nypsfs': shape[-1],
+            'xgrid': xgrid.copy(),
+            'ygrid': ygrid.copy(),
+            'meta': meta,
         }
 
-    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
         from photutils.psf import STDPSFGrid
 
-        return STDPSFGrid(node)
+        return STDPSFGrid(**node)

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -1,0 +1,93 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Converters to and from the ASDF format for photutils.psf.image_models
+and photutils.psf.gridded_models.
+"""
+import numpy as np
+from . import _ASDF_ASTROPY_INSTALLED
+
+if _ASDF_ASTROPY_INSTALLED:
+    from asdf_astropy.converters.transform.core import (TransformConverterBase,
+                                                        parameter_to_value)
+else:
+    TransformConverterBase = object
+
+
+__all__ = ['GriddedPSFConverter', 'ImagePSFConverter']
+
+
+class ImagePSFConverter(TransformConverterBase):
+    """
+    ASDF converter for ImagePSF model.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/image_psf-*',)
+    types = ('photutils.psf.ImagePSF',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'data': model.data,
+            'flux': parameter_to_value(model.flux),
+            'x_0': parameter_to_value(model.x_0),
+            'y_0': parameter_to_value(model.y_0),
+            'oversampling': model.oversampling,
+            'fill_value': model.fill_value,
+            'origin': model.origin,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from photutils.psf import ImagePSF
+
+        return ImagePSF(
+            # Wrapping "data" as an ndarray to ensure the data is properly
+            # converted from NDArrayType. This is necessary because
+            # the validation in ImagePSF happens before "data" is assigned.
+            data=np.array(node['data']),
+            flux=node['flux'],
+            x_0=node['x_0'],
+            y_0=node['y_0'],
+            oversampling=node['oversampling'],
+            fill_value=node['fill_value'],
+            origin=node['origin'],
+        )
+
+
+class GriddedPSFConverter(TransformConverterBase):
+    """
+    ASDF converter for GriddedPSFModel.
+    """
+
+    tags = ('tag:astropy.org:photutils/psf/gridded_psf-*',)
+    types = ('photutils.psf.GriddedPSFModel',)
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        return {
+            'data': model.data,
+            'flux': parameter_to_value(model.flux),
+            'x_0': parameter_to_value(model.x_0),
+            'y_0': parameter_to_value(model.y_0),
+            'oversampling': model.oversampling,
+            'fill_value': model.fill_value,
+            'grid_xypos': model.grid_xypos,
+        }
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        from astropy.nddata import NDData
+
+        from photutils.psf import GriddedPSFModel
+
+        nd_data = NDData(
+            data=np.array(node['data']),
+            meta={'grid_xypos': node['grid_xypos'],
+                  'oversampling': node['oversampling'],
+                  },
+        )
+
+        return GriddedPSFModel(
+            nddata=nd_data,
+            flux=node['flux'],
+            x_0=node['x_0'],
+            y_0=node['y_0'],
+            fill_value=node['fill_value'],
+        )

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -101,7 +101,7 @@ class GriddedPSFConverter(TransformConverterBase):
 
 class STDPSFGridConverter(Converter):
     """
-    ASDF converter for STDPSFModel.
+    ASDF converter for STDPSFGrid.
     """
 
     tags = ('tag:astropy.org:photutils/psf/stdpsf-*',)

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -5,6 +5,7 @@ Converters to and from the ASDF format for photutils.psf.image_models
 and photutils.psf.gridded_models.
 """
 import numpy as np
+
 from . import _ASDF_ASTROPY_INSTALLED
 
 if _ASDF_ASTROPY_INSTALLED:

--- a/photutils/converters/tests/conftest.py
+++ b/photutils/converters/tests/conftest.py
@@ -1,32 +1,78 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-Fixtures for the photutils PSF converters.
 
-Each fixture returns a tuple of ``(psf_instance, parameter_names)``,
-where ``parameter_names`` is the list of attributes to compare in
-round-trip tests.
 """
-
+Tests for the photutils PSF converters.
+"""
 import pytest
-from astropy import units as u
 
-from photutils.psf import AiryDiskPSF
-
-AIRY_DISK_PARAMETERS = ['flux', 'x_0', 'y_0', 'radius', 'bbox_factor']
+from photutils.converters.tests import examples
 
 
-@pytest.fixture(params=['no_units', 'units'], ids=['no_units', 'units'])
-def airy_disk_psf(request):
-    """
-    Return an AiryDiskPSF instance and its parameter names.
+@pytest.fixture
+def airy_disk_units():
+    return examples.airy_disk_units()
 
-    Parametrized to cover both unit-bearing and unit-less inputs.
-    """
-    if request.param == 'units':
-        psf = AiryDiskPSF(flux=1 * u.Jy, x_0=0 * u.arcsec,
-                          y_0=0 * u.arcsec, radius=1 * u.arcsec,
-                          bbox_factor=2)
-    else:
-        psf = AiryDiskPSF(flux=2, x_0=1, y_0=1, radius=2, bbox_factor=3)
 
-    return psf, AIRY_DISK_PARAMETERS
+@pytest.fixture
+def airy_disk():
+    return examples.airy_disk()
+
+
+@pytest.fixture
+def circular_gaussian_prf_units():
+    return examples.circular_gaussian_prf_units()
+
+
+@pytest.fixture
+def circular_gaussian_prf():
+    return examples.circular_gaussian_prf()
+
+
+@pytest.fixture
+def circular_gaussian_psf_units():
+    return examples.circular_gaussian_psf_units()
+
+
+@pytest.fixture
+def circular_gaussian_psf():
+    return examples.circular_gaussian_psf()
+
+
+@pytest.fixture
+def gaussian_prf_units():
+    return examples.gaussian_prf_units()
+
+
+@pytest.fixture
+def gaussian_prf():
+    return examples.gaussian_prf()
+
+
+@pytest.fixture
+def gaussian_psf_units():
+    return examples.gaussian_psf_units()
+
+
+@pytest.fixture
+def gaussian_psf():
+    return examples.gaussian_psf()
+
+
+@pytest.fixture
+def moffat_psf_units():
+    return examples.moffat_psf_units()
+
+
+@pytest.fixture
+def moffat_psf():
+    return examples.moffat_psf()
+
+
+@pytest.fixture
+def image_psf():
+    return examples.image_psf()
+
+
+@pytest.fixture
+def gridded_psf():
+    return examples.gridded_psf()

--- a/photutils/converters/tests/conftest.py
+++ b/photutils/converters/tests/conftest.py
@@ -76,3 +76,8 @@ def image_psf():
 @pytest.fixture
 def gridded_psf():
     return examples.gridded_psf()
+
+
+@pytest.fixture
+def stdpsf_single_detector():
+    return examples.stdpsf_single_detector()

--- a/photutils/converters/tests/conftest.py
+++ b/photutils/converters/tests/conftest.py
@@ -1,7 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
-Tests for the photutils PSF converters.
+Fixtures for the photutils PSF converters.
+
+Each fixture returns a tuple of ``(psf_instance, parameter_names)``,
+where ``parameter_names`` is the list of attributes to compare in
+round-trip tests.
 """
 import pytest
 
@@ -25,6 +29,16 @@ def circular_gaussian_prf_units():
 
 @pytest.fixture
 def circular_gaussian_prf():
+    return examples.circular_gaussian_prf()
+
+
+@pytest.fixture
+def circular_gaussian_sigma_prf_units():
+    return examples.circular_gaussian_prf_units()
+
+
+@pytest.fixture
+def circular_gaussian_sigma_prf():
     return examples.circular_gaussian_prf()
 
 

--- a/photutils/converters/tests/examples.py
+++ b/photutils/converters/tests/examples.py
@@ -1,0 +1,147 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Tests for the photutils PSF converters.
+All examples return a PSF instance and the list of parameters to test.
+"""
+import numpy as np
+from astropy import units as u
+from astropy.nddata import NDData
+
+from photutils.psf import (AiryDiskPSF, CircularGaussianPRF,
+                           CircularGaussianPSF, GaussianPRF, GaussianPSF,
+                           GriddedPSFModel, ImagePSF, MoffatPSF)
+
+parameters = {
+    'AiryDiskPSF': ['flux', 'x_0', 'y_0', 'radius', 'bbox_factor'],
+    'CircularGaussianPRF': ['flux', 'x_0', 'y_0', 'fwhm', 'bbox_factor'],
+    'CircularGaussianPSF': ['flux', 'x_0', 'y_0', 'fwhm', 'bbox_factor'],
+    'CircularGaussianSigmaPRF': ['flux', 'x_0', 'y_0', 'sigma',
+                                 'bbox_factor'],
+    'GaussianPRF': ['flux', 'x_0', 'y_0', 'x_fwhm', 'y_fwhm', 'theta',
+                    'bbox_factor'],
+    'GaussianPSF': ['flux', 'x_0', 'y_0', 'x_fwhm', 'y_fwhm', 'theta',
+                    'bbox_factor'],
+    'MoffatPSF': ['flux', 'x_0', 'y_0', 'alpha', 'beta', 'bbox_factor'],
+    'ImagePSF': ['data', 'flux', 'x_0', 'y_0', 'oversampling',
+                 'fill_value', 'origin'],
+    'GriddedPSF': ['data', 'flux', 'x_0', 'y_0', 'oversampling',
+                   'fill_value', 'grid_xypos'],
+}
+
+
+def airy_disk_units():
+    """Return an AiryDiskPSF with units."""
+    return (AiryDiskPSF(flux=1 * u.Jy, x_0=0 * u.arcsec, y_0=0 * u.arcsec,
+                        radius=1 * u.arcsec, bbox_factor=2),
+            parameters['AiryDiskPSF'])
+
+
+def airy_disk():
+    """Return an AiryDiskPSF without units."""
+    return (AiryDiskPSF(flux=2, x_0=1, y_0=1, radius=2, bbox_factor=3),
+            parameters['AiryDiskPSF'])
+
+
+def circular_gaussian_prf_units():
+    """Return a CircularGaussianPRF with units."""
+    return (CircularGaussianPRF(flux=1 * u.Jy,
+                                x_0=0 * u.arcsec, y_0=0 * u.arcsec,
+                                fwhm=1 * u.arcsec, bbox_factor=2),
+            parameters['CircularGaussianPRF'])
+
+
+def circular_gaussian_prf():
+    """Return a CircularGaussianPRF without units."""
+    return (CircularGaussianPRF(flux=2, x_0=1, y_0=1, fwhm=2, bbox_factor=3),
+            parameters['CircularGaussianPRF'])
+
+
+def circular_gaussian_psf_units():
+    """""Return a CircularGaussianPSF with units."""
+    return (CircularGaussianPSF(flux=1 * u.Jy,
+                                x_0=0 * u.arcsec, y_0=0 * u.arcsec,
+                                fwhm=1 * u.arcsec, bbox_factor=2),
+            parameters['CircularGaussianPSF'])
+
+
+def circular_gaussian_psf():
+    """Return a CircularGaussianPSF without units."""
+    return (CircularGaussianPSF(flux=2, x_0=1, y_0=1, fwhm=2,
+                                bbox_factor=3),
+            parameters['CircularGaussianPSF'])
+
+
+def gaussian_prf_units():
+    """Return a GaussianPRF with units."""
+    return (GaussianPRF(flux=1 * u.Jy,
+                        x_0=0 * u.arcsec, y_0=0 * u.arcsec,
+                        x_fwhm=1 * u.arcsec, y_fwhm=1 * u.arcsec,
+                        theta=0 * u.deg, bbox_factor=2),
+            parameters['GaussianPRF'])
+
+
+def gaussian_prf():
+    """Return a GaussianPRF without units."""
+    return (GaussianPRF(flux=2, x_0=1, y_0=1, x_fwhm=2, y_fwhm=2,
+                        theta=0,
+                        bbox_factor=3),
+            parameters['GaussianPRF'])
+
+
+def gaussian_psf_units():
+    """Return a GaussianPSF with units."""
+    return (GaussianPSF(flux=1 * u.Jy, x_0=0 * u.arcsec, y_0=0 * u.arcsec,
+                        x_fwhm=1 * u.arcsec, y_fwhm=1 * u.arcsec,
+                        theta=0 * u.deg, bbox_factor=2),
+            parameters['GaussianPSF'])
+
+
+def gaussian_psf():
+    """Return a GaussianPSF without units."""
+    return (GaussianPSF(flux=2, x_0=1, y_0=1,
+                        x_fwhm=2, y_fwhm=2,
+                        theta=0, bbox_factor=3),
+            parameters['GaussianPSF'])
+
+
+def moffat_psf_units():
+    """Return a MoffatPSF with units."""
+    return (MoffatPSF(flux=71.4 * u.Jy,
+                      x_0=24.3 * u.pix, y_0=25.2 * u.pix,
+                      alpha=5.1 * u.pix, beta=3.2),
+            parameters['MoffatPSF'])
+
+
+def moffat_psf():
+    """Return a MoffatPSF without units."""
+    return (MoffatPSF(flux=71.4, x_0=24.3, y_0=25.2, alpha=5.1, beta=3.2),
+            parameters['MoffatPSF'])
+
+
+def image_psf():
+    """Return an ImagePSF without units."""
+    return (ImagePSF(data=np.arange(36).reshape((6, 6)),
+                     flux=6,
+                     x_0=0.5, y_0=0.5,
+                     oversampling=1,
+                     fill_value=0,
+                     origin=(0, 0)),
+            parameters['ImagePSF'])
+
+
+def gridded_psf():
+    """Return a GriddedPSFModel without units."""
+    nd_data = NDData(data=np.arange(180).reshape((5, 6, 6)),
+                     meta={'oversampling': 1,
+                           'grid_xypos': [(2, 2),
+                                          (2, 65),
+                                          (65, 2),
+                                          (65, 2),
+                                          (65, 65)],
+                           },
+                     )
+    return (GriddedPSFModel(nddata=nd_data, flux=6,
+                            x_0=0.5, y_0=0.5,
+                            fill_value=np.nan),
+            parameters['GriddedPSF'])

--- a/photutils/converters/tests/examples.py
+++ b/photutils/converters/tests/examples.py
@@ -4,13 +4,16 @@
 Tests for the photutils PSF converters.
 All examples return a PSF instance and the list of parameters to test.
 """
+import os.path as op
+from pathlib import Path
+
 import numpy as np
 from astropy import units as u
 from astropy.nddata import NDData
 
 from photutils.psf import (AiryDiskPSF, CircularGaussianPRF,
                            CircularGaussianPSF, GaussianPRF, GaussianPSF,
-                           GriddedPSFModel, ImagePSF, MoffatPSF)
+                           GriddedPSFModel, ImagePSF, MoffatPSF, STDPSFGrid)
 
 parameters = {
     'AiryDiskPSF': ['flux', 'x_0', 'y_0', 'radius', 'bbox_factor'],
@@ -27,6 +30,7 @@ parameters = {
                  'fill_value', 'origin'],
     'GriddedPSF': ['data', 'flux', 'x_0', 'y_0', 'oversampling',
                    'fill_value', 'grid_xypos'],
+    'STDPSF': ['data', 'grid_xypos', 'oversampling'],
 }
 
 
@@ -145,3 +149,13 @@ def gridded_psf():
                             x_0=0.5, y_0=0.5,
                             fill_value=np.nan),
             parameters['GriddedPSF'])
+
+
+def stdpsf_single_detector():
+    """Return a STDPSFGrid object read from a FITS STDPSF file."""
+    filename = 'STDPSF_NRCA1_F150W_mock.fits'
+
+    filename = op.join(Path(__file__).resolve().parent.parent.parent,
+                       'psf', 'tests', 'data', filename)
+    psfgrid = STDPSFGrid(filename)
+    return psfgrid, parameters['STDPSF']

--- a/photutils/converters/tests/examples.py
+++ b/photutils/converters/tests/examples.py
@@ -12,8 +12,9 @@ from astropy import units as u
 from astropy.nddata import NDData
 
 from photutils.psf import (AiryDiskPSF, CircularGaussianPRF,
-                           CircularGaussianPSF, GaussianPRF, GaussianPSF,
-                           GriddedPSFModel, ImagePSF, MoffatPSF, STDPSFGrid)
+                           CircularGaussianPSF, CircularGaussianSigmaPRF,
+                           GaussianPRF, GaussianPSF, GriddedPSFModel, ImagePSF,
+                           MoffatPSF, STDPSFGrid)
 
 parameters = {
     'AiryDiskPSF': ['flux', 'x_0', 'y_0', 'radius', 'bbox_factor'],
@@ -59,6 +60,21 @@ def circular_gaussian_prf():
     """Return a CircularGaussianPRF without units."""
     return (CircularGaussianPRF(flux=2, x_0=1, y_0=1, fwhm=2, bbox_factor=3),
             parameters['CircularGaussianPRF'])
+
+
+def circular_gaussian_sigma_prf_units():
+    """Return a CircularGaussianPRF with units."""
+    return (CircularGaussianSigmaPRF(flux=71.4 * u.Jy,
+                                     x_0=24.3 * u.pix, y_0=25.2 * u.pix,
+                                     sigma=5.1 * u.pix),
+            parameters['CircularGaussianSigmaPRF'])
+
+
+def circular_gaussian_sigma_prf():
+    """Return a CircularGaussianPRF without units."""
+    return (CircularGaussianSigmaPRF(flux=71.4, x_0=24.3, y_0=25.2,
+                                     sigma=5.1),
+            parameters['CircularGaussianSigmaPRF'])
 
 
 def circular_gaussian_psf_units():

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -24,6 +24,8 @@ psf_params = pytest.mark.parametrize('psfobj', [
     'airy_disk',
     'circular_gaussian_prf_units',
     'circular_gaussian_prf',
+    'circular_gaussian_sigma_prf_units',
+    'circular_gaussian_sigma_prf',
     'circular_gaussian_psf_units',
     'circular_gaussian_psf',
     'gaussian_prf_units',

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -37,7 +37,6 @@ psf_params = pytest.mark.parametrize('psfobj', [
 ], indirect=True)
 
 
-
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
                     reason='asdf-astropy is not installed')
 @psf_params

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -34,6 +34,7 @@ psf_params = pytest.mark.parametrize('psfobj', [
     'moffat_psf',
     'image_psf',
     'gridded_psf',
+    'stdpsf_single_detector',
 ], indirect=True)
 
 

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -10,13 +10,42 @@ from numpy.testing import assert_array_equal
 from photutils.converters import _ASDF_ASTROPY_INSTALLED
 
 
+@pytest.fixture
+def psfobj(request):
+    """
+    A pytest fixture that returns a PSF model and the
+    list of parameters to test.
+    """
+    return request.getfixturevalue(request.param)
+
+
+psf_params = pytest.mark.parametrize('psfobj', [
+    'airy_disk_units',
+    'airy_disk',
+    'circular_gaussian_prf_units',
+    'circular_gaussian_prf',
+    'circular_gaussian_psf_units',
+    'circular_gaussian_psf',
+    'gaussian_prf_units',
+    'gaussian_prf',
+    'gaussian_psf_units',
+    'gaussian_psf',
+    'moffat_psf_units',
+    'moffat_psf',
+    'image_psf',
+    'gridded_psf',
+], indirect=True)
+
+
+
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
                     reason='asdf-astropy is not installed')
-def test_psf_converters(tmp_path, airy_disk_psf):
+@psf_params
+def test_psf_converters(tmp_path, psfobj):
     """
     Test that the PSF converters can round-trip a PSF object.
     """
-    psf, pars = airy_disk_psf
+    psf, pars = psfobj
     with asdf.AsdfFile() as af:
         af['psf'] = psf
         af.write_to(tmp_path / 'psf.asdf')

--- a/photutils/extension.py
+++ b/photutils/extension.py
@@ -25,6 +25,7 @@ PHOTUTILS_PSF_CONVERTERS = [
     functional_models.MoffatPSFConverter(),
     image_models.ImagePSFConverter(),
     image_models.GriddedPSFConverter(),
+    image_models.STDPSFGridConverter(),
 ]
 
 PHOTUTILS_APERTURE_CONVERTERS = [

--- a/photutils/extension.py
+++ b/photutils/extension.py
@@ -9,7 +9,6 @@ from asdf.resource import DirectoryResourceMapping
 
 from .converters import apertures, functional_models, image_models
 
-
 __all__ = [
     'PHOTUTILS_APERTURE_CONVERTERS',
     'PHOTUTILS_MANIFEST_URIS',

--- a/photutils/extension.py
+++ b/photutils/extension.py
@@ -2,14 +2,13 @@
 """
 ASDF extension for photutils.
 """
-
 import importlib.resources as importlib_resources
 
 from asdf.extension import ManifestExtension
 from asdf.resource import DirectoryResourceMapping
 
-from .converters import apertures  # import CircularApertureConverter
-from .converters import functional_models  # import AiryDiskPSFConverter
+from .converters import apertures, functional_models, image_models
+
 
 __all__ = [
     'PHOTUTILS_APERTURE_CONVERTERS',
@@ -19,6 +18,14 @@ __all__ = [
 
 PHOTUTILS_PSF_CONVERTERS = [
     functional_models.AiryDiskPSFConverter(),
+    functional_models.CircularGaussianPRFConverter(),
+    functional_models.CircularGaussianPSFConverter(),
+    functional_models.CircularGaussianSigmaPRFConverter(),
+    functional_models.GaussianPRFConverter(),
+    functional_models.GaussianPSFConverter(),
+    functional_models.MoffatPSFConverter(),
+    image_models.ImagePSFConverter(),
+    image_models.GriddedPSFConverter(),
 ]
 
 PHOTUTILS_APERTURE_CONVERTERS = [
@@ -26,6 +33,7 @@ PHOTUTILS_APERTURE_CONVERTERS = [
 ]
 
 PHOTUTILS_CONVERTERS = PHOTUTILS_PSF_CONVERTERS + PHOTUTILS_APERTURE_CONVERTERS
+
 
 # The order here is important; asdf will prefer to use extensions
 # that occur earlier in the list.
@@ -37,7 +45,6 @@ PHOTUTILS_MANIFEST_URIS = [
 def get_extensions():
     """
     Get the photutils extension.
-
     This method is registered with the asdf.extensions entry point.
 
     Returns

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -773,7 +773,7 @@ class STDPSFGrid:
         When `None`, ``kwargs`` are used to initialize the class.
     kwargs : dict
         A dictionary containing the array with PSFs and the meta data.
-        Used when initializing from an ASDF file. In this case 
+        Used when initializing from an ASDF file. In this case
         ``filename`` is  `None`.
 
     Examples

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -782,8 +782,6 @@ class STDPSFGrid:
         meta = None
         if filename is not None:
             grid_data = _read_stdpsf(filename)
-            if 'meta' in grid_data:
-                meta = grid_data.pop('meta')
         else:
             grid_data = kwargs
             meta = kwargs.pop('meta', None)

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -779,10 +779,14 @@ class STDPSFGrid:
     """
 
     def __init__(self, filename=None, **kwargs):
+        meta = None
         if filename is not None:
             grid_data = _read_stdpsf(filename)
+            if 'meta' in grid_data:
+                meta = grid_data.pop('meta')
         else:
             grid_data = kwargs
+            meta = kwargs.pop('meta', None)
         self.data = grid_data['data']
         self._xgrid = grid_data['xgrid']
         self._ygrid = grid_data['ygrid']
@@ -792,15 +796,16 @@ class STDPSFGrid:
         self.grid_xypos = xy_grid
         self.oversampling = as_pair('oversampling', oversampling,
                                     lower_bound=(0, 0))
-        meta = {'grid_shape': (len(self._ygrid), len(self._xgrid)),
-                'grid_xypos': xy_grid,
-                'oversampling': oversampling}
+        if meta is None:
+            meta = {'grid_shape': (len(self._ygrid), len(self._xgrid)),
+                    'grid_xypos': xy_grid,
+                    'oversampling': oversampling}
 
-        # try to get additional metadata from the filename because this
-        # information is not currently available in the FITS headers
-        file_meta = _get_metadata(filename, None)
-        if file_meta is not None:
-            meta.update(file_meta)
+            # try to get additional metadata from the filename because this
+            # information is not currently available in the FITS headers
+            file_meta = _get_metadata(filename, None)
+            if file_meta is not None:
+                meta.update(file_meta)
 
         self.meta = meta
 

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -768,8 +768,13 @@ class STDPSFGrid:
 
     Parameters
     ----------
-    filename : str
+    filename : str or None
         The name of the STDPDF FITS file. A URL can also be used.
+        When `None`, ``kwargs`` are used to initialize the class.
+    kwargs : dict
+        A dictionary containing the array with PSFs and the meta data.
+        Used when initializing from an ASDF file. In this case 
+        ``filename`` is  `None`.
 
     Examples
     --------

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -778,8 +778,11 @@ class STDPSFGrid:
     >>> fig = psfgrid.plot_grid()
     """
 
-    def __init__(self, filename):
-        grid_data = _read_stdpsf(filename)
+    def __init__(self, filename=None, **kwargs):
+        if filename is not None:
+            grid_data = _read_stdpsf(filename)
+        else:
+            grid_data = kwargs
         self.data = grid_data['data']
         self._xgrid = grid_data['xgrid']
         self._ygrid = grid_data['ygrid']
@@ -834,6 +837,13 @@ class STDPSFGrid:
 
     def __repr__(self):
         return self.__str__()
+    
+    @classmethod
+    def from_asdf(cls, filename):
+        import asdf
+        af = asdf.open(filename)
+
+
 
 
 with registry.delay_doc_updates(GriddedPSFModel):

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -771,7 +771,7 @@ class STDPSFGrid:
     filename : str or None
         The name of the STDPDF FITS file. A URL can also be used.
         When `None`, ``kwargs`` are used to initialize the class.
-    kwargs : dict
+    **kwargs : dict
         A dictionary containing the array with PSFs and the meta data.
         Used when initializing from an ASDF file. In this case
         ``filename`` is  `None`.

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -842,13 +842,6 @@ class STDPSFGrid:
 
     def __repr__(self):
         return self.__str__()
-    
-    @classmethod
-    def from_asdf(cls, filename):
-        import asdf
-        af = asdf.open(filename)
-
-
 
 
 with registry.delay_doc_updates(GriddedPSFModel):

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -82,6 +82,19 @@ class GriddedPSFModelRead(registry.UnifiedReadWrite):
 
 
 def _read_stdpsf(filename):
+    extens = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts', '.fts.gz')
+    if (isinstance(filename, fits.HDUList) or
+        isinstance(filename, io.FileIO) and filename.name.lower().endswith(extens) or
+        filename.lower().endswith(extens)
+        ):
+        return _read_fits_stdpsf(filename)
+    elif filename.endswith('asdf'):
+        return _read_asdf_stdpsf(filename)
+    else:
+        raise TypeError("STDPSF model reads only FITS and ASDF files.")
+
+
+def _read_fits_stdpsf(filename):
     """
     Read a STScI standard-format ePSF (STDPSF) FITS file.
 
@@ -147,6 +160,19 @@ def _read_stdpsf(filename):
             'nypsfs': nypsfs,
             'xgrid': xgrid,
             'ygrid': ygrid}
+
+
+def _read_asdf_stdpsf(filename):
+    import asdf
+    with asdf.open(filename) as af:
+        return {'data': af['stdpsf'].data,
+                'npsfs': af['stdpsf'].npsfs,
+                'nxpsfs': af['stdpsf'].nxpsfs,
+                'nypsfs': af['stdpsf'].nypsfs,
+                'xgrid': af['stdpsf'].xgrid,
+                'ygrid': af['stdpsf'].ygrid,
+                'meta': af['stdpsf'].meta
+                }
 
 
 def _split_detectors(grid_data, detector_data, detector_id):

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -97,12 +97,13 @@ def _read_stdpsf(filename):
     """
     extens = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts', '.fts.gz')
     if (isinstance(filename, fits.HDUList)
-            or isinstance(filename, io.FileIO)
-            and filename.name.lower().endswith(extens)
-            or filename.lower().endswith(extens)):
+        or isinstance(filename, io.FileIO) 
+        and filename.name.lower().endswith(extens)
+        or filename.lower().endswith(extens)):
         return _read_fits_stdpsf(filename)
     else:
-        raise TypeError('This interface supports only FITS files.')
+        msg = 'This interface supports only FITS files.'
+        raise TypeError(msg)
 
 
 def _read_fits_stdpsf(filename):

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -82,11 +82,24 @@ class GriddedPSFModelRead(registry.UnifiedReadWrite):
 
 
 def _read_stdpsf(filename):
+    """
+    Read a STScI standard-format ePSF (STDPSF) FITS or ASDF file.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the STDPDF FITS or ASDF file.
+
+    Returns
+    -------
+    data : dict
+        A dictionary containing the ePSF data and metadata.
+    """
     extens = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts', '.fts.gz')
     if (isinstance(filename, fits.HDUList) or
-        isinstance(filename, io.FileIO) and filename.name.lower().endswith(extens) or
-        filename.lower().endswith(extens)
-        ):
+            isinstance(filename, io.FileIO) and
+            filename.name.lower().endswith(extens) or
+            filename.lower().endswith(extens)):
         return _read_fits_stdpsf(filename)
     elif filename.endswith('asdf'):
         return _read_asdf_stdpsf(filename)
@@ -163,6 +176,19 @@ def _read_fits_stdpsf(filename):
 
 
 def _read_asdf_stdpsf(filename):
+    """
+    Read a STScI standard-format ePSF (STDPSF) ASDF file.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the STDPDF ASDF file.
+
+    Returns
+    -------
+    data : dict
+        A dictionary containing the ePSF data and metadata.
+    """
     import asdf
     with asdf.open(filename) as af:
         return {'data': af['stdpsf'].data,

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -101,10 +101,8 @@ def _read_stdpsf(filename):
             filename.name.lower().endswith(extens) or
             filename.lower().endswith(extens)):
         return _read_fits_stdpsf(filename)
-    elif filename.endswith('asdf'):
-        return _read_asdf_stdpsf(filename)
     else:
-        raise TypeError("STDPSF model reads only FITS and ASDF files.")
+        raise TypeError("This interface supports only FITS files.")
 
 
 def _read_fits_stdpsf(filename):
@@ -173,32 +171,6 @@ def _read_fits_stdpsf(filename):
             'nypsfs': nypsfs,
             'xgrid': xgrid,
             'ygrid': ygrid}
-
-
-def _read_asdf_stdpsf(filename):
-    """
-    Read a STScI standard-format ePSF (STDPSF) ASDF file.
-
-    Parameters
-    ----------
-    filename : str
-        The name of the STDPDF ASDF file.
-
-    Returns
-    -------
-    data : dict
-        A dictionary containing the ePSF data and metadata.
-    """
-    import asdf
-    with asdf.open(filename) as af:
-        return {'data': af['stdpsf'].data,
-                'npsfs': af['stdpsf'].npsfs,
-                'nxpsfs': af['stdpsf'].nxpsfs,
-                'nypsfs': af['stdpsf'].nypsfs,
-                'xgrid': af['stdpsf'].xgrid,
-                'ygrid': af['stdpsf'].ygrid,
-                'meta': af['stdpsf'].meta
-                }
 
 
 def _split_detectors(grid_data, detector_data, detector_id):

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -83,7 +83,7 @@ class GriddedPSFModelRead(registry.UnifiedReadWrite):
 
 def _read_stdpsf(filename):
     """
-    Read a STScI standard-format ePSF (STDPSF) FITS or ASDF file.
+    Read a STScI standard-format ePSF (STDPSF) FITS file.
 
     Parameters
     ----------

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -96,13 +96,13 @@ def _read_stdpsf(filename):
         A dictionary containing the ePSF data and metadata.
     """
     extens = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts', '.fts.gz')
-    if (isinstance(filename, fits.HDUList) or
-            isinstance(filename, io.FileIO) and
-            filename.name.lower().endswith(extens) or
-            filename.lower().endswith(extens)):
+    if (isinstance(filename, fits.HDUList)
+            or isinstance(filename, io.FileIO)
+            and filename.name.lower().endswith(extens)
+            or filename.lower().endswith(extens)):
         return _read_fits_stdpsf(filename)
     else:
-        raise TypeError("This interface supports only FITS files.")
+        raise TypeError('This interface supports only FITS files.')
 
 
 def _read_fits_stdpsf(filename):

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -88,7 +88,7 @@ def _read_stdpsf(filename):
     Parameters
     ----------
     filename : str
-        The name of the STDPDF FITS or ASDF file.
+        The name of the STDPDF FITS file.
 
     Returns
     -------
@@ -96,14 +96,15 @@ def _read_stdpsf(filename):
         A dictionary containing the ePSF data and metadata.
     """
     extens = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts', '.fts.gz')
-    if (isinstance(filename, fits.HDUList)
-        or isinstance(filename, io.FileIO) 
-        and filename.name.lower().endswith(extens)
-        or filename.lower().endswith(extens)):
+    is_hdulist = isinstance(filename, fits.HDUList)
+    is_fileobj = (isinstance(filename, io.FileIO)
+                  and filename.name.lower().endswith(extens))
+    is_fits_ext = (isinstance(filename, str)
+                   and filename.lower().endswith(extens))
+    if is_hdulist or is_fileobj or is_fits_ext:
         return _read_fits_stdpsf(filename)
-    else:
-        msg = 'This interface supports only FITS files.'
-        raise TypeError(msg)
+    msg = 'This interface supports only FITS files.'
+    raise TypeError(msg)
 
 
 def _read_fits_stdpsf(filename):

--- a/photutils/resources/manifests/photutils-1.0.0.yaml
+++ b/photutils/resources/manifests/photutils-1.0.0.yaml
@@ -44,3 +44,7 @@ tags:
     schema_uri: asdf://astropy.org/photutils/schemas/psf/moffat_psf-1.0.0
     title: MoffatPSF
     description: A 2D MoffatPSF model.
+  - tag_uri: tag:astropy.org:photutils/psf/stdpsf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/std_psf-1.0.0
+    title: STDPSF
+    description: STDPSF photutils model.

--- a/photutils/resources/manifests/photutils-1.0.0.yaml
+++ b/photutils/resources/manifests/photutils-1.0.0.yaml
@@ -47,4 +47,4 @@ tags:
   - tag_uri: tag:astropy.org:photutils/psf/stdpsf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/stdpsf-1.0.0
     title: STDPSF
-    description: STDPSF photutils model.
+    description: STDPSF grid container.

--- a/photutils/resources/manifests/photutils-1.0.0.yaml
+++ b/photutils/resources/manifests/photutils-1.0.0.yaml
@@ -45,6 +45,6 @@ tags:
     title: MoffatPSF
     description: A 2D MoffatPSF model.
   - tag_uri: tag:astropy.org:photutils/psf/stdpsf-1.0.0
-    schema_uri: asdf://astropy.org/photutils/schemas/psf/std_psf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/stdpsf-1.0.0
     title: STDPSF
     description: STDPSF photutils model.

--- a/photutils/resources/manifests/photutils-1.0.0.yaml
+++ b/photutils/resources/manifests/photutils-1.0.0.yaml
@@ -12,3 +12,35 @@ tags:
     schema_uri: asdf://astropy.org/photutils/schemas/psf/airy_disk_psf-1.0.0
     title: AiryDiskPSF
     description: A 2D Airy disk PSF model.
+  - tag_uri: tag:astropy.org:photutils/psf/circular_gaussian_prf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/circular_gaussian_prf-1.0.0
+    title: CircularGaussianPRF
+    description: CircularGaussianPRF model.
+  - tag_uri: tag:astropy.org:photutils/psf/circular_gaussian_psf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/circular_gaussian_psf-1.0.0
+    title: CircularGaussianPSF
+    description: CircularGaussianPSF model.
+  - tag_uri: tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/circular_gaussian_sigma_prf-1.0.0
+    title: CircularGaussianSigmaPRF
+    description: CircularGaussianSigmaPRF model.
+  - tag_uri: tag:astropy.org:photutils/psf/gaussian_prf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/gaussian_prf-1.0.0
+    title: GaussianPRF
+    description: A 2D GaussianPRF model.
+  - tag_uri: tag:astropy.org:photutils/psf/gaussian_psf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/gaussian_psf-1.0.0
+    title: GaussianPSF
+    description: A 2D GaussianPSF model.
+  - tag_uri: tag:astropy.org:photutils/psf/gridded_psf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/gridded_psf-1.0.0
+    title: GriddedPSF
+    description: GriddedPSF model.
+  - tag_uri: tag:astropy.org:photutils/psf/image_psf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/image_psf-1.0.0
+    title: ImagePSF
+    description: A 2D ImagePSF model.
+  - tag_uri: tag:astropy.org:photutils/psf/moffat_psf-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/moffat_psf-1.0.0
+    title: MoffatPSF
+    description: A 2D MoffatPSF model.

--- a/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
@@ -1,0 +1,56 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_prf-1.0.0"
+title: CircularGaussianPRF
+description: |
+  ASDF schema for serializing a photutils CircularGaussianPRF.
+
+examples:
+  -
+    - A CircularGaussianPRF with a flux of 71.4, centered at (24.3, 25.2) pixels, and a FWHM of 5 pixels.
+      psf.CircularGaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=5)
+    - |
+      !<tag:astropy.org:photutils/psf/circular_gaussian_prf-1.0.0>
+        bbox_factor: 10.0
+        bounds:
+          fwhm: [1.1754943508222875e-38, null]
+        fixed: {fwhm: true}
+        flux: 71.4
+        inputs: [x, y]
+        outputs: [z]
+        fwhm: 5.0
+        x_0: 24.3
+        y_0: 25.2
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      flux:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: Total integrated flux of the PSF.
+      x_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "X coordinate of the PSF center (pixel coordinates)."
+      y_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "Y coordinate of the PSF center (pixel coordinates)."
+      fwhm:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "Full width at half maximum of the Gaussian profile in pixels."
+      bbox_factor:
+        type: number
+        description: Factor by which to multiply the radius to determine the size of the bounding box.
+
+    required: [flux, x_0, y_0, fwhm]
+...

--- a/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
@@ -1,0 +1,62 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_psf-1.0.0"
+title: A circular 2D Gaussian PSF model.
+description: |
+  ASDF schema for serializing a photutils CircularGaussianPSF.
+  This model is a circular 2D Gaussian PSF defined by the total flux, 
+  center coordinates, and FWHM. 
+ 
+  This model is evaluated by sampling the 2D Gaussian at the input
+  coordinates. The Gaussian is normalized such that the analytical
+  integral over the entire 2D plane is equal to the total flux.
+
+examples:
+  -
+    - A CircularGaussianPSF with a flux of 71.4, centered at (24.3, 25.2) pixels, and a FWHM of 5 pixels.
+      psf.CircularGaussianPSF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=5)
+    - |
+      !<tag:astropy.org:photutils/psf/circular_gaussian_psf-1.0.0>
+        bbox_factor: 10.0
+        bounds:
+          fwhm: [1.1754943508222875e-38, null]
+        fixed: {fwhm: true}
+        flux: 71.4
+        inputs: [x, y]
+        outputs: [z]
+        fwhm: 5.0
+        x_0: 24.3
+        y_0: 25.2
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      flux:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: Total integrated flux of the PSF.
+      x_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "X coordinate of the PSF center (pixel coordinates)."
+      y_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "Y coordinate of the PSF center (pixel coordinates)."
+      fwhm:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "Full width at half maximum of the Gaussian profile in pixels."
+      bbox_factor:
+        type: number
+        description: Factor by which to multiply the radius to determine the size of the bounding box.
+
+    required: [flux, x_0, y_0, fwhm]
+...

--- a/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
@@ -5,9 +5,9 @@ id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_psf-1.0.0"
 title: A circular 2D Gaussian PSF model.
 description: |
   ASDF schema for serializing a photutils CircularGaussianPSF.
-  This model is a circular 2D Gaussian PSF defined by the total flux, 
-  center coordinates, and FWHM. 
- 
+  This model is a circular 2D Gaussian PSF defined by the total flux,
+  center coordinates, and FWHM.
+
   This model is evaluated by sampling the 2D Gaussian at the input
   coordinates. The Gaussian is normalized such that the analytical
   integral over the entire 2D plane is equal to the total flux.

--- a/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
@@ -1,0 +1,56 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_sigma_prf-1.0.0"
+title: CircularGaussianSigmaPRF
+description: |
+  ASDF schema for serializing a photutils CircularGaussianSigmaPRF.
+
+examples:
+  -
+    - A CircularGaussianSigmaPRF with a flux of 71.4, centered at (24.3, 25.2) pixels, and a FWHM of 5 pixels.
+      psf.CircularGaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, sigma=5.1)
+    - |
+      !<tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-1.0.0>
+        bbox_factor: 10.0
+        bounds:
+          fwhm: [1.1754943508222875e-38, null]
+        fixed: {fwhm: true}
+        flux: 71.4
+        inputs: [x, y]
+        outputs: [z]
+        sigma: 5.1
+        x_0: 24.3
+        y_0: 25.2
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      flux:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: Total integrated flux of the PSF.
+      x_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "X coordinate of the PSF center (pixel coordinates)."
+      y_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "Y coordinate of the PSF center (pixel coordinates)."
+      sigma:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: "Standard deviation of the Gaussian profile in pixels."
+      bbox_factor:
+        type: number
+        description: Factor by which to multiply the radius to determine the size of the bounding box.
+
+    required: [flux, x_0, y_0, sigma]
+...

--- a/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
@@ -8,8 +8,9 @@ description: |
 
 examples:
   -
-    - A CircularGaussianSigmaPRF with a flux of 71.4, centered at (24.3, 25.2) pixels, and a FWHM of 5 pixels.
-      psf.CircularGaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, sigma=5.1)
+    - A CircularGaussianSigmaPRF with a flux of 71.4, centered at (24.3, 25.2) pixels,
+      and a standard deviation of the Gaussian of 5.1 pixels.
+      psf.CircularGaussianSigmaPRF(flux=71.4, x_0=24.3, y_0=25.2, sigma=5.1)
     - |
       !<tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-1.0.0>
         bbox_factor: 10.0

--- a/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
@@ -13,10 +13,10 @@ examples:
       psf.CircularGaussianSigmaPRF(flux=71.4, x_0=24.3, y_0=25.2, sigma=5.1)
     - |
       !<tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-1.0.0>
-        bbox_factor: 10.0
+        bbox_factor: 5.5
         bounds:
-          fwhm: [1.1754943508222875e-38, null]
-        fixed: {fwhm: true}
+          sigma: [1.1754943508222875e-38, null]
+        fixed: {sigma: true}
         flux: 71.4
         inputs: [x, y]
         outputs: [z]

--- a/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
@@ -1,0 +1,79 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/gaussian_prf-1.0.0"
+title: GaussianPRF
+description: |
+  ASDF schema for serializing a 2D Gaussian PSF model integrated over pixels.
+
+
+
+examples:
+  -
+    - A GaussianPRF with a flux of 71.4, centered at (24.3, 25.2) pixels,
+      and a FWHM of 5 pixels along the x axis, and 6 pixels along the y axis,
+      with a rotation angle of 21.7 degrees.
+      psf.GaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, x_fwhm=5, y_fwhm=6, theta=21.7)
+    - |
+      !<tag:astropy.org:photutils/psf/gaussian_prf-1.0.0>
+        bbox_factor: 5.5
+        bounds:
+          x_fwhm: [1.1754943508222875e-38, null]
+          y_fwhm: [1.1754943508222875e-38, null]
+        fixed: {theta: true, x_fwhm: true, y_fwhm: true}
+        flux: 71.4
+        inputs: [x, y]
+        outputs: [z]
+        theta: 21.7
+        x_0: 24.3
+        x_fwhm: 5.0
+        y_0: 25.2
+        y_fwhm: 6.0
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      flux:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: Total integrated flux of the PSF.
+      x_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          X coordinate of the PSF center (pixel coordinates).
+      y_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Y coordinate of the PSF center (pixel coordinates).
+      x_fwhm:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Full width at half maximum of the Gaussian profile along the x axis in pixels.
+      y_fwhm:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Full width at half maximum of the Gaussian profile along the y axis in pixels.
+      theta:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Rotation angle of the Gaussian profile in degrees. The angle is 
+          measured counter-clockwise from the positive x axis in degrees." 
+      bbox_factor:
+        type: number
+        description: Factor by which to multiply the radius to determine the size of the bounding box.
+
+    required: [flux, x_0, y_0, x_fwhm, y_fwhm]
+...

--- a/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
@@ -69,8 +69,8 @@ allOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Rotation angle of the Gaussian profile in degrees. The angle is 
-          measured counter-clockwise from the positive x axis in degrees." 
+          Rotation angle of the Gaussian profile in degrees. The angle is
+          measured counter-clockwise from the positive x axis in degrees."
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.

--- a/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
@@ -1,0 +1,79 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/gaussian_psf-1.0.0"
+title: GaussianPSF
+description: |
+  ASDF schema for serializing a 2D Gaussian PSF model.
+
+
+
+examples:
+  -
+    - A GaussianPSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
+      and a FWHM of 5 pixels along the x axis, and 6 pixels along the y axis,
+      with a rotation angle of 21.7 degrees.
+      psf.GaussianPSF(flux=71.4, x_0=24.3, y_0=25.2, x_fwhm=5, y_fwhm=6, theta=21.7)
+    - |
+      !<tag:astropy.org:photutils/psf/gaussian_psf-1.0.0>
+        bbox_factor: 5.5
+        bounds:
+          x_fwhm: [1.1754943508222875e-38, null]
+          y_fwhm: [1.1754943508222875e-38, null]
+        fixed: {theta: true, x_fwhm: true, y_fwhm: true}
+        flux: 71.4
+        inputs: [x, y]
+        outputs: [z]
+        theta: 21.7
+        x_0: 24.3
+        x_fwhm: 5.0
+        y_0: 25.2
+        y_fwhm: 6.0
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      flux:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: Total integrated flux of the PSF.
+      x_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          X coordinate of the PSF center (pixel coordinates).
+      y_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Y coordinate of the PSF center (pixel coordinates).
+      x_fwhm:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Full width at half maximum of the Gaussian profile along the x axis in pixels.
+      y_fwhm:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Full width at half maximum of the Gaussian profile along the y axis in pixels.
+      theta:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Rotation angle of the Gaussian profile in degrees. The angle is 
+          measured counter-clockwise from the positive x axis in degrees." 
+      bbox_factor:
+        type: number
+        description: Factor by which to multiply the radius to determine the size of the bounding box.
+
+    required: [flux, x_0, y_0, x_fwhm, y_fwhm]
+...

--- a/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
@@ -69,8 +69,8 @@ allOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Rotation angle of the Gaussian profile in degrees. The angle is 
-          measured counter-clockwise from the positive x axis in degrees." 
+          Rotation angle of the Gaussian profile in degrees. The angle is
+          measured counter-clockwise from the positive x axis in degrees."
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.

--- a/photutils/resources/schemas/psf/gridded_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf-1.0.0.yaml
@@ -1,0 +1,53 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/gridded_psf-1.0.0"
+title: GriddedPSF
+description: |
+  ASDF schema for serializing a 2D Gridded PSF model.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      data: 
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        description: |
+          A 3D array of shape (N, My, Mx) containing N ePSF
+          images of shape (My, Mx).
+      flux:
+        type: number
+        description: |
+          Intensity scaling factor for the ePSF.
+          This is the total flux of the source, assuming the input
+          ePSF images are properly normalized.
+      x_0:
+        type: number
+        description: |
+          x position in the output coordinate grid where the model
+          is evaluated.
+      y_0:
+        type: number
+        description: |
+          y position in the output coordinate grid where the model
+          is evaluated.
+      fill_value:
+        type: number
+        description: |
+          Assign value to pixels outside the input pixel grid 
+          to avoid extrapolation.
+      oversampling:
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        description: |
+          The integer oversampling factor(s) of the input ePSF images along each axis.
+          It is in Python order - "(y, x)".
+      grid_xypos:
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        description: |
+          A list of the (x, y) grid positions of each reference ePSF. The order of
+          positions should match the first axis of the 3D `~numpy.ndarray` of ePSFs.
+          In other words, ``grid_xypos[i]`` should be the (x, y) position of the 
+          reference ePSF defined in ``nddata.data[i]``. The grid positions must form
+          a rectangular grid.
+    required: [data, oversampling, grid_xypos]
+...

--- a/photutils/resources/schemas/psf/gridded_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf-1.0.0.yaml
@@ -10,7 +10,7 @@ allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
   - type: object
     properties:
-      data: 
+      data:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
           A 3D array of shape (N, My, Mx) containing N ePSF
@@ -34,7 +34,7 @@ allOf:
       fill_value:
         type: number
         description: |
-          Assign value to pixels outside the input pixel grid 
+          Assign value to pixels outside the input pixel grid
           to avoid extrapolation.
       oversampling:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
@@ -46,7 +46,7 @@ allOf:
         description: |
           A list of the (x, y) grid positions of each reference ePSF. The order of
           positions should match the first axis of the 3D `~numpy.ndarray` of ePSFs.
-          In other words, ``grid_xypos[i]`` should be the (x, y) position of the 
+          In other words, ``grid_xypos[i]`` should be the (x, y) position of the
           reference ePSF defined in ``nddata.data[i]``. The grid positions must form
           a rectangular grid.
     required: [data, oversampling, grid_xypos]

--- a/photutils/resources/schemas/psf/gridded_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf-1.0.0.yaml
@@ -6,6 +6,34 @@ title: GriddedPSF
 description: |
   ASDF schema for serializing a 2D Gridded PSF model.
 
+examples:
+  -
+    - A GriddedPSF model example.
+
+    - |
+      !<tag:astropy.org:photutils/psf/gridded_psf-1.0.0>
+        data: !core/ndarray-1.1.0
+          source: 0
+          datatype: int64
+          byteorder: little
+          shape: [5, 6, 6]
+        fill_value: .nan
+        flux: 6.0
+        grid_xypos: !core/ndarray-1.1.0
+          source: 2
+          datatype: int64
+          byteorder: little
+          shape: [5, 2]
+        inputs: [x, y]
+        outputs: [z]
+        oversampling: !core/ndarray-1.1.0
+          source: 1
+          datatype: int64
+          byteorder: little
+          shape: [2]
+        x_0: 0.5
+        y_0: 0.5
+
 allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
   - type: object

--- a/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
@@ -13,22 +13,29 @@ examples:
       psf.ImagePSF(data=np.ones((11, 11)), flux=71.4, x_0=24.3, y_0=25.2)
     - |
       !<tag:astropy.org:photutils/psf/image_psf-1.0.0>
-        bbox_factor: 10.0
-        bounds:
-          data: [1.1754943508222875e-38, null]
-        fixed: {data: true}
         data: !core/ndarray-1.1.0
           source: 0
-          datatype: int64
+          datatype: float64
           byteorder: little
-          shape: [4, 6]
+          shape: [11, 11]
+        fill_value: 0.0
         flux: 71.4
         inputs: [x, y]
+        origin: !core/ndarray-1.1.0
+          source: 2
+          datatype: float64
+          byteorder: little
+          shape: [2]
+          offset: 8
+          strides: [-8]
         outputs: [z]
+        oversampling: !core/ndarray-1.1.0
+          source: 1
+          datatype: int64
+          byteorder: little
+          shape: [2]
         x_0: 24.3
         y_0: 25.2
-        fill_value: 0.0
-        oversampling: [1.0, 1.0]
 
 allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"

--- a/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
@@ -8,7 +8,7 @@ description: |
 
 examples:
   -
-    - An ImagePSF with a flux of 71.4, centered at (24.3, 25.2) pixels, 
+    - An ImagePSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
       and an image of shape (11, 11).
       psf.ImagePSF(data=np.ones((11, 11)), flux=71.4, x_0=24.3, y_0=25.2)
     - |
@@ -29,12 +29,12 @@ examples:
         y_0: 25.2
         fill_value: 0.0
         oversampling: [1.0, 1.0]
-        
+
 allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
   - type: object
     properties:
-      data: 
+      data:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
       flux:
         type: number
@@ -61,7 +61,7 @@ allOf:
       fill_value:
         type: number
         description: |
-          Assign value to pixels outside the input pixel grid 
+          Assign value to pixels outside the input pixel grid
           to avoid extrapolation.
       oversampling:
         anyOf:

--- a/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
@@ -1,0 +1,77 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/image_psf-1.0.0"
+title: ImagePSF
+description: |
+  ASDF schema for serializing a 2D Image PSF model.
+
+examples:
+  -
+    - An ImagePSF with a flux of 71.4, centered at (24.3, 25.2) pixels, 
+      and an image of shape (11, 11).
+      psf.ImagePSF(data=np.ones((11, 11)), flux=71.4, x_0=24.3, y_0=25.2)
+    - |
+      !<tag:astropy.org:photutils/psf/image_psf-1.0.0>
+        bbox_factor: 10.0
+        bounds:
+          data: [1.1754943508222875e-38, null]
+        fixed: {data: true}
+        data: !core/ndarray-1.1.0
+          source: 0
+          datatype: int64
+          byteorder: little
+          shape: [4, 6]
+        flux: 71.4
+        inputs: [x, y]
+        outputs: [z]
+        x_0: 24.3
+        y_0: 25.2
+        fill_value: 0.0
+        oversampling: [1.0, 1.0]
+        
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      data: 
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      flux:
+        type: number
+        description: Total integrated flux of the PSF.
+      x_0:
+        type: number
+        description: |
+          Position of the peak along the x axis.
+      y_0:
+        type: number
+        description: |
+          Position of the peak along the y axis.
+      origin:
+        anyOf:
+        - type: array
+          items:
+            type: number
+          minItems: 2
+          maxItems: 2
+        - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        description: |
+          The ``(x, y)`` coordinate with respect to the input image data
+          array that represents the reference pixel of the input data.
+      fill_value:
+        type: number
+        description: |
+          Assign value to pixels outside the input pixel grid 
+          to avoid extrapolation.
+      oversampling:
+        anyOf:
+        - type: array
+          items:
+            type: number
+          minItems: 2
+          maxItems: 2
+        - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        description: |
+          The integer oversampling factor(s) of the input PSF image in (y, x) order.
+    required: [data]
+...

--- a/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
@@ -1,0 +1,67 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/moffat_psf-1.0.0"
+title: MoffatPSF
+description: |
+  ASDF schema for serializing a 2D Moffat PSF model.
+
+
+
+examples:
+  -
+    - A MoffatPSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
+      and alpha 0f 5.1 and beta 0f 3.2
+      psf.MoffatPSF(flux=71.4, x_0=24.3, y_0=25.2, alpha=5.1, beta=3.2)
+    - |
+      !<tag:astropy.org:photutils/psf/moffat_psf-1.0.0>
+        bbox_factor: 10.0
+        bounds:
+          alpha: [1.1754943508222875e-38, null]
+          beta: [1.0, null]
+        fixed: {alpha: true, beta: true}
+        flux: 71.4
+        inputs: [x, y]
+        outputs: [z]
+        x_0: 24.3
+        y_0: 25.2
+        alpha: 5.1
+        beta: 3.2
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      flux:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: Total integrated flux of the PSF.
+      x_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Position of the peak along the x axis.
+      y_0:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Position of the peak along the y axis.
+      alpha:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - type: number
+        description: |
+          Characteristic radius of the Moffat profile.
+      beta:
+        type: number
+        description: |
+          Power-law index of the Moffat profile.
+      bbox_factor:
+        type: number
+        description: Factor by which to multiply the radius to determine the size of the bounding box.
+
+    required: [flux, x_0, y_0, alpha, beta]
+...

--- a/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
@@ -11,7 +11,7 @@ description: |
 examples:
   -
     - A MoffatPSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
-      and alpha 0f 5.1 and beta 0f 3.2
+      and alpha of 5.1 and beta of 3.2
       psf.MoffatPSF(flux=71.4, x_0=24.3, y_0=25.2, alpha=5.1, beta=3.2)
     - |
       !<tag:astropy.org:photutils/psf/moffat_psf-1.0.0>

--- a/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
@@ -96,6 +96,7 @@ properties:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
           A list of the fiducials of the PSFs in the detector frame.
+      required: [oversampling, grid_shape, grid_xypos]
 
 required: [data, npsfs, nxpsfs, nypsfs, xgrid, ygrid, meta]
 ...

--- a/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
@@ -49,40 +49,53 @@ type: object
 properties:
   data:
     tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-    description: Total integrated flux of the PSF.
+    description: |
+      A 3D array with PSFs.
   npsfs:
     type: integer
     description: |
+      The number of PSFs in the array.
   nxpsfs:
     type: integer
     description: |
+      The size of the PSF array in X.
   nypsfs:
     type: integer
+    description: |
+      The size of the PSF array in Y.
   xgrid:
     tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
     description: |
+      An array containing the X coordinate of the fiducial point of the 
+      PSF in the coordinate frame of the detector.
   ygrid:
     tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
     description: |
-  detector:
-    type: string
-    description: |
+      An array containing the Y coordinate of the fiducial point of the 
+      PSF in the coordinate frame of the detector.
   meta:
     type: object
     properties:
       STDPSF:
         type: string
-        description: |
+        title: The name of the file containing the PSFs/ 
       oversampling:
         type: integer
+        description: |
+          Oversampling factor.
       detector:
         type: string
+        title: The name of the detector
       filter:
         type: string
+        title: The name of the filter.
       grid_shape:
         type: array
+        description: The shape of the array of PSFS in numpy order.
       grid_xypos:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        description: |
+          A list of the fiducials of the PSFs in the detector frame.
 
 required: [data, npsfs, nxpsfs, nypsfs, xgrid, ygrid, meta]
 ...

--- a/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
@@ -96,7 +96,7 @@ properties:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
           A list of the fiducials of the PSFs in the detector frame.
-      required: [oversampling, grid_shape, grid_xypos]
+    required: [oversampling, grid_shape, grid_xypos]
 
 required: [data, npsfs, nxpsfs, nypsfs, xgrid, ygrid, meta]
 ...

--- a/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
@@ -66,19 +66,19 @@ properties:
   xgrid:
     tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
     description: |
-      An array containing the X coordinate of the fiducial point of the 
+      An array containing the X coordinate of the fiducial point of the
       PSF in the coordinate frame of the detector.
   ygrid:
     tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
     description: |
-      An array containing the Y coordinate of the fiducial point of the 
+      An array containing the Y coordinate of the fiducial point of the
       PSF in the coordinate frame of the detector.
   meta:
     type: object
     properties:
       STDPSF:
         type: string
-        title: The name of the file containing the PSFs/ 
+        title: The name of the file containing the PSFs.
       oversampling:
         type: integer
         description: |

--- a/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
@@ -1,0 +1,88 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://astropy.org/photutils/schemas/psf/stdpsf-1.0.0"
+title: STDPSF
+description: |
+  Schema for serializing "STDPSF" format ePSF grids to ASDF.
+
+  By convention the model is saved under a key "stdpsf".
+
+
+examples:
+  -
+    - An STDPSF ASDF file.
+    - |
+      !<tag:astropy.org:photutils/psf/stdpsf-1.0.0>
+        data: !core/ndarray-1.1.0
+          source: 0
+          datatype: float32
+          byteorder: big
+          shape: [9, 101, 101]
+        meta:
+          STDPSF: dev/photutils/STDPSF_WFC3IR_F153M.fits
+          detector: WFC3IR
+          filter: F153M
+          grid_shape: [3, 3]
+          grid_xypos: !core/ndarray-1.1.0
+            source: 3
+            datatype: int64
+            byteorder: little
+            shape: [9, 2]
+          oversampling: 4
+        npsfs: 9
+        nxpsfs: 101
+        nypsfs: 101
+        xgrid: !core/ndarray-1.1.0
+          source: 1
+          datatype: int64
+          byteorder: little
+          shape: [3]
+        ygrid: !core/ndarray-1.1.0
+          source: 2
+          datatype: int64
+          byteorder: little
+          shape: [3]
+
+
+type: object
+properties:
+  data:
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: Total integrated flux of the PSF.
+  npsfs:
+    type: integer
+    description: |
+  nxpsfs:
+    type: integer
+    description: |
+  nypsfs:
+    type: integer
+  xgrid:
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+  ygrid:
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+  detector:
+    type: string
+    description: |
+  meta:
+    type: object
+    properties:
+      STDPSF:
+        type: string
+        description: |
+      oversampling:
+        type: integer
+      detector:
+        type: string
+      filter:
+        type: string
+      grid_shape:
+        type: array
+      grid_xypos:
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+
+required: [data, npsfs, nxpsfs, nypsfs, xgrid, ygrid, meta]
+...


### PR DESCRIPTION
This PR implements ASDF serialization for the rest of the PSF models. It is based on #2211  and contributes to https://github.com/astropy/astropy-project/issues/527.

Closes https://github.com/astropy/photutils/issues/1779