### PR TITLE
PSF model bug fixes and API cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -180,6 +180,12 @@ Bug Fixes
     [0, 90] and (270, 360)). This also makes it consistent with
     ``ApertureStats.orientation``. [#2317]
 
+- ``photutils.psf``
+
+  - Fixed the ``CircularGaussianPSF.fit_deriv`` partial derivative with
+    respect to ``fwhm``. This affected only fits in which the ``fwhm``
+    parameter was unfixed. [#2347]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,9 @@ New Features
     through optimizations that reduce per-evaluation overhead and
     streamline interpolation calculations. [#2289, #2307]
 
+  - Added a ``STDPSFGrid.grid_shape`` property returning the ``(ny,
+    nx)`` shape of the ePSF grid. [#2347]
+
 - ``photutils.segmentation``
 
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``
@@ -207,6 +210,11 @@ Bug Fixes
     previous swapped to the wrong detector positions for any grid whose
     x and y positions differ. [#2347]
 
+  - Fixed ``SourceGroups.plot`` to sample a user-supplied colormap over
+    its full range. Previously the colormap was indexed by the group
+    number, which gave nearly identical colors for every group (and
+    raised an ``IndexError`` for more than 256 groups). [#2347]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a
@@ -259,6 +267,13 @@ API Changes
     ``meta`` dictionary now contains only the metadata parsed from the
     filename (e.g., ``STDPSF``, ``detector``, and ``filter``). Use the
     ``grid_xypos`` and ``oversampling`` attributes instead. [#2344]
+
+  - The ``STDPSFGrid`` ``data`` and ``grid_xypos`` attributes are now
+    read-only properties, matching the ``GriddedPSFModel`` attributes
+    of the same name. [#2347]
+
+  - ``SourceGrouper`` now raises a ``ValueError`` if ``min_separation``
+    is not a positive finite value. [#2347]
 
   - The ``STDPSFGrid`` ``grid_xypos`` attribute is now a ``numpy``
     array instead of a list, matching the ``GriddedPSFModel``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -186,6 +186,12 @@ Bug Fixes
     respect to ``fwhm``. This affected only fits in which the ``fwhm``
     parameter was unfixed. [#2347]
 
+  - Fixed ``ImagePSF`` to discard its cached interpolator when the
+    ``data`` attribute is set. Previously, assigning a new image to an
+    existing model silently continued to evaluate the old image. The
+    ``data`` and ``oversampling`` attributes are now also validated
+    when set, not only when the model is created. [#2347]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -202,6 +202,11 @@ Bug Fixes
     a gzipped STDPSF file (e.g., ``.fits.gz``). The file extension was
     not removed, so the filter name included the extension. [#2346]
 
+  - Fixed ``webbpsf_reader`` to swap the ``DET_YX{i}`` FITS header
+    values when defining ``grid_xypos``. The reference ePSFs were
+    previous swapped to the wrong detector positions for any grid whose
+    x and y positions differ. [#2347]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,6 +215,14 @@ Bug Fixes
     number, which gave nearly identical colors for every group (and
     raised an ``IndexError`` for more than 256 groups). [#2347]
 
+  - Fixed reading a STDPSF file from an already-open
+    ``astropy.io.fits.HDUList``. Such input was accepted but then
+    raised a ``TypeError``. [#2347]
+
+  - Fixed the ``plot_grid`` title when the instrument, detector, or
+    filter metadata is missing. The missing values left stray spaces in
+    the title. [#2347]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -276,13 +276,6 @@ API Changes
     filename (e.g., ``STDPSF``, ``detector``, and ``filter``). Use the
     ``grid_xypos`` and ``oversampling`` attributes instead. [#2344]
 
-  - The ``STDPSFGrid`` ``data`` and ``grid_xypos`` attributes are now
-    read-only properties, matching the ``GriddedPSFModel`` attributes
-    of the same name. [#2347]
-
-  - ``SourceGrouper`` now raises a ``ValueError`` if ``min_separation``
-    is not a positive finite value. [#2347]
-
   - The ``STDPSFGrid`` ``grid_xypos`` attribute is now a ``numpy``
     array instead of a list, matching the ``GriddedPSFModel``
     attribute of the same name. The ``oversampling`` attribute is now

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -192,6 +192,16 @@ Bug Fixes
     ``data`` and ``oversampling`` attributes are now also validated
     when set, not only when the model is created. [#2347]
 
+  - Fixed the ``GriddedPSFModel.origin`` attribute, which returned a
+    three-element array instead of the documented ``(x, y)`` pair. The
+    spurious third element was derived from the number of ePSFs in the
+    grid. Model evaluation was unaffected because it used only the first
+    two elements. [#2347]
+
+  - Fixed the ``filter`` metadata parsed from the filename when reading
+    a gzipped STDPSF file (e.g., ``.fits.gz``). The file extension was
+    not removed, so the filter name included the extension. [#2346]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -476,6 +476,19 @@ Removed Deprecations
 Breaking Changes
 ----------------
 
+WebbPSF ePSF Grid Positions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Reading a WebbPSF gridded-ePSF FITS file with
+:func:`~photutils.psf.webbpsf_reader` (or ``GriddedPSFModel.read(...,
+format='webbpsf')``) now assigns the reference ePSFs to the correct
+detector positions. The ``DET_YX{i}`` header keywords record each
+position as ``(y, x)``, but the values were previously stored as ``(x,
+y)``, which transposed the ePSF grid. Grids whose x and y fiducial
+positions are identical (such as the square NIRCam short-wavelength
+grids) are unaffected.
+
+
 ``StarFinderCatalogBase`` Representation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -46,9 +46,10 @@ class ImagePSFConverter(TransformConverterBase):
         from photutils.psf import ImagePSF
 
         return ImagePSF(
-            # Wrapping "data" as an ndarray to ensure the data is properly
-            # converted from NDArrayType. This is necessary because
-            # the validation in ImagePSF happens before "data" is assigned.
+            # Wrapping "data" as an ndarray to ensure the data is
+            # properly converted from NDArrayType. This is necessary
+            # because the validation in ImagePSF happens before "data"
+            # is assigned.
             data=np.array(node['data']),
             flux=node['flux'],
             x_0=node['x_0'],
@@ -121,7 +122,7 @@ class STDPSFGridConverter(Converter):
         meta.update({
             'oversampling': tuple(int(value)
                                   for value in model.oversampling),
-            'grid_shape': model._grid_shape,
+            'grid_shape': model.grid_shape,
             'grid_xypos': np.array(model.grid_xypos),
         })
         return {
@@ -132,6 +133,6 @@ class STDPSFGridConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
         from photutils.psf import STDPSFGrid
 
-        # Touch the array to load it into memory
-        node['meta']['grid_xypos'][0]
+        # Load the lazily-read grid positions into memory
+        node['meta']['grid_xypos'] = np.asarray(node['meta']['grid_xypos'])
         return STDPSFGrid._from_asdf(node['data'], node['meta'])

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -20,7 +20,13 @@ __all__ = [
     'MoffatPSF',
 ]
 
+# The smallest positive normal float32 value (~1.2e-38), used as the
+# lower bound of the strictly-positive model parameters. Despite its
+# name, this is numpy.finfo.tiny and not the machine epsilon. The name
+# and definition match the constant of the same name in
+# astropy.modeling.functional_models.
 FLOAT_EPSILON = float(np.finfo(np.float32).tiny)
+
 GAUSSIAN_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 
 
@@ -1466,15 +1472,18 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         evaluated_model : `~numpy.ndarray`
             The evaluated model.
         """
-        dpix = 0.5
-        if isinstance(x_0, u.Quantity):
-            dpix *= x_0.unit
+        x0 = x - x_0
+        y0 = y - y_0
 
-        return (flux / 4
-                * ((erf((x - x_0 + dpix) / (np.sqrt(2) * sigma))
-                    - erf((x - x_0 - dpix) / (np.sqrt(2) * sigma)))
-                   * (erf((y - y_0 + dpix) / (np.sqrt(2) * sigma))
-                      - erf((y - y_0 - dpix) / (np.sqrt(2) * sigma)))))
+        dpix = 0.5
+        if isinstance(x0, u.Quantity):
+            dpix <<= x0.unit
+
+        return (flux / 4.0
+                * ((erf((x0 + dpix) / (np.sqrt(2) * sigma))
+                    - erf((x0 - dpix) / (np.sqrt(2) * sigma)))
+                   * (erf((y0 + dpix) / (np.sqrt(2) * sigma))
+                      - erf((y0 - dpix) / (np.sqrt(2) * sigma)))))
 
     @property
     def input_units(self):

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -73,7 +73,8 @@ class GaussianPSF(Fittable2DModel):
 
     See Also
     --------
-    CircularGaussianPSF, GaussianPRF, CircularGaussianPRF, MoffatPSF
+    CircularGaussianPSF, GaussianPRF, CircularGaussianPRF,
+    CircularGaussianSigmaPRF, MoffatPSF, AiryDiskPSF
 
     Notes
     -----
@@ -465,7 +466,8 @@ class CircularGaussianPSF(Fittable2DModel):
 
     See Also
     --------
-    GaussianPSF, GaussianPRF, CircularGaussianPRF, MoffatPSF
+    GaussianPSF, GaussianPRF, CircularGaussianPRF,
+    CircularGaussianSigmaPRF, MoffatPSF, AiryDiskPSF
 
     Notes
     -----
@@ -739,7 +741,8 @@ class GaussianPRF(Fittable2DModel):
 
     See Also
     --------
-    GaussianPSF, CircularGaussianPSF, CircularGaussianPRF, MoffatPSF
+    GaussianPSF, CircularGaussianPSF, CircularGaussianPRF,
+    CircularGaussianSigmaPRF, MoffatPSF, AiryDiskPSF
 
     Notes
     -----
@@ -882,8 +885,8 @@ class GaussianPRF(Fittable2DModel):
         Parameters
         ----------
         factor : float, optional
-            The multiple of the x and y FWHMs used to define the limits.
-            zzzz
+            The multiple of the x and y standard deviations (sigma) used
+            to define the limits.
 
         Returns
         -------
@@ -1041,7 +1044,8 @@ class CircularGaussianPRF(Fittable2DModel):
 
     See Also
     --------
-    GaussianPRF, GaussianPSF, CircularGaussianPSF, MoffatPSF
+    GaussianPSF, CircularGaussianPSF, GaussianPRF,
+    CircularGaussianSigmaPRF, MoffatPSF, AiryDiskPSF
 
     Notes
     -----
@@ -1290,7 +1294,8 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
 
     See Also
     --------
-    GaussianPSF, GaussianPRF, CircularGaussianPSF, CircularGaussianPRF
+    GaussianPSF, CircularGaussianPSF, GaussianPRF, CircularGaussianPRF,
+    MoffatPSF, AiryDiskPSF
 
     Notes
     -----
@@ -1413,25 +1418,25 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
 
         Examples
         --------
-        >>> from photutils.psf import CircularGaussianPRF
-        >>> model = CircularGaussianPRF(x_0=0, y_0=0, fwhm=2)
+        >>> from photutils.psf import CircularGaussianSigmaPRF
+        >>> model = CircularGaussianSigmaPRF(x_0=0, y_0=0, sigma=2)
         >>> model.bounding_box
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-4.671269901584105, upper=4.671269901584105)
-                y: Interval(lower=-4.671269901584105, upper=4.671269901584105)
+                x: Interval(lower=-11.0, upper=11.0)
+                y: Interval(lower=-11.0, upper=11.0)
             }
-            model=CircularGaussianPRF(inputs=('x', 'y'))
+            model=CircularGaussianSigmaPRF(inputs=('x', 'y'))
             order='C'
         )
         >>> model.bbox_factor = 7
         >>> model.bounding_box
         ModelBoundingBox(
             intervals={
-                x: Interval(lower=-5.945252602016134, upper=5.945252602016134)
-                y: Interval(lower=-5.945252602016134, upper=5.945252602016134)
+                x: Interval(lower=-14.0, upper=14.0)
+                y: Interval(lower=-14.0, upper=14.0)
             }
-            model=CircularGaussianPRF(inputs=('x', 'y'))
+            model=CircularGaussianSigmaPRF(inputs=('x', 'y'))
             order='C'
         )
         """
@@ -1538,7 +1543,8 @@ class MoffatPSF(Fittable2DModel):
 
     See Also
     --------
-    GaussianPSF, CircularGaussianPSF, GaussianPRF, CircularGaussianPRF
+    GaussianPSF, CircularGaussianPSF, GaussianPRF, CircularGaussianPRF,
+    CircularGaussianSigmaPRF, AiryDiskPSF
 
     Notes
     -----
@@ -1778,7 +1784,8 @@ class AiryDiskPSF(Fittable2DModel):
 
     See Also
     --------
-    GaussianPSF, CircularGaussianPSF, MoffatPSF
+    GaussianPSF, CircularGaussianPSF, GaussianPRF, CircularGaussianPRF,
+    CircularGaussianSigmaPRF, MoffatPSF
 
     Notes
     -----

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -25,7 +25,7 @@ GAUSSIAN_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 
 
 def _gaussian_amplitude(flux, xsigma, ysigma):
-    # output units should match the input flux units
+    # Output units should match the input flux units
     if isinstance(xsigma, u.Quantity):
         xsigma = xsigma.value
         ysigma = ysigma.value
@@ -299,7 +299,7 @@ class GaussianPSF(Fittable2DModel):
         b = 0.5 * ((sin2t / xstd2) - (sin2t / ystd2))
         c = 0.5 * ((sint2 / xstd2) + (cost2 / ystd2))
 
-        # output units should match the input flux units
+        # Output units should match the input flux units
         if isinstance(xstd, u.Quantity):
             xstd = xstd.value
             ystd = ystd.value
@@ -392,7 +392,7 @@ class GaussianPSF(Fittable2DModel):
         dg_dxstd = damp_dxstd * exp + amplitude * dexp_dxstd
         dg_dystd = damp_dystd * exp + amplitude * dexp_dystd
 
-        # chain rule for change of variables from sigma to fwhm
+        # Chain rule for change of variables from sigma to fwhm
         # std => fwhm * GAUSSIAN_FWHM_TO_SIGMA
         # dstd/dfwhm => GAUSSIAN_FWHM_TO_SIGMA
         dg_dxfwhm = dg_dxstd * GAUSSIAN_FWHM_TO_SIGMA
@@ -400,7 +400,7 @@ class GaussianPSF(Fittable2DModel):
 
         dg_dtheta = g * (-(da_dtheta * xdiff2 + db_dtheta * xdiff * ydiff
                            + dc_dtheta * ydiff2))
-        # chain rule for unit change;
+        # Chain rule for unit change
         # theta[rad] => theta[deg] * pi / 180; drad/dtheta = pi / 180
         dg_dtheta *= np.pi / 180.0
 
@@ -419,8 +419,8 @@ class GaussianPSF(Fittable2DModel):
         return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        # Note that here we need to make sure that x and y are in the same
-        # units otherwise this can lead to issues since rotation is not well
+        # We need to make sure that x and y are in the same units
+        # otherwise this can lead to issues since rotation is not well
         # defined.
         if inputs_unit[self.inputs[0]] != inputs_unit[self.inputs[1]]:
             msg = "Units of 'x' and 'y' inputs should match"
@@ -633,7 +633,7 @@ class CircularGaussianPSF(Fittable2DModel):
         """
         sigma2 = (fwhm * GAUSSIAN_FWHM_TO_SIGMA) ** 2
 
-        # output units should match the input flux units
+        # Output units should match the input flux units
         sigma2_norm = sigma2
         if isinstance(sigma2, u.Quantity):
             sigma2_norm = sigma2.value
@@ -993,8 +993,8 @@ class GaussianPRF(Fittable2DModel):
         return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        # Note that here we need to make sure that x and y are in the same
-        # units otherwise this can lead to issues since rotation is not well
+        # We need to make sure that x and y are in the same units
+        # otherwise this can lead to issues since rotation is not well
         # defined.
         if inputs_unit[self.inputs[0]] != inputs_unit[self.inputs[1]]:
             msg = "Units of 'x' and 'y' inputs should match"
@@ -1489,8 +1489,8 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        # Note that here we need to make sure that x and y are in the same
-        # units otherwise this can lead to issues since rotation is not well
+        # We need to make sure that x and y are in the same units
+        # otherwise this can lead to issues since rotation is not well
         # defined.
         if inputs_unit[self.inputs[0]] != inputs_unit[self.inputs[1]]:
             msg = "Units of 'x' and 'y' inputs should match"
@@ -1724,12 +1724,12 @@ class MoffatPSF(Fittable2DModel):
         result : `~numpy.ndarray`
             The value of the model evaluated at the input coordinates.
         """
-        # output units should match the input flux units
-        alpha2 = alpha.copy()
+        # Output units should match the input flux units
+        alpha_norm = alpha
         if isinstance(alpha, u.Quantity):
-            alpha2 = alpha.value
+            alpha_norm = alpha.value
 
-        amp = flux * (beta - 1) / (np.pi * alpha2 ** 2)
+        amp = flux * (beta - 1) / (np.pi * alpha_norm ** 2)
         r2 = (x - x_0) ** 2 + (y - y_0) ** 2
         return amp * (1 + (r2 / alpha**2)) ** (-beta)
 
@@ -1876,7 +1876,13 @@ class AiryDiskPSF(Fittable2DModel):
         fixed=True,
         description='Radius of the Airy disk at the first zero')
 
+    # The radius of the first zero of the Airy disk profile, in units of
+    # the profile scale radius, i.e., the solution of J1(pi * Rz) = 0.
     _rz = jn_zeros(1, 1)[0] / np.pi
+
+    # The half width at half maximum of the Airy disk profile, i.e., the
+    # solution of (2 * J1(x) / x)**2 = 1/2.
+    _hwhm = 1.616339948310703
 
     def __init__(self, *, flux=flux.default, x_0=x_0.default, y_0=y_0.default,
                  radius=radius.default, bbox_factor=10.0, **kwargs):
@@ -1888,7 +1894,7 @@ class AiryDiskPSF(Fittable2DModel):
         """
         The FWHM of the Airy disk profile.
         """
-        return 2.0 * 1.616339948310703 * self.radius / self._rz / np.pi
+        return 2.0 * self._hwhm * self.radius / self._rz / np.pi
 
     def _calc_bounding_box(self, *, factor=10.0):
         """
@@ -1967,17 +1973,23 @@ class AiryDiskPSF(Fittable2DModel):
         r = np.sqrt((x - x_0) ** 2 + (y - y_0) ** 2) / (radius / self._rz)
 
         if isinstance(r, u.Quantity):
-            # scipy function cannot handle Quantity, so turn into array
+            # Convert to dimensionless_unscaled to avoid unit conversion
+            # issues in scipy functions, since they expect dimensionless
+            # inputs.
             r = r.to_value(u.dimensionless_unscaled)
+        r = np.asarray(r, dtype=float)
 
         # Since r can be zero, we have to take care to treat that case
-        # separately so as not to raise a numpy warning
-        z = np.ones(r.shape)
-        rt = np.pi * r[r > 0]
-        z[r > 0] = (2.0 * j1(rt) / rt) ** 2
+        # separately so as not to raise a numpy warning. The limit of
+        # (2 * J1(x) / x)**2 as x approaches zero is 1.
+        rt = np.pi * np.atleast_1d(r)
+        z = np.ones(rt.shape)
+        nonzero = rt > 0
+        z[nonzero] = (2.0 * j1(rt[nonzero]) / rt[nonzero]) ** 2
+        z = z.reshape(r.shape)
 
         if isinstance(flux, u.Quantity):
-            # make z a quantity to allow in-place multiplication
+            # Make z a quantity to allow in-place multiplication
             z <<= u.dimensionless_unscaled
 
         normalization = (4.0 / np.pi) * (radius / self._rz) ** 2

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -21,13 +21,11 @@ __all__ = [
 ]
 
 # The smallest positive normal float32 value (~1.2e-38), used as the
-# lower bound of the strictly-positive model parameters. Despite its
-# name, this is numpy.finfo.tiny and not the machine epsilon. The name
-# and definition match the constant of the same name in
-# astropy.modeling.functional_models.
-FLOAT_EPSILON = float(np.finfo(np.float32).tiny)
+# lower bound of the strictly-positive model parameters.
+_FLOAT_TINY = float(np.finfo(np.float32).tiny)
 
-GAUSSIAN_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+# Conversion factor from a Gaussian FWHM to its standard deviation.
+_GAUSSIAN_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 
 
 def _gaussian_amplitude(flux, xsigma, ysigma):
@@ -167,12 +165,12 @@ class GaussianPSF(Fittable2DModel):
         default=0, description='Position of the peak along the y axis')
     x_fwhm = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='FWHM of the Gaussian along the x axis')
     y_fwhm = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='FWHM of the Gaussian along the y axis')
     theta = Parameter(
@@ -199,14 +197,14 @@ class GaussianPSF(Fittable2DModel):
         """
         Gaussian sigma (standard deviation) along the x-axis.
         """
-        return self.x_fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        return self.x_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
 
     @property
     def y_sigma(self):
         """
         Gaussian sigma (standard deviation) along the y-axis.
         """
-        return self.y_fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        return self.y_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
 
     def _calc_bounding_box(self, *, factor=5.5):
         """
@@ -295,8 +293,8 @@ class GaussianPSF(Fittable2DModel):
         cost2 = np.cos(theta) ** 2
         sint2 = np.sin(theta) ** 2
         sin2t = np.sin(2.0 * theta)
-        xstd = x_fwhm * GAUSSIAN_FWHM_TO_SIGMA
-        ystd = y_fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        xstd = x_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
+        ystd = y_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
         xstd2 = xstd ** 2
         ystd2 = ystd ** 2
         xdiff = x - x_0
@@ -353,8 +351,8 @@ class GaussianPSF(Fittable2DModel):
         sint2 = sint ** 2
         cos2t = np.cos(2.0 * theta)
         sin2t = np.sin(2.0 * theta)
-        xstd = x_fwhm * GAUSSIAN_FWHM_TO_SIGMA
-        ystd = y_fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        xstd = x_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
+        ystd = y_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
         xstd2 = xstd ** 2
         ystd2 = ystd ** 2
         xstd3 = xstd ** 3
@@ -399,10 +397,10 @@ class GaussianPSF(Fittable2DModel):
         dg_dystd = damp_dystd * exp + amplitude * dexp_dystd
 
         # Chain rule for change of variables from sigma to fwhm
-        # std => fwhm * GAUSSIAN_FWHM_TO_SIGMA
-        # dstd/dfwhm => GAUSSIAN_FWHM_TO_SIGMA
-        dg_dxfwhm = dg_dxstd * GAUSSIAN_FWHM_TO_SIGMA
-        dg_dyfwhm = dg_dystd * GAUSSIAN_FWHM_TO_SIGMA
+        # std => fwhm * _GAUSSIAN_FWHM_TO_SIGMA
+        # dstd/dfwhm => _GAUSSIAN_FWHM_TO_SIGMA
+        dg_dxfwhm = dg_dxstd * _GAUSSIAN_FWHM_TO_SIGMA
+        dg_dyfwhm = dg_dystd * _GAUSSIAN_FWHM_TO_SIGMA
 
         dg_dtheta = g * (-(da_dtheta * xdiff2 + db_dtheta * xdiff * ydiff
                            + dc_dtheta * ydiff2))
@@ -539,7 +537,7 @@ class CircularGaussianPSF(Fittable2DModel):
         default=0, description='Position of the peak along the y axis')
     fwhm = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='FWHM of the Gaussian')
 
@@ -560,7 +558,7 @@ class CircularGaussianPSF(Fittable2DModel):
         """
         Gaussian sigma (standard deviation).
         """
-        return self.fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        return self.fwhm * _GAUSSIAN_FWHM_TO_SIGMA
 
     def _calc_bounding_box(self, *, factor=5.5):
         """
@@ -637,7 +635,7 @@ class CircularGaussianPSF(Fittable2DModel):
         result : `~numpy.ndarray`
             The value of the model evaluated at the input coordinates.
         """
-        sigma2 = (fwhm * GAUSSIAN_FWHM_TO_SIGMA) ** 2
+        sigma2 = (fwhm * _GAUSSIAN_FWHM_TO_SIGMA) ** 2
 
         # Output units should match the input flux units
         sigma2_norm = sigma2
@@ -841,12 +839,12 @@ class GaussianPRF(Fittable2DModel):
         default=0, description='Position of the peak along the y axis')
     x_fwhm = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='FWHM of the Gaussian along the x axis')
     y_fwhm = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='FWHM of the Gaussian along the y axis')
     theta = Parameter(
@@ -873,14 +871,14 @@ class GaussianPRF(Fittable2DModel):
         """
         Gaussian sigma (standard deviation) along the x-axis.
         """
-        return self.x_fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        return self.x_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
 
     @property
     def y_sigma(self):
         """
         Gaussian sigma (standard deviation) along the y-axis.
         """
-        return self.y_fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        return self.y_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
 
     def _calc_bounding_box(self, *, factor=5.5):
         """
@@ -967,8 +965,8 @@ class GaussianPRF(Fittable2DModel):
         if not isinstance(theta, u.Quantity):
             theta = np.deg2rad(theta)
 
-        x_sigma = x_fwhm * GAUSSIAN_FWHM_TO_SIGMA
-        y_sigma = y_fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        x_sigma = x_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
+        y_sigma = y_fwhm * _GAUSSIAN_FWHM_TO_SIGMA
         dx = x - x_0
         dy = y - y_0
         cost = np.cos(theta)
@@ -1129,7 +1127,7 @@ class CircularGaussianPRF(Fittable2DModel):
         default=0, description='Position of the peak along the y axis')
     fwhm = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='FWHM of the Gaussian')
 
@@ -1150,7 +1148,7 @@ class CircularGaussianPRF(Fittable2DModel):
         """
         Gaussian sigma (standard deviation).
         """
-        return self.fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        return self.fwhm * _GAUSSIAN_FWHM_TO_SIGMA
 
     def _calc_bounding_box(self, *, factor=5.5):
         """
@@ -1229,7 +1227,7 @@ class CircularGaussianPRF(Fittable2DModel):
         """
         x0 = x - x_0
         y0 = y - y_0
-        sigma = fwhm * GAUSSIAN_FWHM_TO_SIGMA
+        sigma = fwhm * _GAUSSIAN_FWHM_TO_SIGMA
 
         dpix = 0.5
         if isinstance(x0, u.Quantity):
@@ -1374,7 +1372,7 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         default=0, description='Position of the peak along the y axis')
     sigma = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='Sigma (standard deviation) of the Gaussian')
 
@@ -1395,7 +1393,7 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         """
         Gaussian FWHM.
         """
-        return self.sigma / GAUSSIAN_FWHM_TO_SIGMA
+        return self.sigma / _GAUSSIAN_FWHM_TO_SIGMA
 
     def _calc_bounding_box(self, *, factor=5.5):
         """
@@ -1626,12 +1624,12 @@ class MoffatPSF(Fittable2DModel):
         default=0, description='Position of the peak along the y axis')
     alpha = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='Characteristic radius of the Moffat profile')
     beta = Parameter(
         default=2,
-        bounds=(1.0 + FLOAT_EPSILON, None),
+        bounds=(1.0 + _FLOAT_TINY, None),
         fixed=True,
         description='Power-law index of the Moffat profile')
 
@@ -1881,7 +1879,7 @@ class AiryDiskPSF(Fittable2DModel):
         default=0, description='Position of the peak along the y axis')
     radius = Parameter(
         default=1,
-        bounds=(FLOAT_EPSILON, None),
+        bounds=(_FLOAT_TINY, None),
         fixed=True,
         description='Radius of the Airy disk at the first zero')
 

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -666,8 +666,15 @@ class CircularGaussianPSF(Fittable2DModel):
             The list of partial derivatives with respect to each
             parameter.
         """
-        return GaussianPSF().fit_deriv(x, y, flux, x_0, y_0, fwhm, fwhm,
-                                       0.0)[:-2]
+        derivs = GaussianPSF.fit_deriv(x, y, flux, x_0, y_0, fwhm, fwhm, 0.0)
+
+        # The x and y FWHMs are the same variable for a circular
+        # Gaussian, so the chain rule gives the sum of the two partial
+        # derivatives. The theta derivative is dropped because theta is
+        # not a parameter of this model.
+        dg_dfwhm = derivs[3] + derivs[4]
+
+        return [*derivs[:3], dg_dfwhm]
 
     @property
     def input_units(self):

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -186,7 +186,10 @@ class GriddedPSFModel(Fittable2DModel):
             msg = 'The number of ePSFs must not be 2 or 3'
             raise ValueError(msg)
 
-        # this is required by RectBivariateSpline for kx=3, ky=3
+        # The minimum number of data points required is 4 along each
+        # axis. This is because RectBivariateSpline requires at least 4
+        # points along each axis for cubic spline interpolation (kx=3,
+        # ky=3).
         if np.any(np.array(data.data.shape[1:]) < 4):
             msg = ('The length of the PSF x and y axes must both be at '
                    'least 4')
@@ -255,7 +258,9 @@ class GriddedPSFModel(Fittable2DModel):
             raise ValueError(msg)
 
         if len(grid_xypos) != 1 and not self._is_rectangular_grid(grid_xypos):
-            msg = 'grid_xypos must form a rectangular grid'
+            msg = ('grid_xypos must form a rectangular grid, i.e., there '
+                   'must be at least two unique x and y positions and '
+                   'every combination of them must be present')
             raise ValueError(msg)
 
     def _define_grid(self, nddata):
@@ -280,7 +285,7 @@ class GriddedPSFModel(Fittable2DModel):
         self._validate_grid(nddata)
 
         grid_xypos = np.asarray(nddata.meta['grid_xypos'])
-        # sort by y and then by x (last key is primary)
+        # Sort by y and then by x (last key is primary)
         idx = np.lexsort((grid_xypos[:, 0], grid_xypos[:, 1]))
         return nddata.data[idx], grid_xypos[idx]
 
@@ -491,7 +496,7 @@ class GriddedPSFModel(Fittable2DModel):
         interp : `~scipy.interpolate.RectBivariateSpline`
             The interpolator for the input ePSF image.
         """
-        # check if the interpolator is already cached
+        # Check if the interpolator is already cached
         if grid_idx in self._interpolator:
             return self._interpolator[grid_idx]
 
@@ -500,7 +505,7 @@ class GriddedPSFModel(Fittable2DModel):
         interp = RectBivariateSpline(*self._interp_xyidx, data.T, kx=3, ky=3,
                                      s=0)
 
-        # cache the interpolator for reuse
+        # Cache the interpolator for reuse
         self._interpolator[grid_idx] = interp
 
         return interp
@@ -543,20 +548,23 @@ class GriddedPSFModel(Fittable2DModel):
         """
         nx = len(self._xgrid)
         ny = len(self._ygrid)
-        xcoords, ycoords = self.grid_xypos.T
+
+        # Map each reference (x, y) grid position to its source index.
+        # The grid is rectangular, so every corner is present.
+        pos_to_idx = {(float(x), float(y)): idx
+                      for idx, (x, y) in enumerate(self.grid_xypos)}
+
         out = np.empty((nx - 1, ny - 1, 4), dtype=np.int64)
         for ix in range(nx - 1):
+            x0 = float(self._xgrid[ix])
+            x1 = float(self._xgrid[ix + 1])
             for iy in range(ny - 1):
-                x0 = self._xgrid[ix]
-                x1 = self._xgrid[ix + 1]
-                y0 = self._ygrid[iy]
-                y1 = self._ygrid[iy + 1]
+                y0 = float(self._ygrid[iy])
+                y1 = float(self._ygrid[iy + 1])
                 # Corners in (lower-left, lower-right, upper-left,
                 # upper-right) order
-                corners = ((x0, y0), (x1, y0), (x0, y1), (x1, y1))
-                for k, (xc, yc) in enumerate(corners):
-                    match = np.where((xcoords == xc) & (ycoords == yc))[0]
-                    out[ix, iy, k] = match[0]
+                out[ix, iy] = (pos_to_idx[(x0, y0)], pos_to_idx[(x1, y0)],
+                               pos_to_idx[(x0, y1)], pos_to_idx[(x1, y1)])
         return out
 
     def _find_bounding_points(self, x, y):
@@ -653,8 +661,10 @@ class GriddedPSFModel(Fittable2DModel):
         elif yi > y1:
             yi = y1
 
+        # Weights of the four bounding points for bilinear
+        # interpolation. The order is lower-left, lower-right,
+        # upper-left, upper-right.
         inv_norm = 1.0 / ((x1 - x0) * (y1 - y0))
-        # lower-left, lower-right, upper-left, upper-right
         ll = (x1 - xi) * (y1 - yi) * inv_norm
         lr = (xi - x0) * (y1 - yi) * inv_norm
         ul = (x1 - xi) * (yi - y0) * inv_norm
@@ -722,33 +732,33 @@ class GriddedPSFModel(Fittable2DModel):
             msg = 'x and y must be 1D or 2D'
             raise ValueError(msg)
 
-        # the base Model.__call__() method converts scalar inputs to
+        # The base Model.__call__() method converts scalar inputs to
         # size-1 arrays before calling evaluate(), but we need scalar
-        # values for the interpolator
+        # values for the interpolator.
         if not np.isscalar(x_0):
             x_0 = x_0[0]
         if not np.isscalar(y_0):
             y_0 = y_0[0]
 
-        # now evaluate the ePSF at the (x_0, y_0) subpixel position on
-        # the input (x, y) values
+        # Now evaluate the ePSF at the (x_0, y_0) subpixel position on
+        # the input (x, y) values.
         xi = self.oversampling[1] * (np.asarray(x, dtype=float) - x_0)
         yi = self.oversampling[0] * (np.asarray(y, dtype=float) - y_0)
         xi += self.origin[0]
         yi += self.origin[1]
 
         if self.data.shape[0] == 1:
-            # if there is only one ePSF, we do not need to perform
-            # the bilinear interpolation
+            # If there is only one ePSF, we do not need to perform
+            # the bilinear interpolation.
             evaluated_model = flux * self._calc_interpolator(0)(xi, yi,
                                                                 grid=False)
         else:
             evaluated_model = flux * self._calc_model_values(x_0, y_0, xi, yi)
 
         if self.fill_value is not None:
-            # set pixels that are outside the input pixel grid to the
+            # Set pixels that are outside the input pixel grid to the
             # fill_value to avoid extrapolation; these bounds match the
-            # RegularGridInterpolator bounds
+            # RegularGridInterpolator bounds.
             ny, nx = self.data.shape[1:]
             invalid = (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
             evaluated_model[invalid] = self.fill_value
@@ -871,20 +881,48 @@ class STDPSFGrid:
         meta : dict
             The metadata dictionary.
         """
-        self.data = data
-        self.grid_xypos = grid_xypos
+        self._data = data
+        self._grid_xypos = grid_xypos
         self.meta = meta
         self._grid_shape = tuple(int(value) for value in grid_shape)
 
         # The grid axes are extracted from the first row and column
         # rather than with np.unique because a coordinate can be
-        # repeated where two detectors abut (e.g., ACS/WFC)
+        # repeated where two detectors abut (e.g., ACS/WFC).
         xypos = grid_xypos.reshape(*self._grid_shape, 2)
         self._xgrid = xypos[0, :, 0]
         self._ygrid = xypos[:, 0, 1]
 
         self._oversampling = as_pair('oversampling', oversampling,
                                      lower_bound=(0, 0))
+
+    @property
+    def data(self):
+        """
+        The 3D array of ePSFs.
+
+        The shape is ``(N_psf, ePSF_ny, ePSF_nx)``.
+        """
+        return self._data
+
+    @property
+    def grid_xypos(self):
+        """
+        The (x, y) positions of the ePSFs.
+
+        The order of positions matches the first axis of the 3D
+        `~numpy.ndarray` of ePSFs. In other words, ``grid_xypos[i]``
+        is the (x, y) position of the reference ePSF defined in
+        ``data[i]``.
+        """
+        return self._grid_xypos
+
+    @property
+    def grid_shape(self):
+        """
+        The ``(ny, nx)`` shape of the ePSF grid.
+        """
+        return self._grid_shape
 
     @property
     def oversampling(self):
@@ -916,14 +954,14 @@ class STDPSFGrid:
         # representation
         oversampling = tuple(int(value) for value in self.oversampling)
 
-        keys = ('STDPSF', 'detector', 'filter')
+        keys = ('STDPSF', 'instrument', 'detector', 'filter')
         for key in keys:
             if key in self.meta:
                 name = key.capitalize() if key != 'STDPSF' else key
                 cls_info.append((name, self.meta[key]))
 
-        cls_info.extend([('Grid shape', self._grid_shape),
-                         ('Number of PSFs', len(self.grid_xypos)),
+        cls_info.extend([('Number of PSFs', len(self.grid_xypos)),
+                         ('Grid shape', self.grid_shape),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
                          ('Oversampling', oversampling)])

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -458,7 +458,9 @@ class GriddedPSFModel(Fittable2DModel):
         A 1D `~numpy.ndarray` (x, y) pixel coordinates within the
         model's 2D image of the origin of the coordinate system.
         """
-        xyorigin = (np.array(self.data.shape) - 1) / 2
+        # data.shape is (N_psf, ePSF_ny, ePSF_nx); the leading axis is
+        # excluded so that the result is the (x, y) image center
+        xyorigin = (np.array(self.data.shape[1:]) - 1) / 2
         return xyorigin[::-1]
 
     @lazyproperty
@@ -562,8 +564,8 @@ class GriddedPSFModel(Fittable2DModel):
         Find the grid indices and reference (x, y) points of the four
         bounding grid points for a given (x, y) coordinate.
 
-        If the point is outside the grid, the nearest grid points are
-        selected. The input grid points do not need to be sorted.
+        If the point is outside the grid, the nearest grid cell is
+        selected.
 
         This method is a scalar-only fast path: ``x`` and ``y`` must be
         scalar values (the model ``x_0`` and ``y_0`` positions), which

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -220,7 +220,8 @@ class GriddedPSFModel(Fittable2DModel):
             Returns `True` if the input ``grid_xypos`` forms a
             rectangular grid.
         """
-        if len(grid_xypos) < 4:  # pragma: no cover
+        # Fewer than 4 positions cannot form a 2D rectangular grid
+        if len(grid_xypos) < 4:
             return False
 
         x_vals = np.unique(grid_xypos[:, 0])  # sorted

--- a/photutils/psf/groupers.py
+++ b/photutils/psf/groupers.py
@@ -71,11 +71,11 @@ class SourceGroups:
 
     >>> print(f'Number of groups: {source_groups.n_groups}')
     Number of groups: 3
-    >>> source_groups.size_map  # doctest: +SKIP
+    >>> source_groups.size_map
     {1: 2, 2: 2, 3: 1}
     >>> source_groups.sizes
     array([2, 2, 2, 2, 1])
-    >>> source_groups.group_centers  # doctest: +SKIP
+    >>> source_groups.group_centers
     {1: (12.5, 22.5), 2: (52.5, 62.5), 3: (100.0, 90.0)}
     >>> x_group1, y_group1 = source_groups.get_group_sources(1)
     >>> print(x_group1, y_group1)
@@ -129,7 +129,7 @@ class SourceGroups:
 
         Returns
         -------
-        group_sizes : 1D int `~numpy.ndarray`
+        sizes : 1D int `~numpy.ndarray`
             A 1D array of the group sizes, in the same order as the
             sources. Each element indicates how many sources are in the
             same group as the corresponding source.
@@ -307,7 +307,7 @@ class SourceGrouper:
 
     >>> print(f'Number of groups: {groups.n_groups}')
     Number of groups: 3
-    >>> groups.size_map  # doctest: +SKIP
+    >>> groups.size_map
     {1: 2, 2: 2, 3: 1}
 
     Retrieve the (x, y) positions of sources from a specific group:

--- a/photutils/psf/groupers.py
+++ b/photutils/psf/groupers.py
@@ -234,6 +234,12 @@ class SourceGroups:
         elif isinstance(cmap, str):
             cmap = colormaps[cmap]
 
+        # Sample the colormap over its full range so that the group
+        # colors are distinct. Indexing a colormap by the group number
+        # would map every group to the low end of the colormap.
+        fractions = np.arange(self.n_groups) / max(self.n_groups - 1, 1)
+        colors = cmap(fractions)
+
         # Set default label kwargs
         if label_kwargs is None:
             label_kwargs = {'ha': 'center',
@@ -247,7 +253,7 @@ class SourceGroups:
             mask = self.groups == group_id
             xypos = zip(self.x[mask], self.y[mask], strict=True)
             ap = CircularAperture(xypos, r=radius)
-            color = cmap.colors[i] if hasattr(cmap, 'colors') else cmap(i)
+            color = colors[i]
             ap.plot(ax=ax, color=color, **kwargs)
 
             if label_groups:
@@ -318,6 +324,9 @@ class SourceGrouper:
     """
 
     def __init__(self, min_separation):
+        if not np.isfinite(min_separation) or min_separation <= 0:
+            msg = 'min_separation must be a positive finite value'
+            raise ValueError(msg)
         self.min_separation = min_separation
 
     def __repr__(self):
@@ -356,7 +365,7 @@ class SourceGrouper:
             msg = 'y coordinates must be finite (no NaN or inf values)'
             raise ValueError(msg)
 
-        # single source forms its own group
+        # A single source forms its own group
         if x.shape == (1,):
             return np.array([1])
 

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -42,8 +42,11 @@ class ImagePSF(Fittable2DModel):
         assuming the input PSF image is properly normalized.
 
     x_0, y_0 : float, optional
-        The ``(x, y)`` coordinates of the PSF peak in the output coordinate
-        grid where the model is evaluated.
+        The x and y positions of a feature in the image in the output
+        coordinate grid on which the model is evaluated. Typically, this
+        refers to the position of the PSF peak, which is assumed to be
+        located at the center of the input image (see the ``origin``
+        keyword).
 
     origin : tuple of 2 float or None, optional
         The ``(x, y)`` coordinate in the input image corresponding to the

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -138,11 +138,9 @@ class ImagePSF(Fittable2DModel):
                  y_0=y_0.default, origin=None, oversampling=1,
                  fill_value=0.0, **kwargs):
 
-        self._validate_data(data)
         self.data = data
         self.origin = origin
-        self.oversampling = as_pair('oversampling', oversampling,
-                                    lower_bound=(0, 0))
+        self.oversampling = oversampling
         self.fill_value = fill_value
 
         super().__init__(flux, x_0, y_0, **kwargs)
@@ -223,6 +221,33 @@ class ImagePSF(Fittable2DModel):
         return copy.deepcopy(self)
 
     @property
+    def data(self):
+        """
+        The 2D image of the PSF.
+
+        Setting this attribute revalidates the input array and discards
+        the cached `interpolator`. The `origin` is not updated, so it
+        should be reset explicitly if the new image has a different
+        shape or a different reference pixel.
+        """
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        """
+        Set the 2D image of the PSF.
+
+        Parameters
+        ----------
+        value : 2D `~numpy.ndarray`
+            The 2D image of the PSF.
+        """
+        self._validate_data(value)
+        self._data = value
+        # discard the cached interpolator, which is tied to the old data
+        self.__dict__.pop('interpolator', None)
+
+    @property
     def shape(self):
         """
         The shape of the (oversampled) PSF data array.
@@ -233,6 +258,33 @@ class ImagePSF(Fittable2DModel):
             The shape of the (oversampled) PSF data array.
         """
         return self.data.shape
+
+    @property
+    def oversampling(self):
+        """
+        The integer oversampling factor(s) of the input PSF image.
+
+        If ``oversampling`` is a scalar then it will be used for both
+        axes. If ``oversampling`` has two elements, they must be in
+        ``(y, x)`` order.
+        """
+        return self._oversampling
+
+    @oversampling.setter
+    def oversampling(self, value):
+        """
+        Set the oversampling factor(s) of the input PSF image.
+
+        Parameters
+        ----------
+        value : int or tuple of int
+            The integer oversampling factor(s) of the input PSF image.
+            If ``oversampling`` is a scalar then it will be used for
+            both axes. If ``oversampling`` has two elements, they must
+            be in ``(y, x)`` order.
+        """
+        self._oversampling = as_pair('oversampling', value,
+                                     lower_bound=(0, 0))
 
     @property
     def origin(self):

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -159,7 +159,10 @@ class ImagePSF(Fittable2DModel):
             msg = 'All elements of input data must be finite'
             raise ValueError(msg)
 
-        # this is required by RectBivariateSpline for kx=3, ky=3
+        # The minimum number of data points required is 4 along each
+        # axis. This is because RectBivariateSpline requires at least 4
+        # points along each axis for cubic spline interpolation (kx=3,
+        # ky=3).
         if np.any(np.array(data.shape) < 4):
             msg = 'The length of the x and y axes must both be at least 4'
             raise ValueError(msg)
@@ -244,7 +247,7 @@ class ImagePSF(Fittable2DModel):
         """
         self._validate_data(value)
         self._data = value
-        # discard the cached interpolator, which is tied to the old data
+        # Discard the cached interpolator, which is tied to the old data
         self.__dict__.pop('interpolator', None)
 
     @property
@@ -353,11 +356,10 @@ class ImagePSF(Fittable2DModel):
         """
         dy, dx = np.array(self.data.shape) / 2 / self.oversampling
 
-        # apply the origin shift
-        # if origin is None, the origin is set to the center of the
-        # image and the shift is 0
-        xshift = np.array(self.data.shape[1] - 1) / 2 - self.origin[0]
-        yshift = np.array(self.data.shape[0] - 1) / 2 - self.origin[1]
+        # Apply the origin shift. If origin is None, the origin is set
+        # to the center of the image and the shift is 0.
+        xshift = (self.data.shape[1] - 1) / 2 - self.origin[0]
+        yshift = (self.data.shape[0] - 1) / 2 - self.origin[1]
         xshift /= self.oversampling[1]
         yshift /= self.oversampling[0]
 
@@ -418,9 +420,9 @@ class ImagePSF(Fittable2DModel):
         evaluated_model = flux * self.interpolator(xi, yi, grid=False)
 
         if self.fill_value is not None:
-            # set pixels that are outside the input pixel grid to the
-            # fill_value to avoid extrapolation; these bounds match the
-            # RegularGridInterpolator bounds
+            # Set pixels that are outside the input pixel grid to the
+            # fill_value to avoid extrapolation. These bounds match the
+            # RegularGridInterpolator bounds.
             ny, nx = self.data.shape
             invalid = (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
             evaluated_model[invalid] = self.fill_value

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -605,12 +605,14 @@ def webbpsf_reader(filename):
     meta = dict(header)
     meta = {key.lower(): meta[key] for key in meta}  # user lower-case keys
 
-    # define grid_xypos from DET_YX{} FITS header keywords
+    # Define grid_xypos from the DET_YX{} FITS header keywords. The
+    # header values are the '(y, x)' detector positions, but grid_xypos
+    # is defined in (x, y) order.
     xypos = []
     for key in meta:
         if 'det_yx' in key:
             vals = header[key].lstrip('(').rstrip(')').split(',')
-            xypos.append((float(vals[0]), float(vals[1])))
+            xypos.append((float(vals[1]), float(vals[0])))
     meta['grid_xypos'] = xypos
 
     if 'oversampling' not in meta:

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -6,6 +6,7 @@ Tools for reading and writing PSF models.
 import io
 import itertools
 import os
+import re
 import warnings
 
 import numpy as np
@@ -17,6 +18,13 @@ from photutils.utils._deprecation import deprecated_positional_kwargs
 
 __all__ = ['GriddedPSFModelRead', 'stdpsf_reader', 'webbpsf_reader']
 __doctest_skip__ = ['GriddedPSFModelRead']
+
+# Filename extensions recognized as FITS files
+_FITS_EXTENSIONS = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts',
+                    '.fts.gz')
+
+# Pattern matching the WebbPSF detector-position header keywords
+_DET_YX_PATTERN = re.compile(r'DET_YX(\d+)$')
 
 # Mapping of the STDPSF filename detector field to the (instrument,
 # detector) metadata values
@@ -76,7 +84,7 @@ class GriddedPSFModelRead(registry.UnifiedReadWrite):
     """
 
     def __init__(self, instance, cls):
-        # uses default global registry
+        # Use default global registry
         super().__init__(instance, cls, 'read', registry=None)
 
     def __call__(self, *args, **kwargs):
@@ -116,12 +124,11 @@ def _read_stdpsf(filename):
     data : dict
         A dictionary containing the ePSF data and metadata.
     """
-    extens = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts', '.fts.gz')
     is_hdulist = isinstance(filename, fits.HDUList)
     is_fileobj = (isinstance(filename, io.FileIO)
-                  and filename.name.lower().endswith(extens))
+                  and filename.name.lower().endswith(_FITS_EXTENSIONS))
     is_fits_ext = (isinstance(filename, str)
-                   and filename.lower().endswith(extens))
+                   and filename.lower().endswith(_FITS_EXTENSIONS))
     if is_hdulist or is_fileobj or is_fits_ext:
         return _read_fits_stdpsf(filename)
     msg = 'This interface supports only FITS files.'
@@ -249,7 +256,7 @@ def _split_detectors(grid_data, detector_data, detector_id):
     ii = reshape_as_blocks(ii, (ny_grid, nx_grid))
     ii = ii.reshape(n_detectors, n_psfs // n_detectors)
 
-    # detector_id -> index
+    # Map detector_id to index
     det_idx = det_map[detector_id]
     idx = ii[det_idx]
     data = data[idx]
@@ -344,6 +351,8 @@ def _split_wfpc2(grid_data, detector_id):
     ny_det = 2
     det_size = 800
 
+    # Map of detector ID to index in the 2x2 grid of detectors. The
+    # detector IDs are defined in the STDPSF filenames as follows:
     # det (exten:idx)
     # WF2 (2:2)  PC (1:3)
     # WF3 (3:0)  WF4 (4:1)
@@ -391,6 +400,8 @@ def _split_nrcsw(grid_data, detector_id):
     ny_det = 2
     det_size = 2048
 
+    # Map of detector ID to index in the 4x2 grid of detectors. The
+    # detector IDs are defined in the STDPSF filenames as follows:
     # det (ext:idx)
     # A2 (2:4)  A4 (4:5)  B3 (7:6)  B1 (5:7)
     # A1 (1:0)  A3 (3:1)  B4 (8:2)  B2 (6:3)
@@ -425,7 +436,7 @@ def _get_metadata(filename, detector_id):
         filename = filename.name
 
     # Strip the file extension (e.g., '.fits' or '.fits.gz') before
-    # splitting the filename into its underscore-separated fields
+    # splitting the filename into its underscore-separated fields.
     basename = os.path.basename(filename).split('.')[0]
     parts = basename.split('_')
     if len(parts) not in (3, 4):
@@ -545,8 +556,8 @@ def stdpsf_reader(filename, detector_id=None):
     meta = {'grid_xypos': xy_grid,
             'oversampling': oversampling}
 
-    # try to get additional metadata from the filename because this
-    # information is not currently available in the FITS headers
+    # Try to get additional metadata from the filename because this
+    # information is not currently available in the FITS headers.
     file_meta = _get_metadata(filename, detector_id)
     if file_meta is not None:
         meta.update(file_meta)
@@ -587,7 +598,7 @@ def webbpsf_reader(filename):
             header = hdulist[0].header
             data = hdulist[0].data
 
-    # handle the case of only one 2D PSF
+    # Handle the case of only one 2D PSF
     data = np.atleast_3d(data)
 
     if not any('DET_YX' in key for key in header):
@@ -597,7 +608,7 @@ def webbpsf_reader(filename):
         msg = 'Invalid WebbPSF FITS file; missing "OVERSAMP" header key'
         raise ValueError(msg)
 
-    # convert header to meta dict
+    # Convert header to meta dict
     header = header.copy(strip=True)
     header.pop('HISTORY', None)
     header.pop('COMMENT', None)
@@ -605,14 +616,21 @@ def webbpsf_reader(filename):
     meta = dict(header)
     meta = {key.lower(): meta[key] for key in meta}  # user lower-case keys
 
-    # Define grid_xypos from the DET_YX{} FITS header keywords. The
+    # Define grid_xypos from the DET_YX{i} FITS header keywords. The
+    # keywords are sorted by their numeric index so that the positions
+    # always match the order of the ePSF planes in the data array. The
     # header values are the '(y, x)' detector positions, but grid_xypos
     # is defined in (x, y) order.
+    det_yx_keys = {}
+    for key in header:
+        match = _DET_YX_PATTERN.match(key)
+        if match is not None:
+            det_yx_keys[int(match.group(1))] = key
+
     xypos = []
-    for key in meta:
-        if 'det_yx' in key:
-            vals = header[key].lstrip('(').rstrip(')').split(',')
-            xypos.append((float(vals[1]), float(vals[0])))
+    for index in sorted(det_yx_keys):
+        vals = header[det_yx_keys[index]].lstrip('(').rstrip(')').split(',')
+        xypos.append((float(vals[1]), float(vals[0])))
     meta['grid_xypos'] = xypos
 
     if 'oversampling' not in meta:
@@ -621,6 +639,35 @@ def webbpsf_reader(filename):
     ndd = NDData(data, meta=meta)
 
     return GriddedPSFModel(ndd)
+
+
+def _has_fits_header_keys(filepath, keys):
+    """
+    Determine whether a file is a FITS file whose primary header
+    contains all of the given keywords.
+
+    Parameters
+    ----------
+    filepath : str or `None`
+        The file path of the FITS file.
+
+    keys : tuple of str
+        The FITS header keywords that must all be present.
+
+    Returns
+    -------
+    result : bool
+        Returns `True` if the file is a FITS file containing all of the
+        input keywords.
+    """
+    if filepath is None or not filepath.lower().endswith(_FITS_EXTENSIONS):
+        return False
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', VerifyWarning)
+        header = fits.getheader(filepath)
+
+    return all(key in header for key in keys)
 
 
 def is_stdpsf(origin, filepath, fileobj, *args, **kwargs):
@@ -649,17 +696,7 @@ def is_stdpsf(origin, filepath, fileobj, *args, **kwargs):
     result : bool
         Returns `True` if the given file is a STDPSF FITS file.
     """
-    if filepath is not None:
-        extens = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts', '.fts.gz')
-        isfits = filepath.lower().endswith(extens)
-        if isfits:
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', VerifyWarning)
-                header = fits.getheader(filepath)
-            keys = ('NAXIS3', 'NXPSFS', 'NYPSFS')
-            return all(key in header for key in keys)
-
-    return False
+    return _has_fits_header_keys(filepath, ('NAXIS3', 'NXPSFS', 'NYPSFS'))
 
 
 def is_webbpsf(origin, filepath, fileobj, *args, **kwargs):
@@ -688,14 +725,4 @@ def is_webbpsf(origin, filepath, fileobj, *args, **kwargs):
     result : bool
         Returns `True` if the given file is a WebbPSF FITS file.
     """
-    if filepath is not None:
-        extens = ('.fits', '.fits.gz', '.fit', '.fit.gz', '.fts', '.fts.gz')
-        isfits = filepath.lower().endswith(extens)
-        if isfits:
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', VerifyWarning)
-                header = fits.getheader(filepath)
-            keys = ('NAXIS3', 'OVERSAMP', 'DET_YX0')
-            return all(key in header for key in keys)
-
-    return False
+    return _has_fits_header_keys(filepath, ('NAXIS3', 'OVERSAMP', 'DET_YX0'))

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -116,8 +116,9 @@ def _read_stdpsf(filename):
 
     Parameters
     ----------
-    filename : str
-        The name of the STDPSF FITS file.
+    filename : str or `~astropy.io.fits.HDUList`
+        The name of the STDPSF FITS file, or an already-open
+        `~astropy.io.fits.HDUList`.
 
     Returns
     -------
@@ -141,8 +142,9 @@ def _read_fits_stdpsf(filename):
 
     Parameters
     ----------
-    filename : str
-        The name of the STDPSF FITS file.
+    filename : str or `~astropy.io.fits.HDUList`
+        The name of the STDPSF FITS file, or an already-open
+        `~astropy.io.fits.HDUList`.
 
     Returns
     -------
@@ -151,9 +153,13 @@ def _read_fits_stdpsf(filename):
     """
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', VerifyWarning)
-        with fits.open(filename, ignore_missing_end=True) as hdulist:
-            header = hdulist[0].header
-            data = hdulist[0].data
+        if isinstance(filename, fits.HDUList):
+            header = filename[0].header
+            data = filename[0].data
+        else:
+            with fits.open(filename, ignore_missing_end=True) as hdulist:
+                header = hdulist[0].header
+                data = hdulist[0].data
 
     try:
         n_psfs = header['NAXIS3']

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -18,6 +18,27 @@ from photutils.utils._deprecation import deprecated_positional_kwargs
 __all__ = ['GriddedPSFModelRead', 'stdpsf_reader', 'webbpsf_reader']
 __doctest_skip__ = ['GriddedPSFModelRead']
 
+# Mapping of the STDPSF filename detector field to the (instrument,
+# detector) metadata values
+_STDPSF_DETECTOR_MAP = {'WFPC2': ('HST/WFPC2', 'WFPC2'),
+                        'ACSHRC': ('HST/ACS', 'HRC'),
+                        'ACSWFC': ('HST/ACS', 'WFC'),
+                        'WFC3UV': ('HST/WFC3', 'UVIS'),
+                        'WFC3IR': ('HST/WFC3', 'IR'),
+                        'NRCSW': ('JWST/NIRCam', 'NRCSW'),
+                        'NRCA1': ('JWST/NIRCam', 'A1'),
+                        'NRCA2': ('JWST/NIRCam', 'A2'),
+                        'NRCA3': ('JWST/NIRCam', 'A3'),
+                        'NRCA4': ('JWST/NIRCam', 'A4'),
+                        'NRCB1': ('JWST/NIRCam', 'B1'),
+                        'NRCB2': ('JWST/NIRCam', 'B2'),
+                        'NRCB3': ('JWST/NIRCam', 'B3'),
+                        'NRCB4': ('JWST/NIRCam', 'B4'),
+                        'NRCAL': ('JWST/NIRCam', 'A5'),
+                        'NRCBL': ('JWST/NIRCam', 'B5'),
+                        'NIRISS': ('JWST/NIRISS', 'NIRISS'),
+                        'MIRI': ('JWST/MIRI', 'MIRIM')}
+
 
 class GriddedPSFModelRead(registry.UnifiedReadWrite):
     """
@@ -403,7 +424,10 @@ def _get_metadata(filename, detector_id):
     if isinstance(filename, io.FileIO):
         filename = filename.name
 
-    parts = os.path.basename(filename).strip('.fits').split('_')
+    # Strip the file extension (e.g., '.fits' or '.fits.gz') before
+    # splitting the filename into its underscore-separated fields
+    basename = os.path.basename(filename).split('.')[0]
+    parts = basename.split('_')
     if len(parts) not in (3, 4):
         return None  # filename from astropy download_file
 
@@ -413,27 +437,9 @@ def _get_metadata(filename, detector_id):
             'filter': filter_name}
 
     if detector_id is not None:
-        detector_map = {'WFPC2': ['HST/WFPC2', 'WFPC2'],
-                        'ACSHRC': ['HST/ACS', 'HRC'],
-                        'ACSWFC': ['HST/ACS', 'WFC'],
-                        'WFC3UV': ['HST/WFC3', 'UVIS'],
-                        'WFC3IR': ['HST/WFC3', 'IR'],
-                        'NRCSW': ['JWST/NIRCam', 'NRCSW'],
-                        'NRCA1': ['JWST/NIRCam', 'A1'],
-                        'NRCA2': ['JWST/NIRCam', 'A2'],
-                        'NRCA3': ['JWST/NIRCam', 'A3'],
-                        'NRCA4': ['JWST/NIRCam', 'A4'],
-                        'NRCB1': ['JWST/NIRCam', 'B1'],
-                        'NRCB2': ['JWST/NIRCam', 'B2'],
-                        'NRCB3': ['JWST/NIRCam', 'B3'],
-                        'NRCB4': ['JWST/NIRCam', 'B4'],
-                        'NRCAL': ['JWST/NIRCam', 'A5'],
-                        'NRCBL': ['JWST/NIRCam', 'B5'],
-                        'NIRISS': ['JWST/NIRISS', 'NIRISS'],
-                        'MIRI': ['JWST/MIRI', 'MIRIM']}
-
         try:
-            inst_det = detector_map[detector]
+            # Copy so that the module-level map is never mutated
+            inst_det = list(_STDPSF_DETECTOR_MAP[detector])
         except KeyError as exc:
             msg = f'Unknown detector {detector}'
             raise ValueError(msg) from exc
@@ -516,17 +522,17 @@ def stdpsf_reader(filename, detector_id=None):
 
     grid_data = _read_stdpsf(filename)
 
-    n_psfs = grid_data['n_psfs']
-    if n_psfs in (90, 56, 36, 200):
-        if n_psfs in (90, 56):  # ACS/WFC or WFC3/UVIS data (2 chips)
-            data, xgrid, ygrid = _split_wfc_uvis(grid_data, detector_id)
-        elif n_psfs == 36:  # WFPC2 data (4 chips)
-            data, xgrid, ygrid = _split_wfpc2(grid_data, detector_id)
-        elif n_psfs == 200:  # NIRCam SW data (8 chips)
-            data, xgrid, ygrid = _split_nrcsw(grid_data, detector_id)
-        else:
-            msg = 'Unknown detector or STDPSF format'
-            raise ValueError(msg)
+    # Number of ePSFs in the STDPSF files that contain grids for
+    # multiple detectors, mapped to the function that extracts a single
+    # detector from the grid
+    splitters = {90: _split_wfc_uvis,  # ACS/WFC or WFC3/UVIS (2 chips)
+                 56: _split_wfc_uvis,  # ACS/WFC or WFC3/UVIS (2 chips)
+                 36: _split_wfpc2,  # WFPC2 (4 chips)
+                 200: _split_nrcsw}  # NIRCam SW (8 chips)
+
+    splitter = splitters.get(grid_data['n_psfs'])
+    if splitter is not None:
+        data, xgrid, ygrid = splitter(grid_data, detector_id)
     else:
         data = grid_data['data']
         xgrid = grid_data['xgrid']

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -203,7 +203,7 @@ def _split_detectors(grid_data, detector_data, detector_id):
 
     Notes
     -----
-    In particular::
+    The STDPSF files that contain multiple detectors are:
 
     * HST WFPC2 STDPSF file contains 4 detectors
     * HST ACS/WFC STDPSF file contains 2 detectors

--- a/photutils/psf/model_plotting.py
+++ b/photutils/psf/model_plotting.py
@@ -45,7 +45,7 @@ def _plot_grid_docstring(func):
         divider_color, divider_ls : str, optional
             Matplotlib color and linestyle options for the divider
             lines between ePSFs. These keywords have no effect unless
-            ``show_dividers=True``.
+            ``dividers=True``.
 
         figsize : (float, float), optional
             The figure (width, height) in inches.

--- a/photutils/psf/model_plotting.py
+++ b/photutils/psf/model_plotting.py
@@ -132,7 +132,7 @@ class _ModelGridPlotter:
             fig = ax.get_figure()
 
         if peak_norm and data.max() != 0:
-            # normalize relative to peak
+            # Normalize relative to peak
             data /= data.max()
 
         if deltas:
@@ -151,7 +151,7 @@ class _ModelGridPlotter:
         # Set up the coordinate axes to later set tick labels based on
         # detector ePSF coordinates. This sets up axes to have, behind the
         # scenes, the ePSFs centered at integer coords 0, 1, 2, 3 etc.
-        # extent order: left, right, bottom, top
+        # Extent order: left, right, bottom, top
         ny_grid = self.model._ygrid.shape[0]
         nx_grid = self.model._xgrid.shape[0]
         extent = [-0.5, nx_grid - 0.5, -0.5, ny_grid - 0.5]
@@ -193,9 +193,12 @@ class _ModelGridPlotter:
         if isinstance(filtername, (tuple, list, np.ndarray)):
             filtername = filtername[0]
 
-        title = f'{instrument} {detector} {filtername}'
-        if title != '':
-            # add extra space at end
+        # Join only the metadata values that are present so that
+        # missing values do not leave stray spaces in the title
+        title = ' '.join(str(value) for value in
+                         (instrument, detector, filtername) if value)
+        if title:
+            # Add extra space at end
             title += ' '
 
         if deltas:

--- a/photutils/psf/tests/test_functional_models.py
+++ b/photutils/psf/tests/test_functional_models.py
@@ -121,7 +121,7 @@ def gaussian_tests(name, use_units):
         else:
             assert_allclose(fit_model.fwhm.value, model.fwhm.value)
 
-    # test the model derivatives
+    # Test the model derivatives
     fit_model2 = fitter(model_init, xx, yy, data, estimate_jacobian=True)
     assert_allclose(fit_model2.x_0, fit_model.x_0)
     assert_allclose(fit_model2.y_0, fit_model.y_0)
@@ -159,7 +159,7 @@ class TestFitDeriv:
     derivatives.
     """
 
-    # (x, y) coordinates spanning the model peak
+    # Define (x, y) coordinates spanning the model peak
     yy, xx = np.mgrid[20:30, 19:29]
     xx = xx.astype(float)
     yy = yy.astype(float)
@@ -300,10 +300,55 @@ def test_moffat_psf_model(use_units):
     assert_allclose(fit_model.alpha.value, model.alpha.value)
     assert_allclose(fit_model.beta.value, model.beta.value)
 
-    # test bounding box
+    # Test bounding box
     model = MoffatPSF(x_0=0, y_0=0, alpha=1.0, beta=2.0)
     bbox = 12.871885058111655
     assert_allclose(model.bounding_box, ((-bbox, bbox), (-bbox, bbox)))
+
+
+def test_airydisk_psf_quantity_flux():
+    """
+    Test evaluating the Airy disk model with a flux Quantity.
+    """
+    model = AiryDiskPSF(flux=71.4 * u.Jy, x_0=24.3, y_0=25.2, radius=2.1)
+    yy, xx = np.mgrid[0:51, 0:51]
+    data = model(xx, yy)
+    assert isinstance(data, u.Quantity)
+    assert data.unit == u.Jy
+    assert_allclose(data.value.sum(), model.flux.value, rtol=0.015)
+
+
+def test_airydisk_psf_scalar_coords():
+    """
+    Test that the Airy disk model can be evaluated at a scalar
+    coordinate, including at the peak where the radius is zero.
+    """
+    model = AiryDiskPSF(flux=1.0, x_0=0.0, y_0=0.0, radius=2.0)
+    peak = model.evaluate(0.0, 0.0, 1.0, 0.0, 0.0, 2.0)
+    assert np.ndim(peak) == 0
+
+    normalization = (4.0 / np.pi) * (2.0 / model._rz) ** 2
+    assert_allclose(peak, 1.0 / normalization)
+    assert_allclose(model(0.0, 0.0), peak)
+
+
+def test_moffat_psf_scalar_coords():
+    """
+    Test that the Moffat model can be evaluated with plain float
+    parameters.
+    """
+    model = MoffatPSF(flux=71.4, x_0=0.0, y_0=0.0, alpha=5.1, beta=3.2)
+    value = model.evaluate(1.0, 2.0, 71.4, 0.0, 0.0, 5.1, 3.2)
+    assert_allclose(value, model(1.0, 2.0))
+
+
+def test_circular_gaussian_sigma_prf_unit_mismatch():
+    model = CircularGaussianSigmaPRF(flux=1.0, x_0=0.0, y_0=0.0, sigma=2.0)
+    inputs_unit = {'x': u.m, 'y': u.s}
+    outputs_unit = {'z': u.Jy}
+    match = "Units of 'x' and 'y' inputs should match"
+    with pytest.raises(u.UnitsError, match=match):
+        model._parameter_units_for_data_units(inputs_unit, outputs_unit)
 
 
 @pytest.mark.parametrize('use_units', [False, True])
@@ -333,7 +378,7 @@ def test_airydisk_psf_model(use_units):
     assert_allclose(fit_model.y_0.value, model.y_0.value)
     assert_allclose(fit_model.radius.value, model.radius.value)
 
-    # test bounding box
+    # Test bounding box
     model = AiryDiskPSF(x_0=0, y_0=0, radius=5)
     bbox = 42.18329801081182
     assert_allclose(model.bounding_box, ((-bbox, bbox), (-bbox, bbox)))

--- a/photutils/psf/tests/test_functional_models.py
+++ b/photutils/psf/tests/test_functional_models.py
@@ -153,6 +153,94 @@ def test_gaussian_prfs(name, use_units):
     gaussian_tests(name, use_units)
 
 
+class TestFitDeriv:
+    """
+    Tests of the analytic model derivatives against numerical
+    derivatives.
+    """
+
+    # (x, y) coordinates spanning the model peak
+    yy, xx = np.mgrid[20:30, 19:29]
+    xx = xx.astype(float)
+    yy = yy.astype(float)
+
+    gaussian_params = (71.4, 24.3, 25.2, 10.1, 5.82, 21.7)
+    circular_params = (71.4, 24.3, 25.2, 10.1)
+
+    def numerical_deriv(self, model, params, index, step=1e-6):
+        """
+        Calculate the central-difference derivative of a model with
+        respect to a single parameter.
+
+        Parameters
+        ----------
+        model : `~astropy.modeling.Fittable2DModel`
+            The model to evaluate.
+
+        params : tuple
+            The model parameter values.
+
+        index : int
+            The index of the parameter to differentiate.
+
+        step : float, optional
+            The parameter step size.
+
+        Returns
+        -------
+        result : `~numpy.ndarray`
+            The numerical partial derivative.
+        """
+        params_hi = list(params)
+        params_lo = list(params)
+        params_hi[index] += step
+        params_lo[index] -= step
+        data_hi = model.evaluate(self.xx, self.yy, *params_hi)
+        data_lo = model.evaluate(self.xx, self.yy, *params_lo)
+        return (data_hi - data_lo) / (2.0 * step)
+
+    @pytest.mark.parametrize(('model_class', 'params'),
+                             [(GaussianPSF, gaussian_params),
+                              (CircularGaussianPSF, circular_params)])
+    def test_fit_deriv(self, model_class, params):
+        model = model_class()
+        derivs = model.fit_deriv(self.xx, self.yy, *params)
+        assert len(derivs) == len(params)
+
+        for index in range(len(params)):
+            numerical = self.numerical_deriv(model, params, index)
+            assert_allclose(derivs[index], numerical, rtol=1e-5, atol=1e-9)
+
+    def test_circular_fwhm_deriv(self):
+        """
+        Test that the circular Gaussian FWHM derivative is the sum of
+        the x and y FWHM derivatives of the elliptical Gaussian model.
+        """
+        flux, x_0, y_0, fwhm = self.circular_params
+        circular = CircularGaussianPSF.fit_deriv(self.xx, self.yy, flux,
+                                                 x_0, y_0, fwhm)
+        elliptical = GaussianPSF.fit_deriv(self.xx, self.yy, flux, x_0, y_0,
+                                           fwhm, fwhm, 0.0)
+        assert_allclose(circular[3], elliptical[3] + elliptical[4])
+
+    def test_circular_fit_free_fwhm(self):
+        """
+        Test fitting a circular Gaussian with a free FWHM using the
+        analytic derivatives.
+        """
+        model = CircularGaussianPSF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=6.1)
+        yy, xx = np.mgrid[0:51, 0:51]
+        data = model(xx, yy)
+
+        model_init = CircularGaussianPSF(flux=50.0, x_0=23.0, y_0=27.0,
+                                         fwhm=8.0)
+        model_init.fwhm.fixed = False
+        fitter = TRFLSQFitter()
+        fit_model = fitter(model_init, xx, yy, data)
+        assert_allclose(fit_model.flux.value, model.flux.value, rtol=1e-6)
+        assert_allclose(fit_model.fwhm.value, model.fwhm.value, rtol=1e-6)
+
+
 def test_gaussian_prf_sums():
     """
     Test that subpixel accuracy of Gaussian PRFs by checking the sum of

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -619,7 +619,7 @@ class TestGriddedPSFModel:
         psfmodel.plot_grid(deltas=True)
         psfmodel.plot_grid(deltas=True, peak_norm=True)
 
-        # simulate a grid where one or more ePSFS are blank (all zeros)
+        # Simulate a grid where one or more ePSFS are blank (all zeros)
         model = psfmodel.deepcopy()
         model.data[0] = 0.0
         model.plot_grid(deltas=True)
@@ -725,7 +725,7 @@ class TestSTDPSFGridFromASDF:
         meta = self.make_meta(grid_xypos=grid_xypos, grid_shape=(4, 2))
         psfgrid = STDPSFGrid._from_asdf(np.ones((8, 4, 4)), meta)
 
-        assert psfgrid._grid_shape == (4, 2)
+        assert psfgrid.grid_shape == (4, 2)
         assert_equal(psfgrid._xgrid, [0, 1])
         assert_equal(psfgrid._ygrid, [0, 5, 5, 9])
         assert 'Grid shape: (4, 2)' in repr(psfgrid)

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -8,6 +8,7 @@ from itertools import product
 
 import numpy as np
 import pytest
+from astropy.io import fits
 from astropy.modeling.models import Gaussian2D
 from astropy.nddata import NDData
 from astropy.table import QTable
@@ -29,6 +30,67 @@ WEBBPSF_FILENAMES = ('nircam_nrca1_f200w_fovp101_samp4_npsf16_mock.fits',
                      'nircam_nrca1_f200w_fovp101_samp4_npsf4_mock.fits',
                      'nircam_nrca5_f444w_fovp101_samp4_npsf4_mock.fits',
                      'nircam_nrcb4_f150w_fovp101_samp4_npsf1_mock.fits')
+
+
+def encode_position(x, y):
+    """
+    Encode an ``(x, y)`` grid position as a single unique value.
+
+    This is used to fill each plane of a mock ePSF grid so that the
+    grid position a plane was read back at can be verified.
+
+    Parameters
+    ----------
+    x, y : float
+        The grid position.
+
+    Returns
+    -------
+    result : float
+        The encoded position.
+    """
+    return float(x) + 10000.0 * float(y)
+
+
+def make_webbpsf_file(filename, xgrid, ygrid, psf_shape=(8, 8),
+                      oversampling=4):
+    """
+    Write a mock WebbPSF gridded-ePSF FITS file.
+
+    WebbPSF orders the ePSF planes with the y position varying fastest
+    and records each position as a ``"(y, x)"`` string in the
+    ``DET_YX{i}`` header keywords. Each plane is filled with its
+    `encode_position` value.
+
+    Parameters
+    ----------
+    filename : str
+        The output filename.
+
+    xgrid, ygrid : array_like
+        The x and y detector grid positions.
+
+    psf_shape : tuple of int, optional
+        The ``(ny, nx)`` shape of each ePSF image.
+
+    oversampling : int, optional
+        The oversampling factor written to the ``OVERSAMP`` keyword.
+    """
+    header = fits.Header()
+    header['OVERSAMP'] = oversampling
+    header['INSTRUME'] = 'NIRCam'
+    header['DETECTOR'] = 'NRCA1'
+    header['FILTER'] = 'F200W'
+
+    planes = []
+    for index, (x, y) in enumerate(product(xgrid, ygrid)):
+        planes.append(np.full(psf_shape, encode_position(x, y)))
+        header[f'DET_YX{index}'] = (
+            f'({float(y)}, {float(x)})',
+            f"The #{index} PSF's (y,x) detector pixel position")
+
+    hdu = fits.PrimaryHDU(np.array(planes), header=header)
+    hdu.writeto(filename, overwrite=True)
 
 
 def _reference_find_bounding_points(model, x, y):
@@ -527,6 +589,28 @@ class TestGriddedPSFModel:
         filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
         psfmodel = GriddedPSFModel.read(filename)
         assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
+
+    def test_read_webbpsf_asymmetric_grid(self, tmp_path):
+        """
+        Test that each ePSF plane of a WebbPSF file is placed at the
+        detector position given by its DET_YX header keyword.
+
+        The grid is deliberately non-square so that an x/y transpose
+        cannot go unnoticed.
+        """
+        xgrid = (0.0, 1000.0, 2047.0)
+        ygrid = (0.0, 500.0, 1000.0, 1500.0, 2047.0)
+        filename = str(tmp_path / 'webbpsf_asymmetric_mock.fits')
+        make_webbpsf_file(filename, xgrid, ygrid)
+
+        psfmodel = GriddedPSFModel.read(filename, format='webbpsf')
+        assert_equal(np.unique(psfmodel.grid_xypos[:, 0]), xgrid)
+        assert_equal(np.unique(psfmodel.grid_xypos[:, 1]), ygrid)
+        assert psfmodel.meta['grid_shape'] == (len(ygrid), len(xgrid))
+
+        for (x, y), plane in zip(psfmodel.grid_xypos, psfmodel.data,
+                                 strict=True):
+            assert_allclose(plane, encode_position(x, y))
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_plot(self, psfmodel):

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -289,6 +289,14 @@ class TestGriddedPSFModel:
         edge = psfmodel._calc_bilinear_weights(0.0, 60.0, grid_xy)
         assert_allclose(clamped, edge)
 
+    def test_origin(self, psfmodel):
+        """
+        Test that the origin is set to the center of the ePSF images.
+        """
+        ny, nx = psfmodel.data.shape[1:]
+        assert psfmodel.origin.shape == (2,)
+        assert_allclose(psfmodel.origin, ((nx - 1) / 2, (ny - 1) / 2))
+
     def test_evaluate_matches_reference_algorithm(self, psfmodel):
         """
         The optimized evaluation must produce the same result as the

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -8,7 +8,6 @@ from itertools import product
 
 import numpy as np
 import pytest
-from astropy.io import fits
 from astropy.modeling.models import Gaussian2D
 from astropy.nddata import NDData
 from astropy.table import QTable
@@ -25,72 +24,6 @@ STDPSF_FILENAMES = ('STDPSF_NRCA1_F150W_mock.fits',
                     'STDPSF_NRCSW_F150W_mock.fits',
                     'STDPSF_WFC3UV_F814W_mock.fits',
                     'STDPSF_WFPC2_F814W_mock.fits')
-
-WEBBPSF_FILENAMES = ('nircam_nrca1_f200w_fovp101_samp4_npsf16_mock.fits',
-                     'nircam_nrca1_f200w_fovp101_samp4_npsf4_mock.fits',
-                     'nircam_nrca5_f444w_fovp101_samp4_npsf4_mock.fits',
-                     'nircam_nrcb4_f150w_fovp101_samp4_npsf1_mock.fits')
-
-
-def encode_position(x, y):
-    """
-    Encode an ``(x, y)`` grid position as a single unique value.
-
-    This is used to fill each plane of a mock ePSF grid so that the
-    grid position a plane was read back at can be verified.
-
-    Parameters
-    ----------
-    x, y : float
-        The grid position.
-
-    Returns
-    -------
-    result : float
-        The encoded position.
-    """
-    return float(x) + 10000.0 * float(y)
-
-
-def make_webbpsf_file(filename, xgrid, ygrid, psf_shape=(8, 8),
-                      oversampling=4):
-    """
-    Write a mock WebbPSF gridded-ePSF FITS file.
-
-    WebbPSF orders the ePSF planes with the y position varying fastest
-    and records each position as a ``"(y, x)"`` string in the
-    ``DET_YX{i}`` header keywords. Each plane is filled with its
-    `encode_position` value.
-
-    Parameters
-    ----------
-    filename : str
-        The output filename.
-
-    xgrid, ygrid : array_like
-        The x and y detector grid positions.
-
-    psf_shape : tuple of int, optional
-        The ``(ny, nx)`` shape of each ePSF image.
-
-    oversampling : int, optional
-        The oversampling factor written to the ``OVERSAMP`` keyword.
-    """
-    header = fits.Header()
-    header['OVERSAMP'] = oversampling
-    header['INSTRUME'] = 'NIRCam'
-    header['DETECTOR'] = 'NRCA1'
-    header['FILTER'] = 'F200W'
-
-    planes = []
-    for index, (x, y) in enumerate(product(xgrid, ygrid)):
-        planes.append(np.full(psf_shape, encode_position(x, y)))
-        header[f'DET_YX{index}'] = (
-            f'({float(y)}, {float(x)})',
-            f"The #{index} PSF's (y,x) detector pixel position")
-
-    hdu = fits.PrimaryHDU(np.array(planes), header=header)
-    hdu.writeto(filename, overwrite=True)
 
 
 def _reference_find_bounding_points(model, x, y):
@@ -436,6 +369,13 @@ class TestGriddedPSFModel:
         with pytest.raises(ValueError, match=match):
             GriddedPSFModel(nddata)
 
+        # An empty grid cannot form a rectangular grid
+        meta = {'grid_xypos': [], 'oversampling': 4}
+        nddata = NDData(np.ones((0, 5, 5)), meta=meta)
+        match = 'grid_xypos must form a rectangular grid'
+        with pytest.raises(ValueError, match=match):
+            GriddedPSFModel(nddata)
+
         # Check that oversampling is in meta
         meta = {'grid_xypos': [[0, 0], [0, 1], [1, 0], [1, 1]]}
         nddata = NDData(data, meta=meta)
@@ -506,6 +446,23 @@ class TestGriddedPSFModel:
         for param in psfmodel.param_names:
             assert param in model_str
 
+    def test_str_metadata(self, psfmodel):
+        """
+        Test that the instrument metadata is included in the string
+        representation when present.
+        """
+        model = psfmodel.deepcopy()
+        model.meta['STDPSF'] = 'STDPSF_NRCA1_F150W.fits'
+        model.meta['instrument'] = 'JWST/NIRCam'
+        model.meta['detector'] = 'A1'
+        model.meta['filter'] = 'F150W'
+
+        model_str = str(model)
+        assert 'STDPSF: STDPSF_NRCA1_F150W.fits' in model_str
+        assert 'Instrument: JWST/NIRCam' in model_str
+        assert 'Detector: A1' in model_str
+        assert 'Filter: F150W' in model_str
+
     def test_gridded_psf_oversampling(self, psfmodel):
         nddata = NDData(psfmodel.data, meta=psfmodel.meta)
         nddata.meta['oversampling'] = [4, 4]
@@ -528,7 +485,7 @@ class TestGriddedPSFModel:
         assert model.meta['oversampling'] == (5, 5)
 
     def test_bounding_box(self, psfmodel):
-        # oversampling is 4
+        # Oversampling is 4
         bbox = psfmodel.bounding_box.bounding_box()
         assert_equal(bbox, ((-12.625, 12.625), (-12.625, 12.625)))
 
@@ -536,81 +493,6 @@ class TestGriddedPSFModel:
         model.oversampling = 1
         bbox = model.bounding_box.bounding_box()
         assert_equal(bbox, ((-50.5, 50.5), (-50.5, 50.5)))
-
-    def test_read_stdpsf(self):
-        """
-        Test STDPSF read for a single detector.
-        """
-        filename = 'STDPSF_NRCA1_F150W_mock.fits'
-        filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
-        psfmodel = GriddedPSFModel.read(filename)
-        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
-        assert isinstance(psfmodel.meta['grid_xypos'], np.ndarray)
-        assert_equal(psfmodel.oversampling, [4, 4])
-        assert_equal(psfmodel.meta['oversampling'], psfmodel.oversampling)
-
-    @pytest.mark.parametrize('filename', STDPSF_FILENAMES[1:])
-    @pytest.mark.parametrize('detector_id', [1, 2])
-    def test_read_stdpsf_multi_detector(self, filename, detector_id):
-        """
-        Test STDPSF read for multiple detectors.
-        """
-        filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
-        psfmodel = GriddedPSFModel.read(filename, detector_id=detector_id,
-                                        format='stdpsf')
-        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
-        assert_equal(psfmodel.oversampling, [4, 4])
-        assert_equal(psfmodel.meta['oversampling'], psfmodel.oversampling)
-
-        # Test format auto-detect
-        filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
-        psfmodel = GriddedPSFModel.read(filename, detector_id=detector_id)
-        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
-
-        match = 'detector_id must be specified'
-        with pytest.raises(ValueError, match=match):
-            GriddedPSFModel.read(filename, detector_id=None)
-
-        match = 'detector_id must be '
-        with pytest.raises(ValueError, match=match):
-            GriddedPSFModel.read(filename, detector_id=-1)
-
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    @pytest.mark.parametrize('filename', WEBBPSF_FILENAMES)
-    def test_read_webbpsf(self, filename):
-        filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
-        psfmodel = GriddedPSFModel.read(filename, format='webbpsf')
-        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
-        assert_equal(psfmodel.oversampling, [4, 4])
-        assert_equal(psfmodel.meta['oversampling'], psfmodel.oversampling)
-        psfmodel.plot_grid()
-
-        # Test format auto-detect
-        filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)
-        psfmodel = GriddedPSFModel.read(filename)
-        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
-
-    def test_read_webbpsf_asymmetric_grid(self, tmp_path):
-        """
-        Test that each ePSF plane of a WebbPSF file is placed at the
-        detector position given by its DET_YX header keyword.
-
-        The grid is deliberately non-square so that an x/y transpose
-        cannot go unnoticed.
-        """
-        xgrid = (0.0, 1000.0, 2047.0)
-        ygrid = (0.0, 500.0, 1000.0, 1500.0, 2047.0)
-        filename = str(tmp_path / 'webbpsf_asymmetric_mock.fits')
-        make_webbpsf_file(filename, xgrid, ygrid)
-
-        psfmodel = GriddedPSFModel.read(filename, format='webbpsf')
-        assert_equal(np.unique(psfmodel.grid_xypos[:, 0]), xgrid)
-        assert_equal(np.unique(psfmodel.grid_xypos[:, 1]), ygrid)
-        assert psfmodel.meta['grid_shape'] == (len(ygrid), len(xgrid))
-
-        for (x, y), plane in zip(psfmodel.grid_xypos, psfmodel.data,
-                                 strict=True):
-            assert_allclose(plane, encode_position(x, y))
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_plot(self, psfmodel):
@@ -636,8 +518,7 @@ def test_stdpsfgrid(filename):
     assert_equal(psfgrid.oversampling, [4, 4])
     assert psfgrid.data.shape[0] == len(psfgrid.grid_xypos)
     assert isinstance(psfgrid.grid_xypos, np.ndarray)
-
-    psfgrid.plot_grid()
+    assert psfgrid.grid_shape == (len(psfgrid._ygrid), len(psfgrid._xgrid))
 
 
 def test_stdpsfgrid_repr_str():

--- a/photutils/psf/tests/test_groupers.py
+++ b/photutils/psf/tests/test_groupers.py
@@ -23,6 +23,16 @@ class TestSourceGrouper:
         grouper = SourceGrouper(min_separation=10.0)
         assert grouper.min_separation == 10.0
 
+    @pytest.mark.parametrize('min_separation', [0, -1, -10.0, np.nan, np.inf])
+    def test_invalid_min_separation(self, min_separation):
+        """
+        Test that a non-positive or non-finite min_separation raises
+        ValueError.
+        """
+        match = 'min_separation must be a positive finite value'
+        with pytest.raises(ValueError, match=match):
+            SourceGrouper(min_separation=min_separation)
+
     def test_repr(self):
         """
         Test string representation.

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -143,6 +143,54 @@ class TestImagePSF:
             with pytest.raises(ValueError, match=match):
                 ImagePSF(data, oversampling=oversampling)
 
+    def test_data_setter(self):
+        yy, xx = np.mgrid[0:25, 0:25]
+        data1 = CircularGaussianPSF(x_0=12, y_0=12, fwhm=3.0)(xx, yy)
+        data2 = CircularGaussianPSF(x_0=12, y_0=12, fwhm=8.0)(xx, yy)
+
+        model = ImagePSF(data1, x_0=12, y_0=12)
+        assert_allclose(model(12.0, 12.0), data1[12, 12])
+
+        # The cached interpolator must be discarded when data is set
+        model.data = data2
+        assert_allclose(model(12.0, 12.0), data2[12, 12])
+
+    def test_data_setter_validation(self):
+        model = ImagePSF(np.ones((10, 10)))
+
+        match = 'Input data must be a 2D numpy array'
+        with pytest.raises(TypeError, match=match):
+            model.data = 42
+        with pytest.raises(ValueError, match=match):
+            model.data = np.ones(10)
+
+        match = 'The length of the x and y axes must both be at least 4'
+        with pytest.raises(ValueError, match=match):
+            model.data = np.ones((3, 4))
+
+    def test_data_setter_copy_independence(self, gaussian_psf):
+        yy, xx = np.mgrid[0:25, 0:25]
+        data1 = gaussian_psf(xx, yy)
+        data2 = CircularGaussianPSF(x_0=12, y_0=12, fwhm=8.0)(xx, yy)
+
+        model = ImagePSF(data1, x_0=12, y_0=12)
+        value = model(12.0, 12.0)  # populate the interpolator cache
+
+        model_copy = model.copy()
+        model_copy.data = data2
+        assert_allclose(model(12.0, 12.0), value)
+        assert_allclose(model_copy(12.0, 12.0), data2[12, 12])
+
+    def test_oversampling_setter(self):
+        model = ImagePSF(np.ones((10, 10)))
+        model.oversampling = 4
+        assert_equal(model.oversampling, (4, 4))
+
+        match = 'oversampling must be > 0'
+        with pytest.raises(ValueError, match=match):
+            model.oversampling = -3
+        assert_equal(model.oversampling, (4, 4))
+
     def test_origin_inputs(self):
         match = 'origin must be 1D and have 2-elements'
         with pytest.raises(ValueError, match=match):

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -33,7 +33,7 @@ class TestImagePSF:
 
         assert_allclose(model(xx, yy), gaussian_psf(xx, yy), atol=1e-6)
 
-        # subpixel should not match, but be reasonably close
+        # Subpixel should not match, but be reasonably close
         for x, y in [(0.5, 0.5), (-0.5, 1.75)]:
             assert_allclose(model(x, y), gaussian_psf(x, y), atol=4e-3)
 
@@ -58,7 +58,7 @@ class TestImagePSF:
             assert_allclose(model(x, y), gaussian_psf(x + x_0, y + y_0),
                             atol=3.0e-6)
 
-        # without oversampling the same tests should fail except for at
+        # Without oversampling the same tests should fail except for at
         # the origin
         model = ImagePSF(psf_data)
         assert_allclose(model(0, 0), gaussian_psf(0, 0))
@@ -142,6 +142,10 @@ class TestImagePSF:
         for oversampling in [np.nan, (1, np.inf)]:
             with pytest.raises(ValueError, match=match):
                 ImagePSF(data, oversampling=oversampling)
+
+    def test_shape(self, image_psf):
+        assert image_psf.shape == image_psf.data.shape
+        assert image_psf.shape == (21, 21)
 
     def test_data_setter(self):
         yy, xx = np.mgrid[0:25, 0:25]

--- a/photutils/psf/tests/test_model_io.py
+++ b/photutils/psf/tests/test_model_io.py
@@ -1,0 +1,369 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the model_io module.
+"""
+
+import io
+import os.path as op
+from itertools import product
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from numpy.testing import assert_allclose, assert_equal
+
+from photutils.psf import GriddedPSFModel
+from photutils.psf.model_io import (_get_metadata, _has_fits_header_keys,
+                                    _read_stdpsf, is_stdpsf, is_webbpsf)
+
+# The first file has a single detector, the rest have multiple detectors
+STDPSF_FILENAMES = ('STDPSF_NRCA1_F150W_mock.fits',
+                    'STDPSF_ACSWFC_F814W_mock.fits',
+                    'STDPSF_NRCSW_F150W_mock.fits',
+                    'STDPSF_WFC3UV_F814W_mock.fits',
+                    'STDPSF_WFPC2_F814W_mock.fits')
+
+WEBBPSF_FILENAMES = ('nircam_nrca1_f200w_fovp101_samp4_npsf16_mock.fits',
+                     'nircam_nrca1_f200w_fovp101_samp4_npsf4_mock.fits',
+                     'nircam_nrca5_f444w_fovp101_samp4_npsf4_mock.fits',
+                     'nircam_nrcb4_f150w_fovp101_samp4_npsf1_mock.fits')
+
+
+def get_data_filename(filename):
+    """
+    Get the full path of a test data file.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file in the test data directory.
+
+    Returns
+    -------
+    result : str
+        The full path of the test data file.
+    """
+    return op.join(op.dirname(op.abspath(__file__)), 'data', filename)
+
+
+def encode_position(x, y):
+    """
+    Encode an ``(x, y)`` grid position as a single unique value.
+
+    This is used to fill each plane of a mock ePSF grid so that the
+    grid position a plane was read back at can be verified.
+
+    Parameters
+    ----------
+    x, y : float
+        The grid position.
+
+    Returns
+    -------
+    result : float
+        The encoded position.
+    """
+    return float(x) + 10000.0 * float(y)
+
+
+def make_webbpsf_file(filename, xgrid, ygrid, psf_shape=(8, 8),
+                      oversampling=4, keys_to_remove=()):
+    """
+    Write a mock WebbPSF gridded-ePSF FITS file.
+
+    WebbPSF orders the ePSF planes with the y position varying fastest
+    and records each position as a ``"(y, x)"`` string in the
+    ``DET_YX{i}`` header keywords. Each plane is filled with its
+    `encode_position` value.
+
+    Parameters
+    ----------
+    filename : str
+        The output filename.
+
+    xgrid, ygrid : array_like
+        The x and y detector grid positions.
+
+    psf_shape : tuple of int, optional
+        The ``(ny, nx)`` shape of each ePSF image.
+
+    oversampling : int, optional
+        The oversampling factor written to the ``OVERSAMP`` keyword.
+
+    keys_to_remove : tuple of str, optional
+        FITS header keywords to omit from the output file. This is used
+        to create invalid files.
+    """
+    header = fits.Header()
+    header['OVERSAMP'] = oversampling
+    header['INSTRUME'] = 'NIRCam'
+    header['DETECTOR'] = 'NRCA1'
+    header['FILTER'] = 'F200W'
+
+    planes = []
+    for index, (x, y) in enumerate(product(xgrid, ygrid)):
+        planes.append(np.full(psf_shape, encode_position(x, y)))
+        header[f'DET_YX{index}'] = (
+            f'({float(y)}, {float(x)})',
+            f"The #{index} PSF's (y,x) detector pixel position")
+
+    for key in keys_to_remove:
+        del header[key]
+
+    hdu = fits.PrimaryHDU(np.array(planes), header=header)
+    hdu.writeto(filename, overwrite=True)
+
+
+class TestSTDPSFReader:
+    """
+    Tests for reading STDPSF FITS files.
+    """
+
+    def test_read_stdpsf(self):
+        """
+        Test STDPSF read for a single detector.
+        """
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        psfmodel = GriddedPSFModel.read(filename)
+        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
+        assert isinstance(psfmodel.meta['grid_xypos'], np.ndarray)
+        assert_equal(psfmodel.oversampling, [4, 4])
+        assert_equal(psfmodel.meta['oversampling'], psfmodel.oversampling)
+
+    @pytest.mark.parametrize('filename', STDPSF_FILENAMES[1:])
+    @pytest.mark.parametrize('detector_id', [1, 2])
+    def test_read_stdpsf_multi_detector(self, filename, detector_id):
+        """
+        Test STDPSF read for multiple detectors.
+        """
+        filename = get_data_filename(filename)
+        psfmodel = GriddedPSFModel.read(filename, detector_id=detector_id,
+                                        format='stdpsf')
+        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
+        assert_equal(psfmodel.oversampling, [4, 4])
+        assert_equal(psfmodel.meta['oversampling'], psfmodel.oversampling)
+
+        # Test format auto-detect
+        psfmodel = GriddedPSFModel.read(filename, detector_id=detector_id)
+        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
+
+        match = 'detector_id must be specified'
+        with pytest.raises(ValueError, match=match):
+            GriddedPSFModel.read(filename, detector_id=None)
+
+        match = 'detector_id must be '
+        with pytest.raises(ValueError, match=match):
+            GriddedPSFModel.read(filename, detector_id=-1)
+
+    def test_read_stdpsf_hdulist(self):
+        """
+        Test that an open HDUList is accepted.
+        """
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        with fits.open(filename) as hdulist:
+            grid_data = _read_stdpsf(hdulist)
+        assert grid_data['data'].shape[0] == grid_data['n_psfs']
+
+    def test_read_stdpsf_fileobj(self):
+        """
+        Test that an open file object is accepted.
+        """
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        with io.FileIO(filename) as fileobj:
+            grid_data = _read_stdpsf(fileobj)
+        assert grid_data['data'].shape[0] == grid_data['n_psfs']
+
+    def test_read_stdpsf_not_fits(self):
+        match = 'This interface supports only FITS files'
+        with pytest.raises(TypeError, match=match):
+            _read_stdpsf('filename.txt')
+        with pytest.raises(TypeError, match=match):
+            _read_stdpsf(42)
+
+    def test_read_stdpsf_missing_keys(self, tmp_path):
+        filename = str(tmp_path / 'bad_stdpsf.fits')
+        fits.PrimaryHDU(np.ones((4, 5, 5))).writeto(filename)
+
+        match = 'Invalid STDPSF FITS file'
+        with pytest.raises(ValueError, match=match):
+            _read_stdpsf(filename)
+
+    def test_read_stdpsf_unknown_grid_keys(self, tmp_path):
+        header = fits.Header()
+        header['NXPSFS'] = 2
+        header['NYPSFS'] = 2
+        filename = str(tmp_path / 'unknown_stdpsf.fits')
+        fits.PrimaryHDU(np.ones((4, 5, 5)), header=header).writeto(filename)
+
+        match = 'Unknown STDPSF FITS file'
+        with pytest.raises(ValueError, match=match):
+            _read_stdpsf(filename)
+
+
+class TestWebbPSFReader:
+    """
+    Tests for reading WebbPSF FITS files.
+    """
+
+    @pytest.mark.parametrize('filename', WEBBPSF_FILENAMES)
+    def test_read_webbpsf(self, filename):
+        filename = get_data_filename(filename)
+        psfmodel = GriddedPSFModel.read(filename, format='webbpsf')
+        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
+        assert_equal(psfmodel.oversampling, [4, 4])
+        assert_equal(psfmodel.meta['oversampling'], psfmodel.oversampling)
+
+        # Test format auto-detect
+        psfmodel = GriddedPSFModel.read(filename)
+        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
+
+    def test_read_webbpsf_asymmetric_grid(self, tmp_path):
+        """
+        Test that each ePSF plane of a WebbPSF file is placed at the
+        detector position given by its DET_YX header keyword.
+
+        The grid is deliberately non-square so that an x/y transpose
+        cannot go unnoticed.
+        """
+        xgrid = (0.0, 1000.0, 2047.0)
+        ygrid = (0.0, 500.0, 1000.0, 1500.0, 2047.0)
+        filename = str(tmp_path / 'webbpsf_asymmetric_mock.fits')
+        make_webbpsf_file(filename, xgrid, ygrid)
+
+        psfmodel = GriddedPSFModel.read(filename, format='webbpsf')
+        assert_equal(np.unique(psfmodel.grid_xypos[:, 0]), xgrid)
+        assert_equal(np.unique(psfmodel.grid_xypos[:, 1]), ygrid)
+        assert psfmodel.meta['grid_shape'] == (len(ygrid), len(xgrid))
+
+        for (x, y), plane in zip(psfmodel.grid_xypos, psfmodel.data,
+                                 strict=True):
+            assert_allclose(plane, encode_position(x, y))
+
+    def test_read_webbpsf_key_order(self, tmp_path):
+        """
+        Test that the DET_YX keywords are ordered by their numeric
+        index and not by their string ordering (e.g., DET_YX10 must
+        follow DET_YX9).
+        """
+        xgrid = (0.0, 1000.0)
+        ygrid = (0.0, 400.0, 800.0, 1200.0, 1600.0, 2047.0)
+        filename = str(tmp_path / 'webbpsf_key_order_mock.fits')
+        make_webbpsf_file(filename, xgrid, ygrid)
+
+        psfmodel = GriddedPSFModel.read(filename, format='webbpsf')
+        assert len(psfmodel.grid_xypos) == 12
+        for (x, y), plane in zip(psfmodel.grid_xypos, psfmodel.data,
+                                 strict=True):
+            assert_allclose(plane, encode_position(x, y))
+
+    def test_read_webbpsf_missing_det_yx(self, tmp_path):
+        filename = str(tmp_path / 'webbpsf_no_det_yx.fits')
+        make_webbpsf_file(filename, (0.0, 10.0), (0.0, 10.0),
+                          keys_to_remove=('DET_YX0', 'DET_YX1', 'DET_YX2',
+                                          'DET_YX3'))
+
+        match = 'missing "DET_YX'
+        with pytest.raises(ValueError, match=match):
+            GriddedPSFModel.read(filename, format='webbpsf')
+
+    def test_read_webbpsf_missing_oversamp(self, tmp_path):
+        filename = str(tmp_path / 'webbpsf_no_oversamp.fits')
+        make_webbpsf_file(filename, (0.0, 10.0), (0.0, 10.0),
+                          keys_to_remove=('OVERSAMP',))
+
+        match = 'missing "OVERSAMP" header key'
+        with pytest.raises(ValueError, match=match):
+            GriddedPSFModel.read(filename, format='webbpsf')
+
+
+class TestGetMetadata:
+    """
+    Tests for parsing metadata from the STDPSF filename.
+    """
+
+    @pytest.mark.parametrize(('filename', 'detector', 'filter_name'),
+                             [('STDPSF_ACSWFC_F814W.fits', 'ACSWFC', 'F814W'),
+                              ('STDPSF_MIRI_F560W.fits.gz', 'MIRI', 'F560W'),
+                              ('STDPSF_NRCA1_F150W_mock.fits', 'NRCA1',
+                               'F150W'),
+                              ('/a/b/STDPSF_WFC3IR_F160W.fits', 'WFC3IR',
+                               'F160W')])
+    def test_filename_fields(self, filename, detector, filter_name):
+        meta = _get_metadata(filename, None)
+        assert meta['STDPSF'] == filename
+        assert meta['detector'] == detector
+        assert meta['filter'] == filter_name
+
+    def test_fileobj(self, tmp_path):
+        path = tmp_path / 'STDPSF_ACSHRC_F606W.fits'
+        path.write_bytes(b'')
+        with io.FileIO(str(path)) as fileobj:
+            meta = _get_metadata(fileobj, None)
+        assert meta['detector'] == 'ACSHRC'
+        assert meta['filter'] == 'F606W'
+
+    @pytest.mark.parametrize('filename', ['abcdef123456', 'a_b', 'a_b_c_d_e'])
+    def test_unparsable_filename(self, filename):
+        # Test a cache filename from astropy download_file
+        assert _get_metadata(filename, None) is None
+
+    @pytest.mark.parametrize(('detector_id', 'detector'),
+                             [(1, 'PC'), (2, 'WF2'), (3, 'WF3'), (4, 'WF4')])
+    def test_wfpc2_detectors(self, detector_id, detector):
+        meta = _get_metadata('STDPSF_WFPC2_F814W.fits', detector_id)
+        assert meta['instrument'] == 'HST/WFPC2'
+        assert meta['detector'] == detector
+
+    @pytest.mark.parametrize(('detector_id', 'detector'),
+                             [(1, 'WFC2'), (2, 'WFC1')])
+    def test_wfc_chips(self, detector_id, detector):
+        meta = _get_metadata('STDPSF_ACSWFC_F814W.fits', detector_id)
+        assert meta['instrument'] == 'HST/ACS'
+        assert meta['detector'] == detector
+
+    def test_nrcsw_detectors(self):
+        detectors = ['A1', 'A2', 'A3', 'A4', 'B1', 'B2', 'B3', 'B4']
+        for detector_id, detector in enumerate(detectors, start=1):
+            meta = _get_metadata('STDPSF_NRCSW_F150W.fits', detector_id)
+            assert meta['instrument'] == 'JWST/NIRCam'
+            assert meta['detector'] == detector
+
+    def test_unknown_detector(self):
+        match = 'Unknown detector BADDET'
+        with pytest.raises(ValueError, match=match):
+            _get_metadata('STDPSF_BADDET_F814W.fits', 1)
+
+    def test_detector_map_not_mutated(self):
+        """
+        Repeated calls must not corrupt the module-level lookup table.
+        """
+        first = _get_metadata('STDPSF_ACSWFC_F814W.fits', 1)['detector']
+        _get_metadata('STDPSF_ACSWFC_F814W.fits', 2)
+        third = _get_metadata('STDPSF_ACSWFC_F814W.fits', 1)['detector']
+        assert first == third == 'WFC2'
+
+
+class TestFormatIdentifiers:
+    """
+    Tests for the unified-I/O format identifier functions.
+    """
+
+    def test_is_stdpsf(self):
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        assert is_stdpsf('read', filename, None)
+        assert not is_webbpsf('read', filename, None)
+
+    def test_is_webbpsf(self):
+        filename = get_data_filename(WEBBPSF_FILENAMES[0])
+        assert is_webbpsf('read', filename, None)
+        assert not is_stdpsf('read', filename, None)
+
+    @pytest.mark.parametrize('filepath', [None, 'filename.txt'])
+    def test_not_a_fits_file(self, filepath):
+        assert not is_stdpsf('read', filepath, None)
+        assert not is_webbpsf('read', filepath, None)
+
+    def test_has_fits_header_keys(self):
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        assert _has_fits_header_keys(filename, ('NAXIS3',))
+        assert not _has_fits_header_keys(filename, ('NAXIS3', 'NOSUCHKEY'))

--- a/photutils/psf/tests/test_model_plotting.py
+++ b/photutils/psf/tests/test_model_plotting.py
@@ -1,0 +1,161 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the model_plotting module.
+"""
+
+from itertools import product
+
+import numpy as np
+import pytest
+from astropy.modeling.models import Gaussian2D
+from astropy.nddata import NDData
+
+from photutils.psf import GriddedPSFModel, STDPSFGrid
+from photutils.psf.tests.test_model_io import (STDPSF_FILENAMES,
+                                               WEBBPSF_FILENAMES,
+                                               get_data_filename)
+from photutils.utils._optional_deps import HAS_MATPLOTLIB
+
+pytestmark = pytest.mark.skipif(not HAS_MATPLOTLIB,
+                                reason='matplotlib is required')
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    """
+    Close all matplotlib figures after each test so that the open
+    figure limit is not exceeded.
+    """
+    yield
+
+    import matplotlib.pyplot as plt
+    plt.close('all')
+
+
+@pytest.fixture(name='psfmodel')
+def fixture_griddedpsf_data():
+    psfs = []
+    yy, xx = np.mgrid[0:101, 0:101]
+    for i in range(16):
+        theta = np.deg2rad(i * 10.0)
+        gmodel = Gaussian2D(1, 50, 50, 10, 5, theta=theta)
+        psfs.append(gmodel(xx, yy))
+
+    xgrid = [0, 40, 160, 200]
+    ygrid = [0, 60, 140, 200]
+    meta = {'grid_xypos': list(product(xgrid, ygrid)),
+            'oversampling': 4}
+
+    return GriddedPSFModel(NDData(psfs, meta=meta))
+
+
+class TestPlotGrid:
+    """
+    Tests for the GriddedPSFModel and STDPSFGrid plot_grid methods.
+    """
+
+    def test_plot_grid(self, psfmodel):
+        psfmodel.plot_grid()
+        psfmodel.plot_grid(peak_norm=True, cmap='Blues', vmax_scale=0.9)
+        psfmodel.plot_grid(deltas=True)
+        psfmodel.plot_grid(deltas=True, peak_norm=True)
+
+    def test_plot_grid_blank_epsfs(self, psfmodel):
+        """
+        Test a grid where one or more ePSFs are blank (all zeros), as
+        is the case for MIRI with its non-square FOV.
+        """
+        model = psfmodel.deepcopy()
+        model._data[0] = 0.0
+        model.plot_grid(deltas=True)
+
+    def test_plot_grid_input_axes(self, psfmodel):
+        """
+        Test that a user-supplied axes is used and that its figure is
+        returned.
+        """
+        import matplotlib.pyplot as plt
+
+        fig_in, ax = plt.subplots()
+        fig_out = psfmodel.plot_grid(ax=ax)
+        assert fig_out is fig_in
+
+    def test_plot_grid_dividers(self, psfmodel):
+        fig = psfmodel.plot_grid(dividers=False)
+        ax = fig.axes[0]
+        assert len(ax.lines) == 0
+
+        fig = psfmodel.plot_grid(dividers=True, divider_color='red',
+                                 divider_ls=':')
+        ax = fig.axes[0]
+        # 3 vertical and 3 horizontal dividers for a 4x4 grid
+        assert len(ax.lines) == 6
+
+    def test_plot_grid_figsize(self, psfmodel):
+        fig = psfmodel.plot_grid(figsize=(6, 5))
+        assert tuple(fig.get_size_inches()) == (6.0, 5.0)
+
+    @pytest.mark.parametrize('filename', WEBBPSF_FILENAMES)
+    def test_plot_grid_webbpsf(self, filename):
+        psfmodel = GriddedPSFModel.read(get_data_filename(filename),
+                                        format='webbpsf')
+        psfmodel.plot_grid()
+
+    @pytest.mark.parametrize('filename', STDPSF_FILENAMES)
+    def test_plot_grid_stdpsfgrid(self, filename):
+        psfgrid = STDPSFGrid(get_data_filename(filename))
+        psfgrid.plot_grid()
+
+    def test_plot_grid_tuple_metadata(self, psfmodel):
+        """
+        Test that tuple-valued metadata is unwrapped for the plot title.
+
+        WebbPSF stores each header value as a ``(value, comment)``
+        tuple.
+        """
+        model = psfmodel.deepcopy()
+        model.meta['instrument'] = ('NIRCam', 'instrument name')
+        model.meta['detector'] = ['NRCA1', 'detector name']
+        model.meta['filter'] = np.array(['F200W', 'filter name'])
+
+        fig = model.plot_grid()
+        assert fig.axes[0].get_title() == 'NIRCam NRCA1 F200W ePSFs'
+
+    def test_plot_grid_instrume_metadata(self, psfmodel):
+        """
+        Test the WebbPSF 'instrume' metadata key fallback.
+        """
+        model = psfmodel.deepcopy()
+        model.meta['instrume'] = 'NIRCam'
+
+        fig = model.plot_grid()
+        assert fig.axes[0].get_title().startswith('NIRCam')
+
+    def test_plot_grid_no_metadata(self, psfmodel):
+        """
+        Test that no leading space is added when there is no
+        instrument, detector, or filter metadata.
+        """
+        fig = psfmodel.plot_grid()
+        assert fig.axes[0].get_title() == 'ePSFs'
+
+    def test_plot_grid_nrcsw(self):
+        """
+        Test the NIRCam NRCSW special case, which adds detector labels
+        and extra divider lines.
+        """
+        psfgrid = STDPSFGrid(get_data_filename('STDPSF_NRCSW_F150W_mock.fits'))
+        assert psfgrid.meta['detector'] == 'NRCSW'
+
+        fig = psfgrid.plot_grid()
+        texts = [text.get_text() for text in fig.axes[0].texts]
+        assert set(texts) == {'A1', 'A2', 'A3', 'A4',
+                              'B1', 'B2', 'B3', 'B4'}
+        assert tuple(fig.get_size_inches()) == (20.0, 8.0)
+
+    @pytest.mark.parametrize('deltas', [False, True])
+    def test_plot_grid_colorbar_label(self, psfmodel, deltas):
+        for peak_norm in (False, True):
+            fig = psfmodel.plot_grid(deltas=deltas, peak_norm=peak_norm)
+            # The colorbar is the second axes
+            assert fig.axes[1].get_ylabel() != ''


### PR DESCRIPTION
This PR does the following:

- Adds a ``STDPSFGrid.grid_shape`` property returning the ``(ny, nx)``
  shape of the ePSF grid.

- Fixes the ``CircularGaussianPSF.fit_deriv`` partial derivative with
  respect to ``fwhm``. This affected only fits in which the ``fwhm``
  parameter was unfixed.

- Fixes ``ImagePSF`` to discard its cached interpolator when the
  ``data`` attribute is set. Previously, assigning a new image to an
  existing model silently continued to evaluate the old image. The
  ``data`` and ``oversampling`` attributes are now also validated
  when set, not only when the model is created.

- Fixes the ``GriddedPSFModel.origin`` attribute, which returned a
  three-element array instead of the documented ``(x, y)`` pair.

- Fixes the ``filter`` metadata parsed from the filename when reading
  a gzipped STDPSF file (e.g., ``.fits.gz``). The file extension was
  not removed, so the filter name included the extension.

- Fixes ``webbpsf_reader`` to swap the ``DET_YX{i}`` FITS header
  values when defining ``grid_xypos``. The reference ePSFs were
  previous swapped to the wrong detector positions for any grid whose
  x and y positions differ.
  
  Assisted by AI review