### PR TITLE
Align aperture photometry and statistics APIs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,20 @@ Bug Fixes
     not input. Previously, an all-NaN error array was returned only
     for sources with no overlap with the data. [#2316]
 
+  - Fixed the elliptical and rectangular apertures (and their annulus
+    and sky variants) so that reassigning ``theta`` after construction
+    updates the aperture geometry. Previously, the rotation angle was
+    computed only once, so the bounding box, aperture mask, and
+    photometry silently continued to use the original angle. [#2348]
+
+  - Fixed ``BoundingBox`` so that it can be used in a `set` or as a
+    `dict` key. Defining ``__eq__`` without ``__hash__`` had left the
+    class unhashable. [#2348]
+
+  - Fixed ``PixelAperture.area_overlap`` so that it no longer modifies
+    the data of the aperture mask it creates when a ``mask`` is input.
+    [#2348]
+
 - ``photutils.detection``
 
   - Fixed ``DAOStarFinder`` and ``IRAFStarFinder`` ``orientation``
@@ -253,6 +267,24 @@ API Changes
   - The ``ApertureStats.ids`` attribute is now deprecated and will
     be removed in version 4.0. Use the ``ApertureStats.id`` attribute
     instead. [#2331]
+
+  - ``AperturePhotometry`` and ``ApertureStats`` now validate the
+    ``method``/``sum_method`` and ``subpixels`` keywords when the
+    object is created instead of when a measured attribute is first
+    accessed. [#2348]
+
+  - ``ApertureStats`` now stores the ``segmentation_image``,
+    ``labels``, and ``mask_method`` inputs as public attributes,
+    matching ``AperturePhotometry``. [#2348]
+
+  - The ``'aperture_photometry_args'`` metadata in the
+    ``AperturePhotometry.to_table()`` output now also records the
+    ``mask_method`` keyword. [#2348]
+
+  - ``BoundingBox.__eq__`` now returns `NotImplemented` instead of
+    raising a ``TypeError`` when the other object is not a
+    ``BoundingBox``, so that comparing a ``BoundingBox`` to another
+    type returns `False` rather than raising. [#2348]
 
 - ``photutils.detection``
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -501,7 +501,6 @@ y)``, which transposed the ePSF grid. Grids whose x and y fiducial
 positions are identical (such as the square NIRCam short-wavelength
 grids) are unaffected.
 
-
 ``StarFinderCatalogBase`` Representation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/photutils/aperture/_common.py
+++ b/photutils/aperture/_common.py
@@ -147,6 +147,43 @@ def collapse_scalar_value(value):
     return value
 
 
+def validate_mask_method(method, subpixels, *, method_name='mask method'):
+    """
+    Validate the aperture-mask method and subpixels keywords.
+
+    Parameters
+    ----------
+    method : {'exact', 'center', 'subpixel'}
+        The aperture-mask method.
+
+    subpixels : int
+        The subsampling factor per axis used when
+        ``method='subpixel'``. It is not validated for the other
+        methods, which ignore it.
+
+    method_name : str, optional
+        The name of the method keyword, used in the error message.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is not one of ``'exact'``, ``'center'``, or
+        ``'subpixel'``, or if ``subpixels`` is not a strictly positive
+        integer when ``method='subpixel'``.
+    """
+    if method not in ('center', 'subpixel', 'exact'):
+        msg = f'Invalid {method_name}: {method!r}'
+        raise ValueError(msg)
+
+    # bool is a subclass of int, so it is rejected explicitly to
+    # prevent subpixels=True from being silently used as 1
+    if ((method == 'subpixel')
+            and (isinstance(subpixels, bool)
+                 or not isinstance(subpixels, int) or subpixels <= 0)):
+        msg = 'subpixels must be a strictly positive integer'
+        raise ValueError(msg)
+
+
 def batch_array_supported(array):
     """
     Whether an array has a dtype supported by the batch Cython drivers.

--- a/photutils/aperture/_common.py
+++ b/photutils/aperture/_common.py
@@ -1,0 +1,278 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Helpers shared by the aperture photometry and statistics classes.
+
+The `~photutils.aperture.AperturePhotometry` and
+`~photutils.aperture.ApertureStats` classes accept the same ``data``,
+``error``, ``mask``, and ``wcs`` inputs and present their per-source
+results with the same scalar-collapse convention. Both also feed the
+same batch Cython drivers. The shared logic lives here so that the two
+code paths cannot silently diverge.
+"""
+
+import warnings
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.nddata import StdDevUncertainty
+from astropy.utils.exceptions import AstropyUserWarning
+
+from photutils.aperture._segmentation import SEG_METHOD_CODES
+
+__all__ = []
+
+
+# Types of the public per-source attributes that are collapsed to a
+# scalar for a scalar instance (see ``collapse_scalar_value``).
+SCALAR_COLLAPSE_TYPES = (np.ndarray, SkyCoord, list, tuple)
+
+
+def unpack_nddata(data, error, mask, wcs):
+    """
+    Extract the data, error, mask, and WCS from a
+    `~astropy.nddata.NDData` object.
+
+    A warning is emitted for each of the ``error``, ``mask``, and
+    ``wcs`` keywords that was also input directly, because the
+    `~astropy.nddata.NDData` attributes take precedence.
+
+    Parameters
+    ----------
+    data : `~astropy.nddata.NDData`
+        The NDData object.
+
+    error, mask, wcs : object
+        The values input directly by the user. These are ignored and
+        are used only to emit the warnings.
+
+    Returns
+    -------
+    data : `~numpy.ndarray` or `~astropy.units.Quantity`
+        The NDData data array, as a Quantity if it has units.
+
+    error : `~numpy.ndarray`, `~astropy.units.Quantity`, or `None`
+        The standard-deviation uncertainty array, or `None` if the
+        NDData uncertainty is not a
+        `~astropy.nddata.StdDevUncertainty`.
+
+    mask : `~numpy.ndarray` or `None`
+        The NDData mask.
+
+    wcs : WCS object or `None`
+        The NDData WCS.
+    """
+    nddata_attr = {'error': error, 'mask': mask, 'wcs': wcs}
+    for key, value in nddata_attr.items():
+        if value is not None:
+            msg = (f'The {key!r} keyword is ignored. Its value '
+                   'is obtained from the input NDData object.')
+            warnings.warn(msg, AstropyUserWarning)
+
+    mask = data.mask
+    wcs = data.wcs
+
+    error = None
+    if isinstance(data.uncertainty, StdDevUncertainty):
+        if data.uncertainty.unit is None:
+            error = data.uncertainty.array
+        else:
+            error = data.uncertainty.array * data.uncertainty.unit
+
+    if data.unit is not None:
+        data = u.Quantity(data.data, unit=data.unit)
+    else:
+        data = data.data
+
+    return data, error, mask, wcs
+
+
+def validate_array(array, name, *, ndim=2, shape=None):
+    """
+    Validate the dimensionality and shape of an input array.
+
+    Parameters
+    ----------
+    array : array_like or `None`
+        The array to validate. `None` (and, for a mask,
+        `numpy.ma.nomask`) is returned unchanged.
+
+    name : str
+        The name of the array, used in the error messages.
+
+    ndim : int, optional
+        The required number of dimensions.
+
+    shape : tuple of int or `None`, optional
+        The required shape. If `None`, the shape is not checked.
+
+    Returns
+    -------
+    array : `~numpy.ndarray` or `None`
+        The input array as an ndarray, or `None`.
+    """
+    if name == 'mask' and array is np.ma.nomask:
+        array = None
+    if array is not None:
+        array = np.asanyarray(array)
+        if array.ndim != ndim:
+            msg = f'{name} must be a {ndim}D array'
+            raise ValueError(msg)
+        if shape is not None and array.shape != shape:
+            msg = f'data and {name} must have the same shape'
+            raise ValueError(msg)
+    return array
+
+
+def collapse_scalar_value(value):
+    """
+    Collapse the leading length-1 (source) axis of a per-source value.
+
+    Parameters
+    ----------
+    value : object
+        The per-source value.
+
+    Returns
+    -------
+    value : object
+        The first element of ``value`` if it has a leading length-1
+        axis, otherwise ``value`` unchanged.
+    """
+    try:
+        if len(value) == 1:
+            return value[0]
+    except TypeError:  # value has no len
+        pass
+    return value
+
+
+def batch_array_supported(array):
+    """
+    Whether an array has a dtype supported by the batch Cython drivers.
+
+    Parameters
+    ----------
+    array : object
+        The array to test.
+
+    Returns
+    -------
+    supported : bool
+        `True` if the array is a plain `~numpy.ndarray` with a numeric
+        or boolean dtype of at most 8 bytes.
+    """
+    return (type(array) is np.ndarray and array.dtype.kind in 'fiub'
+            and array.dtype.itemsize <= 8)
+
+
+def batch_inputs_supported(data, error, mask):
+    """
+    Whether the data, error, and mask arrays are supported by the batch
+    Cython drivers.
+
+    Parameters
+    ----------
+    data : object
+        The data array.
+
+    error : object or `None`
+        The error array.
+
+    mask : object or `None`
+        The boolean mask array.
+
+    Returns
+    -------
+    supported : bool
+        `True` if all of the input arrays are supported, in which case
+        the batch code path can be used. Otherwise `False`, and the
+        caller must use the mask-based code path.
+    """
+    if not batch_array_supported(data):
+        return False
+    if error is not None and not batch_array_supported(error):
+        return False
+    return not (mask is not None
+                and (not isinstance(mask, np.ndarray)
+                     or mask.dtype != bool
+                     or mask.shape != data.shape))
+
+
+def batch_mask_plane(data, mask, *, mask_nonfinite):
+    """
+    Build the uint8 mask plane used by the batch Cython kernels.
+
+    Bit 1 (value 1) marks input-masked pixels and bit 2 (value 2) marks
+    non-finite ``data`` pixels; any nonzero value excludes the pixel.
+    Folding the non-finite pixels into the plane lets the caller exclude
+    them from the sum, area, and valid-pixel count while still flagging
+    them as ``non_finite_data`` rather than ``masked_pixels``.
+
+    Parameters
+    ----------
+    data : `~numpy.ndarray`
+        The data array.
+
+    mask : `~numpy.ndarray` (bool) or `None`
+        The input mask.
+
+    mask_nonfinite : bool
+        Whether to fold the non-finite ``data`` values into the plane.
+        When `False`, the non-finite pixels are left in the data so
+        that they corrupt the sum (the 3.0.0 behavior, used by the
+        legacy `~photutils.aperture.aperture_photometry` function).
+
+    Returns
+    -------
+    plane : `~numpy.ndarray` (uint8) or `None`
+        The C-contiguous mask plane, or `None` if no pixels are
+        excluded.
+    """
+    plane = None
+    if mask is not None:
+        plane = mask.astype(np.uint8)
+    if mask_nonfinite and data.dtype.kind == 'f':
+        nonfinite = ~np.isfinite(data)
+        if nonfinite.any():
+            if plane is None:
+                plane = np.zeros(data.shape, dtype=np.uint8)
+                plane[nonfinite] = 2
+            else:
+                plane[nonfinite & (plane == 0)] = 2
+
+    if plane is None:
+        return None
+    return np.ascontiguousarray(plane)
+
+
+def batch_segmentation_arrays(segmentation, labels, mask_method):
+    """
+    Build the segmentation inputs for the batch Cython kernels.
+
+    Parameters
+    ----------
+    segmentation : `~numpy.ndarray` or `None`
+        The validated segmentation array.
+
+    labels : `~numpy.ndarray` or `None`
+        The per-aperture source labels.
+
+    mask_method : {'none', 'mask', 'source_only', 'correct'}
+        The segmentation masking method.
+
+    Returns
+    -------
+    segmentation, labels : `~numpy.ndarray` (intp) or `None`
+        The C-contiguous segmentation array and source labels, or
+        `None` if no segmentation masking is performed.
+
+    method_code : int
+        The segmentation method code (0 disables masking).
+    """
+    if segmentation is None or mask_method == 'none':
+        return None, None, 0
+
+    return (np.ascontiguousarray(segmentation, dtype=np.intp),
+            np.ascontiguousarray(labels, dtype=np.intp),
+            SEG_METHOD_CODES[mask_method])

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -11,6 +11,7 @@ __all__ = [
     'ApertureAttribute',
     'PixelPositions',
     'PositiveScalar',
+    'PositiveScalarAngle',
     'ScalarAngle',
     'ScalarAngleOrValue',
     'SkyCoordPositions',
@@ -156,25 +157,15 @@ class ScalarAngle(ApertureAttribute):
             raise TypeError(msg)
 
 
-class PositiveScalarAngle(ApertureAttribute):
+class PositiveScalarAngle(ScalarAngle):
     """
-    Check that value is a positive scalar angle, either as a
-    `~astropy.coordinates.Angle` or `~astropy.units.Quantity` with
+    Check that value is a strictly positive (> 0) scalar angle, either
+    as a `~astropy.coordinates.Angle` or `~astropy.units.Quantity` with
     angular units.
     """
 
     def _validate(self, value):
-        if isinstance(value, u.Quantity):
-            if not value.isscalar:
-                msg = f'{self.name!r} must be a scalar'
-                raise ValueError(msg)
-
-            if value.unit.physical_type != 'angle':
-                msg = f'{self.name!r} must have angular units'
-                raise ValueError(msg)
-        else:
-            msg = f'{self.name!r} must be a scalar angle'
-            raise TypeError(msg)
+        super()._validate(value)
 
         if value <= 0:
             msg = f'{self.name!r} must be greater than zero'

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -124,14 +124,22 @@ class BoundingBox:
         return cls(ixmin, ixmax, iymin, iymax)
 
     def __eq__(self, other):
+        # NotImplemented lets Python fall back to the reflected
+        # comparison and then to identity, so that comparing to a
+        # non-BoundingBox returns False instead of raising. This keeps
+        # ``!=``, ``in``, and ``list.remove`` usable.
         if not isinstance(other, BoundingBox):
-            msg = 'Can compare BoundingBox only to another BoundingBox.'
-            raise TypeError(msg)
+            return NotImplemented
 
         return ((self.ixmin == other.ixmin)
                 and (self.ixmax == other.ixmax)
                 and (self.iymin == other.iymin)
                 and (self.iymax == other.iymax))
+
+    def __hash__(self):
+        # Return a hash value for the BoundingBox using its four
+        # defining indices.
+        return hash((self.ixmin, self.ixmax, self.iymin, self.iymax))
 
     def __or__(self, other):
         return self.union(other)
@@ -345,9 +353,10 @@ class BoundingBox:
 
         Returns
         -------
-        result : `BoundingBox`
+        result : `BoundingBox` or `None`
             A `BoundingBox` representing the intersection of the input
-            `BoundingBox` with this one.
+            `BoundingBox` with this one. `None` is returned if the two
+            bounding boxes do not overlap.
         """
         if not isinstance(other, BoundingBox):
             msg = ('BoundingBox can be intersected only with another '

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -220,32 +220,12 @@ class CircularAperture(PixelAperture):
 
         return patches
 
+    @_update_method_subpixels_docstring
     def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
         """
         Compute the overlap of the aperture on the pixel grid.
 
-        Parameters
-        ----------
-        edges : list of 4 1D `~numpy.ndarray`
-            The edges of the pixel grid in the form of
-            ``[x_edges, y_edges, x_centers, y_centers]``.
-
-        nx, ny : int
-            The number of pixels in the x and y directions.
-
-        use_exact : bool
-            Whether to use the exact method for calculating the overlap.
-
-        subpixels : int
-            The number of subpixels to use in each dimension for the
-            subpixel method.
-
-        Returns
-        -------
-        overlap : 2D `~numpy.ndarray`
-            The overlap of the aperture on the pixel grid. The values
-            will be between 0 and 1, where 0 means no overlap and 1
-            means full overlap.
+        <compute_overlap_docs>
         """
         return circular_overlap_grid(edges[0], edges[1], edges[2],
                                      edges[3], nx, ny, self.r,
@@ -420,32 +400,12 @@ class CircularAnnulus(PixelAperture):
 
         return patches
 
+    @_update_method_subpixels_docstring
     def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
         """
         Compute the overlap of the aperture on the pixel grid.
 
-        Parameters
-        ----------
-        edges : list of 4 1D `~numpy.ndarray`
-            The edges of the pixel grid in the form of
-            ``[x_edges, y_edges, x_centers, y_centers]``.
-
-        nx, ny : int
-            The number of pixels in the x and y directions.
-
-        use_exact : bool
-            Whether to use the exact method for calculating the overlap.
-
-        subpixels : int
-            The number of subpixels to use in each dimension for the
-            subpixel method.
-
-        Returns
-        -------
-        overlap : 2D `~numpy.ndarray`
-            The overlap of the aperture on the pixel grid. The values
-            will be between 0 and 1, where 0 means no overlap and 1
-            means full overlap.
+        <compute_overlap_docs>
         """
         overlap = circular_overlap_grid(edges[0], edges[1], edges[2],
                                         edges[3], nx, ny, self.r_out,

--- a/photutils/aperture/converters.py
+++ b/photutils/aperture/converters.py
@@ -292,7 +292,7 @@ def aperture_to_region(aperture):
         msg = 'Input aperture must be an Aperture object'
         raise TypeError(msg)
 
-    if aperture.shape == ():
+    if aperture.isscalar:
         return _scalar_aperture_to_region(aperture)
 
     # Multiple aperture positions return a Regions object
@@ -325,7 +325,7 @@ def _scalar_aperture_to_region(aperture):
                          RectangleAnnulusSkyRegion, RectanglePixelRegion,
                          RectangleSkyRegion)
 
-    if aperture.shape != ():
+    if not aperture.isscalar:
         msg = 'Only scalar (single-position) apertures are supported'
         raise ValueError(msg)
 
@@ -428,7 +428,7 @@ def _shapely_polygon_to_region(polygon, *, label=None, visual_kwargs=None):
 
     Returns
     -------
-    result : list of `regions.PolygonPixelRegion` or `regions.Regions`
+    result : `regions.PolygonPixelRegion` or `regions.Regions`
         If the polygon is a `shapely.Polygon`, then a
         `regions.PolygonPixelRegion` object is returned. If the polygon
         is a `shapely.MultiPolygon`, then a `regions.Regions` object is

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -25,8 +25,10 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_UNCORRECTED,
                                                   FLAG_COL_VALID,
                                                   batch_aperture_sums)
-from photutils.aperture._segmentation import (SEG_METHOD_CODES,
-                                              make_segmentation_exclusion,
+from photutils.aperture._common import (batch_inputs_supported,
+                                        batch_mask_plane,
+                                        batch_segmentation_arrays)
+from photutils.aperture._segmentation import (make_segmentation_exclusion,
                                               process_segmentation_inputs)
 from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.flags import APERTURE_FLAGS, _counts_to_flag_bits
@@ -900,49 +902,12 @@ class PixelAperture(Aperture):
         if spec is None:
             return None
 
-        def _supported(arr):
-            return (type(arr) is np.ndarray and arr.dtype.kind in 'fiub'
-                    and arr.dtype.itemsize <= 8)
-
-        if not _supported(data) or (error is not None
-                                    and not _supported(error)):
+        if not batch_inputs_supported(data, error, mask):
             return None
 
-        if mask is not None and (not isinstance(mask, np.ndarray)
-                                 or mask.dtype != bool
-                                 or mask.shape != data.shape):
-            return None
-
-        # Build a uint8 mask plane for the batch kernels. Bit 1 (value
-        # 1) marks input-masked pixels and bit 2 (value 2) marks
-        # non-finite ``data`` pixels; any nonzero value excludes the
-        # pixel. Folding the non-finite pixels into the plane lets
-        # the class exclude them from the sum, area, and valid-pixel
-        # count while still flagging them as ``non_finite_data``
-        # (not ``masked_pixels``), matching `ApertureStats`. When
-        # ``mask_nonfinite`` is `False` (the legacy function), the
-        # non-finite pixels are left in the data so they corrupt the sum
-        # (the 3.0.0 behavior).
-        plane = None
-        if mask is not None:
-            plane = mask.astype(np.uint8)
-        if mask_nonfinite and data.dtype.kind == 'f':
-            nonfinite = ~np.isfinite(data)
-            if nonfinite.any():
-                if plane is None:
-                    plane = np.zeros(data.shape, dtype=np.uint8)
-                    plane[nonfinite] = 2
-                else:
-                    plane[nonfinite & (plane == 0)] = 2
-        mask = None if plane is None else np.ascontiguousarray(plane)
-
-        seg_arr = None
-        labels_arr = None
-        seg_code = 0
-        if segmentation is not None and mask_method != 'none':
-            seg_arr = np.ascontiguousarray(segmentation, dtype=np.intp)
-            labels_arr = np.ascontiguousarray(labels, dtype=np.intp)
-            seg_code = SEG_METHOD_CODES[mask_method]
+        mask = batch_mask_plane(data, mask, mask_nonfinite=mask_nonfinite)
+        seg_arr, labels_arr, seg_code = batch_segmentation_arrays(
+            segmentation, labels, mask_method)
 
         use_exact, subpixels = self._translate_mask_method(method, subpixels)
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -296,10 +296,14 @@ class Aperture(metaclass=abc.ABCMeta):
                 # np.any is used for SkyCoord array comparisons
                 if np.any(getattr(self, param) != getattr(other, param)):
                     return False
-        except TypeError:
-            # TypeError is raised from SkyCoord comparison when they do
-            # not have equivalent frames. Here return False instead of
-            # the TypeError.
+        except (TypeError, ValueError):
+            # A TypeError is raised by a SkyCoord comparison when
+            # the two coordinates do not have equivalent frames. A
+            # ValueError is raised by an array comparison when the two
+            # parameters do not broadcast together (e.g., polygons with
+            # different numbers of vertices). Both mean the apertures
+            # are not equal, so return False instead of propagating the
+            # exception.
             return False
 
         return True
@@ -380,6 +384,15 @@ class PixelAperture(Aperture):
     """
     Abstract base class for apertures defined in pixel coordinates.
     """
+
+    # Whether the minimal bounding box is tight, i.e., whether the
+    # aperture is tangent to each side of its bounding box. This holds
+    # for any aperture whose ``_xy_extents`` are the true half-extents
+    # of its shape, which is the case for all of the built-in apertures
+    # except `~photutils.aperture.PolygonAperture` (whose extents are
+    # symmetric about ``positions``, while the polygon itself need not
+    # be). See `_resolve_outside_weights`.
+    _bbox_is_tight = True
 
     @lazyproperty
     def _default_patch_properties(self):
@@ -1161,13 +1174,17 @@ class PixelAperture(Aperture):
             Whether each aperture has one or more pixels with nonzero
             aperture weight outside the data.
         """
-        # For the 'exact' method the minimal bounding box is tight (the
-        # aperture is tangent to each bbox side), so a bbox that is
-        # clipped by a data edge always leaves a positive-area sliver of
-        # the aperture outside the data. The precise outside-weight test
-        # therefore agrees exactly with the bbox-clipped candidates, and
-        # no per-source aperture masks need to be built.
-        if method == 'exact':
+        # For the 'exact' method, if the bounding box is tight (the
+        # aperture is tangent to each bbox side), then a bbox that
+        # is clipped by a data edge always leaves a positive-area
+        # portion of the aperture outside the data. The precise
+        # outside-weight test therefore agrees exactly with the
+        # bbox-clipped candidates, and no per-source aperture masks
+        # need to be built. An aperture with a non-tight bounding box
+        # (e.g., an off-center polygon) can have a clipped bbox with no
+        # aperture area outside the data, so it must use the precise
+        # test below.
+        if method == 'exact' and self._bbox_is_tight:
             return candidates.copy()
 
         w_out = np.zeros(candidates.shape, dtype=bool)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -118,6 +118,30 @@ mask_method : {'none', 'mask', 'source_only', 'correct'}, optional
       values of the pixels mirrored across the aperture center. If a
       mirror pixel is unavailable, the pixel is excluded."""
 
+_COMPUTE_OVERLAP_DOC = """\
+Parameters
+----------
+edges : tuple of float
+    The ``(xmin, xmax, ymin, ymax)`` pixel edges of the aperture
+    bounding box, recentered at the origin.
+
+nx, ny : int
+    The number of pixels in the x and y directions.
+
+use_exact : int
+    Whether to compute the exact overlap area (1) or to use
+    subpixel sampling (0).
+
+subpixels : int
+    The number of subpixels in each dimension used when
+    ``use_exact`` is 0.
+
+Returns
+-------
+overlap : 2D `~numpy.ndarray`
+    The fraction of each pixel that overlaps the aperture. The
+    values are between 0 (no overlap) and 1 (full overlap)."""
+
 # Bullet list of the aperture quality flags, generated from the central
 # flag registry, used in docstrings via the ``flag_descriptions``
 # placeholder.
@@ -132,6 +156,7 @@ _DOC_PLACEHOLDERS = {
     'subpixels_description': _SUBPIXELS_DOC,
     'segmentation_descriptions': _SEGMENTATION_DOC,
     'flag_descriptions': _FLAG_DESCRIPTIONS_DOC,
+    'compute_overlap_docs': _COMPUTE_OVERLAP_DOC,
 }
 
 _DOC_PLACEHOLDER_RE = re.compile(
@@ -156,6 +181,12 @@ def _update_method_subpixels_docstring(obj):
       custom name and introduction.
     * ``<subpixels_description>`` : only the ``subpixels`` parameter
       description.
+    * ``<segmentation_descriptions>`` : the ``segmentation_image``,
+      ``labels``, and ``mask_method`` parameter descriptions.
+    * ``<flag_descriptions>`` : the bullet list of aperture quality
+      flags.
+    * ``<compute_overlap_docs>`` : the Parameters and Returns sections
+      of the ``_compute_overlap`` method.
 
     Parameters
     ----------
@@ -636,29 +667,12 @@ class PixelAperture(Aperture):
         return masks
 
     @abc.abstractmethod
+    @_update_method_subpixels_docstring
     def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
         """
         Compute the overlap of the aperture for a single position.
 
-        Parameters
-        ----------
-        edges : tuple of float
-            The ``(xmin, xmax, ymin, ymax)`` pixel edges centered at
-            the origin.
-
-        nx, ny : int
-            The number of pixels in x and y.
-
-        use_exact : int
-            Whether to use exact method (1) or not (0).
-
-        subpixels : int
-            The number of subpixels for subpixel method.
-
-        Returns
-        -------
-        overlap : 2D `~numpy.ndarray`
-            The overlap array.
+        <compute_overlap_docs>
         """
 
     def _mask_photometry(self, data, *, error, mask, method, subpixels,

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -434,8 +434,11 @@ class PixelAperture(Aperture):
             msg = f'Invalid mask method: {method}'
             raise ValueError(msg)
 
+        # bool is a subclass of int, so it is rejected explicitly to
+        # prevent subpixels=True from being silently used as 1
         if ((method == 'subpixel')
-                and (not isinstance(subpixels, int) or subpixels <= 0)):
+                and (isinstance(subpixels, bool)
+                     or not isinstance(subpixels, int) or subpixels <= 0)):
             msg = 'subpixels must be a strictly positive integer'
             raise ValueError(msg)
 
@@ -594,6 +597,9 @@ class PixelAperture(Aperture):
             else:
                 aper_weights = apermask.data[slc_small]
                 if mask is not None:
+                    # Copy aper_weights before modifying it, because the
+                    # slice above is a view.
+                    aper_weights = aper_weights.copy()
                     aper_weights[mask[slc_large]] = 0.0
                 area = np.sum(aper_weights)
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -360,6 +360,22 @@ class Aperture(metaclass=abc.ABCMeta):
         return self.shape == ()
 
 
+class _RotatableApertureMixin:
+    """
+    Mixin class for apertures that have a rotation angle ``theta``.
+    """
+
+    @lazyproperty
+    def _theta_rad(self):
+        """
+        The rotation angle in radians.
+
+        This is a lazyproperty so that it is invalidated together with
+        the other lazyproperties when ``theta`` is reassigned.
+        """
+        return self.theta.to_value(u.radian)
+
+
 class PixelAperture(Aperture):
     """
     Abstract base class for apertures defined in pixel coordinates.

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -27,7 +27,8 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   batch_aperture_sums)
 from photutils.aperture._common import (batch_inputs_supported,
                                         batch_mask_plane,
-                                        batch_segmentation_arrays)
+                                        batch_segmentation_arrays,
+                                        validate_mask_method)
 from photutils.aperture._segmentation import (make_segmentation_exclusion,
                                               process_segmentation_inputs)
 from photutils.aperture.bounding_box import BoundingBox
@@ -430,17 +431,7 @@ class PixelAperture(Aperture):
         subpixels : int
             The number of subpixels for subpixel method.
         """
-        if method not in ('center', 'subpixel', 'exact'):
-            msg = f'Invalid mask method: {method}'
-            raise ValueError(msg)
-
-        # bool is a subclass of int, so it is rejected explicitly to
-        # prevent subpixels=True from being silently used as 1
-        if ((method == 'subpixel')
-                and (isinstance(subpixels, bool)
-                     or not isinstance(subpixels, int) or subpixels <= 0)):
-            msg = 'subpixels must be a strictly positive integer'
-            raise ValueError(msg)
+        validate_mask_method(method, subpixels)
 
         if method == 'center':
             use_exact = 0

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -18,6 +18,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            ScalarAngleOrValue,
                                            SkyCoordPositions)
 from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _RotatableApertureMixin,
                                      _update_method_subpixels_docstring)
 from photutils.aperture.mask import ApertureMask
 from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
@@ -179,7 +180,7 @@ def _calc_ellipse_extents(semimajor_axis, semiminor_axis, theta_rad):
     return x_extent, y_extent
 
 
-class EllipticalAperture(PixelAperture):
+class EllipticalAperture(_RotatableApertureMixin, PixelAperture):
     """
     An elliptical aperture defined in pixel coordinates.
 
@@ -242,7 +243,6 @@ class EllipticalAperture(PixelAperture):
         self.a = a
         self.b = b
         self.theta = theta
-        self._theta_rad = self.theta.to_value(u.radian)
 
     @lazyproperty
     def _xy_extents(self):
@@ -392,7 +392,7 @@ class EllipticalAperture(PixelAperture):
         return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
-class EllipticalAnnulus(PixelAperture):
+class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
     r"""
     An elliptical annulus aperture defined in pixel coordinates.
 
@@ -487,7 +487,6 @@ class EllipticalAnnulus(PixelAperture):
         self.b_in = b_in
 
         self.theta = theta
-        self._theta_rad = self.theta.to_value(u.radian)
 
     @lazyproperty
     def _xy_extents(self):
@@ -638,7 +637,7 @@ class EllipticalAnnulus(PixelAperture):
                                     b_in=b_in, theta=sky_angle)
 
 
-class SkyEllipticalAperture(SkyAperture):
+class SkyEllipticalAperture(_RotatableApertureMixin, SkyAperture):
     """
     An elliptical aperture defined in sky coordinates.
 
@@ -684,7 +683,6 @@ class SkyEllipticalAperture(SkyAperture):
         self.a = a
         self.b = b
         self.theta = theta
-        self._theta_rad = self.theta.to_value(u.radian)
 
     def to_pixel(self, wcs):
         """
@@ -752,7 +750,7 @@ class SkyEllipticalAperture(SkyAperture):
         return SkyPolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
-class SkyEllipticalAnnulus(SkyAperture):
+class SkyEllipticalAnnulus(_RotatableApertureMixin, SkyAperture):
     r"""
     An elliptical annulus aperture defined in sky coordinates.
 
@@ -826,7 +824,6 @@ class SkyEllipticalAnnulus(SkyAperture):
         self.b_in = b_in
 
         self.theta = theta
-        self._theta_rad = self.theta.to_value(u.radian)
 
     def to_pixel(self, wcs):
         """

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -299,32 +299,12 @@ class EllipticalAperture(_RotatableApertureMixin, PixelAperture):
 
         return patches
 
+    @_update_method_subpixels_docstring
     def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
         """
         Compute the overlap of the aperture on the pixel grid.
 
-        Parameters
-        ----------
-        edges : list of 4 1D `~numpy.ndarray`
-            The edges of the pixel grid in the form of
-            ``[x_edges, y_edges, x_centers, y_centers]``.
-
-        nx, ny : int
-            The number of pixels in the x and y directions.
-
-        use_exact : bool
-            Whether to use the exact method for calculating the overlap.
-
-        subpixels : int
-            The number of subpixels to use in each dimension for the
-            subpixel method.
-
-        Returns
-        -------
-        overlap : 2D `~numpy.ndarray`
-            The overlap of the aperture on the pixel grid. The values
-            will be between 0 and 1, where 0 means no overlap and 1
-            means full overlap.
+        <compute_overlap_docs>
         """
         return elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                        edges[3], nx, ny, self.a, self.b,
@@ -549,32 +529,12 @@ class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
 
         return patches
 
+    @_update_method_subpixels_docstring
     def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
         """
         Compute the overlap of the aperture on the pixel grid.
 
-        Parameters
-        ----------
-        edges : list of 4 1D `~numpy.ndarray`
-            The edges of the pixel grid in the form of
-            ``[x_edges, y_edges, x_centers, y_centers]``.
-
-        nx, ny : int
-            The number of pixels in the x and y directions.
-
-        use_exact : bool
-            Whether to use the exact method for calculating the overlap.
-
-        subpixels : int
-            The number of subpixels to use in each dimension for the
-            subpixel method.
-
-        Returns
-        -------
-        overlap : 2D `~numpy.ndarray`
-            The overlap of the aperture on the pixel grid. The values
-            will be between 0 and 1, where 0 means no overlap and 1
-            means full overlap.
+        <compute_overlap_docs>
         """
         overlap = elliptical_overlap_grid(edges[0], edges[1], edges[2],
                                           edges[3], nx, ny, self.a_out,

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -104,8 +104,9 @@ class ApertureMask:
 
         Returns
         -------
-        result : `~numpy.ndarray`
-            A 2D array of the mask.
+        result : `~numpy.ndarray` or `None`
+            A 2D array of the mask. `None` is returned if there is no
+            overlap of the mask with the output image shape.
         """
         if len(shape) != 2:
             msg = 'input shape must have 2 elements'

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -11,7 +11,7 @@ from astropy.utils import lazyproperty
 
 from photutils.aperture._common import (SCALAR_COLLAPSE_TYPES,
                                         collapse_scalar_value, unpack_nddata,
-                                        validate_array)
+                                        validate_array, validate_mask_method)
 from photutils.aperture._segmentation import process_segmentation_inputs
 from photutils.aperture.converters import region_to_aperture
 from photutils.aperture.core import (Aperture, SkyAperture, _aperture_metadata,
@@ -191,6 +191,11 @@ class AperturePhotometry:
         self._error = validate_array(error, 'error', shape=data_shape)
         self._mask = validate_array(mask, 'mask', shape=data_shape)
         self._wcs = wcs
+
+        # Validate the mask-method keywords here so that an invalid
+        # value is reported at construction rather than at the first
+        # access of a measured attribute, far from its cause.
+        validate_mask_method(method, subpixels, method_name='method')
         self.method = method
         self.subpixels = subpixels
         self.mask_method = mask_method
@@ -245,7 +250,8 @@ class AperturePhotometry:
 
         # Define output table metadata
         self.meta = _get_meta()
-        calling_args = f"method='{method}', subpixels={subpixels}"
+        calling_args = (f"method='{method}', subpixels={subpixels}, "
+                        f"mask_method='{mask_method}'")
         self.meta['aperture_photometry_args'] = calling_args
         self.meta.update(aper_meta)
 

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -3,16 +3,15 @@
 Tools for performing aperture photometry.
 """
 
-import warnings
-
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import SkyCoord
-from astropy.nddata import NDData, StdDevUncertainty
+from astropy.nddata import NDData
 from astropy.table import QTable
 from astropy.utils import lazyproperty
-from astropy.utils.exceptions import AstropyUserWarning
 
+from photutils.aperture._common import (SCALAR_COLLAPSE_TYPES,
+                                        collapse_scalar_value, unpack_nddata,
+                                        validate_array)
 from photutils.aperture._segmentation import process_segmentation_inputs
 from photutils.aperture.converters import region_to_aperture
 from photutils.aperture.core import (Aperture, SkyAperture, _aperture_metadata,
@@ -182,15 +181,15 @@ class AperturePhotometry:
                  labels=None, mask_method='none'):
 
         if isinstance(data, NDData):
-            data, error, mask, wcs = self._unpack_nddata(data, error, mask,
-                                                         wcs)
+            data, error, mask, wcs = unpack_nddata(data, error, mask, wcs)
 
         (data, error), unit = process_quantities(
             (data, error), ('data', 'error'))
-        self._data = self._validate_array(data, 'data', shape=False)
+        self._data = validate_array(data, 'data')
         self._data_unit = unit
-        self._error = self._validate_array(error, 'error')
-        self._mask = self._validate_array(mask, 'mask')
+        data_shape = self._data.shape
+        self._error = validate_array(error, 'error', shape=data_shape)
+        self._mask = validate_array(mask, 'mask', shape=data_shape)
         self._wcs = wcs
         self.method = method
         self.subpixels = subpixels
@@ -256,44 +255,6 @@ class AperturePhotometry:
         default_columns += ['flux', 'flux_err', 'area', 'flags']
         self.default_columns = default_columns
 
-    @staticmethod
-    def _unpack_nddata(data, error, mask, wcs):
-        nddata_attr = {'error': error, 'mask': mask, 'wcs': wcs}
-        for key, value in nddata_attr.items():
-            if value is not None:
-                msg = (f'The {key!r} keyword is ignored. Its value '
-                       'is obtained from the input NDData object.')
-                warnings.warn(msg, AstropyUserWarning)
-
-        mask = data.mask
-        wcs = data.wcs
-
-        if isinstance(data.uncertainty, StdDevUncertainty):
-            if data.uncertainty.unit is None:
-                error = data.uncertainty.array
-            else:
-                error = data.uncertainty.array * data.uncertainty.unit
-
-        if data.unit is not None:
-            data = u.Quantity(data.data, unit=data.unit)
-        else:
-            data = data.data
-
-        return data, error, mask, wcs
-
-    def _validate_array(self, array, name, *, ndim=2, shape=True):
-        if name == 'mask' and array is np.ma.nomask:
-            array = None
-        if array is not None:
-            array = np.asanyarray(array)
-            if array.ndim != ndim:
-                msg = f'{name} must be a {ndim}D array'
-                raise ValueError(msg)
-            if shape and array.shape != self._data.shape:
-                msg = f'data and {name} must have the same shape'
-                raise ValueError(msg)
-        return array
-
     def __repr__(self):
         return make_repr(self, self._repr_params)
 
@@ -312,9 +273,9 @@ class AperturePhotometry:
         value = super().__getattribute__(name)
         if (not name.startswith('_')
                 and name not in _SCALAR_EXCLUDE
-                and isinstance(value, (np.ndarray, SkyCoord))
+                and isinstance(value, SCALAR_COLLAPSE_TYPES)
                 and self.isscalar):
-            return value[0]
+            return collapse_scalar_value(value)
         return value
 
     def _array(self, name):
@@ -667,27 +628,7 @@ def aperture_photometry(data, apertures, error=None, mask=None,
     `~astropy.nddata.StdDevUncertainty` instance.
     """
     if isinstance(data, NDData):
-        nddata_attr = {'error': error, 'mask': mask, 'wcs': wcs}
-        for key, value in nddata_attr.items():
-            if value is not None:
-                msg = (f'The {key!r} keyword is ignored. Its value '
-                       'is obtained from the input NDData object.')
-                warnings.warn(msg, AstropyUserWarning)
-
-        mask = data.mask
-        wcs = data.wcs
-
-        if isinstance(data.uncertainty, StdDevUncertainty):
-            if data.uncertainty.unit is None:
-                error = data.uncertainty.array
-            else:
-                error = data.uncertainty.array * data.uncertainty.unit
-
-        if data.unit is not None:
-            data = u.Quantity(data.data, unit=data.unit)
-        else:
-            data = data.data
-
+        data, error, mask, wcs = unpack_nddata(data, error, mask, wcs)
         return aperture_photometry(data, apertures, error=error, mask=mask,
                                    method=method, subpixels=subpixels,
                                    wcs=wcs)

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -151,6 +151,15 @@ class AperturePhotometry:
     instance can be safely shared across threads. Do not reassign its
     attributes after construction.
 
+    One caveat applies to apertures that are not supported by the
+    compiled batch code path (e.g., a `~photutils.aperture.Aperture`
+    subclass that overrides ``to_mask``). That path suppresses warnings
+    using `warnings.catch_warnings`, which mutates process-global
+    warning-filter state, so concurrent calls can transiently affect
+    the warning filters seen by other threads. On free-threaded Python
+    builds the warning filters are context-aware, so this does not
+    apply.
+
     Examples
     --------
     >>> import numpy as np
@@ -639,6 +648,11 @@ def aperture_photometry(data, apertures, error=None, mask=None,
                                    method=method, subpixels=subpixels,
                                    wcs=wcs)
 
+    # The aperture-list handling, sky-to-pixel conversion, and
+    # position-equality checking below duplicate the equivalent code in
+    # AperturePhotometry.__init__. The duplication is intentional. This
+    # function is frozen and must not gain new behavior, so it must not
+    # be refactored to share the class logic.
     single_aperture = False
     if not isinstance(apertures, (list, tuple, np.ndarray)):
         single_aperture = True

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -35,6 +35,15 @@ _DEPRECATED_COLUMNS: dict = {
 }
 
 
+# Public attributes that are never collapsed to a scalar for a scalar
+# instance because they are not per-position output values (see
+# ``AperturePhotometry.__getattribute__``). ``segmentation_image`` and
+# ``labels`` are the inputs echoed back to the user, and the others
+# describe the whole object.
+_SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'labels',
+                             'n_positions', 'segmentation_image'})
+
+
 @_update_method_subpixels_docstring
 class AperturePhotometry:
     # numpydoc ignore: PR01,PR02,PR04,PR07
@@ -295,12 +304,14 @@ class AperturePhotometry:
         # Collapse the leading position axis of the public array-valued
         # output attributes to a scalar when a single scalar aperture
         # position is input (e.g., ``CircularAperture((10, 20), r=5)``).
-        # These are the only public array-valued attributes, so the
-        # scalar conversion is applied centrally here instead of being
-        # repeated on each individual property.
+        # The scalar conversion is applied centrally here instead of
+        # being repeated on each individual property. Public attributes
+        # that are not per-position outputs are excluded, so that, for
+        # example, the input ``segmentation_image`` is not reduced to
+        # its first row.
         value = super().__getattribute__(name)
         if (not name.startswith('_')
-                and name not in ('isscalar', 'n_positions')
+                and name not in _SCALAR_EXCLUDE
                 and isinstance(value, (np.ndarray, SkyCoord))
                 and self.isscalar):
             return value[0]

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -436,6 +436,11 @@ class PolygonAperture(PixelAperture):
         'The (n_vertices, 2) array of pixel offsets of the polygon '
         'vertices, measured relative to ``positions``.')
 
+    # The bounding box is symmetric about ``positions`` (see
+    # ``_xy_extents``), so it is not tight for a polygon whose vertices
+    # are not symmetric about ``positions``.
+    _bbox_is_tight = False
+
     def __init__(self, positions, vertex_offsets):
         self.positions = positions
         self.vertex_offsets = vertex_offsets

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -11,7 +11,8 @@ from astropy.utils import lazyproperty
 from photutils.aperture._batch_photometry import SHAPE_POLYGON
 from photutils.aperture.attributes import (ApertureAttribute, PixelPositions,
                                            SkyCoordPositions)
-from photutils.aperture.core import PixelAperture, SkyAperture
+from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _update_method_subpixels_docstring)
 from photutils.geometry._polygon_overlap import polygon_overlap_grid
 
 __all__ = [
@@ -674,7 +675,7 @@ class PolygonAperture(PixelAperture):
         else:
             if inner_radius is None:
                 msg = ('inner_radius must be provided if both optimal_shape '
-                       'and horizontal_edges are False')
+                       'and collinear_edges are False')
                 raise ValueError(msg)
 
             inner_radius = float(inner_radius)
@@ -871,9 +872,19 @@ class PolygonAperture(PixelAperture):
         `~astropy.units.Quantity` in degrees.
 
         The angle is measured counter-clockwise from the ``+y``
-        axis to the first vertex, in the range ``[0, 360) deg``.
-        This convention matches the ``theta`` parameter of
+        axis to the first stored vertex, in the range ``[0, 360)
+        deg``. This convention matches the ``theta`` parameter of
         `~PolygonAperture.from_regular_polygon`.
+
+        Note that the rotation of a regular polygon with ``n``
+        vertices is defined only modulo ``360 / n`` degrees, because
+        rotating it by its exterior angle reproduces the same shape.
+        The reported value therefore depends on which vertex is stored
+        first, which is not necessarily the first vertex the user
+        input: clockwise ``vertex_offsets`` are reversed when they are
+        normalized to counter-clockwise order. For example, a square
+        specified clockwise reports ``90 deg`` where the identical
+        square specified counter-clockwise reports ``0 deg``.
 
         This attribute is only defined for regular polygons. Accessing
         it for a non-regular polygon raises `ValueError`.
@@ -881,32 +892,12 @@ class PolygonAperture(PixelAperture):
         self._check_regular('theta')
         return self._regular_geometry.theta
 
+    @_update_method_subpixels_docstring
     def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
         """
         Compute the overlap of the aperture on the pixel grid.
 
-        Parameters
-        ----------
-        edges : list of 4 1D `~numpy.ndarray`
-            The edges of the pixel grid in the form of
-            ``[x_edges, y_edges, x_centers, y_centers]``.
-
-        nx, ny : int
-            The number of pixels in the x and y directions.
-
-        use_exact : bool
-            Whether to use the exact method for calculating the overlap.
-
-        subpixels : int
-            The number of subpixels to use in each dimension for the
-            subpixel method.
-
-        Returns
-        -------
-        overlap : 2D `~numpy.ndarray`
-            The overlap of the aperture on the pixel grid. The values
-            will be between 0 and 1, where 0 means no overlap and 1
-            means full overlap.
+        <compute_overlap_docs>
         """
         verts_x = np.ascontiguousarray(self.vertex_offsets[:, 0])
         verts_y = np.ascontiguousarray(self.vertex_offsets[:, 1])
@@ -1294,12 +1285,20 @@ class SkyPolygonAperture(SkyAperture):
         The rotation angle of the regular polygon as an angular
         `~astropy.units.Quantity` in degrees.
 
-        The angle is measured counter-clockwise from the ``+lat``
-        axis on the local tangent plane to the first vertex, in
+        The angle is measured counter-clockwise from the ``+lat`` axis
+        on the local tangent plane to the first stored vertex, in
         the range ``[0, 360) deg``. This assumes a right-handed
         coordinate system (e.g., standard celestial coordinates).
         This convention matches the ``theta`` parameter of
         `~SkyPolygonAperture.from_regular_polygon`.
+
+        Note that the rotation of a regular polygon with ``n``
+        vertices is defined only modulo ``360 / n`` degrees, because
+        rotating it by its exterior angle reproduces the same shape.
+        The reported value therefore depends on which vertex is stored
+        first, which is not necessarily the first vertex the user
+        input: clockwise ``vertex_offsets`` are reversed when they are
+        normalized to counter-clockwise order.
 
         This attribute is only defined for regular polygons. Accessing
         it for a non-regular polygon raises `ValueError`.

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -18,6 +18,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            ScalarAngleOrValue,
                                            SkyCoordPositions)
 from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _RotatableApertureMixin,
                                      _update_method_subpixels_docstring)
 from photutils.aperture.mask import ApertureMask
 from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
@@ -185,7 +186,7 @@ def _calc_lower_left_positions(positions, width, height, theta_rad):
     return np.atleast_2d(positions) + np.array([xshift, yshift])
 
 
-class RectangularAperture(PixelAperture):
+class RectangularAperture(_RotatableApertureMixin, PixelAperture):
     """
     A rectangular aperture defined in pixel coordinates.
 
@@ -250,7 +251,6 @@ class RectangularAperture(PixelAperture):
         self.w = w
         self.h = h
         self.theta = theta
-        self._theta_rad = self.theta.to_value(u.radian)
 
     @lazyproperty
     def _xy_extents(self):
@@ -397,7 +397,7 @@ class RectangularAperture(PixelAperture):
         return PolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
-class RectangularAnnulus(PixelAperture):
+class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
     r"""
     A rectangular annulus aperture defined in pixel coordinates.
 
@@ -496,7 +496,6 @@ class RectangularAnnulus(PixelAperture):
         self.h_in = h_in
 
         self.theta = theta
-        self._theta_rad = self.theta.to_value(u.radian)
 
     @lazyproperty
     def _xy_extents(self):
@@ -655,7 +654,7 @@ class RectangularAnnulus(PixelAperture):
                                      h_in=h_in, theta=sky_angle)
 
 
-class SkyRectangularAperture(SkyAperture):
+class SkyRectangularAperture(_RotatableApertureMixin, SkyAperture):
     """
     A rectangular aperture defined in sky coordinates.
 
@@ -703,7 +702,6 @@ class SkyRectangularAperture(SkyAperture):
         self.w = w
         self.h = h
         self.theta = theta
-        self._theta_rad = self.theta.to_value(u.radian)
 
     def to_pixel(self, wcs):
         """
@@ -766,7 +764,7 @@ class SkyRectangularAperture(SkyAperture):
         return SkyPolygonAperture._from_convex_offsets(self.positions, offsets)
 
 
-class SkyRectangularAnnulus(SkyAperture):
+class SkyRectangularAnnulus(_RotatableApertureMixin, SkyAperture):
     r"""
     A rectangular annulus aperture defined in sky coordinates.
 
@@ -847,7 +845,6 @@ class SkyRectangularAnnulus(SkyAperture):
         self.h_in = h_in
 
         self.theta = theta
-        self._theta_rad = self.theta.to_value(u.radian)
 
     def to_pixel(self, wcs):
         """

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -108,7 +108,7 @@ class RectangularMaskMixin:  # pragma: no cover
             w = self.w_out
             h = self.h_out
         else:
-            msg = 'Cannot determine the aperture radius'
+            msg = 'Cannot determine the aperture width and height'
             raise ValueError(msg)
 
         masks = []
@@ -309,32 +309,12 @@ class RectangularAperture(_RotatableApertureMixin, PixelAperture):
 
         return patches
 
+    @_update_method_subpixels_docstring
     def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
         """
         Compute the overlap of the aperture on the pixel grid.
 
-        Parameters
-        ----------
-        edges : list of 4 1D `~numpy.ndarray`
-            The edges of the pixel grid in the form of
-            ``[x_edges, y_edges, x_centers, y_centers]``.
-
-        nx, ny : int
-            The number of pixels in the x and y directions.
-
-        use_exact : bool
-            Whether to use the exact method for calculating the overlap.
-
-        subpixels : int
-            The number of subpixels to use in each dimension for the
-            subpixel method.
-
-        Returns
-        -------
-        overlap : 2D `~numpy.ndarray`
-            The overlap of the aperture on the pixel grid. The values
-            will be between 0 and 1, where 0 means no overlap and 1
-            means full overlap.
+        <compute_overlap_docs>
         """
         return rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                         edges[3], nx, ny, self.w,
@@ -567,32 +547,12 @@ class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
 
         return patches
 
+    @_update_method_subpixels_docstring
     def _compute_overlap(self, edges, nx, ny, use_exact, subpixels):
         """
         Compute the overlap of the aperture on the pixel grid.
 
-        Parameters
-        ----------
-        edges : list of 4 1D `~numpy.ndarray`
-            The edges of the pixel grid in the form of
-            ``[x_edges, y_edges, x_centers, y_centers]``.
-
-        nx, ny : int
-            The number of pixels in the x and y directions.
-
-        use_exact : bool
-            Whether to use the exact method for calculating the overlap.
-
-        subpixels : int
-            The number of subpixels to use in each dimension for the
-            subpixel method.
-
-        Returns
-        -------
-        overlap : 2D `~numpy.ndarray`
-            The overlap of the aperture on the pixel grid. The values
-            will be between 0 and 1, where 0 means no overlap and 1
-            means full overlap.
+        <compute_overlap_docs>
         """
         overlap = rectangular_overlap_grid(edges[0], edges[1], edges[2],
                                            edges[3], nx, ny, self.w_out,

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -673,7 +673,21 @@ class ApertureStats:
         result : `ApertureStats`
             A new `ApertureStats` object containing only the sources with
             the input ID numbers.
+
+        Raises
+        ------
+        TypeError
+            If this is a scalar `ApertureStats` object, which cannot be
+            indexed.
+
+        ValueError
+            If any input ID number is not a valid source ID number.
         """
+        if self.isscalar:
+            msg = (f'A scalar {self.__class__.__name__!r} object cannot '
+                   'be indexed')
+            raise TypeError(msg)
+
         for id_num in np.atleast_1d(id_nums):
             if id_num not in self._array('id'):
                 msg = f'{id_num} is not a valid source ID number'
@@ -2485,10 +2499,10 @@ class ApertureStats:
         The two eigenvalues of the `covariance` matrix in decreasing
         order.
         """
-        eigvals = np.empty((self.n_apertures, 2))
-        eigvals.fill(np.nan)
-        # np.linalg.eigvalsh requires finite input values
-        idx = np.unique(np.where(np.isfinite(self._covariance))[0])
+        eigvals = np.full((self.n_apertures, 2), np.nan)
+        # np.linalg.eigvalsh requires that every element of a covariance
+        # matrix be finite, so select only the wholly finite matrices
+        idx = np.flatnonzero(np.isfinite(self._covariance).all(axis=(1, 2)))
         eigvals[idx] = np.linalg.eigvalsh(self._covariance[idx])
 
         # Check for negative variance

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -36,7 +36,7 @@ from photutils.aperture._common import (SCALAR_COLLAPSE_TYPES,
                                         batch_mask_plane,
                                         batch_segmentation_arrays,
                                         collapse_scalar_value, unpack_nddata,
-                                        validate_array)
+                                        validate_array, validate_mask_method)
 from photutils.aperture._segmentation import (make_segmentation_exclusion,
                                               process_segmentation_inputs)
 from photutils.aperture.core import (_aperture_metadata,
@@ -84,8 +84,9 @@ _DEPRECATED_ATTRIBUTES: dict = {
 # Public attributes that are never collapsed to a scalar for a scalar
 # instance because they describe the whole object rather than a single
 # per-source value (see ``ApertureStats.__getattribute__``).
-_SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'n_apertures',
-                             'properties'})
+_SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'labels',
+                             'n_apertures', 'properties',
+                             'segmentation_image'})
 
 
 class _UncachedLazyProperty(lazyproperty):
@@ -341,6 +342,11 @@ class ApertureStats:
             raise TypeError(msg)
         self.sigma_clip = sigma_clip
 
+        # Validate the mask-method keywords here so that an invalid
+        # value is reported at construction rather than at the first
+        # access of a measured property, far from its cause.
+        validate_mask_method(sum_method, subpixels,
+                             method_name='sum_method')
         self.sum_method = sum_method
         self.subpixels = subpixels
 
@@ -384,8 +390,10 @@ class ApertureStats:
         self.meta.update(aperture_meta)
 
         # Validate the segmentation-masking inputs and resolve the
-        # per-aperture source labels
-        self._mask_method = mask_method
+        # per-aperture source labels.
+        self.segmentation_image = segmentation_image
+        self.labels = labels
+        self.mask_method = mask_method
         seg_positions = np.atleast_2d(self._pixel_aperture.positions)
         (self._segmentation,
          self._seg_labels) = process_segmentation_inputs(
@@ -453,7 +461,7 @@ class ApertureStats:
         init_attr = ('_data', '_data_unit', '_error', '_mask', '_wcs',
                      'sigma_clip', 'sum_method', 'subpixels', 'ddof',
                      'default_columns', 'meta', '_segmentation',
-                     '_mask_method')
+                     'segmentation_image', 'mask_method')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
@@ -464,7 +472,14 @@ class ApertureStats:
         # backed by a length-1 iterable (see the id property).
         newcls._ids = np.atleast_1d(self._ids[index])
 
-        # Slice the per-aperture segmentation labels
+        # Slice the per-aperture segmentation labels. Both the input
+        # ``labels`` and the resolved ``_seg_labels`` have one entry per
+        # aperture, so the sliced object reports the labels of the
+        # apertures it actually contains.
+        if self.labels is None:
+            newcls.labels = None
+        else:
+            newcls.labels = np.atleast_1d(self.labels)[index]
         if self._seg_labels is None:
             newcls._seg_labels = None
         else:
@@ -844,7 +859,7 @@ class ApertureStats:
         # non-finite data before any segmentation correction.
         mask = batch_mask_plane(data, self._mask, mask_nonfinite=True)
         seg_arr, labels_arr, seg_code = batch_segmentation_arrays(
-            self._segmentation, self._seg_labels, self._mask_method)
+            self._segmentation, self._seg_labels, self.mask_method)
 
         shape_code, params = spec
         sum_use_exact, sum_subpixels = aper._translate_mask_method(
@@ -1275,13 +1290,13 @@ class ApertureStats:
                 exclude = None
                 affected = None
                 if (self._segmentation is not None
-                        and self._mask_method != 'none'):
+                        and self.mask_method != 'none'):
                     segm_cutout = self._segmentation[slc_large]
                     cutout_xycen = (positions[idx, 0] - slc_large[1].start,
                                     positions[idx, 1] - slc_large[0].start)
                     (data_cutout, error_cutout, exclude,
                      affected) = make_segmentation_exclusion(
-                        self._mask_method, segm_cutout,
+                        self.mask_method, segm_cutout,
                         self._seg_labels[idx], data=data_cutout,
                         error=error_cutout, base_mask=data_mask,
                         cutout_xycen=cutout_xycen)
@@ -1311,7 +1326,7 @@ class ApertureStats:
                     pre_valid = weighted & ~pre_seg_mask
                     fc_row[FLAG_COL_SEG] = np.count_nonzero(
                         affected & pre_valid)
-                    if self._mask_method == 'correct':
+                    if self.mask_method == 'correct':
                         # In 'correct' mode, the excluded pixels are
                         # exactly the uncorrectable neighbor pixels
                         fc_row[FLAG_COL_UNCORRECTED] = np.count_nonzero(

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -2622,12 +2622,14 @@ class ApertureStats:
     @lazyproperty
     def ellipticity(self):
         r"""
-        1.0 minus the ratio of the lengths of the semimajor and
-        semiminor axes (or 1.0 minus the `elongation`).
+        1.0 minus the ratio of the lengths of the semiminor and
+        semimajor axes (or 1.0 divided by the `elongation`, subtracted
+        from 1.0).
 
         .. math::
 
-            \mathrm{ellipticity} = 1 - \frac{b}{a}
+            \mathrm{ellipticity} = \frac{a - b}{a} = 1 - \frac{b}{a}
+                                 = 1 - \frac{1}{\mathrm{elongation}}
 
         where :math:`a` and :math:`b` are the lengths of the semimajor
         and semiminor axes, respectively.

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -9,12 +9,10 @@ from copy import deepcopy
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import SkyCoord
-from astropy.nddata import NDData, StdDevUncertainty
+from astropy.nddata import NDData
 from astropy.stats import (SigmaClip, biweight_location, biweight_midvariance,
                            mad_std)
 from astropy.utils import lazyproperty
-from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import Aperture, SkyAperture, region_to_aperture
 from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
@@ -33,8 +31,13 @@ from photutils.aperture._batch_stats import (batch_aperture_gather,
                                              batch_sigma_clip_center,
                                              batch_sigma_clip_sum,
                                              batch_sort_values)
-from photutils.aperture._segmentation import (SEG_METHOD_CODES,
-                                              make_segmentation_exclusion,
+from photutils.aperture._common import (SCALAR_COLLAPSE_TYPES,
+                                        batch_inputs_supported,
+                                        batch_mask_plane,
+                                        batch_segmentation_arrays,
+                                        collapse_scalar_value, unpack_nddata,
+                                        validate_array)
+from photutils.aperture._segmentation import (make_segmentation_exclusion,
                                               process_segmentation_inputs)
 from photutils.aperture.core import (_aperture_metadata,
                                      _update_method_subpixels_docstring)
@@ -307,15 +310,14 @@ class ApertureStats:
                  mask_method='none'):
 
         if isinstance(data, NDData):
-            data, error, mask, wcs = self._unpack_nddata(data, error, mask,
-                                                         wcs)
+            data, error, mask, wcs = unpack_nddata(data, error, mask, wcs)
 
         inputs = (data, error, local_bkg)
         names = ('data', 'error', 'local_bkg')
         inputs, unit = process_quantities(inputs, names)
         (data, error, local_bkg) = inputs
 
-        self._data = self._validate_array(data, 'data', shape=False)
+        self._data = validate_array(data, 'data')
         self._data_unit = unit
         self._input_aperture = self._validate_aperture(aperture)
         aperture_meta = _aperture_metadata(aperture)  # use input aperture
@@ -329,8 +331,9 @@ class ApertureStats:
             aperture = region_to_aperture(aperture)
         self.aperture = aperture
 
-        self._error = self._validate_array(error, 'error')
-        self._mask = self._validate_array(mask, 'mask')
+        data_shape = self._data.shape
+        self._error = validate_array(error, 'error', shape=data_shape)
+        self._mask = validate_array(mask, 'mask', shape=data_shape)
         self._wcs = wcs
 
         if sigma_clip is not None and not isinstance(sigma_clip, SigmaClip):
@@ -390,31 +393,6 @@ class ApertureStats:
             seg_positions, self._data.shape)
 
     @staticmethod
-    def _unpack_nddata(data, error, mask, wcs):
-        nddata_attr = {'error': error, 'mask': mask, 'wcs': wcs}
-        for key, value in nddata_attr.items():
-            if value is not None:
-                msg = (f'The {key!r} keyword will be ignored. Its value '
-                       'is obtained from the input NDData object.')
-                warnings.warn(msg, AstropyUserWarning)
-
-        mask = data.mask
-        wcs = data.wcs
-
-        if isinstance(data.uncertainty, StdDevUncertainty):
-            if data.uncertainty.unit is None:
-                error = data.uncertainty.array
-            else:
-                error = data.uncertainty.array * data.uncertainty.unit
-
-        if data.unit is not None:
-            data = u.Quantity(data.data, unit=data.unit)
-        else:
-            data = data.data
-
-        return data, error, mask, wcs
-
-    @staticmethod
     def _validate_aperture(aperture):
         try:
             from regions import Region
@@ -426,19 +404,6 @@ class ApertureStats:
             msg = 'aperture must be an Aperture or Region object'
             raise TypeError(msg)
         return aperture
-
-    def _validate_array(self, array, name, *, ndim=2, shape=True):
-        if name == 'mask' and array is np.ma.nomask:
-            array = None
-        if array is not None:
-            array = np.asanyarray(array)
-            if array.ndim != ndim:
-                msg = f'{name} must be a {ndim}D array'
-                raise ValueError(msg)
-            if shape and array.shape != self._data.shape:
-                msg = f'data and {name} must have the same shape'
-                raise ValueError(msg)
-        return array
 
     @property
     def _lazyproperties(self):
@@ -586,13 +551,9 @@ class ApertureStats:
         value = super().__getattribute__(name)
         if (not name.startswith('_')
                 and name not in _SCALAR_EXCLUDE
-                and isinstance(value, (np.ndarray, SkyCoord, list, tuple))
+                and isinstance(value, SCALAR_COLLAPSE_TYPES)
                 and self.isscalar):
-            try:
-                if len(value) == 1:
-                    return value[0]
-            except TypeError:  # value has no len
-                pass
+            return collapse_scalar_value(value)
         return value
 
     def _array(self, name):
@@ -859,52 +820,17 @@ class ApertureStats:
 
         data = self._data
         error = self._error
-
-        def _supported(arr):
-            return (type(arr) is np.ndarray and arr.dtype.kind in 'fiub'
-                    and arr.dtype.itemsize <= 8)
-
-        if not _supported(data) or (error is not None
-                                    and not _supported(error)):
+        if not batch_inputs_supported(data, error, self._mask):
             return None
 
-        mask = self._mask
-        if mask is not None and (not isinstance(mask, np.ndarray)
-                                 or mask.dtype != bool
-                                 or mask.shape != data.shape):
-            return None
-
-        # Fold non-finite ``data`` values into the mask plane so the
-        # batch kernels can skip the per-pixel finiteness test (and
-        # defer the pixel-value load to contributing pixels only, like
-        # the ``photometry`` method). This matches the mask-based
-        # path, which masks non-finite data before any segmentation
-        # correction. The plane distinguishes the two causes for the
-        # flag counts: bit 1 (value 1) marks input-masked pixels and bit
-        # 2 (value 2) marks non-finite data pixels. Any nonzero value
-        # excludes the pixel.
-        plane = None
-        if mask is not None:
-            plane = mask.astype(np.uint8)
-        if data.dtype.kind == 'f':
-            nonfinite = ~np.isfinite(data)
-            if nonfinite.any():
-                if plane is None:
-                    plane = np.zeros(data.shape, dtype=np.uint8)
-                    plane[nonfinite] = 2
-                else:
-                    plane[nonfinite & (plane == 0)] = 2
-        mask = plane
-        if mask is not None:
-            mask = np.ascontiguousarray(mask)
-
-        seg_arr = None
-        labels_arr = None
-        seg_code = 0
-        if self._segmentation is not None and self._mask_method != 'none':
-            seg_arr = np.ascontiguousarray(self._segmentation, dtype=np.intp)
-            labels_arr = np.ascontiguousarray(self._seg_labels, dtype=np.intp)
-            seg_code = SEG_METHOD_CODES[self._mask_method]
+        # Non-finite ``data`` values are always folded into the mask
+        # plane so the batch kernels can skip the per-pixel finiteness
+        # test (and defer the pixel-value load to contributing pixels
+        # only). This matches the mask-based path, which masks
+        # non-finite data before any segmentation correction.
+        mask = batch_mask_plane(data, self._mask, mask_nonfinite=True)
+        seg_arr, labels_arr, seg_code = batch_segmentation_arrays(
+            self._segmentation, self._seg_labels, self._mask_method)
 
         shape_code, params = spec
         sum_use_exact, sum_subpixels = aper._translate_mask_method(

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -232,6 +232,13 @@ def test_photometry_no_error_flux_err_shape(aperture):
     assert np.all(np.isnan(result.flux_err))
 
 
+class _ErrorSubclass(np.ndarray):
+    """
+    An ndarray subclass, which the batch driver does not accept because
+    it may override the array behavior it relies on.
+    """
+
+
 def test_fallback_inputs():
     """
     Test that inputs not supported by the batch photometry driver cause
@@ -254,10 +261,32 @@ def test_fallback_inputs():
     assert aperture._batch_photometry(DATA, error=None, mask=MASK[1:, :],
                                       method='exact', subpixels=5) is None
 
-    # Unsupported dtype
+    # Unsupported data dtype
     assert aperture._batch_photometry(DATA.astype(complex), error=None,
                                       mask=None, method='exact',
                                       subpixels=5) is None
+
+    # Unsupported error dtype
+    assert aperture._batch_photometry(DATA, error=ERROR.astype(complex),
+                                      mask=None, method='exact',
+                                      subpixels=5) is None
+
+
+def test_fallback_error_subclass_matches_mask_path():
+    """
+    Test that an ``error`` array that the batch driver does not accept
+    gives the same results via the mask-based code path.
+    """
+    aperture = CircularAperture(POSITIONS, r=5.5)
+    error = ERROR.view(_ErrorSubclass)
+    assert aperture._batch_photometry(DATA, error=error, mask=None,
+                                      method='exact', subpixels=5) is None
+
+    result = aperture._photometry(DATA, error=error)
+    expected = aperture._photometry(DATA, error=ERROR)
+    assert_allclose(result.flux, expected.flux, rtol=1e-12, equal_nan=True)
+    assert_allclose(result.flux_err, expected.flux_err, rtol=1e-12,
+                    equal_nan=True)
 
 
 def test_fallback_subclass():

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -62,9 +62,30 @@ def test_bounding_box_eq():
     assert bbox != BoundingBox(1, 10, 9, 20)
     assert bbox != BoundingBox(1, 10, 2, 99)
 
-    match = 'Can compare BoundingBox only to another BoundingBox'
-    with pytest.raises(TypeError, match=match):
-        assert bbox == (1, 10, 2, 20)
+
+def test_bounding_box_eq_other_type():
+    """
+    Test that comparing to a non-BoundingBox returns False instead of
+    raising, so that ``!=`` and container membership work.
+    """
+    bbox = BoundingBox(1, 10, 2, 20)
+    assert bbox != (1, 10, 2, 20)
+    assert bbox != 3
+    assert not bbox == (1, 10, 2, 20)  # noqa: SIM201
+    assert bbox not in [(1, 10, 2, 20), 3]
+    assert bbox in [3, BoundingBox(1, 10, 2, 20)]
+
+
+def test_bounding_box_hash():
+    """
+    Test that a BoundingBox is hashable and that equal bounding boxes
+    hash equally.
+    """
+    bbox = BoundingBox(1, 10, 2, 20)
+    assert hash(bbox) == hash(BoundingBox(1, 10, 2, 20))
+    assert hash(bbox) != hash(BoundingBox(1, 10, 2, 21))
+    assert len({bbox, BoundingBox(1, 10, 2, 20)}) == 1
+    assert {bbox: 'value'}[BoundingBox(1, 10, 2, 20)] == 'value'
 
 
 def test_bounding_box_repr():

--- a/photutils/aperture/tests/test_converters.py
+++ b/photutils/aperture/tests/test_converters.py
@@ -586,11 +586,11 @@ def test_scalar_aperture_to_region_unknown_type():
 
     class _FakeAperture:
         """
-        Minimal fake aperture with shape=() that passes the scalar check
-        but has no matching isinstance branch.
+        Minimal fake scalar aperture that passes the scalar check but
+        has no matching isinstance branch.
         """
 
-        shape = ()
+        isscalar = True
 
     match = 'Cannot convert input aperture to a Region object'
     with pytest.raises(TypeError, match=match):

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -65,6 +65,22 @@ class MinimalAperture(Aperture):
         return np.array([[5.0, 5.0]])
 
 
+class _CachedMaskAperture(CircularAperture):
+    """
+    A CircularAperture that caches and reuses its aperture mask, so that
+    any in-place modification of the mask data is observable.
+    """
+
+    def to_mask(self, method='exact', subpixels=5):
+        """
+        Return the cached aperture mask, computing it if needed.
+        """
+        if '_mask_cache' not in self.__dict__:
+            self.__dict__['_mask_cache'] = super().to_mask(
+                method=method, subpixels=subpixels)
+        return self.__dict__['_mask_cache']
+
+
 class RaisesOnCompare:
     """
     Helper object that raises TypeError on any != comparison, used to
@@ -190,6 +206,34 @@ class TestPixelAperture:
         bbox = aper.bbox
         assert isinstance(bbox, list)
         assert len(bbox) == len(POSITIONS)
+
+    @pytest.mark.parametrize('subpixels', [True, False])
+    def test_to_mask_bool_subpixels(self, subpixels):
+        """
+        Test that a bool subpixels value is rejected. bool is a subclass
+        of int, so True would otherwise be silently used as subpixels=1.
+        """
+        aper = CircularAperture(SCALAR_POS, r=3)
+        match = 'subpixels must be a strictly positive integer'
+        with pytest.raises(ValueError, match=match):
+            aper.to_mask(method='subpixel', subpixels=subpixels)
+
+    def test_area_overlap_does_not_modify_mask(self):
+        """
+        Test that area_overlap does not modify the data of the aperture
+        mask it is given, which it would if a cached mask were reused.
+        """
+        data = np.ones((25, 25))
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[12, 12] = True
+
+        aper = _CachedMaskAperture((12, 12), r=5)
+        expected = aper.to_mask().data.copy()
+        area = aper.area_overlap(data, mask=mask)
+
+        assert_allclose(aper.to_mask().data, expected)
+        # The masked pixel is still excluded from the area
+        assert_allclose(area, aper.area_overlap(data) - 1.0)
 
 
 class TestPixelAperturePhotometry:

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -10,13 +10,39 @@ from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 
-from photutils.aperture import (Aperture, CircularAperture, EllipticalAperture,
-                                SkyCircularAperture)
+from photutils.aperture import (Aperture, AperturePhotometry, CircularAperture,
+                                EllipticalAnnulus, EllipticalAperture,
+                                RectangularAnnulus, RectangularAperture,
+                                SkyCircularAperture, SkyEllipticalAnnulus,
+                                SkyEllipticalAperture, SkyRectangularAnnulus,
+                                SkyRectangularAperture)
 from photutils.aperture.core import (_aperture_metadata,
                                      _update_method_subpixels_docstring)
 
 POSITIONS = [(5, 5), (10, 10), (15, 15)]
 SCALAR_POS = (5, 5)
+SCALAR_POS_20 = (20.0, 20.0)
+
+# Apertures with a ``theta`` rotation angle, with the size parameters
+# needed to construct them. The annuli pass their inner axis explicitly
+# so that no parameter is derived from another at construction, letting
+# the mutation tests below vary a single parameter in isolation.
+ROTATABLE_PIXEL_APERTURES = [
+    (EllipticalAperture, {'a': 6.0, 'b': 2.0}),
+    (EllipticalAnnulus, {'a_in': 3.0, 'a_out': 6.0, 'b_in': 1.5,
+                         'b_out': 4.0}),
+    (RectangularAperture, {'w': 9.0, 'h': 3.0}),
+    (RectangularAnnulus, {'w_in': 4.0, 'w_out': 9.0, 'h_in': 2.0,
+                          'h_out': 6.0}),
+]
+ROTATABLE_SKY_APERTURES = [
+    (SkyEllipticalAperture, {'a': 6.0 * u.arcsec, 'b': 2.0 * u.arcsec}),
+    (SkyEllipticalAnnulus, {'a_in': 3.0 * u.arcsec, 'a_out': 6.0 * u.arcsec,
+                            'b_out': 4.0 * u.arcsec}),
+    (SkyRectangularAperture, {'w': 9.0 * u.arcsec, 'h': 3.0 * u.arcsec}),
+    (SkyRectangularAnnulus, {'w_in': 4.0 * u.arcsec, 'w_out': 9.0 * u.arcsec,
+                             'h_out': 6.0 * u.arcsec}),
+]
 
 
 class MinimalAperture(Aperture):
@@ -250,6 +276,89 @@ class TestPixelAperturePhotometry:
         flux, flux_err = result
         assert_allclose(flux, expected.flux)
         assert_allclose(flux_err, expected.flux_err)
+
+
+class TestApertureParameterMutation:
+    """
+    Tests that reassigning an aperture parameter after construction
+    gives results identical to a freshly constructed aperture.
+    """
+
+    @staticmethod
+    def _assert_same_geometry(aper, expected):
+        assert_allclose(aper._xy_extents, expected._xy_extents)
+        assert aper.bbox == expected.bbox
+        assert_allclose(aper.to_mask().data, expected.to_mask().data)
+        assert_allclose(aper.area, expected.area)
+
+        data = np.arange(41 * 41, dtype=float).reshape((41, 41))
+        assert_allclose(AperturePhotometry(data, aper).flux,
+                        AperturePhotometry(data, expected).flux)
+
+    @pytest.mark.parametrize(('aperture_class', 'params'),
+                             ROTATABLE_PIXEL_APERTURES)
+    def test_theta_reassignment(self, aperture_class, params):
+        """
+        Test that reassigning theta invalidates all of the cached
+        geometry, including the rotation angle in radians.
+        """
+        theta = 0.7
+        aper = aperture_class(SCALAR_POS_20, theta=0.0, **params)
+        # Cache the lazyproperties derived from the original theta
+        aper.to_mask()
+        aper.theta = theta
+
+        expected = aperture_class(SCALAR_POS_20, theta=theta, **params)
+        assert aper._theta_rad == expected._theta_rad
+        self._assert_same_geometry(aper, expected)
+
+    @pytest.mark.parametrize(('aperture_class', 'params'),
+                             ROTATABLE_PIXEL_APERTURES)
+    def test_size_reassignment(self, aperture_class, params):
+        """
+        Test that reassigning a size parameter invalidates all of the
+        cached geometry.
+        """
+        name, value = next(iter(params.items()))
+        aper = aperture_class(SCALAR_POS_20, theta=0.3, **params)
+        aper.to_mask()
+        setattr(aper, name, value * 0.5)
+
+        expected = aperture_class(SCALAR_POS_20, theta=0.3,
+                                  **{**params, name: value * 0.5})
+        self._assert_same_geometry(aper, expected)
+
+    @pytest.mark.parametrize(('aperture_class', 'params'),
+                             ROTATABLE_PIXEL_APERTURES)
+    def test_positions_reassignment(self, aperture_class, params):
+        """
+        Test that reassigning positions invalidates all of the cached
+        geometry.
+        """
+        aper = aperture_class(SCALAR_POS_20, theta=0.3, **params)
+        aper.to_mask()
+        aper.positions = (23.0, 17.0)
+
+        expected = aperture_class((23.0, 17.0), theta=0.3, **params)
+        self._assert_same_geometry(aper, expected)
+
+    @pytest.mark.parametrize(('aperture_class', 'params'),
+                             ROTATABLE_SKY_APERTURES)
+    def test_sky_theta_reassignment(self, aperture_class, params, tan_wcs):
+        """
+        Test that reassigning theta on a sky aperture invalidates the
+        cached rotation angle in radians.
+        """
+        theta = 35.0 * u.deg
+        position = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+        aper = aperture_class(position, theta=0.0 * u.deg, **params)
+        # Cache the lazyproperties derived from the original theta
+        aper.to_pixel(tan_wcs)
+        aper.theta = theta
+
+        expected = aperture_class(position, theta=theta, **params)
+        assert aper._theta_rad == expected._theta_rad
+        assert aper.to_pixel(tan_wcs) == expected.to_pixel(tan_wcs)
 
 
 class TestApertureReprStr:

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -12,16 +12,18 @@ from numpy.testing import assert_allclose
 
 from photutils.aperture import (Aperture, AperturePhotometry, CircularAperture,
                                 EllipticalAnnulus, EllipticalAperture,
-                                RectangularAnnulus, RectangularAperture,
-                                SkyCircularAperture, SkyEllipticalAnnulus,
-                                SkyEllipticalAperture, SkyRectangularAnnulus,
-                                SkyRectangularAperture)
+                                PolygonAperture, RectangularAnnulus,
+                                RectangularAperture, SkyCircularAperture,
+                                SkyEllipticalAnnulus, SkyEllipticalAperture,
+                                SkyRectangularAnnulus, SkyRectangularAperture)
 from photutils.aperture.core import (_aperture_metadata,
                                      _update_method_subpixels_docstring)
 
 POSITIONS = [(5, 5), (10, 10), (15, 15)]
 SCALAR_POS = (5, 5)
 SCALAR_POS_20 = (20.0, 20.0)
+TRIANGLE_OFFSETS = [(0.0, 1.0), (-1.0, -1.0), (1.0, -1.0)]
+SQUARE_OFFSETS = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
 
 # Apertures with a ``theta`` rotation angle, with the size parameters
 # needed to construct them. The annuli pass their inner axis explicitly
@@ -126,6 +128,40 @@ class TestAperture:
         # TypeError on != comparison, mimicking incompatible SkyCoords.
         aper1.__dict__['positions'] = RaisesOnCompare()
         aper2.__dict__['positions'] = RaisesOnCompare()
+        assert aper1 != aper2
+
+    def test_eq_polygons_different_vertex_counts(self):
+        """
+        Test that __eq__ returns False (rather than propagating the
+        broadcasting ValueError) for polygons with different numbers of
+        vertices.
+        """
+        aper1 = PolygonAperture(SCALAR_POS, TRIANGLE_OFFSETS)
+        aper2 = PolygonAperture(SCALAR_POS, SQUARE_OFFSETS)
+        assert aper1 != aper2
+        assert aper2 != aper1
+        assert not aper1 == aper2  # noqa: SIM201
+
+    def test_eq_polygons_different_vertex_counts_containment(self):
+        """
+        Test that container operations that rely on __eq__ work for
+        polygons with different numbers of vertices.
+        """
+        aper1 = PolygonAperture(SCALAR_POS, TRIANGLE_OFFSETS)
+        aper2 = PolygonAperture(SCALAR_POS, SQUARE_OFFSETS)
+        apertures = [aper2, aper1]
+        assert aper1 in apertures
+        apertures.remove(aper1)
+        assert apertures == [aper2]
+
+    def test_eq_different_position_counts(self):
+        """
+        Test that __eq__ returns False (rather than propagating the
+        broadcasting ValueError) for apertures with different numbers of
+        positions.
+        """
+        aper1 = CircularAperture(POSITIONS, r=3)
+        aper2 = CircularAperture(POSITIONS[:2], r=3)
         assert aper1 != aper2
 
 

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -11,7 +11,7 @@ import pytest
 from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.utils.exceptions import AstropyUserWarning
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAperture)
@@ -462,6 +462,27 @@ class TestScalarBehavior:
         aper = CircularAperture((12, 12), r=3)
         phot = AperturePhotometry(data, aper, mask=mask)
         assert phot.decode_flags() == [['masked_pixels']]
+
+    @pytest.mark.parametrize('use_segm_obj', [True, False])
+    def test_scalar_input_attributes_not_collapsed(self, use_segm_obj):
+        """
+        Test that the ``segmentation_image`` and ``labels`` inputs are
+        echoed back unchanged for a scalar instance, i.e., that they are
+        not treated as per-position output arrays.
+        """
+        data, segm = make_scene()
+        segm_in = SegmentationImage(segm) if use_segm_obj else segm
+        aper = CircularAperture((21, 21), r=8)
+        phot = AperturePhotometry(data, aper, segmentation_image=segm_in,
+                                  labels=np.array([1]), mask_method='mask')
+        assert phot.isscalar is True
+        assert phot.segmentation_image is segm_in
+        assert_equal(phot.labels, np.array([1]))
+
+        # The photometry itself is unaffected
+        ref = AperturePhotometry(data, aper,
+                                 mask=(segm > 0) & (segm != 1))
+        assert_allclose(phot.flux, ref.flux)
 
     def test_isscalar_matches_aperture_stats(self, data):
         scalar_aper = CircularAperture((150, 25), r=8)

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -650,6 +650,97 @@ class TestInputValidation:
         with pytest.raises(ValueError, match='must all have the same units'):
             AperturePhotometry(data, aper, error=np.ones((11, 11)))
 
+    @pytest.mark.parametrize('method', ['exact ', 'Exact', 'invalid'])
+    def test_invalid_method_at_init(self, method):
+        """
+        Test that an invalid method is reported at construction rather
+        than at the first access of a measured attribute.
+        """
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+        with pytest.raises(ValueError, match=f'Invalid method: {method!r}'):
+            AperturePhotometry(data, aper, method=method)
+        with pytest.raises(ValueError,
+                           match=f'Invalid sum_method: {method!r}'):
+            ApertureStats(data, aper, sum_method=method)
+
+    @pytest.mark.parametrize('subpixels', [0, -1, 2.5, True])
+    def test_invalid_subpixels_at_init(self, subpixels):
+        """
+        Test that an invalid subpixels value is reported at
+        construction.
+        """
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+        match = 'subpixels must be a strictly positive integer'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, aper, method='subpixel',
+                               subpixels=subpixels)
+        with pytest.raises(ValueError, match=match):
+            ApertureStats(data, aper, sum_method='subpixel',
+                          subpixels=subpixels)
+
+    def test_invalid_mask_method_at_init(self):
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+        match = 'mask_method must be one of'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, aper, mask_method='invalid')
+        with pytest.raises(ValueError, match=match):
+            ApertureStats(data, aper, mask_method='invalid')
+
+
+class TestSegmentationAttributes:
+    """
+    Both classes echo the segmentation-masking inputs back as public
+    attributes.
+    """
+
+    @pytest.mark.parametrize('cls', [AperturePhotometry, ApertureStats])
+    def test_defaults(self, cls):
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+        obj = cls(data, aper)
+        assert obj.segmentation_image is None
+        assert obj.labels is None
+        assert obj.mask_method == 'none'
+
+    @pytest.mark.parametrize('cls', [AperturePhotometry, ApertureStats])
+    def test_inputs_echoed(self, cls):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        obj = cls(data, aper, segmentation_image=segm, labels=[1],
+                  mask_method='mask')
+        assert obj.segmentation_image is segm
+        assert_equal(obj.labels, [1])
+        assert obj.mask_method == 'mask'
+
+    def test_stats_slicing_slices_labels(self):
+        """
+        Test that slicing an ApertureStats also slices the per-aperture
+        ``labels``, so the sliced object reports the labels of the
+        apertures it contains.
+        """
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21), (21, 21)], r=8)
+        stats = ApertureStats(data, aper, segmentation_image=segm,
+                              labels=[1, 2], mask_method='mask')
+        assert_equal(stats.labels, [1, 2])
+        assert_equal(stats[1:].labels, [2])
+        assert stats[0].labels == 1
+        assert stats[0].mask_method == 'mask'
+        assert stats[0].segmentation_image is segm
+
+    def test_photometry_meta_records_mask_method(self):
+        data, segm = make_scene()
+        aper = CircularAperture([(21, 21)], r=8)
+        phot = AperturePhotometry(data, aper, segmentation_image=segm,
+                                  labels=[1], mask_method='mask')
+        args = phot.to_table().meta['aperture_photometry_args']
+        assert "method='exact'" in args
+        assert 'subpixels=5' in args
+        assert "mask_method='mask'" in args
+
 
 class TestReprAndImmutability:
     def test_repr(self, data):

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -202,6 +202,24 @@ class TestNDDataInput:
         with pytest.warns(AstropyUserWarning, match=match):
             AperturePhotometry(nddata, aper, mask=mask)
 
+    def test_nddata_error_keyword_is_ignored(self, data):
+        """
+        Test that the ``error`` keyword is ignored, as warned, when the
+        NDData object has no StdDevUncertainty, matching the handling of
+        the ``mask`` and ``wcs`` keywords.
+        """
+        nddata = NDData(data)
+        aper = CircularAperture((150, 25), 8)
+        error = np.sqrt(np.abs(data))
+        match = 'is obtained from the input NDData object'
+        with pytest.warns(AstropyUserWarning, match=match):
+            phot = AperturePhotometry(nddata, aper, error=error)
+        assert np.isnan(phot.flux_err)
+
+        with pytest.warns(AstropyUserWarning, match=match):
+            stats = ApertureStats(nddata, aper, error=error)
+        assert np.isnan(stats.sum_err)
+
     def test_nddata_units(self, data):
         nddata = NDData(data * u.Jy)
         aper = CircularAperture((150, 25), 8)

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from photutils.aperture import (APERTURE_FLAGS, AperturePhotometry,
                                 ApertureStats, CircularAnnulus,
                                 CircularAperture, EllipticalAperture,
-                                RectangularAperture)
+                                PolygonAperture, RectangularAperture)
 from photutils.aperture.flags import _counts_to_flag_bits
 
 SHAPE = (25, 25)
@@ -111,6 +111,47 @@ def test_partial_overlap_clipped_bbox_only():
     # The exact-method footprint does extend outside
     flags = _flags(aper, data, method='exact')
     assert_array_equal(flags, [APERTURE_FLAGS.PARTIAL_OVERLAP])
+
+
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_polygon_offcenter_no_partial_overlap(method, subpixels):
+    """
+    Test that a polygon lying entirely inside the data is not flagged as
+    partial_overlap even though its bounding box, which is symmetric
+    about ``positions``, is clipped by a data edge.
+    """
+    data = np.ones((12, 12))
+    # The centroid of this triangle is well off-center, so the symmetric
+    # bounding box extends outside the data on two sides
+    aper = PolygonAperture.from_vertices([(1.0, 1.0), (9.0, 1.0),
+                                          (9.0, 9.0)])
+    bbox = aper.bbox
+    assert bbox.ixmax > data.shape[1] or bbox.iymin < 0
+
+    result = AperturePhotometry(data, aper, method=method,
+                                subpixels=subpixels)
+    assert result.flags == 0
+    stats = ApertureStats(data, aper, sum_method=method,
+                          subpixels=subpixels)
+    assert stats.sum_flags == 0
+    assert stats.flags == 0
+
+
+@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+def test_polygon_partial_overlap(method, subpixels):
+    """
+    Test that a polygon extending past a data edge is still flagged as
+    partial_overlap.
+    """
+    data = np.ones((12, 12))
+    aper = PolygonAperture.from_vertices([(-2.0, 1.0), (9.0, 1.0),
+                                          (9.0, 9.0)])
+    result = AperturePhotometry(data, aper, method=method,
+                                subpixels=subpixels)
+    assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
+    stats = ApertureStats(data, aper, sum_method=method,
+                          subpixels=subpixels)
+    assert stats.sum_flags == APERTURE_FLAGS.PARTIAL_OVERLAP
 
 
 def test_no_pixels_tiny_aperture():

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -545,7 +545,7 @@ class TestApertureStats:
         if with_units:
             assert apstats1.sum.unit == unit
 
-        match = 'keyword will be ignored'
+        match = 'keyword is ignored. Its value is obtained from the input'
         nddata = NDData(self.data, uncertainty=uncertainty, mask=mask,
                         wcs=self.wcs, unit=unit)
         with pytest.warns(AstropyUserWarning, match=match):

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -383,6 +383,18 @@ class TestApertureStats:
         tbl = apstats.to_table()
         assert len(tbl) == 1
 
+    def test_select_ids_scalar(self):
+        """
+        Test that select_id(s) on a scalar object raises the same clear
+        TypeError as indexing it.
+        """
+        apstats = self.apstats1[0]
+        match = "A scalar 'ApertureStats' object cannot be indexed"
+        with pytest.raises(TypeError, match=match):
+            apstats.select_ids(1)
+        with pytest.raises(TypeError, match=match):
+            apstats.select_id(1)
+
     @pytest.mark.parametrize('cached', ['moments', 'moments_central',
                                         'cutout_centroid', 'centroid',
                                         'covariance_eigvals', 'data_cutout',

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2842,8 +2842,8 @@ class SourceCatalog:
     @use_detcat
     def ellipticity(self):
         r"""
-        1.0 minus the ratio of the lengths of the semimajor and
-        semiminor axes.
+        1.0 minus the ratio of the lengths of the semiminor and
+        semimajor axes.
 
         .. math::
 


### PR DESCRIPTION
This PR consolidates shared validation and measurement logic between `AperturePhotometry` and `ApertureStats`, making their inputs, scalar outputs, and public attributes consistent. It also fixes aperture edge cases involving reassigned `theta` values, polygon partial-overlap flags, `BoundingBox` comparisons and hashing, and mask mutation in `area_overlap`.

