### PR TITLE
Clean up STDPSFGrid and GriddedPSFModel metadata handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -226,7 +226,31 @@ API Changes
     ``GriddedPSFModel`` returned when reading a STDPSF file have been
     removed. They were redundant with the ``grid_shape`` metadata key,
     which is always set and contains the same information as
-    ``(nypsfs, nxpsfs)``. [#2335]
+    ``(nypsfs, nxpsfs)``. [#2344]
+
+  - The ``grid_xypos``, ``oversampling``, and ``grid_shape`` keys have
+    been removed from the ``STDPSFGrid`` ``meta`` dictionary. The
+    ``meta`` dictionary now contains only the metadata parsed from the
+    filename (e.g., ``STDPSF``, ``detector``, and ``filter``). Use the
+    ``grid_xypos`` and ``oversampling`` attributes instead. [#2344]
+
+  - The ``STDPSFGrid`` ``grid_xypos`` attribute is now a ``numpy``
+    array instead of a list, matching the ``GriddedPSFModel``
+    attribute of the same name. The ``oversampling`` attribute is now
+    a read-only property. [#2344]
+
+  - The ``GriddedPSFModel`` ``meta`` dictionary now always stores
+    ``'grid_xypos'`` as the sorted array of grid positions and
+    ``'oversampling'`` as a normalized ``(y, x)`` tuple, so that both
+    always match the attributes of the same name. Previously, these
+    keys held the input values unchanged, which could differ from the
+    attributes in ordering, type, or shape. [#2344]
+
+  - The ``repr`` and ``str`` output of ``GriddedPSFModel``,
+    ``ImagePSF``, and ``STDPSFGrid`` now show the oversampling as a
+    tuple (e.g., ``(4, 4)``) instead of a list or ``numpy`` array. The
+    ``STDPSFGrid`` output now labels the grid shape as ``Grid shape``
+    instead of ``Grid_shape``. [#2344]
 
 
 3.0.0 (2026-04-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -222,6 +222,12 @@ API Changes
   - The default ``ApertureStats.to_table()`` columns now include a
     ``'flags'`` column. [#2327]
 
+  - The ``nxpsfs`` and ``nypsfs`` metadata keys of the
+    ``GriddedPSFModel`` returned when reading a STDPSF file have been
+    renamed to ``nx_grid`` and ``ny_grid``, respectively, to clarify
+    that they describe the shape of the ePSF grid and not the shape of
+    the ePSF images. [#2335]
+
 
 3.0.0 (2026-04-17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -224,9 +224,9 @@ API Changes
 
   - The ``nxpsfs`` and ``nypsfs`` metadata keys of the
     ``GriddedPSFModel`` returned when reading a STDPSF file have been
-    renamed to ``nx_grid`` and ``ny_grid``, respectively, to clarify
-    that they describe the shape of the ePSF grid and not the shape of
-    the ePSF images. [#2335]
+    removed. They were redundant with the ``grid_shape`` metadata key,
+    which is always set and contains the same information as
+    ``(nypsfs, nxpsfs)``. [#2335]
 
 
 3.0.0 (2026-04-17)

--- a/docs/whats_new/1.9.rst
+++ b/docs/whats_new/1.9.rst
@@ -79,5 +79,5 @@ method to plot the ePSF models.
 
 Similarly, the `~photutils.psf.STDPSFGrid` class was added to read
 STDPSF FITS files. This class can read and plot multi-detector ePSF
-grids. Note that it is merely a container for STDPDF files. It cannot be
+grids. Note that it is merely a container for STDPSF files. It cannot be
 used as a PSF model in the photometry classes.

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -475,3 +475,28 @@ The ``repr`` and ``str`` output of
 `~photutils.detection.StarFinderCatalogBase` now labels the number of
 sources as ``n_sources`` instead of ``nsources`` for naming consistency
 within photutils.
+
+``STDPSFGrid`` Metadata
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``grid_xypos``, ``oversampling``, and ``grid_shape`` keys have
+been removed from the `~photutils.psf.STDPSFGrid` ``meta`` dictionary.
+The ``meta`` dictionary now contains only the metadata parsed from the
+filename (e.g., ``STDPSF``, ``detector``, and ``filter``). The grid
+positions and oversampling factors are available as the ``grid_xypos``
+and ``oversampling`` attributes, which are now the single source of
+truth for this information::
+
+    >>> from photutils.psf import STDPSFGrid
+    >>> psfgrid = STDPSFGrid('STDPSF_ACSWFC_F814W.fits')
+    >>> psfgrid.grid_xypos  # instead of psfgrid.meta['grid_xypos']
+    >>> psfgrid.oversampling  # instead of psfgrid.meta['oversampling']
+
+The ``grid_xypos`` attribute is now a `~numpy.ndarray` instead of a
+list, matching the `~photutils.psf.GriddedPSFModel` attribute of the
+same name, and ``oversampling`` is now a read-only property.
+
+Relatedly, the `~photutils.psf.GriddedPSFModel` ``meta`` dictionary
+now always stores ``'grid_xypos'`` as the sorted array of grid
+positions and ``'oversampling'`` as a normalized ``(y, x)`` tuple, so
+that both always match the attributes of the same name.

--- a/photutils/converters/__init__.py
+++ b/photutils/converters/__init__.py
@@ -22,7 +22,7 @@ if _ASDF_ASTROPY_INSTALLED:
         MoffatPSFConverter,
     )
     from .image_models import (
-        GriddedPSFConverter,
+        GriddedPSFModelConverter,
         ImagePSFConverter,
         STDPSFGridConverter,
     )
@@ -36,7 +36,7 @@ __all__ = [
     'CircularGaussianSigmaPRFConverter',
     'GaussianPRFConverter',
     'GaussianPSFConverter',
-    'GriddedPSFConverter',
+    'GriddedPSFModelConverter',
     'ImagePSFConverter',
     'MoffatPSFConverter',
     'STDPSFGridConverter',

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -79,11 +79,11 @@ class GriddedPSFModelConverter(TransformConverterBase):
         }
 
         # Preserve any additional meta items (e.g., 'STDPSF', 'detector',
-        # 'filter'). 'grid_xypos' is excluded because it is already stored
-        # above.
-        node['meta'] = {key: value for key, value in model.meta.items()
-                        if key != 'grid_xypos'}
-        node['meta']['oversampling'] = model.oversampling
+        # 'filter'). 'grid_xypos' and 'oversampling' are stored above.
+        node['meta'] = {
+            key: value for key, value in model.meta.items()
+            if key not in ('grid_xypos', 'oversampling')
+        }
 
         return node
 
@@ -94,6 +94,7 @@ class GriddedPSFModelConverter(TransformConverterBase):
 
         meta = dict(node['meta'])
         meta['grid_xypos'] = node['grid_xypos']
+        meta['oversampling'] = node['oversampling']
 
         nd_data = NDData(data=np.array(node['data']), meta=meta)
 

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -17,7 +17,7 @@ else:
     Converter = object
 
 
-__all__ = ['GriddedPSFConverter',
+__all__ = ['GriddedPSFModelConverter',
            'ImagePSFConverter',
            'STDPSFGridConverter',
            ]
@@ -59,7 +59,7 @@ class ImagePSFConverter(TransformConverterBase):
         )
 
 
-class GriddedPSFConverter(TransformConverterBase):
+class GriddedPSFModelConverter(TransformConverterBase):
     """
     ASDF converter for GriddedPSFModel.
     """

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -116,17 +116,16 @@ class STDPSFGridConverter(Converter):
     types = ('photutils.psf.STDPSFGrid',)
 
     def to_yaml_tree(self, model, tag, ctx):  # noqa: ARG002
-        meta = {
-            'oversampling': model.meta['oversampling'],
-            'grid_shape': model.meta['grid_shape'],
-            'grid_xypos': np.array(model.grid_xypos),
-        }
-        if 'filter' in model.meta:
-            meta['filter'] = model.meta['filter']
-        if 'detector' in model.meta:
-            meta['detector'] = model.meta['detector']
-        if 'STDPSF' in model.meta:
-            meta['STDPSF'] = model.meta['STDPSF']
+        grid_xypos = np.array(model.grid_xypos)
+        xgrid = np.unique(grid_xypos[:, 0])
+        ygrid = np.unique(grid_xypos[:, 1])
+        meta = dict(model.meta)
+        meta.update({
+            'oversampling': tuple(int(value)
+                                  for value in model.oversampling),
+            'grid_shape': (len(ygrid), len(xgrid)),
+            'grid_xypos': grid_xypos,
+        })
         return {
             'data': model.data,
             'meta': meta,

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -79,10 +79,11 @@ class GriddedPSFModelConverter(TransformConverterBase):
         }
 
         # Preserve any additional meta items (e.g., 'STDPSF', 'detector',
-        # 'filter') and the original 'oversampling' value. 'grid_xypos'
-        # is excluded because it is already stored above.
+        # 'filter'). 'grid_xypos' is excluded because it is already stored
+        # above.
         node['meta'] = {key: value for key, value in model.meta.items()
                         if key != 'grid_xypos'}
+        node['meta']['oversampling'] = model.oversampling
 
         return node
 

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -108,16 +108,10 @@ class STDPSFGridConverter(Converter):
     types = ('photutils.psf.STDPSFGrid',)
 
     def to_yaml_tree(self, model, tag, ctx):  # noqa: ARG002
-        shape = model.data.shape
-        xypos = np.array(model.grid_xypos)
-        xgrid = np.array(list(set(xypos[:, 0])))
-        ygrid = np.array(list(set(xypos[:, 1])))
-        xgrid.sort()
-        ygrid.sort()
         meta = {
             'oversampling': model.meta['oversampling'],
             'grid_shape': model.meta['grid_shape'],
-            'grid_xypos': xypos.copy(),
+            'grid_xypos': np.array(model.grid_xypos),
         }
         if 'filter' in model.meta:
             meta['filter'] = model.meta['filter']
@@ -127,11 +121,6 @@ class STDPSFGridConverter(Converter):
             meta['STDPSF'] = model.meta['STDPSF']
         return {
             'data': model.data,
-            'npsfs': shape[0],
-            'nx_psf': shape[2],
-            'ny_psf': shape[1],
-            'xgrid': xgrid,
-            'ygrid': ygrid,
             'meta': meta,
         }
 

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -68,7 +68,7 @@ class GriddedPSFConverter(TransformConverterBase):
     types = ('photutils.psf.GriddedPSFModel',)
 
     def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
-        return {
+        node = {
             'data': model.data,
             'flux': parameter_to_value(model.flux),
             'x_0': parameter_to_value(model.x_0),
@@ -78,17 +78,23 @@ class GriddedPSFConverter(TransformConverterBase):
             'grid_xypos': model.grid_xypos,
         }
 
+        # Preserve any additional meta items (e.g., 'STDPSF', 'detector',
+        # 'filter') and the original 'oversampling' value. 'grid_xypos'
+        # is excluded because it is already stored above.
+        node['meta'] = {key: value for key, value in model.meta.items()
+                        if key != 'grid_xypos'}
+
+        return node
+
     def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
         from astropy.nddata import NDData
 
         from photutils.psf import GriddedPSFModel
 
-        nd_data = NDData(
-            data=np.array(node['data']),
-            meta={'grid_xypos': node['grid_xypos'],
-                  'oversampling': node['oversampling'],
-                  },
-        )
+        meta = dict(node['meta'])
+        meta['grid_xypos'] = node['grid_xypos']
+
+        nd_data = NDData(data=np.array(node['data']), meta=meta)
 
         return GriddedPSFModel(
             nddata=nd_data,

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -79,10 +79,11 @@ class GriddedPSFModelConverter(TransformConverterBase):
         }
 
         # Preserve any additional meta items (e.g., 'STDPSF', 'detector',
-        # 'filter'). 'grid_xypos' and 'oversampling' are stored above.
+        # 'filter'). 'grid_xypos' and 'oversampling' are stored above and
+        # 'grid_shape' is recomputed when the model is initialized.
         node['meta'] = {
             key: value for key, value in model.meta.items()
-            if key not in ('grid_xypos', 'oversampling')
+            if key not in ('grid_xypos', 'oversampling', 'grid_shape')
         }
 
         return node
@@ -116,15 +117,12 @@ class STDPSFGridConverter(Converter):
     types = ('photutils.psf.STDPSFGrid',)
 
     def to_yaml_tree(self, model, tag, ctx):  # noqa: ARG002
-        grid_xypos = np.array(model.grid_xypos)
-        xgrid = np.unique(grid_xypos[:, 0])
-        ygrid = np.unique(grid_xypos[:, 1])
         meta = dict(model.meta)
         meta.update({
             'oversampling': tuple(int(value)
                                   for value in model.oversampling),
-            'grid_shape': (len(ygrid), len(xgrid)),
-            'grid_xypos': grid_xypos,
+            'grid_shape': model._grid_shape,
+            'grid_xypos': np.array(model.grid_xypos),
         })
         return {
             'data': model.data,
@@ -136,4 +134,4 @@ class STDPSFGridConverter(Converter):
 
         # Touch the array to load it into memory
         node['meta']['grid_xypos'][0]
-        return STDPSFGrid(**node)
+        return STDPSFGrid._from_asdf(node['data'], node['meta'])

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -128,8 +128,8 @@ class STDPSFGridConverter(Converter):
         return {
             'data': model.data,
             'npsfs': shape[0],
-            'nxpsfs': shape[-2],
-            'nypsfs': shape[-1],
+            'nx_psf': shape[2],
+            'ny_psf': shape[1],
             'xgrid': xgrid,
             'ygrid': ygrid,
             'meta': meta,

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -8,6 +8,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from photutils.converters import _ASDF_ASTROPY_INSTALLED
+from photutils.converters.image_models import GriddedPSFModelConverter
 
 
 @pytest.fixture
@@ -67,6 +68,10 @@ def test_gridded_psf_converter_preserves_modified_oversampling(tmp_path,
     """Test that a modified oversampling value survives a round trip."""
     psf, _ = psfobj
     psf.oversampling = (2, 3)
+
+    node = GriddedPSFModelConverter().to_yaml_tree_transform(psf, None, None)
+    assert 'oversampling' in node
+    assert 'oversampling' not in node['meta']
 
     filename = tmp_path / 'psf.asdf'
     with asdf.AsdfFile() as af:

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -4,11 +4,13 @@ Tests for the photutils PSF converters.
 """
 
 import asdf
+import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
 from photutils.converters import _ASDF_ASTROPY_INSTALLED
 from photutils.converters.image_models import GriddedPSFModelConverter
+from photutils.psf import STDPSFGrid
 
 
 @pytest.fixture
@@ -82,3 +84,22 @@ def test_gridded_psf_converter_preserves_modified_oversampling(tmp_path,
         psf2 = af['psf']
         assert_array_equal(psf2.oversampling, (2, 3))
         assert psf2.meta['oversampling'] == (2, 3)
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+def test_stdpsf_grid_converter_preserves_oversampling(tmp_path):
+    """Test that a non-default oversampling value survives a round trip."""
+    data = np.ones((4, 4, 4))
+    meta = {'grid_xypos': np.array([(0, 0), (1, 0), (0, 1), (1, 1)]),
+            'oversampling': 8}
+    psfgrid = STDPSFGrid(data=data, meta=meta)
+
+    filename = tmp_path / 'psf.asdf'
+    with asdf.AsdfFile() as af:
+        af['psf'] = psfgrid
+        af.write_to(filename)
+
+    with asdf.open(filename) as af:
+        psfgrid2 = af['psf']
+        assert_array_equal(psfgrid2.oversampling, (8, 8))

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -91,8 +91,12 @@ def test_gridded_psf_converter_preserves_modified_oversampling(tmp_path,
 def test_stdpsf_grid_converter_preserves_oversampling(tmp_path):
     """Test that a non-default oversampling value survives a round trip."""
     data = np.ones((4, 4, 4))
-    meta = {'grid_xypos': np.array([(0, 0), (1, 0), (0, 1), (1, 1)]),
-            'oversampling': 8}
+    meta = {
+        'grid_xypos': np.array([(0, 0), (1, 0), (0, 1), (1, 1)]),
+        'oversampling': 8,
+        'instrument': 'test-instrument',
+        'custom': {'value': 42},
+    }
     psfgrid = STDPSFGrid(data=data, meta=meta)
 
     filename = tmp_path / 'psf.asdf'
@@ -103,3 +107,8 @@ def test_stdpsf_grid_converter_preserves_oversampling(tmp_path):
     with asdf.open(filename) as af:
         psfgrid2 = af['psf']
         assert_array_equal(psfgrid2.oversampling, (8, 8))
+        assert psfgrid2.meta['instrument'] == 'test-instrument'
+        assert psfgrid2.meta['custom'] == {'value': 42}
+        assert 'grid_xypos' not in psfgrid2.meta
+        assert 'oversampling' not in psfgrid2.meta
+        assert 'grid_shape' not in psfgrid2.meta

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -57,3 +57,23 @@ def test_psf_converters(tmp_path, psfobj):
             for parameter in pars:
                 assert_array_equal(getattr(psf, parameter),
                                    getattr(psf2, parameter))
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('psfobj', ['gridded_psf'], indirect=True)
+def test_gridded_psf_converter_preserves_modified_oversampling(tmp_path,
+                                                               psfobj):
+    """Test that a modified oversampling value survives a round trip."""
+    psf, _ = psfobj
+    psf.oversampling = (2, 3)
+
+    filename = tmp_path / 'psf.asdf'
+    with asdf.AsdfFile() as af:
+        af['psf'] = psf
+        af.write_to(filename)
+
+    with asdf.open(filename) as af:
+        psf2 = af['psf']
+        assert_array_equal(psf2.oversampling, (2, 3))
+        assert psf2.meta['oversampling'] == (2, 3)

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -69,7 +69,9 @@ def test_psf_converters(tmp_path, psfobj):
 @pytest.mark.parametrize('psfobj', ['gridded_psf'], indirect=True)
 def test_gridded_psf_converter_preserves_modified_oversampling(tmp_path,
                                                                psfobj):
-    """Test that a modified oversampling value survives a round trip."""
+    """
+    Test that a modified oversampling value survives a round trip.
+    """
     psf, _ = psfobj
     psf.oversampling = (2, 3)
 
@@ -91,7 +93,9 @@ def test_gridded_psf_converter_preserves_modified_oversampling(tmp_path,
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
                     reason='asdf-astropy is not installed')
 def test_stdpsf_grid_converter_preserves_oversampling(tmp_path):
-    """Test that a non-default oversampling value survives a round trip."""
+    """
+    Test that a non-default oversampling value survives a round trip.
+    """
     data = np.ones((4, 4, 4))
     meta = {
         'grid_xypos': np.array([(0, 0), (1, 0), (0, 1), (1, 1)]),

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -3,6 +3,8 @@
 Tests for the photutils PSF converters.
 """
 
+import os.path as op
+
 import asdf
 import numpy as np
 import pytest
@@ -93,11 +95,12 @@ def test_stdpsf_grid_converter_preserves_oversampling(tmp_path):
     data = np.ones((4, 4, 4))
     meta = {
         'grid_xypos': np.array([(0, 0), (1, 0), (0, 1), (1, 1)]),
+        'grid_shape': (2, 2),
         'oversampling': 8,
         'instrument': 'test-instrument',
         'custom': {'value': 42},
     }
-    psfgrid = STDPSFGrid(data=data, meta=meta)
+    psfgrid = STDPSFGrid._from_asdf(data, meta)
 
     filename = tmp_path / 'psf.asdf'
     with asdf.AsdfFile() as af:
@@ -112,3 +115,30 @@ def test_stdpsf_grid_converter_preserves_oversampling(tmp_path):
         assert 'grid_xypos' not in psfgrid2.meta
         assert 'oversampling' not in psfgrid2.meta
         assert 'grid_shape' not in psfgrid2.meta
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+def test_stdpsf_grid_converter_repeated_grid_coordinate(tmp_path):
+    """
+    Test a round trip for an ACS/WFC grid, whose y coordinates are
+    repeated where the two detectors abut.
+    """
+    filename = op.join(op.dirname(op.abspath(__file__)), '..', '..', 'psf',
+                       'tests', 'data', 'STDPSF_ACSWFC_F814W_mock.fits')
+    psfgrid = STDPSFGrid(filename)
+    assert psfgrid._grid_shape == (10, 9)
+
+    asdf_filename = tmp_path / 'psf.asdf'
+    with asdf.AsdfFile() as af:
+        af['psf'] = psfgrid
+        af.write_to(asdf_filename)
+
+    with asdf.open(asdf_filename) as af:
+        psfgrid2 = af['psf']
+        assert psfgrid2._grid_shape == psfgrid._grid_shape
+        assert_array_equal(psfgrid2.grid_xypos, psfgrid.grid_xypos)
+        assert_array_equal(psfgrid2._xgrid, psfgrid._xgrid)
+        assert_array_equal(psfgrid2._ygrid, psfgrid._ygrid)
+        assert_array_equal(psfgrid2.data, psfgrid.data)
+        assert repr(psfgrid2) == repr(psfgrid)

--- a/photutils/extension.py
+++ b/photutils/extension.py
@@ -24,7 +24,7 @@ PHOTUTILS_PSF_CONVERTERS = [
     functional_models.GaussianPSFConverter(),
     functional_models.MoffatPSFConverter(),
     image_models.ImagePSFConverter(),
-    image_models.GriddedPSFConverter(),
+    image_models.GriddedPSFModelConverter(),
     image_models.STDPSFGridConverter(),
 ]
 

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -780,26 +780,8 @@ class STDPSFGrid:
 
     Parameters
     ----------
-    filename : str or None
-        The name or URL of a STDPSF FITS file. If `None`, the class is
-        initialized from ``kwargs``.
-
-    **kwargs : dict
-        Keyword arguments used to initialize the class when ``filename``
-        is `None` (e.g., when restoring from an ASDF file). Recognized
-        keys are:
-
-        * ``'data'`` : `~numpy.ndarray`
-            A 3D array containing the ePSF grid.
-
-        * ``'meta'`` : `dict`
-            A metadata dictionary containing at least ``'grid_xypos'``,
-            an ``(N, 2)`` array of fiducial ``(x, y)`` detector
-            coordinates. It may also contain ``'oversampling'``; if
-            omitted, the default is ``(4, 4)``. The structural keys
-            ``'grid_xypos'``, ``'oversampling'``, and ``'grid_shape'``
-            are consumed during initialization and are not retained in
-            ``meta``.
+    filename : str
+        The name or URL of a STDPSF FITS file.
 
     Examples
     --------
@@ -808,42 +790,101 @@ class STDPSFGrid:
     >>> fig = psfgrid.plot_grid()
     """
 
-    def __init__(self, filename=None, **kwargs):
-        # STDPSF files are assumed to have an oversampling factor of 4
-        # along both axes. This is the default if the oversampling is
-        # not provided in the meta dictionary.
-        oversampling_default = (4, 4)
+    # STDPSF files are assumed to have an oversampling factor of 4 along
+    # both axes
+    _default_oversampling = (4, 4)
 
-        if filename is not None:
-            grid_data = _read_stdpsf(filename)
-            data = grid_data['data']
-            xgrid = grid_data['xgrid']
-            ygrid = grid_data['ygrid']
-            # itertools.product iterates over the last input first
-            xy_grid = np.array([yx[::-1] for yx in itertools.product(
-                ygrid, xgrid)])
-            oversampling = oversampling_default
+    def __init__(self, filename):
+        grid_data = _read_stdpsf(filename)
+        xgrid = grid_data['xgrid']
+        ygrid = grid_data['ygrid']
 
-            # Try to get additional metadata from the filename because
-            # this information is not currently available in the FITS
-            # headers.
-            meta = _get_metadata(filename, None) or {}
-        else:
-            data = kwargs['data']
-            meta = kwargs['meta'].copy()
-            xy_grid = np.asarray(meta.pop('grid_xypos'))
-            oversampling = meta.pop('oversampling', oversampling_default)
-            meta.pop('grid_shape', None)
-            xgrid = np.unique(xy_grid[:, 0])  # sorted
-            ygrid = np.unique(xy_grid[:, 1])  # sorted
+        # itertools.product iterates over the last input first
+        grid_xypos = np.array([yx[::-1]
+                               for yx in itertools.product(ygrid, xgrid)])
 
+        # try to get additional metadata from the filename because this
+        # information is not currently available in the FITS headers
+        meta = _get_metadata(filename, None) or {}
+
+        self._init_grid(grid_data['data'], grid_xypos,
+                        (len(ygrid), len(xgrid)),
+                        self._default_oversampling, meta)
+
+    @classmethod
+    def _from_asdf(cls, data, meta):
+        """
+        Create a `STDPSFGrid` from the contents of an ASDF file.
+
+        Parameters
+        ----------
+        data : `~numpy.ndarray`
+            A 3D array containing the ePSF grid.
+
+        meta : dict
+            A metadata dictionary. It must contain a ``'grid_xypos'``
+            key holding an ``(N, 2)`` array of the fiducial ``(x, y)``
+            detector coordinates and a ``'grid_shape'`` key holding the
+            ``(ny, nx)`` shape of the grid. It may also contain an
+            ``'oversampling'`` key; if absent, the default is ``(4,
+            4)``. These three keys are consumed here and are not
+            retained in the ``meta`` attribute.
+
+        Returns
+        -------
+        result : `STDPSFGrid`
+            The ePSF grid.
+        """
+        meta = dict(meta)
+        for key in ('grid_xypos', 'grid_shape'):
+            if key not in meta:
+                msg = f'{key!r} must be in the meta dictionary'
+                raise ValueError(msg)
+
+        grid_xypos = np.asarray(meta.pop('grid_xypos'))
+        grid_shape = meta.pop('grid_shape')
+        oversampling = meta.pop('oversampling', cls._default_oversampling)
+
+        obj = cls.__new__(cls)
+        obj._init_grid(data, grid_xypos, grid_shape, oversampling, meta)
+        return obj
+
+    def _init_grid(self, data, grid_xypos, grid_shape, oversampling, meta):
+        """
+        Set the ePSF grid attributes.
+
+        Parameters
+        ----------
+        data : `~numpy.ndarray`
+            A 3D array containing the ePSF grid.
+
+        grid_xypos : `~numpy.ndarray`
+            An ``(N, 2)`` array of the fiducial ``(x, y)`` detector
+            coordinates of each ePSF, ordered along y and then x.
+
+        grid_shape : tuple of int
+            The ``(ny, nx)`` shape of the ePSF grid.
+
+        oversampling : int or array_like of int
+            The integer oversampling factor(s) of the ePSF images.
+
+        meta : dict
+            The metadata dictionary.
+        """
         self.data = data
-        self.grid_xypos = xy_grid
-        self._xgrid = xgrid
-        self._ygrid = ygrid
+        self.grid_xypos = grid_xypos
+        self.meta = meta
+        self._grid_shape = tuple(int(value) for value in grid_shape)
+
+        # The grid axes are extracted from the first row and column
+        # rather than with np.unique because a coordinate can be
+        # repeated where two detectors abut (e.g., ACS/WFC)
+        xypos = grid_xypos.reshape(*self._grid_shape, 2)
+        self._xgrid = xypos[0, :, 0]
+        self._ygrid = xypos[:, 0, 1]
+
         self._oversampling = as_pair('oversampling', oversampling,
                                      lower_bound=(0, 0))
-        self.meta = meta
 
     @property
     def oversampling(self):
@@ -871,7 +912,6 @@ class STDPSFGrid:
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
         cls_info = []
-        grid_shape = (self._ygrid.size, self._xgrid.size)
         # Use int to avoid printing numpy int64 values in the string
         # representation
         oversampling = tuple(int(value) for value in self.oversampling)
@@ -882,7 +922,7 @@ class STDPSFGrid:
                 name = key.capitalize() if key != 'STDPSF' else key
                 cls_info.append((name, self.meta[key]))
 
-        cls_info.extend([('Grid shape', grid_shape),
+        cls_info.extend([('Grid shape', self._grid_shape),
                          ('Number of PSFs', len(self.grid_xypos)),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -142,6 +142,9 @@ class GriddedPSFModel(Fittable2DModel):
         self._xgrid = np.unique(self.grid_xypos[:, 0])  # sorted
         self._ygrid = np.unique(self.grid_xypos[:, 1])  # sorted
         self.meta['grid_shape'] = (len(self._ygrid), len(self._xgrid))
+        # Store the normalized (y, x) pair so meta always matches
+        # the oversampling attribute, regardless of the input form.
+        self.meta['oversampling'] = tuple(int(v) for v in self._oversampling)
 
         self._interpolator = {}
 
@@ -293,7 +296,7 @@ class GriddedPSFModel(Fittable2DModel):
                          ('Grid positions', self.grid_xypos.tolist()),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
-                         ('Oversampling', self.oversampling.tolist()),
+                         ('Oversampling', tuple(self.oversampling.tolist())),
                          ('Fill Value', self.fill_value)])
 
         return self._format_str(keywords=keywords)
@@ -817,6 +820,11 @@ class STDPSFGrid:
                 meta.update(file_meta)
 
         self.meta = meta
+        # Store the normalized (y, x) pairs so meta always matches
+        # the oversampling attribute and grid shape, regardless of
+        # the input form (e.g., after an ASDF round trip).
+        self.meta['oversampling'] = tuple(int(v) for v in self.oversampling)
+        self.meta['grid_shape'] = (len(self._ygrid), len(self._xgrid))
 
     @_plot_grid_docstring
     def plot_grid(self, *, ax=None, vmax_scale=None, peak_norm=False,
@@ -842,7 +850,7 @@ class STDPSFGrid:
         cls_info.extend([('Number of PSFs', len(self.grid_xypos)),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
-                         ('Oversampling', self.oversampling)])
+                         ('Oversampling', tuple(self.oversampling.tolist()))])
 
         with np.printoptions(threshold=25, edgeitems=5):
             fmt = [f'{key}: {val}' for key, val in cls_info]

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -284,6 +284,7 @@ class GriddedPSFModel(Fittable2DModel):
 
     def __str__(self):
         keywords = []
+        oversampling = tuple(int(value) for value in self.oversampling)
 
         keys = ('STDPSF', 'instrument', 'detector', 'filter')
         for key in keys:
@@ -296,7 +297,7 @@ class GriddedPSFModel(Fittable2DModel):
                          ('Grid positions', self.grid_xypos.tolist()),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
-                         ('Oversampling', tuple(self.oversampling.tolist())),
+                         ('Oversampling', oversampling),
                          ('Fill Value', self.fill_value)])
 
         return self._format_str(keywords=keywords)
@@ -794,39 +795,41 @@ class STDPSFGrid:
     """
 
     def __init__(self, filename=None, **kwargs):
-        meta = None
         if filename is not None:
             grid_data = _read_stdpsf(filename)
-            self.data = grid_data['data']
-            self._xgrid = grid_data['xgrid']
-            self._ygrid = grid_data['ygrid']
+            data = grid_data['data']
+            xgrid = grid_data['xgrid']
+            ygrid = grid_data['ygrid']
             # itertools.product iterates over the last input first
             xy_grid = np.array([yx[::-1] for yx in itertools.product(
-                self._ygrid, self._xgrid)])
+                ygrid, xgrid)])
 
-        else:
-            meta = kwargs['meta']
-            self.data = kwargs['data']
-            xy_grid = np.asarray(meta['grid_xypos'])
-            self._xgrid = np.unique(xy_grid[:, 0])  # sorted
-            self._ygrid = np.unique(xy_grid[:, 1])  # sorted
-
-        oversampling = 4  # assumption for STDPSF files
-        self.grid_xypos = xy_grid
-        self.oversampling = as_pair('oversampling', oversampling,
-                                    lower_bound=(0, 0))
-        if meta is None:
-            meta = {'grid_shape': (len(self._ygrid), len(self._xgrid)),
+            meta = {'grid_shape': (len(ygrid), len(xgrid)),
                     'grid_xypos': xy_grid,
-                    'oversampling': oversampling}
+                    'oversampling': 4}
 
-            # try to get additional metadata from the filename because this
-            # information is not currently available in the FITS headers
+            # Try to get additional metadata from the filename because this
+            # information is not currently available in the FITS headers.
             file_meta = _get_metadata(filename, None)
             if file_meta is not None:
                 meta.update(file_meta)
+        else:
+            data = kwargs['data']
+            meta = kwargs['meta'].copy()
+            xy_grid = np.asarray(meta['grid_xypos'])
+            xgrid = np.unique(xy_grid[:, 0])  # sorted
+            ygrid = np.unique(xy_grid[:, 1])  # sorted
+            meta.setdefault('oversampling', 4)
+
+        self.data = data
+        self._xgrid = xgrid
+        self._ygrid = ygrid
+        self.grid_xypos = xy_grid
+        self.oversampling = as_pair('oversampling', meta['oversampling'],
+                                    lower_bound=(0, 0))
 
         self.meta = meta
+        self.meta['grid_xypos'] = xy_grid
         # Store the normalized (y, x) pairs so meta always matches
         # the oversampling attribute and grid shape, regardless of
         # the input form (e.g., after an ASDF round trip).
@@ -847,6 +850,7 @@ class STDPSFGrid:
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
         cls_info = []
+        oversampling = tuple(int(value) for value in self.oversampling)
 
         keys = ('STDPSF', 'detector', 'filter', 'grid_shape')
         for key in keys:
@@ -857,7 +861,7 @@ class STDPSFGrid:
         cls_info.extend([('Number of PSFs', len(self.grid_xypos)),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
-                         ('Oversampling', tuple(self.oversampling.tolist()))])
+                         ('Oversampling', oversampling)])
 
         with np.printoptions(threshold=25, edgeitems=5):
             fmt = [f'{key}: {val}' for key, val in cls_info]

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -882,8 +882,8 @@ class STDPSFGrid:
                 name = key.capitalize() if key != 'STDPSF' else key
                 cls_info.append((name, self.meta[key]))
 
-        cls_info.extend([('Grid_shape', grid_shape),
-                         ('Number of PSFs', self.grid_xypos.size),
+        cls_info.extend([('Grid shape', grid_shape),
+                         ('Number of PSFs', len(self.grid_xypos)),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
                          ('Oversampling', oversampling)])

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -139,17 +139,16 @@ class GriddedPSFModel(Fittable2DModel):
 
         self._data, self._grid_xypos = self._define_grid(nddata)
         self._meta = nddata.meta.copy()  # _meta to avoid the meta descriptor
-        self._oversampling = as_pair('oversampling',
-                                     nddata.meta['oversampling'],
-                                     lower_bound=(0, 0))
+        # The setter also stores the normalized (y, x) pair in meta
+        self.oversampling = nddata.meta['oversampling']
         self.fill_value = fill_value
 
         self._xgrid = np.unique(self.grid_xypos[:, 0])  # sorted
         self._ygrid = np.unique(self.grid_xypos[:, 1])  # sorted
         self.meta['grid_shape'] = (len(self._ygrid), len(self._xgrid))
-        # Store the normalized (y, x) pair so meta always matches
-        # the oversampling attribute, regardless of the input form.
-        self.meta['oversampling'] = tuple(int(v) for v in self._oversampling)
+        # Store the sorted grid positions so that meta always matches
+        # the grid_xypos attribute, regardless of the input form
+        self.meta['grid_xypos'] = self.grid_xypos
 
         self._interpolator = {}
 
@@ -401,6 +400,9 @@ class GriddedPSFModel(Fittable2DModel):
             ``(y, x)`` order.
         """
         self._oversampling = as_pair('oversampling', value, lower_bound=(0, 0))
+        # Keep meta in sync with the normalized (y, x) pair
+        self.meta['oversampling'] = tuple(int(val)
+                                          for val in self._oversampling)
 
     def _calc_bounding_box(self):
         """

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -801,8 +801,8 @@ class STDPSFGrid:
         grid_xypos = np.array([yx[::-1]
                                for yx in itertools.product(ygrid, xgrid)])
 
-        # try to get additional metadata from the filename because this
-        # information is not currently available in the FITS headers
+        # Try to get additional metadata from the filename because this
+        # information is not currently available in the FITS headers.
         meta = _get_metadata(filename, None) or {}
 
         self._init_grid(grid_data['data'], grid_xypos,

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -783,9 +783,14 @@ class STDPSFGrid:
 
         * ``'data'`` : `~numpy.ndarray` The 3D array of ePSF stacks.
 
-        * ``'meta'`` : `dict` A dictionary of metadata that must contain
-          at least ``'grid_xypos'``, a (N, 2) array of the (x, y) grid
-          positions in detector coordinates.
+                * ``'meta'`` : `dict`
+                    A metadata dictionary containing at least
+                    ``'grid_xypos'``, a (N, 2) array of the (x, y) grid
+                    positions in detector coordinates. It may also contain
+                    ``'oversampling'``; the default is 4. The structural keys
+                    ``'grid_xypos'``, ``'oversampling'``, and ``'grid_shape'``
+                    are consumed during initialization and are not retained
+                    in ``meta``.
 
     Examples
     --------
@@ -804,37 +809,40 @@ class STDPSFGrid:
             xy_grid = np.array([yx[::-1] for yx in itertools.product(
                 ygrid, xgrid)])
 
-            meta = {'grid_shape': (len(ygrid), len(xgrid)),
-                    'grid_xypos': xy_grid,
-                    'oversampling': 4}
+            oversampling = 4
 
             # Try to get additional metadata from the filename because this
             # information is not currently available in the FITS headers.
-            file_meta = _get_metadata(filename, None)
-            if file_meta is not None:
-                meta.update(file_meta)
+            meta = _get_metadata(filename, None) or {}
         else:
             data = kwargs['data']
             meta = kwargs['meta'].copy()
-            xy_grid = np.asarray(meta['grid_xypos'])
+            xy_grid = np.asarray(meta.pop('grid_xypos'))
+            oversampling = meta.pop('oversampling', 4)
+            meta.pop('grid_shape', None)
             xgrid = np.unique(xy_grid[:, 0])  # sorted
             ygrid = np.unique(xy_grid[:, 1])  # sorted
-            meta.setdefault('oversampling', 4)
 
         self.data = data
         self._xgrid = xgrid
         self._ygrid = ygrid
         self.grid_xypos = xy_grid
-        self.oversampling = as_pair('oversampling', meta['oversampling'],
-                                    lower_bound=(0, 0))
+        self._oversampling = as_pair('oversampling', oversampling,
+                                     lower_bound=(0, 0))
 
         self.meta = meta
-        self.meta['grid_xypos'] = xy_grid
-        # Store the normalized (y, x) pairs so meta always matches
-        # the oversampling attribute and grid shape, regardless of
-        # the input form (e.g., after an ASDF round trip).
-        self.meta['oversampling'] = tuple(int(v) for v in self.oversampling)
-        self.meta['grid_shape'] = (len(self._ygrid), len(self._xgrid))
+
+    @property
+    def oversampling(self):
+        """
+        The integer oversampling factor(s) of the input ePSF images.
+
+        Returns
+        -------
+        oversampling : `~numpy.ndarray`
+            The oversampling factors in ``(y, x)`` order.
+        """
+        return self._oversampling
 
     @_plot_grid_docstring
     def plot_grid(self, *, ax=None, vmax_scale=None, peak_norm=False,
@@ -850,15 +858,17 @@ class STDPSFGrid:
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
         cls_info = []
+        grid_shape = (len(self._ygrid), len(self._xgrid))
         oversampling = tuple(int(value) for value in self.oversampling)
 
-        keys = ('STDPSF', 'detector', 'filter', 'grid_shape')
+        keys = ('STDPSF', 'detector', 'filter')
         for key in keys:
             if key in self.meta:
                 name = key.capitalize() if key != 'STDPSF' else key
                 cls_info.append((name, self.meta[key]))
 
-        cls_info.extend([('Number of PSFs', len(self.grid_xypos)),
+        cls_info.extend([('Grid_shape', grid_shape),
+                         ('Number of PSFs', len(self.grid_xypos)),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
                          ('Oversampling', oversampling)])

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -787,14 +787,20 @@ class STDPSFGrid:
         meta = None
         if filename is not None:
             grid_data = _read_stdpsf(filename)
+            self.data = grid_data['data']
+            self._xgrid = grid_data['xgrid']
+            self._ygrid = grid_data['ygrid']
+            # itertools.product iterates over the last input first
+            xy_grid = [yx[::-1] for yx in itertools.product(self._ygrid,
+                                                            self._xgrid)]
         else:
-            grid_data = kwargs
-            meta = kwargs.pop('meta', None)
-        self.data = grid_data['data']
-        self._xgrid = grid_data['xgrid']
-        self._ygrid = grid_data['ygrid']
-        xy_grid = [yx[::-1] for yx in itertools.product(self._ygrid,
-                                                        self._xgrid)]
+            meta = kwargs['meta']
+            self.data = kwargs['data']
+            xy_grid = meta['grid_xypos']
+            xypos = np.asarray(xy_grid)
+            self._xgrid = np.unique(xypos[:, 0])  # sorted
+            self._ygrid = np.unique(xypos[:, 1])  # sorted
+
         oversampling = 4  # assumption for STDPSF files
         self.grid_xypos = xy_grid
         self.oversampling = as_pair('oversampling', oversampling,

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -59,21 +59,19 @@ class GriddedPSFModel(Fittable2DModel):
 
         The ``meta`` attribute must be a dictionary containing:
 
-            * ``'grid_xypos'``: A sequence of the fiducial ``(x, y)``
-              detector coordinates for each reference ePSF. The
-              order must match the first axis of ``data``; that
-              is, ``grid_xypos[i]`` gives the detector coordinates
-              of ``nddata.data[i]``. The coordinates must form a
-              rectangular grid.
+        * ``'grid_xypos'``: A sequence of the fiducial ``(x, y)``
+          detector coordinates for each reference ePSF. The order must
+          match the first axis of ``data``; that is, ``grid_xypos[i]``
+          gives the detector coordinates of ``nddata.data[i]``. The
+          coordinates must form a rectangular grid.
 
-            * ``'oversampling'``: The integer oversampling factor(s)
-              of the input ePSF images. If a scalar is provided, it is
-              applied to both axes. If two values are provided, they
-              must be in ``(y, x)`` order.
+        * ``'oversampling'``: The integer oversampling factor(s) of the
+          input ePSF images. If a scalar is provided, it is applied to
+          both axes. If two values are provided, they must be in ``(y,
+          x)`` order.
 
-            The ``meta`` dictionary may also contain additional
-            metadata, such as the telescope, instrument, detector, or
-            filter.
+        The ``meta`` dictionary may also contain additional metadata,
+        such as the telescope, instrument, detector, or filter.
 
     flux : float, optional
         The flux scaling factor. This corresponds to the total

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -239,7 +239,7 @@ class GriddedPSFModel(Fittable2DModel):
             If the input grid_xypos does not form a rectangular grid.
         """
         try:
-            grid_xypos = np.array(data.meta['grid_xypos'])
+            grid_xypos = np.asarray(data.meta['grid_xypos'])
         except KeyError as exc:
             msg = "'grid_xypos' must be in the nddata meta dictionary"
             raise ValueError(msg) from exc
@@ -274,7 +274,7 @@ class GriddedPSFModel(Fittable2DModel):
         self._validate_data(nddata)
         self._validate_grid(nddata)
 
-        grid_xypos = np.array(nddata.meta['grid_xypos'])
+        grid_xypos = np.asarray(nddata.meta['grid_xypos'])
         # sort by y and then by x (last key is primary)
         idx = np.lexsort((grid_xypos[:, 0], grid_xypos[:, 1]))
         return nddata.data[idx], grid_xypos[idx]
@@ -791,15 +791,15 @@ class STDPSFGrid:
             self._xgrid = grid_data['xgrid']
             self._ygrid = grid_data['ygrid']
             # itertools.product iterates over the last input first
-            xy_grid = [yx[::-1] for yx in itertools.product(self._ygrid,
-                                                            self._xgrid)]
+            xy_grid = np.array([yx[::-1] for yx in itertools.product(
+                self._ygrid, self._xgrid)])
+
         else:
             meta = kwargs['meta']
             self.data = kwargs['data']
-            xy_grid = meta['grid_xypos']
-            xypos = np.asarray(xy_grid)
-            self._xgrid = np.unique(xypos[:, 0])  # sorted
-            self._ygrid = np.unique(xypos[:, 1])  # sorted
+            xy_grid = np.asarray(meta['grid_xypos'])
+            self._xgrid = np.unique(xy_grid[:, 0])  # sorted
+            self._ygrid = np.unique(xy_grid[:, 1])  # sorted
 
         oversampling = 4  # assumption for STDPSF files
         self.grid_xypos = xy_grid

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -27,65 +27,65 @@ __doctest_skip__ = ['STDPSFGrid']
 
 class GriddedPSFModel(Fittable2DModel):
     """
-    A model for a grid of 2D ePSF models.
+    A model representing a grid of 2D ePSF models.
 
-    The ePSF models are defined at fiducial detector locations and are
-    (x, y) detector position. The fiducial detector locations are must
-    form a rectangular grid.
+    The ePSF models are defined at fiducial detector locations specified
+    by their ``(x, y)`` detector coordinates. The fiducial locations
+    must form a rectangular grid.
 
-    The model has three model parameters: an image intensity scaling
-    factor (``flux``) which is applied to the input image, and two
-    positional parameters (``x_0`` and ``y_0``) indicating the location
-    of a feature in the coordinate grid on which the model is evaluated.
+    This model has three parameters: an image intensity scaling factor
+    (``flux``), which scales the input image, and two positional
+    parameters (``x_0`` and ``y_0``), which specify the location of the
+    feature in the coordinate grid where the model is evaluated.
 
-    When evaluating this model, it cannot be called with x and y arrays
-    that have greater than 2 dimensions.
+    When evaluating this model, the input ``x`` and ``y`` arrays must
+    have no more than two dimensions.
 
     Parameters
     ----------
     nddata : `~astropy.nddata.NDData`
-        A `~astropy.nddata.NDData` object containing the grid of
-        reference ePSF arrays. The data attribute must contain a 3D
-        `~numpy.ndarray` containing a stack of the 2D ePSFs with a shape
-        of ``(N_psf, ePSF_ny, ePSF_nx)``. The length of the x and y
-        axes must both be at least 4. ``N_psf`` must not be 2 or 3. All
-        elements of the input image data must be finite. The PSF peak is
-        assumed to be located at the center of the input image. Please
-        see the Notes section below for details on the normalization of
-        the input image data.
+        A `~astropy.nddata.NDData` object containing the reference ePSF
+        grid. Its ``data`` attribute must be a 3D `~numpy.ndarray` with
+        shape ``(N_psf, ePSF_ny, ePSF_nx)``, where each plane is a 2D
+        ePSF image. The x and y dimensions of each ePSF image must both
+        be at least 4 pixels. ``N_psf`` must not be 2 or 3. All values
+        in ``data`` must be finite. The ePSF peak is assumed to be
+        centered in each input image. See the Notes section for details
+        on the required normalization of the input ePSF images.
 
-        If ``N_psf`` is 1, the model will be evaluated using the single
-        ePSF image at every (x, y) position. This is equivalent to using
-        the `~photutils.psf.ImagePSF` model with the single ePSF.
+        If ``N_psf`` is 1, the single ePSF image is used at all detector
+        positions. This is equivalent to using `~photutils.psf.ImagePSF`
+        with the same ePSF image.
 
-        The meta attribute must be dictionary containing the following:
+        The ``meta`` attribute must be a dictionary containing:
 
-        * ``'grid_xypos'``: A list of the (x, y) grid positions of
-          each reference ePSF. The order of positions should match the
-          first axis of the 3D `~numpy.ndarray` of ePSFs. In other words,
-          ``grid_xypos[i]`` should be the (x, y) position of the reference
-          ePSF defined in ``nddata.data[i]``. The grid positions must form
-          a rectangular grid.
+            * ``'grid_xypos'``: A sequence of the fiducial ``(x, y)``
+              detector coordinates for each reference ePSF. The
+              order must match the first axis of ``data``; that
+              is, ``grid_xypos[i]`` gives the detector coordinates
+              of ``nddata.data[i]``. The coordinates must form a
+              rectangular grid.
 
-        * ``'oversampling'``: The integer oversampling factor(s) of the
-          input ePSF images. If ``oversampling`` is a scalar then it will
-          be used for both axes. If ``oversampling`` has two elements,
-          they must be in ``(y, x)`` order.
+            * ``'oversampling'``: The integer oversampling factor(s)
+              of the input ePSF images. If a scalar is provided, it is
+              applied to both axes. If two values are provided, they
+              must be in ``(y, x)`` order.
 
-        The meta attribute may contain other properties such as the
-        telescope, instrument, detector, and filter of the ePSF.
+            The ``meta`` dictionary may also contain additional
+            metadata, such as the telescope, instrument, detector, or
+            filter.
 
     flux : float, optional
-        The flux scaling factor for the model. This is the total flux
-        of the source, assuming the input ePSF images are properly
+        The flux scaling factor. This corresponds to the total
+        source flux, assuming the input ePSF images are properly
         normalized.
 
     x_0, y_0 : float, optional
-        The (x, y) position of the PSF peak in the image in the output
-        coordinate grid on which the model is evaluated.
+        The ``(x, y)`` coordinates of the ePSF peak in the output
+        coordinate grid where the model is evaluated.
 
     fill_value : float, optional
-        The value to use for points outside the input pixel grid. The
+        The value used for points outside the input pixel grid. The
         default is 0.0.
 
     Methods
@@ -98,26 +98,31 @@ class GriddedPSFModel(Fittable2DModel):
 
     Notes
     -----
-    The fitted PSF model flux represents the total flux of the source,
-    assuming the input image was properly normalized. This flux is
-    determined as a multiplicative scale factor applied to the input
-    image PSF, after accounting for any oversampling. Theoretically,
-    the sum of all values in the PSF image over an infinite grid should
-    equal 1.0 (assuming no oversampling). However, when the PSF is
-    represented over a finite region, the sum of the values may be less
-    than 1.0. For oversampled PSF images, the normalization should be
-    adjusted so that the sum of the array values equals the product
-    of the oversampling factors (e.g., oversampling squared if the
-    oversampling is the same along both axes). If the input image only
-    covers a finite region of the PSF, the sum may again be less than
-    the product of the oversampling factors. Correction factors based on
-    the encircled or ensquared energy of the PSF can be used to estimate
-    the proper scaling for the finite region of the input PSF image and
-    ensure correct flux normalization.
+    The fitted ``flux`` parameter represents the total source flux,
+    provided the input ePSF images are properly normalized. The fitted
+    flux is a multiplicative scale factor applied to the input ePSF
+    after accounting for any oversampling.
 
-    Internally, the grid of ePSFs will be arranged and stored such that
-    it is sorted first by the y reference pixel coordinate and then by
-    the x reference pixel coordinate.
+    For a fully sampled ePSF (i.e., no oversampling), the sum of
+    the ePSF values over an infinite grid is 1.0. Because ePSFs are
+    represented by finite images in practice, the sum of the array
+    values may be less than 1.0.
+
+    For oversampled ePSFs, the normalization should instead be such
+    that the sum of the array values over an infinite grid equals the
+    product of the oversampling factors (e.g., ``oversampling**2`` when
+    the oversampling is the same along both axes). Again, a finite image
+    will generally have a smaller sum because it does not contain the
+    full PSF wings.
+
+    If the input ePSF image covers only a finite region of the PSF,
+    correction factors based on the encircled or ensquared energy
+    can be used to estimate the missing flux and obtain the proper
+    normalization.
+
+    Internally, the ePSF grid is reordered so that the reference ePSFs
+    are sorted first by their y detector coordinate and then by their x
+    detector coordinate.
     """
 
     flux = Parameter(description='Intensity scaling factor for the ePSF '
@@ -762,35 +767,37 @@ class GriddedPSFModel(Fittable2DModel):
 
 class STDPSFGrid:
     """
-    Class to read and plot "STDPSF" format ePSF model grids.
+    Class to read and plot ePSF model grids stored in the STDPSF format.
 
-    STDPSF files are FITS files that contain a 3D array of ePSFs with
-    the header detailing where the fiducial ePSFs are located in the
-    detector coordinate frame.
+    STDPSF files are FITS files containing a 3D array of ePSF models.
+    The FITS header specifies the fiducial detector coordinates
+    associated with each ePSF in the grid.
 
-    The oversampling factor for STDPSF FITS files is assumed to be 4.
+    For STDPSF files, the oversampling factor is assumed to be 4 along
+    both axes.
 
     Parameters
     ----------
     filename : str or None
-        The name of the STDPSF FITS file. A URL can also be used.
-        When `None`, ``kwargs`` are used to initialize the class.
+        The name or URL of a STDPSF FITS file. If `None`, the class is
+        initialized from ``kwargs``.
 
     **kwargs : dict
         Keyword arguments used to initialize the class when ``filename``
-        is `None` (e.g., when restoring from an ASDF archive). The
-        recognized keys are:
+        is `None` (e.g., when restoring from an ASDF file). Recognized
+        keys are:
 
-        * ``'data'`` : `~numpy.ndarray` The 3D array of ePSF stacks.
+        * ``'data'`` : `~numpy.ndarray`
+            A 3D array containing the ePSF grid.
 
-                * ``'meta'`` : `dict`
-                    A metadata dictionary containing at least
-                    ``'grid_xypos'``, a (N, 2) array of the (x, y) grid
-                    positions in detector coordinates. It may also contain
-                    ``'oversampling'``; the default is 4. The structural keys
-                    ``'grid_xypos'``, ``'oversampling'``, and ``'grid_shape'``
-                    are consumed during initialization and are not retained
-                    in ``meta``.
+        * ``'meta'`` : `dict`
+            A metadata dictionary containing at least ``'grid_xypos'``,
+            an ``(N, 2)`` array of fiducial ``(x, y)`` detector
+            coordinates. It may also contain ``'oversampling'``; if
+            omitted, the default is ``(4, 4)``. The structural keys
+            ``'grid_xypos'``, ``'oversampling'``, and ``'grid_shape'``
+            are consumed during initialization and are not retained in
+            ``meta``.
 
     Examples
     --------
@@ -800,6 +807,11 @@ class STDPSFGrid:
     """
 
     def __init__(self, filename=None, **kwargs):
+        # STDPSF files are assumed to have an oversampling factor of 4
+        # along both axes. This is the default if the oversampling is
+        # not provided in the meta dictionary.
+        oversampling_default = (4, 4)
+
         if filename is not None:
             grid_data = _read_stdpsf(filename)
             data = grid_data['data']
@@ -808,28 +820,27 @@ class STDPSFGrid:
             # itertools.product iterates over the last input first
             xy_grid = np.array([yx[::-1] for yx in itertools.product(
                 ygrid, xgrid)])
+            oversampling = oversampling_default
 
-            oversampling = 4
-
-            # Try to get additional metadata from the filename because this
-            # information is not currently available in the FITS headers.
+            # Try to get additional metadata from the filename because
+            # this information is not currently available in the FITS
+            # headers.
             meta = _get_metadata(filename, None) or {}
         else:
             data = kwargs['data']
             meta = kwargs['meta'].copy()
             xy_grid = np.asarray(meta.pop('grid_xypos'))
-            oversampling = meta.pop('oversampling', 4)
+            oversampling = meta.pop('oversampling', oversampling_default)
             meta.pop('grid_shape', None)
             xgrid = np.unique(xy_grid[:, 0])  # sorted
             ygrid = np.unique(xy_grid[:, 1])  # sorted
 
         self.data = data
+        self.grid_xypos = xy_grid
         self._xgrid = xgrid
         self._ygrid = ygrid
-        self.grid_xypos = xy_grid
         self._oversampling = as_pair('oversampling', oversampling,
                                      lower_bound=(0, 0))
-
         self.meta = meta
 
     @property
@@ -858,7 +869,9 @@ class STDPSFGrid:
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
         cls_info = []
-        grid_shape = (len(self._ygrid), len(self._xgrid))
+        grid_shape = (self._ygrid.size, self._xgrid.size)
+        # Use int to avoid printing numpy int64 values in the string
+        # representation
         oversampling = tuple(int(value) for value in self.oversampling)
 
         keys = ('STDPSF', 'detector', 'filter')
@@ -868,7 +881,7 @@ class STDPSFGrid:
                 cls_info.append((name, self.meta[key]))
 
         cls_info.extend([('Grid_shape', grid_shape),
-                         ('Number of PSFs', len(self.grid_xypos)),
+                         ('Number of PSFs', self.grid_xypos.size),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
                          ('Oversampling', oversampling)])

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -772,12 +772,19 @@ class STDPSFGrid:
     Parameters
     ----------
     filename : str or None
-        The name of the STDPDF FITS file. A URL can also be used.
+        The name of the STDPSF FITS file. A URL can also be used.
         When `None`, ``kwargs`` are used to initialize the class.
+
     **kwargs : dict
-        A dictionary containing the array with PSFs and the meta data.
-        Used when initializing from an ASDF file. In this case
-        ``filename`` is  `None`.
+        Keyword arguments used to initialize the class when ``filename``
+        is `None` (e.g., when restoring from an ASDF archive). The
+        recognized keys are:
+
+        * ``'data'`` : `~numpy.ndarray` The 3D array of ePSF stacks.
+
+        * ``'meta'`` : `dict` A dictionary of metadata that must contain
+          at least ``'grid_xypos'``, a (N, 2) array of the (x, y) grid
+          positions in detector coordinates.
 
     Examples
     --------

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -169,7 +169,7 @@ class ImagePSF(Fittable2DModel):
     def __str__(self):
         keywords = [('PSF shape (oversampled pixels)', self.data.shape),
                     ('Origin', self.origin.tolist()),
-                    ('Oversampling', self.oversampling.tolist()),
+                    ('Oversampling', tuple(self.oversampling.tolist())),
                     ('Fill Value', self.fill_value),
                     ]
         return self._format_str(keywords=keywords)

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -128,16 +128,16 @@ def _read_fits_stdpsf(filename):
             data = hdulist[0].data
 
     try:
-        npsfs = header['NAXIS3']
-        nxpsfs = header['NXPSFS']
-        nypsfs = header['NYPSFS']
+        n_psfs = header['NAXIS3']
+        nx_grid = header['NXPSFS']
+        ny_grid = header['NYPSFS']
     except KeyError as exc:
         msg = 'Invalid STDPDF FITS file'
         raise ValueError(msg) from exc
 
     if 'IPSFX01' in header:
-        xgrid = [header[f'IPSFX{i:02d}'] for i in range(1, nxpsfs + 1)]
-        ygrid = [header[f'JPSFY{i:02d}'] for i in range(1, nypsfs + 1)]
+        xgrid = [header[f'IPSFX{i:02d}'] for i in range(1, nx_grid + 1)]
+        ygrid = [header[f'JPSFY{i:02d}'] for i in range(1, ny_grid + 1)]
     elif 'IPSFXA5' in header:
         xgrid = []
         ygrid = []
@@ -155,7 +155,7 @@ def _read_fits_stdpsf(filename):
     xgrid = np.array(xgrid) - 1
     ygrid = np.array(ygrid) - 1
 
-    # nypsfs, nxpsfs, detector
+    # ny_grid, nx_grid, detector
     # 6, 6     WFPC2, 4 det
     # 1, 1     ACS/HRC
     # 10, 9    ACS/WFC, 2 det
@@ -168,9 +168,9 @@ def _read_fits_stdpsf(filename):
     # 3, 3     MIRI
 
     return {'data': data,
-            'npsfs': npsfs,
-            'nxpsfs': nxpsfs,
-            'nypsfs': nypsfs,
+            'n_psfs': n_psfs,
+            'nx_grid': nx_grid,
+            'ny_grid': ny_grid,
             'xgrid': xgrid,
             'ygrid': ygrid}
 
@@ -211,9 +211,9 @@ def _split_detectors(grid_data, detector_data, detector_id):
     * JWST NIRCam "NRCSW" STDPSF file contains 8 detectors
     """
     data = grid_data['data']
-    npsfs = grid_data['npsfs']
-    nxpsfs = grid_data['nxpsfs']
-    nypsfs = grid_data['nypsfs']
+    n_psfs = grid_data['n_psfs']
+    nx_grid = grid_data['nx_grid']
+    ny_grid = grid_data['ny_grid']
     xgrid = grid_data['xgrid']
     ygrid = grid_data['ygrid']
     nxdet = detector_data['nxdet']
@@ -221,12 +221,12 @@ def _split_detectors(grid_data, detector_data, detector_id):
     det_map = detector_data['det_map']
     det_size = detector_data['det_size']
 
-    ii = np.arange(npsfs).reshape((nypsfs, nxpsfs))
-    nxpsfs //= nxdet
-    nypsfs //= nydet
+    ii = np.arange(n_psfs).reshape((ny_grid, nx_grid))
+    nx_grid //= nxdet
+    ny_grid //= nydet
     ndet = nxdet * nydet
-    ii = reshape_as_blocks(ii, (nypsfs, nxpsfs))
-    ii = ii.reshape(ndet, npsfs // ndet)
+    ii = reshape_as_blocks(ii, (ny_grid, nx_grid))
+    ii = ii.reshape(ndet, n_psfs // ndet)
 
     # detector_id -> index
     det_idx = det_map[detector_id]
@@ -234,11 +234,11 @@ def _split_detectors(grid_data, detector_data, detector_id):
     data = data[idx]
 
     xp = det_idx % nxdet
-    i0 = xp * nxpsfs
-    i1 = i0 + nxpsfs
+    i0 = xp * nx_grid
+    i1 = i0 + nx_grid
     xgrid = xgrid[i0:i1] - xp * det_size
-
-    ygrid = ygrid[:nypsfs] if det_idx < nxdet else ygrid[nypsfs:] - det_size
+    ygrid = (ygrid[:ny_grid] if det_idx < nxdet
+             else ygrid[ny_grid:] - det_size)
 
     return data, xgrid, ygrid
 
@@ -281,10 +281,10 @@ def _split_wfc_uvis(grid_data, detector_id):
     if detector_id == 2:
         ygrid -= 2048
 
-    npsfs = grid_data['npsfs']
+    n_psfs = grid_data['n_psfs']
     data = grid_data['data']
     data_ny, data_nx = data.shape[1:]
-    data = data.reshape((2, npsfs // 2, data_ny, data_nx))[detector_id - 1]
+    data = data.reshape((2, n_psfs // 2, data_ny, data_nx))[detector_id - 1]
 
     return data, xgrid, ygrid
 
@@ -516,13 +516,13 @@ def stdpsf_reader(filename, detector_id=None):
 
     grid_data = _read_stdpsf(filename)
 
-    npsfs = grid_data['npsfs']
-    if npsfs in (90, 56, 36, 200):
-        if npsfs in (90, 56):  # ACS/WFC or WFC3/UVIS data (2 chips)
+    n_psfs = grid_data['n_psfs']
+    if n_psfs in (90, 56, 36, 200):
+        if n_psfs in (90, 56):  # ACS/WFC or WFC3/UVIS data (2 chips)
             data, xgrid, ygrid = _split_wfc_uvis(grid_data, detector_id)
-        elif npsfs == 36:  # WFPC2 data (4 chips)
+        elif n_psfs == 36:  # WFPC2 data (4 chips)
             data, xgrid, ygrid = _split_wfpc2(grid_data, detector_id)
-        elif npsfs == 200:  # NIRCam SW data (8 chips)
+        elif n_psfs == 200:  # NIRCam SW data (8 chips)
             data, xgrid, ygrid = _split_nrcsw(grid_data, detector_id)
         else:
             msg = 'Unknown detector or STDPSF format'
@@ -536,12 +536,12 @@ def stdpsf_reader(filename, detector_id=None):
     xy_grid = [yx[::-1] for yx in itertools.product(ygrid, xgrid)]
 
     oversampling = 4  # assumption for STDPSF files
-    nxpsfs = xgrid.shape[0]
-    nypsfs = ygrid.shape[0]
+    nx_grid = xgrid.shape[0]
+    ny_grid = ygrid.shape[0]
     meta = {'grid_xypos': xy_grid,
             'oversampling': oversampling,
-            'nxpsfs': nxpsfs,
-            'nypsfs': nypsfs}
+            'nx_grid': nx_grid,
+            'ny_grid': ny_grid}
 
     # try to get additional metadata from the filename because this
     # information is not currently available in the FITS headers

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -536,12 +536,8 @@ def stdpsf_reader(filename, detector_id=None):
     xy_grid = [yx[::-1] for yx in itertools.product(ygrid, xgrid)]
 
     oversampling = 4  # assumption for STDPSF files
-    nx_grid = xgrid.shape[0]
-    ny_grid = ygrid.shape[0]
     meta = {'grid_xypos': xy_grid,
-            'oversampling': oversampling,
-            'nx_grid': nx_grid,
-            'ny_grid': ny_grid}
+            'oversampling': oversampling}
 
     # try to get additional metadata from the filename because this
     # information is not currently available in the FITS headers

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -88,7 +88,7 @@ def _read_stdpsf(filename):
     Parameters
     ----------
     filename : str
-        The name of the STDPDF FITS file.
+        The name of the STDPSF FITS file.
 
     Returns
     -------
@@ -114,7 +114,7 @@ def _read_fits_stdpsf(filename):
     Parameters
     ----------
     filename : str
-        The name of the STDPDF FITS file.
+        The name of the STDPSF FITS file.
 
     Returns
     -------
@@ -132,7 +132,7 @@ def _read_fits_stdpsf(filename):
         nx_grid = header['NXPSFS']
         ny_grid = header['NYPSFS']
     except KeyError as exc:
-        msg = 'Invalid STDPDF FITS file'
+        msg = 'Invalid STDPSF FITS file'
         raise ValueError(msg) from exc
 
     if 'IPSFX01' in header:
@@ -151,7 +151,7 @@ def _read_fits_stdpsf(filename):
         msg = 'Unknown STDPSF FITS file'
         raise ValueError(msg)
 
-    # STDPDF FITS positions are 1-indexed
+    # STDPSF FITS positions are 1-indexed
     xgrid = np.array(xgrid) - 1
     ygrid = np.array(ygrid) - 1
 
@@ -390,7 +390,7 @@ def _get_metadata(filename, detector_id):
     Parameters
     ----------
     filename : str
-        The name of the STDPDF FITS file.
+        The name of the STDPSF FITS file.
 
     detector_id : int
         The detector ID.
@@ -478,7 +478,7 @@ def stdpsf_reader(filename, detector_id=None):
     Parameters
     ----------
     filename : str
-        The name of the STDPDF FITS file. A URL can also be used.
+        The name of the STDPSF FITS file. A URL can also be used.
 
     detector_id : `None` or int, optional
         For STDPSF files that contain ePSF grids for multiple detectors,

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -533,7 +533,7 @@ def stdpsf_reader(filename, detector_id=None):
         ygrid = grid_data['ygrid']
 
     # itertools.product iterates over the last input first
-    xy_grid = [yx[::-1] for yx in itertools.product(ygrid, xgrid)]
+    xy_grid = np.array([yx[::-1] for yx in itertools.product(ygrid, xgrid)])
 
     oversampling = 4  # assumption for STDPSF files
     meta = {'grid_xypos': xy_grid,

--- a/photutils/psf/model_plotting.py
+++ b/photutils/psf/model_plotting.py
@@ -96,12 +96,12 @@ class _ModelGridPlotter:
         reshaped_data : `numpy.ndarray`
             The 2D array of ePSF data.
         """
-        nypsfs = self.model._ygrid.shape[0]
-        nxpsfs = self.model._xgrid.shape[0]
+        ny_grid = self.model._ygrid.shape[0]
+        nx_grid = self.model._xgrid.shape[0]
         ny, nx = self.model.data.shape[1:]
-        return (data.reshape(nypsfs, nxpsfs, ny, nx)
+        return (data.reshape(ny_grid, nx_grid, ny, nx)
                 .transpose([0, 2, 1, 3])
-                .reshape(nypsfs * ny, nxpsfs * nx))
+                .reshape(ny_grid * ny, nx_grid * nx))
 
     @_plot_grid_docstring
     def plot_grid(self, *, ax=None, vmax_scale=None, peak_norm=False,
@@ -152,9 +152,9 @@ class _ModelGridPlotter:
         # detector ePSF coordinates. This sets up axes to have, behind the
         # scenes, the ePSFs centered at integer coords 0, 1, 2, 3 etc.
         # extent order: left, right, bottom, top
-        nypsfs = self.model._ygrid.shape[0]
-        nxpsfs = self.model._xgrid.shape[0]
-        extent = [-0.5, nxpsfs - 0.5, -0.5, nypsfs - 0.5]
+        ny_grid = self.model._ygrid.shape[0]
+        nx_grid = self.model._xgrid.shape[0]
+        extent = [-0.5, nx_grid - 0.5, -0.5, ny_grid - 0.5]
 
         axim = ax.imshow(data, extent=extent, norm=norm, cmap=cmap,
                          origin='lower')
@@ -165,17 +165,17 @@ class _ModelGridPlotter:
         if self.model.meta.get('detector', '') == 'NRCSW':
             xticklabels = list(xticklabels[0:5]) * 4
             yticklabels = list(yticklabels[0:5]) * 2
-        ax.set_xticks(np.arange(nxpsfs))
+        ax.set_xticks(np.arange(nx_grid))
         ax.set_xticklabels(xticklabels)
         ax.set_xlabel('ePSF location in detector X pixels')
-        ax.set_yticks(np.arange(nypsfs))
+        ax.set_yticks(np.arange(ny_grid))
         ax.set_yticklabels(yticklabels)
         ax.set_ylabel('ePSF location in detector Y pixels')
 
         if dividers:
-            for ix in range(nxpsfs - 1):
+            for ix in range(nx_grid - 1):
                 ax.axvline(ix + 0.5, color=divider_color, ls=divider_ls)
-            for iy in range(nypsfs - 1):
+            for iy in range(ny_grid - 1):
                 ax.axhline(iy + 0.5, color=divider_color, ls=divider_ls)
 
         instrument = self.model.meta.get('instrument', '')
@@ -222,17 +222,17 @@ class _ModelGridPlotter:
         if self.model.meta.get('detector', '') == 'NRCSW':
             # NIRCam NRCSW STDPSF files contain all detectors.
             # The plot gets extra divider lines and SCA name labels.
-            nxpsfs = len(self.model._xgrid)
-            nypsfs = len(self.model._ygrid)
-            ax.axhline(nypsfs / 2 - 0.5, color='orange')
+            nx_grid = len(self.model._xgrid)
+            ny_grid = len(self.model._ygrid)
+            ax.axhline(ny_grid / 2 - 0.5, color='orange')
             for i in range(1, 4):
-                ax.axvline(nxpsfs / 4 * i - 0.5, color='orange')
+                ax.axvline(nx_grid / 4 * i - 0.5, color='orange')
 
             det_labels = [['A1', 'A3', 'B4', 'B2'], ['A2', 'A4', 'B3', 'B1']]
             for i in range(2):
                 for j in range(4):
-                    ax.text(j * nxpsfs / 4 - 0.45,
-                            (i + 1) * nypsfs / 2 - 0.55,
+                    ax.text(j * nx_grid / 4 - 0.45,
+                            (i + 1) * ny_grid / 2 - 0.55,
                             det_labels[i][j], color='orange',
                             verticalalignment='top', fontsize=12)
 

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -538,3 +538,16 @@ def test_stdpsfgrid_repr_str():
             'Oversampling')
     for key in keys:
         assert key in repr(psfgrid)
+
+
+def test_stdpsfgrid_kwargs_preserve_oversampling_and_meta():
+    data = np.ones((4, 4, 4))
+    grid_xypos = np.array([(0, 0), (1, 0), (0, 1), (1, 1)])
+    meta = {'grid_xypos': grid_xypos, 'oversampling': 8}
+
+    psfgrid = STDPSFGrid(data=data, meta=meta)
+
+    assert_equal(psfgrid.oversampling, [8, 8])
+    assert_equal(psfgrid.meta['oversampling'], (8, 8))
+    assert_equal(meta['oversampling'], 8)
+    assert 'grid_shape' not in meta

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -564,20 +564,84 @@ def test_stdpsfgrid_repr_str():
     assert 'Oversampling: (4, 4)' in grid_str
 
 
-def test_stdpsfgrid_kwargs_preserve_oversampling_and_meta():
-    data = np.ones((4, 4, 4))
-    grid_xypos = np.array([(0, 0), (1, 0), (0, 1), (1, 1)])
-    meta = {'grid_xypos': grid_xypos, 'oversampling': 8}
+class TestSTDPSFGridFromASDF:
+    """
+    Tests for the private STDPSFGrid._from_asdf constructor.
+    """
 
-    psfgrid = STDPSFGrid(data=data, meta=meta)
+    @staticmethod
+    def make_meta(**kwargs):
+        meta = {'grid_xypos': np.array([(0, 0), (1, 0), (0, 1), (1, 1)]),
+                'oversampling': 8,
+                'grid_shape': (2, 2)}
+        meta.update(kwargs)
+        return meta
 
-    assert_equal(psfgrid.oversampling, [8, 8])
-    assert 'grid_xypos' not in psfgrid.meta
-    assert 'oversampling' not in psfgrid.meta
-    assert 'grid_shape' not in psfgrid.meta
-    assert_equal(meta['oversampling'], 8)
-    assert 'grid_shape' not in meta
+    def test_grid_attributes(self):
+        data = np.ones((4, 4, 4))
+        psfgrid = STDPSFGrid._from_asdf(data, self.make_meta())
 
-    match = "property 'oversampling' of 'STDPSFGrid' object has no setter"
-    with pytest.raises(AttributeError, match=match):
-        psfgrid.oversampling = (4, 5)
+        assert_equal(psfgrid.data, data)
+        assert_equal(psfgrid.oversampling, [8, 8])
+        assert_equal(psfgrid.grid_xypos, [(0, 0), (1, 0), (0, 1), (1, 1)])
+        assert_equal(psfgrid._xgrid, [0, 1])
+        assert_equal(psfgrid._ygrid, [0, 1])
+
+    def test_structural_keys_removed(self):
+        psfgrid = STDPSFGrid._from_asdf(np.ones((4, 4, 4)), self.make_meta())
+
+        for key in ('grid_xypos', 'oversampling', 'grid_shape'):
+            assert key not in psfgrid.meta
+
+    def test_extra_meta_preserved(self):
+        meta = self.make_meta(detector='TEST', custom={'value': 42})
+        psfgrid = STDPSFGrid._from_asdf(np.ones((4, 4, 4)), meta)
+
+        assert psfgrid.meta == {'detector': 'TEST', 'custom': {'value': 42}}
+
+    def test_input_meta_not_modified(self):
+        meta = self.make_meta()
+        STDPSFGrid._from_asdf(np.ones((4, 4, 4)), meta)
+
+        assert meta['oversampling'] == 8
+        assert 'grid_shape' in meta
+        assert 'grid_xypos' in meta
+
+    def test_default_oversampling(self):
+        meta = self.make_meta()
+        del meta['oversampling']
+        psfgrid = STDPSFGrid._from_asdf(np.ones((4, 4, 4)), meta)
+
+        assert_equal(psfgrid.oversampling, [4, 4])
+
+    @pytest.mark.parametrize('key', ['grid_xypos', 'grid_shape'])
+    def test_missing_required_meta(self, key):
+        meta = self.make_meta()
+        del meta[key]
+
+        match = f"'{key}' must be in the meta dictionary"
+        with pytest.raises(ValueError, match=match):
+            STDPSFGrid._from_asdf(np.ones((4, 4, 4)), meta)
+
+    def test_repeated_grid_coordinate(self):
+        """
+        Test a grid where a coordinate is repeated because two
+        detectors abut (e.g., ACS/WFC).
+        """
+        grid_xypos = np.array([(0, 0), (1, 0), (0, 5), (1, 5),
+                               (0, 5), (1, 5), (0, 9), (1, 9)])
+        meta = self.make_meta(grid_xypos=grid_xypos, grid_shape=(4, 2))
+        psfgrid = STDPSFGrid._from_asdf(np.ones((8, 4, 4)), meta)
+
+        assert psfgrid._grid_shape == (4, 2)
+        assert_equal(psfgrid._xgrid, [0, 1])
+        assert_equal(psfgrid._ygrid, [0, 5, 5, 9])
+        assert 'Grid shape: (4, 2)' in repr(psfgrid)
+        assert 'Number of PSFs: 8' in repr(psfgrid)
+
+    def test_oversampling_is_read_only(self):
+        psfgrid = STDPSFGrid._from_asdf(np.ones((4, 4, 4)), self.make_meta())
+
+        match = "property 'oversampling' of 'STDPSFGrid' object has no setter"
+        with pytest.raises(AttributeError, match=match):
+            psfgrid.oversampling = (4, 5)

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -149,7 +149,7 @@ class TestGriddedPSFModel:
         assert 'GriddedPSFModel' in str_str
         assert 'Number of PSFs: 16' in str_str
         assert 'PSF shape (oversampled pixels): (101, 101)' in str_str
-        assert 'Oversampling: [4, 4]' in str_str
+        assert 'Oversampling: (4, 4)' in str_str
         assert 'Fill Value: 0.0' in str_str
 
     def test_gridded_psf_model_basic_eval(self, psfmodel):

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -456,6 +456,7 @@ class TestGriddedPSFModel:
         filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
         psfmodel = GriddedPSFModel.read(filename)
         assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
+        assert isinstance(psfmodel.meta['grid_xypos'], np.ndarray)
         assert_equal(psfmodel.oversampling, [4, 4])
         assert_equal(psfmodel.meta['oversampling'], psfmodel.oversampling)
 
@@ -522,6 +523,8 @@ def test_stdpsfgrid(filename):
     assert 'oversampling' in psfgrid.meta
     assert_equal(psfgrid.oversampling, [4, 4])
     assert psfgrid.data.shape[0] == len(psfgrid.meta['grid_xypos'])
+    assert isinstance(psfgrid.grid_xypos, np.ndarray)
+    assert isinstance(psfgrid.meta['grid_xypos'], np.ndarray)
 
     psfgrid.plot_grid()
 

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -519,12 +519,12 @@ class TestGriddedPSFModel:
 def test_stdpsfgrid(filename):
     filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
     psfgrid = STDPSFGrid(filename)
-    assert 'grid_xypos' in psfgrid.meta
-    assert 'oversampling' in psfgrid.meta
+    assert 'grid_xypos' not in psfgrid.meta
+    assert 'oversampling' not in psfgrid.meta
+    assert 'grid_shape' not in psfgrid.meta
     assert_equal(psfgrid.oversampling, [4, 4])
-    assert psfgrid.data.shape[0] == len(psfgrid.meta['grid_xypos'])
+    assert psfgrid.data.shape[0] == len(psfgrid.grid_xypos)
     assert isinstance(psfgrid.grid_xypos, np.ndarray)
-    assert isinstance(psfgrid.meta['grid_xypos'], np.ndarray)
 
     psfgrid.plot_grid()
 
@@ -548,6 +548,12 @@ def test_stdpsfgrid_kwargs_preserve_oversampling_and_meta():
     psfgrid = STDPSFGrid(data=data, meta=meta)
 
     assert_equal(psfgrid.oversampling, [8, 8])
-    assert_equal(psfgrid.meta['oversampling'], (8, 8))
+    assert 'grid_xypos' not in psfgrid.meta
+    assert 'oversampling' not in psfgrid.meta
+    assert 'grid_shape' not in psfgrid.meta
     assert_equal(meta['oversampling'], 8)
     assert 'grid_shape' not in meta
+
+    match = "property 'oversampling' of 'STDPSFGrid' object has no setter"
+    with pytest.raises(AttributeError, match=match):
+        psfgrid.oversampling = (4, 5)

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -552,11 +552,16 @@ def test_stdpsfgrid_repr_str():
     filename = STDPSF_FILENAMES[0]
     filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
     psfgrid = STDPSFGrid(filename)
-    assert repr(psfgrid) == str(psfgrid)
-    keys = ('STDPSF', 'Grid_shape', 'Number of PSFs', 'PSF shape',
-            'Oversampling')
-    for key in keys:
-        assert key in repr(psfgrid)
+    grid_str = repr(psfgrid)
+    assert grid_str == str(psfgrid)
+
+    assert 'STDPSF_NRCA1_F150W_mock.fits' in grid_str
+    assert 'Detector: NRCA1' in grid_str
+    assert 'Filter: F150W' in grid_str
+    assert 'Grid shape: (5, 5)' in grid_str
+    assert f'Number of PSFs: {psfgrid.data.shape[0]}' in grid_str
+    assert 'PSF shape (oversampled pixels): (5, 5)' in grid_str
+    assert 'Oversampling: (4, 4)' in grid_str
 
 
 def test_stdpsfgrid_kwargs_preserve_oversampling_and_meta():

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -129,6 +129,10 @@ class TestGriddedPSFModel:
         xypos = grid_xypos[idx]
         assert_allclose(xypos, grid_xypos)
 
+        # meta must store the sorted positions, not the input ordering
+        assert isinstance(psfmodel.meta['grid_xypos'], np.ndarray)
+        assert_equal(psfmodel.meta['grid_xypos'], grid_xypos)
+
         # Check that data and grid_xypos attributes are read-only
         match = 'object has no setter'
         with pytest.raises(AttributeError, match=match):
@@ -437,6 +441,21 @@ class TestGriddedPSFModel:
         nddata.meta['oversampling'] = [4, 4]
         psfmodel2 = GriddedPSFModel(nddata)
         assert_equal(psfmodel2.oversampling, psfmodel.oversampling)
+
+    def test_gridded_psf_oversampling_meta_sync(self, psfmodel):
+        """
+        Test that meta['oversampling'] tracks the oversampling setter.
+        """
+        model = psfmodel.copy()
+        assert model.meta['oversampling'] == (4, 4)
+
+        model.oversampling = (2, 3)
+        assert_equal(model.oversampling, [2, 3])
+        assert model.meta['oversampling'] == (2, 3)
+
+        model.oversampling = 5
+        assert_equal(model.oversampling, [5, 5])
+        assert model.meta['oversampling'] == (5, 5)
 
     def test_bounding_box(self, psfmodel):
         # oversampling is 4

--- a/photutils/psf/tests/test_model_helpers.py
+++ b/photutils/psf/tests/test_model_helpers.py
@@ -263,8 +263,11 @@ class TestGridFromEPSFs:
         with pytest.warns(AstropyDeprecationWarning):
             psf_grid = grid_from_epsfs(self.epsfs)
 
-        assert psf_grid.meta['grid_xypos'] == [(0.0, 0.0), (1000.0, 1000.0),
-                                               (0.0, 1000.0), (1000.0, 0.0)]
+        # meta stores the positions sorted by y and then by x
+        assert_equal(psf_grid.meta['grid_xypos'],
+                     [(0.0, 0.0), (1000.0, 0.0),
+                      (0.0, 1000.0), (1000.0, 1000.0)])
+        assert_equal(psf_grid.meta['grid_xypos'], psf_grid.grid_xypos)
 
         # or pass in a list
         grid_xypos = [(250.0, 250.0), (750.0, 750.0),
@@ -272,7 +275,10 @@ class TestGridFromEPSFs:
 
         with pytest.warns(AstropyDeprecationWarning):
             psf_grid = grid_from_epsfs(self.epsfs, grid_xypos=grid_xypos)
-        assert psf_grid.meta['grid_xypos'] == grid_xypos
+        assert_equal(psf_grid.meta['grid_xypos'],
+                     [(250.0, 250.0), (750.0, 250.0),
+                      (250.0, 750.0), (750.0, 750.0)])
+        assert_equal(psf_grid.meta['grid_xypos'], psf_grid.grid_xypos)
 
     def test_meta(self):
         """
@@ -294,6 +300,8 @@ class TestGridFromEPSFs:
             psf_grid = grid_from_epsfs(self.epsfs, meta=meta)
         for key in [*keys, 'extra_key']:
             assert key in psf_grid.meta
-        assert psf_grid.meta['grid_xypos'].sort() == self.grid_xypos.sort()
+        assert_equal(psf_grid.meta['grid_xypos'],
+                     [(0.0, 0.0), (1000.0, 0.0),
+                      (0.0, 1000.0), (1000.0, 1000.0)])
         assert_equal(psf_grid.meta['oversampling'], [4, 4])
         assert psf_grid.meta['fill_value'] == 0.0

--- a/photutils/resources/schemas/psf/gridded_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf-1.0.0.yaml
@@ -25,6 +25,10 @@ examples:
           byteorder: little
           shape: [5, 2]
         inputs: [x, y]
+        meta:
+          detector: NRCA1
+          filter: F150W
+          instrument: NIRCam
         outputs: [z]
         oversampling: !core/ndarray-1.1.0
           source: 1
@@ -77,5 +81,12 @@ allOf:
           In other words, ``grid_xypos[i]`` should be the (x, y) position of the
           reference ePSF defined in ``nddata.data[i]``. The grid positions must form
           a rectangular grid.
-    required: [data, oversampling, grid_xypos]
+      meta:
+        type: object
+        description: |
+          Additional metadata describing the ePSF grid, such as the telescope,
+          instrument, detector, or filter. The grid_xypos and oversampling items
+          are stored as separate properties and the grid_shape item is recomputed
+          when the model is initialized, so none of them appear here.
+    required: [data, oversampling, grid_xypos, meta]
 ...

--- a/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
@@ -20,29 +20,16 @@ examples:
           byteorder: big
           shape: [9, 101, 101]
         meta:
-          STDPSF: dev/photutils/STDPSF_WFC3IR_F153M.fits
+          STDPSF: STDPSF_WFC3IR_F153M.fits
           detector: WFC3IR
           filter: F153M
           grid_shape: [3, 3]
           grid_xypos: !core/ndarray-1.1.0
-            source: 3
+            source: 1
             datatype: int64
             byteorder: little
             shape: [9, 2]
           oversampling: 4
-        npsfs: 9
-        nx_psf: 101
-        ny_psf: 101
-        xgrid: !core/ndarray-1.1.0
-          source: 1
-          datatype: int64
-          byteorder: little
-          shape: [3]
-        ygrid: !core/ndarray-1.1.0
-          source: 2
-          datatype: int64
-          byteorder: little
-          shape: [3]
 
 
 type: object
@@ -51,28 +38,6 @@ properties:
     tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
     description: |
       A 3D array with PSFs.
-  npsfs:
-    type: integer
-    description: |
-      The number of PSFs in the array.
-  nx_psf:
-    type: integer
-    description: |
-      The size of each PSF image along the X axis.
-  ny_psf:
-    type: integer
-    description: |
-      The size of each PSF image along the Y axis.
-  xgrid:
-    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-    description: |
-      An array containing the X coordinate of the fiducial point of the
-      PSF in the coordinate frame of the detector.
-  ygrid:
-    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-    description: |
-      An array containing the Y coordinate of the fiducial point of the
-      PSF in the coordinate frame of the detector.
   meta:
     type: object
     properties:
@@ -95,8 +60,8 @@ properties:
       grid_xypos:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
-          A list of the fiducials of the PSFs in the detector frame.
+          A list of the fiducial positions of the PSFs in the detector frame.
     required: [oversampling, grid_shape, grid_xypos]
 
-required: [data, npsfs, nx_psf, ny_psf, xgrid, ygrid, meta]
+required: [data, meta]
 ...

--- a/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
@@ -29,7 +29,7 @@ examples:
             datatype: int64
             byteorder: little
             shape: [9, 2]
-          oversampling: 4
+          oversampling: [4, 4]
 
 
 type: object
@@ -45,9 +45,13 @@ properties:
         type: string
         title: The name of the file containing the PSFs.
       oversampling:
-        type: integer
+        type: array
         description: |
-          Oversampling factor.
+          Oversampling factor(s), as a 2-element (y, x) array.
+        items:
+          type: integer
+        minItems: 2
+        maxItems: 2
       detector:
         type: string
         title: The name of the detector

--- a/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf-1.0.0.yaml
@@ -31,8 +31,8 @@ examples:
             shape: [9, 2]
           oversampling: 4
         npsfs: 9
-        nxpsfs: 101
-        nypsfs: 101
+        nx_psf: 101
+        ny_psf: 101
         xgrid: !core/ndarray-1.1.0
           source: 1
           datatype: int64
@@ -55,14 +55,14 @@ properties:
     type: integer
     description: |
       The number of PSFs in the array.
-  nxpsfs:
+  nx_psf:
     type: integer
     description: |
-      The size of the PSF array in X.
-  nypsfs:
+      The size of each PSF image along the X axis.
+  ny_psf:
     type: integer
     description: |
-      The size of the PSF array in Y.
+      The size of each PSF image along the Y axis.
   xgrid:
     tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
     description: |
@@ -98,5 +98,5 @@ properties:
           A list of the fiducials of the PSFs in the detector frame.
     required: [oversampling, grid_shape, grid_xypos]
 
-required: [data, npsfs, nxpsfs, nypsfs, xgrid, ygrid, meta]
+required: [data, npsfs, nx_psf, ny_psf, xgrid, ygrid, meta]
 ...


### PR DESCRIPTION
This PR makes the grid metadata on `GriddedPSFModel` and `STDPSFGrid` consistent and unambiguous, and renames the internal grid-size variables for clarity.