### PR TITLE
Fix the multithreshold docstring, which describes a parameter it does not take

### DIFF
--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -444,19 +444,12 @@ class _SingleSourceDeblender:
 
         This method is useful for debugging and testing.
 
-        Parameters
-        ----------
-        deblend_mode : bool, optional
-            If `True` then only segmentation images with more than one
-            label will be returned. If `False` then all segmentation
-            images will be returned.
-
         Returns
         -------
-        segments : list of 2D `~numpy.ndarray`
-            A list of segmentation images, one for each threshold.
-            Only segmentation images with more than one label will be
-            returned.
+        segments : list of 2D `~numpy.ndarray` or `None`
+            A list of segmentation images, one for each threshold. An
+            entry is `None` where the threshold produced fewer than two
+            sources.
         """
         thresholds = self.compute_thresholds()
         segms = []


### PR DESCRIPTION
### Problem

`_SingleSourceDeblender.multithreshold` takes no arguments:

```python
def multithreshold(self):
```

but its docstring documents one:

```
Parameters
----------
deblend_mode : bool, optional
    If `True` then only segmentation images with more than one
    label will be returned. If `False` then all segmentation
    images will be returned.
```

`deblend_mode` appears nowhere else in the package. `grep -rn deblend_mode photutils/` returns this docstring line and nothing more.

The `Returns` section is off too. It promises that only segmentation images with more than one label come back, but the method appends whatever `_detect_sources` returns, without filtering:

```python
segm = _detect_sources(..., relabel=False, return_segmimg=False)
segms.append(segm)
```

and `_detect_sources` documents that with `return_segmimg=False`, "if only one source is found, then `None` is returned". So the list can hold `None` entries, which a caller reading this docstring would not expect.

### Change

Dropped the `Parameters` block, since there are no parameters, and rewrote `Returns` to say that entries can be `None`. Docstring only, no behaviour touched.

### Checks

```
$ pytest --pyargs photutils.segmentation.tests.test_deblend
39 passed

$ ruff check photutils/segmentation/deblend.py
All checks passed!
```

Found with a script that pulls every numpydoc `Parameters` name out of a docstring and compares it against the signature below it. This was the only hit in photutils; `astropy-healpix` came back clean.
