### PR TITLE
Rename ShepardIDWInterpolator ncoords to n_coords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -252,6 +252,19 @@ API Changes
     ``STDPSFGrid`` output now labels the grid shape as ``Grid shape``
     instead of ``Grid_shape``. [#2344]
 
+- ``photutils.segmentation``
+
+  - The ``deblend_sources`` "too many markers" warning key stored in
+    the returned ``SegmentationImage.info['warnings']`` dictionary has
+    been renamed from ``'nmarkers'`` to ``'n_markers'``, consistent
+    with the ``n_*`` naming used elsewhere in photutils. [#2335]
+
+- ``photutils.utils``
+
+  - The ``ShepardIDWInterpolator`` ``ncoords`` attribute has been
+    renamed to ``n_coords``, consistent with the ``n_*`` naming used
+    elsewhere in photutils. [#2335]
+
 
 3.0.0 (2026-04-17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -218,9 +218,8 @@ API Changes
 - ``photutils.psf``
 
   - The ``EPSFBuildResult`` class returned by ``EPSFBuilder`` has been
-    renamed to ``EPSFBuildResults`` for consistency with the plural
-    naming of the other results classes. The old ``EPSFBuildResult``
-    name is deprecated and will be removed in a future version. [#2326]
+    renamed to ``EPSFBuildResults``. The old ``EPSFBuildResult`` name is
+    deprecated and will be removed in a future version. [#2326]
 
   - The ``nxpsfs`` and ``nypsfs`` metadata keys of the
     ``GriddedPSFModel`` returned when reading a STDPSF file have been
@@ -257,13 +256,14 @@ API Changes
   - The ``deblend_sources`` "too many markers" warning key stored in
     the returned ``SegmentationImage.info['warnings']`` dictionary has
     been renamed from ``'nmarkers'`` to ``'n_markers'``, consistent
-    with the ``n_*`` naming used elsewhere in photutils. [#2335]
+    with the ``n_*`` naming used elsewhere in photutils. [#2346]
 
 - ``photutils.utils``
 
   - The ``ShepardIDWInterpolator`` ``ncoords`` attribute has been
     renamed to ``n_coords``, consistent with the ``n_*`` naming used
-    elsewhere in photutils. [#2335]
+    elsewhere in photutils. The old ``ncoords`` name is deprecated and
+    will be removed in version 4.0. [#2346]
 
 
 3.0.0 (2026-04-17)

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -468,14 +468,6 @@ Removed Deprecations
 Breaking Changes
 ----------------
 
-``StarFinderCatalogBase`` Representation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``repr`` and ``str`` output of
-`~photutils.detection.StarFinderCatalogBase` now labels the number of
-sources as ``n_sources`` instead of ``nsources`` for naming consistency
-within photutils.
-
 ``STDPSFGrid`` Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -500,3 +492,28 @@ Relatedly, the `~photutils.psf.GriddedPSFModel` ``meta`` dictionary
 now always stores ``'grid_xypos'`` as the sorted array of grid
 positions and ``'oversampling'`` as a normalized ``(y, x)`` tuple, so
 that both always match the attributes of the same name.
+
+
+``StarFinderCatalogBase`` Representation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``repr`` and ``str`` output of
+`~photutils.detection.StarFinderCatalogBase` now labels the number of
+sources as ``n_sources`` instead of ``nsources`` for naming consistency
+within photutils.
+
+
+Deblending ``n_markers`` Warning Key
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The "too many markers" warning entry recorded by
+`~photutils.segmentation.deblend_sources` in the returned
+`~photutils.segmentation.SegmentationImage` ``info['warnings']``
+dictionary has been renamed from ``'nmarkers'`` to ``'n_markers'``.
+
+
+``ShepardIDWInterpolator.ncoords`` Renamed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `~photutils.utils.ShepardIDWInterpolator` ``ncoords`` attribute has
+been renamed to ``n_coords``.

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -458,6 +458,14 @@ has been renamed to `~photutils.psf.EPSFBuildResults`. The old
 ``EPSFBuildResult`` name is deprecated and will be removed in a future
 version.
 
+``ShepardIDWInterpolator.ncoords`` Renamed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `~photutils.utils.ShepardIDWInterpolator` ``ncoords`` attribute has
+been renamed to ``n_coords`` for naming consistency within photutils.
+The old ``ncoords`` name is deprecated and will be removed in version
+4.0.
+
 
 Removed Deprecations
 --------------------
@@ -467,6 +475,14 @@ Removed Deprecations
 
 Breaking Changes
 ----------------
+
+``StarFinderCatalogBase`` Representation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``repr`` and ``str`` output of
+`~photutils.detection.StarFinderCatalogBase` now labels the number of
+sources as ``n_sources`` instead of ``nsources`` for naming consistency
+within photutils.
 
 ``STDPSFGrid`` Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -493,16 +509,6 @@ now always stores ``'grid_xypos'`` as the sorted array of grid
 positions and ``'oversampling'`` as a normalized ``(y, x)`` tuple, so
 that both always match the attributes of the same name.
 
-
-``StarFinderCatalogBase`` Representation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``repr`` and ``str`` output of
-`~photutils.detection.StarFinderCatalogBase` now labels the number of
-sources as ``n_sources`` instead of ``nsources`` for naming consistency
-within photutils.
-
-
 Deblending ``n_markers`` Warning Key
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -510,10 +516,3 @@ The "too many markers" warning entry recorded by
 `~photutils.segmentation.deblend_sources` in the returned
 `~photutils.segmentation.SegmentationImage` ``info['warnings']``
 dictionary has been renamed from ``'nmarkers'`` to ``'n_markers'``.
-
-
-``ShepardIDWInterpolator.ncoords`` Renamed
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The `~photutils.utils.ShepardIDWInterpolator` ``ncoords`` attribute has
-been renamed to ``n_coords``.

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -54,7 +54,7 @@ SHAPE_POLYGON = _POLYGON
 # Column indices of the per-source ``flag_counts`` arrays returned by
 # the batch drivers (see ``batch_aperture_sums`` and
 # ``photutils.aperture._batch_stats.batch_aperture_gather``)
-FLAG_COL_NPIX = 0
+FLAG_COL_N_PIXELS = 0
 FLAG_COL_MASKED = 1
 FLAG_COL_NONFINITE_DATA = 2
 FLAG_COL_NONFINITE_ERROR = 3
@@ -216,7 +216,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
         source and the columns given by the module-level ``FLAG_COL_*``
         constants:
 
-        * ``FLAG_COL_NPIX``: the number of nonzero-fraction pixels
+        * ``FLAG_COL_N_PIXELS``: the number of nonzero-fraction pixels
           inside the data
         * ``FLAG_COL_MASKED``: the number of those pixels that are
           input-masked

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -294,7 +294,7 @@ def batch_aperture_gather(const double[:, ::1] data,
         source and the columns given by the module-level ``FLAG_COL_*``
         constants in `photutils.aperture._batch_photometry`:
 
-        * ``FLAG_COL_NPIX``: the number of nonzero-fraction pixels
+        * ``FLAG_COL_N_PIXELS``: the number of nonzero-fraction pixels
           inside the data
         * ``FLAG_COL_MASKED``: the number of those pixels that are
           input-masked

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -18,9 +18,10 @@ from astropy.utils import lazyproperty
 
 from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_MASKED,
+                                                  FLAG_COL_N_PIXELS,
                                                   FLAG_COL_NONFINITE_DATA,
                                                   FLAG_COL_NONFINITE_ERROR,
-                                                  FLAG_COL_NPIX, FLAG_COL_SEG,
+                                                  FLAG_COL_SEG,
                                                   FLAG_COL_UNCORRECTED,
                                                   FLAG_COL_VALID,
                                                   batch_aperture_sums)
@@ -715,7 +716,7 @@ class PixelAperture(Aperture):
                 overlap[idx] = True
                 weighted = aper_weights > 0
                 w_in = np.count_nonzero(weighted)
-                flag_counts[idx, FLAG_COL_NPIX] = w_in
+                flag_counts[idx, FLAG_COL_N_PIXELS] = w_in
                 flag_counts[idx, FLAG_COL_BBOX_CLIPPED] = (
                     aper_weights.shape != apermask.data.shape)
                 if mask is not None:

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -292,9 +292,9 @@ def _counts_to_flag_bits(flag_counts, overlap, w_out):
     # Import here to avoid loading the compiled extension when only the
     # registry or decoder is needed
     from photutils.aperture._batch_photometry import (FLAG_COL_MASKED,
+                                                      FLAG_COL_N_PIXELS,
                                                       FLAG_COL_NONFINITE_DATA,
                                                       FLAG_COL_NONFINITE_ERROR,
-                                                      FLAG_COL_NPIX,
                                                       FLAG_COL_SEG,
                                                       FLAG_COL_UNCORRECTED,
                                                       FLAG_COL_VALID)
@@ -302,7 +302,7 @@ def _counts_to_flag_bits(flag_counts, overlap, w_out):
     flag_counts = np.atleast_2d(flag_counts)
     overlap = np.atleast_1d(overlap)
     w_out = np.atleast_1d(w_out)
-    w_in = flag_counts[:, FLAG_COL_NPIX]
+    w_in = flag_counts[:, FLAG_COL_N_PIXELS]
 
     flags = np.zeros(overlap.shape, dtype=int)
     no_overlap = ~overlap | ((w_in == 0) & w_out)

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -642,8 +642,8 @@ class PolygonAperture(PixelAperture):
             raise ValueError(msg)
 
         # Determine which automatic mode to use, if any
-        num_auto_modes = sum([optimal_shape, collinear_edges])
-        if num_auto_modes > 1:
+        n_auto_modes = sum([optimal_shape, collinear_edges])
+        if n_auto_modes > 1:
             msg = 'optimal_shape and collinear_edges cannot both be True'
             raise ValueError(msg)
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -2122,7 +2122,7 @@ class ApertureStats:
         return np.transpose(self._bbox_bounds)[3]
 
     @lazyproperty
-    def _center_npixels(self):
+    def _center_n_pixels(self):
         """
         The number of unmasked pixels within each aperture using the
         "center" mask method.
@@ -2133,13 +2133,13 @@ class ApertureStats:
         gather = self._fast_gather
         if gather is not None:
             counts = gather[4]
-            npix = counts.astype(float)
-            npix[counts == 0] = np.nan
-            return npix
-        npix = np.array([np.sum(weight.filled(0.0))
-                         for weight in self._weight_cutout_center])
-        npix[self._all_masked] = np.nan
-        return npix
+            n_pixels = counts.astype(float)
+            n_pixels[counts == 0] = np.nan
+            return n_pixels
+        n_pixels = np.array([np.sum(weight.filled(0.0))
+                             for weight in self._weight_cutout_center])
+        n_pixels[self._all_masked] = np.nan
+        return n_pixels
 
     @lazyproperty
     def _sem(self):
@@ -2158,12 +2158,12 @@ class ApertureStats:
         else:
             var = np.array([np.var(values)
                             for values in self._data_values_center])
-        npix = self._center_npixels
+        n_pixels = self._center_n_pixels
         sem = np.full(self.n_apertures, np.nan)
-        mask = npix >= 2
+        mask = n_pixels >= 2
         # var is the population (ddof=0) variance, so var / (N - 1)
         # equals the squared standard error of the mean.
-        sem[mask] = np.sqrt(var[mask] / (npix[mask] - 1.0))
+        sem[mask] = np.sqrt(var[mask] / (n_pixels[mask] - 1.0))
         return sem
 
     @lazyproperty
@@ -2172,7 +2172,7 @@ class ApertureStats:
         The total area of the unmasked pixels within the aperture using
         the "center" aperture mask method.
         """
-        return self._center_npixels * (u.pix**2)
+        return self._center_n_pixels * (u.pix**2)
 
     @lazyproperty
     def sum_aper_area(self):
@@ -2386,11 +2386,11 @@ class ApertureStats:
         var = self._finalize_value_stat(fast, np.var, apply_unit=False)
         if self.ddof == 0:
             return var
-        npix = self._center_npixels
+        n_pixels = self._center_n_pixels
         result = np.full(self.n_apertures, np.nan)
-        mask = npix > self.ddof
-        result[mask] = (var[mask] * npix[mask]
-                        / (npix[mask] - self.ddof))
+        mask = n_pixels > self.ddof
+        result[mask] = (var[mask] * n_pixels[mask]
+                        / (n_pixels[mask] - self.ddof))
         return result
 
     @lazyproperty

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -19,9 +19,10 @@ from astropy.utils.exceptions import AstropyUserWarning
 from photutils.aperture import Aperture, SkyAperture, region_to_aperture
 from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_MASKED,
+                                                  FLAG_COL_N_PIXELS,
                                                   FLAG_COL_NONFINITE_DATA,
                                                   FLAG_COL_NONFINITE_ERROR,
-                                                  FLAG_COL_NPIX, FLAG_COL_SEG,
+                                                  FLAG_COL_SEG,
                                                   FLAG_COL_UNCORRECTED,
                                                   FLAG_COL_VALID,
                                                   batch_aperture_sums)
@@ -1355,7 +1356,7 @@ class ApertureStats:
                 # matching the batch-driver semantics (computed before
                 # any sigma clipping)
                 weighted = aperweight_cutout > 0
-                fc_row[FLAG_COL_NPIX] = np.count_nonzero(weighted)
+                fc_row[FLAG_COL_N_PIXELS] = np.count_nonzero(weighted)
                 fc_row[FLAG_COL_BBOX_CLIPPED] = (
                     aperweight_cutout.shape != apermask.data.shape)
                 if user_mask is not None:
@@ -1746,7 +1747,7 @@ class ApertureStats:
                   & (n_kept == 0)] |= APERTURE_FLAGS.ALL_CLIPPED
 
         if self.ddof > 0:
-            w_in = flag_counts[:, FLAG_COL_NPIX]
+            w_in = flag_counts[:, FLAG_COL_N_PIXELS]
             flags[(w_in > 0)
                   & (n_kept <= self.ddof)] |= APERTURE_FLAGS.TOO_FEW_PIXELS
 

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -10,9 +10,10 @@ from numpy.testing import assert_array_equal
 from photutils.aperture import CircularAperture
 from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_MASKED,
+                                                  FLAG_COL_N_PIXELS,
                                                   FLAG_COL_NONFINITE_DATA,
                                                   FLAG_COL_NONFINITE_ERROR,
-                                                  FLAG_COL_NPIX, FLAG_COL_SEG,
+                                                  FLAG_COL_SEG,
                                                   FLAG_COL_UNCORRECTED,
                                                   FLAG_COL_VALID, SHAPE_CIRCLE,
                                                   batch_aperture_sums)
@@ -54,12 +55,12 @@ def _gather_fcounts(data, positions, radius, *, mask=None,
 
 def test_interior_source():
     """
-    Test that a clean interior source has only npix/valid counts.
+    Test that a clean interior source has only n_pixels/valid counts.
     """
     data = np.ones(SHAPE)
     fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
-    assert fc[FLAG_COL_NPIX] > 0
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX]
+    assert fc[FLAG_COL_N_PIXELS] > 0
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
     assert fc[FLAG_COL_MASKED] == 0
     assert fc[FLAG_COL_NONFINITE_DATA] == 0
     assert fc[FLAG_COL_NONFINITE_ERROR] == 0
@@ -93,7 +94,7 @@ def test_masked_pixel_membership(use_exact):
     fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
                        use_exact=use_exact)[0]
     assert fc[FLAG_COL_MASKED] == 1
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX] - 1
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 1
 
     # Pixel inside the bounding box but outside the aperture (bbox
     # corner)
@@ -102,7 +103,7 @@ def test_masked_pixel_membership(use_exact):
     fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
                        use_exact=use_exact)[0]
     assert fc[FLAG_COL_MASKED] == 0
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX]
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
 
 
 def test_mask_plane_bits():
@@ -119,7 +120,7 @@ def test_mask_plane_bits():
         fc = func(data, (12.0, 12.0), 3.0, mask=mask)[0]
         assert fc[FLAG_COL_MASKED] == 2
         assert fc[FLAG_COL_NONFINITE_DATA] == 1
-        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX] - 3
+        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 3
 
 
 def test_nonfinite_data_unmasked():
@@ -135,7 +136,7 @@ def test_nonfinite_data_unmasked():
     data[12, 13] = np.inf
     fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
     assert fc[FLAG_COL_NONFINITE_DATA] == 1
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX]
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
 
 
 def test_nonfinite_error():
@@ -170,19 +171,19 @@ def test_bbox_clipped_indicator(use_exact):
     # Aperture straddling the left edge
     fc = _sums_fcounts(data, (0.0, 12.0), 3.0, use_exact=use_exact)[0]
     assert fc[FLAG_COL_BBOX_CLIPPED] == 1
-    assert fc[FLAG_COL_NPIX] > 0
+    assert fc[FLAG_COL_N_PIXELS] > 0
 
     # Clipped bbox whose "center"-method weights are all inside the data
     # (the caller resolves the precise outside-weight test)
     fc = _sums_fcounts(data, (0.2, 12.0), 0.8, use_exact=0,
                        subpixels=1)[0]
     assert fc[FLAG_COL_BBOX_CLIPPED] == 1
-    assert fc[FLAG_COL_NPIX] > 0
+    assert fc[FLAG_COL_N_PIXELS] > 0
 
 
 def test_bbox_clipped_parity_with_aperture_mask():
     """
-    Test that npix matches the nonzero in-data aperture-mask weights
+    Test that n_pixels matches the nonzero in-data aperture-mask weights
     and that the bbox-clipped indicator matches the overlap slices, for
     randomized positions including edge and rounding cases.
     """
@@ -206,7 +207,7 @@ def test_bbox_clipped_parity_with_aperture_mask():
                 assert_array_equal(fc, 0)
                 continue
             n_in = np.count_nonzero(apermask.data[slc_small])
-            assert fc[FLAG_COL_NPIX] == n_in
+            assert fc[FLAG_COL_N_PIXELS] == n_in
             full = (slice(0, apermask.data.shape[0]),
                     slice(0, apermask.data.shape[1]))
             assert fc[FLAG_COL_BBOX_CLIPPED] == int(slc_small != full)
@@ -228,7 +229,7 @@ def test_seg_counts():
                        labels=labels, seg_method=1)[0]
     assert fc[FLAG_COL_SEG] == 1
     assert fc[FLAG_COL_UNCORRECTED] == 0
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX] - 1
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 1
 
     # Method 2 ('source_only'): background exclusions are not counted
     # as neighbor pixels
@@ -242,7 +243,7 @@ def test_seg_counts():
                        labels=labels, seg_method=3)[0]
     assert fc[FLAG_COL_SEG] == 1
     assert fc[FLAG_COL_UNCORRECTED] == 0
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_NPIX]
+    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
 
     # Method 3 with the mirror pixel also a neighbor: uncorrectable
     segm2 = segm.copy()
@@ -282,7 +283,7 @@ def test_gather_matches_sums_center():
                             subpixels=1)
     fc_gather = _gather_fcounts(data, xy, 3.0, mask=plane)
     # The gather kernel never reads error values
-    cols = [FLAG_COL_NPIX, FLAG_COL_MASKED, FLAG_COL_NONFINITE_DATA,
+    cols = [FLAG_COL_N_PIXELS, FLAG_COL_MASKED, FLAG_COL_NONFINITE_DATA,
             FLAG_COL_SEG, FLAG_COL_UNCORRECTED, FLAG_COL_VALID,
             FLAG_COL_BBOX_CLIPPED]
     assert_array_equal(fc_gather[:, cols], fc_sums[:, cols])

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -836,9 +836,9 @@ class TestApertureStats:
         Test the standard-error properties against their definitions.
         """
         apstats = ApertureStats(self.data, self.aperture, error=self.error)
-        npix = apstats.center_aper_area.value
-        sample_std = apstats.std * np.sqrt(npix / (npix - 1.0))
-        expected_mean_err = sample_std / np.sqrt(npix)
+        n_pixels = apstats.center_aper_area.value
+        sample_std = apstats.std * np.sqrt(n_pixels / (n_pixels - 1.0))
+        expected_mean_err = sample_std / np.sqrt(n_pixels)
         assert_allclose(apstats.mean_err, expected_mean_err)
         assert_allclose(apstats.median_err,
                         np.sqrt(np.pi / 2.0) * expected_mean_err)
@@ -877,7 +877,7 @@ class TestApertureStats:
             error = error * self.unit
         apstats0 = ApertureStats(data, self.aperture, error=error)
         apstats1 = ApertureStats(data, self.aperture, error=error, ddof=1)
-        npix = apstats0.center_aper_area.value
+        n_pixels = apstats0.center_aper_area.value
         var0 = apstats0.var
         std0 = apstats0.std
         var1 = apstats1.var
@@ -887,8 +887,8 @@ class TestApertureStats:
             assert std1.unit == self.unit
             var0, std0 = var0.value, std0.value
             var1, std1 = var1.value, std1.value
-        assert_allclose(var1, var0 * npix / (npix - 1.0))
-        assert_allclose(std1, std0 * np.sqrt(npix / (npix - 1.0)))
+        assert_allclose(var1, var0 * n_pixels / (n_pixels - 1.0))
+        assert_allclose(std1, std0 * np.sqrt(n_pixels / (n_pixels - 1.0)))
         # The standard errors are defined with the sample std and are
         # independent of the ``ddof`` keyword
         assert_allclose(apstats0.mean_err, apstats1.mean_err, equal_nan=True)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -257,7 +257,7 @@ class Background2D:
         self.bkg_estimator = bkg_estimator
         self.bkg_rms_estimator = bkg_rms_estimator
 
-        self._box_npixels = None
+        self._box_n_pixels = None
 
         # Store the interpolator keyword arguments for later use
         # (before self._data is deleted in self._calculate_stats)
@@ -272,7 +272,7 @@ class Background2D:
         # arrays and to keep the memory usage minimal
         (self._bkg_stats,
          self._bkgrms_stats,
-         self._ngood) = self._calculate_stats()
+         self._n_good) = self._calculate_stats()
 
         # This is used to selectively filter the low-resolution maps
         self._min_bkg_stats = nanmin(self._bkg_stats)
@@ -394,7 +394,7 @@ class Background2D:
         return total_mask
 
     @lazyproperty
-    def _good_npixels_threshold(self):
+    def _good_n_pixels_threshold(self):
         """
         The minimum number of required unmasked pixels in a box used for
         it to be included in the low-resolution map.
@@ -405,7 +405,7 @@ class Background2D:
 
         Boxes that are completely masked are always excluded.
         """
-        return (1 - (self.exclude_percentile / 100.0)) * self._box_npixels
+        return (1 - (self.exclude_percentile / 100.0)) * self._box_n_pixels
 
     def _sigmaclip_boxes(self, data, axis):
         """
@@ -470,8 +470,8 @@ class Background2D:
         bkgrms = self.bkg_rms_estimator(data, axis=axis)
 
         # Mask boxes with too few unmasked pixels
-        ngood = np.count_nonzero(~np.isnan(data), axis=axis)
-        box_mask = ngood <= self._good_npixels_threshold
+        n_good = np.count_nonzero(~np.isnan(data), axis=axis)
+        box_mask = n_good <= self._good_n_pixels_threshold
 
         if np.ndim(bkg) == 0:
             if box_mask:  # single corner box
@@ -484,7 +484,7 @@ class Background2D:
             bkg[box_mask] = np.nan
             bkgrms[box_mask] = np.nan
 
-        return bkg, bkgrms, ngood
+        return bkg, bkgrms, n_good
 
     def _calculate_stats(self):
         """
@@ -499,7 +499,7 @@ class Background2D:
         bkgrms : 2D `~numpy.ndarray`
             The background RMS statistics in each box.
 
-        ngood : 2D `~numpy.ndarray`
+        n_good : 2D `~numpy.ndarray`
             The number of unmasked pixels in each box.
         """
         # If needed, copy the data to a float32 array to insert NaNs
@@ -510,9 +510,9 @@ class Background2D:
         # masked and combine all masks
         mask = self._combine_all_masks(~np.isfinite(self._data))
 
-        self._box_npixels = np.prod(self.box_size)
-        nboxes = self._data.shape // self.box_size
-        y1, x1 = nboxes * self.box_size
+        self._box_n_pixels = np.prod(self.box_size)
+        n_boxes = self._data.shape // self.box_size
+        y1, x1 = n_boxes * self.box_size
 
         # Core boxes - the part of the data array that is an integer
         # multiple of the box size.
@@ -527,10 +527,10 @@ class Background2D:
         # array is (y1, x1) (i.e., box_size = data.shape).
         core = reshape_as_blocks(self._data[:y1, :x1].copy(), self.box_size)
         core_mask = reshape_as_blocks(mask[:y1, :x1], self.box_size)
-        core = core.reshape((*nboxes, -1))
-        core_mask = core_mask.reshape((*nboxes, -1))
+        core = core.reshape((*n_boxes, -1))
+        core_mask = core_mask.reshape((*n_boxes, -1))
         core[core_mask] = np.nan
-        bkg, bkgrms, ngood = self._compute_box_statistics(core, axis=-1)
+        bkg, bkgrms, n_good = self._compute_box_statistics(core, axis=-1)
 
         extra_row = y1 < self._data.shape[0]
         extra_col = x1 < self._data.shape[1]
@@ -546,8 +546,8 @@ class Background2D:
                 row_data = reshape_as_blocks(row_data, (1, self.box_size[1]))
                 row_data = np.moveaxis(row_data, 0, -1)
                 row_data = row_data.reshape((*row_data.shape[:-2], -1))
-                row_bkg, row_bkgrms, row_ngood = self._compute_box_statistics(
-                    row_data, axis=-1)
+                row_bkg, row_bkgrms, row_n_good = (
+                    self._compute_box_statistics(row_data, axis=-1))
 
             if extra_col:
                 # Extra column of boxes.
@@ -560,8 +560,8 @@ class Background2D:
                 col_data = reshape_as_blocks(col_data, (self.box_size[0], 1))
                 col_data = np.transpose(col_data, (0, 3, 1, 2))
                 col_data = col_data.reshape((*col_data.shape[:-2], -1))
-                col_bkg, col_bkgrms, col_ngood = self._compute_box_statistics(
-                    col_data, axis=-1)
+                col_bkg, col_bkgrms, col_n_good = (
+                    self._compute_box_statistics(col_data, axis=-1))
 
             if extra_row and extra_col:
                 # Extra corner box -- append to extra column.
@@ -570,26 +570,26 @@ class Background2D:
                 corner_data = self._data[y1:, x1:].copy()
                 corner_mask = mask[y1:, x1:]
                 corner_data[corner_mask] = np.nan
-                crn_bkg, crn_bkgrms, crn_ngood = self._compute_box_statistics(
-                    corner_data, axis=None)
+                crn_bkg, crn_bkgrms, crn_n_good = (
+                    self._compute_box_statistics(corner_data, axis=None))
                 col_bkg = np.vstack((col_bkg, crn_bkg))
                 col_bkgrms = np.vstack((col_bkgrms, crn_bkgrms))
-                col_ngood = np.vstack((col_ngood, crn_ngood))
+                col_n_good = np.vstack((col_n_good, crn_n_good))
 
             # Combine the core and extra boxes to construct the
             # complete 2D bkg and bkgrms arrays
             if extra_row:
                 bkg = np.vstack([bkg, row_bkg[:, 0]])
                 bkgrms = np.vstack([bkgrms, row_bkgrms[:, 0]])
-                ngood = np.vstack([ngood, row_ngood[:, 0]])
+                n_good = np.vstack([n_good, row_n_good[:, 0]])
 
             if extra_col:
                 bkg = np.hstack([bkg, col_bkg])
                 bkgrms = np.hstack([bkgrms, col_bkgrms])
-                ngood = np.hstack([ngood, col_ngood])
+                n_good = np.hstack([n_good, col_n_good])
 
         if np.all(np.isnan(bkg)):
-            msg = (f'All boxes contain <= {self._good_npixels_threshold} '
+            msg = (f'All boxes contain <= {self._good_n_pixels_threshold} '
                    f'unmasked or finite pixels ({self.box_size=}, '
                    f'{self.exclude_percentile=}). Please check your data '
                    'or increase "exclude_percentile" to allow more boxes to '
@@ -600,7 +600,7 @@ class Background2D:
         del self._data
         del self._mask
 
-        return bkg, bkgrms, ngood
+        return bkg, bkgrms, n_good
 
     def _interpolate_grid(self, data, *, n_neighbors=10, eps=0.0, power=1.0,
                           regularization=0.0):
@@ -792,7 +792,7 @@ class Background2D:
         .. deprecated:: 3.0
             Use ``n_pixels_mesh`` instead.
         """
-        return self._ngood
+        return self._n_good
 
     @property
     def n_pixels_mesh(self):
@@ -800,7 +800,7 @@ class Background2D:
         A 2D array of the number pixels used to compute the statistics
         in each mesh.
         """
-        return self._ngood
+        return self._n_good
 
     @property
     @deprecated(since='3.0', alternative='n_pixels_map', until='4.0')

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -546,8 +546,8 @@ class Background2D:
                 row_data = reshape_as_blocks(row_data, (1, self.box_size[1]))
                 row_data = np.moveaxis(row_data, 0, -1)
                 row_data = row_data.reshape((*row_data.shape[:-2], -1))
-                row_bkg, row_bkgrms, row_n_good = (
-                    self._compute_box_statistics(row_data, axis=-1))
+                row_bkg, row_bkgrms, row_n_good = self._compute_box_statistics(
+                    row_data, axis=-1)
 
             if extra_col:
                 # Extra column of boxes.
@@ -560,8 +560,8 @@ class Background2D:
                 col_data = reshape_as_blocks(col_data, (self.box_size[0], 1))
                 col_data = np.transpose(col_data, (0, 3, 1, 2))
                 col_data = col_data.reshape((*col_data.shape[:-2], -1))
-                col_bkg, col_bkgrms, col_n_good = (
-                    self._compute_box_statistics(col_data, axis=-1))
+                col_bkg, col_bkgrms, col_n_good = self._compute_box_statistics(
+                    col_data, axis=-1)
 
             if extra_row and extra_col:
                 # Extra corner box -- append to extra column.
@@ -570,8 +570,8 @@ class Background2D:
                 corner_data = self._data[y1:, x1:].copy()
                 corner_mask = mask[y1:, x1:]
                 corner_data[corner_mask] = np.nan
-                crn_bkg, crn_bkgrms, crn_n_good = (
-                    self._compute_box_statistics(corner_data, axis=None))
+                crn_bkg, crn_bkgrms, crn_n_good = self._compute_box_statistics(
+                    corner_data, axis=None)
                 col_bkg = np.vstack((col_bkg, crn_bkg))
                 col_bkgrms = np.vstack((col_bkgrms, crn_bkgrms))
                 col_n_good = np.vstack((col_n_good, crn_n_good))

--- a/photutils/centroids/tests/test_gaussian.py
+++ b/photutils/centroids/tests/test_gaussian.py
@@ -82,25 +82,25 @@ def test_centroids_nan_withmask(use_mask):
     if use_mask:
         mask = np.zeros(data.shape, dtype=bool)
         mask[20, :] = True
-        nwarn = 0
+        n_warn = 0
         ctx = nullcontext()
     else:
         mask = None
-        nwarn = 1
+        n_warn = 1
         match = 'Input data contains non-finite values'
         ctx = pytest.warns(AstropyUserWarning, match=match)
 
     with ctx as warnlist:
         xc, yc = centroid_1dg(data, mask=mask)
         assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.0e-3)
-        if nwarn == 1:
-            assert len(warnlist) == nwarn
+        if n_warn == 1:
+            assert len(warnlist) == n_warn
 
     with ctx as warnlist:
         xc, yc = centroid_2dg(data, mask=mask)
         assert_allclose([xc, yc], [xc_ref, yc_ref], rtol=0, atol=1.0e-3)
-        if nwarn == 1:
-            assert len(warnlist) == nwarn
+        if n_warn == 1:
+            assert len(warnlist) == n_warn
 
 
 def test_invalid_shapes():

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -466,12 +466,12 @@ class _IRAFStarFinderCatalog(StarFinderCatalogBase):
         within the kernel footprint.
         """
         skymask = ~self.kernel.mask.astype(bool)  # True=sky, False=obj
-        # nsky is always > 0 because the kernel mask never covers the
+        # n_sky is always > 0 because the kernel mask never covers the
         # entire footprint (the Gaussian kernel is always truncated
         # within the array, leaving unmasked border pixels).
-        nsky = np.count_nonzero(skymask)
+        n_sky = np.count_nonzero(skymask)
         axis = (1, 2)
-        sky = np.sum(self.cutout_data_nosub * skymask, axis=axis) / nsky
+        sky = np.sum(self.cutout_data_nosub * skymask, axis=axis) / n_sky
 
         if self.unit is not None:
             sky <<= self.unit

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -458,30 +458,30 @@ class TestIRAFStarFinder:
                                 roundness_range=(-np.inf, np.inf))
         cat = finder._get_raw_catalog(data)
         assert cat is not None
-        nsrc = len(cat)
+        n_sources = len(cat)
 
         # sky should be finite and have same length as nsources
         sky = cat.sky
-        assert sky.shape == (nsrc,)
+        assert sky.shape == (n_sources,)
         assert np.all(np.isfinite(sky))
 
-        # cutout_data_nosub should have shape (nsrc, ky, kx) with no
+        # cutout_data_nosub should have shape (n_sources, ky, kx) with no
         # sky subtraction
         cdata = cat.cutout_data_nosub
         assert cdata.ndim == 3
-        assert cdata.shape[0] == nsrc
+        assert cdata.shape[0] == n_sources
 
         # cutout_xorigin/cutout_yorigin should be finite 1D arrays
         xorig = cat.cutout_xorigin
         yorig = cat.cutout_yorigin
-        assert xorig.shape == (nsrc,)
-        assert yorig.shape == (nsrc,)
+        assert xorig.shape == (n_sources,)
+        assert yorig.shape == (n_sources,)
         assert np.all(np.isfinite(xorig))
         assert np.all(np.isfinite(yorig))
 
         # sharpness should be finite for detected sources
         sharpness = cat.sharpness
-        assert sharpness.shape == (nsrc,)
+        assert sharpness.shape == (n_sources,)
         assert np.all(np.isfinite(sharpness))
 
     def test_deprecated_sharplo_sharphi(self):

--- a/photutils/isophote/integrator.py
+++ b/photutils/isophote/integrator.py
@@ -248,7 +248,7 @@ class _AreaIntegrator(_Integrator):
         if ((i1 in self._i_range) and (j1 in self._j_range)
                 and (i2 in self._i_range) and (j2 in self._j_range)):
             # Scan rectangular image area, compute sample value.
-            npix = 0
+            n_pixels = 0
             accumulator = self.initialize_accumulator()
             for j in range(j1, j2):
                 for i in range(i1, i2):
@@ -273,12 +273,12 @@ class _AreaIntegrator(_Integrator):
                             # update accumulator with pixel value
                             pix_value = self._image[j][i]
                             if pix_value is not np.ma.masked:
-                                accumulator, npix = self.accumulate(
+                                accumulator, n_pixels = self.accumulate(
                                     pix_value, accumulator)
 
             # If 6 or less pixels were sampled, get the bilinear
             # interpolated value instead.
-            if npix in range(7):
+            if n_pixels in range(7):
                 # must reset integrator to remove older samples.
                 self._bilinear_integrator._reset()
                 self._bilinear_integrator.integrate(radius, phi)
@@ -289,7 +289,7 @@ class _AreaIntegrator(_Integrator):
                     sample_value = self._bilinear_integrator._intensities[0]
                     self._store_results(phi, radius, sample_value)
 
-            elif npix > 6:
+            elif n_pixels > 6:
                 sample_value = self.compute_sample_value(accumulator)
                 self._store_results(phi, radius, sample_value)
 

--- a/photutils/morphology/non_parametric.py
+++ b/photutils/morphology/non_parametric.py
@@ -82,17 +82,18 @@ def gini(data, mask=None):
 
     # Exclude invalid values (NaN, inf)
     values = np.abs(values[np.isfinite(values)])
-    npix = values.size
-    if npix == 0:
+    n_pixels = values.size
+    if n_pixels == 0:
         return np.nan
 
-    if npix == 1:
+    if n_pixels == 1:
         return 0.0
 
-    normalization = np.mean(values) * npix * (npix - 1)
+    normalization = np.mean(values) * n_pixels * (n_pixels - 1)
     if normalization == 0.0:
         return 0.0
 
-    kernel = (2.0 * np.arange(1, npix + 1) - npix - 1) * np.sort(values)
+    kernel = ((2.0 * np.arange(1, n_pixels + 1) - n_pixels - 1)
+              * np.sort(values))
 
     return np.sum(kernel) / normalization

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -1020,7 +1020,7 @@ class PSFFitter:
         return fit_model, fit_info
 
     # @staticmethod
-    def extract_source_covariances(self, group_cov, num_sources,
+    def extract_source_covariances(self, group_cov, n_sources,
                                    n_fit_params):
         """
         Extract individual source covariance matrices from group
@@ -1036,7 +1036,7 @@ class PSFFitter:
         group_cov : `~numpy.ndarray`
             2D covariance matrix for the entire group of sources.
 
-        num_sources : int
+        n_sources : int
             Number of sources in the group.
 
         n_fit_params : int
@@ -1049,7 +1049,7 @@ class PSFFitter:
             the group.
         """
         source_covs = []
-        for i in range(num_sources):
+        for i in range(n_sources):
             start = i * n_fit_params
             end = (i + 1) * n_fit_params
             source_cov = group_cov[start:end, start:end]

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -739,7 +739,7 @@ class PSFDataProcessor:
             - 'xx' : array, x pixel coordinates (flattened)
             - 'yy' : array, y pixel coordinates (flattened)
             - 'cutout' : array, data values (background-subtracted)
-            - 'npix' : int, number of pixels in cutout
+            - 'n_pixels' : int, number of pixels in cutout
             - 'cen_index' : int or nan, index of center pixel
         """
         x_cen = row[self.param_mapper.init_colnames['x']]
@@ -754,7 +754,7 @@ class PSFDataProcessor:
                     'xx': None,
                     'yy': None,
                     'cutout': None,
-                    'npix': 0,
+                    'n_pixels': 0,
                     'cen_index': np.nan,
                     }
 
@@ -775,7 +775,7 @@ class PSFDataProcessor:
                         'xx': None,
                         'yy': None,
                         'cutout': None,
-                        'npix': 0,
+                        'n_pixels': 0,
                         'cen_index': np.nan,
                         }
 
@@ -812,7 +812,7 @@ class PSFDataProcessor:
                 'xx': xx_flat,
                 'yy': yy_flat,
                 'cutout': cutout,
-                'npix': len(xx_flat),
+                'n_pixels': len(xx_flat),
                 'cen_index': cen_index,
                 }
 
@@ -1020,7 +1020,8 @@ class PSFFitter:
         return fit_model, fit_info
 
     # @staticmethod
-    def extract_source_covariances(self, group_cov, num_sources, nfitparam):
+    def extract_source_covariances(self, group_cov, num_sources,
+                                   n_fit_params):
         """
         Extract individual source covariance matrices from group
         covariance.
@@ -1038,7 +1039,7 @@ class PSFFitter:
         num_sources : int
             Number of sources in the group.
 
-        nfitparam : int
+        n_fit_params : int
             Number of fitted parameters per source.
 
         Returns
@@ -1049,8 +1050,8 @@ class PSFFitter:
         """
         source_covs = []
         for i in range(num_sources):
-            start = i * nfitparam
-            end = (i + 1) * nfitparam
+            start = i * n_fit_params
+            end = (i + 1) * n_fit_params
             source_cov = group_cov[start:end, start:end]
             source_covs.append(source_cov)
 
@@ -1319,9 +1320,9 @@ class PSFResultsAssembler:
         if isinstance(flux_vals, u.Quantity):
             flux_vals = flux_vals.value
 
-        nsrc = len(sum_abs_residuals)
-        qfit = np.full(nsrc, np.nan, dtype=float)
-        cfit = np.full(nsrc, np.nan, dtype=float)
+        n_sources = len(sum_abs_residuals)
+        qfit = np.full(n_sources, np.nan, dtype=float)
+        cfit = np.full(n_sources, np.nan, dtype=float)
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -17,67 +17,59 @@ __all__ = ['ImagePSF']
 
 class ImagePSF(Fittable2DModel):
     """
-    A model for a 2D image PSF.
+    A model representing a 2D image PSF.
 
-    This class takes 2D image data and computes the values of the model
-    at arbitrary locations, including fractional pixel positions, within
-    the image using spline interpolation provided by
-    :py:class:`~scipy.interpolate.RectBivariateSpline`.
+    This class evaluates a 2D image PSF at arbitrary positions,
+    including fractional pixel coordinates, using spline interpolation
+    provided by `~scipy.interpolate.RectBivariateSpline`.
 
-    The model has three model parameters: an image intensity scaling
-    factor (``flux``) which is applied to the input image, and two
-    positional parameters (``x_0`` and ``y_0``) indicating the location
-    of a feature in the coordinate grid on which the model is evaluated.
+    This model has three parameters: an image intensity scaling factor
+    (``flux``), which scales the input image, and two positional
+    parameters (``x_0`` and ``y_0``), which specify the location of the
+    feature in the coordinate grid where the model is evaluated.
 
     Parameters
     ----------
     data : 2D `~numpy.ndarray`
-        Array containing the 2D image. The length of the x and y axes
-        must both be at least 4. All elements of the input image data
-        must be finite. By default, the PSF peak is assumed to be
-        located at the center of the input image (see the ``origin``
-        keyword). Please see the Notes section below for details on the
-        normalization of the input image data.
+        A 2D array containing the PSF image. The x and y dimensions
+        must both be at least 4 pixels. All values must be finite. By
+        default, the PSF peak is assumed to be centered in the input
+        image (see ``origin``). See the Notes section for details on the
+        required normalization of the input image.
 
     flux : float, optional
-        The total flux of the source, assuming the input image
-        was properly normalized.
+        The flux scaling factor. This corresponds to the total source flux,
+        assuming the input PSF image is properly normalized.
 
-    x_0, y_0 : float
-        The x and y positions of a feature in the image in the output
-        coordinate grid on which the model is evaluated. Typically, this
-        refers to the position of the PSF peak, which is assumed to be
-        located at the center of the input image (see the ``origin``
-        keyword).
+    x_0, y_0 : float, optional
+        The ``(x, y)`` coordinates of the PSF peak in the output coordinate
+        grid where the model is evaluated.
 
     origin : tuple of 2 float or None, optional
-        The ``(x, y)`` coordinate with respect to the input image data
-        array that represents the reference pixel of the input data.
+        The ``(x, y)`` coordinate in the input image corresponding to the
+        reference pixel.
 
-        The reference ``origin`` pixel will be placed at the model
-        ``x_0`` and ``y_0`` coordinates in the output coordinate system
-        on which the model is evaluated.
+        The reference pixel is placed at the model ``x_0`` and ``y_0``
+        coordinates in the output coordinate grid.
 
-        Most typically, the input PSF should be centered in the input
-        image, and thus the origin should be set to the central pixel of
-        the ``data`` array.
+        In most cases, the PSF should be centered in the input image, so
+        ``origin`` should be set to the central pixel of ``data``.
 
-        If the origin is set to `None`, then the origin will be set to
-        the center of the ``data`` array (``(npix - 1) / 2.0``).
+        If `None`, ``origin`` is set to the center of the input image,
+        ``((n_x - 1) / 2, (n_y - 1) / 2)``.
 
     oversampling : int or array_like (int), optional
-        The integer oversampling factor(s) of the input PSF image. If
-        ``oversampling`` is a scalar then it will be used for both axes.
-        If ``oversampling`` has two elements, they must be in ``(y, x)``
-        order.
+        The integer oversampling factor(s) of the input PSF image. If a
+        scalar is provided, it is applied to both axes. If two values are
+        provided, they must be in ``(y, x)`` order.
 
     fill_value : float, optional
-        The value to use for points outside the input pixel grid. The
-        default is 0.0.
+        The value used for points outside the input pixel grid. The default
+        is 0.0.
 
     **kwargs : dict, optional
-        Additional optional keyword arguments to be passed to the
-        `astropy.modeling.Model` base class.
+        Additional keyword arguments passed to the
+        `~astropy.modeling.Model` base class.
 
     See Also
     --------
@@ -85,22 +77,27 @@ class ImagePSF(Fittable2DModel):
 
     Notes
     -----
-    The fitted PSF model flux represents the total flux of the source,
-    assuming the input image was properly normalized. This flux is
-    determined as a multiplicative scale factor applied to the input
-    image PSF, after accounting for any oversampling. Theoretically,
-    the sum of all values in the PSF image over an infinite grid should
-    equal 1.0 (assuming no oversampling). However, when the PSF is
-    represented over a finite region, the sum of the values may be less
-    than 1.0. For oversampled PSF images, the normalization should be
-    adjusted so that the sum of the array values equals the product
-    of the oversampling factors (e.g., oversampling squared if the
-    oversampling is the same along both axes). If the input image only
-    covers a finite region of the PSF, the sum may again be less than
-    the product of the oversampling factors. Correction factors based on
-    the encircled or ensquared energy of the PSF can be used to estimate
-    the proper scaling for the finite region of the input PSF image and
-    ensure correct flux normalization.
+    The fitted ``flux`` parameter represents the total source flux,
+    provided the input PSF image is properly normalized. The fitted flux
+    is a multiplicative scale factor applied to the input PSF after
+    accounting for any oversampling.
+
+    For a fully sampled ePSF (i.e., no oversampling), the sum of
+    the ePSF values over an infinite grid is 1.0. Because ePSFs are
+    represented by finite images in practice, the sum of the array
+    values may be less than 1.0.
+
+    For oversampled ePSF images, the normalization should instead be
+    such that the sum of the array values over an infinite grid equals
+    the product of the oversampling factors (e.g., ``oversampling**2``
+    when the oversampling is the same along both axes). Again, a finite
+    image will generally have a smaller sum because it does not contain
+    the full PSF wings.
+
+    If the input PSF image covers only a finite region of the PSF,
+    correction factors based on the encircled or ensquared energy
+    can be used to estimate the missing flux and obtain the proper
+    normalization.
 
     Examples
     --------
@@ -249,7 +246,7 @@ class ImagePSF(Fittable2DModel):
         the ``data`` array.
 
         If the origin is set to `None`, then the origin will be set to
-        the center of the ``data`` array (``(npix - 1) / 2.0``).
+        the center of the ``data`` array (``(n_pixels - 1) / 2.0``).
         """
         return self._origin
 

--- a/photutils/psf/model_helpers.py
+++ b/photutils/psf/model_helpers.py
@@ -297,10 +297,10 @@ def _integrate_model(model, *, x_name=None, y_name=None, dx=50, dy=50,
 
     hx = (dx - 1) / 2
     hy = (dy - 1) / 2
-    nxpts = int(dx * subsample)
-    nypts = int(dy * subsample)
-    xvals = np.linspace(xc - hx, xc + hx, nxpts)
-    yvals = np.linspace(yc - hy, yc + hy, nypts)
+    nx_pts = int(dx * subsample)
+    ny_pts = int(dy * subsample)
+    xvals = np.linspace(xc - hx, xc + hx, nx_pts)
+    yvals = np.linspace(yc - hy, yc + hy, ny_pts)
 
     # evaluate the model on the subsampled grid
     data = model(xvals.reshape(-1, 1), yvals.reshape(1, -1))

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -225,7 +225,6 @@ def _split_detectors(grid_data, detector_data, detector_id):
     nx_grid //= nx_det
     ny_grid //= ny_det
     n_detectors = nx_det * ny_det
-
     ii = reshape_as_blocks(ii, (ny_grid, nx_grid))
     ii = ii.reshape(n_detectors, n_psfs // n_detectors)
 

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -216,28 +216,29 @@ def _split_detectors(grid_data, detector_data, detector_id):
     ny_grid = grid_data['ny_grid']
     xgrid = grid_data['xgrid']
     ygrid = grid_data['ygrid']
-    nxdet = detector_data['nxdet']
-    nydet = detector_data['nydet']
+    nx_det = detector_data['nx_det']
+    ny_det = detector_data['ny_det']
     det_map = detector_data['det_map']
     det_size = detector_data['det_size']
 
     ii = np.arange(n_psfs).reshape((ny_grid, nx_grid))
-    nx_grid //= nxdet
-    ny_grid //= nydet
-    ndet = nxdet * nydet
+    nx_grid //= nx_det
+    ny_grid //= ny_det
+    n_detectors = nx_det * ny_det
+
     ii = reshape_as_blocks(ii, (ny_grid, nx_grid))
-    ii = ii.reshape(ndet, n_psfs // ndet)
+    ii = ii.reshape(n_detectors, n_psfs // n_detectors)
 
     # detector_id -> index
     det_idx = det_map[detector_id]
     idx = ii[det_idx]
     data = data[idx]
 
-    xp = det_idx % nxdet
+    xp = det_idx % nx_det
     i0 = xp * nx_grid
     i1 = i0 + nx_grid
     xgrid = xgrid[i0:i1] - xp * det_size
-    ygrid = (ygrid[:ny_grid] if det_idx < nxdet
+    ygrid = (ygrid[:ny_grid] if det_idx < nx_det
              else ygrid[ny_grid:] - det_size)
 
     return data, xgrid, ygrid
@@ -319,8 +320,8 @@ def _split_wfpc2(grid_data, detector_id):
         msg = 'detector_id must be between 1 and 4, inclusive'
         raise ValueError(msg)
 
-    nxdet = 2
-    nydet = 2
+    nx_det = 2
+    ny_det = 2
     det_size = 800
 
     # det (exten:idx)
@@ -328,8 +329,8 @@ def _split_wfpc2(grid_data, detector_id):
     # WF3 (3:0)  WF4 (4:1)
     det_map = {1: 3, 2: 2, 3: 0, 4: 1}
 
-    detector_data = {'nxdet': nxdet,
-                     'nydet': nydet,
+    detector_data = {'nx_det': nx_det,
+                     'ny_det': ny_det,
                      'det_size': det_size,
                      'det_map': det_map}
 
@@ -366,8 +367,8 @@ def _split_nrcsw(grid_data, detector_id):
         msg = 'detector_id must be between 1 and 8, inclusive'
         raise ValueError(msg)
 
-    nxdet = 4
-    nydet = 2
+    nx_det = 4
+    ny_det = 2
     det_size = 2048
 
     # det (ext:idx)
@@ -375,8 +376,8 @@ def _split_nrcsw(grid_data, detector_id):
     # A1 (1:0)  A3 (3:1)  B4 (8:2)  B2 (6:3)
     det_map = {1: 0, 3: 1, 8: 2, 6: 3, 2: 4, 4: 5, 7: 6, 5: 7}
 
-    detector_data = {'nxdet': nxdet,
-                     'nydet': nydet,
+    detector_data = {'nx_det': nx_det,
+                     'ny_det': ny_det,
                      'det_size': det_size,
                      'det_map': det_map}
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -998,32 +998,32 @@ class PSFPhotometry:
             The fit_info dictionary corresponding to the group fit.
         """
         n_fit_params = len(self._param_mapper.fitted_param_names)
-        num_valid = int(np.count_nonzero(valid_mask))
+        n_valid = int(np.count_nonzero(valid_mask))
 
         # Extract parameter errors from the group covariance matrix
         param_cov = group_fit_info.get('param_cov')
         if param_cov is None:
-            source_param_errs = np.full((num_valid, n_fit_params), np.nan)
-            source_covs = [None] * num_valid
+            source_param_errs = np.full((n_valid, n_fit_params), np.nan)
+            source_covs = [None] * n_valid
         else:
             param_err_1d = np.sqrt(np.diag(param_cov))
 
             # For grouped (flat) models, parameters are arranged as,
             # e.g., [flux_0, x_0_0, y_0_0, fwhm_0, flux_1, x_0_1, ...]
-            source_param_errs = param_err_1d.reshape(num_valid, n_fit_params)
+            source_param_errs = param_err_1d.reshape(n_valid, n_fit_params)
 
             # Extract individual covariance matrices for each source
             source_covs = self._psf_fitter.extract_source_covariances(
-                param_cov, num_valid, n_fit_params)
+                param_cov, n_valid, n_fit_params)
 
         # Split models and extract parameters
-        if num_valid == 1:
+        if n_valid == 1:
             source_models = [group_model]
         else:
             # For grouped (flat) models, create individual models from
             # params
             source_models = self._psf_fitter.split_flat_model(group_model,
-                                                              num_valid)
+                                                              n_valid)
 
         # Store results for each valid source
         valid_idx = 0
@@ -1270,7 +1270,7 @@ class PSFPhotometry:
                     valid_mask_list.append(False)
 
             valid_mask = np.array(valid_mask_list, dtype=bool)
-            num_valid = int(np.count_nonzero(valid_mask))
+            n_valid = int(np.count_nonzero(valid_mask))
 
             # Store basic info for all sources in group.
             # row_indices is used to store results in the original
@@ -1286,7 +1286,7 @@ class PSFPhotometry:
                     '' if reason is None else reason
                 )
 
-            if num_valid == 0:
+            if n_valid == 0:
                 # Handle all-invalid group
                 for row_index in row_indices:
                     self._state['valid_mask_by_id'][row_index] = False

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -466,9 +466,9 @@ class PSFPhotometry:
         n_sources : int
             The number of sources to initialize the arrays for.
         """
-        nfitparam = len(self._param_mapper.fitted_param_names)
+        n_fit_params = len(self._param_mapper.fitted_param_names)
         self._state.update({
-            'fit_param_errs': np.full((n_sources, nfitparam), np.nan),
+            'fit_param_errs': np.full((n_sources, n_fit_params), np.nan),
             'n_pixels_fit': np.zeros(n_sources, dtype=int),
             'invalid_reasons': [''] * n_sources,
             'sum_abs_residuals': np.full(n_sources, np.nan, dtype=float),
@@ -997,24 +997,24 @@ class PSFPhotometry:
         group_fit_info : dict
             The fit_info dictionary corresponding to the group fit.
         """
-        nfitparam = len(self._param_mapper.fitted_param_names)
+        n_fit_params = len(self._param_mapper.fitted_param_names)
         num_valid = int(np.count_nonzero(valid_mask))
 
         # Extract parameter errors from the group covariance matrix
         param_cov = group_fit_info.get('param_cov')
         if param_cov is None:
-            source_param_errs = np.full((num_valid, nfitparam), np.nan)
+            source_param_errs = np.full((num_valid, n_fit_params), np.nan)
             source_covs = [None] * num_valid
         else:
             param_err_1d = np.sqrt(np.diag(param_cov))
 
             # For grouped (flat) models, parameters are arranged as,
             # e.g., [flux_0, x_0_0, y_0_0, fwhm_0, flux_1, x_0_1, ...]
-            source_param_errs = param_err_1d.reshape(num_valid, nfitparam)
+            source_param_errs = param_err_1d.reshape(num_valid, n_fit_params)
 
             # Extract individual covariance matrices for each source
             source_covs = self._psf_fitter.extract_source_covariances(
-                param_cov, num_valid, nfitparam)
+                param_cov, num_valid, n_fit_params)
 
         # Split models and extract parameters
         if num_valid == 1:
@@ -1050,7 +1050,7 @@ class PSFPhotometry:
             valid_idx += 1
 
     def _calculate_residual_metrics(self, row_indices, valid_mask,
-                                    npixfit_full, cen_index_full, *,
+                                    n_pixels_fit_full, cen_index_full, *,
                                     error=None, xi_all=None, yi_all=None):
         """
         Calculate residual-based fit metrics for valid sources.
@@ -1063,7 +1063,7 @@ class PSFPhotometry:
         valid_mask : array-like
             Boolean mask for valid sources.
 
-        npixfit_full : array-like
+        n_pixels_fit_full : array-like
             Number of pixels used in fit for each source.
 
         cen_index_full : array-like
@@ -1116,24 +1116,25 @@ class PSFPhotometry:
         if residuals is not None:
             # convert to numpy arrays for vectorized operations
             valid_mask_arr = np.array(valid_mask, dtype=bool)
-            npixfit_arr = np.array(npixfit_full)
+            n_pixels_fit_arr = np.array(n_pixels_fit_full)
             cen_index_arr = np.array(cen_index_full)
 
             # get valid source indices
             valid_indices = np.where(valid_mask_arr)[0]
             if len(valid_indices) > 0:
-                npix_valid = npixfit_arr[valid_indices]
+                n_pixels_valid = n_pixels_fit_arr[valid_indices]
 
                 # calculate cumulative pixel positions
-                cumsum_npix = np.concatenate(([0], np.cumsum(npix_valid)))
+                cumsum_n_pixels = np.concatenate(
+                    ([0], np.cumsum(n_pixels_valid)))
 
                 # get the number of fitted parameters
-                nfitparam = len(self._param_mapper.fitted_param_names)
+                n_fit_params = len(self._param_mapper.fitted_param_names)
 
                 # process all valid sources
                 for idx, valid_idx in enumerate(valid_indices):
-                    start_pos = cumsum_npix[idx]
-                    end_pos = cumsum_npix[idx + 1]
+                    start_pos = cumsum_n_pixels[idx]
+                    end_pos = cumsum_n_pixels[idx + 1]
                     source_residuals = residuals[start_pos:end_pos]
 
                     # For qfit and cfit calculations, we need raw residuals
@@ -1169,7 +1170,7 @@ class PSFPhotometry:
                     # Calculate chi-squared. The residuals have already
                     # been weighted by (1 / error). If errors are not
                     # input, then reduced_chi2 will be NaN.
-                    dof = float(npix_valid[idx] - nfitparam)
+                    dof = float(n_pixels_valid[idx] - n_fit_params)
                     if (error is not None and xi_all is not None
                             and yi_all is not None):
                         # Extract error values for this source's pixels
@@ -1217,7 +1218,7 @@ class PSFPhotometry:
                                              desc='Fit source/group')
 
         y_offsets, x_offsets = self._data_processor.get_fit_offsets()
-        nfitparam_per_source = len(self._param_mapper.fitted_param_names)
+        n_fit_params_per_source = len(self._param_mapper.fitted_param_names)
 
         # sources are fit by groups in group ID order
         for source_group in source_groups:
@@ -1225,7 +1226,7 @@ class PSFPhotometry:
             xi_all = []
             yi_all = []
             cutout_all = []
-            npixfit_full = []
+            n_pixels_fit_full = []
             cen_index_full = []
             valid_mask_list = []
             invalid_reasons = []
@@ -1243,7 +1244,7 @@ class PSFPhotometry:
                         'xx': None,
                         'yy': None,
                         'cutout': None,
-                        'npix': 0,
+                        'n_pixels': 0,
                         'cen_index': np.nan,
                     }
                 else:
@@ -1251,18 +1252,20 @@ class PSFPhotometry:
                         row, data, mask, y_offsets, x_offsets)
 
                 # Common processing for all sources
-                npixfit_full.append(res['npix'])
+                n_pixels_fit_full.append(res['n_pixels'])
                 cen_index_full.append(res['cen_index'])
                 invalid_reasons.append(res['reason'])
                 row_indices.append(row['_row_index'])
 
-                if res['valid'] and res['npix'] >= nfitparam_per_source:
+                if (res['valid']
+                        and res['n_pixels'] >= n_fit_params_per_source):
                     valid_mask_list.append(True)
                     xi_all.append(res['xx'])
                     yi_all.append(res['yy'])
                     cutout_all.append(res['cutout'])
                 else:
-                    if res['valid'] and res['npix'] < nfitparam_per_source:
+                    if (res['valid']
+                            and res['n_pixels'] < n_fit_params_per_source):
                         invalid_reasons[-1] = 'too_few_pixels'
                     valid_mask_list.append(False)
 
@@ -1275,7 +1278,7 @@ class PSFPhotometry:
             row_indices_arr = np.array(row_indices)
             self._state['group_size'][row_indices_arr] = group_size
             self._state['n_pixels_fit'][row_indices_arr] = np.array(
-                npixfit_full, dtype=int)
+                n_pixels_fit_full, dtype=int)
 
             for i, row_index in enumerate(row_indices):
                 reason = invalid_reasons[i]
@@ -1307,7 +1310,7 @@ class PSFPhotometry:
 
             # Calculate residual metrics for valid sources
             self._calculate_residual_metrics(
-                row_indices, valid_mask, npixfit_full, cen_index_full,
+                row_indices, valid_mask, n_pixels_fit_full, cen_index_full,
                 error=error, xi_all=xi_all, yi_all=yi_all)
 
     def _get_fit_error_indices(self):

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -2097,7 +2097,7 @@ class TestEPSFBuilder:
         xdithers = np.transpose(xydithers)[0]
         ydithers = np.transpose(xydithers)[1]
 
-        nstars = oversamp**2
+        n_stars = oversamp**2
         fwhm = 7.0
         sources = Table()
         offset = 50
@@ -2105,7 +2105,7 @@ class TestEPSFBuilder:
         y, x = np.mgrid[0:oversamp, 0:oversamp] * offset + offset
         sources['x_0'] = x.ravel() + xdithers
         sources['y_0'] = y.ravel() + ydithers
-        sources['fwhm'] = np.full((nstars,), fwhm)
+        sources['fwhm'] = np.full((n_stars,), fwhm)
 
         psf_model = CircularGaussianPRF(fwhm=fwhm)
         shape = (size, size)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -833,18 +833,20 @@ def test_grouper_init_params(test_data):
     init_params['y'] = phot0['y_init']
     init_params['flux'] = phot0['flux_init']
     phot1 = psfphot(data, error=error, init_params=init_params)
-    nsources = len(phot1)
+    n_sources = len(phot1)
     assert isinstance(phot1, QTable)
-    assert_equal(phot1['group_id'], np.ones(nsources, dtype=int))
-    assert_equal(phot1['group_size'], np.ones(nsources, dtype=int) * nsources)
+    assert_equal(phot1['group_id'], np.ones(n_sources, dtype=int))
+    assert_equal(phot1['group_size'],
+                 np.ones(n_sources, dtype=int) * n_sources)
 
     # test with grouper=None
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                             grouper=None, aperture_radius=4)
     phot2 = psfphot(data, error=error, init_params=init_params)
     assert isinstance(phot2, QTable)
-    assert_equal(phot1['group_id'], np.ones(nsources, dtype=int))
-    assert_equal(phot1['group_size'], np.ones(nsources, dtype=int) * nsources)
+    assert_equal(phot1['group_id'], np.ones(n_sources, dtype=int))
+    assert_equal(phot1['group_size'],
+                 np.ones(n_sources, dtype=int) * n_sources)
 
 
 def test_large_group_warning():
@@ -1981,9 +1983,9 @@ def test_init_params_id_order(test_data, reorder, with_groups,
     data, error, sources = test_data
     init_params = sources.copy()
 
-    nsrc = len(sources)
+    n_sources = len(sources)
     rng = np.random.default_rng(seed=0)
-    init_params['id'] = np.arange(1, nsrc + 1)
+    init_params['id'] = np.arange(1, n_sources + 1)
     if with_groups:
         # same groupings, but different group ids
         if nonconsec_groups:
@@ -1991,7 +1993,7 @@ def test_init_params_id_order(test_data, reorder, with_groups,
         else:
             group_ids = [1, 2, 1, 2, 2, 3, 2, 3, 4, 4]
         init_params['group_id'] = group_ids
-    init_params['local_bkg'] = rng.normal(size=nsrc)
+    init_params['local_bkg'] = rng.normal(size=n_sources)
     init_params['x_0'][0] = 1000
     init_params['y_0'][0] = 1000
     init_params['x_0'][5] = 1000
@@ -2008,12 +2010,12 @@ def test_init_params_id_order(test_data, reorder, with_groups,
     if nonconsec_ids:
         # non-consecutive random ids
         # monotonically increasing so final results order should be same
-        steps = rng.integers(1, 51, size=nsrc - 1)
+        steps = rng.integers(1, 51, size=n_sources - 1)
         init_params2['id'] = np.concatenate(([1], 1 + np.cumsum(steps)))
     if reorder == 'reversed':
         init_params2 = init_params2[::-1]
     elif reorder == 'permutate':
-        init_params2 = init_params2[rng.permutation(nsrc)]
+        init_params2 = init_params2[rng.permutation(n_sources)]
 
     psfphot2 = PSFPhotometry(psf_model, fit_shape)
     phot2 = psfphot2(data, error=error, init_params=init_params2)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -1869,7 +1869,7 @@ def test_get_source_cutout_data_no_overlap():
     assert result['xx'] is None
     assert result['yy'] is None
     assert result['cutout'] is None
-    assert result['npix'] == 0
+    assert result['n_pixels'] == 0
     assert np.isnan(result['cen_index'])
 
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -464,8 +464,8 @@ class SourceCatalog:
         if np.ndim(kron_params) != 1:
             msg = 'kron_params must be 1D'
             raise ValueError(msg)
-        nparams = len(kron_params)
-        if nparams not in (2, 3):
+        n_params = len(kron_params)
+        if n_params not in (2, 3):
             msg = 'kron_params must have 2 or 3 elements'
             raise ValueError(msg)
         if kron_params[0] <= 0:
@@ -474,7 +474,7 @@ class SourceCatalog:
         if kron_params[1] <= 0:
             msg = 'kron_params[1] must be > 0'
             raise ValueError(msg)
-        if nparams == 3 and kron_params[2] < 0:
+        if n_params == 3 and kron_params[2] < 0:
             msg = 'kron_params[2] must be >= 0'
             raise ValueError(msg)
         return tuple(kron_params)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -203,7 +203,7 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
             label_indices = add_progress_bar(label_indices, desc=desc)
 
         nonposmin_labels = []
-        nmarkers_labels = []
+        n_markers_labels = []
         for label, label_idx in zip(labels, label_indices, strict=True):
             if not isinstance(label_indices, np.ndarray):
                 label_indices.set_postfix_str(f'ID: {label}')
@@ -218,8 +218,8 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
             if warns:
                 if 'nonposmin' in warns:
                     nonposmin_labels.append(label)
-                if 'nmarkers' in warns:
-                    nmarkers_labels.append(label)
+                if 'n_markers' in warns:
+                    n_markers_labels.append(label)
 
             if source_deblended is not None:
                 source_mask = source_deblended > 0
@@ -276,7 +276,7 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
 
         # Process the results
         nonposmin_labels = []
-        nmarkers_labels = []
+        n_markers_labels = []
         for label, source_slice, source_deblended in zip(labels,
                                                          all_source_slices,
                                                          results, strict=True):
@@ -285,8 +285,8 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
             if warns:
                 if 'nonposmin' in warns:
                     nonposmin_labels.append(label)
-                if 'nmarkers' in warns:
-                    nmarkers_labels.append(label)
+                if 'n_markers' in warns:
+                    n_markers_labels.append(label)
 
             if source_deblended is not None:
                 source_mask = source_deblended > 0
@@ -299,7 +299,7 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
 
     # Process any warnings during deblending
     warning_info = {}
-    if nonposmin_labels or nmarkers_labels:
+    if nonposmin_labels or n_markers_labels:
         msg = ('The deblending mode of one or more source labels from the '
                f'input segmentation image was changed from "{mode}" to '
                '"linear". See the "info" attribute for the list of affected '
@@ -313,12 +313,12 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
             warn = {'message': msg, 'input_labels': nonposmin_labels}
             warning_info['nonposmin'] = warn
 
-        if nmarkers_labels:
-            nmarkers_labels = np.array(nmarkers_labels)
+        if n_markers_labels:
+            n_markers_labels = np.array(n_markers_labels)
             msg = (f'Deblending mode changed from {mode} to linear due to '
                    'too many potential deblended sources.')
-            warn = {'message': msg, 'input_labels': nmarkers_labels}
-            warning_info['nmarkers'] = warn
+            warn = {'message': msg, 'input_labels': n_markers_labels}
+            warning_info['n_markers'] = warn
 
     if relabel:
         relabel_map = _create_relabel_map(segm_deblended, start_label=1)
@@ -627,10 +627,10 @@ class _SingleSourceDeblender:
         # This mostly affects the "exponential" mode, where there are
         # many levels at low thresholds, so here we try again with
         # "linear" mode.
-        nlabels = len(_get_labels(markers))
-        if self.mode != 'linear' and nlabels > 200:
+        n_labels = len(_get_labels(markers))
+        if self.mode != 'linear' and n_labels > 200:
             del markers  # free memory
-            self.warnings['nmarkers'] = 'too many markers'
+            self.warnings['n_markers'] = 'too many markers'
             self.mode = 'linear'
             markers = self.make_markers()
             if markers is None:

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -215,8 +215,8 @@ def _detect_sources(data, threshold, n_pixels, footprint, inverse_mask, *,
 
     # NOTE: recasting segment_img to int and using output=segment_img
     # gives similar performance
-    segment_img, nlabels = ndi_label(segment_img, structure=footprint)
-    labels = np.arange(nlabels, dtype=segment_img.dtype) + 1
+    segment_img, n_labels = ndi_label(segment_img, structure=footprint)
+    labels = np.arange(n_labels, dtype=segment_img.dtype) + 1
 
     # Remove objects with less than n_pixels
     # NOTE: making cutout images and setting their pixels to 0 is
@@ -241,11 +241,11 @@ def _detect_sources(data, threshold, n_pixels, footprint, inverse_mask, *,
         # Relabel the segmentation image with consecutive numbers;
         # ndimage.label returns segment_img with dtype = np.int32
         # unless the input array has more than 2**31 - 1 pixels
-        nlabels = len(segm_labels)
-        if len(labels) != nlabels:
+        n_labels = len(segm_labels)
+        if len(labels) != n_labels:
             label_map = np.zeros(np.max(labels) + 1,
                                  dtype=segment_img.dtype)
-            labels = np.arange(nlabels, dtype=segment_img.dtype) + 1
+            labels = np.arange(n_labels, dtype=segment_img.dtype) + 1
             label_map[segm_labels] = labels
             segment_img = label_map[segment_img]
     else:

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -114,10 +114,10 @@ class TestDeblendSources:
                                  progress_bar=False)
         assert result.n_labels == 2
 
-    @pytest.mark.parametrize(('contrast', 'nlabels'),
+    @pytest.mark.parametrize(('contrast', 'n_labels'),
                              [(0.001, 6), (0.017, 5), (0.06, 4), (0.1, 3),
                               (0.15, 2), (0.45, 1)])
-    def test_deblend_contrast(self, contrast, nlabels):
+    def test_deblend_contrast(self, contrast, n_labels):
         """
         Test deblend contrast.
         """
@@ -135,7 +135,7 @@ class TestDeblendSources:
         segm2 = deblend_sources(data, segm, n_pixels, mode='linear',
                                 n_levels=32, contrast=contrast,
                                 progress_bar=False)
-        assert segm2.n_labels == nlabels
+        assert segm2.n_labels == n_labels
 
     def test_deblend_contrast_levels(self):
         """

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -440,7 +440,7 @@ class TestDeblendSources:
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
-def test_nmarkers_fallback():
+def test_n_markers_fallback():
     """
     Test that if there are too many markers, a warning is raised.
     """
@@ -461,16 +461,17 @@ def test_nmarkers_fallback():
     match = 'The deblending mode of one or more source labels from the'
     with pytest.warns(AstropyUserWarning, match=match):
         segm2 = deblend_sources(data, segm, 1, mode='exponential')
-    assert segm2.info['warnings']['nmarkers']['input_labels'][0] == 1
-    mesg = segm2.info['warnings']['nmarkers']['message']
+    assert segm2.info['warnings']['n_markers']['input_labels'][0] == 1
+    mesg = segm2.info['warnings']['n_markers']['message']
     assert mesg.startswith('Deblending mode changed')
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
-def test_nmarkers_fallback_multiproc():
+def test_n_markers_fallback_multiproc():
     """
-    Test the nmarkers fallback warning via multiprocessing (n_processes=2).
-    This covers the multiprocessing result-processing block for nmarkers.
+    Test the n_markers fallback warning via multiprocessing
+    (n_processes=2). This covers the multiprocessing result-processing
+    block for n_markers.
     """
     size = 51
     data1 = np.resize([0, 0, 1, 1], size)
@@ -490,7 +491,7 @@ def test_nmarkers_fallback_multiproc():
     with pytest.warns(AstropyUserWarning, match=match):
         segm2 = deblend_sources(data, segm, 1, mode='exponential',
                                 n_processes=2)
-    assert segm2.info['warnings']['nmarkers']['input_labels'][0] == 1
+    assert segm2.info['warnings']['n_markers']['input_labels'][0] == 1
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
@@ -514,7 +515,7 @@ def test_nonposmin_multiproc():
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
-def test_nmarkers_fallback_returns_none():
+def test_n_markers_fallback_returns_none():
     """
     Test that deblend_source returns None when make_markers returns
     None on the linear-mode fallback (second attempt after >200

--- a/photutils/utils/_coords.py
+++ b/photutils/utils/_coords.py
@@ -103,15 +103,15 @@ def make_random_xycoords(size, x_range, y_range, *, min_separation=0.0,
         msg = 'x_range and y_range must be (min, max) with min < max.'
         raise ValueError(msg)
 
-    ncoords = size
+    n_coords = size
     if min_separation > 0:
         # Scale the number of random coordinates to account for
         # some being discarded due to min_separation
-        ncoords *= oversample
+        n_coords *= oversample
 
     rng = np.random.default_rng(seed)
-    xc = rng.uniform(x_range[0], x_range[1], ncoords)
-    yc = rng.uniform(y_range[0], y_range[1], ncoords)
+    xc = rng.uniform(x_range[0], x_range[1], n_coords)
+    yc = rng.uniform(y_range[0], y_range[1], n_coords)
     xycoords = np.transpose(np.array((xc, yc)))
 
     xycoords = apply_separation(xycoords, min_separation)

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -546,9 +546,9 @@ class ImageDepth:
 
         return np.column_stack((xi, yi))
 
-    def _make_coords(self, xycoords, napers):
+    def _make_coords(self, xycoords, n_apertures):
         """
-        Randomly choose ``napers`` (without replacement) coordinates
+        Randomly choose ``n_apertures`` (without replacement) coordinates
         from the input ``xycoords``.
 
         This function also adds < +/-0.5 pixel random shifts so that the
@@ -558,7 +558,7 @@ class ImageDepth:
         ----------
         xycoords : 2xN `~numpy.ndarray`
             The (x, y) coordinates.
-        napers : int
+        n_apertures : int
             The number of aperture to make.
 
         Returns
@@ -566,11 +566,11 @@ class ImageDepth:
         xycoords : 2xN `~numpy.ndarray`
             The (x, y) coordinates.
         """
-        if napers > xycoords.shape[0]:
+        if n_apertures > xycoords.shape[0]:
             msg = 'Too many apertures for given unmasked area'
             raise ValueError(msg)
 
-        idx = self.rng.choice(xycoords.shape[0], napers, replace=False)
+        idx = self.rng.choice(xycoords.shape[0], n_apertures, replace=False)
         xycoords = xycoords[idx, :].astype(float)
 
         shift = self.rng.uniform(-0.5, 0.5, size=xycoords.shape)

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -6,10 +6,16 @@ Tools for interpolating data.
 import numpy as np
 from scipy.spatial import cKDTree
 
-from photutils.utils._deprecation import (deprecated_positional_kwargs,
+from photutils.utils._deprecation import (deprecated_getattr,
+                                          deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
 
 __all__ = ['ShepardIDWInterpolator']
+
+# Remove in 4.0
+_DEPRECATED_ATTRIBUTES = {
+    'ncoords': 'n_coords',
+}
 
 
 class ShepardIDWInterpolator:
@@ -59,6 +65,32 @@ class ShepardIDWInterpolator:
         The number of points at which the k-d tree algorithm switches
         over to brute-force. ``leafsize`` must be positive. See
         `scipy.spatial.cKDTree` for further information.
+
+    Attributes
+    ----------
+    coordinates : NxM `~numpy.ndarray`
+        The coordinates of the known data points, where N is the number
+        of points and M is the dimension of the coordinate space.
+
+    ncoords : int
+        .. deprecated:: 3.1
+            Use ``n_coords`` instead.
+
+    n_coords : int
+        The number of known data points.
+
+    coords_ndim : int
+        The dimension of the coordinate space.
+
+    values : 1D `~numpy.ndarray`
+        The values of the known data points.
+
+    weights : 1D `~numpy.ndarray` or `None`
+        The weights associated with each data value, or `None` if no
+        weights were input.
+
+    kdtree : `scipy.spatial.cKDTree`
+        The k-d tree built from the input ``coordinates``.
 
     Notes
     -----
@@ -158,6 +190,11 @@ class ShepardIDWInterpolator:
         self.values = values
         self.weights = weights
         self.kdtree = cKDTree(coordinates, leafsize=leafsize)
+
+    def __getattr__(self, name):
+        return deprecated_getattr(self, name,
+                                  _DEPRECATED_ATTRIBUTES,
+                                  since='3.1', until='4.0')
 
     @deprecated_renamed_argument('reg', 'regularization', '3.0',
                                  until='4.0')

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -133,18 +133,18 @@ class ShepardIDWInterpolator:
 
         values = np.asanyarray(values).ravel()
 
-        ncoords = coordinates.shape[0]
-        if ncoords < 1:
+        n_coords = coordinates.shape[0]
+        if n_coords < 1:
             msg = 'coordinates must have at least one data point'
             raise ValueError(msg)
 
-        if values.shape[0] != ncoords:
+        if values.shape[0] != n_coords:
             msg = 'The number of values must match the number of coordinates.'
             raise ValueError(msg)
 
         if weights is not None:
             weights = np.asanyarray(weights).ravel()
-            if weights.shape[0] != ncoords:
+            if weights.shape[0] != n_coords:
                 msg = ('The number of weights must match the number of '
                        'coordinates.')
                 raise ValueError(msg)
@@ -153,7 +153,7 @@ class ShepardIDWInterpolator:
                 raise ValueError(msg)
 
         self.coordinates = coordinates
-        self.ncoords = ncoords
+        self.n_coords = n_coords
         self.coords_ndim = coordinates.shape[1]
         self.values = values
         self.weights = weights

--- a/photutils/utils/tests/test_coords.py
+++ b/photutils/utils/tests/test_coords.py
@@ -16,11 +16,11 @@ def test_make_random_xycoords(min_sep):
     """
     xmin, xmax = 97, 903
     ymin, ymax = 0, 501
-    ncoords = 100
-    xycoords = make_random_xycoords(ncoords, (xmin, xmax), (ymin, ymax),
+    n_coords = 100
+    xycoords = make_random_xycoords(n_coords, (xmin, xmax), (ymin, ymax),
                                     min_separation=min_sep, seed=0)
 
-    assert xycoords.shape == (ncoords, 2)
+    assert xycoords.shape == (n_coords, 2)
     assert xycoords[:, 0].min() >= xmin
     assert xycoords[:, 0].max() <= xmax
     assert xycoords[:, 1].min() >= ymin

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 
 from photutils.utils import ShepardIDWInterpolator as IDWInterp
@@ -63,6 +64,35 @@ class TestShepardIDWInterpolator:
         pos = np.indices(val.shape)
         f = IDWInterp(pos, val)
         assert_allclose(f([0.5, 0.5, 0.5]), 1.0)
+
+    @pytest.mark.parametrize(('coordinates', 'n_coords', 'coords_ndim'),
+                             [(np.arange(4.0), 4, 1),
+                              (np.zeros((7, 2)), 7, 2),
+                              (np.zeros((3, 4, 5)), 12, 5)])
+    def test_attributes(self, coordinates, n_coords, coords_ndim):
+        """
+        Test the number and dimension of the input coordinates.
+        """
+        values = np.ones(n_coords)
+        f = IDWInterp(coordinates, values)
+        assert f.n_coords == n_coords
+        assert f.coords_ndim == coords_ndim
+
+    def test_deprecated_attribute(self):
+        """
+        Test the deprecated ncoords attribute.
+        """
+        match = "The 'ncoords' attribute was deprecated"
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            assert self.f.ncoords == self.f.n_coords
+
+    def test_invalid_attribute(self):
+        """
+        Test that an unknown attribute raises AttributeError.
+        """
+        match = "object has no attribute 'invalid'"
+        with pytest.raises(AttributeError, match=match):
+            _ = self.f.invalid
 
     def test_no_coordinates(self):
         """

--- a/photutils/utils/tests/test_wcs_helpers.py
+++ b/photutils/utils/tests/test_wcs_helpers.py
@@ -610,7 +610,7 @@ class TestSVDShapeConversions:
 
 
 def _project_sky_ellipse_boundary(skycoord, wcs, a_arcsec, b_arcsec, pa_rad, *,
-                                  npts=720):
+                                  n_points=720):
     """
     Project the boundary of a sky ellipse to pixel coordinates.
 
@@ -620,7 +620,7 @@ def _project_sky_ellipse_boundary(skycoord, wcs, a_arcsec, b_arcsec, pa_rad, *,
     ``wcs.world_to_pixel``. This is an independent ground truth for the
     pixel image of a sky ellipse.
     """
-    theta = np.linspace(0, 2 * np.pi, npts, endpoint=False)
+    theta = np.linspace(0, 2 * np.pi, n_points, endpoint=False)
     xi = (a_arcsec * np.cos(theta) * np.sin(pa_rad)
           + b_arcsec * np.sin(theta) * np.cos(pa_rad))
     eta = (a_arcsec * np.cos(theta) * np.cos(pa_rad)
@@ -739,7 +739,7 @@ def _make_sheared_wcs():
 
 
 def _project_pixel_circle_to_sky_tangent(pixcoord, wcs, radius_pix, *,
-                                         npts=720):
+                                         n_points=720):
     """
     Project a pixel circle boundary to tangent-plane sky offsets.
 
@@ -749,7 +749,7 @@ def _project_pixel_circle_to_sky_tangent(pixcoord, wcs, radius_pix, *,
     great-circle separation and position angle. This is an independent
     ground truth for the sky image of a pixel circle.
     """
-    theta = np.linspace(0, 2 * np.pi, npts, endpoint=False)
+    theta = np.linspace(0, 2 * np.pi, n_points, endpoint=False)
     cx, cy = pixcoord
     x = cx + radius_pix * np.cos(theta)
     y = cy + radius_pix * np.sin(theta)


### PR DESCRIPTION
The ``ShepardIDWInterpolator`` ``ncoords`` attribute has been renamed to ``n_coords``, consistent with the ``n_*`` naming used elsewhere in photutils. The old ``ncoords`` name is deprecated and will be removed in version 4.0.

The ``deblend_sources`` "too many markers" warning key stored in the returned ``SegmentationImage.info['warnings']`` dictionary has been renamed from ``'nmarkers'`` to ``'n_markers'``.

This PR also includes many other internal variable renames for consistency.