### PR TITLE
Refactor aperture tests with shared fixtures and base classes

### DIFF
--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -681,11 +681,14 @@ class PixelAperture(Aperture):
         """
         Perform aperture photometry using per-source aperture masks.
 
-        This is the fallback code path for apertures or inputs that are
-        not supported by the batch Cython driver. It also handles the
-        ``mask_method='correct'`` segmentation masking for apertures
-        (e.g., `PolygonAperture`) or statistics (e.g., `ApertureStats`)
-        that do not use the batch driver.
+        This is the fallback code path for apertures or inputs that
+        are not supported by the batch Cython driver, including
+        the segmentation masking methods for such apertures. All
+        of the built-in apertures opt in to the batch driver, so
+        this path is reached only for an unsupported input (see
+        `~photutils.aperture._common.batch_inputs_supported`)
+        or for an `Aperture` subclass that does not define the
+        ``_batch_shape_params`` hook in its own class.
 
         Parameters
         ----------

--- a/photutils/aperture/tests/conftest.py
+++ b/photutils/aperture/tests/conftest.py
@@ -3,10 +3,14 @@
 Shared pytest fixtures for the aperture tests.
 """
 
+import numpy as np
 import pytest
 from astropy.wcs import WCS
 
 from photutils.datasets import make_4gaussians_image
+
+# The shape of the small uniform image used by the quality-flag tests
+UNIT_SHAPE = (25, 25)
 
 
 @pytest.fixture(name='data')
@@ -18,6 +22,26 @@ def fixture_data():
     tests.
     """
     return make_4gaussians_image()
+
+
+@pytest.fixture(name='unit_data')
+def fixture_unit_data():
+    """
+    A small uniform image of ones.
+
+    A fresh array is returned for each test, so it may be modified.
+    """
+    return np.ones(UNIT_SHAPE)
+
+
+@pytest.fixture(name='unit_mask')
+def fixture_unit_mask():
+    """
+    An all-`False` boolean mask matching the ``unit_data`` shape.
+
+    A fresh array is returned for each test, so it may be modified.
+    """
+    return np.zeros(UNIT_SHAPE, dtype=bool)
 
 
 @pytest.fixture

--- a/photutils/aperture/tests/test_aperture_common.py
+++ b/photutils/aperture/tests/test_aperture_common.py
@@ -1,11 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Base classes for aperture tests.
+
+The shape-specific test modules (e.g., ``test_circle``, ``test_ellipse``,
+``test_rectangle``) define one class per aperture class. Each of those
+classes sets the ``aperture`` attribute (a multi-position aperture) and
+the ``copy_param``/``copy_value`` pair naming a parameter to change, and
+inherits the tests that apply to every aperture of that kind from the
+base classes here.
 """
 
+import astropy.units as u
+import pytest
 from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_equal
+
+from photutils.utils._optional_deps import HAS_MATPLOTLIB
 
 
 class BaseTestApertureParams:
@@ -15,6 +26,15 @@ class BaseTestApertureParams:
 
 
 class BaseTestAperture(BaseTestApertureParams):
+    """
+    Tests that apply to every aperture, pixel or sky.
+    """
+
+    # The name and new value of an aperture parameter to change in
+    # test_copy_eq
+    copy_param = None
+    copy_value = None
+
     def test_index(self):
         aper = self.aperture[self.index]
         assert isinstance(aper, self.aperture.__class__)
@@ -52,3 +72,61 @@ class BaseTestAperture(BaseTestApertureParams):
             else:
                 assert (getattr(aper, param)
                         == getattr(self.aperture, param))
+
+    def test_copy_eq(self):
+        """
+        Test that a copy compares equal until one of its parameters is
+        changed.
+        """
+        aper = self.aperture.copy()
+        assert aper == self.aperture
+        setattr(aper, self.copy_param, self.copy_value)
+        assert aper != self.aperture
+
+
+class BaseTestPixelAperture(BaseTestAperture):
+    """
+    Tests that apply to every pixel aperture.
+    """
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_plot(self):
+        self.aperture.plot()
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_plot_returns_patches(self):
+        """
+        Test that plot returns a list of patches usable in a legend.
+        """
+        from matplotlib import pyplot as plt
+        from matplotlib.patches import Patch
+
+        patches = self.aperture.plot()
+        assert isinstance(patches, list)
+        for patch in patches:
+            assert isinstance(patch, Patch)
+
+        _, ax = plt.subplots()
+        ax.legend(patches, list(range(len(patches))))
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_to_patch_nonscalar(self):
+        """
+        Test that _to_patch returns a list for non-scalar apertures.
+        """
+        patches = self.aperture._to_patch()
+        assert isinstance(patches, list)
+
+
+class BaseTestRotatedPixelAperture(BaseTestPixelAperture):
+    """
+    Tests that apply to every pixel aperture with a rotation angle.
+    """
+
+    def test_theta(self):
+        """
+        Test that a theta input as a float is stored as a Quantity in
+        radians.
+        """
+        assert isinstance(self.aperture.theta, u.Quantity)
+        assert self.aperture.theta.unit == u.rad

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -53,237 +53,252 @@ def _gather_fcounts(data, positions, radius, *, mask=None,
     return result[-1]
 
 
-def test_interior_source():
+class TestPixelCounts:
     """
-    Test that a clean interior source has only n_pixels/valid counts.
+    Tests for the per-source pixel counts returned by the batch
+    drivers.
     """
-    data = np.ones(SHAPE)
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
-    assert fc[FLAG_COL_N_PIXELS] > 0
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
-    assert fc[FLAG_COL_MASKED] == 0
-    assert fc[FLAG_COL_NONFINITE_DATA] == 0
-    assert fc[FLAG_COL_NONFINITE_ERROR] == 0
-    assert fc[FLAG_COL_SEG] == 0
-    assert fc[FLAG_COL_UNCORRECTED] == 0
-    assert fc[FLAG_COL_BBOX_CLIPPED] == 0
+
+    def test_interior_source(self):
+        """
+        Test that a clean interior source has only n_pixels/valid counts.
+        """
+        data = np.ones(SHAPE)
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
+        assert fc[FLAG_COL_N_PIXELS] > 0
+        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
+        assert fc[FLAG_COL_MASKED] == 0
+        assert fc[FLAG_COL_NONFINITE_DATA] == 0
+        assert fc[FLAG_COL_NONFINITE_ERROR] == 0
+        assert fc[FLAG_COL_SEG] == 0
+        assert fc[FLAG_COL_UNCORRECTED] == 0
+        assert fc[FLAG_COL_BBOX_CLIPPED] == 0
+
+    def test_no_bbox_overlap(self):
+        """
+        Test that a source with no bounding-box overlap has all-zero counts.
+        """
+        data = np.ones(SHAPE)
+        fc = _sums_fcounts(data, (100.0, 100.0), 3.0)[0]
+        assert_array_equal(fc, 0)
+        fc = _gather_fcounts(data, (100.0, 100.0), 3.0)[0]
+        assert_array_equal(fc, 0)
+
+    @pytest.mark.parametrize('use_exact', [0, 1])
+    def test_masked_pixel_membership(self, use_exact):
+        """
+        Test that only masked pixels with nonzero overlap fraction are
+        counted.
+        """
+        data = np.ones(SHAPE)
+
+        # Pixel inside the aperture
+        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask[12, 12] = 1
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
+                           use_exact=use_exact)[0]
+        assert fc[FLAG_COL_MASKED] == 1
+        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 1
+
+        # Pixel inside the bounding box but outside the aperture (bbox
+        # corner)
+        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask[9, 9] = 1
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
+                           use_exact=use_exact)[0]
+        assert fc[FLAG_COL_MASKED] == 0
+        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
+
+    def test_mask_plane_bits(self):
+        """
+        Test that mask-plane bit 1 counts as masked and bit 2 as non-finite
+        data, with bit 1 taking precedence.
+        """
+        data = np.ones(SHAPE)
+        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask[12, 12] = 1  # input-masked
+        mask[12, 13] = 2  # non-finite data
+        mask[13, 12] = 3  # both; masked wins
+        for func in (_sums_fcounts, _gather_fcounts):
+            fc = func(data, (12.0, 12.0), 3.0, mask=mask)[0]
+            assert fc[FLAG_COL_MASKED] == 2
+            assert fc[FLAG_COL_NONFINITE_DATA] == 1
+            assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 3
+
+    def test_gather_matches_sums_center(self):
+        """
+        Test that the gather kernel flag counts match the photometry kernel
+        with the "center" method.
+        """
+        rng = np.random.default_rng(1)
+        data = rng.normal(size=SHAPE)
+        data[11, 12] = np.nan
+        user_mask = np.zeros(SHAPE, dtype=bool)
+        user_mask[12, 13] = True
+
+        xy = np.array([(12.0, 12.0), (0.5, 3.0), (24.0, 24.0)])
+
+        # 2-bit plane: bit 1 = user mask, bit 2 = non-finite data
+        plane = user_mask.astype(np.uint8)
+        plane |= (~np.isfinite(data) & ~user_mask) * np.uint8(2)
+
+        fc_sums = _sums_fcounts(data, xy, 3.0, mask=plane, use_exact=0,
+                                subpixels=1)
+        fc_gather = _gather_fcounts(data, xy, 3.0, mask=plane)
+        # The gather kernel never reads error values
+        cols = [FLAG_COL_N_PIXELS, FLAG_COL_MASKED, FLAG_COL_NONFINITE_DATA,
+                FLAG_COL_SEG, FLAG_COL_UNCORRECTED, FLAG_COL_VALID,
+                FLAG_COL_BBOX_CLIPPED]
+        assert_array_equal(fc_gather[:, cols], fc_sums[:, cols])
 
 
-def test_no_bbox_overlap():
+class TestNonFiniteCounts:
     """
-    Test that a source with no bounding-box overlap has all-zero counts.
+    Tests for the non-finite data and error indicator counts.
     """
-    data = np.ones(SHAPE)
-    fc = _sums_fcounts(data, (100.0, 100.0), 3.0)[0]
-    assert_array_equal(fc, 0)
-    fc = _gather_fcounts(data, (100.0, 100.0), 3.0)[0]
-    assert_array_equal(fc, 0)
 
+    def test_nonfinite_data_unmasked(self):
+        """
+        Test that unmasked non-finite data values are detected (and still
+        contribute) in the photometry kernel.
 
-@pytest.mark.parametrize('use_exact', [0, 1])
-def test_masked_pixel_membership(use_exact):
-    """
-    Test that only masked pixels with nonzero overlap fraction are
-    counted.
-    """
-    data = np.ones(SHAPE)
-
-    # Pixel inside the aperture
-    mask = np.zeros(SHAPE, dtype=np.uint8)
-    mask[12, 12] = 1
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
-                       use_exact=use_exact)[0]
-    assert fc[FLAG_COL_MASKED] == 1
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 1
-
-    # Pixel inside the bounding box but outside the aperture (bbox
-    # corner)
-    mask = np.zeros(SHAPE, dtype=np.uint8)
-    mask[9, 9] = 1
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
-                       use_exact=use_exact)[0]
-    assert fc[FLAG_COL_MASKED] == 0
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
-
-
-def test_mask_plane_bits():
-    """
-    Test that mask-plane bit 1 counts as masked and bit 2 as non-finite
-    data, with bit 1 taking precedence.
-    """
-    data = np.ones(SHAPE)
-    mask = np.zeros(SHAPE, dtype=np.uint8)
-    mask[12, 12] = 1  # input-masked
-    mask[12, 13] = 2  # non-finite data
-    mask[13, 12] = 3  # both; masked wins
-    for func in (_sums_fcounts, _gather_fcounts):
-        fc = func(data, (12.0, 12.0), 3.0, mask=mask)[0]
-        assert fc[FLAG_COL_MASKED] == 2
+        Unmasked non-finite contributions are detected from the accumulated
+        sums as a 0/1 indicator.
+        """
+        data = np.ones(SHAPE)
+        data[12, 12] = np.nan
+        data[12, 13] = np.inf
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
         assert fc[FLAG_COL_NONFINITE_DATA] == 1
-        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 3
+        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
+
+    def test_nonfinite_error(self):
+        """
+        Test that non-finite error values among contributing pixels are
+        counted.
+        """
+        data = np.ones(SHAPE)
+        error = np.ones(SHAPE)
+        error[12, 12] = np.nan
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error)[0]
+        assert fc[FLAG_COL_NONFINITE_ERROR] == 1
+
+        # A masked pixel with non-finite error is not counted
+        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask[12, 12] = 1
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error, mask=mask)[0]
+        assert fc[FLAG_COL_NONFINITE_ERROR] == 0
 
 
-def test_nonfinite_data_unmasked():
+class TestBboxClipped:
     """
-    Test that unmasked non-finite data values are detected (and still
-    contribute) in the photometry kernel.
-
-    Unmasked non-finite contributions are detected from the accumulated
-    sums as a 0/1 indicator.
+    Tests for the bounding-box-clipped candidate indicator.
     """
-    data = np.ones(SHAPE)
-    data[12, 12] = np.nan
-    data[12, 13] = np.inf
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
-    assert fc[FLAG_COL_NONFINITE_DATA] == 1
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
+
+    @pytest.mark.parametrize('use_exact', [0, 1])
+    def test_indicator(self, use_exact):
+        """
+        Test the bbox-clipped indicator for interior and edge sources.
+        """
+        data = np.ones(SHAPE)
+
+        # Interior source
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, use_exact=use_exact)[0]
+        assert fc[FLAG_COL_BBOX_CLIPPED] == 0
+
+        # Aperture straddling the left edge
+        fc = _sums_fcounts(data, (0.0, 12.0), 3.0, use_exact=use_exact)[0]
+        assert fc[FLAG_COL_BBOX_CLIPPED] == 1
+        assert fc[FLAG_COL_N_PIXELS] > 0
+
+        # Clipped bbox whose "center"-method weights are all inside the data
+        # (the caller resolves the precise outside-weight test)
+        fc = _sums_fcounts(data, (0.2, 12.0), 0.8, use_exact=0,
+                           subpixels=1)[0]
+        assert fc[FLAG_COL_BBOX_CLIPPED] == 1
+        assert fc[FLAG_COL_N_PIXELS] > 0
+
+    def test_parity_with_mask(self):
+        """
+        Test that n_pixels matches the nonzero in-data aperture-mask weights
+        and that the bbox-clipped indicator matches the overlap slices, for
+        randomized positions including edge and rounding cases.
+        """
+        rng = np.random.default_rng(0)
+        data = np.ones(SHAPE)
+        n_src = 50
+        xy = rng.uniform(-6.0, 30.0, size=(n_src, 2))
+        # Include exact half-integer rounding cases
+        xy[:5] = [(0.5, 0.5), (-0.5, 12.0), (24.5, 24.5), (0.0, 0.0),
+                  (12.5, -0.5)]
+        radius = 2.5
+
+        for use_exact, method in ((1, 'exact'), (0, 'center')):
+            fcs = _sums_fcounts(data, xy, radius, use_exact=use_exact,
+                                subpixels=1)
+            apertures = CircularAperture(xy, r=radius)
+            masks = apertures.to_mask(method=method)
+            for fc, apermask in zip(fcs, masks, strict=True):
+                slc_large, slc_small = apermask.get_overlap_slices(SHAPE)
+                if slc_large is None:
+                    assert_array_equal(fc, 0)
+                    continue
+                n_in = np.count_nonzero(apermask.data[slc_small])
+                assert fc[FLAG_COL_N_PIXELS] == n_in
+                full = (slice(0, apermask.data.shape[0]),
+                        slice(0, apermask.data.shape[1]))
+                assert fc[FLAG_COL_BBOX_CLIPPED] == int(slc_small != full)
 
 
-def test_nonfinite_error():
+class TestSegmentationCounts:
     """
-    Test that non-finite error values among contributing pixels are
-    counted.
+    Tests for the segmentation neighbor and uncorrected pixel counts.
     """
-    data = np.ones(SHAPE)
-    error = np.ones(SHAPE)
-    error[12, 12] = np.nan
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error)[0]
-    assert fc[FLAG_COL_NONFINITE_ERROR] == 1
 
-    # A masked pixel with non-finite error is not counted
-    mask = np.zeros(SHAPE, dtype=np.uint8)
-    mask[12, 12] = 1
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error, mask=mask)[0]
-    assert fc[FLAG_COL_NONFINITE_ERROR] == 0
+    def test_seg_counts(self):
+        """
+        Test the segmentation-affected pixel counts for the mask,
+        source_only, and correct methods.
+        """
+        data = np.ones(SHAPE)
+        segm = np.zeros(SHAPE, dtype=np.intp)
+        segm[10:15, 10:15] = 1
+        segm[12, 14] = 2  # neighbor pixel inside the aperture
+        labels = np.array([1], dtype=np.intp)
 
+        # Method 1 ('mask'): neighbor pixels are excluded
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
+                           labels=labels, seg_method=1)[0]
+        assert fc[FLAG_COL_SEG] == 1
+        assert fc[FLAG_COL_UNCORRECTED] == 0
+        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 1
 
-@pytest.mark.parametrize('use_exact', [0, 1])
-def test_bbox_clipped_indicator(use_exact):
-    """
-    Test the bbox-clipped indicator for interior and edge sources.
-    """
-    data = np.ones(SHAPE)
+        # Method 2 ('source_only'): background exclusions are not counted
+        # as neighbor pixels
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
+                           labels=labels, seg_method=2)[0]
+        assert fc[FLAG_COL_SEG] == 1
 
-    # Interior source
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, use_exact=use_exact)[0]
-    assert fc[FLAG_COL_BBOX_CLIPPED] == 0
+        # Method 3 ('correct'): the neighbor pixel is corrected (mirror
+        # pixel is valid)
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
+                           labels=labels, seg_method=3)[0]
+        assert fc[FLAG_COL_SEG] == 1
+        assert fc[FLAG_COL_UNCORRECTED] == 0
+        assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
 
-    # Aperture straddling the left edge
-    fc = _sums_fcounts(data, (0.0, 12.0), 3.0, use_exact=use_exact)[0]
-    assert fc[FLAG_COL_BBOX_CLIPPED] == 1
-    assert fc[FLAG_COL_N_PIXELS] > 0
+        # Method 3 with the mirror pixel also a neighbor: uncorrectable
+        segm2 = segm.copy()
+        segm2[12, 10] = 2  # mirror of (12, 14) across (12, 12)
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm2,
+                           labels=labels, seg_method=3)[0]
+        assert fc[FLAG_COL_SEG] == 2
+        assert fc[FLAG_COL_UNCORRECTED] == 2
 
-    # Clipped bbox whose "center"-method weights are all inside the data
-    # (the caller resolves the precise outside-weight test)
-    fc = _sums_fcounts(data, (0.2, 12.0), 0.8, use_exact=0,
-                       subpixels=1)[0]
-    assert fc[FLAG_COL_BBOX_CLIPPED] == 1
-    assert fc[FLAG_COL_N_PIXELS] > 0
-
-
-def test_bbox_clipped_parity_with_aperture_mask():
-    """
-    Test that n_pixels matches the nonzero in-data aperture-mask weights
-    and that the bbox-clipped indicator matches the overlap slices, for
-    randomized positions including edge and rounding cases.
-    """
-    rng = np.random.default_rng(0)
-    data = np.ones(SHAPE)
-    n_src = 50
-    xy = rng.uniform(-6.0, 30.0, size=(n_src, 2))
-    # Include exact half-integer rounding cases
-    xy[:5] = [(0.5, 0.5), (-0.5, 12.0), (24.5, 24.5), (0.0, 0.0),
-              (12.5, -0.5)]
-    radius = 2.5
-
-    for use_exact, method in ((1, 'exact'), (0, 'center')):
-        fcs = _sums_fcounts(data, xy, radius, use_exact=use_exact,
-                            subpixels=1)
-        apertures = CircularAperture(xy, r=radius)
-        masks = apertures.to_mask(method=method)
-        for fc, apermask in zip(fcs, masks, strict=True):
-            slc_large, slc_small = apermask.get_overlap_slices(SHAPE)
-            if slc_large is None:
-                assert_array_equal(fc, 0)
-                continue
-            n_in = np.count_nonzero(apermask.data[slc_small])
-            assert fc[FLAG_COL_N_PIXELS] == n_in
-            full = (slice(0, apermask.data.shape[0]),
-                    slice(0, apermask.data.shape[1]))
-            assert fc[FLAG_COL_BBOX_CLIPPED] == int(slc_small != full)
-
-
-def test_seg_counts():
-    """
-    Test the segmentation-affected pixel counts for the mask,
-    source_only, and correct methods.
-    """
-    data = np.ones(SHAPE)
-    segm = np.zeros(SHAPE, dtype=np.intp)
-    segm[10:15, 10:15] = 1
-    segm[12, 14] = 2  # neighbor pixel inside the aperture
-    labels = np.array([1], dtype=np.intp)
-
-    # Method 1 ('mask'): neighbor pixels are excluded
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
-                       labels=labels, seg_method=1)[0]
-    assert fc[FLAG_COL_SEG] == 1
-    assert fc[FLAG_COL_UNCORRECTED] == 0
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS] - 1
-
-    # Method 2 ('source_only'): background exclusions are not counted
-    # as neighbor pixels
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
-                       labels=labels, seg_method=2)[0]
-    assert fc[FLAG_COL_SEG] == 1
-
-    # Method 3 ('correct'): the neighbor pixel is corrected (mirror
-    # pixel is valid)
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm,
-                       labels=labels, seg_method=3)[0]
-    assert fc[FLAG_COL_SEG] == 1
-    assert fc[FLAG_COL_UNCORRECTED] == 0
-    assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
-
-    # Method 3 with the mirror pixel also a neighbor: uncorrectable
-    segm2 = segm.copy()
-    segm2[12, 10] = 2  # mirror of (12, 14) across (12, 12)
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, segmentation=segm2,
-                       labels=labels, seg_method=3)[0]
-    assert fc[FLAG_COL_SEG] == 2
-    assert fc[FLAG_COL_UNCORRECTED] == 2
-
-    # Method 3 with a masked mirror pixel: uncorrectable
-    mask = np.zeros(SHAPE, dtype=np.uint8)
-    mask[12, 10] = 1
-    fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
-                       segmentation=segm, labels=labels, seg_method=3)[0]
-    assert fc[FLAG_COL_SEG] == 1
-    assert fc[FLAG_COL_UNCORRECTED] == 1
-
-
-def test_gather_matches_sums_center():
-    """
-    Test that the gather kernel flag counts match the photometry kernel
-    with the "center" method.
-    """
-    rng = np.random.default_rng(1)
-    data = rng.normal(size=SHAPE)
-    data[11, 12] = np.nan
-    user_mask = np.zeros(SHAPE, dtype=bool)
-    user_mask[12, 13] = True
-
-    xy = np.array([(12.0, 12.0), (0.5, 3.0), (24.0, 24.0)])
-
-    # 2-bit plane: bit 1 = user mask, bit 2 = non-finite data
-    plane = user_mask.astype(np.uint8)
-    plane |= (~np.isfinite(data) & ~user_mask) * np.uint8(2)
-
-    fc_sums = _sums_fcounts(data, xy, 3.0, mask=plane, use_exact=0,
-                            subpixels=1)
-    fc_gather = _gather_fcounts(data, xy, 3.0, mask=plane)
-    # The gather kernel never reads error values
-    cols = [FLAG_COL_N_PIXELS, FLAG_COL_MASKED, FLAG_COL_NONFINITE_DATA,
-            FLAG_COL_SEG, FLAG_COL_UNCORRECTED, FLAG_COL_VALID,
-            FLAG_COL_BBOX_CLIPPED]
-    assert_array_equal(fc_gather[:, cols], fc_sums[:, cols])
+        # Method 3 with a masked mirror pixel: uncorrectable
+        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask[12, 10] = 1
+        fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
+                           segmentation=segm, labels=labels, seg_method=3)[0]
+        assert fc[FLAG_COL_SEG] == 1
+        assert fc[FLAG_COL_UNCORRECTED] == 1

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -59,11 +59,11 @@ class TestPixelCounts:
     drivers.
     """
 
-    def test_interior_source(self):
+    def test_interior_source(self, unit_data):
         """
         Test that a clean interior source has only n_pixels/valid counts.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
         assert fc[FLAG_COL_N_PIXELS] > 0
         assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
@@ -74,23 +74,23 @@ class TestPixelCounts:
         assert fc[FLAG_COL_UNCORRECTED] == 0
         assert fc[FLAG_COL_BBOX_CLIPPED] == 0
 
-    def test_no_bbox_overlap(self):
+    def test_no_bbox_overlap(self, unit_data):
         """
         Test that a source with no bounding-box overlap has all-zero counts.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         fc = _sums_fcounts(data, (100.0, 100.0), 3.0)[0]
         assert_array_equal(fc, 0)
         fc = _gather_fcounts(data, (100.0, 100.0), 3.0)[0]
         assert_array_equal(fc, 0)
 
     @pytest.mark.parametrize('use_exact', [0, 1])
-    def test_masked_pixel_membership(self, use_exact):
+    def test_masked_pixel_membership(self, unit_data, use_exact):
         """
         Test that only masked pixels with nonzero overlap fraction are
         counted.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
 
         # Pixel inside the aperture
         mask = np.zeros(SHAPE, dtype=np.uint8)
@@ -109,12 +109,12 @@ class TestPixelCounts:
         assert fc[FLAG_COL_MASKED] == 0
         assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
 
-    def test_mask_plane_bits(self):
+    def test_mask_plane_bits(self, unit_data):
         """
         Test that mask-plane bit 1 counts as masked and bit 2 as non-finite
         data, with bit 1 taking precedence.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         mask = np.zeros(SHAPE, dtype=np.uint8)
         mask[12, 12] = 1  # input-masked
         mask[12, 13] = 2  # non-finite data
@@ -157,7 +157,7 @@ class TestNonFiniteCounts:
     Tests for the non-finite data and error indicator counts.
     """
 
-    def test_nonfinite_data_unmasked(self):
+    def test_nonfinite_data_unmasked(self, unit_data):
         """
         Test that unmasked non-finite data values are detected (and still
         contribute) in the photometry kernel.
@@ -165,19 +165,19 @@ class TestNonFiniteCounts:
         Unmasked non-finite contributions are detected from the accumulated
         sums as a 0/1 indicator.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         data[12, 12] = np.nan
         data[12, 13] = np.inf
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0)[0]
         assert fc[FLAG_COL_NONFINITE_DATA] == 1
         assert fc[FLAG_COL_VALID] == fc[FLAG_COL_N_PIXELS]
 
-    def test_nonfinite_error(self):
+    def test_nonfinite_error(self, unit_data):
         """
         Test that non-finite error values among contributing pixels are
         counted.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         error = np.ones(SHAPE)
         error[12, 12] = np.nan
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error)[0]
@@ -196,11 +196,11 @@ class TestBboxClipped:
     """
 
     @pytest.mark.parametrize('use_exact', [0, 1])
-    def test_indicator(self, use_exact):
+    def test_indicator(self, unit_data, use_exact):
         """
         Test the bbox-clipped indicator for interior and edge sources.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
 
         # Interior source
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0, use_exact=use_exact)[0]
@@ -218,14 +218,14 @@ class TestBboxClipped:
         assert fc[FLAG_COL_BBOX_CLIPPED] == 1
         assert fc[FLAG_COL_N_PIXELS] > 0
 
-    def test_parity_with_mask(self):
+    def test_parity_with_mask(self, unit_data):
         """
         Test that n_pixels matches the nonzero in-data aperture-mask weights
         and that the bbox-clipped indicator matches the overlap slices, for
         randomized positions including edge and rounding cases.
         """
         rng = np.random.default_rng(0)
-        data = np.ones(SHAPE)
+        data = unit_data
         n_src = 50
         xy = rng.uniform(-6.0, 30.0, size=(n_src, 2))
         # Include exact half-integer rounding cases
@@ -255,12 +255,12 @@ class TestSegmentationCounts:
     Tests for the segmentation neighbor and uncorrected pixel counts.
     """
 
-    def test_seg_counts(self):
+    def test_seg_counts(self, unit_data):
         """
         Test the segmentation-affected pixel counts for the mask,
         source_only, and correct methods.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         segm = np.zeros(SHAPE, dtype=np.intp)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor pixel inside the aperture

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -69,169 +69,6 @@ def assert_batch_matches_legacy(aperture, data, *, error=None, mask=None,
                         equal_nan=True)
 
 
-@pytest.mark.parametrize('aperture', APERTURES)
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_matches_legacy(aperture, method, subpixels):
-    """
-    Test that the batch photometry driver gives results identical to the
-    legacy mask-based code path for the given inputs.
-    """
-    assert_batch_matches_legacy(aperture, DATA, method=method,
-                                subpixels=subpixels)
-
-
-@pytest.mark.parametrize('aperture', APERTURES)
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_matches_legacy_error_mask(aperture, method, subpixels):
-    """
-    Test that the batch photometry driver gives results identical to the
-    legacy mask-based code path for the given inputs, including error
-    and mask.
-    """
-    assert_batch_matches_legacy(aperture, DATA, error=ERROR, mask=MASK,
-                                method=method, subpixels=subpixels)
-
-
-@pytest.mark.parametrize('aperture', APERTURES)
-def test_matches_legacy_nan_data(aperture):
-    """
-    Test that the batch photometry driver gives results identical to the
-    legacy mask-based code path for data containing NaN values.
-    """
-    assert_batch_matches_legacy(aperture, DATA_NAN, error=ERROR)
-
-
-@pytest.mark.parametrize('dtype', ['int32', 'uint16', 'float32', 'bool'])
-def test_data_dtypes(dtype):
-    """
-    Test that the batch photometry driver gives results identical to the
-    legacy mask-based code path for different data dtypes, including
-    bool.
-    """
-    rtol = 1e-5 if dtype == 'float32' else 1e-12
-    aperture = CircularAperture(POSITIONS, r=5.5)
-    data = (DATA > 100.0) if dtype == 'bool' else DATA.astype(dtype)
-    batch = aperture._batch_photometry(data, error=None, mask=None,
-                                       method='exact', subpixels=5)
-    legacy = aperture._mask_photometry(data, error=None, mask=None,
-                                       method='exact', subpixels=5)
-    assert batch is not None
-    assert_allclose(batch[0], legacy[0], rtol=rtol, equal_nan=True)
-
-
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_readonly_arrays(method, subpixels):
-    """
-    Test that read-only (non-writeable) data, error, and mask arrays are
-    accepted by the batch photometry driver and give results identical
-    to writeable arrays.
-
-    The batch Cython driver buffers the data, error, and positions into
-    ``const`` typed memoryviews so that read-only arrays do not raise a
-    ``ValueError``.
-    """
-    aperture = CircularAperture(POSITIONS, r=5.5)
-    data = DATA.copy()
-    error = ERROR.copy()
-    mask = MASK.copy()
-    for arr in (data, error, mask):
-        arr.setflags(write=False)
-
-    batch = aperture._batch_photometry(data, error=error, mask=mask,
-                                       method=method, subpixels=subpixels)
-    assert batch is not None
-
-    expected = aperture._batch_photometry(DATA, error=ERROR, mask=MASK,
-                                          method=method,
-                                          subpixels=subpixels)
-    for batch_arr, exp_arr in zip(batch, expected, strict=True):
-        assert_allclose(batch_arr, exp_arr, rtol=1e-12, atol=0,
-                        equal_nan=True)
-
-
-def test_readonly_data_photometry():
-    """
-    Test that ``_photometry`` works with read-only data arrays.
-    """
-    data = np.ones((10, 10))
-    data.setflags(write=False)
-    aperture = CircularAperture((4.5, 4.5), r=4.5)
-    results = aperture._photometry(data, method='exact')
-
-    expected = aperture._photometry(np.ones((10, 10)), method='exact')
-    assert_allclose(results.flux, expected.flux, rtol=1e-12)
-
-
-def test_scalar_position():
-    """
-    Test that the batch photometry driver gives results identical to the
-    legacy mask-based code path for a single scalar position.
-    """
-    aperture = CircularAperture((70.0, 80.0), r=5.5)
-    assert_batch_matches_legacy(aperture, DATA, error=ERROR)
-
-    aperture = EllipticalAperture((70.0, 80.0), 10.124, 5.073)
-    assert_batch_matches_legacy(aperture, DATA, error=ERROR)
-
-
-def test_units():
-    """
-    Test that the batch photometry driver gives results with the same
-    units as the input data and error, and that the values match the
-    legacy code path.
-    """
-    unit = u.Jy
-    aperture = CircularAperture(POSITIONS, r=5.5)
-    results = aperture._photometry(DATA << unit, error=ERROR << unit)
-    assert results.flux.unit == unit
-    assert results.flux_err.unit == unit
-    results2 = aperture._photometry(DATA, error=ERROR)
-    assert_allclose(results.flux.value, results2.flux, equal_nan=True)
-    assert_allclose(results.flux_err.value, results2.flux_err, equal_nan=True)
-
-
-def test_no_overlap_nan_and_err_shape():
-    """
-    Test that sources with no overlap with the data give NaN sums.
-
-    Also, test that the error array always has the same shape as the
-    sums array, filled with NaN when error is not input.
-    """
-    aperture = CircularAperture(POSITIONS, r=5.5)
-    n_outside = 3
-
-    sums, errs, _area, *_ = aperture._batch_photometry(
-        DATA, error=None, mask=None, method='exact', subpixels=5)
-    assert np.isnan(sums).sum() == n_outside
-    assert errs.shape == sums.shape
-    assert np.all(np.isnan(errs))
-
-    sums, errs, _area, *_ = aperture._batch_photometry(
-        DATA, error=ERROR, mask=None, method='exact', subpixels=5)
-    assert errs.shape == sums.shape
-    assert np.isnan(errs).sum() == n_outside
-
-
-@pytest.mark.parametrize('aperture', [
-    CircularAperture(POSITIONS, r=5.5),
-    PolygonAperture.from_regular_polygon(POSITIONS, 6, radius=5.5),
-])
-def test_photometry_no_error_flux_err_shape(aperture):
-    """
-    Test that `photometry` returns a ``flux_err`` array that always
-    has the same length as ``flux`` and is filled with NaN when
-    ``error`` is not input, both for sources with and without overlap.
-
-    ``CircularAperture`` exercises the batch code path and
-    ``PolygonAperture`` exercises the mask-based code path.
-    """
-    result = aperture._photometry(DATA, error=None)
-    assert result.flux_err.shape == result.flux.shape
-    assert np.any(np.isnan(result.flux))
-    assert np.any(~np.isnan(result.flux))
-    assert np.all(np.isnan(result.flux_err))
-
-
 class _ErrorSubclass(np.ndarray):
     """
     An ndarray subclass, which the batch driver does not accept because
@@ -239,133 +76,314 @@ class _ErrorSubclass(np.ndarray):
     """
 
 
-def test_fallback_inputs():
+class TestMaskPathParity:
     """
-    Test that inputs not supported by the batch photometry driver cause
-    it to return None so that the caller falls back to the mask-based
+    The batch driver must give results identical to the mask-based
     code path.
     """
-    aperture = CircularAperture(POSITIONS, r=5.5)
 
-    # Masked-array data
-    data = np.ma.MaskedArray(DATA, mask=MASK)
-    assert aperture._batch_photometry(data, error=None, mask=None,
-                                      method='exact', subpixels=5) is None
+    @pytest.mark.parametrize('aperture', APERTURES)
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_basic(self, aperture, method, subpixels):
+        """
+        Test that the batch photometry driver gives results identical to the
+        legacy mask-based code path for the given inputs.
+        """
+        assert_batch_matches_legacy(aperture, DATA, method=method,
+                                    subpixels=subpixels)
 
-    # Non-bool mask
-    assert aperture._batch_photometry(DATA, error=None,
-                                      mask=MASK.astype(int),
-                                      method='exact', subpixels=5) is None
+    @pytest.mark.parametrize('aperture', APERTURES)
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_error_and_mask(self, aperture, method, subpixels):
+        """
+        Test that the batch photometry driver gives results identical to the
+        legacy mask-based code path for the given inputs, including error
+        and mask.
+        """
+        assert_batch_matches_legacy(aperture, DATA, error=ERROR, mask=MASK,
+                                    method=method, subpixels=subpixels)
 
-    # Mask with mismatched shape
-    assert aperture._batch_photometry(DATA, error=None, mask=MASK[1:, :],
-                                      method='exact', subpixels=5) is None
+    @pytest.mark.parametrize('aperture', APERTURES)
+    def test_nan_data(self, aperture):
+        """
+        Test that the batch photometry driver gives results identical to the
+        legacy mask-based code path for data containing NaN values.
+        """
+        assert_batch_matches_legacy(aperture, DATA_NAN, error=ERROR)
 
-    # Unsupported data dtype
-    assert aperture._batch_photometry(DATA.astype(complex), error=None,
-                                      mask=None, method='exact',
-                                      subpixels=5) is None
+    @pytest.mark.parametrize('dtype', ['int32', 'uint16', 'float32', 'bool'])
+    def test_data_dtypes(self, dtype):
+        """
+        Test that the batch photometry driver gives results identical to the
+        legacy mask-based code path for different data dtypes, including
+        bool.
+        """
+        rtol = 1e-5 if dtype == 'float32' else 1e-12
+        aperture = CircularAperture(POSITIONS, r=5.5)
+        data = (DATA > 100.0) if dtype == 'bool' else DATA.astype(dtype)
+        batch = aperture._batch_photometry(data, error=None, mask=None,
+                                           method='exact', subpixels=5)
+        legacy = aperture._mask_photometry(data, error=None, mask=None,
+                                           method='exact', subpixels=5)
+        assert batch is not None
+        assert_allclose(batch[0], legacy[0], rtol=rtol, equal_nan=True)
 
-    # Unsupported error dtype
-    assert aperture._batch_photometry(DATA, error=ERROR.astype(complex),
-                                      mask=None, method='exact',
-                                      subpixels=5) is None
+    def test_scalar_position(self):
+        """
+        Test that the batch photometry driver gives results identical to the
+        legacy mask-based code path for a single scalar position.
+        """
+        aperture = CircularAperture((70.0, 80.0), r=5.5)
+        assert_batch_matches_legacy(aperture, DATA, error=ERROR)
 
+        aperture = EllipticalAperture((70.0, 80.0), 10.124, 5.073)
+        assert_batch_matches_legacy(aperture, DATA, error=ERROR)
 
-def test_fallback_error_subclass_matches_mask_path():
-    """
-    Test that an ``error`` array that the batch driver does not accept
-    gives the same results via the mask-based code path.
-    """
-    aperture = CircularAperture(POSITIONS, r=5.5)
-    error = ERROR.view(_ErrorSubclass)
-    assert aperture._batch_photometry(DATA, error=error, mask=None,
-                                      method='exact', subpixels=5) is None
-
-    result = aperture._photometry(DATA, error=error)
-    expected = aperture._photometry(DATA, error=ERROR)
-    assert_allclose(result.flux, expected.flux, rtol=1e-12, equal_nan=True)
-    assert_allclose(result.flux_err, expected.flux_err, rtol=1e-12,
-                    equal_nan=True)
-
-
-def test_fallback_subclass():
-    """
-    Test that aperture subclasses that do not themselves define
-    _batch_shape_params fall back to the mask-based code path in
-    photometry, so that any overridden behavior (e.g., to_mask) is
-    honored.
-    """
-
-    class MyAperture(CircularAperture):
-        # Inherits _batch_shape_params, but does not define it in its
-        # own class, so the batch driver must not be used.
-        pass
-
-    aperture = MyAperture(POSITIONS, r=5.5)
-    assert aperture._batch_photometry(DATA, error=None, mask=None,
-                                      method='exact', subpixels=5) is None
-    result = aperture._photometry(DATA)
-    result2 = CircularAperture(POSITIONS, r=5.5)._photometry(DATA)
-    assert_allclose(result.flux, result2.flux, rtol=1e-12, equal_nan=True)
-
-
-def test_optin_subclass():
-    """
-    Test that aperture subclasses that define the _batch_shape_params
-    hook in their own class opt in to the batch code path.
-    """
-
-    class MyAperture(CircularAperture):
-        def _batch_shape_params(self):
-            return super()._batch_shape_params()
-
-    aperture = MyAperture(POSITIONS, r=5.5)
-    result = aperture._batch_photometry(DATA, error=None, mask=None,
-                                        method='exact', subpixels=5)
-    assert result is not None
-    assert_batch_matches_legacy(aperture, DATA, error=ERROR, mask=MASK)
-
-
-def test_optin_subclass_base_hook_returns_none():
-    """
-    Test that when a subclass defines _batch_shape_params (opting in)
-    but the method returns None, _batch_photometry falls back to
-    None.
-
-    This covers:
-    - PixelAperture._batch_shape_params (the base ``return`` on its own
-      line, which is the hook's default no-op implementation), and
-    - the ``if spec is None: return None`` branch in _batch_photometry.
-    """
-
-    class MyAperture(CircularAperture):
-        def _batch_shape_params(self):
-            # Explicitly delegate to the base PixelAperture hook, which
-            # returns None, signalling that the batch driver is not
-            # supported for this subclass.
-            return PixelAperture._batch_shape_params(self)
-
-    aperture = MyAperture(POSITIONS, r=5.5)
-    assert aperture._batch_photometry(DATA, error=None, mask=None,
-                                      method='exact', subpixels=5) is None
-
-
-def test_thread_safety():
-    """
-    Test that the batch driver releases the GIL and is therefore
-    thread-safe by running multiple photometry calls in parallel threads
-    and checking that they all give the same results.
-    """
-    aperture = CircularAperture(POSITIONS, r=5.5)
-    expected = aperture._photometry(DATA, error=ERROR)
-
-    def run(_):
-        return aperture._photometry(DATA, error=ERROR)
-
-    with ThreadPoolExecutor(max_workers=4) as executor:
-        results = list(executor.map(run, range(8)))
-
-    for result in results:
-        assert_allclose(result.flux, expected.flux, rtol=0, atol=0,
+    def test_units(self):
+        """
+        Test that the batch photometry driver gives results with the same
+        units as the input data and error, and that the values match the
+        legacy code path.
+        """
+        unit = u.Jy
+        aperture = CircularAperture(POSITIONS, r=5.5)
+        results = aperture._photometry(DATA << unit, error=ERROR << unit)
+        assert results.flux.unit == unit
+        assert results.flux_err.unit == unit
+        results2 = aperture._photometry(DATA, error=ERROR)
+        assert_allclose(results.flux.value, results2.flux, equal_nan=True)
+        assert_allclose(results.flux_err.value, results2.flux_err,
                         equal_nan=True)
+
+
+class TestReadonlyArrays:
+    """
+    Read-only input arrays must be accepted by the batch driver.
+    """
+
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_batch_driver(self, method, subpixels):
+        """
+        Test that read-only (non-writeable) data, error, and mask arrays are
+        accepted by the batch photometry driver and give results identical
+        to writeable arrays.
+
+        The batch Cython driver buffers the data, error, and positions into
+        ``const`` typed memoryviews so that read-only arrays do not raise a
+        ``ValueError``.
+        """
+        aperture = CircularAperture(POSITIONS, r=5.5)
+        data = DATA.copy()
+        error = ERROR.copy()
+        mask = MASK.copy()
+        for arr in (data, error, mask):
+            arr.setflags(write=False)
+
+        batch = aperture._batch_photometry(data, error=error, mask=mask,
+                                           method=method, subpixels=subpixels)
+        assert batch is not None
+
+        expected = aperture._batch_photometry(DATA, error=ERROR, mask=MASK,
+                                              method=method,
+                                              subpixels=subpixels)
+        for batch_arr, exp_arr in zip(batch, expected, strict=True):
+            assert_allclose(batch_arr, exp_arr, rtol=1e-12, atol=0,
+                            equal_nan=True)
+
+    def test_photometry(self):
+        """
+        Test that ``_photometry`` works with read-only data arrays.
+        """
+        data = np.ones((10, 10))
+        data.setflags(write=False)
+        aperture = CircularAperture((4.5, 4.5), r=4.5)
+        results = aperture._photometry(data, method='exact')
+
+        expected = aperture._photometry(np.ones((10, 10)), method='exact')
+        assert_allclose(results.flux, expected.flux, rtol=1e-12)
+
+
+class TestErrorArrayShape:
+    """
+    The flux errors must always have the same shape as the fluxes.
+    """
+
+    def test_no_overlap(self):
+        """
+        Test that sources with no overlap with the data give NaN sums.
+
+        Also, test that the error array always has the same shape as the
+        sums array, filled with NaN when error is not input.
+        """
+        aperture = CircularAperture(POSITIONS, r=5.5)
+        n_outside = 3
+
+        sums, errs, _area, *_ = aperture._batch_photometry(
+            DATA, error=None, mask=None, method='exact', subpixels=5)
+        assert np.isnan(sums).sum() == n_outside
+        assert errs.shape == sums.shape
+        assert np.all(np.isnan(errs))
+
+        sums, errs, _area, *_ = aperture._batch_photometry(
+            DATA, error=ERROR, mask=None, method='exact', subpixels=5)
+        assert errs.shape == sums.shape
+        assert np.isnan(errs).sum() == n_outside
+
+    @pytest.mark.parametrize('aperture', [
+        CircularAperture(POSITIONS, r=5.5),
+        PolygonAperture.from_regular_polygon(POSITIONS, 6, radius=5.5),
+    ])
+    def test_no_error_input(self, aperture):
+        """
+        Test that `photometry` returns a ``flux_err`` array that always
+        has the same length as ``flux`` and is filled with NaN when
+        ``error`` is not input, both for sources with and without overlap.
+
+        ``CircularAperture`` exercises the batch code path and
+        ``PolygonAperture`` exercises the mask-based code path.
+        """
+        result = aperture._photometry(DATA, error=None)
+        assert result.flux_err.shape == result.flux.shape
+        assert np.any(np.isnan(result.flux))
+        assert np.any(~np.isnan(result.flux))
+        assert np.all(np.isnan(result.flux_err))
+
+
+class TestFallback:
+    """
+    Inputs and apertures that the batch driver does not support must
+    fall back to the mask-based code path.
+    """
+
+    def test_unsupported_inputs(self):
+        """
+        Test that inputs not supported by the batch photometry driver cause
+        it to return None so that the caller falls back to the mask-based
+        code path.
+        """
+        aperture = CircularAperture(POSITIONS, r=5.5)
+
+        # Masked-array data
+        data = np.ma.MaskedArray(DATA, mask=MASK)
+        assert aperture._batch_photometry(data, error=None, mask=None,
+                                          method='exact', subpixels=5) is None
+
+        # Non-bool mask
+        assert aperture._batch_photometry(DATA, error=None,
+                                          mask=MASK.astype(int),
+                                          method='exact', subpixels=5) is None
+
+        # Mask with mismatched shape
+        assert aperture._batch_photometry(DATA, error=None, mask=MASK[1:, :],
+                                          method='exact', subpixels=5) is None
+
+        # Unsupported data dtype
+        assert aperture._batch_photometry(DATA.astype(complex), error=None,
+                                          mask=None, method='exact',
+                                          subpixels=5) is None
+
+        # Unsupported error dtype
+        assert aperture._batch_photometry(DATA, error=ERROR.astype(complex),
+                                          mask=None, method='exact',
+                                          subpixels=5) is None
+
+    def test_error_subclass_matches_mask_path(self):
+        """
+        Test that an ``error`` array that the batch driver does not accept
+        gives the same results via the mask-based code path.
+        """
+        aperture = CircularAperture(POSITIONS, r=5.5)
+        error = ERROR.view(_ErrorSubclass)
+        assert aperture._batch_photometry(DATA, error=error, mask=None,
+                                          method='exact', subpixels=5) is None
+
+        result = aperture._photometry(DATA, error=error)
+        expected = aperture._photometry(DATA, error=ERROR)
+        assert_allclose(result.flux, expected.flux, rtol=1e-12, equal_nan=True)
+        assert_allclose(result.flux_err, expected.flux_err, rtol=1e-12,
+                        equal_nan=True)
+
+    def test_subclass_without_hook(self):
+        """
+        Test that aperture subclasses that do not themselves define
+        _batch_shape_params fall back to the mask-based code path in
+        photometry, so that any overridden behavior (e.g., to_mask) is
+        honored.
+        """
+
+        class MyAperture(CircularAperture):
+            # Inherits _batch_shape_params, but does not define it in its
+            # own class, so the batch driver must not be used.
+            pass
+
+        aperture = MyAperture(POSITIONS, r=5.5)
+        assert aperture._batch_photometry(DATA, error=None, mask=None,
+                                          method='exact', subpixels=5) is None
+        result = aperture._photometry(DATA)
+        result2 = CircularAperture(POSITIONS, r=5.5)._photometry(DATA)
+        assert_allclose(result.flux, result2.flux, rtol=1e-12, equal_nan=True)
+
+    def test_subclass_with_hook(self):
+        """
+        Test that aperture subclasses that define the _batch_shape_params
+        hook in their own class opt in to the batch code path.
+        """
+
+        class MyAperture(CircularAperture):
+            def _batch_shape_params(self):
+                return super()._batch_shape_params()
+
+        aperture = MyAperture(POSITIONS, r=5.5)
+        result = aperture._batch_photometry(DATA, error=None, mask=None,
+                                            method='exact', subpixels=5)
+        assert result is not None
+        assert_batch_matches_legacy(aperture, DATA, error=ERROR, mask=MASK)
+
+    def test_base_hook_none(self):
+        """
+        Test that when a subclass defines _batch_shape_params (opting in)
+        but the method returns None, _batch_photometry falls back to
+        None.
+
+        This covers:
+        - PixelAperture._batch_shape_params (the base ``return`` on its own
+          line, which is the hook's default no-op implementation), and
+        - the ``if spec is None: return None`` branch in _batch_photometry.
+        """
+
+        class MyAperture(CircularAperture):
+            def _batch_shape_params(self):
+                # Explicitly delegate to the base PixelAperture hook, which
+                # returns None, signalling that the batch driver is not
+                # supported for this subclass.
+                return PixelAperture._batch_shape_params(self)
+
+        aperture = MyAperture(POSITIONS, r=5.5)
+        assert aperture._batch_photometry(DATA, error=None, mask=None,
+                                          method='exact', subpixels=5) is None
+
+
+class TestThreadSafety:
+    """
+    The batch driver must give identical results when called
+    concurrently.
+    """
+
+    def test_concurrent_photometry(self):
+        """
+        Test that the batch driver releases the GIL and is therefore
+        thread-safe by running multiple photometry calls in parallel threads
+        and checking that they all give the same results.
+        """
+        aperture = CircularAperture(POSITIONS, r=5.5)
+        expected = aperture._photometry(DATA, error=ERROR)
+
+        def run(_):
+            return aperture._photometry(DATA, error=ERROR)
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(run, range(8)))
+
+        for result in results:
+            assert_allclose(result.flux, expected.flux, rtol=0, atol=0,
+                            equal_nan=True)

--- a/photutils/aperture/tests/test_batch_photometry_driver.py
+++ b/photutils/aperture/tests/test_batch_photometry_driver.py
@@ -49,77 +49,83 @@ _BATCH_SPECS = [
 ]
 
 
-@pytest.mark.parametrize('use_exact', [1, 0])
-def test_readonly_arrays(use_exact):
+class TestBatchApertureSums:
     """
-    Test that the batch driver accepts read-only (non-writeable) data,
-    error, positions, and params arrays and returns results identical to
-    writeable arrays.
-
-    The data, error, positions, and params arguments are declared as
-    ``const`` typed memoryviews so that read-only arrays do not raise a
-    ``ValueError``.
+    Tests for the batch_aperture_sums Cython driver.
     """
-    data, error, mask, positions = _batch_inputs()
-    params = np.array([8.0], dtype=np.float64)
 
-    expected = batch_aperture_sums(data, error, mask, positions, SHAPE_CIRCLE,
-                                   params, 8.0, 8.0, use_exact, 8)
+    @pytest.mark.parametrize('use_exact', [1, 0])
+    def test_readonly_arrays(self, use_exact):
+        """
+        Test that the batch driver accepts read-only (non-writeable) data,
+        error, positions, and params arrays and returns results identical to
+        writeable arrays.
 
-    for arr in (data, error, positions, params):
-        arr.setflags(write=False)
-    result = batch_aperture_sums(data, error, mask, positions, SHAPE_CIRCLE,
-                                 params, 8.0, 8.0, use_exact, 8)
+        The data, error, positions, and params arguments are declared as
+        ``const`` typed memoryviews so that read-only arrays do not raise a
+        ``ValueError``.
+        """
+        data, error, mask, positions = _batch_inputs()
+        params = np.array([8.0], dtype=np.float64)
 
-    for res_arr, exp_arr in zip(result, expected, strict=True):
-        assert_array_equal(res_arr, exp_arr)
+        expected = batch_aperture_sums(data, error, mask, positions,
+                                       SHAPE_CIRCLE,
+                                       params, 8.0, 8.0, use_exact, 8)
 
+        for arr in (data, error, positions, params):
+            arr.setflags(write=False)
+        result = batch_aperture_sums(data, error, mask, positions,
+                                     SHAPE_CIRCLE,
+                                     params, 8.0, 8.0, use_exact, 8)
 
-@pytest.mark.parametrize(('shape_code', 'params', 'ext_x', 'ext_y'),
-                         _BATCH_SPECS)
-@pytest.mark.parametrize('use_exact', [1, 0])
-def test_batch_aperture_sums_threadsafe(shape_code, params, ext_x, ext_y,
-                                        use_exact):
-    data, error, mask, positions = _batch_inputs()
-    params = np.array(params, dtype=np.float64)
+        for res_arr, exp_arr in zip(result, expected, strict=True):
+            assert_array_equal(res_arr, exp_arr)
 
-    def fn():
-        return batch_aperture_sums(data, error, mask, positions, shape_code,
-                                   params, ext_x, ext_y, use_exact, 8)
-
-    expected = fn()
-    with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
-        futures = [ex.submit(fn)
-                   for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
-        for future in futures:
-            result = future.result()
-            for res_arr, exp_arr in zip(result, expected, strict=True):
-                assert_array_equal(res_arr, exp_arr)
-
-
-def test_batch_aperture_sums_mixed_concurrent():
-    """
-    Run every aperture shape through the batch driver concurrently.
-
-    Mixing shapes within the thread pool surfaces interference between
-    calls if any shared mutable state (e.g., a module-level scratch
-    buffer) were introduced into the ``nogil`` source loop.
-    """
-    data, error, mask, positions = _batch_inputs()
-
-    def task(spec):
-        shape_code, params, ext_x, ext_y = spec
+    @pytest.mark.parametrize(('shape_code', 'params', 'ext_x', 'ext_y'),
+                             _BATCH_SPECS)
+    @pytest.mark.parametrize('use_exact', [1, 0])
+    def test_threadsafe(self, shape_code, params, ext_x, ext_y, use_exact):
+        data, error, mask, positions = _batch_inputs()
         params = np.array(params, dtype=np.float64)
-        return batch_aperture_sums(data, error, mask, positions, shape_code,
-                                   params, ext_x, ext_y, 1, 5)
 
-    expected = {spec[0]: task(spec) for spec in _BATCH_SPECS}
+        def fn():
+            return batch_aperture_sums(data, error, mask, positions,
+                                       shape_code, params, ext_x, ext_y,
+                                       use_exact, 8)
 
-    with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
-        futures = {ex.submit(task, spec): spec[0]
-                   for spec in _BATCH_SPECS for _ in range(N_THREADS)}
-        for fut, shape_code in futures.items():
-            result = fut.result()
-            for res_arr, exp_arr in zip(result, expected[shape_code],
-                                        strict=True):
-                assert_array_equal(res_arr, exp_arr)
+        expected = fn()
+        with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+            futures = [ex.submit(fn)
+                       for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
+            for future in futures:
+                result = future.result()
+                for res_arr, exp_arr in zip(result, expected, strict=True):
+                    assert_array_equal(res_arr, exp_arr)
+
+    def test_mixed_concurrent(self):
+        """
+        Run every aperture shape through the batch driver concurrently.
+
+        Mixing shapes within the thread pool surfaces interference between
+        calls if any shared mutable state (e.g., a module-level scratch
+        buffer) were introduced into the ``nogil`` source loop.
+        """
+        data, error, mask, positions = _batch_inputs()
+
+        def task(spec):
+            shape_code, params, ext_x, ext_y = spec
+            params = np.array(params, dtype=np.float64)
+            return batch_aperture_sums(data, error, mask, positions,
+                                       shape_code, params, ext_x, ext_y,
+                                       1, 5)
+
+        expected = {spec[0]: task(spec) for spec in _BATCH_SPECS}
+
+        with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+            futures = {ex.submit(task, spec): spec[0]
+                       for spec in _BATCH_SPECS for _ in range(N_THREADS)}
+            for fut, shape_code in futures.items():
+                result = fut.result()
+                for res_arr, exp_arr in zip(result, expected[shape_code],
+                                            strict=True):
+                    assert_array_equal(res_arr, exp_arr)

--- a/photutils/aperture/tests/test_batch_thread_safety.py
+++ b/photutils/aperture/tests/test_batch_thread_safety.py
@@ -40,37 +40,6 @@ APERTURE_MODULES = ('_batch_photometry', '_batch_stats')
 GIL_DISABLED = bool(sysconfig.get_config_var('Py_GIL_DISABLED'))
 
 
-@pytest.mark.parametrize('modname', APERTURE_MODULES)
-def test_aperture_module_importable(modname):
-    """
-    Test that each compiled aperture batch module imports cleanly.
-
-    On a free-threaded build, importing a module that was not compiled
-    with ``freethreading_compatible=True`` emits a ``RuntimeWarning``
-    and reenables the GIL. This import check is the entry point for the
-    free-threading verification below.
-    """
-    assert importlib.import_module(f'photutils.aperture.{modname}') is not None
-
-
-@pytest.mark.skipif(not GIL_DISABLED,
-                    reason='requires a free-threaded (GIL-disabled) build')
-def test_aperture_modules_do_not_reenable_gil():
-    """
-    Test that importing the aperture Cython batch modules does not
-    reenable the GIL on a free-threaded build.
-
-    Each module is compiled with the ``freethreading_compatible=True``
-    directive, which marks it as free-threading compatible
-    (``Py_MOD_GIL_NOT_USED``). A module lacking that directive would
-    force the runtime to reenable the GIL on import, which this test
-    detects.
-    """
-    for modname in APERTURE_MODULES:
-        importlib.import_module(f'photutils.aperture.{modname}')
-    assert sys._is_gil_enabled() is False
-
-
 def _gather_inputs():
     """
     Build deterministic data, mask, and source positions for the
@@ -118,72 +87,6 @@ def _assert_gather_equal(result, expected):
         assert_array_equal(ly[sl], e_ly[sl])
 
 
-def test_batch_aperture_gather_accepts_none_local_bkg():
-    """
-    Test that ``batch_aperture_gather`` accepts ``local_bkg=None`` and
-    matches an all-zero local background.
-
-    The per-pixel background subtraction is guarded by a ``has_bkg``
-    check so that a `None` ``local_bkg`` is treated as no subtraction
-    rather than dereferencing a NULL memoryview.
-    """
-    data, mask, positions = _gather_inputs()
-    params = np.array([8.0], dtype=np.float64)
-    zeros = np.zeros(positions.shape[0], dtype=np.float64)
-
-    none_result = batch_aperture_gather(data, mask, positions, SHAPE_CIRCLE,
-                                        params, 8.0, 8.0, None)
-    zero_result = batch_aperture_gather(data, mask, positions, SHAPE_CIRCLE,
-                                        params, 8.0, 8.0, zeros)
-
-    _assert_gather_equal(none_result, zero_result)
-
-
-@pytest.mark.parametrize(('shape_code', 'params', 'ext_x', 'ext_y'),
-                         _GATHER_SPECS)
-def test_batch_aperture_gather_threadsafe(shape_code, params, ext_x, ext_y):
-    data, mask, positions = _gather_inputs()
-    params = np.array(params, dtype=np.float64)
-    local_bkg = np.linspace(0.0, 0.5, positions.shape[0])
-
-    def fn():
-        return batch_aperture_gather(data, mask, positions, shape_code,
-                                     params, ext_x, ext_y, local_bkg)
-
-    expected = fn()
-    with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
-        futures = [ex.submit(fn)
-                   for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
-        for future in futures:
-            _assert_gather_equal(future.result(), expected)
-
-
-def test_batch_aperture_gather_mixed_concurrent():
-    """
-    Run every aperture shape through the gatherer concurrently.
-
-    Mixing shapes within the thread pool surfaces interference between
-    calls if any shared mutable state (e.g., a module-level scratch
-    buffer) were introduced into the ``nogil`` gather loop.
-    """
-    data, mask, positions = _gather_inputs()
-    local_bkg = np.linspace(0.0, 0.5, positions.shape[0])
-
-    def task(spec):
-        shape_code, params, ext_x, ext_y = spec
-        params = np.array(params, dtype=np.float64)
-        return batch_aperture_gather(data, mask, positions, shape_code,
-                                     params, ext_x, ext_y, local_bkg)
-
-    expected = {spec[0]: task(spec) for spec in _GATHER_SPECS}
-
-    with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
-        futures = {ex.submit(task, spec): spec[0]
-                   for spec in _GATHER_SPECS for _ in range(N_THREADS)}
-        for fut, shape_code in futures.items():
-            _assert_gather_equal(fut.result(), expected[shape_code])
-
-
 # Properties that exercise the ``_batch_stats`` order-statistic, moment,
 # MAD, biweight, Gini, and mean/variance nogil kernels.
 _STATS_PROPERTIES = ('mean', 'median', 'std', 'mad_std', 'biweight_location',
@@ -191,31 +94,147 @@ _STATS_PROPERTIES = ('mean', 'median', 'std', 'mad_std', 'biweight_location',
                      'sum', 'var', 'centroid')
 
 
-@pytest.mark.parametrize('use_sigma_clip', [False, True])
-def test_aperture_stats_threadsafe(use_sigma_clip):
+class TestFreeThreadingSupport:
     """
-    Test that `ApertureStats` releases the GIL and is thread-safe by
-    running many concurrent calls that drive the ``_batch_stats`` nogil
-    kernels and checking that they all give identical results.
+    The compiled aperture modules must not re-enable the GIL on a
+    free-threaded build.
     """
-    data = make_100gaussians_image()
-    error = np.sqrt(np.abs(data))
-    positions = ((145.1, 168.3), (84.7, 224.1), (48.3, 200.3), (200.0, 100.0))
-    aperture = CircularAperture(positions, r=6.0)
-    sigma_clip = SigmaClip(sigma=3.0, maxiters=10) if use_sigma_clip else None
 
-    def compute():
-        stats = ApertureStats(data, aperture, error=error,
-                              sigma_clip=sigma_clip)
-        return {name: np.asarray(getattr(stats, name))
-                for name in _STATS_PROPERTIES}
+    @pytest.mark.parametrize('modname', APERTURE_MODULES)
+    def test_module_importable(self, modname):
+        """
+        Test that each compiled aperture batch module imports cleanly.
 
-    expected = compute()
-    with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
-        futures = [ex.submit(compute)
-                   for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
-        for future in futures:
-            result = future.result()
-            for name in _STATS_PROPERTIES:
-                assert_allclose(result[name], expected[name],
-                                rtol=0, atol=0, equal_nan=True)
+        On a free-threaded build, importing a module that was not compiled
+        with ``freethreading_compatible=True`` emits a ``RuntimeWarning``
+        and reenables the GIL. This import check is the entry point for the
+        free-threading verification below.
+        """
+        module = importlib.import_module(f'photutils.aperture.{modname}')
+        assert module is not None
+
+    @pytest.mark.skipif(not GIL_DISABLED,
+                        reason='requires a free-threaded (GIL-disabled) build')
+    def test_gil_not_reenabled(self):
+        """
+        Test that importing the aperture Cython batch modules does not
+        reenable the GIL on a free-threaded build.
+
+        Each module is compiled with the ``freethreading_compatible=True``
+        directive, which marks it as free-threading compatible
+        (``Py_MOD_GIL_NOT_USED``). A module lacking that directive would
+        force the runtime to reenable the GIL on import, which this test
+        detects.
+        """
+        for modname in APERTURE_MODULES:
+            importlib.import_module(f'photutils.aperture.{modname}')
+        assert sys._is_gil_enabled() is False
+
+
+class TestBatchApertureGather:
+    """
+    Tests for the batch_aperture_gather Cython driver.
+    """
+
+    def test_accepts_none_local_bkg(self):
+        """
+        Test that ``batch_aperture_gather`` accepts ``local_bkg=None`` and
+        matches an all-zero local background.
+
+        The per-pixel background subtraction is guarded by a ``has_bkg``
+        check so that a `None` ``local_bkg`` is treated as no subtraction
+        rather than dereferencing a NULL memoryview.
+        """
+        data, mask, positions = _gather_inputs()
+        params = np.array([8.0], dtype=np.float64)
+        zeros = np.zeros(positions.shape[0], dtype=np.float64)
+
+        none_result = batch_aperture_gather(data, mask, positions,
+                                            SHAPE_CIRCLE, params, 8.0, 8.0,
+                                            None)
+        zero_result = batch_aperture_gather(data, mask, positions,
+                                            SHAPE_CIRCLE, params, 8.0, 8.0,
+                                            zeros)
+
+        _assert_gather_equal(none_result, zero_result)
+
+    @pytest.mark.parametrize(('shape_code', 'params', 'ext_x', 'ext_y'),
+                             _GATHER_SPECS)
+    def test_threadsafe(self, shape_code, params, ext_x, ext_y):
+        data, mask, positions = _gather_inputs()
+        params = np.array(params, dtype=np.float64)
+        local_bkg = np.linspace(0.0, 0.5, positions.shape[0])
+
+        def fn():
+            return batch_aperture_gather(data, mask, positions, shape_code,
+                                         params, ext_x, ext_y, local_bkg)
+
+        expected = fn()
+        with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+            futures = [ex.submit(fn)
+                       for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
+            for future in futures:
+                _assert_gather_equal(future.result(), expected)
+
+    def test_mixed_concurrent(self):
+        """
+        Run every aperture shape through the gatherer concurrently.
+
+        Mixing shapes within the thread pool surfaces interference between
+        calls if any shared mutable state (e.g., a module-level scratch
+        buffer) were introduced into the ``nogil`` gather loop.
+        """
+        data, mask, positions = _gather_inputs()
+        local_bkg = np.linspace(0.0, 0.5, positions.shape[0])
+
+        def task(spec):
+            shape_code, params, ext_x, ext_y = spec
+            params = np.array(params, dtype=np.float64)
+            return batch_aperture_gather(data, mask, positions, shape_code,
+                                         params, ext_x, ext_y, local_bkg)
+
+        expected = {spec[0]: task(spec) for spec in _GATHER_SPECS}
+
+        with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+            futures = {ex.submit(task, spec): spec[0]
+                       for spec in _GATHER_SPECS for _ in range(N_THREADS)}
+            for fut, shape_code in futures.items():
+                _assert_gather_equal(fut.result(), expected[shape_code])
+
+
+class TestApertureStatsThreadSafety:
+    """
+    ApertureStats must give identical results when computed
+    concurrently.
+    """
+
+    @pytest.mark.parametrize('use_sigma_clip', [False, True])
+    def test_concurrent_stats(self, use_sigma_clip):
+        """
+        Test that `ApertureStats` releases the GIL and is thread-safe by
+        running many concurrent calls that drive the ``_batch_stats`` nogil
+        kernels and checking that they all give identical results.
+        """
+        data = make_100gaussians_image()
+        error = np.sqrt(np.abs(data))
+        positions = ((145.1, 168.3), (84.7, 224.1), (48.3, 200.3),
+                     (200.0, 100.0))
+        aperture = CircularAperture(positions, r=6.0)
+        sigma_clip = (SigmaClip(sigma=3.0, maxiters=10) if use_sigma_clip
+                      else None)
+
+        def compute():
+            stats = ApertureStats(data, aperture, error=error,
+                                  sigma_clip=sigma_clip)
+            return {name: np.asarray(getattr(stats, name))
+                    for name in _STATS_PROPERTIES}
+
+        expected = compute()
+        with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+            futures = [ex.submit(compute)
+                       for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
+            for future in futures:
+                result = future.result()
+                for name in _STATS_PROPERTIES:
+                    assert_allclose(result[name], expected[name],
+                                    rtol=0, atol=0, equal_nan=True)

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -11,186 +11,198 @@ from photutils.aperture.rectangle import RectangularAperture
 from photutils.utils._optional_deps import HAS_MATPLOTLIB
 
 
-def test_bounding_box_init():
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox.ixmin == 1
-    assert bbox.ixmax == 10
-    assert bbox.iymin == 2
-    assert bbox.iymax == 20
-
-
-def test_bounding_box_init_minmax():
-    match = 'ixmin must be <= ixmax'
-    with pytest.raises(ValueError, match=match):
-        BoundingBox(100, 1, 1, 100)
-    match = 'iymin must be <= iymax'
-    with pytest.raises(ValueError, match=match):
-        BoundingBox(1, 100, 100, 1)
-
-
-def test_bounding_box_inputs():
-    match = 'ixmin, ixmax, iymin, and iymax must all be integers'
-    with pytest.raises(TypeError, match=match):
-        BoundingBox([1], [10], [2], [9])
-    with pytest.raises(TypeError, match=match):
-        BoundingBox([1, 2], 10, 2, 9)
-    with pytest.raises(TypeError, match=match):
-        BoundingBox(1.0, 10.0, 2.0, 9.0)
-    with pytest.raises(TypeError, match=match):
-        BoundingBox(1.3, 10, 2, 9)
-    with pytest.raises(TypeError, match=match):
-        BoundingBox(1, 10.3, 2, 9)
-    with pytest.raises(TypeError, match=match):
-        BoundingBox(1, 10, 2.3, 9)
-    with pytest.raises(TypeError, match=match):
-        BoundingBox(1, 10, 2, 9.3)
-
-
-def test_bounding_box_from_float():
-    bbox = BoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
-    assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
-
-    bbox = BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
-    assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
-
-
-def test_bounding_box_eq():
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox == BoundingBox(1, 10, 2, 20)
-    assert bbox != BoundingBox(9, 10, 2, 20)
-    assert bbox != BoundingBox(1, 99, 2, 20)
-    assert bbox != BoundingBox(1, 10, 9, 20)
-    assert bbox != BoundingBox(1, 10, 2, 99)
-
-
-def test_bounding_box_eq_other_type():
+class TestConstruction:
     """
-    Test that comparing to a non-BoundingBox returns False instead of
-    raising, so that ``!=`` and container membership work.
+    Tests for creating BoundingBox objects and validating their inputs.
     """
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox != (1, 10, 2, 20)
-    assert bbox != 3
-    assert not bbox == (1, 10, 2, 20)  # noqa: SIM201
-    assert bbox not in [(1, 10, 2, 20), 3]
-    assert bbox in [3, BoundingBox(1, 10, 2, 20)]
+
+    def test_init(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        assert bbox.ixmin == 1
+        assert bbox.ixmax == 10
+        assert bbox.iymin == 2
+        assert bbox.iymax == 20
+
+    def test_init_minmax(self):
+        match = 'ixmin must be <= ixmax'
+        with pytest.raises(ValueError, match=match):
+            BoundingBox(100, 1, 1, 100)
+        match = 'iymin must be <= iymax'
+        with pytest.raises(ValueError, match=match):
+            BoundingBox(1, 100, 100, 1)
+
+    @pytest.mark.parametrize('inputs', [([1], [10], [2], [9]),
+                                        ([1, 2], 10, 2, 9),
+                                        (1.0, 10.0, 2.0, 9.0),
+                                        (1.3, 10, 2, 9),
+                                        (1, 10.3, 2, 9),
+                                        (1, 10, 2.3, 9),
+                                        (1, 10, 2, 9.3)])
+    def test_non_integer_inputs(self, inputs):
+        match = 'ixmin, ixmax, iymin, and iymax must all be integers'
+        with pytest.raises(TypeError, match=match):
+            BoundingBox(*inputs)
+
+    def test_from_float(self):
+        bbox = BoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
+        assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
+
+        bbox = BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
+        assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
 
 
-def test_bounding_box_hash():
+class TestEqualityAndHashing:
     """
-    Test that a BoundingBox is hashable and that equal bounding boxes
-    hash equally.
+    Tests for BoundingBox comparison and hashing.
     """
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert hash(bbox) == hash(BoundingBox(1, 10, 2, 20))
-    assert hash(bbox) != hash(BoundingBox(1, 10, 2, 21))
-    assert len({bbox, BoundingBox(1, 10, 2, 20)}) == 1
-    assert {bbox: 'value'}[BoundingBox(1, 10, 2, 20)] == 'value'
+
+    def test_eq(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        assert bbox == BoundingBox(1, 10, 2, 20)
+        assert bbox != BoundingBox(9, 10, 2, 20)
+        assert bbox != BoundingBox(1, 99, 2, 20)
+        assert bbox != BoundingBox(1, 10, 9, 20)
+        assert bbox != BoundingBox(1, 10, 2, 99)
+
+    def test_eq_other_type(self):
+        """
+        Test that comparing to a non-BoundingBox returns False instead
+        of raising, so that ``!=`` and container membership work.
+        """
+        bbox = BoundingBox(1, 10, 2, 20)
+        assert bbox != (1, 10, 2, 20)
+        assert bbox != 3
+        assert not bbox == (1, 10, 2, 20)  # noqa: SIM201
+        assert bbox not in [(1, 10, 2, 20), 3]
+        assert bbox in [3, BoundingBox(1, 10, 2, 20)]
+
+    def test_hash(self):
+        """
+        Test that a BoundingBox is hashable and that equal bounding
+        boxes hash equally.
+        """
+        bbox = BoundingBox(1, 10, 2, 20)
+        assert hash(bbox) == hash(BoundingBox(1, 10, 2, 20))
+        assert hash(bbox) != hash(BoundingBox(1, 10, 2, 21))
+        assert len({bbox, BoundingBox(1, 10, 2, 20)}) == 1
+        assert {bbox: 'value'}[BoundingBox(1, 10, 2, 20)] == 'value'
 
 
-def test_bounding_box_repr():
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert repr(bbox) == 'BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)'
-
-
-def test_bounding_box_shape():
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox.shape == (18, 9)
-
-
-def test_bounding_box_center():
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox.center == (10.5, 5)
-
-
-def test_bounding_box_get_overlap_slices():
-    bbox = BoundingBox(1, 10, 2, 20)
-    slc = ((slice(2, 20, None), slice(1, 10, None)),
-           (slice(0, 18, None), slice(0, 9, None)))
-    assert bbox.get_overlap_slices((50, 50)) == slc
-
-    bbox = BoundingBox(-10, -1, 2, 20)
-    assert bbox.get_overlap_slices((50, 50)) == (None, None)
-
-    bbox = BoundingBox(-10, 10, -10, 20)
-    slc = ((slice(0, 20, None), slice(0, 10, None)),
-           (slice(10, 30, None), slice(10, 20, None)))
-    assert bbox.get_overlap_slices((50, 50)) == slc
-
-
-def test_bounding_box_get_overlap_slices_invalid_shape():
+class TestProperties:
     """
-    Test that get_overlap_slices raises ValueError when shape does not
-    have exactly 2 elements.
+    Tests for the BoundingBox geometric properties and repr.
     """
-    bbox = BoundingBox(1, 10, 2, 20)
-    match = 'input shape must have 2 elements'
-    with pytest.raises(ValueError, match=match):
-        bbox.get_overlap_slices((50,))
+
+    def test_repr(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        expected = 'BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)'
+        assert repr(bbox) == expected
+
+    def test_shape(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        assert bbox.shape == (18, 9)
+
+    def test_center(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        assert bbox.center == (10.5, 5)
+
+    def test_extent(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        assert_allclose(bbox.extent, (0.5, 9.5, 1.5, 19.5))
 
 
-def test_bounding_box_extent():
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert_allclose(bbox.extent, (0.5, 9.5, 1.5, 19.5))
+class TestOverlapSlices:
+    """
+    Tests for the BoundingBox get_overlap_slices method.
+    """
+
+    def test_get_overlap_slices(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        slc = ((slice(2, 20, None), slice(1, 10, None)),
+               (slice(0, 18, None), slice(0, 9, None)))
+        assert bbox.get_overlap_slices((50, 50)) == slc
+
+        bbox = BoundingBox(-10, -1, 2, 20)
+        assert bbox.get_overlap_slices((50, 50)) == (None, None)
+
+        bbox = BoundingBox(-10, 10, -10, 20)
+        slc = ((slice(0, 20, None), slice(0, 10, None)),
+               (slice(10, 30, None), slice(10, 20, None)))
+        assert bbox.get_overlap_slices((50, 50)) == slc
+
+    def test_get_overlap_slices_invalid_shape(self):
+        """
+        Test that get_overlap_slices raises ValueError when shape does
+        not have exactly 2 elements.
+        """
+        bbox = BoundingBox(1, 10, 2, 20)
+        match = 'input shape must have 2 elements'
+        with pytest.raises(ValueError, match=match):
+            bbox.get_overlap_slices((50,))
+
+
+class TestSetOperations:
+    """
+    Tests for the BoundingBox union and intersection methods.
+    """
+
+    def test_union(self):
+        bbox1 = BoundingBox(1, 10, 2, 20)
+        bbox2 = BoundingBox(5, 21, 7, 32)
+        bbox_union_expected = BoundingBox(1, 21, 2, 32)
+        bbox_union1 = bbox1 | bbox2
+        bbox_union2 = bbox1.union(bbox2)
+
+        assert bbox_union1 == bbox_union_expected
+        assert bbox_union1 == bbox_union2
+
+        match = 'BoundingBox can be joined only with another BoundingBox'
+        with pytest.raises(TypeError, match=match):
+            bbox1.union((5, 21, 7, 32))
+
+    def test_intersect(self):
+        bbox1 = BoundingBox(1, 10, 2, 20)
+        bbox2 = BoundingBox(5, 21, 7, 32)
+        bbox_intersect_expected = BoundingBox(5, 10, 7, 20)
+        bbox_intersect1 = bbox1 & bbox2
+        bbox_intersect2 = bbox1.intersection(bbox2)
+
+        assert bbox_intersect1 == bbox_intersect_expected
+        assert bbox_intersect1 == bbox_intersect2
+
+        match = 'BoundingBox can be intersected only with another BoundingBox'
+        with pytest.raises(TypeError, match=match):
+            bbox1.intersection((5, 21, 7, 32))
+
+        assert bbox1.intersection(BoundingBox(30, 40, 50, 60)) is None
 
 
 @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-def test_bounding_box_as_artist():
-    bbox = BoundingBox(1, 10, 2, 20)
-    patch = bbox.as_artist()
+class TestPlotting:
+    """
+    Tests for the BoundingBox matplotlib and aperture conversions.
+    """
 
-    assert_allclose(patch.get_xy(), (0.5, 1.5))
-    assert_allclose(patch.get_width(), 9)
-    assert_allclose(patch.get_height(), 18)
+    def test_as_artist(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        patch = bbox.as_artist()
 
+        assert_allclose(patch.get_xy(), (0.5, 1.5))
+        assert_allclose(patch.get_width(), 9)
+        assert_allclose(patch.get_height(), 18)
 
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-def test_bounding_box_plot():
-    from matplotlib.patches import Rectangle
-    bbox = BoundingBox(1, 10, 2, 20)
-    patch = bbox.plot()
-    assert isinstance(patch, Rectangle)
+    def test_plot(self):
+        from matplotlib.patches import Rectangle
+        bbox = BoundingBox(1, 10, 2, 20)
+        patch = bbox.plot()
+        assert isinstance(patch, Rectangle)
 
+    def test_to_aperture(self):
+        bbox = BoundingBox(1, 10, 2, 20)
+        aper = RectangularAperture((5.0, 10.5), w=9.0, h=18.0, theta=0.0)
+        bbox_aper = bbox.to_aperture()
 
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-def test_bounding_box_to_aperture():
-    bbox = BoundingBox(1, 10, 2, 20)
-    aper = RectangularAperture((5.0, 10.5), w=9.0, h=18.0, theta=0.0)
-    bbox_aper = bbox.to_aperture()
-
-    assert_allclose(bbox_aper.positions, aper.positions)
-    assert bbox_aper.w == aper.w
-    assert bbox_aper.h == aper.h
-    assert bbox_aper.theta == aper.theta
-
-
-def test_bounding_box_union():
-    bbox1 = BoundingBox(1, 10, 2, 20)
-    bbox2 = BoundingBox(5, 21, 7, 32)
-    bbox_union_expected = BoundingBox(1, 21, 2, 32)
-    bbox_union1 = bbox1 | bbox2
-    bbox_union2 = bbox1.union(bbox2)
-
-    assert bbox_union1 == bbox_union_expected
-    assert bbox_union1 == bbox_union2
-
-    match = 'BoundingBox can be joined only with another BoundingBox'
-    with pytest.raises(TypeError, match=match):
-        bbox1.union((5, 21, 7, 32))
-
-
-def test_bounding_box_intersect():
-    bbox1 = BoundingBox(1, 10, 2, 20)
-    bbox2 = BoundingBox(5, 21, 7, 32)
-    bbox_intersect_expected = BoundingBox(5, 10, 7, 20)
-    bbox_intersect1 = bbox1 & bbox2
-    bbox_intersect2 = bbox1.intersection(bbox2)
-
-    assert bbox_intersect1 == bbox_intersect_expected
-    assert bbox_intersect1 == bbox_intersect2
-
-    match = 'BoundingBox can be intersected only with another BoundingBox'
-    with pytest.raises(TypeError, match=match):
-        bbox1.intersection((5, 21, 7, 32))
-
-    assert bbox1.intersection(BoundingBox(30, 40, 50, 60)) is None
+        assert_allclose(bbox_aper.positions, aper.positions)
+        assert bbox_aper.w == aper.w
+        assert bbox_aper.h == aper.h
+        assert bbox_aper.theta == aper.theta

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -12,8 +12,8 @@ from numpy.testing import assert_allclose
 from photutils.aperture import PolygonAperture, SkyPolygonAperture
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAnnulus, SkyCircularAperture)
-from photutils.aperture.tests.test_aperture_common import BaseTestAperture
-from photutils.utils._optional_deps import HAS_MATPLOTLIB
+from photutils.aperture.tests.test_aperture_common import (
+    BaseTestAperture, BaseTestPixelAperture)
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
@@ -22,25 +22,10 @@ UNIT = u.arcsec
 RADII = (0.0, -1.0, -np.inf)
 
 
-class TestCircularAperture(BaseTestAperture):
+class TestCircularAperture(BaseTestPixelAperture):
     aperture = CircularAperture(POSITIONS, r=3.0)
-
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_plot(self):
-        self.aperture.plot()
-
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_plot_returns_patches(self):
-        from matplotlib import pyplot as plt
-        from matplotlib.patches import Patch
-
-        my_patches = self.aperture.plot()
-        assert isinstance(my_patches, list)
-        for patch in my_patches:
-            assert isinstance(patch, Patch)
-
-        # Test creating a legend with these patches
-        plt.legend(my_patches, list(range(len(my_patches))))
+    copy_param = 'r'
+    copy_value = 2.0
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -49,35 +34,11 @@ class TestCircularAperture(BaseTestAperture):
         with pytest.raises(ValueError, match=match):
             CircularAperture(POSITIONS, radius)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.r = 2.0
-        assert aper != self.aperture
 
-
-class TestCircularAnnulus(BaseTestAperture):
+class TestCircularAnnulus(BaseTestPixelAperture):
     aperture = CircularAnnulus(POSITIONS, r_in=3.0, r_out=7.0)
-
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_plot(self):
-        self.aperture.plot()
-
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_plot_returns_patches(self):
-        from matplotlib import pyplot as plt
-        from matplotlib.patches import Patch
-
-        my_patches = self.aperture.plot()
-        assert isinstance(my_patches, list)
-
-        for p in my_patches:
-            assert isinstance(p, Patch)
-
-        # Test creating a legend with these patches
-        labels = list(range(len(my_patches)))
-        _, ax = plt.subplots()
-        ax.legend(my_patches, labels)
+    copy_param = 'r_in'
+    copy_value = 2.0
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -90,15 +51,11 @@ class TestCircularAnnulus(BaseTestAperture):
         with pytest.raises(ValueError, match=match):
             CircularAnnulus(POSITIONS, r_in=3.0, r_out=radius)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.r_in = 2.0
-        assert aper != self.aperture
-
 
 class TestSkyCircularAperture(BaseTestAperture):
     aperture = SkyCircularAperture(SKYCOORD, r=3.0 * UNIT)
+    copy_param = 'r'
+    copy_value = 2.0 * UNIT
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -107,15 +64,11 @@ class TestSkyCircularAperture(BaseTestAperture):
         with pytest.raises(ValueError, match=match):
             SkyCircularAperture(SKYCOORD, r=radius * UNIT)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.r = 2.0 * UNIT
-        assert aper != self.aperture
-
 
 class TestSkyCircularAnnulus(BaseTestAperture):
     aperture = SkyCircularAnnulus(SKYCOORD, r_in=3.0 * UNIT, r_out=7.0 * UNIT)
+    copy_param = 'r_in'
+    copy_value = 2.0 * UNIT
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -127,12 +80,6 @@ class TestSkyCircularAnnulus(BaseTestAperture):
         match = "'r_out' must be greater than 'r_in'"
         with pytest.raises(ValueError, match=match):
             SkyCircularAnnulus(SKYCOORD, r_in=3.0 * UNIT, r_out=radius * UNIT)
-
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.r_in = 2.0 * UNIT
-        assert aper != self.aperture
 
     @staticmethod
     def test_r_out_less_than_r_in():
@@ -154,190 +101,195 @@ class TestSkyCircularAnnulus(BaseTestAperture):
             SkyCircularAnnulus(SKYCOORD, r_in=0.5 * u.pix, r_out=7.0 * u.pix)
 
 
-def test_slicing():
-    xypos = [(10, 10), (20, 20), (30, 30)]
-    aper1 = CircularAperture(xypos, r=3)
-    aper2 = aper1[0:2]
-    assert len(aper2) == 2
-
-    aper3 = aper1[0]
-    assert aper3.isscalar
-    match = "A scalar 'CircularAperture' object has no len"
-    with pytest.raises(TypeError, match=match):
-        len(aper3)
-
-    match = "A scalar 'CircularAperture' object cannot be indexed"
-    with pytest.raises(TypeError, match=match):
-        _ = aper3[0]
-
-
-def test_area_overlap():
-    data = np.ones((11, 11))
-    xypos = [(0, 0), (5, 5), (50, 50)]
-    aper = CircularAperture(xypos, r=3)
-    areas = aper.area_overlap(data)
-    assert_allclose(areas, [10.304636, np.pi * 9.0, np.nan])
-
-    data2 = np.ones((11, 11)) * u.Jy
-    areas = aper.area_overlap(data2)
-    assert not isinstance(areas[0], u.Quantity)
-    assert_allclose(areas, [10.304636, np.pi * 9.0, np.nan])
-
-    aper2 = CircularAperture(xypos[1], r=3)
-    area2 = aper2.area_overlap(data)
-    assert_allclose(area2, np.pi * 9.0)
-
-    area2 = aper2.area_overlap(data2)
-    assert not isinstance(area2, u.Quantity)
-    assert_allclose(area2, np.pi * 9.0)
-
-
-def test_area_overlap_mask():
-    data = np.ones((11, 11))
-    mask = np.zeros((11, 11), dtype=bool)
-    mask[0, 0:2] = True
-    mask[5, 5:7] = True
-    xypos = [(0, 0), (5, 5), (50, 50)]
-    aper = CircularAperture(xypos, r=3)
-    areas = aper.area_overlap(data, mask=mask)
-    areas_exp = np.array([10.304636, np.pi * 9.0, np.nan]) - 2.0
-    assert_allclose(areas, areas_exp)
-
-    mask = np.zeros((3, 3), dtype=bool)
-    match = 'mask and data must have the same shape'
-    with pytest.raises(ValueError, match=match):
-        aper.area_overlap(data, mask=mask)
-
-
-def test_invalid_positions():
-    match = r"'positions' must be a \(x, y\) pixel position or a list"
-    with pytest.raises(ValueError, match=match):
-        _ = CircularAperture([], r=3)
-
-    with pytest.raises(ValueError, match=match):
-        _ = CircularAperture([1], r=3)
-
-    with pytest.raises(ValueError, match=match):
-        _ = CircularAperture([[1]], r=3)
-
-    with pytest.raises(ValueError, match=match):
-        _ = CircularAperture([1, 2, 3], r=3)
-
-    with pytest.raises(ValueError, match=match):
-        _ = CircularAperture([[1, 2, 3]], r=3)
-
-    x = np.arange(3)
-    y = np.arange(3)
-    xypos = np.transpose((x, y)) * u.pix
-    match = "'positions' must not be a Quantity"
-    with pytest.raises(TypeError, match=match):
-        _ = CircularAperture(xypos, r=3)
-
-    x = np.arange(3) * u.pix
-    y = np.arange(3)
-    xypos = zip(x, y, strict=True)
-    with pytest.raises(TypeError, match=match):
-        _ = CircularAperture(xypos, r=3)
-
-    x = np.arange(3) * u.pix
-    y = np.arange(3) * u.pix
-    xypos = zip(x, y, strict=True)
-    with pytest.raises(TypeError, match=match):
-        _ = CircularAperture(xypos, r=3)
-
-
-def test_circular_aperture_to_polygon():
-    aper = CircularAperture((10.0, 20.0), r=5.0)
-    poly = aper.to_polygon(n_vertices=200)
-    assert isinstance(poly, PolygonAperture)
-    assert poly.n_vertices == 200
-    assert poly.is_regular
-    assert abs(poly.area - aper.area) / aper.area < 1e-3
-
-    # All vertices lie on the circle of radius r
-    radii = np.hypot(*poly.vertex_offsets.T)
-    assert_allclose(radii, 5.0)
-
-
-def test_circular_aperture_to_polygon_float_n_vertices():
+class TestSlicingAndPositions:
     """
-    Test that a float n_vertices is coerced to an integer.
+    Tests for slicing circular apertures and validating positions.
     """
-    aper = CircularAperture((10.0, 20.0), r=1.0)
-    poly = aper.to_polygon(n_vertices=50.0)
-    assert poly.n_vertices == 50
+
+    def test_slicing(self):
+        xypos = [(10, 10), (20, 20), (30, 30)]
+        aper1 = CircularAperture(xypos, r=3)
+        aper2 = aper1[0:2]
+        assert len(aper2) == 2
+
+        aper3 = aper1[0]
+        assert aper3.isscalar
+        match = "A scalar 'CircularAperture' object has no len"
+        with pytest.raises(TypeError, match=match):
+            len(aper3)
+
+        match = "A scalar 'CircularAperture' object cannot be indexed"
+        with pytest.raises(TypeError, match=match):
+            _ = aper3[0]
+
+    def test_invalid_positions(self):
+        match = r"'positions' must be a \(x, y\) pixel position or a list"
+        with pytest.raises(ValueError, match=match):
+            _ = CircularAperture([], r=3)
+
+        with pytest.raises(ValueError, match=match):
+            _ = CircularAperture([1], r=3)
+
+        with pytest.raises(ValueError, match=match):
+            _ = CircularAperture([[1]], r=3)
+
+        with pytest.raises(ValueError, match=match):
+            _ = CircularAperture([1, 2, 3], r=3)
+
+        with pytest.raises(ValueError, match=match):
+            _ = CircularAperture([[1, 2, 3]], r=3)
+
+        x = np.arange(3)
+        y = np.arange(3)
+        xypos = np.transpose((x, y)) * u.pix
+        match = "'positions' must not be a Quantity"
+        with pytest.raises(TypeError, match=match):
+            _ = CircularAperture(xypos, r=3)
+
+        x = np.arange(3) * u.pix
+        y = np.arange(3)
+        xypos = zip(x, y, strict=True)
+        with pytest.raises(TypeError, match=match):
+            _ = CircularAperture(xypos, r=3)
+
+        x = np.arange(3) * u.pix
+        y = np.arange(3) * u.pix
+        xypos = zip(x, y, strict=True)
+        with pytest.raises(TypeError, match=match):
+            _ = CircularAperture(xypos, r=3)
 
 
-def test_circular_aperture_to_polygon_multi_position():
-    aper = CircularAperture([(10.0, 20.0), (30.0, 40.0)], r=3.0)
-    poly = aper.to_polygon(n_vertices=50)
-    assert poly.vertices.shape == (2, 50, 2)
-
-
-def test_circular_aperture_to_polygon_invalid_n_vertices():
-    aper = CircularAperture((0.0, 0.0), r=1.0)
-    match = 'n_vertices must be at least 3'
-    with pytest.raises(ValueError, match=match):
-        aper.to_polygon(n_vertices=2)
-
-
-def test_sky_circular_aperture_to_polygon():
-    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
-    aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
-    poly = aper.to_polygon(n_vertices=200)
-    assert isinstance(poly, SkyPolygonAperture)
-    assert poly.n_vertices == 200
-    assert poly.is_regular
-    assert_allclose(poly.outer_radius.to_value(u.arcsec), 5.0)
-    assert poly.vertices.shape == (200,)
-
-
-def test_sky_circular_aperture_to_polygon_multi_position():
-    pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
-    aper = SkyCircularAperture(pos, r=3.0 * u.arcsec)
-    poly = aper.to_polygon(n_vertices=50)
-    assert poly.vertices.shape == (2, 50)
-
-
-def test_sky_circular_aperture_to_polygon_invalid_n_vertices():
-    pos = SkyCoord(ra=0.0, dec=0.0, unit='deg')
-    aper = SkyCircularAperture(pos, r=1.0 * u.arcsec)
-    match = 'n_vertices must be at least 3'
-    with pytest.raises(ValueError, match=match):
-        aper.to_polygon(n_vertices=2)
-
-
-def test_sky_circular_aperture_to_polygon_wcs_round_trip(tan_wcs):
+class TestAreaOverlap:
     """
-    Test that converting a SkyCircularAperture to a polygon and then to
-    pixels is equivalent to converting to pixels and then to a polygon.
+    Tests for the circular aperture area_overlap method.
     """
-    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
-    aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
-    poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(tan_wcs)
-    poly_from_pix = aper.to_pixel(tan_wcs).to_polygon(n_vertices=200)
-    assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
-    assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
-                    rtol=1e-6)
+
+    def test_area_overlap(self):
+        data = np.ones((11, 11))
+        xypos = [(0, 0), (5, 5), (50, 50)]
+        aper = CircularAperture(xypos, r=3)
+        areas = aper.area_overlap(data)
+        assert_allclose(areas, [10.304636, np.pi * 9.0, np.nan])
+
+        data2 = np.ones((11, 11)) * u.Jy
+        areas = aper.area_overlap(data2)
+        assert not isinstance(areas[0], u.Quantity)
+        assert_allclose(areas, [10.304636, np.pi * 9.0, np.nan])
+
+        aper2 = CircularAperture(xypos[1], r=3)
+        area2 = aper2.area_overlap(data)
+        assert_allclose(area2, np.pi * 9.0)
+
+        area2 = aper2.area_overlap(data2)
+        assert not isinstance(area2, u.Quantity)
+        assert_allclose(area2, np.pi * 9.0)
+
+    def test_area_overlap_mask(self):
+        data = np.ones((11, 11))
+        mask = np.zeros((11, 11), dtype=bool)
+        mask[0, 0:2] = True
+        mask[5, 5:7] = True
+        xypos = [(0, 0), (5, 5), (50, 50)]
+        aper = CircularAperture(xypos, r=3)
+        areas = aper.area_overlap(data, mask=mask)
+        areas_exp = np.array([10.304636, np.pi * 9.0, np.nan]) - 2.0
+        assert_allclose(areas, areas_exp)
+
+        mask = np.zeros((3, 3), dtype=bool)
+        match = 'mask and data must have the same shape'
+        with pytest.raises(ValueError, match=match):
+            aper.area_overlap(data, mask=mask)
 
 
-def test_circular_aperture_to_polygon_to_sky_round_trip(tan_wcs):
+class TestToPolygon:
     """
-    Test that converting a CircularAperture to a polygon and then to sky
-    is equivalent to converting to sky and then to a polygon.
+    Tests for converting circular apertures to polygon apertures.
     """
-    # The bounding-box orientation can differ at the ~1e-5 level because
-    # the sky shape parameters from ``to_sky`` are derived from a local
-    # linear (SVD) approximation, while the polygon ``to_sky`` maps each
-    # vertex exactly, so only rotation-invariant quantities are compared.
-    aper = CircularAperture((50.0, 50.0), r=5.0)
-    sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(tan_wcs)
-    sky_from_aper = aper.to_sky(tan_wcs).to_polygon(n_vertices=200)
-    assert_allclose(sky_from_poly.positions.ra.deg,
-                    sky_from_aper.positions.ra.deg)
-    assert_allclose(sky_from_poly.positions.dec.deg,
-                    sky_from_aper.positions.dec.deg)
-    assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
-                    sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
-    assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
-                    sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)
+
+    def test_pixel(self):
+        aper = CircularAperture((10.0, 20.0), r=5.0)
+        poly = aper.to_polygon(n_vertices=200)
+        assert isinstance(poly, PolygonAperture)
+        assert poly.n_vertices == 200
+        assert poly.is_regular
+        assert abs(poly.area - aper.area) / aper.area < 1e-3
+
+        # All vertices lie on the circle of radius r
+        radii = np.hypot(*poly.vertex_offsets.T)
+        assert_allclose(radii, 5.0)
+
+    def test_pixel_float_n_vertices(self):
+        """
+        Test that a float n_vertices is coerced to an integer.
+        """
+        aper = CircularAperture((10.0, 20.0), r=1.0)
+        poly = aper.to_polygon(n_vertices=50.0)
+        assert poly.n_vertices == 50
+
+    def test_pixel_multi_position(self):
+        aper = CircularAperture([(10.0, 20.0), (30.0, 40.0)], r=3.0)
+        poly = aper.to_polygon(n_vertices=50)
+        assert poly.vertices.shape == (2, 50, 2)
+
+    def test_pixel_invalid_n_vertices(self):
+        aper = CircularAperture((0.0, 0.0), r=1.0)
+        match = 'n_vertices must be at least 3'
+        with pytest.raises(ValueError, match=match):
+            aper.to_polygon(n_vertices=2)
+
+    def test_sky(self):
+        pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+        aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
+        poly = aper.to_polygon(n_vertices=200)
+        assert isinstance(poly, SkyPolygonAperture)
+        assert poly.n_vertices == 200
+        assert poly.is_regular
+        assert_allclose(poly.outer_radius.to_value(u.arcsec), 5.0)
+        assert poly.vertices.shape == (200,)
+
+    def test_sky_multi_position(self):
+        pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
+        aper = SkyCircularAperture(pos, r=3.0 * u.arcsec)
+        poly = aper.to_polygon(n_vertices=50)
+        assert poly.vertices.shape == (2, 50)
+
+    def test_sky_invalid_n_vertices(self):
+        pos = SkyCoord(ra=0.0, dec=0.0, unit='deg')
+        aper = SkyCircularAperture(pos, r=1.0 * u.arcsec)
+        match = 'n_vertices must be at least 3'
+        with pytest.raises(ValueError, match=match):
+            aper.to_polygon(n_vertices=2)
+
+    def test_sky_wcs_round_trip(self, tan_wcs):
+        """
+        Test that converting a SkyCircularAperture to a polygon and then to
+        pixels is equivalent to converting to pixels and then to a polygon.
+        """
+        pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+        aper = SkyCircularAperture(pos, r=5.0 * u.arcsec)
+        poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(tan_wcs)
+        poly_from_pix = aper.to_pixel(tan_wcs).to_polygon(n_vertices=200)
+        assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
+        assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
+                        rtol=1e-6)
+
+    def test_pixel_to_sky_round_trip(self, tan_wcs):
+        """
+        Test that converting a CircularAperture to a polygon and then to sky
+        is equivalent to converting to sky and then to a polygon.
+        """
+        # The bounding-box orientation can differ at the ~1e-5 level because
+        # the sky shape parameters from ``to_sky`` are derived from a local
+        # linear (SVD) approximation, while the polygon ``to_sky`` maps each
+        # vertex exactly, so only rotation-invariant quantities are compared.
+        aper = CircularAperture((50.0, 50.0), r=5.0)
+        sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(tan_wcs)
+        sky_from_aper = aper.to_sky(tan_wcs).to_polygon(n_vertices=200)
+        assert_allclose(sky_from_poly.positions.ra.deg,
+                        sky_from_aper.positions.ra.deg)
+        assert_allclose(sky_from_poly.positions.dec.deg,
+                        sky_from_aper.positions.dec.deg)
+        assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
+                        sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
+        assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
+                        sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)

--- a/photutils/aperture/tests/test_converters.py
+++ b/photutils/aperture/tests/test_converters.py
@@ -60,538 +60,562 @@ def compare_region_shapes(reg1, reg2):
             assert_allclose(par1, par2)
 
 
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_translation_circle(image_2d_wcs):
-    from regions import CirclePixelRegion, PixCoord
-
-    region_shape = CirclePixelRegion(center=PixCoord(x=42, y=43), radius=4.2)
-    aperture = region_to_aperture(region_shape)
-    assert isinstance(aperture, CircularAperture)
-    assert_allclose(aperture.positions, region_shape.center.xy)
-    assert_allclose(aperture.r, region_shape.radius)
-
-    region_sky = region_shape.to_sky(image_2d_wcs)
-    aperture_sky = region_to_aperture(region_sky)
-    assert isinstance(aperture_sky, SkyCircularAperture)
-    assert aperture_sky.positions == region_sky.center  # SkyCoord
-    assert_quantity_allclose(aperture_sky.r, region_sky.radius)
-
-    # Check that non-scalar center and radius raise ValueError
-    match = 'must be a scalar PixCoord'
-    with pytest.raises(ValueError, match=match):
-        CirclePixelRegion(center=PixCoord(x=[0, 42], y=[1, 43]), radius=4.2)
-    match = 'must be a strictly positive scalar'
-    with pytest.raises(ValueError, match=match):
-        CirclePixelRegion(center=PixCoord(x=42, y=43), radius=[1, 4.2])
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_translation_ellipse(image_2d_wcs):
-    from regions import EllipsePixelRegion, PixCoord
-
-    region_shape = EllipsePixelRegion(
-        center=PixCoord(x=42, y=43), width=16, height=10,
-        angle=Angle(30, 'deg'),
-    )
-    aperture = region_to_aperture(region_shape)
-    assert isinstance(aperture, EllipticalAperture)
-    assert_allclose(aperture.positions, region_shape.center.xy)
-    assert_allclose(aperture.a * 2, region_shape.width)
-    assert_allclose(aperture.b * 2, region_shape.height)
-    assert_quantity_allclose(aperture.theta, region_shape.angle)
-
-    region_sky = region_shape.to_sky(image_2d_wcs)
-    aperture_sky = region_to_aperture(region_sky)
-    assert isinstance(aperture_sky, SkyEllipticalAperture)
-    assert aperture_sky.positions == region_sky.center  # SkyCoord
-    assert_quantity_allclose(aperture_sky.a * 2, region_sky.width)
-    assert_quantity_allclose(aperture_sky.b * 2, region_sky.height)
-    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
-                             region_sky.angle)
-
-    # Check that non-scalar center, width, height, and angle raise
-    # ValueError
-    match = 'must be a scalar PixCoord'
-    with pytest.raises(ValueError, match=match):
-        EllipsePixelRegion(
-            center=PixCoord(x=[0, 42], y=[1, 43]),
-            width=16,
-            height=10,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        EllipsePixelRegion(
-            center=PixCoord(x=42, y=43),
-            width=[1, 16],
-            height=10,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        EllipsePixelRegion(
-            center=PixCoord(x=42, y=43),
-            width=16,
-            height=[1, 10],
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        EllipsePixelRegion(
-            center=PixCoord(x=42, y=43),
-            width=16,
-            height=10,
-            angle=Angle([0, 30], 'deg'),
-        )
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_translation_rectangle(image_2d_wcs):
-    from regions import PixCoord, RectanglePixelRegion
-
-    region_shape = RectanglePixelRegion(
-        center=PixCoord(x=42, y=43), width=16, height=10,
-        angle=Angle(30, 'deg'),
-    )
-    aperture = region_to_aperture(region_shape)
-    assert isinstance(aperture, RectangularAperture)
-    assert_allclose(aperture.positions, region_shape.center.xy)
-    assert_allclose(aperture.w, region_shape.width)
-    assert_allclose(aperture.h, region_shape.height)
-    assert_quantity_allclose(aperture.theta, region_shape.angle)
-
-    region_sky = region_shape.to_sky(image_2d_wcs)
-    aperture_sky = region_to_aperture(region_sky)
-    assert isinstance(aperture_sky, SkyRectangularAperture)
-    assert aperture_sky.positions == region_sky.center  # SkyCoord
-    assert_quantity_allclose(aperture_sky.w, region_sky.width)
-    assert_quantity_allclose(aperture_sky.h, region_sky.height)
-    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
-                             region_sky.angle)
-
-    # Check that non-scalar center, width, height, and angle raise
-    # ValueError
-    match = 'must be a scalar PixCoord'
-    with pytest.raises(ValueError, match=match):
-        RectanglePixelRegion(
-            center=PixCoord(x=[0, 42], y=[1, 43]),
-            width=16,
-            height=10,
-            angle=Angle(30, 'deg'),
-        )
-
-    match = 'must be a strictly positive scalar'
-    with pytest.raises(ValueError, match=match):
-        RectanglePixelRegion(
-            center=PixCoord(x=42, y=43),
-            width=[1, 16],
-            height=10,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=match):
-        RectanglePixelRegion(
-            center=PixCoord(x=42, y=43),
-            width=16,
-            height=[1, 10],
-            angle=Angle(30, 'deg'),
-        )
-    match = 'must be a scalar'
-    with pytest.raises(ValueError, match=match):
-        RectanglePixelRegion(
-            center=PixCoord(x=42, y=43),
-            width=16,
-            height=10,
-            angle=Angle([0, 30], 'deg'),
-        )
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_translation_circle_annulus(image_2d_wcs):
-    from regions import CircleAnnulusPixelRegion, PixCoord
-
-    region_shape = CircleAnnulusPixelRegion(
-        center=PixCoord(x=42, y=43), inner_radius=5, outer_radius=8,
-    )
-    aperture = region_to_aperture(region_shape)
-    assert isinstance(aperture, CircularAnnulus)
-    assert_allclose(aperture.positions, region_shape.center.xy)
-    assert_allclose(aperture.r_in, region_shape.inner_radius)
-    assert_allclose(aperture.r_out, region_shape.outer_radius)
-
-    region_sky = region_shape.to_sky(image_2d_wcs)
-    aperture_sky = region_to_aperture(region_sky)
-    assert isinstance(aperture_sky, SkyCircularAnnulus)
-    assert aperture_sky.positions == region_sky.center  # SkyCoord
-    assert_quantity_allclose(aperture_sky.r_in, region_sky.inner_radius)
-    assert_quantity_allclose(aperture_sky.r_out, region_sky.outer_radius)
-
-    # Check that non-scalar center, inner_radius, and outer_radius raise
-    # ValueError
-    match = 'must be a scalar PixCoord'
-    with pytest.raises(ValueError, match=match):
-        CircleAnnulusPixelRegion(
-            center=PixCoord(x=[0, 42], y=[1, 43]), inner_radius=5,
-            outer_radius=8,
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        CircleAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43), inner_radius=[1, 5], outer_radius=8,
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        CircleAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43), inner_radius=5, outer_radius=[8, 10],
-        )
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_translation_ellipse_annulus(image_2d_wcs):
-    from regions import EllipseAnnulusPixelRegion, PixCoord
-
-    region_shape = EllipseAnnulusPixelRegion(
-        center=PixCoord(x=42, y=43),
-        inner_width=5.5,
-        inner_height=3.5,
-        outer_width=8.5,
-        outer_height=6.5,
-        angle=Angle(30, 'deg'),
-    )
-    aperture = region_to_aperture(region_shape)
-    assert isinstance(aperture, EllipticalAnnulus)
-    assert_allclose(aperture.positions, region_shape.center.xy)
-    assert_allclose(aperture.a_in * 2, region_shape.inner_width)
-    assert_allclose(aperture.a_out * 2, region_shape.outer_width)
-    assert_allclose(aperture.b_in * 2, region_shape.inner_height)
-    assert_allclose(aperture.b_out * 2, region_shape.outer_height)
-    assert_quantity_allclose(aperture.theta, region_shape.angle)
-
-    region_sky = region_shape.to_sky(image_2d_wcs)
-    aperture_sky = region_to_aperture(region_sky)
-    assert isinstance(aperture_sky, SkyEllipticalAnnulus)
-    assert aperture_sky.positions == region_sky.center  # SkyCoord
-    assert_quantity_allclose(aperture_sky.a_in * 2, region_sky.inner_width)
-    assert_quantity_allclose(aperture_sky.a_out * 2, region_sky.outer_width)
-    assert_quantity_allclose(aperture_sky.b_in * 2, region_sky.inner_height)
-    assert_quantity_allclose(aperture_sky.b_out * 2, region_sky.outer_height)
-    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
-                             region_sky.angle)
-
-    # Check that non-scalar center, inner_width, inner_height,
-    # outer_width, outer_height, and angle raise ValueError
-    match = 'must be a scalar PixCoord'
-    with pytest.raises(ValueError, match=match):
-        EllipseAnnulusPixelRegion(
-            center=PixCoord(x=[0, 42], y=[1, 43]),
-            inner_width=5.5,
-            inner_height=3.5,
-            outer_width=8.5,
-            outer_height=6.5,
-            angle=Angle(30, 'deg'),
-        )
-    match = 'must be a strictly positive scalar'
-    with pytest.raises(ValueError, match=match):
-        EllipseAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=[1, 5.5],
-            inner_height=3.5,
-            outer_width=8.5,
-            outer_height=6.5,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=match):
-        EllipseAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=5.5,
-            inner_height=[1, 3.5],
-            outer_width=8.5,
-            outer_height=6.5,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        EllipseAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=5.5,
-            inner_height=3.5,
-            outer_width=[8.5, 10],
-            outer_height=6.5,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        EllipseAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=5.5,
-            inner_height=3.5,
-            outer_width=8.5,
-            outer_height=[6.5, 10],
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        EllipseAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=5.5,
-            inner_height=3.5,
-            outer_width=8.5,
-            outer_height=6.5,
-            angle=Angle([0, 30], 'deg'),
-        )
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_translation_rectangle_annulus(image_2d_wcs):
-    from regions import PixCoord, RectangleAnnulusPixelRegion
-
-    region_shape = RectangleAnnulusPixelRegion(
-        center=PixCoord(x=42, y=43),
-        inner_width=5.5,
-        inner_height=3.5,
-        outer_width=8.5,
-        outer_height=6.5,
-        angle=Angle(30, 'deg'),
-    )
-    aperture = region_to_aperture(region_shape)
-    assert isinstance(aperture, RectangularAnnulus)
-    assert_allclose(aperture.positions, region_shape.center.xy)
-    assert_allclose(aperture.w_in, region_shape.inner_width)
-    assert_allclose(aperture.w_out, region_shape.outer_width)
-    assert_allclose(aperture.h_in, region_shape.inner_height)
-    assert_allclose(aperture.h_out, region_shape.outer_height)
-    assert_quantity_allclose(aperture.theta, region_shape.angle)
-
-    region_sky = region_shape.to_sky(image_2d_wcs)
-    aperture_sky = region_to_aperture(region_sky)
-    assert isinstance(aperture_sky, SkyRectangularAnnulus)
-    assert aperture_sky.positions == region_sky.center  # SkyCoord
-    assert_quantity_allclose(aperture_sky.w_in, region_sky.inner_width)
-    assert_quantity_allclose(aperture_sky.w_out, region_sky.outer_width)
-    assert_quantity_allclose(aperture_sky.h_in, region_sky.inner_height)
-    assert_quantity_allclose(aperture_sky.h_out, region_sky.outer_height)
-    assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
-                             region_sky.angle)
-
-    # Check that non-scalar center, inner_width, inner_height,
-    # outer_width, outer_height, and angle raise ValueError
-    match = 'must be a scalar PixCoord'
-    with pytest.raises(ValueError, match=match):
-        RectangleAnnulusPixelRegion(
-            center=PixCoord(x=[0, 42], y=[1, 43]),
-            inner_width=5.5,
-            inner_height=3.5,
-            outer_width=8.5,
-            outer_height=6.5,
-            angle=Angle(30, 'deg'),
-        )
-
-    match = 'must be a strictly positive scalar'
-    with pytest.raises(ValueError, match=match):
-        RectangleAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=[1, 5.5],
-            inner_height=3.5,
-            outer_width=8.5,
-            outer_height=6.5,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=match):
-        RectangleAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=5.5,
-            inner_height=[1, 3.5],
-            outer_width=8.5,
-            outer_height=6.5,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        RectangleAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=5.5,
-            inner_height=3.5,
-            outer_width=[8.5, 10],
-            outer_height=6.5,
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        RectangleAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=5.5,
-            inner_height=3.5,
-            outer_width=8.5,
-            outer_height=[6.5, 10],
-            angle=Angle(30, 'deg'),
-        )
-    with pytest.raises(ValueError, match=r'must be .* scalar'):
-        RectangleAnnulusPixelRegion(
-            center=PixCoord(x=42, y=43),
-            inner_width=5.5,
-            inner_height=3.5,
-            outer_width=8.5,
-            outer_height=6.5,
-            angle=Angle([0, 30], 'deg'),
-        )
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_translation_polygon(image_2d_wcs):
-    from regions import PixCoord, PolygonPixelRegion
-
-    # Counter-clockwise simple (non-self-intersecting) quadrilateral.
-    x = [42, 50, 47, 40]
-    y = [43, 45, 52, 50]
-    region_shape = PolygonPixelRegion(vertices=PixCoord(x=x, y=y))
-    aperture = region_to_aperture(region_shape)
-    assert isinstance(aperture, PolygonAperture)
-    ref_vertices = np.column_stack((region_shape.vertices.x,
-                                    region_shape.vertices.y))
-    assert_allclose(aperture.vertices, ref_vertices)
-
-    region_sky = region_shape.to_sky(image_2d_wcs)
-    aperture_sky = region_to_aperture(region_sky)
-    assert isinstance(aperture_sky, SkyPolygonAperture)
-    # The inverted RA axis flips the polygon orientation, so the
-    # counter-clockwise normalization reverses the vertex order. Compare
-    # the vertices independently of their ordering.
-    ap_verts = np.column_stack((aperture_sky.vertices.ra.deg,
-                                aperture_sky.vertices.dec.deg))
-    reg_verts = np.column_stack((region_sky.vertices.ra.deg,
-                                 region_sky.vertices.dec.deg))
-    ap_sorted = ap_verts[np.lexsort((ap_verts[:, 1], ap_verts[:, 0]))]
-    reg_sorted = reg_verts[np.lexsort((reg_verts[:, 1], reg_verts[:, 0]))]
-    assert_allclose(ap_sorted, reg_sorted, atol=1e-9)
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_aperture_to_region():
-    from regions import Region, Regions
-
-    xypos = [(10, 20), (30, 40), (50, 60), (70, 80)]
-    ra, dec = np.transpose(xypos)
-    skycoord = SkyCoord(ra=ra, dec=dec, unit='deg')
-    unit = u.arcsec
-
-    # A square polygon centered on each position (zero-centroid offsets
-    # so the pixel round-trip is exact).
-    poly_offsets = np.array([(-5.0, -5.0), (5.0, -5.0),
-                             (5.0, 5.0), (-5.0, 5.0)])
-    theta = np.linspace(0.0, 2 * np.pi, 5, endpoint=False)
-    sky_poly_offsets = np.column_stack([3.0 * np.cos(theta),
-                                        3.0 * np.sin(theta)]) * unit
-
-    apertures = [CircularAperture(xypos, r=3.0),
-                 CircularAnnulus(xypos, r_in=3.0, r_out=7.0),
-                 SkyCircularAperture(skycoord, r=3.0 * unit),
-                 SkyCircularAnnulus(skycoord, r_in=3.0 * unit,
-                                    r_out=7.0 * unit),
-                 EllipticalAperture(xypos, a=10.0, b=5.0, theta=np.pi / 2.0),
-                 EllipticalAnnulus(xypos, a_in=10.0, a_out=20.0, b_out=17.0,
-                                   theta=np.pi / 3),
-                 SkyEllipticalAperture(skycoord, a=10.0 * unit, b=5.0 * unit,
-                                       theta=30 * u.deg),
-                 SkyEllipticalAnnulus(skycoord, a_in=10.0 * unit,
-                                      a_out=20.0 * unit, b_out=17.0 * unit,
-                                      theta=60 * u.deg),
-                 RectangularAperture(xypos, w=10.0, h=5.0, theta=np.pi / 2.0),
-                 RectangularAnnulus(xypos, w_in=10.0, w_out=20.0, h_out=17,
-                                    theta=np.pi / 3),
-                 SkyRectangularAperture(skycoord, w=10.0 * unit, h=5.0 * unit,
-                                        theta=30 * u.deg),
-                 SkyRectangularAnnulus(skycoord, w_in=10.0 * unit,
-                                       w_out=20.0 * unit, h_out=17.0 * unit,
-                                       theta=60 * u.deg),
-                 PolygonAperture(xypos, poly_offsets),
-                 SkyPolygonAperture(skycoord, sky_poly_offsets),
-                 ]
-
-    for aperture in apertures:
-        region0 = aperture_to_region(aperture[0])
-        region = aperture_to_region(aperture)
-
-        assert isinstance(region0, Region)
-        assert isinstance(region, Regions)
-        assert len(region) == len(aperture)
-
-        aper0 = region_to_aperture(region0)
-        if isinstance(aperture, SkyPolygonAperture):
-            # The sky polygon round-trip recomputes the centroid from
-            # the vertices, so positions and offsets match only to
-            # within floating-point tolerance.
-            assert isinstance(aper0, SkyPolygonAperture)
-            sep = aper0.positions.separation(aperture[0].positions)
-            assert_quantity_allclose(sep, 0 * u.deg, atol=1e-9 * u.arcsec)
-            assert_quantity_allclose(aper0.vertex_offsets,
-                                     aperture[0].vertex_offsets,
-                                     atol=1e-9 * u.arcsec)
-        else:
-            assert aper0 == aperture[0]
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_invalid_inputs():
-    from regions import CirclePixelRegion, PixCoord
-
-    aperture = CircularAperture((10, 12), r=4.2)
-    region = CirclePixelRegion(center=PixCoord(x=10, y=12), radius=4.2)
-
-    match = 'Input region must be a Region object'
-    with pytest.raises(TypeError, match=match):
-        region_to_aperture(aperture)
-
-    match = 'Input aperture must be an Aperture object'
-    with pytest.raises(TypeError, match=match):
-        aperture_to_region(region)
-
-    aperture = CircularAperture(((10, 12), (21, 7)), r=4.2)
-    match = r'Only scalar .* apertures are supported'
-    with pytest.raises(ValueError, match=match):
-        _scalar_aperture_to_region(aperture)
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-@pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
-def test_shapely_polygon_to_region():
-    from regions import PixCoord, PolygonPixelRegion
-    from shapely import Polygon
-
-    ref_region = PolygonPixelRegion(vertices=PixCoord(x=[1, 3, 2, 1],
-                                                      y=[1, 1, 4, 2]))
-
-    polygon = Polygon([(1, 1), (3, 1), (2, 4), (1, 2)])
-    region = _shapely_polygon_to_region(polygon)
-    assert region == ref_region
-
-    match = 'Input must be a Polygon or MultiPolygon object'
-    with pytest.raises(TypeError, match=match):
-        _shapely_polygon_to_region('foo')
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-@pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
-def test_shapely_multipolygon_to_region():
+class TestRegionApertureRoundTrip:
     """
-    Test that _shapely_polygon_to_region handles MultiPolygon inputs by
-    returning a Regions object containing one PolygonPixelRegion per
-    polygon.
-    """
-    from regions import Regions
-    from shapely import MultiPolygon, Polygon
-
-    poly1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-    poly2 = Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])
-    multi = MultiPolygon([poly1, poly2])
-    result = _shapely_polygon_to_region(multi)
-    assert isinstance(result, Regions)
-    assert len(result) == 2
-
-
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_scalar_aperture_to_region_unknown_type():
-    """
-    Test that _scalar_aperture_to_region raises TypeError for an
-    aperture type that is not one of the 12 supported classes.
+    Round-trip conversions between regions and apertures for each
+    supported shape.
     """
 
-    class _FakeAperture:
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_circle(self, image_2d_wcs):
+        from regions import CirclePixelRegion, PixCoord
+
+        region_shape = CirclePixelRegion(center=PixCoord(x=42, y=43),
+                                         radius=4.2)
+        aperture = region_to_aperture(region_shape)
+        assert isinstance(aperture, CircularAperture)
+        assert_allclose(aperture.positions, region_shape.center.xy)
+        assert_allclose(aperture.r, region_shape.radius)
+
+        region_sky = region_shape.to_sky(image_2d_wcs)
+        aperture_sky = region_to_aperture(region_sky)
+        assert isinstance(aperture_sky, SkyCircularAperture)
+        assert aperture_sky.positions == region_sky.center  # SkyCoord
+        assert_quantity_allclose(aperture_sky.r, region_sky.radius)
+
+        # Check that non-scalar center and radius raise ValueError
+        match = 'must be a scalar PixCoord'
+        with pytest.raises(ValueError, match=match):
+            CirclePixelRegion(center=PixCoord(x=[0, 42], y=[1, 43]),
+                              radius=4.2)
+        match = 'must be a strictly positive scalar'
+        with pytest.raises(ValueError, match=match):
+            CirclePixelRegion(center=PixCoord(x=42, y=43), radius=[1, 4.2])
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_ellipse(self, image_2d_wcs):
+        from regions import EllipsePixelRegion, PixCoord
+
+        region_shape = EllipsePixelRegion(
+            center=PixCoord(x=42, y=43), width=16, height=10,
+            angle=Angle(30, 'deg'),
+        )
+        aperture = region_to_aperture(region_shape)
+        assert isinstance(aperture, EllipticalAperture)
+        assert_allclose(aperture.positions, region_shape.center.xy)
+        assert_allclose(aperture.a * 2, region_shape.width)
+        assert_allclose(aperture.b * 2, region_shape.height)
+        assert_quantity_allclose(aperture.theta, region_shape.angle)
+
+        region_sky = region_shape.to_sky(image_2d_wcs)
+        aperture_sky = region_to_aperture(region_sky)
+        assert isinstance(aperture_sky, SkyEllipticalAperture)
+        assert aperture_sky.positions == region_sky.center  # SkyCoord
+        assert_quantity_allclose(aperture_sky.a * 2, region_sky.width)
+        assert_quantity_allclose(aperture_sky.b * 2, region_sky.height)
+        assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
+                                 region_sky.angle)
+
+        # Check that non-scalar center, width, height, and angle raise
+        # ValueError
+        match = 'must be a scalar PixCoord'
+        with pytest.raises(ValueError, match=match):
+            EllipsePixelRegion(
+                center=PixCoord(x=[0, 42], y=[1, 43]),
+                width=16,
+                height=10,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            EllipsePixelRegion(
+                center=PixCoord(x=42, y=43),
+                width=[1, 16],
+                height=10,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            EllipsePixelRegion(
+                center=PixCoord(x=42, y=43),
+                width=16,
+                height=[1, 10],
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            EllipsePixelRegion(
+                center=PixCoord(x=42, y=43),
+                width=16,
+                height=10,
+                angle=Angle([0, 30], 'deg'),
+            )
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_rectangle(self, image_2d_wcs):
+        from regions import PixCoord, RectanglePixelRegion
+
+        region_shape = RectanglePixelRegion(
+            center=PixCoord(x=42, y=43), width=16, height=10,
+            angle=Angle(30, 'deg'),
+        )
+        aperture = region_to_aperture(region_shape)
+        assert isinstance(aperture, RectangularAperture)
+        assert_allclose(aperture.positions, region_shape.center.xy)
+        assert_allclose(aperture.w, region_shape.width)
+        assert_allclose(aperture.h, region_shape.height)
+        assert_quantity_allclose(aperture.theta, region_shape.angle)
+
+        region_sky = region_shape.to_sky(image_2d_wcs)
+        aperture_sky = region_to_aperture(region_sky)
+        assert isinstance(aperture_sky, SkyRectangularAperture)
+        assert aperture_sky.positions == region_sky.center  # SkyCoord
+        assert_quantity_allclose(aperture_sky.w, region_sky.width)
+        assert_quantity_allclose(aperture_sky.h, region_sky.height)
+        assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
+                                 region_sky.angle)
+
+        # Check that non-scalar center, width, height, and angle raise
+        # ValueError
+        match = 'must be a scalar PixCoord'
+        with pytest.raises(ValueError, match=match):
+            RectanglePixelRegion(
+                center=PixCoord(x=[0, 42], y=[1, 43]),
+                width=16,
+                height=10,
+                angle=Angle(30, 'deg'),
+            )
+
+        match = 'must be a strictly positive scalar'
+        with pytest.raises(ValueError, match=match):
+            RectanglePixelRegion(
+                center=PixCoord(x=42, y=43),
+                width=[1, 16],
+                height=10,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=match):
+            RectanglePixelRegion(
+                center=PixCoord(x=42, y=43),
+                width=16,
+                height=[1, 10],
+                angle=Angle(30, 'deg'),
+            )
+        match = 'must be a scalar'
+        with pytest.raises(ValueError, match=match):
+            RectanglePixelRegion(
+                center=PixCoord(x=42, y=43),
+                width=16,
+                height=10,
+                angle=Angle([0, 30], 'deg'),
+            )
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_circle_annulus(self, image_2d_wcs):
+        from regions import CircleAnnulusPixelRegion, PixCoord
+
+        region_shape = CircleAnnulusPixelRegion(
+            center=PixCoord(x=42, y=43), inner_radius=5, outer_radius=8,
+        )
+        aperture = region_to_aperture(region_shape)
+        assert isinstance(aperture, CircularAnnulus)
+        assert_allclose(aperture.positions, region_shape.center.xy)
+        assert_allclose(aperture.r_in, region_shape.inner_radius)
+        assert_allclose(aperture.r_out, region_shape.outer_radius)
+
+        region_sky = region_shape.to_sky(image_2d_wcs)
+        aperture_sky = region_to_aperture(region_sky)
+        assert isinstance(aperture_sky, SkyCircularAnnulus)
+        assert aperture_sky.positions == region_sky.center  # SkyCoord
+        assert_quantity_allclose(aperture_sky.r_in, region_sky.inner_radius)
+        assert_quantity_allclose(aperture_sky.r_out, region_sky.outer_radius)
+
+        # Check that non-scalar center, inner_radius, and outer_radius raise
+        # ValueError
+        match = 'must be a scalar PixCoord'
+        with pytest.raises(ValueError, match=match):
+            CircleAnnulusPixelRegion(
+                center=PixCoord(x=[0, 42], y=[1, 43]), inner_radius=5,
+                outer_radius=8,
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            CircleAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43), inner_radius=[1, 5],
+                outer_radius=8,
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            CircleAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43), inner_radius=5,
+                outer_radius=[8, 10],
+            )
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_ellipse_annulus(self, image_2d_wcs):
+        from regions import EllipseAnnulusPixelRegion, PixCoord
+
+        region_shape = EllipseAnnulusPixelRegion(
+            center=PixCoord(x=42, y=43),
+            inner_width=5.5,
+            inner_height=3.5,
+            outer_width=8.5,
+            outer_height=6.5,
+            angle=Angle(30, 'deg'),
+        )
+        aperture = region_to_aperture(region_shape)
+        assert isinstance(aperture, EllipticalAnnulus)
+        assert_allclose(aperture.positions, region_shape.center.xy)
+        assert_allclose(aperture.a_in * 2, region_shape.inner_width)
+        assert_allclose(aperture.a_out * 2, region_shape.outer_width)
+        assert_allclose(aperture.b_in * 2, region_shape.inner_height)
+        assert_allclose(aperture.b_out * 2, region_shape.outer_height)
+        assert_quantity_allclose(aperture.theta, region_shape.angle)
+
+        region_sky = region_shape.to_sky(image_2d_wcs)
+        aperture_sky = region_to_aperture(region_sky)
+        assert isinstance(aperture_sky, SkyEllipticalAnnulus)
+        assert aperture_sky.positions == region_sky.center  # SkyCoord
+        assert_quantity_allclose(aperture_sky.a_in * 2, region_sky.inner_width)
+        assert_quantity_allclose(aperture_sky.a_out * 2,
+                                 region_sky.outer_width)
+        assert_quantity_allclose(aperture_sky.b_in * 2,
+                                 region_sky.inner_height)
+        assert_quantity_allclose(aperture_sky.b_out * 2,
+                                 region_sky.outer_height)
+        assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
+                                 region_sky.angle)
+
+        # Check that non-scalar center, inner_width, inner_height,
+        # outer_width, outer_height, and angle raise ValueError
+        match = 'must be a scalar PixCoord'
+        with pytest.raises(ValueError, match=match):
+            EllipseAnnulusPixelRegion(
+                center=PixCoord(x=[0, 42], y=[1, 43]),
+                inner_width=5.5,
+                inner_height=3.5,
+                outer_width=8.5,
+                outer_height=6.5,
+                angle=Angle(30, 'deg'),
+            )
+        match = 'must be a strictly positive scalar'
+        with pytest.raises(ValueError, match=match):
+            EllipseAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=[1, 5.5],
+                inner_height=3.5,
+                outer_width=8.5,
+                outer_height=6.5,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=match):
+            EllipseAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=5.5,
+                inner_height=[1, 3.5],
+                outer_width=8.5,
+                outer_height=6.5,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            EllipseAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=5.5,
+                inner_height=3.5,
+                outer_width=[8.5, 10],
+                outer_height=6.5,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            EllipseAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=5.5,
+                inner_height=3.5,
+                outer_width=8.5,
+                outer_height=[6.5, 10],
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            EllipseAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=5.5,
+                inner_height=3.5,
+                outer_width=8.5,
+                outer_height=6.5,
+                angle=Angle([0, 30], 'deg'),
+            )
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_rectangle_annulus(self, image_2d_wcs):
+        from regions import PixCoord, RectangleAnnulusPixelRegion
+
+        region_shape = RectangleAnnulusPixelRegion(
+            center=PixCoord(x=42, y=43),
+            inner_width=5.5,
+            inner_height=3.5,
+            outer_width=8.5,
+            outer_height=6.5,
+            angle=Angle(30, 'deg'),
+        )
+        aperture = region_to_aperture(region_shape)
+        assert isinstance(aperture, RectangularAnnulus)
+        assert_allclose(aperture.positions, region_shape.center.xy)
+        assert_allclose(aperture.w_in, region_shape.inner_width)
+        assert_allclose(aperture.w_out, region_shape.outer_width)
+        assert_allclose(aperture.h_in, region_shape.inner_height)
+        assert_allclose(aperture.h_out, region_shape.outer_height)
+        assert_quantity_allclose(aperture.theta, region_shape.angle)
+
+        region_sky = region_shape.to_sky(image_2d_wcs)
+        aperture_sky = region_to_aperture(region_sky)
+        assert isinstance(aperture_sky, SkyRectangularAnnulus)
+        assert aperture_sky.positions == region_sky.center  # SkyCoord
+        assert_quantity_allclose(aperture_sky.w_in, region_sky.inner_width)
+        assert_quantity_allclose(aperture_sky.w_out, region_sky.outer_width)
+        assert_quantity_allclose(aperture_sky.h_in, region_sky.inner_height)
+        assert_quantity_allclose(aperture_sky.h_out, region_sky.outer_height)
+        assert_quantity_allclose(aperture_sky.theta + (90 * u.deg),
+                                 region_sky.angle)
+
+        # Check that non-scalar center, inner_width, inner_height,
+        # outer_width, outer_height, and angle raise ValueError
+        match = 'must be a scalar PixCoord'
+        with pytest.raises(ValueError, match=match):
+            RectangleAnnulusPixelRegion(
+                center=PixCoord(x=[0, 42], y=[1, 43]),
+                inner_width=5.5,
+                inner_height=3.5,
+                outer_width=8.5,
+                outer_height=6.5,
+                angle=Angle(30, 'deg'),
+            )
+
+        match = 'must be a strictly positive scalar'
+        with pytest.raises(ValueError, match=match):
+            RectangleAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=[1, 5.5],
+                inner_height=3.5,
+                outer_width=8.5,
+                outer_height=6.5,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=match):
+            RectangleAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=5.5,
+                inner_height=[1, 3.5],
+                outer_width=8.5,
+                outer_height=6.5,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            RectangleAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=5.5,
+                inner_height=3.5,
+                outer_width=[8.5, 10],
+                outer_height=6.5,
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            RectangleAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=5.5,
+                inner_height=3.5,
+                outer_width=8.5,
+                outer_height=[6.5, 10],
+                angle=Angle(30, 'deg'),
+            )
+        with pytest.raises(ValueError, match=r'must be .* scalar'):
+            RectangleAnnulusPixelRegion(
+                center=PixCoord(x=42, y=43),
+                inner_width=5.5,
+                inner_height=3.5,
+                outer_width=8.5,
+                outer_height=6.5,
+                angle=Angle([0, 30], 'deg'),
+            )
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_polygon(self, image_2d_wcs):
+        from regions import PixCoord, PolygonPixelRegion
+
+        # Counter-clockwise simple (non-self-intersecting) quadrilateral.
+        x = [42, 50, 47, 40]
+        y = [43, 45, 52, 50]
+        region_shape = PolygonPixelRegion(vertices=PixCoord(x=x, y=y))
+        aperture = region_to_aperture(region_shape)
+        assert isinstance(aperture, PolygonAperture)
+        ref_vertices = np.column_stack((region_shape.vertices.x,
+                                        region_shape.vertices.y))
+        assert_allclose(aperture.vertices, ref_vertices)
+
+        region_sky = region_shape.to_sky(image_2d_wcs)
+        aperture_sky = region_to_aperture(region_sky)
+        assert isinstance(aperture_sky, SkyPolygonAperture)
+        # The inverted RA axis flips the polygon orientation, so the
+        # counter-clockwise normalization reverses the vertex order. Compare
+        # the vertices independently of their ordering.
+        ap_verts = np.column_stack((aperture_sky.vertices.ra.deg,
+                                    aperture_sky.vertices.dec.deg))
+        reg_verts = np.column_stack((region_sky.vertices.ra.deg,
+                                     region_sky.vertices.dec.deg))
+        ap_sorted = ap_verts[np.lexsort((ap_verts[:, 1], ap_verts[:, 0]))]
+        reg_sorted = reg_verts[np.lexsort((reg_verts[:, 1], reg_verts[:, 0]))]
+        assert_allclose(ap_sorted, reg_sorted, atol=1e-9)
+
+
+class TestApertureToRegion:
+    """
+    Tests for the aperture_to_region function.
+    """
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_aperture_to_region(self):
+        from regions import Region, Regions
+
+        xypos = [(10, 20), (30, 40), (50, 60), (70, 80)]
+        ra, dec = np.transpose(xypos)
+        skycoord = SkyCoord(ra=ra, dec=dec, unit='deg')
+        unit = u.arcsec
+
+        # A square polygon centered on each position (zero-centroid offsets
+        # so the pixel round-trip is exact).
+        poly_offsets = np.array([(-5.0, -5.0), (5.0, -5.0),
+                                 (5.0, 5.0), (-5.0, 5.0)])
+        theta = np.linspace(0.0, 2 * np.pi, 5, endpoint=False)
+        sky_poly_offsets = np.column_stack([3.0 * np.cos(theta),
+                                            3.0 * np.sin(theta)]) * unit
+
+        apertures = [CircularAperture(xypos, r=3.0),
+                     CircularAnnulus(xypos, r_in=3.0, r_out=7.0),
+                     SkyCircularAperture(skycoord, r=3.0 * unit),
+                     SkyCircularAnnulus(skycoord, r_in=3.0 * unit,
+                                        r_out=7.0 * unit),
+                     EllipticalAperture(xypos, a=10.0, b=5.0,
+                                        theta=np.pi / 2.0),
+                     EllipticalAnnulus(xypos, a_in=10.0, a_out=20.0,
+                                       b_out=17.0, theta=np.pi / 3),
+                     SkyEllipticalAperture(skycoord, a=10.0 * unit,
+                                           b=5.0 * unit, theta=30 * u.deg),
+                     SkyEllipticalAnnulus(skycoord, a_in=10.0 * unit,
+                                          a_out=20.0 * unit, b_out=17.0 * unit,
+                                          theta=60 * u.deg),
+                     RectangularAperture(xypos, w=10.0, h=5.0,
+                                         theta=np.pi / 2.0),
+                     RectangularAnnulus(xypos, w_in=10.0, w_out=20.0, h_out=17,
+                                        theta=np.pi / 3),
+                     SkyRectangularAperture(skycoord, w=10.0 * unit,
+                                            h=5.0 * unit,
+                                            theta=30 * u.deg),
+                     SkyRectangularAnnulus(skycoord, w_in=10.0 * unit,
+                                           w_out=20.0 * unit,
+                                           h_out=17.0 * unit,
+                                           theta=60 * u.deg),
+                     PolygonAperture(xypos, poly_offsets),
+                     SkyPolygonAperture(skycoord, sky_poly_offsets),
+                     ]
+
+        for aperture in apertures:
+            region0 = aperture_to_region(aperture[0])
+            region = aperture_to_region(aperture)
+
+            assert isinstance(region0, Region)
+            assert isinstance(region, Regions)
+            assert len(region) == len(aperture)
+
+            aper0 = region_to_aperture(region0)
+            if isinstance(aperture, SkyPolygonAperture):
+                # The sky polygon round-trip recomputes the centroid from
+                # the vertices, so positions and offsets match only to
+                # within floating-point tolerance.
+                assert isinstance(aper0, SkyPolygonAperture)
+                sep = aper0.positions.separation(aperture[0].positions)
+                assert_quantity_allclose(sep, 0 * u.deg, atol=1e-9 * u.arcsec)
+                assert_quantity_allclose(aper0.vertex_offsets,
+                                         aperture[0].vertex_offsets,
+                                         atol=1e-9 * u.arcsec)
+            else:
+                assert aper0 == aperture[0]
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_unknown_type(self):
         """
-        Minimal fake scalar aperture that passes the scalar check but
-        has no matching isinstance branch.
+        Test that _scalar_aperture_to_region raises TypeError for an
+        aperture type that is not one of the 12 supported classes.
         """
 
-        isscalar = True
+        class _FakeAperture:
+            """
+            Minimal fake scalar aperture that passes the scalar check but
+            has no matching isinstance branch.
+            """
 
-    match = 'Cannot convert input aperture to a Region object'
-    with pytest.raises(TypeError, match=match):
-        _scalar_aperture_to_region(_FakeAperture())
+            isscalar = True
+
+        match = 'Cannot convert input aperture to a Region object'
+        with pytest.raises(TypeError, match=match):
+            _scalar_aperture_to_region(_FakeAperture())
+
+
+class TestShapelyConversions:
+    """
+    Tests for converting Shapely polygons to regions.
+    """
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
+    def test_polygon_to_region(self):
+        from regions import PixCoord, PolygonPixelRegion
+        from shapely import Polygon
+
+        ref_region = PolygonPixelRegion(vertices=PixCoord(x=[1, 3, 2, 1],
+                                                          y=[1, 1, 4, 2]))
+
+        polygon = Polygon([(1, 1), (3, 1), (2, 4), (1, 2)])
+        region = _shapely_polygon_to_region(polygon)
+        assert region == ref_region
+
+        match = 'Input must be a Polygon or MultiPolygon object'
+        with pytest.raises(TypeError, match=match):
+            _shapely_polygon_to_region('foo')
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    @pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
+    def test_multipolygon_to_region(self):
+        """
+        Test that _shapely_polygon_to_region handles MultiPolygon inputs by
+        returning a Regions object containing one PolygonPixelRegion per
+        polygon.
+        """
+        from regions import Regions
+        from shapely import MultiPolygon, Polygon
+
+        poly1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        poly2 = Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])
+        multi = MultiPolygon([poly1, poly2])
+        result = _shapely_polygon_to_region(multi)
+        assert isinstance(result, Regions)
+        assert len(result) == 2
+
+
+class TestInvalidInputs:
+    """
+    Tests for the converter input validation.
+    """
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_invalid_inputs(self):
+        from regions import CirclePixelRegion, PixCoord
+
+        aperture = CircularAperture((10, 12), r=4.2)
+        region = CirclePixelRegion(center=PixCoord(x=10, y=12), radius=4.2)
+
+        match = 'Input region must be a Region object'
+        with pytest.raises(TypeError, match=match):
+            region_to_aperture(aperture)
+
+        match = 'Input aperture must be an Aperture object'
+        with pytest.raises(TypeError, match=match):
+            aperture_to_region(region)
+
+        aperture = CircularAperture(((10, 12), (21, 7)), r=4.2)
+        match = r'Only scalar .* apertures are supported'
+        with pytest.raises(ValueError, match=match):
+            _scalar_aperture_to_region(aperture)

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -14,8 +14,8 @@ from photutils.aperture import PolygonAperture, SkyPolygonAperture
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus,
                                         SkyEllipticalAperture)
-from photutils.aperture.tests.test_aperture_common import BaseTestAperture
-from photutils.utils._optional_deps import HAS_MATPLOTLIB
+from photutils.aperture.tests.test_aperture_common import (
+    BaseTestAperture, BaseTestRotatedPixelAperture)
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
@@ -24,8 +24,10 @@ UNIT = u.arcsec
 RADII = (0.0, -1.0, -np.inf)
 
 
-class TestEllipticalAperture(BaseTestAperture):
+class TestEllipticalAperture(BaseTestRotatedPixelAperture):
     aperture = EllipticalAperture(POSITIONS, a=10.0, b=5.0, theta=np.pi / 2.0)
+    copy_param = 'a'
+    copy_value = 20.0
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -38,28 +40,12 @@ class TestEllipticalAperture(BaseTestAperture):
         with pytest.raises(ValueError, match=match):
             EllipticalAperture(POSITIONS, a=10.0, b=radius, theta=np.pi / 2.0)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.a = 20.0
-        assert aper != self.aperture
 
-    def test_theta(self):
-        assert isinstance(self.aperture.theta, u.Quantity)
-        assert self.aperture.theta.unit == u.rad
-
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_to_patch_nonscalar(self):
-        """
-        Test that _to_patch returns a list for non-scalar apertures.
-        """
-        patches = self.aperture._to_patch()
-        assert isinstance(patches, list)
-
-
-class TestEllipticalAnnulus(BaseTestAperture):
+class TestEllipticalAnnulus(BaseTestRotatedPixelAperture):
     aperture = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
                                  theta=np.pi / 3)
+    copy_param = 'a_in'
+    copy_value = 2.0
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -84,16 +70,6 @@ class TestEllipticalAnnulus(BaseTestAperture):
             EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
                               b_in=radius, theta=np.pi / 3)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.a_in = 2.0
-        assert aper != self.aperture
-
-    def test_theta(self):
-        assert isinstance(self.aperture.theta, u.Quantity)
-        assert self.aperture.theta.unit == u.rad
-
     def test_b_in_greater_than_b_out(self):
         """
         Test that a ValueError is raised when b_in >= b_out.
@@ -103,18 +79,12 @@ class TestEllipticalAnnulus(BaseTestAperture):
             EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=5.0,
                               b_in=8.0, theta=np.pi / 3)
 
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_to_patch_nonscalar(self):
-        """
-        Test that _to_patch returns a list for non-scalar apertures.
-        """
-        patches = self.aperture._to_patch()
-        assert isinstance(patches, list)
-
 
 class TestSkyEllipticalAperture(BaseTestAperture):
     aperture = SkyEllipticalAperture(SKYCOORD, a=10.0 * UNIT, b=5.0 * UNIT,
                                      theta=30 * u.deg)
+    copy_param = 'a'
+    copy_value = 2.0 * UNIT
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -129,17 +99,13 @@ class TestSkyEllipticalAperture(BaseTestAperture):
             SkyEllipticalAperture(SKYCOORD, a=10.0 * UNIT, b=radius * UNIT,
                                   theta=30 * u.deg)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.a = 2.0 * UNIT
-        assert aper != self.aperture
-
 
 class TestSkyEllipticalAnnulus(BaseTestAperture):
     aperture = SkyEllipticalAnnulus(SKYCOORD, a_in=10.0 * UNIT,
                                     a_out=20.0 * UNIT, b_out=17.0 * UNIT,
                                     theta=60 * u.deg)
+    copy_param = 'a_in'
+    copy_value = 2.0 * UNIT
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -167,12 +133,6 @@ class TestSkyEllipticalAnnulus(BaseTestAperture):
                                  b_out=17.0 * UNIT, b_in=radius * UNIT,
                                  theta=60 * u.deg)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.a_in = 2.0 * UNIT
-        assert aper != self.aperture
-
     def test_b_in_greater_than_b_out(self):
         """
         Test that a ValueError is raised when b_in >= b_out.
@@ -184,121 +144,123 @@ class TestSkyEllipticalAnnulus(BaseTestAperture):
                                  theta=60 * u.deg)
 
 
-def test_ellipse_theta_quantity():
-    aper1 = EllipticalAperture(POSITIONS, a=10.0, b=5.0, theta=np.pi / 2.0)
-    theta = u.Quantity(90 * u.deg)
-    aper2 = EllipticalAperture(POSITIONS, a=10.0, b=5.0, theta=theta)
-    theta = Angle(90 * u.deg)
-    aper3 = EllipticalAperture(POSITIONS, a=10.0, b=5.0, theta=theta)
-
-    assert_quantity_allclose(aper1.theta, aper2.theta)
-    assert_quantity_allclose(aper1.theta, aper3.theta)
-
-
-def test_ellipse_annulus_theta_quantity():
-    aper1 = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
-                              theta=np.pi / 3)
-    theta = u.Quantity(60 * u.deg)
-    aper2 = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
-                              theta=theta)
-    theta = Angle(60 * u.deg)
-    aper3 = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
-                              theta=theta)
-
-    assert_quantity_allclose(aper1.theta, aper2.theta)
-    assert_quantity_allclose(aper1.theta, aper3.theta)
-
-
-def test_elliptical_aperture_to_polygon():
-    aper = EllipticalAperture((10.0, 20.0), a=5.0, b=3.0, theta=np.pi / 4)
-    poly = aper.to_polygon(n_vertices=200)
-    assert isinstance(poly, PolygonAperture)
-    assert poly.n_vertices == 200
-    assert abs(poly.area - aper.area) / aper.area < 1e-3
-
-
-def test_elliptical_aperture_to_polygon_multi_position():
-    aper = EllipticalAperture([(10.0, 20.0), (30.0, 40.0)],
-                              a=4.0, b=2.0, theta=0.5)
-    poly = aper.to_polygon(n_vertices=50)
-    assert poly.vertices.shape == (2, 50, 2)
-
-
-def test_elliptical_aperture_to_polygon_invalid_n_vertices():
-    aper = EllipticalAperture((0.0, 0.0), a=1.0, b=1.0)
-    match = 'n_vertices must be at least 3'
-    with pytest.raises(ValueError, match=match):
-        aper.to_polygon(n_vertices=2)
-
-
-def test_sky_elliptical_aperture_to_polygon():
-    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
-    aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
-                                 theta=30 * u.deg)
-    poly = aper.to_polygon(n_vertices=200)
-    assert isinstance(poly, SkyPolygonAperture)
-    assert poly.n_vertices == 200
-    assert poly.vertices.shape == (200,)
-    # The maximum and minimum vertex distances equal the semimajor and
-    # semiminor axes, respectively.
-    radii = np.hypot(*poly.vertex_offsets.to_value(u.arcsec).T)
-    assert_allclose(radii.max(), 5.0)
-    assert_allclose(radii.min(), 3.0)
-
-
-def test_sky_elliptical_aperture_to_polygon_multi_position():
-    pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
-    aper = SkyEllipticalAperture(pos, a=4.0 * u.arcsec, b=2.0 * u.arcsec,
-                                 theta=0.5 * u.rad)
-    poly = aper.to_polygon(n_vertices=50)
-    assert poly.vertices.shape == (2, 50)
-
-
-def test_sky_elliptical_aperture_to_polygon_invalid_n_vertices():
-    pos = SkyCoord(ra=0.0, dec=0.0, unit='deg')
-    aper = SkyEllipticalAperture(pos, a=1.0 * u.arcsec, b=1.0 * u.arcsec)
-    match = 'n_vertices must be at least 3'
-    with pytest.raises(ValueError, match=match):
-        aper.to_polygon(n_vertices=2)
-
-
-@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_sky_elliptical_aperture_to_polygon_wcs_round_trip(theta_deg, tan_wcs):
+class TestThetaQuantity:
     """
-    Test that converting a SkyEllipticalAperture to a polygon and then
-    to pixels is equivalent to converting to pixels and then to a
-    polygon.
+    Tests for a theta input as an angular Quantity.
     """
-    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
-    aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
-                                 theta=theta_deg * u.deg)
-    poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(tan_wcs)
-    poly_from_pix = aper.to_pixel(tan_wcs).to_polygon(n_vertices=200)
-    assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
-    assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
-                    rtol=1e-6)
+
+    def test_aperture(self):
+        aper1 = EllipticalAperture(POSITIONS, a=10.0, b=5.0, theta=np.pi / 2.0)
+        theta = u.Quantity(90 * u.deg)
+        aper2 = EllipticalAperture(POSITIONS, a=10.0, b=5.0, theta=theta)
+        theta = Angle(90 * u.deg)
+        aper3 = EllipticalAperture(POSITIONS, a=10.0, b=5.0, theta=theta)
+
+        assert_quantity_allclose(aper1.theta, aper2.theta)
+        assert_quantity_allclose(aper1.theta, aper3.theta)
+
+    def test_annulus(self):
+        aper1 = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
+                                  theta=np.pi / 3)
+        theta = u.Quantity(60 * u.deg)
+        aper2 = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
+                                  theta=theta)
+        theta = Angle(60 * u.deg)
+        aper3 = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
+                                  theta=theta)
+
+        assert_quantity_allclose(aper1.theta, aper2.theta)
+        assert_quantity_allclose(aper1.theta, aper3.theta)
 
 
-@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_elliptical_aperture_to_polygon_to_sky_round_trip(theta_deg, tan_wcs):
+class TestToPolygon:
     """
-    Test that converting an EllipticalAperture to a polygon and then to
-    sky is equivalent to converting to sky and then to a polygon.
+    Tests for converting elliptical apertures to polygon apertures.
     """
-    # The bounding-box orientation can differ at the ~1e-5 level because
-    # the sky shape parameters from ``to_sky`` are derived from a local
-    # linear (SVD) approximation, while the polygon ``to_sky`` maps
-    # each vertex exactly, so only rotation-invariant quantities are
-    # compared.
-    aper = EllipticalAperture((50.0, 50.0), a=5.0, b=3.0,
-                              theta=np.deg2rad(theta_deg))
-    sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(tan_wcs)
-    sky_from_aper = aper.to_sky(tan_wcs).to_polygon(n_vertices=200)
-    assert_allclose(sky_from_poly.positions.ra.deg,
-                    sky_from_aper.positions.ra.deg)
-    assert_allclose(sky_from_poly.positions.dec.deg,
-                    sky_from_aper.positions.dec.deg)
-    assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
-                    sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
-    assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
-                    sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)
+
+    def test_pixel(self):
+        aper = EllipticalAperture((10.0, 20.0), a=5.0, b=3.0, theta=np.pi / 4)
+        poly = aper.to_polygon(n_vertices=200)
+        assert isinstance(poly, PolygonAperture)
+        assert poly.n_vertices == 200
+        assert abs(poly.area - aper.area) / aper.area < 1e-3
+
+    def test_pixel_multi_position(self):
+        aper = EllipticalAperture([(10.0, 20.0), (30.0, 40.0)],
+                                  a=4.0, b=2.0, theta=0.5)
+        poly = aper.to_polygon(n_vertices=50)
+        assert poly.vertices.shape == (2, 50, 2)
+
+    def test_pixel_invalid_n_vertices(self):
+        aper = EllipticalAperture((0.0, 0.0), a=1.0, b=1.0)
+        match = 'n_vertices must be at least 3'
+        with pytest.raises(ValueError, match=match):
+            aper.to_polygon(n_vertices=2)
+
+    def test_sky(self):
+        pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+        aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
+                                     theta=30 * u.deg)
+        poly = aper.to_polygon(n_vertices=200)
+        assert isinstance(poly, SkyPolygonAperture)
+        assert poly.n_vertices == 200
+        assert poly.vertices.shape == (200,)
+        # The maximum and minimum vertex distances equal the semimajor and
+        # semiminor axes, respectively.
+        radii = np.hypot(*poly.vertex_offsets.to_value(u.arcsec).T)
+        assert_allclose(radii.max(), 5.0)
+        assert_allclose(radii.min(), 3.0)
+
+    def test_sky_multi_position(self):
+        pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
+        aper = SkyEllipticalAperture(pos, a=4.0 * u.arcsec, b=2.0 * u.arcsec,
+                                     theta=0.5 * u.rad)
+        poly = aper.to_polygon(n_vertices=50)
+        assert poly.vertices.shape == (2, 50)
+
+    def test_sky_invalid_n_vertices(self):
+        pos = SkyCoord(ra=0.0, dec=0.0, unit='deg')
+        aper = SkyEllipticalAperture(pos, a=1.0 * u.arcsec, b=1.0 * u.arcsec)
+        match = 'n_vertices must be at least 3'
+        with pytest.raises(ValueError, match=match):
+            aper.to_polygon(n_vertices=2)
+
+    @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+    def test_sky_wcs_round_trip(self, theta_deg, tan_wcs):
+        """
+        Test that converting a SkyEllipticalAperture to a polygon and then
+        to pixels is equivalent to converting to pixels and then to a
+        polygon.
+        """
+        pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+        aper = SkyEllipticalAperture(pos, a=5.0 * u.arcsec, b=3.0 * u.arcsec,
+                                     theta=theta_deg * u.deg)
+        poly_from_sky = aper.to_polygon(n_vertices=200).to_pixel(tan_wcs)
+        poly_from_pix = aper.to_pixel(tan_wcs).to_polygon(n_vertices=200)
+        assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
+        assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
+                        rtol=1e-6)
+
+    @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+    def test_pixel_to_sky_round_trip(self, theta_deg, tan_wcs):
+        """
+        Test that converting an EllipticalAperture to a polygon and then to
+        sky is equivalent to converting to sky and then to a polygon.
+        """
+        # The bounding-box orientation can differ at the ~1e-5 level because
+        # the sky shape parameters from ``to_sky`` are derived from a local
+        # linear (SVD) approximation, while the polygon ``to_sky`` maps
+        # each vertex exactly, so only rotation-invariant quantities are
+        # compared.
+        aper = EllipticalAperture((50.0, 50.0), a=5.0, b=3.0,
+                                  theta=np.deg2rad(theta_deg))
+        sky_from_poly = aper.to_polygon(n_vertices=200).to_sky(tan_wcs)
+        sky_from_aper = aper.to_sky(tan_wcs).to_polygon(n_vertices=200)
+        assert_allclose(sky_from_poly.positions.ra.deg,
+                        sky_from_aper.positions.ra.deg)
+        assert_allclose(sky_from_poly.positions.dec.deg,
+                        sky_from_aper.positions.dec.deg)
+        assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
+                        sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
+        assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
+                        sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)

--- a/photutils/aperture/tests/test_exact_area_photometry.py
+++ b/photutils/aperture/tests/test_exact_area_photometry.py
@@ -29,61 +29,6 @@ def _phot_sum(aperture, *, data=None):
     return float(table['aperture_sum'][0])
 
 
-@pytest.mark.parametrize('center', [(50.0, 50.0), (50.3, 50.7),
-                                    (49.5, 50.5), (12.123, 87.987)])
-@pytest.mark.parametrize('r', [1.0, 3.5, 7.25])
-def test_circular_aperture_exact_area(center, r):
-    aper = CircularAperture(center, r=r)
-    assert_allclose(_phot_sum(aper), aper.area, rtol=1e-6, atol=1e-10)
-
-
-@pytest.mark.parametrize('center', [(50.0, 50.0), (50.4, 50.6)])
-@pytest.mark.parametrize(('r_in', 'r_out'), [(1.0, 3.0), (2.5, 4.75),
-                                             (5.0, 8.0)])
-def test_circular_annulus_exact_area(center, r_in, r_out):
-    aper = CircularAnnulus(center, r_in=r_in, r_out=r_out)
-    assert_allclose(_phot_sum(aper), aper.area, rtol=1e-6, atol=1e-10)
-
-
-@pytest.mark.parametrize('center', [(50.0, 50.0), (50.3, 49.8)])
-@pytest.mark.parametrize(('a', 'b'), [(5.0, 3.0), (3.5, 1.25),
-                                      (8.0, 8.0)])
-@pytest.mark.parametrize('theta_deg', [0.0, 17.5, 45.0, 90.0, 137.0])
-def test_elliptical_aperture_exact_area(center, a, b, theta_deg):
-    aper = EllipticalAperture(center, a=a, b=b,
-                              theta=np.deg2rad(theta_deg))
-    assert_allclose(_phot_sum(aper), aper.area, rtol=1e-6, atol=1e-10)
-
-
-@pytest.mark.parametrize(('a_in', 'a_out', 'b_out'),
-                         [(2.0, 5.0, 3.0), (1.0, 4.0, 4.0)])
-@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 65.0])
-def test_elliptical_annulus_exact_area(a_in, a_out, b_out, theta_deg):
-    aper = EllipticalAnnulus((50.0, 50.0), a_in=a_in, a_out=a_out,
-                             b_out=b_out, theta=np.deg2rad(theta_deg))
-    assert_allclose(_phot_sum(aper), aper.area, rtol=1e-6, atol=1e-10)
-
-
-@pytest.mark.parametrize('center', [(50.0, 50.0), (50.5, 50.5),
-                                    (50.123, 49.876)])
-@pytest.mark.parametrize(('w', 'h'), [(4.0, 2.0), (5.5, 5.5),
-                                      (10.0, 1.0)])
-@pytest.mark.parametrize('theta_deg', [0.0, 22.5, 45.0, 90.0, 117.0])
-def test_rectangular_aperture_exact_area(center, w, h, theta_deg):
-    aper = RectangularAperture(center, w=w, h=h,
-                               theta=np.deg2rad(theta_deg))
-    assert_allclose(_phot_sum(aper), aper.area, rtol=1e-12, atol=1e-12)
-
-
-@pytest.mark.parametrize(('w_in', 'w_out', 'h_out'),
-                         [(2.0, 6.0, 4.0), (1.5, 5.5, 5.5)])
-@pytest.mark.parametrize('theta_deg', [0.0, 33.0, 90.0])
-def test_rectangular_annulus_exact_area(w_in, w_out, h_out, theta_deg):
-    aper = RectangularAnnulus((50.0, 50.0), w_in=w_in, w_out=w_out,
-                              h_out=h_out, theta=np.deg2rad(theta_deg))
-    assert_allclose(_phot_sum(aper), aper.area, rtol=1e-12, atol=1e-12)
-
-
 # Polygon shape library: (name, vertex_offsets) - each polygon is
 # centered at the origin so it can be placed at arbitrary positions.
 def _triangle():
@@ -136,29 +81,90 @@ POLY_SHAPES = {
 }
 
 
-@pytest.mark.parametrize('shape_name', list(POLY_SHAPES))
-@pytest.mark.parametrize('center', [(50.0, 50.0), (50.5, 50.5),
-                                    (50.123, 49.876)])
-@pytest.mark.parametrize('theta_deg', [0.0, 23.5, 60.0])
-def test_polygon_aperture_exact_area(shape_name, center, theta_deg):
-    offsets = _rotate(POLY_SHAPES[shape_name], theta_deg)
-    aper = PolygonAperture(center, offsets)
-    assert_allclose(_phot_sum(aper), aper.area, rtol=1e-12, atol=1e-12)
-
-
-def test_polygon_aperture_exact_area_multiple_positions():
+class TestBuiltinShapeAreas:
     """
-    Test that the exact area is returned for multiple positions.
-
-    The photometric sum should equal the area regardless of the
-    position.
+    The exact-method aperture sum over a uniform image must equal the
+    analytic aperture area.
     """
-    offsets = _hexagon()
-    positions = [(30.0, 40.0), (50.5, 50.5), (70.123, 60.876)]
-    aper = PolygonAperture(positions, offsets)
-    shape = (101, 101)
-    data = np.ones(shape, dtype=float)
-    table = aperture_photometry(data, aper, method='exact')
-    expected = aper.area
-    assert_allclose(table['aperture_sum'], expected, rtol=1e-12,
-                    atol=1e-12)
+
+    @pytest.mark.parametrize('center', [(50.0, 50.0), (50.3, 50.7),
+                                        (49.5, 50.5), (12.123, 87.987)])
+    @pytest.mark.parametrize('r', [1.0, 3.5, 7.25])
+    def test_circular_aperture(self, center, r):
+        aper = CircularAperture(center, r=r)
+        assert_allclose(_phot_sum(aper), aper.area, rtol=1e-6, atol=1e-10)
+
+    @pytest.mark.parametrize('center', [(50.0, 50.0), (50.4, 50.6)])
+    @pytest.mark.parametrize(('r_in', 'r_out'), [(1.0, 3.0), (2.5, 4.75),
+                                                 (5.0, 8.0)])
+    def test_circular_annulus(self, center, r_in, r_out):
+        aper = CircularAnnulus(center, r_in=r_in, r_out=r_out)
+        assert_allclose(_phot_sum(aper), aper.area, rtol=1e-6, atol=1e-10)
+
+    @pytest.mark.parametrize('center', [(50.0, 50.0), (50.3, 49.8)])
+    @pytest.mark.parametrize(('a', 'b'), [(5.0, 3.0), (3.5, 1.25),
+                                          (8.0, 8.0)])
+    @pytest.mark.parametrize('theta_deg', [0.0, 17.5, 45.0, 90.0, 137.0])
+    def test_elliptical_aperture(self, center, a, b, theta_deg):
+        aper = EllipticalAperture(center, a=a, b=b,
+                                  theta=np.deg2rad(theta_deg))
+        assert_allclose(_phot_sum(aper), aper.area, rtol=1e-6, atol=1e-10)
+
+    @pytest.mark.parametrize(('a_in', 'a_out', 'b_out'),
+                             [(2.0, 5.0, 3.0), (1.0, 4.0, 4.0)])
+    @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 65.0])
+    def test_elliptical_annulus(self, a_in, a_out, b_out, theta_deg):
+        aper = EllipticalAnnulus((50.0, 50.0), a_in=a_in, a_out=a_out,
+                                 b_out=b_out, theta=np.deg2rad(theta_deg))
+        assert_allclose(_phot_sum(aper), aper.area, rtol=1e-6, atol=1e-10)
+
+    @pytest.mark.parametrize('center', [(50.0, 50.0), (50.5, 50.5),
+                                        (50.123, 49.876)])
+    @pytest.mark.parametrize(('w', 'h'), [(4.0, 2.0), (5.5, 5.5),
+                                          (10.0, 1.0)])
+    @pytest.mark.parametrize('theta_deg', [0.0, 22.5, 45.0, 90.0, 117.0])
+    def test_rectangular_aperture(self, center, w, h, theta_deg):
+        aper = RectangularAperture(center, w=w, h=h,
+                                   theta=np.deg2rad(theta_deg))
+        assert_allclose(_phot_sum(aper), aper.area, rtol=1e-12, atol=1e-12)
+
+    @pytest.mark.parametrize(('w_in', 'w_out', 'h_out'),
+                             [(2.0, 6.0, 4.0), (1.5, 5.5, 5.5)])
+    @pytest.mark.parametrize('theta_deg', [0.0, 33.0, 90.0])
+    def test_rectangular_annulus(self, w_in, w_out, h_out, theta_deg):
+        aper = RectangularAnnulus((50.0, 50.0), w_in=w_in, w_out=w_out,
+                                  h_out=h_out, theta=np.deg2rad(theta_deg))
+        assert_allclose(_phot_sum(aper), aper.area, rtol=1e-12, atol=1e-12)
+
+
+class TestPolygonAreas:
+    """
+    The exact-method polygon aperture sum must equal the analytic
+    polygon area, including for non-convex shapes.
+    """
+
+    @pytest.mark.parametrize('shape_name', list(POLY_SHAPES))
+    @pytest.mark.parametrize('center', [(50.0, 50.0), (50.5, 50.5),
+                                        (50.123, 49.876)])
+    @pytest.mark.parametrize('theta_deg', [0.0, 23.5, 60.0])
+    def test_polygon_aperture(self, shape_name, center, theta_deg):
+        offsets = _rotate(POLY_SHAPES[shape_name], theta_deg)
+        aper = PolygonAperture(center, offsets)
+        assert_allclose(_phot_sum(aper), aper.area, rtol=1e-12, atol=1e-12)
+
+    def test_polygon_multiple_positions(self):
+        """
+        Test that the exact area is returned for multiple positions.
+
+        The photometric sum should equal the area regardless of the
+        position.
+        """
+        offsets = _hexagon()
+        positions = [(30.0, 40.0), (50.5, 50.5), (70.123, 60.876)]
+        aper = PolygonAperture(positions, offsets)
+        shape = (101, 101)
+        data = np.ones(shape, dtype=float)
+        table = aperture_photometry(data, aper, method='exact')
+        expected = aper.area
+        assert_allclose(table['aperture_sum'], expected, rtol=1e-12,
+                        atol=1e-12)

--- a/photutils/aperture/tests/test_flags.py
+++ b/photutils/aperture/tests/test_flags.py
@@ -27,205 +27,207 @@ EXPECTED_FLAGS = {
 }
 
 
-def test_decode_aperture_flags():
+class TestDecodeApertureFlags:
     """
-    Test the decode_aperture_flags standalone function.
+    Tests for the decode_aperture_flags function.
     """
-    decoded = decode_aperture_flags(0)
-    assert decoded == []
-    assert isinstance(decoded, list)
 
-    # Test each single flag value
-    for name, bit_value in EXPECTED_FLAGS.items():
-        assert decode_aperture_flags(bit_value) == [name]
+    def test_decode(self):
+        """
+        Test the decode_aperture_flags standalone function.
+        """
+        decoded = decode_aperture_flags(0)
+        assert decoded == []
+        assert isinstance(decoded, list)
 
-    # Test combination of flags
-    decoded = decode_aperture_flags(10)  # bits 2 and 8
-    assert decoded == ['partial_overlap', 'masked_pixels']
+        # Test each single flag value
+        for name, bit_value in EXPECTED_FLAGS.items():
+            assert decode_aperture_flags(bit_value) == [name]
 
-    decoded = decode_aperture_flags(5)  # bits 1 and 4
-    assert decoded == ['no_overlap', 'no_pixels']
+        # Test combination of flags
+        decoded = decode_aperture_flags(10)  # bits 2 and 8
+        assert decoded == ['partial_overlap', 'masked_pixels']
 
-    # Test with all flags set
-    all_flags = sum(EXPECTED_FLAGS.values())
-    decoded = decode_aperture_flags(all_flags)
-    assert decoded == list(EXPECTED_FLAGS)
+        decoded = decode_aperture_flags(5)  # bits 1 and 4
+        assert decoded == ['no_overlap', 'no_pixels']
 
-    # Test with array input
-    flags_array = [0, 1, 2, 10]
-    decoded_list = decode_aperture_flags(flags_array)
-    assert len(decoded_list) == 4
-    assert decoded_list[0] == []
-    assert decoded_list[1] == ['no_overlap']
-    assert decoded_list[2] == ['partial_overlap']
-    assert decoded_list[3] == ['partial_overlap', 'masked_pixels']
+        # Test with all flags set
+        all_flags = sum(EXPECTED_FLAGS.values())
+        decoded = decode_aperture_flags(all_flags)
+        assert decoded == list(EXPECTED_FLAGS)
 
-    # Test with numpy array
-    decoded_list = decode_aperture_flags(np.array([8, 16, 32]))
-    assert decoded_list == [['masked_pixels'], ['all_masked'],
-                            ['non_finite_data']]
+        # Test with array input
+        flags_array = [0, 1, 2, 10]
+        decoded_list = decode_aperture_flags(flags_array)
+        assert len(decoded_list) == 4
+        assert decoded_list[0] == []
+        assert decoded_list[1] == ['no_overlap']
+        assert decoded_list[2] == ['partial_overlap']
+        assert decoded_list[3] == ['partial_overlap', 'masked_pixels']
 
-    # Test with 0D numpy array (scalar array)
-    decoded = decode_aperture_flags(np.array(64))
-    assert decoded == ['non_finite_error']
+        # Test with numpy array
+        decoded_list = decode_aperture_flags(np.array([8, 16, 32]))
+        assert decoded_list == [['masked_pixels'], ['all_masked'],
+                                ['non_finite_data']]
 
-    # Test with empty array
-    decoded = decode_aperture_flags(np.array([], dtype=int))
-    assert decoded == []
+        # Test with 0D numpy array (scalar array)
+        decoded = decode_aperture_flags(np.array(64))
+        assert decoded == ['non_finite_error']
 
-    # Test with 2D array (shape preserved as nested lists)
-    decoded = decode_aperture_flags(np.array([[0, 1], [8, 24]]))
-    assert len(decoded) == 2
-    assert decoded == [[[], ['no_overlap']],
-                       [['masked_pixels'],
-                        ['masked_pixels', 'all_masked']]]
+        # Test with empty array
+        decoded = decode_aperture_flags(np.array([], dtype=int))
+        assert decoded == []
+
+        # Test with 2D array (shape preserved as nested lists)
+        decoded = decode_aperture_flags(np.array([[0, 1], [8, 24]]))
+        assert len(decoded) == 2
+        assert decoded == [[[], ['no_overlap']],
+                           [['masked_pixels'],
+                            ['masked_pixels', 'all_masked']]]
+
+    def test_return_bit_values(self):
+        """
+        Test decode_aperture_flags with return_bit_values=True.
+        """
+        assert decode_aperture_flags(0, return_bit_values=True) == []
+        assert decode_aperture_flags(10, return_bit_values=True) == [2, 8]
+
+        decoded_list = decode_aperture_flags([1, 24],
+                                             return_bit_values=True)
+        assert decoded_list == [[1], [8, 16]]
+
+    def test_errors(self):
+        """
+        Test decode_aperture_flags error conditions.
+        """
+        match = 'Flag value must be an integer'
+        with pytest.raises(TypeError, match=match):
+            decode_aperture_flags(3.14)
+        with pytest.raises(TypeError, match=match):
+            decode_aperture_flags('invalid')
+        with pytest.raises(TypeError, match=match):
+            decode_aperture_flags([1, 2.5, 3])
+
+        match = 'Flag value must be a non-negative integer'
+        with pytest.raises(ValueError, match=match):
+            decode_aperture_flags(-2)
+
+    def test_docstring(self):
+        """
+        Test that decode_aperture_flags has dynamic flag documentation.
+        """
+        docstring = decode_aperture_flags.__doc__
+        assert '<flag_descriptions>' not in docstring
+
+        for name, bit_value in EXPECTED_FLAGS.items():
+            expected = f"**{bit_value}** (``'{name}'``)"
+            assert expected in docstring
 
 
-def test_decode_aperture_flags_return_bit_values():
+class TestApertureFlagsRegistry:
     """
-    Test decode_aperture_flags with return_bit_values=True.
+    Tests for the APERTURE_FLAGS registry singleton.
     """
-    assert decode_aperture_flags(0, return_bit_values=True) == []
-    assert decode_aperture_flags(10, return_bit_values=True) == [2, 8]
 
-    decoded_list = decode_aperture_flags([1, 24],
-                                         return_bit_values=True)
-    assert decoded_list == [[1], [8, 16]]
+    def test_singleton(self):
+        """
+        Test APERTURE_FLAGS singleton behavior.
+        """
+        assert isinstance(APERTURE_FLAGS, _ApertureFlags)
+        assert APERTURE_FLAGS.domain == 'aperture'
 
+        new_flags = _ApertureFlags()
+        assert isinstance(new_flags, _ApertureFlags)
+        assert new_flags is not APERTURE_FLAGS
 
-def test_decode_aperture_flags_errors():
-    """
-    Test decode_aperture_flags error conditions.
-    """
-    match = 'Flag value must be an integer'
-    with pytest.raises(TypeError, match=match):
-        decode_aperture_flags(3.14)
-    with pytest.raises(TypeError, match=match):
-        decode_aperture_flags('invalid')
-    with pytest.raises(TypeError, match=match):
-        decode_aperture_flags([1, 2.5, 3])
+    def test_constants(self):
+        """
+        Test _ApertureFlags constant access.
+        """
+        for name, bit_value in EXPECTED_FLAGS.items():
+            const_name = name.upper()
+            assert hasattr(APERTURE_FLAGS, const_name)
+            actual_value = getattr(APERTURE_FLAGS, const_name)
+            assert actual_value == bit_value
+            assert isinstance(actual_value, int)
 
-    match = 'Flag value must be a non-negative integer'
-    with pytest.raises(ValueError, match=match):
-        decode_aperture_flags(-2)
+        match = "has no attribute 'INVALID'"
+        with pytest.raises(AttributeError, match=match):
+            _ = APERTURE_FLAGS.INVALID
 
+    def test_properties(self):
+        """
+        Test _ApertureFlags property access methods.
+        """
+        assert APERTURE_FLAGS.bit_values == list(EXPECTED_FLAGS.values())
+        assert APERTURE_FLAGS.names == list(EXPECTED_FLAGS)
+        assert APERTURE_FLAGS.flag_dict == {bit: name for name, bit
+                                            in EXPECTED_FLAGS.items()}
 
-def test_aperture_flags_singleton():
-    """
-    Test APERTURE_FLAGS singleton behavior.
-    """
-    assert isinstance(APERTURE_FLAGS, _ApertureFlags)
-    assert APERTURE_FLAGS.domain == 'aperture'
+        all_flags = APERTURE_FLAGS.all_flags
+        assert isinstance(all_flags, list)
+        assert len(all_flags) == len(EXPECTED_FLAGS)
+        for flag_def in all_flags:
+            assert isinstance(flag_def, FlagDefinition)
 
-    new_flags = _ApertureFlags()
-    assert isinstance(new_flags, _ApertureFlags)
-    assert new_flags is not APERTURE_FLAGS
+    def test_get_methods(self):
+        """
+        Test _ApertureFlags getter methods.
+        """
+        for name, bit_value in EXPECTED_FLAGS.items():
+            assert APERTURE_FLAGS.get_name(bit_value) == name
+            assert APERTURE_FLAGS.get_bit_value(name) == bit_value
+            assert isinstance(APERTURE_FLAGS.get_description(bit_value), str)
+            detailed = APERTURE_FLAGS.get_detailed_description(bit_value)
+            assert isinstance(detailed, str)
 
+        # Test get_definition by bit value and name
+        def_by_bit = APERTURE_FLAGS.get_definition(1)
+        def_by_name = APERTURE_FLAGS.get_definition('no_overlap')
+        assert def_by_bit is def_by_name
+        assert def_by_bit.name == 'no_overlap'
 
-def test_aperture_flags_constants():
-    """
-    Test _ApertureFlags constant access.
-    """
-    for name, bit_value in EXPECTED_FLAGS.items():
-        const_name = name.upper()
-        assert hasattr(APERTURE_FLAGS, const_name)
-        actual_value = getattr(APERTURE_FLAGS, const_name)
-        assert actual_value == bit_value
-        assert isinstance(actual_value, int)
+        # NumPy integers (e.g., values from a flags table column) are
+        # accepted as bit values
+        assert APERTURE_FLAGS.get_name(np.int64(8)) == 'masked_pixels'
+        assert APERTURE_FLAGS.get_definition(np.int32(1)) is def_by_bit
 
-    match = "has no attribute 'INVALID'"
-    with pytest.raises(AttributeError, match=match):
-        _ = APERTURE_FLAGS.INVALID
+        # Test error cases
+        match = 'No flag with bit value 999'
+        with pytest.raises(KeyError, match=match):
+            APERTURE_FLAGS.get_definition(999)
 
+        match = "No flag with name 'invalid'"
+        with pytest.raises(KeyError, match=match):
+            APERTURE_FLAGS.get_definition('invalid')
 
-def test_aperture_flags_properties():
-    """
-    Test _ApertureFlags property access methods.
-    """
-    assert APERTURE_FLAGS.bit_values == list(EXPECTED_FLAGS.values())
-    assert APERTURE_FLAGS.names == list(EXPECTED_FLAGS)
-    assert APERTURE_FLAGS.flag_dict == {bit: name for name, bit
-                                        in EXPECTED_FLAGS.items()}
+        match = 'identifier must be int'
+        with pytest.raises(TypeError, match=match):
+            APERTURE_FLAGS.get_definition(3.14)
 
-    all_flags = APERTURE_FLAGS.all_flags
-    assert isinstance(all_flags, list)
-    assert len(all_flags) == len(EXPECTED_FLAGS)
-    for flag_def in all_flags:
-        assert isinstance(flag_def, FlagDefinition)
+    def test_completeness(self):
+        """
+        Test that _ApertureFlags bit values and names are consistent.
+        """
+        bit_values = APERTURE_FLAGS.bit_values
+        names = APERTURE_FLAGS.names
 
+        # Bit values are unique powers of 2
+        assert len(bit_values) == len(set(bit_values))
+        for bit_val in bit_values:
+            assert bit_val > 0
+            assert (bit_val & (bit_val - 1)) == 0
 
-def test_aperture_flags_get_methods():
-    """
-    Test _ApertureFlags getter methods.
-    """
-    for name, bit_value in EXPECTED_FLAGS.items():
-        assert APERTURE_FLAGS.get_name(bit_value) == name
-        assert APERTURE_FLAGS.get_bit_value(name) == bit_value
-        assert isinstance(APERTURE_FLAGS.get_description(bit_value), str)
-        detailed = APERTURE_FLAGS.get_detailed_description(bit_value)
-        assert isinstance(detailed, str)
+        # Names are unique, valid snake_case identifiers
+        assert len(names) == len(set(names))
+        for name in names:
+            assert name.isidentifier()
+            assert name == name.lower()
 
-    # Test get_definition by bit value and name
-    def_by_bit = APERTURE_FLAGS.get_definition(1)
-    def_by_name = APERTURE_FLAGS.get_definition('no_overlap')
-    assert def_by_bit is def_by_name
-    assert def_by_bit.name == 'no_overlap'
-
-    # NumPy integers (e.g., values from a flags table column) are
-    # accepted as bit values
-    assert APERTURE_FLAGS.get_name(np.int64(8)) == 'masked_pixels'
-    assert APERTURE_FLAGS.get_definition(np.int32(1)) is def_by_bit
-
-    # Test error cases
-    match = 'No flag with bit value 999'
-    with pytest.raises(KeyError, match=match):
-        APERTURE_FLAGS.get_definition(999)
-
-    match = "No flag with name 'invalid'"
-    with pytest.raises(KeyError, match=match):
-        APERTURE_FLAGS.get_definition('invalid')
-
-    match = 'identifier must be int'
-    with pytest.raises(TypeError, match=match):
-        APERTURE_FLAGS.get_definition(3.14)
-
-
-def test_aperture_flags_completeness():
-    """
-    Test that _ApertureFlags bit values and names are consistent.
-    """
-    bit_values = APERTURE_FLAGS.bit_values
-    names = APERTURE_FLAGS.names
-
-    # Bit values are unique powers of 2
-    assert len(bit_values) == len(set(bit_values))
-    for bit_val in bit_values:
-        assert bit_val > 0
-        assert (bit_val & (bit_val - 1)) == 0
-
-    # Names are unique, valid snake_case identifiers
-    assert len(names) == len(set(names))
-    for name in names:
-        assert name.isidentifier()
-        assert name == name.lower()
-
-
-def test_define_flag_docstring_invalid_registry():
-    """
-    Test that define_flag_docstring rejects a non-FlagRegistry input.
-    """
-    match = 'registry must be an instance of FlagRegistry'
-    with pytest.raises(TypeError, match=match):
-        define_flag_docstring('invalid')
-
-
-def test_decode_aperture_flags_docstring():
-    """
-    Test that decode_aperture_flags has dynamic flag documentation.
-    """
-    docstring = decode_aperture_flags.__doc__
-    assert '<flag_descriptions>' not in docstring
-
-    for name, bit_value in EXPECTED_FLAGS.items():
-        expected = f"**{bit_value}** (``'{name}'``)"
-        assert expected in docstring
+    def test_define_docstring_invalid_registry(self):
+        """
+        Test that define_flag_docstring rejects a non-FlagRegistry input.
+        """
+        match = 'registry must be an instance of FlagRegistry'
+        with pytest.raises(TypeError, match=match):
+            define_flag_docstring('invalid')

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -14,275 +14,289 @@ from photutils.aperture.ellipse import EllipticalAnnulus
 from photutils.aperture.mask import ApertureMask
 from photutils.aperture.rectangle import RectangularAnnulus
 
+# Positions with no or partial overlap with a 50x50 array
 POSITIONS = [(-20, -20), (-20, 20), (20, -20), (60, 60)]
 
 
-def test_mask_input_shapes():
-    mask_data = np.ones((10, 10))
-    bbox = BoundingBox(5, 10, 5, 10)
-    match = 'mask data and bounding box must have the same shape'
-    with pytest.raises(ValueError, match=match):
-        ApertureMask(mask_data, bbox)
-
-
-def test_mask_array():
-    mask_data = np.ones((10, 10))
-    bbox = BoundingBox(5, 15, 5, 15)
-    mask = ApertureMask(mask_data, bbox)
-    data = np.array(mask)
-    assert_allclose(data, mask.data)
-
-
-def test_mask_copy():
-    bbox = BoundingBox(5, 15, 5, 15)
-
-    mask = ApertureMask(np.ones((10, 10)), bbox)
-    mask_copy = np.array(mask, copy=True)
-    mask_copy[0, 0] = 100.0
-    assert mask.data[0, 0] == 1.0
-
-    mask = ApertureMask(np.ones((10, 10)), bbox)
-    mask_copy = np.array(mask, copy=False)
-    mask_copy[0, 0] = 100.0
-    assert mask.data[0, 0] == 100.0
-
-    # No copy: copy=None returns a copy only if __array__ returns a
-    # copy; copy=None was introduced in NumPy 2.0
-    mask = ApertureMask(np.ones((10, 10)), bbox)
-    mask_copy = np.array(mask, copy=None)
-    mask_copy[0, 0] = 100.0
-    assert mask.data[0, 0] == 100.0
-
-    # No copy
-    mask = ApertureMask(np.ones((10, 10)), bbox)
-    mask_copy = np.asarray(mask)
-    mask_copy[0, 0] = 100.0
-    assert mask.data[0, 0] == 100.0
-
-    # Needs to copy because of the dtype change
-    mask = ApertureMask(np.ones((10, 10)), bbox)
-    mask_copy = np.asarray(mask, dtype=int)
-    mask_copy[0, 0] = 100.0
-    assert mask.data[0, 0] == 1.0
-
-
-def test_mask_get_overlap_slices():
-    aper = CircularAperture((5, 5), r=10.0)
-    mask = aper.to_mask()
-    slc = ((slice(0, 16, None), slice(0, 16, None)),
-           (slice(5, 21, None), slice(5, 21, None)))
-    assert mask.get_overlap_slices((25, 25)) == slc
-
-
-def test_mask_cutout_shape():
-    mask_data = np.ones((10, 10))
-    bbox = BoundingBox(5, 15, 5, 15)
-    mask = ApertureMask(mask_data, bbox)
-
-    match = 'data must be a 2D array'
-    with pytest.raises(ValueError, match=match):
-        mask.cutout(np.arange(10))
-
-    match = 'input shape must have 2 elements'
-    with pytest.raises(ValueError, match=match):
-        mask.to_image((10,))
-
-
-def test_mask_cutout_copy():
-    data = np.ones((50, 50))
-    aper = CircularAperture((25, 25), r=10.0)
-    mask = aper.to_mask()
-    cutout = mask.cutout(data, copy=True)
-    data[25, 25] = 100.0
-    assert cutout[10, 10] == 1.0
-
-    # Test quantity data
-    data2 = np.ones((50, 50)) * u.adu
-    cutout2 = mask.cutout(data2, copy=True)
-    assert cutout2.unit == data2.unit
-    data2[25, 25] = 100.0 * u.adu
-    assert cutout2[10, 10].value == 1.0
-
-
-@pytest.mark.parametrize('position', POSITIONS)
-def test_mask_cutout_no_overlap(position):
-    data = np.ones((50, 50))
-    aper = CircularAperture(position, r=10.0)
-    mask = aper.to_mask()
-
-    cutout = mask.cutout(data)
-    assert cutout is None
-
-    weighted_data = mask.multiply(data)
-    assert weighted_data is None
-
-    image = mask.to_image(data.shape)
-    assert image is None
-
-
-@pytest.mark.parametrize('position', POSITIONS)
-def test_mask_cutout_partial_overlap(position):
-    data = np.ones((50, 50))
-    aper = CircularAperture(position, r=30.0)
-    mask = aper.to_mask()
-
-    cutout = mask.cutout(data)
-    assert cutout.shape == mask.shape
-
-    weighted_data = mask.multiply(data)
-    assert weighted_data.shape == mask.shape
-
-    image = mask.to_image(data.shape)
-    assert image.shape == data.shape
-
-
-def test_mask_cutout_partial_overlap_quantity():
+class TestApertureMaskConstruction:
     """
-    Test that cutout with a Quantity array and partial overlap applies
-    the data unit to the output cutout (covers the `cutout <<=
-    data.unit` branch).
+    Tests for creating ApertureMask objects and converting them to
+    arrays.
     """
-    aper = CircularAperture((-20, -20), r=30.0)
-    mask = aper.to_mask()
-    data = np.ones((50, 50)) * u.adu
-    cutout = mask.cutout(data)
-    assert isinstance(cutout, u.Quantity)
-    assert cutout.unit == u.adu
+
+    def test_input_shapes(self):
+        mask_data = np.ones((10, 10))
+        bbox = BoundingBox(5, 10, 5, 10)
+        match = 'mask data and bounding box must have the same shape'
+        with pytest.raises(ValueError, match=match):
+            ApertureMask(mask_data, bbox)
+
+    def test_array(self):
+        mask_data = np.ones((10, 10))
+        bbox = BoundingBox(5, 15, 5, 15)
+        mask = ApertureMask(mask_data, bbox)
+        data = np.array(mask)
+        assert_allclose(data, mask.data)
+
+    def test_copy(self):
+        bbox = BoundingBox(5, 15, 5, 15)
+
+        mask = ApertureMask(np.ones((10, 10)), bbox)
+        mask_copy = np.array(mask, copy=True)
+        mask_copy[0, 0] = 100.0
+        assert mask.data[0, 0] == 1.0
+
+        mask = ApertureMask(np.ones((10, 10)), bbox)
+        mask_copy = np.array(mask, copy=False)
+        mask_copy[0, 0] = 100.0
+        assert mask.data[0, 0] == 100.0
+
+        # No copy: copy=None returns a copy only if __array__ returns a
+        # copy; copy=None was introduced in NumPy 2.0
+        mask = ApertureMask(np.ones((10, 10)), bbox)
+        mask_copy = np.array(mask, copy=None)
+        mask_copy[0, 0] = 100.0
+        assert mask.data[0, 0] == 100.0
+
+        # No copy
+        mask = ApertureMask(np.ones((10, 10)), bbox)
+        mask_copy = np.asarray(mask)
+        mask_copy[0, 0] = 100.0
+        assert mask.data[0, 0] == 100.0
+
+        # Needs to copy because of the dtype change
+        mask = ApertureMask(np.ones((10, 10)), bbox)
+        mask_copy = np.asarray(mask, dtype=int)
+        mask_copy[0, 0] = 100.0
+        assert mask.data[0, 0] == 1.0
 
 
-def test_mask_multiply():
-    radius = 10.0
-    data = np.ones((50, 50))
-    aper = CircularAperture((25, 25), r=radius)
-    mask = aper.to_mask()
-    data_weighted = mask.multiply(data)
-    assert_almost_equal(np.sum(data_weighted), np.pi * radius**2)
-
-    # Test that multiply() returns a copy
-    data[25, 25] = 100.0
-    assert data_weighted[10, 10] == 1.0
-
-
-def test_mask_multiply_quantity():
-    radius = 10.0
-    data = np.ones((50, 50)) * u.adu
-    aper = CircularAperture((25, 25), r=radius)
-    mask = aper.to_mask()
-    data_weighted = mask.multiply(data)
-    assert data_weighted.unit == u.adu
-    assert_almost_equal(np.sum(data_weighted.value), np.pi * radius**2)
-
-    # Test that multiply() returns a copy
-    data[25, 25] = 100.0 * u.adu
-    assert data_weighted[10, 10].value == 1.0
-
-
-@pytest.mark.parametrize('value', [np.nan, np.inf])
-def test_mask_nonfinite_fill_value(value):
-    aper = CircularAnnulus((0, 0), 10, 20)
-    data = np.ones((101, 101)).astype(int)
-    cutout = aper.to_mask().cutout(data, fill_value=value)
-    assert ~np.isfinite(cutout[0, 0])
-
-
-def test_mask_multiply_fill_value():
-    aper = CircularAnnulus((0, 0), 10, 20)
-    data = np.ones((101, 101)).astype(int)
-    cutout = aper.to_mask().multiply(data, fill_value=np.nan)
-    xypos = ((20, 20), (5, 5), (5, 35), (35, 5), (35, 35))
-    for x, y in xypos:
-        assert np.isnan(cutout[y, x])
-
-
-def test_mask_nonfinite_in_bbox():
+class TestCutout:
     """
-    Regression test that non-finite data values outside the mask but
-    within the bounding box are set to zero.
+    Tests for the ApertureMask cutout, to_image, and overlap-slice
+    methods.
     """
-    data = np.ones((101, 101))
-    data[33, 33] = np.nan
-    data[67, 67] = np.inf
-    data[33, 67] = -np.inf
-    data[22, 22] = np.nan
-    data[22, 23] = np.inf
 
-    radius = 20.0
-    aper1 = CircularAperture((50, 50), r=radius)
-    aper2 = CircularAperture((5, 5), r=radius)
+    def test_get_overlap_slices(self):
+        aper = CircularAperture((5, 5), r=10.0)
+        mask = aper.to_mask()
+        slc = ((slice(0, 16, None), slice(0, 16, None)),
+               (slice(5, 21, None), slice(5, 21, None)))
+        assert mask.get_overlap_slices((25, 25)) == slc
 
-    wdata1 = aper1.to_mask(method='exact').multiply(data)
-    assert_allclose(np.sum(wdata1), np.pi * radius**2)
+    def test_cutout_shape(self):
+        mask_data = np.ones((10, 10))
+        bbox = BoundingBox(5, 15, 5, 15)
+        mask = ApertureMask(mask_data, bbox)
 
-    wdata2 = aper2.to_mask(method='exact').multiply(data)
-    assert_allclose(np.sum(wdata2), 561.6040111923013)
+        match = 'data must be a 2D array'
+        with pytest.raises(ValueError, match=match):
+            mask.cutout(np.arange(10))
+
+        match = 'input shape must have 2 elements'
+        with pytest.raises(ValueError, match=match):
+            mask.to_image((10,))
+
+    def test_cutout_copy(self):
+        data = np.ones((50, 50))
+        aper = CircularAperture((25, 25), r=10.0)
+        mask = aper.to_mask()
+        cutout = mask.cutout(data, copy=True)
+        data[25, 25] = 100.0
+        assert cutout[10, 10] == 1.0
+
+        # Test quantity data
+        data2 = np.ones((50, 50)) * u.adu
+        cutout2 = mask.cutout(data2, copy=True)
+        assert cutout2.unit == data2.unit
+        data2[25, 25] = 100.0 * u.adu
+        assert cutout2[10, 10].value == 1.0
+
+    @pytest.mark.parametrize('position', POSITIONS)
+    def test_cutout_no_overlap(self, position):
+        data = np.ones((50, 50))
+        aper = CircularAperture(position, r=10.0)
+        mask = aper.to_mask()
+
+        cutout = mask.cutout(data)
+        assert cutout is None
+
+        weighted_data = mask.multiply(data)
+        assert weighted_data is None
+
+        image = mask.to_image(data.shape)
+        assert image is None
+
+    @pytest.mark.parametrize('position', POSITIONS)
+    def test_cutout_partial_overlap(self, position):
+        data = np.ones((50, 50))
+        aper = CircularAperture(position, r=30.0)
+        mask = aper.to_mask()
+
+        cutout = mask.cutout(data)
+        assert cutout.shape == mask.shape
+
+        weighted_data = mask.multiply(data)
+        assert weighted_data.shape == mask.shape
+
+        image = mask.to_image(data.shape)
+        assert image.shape == data.shape
+
+    def test_cutout_partial_overlap_quantity(self):
+        """
+        Test that cutout with a Quantity array and partial overlap
+        applies the data unit to the output cutout (covers the `cutout
+        <<= data.unit` branch).
+        """
+        aper = CircularAperture((-20, -20), r=30.0)
+        mask = aper.to_mask()
+        data = np.ones((50, 50)) * u.adu
+        cutout = mask.cutout(data)
+        assert isinstance(cutout, u.Quantity)
+        assert cutout.unit == u.adu
+
+    @pytest.mark.parametrize('value', [np.nan, np.inf])
+    def test_nonfinite_fill_value(self, value):
+        aper = CircularAnnulus((0, 0), 10, 20)
+        data = np.ones((101, 101)).astype(int)
+        cutout = aper.to_mask().cutout(data, fill_value=value)
+        assert ~np.isfinite(cutout[0, 0])
 
 
-def test_mask_get_values():
-    aper = CircularAnnulus(((0, 0), (50, 50), (100, 100)), 10, 20)
-    data = np.ones((101, 101))
-    values = [mask.get_values(data) for mask in aper.to_mask()]
-    shapes = [val.shape for val in values]
-    sums = [np.sum(val) for val in values]
-    assert shapes[0] == (278,)
-    assert shapes[1] == (1068,)
-    assert shapes[2] == (278,)
-    sums_expected = (245.621534, 942.477796, 245.621534)
-    assert_allclose(sums, sums_expected)
-
-
-def test_mask_get_values_no_overlap():
-    aper = CircularAperture((-100, -100), r=3)
-    data = np.ones((51, 51))
-    values = aper.to_mask().get_values(data)
-    assert values.shape == (0,)
-
-
-def test_mask_get_values_mask():
-    aper = CircularAperture((24.5, 24.5), r=10.0)
-    data = np.ones((51, 51))
-    mask = aper.to_mask()
-    match = 'mask and data must have the same shape'
-    with pytest.raises(ValueError, match=match):
-        mask.get_values(data, mask=np.ones(3))
-
-    arr = mask.get_values(data, mask=None)
-    assert_allclose(np.sum(arr), 100.0 * np.pi)
-
-    data_mask = np.zeros(data.shape, dtype=bool)
-    data_mask[25:] = True
-    arr2 = mask.get_values(data, mask=data_mask)
-    assert_allclose(np.sum(arr2), 100.0 * np.pi / 2.0)
-
-
-def test_rectangular_annulus_hin():
-    aper = RectangularAnnulus((25, 25), 2, 4, 20, h_in=18, theta=0)
-    mask = aper.to_mask(method='center')
-    assert mask.data.shape == (21, 5)
-    assert np.count_nonzero(mask.data) == 40
-
-
-@pytest.mark.parametrize('method', ['center', 'subpixel', 'exact'])
-def test_annulus_mask_nonnegative(method):
+class TestMultiply:
     """
-    Regression test that annulus aperture masks never contain negative
-    overlap fractions.
-
-    An annulus overlap is computed as the difference of the outer and
-    inner overlaps, which can leave a boundary pixel with a tiny
-    negative value from floating-point noise. These must be clipped to
-    zero.
+    Tests for the ApertureMask multiply method.
     """
-    # Fractional positions place pixel centers near the annulus edges,
-    # where the subtraction is prone to tiny negative floating-point
-    # values.
-    positions = [(24.3, 27.7), (25.55, 22.15), (28.1, 29.9)]
-    apertures = [
-        CircularAnnulus(positions, r_in=3.0, r_out=6.0),
-        EllipticalAnnulus(positions, a_in=3.0, a_out=6.0, b_out=4.0,
-                          theta=0.5),
-        RectangularAnnulus(positions, w_in=3.0, w_out=6.0, h_out=4.0,
-                           theta=0.5),
-    ]
-    for aperture in apertures:
-        for mask in aperture.to_mask(method=method):
-            assert mask.data.min() >= 0.0
+
+    def test_multiply(self):
+        radius = 10.0
+        data = np.ones((50, 50))
+        aper = CircularAperture((25, 25), r=radius)
+        mask = aper.to_mask()
+        data_weighted = mask.multiply(data)
+        assert_almost_equal(np.sum(data_weighted), np.pi * radius**2)
+
+        # Test that multiply() returns a copy
+        data[25, 25] = 100.0
+        assert data_weighted[10, 10] == 1.0
+
+    def test_multiply_quantity(self):
+        radius = 10.0
+        data = np.ones((50, 50)) * u.adu
+        aper = CircularAperture((25, 25), r=radius)
+        mask = aper.to_mask()
+        data_weighted = mask.multiply(data)
+        assert data_weighted.unit == u.adu
+        assert_almost_equal(np.sum(data_weighted.value), np.pi * radius**2)
+
+        # Test that multiply() returns a copy
+        data[25, 25] = 100.0 * u.adu
+        assert data_weighted[10, 10].value == 1.0
+
+    def test_multiply_fill_value(self):
+        aper = CircularAnnulus((0, 0), 10, 20)
+        data = np.ones((101, 101)).astype(int)
+        cutout = aper.to_mask().multiply(data, fill_value=np.nan)
+        xypos = ((20, 20), (5, 5), (5, 35), (35, 5), (35, 35))
+        for x, y in xypos:
+            assert np.isnan(cutout[y, x])
+
+    def test_nonfinite_in_bbox(self):
+        """
+        Regression test that non-finite data values outside the mask but
+        within the bounding box are set to zero.
+        """
+        data = np.ones((101, 101))
+        data[33, 33] = np.nan
+        data[67, 67] = np.inf
+        data[33, 67] = -np.inf
+        data[22, 22] = np.nan
+        data[22, 23] = np.inf
+
+        radius = 20.0
+        aper1 = CircularAperture((50, 50), r=radius)
+        aper2 = CircularAperture((5, 5), r=radius)
+
+        wdata1 = aper1.to_mask(method='exact').multiply(data)
+        assert_allclose(np.sum(wdata1), np.pi * radius**2)
+
+        wdata2 = aper2.to_mask(method='exact').multiply(data)
+        assert_allclose(np.sum(wdata2), 561.6040111923013)
+
+
+class TestGetValues:
+    """
+    Tests for the ApertureMask get_values method.
+    """
+
+    def test_get_values(self):
+        aper = CircularAnnulus(((0, 0), (50, 50), (100, 100)), 10, 20)
+        data = np.ones((101, 101))
+        values = [mask.get_values(data) for mask in aper.to_mask()]
+        shapes = [val.shape for val in values]
+        sums = [np.sum(val) for val in values]
+        assert shapes[0] == (278,)
+        assert shapes[1] == (1068,)
+        assert shapes[2] == (278,)
+        sums_expected = (245.621534, 942.477796, 245.621534)
+        assert_allclose(sums, sums_expected)
+
+    def test_get_values_no_overlap(self):
+        aper = CircularAperture((-100, -100), r=3)
+        data = np.ones((51, 51))
+        values = aper.to_mask().get_values(data)
+        assert values.shape == (0,)
+
+    def test_get_values_mask(self):
+        aper = CircularAperture((24.5, 24.5), r=10.0)
+        data = np.ones((51, 51))
+        mask = aper.to_mask()
+        match = 'mask and data must have the same shape'
+        with pytest.raises(ValueError, match=match):
+            mask.get_values(data, mask=np.ones(3))
+
+        arr = mask.get_values(data, mask=None)
+        assert_allclose(np.sum(arr), 100.0 * np.pi)
+
+        data_mask = np.zeros(data.shape, dtype=bool)
+        data_mask[25:] = True
+        arr2 = mask.get_values(data, mask=data_mask)
+        assert_allclose(np.sum(arr2), 100.0 * np.pi / 2.0)
+
+
+class TestAnnulusMasks:
+    """
+    Tests for the masks produced by the annulus apertures.
+    """
+
+    def test_rectangular_annulus_hin(self):
+        aper = RectangularAnnulus((25, 25), 2, 4, 20, h_in=18, theta=0)
+        mask = aper.to_mask(method='center')
+        assert mask.data.shape == (21, 5)
+        assert np.count_nonzero(mask.data) == 40
+
+    @pytest.mark.parametrize('method', ['center', 'subpixel', 'exact'])
+    def test_annulus_mask_nonnegative(self, method):
+        """
+        Regression test that annulus aperture masks never contain
+        negative overlap fractions.
+
+        An annulus overlap is computed as the difference of the outer
+        and inner overlaps, which can leave a boundary pixel with a tiny
+        negative value from floating-point noise. These must be clipped
+        to zero.
+        """
+        # Fractional positions place pixel centers near the annulus
+        # edges, where the subtraction is prone to tiny negative
+        # floating-point values.
+        positions = [(24.3, 27.7), (25.55, 22.15), (28.1, 29.9)]
+        apertures = [
+            CircularAnnulus(positions, r_in=3.0, r_out=6.0),
+            EllipticalAnnulus(positions, a_in=3.0, a_out=6.0, b_out=4.0,
+                              theta=0.5),
+            RectangularAnnulus(positions, w_in=3.0, w_out=6.0, h_out=4.0,
+                               theta=0.5),
+        ]
+        for aperture in apertures:
+            for mask in aperture.to_mask(method=method):
+                assert mask.data.min() >= 0.0

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -44,51 +44,6 @@ TEST_APERTURES = list(zip(APERTURE_CL,
                           strict=True))
 
 
-@pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
-def test_outside_array(aperture_class, params):
-    data = np.ones((10, 10), dtype=float)
-    aperture = aperture_class((-60, 60), **params)
-    fluxtable = aperture_photometry(data, aperture)
-    # Aperture is fully outside array
-    assert np.isnan(fluxtable['aperture_sum'])
-
-
-@pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
-def test_inside_array_simple(aperture_class, params):
-    data = np.ones((40, 40), dtype=float)
-    aperture = aperture_class((20.0, 20.0), **params)
-    table1 = aperture_photometry(data, aperture, method='center',
-                                 subpixels=10)
-    table2 = aperture_photometry(data, aperture, method='subpixel',
-                                 subpixels=10)
-    table3 = aperture_photometry(data, aperture, method='exact', subpixels=10)
-    true_flux = aperture.area
-    assert table1['aperture_sum'] < table3['aperture_sum']
-
-    if not isinstance(aperture, (RectangularAperture, RectangularAnnulus)):
-        assert_allclose(table3['aperture_sum'], true_flux)
-        assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
-                        atol=0.1)
-
-
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-@pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
-def test_aperture_plots(aperture_class, params):
-    # This test should run without any errors, and there is no return
-    # value.
-    aperture = aperture_class((20.0, 20.0), **params)
-    aperture.plot()
-
-
-def test_aperture_pixel_positions():
-    pos1 = (10, 20)
-    pos2 = [(10, 20)]
-    r = 3
-    ap1 = CircularAperture(pos1, r)
-    ap2 = CircularAperture(pos2, r)
-    assert not np.array_equal(ap1.positions, ap2.positions)
-
-
 class BaseTestAperturePhotometry:
     def test_array_error(self):
         # Array error
@@ -275,505 +230,8 @@ class TestInputNDData(BaseTestDifferentData):
         self.fluxunit = u.adu
 
 
-def test_input_wcs(data):
-    wcs = make_wcs(data.shape)
-
-    # Hard wired positions in make_4gaussian_image
-    xypos = np.transpose(([160.0, 25.0, 150.0, 90.0],
-                          [70.0, 40.0, 25.0, 60.0]))
-    aper = CircularAperture(xypos, 3.0)
-    aper3 = [CircularAperture((160.0, 70.0), r) for r in (3, 4, 5)]
-
-    phot1 = aperture_photometry(data, aper[0], wcs=wcs)
-    phot2 = aperture_photometry(data, aper, wcs=wcs)
-    phot3 = aperture_photometry(data, aper3, wcs=wcs)
-
-    assert 'sky_center' in phot1.colnames
-    assert 'sky_center' in phot2.colnames
-    assert 'sky_center' in phot3.colnames
-
-
-def test_wcs_based_photometry(data):
-    wcs = make_wcs(data.shape)
-
-    # Hard wired positions in make_4gaussian_image
-    pos_orig_pixel = u.Quantity(([160.0, 25.0, 150.0, 90.0],
-                                 [70.0, 40.0, 25.0, 60.0]), unit=u.pixel)
-
-    pos_skycoord = wcs.pixel_to_world(pos_orig_pixel[0], pos_orig_pixel[1])
-    pos_skycoord_s = pos_skycoord[2]
-
-    photometry_skycoord_circ = aperture_photometry(
-        data, SkyCircularAperture(pos_skycoord, 3 * u.arcsec), wcs=wcs)
-    photometry_skycoord_circ_2 = aperture_photometry(
-        data, SkyCircularAperture(pos_skycoord, 2 * u.arcsec), wcs=wcs)
-    photometry_skycoord_circ_s = aperture_photometry(
-        data, SkyCircularAperture(pos_skycoord_s, 3 * u.arcsec), wcs=wcs)
-
-    assert_allclose(photometry_skycoord_circ['aperture_sum'][2],
-                    photometry_skycoord_circ_s['aperture_sum'])
-
-    photometry_skycoord_circ_ann = aperture_photometry(
-        data, SkyCircularAnnulus(pos_skycoord, 2 * u.arcsec, 3 * u.arcsec),
-        wcs=wcs)
-    photometry_skycoord_circ_ann_s = aperture_photometry(
-        data, SkyCircularAnnulus(pos_skycoord_s, 2 * u.arcsec, 3 * u.arcsec),
-        wcs=wcs)
-
-    assert_allclose(photometry_skycoord_circ_ann['aperture_sum'][2],
-                    photometry_skycoord_circ_ann_s['aperture_sum'])
-
-    assert_allclose(photometry_skycoord_circ_ann['aperture_sum'],
-                    photometry_skycoord_circ['aperture_sum']
-                    - photometry_skycoord_circ_2['aperture_sum'])
-
-    photometry_skycoord_ell = aperture_photometry(
-        data, SkyEllipticalAperture(pos_skycoord, 3 * u.arcsec,
-                                    3.0001 * u.arcsec, theta=45 * u.arcsec),
-        wcs=wcs)
-    photometry_skycoord_ell_2 = aperture_photometry(
-        data, SkyEllipticalAperture(pos_skycoord, 2 * u.arcsec,
-                                    2.0001 * u.arcsec, theta=45 * u.arcsec),
-        wcs=wcs)
-    photometry_skycoord_ell_s = aperture_photometry(
-        data, SkyEllipticalAperture(pos_skycoord_s, 3 * u.arcsec,
-                                    3.0001 * u.arcsec, theta=45 * u.arcsec),
-        wcs=wcs)
-    photometry_skycoord_ell_ann = aperture_photometry(
-        data, SkyEllipticalAnnulus(pos_skycoord, 2 * u.arcsec, 3 * u.arcsec,
-                                   3.0001 * u.arcsec, theta=45 * u.arcsec),
-        wcs=wcs)
-    photometry_skycoord_ell_ann_s = aperture_photometry(
-        data, SkyEllipticalAnnulus(pos_skycoord_s, 2 * u.arcsec, 3 * u.arcsec,
-                                   3.0001 * u.arcsec, theta=45 * u.arcsec),
-        wcs=wcs)
-
-    assert_allclose(photometry_skycoord_ell['aperture_sum'][2],
-                    photometry_skycoord_ell_s['aperture_sum'])
-
-    assert_allclose(photometry_skycoord_ell_ann['aperture_sum'][2],
-                    photometry_skycoord_ell_ann_s['aperture_sum'])
-
-    assert_allclose(photometry_skycoord_ell['aperture_sum'],
-                    photometry_skycoord_circ['aperture_sum'], rtol=5e-3)
-
-    assert_allclose(photometry_skycoord_ell_ann['aperture_sum'],
-                    photometry_skycoord_ell['aperture_sum']
-                    - photometry_skycoord_ell_2['aperture_sum'], rtol=1e-4)
-
-    photometry_skycoord_rec = aperture_photometry(
-        data, SkyRectangularAperture(pos_skycoord,
-                                     6 * u.arcsec, 6 * u.arcsec,
-                                     theta=0 * u.arcsec),
-        method='subpixel', subpixels=20, wcs=wcs)
-    photometry_skycoord_rec_4 = aperture_photometry(
-        data, SkyRectangularAperture(pos_skycoord,
-                                     4 * u.arcsec, 4 * u.arcsec,
-                                     theta=0 * u.arcsec),
-        method='subpixel', subpixels=20, wcs=wcs)
-    photometry_skycoord_rec_s = aperture_photometry(
-        data, SkyRectangularAperture(pos_skycoord_s,
-                                     6 * u.arcsec, 6 * u.arcsec,
-                                     theta=0 * u.arcsec),
-        method='subpixel', subpixels=20, wcs=wcs)
-    photometry_skycoord_rec_ann = aperture_photometry(
-        data, SkyRectangularAnnulus(pos_skycoord, 4 * u.arcsec, 6 * u.arcsec,
-                                    6 * u.arcsec, theta=0 * u.arcsec),
-        method='subpixel', subpixels=20, wcs=wcs)
-    photometry_skycoord_rec_ann_s = aperture_photometry(
-        data, SkyRectangularAnnulus(pos_skycoord_s, 4 * u.arcsec,
-                                    6 * u.arcsec, 6 * u.arcsec,
-                                    theta=0 * u.arcsec),
-        method='subpixel', subpixels=20, wcs=wcs)
-
-    assert_allclose(photometry_skycoord_rec['aperture_sum'][2],
-                    photometry_skycoord_rec_s['aperture_sum'])
-
-    assert np.all(photometry_skycoord_rec['aperture_sum']
-                  > photometry_skycoord_circ['aperture_sum'])
-
-    assert_allclose(photometry_skycoord_rec_ann['aperture_sum'][2],
-                    photometry_skycoord_rec_ann_s['aperture_sum'])
-
-    assert_allclose(photometry_skycoord_rec_ann['aperture_sum'],
-                    photometry_skycoord_rec['aperture_sum']
-                    - photometry_skycoord_rec_4['aperture_sum'], rtol=1e-4)
-
-
-def test_basic_circular_aperture_photometry_unit():
-    radius = 3
-    true_flux = np.pi * radius * radius
-    aper = CircularAperture((12, 12), radius)
-
-    data1 = np.ones((25, 25), dtype=float)
-    table1 = aperture_photometry(data1, aper)
-    assert_allclose(table1['aperture_sum'], true_flux)
-
-    unit = u.adu
-    data2 = u.Quantity(data1 * unit)
-    table2 = aperture_photometry(data2, aper)
-    assert_allclose(table2['aperture_sum'].value, true_flux)
-    assert table2['aperture_sum'].unit == data2.unit == unit
-
-    error1 = np.ones((25, 25))
-    match = 'then they both must have the same units'
-    with pytest.raises(ValueError, match=match):
-        # data has unit, but error does not
-        aperture_photometry(data2, aper, error=error1)
-
-    error2 = u.Quantity(error1 * u.Jy)
-    with pytest.raises(ValueError, match=match):
-        # data and error have different units
-        aperture_photometry(data2, aper, error=error2)
-
-
-def test_aperture_photometry_with_error_units():
-    """
-    Test aperture_photometry when error has units (see #176).
-    """
-    data1 = np.ones((40, 40), dtype=float)
-    data2 = u.Quantity(data1, unit=u.adu)
-    error = u.Quantity(data1, unit=u.adu)
-    radius = 3
-    true_flux = np.pi * radius * radius
-    unit = u.adu
-    position = (20, 20)
-    table1 = aperture_photometry(data2, CircularAperture(position, radius),
-                                 error=error)
-    assert_allclose(table1['aperture_sum'].value, true_flux)
-    assert_allclose(table1['aperture_sum_err'].value, np.sqrt(true_flux))
-    assert table1['aperture_sum'].unit == unit
-    assert table1['aperture_sum_err'].unit == unit
-
-
-def test_aperture_photometry_inputs_with_mask():
-    """
-    Test that aperture_photometry does not modify the input data or
-    error array when a mask is input.
-    """
-    data = np.ones((5, 5))
-    aperture = CircularAperture((2, 2), 2.0)
-    mask = np.zeros_like(data, dtype=bool)
-    data[2, 2] = 100.0  # bad pixel
-    mask[2, 2] = True
-    error = np.sqrt(data)
-    data_in = data.copy()
-    error_in = error.copy()
-    t1 = aperture_photometry(data, aperture, error=error, mask=mask)
-    assert_equal(data, data_in)
-    assert_equal(error, error_in)
-    assert_allclose(t1['aperture_sum'][0], 11.5663706144)
-    t2 = aperture_photometry(data, aperture)
-    assert_allclose(t2['aperture_sum'][0], 111.566370614)
-
-
 TEST_ELLIPSE_EXACT_APERTURES = [(3.469906, 3.923861394, 3.0),
                                 (0.3834415188257778, 0.3834415188257778, 0.3)]
-
-
-@pytest.mark.parametrize(('x', 'y', 'r'), TEST_ELLIPSE_EXACT_APERTURES)
-def test_ellipse_exact_grid(x, y, r):
-    """
-    Test elliptical exact aperture photometry on a grid of pixel
-    positions.
-
-    This is a regression test for the bug discovered in this issue:
-    https://github.com/astropy/photutils/issues/198
-    """
-    data = np.ones((10, 10))
-
-    aperture = EllipticalAperture((x, y), a=r, b=r, theta=0.0)
-    t = aperture_photometry(data, aperture, method='exact')
-    actual = t['aperture_sum'][0] / (np.pi * r**2)
-    assert_allclose(actual, 1)
-
-
-@pytest.mark.parametrize('value', [np.nan, np.inf])
-def test_nan_inf_mask(value):
-    """
-    Test that nans and infs are properly masked [#267].
-    """
-    data = np.ones((9, 9))
-    mask = np.zeros_like(data, dtype=bool)
-    data[4, 4] = value
-    mask[4, 4] = True
-    radius = 2.0
-    aper = CircularAperture((4, 4), radius)
-    tbl = aperture_photometry(data, aper, mask=mask)
-    desired = (np.pi * radius**2) - 1
-    assert_allclose(tbl['aperture_sum'], desired)
-
-
-def test_aperture_partial_overlap():
-    data = np.ones((20, 20))
-    error = np.ones((20, 20))
-    xypos = [(10, 10), (0, 0), (0, 19), (19, 0), (19, 19)]
-    r = 5.0
-    aper = CircularAperture(xypos, r=r)
-    tbl = aperture_photometry(data, aper, error=error)
-    assert_allclose(tbl['aperture_sum'][0], np.pi * r**2)
-    assert_array_less(tbl['aperture_sum'][1:], np.pi * r**2)
-
-    unit = u.MJy / u.sr
-    tbl = aperture_photometry(data * unit, aper, error=error * unit)
-    assert_allclose(tbl['aperture_sum'][0].value, np.pi * r**2)
-    assert_array_less(tbl['aperture_sum'][1:].value, np.pi * r**2)
-    assert_array_less(tbl['aperture_sum_err'][1:].value, np.pi * r**2)
-    assert tbl['aperture_sum'].unit == unit
-    assert tbl['aperture_sum_err'].unit == unit
-
-
-def test_pixel_aperture_repr():
-    aper = CircularAperture((10, 20), r=3.0)
-    assert '<CircularAperture(' in repr(aper)
-    assert 'Aperture: CircularAperture' in str(aper)
-
-    aper = CircularAnnulus((10, 20), r_in=3.0, r_out=5.0)
-    assert '<CircularAnnulus(' in repr(aper)
-    assert 'Aperture: CircularAnnulus' in str(aper)
-
-    aper = EllipticalAperture((10, 20), a=5.0, b=3.0, theta=15.0)
-    assert '<EllipticalAperture(' in repr(aper)
-    assert 'Aperture: EllipticalAperture' in str(aper)
-
-    aper = EllipticalAnnulus((10, 20), a_in=4.0, a_out=8.0, b_out=4.0,
-                             theta=15.0)
-    assert '<EllipticalAnnulus(' in repr(aper)
-    assert 'Aperture: EllipticalAnnulus' in str(aper)
-
-    aper = RectangularAperture((10, 20), w=5.0, h=3.0, theta=15.0)
-    assert '<RectangularAperture(' in repr(aper)
-    assert 'Aperture: RectangularAperture' in str(aper)
-
-    aper = RectangularAnnulus((10, 20), w_in=4.0, w_out=8.0, h_out=4.0,
-                              theta=15.0)
-    assert '<RectangularAnnulus(' in repr(aper)
-    assert 'Aperture: RectangularAnnulus' in str(aper)
-
-
-def test_sky_aperture_repr():
-    s = SkyCoord([1, 2], [3, 4], unit='deg')
-
-    aper = SkyCircularAperture(s, r=3 * u.deg)
-    a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
-              '    [(1., 3.), (2., 4.)]>, r=3.0 deg)>')
-    a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
-             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'r: 3.0 deg')
-
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
-
-    aper = SkyCircularAnnulus(s, r_in=3.0 * u.deg, r_out=5 * u.deg)
-    a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
-              '    [(1., 3.), (2., 4.)]>, r_in=3.0 deg, r_out=5.0 deg)>')
-    a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
-             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'r_in: 3.0 deg\nr_out: 5.0 deg')
-
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
-
-    aper = SkyEllipticalAperture(s, a=3 * u.deg, b=5 * u.deg, theta=15 * u.deg)
-    a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
-              'deg\n    [(1., 3.), (2., 4.)]>, a=3.0 deg, b=5.0 deg, '
-              'theta=15.0 deg)>')
-    a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
-             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'a: 3.0 deg\nb: 5.0 deg\ntheta: 15.0 deg')
-
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
-
-    aper = SkyEllipticalAnnulus(s, a_in=3 * u.deg, a_out=5 * u.deg,
-                                b_out=3 * u.deg, theta=15 * u.deg)
-    a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
-              'deg\n    [(1., 3.), (2., 4.)]>, a_in=3.0 deg, '
-              'a_out=5.0 deg, b_in=1.8 deg, b_out=3.0 deg, '
-              'theta=15.0 deg)>')
-    a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
-             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'a_in: 3.0 deg\na_out: 5.0 deg\nb_in: 1.8 deg\n'
-             'b_out: 3.0 deg\ntheta: 15.0 deg')
-
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
-
-    aper = SkyRectangularAperture(s, w=3 * u.deg, h=5 * u.deg,
-                                  theta=15 * u.deg)
-    a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
-              'deg\n    [(1., 3.), (2., 4.)]>, w=3.0 deg, h=5.0 deg'
-              ', theta=15.0 deg)>')
-    a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
-             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'w: 3.0 deg\nh: 5.0 deg\ntheta: 15.0 deg')
-
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
-
-    aper = SkyRectangularAnnulus(s, w_in=5 * u.deg, w_out=10 * u.deg,
-                                 h_out=6 * u.deg, theta=15 * u.deg)
-    a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
-              '\n    [(1., 3.), (2., 4.)]>, w_in=5.0 deg, '
-              'w_out=10.0 deg, h_in=3.0 deg, h_out=6.0 deg, '
-              'theta=15.0 deg)>')
-    a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
-             '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
-             'w_in: 5.0 deg\nw_out: 10.0 deg\nh_in: 3.0 deg\n'
-             'h_out: 6.0 deg\ntheta: 15.0 deg')
-
-    assert repr(aper) == a_repr
-    assert str(aper) == a_str
-
-
-def test_rectangular_bbox():
-    # Test odd sizes
-    width = 7
-    height = 3
-    a = RectangularAperture((50, 50), w=width, h=height, theta=0)
-    assert a.bbox.shape == (height, width)
-
-    a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
-    assert a.bbox.shape == (height + 1, width + 1)
-
-    a = RectangularAperture((50, 50), w=width, h=height,
-                            theta=np.deg2rad(90.0))
-    assert a.bbox.shape == (width, height)
-
-    # Test even sizes
-    width = 8
-    height = 4
-    a = RectangularAperture((50, 50), w=width, h=height, theta=0)
-    assert a.bbox.shape == (height + 1, width + 1)
-
-    a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
-    assert a.bbox.shape == (height, width)
-
-    a = RectangularAperture((50.5, 50.5), w=width, h=height,
-                            theta=np.deg2rad(90.0))
-    assert a.bbox.shape == (width, height)
-
-
-def test_elliptical_bbox():
-    # Integer axes
-    a = 7
-    b = 3
-    ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
-    assert ap.bbox.shape == (2 * b + 1, 2 * a + 1)
-
-    ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
-    assert ap.bbox.shape == (2 * b, 2 * a)
-
-    ap = EllipticalAperture((50, 50), a=a, b=b, theta=np.deg2rad(90.0))
-    assert ap.bbox.shape == (2 * a + 1, 2 * b + 1)
-
-    # Fractional axes
-    a = 7.5
-    b = 4.5
-    ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
-    assert ap.bbox.shape == (2 * b, 2 * a)
-
-    ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
-    assert ap.bbox.shape == (2 * b + 1, 2 * a + 1)
-
-    ap = EllipticalAperture((50, 50), a=a, b=b, theta=np.deg2rad(90.0))
-    assert ap.bbox.shape == (2 * a, 2 * b)
-
-
-def test_scalar_aperture():
-    """
-    Regression test to check that a length-1 aperture list appends a
-    "_0" to the column names to be consistent with list inputs.
-    """
-    data = np.ones((20, 20), dtype=float)
-
-    ap = CircularAperture((10, 10), r=3.0)
-    colnames1 = aperture_photometry(data, ap, error=data).colnames
-    assert (colnames1 == ['id', 'x_center', 'y_center', 'aperture_sum',
-                          'aperture_sum_err'])
-
-    colnames2 = aperture_photometry(data, [ap], error=data).colnames
-    assert (colnames2 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
-                          'aperture_sum_err_0'])
-
-    colnames3 = aperture_photometry(data, [ap, ap], error=data).colnames
-    assert (colnames3 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
-                          'aperture_sum_err_0', 'aperture_sum_1',
-                          'aperture_sum_err_1'])
-
-
-def test_nan_in_bbox():
-    """
-    Regression test that non-finite data values outside the aperture
-    mask but within the bounding box do not affect the photometry.
-    """
-    data1 = np.ones((101, 101))
-    data2 = data1.copy()
-    data1[33, 33] = np.nan
-    data1[67, 67] = np.inf
-    data1[33, 67] = -np.inf
-    data1[22, 22] = np.nan
-    data1[22, 23] = np.inf
-    error = data1.copy()
-
-    aper1 = CircularAperture((50, 50), r=20.0)
-    aper2 = CircularAperture((5, 5), r=20.0)
-
-    tbl1 = aperture_photometry(data1, aper1, error=error)
-    tbl2 = aperture_photometry(data2, aper1, error=error)
-    assert_allclose(tbl1['aperture_sum'], tbl2['aperture_sum'])
-    assert_allclose(tbl1['aperture_sum_err'], tbl2['aperture_sum_err'])
-
-    tbl3 = aperture_photometry(data1, aper2, error=error)
-    tbl4 = aperture_photometry(data2, aper2, error=error)
-    assert_allclose(tbl3['aperture_sum'], tbl4['aperture_sum'])
-    assert_allclose(tbl3['aperture_sum_err'], tbl4['aperture_sum_err'])
-
-
-def test_scalar_skycoord(data):
-    """
-    Regression test to check that scalar SkyCoords are added to the
-    table as a length-1 SkyCoord array.
-    """
-    wcs = make_wcs(data.shape)
-    skycoord = wcs.pixel_to_world(90, 60)
-    aper = SkyCircularAperture(skycoord, r=0.1 * u.arcsec)
-    tbl = aperture_photometry(data, aper, wcs=wcs)
-    assert isinstance(tbl['sky_center'], SkyCoord)
-
-
-@pytest.mark.parametrize('units', [False, True])
-def test_nddata_input(units):
-    data = np.arange(400).reshape((20, 20))
-    error = np.sqrt(data)
-    mask = np.zeros((20, 20), dtype=bool)
-    mask[8:13, 8:13] = True
-    if units:
-        unit = u.Jy
-        data = data * unit
-        error = error * unit
-    else:
-        unit = None
-
-    wcs = make_wcs(data.shape)
-    skycoord = wcs.pixel_to_world(10, 10)
-    aper = SkyCircularAperture(skycoord, r=0.7 * u.arcsec)
-
-    tbl1 = aperture_photometry(data, aper, error=error, mask=mask, wcs=wcs)
-
-    uncertainty = StdDevUncertainty(error)
-    nddata = NDData(data, uncertainty=uncertainty, mask=mask, wcs=wcs,
-                    unit=unit)
-    tbl2 = aperture_photometry(nddata, aper)
-
-    for column in tbl1.columns:
-        if column == 'sky_center':  # cannot test SkyCoord equality
-            continue
-        assert_allclose(tbl1[column], tbl2[column])
-
-    match = 'keyword is ignored. Its value is obtained from the input'
-    with pytest.warns(AstropyUserWarning, match=match):
-        aperture_photometry(nddata, aper, error=error)
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
@@ -806,36 +264,6 @@ class BaseTestRegionPhotometry:
                             ap_table['aperture_sum'])
             assert_allclose(reg_table['aperture_sum_err'],
                             ap_table['aperture_sum_err'])
-
-
-def test_invalid_inputs():
-    data = np.ones((11, 11))
-    aper = CircularAperture((5, 5), r=3)
-    wcs = make_wcs(data.shape)
-    sky_aper = aper.to_sky(wcs=wcs)
-
-    match = 'A WCS transform must be defined'
-    with pytest.raises(ValueError, match=match):
-        aperture_photometry(data, sky_aper)
-
-    aper2 = CircularAperture((7, 7), r=3)
-    sky_aper2 = aper2.to_sky(wcs=wcs)
-    apers = [aper, aper2]
-    sky_apers = [sky_aper, sky_aper2]
-
-    match = 'Input apertures must all have identical positions'
-    with pytest.raises(ValueError, match=match):
-        aperture_photometry(data, apers)
-    with pytest.raises(ValueError, match=match):
-        aperture_photometry(data, sky_apers, wcs=wcs)
-
-    data = np.ones((11, 11))
-    aper = CircularAperture((5, 5), r=3)
-    match = 'subpixels must be a strictly positive integer'
-    with pytest.raises(ValueError, match=match):
-        aperture_photometry(data, aper, method='subpixel', subpixels=0)
-    with pytest.raises(ValueError, match=match):
-        aperture_photometry(data, aper, method='subpixel', subpixels=-1)
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
@@ -922,51 +350,659 @@ class TestRectangleAnnulusRegionPhotometry(BaseTestRegionPhotometry):
                                            h_out, h_in=h_in, theta=theta)
 
 
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_unsupported_region_input():
-    from regions import LinePixelRegion, PixCoord
+class TestArrayBounds:
+    """
+    Tests for apertures inside, outside, and straddling the data.
+    """
 
-    region = LinePixelRegion(start=PixCoord(x=1, y=1),
-                             end=PixCoord(x=5, y=5))
-    data = np.ones((10, 10))
-    match = r'Cannot convert .* to an Aperture object'
-    with pytest.raises(TypeError, match=match):
-        aperture_photometry(data, region)
+    @pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
+    def test_outside_array(self, aperture_class, params):
+        data = np.ones((10, 10), dtype=float)
+        aperture = aperture_class((-60, 60), **params)
+        fluxtable = aperture_photometry(data, aperture)
+        # Aperture is fully outside array
+        assert np.isnan(fluxtable['aperture_sum'])
+
+    @pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
+    def test_inside_array_simple(self, aperture_class, params):
+        data = np.ones((40, 40), dtype=float)
+        aperture = aperture_class((20.0, 20.0), **params)
+        table1 = aperture_photometry(data, aperture, method='center',
+                                     subpixels=10)
+        table2 = aperture_photometry(data, aperture, method='subpixel',
+                                     subpixels=10)
+        table3 = aperture_photometry(data, aperture, method='exact',
+                                     subpixels=10)
+        true_flux = aperture.area
+        assert table1['aperture_sum'] < table3['aperture_sum']
+
+        if not isinstance(aperture, (RectangularAperture, RectangularAnnulus)):
+            assert_allclose(table3['aperture_sum'], true_flux)
+            assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
+                            atol=0.1)
+
+    def test_pixel_positions(self):
+        pos1 = (10, 20)
+        pos2 = [(10, 20)]
+        r = 3
+        ap1 = CircularAperture(pos1, r)
+        ap2 = CircularAperture(pos2, r)
+        assert not np.array_equal(ap1.positions, ap2.positions)
+
+    def test_partial_overlap(self):
+        data = np.ones((20, 20))
+        error = np.ones((20, 20))
+        xypos = [(10, 10), (0, 0), (0, 19), (19, 0), (19, 19)]
+        r = 5.0
+        aper = CircularAperture(xypos, r=r)
+        tbl = aperture_photometry(data, aper, error=error)
+        assert_allclose(tbl['aperture_sum'][0], np.pi * r**2)
+        assert_array_less(tbl['aperture_sum'][1:], np.pi * r**2)
+
+        unit = u.MJy / u.sr
+        tbl = aperture_photometry(data * unit, aper, error=error * unit)
+        assert_allclose(tbl['aperture_sum'][0].value, np.pi * r**2)
+        assert_array_less(tbl['aperture_sum'][1:].value, np.pi * r**2)
+        assert_array_less(tbl['aperture_sum_err'][1:].value, np.pi * r**2)
+        assert tbl['aperture_sum'].unit == unit
+        assert tbl['aperture_sum_err'].unit == unit
+
+    def test_scalar_aperture(self):
+        """
+        Regression test to check that a length-1 aperture list appends a
+        "_0" to the column names to be consistent with list inputs.
+        """
+        data = np.ones((20, 20), dtype=float)
+
+        ap = CircularAperture((10, 10), r=3.0)
+        colnames1 = aperture_photometry(data, ap, error=data).colnames
+        assert (colnames1 == ['id', 'x_center', 'y_center', 'aperture_sum',
+                              'aperture_sum_err'])
+
+        colnames2 = aperture_photometry(data, [ap], error=data).colnames
+        assert (colnames2 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
+                              'aperture_sum_err_0'])
+
+        colnames3 = aperture_photometry(data, [ap, ap], error=data).colnames
+        assert (colnames3 == ['id', 'x_center', 'y_center', 'aperture_sum_0',
+                              'aperture_sum_err_0', 'aperture_sum_1',
+                              'aperture_sum_err_1'])
+
+    def test_nan_in_bbox(self):
+        """
+        Regression test that non-finite data values outside the aperture
+        mask but within the bounding box do not affect the photometry.
+        """
+        data1 = np.ones((101, 101))
+        data2 = data1.copy()
+        data1[33, 33] = np.nan
+        data1[67, 67] = np.inf
+        data1[33, 67] = -np.inf
+        data1[22, 22] = np.nan
+        data1[22, 23] = np.inf
+        error = data1.copy()
+
+        aper1 = CircularAperture((50, 50), r=20.0)
+        aper2 = CircularAperture((5, 5), r=20.0)
+
+        tbl1 = aperture_photometry(data1, aper1, error=error)
+        tbl2 = aperture_photometry(data2, aper1, error=error)
+        assert_allclose(tbl1['aperture_sum'], tbl2['aperture_sum'])
+        assert_allclose(tbl1['aperture_sum_err'], tbl2['aperture_sum_err'])
+
+        tbl3 = aperture_photometry(data1, aper2, error=error)
+        tbl4 = aperture_photometry(data2, aper2, error=error)
+        assert_allclose(tbl3['aperture_sum'], tbl4['aperture_sum'])
+        assert_allclose(tbl3['aperture_sum_err'], tbl4['aperture_sum_err'])
 
 
-def test_aperture_metadata():
-    x = [10, 20, 3]
-    y = [3, 5, 10]
-    xypos = list(zip(x, y, strict=False))
-    a1 = CircularAperture(xypos, r=3)
-    a2 = CircularAperture(xypos, r=4)
-    a3 = CircularAnnulus(xypos, 5, 10)
-    a4 = EllipticalAperture(xypos, 10, 5, theta=10 * u.deg)
-    a5 = EllipticalAnnulus(xypos, a_in=5, a_out=10, b_in=3, b_out=5,
-                           theta=20 * u.deg)
-    a6 = RectangularAperture(xypos, 10, 5, theta=30 * u.deg)
-    a7 = RectangularAnnulus(xypos, w_in=5, w_out=10, h_in=3, h_out=5,
-                            theta=40 * u.deg)
-    apers = (a1, a2, a3, a4, a5, a6, a7)
-    data = np.ones((50, 50))
-    tbl = aperture_photometry(data, apers)
+class TestPlots:
+    """
+    Tests for plotting apertures.
+    """
 
-    for i, aper in enumerate(apers):
-        assert tbl.meta[f'aperture{i}'] == aper.__class__.__name__
-        params = aper._params
-        for param in params:
-            if param != 'positions':
-                assert tbl.meta[f'aperture{i}_{param}'] == getattr(aper, param)
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    @pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
+    def test_plots(self, aperture_class, params):
+        # This test should run without any errors, and there is no return
+        # value.
+        aperture = aperture_class((20.0, 20.0), **params)
+        aperture.plot()
 
-    wcs = make_wcs(data.shape)
-    skycoord = wcs.pixel_to_world(10, 10)
-    unit = u.arcsec
-    saper = SkyEllipticalAnnulus(skycoord, a_in=0.1 * unit, a_out=0.2 * unit,
-                                 b_in=0.05 * unit, b_out=0.1 * unit,
-                                 theta=10 * u.deg)
-    tbl = aperture_photometry(data, saper, wcs=wcs)
-    assert tbl.meta['aperture'] == saper.__class__.__name__
-    assert tbl.meta['aperture_a_in'] == saper.a_in
-    assert tbl.meta['aperture_a_out'] == saper.a_out
-    assert tbl.meta['aperture_b_out'] == saper.b_out
-    assert tbl.meta['aperture_theta'] == saper.theta
+
+class TestWcsInput:
+    """
+    Tests for photometry with a WCS and sky apertures.
+    """
+
+    def test_input_wcs(self, data):
+        wcs = make_wcs(data.shape)
+
+        # Hard wired positions in make_4gaussian_image
+        xypos = np.transpose(([160.0, 25.0, 150.0, 90.0],
+                              [70.0, 40.0, 25.0, 60.0]))
+        aper = CircularAperture(xypos, 3.0)
+        aper3 = [CircularAperture((160.0, 70.0), r) for r in (3, 4, 5)]
+
+        phot1 = aperture_photometry(data, aper[0], wcs=wcs)
+        phot2 = aperture_photometry(data, aper, wcs=wcs)
+        phot3 = aperture_photometry(data, aper3, wcs=wcs)
+
+        assert 'sky_center' in phot1.colnames
+        assert 'sky_center' in phot2.colnames
+        assert 'sky_center' in phot3.colnames
+
+    def test_wcs_based(self, data):
+        wcs = make_wcs(data.shape)
+
+        # Hard wired positions in make_4gaussian_image
+        pos_orig_pixel = u.Quantity(([160.0, 25.0, 150.0, 90.0],
+                                     [70.0, 40.0, 25.0, 60.0]), unit=u.pixel)
+
+        pos_skycoord = wcs.pixel_to_world(pos_orig_pixel[0], pos_orig_pixel[1])
+        pos_skycoord_s = pos_skycoord[2]
+
+        photometry_skycoord_circ = aperture_photometry(
+            data, SkyCircularAperture(pos_skycoord, 3 * u.arcsec), wcs=wcs)
+        photometry_skycoord_circ_2 = aperture_photometry(
+            data, SkyCircularAperture(pos_skycoord, 2 * u.arcsec), wcs=wcs)
+        photometry_skycoord_circ_s = aperture_photometry(
+            data, SkyCircularAperture(pos_skycoord_s, 3 * u.arcsec), wcs=wcs)
+
+        assert_allclose(photometry_skycoord_circ['aperture_sum'][2],
+                        photometry_skycoord_circ_s['aperture_sum'])
+
+        photometry_skycoord_circ_ann = aperture_photometry(
+            data, SkyCircularAnnulus(pos_skycoord, 2 * u.arcsec, 3 * u.arcsec),
+            wcs=wcs)
+        photometry_skycoord_circ_ann_s = aperture_photometry(
+            data, SkyCircularAnnulus(pos_skycoord_s, 2 * u.arcsec,
+                                     3 * u.arcsec),
+            wcs=wcs)
+
+        assert_allclose(photometry_skycoord_circ_ann['aperture_sum'][2],
+                        photometry_skycoord_circ_ann_s['aperture_sum'])
+
+        assert_allclose(photometry_skycoord_circ_ann['aperture_sum'],
+                        photometry_skycoord_circ['aperture_sum']
+                        - photometry_skycoord_circ_2['aperture_sum'])
+
+        photometry_skycoord_ell = aperture_photometry(
+            data, SkyEllipticalAperture(pos_skycoord, 3 * u.arcsec,
+                                        3.0001 * u.arcsec,
+                                        theta=45 * u.arcsec),
+            wcs=wcs)
+        photometry_skycoord_ell_2 = aperture_photometry(
+            data, SkyEllipticalAperture(pos_skycoord, 2 * u.arcsec,
+                                        2.0001 * u.arcsec,
+                                        theta=45 * u.arcsec),
+            wcs=wcs)
+        photometry_skycoord_ell_s = aperture_photometry(
+            data, SkyEllipticalAperture(pos_skycoord_s, 3 * u.arcsec,
+                                        3.0001 * u.arcsec,
+                                        theta=45 * u.arcsec),
+            wcs=wcs)
+        photometry_skycoord_ell_ann = aperture_photometry(
+            data, SkyEllipticalAnnulus(pos_skycoord, 2 * u.arcsec,
+                                       3 * u.arcsec,
+                                       3.0001 * u.arcsec, theta=45 * u.arcsec),
+            wcs=wcs)
+        photometry_skycoord_ell_ann_s = aperture_photometry(
+            data, SkyEllipticalAnnulus(pos_skycoord_s, 2 * u.arcsec,
+                                       3 * u.arcsec,
+                                       3.0001 * u.arcsec, theta=45 * u.arcsec),
+            wcs=wcs)
+
+        assert_allclose(photometry_skycoord_ell['aperture_sum'][2],
+                        photometry_skycoord_ell_s['aperture_sum'])
+
+        assert_allclose(photometry_skycoord_ell_ann['aperture_sum'][2],
+                        photometry_skycoord_ell_ann_s['aperture_sum'])
+
+        assert_allclose(photometry_skycoord_ell['aperture_sum'],
+                        photometry_skycoord_circ['aperture_sum'], rtol=5e-3)
+
+        assert_allclose(photometry_skycoord_ell_ann['aperture_sum'],
+                        photometry_skycoord_ell['aperture_sum']
+                        - photometry_skycoord_ell_2['aperture_sum'], rtol=1e-4)
+
+        photometry_skycoord_rec = aperture_photometry(
+            data, SkyRectangularAperture(pos_skycoord,
+                                         6 * u.arcsec, 6 * u.arcsec,
+                                         theta=0 * u.arcsec),
+            method='subpixel', subpixels=20, wcs=wcs)
+        photometry_skycoord_rec_4 = aperture_photometry(
+            data, SkyRectangularAperture(pos_skycoord,
+                                         4 * u.arcsec, 4 * u.arcsec,
+                                         theta=0 * u.arcsec),
+            method='subpixel', subpixels=20, wcs=wcs)
+        photometry_skycoord_rec_s = aperture_photometry(
+            data, SkyRectangularAperture(pos_skycoord_s,
+                                         6 * u.arcsec, 6 * u.arcsec,
+                                         theta=0 * u.arcsec),
+            method='subpixel', subpixels=20, wcs=wcs)
+        photometry_skycoord_rec_ann = aperture_photometry(
+            data, SkyRectangularAnnulus(pos_skycoord, 4 * u.arcsec,
+                                        6 * u.arcsec,
+                                        6 * u.arcsec, theta=0 * u.arcsec),
+            method='subpixel', subpixels=20, wcs=wcs)
+        photometry_skycoord_rec_ann_s = aperture_photometry(
+            data, SkyRectangularAnnulus(pos_skycoord_s, 4 * u.arcsec,
+                                        6 * u.arcsec, 6 * u.arcsec,
+                                        theta=0 * u.arcsec),
+            method='subpixel', subpixels=20, wcs=wcs)
+
+        assert_allclose(photometry_skycoord_rec['aperture_sum'][2],
+                        photometry_skycoord_rec_s['aperture_sum'])
+
+        assert np.all(photometry_skycoord_rec['aperture_sum']
+                      > photometry_skycoord_circ['aperture_sum'])
+
+        assert_allclose(photometry_skycoord_rec_ann['aperture_sum'][2],
+                        photometry_skycoord_rec_ann_s['aperture_sum'])
+
+        assert_allclose(photometry_skycoord_rec_ann['aperture_sum'],
+                        photometry_skycoord_rec['aperture_sum']
+                        - photometry_skycoord_rec_4['aperture_sum'], rtol=1e-4)
+
+    def test_scalar_skycoord(self, data):
+        """
+        Regression test to check that scalar SkyCoords are added to the
+        table as a length-1 SkyCoord array.
+        """
+        wcs = make_wcs(data.shape)
+        skycoord = wcs.pixel_to_world(90, 60)
+        aper = SkyCircularAperture(skycoord, r=0.1 * u.arcsec)
+        tbl = aperture_photometry(data, aper, wcs=wcs)
+        assert isinstance(tbl['sky_center'], SkyCoord)
+
+
+class TestUnitsAndMasking:
+    """
+    Tests for Quantity inputs, masks, and non-finite values.
+    """
+
+    def test_data_units(self):
+        radius = 3
+        true_flux = np.pi * radius * radius
+        aper = CircularAperture((12, 12), radius)
+
+        data1 = np.ones((25, 25), dtype=float)
+        table1 = aperture_photometry(data1, aper)
+        assert_allclose(table1['aperture_sum'], true_flux)
+
+        unit = u.adu
+        data2 = u.Quantity(data1 * unit)
+        table2 = aperture_photometry(data2, aper)
+        assert_allclose(table2['aperture_sum'].value, true_flux)
+        assert table2['aperture_sum'].unit == data2.unit == unit
+
+        error1 = np.ones((25, 25))
+        match = 'then they both must have the same units'
+        with pytest.raises(ValueError, match=match):
+            # data has unit, but error does not
+            aperture_photometry(data2, aper, error=error1)
+
+        error2 = u.Quantity(error1 * u.Jy)
+        with pytest.raises(ValueError, match=match):
+            # data and error have different units
+            aperture_photometry(data2, aper, error=error2)
+
+    def test_error_units(self):
+        """
+        Test aperture_photometry when error has units (see #176).
+        """
+        data1 = np.ones((40, 40), dtype=float)
+        data2 = u.Quantity(data1, unit=u.adu)
+        error = u.Quantity(data1, unit=u.adu)
+        radius = 3
+        true_flux = np.pi * radius * radius
+        unit = u.adu
+        position = (20, 20)
+        table1 = aperture_photometry(data2, CircularAperture(position, radius),
+                                     error=error)
+        assert_allclose(table1['aperture_sum'].value, true_flux)
+        assert_allclose(table1['aperture_sum_err'].value, np.sqrt(true_flux))
+        assert table1['aperture_sum'].unit == unit
+        assert table1['aperture_sum_err'].unit == unit
+
+    def test_mask(self):
+        """
+        Test that aperture_photometry does not modify the input data or
+        error array when a mask is input.
+        """
+        data = np.ones((5, 5))
+        aperture = CircularAperture((2, 2), 2.0)
+        mask = np.zeros_like(data, dtype=bool)
+        data[2, 2] = 100.0  # bad pixel
+        mask[2, 2] = True
+        error = np.sqrt(data)
+        data_in = data.copy()
+        error_in = error.copy()
+        t1 = aperture_photometry(data, aperture, error=error, mask=mask)
+        assert_equal(data, data_in)
+        assert_equal(error, error_in)
+        assert_allclose(t1['aperture_sum'][0], 11.5663706144)
+        t2 = aperture_photometry(data, aperture)
+        assert_allclose(t2['aperture_sum'][0], 111.566370614)
+
+    @pytest.mark.parametrize('value', [np.nan, np.inf])
+    def test_nan_inf_mask(self, value):
+        """
+        Test that nans and infs are properly masked [#267].
+        """
+        data = np.ones((9, 9))
+        mask = np.zeros_like(data, dtype=bool)
+        data[4, 4] = value
+        mask[4, 4] = True
+        radius = 2.0
+        aper = CircularAperture((4, 4), radius)
+        tbl = aperture_photometry(data, aper, mask=mask)
+        desired = (np.pi * radius**2) - 1
+        assert_allclose(tbl['aperture_sum'], desired)
+
+    @pytest.mark.parametrize('units', [False, True])
+    def test_nddata_input(self, units):
+        data = np.arange(400).reshape((20, 20))
+        error = np.sqrt(data)
+        mask = np.zeros((20, 20), dtype=bool)
+        mask[8:13, 8:13] = True
+        if units:
+            unit = u.Jy
+            data = data * unit
+            error = error * unit
+        else:
+            unit = None
+
+        wcs = make_wcs(data.shape)
+        skycoord = wcs.pixel_to_world(10, 10)
+        aper = SkyCircularAperture(skycoord, r=0.7 * u.arcsec)
+
+        tbl1 = aperture_photometry(data, aper, error=error, mask=mask, wcs=wcs)
+
+        uncertainty = StdDevUncertainty(error)
+        nddata = NDData(data, uncertainty=uncertainty, mask=mask, wcs=wcs,
+                        unit=unit)
+        tbl2 = aperture_photometry(nddata, aper)
+
+        for column in tbl1.columns:
+            if column == 'sky_center':  # cannot test SkyCoord equality
+                continue
+            assert_allclose(tbl1[column], tbl2[column])
+
+        match = 'keyword is ignored. Its value is obtained from the input'
+        with pytest.warns(AstropyUserWarning, match=match):
+            aperture_photometry(nddata, aper, error=error)
+
+
+class TestExactOverlap:
+    """
+    Tests for the exact overlap grid and the aperture bounding boxes.
+    """
+
+    @pytest.mark.parametrize(('x', 'y', 'r'), TEST_ELLIPSE_EXACT_APERTURES)
+    def test_ellipse_exact_grid(self, x, y, r):
+        """
+        Test elliptical exact aperture photometry on a grid of pixel
+        positions.
+
+        This is a regression test for the bug discovered in this issue:
+        https://github.com/astropy/photutils/issues/198
+        """
+        data = np.ones((10, 10))
+
+        aperture = EllipticalAperture((x, y), a=r, b=r, theta=0.0)
+        t = aperture_photometry(data, aperture, method='exact')
+        actual = t['aperture_sum'][0] / (np.pi * r**2)
+        assert_allclose(actual, 1)
+
+    def test_rectangular_bbox(self):
+        # Test odd sizes
+        width = 7
+        height = 3
+        a = RectangularAperture((50, 50), w=width, h=height, theta=0)
+        assert a.bbox.shape == (height, width)
+
+        a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
+        assert a.bbox.shape == (height + 1, width + 1)
+
+        a = RectangularAperture((50, 50), w=width, h=height,
+                                theta=np.deg2rad(90.0))
+        assert a.bbox.shape == (width, height)
+
+        # Test even sizes
+        width = 8
+        height = 4
+        a = RectangularAperture((50, 50), w=width, h=height, theta=0)
+        assert a.bbox.shape == (height + 1, width + 1)
+
+        a = RectangularAperture((50.5, 50.5), w=width, h=height, theta=0)
+        assert a.bbox.shape == (height, width)
+
+        a = RectangularAperture((50.5, 50.5), w=width, h=height,
+                                theta=np.deg2rad(90.0))
+        assert a.bbox.shape == (width, height)
+
+    def test_elliptical_bbox(self):
+        # Integer axes
+        a = 7
+        b = 3
+        ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
+        assert ap.bbox.shape == (2 * b + 1, 2 * a + 1)
+
+        ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
+        assert ap.bbox.shape == (2 * b, 2 * a)
+
+        ap = EllipticalAperture((50, 50), a=a, b=b, theta=np.deg2rad(90.0))
+        assert ap.bbox.shape == (2 * a + 1, 2 * b + 1)
+
+        # Fractional axes
+        a = 7.5
+        b = 4.5
+        ap = EllipticalAperture((50, 50), a=a, b=b, theta=0)
+        assert ap.bbox.shape == (2 * b, 2 * a)
+
+        ap = EllipticalAperture((50.5, 50.5), a=a, b=b, theta=0)
+        assert ap.bbox.shape == (2 * b + 1, 2 * a + 1)
+
+        ap = EllipticalAperture((50, 50), a=a, b=b, theta=np.deg2rad(90.0))
+        assert ap.bbox.shape == (2 * a, 2 * b)
+
+
+class TestApertureRepr:
+    """
+    Tests for the aperture repr and str output.
+    """
+
+    def test_pixel(self):
+        aper = CircularAperture((10, 20), r=3.0)
+        assert '<CircularAperture(' in repr(aper)
+        assert 'Aperture: CircularAperture' in str(aper)
+
+        aper = CircularAnnulus((10, 20), r_in=3.0, r_out=5.0)
+        assert '<CircularAnnulus(' in repr(aper)
+        assert 'Aperture: CircularAnnulus' in str(aper)
+
+        aper = EllipticalAperture((10, 20), a=5.0, b=3.0, theta=15.0)
+        assert '<EllipticalAperture(' in repr(aper)
+        assert 'Aperture: EllipticalAperture' in str(aper)
+
+        aper = EllipticalAnnulus((10, 20), a_in=4.0, a_out=8.0, b_out=4.0,
+                                 theta=15.0)
+        assert '<EllipticalAnnulus(' in repr(aper)
+        assert 'Aperture: EllipticalAnnulus' in str(aper)
+
+        aper = RectangularAperture((10, 20), w=5.0, h=3.0, theta=15.0)
+        assert '<RectangularAperture(' in repr(aper)
+        assert 'Aperture: RectangularAperture' in str(aper)
+
+        aper = RectangularAnnulus((10, 20), w_in=4.0, w_out=8.0, h_out=4.0,
+                                  theta=15.0)
+        assert '<RectangularAnnulus(' in repr(aper)
+        assert 'Aperture: RectangularAnnulus' in str(aper)
+
+    def test_sky(self):
+        s = SkyCoord([1, 2], [3, 4], unit='deg')
+
+        aper = SkyCircularAperture(s, r=3 * u.deg)
+        a_repr = ('<SkyCircularAperture(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                  '    [(1., 3.), (2., 4.)]>, r=3.0 deg)>')
+        a_str = ('Aperture: SkyCircularAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                 'r: 3.0 deg')
+
+        assert repr(aper) == a_repr
+        assert str(aper) == a_str
+
+        aper = SkyCircularAnnulus(s, r_in=3.0 * u.deg, r_out=5 * u.deg)
+        a_repr = ('<SkyCircularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                  '    [(1., 3.), (2., 4.)]>, r_in=3.0 deg, r_out=5.0 deg)>')
+        a_str = ('Aperture: SkyCircularAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                 'r_in: 3.0 deg\nr_out: 5.0 deg')
+
+        assert repr(aper) == a_repr
+        assert str(aper) == a_str
+
+        aper = SkyEllipticalAperture(s, a=3 * u.deg, b=5 * u.deg,
+                                     theta=15 * u.deg)
+        a_repr = ('<SkyEllipticalAperture(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [(1., 3.), (2., 4.)]>, a=3.0 deg, b=5.0 deg, '
+                  'theta=15.0 deg)>')
+        a_str = ('Aperture: SkyEllipticalAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                 'a: 3.0 deg\nb: 5.0 deg\ntheta: 15.0 deg')
+
+        assert repr(aper) == a_repr
+        assert str(aper) == a_str
+
+        aper = SkyEllipticalAnnulus(s, a_in=3 * u.deg, a_out=5 * u.deg,
+                                    b_out=3 * u.deg, theta=15 * u.deg)
+        a_repr = ('<SkyEllipticalAnnulus(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [(1., 3.), (2., 4.)]>, a_in=3.0 deg, '
+                  'a_out=5.0 deg, b_in=1.8 deg, b_out=3.0 deg, '
+                  'theta=15.0 deg)>')
+        a_str = ('Aperture: SkyEllipticalAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                 'a_in: 3.0 deg\na_out: 5.0 deg\nb_in: 1.8 deg\n'
+                 'b_out: 3.0 deg\ntheta: 15.0 deg')
+
+        assert repr(aper) == a_repr
+        assert str(aper) == a_str
+
+        aper = SkyRectangularAperture(s, w=3 * u.deg, h=5 * u.deg,
+                                      theta=15 * u.deg)
+        a_repr = ('<SkyRectangularAperture(<SkyCoord (ICRS): (ra, dec) in '
+                  'deg\n    [(1., 3.), (2., 4.)]>, w=3.0 deg, h=5.0 deg'
+                  ', theta=15.0 deg)>')
+        a_str = ('Aperture: SkyRectangularAperture\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                 'w: 3.0 deg\nh: 5.0 deg\ntheta: 15.0 deg')
+
+        assert repr(aper) == a_repr
+        assert str(aper) == a_str
+
+        aper = SkyRectangularAnnulus(s, w_in=5 * u.deg, w_out=10 * u.deg,
+                                     h_out=6 * u.deg, theta=15 * u.deg)
+        a_repr = ('<SkyRectangularAnnulus(<SkyCoord (ICRS): (ra, dec) in deg'
+                  '\n    [(1., 3.), (2., 4.)]>, w_in=5.0 deg, '
+                  'w_out=10.0 deg, h_in=3.0 deg, h_out=6.0 deg, '
+                  'theta=15.0 deg)>')
+        a_str = ('Aperture: SkyRectangularAnnulus\npositions: <SkyCoord '
+                 '(ICRS): (ra, dec) in deg\n    [(1., 3.), (2., 4.)]>\n'
+                 'w_in: 5.0 deg\nw_out: 10.0 deg\nh_in: 3.0 deg\n'
+                 'h_out: 6.0 deg\ntheta: 15.0 deg')
+
+        assert repr(aper) == a_repr
+        assert str(aper) == a_str
+
+
+class TestInputValidation:
+    """
+    Tests for the aperture_photometry input validation.
+    """
+
+    def test_invalid_inputs(self):
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+        wcs = make_wcs(data.shape)
+        sky_aper = aper.to_sky(wcs=wcs)
+
+        match = 'A WCS transform must be defined'
+        with pytest.raises(ValueError, match=match):
+            aperture_photometry(data, sky_aper)
+
+        aper2 = CircularAperture((7, 7), r=3)
+        sky_aper2 = aper2.to_sky(wcs=wcs)
+        apers = [aper, aper2]
+        sky_apers = [sky_aper, sky_aper2]
+
+        match = 'Input apertures must all have identical positions'
+        with pytest.raises(ValueError, match=match):
+            aperture_photometry(data, apers)
+        with pytest.raises(ValueError, match=match):
+            aperture_photometry(data, sky_apers, wcs=wcs)
+
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+        match = 'subpixels must be a strictly positive integer'
+        with pytest.raises(ValueError, match=match):
+            aperture_photometry(data, aper, method='subpixel', subpixels=0)
+        with pytest.raises(ValueError, match=match):
+            aperture_photometry(data, aper, method='subpixel', subpixels=-1)
+
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_unsupported_region_input(self):
+        from regions import LinePixelRegion, PixCoord
+
+        region = LinePixelRegion(start=PixCoord(x=1, y=1),
+                                 end=PixCoord(x=5, y=5))
+        data = np.ones((10, 10))
+        match = r'Cannot convert .* to an Aperture object'
+        with pytest.raises(TypeError, match=match):
+            aperture_photometry(data, region)
+
+
+class TestApertureMetadata:
+    """
+    Tests for the aperture metadata stored in the output table.
+    """
+
+    def test_metadata(self):
+        x = [10, 20, 3]
+        y = [3, 5, 10]
+        xypos = list(zip(x, y, strict=False))
+        a1 = CircularAperture(xypos, r=3)
+        a2 = CircularAperture(xypos, r=4)
+        a3 = CircularAnnulus(xypos, 5, 10)
+        a4 = EllipticalAperture(xypos, 10, 5, theta=10 * u.deg)
+        a5 = EllipticalAnnulus(xypos, a_in=5, a_out=10, b_in=3, b_out=5,
+                               theta=20 * u.deg)
+        a6 = RectangularAperture(xypos, 10, 5, theta=30 * u.deg)
+        a7 = RectangularAnnulus(xypos, w_in=5, w_out=10, h_in=3, h_out=5,
+                                theta=40 * u.deg)
+        apers = (a1, a2, a3, a4, a5, a6, a7)
+        data = np.ones((50, 50))
+        tbl = aperture_photometry(data, apers)
+
+        for i, aper in enumerate(apers):
+            assert tbl.meta[f'aperture{i}'] == aper.__class__.__name__
+            params = aper._params
+            for param in params:
+                if param != 'positions':
+                    assert (tbl.meta[f'aperture{i}_{param}']
+                            == getattr(aper, param))
+
+        wcs = make_wcs(data.shape)
+        skycoord = wcs.pixel_to_world(10, 10)
+        unit = u.arcsec
+        saper = SkyEllipticalAnnulus(skycoord, a_in=0.1 * unit,
+                                     a_out=0.2 * unit,
+                                     b_in=0.05 * unit, b_out=0.1 * unit,
+                                     theta=10 * u.deg)
+        tbl = aperture_photometry(data, saper, wcs=wcs)
+        assert tbl.meta['aperture'] == saper.__class__.__name__
+        assert tbl.meta['aperture_a_in'] == saper.a_in
+        assert tbl.meta['aperture_a_out'] == saper.a_out
+        assert tbl.meta['aperture_b_out'] == saper.b_out
+        assert tbl.meta['aperture_theta'] == saper.theta

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -202,30 +202,11 @@ class TestMaskedSkipCircular(BaseTestAperturePhotometry):
         return mask
 
 
-class BaseTestDifferentData:
+class TestInputNDData:
     """
-    Tests shared by the classes using a different type of data input.
-
-    Each subclass defines an ``input_data`` fixture returning the data
-    to measure, along with the aperture ``position``, ``radius``, and
-    the expected ``true_flux`` and ``fluxunit``.
+    Tests for photometry with `~astropy.nddata.NDData` input.
     """
 
-    def test_basic_circular_aperture_photometry(self, input_data):
-        aperture = CircularAperture(self.position, self.radius)
-        table = aperture_photometry(input_data, aperture,
-                                    method='exact')
-
-        assert_allclose(table['aperture_sum'].value, self.true_flux)
-        assert table['aperture_sum'].unit == self.fluxunit
-
-        assert np.all(table['x_center'].value
-                      == np.transpose(self.position)[0])
-        assert np.all(table['y_center'].value
-                      == np.transpose(self.position)[1])
-
-
-class TestInputNDData(BaseTestDifferentData):
     radius = 3
     position = ((20, 20), (30, 30))
     true_flux = np.pi * radius * radius
@@ -238,6 +219,18 @@ class TestInputNDData(BaseTestDifferentData):
         units.
         """
         return NDData(ones_data, unit=self.fluxunit)
+
+    def test_basic_circular_aperture_photometry(self, input_data):
+        aperture = CircularAperture(self.position, self.radius)
+        table = aperture_photometry(input_data, aperture, method='exact')
+
+        assert_allclose(table['aperture_sum'].value, self.true_flux)
+        assert table['aperture_sum'].unit == self.fluxunit
+
+        assert np.all(table['x_center'].value
+                      == np.transpose(self.position)[0])
+        assert np.all(table['y_center'].value
+                      == np.transpose(self.position)[1])
 
 
 TEST_ELLIPSE_EXACT_APERTURES = [(3.469906, 3.923861394, 3.0),

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -43,27 +43,54 @@ TEST_APERTURES = list(zip(APERTURE_CL,
                             'h_in': 16.0 / 3.0, 'theta': np.pi / 8}),
                           strict=True))
 
+# The aperture position(s) used by the shape-specific photometry tests
+POSITION = (20.0, 20.0)
+POSITIONS = ((20.0, 20.0), (25.0, 25.0))
+
+
+@pytest.fixture(name='ones_data')
+def fixture_ones_data():
+    """
+    A 40x40 image of ones.
+
+    A fresh array is returned for each test, so it may be modified.
+    """
+    return np.ones((40, 40), dtype=float)
+
 
 class BaseTestAperturePhotometry:
-    def test_array_error(self):
+    """
+    Tests shared by the shape-specific aperture photometry classes.
+
+    Each subclass defines the ``aperture`` to measure, along with its
+    true ``area`` and ``true_flux`` in an image of ones. A subclass that
+    masks a data pixel also overrides the ``mask`` fixture.
+    """
+
+    @pytest.fixture(name='mask')
+    def fixture_mask(self):
+        """
+        The data mask, `None` unless a subclass overrides it.
+        """
+        return
+
+    def test_array_error(self, ones_data, mask):
         # Array error
-        error = np.ones(self.data.shape, dtype=float)
-        if not hasattr(self, 'mask'):
-            mask = None
+        error = np.ones(ones_data.shape, dtype=float)
+        if mask is None:
             true_error = np.sqrt(self.area)
         else:
-            mask = self.mask
             # 1 masked pixel
             true_error = np.sqrt(self.area - 1)
 
-        table1 = aperture_photometry(self.data,
+        table1 = aperture_photometry(ones_data,
                                      self.aperture, method='center',
                                      mask=mask, error=error)
-        table2 = aperture_photometry(self.data,
+        table2 = aperture_photometry(ones_data,
                                      self.aperture,
                                      method='subpixel', subpixels=12,
                                      mask=mask, error=error)
-        table3 = aperture_photometry(self.data,
+        table3 = aperture_photometry(ones_data,
                                      self.aperture, method='exact',
                                      mask=mask, error=error)
 
@@ -83,132 +110,110 @@ class BaseTestAperturePhotometry:
 
 
 class TestCircular(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = (20.0, 20.0)
-        r = 10.0
-        self.aperture = CircularAperture(position, r)
-        self.area = np.pi * r * r
-        self.true_flux = self.area
+    r = 10.0
+    aperture = CircularAperture(POSITION, r)
+    area = np.pi * r * r
+    true_flux = area
 
 
 class TestCircularArray(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = ((20.0, 20.0), (25.0, 25.0))
-        r = 10.0
-        self.aperture = CircularAperture(position, r)
-        self.area = np.pi * r * r
-        self.area = np.array((self.area,) * 2)
-        self.true_flux = self.area
+    r = 10.0
+    aperture = CircularAperture(POSITIONS, r)
+    area = np.full(len(POSITIONS), np.pi * r * r)
+    true_flux = area
 
 
 class TestCircularAnnulus(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = (20.0, 20.0)
-        r_in = 8.0
-        r_out = 10.0
-        self.aperture = CircularAnnulus(position, r_in, r_out)
-        self.area = np.pi * (r_out * r_out - r_in * r_in)
-        self.true_flux = self.area
+    r_in = 8.0
+    r_out = 10.0
+    aperture = CircularAnnulus(POSITION, r_in, r_out)
+    area = np.pi * (r_out * r_out - r_in * r_in)
+    true_flux = area
 
 
 class TestCircularAnnulusArray(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = ((20.0, 20.0), (25.0, 25.0))
-        r_in = 8.0
-        r_out = 10.0
-        self.aperture = CircularAnnulus(position, r_in, r_out)
-        self.area = np.pi * (r_out * r_out - r_in * r_in)
-        self.area = np.array((self.area,) * 2)
-        self.true_flux = self.area
+    r_in = 8.0
+    r_out = 10.0
+    aperture = CircularAnnulus(POSITIONS, r_in, r_out)
+    area = np.full(len(POSITIONS), np.pi * (r_out * r_out - r_in * r_in))
+    true_flux = area
 
 
 class TestElliptical(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = (20.0, 20.0)
-        a = 10.0
-        b = 5.0
-        theta = -np.pi / 4.0
-        self.aperture = EllipticalAperture(position, a, b, theta=theta)
-        self.area = np.pi * a * b
-        self.true_flux = self.area
+    a = 10.0
+    b = 5.0
+    aperture = EllipticalAperture(POSITION, a, b, theta=-np.pi / 4.0)
+    area = np.pi * a * b
+    true_flux = area
 
 
 class TestEllipticalAnnulus(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = (20.0, 20.0)
-        a_in = 5.0
-        a_out = 8.0
-        b_out = 5.0
-        theta = -np.pi / 4.0
-        self.aperture = EllipticalAnnulus(position, a_in, a_out, b_out,
-                                          theta=theta)
-        self.area = (np.pi * (a_out * b_out)
-                     - np.pi * (a_in * b_out * a_in / a_out))
-        self.true_flux = self.area
+    a_in = 5.0
+    a_out = 8.0
+    b_out = 5.0
+    aperture = EllipticalAnnulus(POSITION, a_in, a_out, b_out,
+                                 theta=-np.pi / 4.0)
+    area = (np.pi * (a_out * b_out)
+            - np.pi * (a_in * b_out * a_in / a_out))
+    true_flux = area
 
 
 class TestRectangularAperture(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = (20.0, 20.0)
-        h = 5.0
-        w = 8.0
-        theta = np.pi / 4.0
-        self.aperture = RectangularAperture(position, w, h, theta=theta)
-        self.area = h * w
-        self.true_flux = self.area
+    w = 8.0
+    h = 5.0
+    aperture = RectangularAperture(POSITION, w, h, theta=np.pi / 4.0)
+    area = h * w
+    true_flux = area
 
 
 class TestRectangularAnnulus(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = (20.0, 20.0)
-        h_out = 8.0
-        w_in = 8.0
-        w_out = 12.0
-        h_in = w_in * h_out / w_out
-        theta = np.pi / 8.0
-        self.aperture = RectangularAnnulus(position, w_in, w_out, h_out,
-                                           theta=theta)
-        self.area = h_out * w_out - h_in * w_in
-        self.true_flux = self.area
+    w_in = 8.0
+    w_out = 12.0
+    h_out = 8.0
+    h_in = w_in * h_out / w_out
+    aperture = RectangularAnnulus(POSITION, w_in, w_out, h_out,
+                                  theta=np.pi / 8.0)
+    area = h_out * w_out - h_in * w_in
+    true_flux = area
 
 
 class TestPolygon(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        position = (20.0, 20.0)
-        n_vertices = 5
-        radius = 6.0
-        theta = 30 * u.deg
-        self.aperture = PolygonAperture.from_regular_polygon(
-            position, n_vertices, radius, theta=theta)
-        self.area = self.aperture.area
-        self.true_flux = self.area
+    n_vertices = 5
+    radius = 6.0
+    aperture = PolygonAperture.from_regular_polygon(POSITION, n_vertices,
+                                                    radius, theta=30 * u.deg)
+    area = aperture.area
+    true_flux = area
 
 
 class TestMaskedSkipCircular(BaseTestAperturePhotometry):
-    def setup_class(self):
-        self.data = np.ones((40, 40), dtype=float)
-        self.mask = np.zeros((40, 40), dtype=bool)
-        self.mask[20, 20] = True
-        position = (20.0, 20.0)
-        r = 10.0
-        self.aperture = CircularAperture(position, r)
-        self.area = np.pi * r * r
-        self.true_flux = self.area - 1
+    r = 10.0
+    aperture = CircularAperture(POSITION, r)
+    area = np.pi * r * r
+    true_flux = area - 1
+
+    @pytest.fixture(name='mask')
+    def fixture_mask(self, ones_data):
+        """
+        A mask with the single pixel at the aperture center masked.
+        """
+        mask = np.zeros(ones_data.shape, dtype=bool)
+        mask[20, 20] = True
+        return mask
 
 
 class BaseTestDifferentData:
-    def test_basic_circular_aperture_photometry(self):
+    """
+    Tests shared by the classes using a different type of data input.
+
+    Each subclass defines an ``input_data`` fixture returning the data
+    to measure, along with the aperture ``position``, ``radius``, and
+    the expected ``true_flux`` and ``fluxunit``.
+    """
+
+    def test_basic_circular_aperture_photometry(self, input_data):
         aperture = CircularAperture(self.position, self.radius)
-        table = aperture_photometry(self.data, aperture,
+        table = aperture_photometry(input_data, aperture,
                                     method='exact')
 
         assert_allclose(table['aperture_sum'].value, self.true_flux)
@@ -221,13 +226,18 @@ class BaseTestDifferentData:
 
 
 class TestInputNDData(BaseTestDifferentData):
-    def setup_class(self):
-        data = np.ones((40, 40), dtype=float)
-        self.data = NDData(data, unit=u.adu)
-        self.radius = 3
-        self.position = [(20, 20), (30, 30)]
-        self.true_flux = np.pi * self.radius * self.radius
-        self.fluxunit = u.adu
+    radius = 3
+    position = ((20, 20), (30, 30))
+    true_flux = np.pi * radius * radius
+    fluxunit = u.adu
+
+    @pytest.fixture(name='input_data')
+    def fixture_input_data(self, ones_data):
+        """
+        An image of ones as an `~astropy.nddata.NDData` object with
+        units.
+        """
+        return NDData(ones_data, unit=self.fluxunit)
 
 
 TEST_ELLIPSE_EXACT_APERTURES = [(3.469906, 3.923861394, 3.0),
@@ -236,25 +246,35 @@ TEST_ELLIPSE_EXACT_APERTURES = [(3.469906, 3.923861394, 3.0),
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
 class BaseTestRegionPhotometry:
-    def test_region_matches_aperture(self):
-        data = np.ones((40, 40), dtype=float)
-        error = np.ones(data.shape, dtype=float)
+    """
+    Tests that a region gives the same photometry as its equivalent
+    aperture.
+
+    Each subclass defines a ``region_aperture`` fixture returning the
+    equivalent ``(region, aperture)`` pair. The ``regions`` package is
+    imported within the fixture so that the module can be collected
+    without it installed.
+    """
+
+    def test_region_matches_aperture(self, ones_data, region_aperture):
+        region, aperture = region_aperture
+        error = np.ones(ones_data.shape, dtype=float)
         region_tables = [
-            aperture_photometry(data, self.region, method='center',
+            aperture_photometry(ones_data, region, method='center',
                                 error=error),
-            aperture_photometry(data, self.region,
+            aperture_photometry(ones_data, region,
                                 method='subpixel', subpixels=12,
                                 error=error),
-            aperture_photometry(data, self.region, method='exact',
+            aperture_photometry(ones_data, region, method='exact',
                                 error=error),
         ]
         aperture_tables = [
-            aperture_photometry(data, self.aperture, method='center',
+            aperture_photometry(ones_data, aperture, method='center',
                                 error=error),
-            aperture_photometry(data, self.aperture,
+            aperture_photometry(ones_data, aperture,
                                 method='subpixel', subpixels=12,
                                 error=error),
-            aperture_photometry(data, self.aperture, method='exact',
+            aperture_photometry(ones_data, aperture, method='exact',
                                 error=error),
         ]
 
@@ -268,86 +288,110 @@ class BaseTestRegionPhotometry:
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
 class TestCircleRegionPhotometry(BaseTestRegionPhotometry):
-    def setup_class(self):
+    @pytest.fixture(name='region_aperture')
+    def fixture_region_aperture(self):
+        """
+        A circular region and the equivalent aperture.
+        """
         from regions import CirclePixelRegion, PixCoord
-        position = (20.0, 20.0)
+
         r = 10.0
-        self.region = CirclePixelRegion(PixCoord(*position), r)
-        self.aperture = CircularAperture(position, r)
+        region = CirclePixelRegion(PixCoord(*POSITION), r)
+        aperture = CircularAperture(POSITION, r)
+        return region, aperture
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
 class TestCircleAnnulusRegionPhotometry(BaseTestRegionPhotometry):
-    def setup_class(self):
+    @pytest.fixture(name='region_aperture')
+    def fixture_region_aperture(self):
+        """
+        A circular annulus region and the equivalent aperture.
+        """
         from regions import CircleAnnulusPixelRegion, PixCoord
-        position = (20.0, 20.0)
+
         r_in = 8.0
         r_out = 10.0
-        self.region = CircleAnnulusPixelRegion(PixCoord(*position), r_in,
-                                               r_out)
-        self.aperture = CircularAnnulus(position, r_in, r_out)
+        region = CircleAnnulusPixelRegion(PixCoord(*POSITION), r_in, r_out)
+        aperture = CircularAnnulus(POSITION, r_in, r_out)
+        return region, aperture
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
 class TestEllipseRegionPhotometry(BaseTestRegionPhotometry):
-    def setup_class(self):
+    @pytest.fixture(name='region_aperture')
+    def fixture_region_aperture(self):
+        """
+        An elliptical region and the equivalent aperture.
+        """
         from regions import EllipsePixelRegion, PixCoord
-        position = (20.0, 20.0)
+
         a = 10.0
         b = 5.0
         theta = (-np.pi / 4.0) * u.rad
-        self.region = EllipsePixelRegion(PixCoord(*position), a * 2, b * 2,
-                                         theta)
-        self.aperture = EllipticalAperture(position, a, b, theta=theta)
+        region = EllipsePixelRegion(PixCoord(*POSITION), a * 2, b * 2, theta)
+        aperture = EllipticalAperture(POSITION, a, b, theta=theta)
+        return region, aperture
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
 class TestEllipseAnnulusRegionPhotometry(BaseTestRegionPhotometry):
-    def setup_class(self):
+    @pytest.fixture(name='region_aperture')
+    def fixture_region_aperture(self):
+        """
+        An elliptical annulus region and the equivalent aperture.
+        """
         from regions import EllipseAnnulusPixelRegion, PixCoord
-        position = (20.0, 20.0)
+
         a_in = 5.0
         a_out = 8.0
         b_in = 3.0
         b_out = 5.0
         theta = (-np.pi / 4.0) * u.rad
-        self.region = EllipseAnnulusPixelRegion(PixCoord(*position),
-                                                a_in * 2, a_out * 2,
-                                                b_in * 2, b_out * 2,
-                                                theta)
-        self.aperture = EllipticalAnnulus(position,
-                                          a_in, a_out,
-                                          b_out, b_in=b_in,
-                                          theta=theta)
+        region = EllipseAnnulusPixelRegion(PixCoord(*POSITION),
+                                           a_in * 2, a_out * 2,
+                                           b_in * 2, b_out * 2, theta)
+        aperture = EllipticalAnnulus(POSITION, a_in, a_out, b_out,
+                                     b_in=b_in, theta=theta)
+        return region, aperture
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
 class TestRectangleRegionPhotometry(BaseTestRegionPhotometry):
-    def setup_class(self):
+    @pytest.fixture(name='region_aperture')
+    def fixture_region_aperture(self):
+        """
+        A rectangular region and the equivalent aperture.
+        """
         from regions import PixCoord, RectanglePixelRegion
-        position = (20.0, 20.0)
-        h = 5.0
+
         w = 8.0
+        h = 5.0
         theta = (np.pi / 4.0) * u.rad
-        self.region = RectanglePixelRegion(PixCoord(*position), w, h, theta)
-        self.aperture = RectangularAperture(position, w, h, theta=theta)
+        region = RectanglePixelRegion(PixCoord(*POSITION), w, h, theta)
+        aperture = RectangularAperture(POSITION, w, h, theta=theta)
+        return region, aperture
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
 class TestRectangleAnnulusRegionPhotometry(BaseTestRegionPhotometry):
-    def setup_class(self):
+    @pytest.fixture(name='region_aperture')
+    def fixture_region_aperture(self):
+        """
+        A rectangular annulus region and the equivalent aperture.
+        """
         from regions import PixCoord, RectangleAnnulusPixelRegion
-        position = (20.0, 20.0)
-        h_out = 8.0
+
         w_in = 8.0
         w_out = 12.0
+        h_out = 8.0
         h_in = w_in * h_out / w_out
         theta = (np.pi / 8.0) * u.rad
-        self.region = RectangleAnnulusPixelRegion(PixCoord(*position),
-                                                  w_in, w_out, h_in, h_out,
-                                                  theta)
-        self.aperture = RectangularAnnulus(position, w_in, w_out,
-                                           h_out, h_in=h_in, theta=theta)
+        region = RectangleAnnulusPixelRegion(PixCoord(*POSITION), w_in, w_out,
+                                             h_in, h_out, theta)
+        aperture = RectangularAnnulus(POSITION, w_in, w_out, h_out,
+                                      h_in=h_in, theta=theta)
+        return region, aperture
 
 
 class TestArrayBounds:

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -217,7 +217,7 @@ class BaseTestDifferentData:
                                     method='exact')
 
         assert_allclose(table['aperture_sum'].value, self.true_flux)
-        assert table['aperture_sum'].unit, self.fluxunit
+        assert table['aperture_sum'].unit == self.fluxunit
 
         assert np.all(table['x_center'].value
                       == np.transpose(self.position)[0])

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -37,431 +37,6 @@ def _flags(aperture, data, **kwargs):
     return AperturePhotometry(data, aperture, **kwargs).flags
 
 
-def test_no_flags():
-    """
-    Test that a clean interior source has no flags set.
-    """
-    data = np.ones(SHAPE)
-    aper = CircularAperture((12, 12), r=3.0)
-    assert_array_equal(_flags(aper, data), [0])
-
-
-@pytest.mark.parametrize('factory', APERTURE_FACTORIES)
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_no_overlap(factory, method, subpixels):
-    """
-    Test that fully off-image apertures set no_overlap and no_pixels.
-    """
-    data = np.ones(SHAPE)
-    aper = factory([(-50.0, 12.0), (12.0, 12.0)])
-    result = AperturePhotometry(data, aper, method=method,
-                                subpixels=subpixels)
-    expected = APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS
-    assert result.flags[0] == expected
-    assert np.isnan(result.flux[0])
-    assert result.flags[1] == 0
-
-
-@pytest.mark.parametrize('factory', APERTURE_FACTORIES)
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_partial_overlap(factory, method, subpixels):
-    """
-    Test that apertures straddling an edge set partial_overlap.
-    """
-    data = np.ones(SHAPE)
-    aper = factory([(0.0, 12.0), (12.0, 24.5), (12.0, 12.0)])
-    flags = _flags(aper, data, method=method, subpixels=subpixels)
-    assert flags[0] == APERTURE_FLAGS.PARTIAL_OVERLAP
-    assert flags[1] == APERTURE_FLAGS.PARTIAL_OVERLAP
-    assert flags[2] == 0
-
-
-def test_no_overlap_close_to_edge():
-    """
-    Test an aperture whose bounding box overlaps the data but whose
-    nonzero-weight pixels are all outside (precise no_overlap).
-    """
-    data = np.ones(SHAPE)
-    # bbox column 0 overlaps the data, but with the "center" method
-    # the pixel center at x=0 (distance 1.2) is outside the circle
-    aper = CircularAperture((-1.2, 12.0), r=0.8)
-    result = AperturePhotometry(data, aper, method='center')
-    assert result.flags == (APERTURE_FLAGS.NO_OVERLAP
-                            | APERTURE_FLAGS.NO_PIXELS)
-    # The sum is 0.0 (not NaN) here: the bounding box overlaps the
-    # data, but no weighted pixel falls inside
-    assert result.flux == 0.0
-
-    # With the exact method, the aperture area extends into the data
-    result = AperturePhotometry(data, aper, method='exact')
-    assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
-
-
-def test_partial_overlap_clipped_bbox_only():
-    """
-    Test that a clipped bounding box alone does not set
-    partial_overlap when all nonzero weights are inside the data.
-    """
-    data = np.ones(SHAPE)
-    # bbox extends to column -1, but the pixel center at x=-1
-    # (distance 1.2 > r=0.8) is outside the circle
-    aper = CircularAperture((0.2, 12.0), r=0.8)
-    assert_array_equal(_flags(aper, data, method='center'), [0])
-
-    # The exact-method footprint does extend outside
-    flags = _flags(aper, data, method='exact')
-    assert_array_equal(flags, [APERTURE_FLAGS.PARTIAL_OVERLAP])
-
-
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_polygon_offcenter_no_partial_overlap(method, subpixels):
-    """
-    Test that a polygon lying entirely inside the data is not flagged as
-    partial_overlap even though its bounding box, which is symmetric
-    about ``positions``, is clipped by a data edge.
-    """
-    data = np.ones((12, 12))
-    # The centroid of this triangle is well off-center, so the symmetric
-    # bounding box extends outside the data on two sides
-    aper = PolygonAperture.from_vertices([(1.0, 1.0), (9.0, 1.0),
-                                          (9.0, 9.0)])
-    bbox = aper.bbox
-    assert bbox.ixmax > data.shape[1] or bbox.iymin < 0
-
-    result = AperturePhotometry(data, aper, method=method,
-                                subpixels=subpixels)
-    assert result.flags == 0
-    stats = ApertureStats(data, aper, sum_method=method,
-                          subpixels=subpixels)
-    assert stats.sum_flags == 0
-    assert stats.flags == 0
-
-
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_polygon_partial_overlap(method, subpixels):
-    """
-    Test that a polygon extending past a data edge is still flagged as
-    partial_overlap.
-    """
-    data = np.ones((12, 12))
-    aper = PolygonAperture.from_vertices([(-2.0, 1.0), (9.0, 1.0),
-                                          (9.0, 9.0)])
-    result = AperturePhotometry(data, aper, method=method,
-                                subpixels=subpixels)
-    assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
-    stats = ApertureStats(data, aper, sum_method=method,
-                          subpixels=subpixels)
-    assert stats.sum_flags == APERTURE_FLAGS.PARTIAL_OVERLAP
-
-
-def test_no_pixels_tiny_aperture():
-    """
-    Test that a tiny aperture with the "center" method sets no_pixels.
-    """
-    data = np.ones(SHAPE)
-    # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
-    aper = CircularAperture((12.5, 12.5), r=0.4)
-    result = AperturePhotometry(data, aper, method='center')
-    assert result.flags == APERTURE_FLAGS.NO_PIXELS
-    assert result.flux == 0.0
-
-    # The exact method has a nonzero footprint
-    assert_array_equal(_flags(aper, data, method='exact'), [0])
-
-
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_masked_pixels(method, subpixels):
-    """
-    Test the masked_pixels and all_masked flags.
-    """
-    data = np.ones(SHAPE)
-
-    # One masked pixel inside the aperture
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[12, 12] = True
-    aper = CircularAperture((12, 12), r=3.0)
-    flags = _flags(aper, data, mask=mask, method=method,
-                   subpixels=subpixels)
-    assert flags == APERTURE_FLAGS.MASKED_PIXELS
-
-    # Masked pixel inside the bounding box but outside the aperture
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[9, 9] = True
-    flags = _flags(aper, data, mask=mask, method=method,
-                   subpixels=subpixels)
-    assert flags == 0
-
-    # Fully masked aperture
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[8:17, 8:17] = True
-    flags = _flags(aper, data, mask=mask, method=method,
-                   subpixels=subpixels)
-    assert flags == (APERTURE_FLAGS.MASKED_PIXELS
-                     | APERTURE_FLAGS.ALL_MASKED)
-
-
-def test_non_finite_data():
-    """
-    Test the non_finite_data flag.
-
-    In photometry, unmasked non-finite values contribute to the sum
-    (making it NaN). They do not set all_masked.
-
-    This tests the legacy (non-class) engine call directly
-    (``mask_nonfinite=False``, the default), which corrupts the sum
-    with the non-finite value instead of masking it out, unlike
-    `AperturePhotometry`.
-    """
-    data = np.ones(SHAPE)
-    data[12, 12] = np.nan
-    aper = CircularAperture((12, 12), r=3.0)
-    result = aper._photometry(data)
-    assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
-    assert np.isnan(result.flux[0])
-
-    # An all-NaN aperture is still non_finite_data only (the pixels
-    # contribute, so all_masked is not set)
-    data = np.full(SHAPE, np.nan)
-    result = aper._photometry(data)
-    assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
-
-    # A masked non-finite pixel counts only as masked
-    data = np.ones(SHAPE)
-    data[12, 12] = np.nan
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[12, 12] = True
-    flags = _flags(aper, data, mask=mask)
-    assert flags == APERTURE_FLAGS.MASKED_PIXELS
-
-
-def test_non_finite_error():
-    """
-    Test the non_finite_error flag.
-    """
-    data = np.ones(SHAPE)
-    error = np.ones(SHAPE)
-    error[12, 12] = np.inf
-    aper = CircularAperture((12, 12), r=3.0)
-    flags = _flags(aper, data, error=error)
-    assert flags == APERTURE_FLAGS.NON_FINITE_ERROR
-
-    # Without an error array, the flag is never set
-    assert_array_equal(_flags(aper, data), [0])
-
-
-@pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
-def test_neighbor_pixels(mask_method):
-    """
-    Test the neighbor_pixels flag for all segmentation mask methods.
-    """
-    data = np.ones(SHAPE)
-    segm = np.zeros(SHAPE, dtype=int)
-    segm[10:15, 10:15] = 1
-    segm[12, 14] = 2  # neighbor pixel inside the aperture
-    aper = CircularAperture((12, 12), r=3.0)
-    flags = _flags(aper, data, segmentation_image=segm, labels=1,
-                   mask_method=mask_method)
-    assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
-
-    # Without any neighbor pixels inside the aperture, no flag is set
-    segm2 = np.zeros(SHAPE, dtype=int)
-    segm2[10:15, 10:15] = 1
-    flags = _flags(aper, data, segmentation_image=segm2, labels=1,
-                   mask_method=mask_method)
-    assert flags == 0
-
-
-def test_uncorrected_pixels():
-    """
-    Test the uncorrected_pixels flag with mask_method='correct'.
-    """
-    data = np.ones(SHAPE)
-    segm = np.zeros(SHAPE, dtype=int)
-    segm[10:15, 10:15] = 1
-    segm[12, 14] = 2  # neighbor; its mirror (12, 10) is source pixel
-    segm[12, 10] = 2  # make the mirror a neighbor too: uncorrectable
-    aper = CircularAperture((12, 12), r=3.0)
-    flags = _flags(aper, data, segmentation_image=segm, labels=1,
-                   mask_method='correct')
-    assert flags == (APERTURE_FLAGS.NEIGHBOR_PIXELS
-                     | APERTURE_FLAGS.UNCORRECTED_PIXELS)
-
-    # A correctable neighbor does not set uncorrected_pixels
-    segm[12, 10] = 0
-    flags = _flags(aper, data, segmentation_image=segm, labels=1,
-                   mask_method='correct')
-    assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
-
-
-def test_flag_combinations():
-    """
-    Test that multiple conditions combine bitwise.
-    """
-    data = np.ones(SHAPE)
-    data[12, 6] = np.nan  # outside the r=3 aperture at (0, 12)
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[10, 1] = True
-    aper = CircularAperture((0.0, 12.0), r=3.0)  # straddles left edge
-    flags = _flags(aper, data, mask=mask)
-    assert flags == (APERTURE_FLAGS.PARTIAL_OVERLAP
-                     | APERTURE_FLAGS.MASKED_PIXELS)
-
-
-@pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-def test_mask_path_parity(method, subpixels):
-    """
-    Test that the mask-based code path produces flags identical to the
-    batch Cython driver.
-    """
-    rng = np.random.default_rng(0)
-    data = rng.normal(1.0, 0.1, size=SHAPE)
-    data[13, 12] = np.nan
-    error = np.ones(SHAPE)
-    error[10, 12] = np.inf
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[12, 12] = True
-
-    xy = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0), (24.5, 24.5),
-          (0.2, 12.0), (-1.2, 12.0)]
-    batch_aper = CircularAperture(xy, r=3.0)
-    nobatch_aper = _NoBatchCircularAperture(xy, r=3.0)
-
-    kwargs = {'error': error, 'mask': mask, 'method': method,
-              'subpixels': subpixels}
-    result_batch = batch_aper._photometry(data, **kwargs)
-    result_nobatch = nobatch_aper._photometry(data, **kwargs)
-    assert_array_equal(result_batch.flags, result_nobatch.flags)
-    assert_allclose(result_batch.flux,
-                    result_nobatch.flux, rtol=1e-12,
-                    equal_nan=True)
-
-
-def test_mask_path_parity_segmentation():
-    """
-    Test batch/mask-path flag parity with segmentation masking.
-    """
-    data = np.ones(SHAPE)
-    segm = np.zeros(SHAPE, dtype=int)
-    segm[10:15, 10:15] = 1
-    segm[12, 14] = 2
-    segm[12, 10] = 2
-    segm[3:7, 3:7] = 3
-    xy = [(12.0, 12.0), (5.0, 5.0)]
-    labels = [1, 3]
-
-    for mask_method in ('mask', 'source_only', 'correct'):
-        flags_batch = CircularAperture(xy, r=3.0)._photometry(
-            data, segmentation_image=segm, labels=labels,
-            mask_method=mask_method).flags
-        flags_nobatch = _NoBatchCircularAperture(xy, r=3.0)._photometry(
-            data, segmentation_image=segm, labels=labels,
-            mask_method=mask_method).flags
-        assert_array_equal(flags_batch, flags_nobatch)
-
-
-@pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
-@pytest.mark.parametrize('nan_pixel', [(12, 14), (12, 10)],
-                         ids=['nan_neighbor', 'nan_mirror'])
-def test_mask_path_parity_nonfinite_segmentation(mask_method, nan_pixel):
-    """
-    Test batch/mask-path parity when non-finite masking (the
-    AperturePhotometry path) combines with segmentation masking.
-
-    Non-finite pixels must be masked before the segmentation handling,
-    so a NaN neighbor pixel is excluded as non-finite (not counted as
-    a neighbor pixel or mirror-corrected) and a NaN mirror pixel makes
-    its neighbor uncorrectable with mask_method='correct', matching the
-    batch kernel and ApertureStats.
-    """
-    data = np.ones(SHAPE)
-    data[nan_pixel] = np.nan
-    segm = np.zeros(SHAPE, dtype=int)
-    segm[10:15, 10:15] = 1
-    segm[12, 14] = 2  # neighbor pixel; its mirror is (12, 10)
-
-    kwargs = {'segmentation_image': segm, 'labels': [1],
-              'mask_method': mask_method}
-    batch_aper = CircularAperture((12.0, 12.0), r=3.0)
-    nobatch_aper = _NoBatchCircularAperture((12.0, 12.0), r=3.0)
-    result_batch = AperturePhotometry(data, batch_aper, **kwargs)
-    result_nobatch = AperturePhotometry(data, nobatch_aper, **kwargs)
-    assert_array_equal(result_batch.flags, result_nobatch.flags)
-    assert_allclose(result_batch.flux, result_nobatch.flux, rtol=1e-12)
-    assert_allclose(result_batch.area.value, result_nobatch.area.value,
-                    rtol=1e-12)
-
-    # The NaN pixel is excluded as non_finite_data in both paths
-    assert result_batch.flags & APERTURE_FLAGS.NON_FINITE_DATA
-    stats = ApertureStats(data, batch_aper, **kwargs)
-    assert result_batch.flags == stats.flags
-    assert_allclose(result_batch.flux, stats.sum, rtol=1e-12)
-
-
-def test_aperture_photometry_flags():
-    """
-    Test the AperturePhotometry flags.
-    """
-    data = np.ones(SHAPE)
-    xy = [(12.0, 12.0), (-50.0, 12.0), (0.0, 12.0)]
-    aper = CircularAperture(xy, r=3.0)
-    phot = AperturePhotometry(data, aper)
-    expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS,
-                APERTURE_FLAGS.PARTIAL_OVERLAP]
-    assert_array_equal(phot.flags, expected)
-
-    # The flags are multi-dimensional for multiple apertures
-    aper2 = CircularAperture(xy, r=4.0)
-    phot = AperturePhotometry(data, [aper, aper2])
-    assert_array_equal(phot.flags[:, 0], expected)
-    assert_array_equal(phot.flags[:, 1], expected)
-
-
-def test_flags_with_units():
-    """
-    Test that flags are also set for Quantity inputs.
-    """
-    data = np.ones(SHAPE) * u.Jy
-    data[12, 12] = np.nan * u.Jy
-    aper = CircularAperture((12, 12), r=3.0)
-    phot = AperturePhotometry(data, aper)
-    assert phot.flags == APERTURE_FLAGS.NON_FINITE_DATA
-
-
-def test_counts_to_flag_bits_scalar_inputs():
-    """
-    Test that _counts_to_flag_bits accepts 1D count rows and scalar
-    overlap/w_out values.
-    """
-    counts = np.zeros(8, dtype=int)
-    flags = _counts_to_flag_bits(counts, np.False_, np.False_)
-    assert flags[0] == (APERTURE_FLAGS.NO_OVERLAP
-                        | APERTURE_FLAGS.NO_PIXELS)
-
-
-def test_resolve_outside_weights_no_mask_overlap():
-    """
-    Test that _resolve_outside_weights returns True for a candidate
-    whose aperture mask does not actually overlap the data.
-
-    In practice, the caller only ever marks a source as a candidate
-    when its aperture mask does overlap the data, so the mask's
-    bounding box is never actually clipped away entirely. This
-    directly exercises that defensive branch. A non-'exact' method is
-    used because the 'exact' method takes the gated fast path (see
-    ``_resolve_outside_weights``).
-    """
-    aper = CircularAperture((-5.0, 12.0), r=3.0)
-    shape = (25, 25)
-    mask = aper.to_mask(method='center')
-    assert mask.get_overlap_slices(shape) == (None, None)
-
-    candidates = np.array([True])
-    w_out = aper._resolve_outside_weights(shape, method='center',
-                                          subpixels=5,
-                                          candidates=candidates)
-    assert w_out[0]
-
-
 def _bbox_clipped_candidates(aper, shape):
     """
     Per-source indicator of whether the aperture bounding
@@ -507,51 +82,498 @@ def _bruteforce_outside_weights(aper, shape, *, method, subpixels, candidates):
     return w_out
 
 
-@pytest.mark.parametrize('factory', APERTURE_FACTORIES)
-def test_resolve_outside_weights_exact_gating(factory):
+class TestOverlapFlags:
     """
-    Test that the gated 'exact' fast path in _resolve_outside_weights
-    matches the explicit per-source mask computation.
-
-    For the 'exact' method the minimal bounding box is tight, so a
-    bbox that is clipped by a data edge always leaves a positive-area
-    aperture sliver outside the data. The gated path returns the
-    bbox-clipped candidates unchanged; this must equal the reference
-    mask-based outside-weight test for a mix of interior, edge, corner,
-    and fully off-image positions.
+    Tests for the no_overlap, partial_overlap, and no_pixels flags.
     """
-    ny, nx = SHAPE
-    xy = [(12.0, 12.0),  # interior (not a candidate)
-          (0.0, 12.0), (nx - 1.0, 12.0),  # left/right edges
-          (12.0, 0.0), (12.0, ny - 1.0),  # bottom/top edges
-          (0.0, 0.0), (nx - 1.0, ny - 1.0),  # corners
-          (0.0, ny - 1.0), (nx - 1.0, 0.0),  # corners
-          (1.5, 12.0), (12.0, ny - 2.0),  # near edges
-          (-50.0, 12.0)]  # fully off-image (not a candidate)
-    aper = factory(xy)
 
-    candidates = _bbox_clipped_candidates(aper, SHAPE)
-    gated = aper._resolve_outside_weights(SHAPE, method='exact',
-                                          subpixels=5,
-                                          candidates=candidates)
-    brute = _bruteforce_outside_weights(aper, SHAPE, method='exact',
-                                        subpixels=5, candidates=candidates)
+    def test_no_flags(self):
+        """
+        Test that a clean interior source has no flags set.
+        """
+        data = np.ones(SHAPE)
+        aper = CircularAperture((12, 12), r=3.0)
+        assert_array_equal(_flags(aper, data), [0])
 
-    # The gated path returns the candidates unchanged.
-    assert_array_equal(gated, candidates)
-    # That exactly matches the explicit mask-based computation.
-    assert_array_equal(gated, brute)
+    @pytest.mark.parametrize('factory', APERTURE_FACTORIES)
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_no_overlap(self, factory, method, subpixels):
+        """
+        Test that fully off-image apertures set no_overlap and no_pixels.
+        """
+        data = np.ones(SHAPE)
+        aper = factory([(-50.0, 12.0), (12.0, 12.0)])
+        result = AperturePhotometry(data, aper, method=method,
+                                    subpixels=subpixels)
+        expected = APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS
+        assert result.flags[0] == expected
+        assert np.isnan(result.flux[0])
+        assert result.flags[1] == 0
+
+    @pytest.mark.parametrize('factory', APERTURE_FACTORIES)
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_partial_overlap(self, factory, method, subpixels):
+        """
+        Test that apertures straddling an edge set partial_overlap.
+        """
+        data = np.ones(SHAPE)
+        aper = factory([(0.0, 12.0), (12.0, 24.5), (12.0, 12.0)])
+        flags = _flags(aper, data, method=method, subpixels=subpixels)
+        assert flags[0] == APERTURE_FLAGS.PARTIAL_OVERLAP
+        assert flags[1] == APERTURE_FLAGS.PARTIAL_OVERLAP
+        assert flags[2] == 0
+
+    def test_no_overlap_close_to_edge(self):
+        """
+        Test an aperture whose bounding box overlaps the data but whose
+        nonzero-weight pixels are all outside (precise no_overlap).
+        """
+        data = np.ones(SHAPE)
+        # bbox column 0 overlaps the data, but with the "center" method
+        # the pixel center at x=0 (distance 1.2) is outside the circle
+        aper = CircularAperture((-1.2, 12.0), r=0.8)
+        result = AperturePhotometry(data, aper, method='center')
+        assert result.flags == (APERTURE_FLAGS.NO_OVERLAP
+                                | APERTURE_FLAGS.NO_PIXELS)
+        # The sum is 0.0 (not NaN) here: the bounding box overlaps the
+        # data, but no weighted pixel falls inside
+        assert result.flux == 0.0
+
+        # With the exact method, the aperture area extends into the data
+        result = AperturePhotometry(data, aper, method='exact')
+        assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
+
+    def test_clipped_bbox_only(self):
+        """
+        Test that a clipped bounding box alone does not set
+        partial_overlap when all nonzero weights are inside the data.
+        """
+        data = np.ones(SHAPE)
+        # bbox extends to column -1, but the pixel center at x=-1
+        # (distance 1.2 > r=0.8) is outside the circle
+        aper = CircularAperture((0.2, 12.0), r=0.8)
+        assert_array_equal(_flags(aper, data, method='center'), [0])
+
+        # The exact-method footprint does extend outside
+        flags = _flags(aper, data, method='exact')
+        assert_array_equal(flags, [APERTURE_FLAGS.PARTIAL_OVERLAP])
+
+    def test_no_pixels_tiny_aperture(self):
+        """
+        Test that a tiny aperture with the "center" method sets no_pixels.
+        """
+        data = np.ones(SHAPE)
+        # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
+        aper = CircularAperture((12.5, 12.5), r=0.4)
+        result = AperturePhotometry(data, aper, method='center')
+        assert result.flags == APERTURE_FLAGS.NO_PIXELS
+        assert result.flux == 0.0
+
+        # The exact method has a nonzero footprint
+        assert_array_equal(_flags(aper, data, method='exact'), [0])
 
 
-def test_resolve_outside_weights_exact_returns_copy():
+class TestPolygonOverlapFlags:
     """
-    Test that the gated 'exact' path returns a copy, not the input
-    candidates array.
+    A polygon bounding box is symmetric about its positions, so it can
+    be clipped by a data edge while the polygon is fully inside.
     """
-    aper = CircularAperture([(0.0, 12.0), (12.0, 12.0)], r=3.0)
-    candidates = _bbox_clipped_candidates(aper, SHAPE)
-    w_out = aper._resolve_outside_weights(SHAPE, method='exact',
-                                          subpixels=5,
-                                          candidates=candidates)
-    assert w_out is not candidates
-    assert_array_equal(w_out, candidates)
+
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_offcenter_inside(self, method, subpixels):
+        """
+        Test that a polygon lying entirely inside the data is not flagged as
+        partial_overlap even though its bounding box, which is symmetric
+        about ``positions``, is clipped by a data edge.
+        """
+        data = np.ones((12, 12))
+        # The centroid of this triangle is well off-center, so the symmetric
+        # bounding box extends outside the data on two sides
+        aper = PolygonAperture.from_vertices([(1.0, 1.0), (9.0, 1.0),
+                                              (9.0, 9.0)])
+        bbox = aper.bbox
+        assert bbox.ixmax > data.shape[1] or bbox.iymin < 0
+
+        result = AperturePhotometry(data, aper, method=method,
+                                    subpixels=subpixels)
+        assert result.flags == 0
+        stats = ApertureStats(data, aper, sum_method=method,
+                              subpixels=subpixels)
+        assert stats.sum_flags == 0
+        assert stats.flags == 0
+
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_offcenter_partial(self, method, subpixels):
+        """
+        Test that a polygon extending past a data edge is still flagged as
+        partial_overlap.
+        """
+        data = np.ones((12, 12))
+        aper = PolygonAperture.from_vertices([(-2.0, 1.0), (9.0, 1.0),
+                                              (9.0, 9.0)])
+        result = AperturePhotometry(data, aper, method=method,
+                                    subpixels=subpixels)
+        assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
+        stats = ApertureStats(data, aper, sum_method=method,
+                              subpixels=subpixels)
+        assert stats.sum_flags == APERTURE_FLAGS.PARTIAL_OVERLAP
+
+
+class TestMaskedAndNonFiniteFlags:
+    """
+    Tests for the masked_pixels, all_masked, and non-finite flags.
+    """
+
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_masked_pixels(self, method, subpixels):
+        """
+        Test the masked_pixels and all_masked flags.
+        """
+        data = np.ones(SHAPE)
+
+        # One masked pixel inside the aperture
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[12, 12] = True
+        aper = CircularAperture((12, 12), r=3.0)
+        flags = _flags(aper, data, mask=mask, method=method,
+                       subpixels=subpixels)
+        assert flags == APERTURE_FLAGS.MASKED_PIXELS
+
+        # Masked pixel inside the bounding box but outside the aperture
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[9, 9] = True
+        flags = _flags(aper, data, mask=mask, method=method,
+                       subpixels=subpixels)
+        assert flags == 0
+
+        # Fully masked aperture
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[8:17, 8:17] = True
+        flags = _flags(aper, data, mask=mask, method=method,
+                       subpixels=subpixels)
+        assert flags == (APERTURE_FLAGS.MASKED_PIXELS
+                         | APERTURE_FLAGS.ALL_MASKED)
+
+    def test_non_finite_data(self):
+        """
+        Test the non_finite_data flag.
+
+        In photometry, unmasked non-finite values contribute to the sum
+        (making it NaN). They do not set all_masked.
+
+        This tests the legacy (non-class) engine call directly
+        (``mask_nonfinite=False``, the default), which corrupts the sum
+        with the non-finite value instead of masking it out, unlike
+        `AperturePhotometry`.
+        """
+        data = np.ones(SHAPE)
+        data[12, 12] = np.nan
+        aper = CircularAperture((12, 12), r=3.0)
+        result = aper._photometry(data)
+        assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
+        assert np.isnan(result.flux[0])
+
+        # An all-NaN aperture is still non_finite_data only (the pixels
+        # contribute, so all_masked is not set)
+        data = np.full(SHAPE, np.nan)
+        result = aper._photometry(data)
+        assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
+
+        # A masked non-finite pixel counts only as masked
+        data = np.ones(SHAPE)
+        data[12, 12] = np.nan
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[12, 12] = True
+        flags = _flags(aper, data, mask=mask)
+        assert flags == APERTURE_FLAGS.MASKED_PIXELS
+
+    def test_non_finite_error(self):
+        """
+        Test the non_finite_error flag.
+        """
+        data = np.ones(SHAPE)
+        error = np.ones(SHAPE)
+        error[12, 12] = np.inf
+        aper = CircularAperture((12, 12), r=3.0)
+        flags = _flags(aper, data, error=error)
+        assert flags == APERTURE_FLAGS.NON_FINITE_ERROR
+
+        # Without an error array, the flag is never set
+        assert_array_equal(_flags(aper, data), [0])
+
+
+class TestSegmentationFlags:
+    """
+    Tests for the neighbor_pixels and uncorrected_pixels flags.
+    """
+
+    @pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
+    def test_neighbor_pixels(self, mask_method):
+        """
+        Test the neighbor_pixels flag for all segmentation mask methods.
+        """
+        data = np.ones(SHAPE)
+        segm = np.zeros(SHAPE, dtype=int)
+        segm[10:15, 10:15] = 1
+        segm[12, 14] = 2  # neighbor pixel inside the aperture
+        aper = CircularAperture((12, 12), r=3.0)
+        flags = _flags(aper, data, segmentation_image=segm, labels=1,
+                       mask_method=mask_method)
+        assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
+
+        # Without any neighbor pixels inside the aperture, no flag is set
+        segm2 = np.zeros(SHAPE, dtype=int)
+        segm2[10:15, 10:15] = 1
+        flags = _flags(aper, data, segmentation_image=segm2, labels=1,
+                       mask_method=mask_method)
+        assert flags == 0
+
+    def test_uncorrected_pixels(self):
+        """
+        Test the uncorrected_pixels flag with mask_method='correct'.
+        """
+        data = np.ones(SHAPE)
+        segm = np.zeros(SHAPE, dtype=int)
+        segm[10:15, 10:15] = 1
+        segm[12, 14] = 2  # neighbor; its mirror (12, 10) is source pixel
+        segm[12, 10] = 2  # make the mirror a neighbor too: uncorrectable
+        aper = CircularAperture((12, 12), r=3.0)
+        flags = _flags(aper, data, segmentation_image=segm, labels=1,
+                       mask_method='correct')
+        assert flags == (APERTURE_FLAGS.NEIGHBOR_PIXELS
+                         | APERTURE_FLAGS.UNCORRECTED_PIXELS)
+
+        # A correctable neighbor does not set uncorrected_pixels
+        segm[12, 10] = 0
+        flags = _flags(aper, data, segmentation_image=segm, labels=1,
+                       mask_method='correct')
+        assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
+
+
+class TestMaskPathParity:
+    """
+    The mask-based code path must set the same flags as the batch
+    driver.
+    """
+
+    @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
+    def test_basic(self, method, subpixels):
+        """
+        Test that the mask-based code path produces flags identical to the
+        batch Cython driver.
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(1.0, 0.1, size=SHAPE)
+        data[13, 12] = np.nan
+        error = np.ones(SHAPE)
+        error[10, 12] = np.inf
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[12, 12] = True
+
+        xy = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0), (24.5, 24.5),
+              (0.2, 12.0), (-1.2, 12.0)]
+        batch_aper = CircularAperture(xy, r=3.0)
+        nobatch_aper = _NoBatchCircularAperture(xy, r=3.0)
+
+        kwargs = {'error': error, 'mask': mask, 'method': method,
+                  'subpixels': subpixels}
+        result_batch = batch_aper._photometry(data, **kwargs)
+        result_nobatch = nobatch_aper._photometry(data, **kwargs)
+        assert_array_equal(result_batch.flags, result_nobatch.flags)
+        assert_allclose(result_batch.flux,
+                        result_nobatch.flux, rtol=1e-12,
+                        equal_nan=True)
+
+    def test_segmentation(self):
+        """
+        Test batch/mask-path flag parity with segmentation masking.
+        """
+        data = np.ones(SHAPE)
+        segm = np.zeros(SHAPE, dtype=int)
+        segm[10:15, 10:15] = 1
+        segm[12, 14] = 2
+        segm[12, 10] = 2
+        segm[3:7, 3:7] = 3
+        xy = [(12.0, 12.0), (5.0, 5.0)]
+        labels = [1, 3]
+
+        for mask_method in ('mask', 'source_only', 'correct'):
+            flags_batch = CircularAperture(xy, r=3.0)._photometry(
+                data, segmentation_image=segm, labels=labels,
+                mask_method=mask_method).flags
+            flags_nobatch = _NoBatchCircularAperture(xy, r=3.0)._photometry(
+                data, segmentation_image=segm, labels=labels,
+                mask_method=mask_method).flags
+            assert_array_equal(flags_batch, flags_nobatch)
+
+    @pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
+    @pytest.mark.parametrize('nan_pixel', [(12, 14), (12, 10)],
+                             ids=['nan_neighbor', 'nan_mirror'])
+    def test_nonfinite_segmentation(self, mask_method, nan_pixel):
+        """
+        Test batch/mask-path parity when non-finite masking (the
+        AperturePhotometry path) combines with segmentation masking.
+
+        Non-finite pixels must be masked before the segmentation handling,
+        so a NaN neighbor pixel is excluded as non-finite (not counted as
+        a neighbor pixel or mirror-corrected) and a NaN mirror pixel makes
+        its neighbor uncorrectable with mask_method='correct', matching the
+        batch kernel and ApertureStats.
+        """
+        data = np.ones(SHAPE)
+        data[nan_pixel] = np.nan
+        segm = np.zeros(SHAPE, dtype=int)
+        segm[10:15, 10:15] = 1
+        segm[12, 14] = 2  # neighbor pixel; its mirror is (12, 10)
+
+        kwargs = {'segmentation_image': segm, 'labels': [1],
+                  'mask_method': mask_method}
+        batch_aper = CircularAperture((12.0, 12.0), r=3.0)
+        nobatch_aper = _NoBatchCircularAperture((12.0, 12.0), r=3.0)
+        result_batch = AperturePhotometry(data, batch_aper, **kwargs)
+        result_nobatch = AperturePhotometry(data, nobatch_aper, **kwargs)
+        assert_array_equal(result_batch.flags, result_nobatch.flags)
+        assert_allclose(result_batch.flux, result_nobatch.flux, rtol=1e-12)
+        assert_allclose(result_batch.area.value, result_nobatch.area.value,
+                        rtol=1e-12)
+
+        # The NaN pixel is excluded as non_finite_data in both paths
+        assert result_batch.flags & APERTURE_FLAGS.NON_FINITE_DATA
+        stats = ApertureStats(data, batch_aper, **kwargs)
+        assert result_batch.flags == stats.flags
+        assert_allclose(result_batch.flux, stats.sum, rtol=1e-12)
+
+
+class TestFlagsAPI:
+    """
+    Tests for how the flags are exposed by the photometry classes.
+    """
+
+    def test_flag_combinations(self):
+        """
+        Test that multiple conditions combine bitwise.
+        """
+        data = np.ones(SHAPE)
+        data[12, 6] = np.nan  # outside the r=3 aperture at (0, 12)
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[10, 1] = True
+        aper = CircularAperture((0.0, 12.0), r=3.0)  # straddles left edge
+        flags = _flags(aper, data, mask=mask)
+        assert flags == (APERTURE_FLAGS.PARTIAL_OVERLAP
+                         | APERTURE_FLAGS.MASKED_PIXELS)
+
+    def test_legacy_function_has_no_flags(self):
+        """
+        Test the AperturePhotometry flags.
+        """
+        data = np.ones(SHAPE)
+        xy = [(12.0, 12.0), (-50.0, 12.0), (0.0, 12.0)]
+        aper = CircularAperture(xy, r=3.0)
+        phot = AperturePhotometry(data, aper)
+        expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS,
+                    APERTURE_FLAGS.PARTIAL_OVERLAP]
+        assert_array_equal(phot.flags, expected)
+
+        # The flags are multi-dimensional for multiple apertures
+        aper2 = CircularAperture(xy, r=4.0)
+        phot = AperturePhotometry(data, [aper, aper2])
+        assert_array_equal(phot.flags[:, 0], expected)
+        assert_array_equal(phot.flags[:, 1], expected)
+
+    def test_flags_with_units(self):
+        """
+        Test that flags are also set for Quantity inputs.
+        """
+        data = np.ones(SHAPE) * u.Jy
+        data[12, 12] = np.nan * u.Jy
+        aper = CircularAperture((12, 12), r=3.0)
+        phot = AperturePhotometry(data, aper)
+        assert phot.flags == APERTURE_FLAGS.NON_FINITE_DATA
+
+    def test_scalar_flag_counts(self):
+        """
+        Test that _counts_to_flag_bits accepts 1D count rows and scalar
+        overlap/w_out values.
+        """
+        counts = np.zeros(8, dtype=int)
+        flags = _counts_to_flag_bits(counts, np.False_, np.False_)
+        assert flags[0] == (APERTURE_FLAGS.NO_OVERLAP
+                            | APERTURE_FLAGS.NO_PIXELS)
+
+
+class TestResolveOutsideWeights:
+    """
+    Tests for the precise outside-weight test used by the
+    partial_overlap flag.
+    """
+
+    def test_no_mask_overlap(self):
+        """
+        Test that _resolve_outside_weights returns True for a candidate
+        whose aperture mask does not actually overlap the data.
+
+        In practice, the caller only ever marks a source as a candidate
+        when its aperture mask does overlap the data, so the mask's
+        bounding box is never actually clipped away entirely. This
+        directly exercises that defensive branch. A non-'exact' method is
+        used because the 'exact' method takes the gated fast path (see
+        ``_resolve_outside_weights``).
+        """
+        aper = CircularAperture((-5.0, 12.0), r=3.0)
+        shape = (25, 25)
+        mask = aper.to_mask(method='center')
+        assert mask.get_overlap_slices(shape) == (None, None)
+
+        candidates = np.array([True])
+        w_out = aper._resolve_outside_weights(shape, method='center',
+                                              subpixels=5,
+                                              candidates=candidates)
+        assert w_out[0]
+
+    @pytest.mark.parametrize('factory', APERTURE_FACTORIES)
+    def test_exact_gating(self, factory):
+        """
+        Test that the gated 'exact' fast path in _resolve_outside_weights
+        matches the explicit per-source mask computation.
+
+        For the 'exact' method the minimal bounding box is tight, so a
+        bbox that is clipped by a data edge always leaves a positive-area
+        aperture sliver outside the data. The gated path returns the
+        bbox-clipped candidates unchanged; this must equal the reference
+        mask-based outside-weight test for a mix of interior, edge, corner,
+        and fully off-image positions.
+        """
+        ny, nx = SHAPE
+        xy = [(12.0, 12.0),  # interior (not a candidate)
+              (0.0, 12.0), (nx - 1.0, 12.0),  # left/right edges
+              (12.0, 0.0), (12.0, ny - 1.0),  # bottom/top edges
+              (0.0, 0.0), (nx - 1.0, ny - 1.0),  # corners
+              (0.0, ny - 1.0), (nx - 1.0, 0.0),  # corners
+              (1.5, 12.0), (12.0, ny - 2.0),  # near edges
+              (-50.0, 12.0)]  # fully off-image (not a candidate)
+        aper = factory(xy)
+
+        candidates = _bbox_clipped_candidates(aper, SHAPE)
+        gated = aper._resolve_outside_weights(SHAPE, method='exact',
+                                              subpixels=5,
+                                              candidates=candidates)
+        brute = _bruteforce_outside_weights(aper, SHAPE, method='exact',
+                                            subpixels=5, candidates=candidates)
+
+        # The gated path returns the candidates unchanged.
+        assert_array_equal(gated, candidates)
+        # That exactly matches the explicit mask-based computation.
+        assert_array_equal(gated, brute)
+
+    def test_exact_copy(self):
+        """
+        Test that the gated 'exact' path returns a copy, not the input
+        candidates array.
+        """
+        aper = CircularAperture([(0.0, 12.0), (12.0, 12.0)], r=3.0)
+        candidates = _bbox_clipped_candidates(aper, SHAPE)
+        w_out = aper._resolve_outside_weights(SHAPE, method='exact',
+                                              subpixels=5,
+                                              candidates=candidates)
+        assert w_out is not candidates
+        assert_array_equal(w_out, candidates)

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -87,21 +87,21 @@ class TestOverlapFlags:
     Tests for the no_overlap, partial_overlap, and no_pixels flags.
     """
 
-    def test_no_flags(self):
+    def test_no_flags(self, unit_data):
         """
         Test that a clean interior source has no flags set.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = CircularAperture((12, 12), r=3.0)
         assert_array_equal(_flags(aper, data), [0])
 
     @pytest.mark.parametrize('factory', APERTURE_FACTORIES)
     @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-    def test_no_overlap(self, factory, method, subpixels):
+    def test_no_overlap(self, unit_data, factory, method, subpixels):
         """
         Test that fully off-image apertures set no_overlap and no_pixels.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = factory([(-50.0, 12.0), (12.0, 12.0)])
         result = AperturePhotometry(data, aper, method=method,
                                     subpixels=subpixels)
@@ -112,23 +112,23 @@ class TestOverlapFlags:
 
     @pytest.mark.parametrize('factory', APERTURE_FACTORIES)
     @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-    def test_partial_overlap(self, factory, method, subpixels):
+    def test_partial_overlap(self, unit_data, factory, method, subpixels):
         """
         Test that apertures straddling an edge set partial_overlap.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = factory([(0.0, 12.0), (12.0, 24.5), (12.0, 12.0)])
         flags = _flags(aper, data, method=method, subpixels=subpixels)
         assert flags[0] == APERTURE_FLAGS.PARTIAL_OVERLAP
         assert flags[1] == APERTURE_FLAGS.PARTIAL_OVERLAP
         assert flags[2] == 0
 
-    def test_no_overlap_close_to_edge(self):
+    def test_no_overlap_close_to_edge(self, unit_data):
         """
         Test an aperture whose bounding box overlaps the data but whose
         nonzero-weight pixels are all outside (precise no_overlap).
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         # bbox column 0 overlaps the data, but with the "center" method
         # the pixel center at x=0 (distance 1.2) is outside the circle
         aper = CircularAperture((-1.2, 12.0), r=0.8)
@@ -143,12 +143,12 @@ class TestOverlapFlags:
         result = AperturePhotometry(data, aper, method='exact')
         assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
 
-    def test_clipped_bbox_only(self):
+    def test_clipped_bbox_only(self, unit_data):
         """
         Test that a clipped bounding box alone does not set
         partial_overlap when all nonzero weights are inside the data.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         # bbox extends to column -1, but the pixel center at x=-1
         # (distance 1.2 > r=0.8) is outside the circle
         aper = CircularAperture((0.2, 12.0), r=0.8)
@@ -158,11 +158,11 @@ class TestOverlapFlags:
         flags = _flags(aper, data, method='exact')
         assert_array_equal(flags, [APERTURE_FLAGS.PARTIAL_OVERLAP])
 
-    def test_no_pixels_tiny_aperture(self):
+    def test_no_pixels_tiny_aperture(self, unit_data):
         """
         Test that a tiny aperture with the "center" method sets no_pixels.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
         aper = CircularAperture((12.5, 12.5), r=0.4)
         result = AperturePhotometry(data, aper, method='center')
@@ -225,11 +225,11 @@ class TestMaskedAndNonFiniteFlags:
     """
 
     @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-    def test_masked_pixels(self, method, subpixels):
+    def test_masked_pixels(self, unit_data, method, subpixels):
         """
         Test the masked_pixels and all_masked flags.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
 
         # One masked pixel inside the aperture
         mask = np.zeros(SHAPE, dtype=bool)
@@ -254,7 +254,7 @@ class TestMaskedAndNonFiniteFlags:
         assert flags == (APERTURE_FLAGS.MASKED_PIXELS
                          | APERTURE_FLAGS.ALL_MASKED)
 
-    def test_non_finite_data(self):
+    def test_non_finite_data(self, unit_mask):
         """
         Test the non_finite_data flag.
 
@@ -282,16 +282,16 @@ class TestMaskedAndNonFiniteFlags:
         # A masked non-finite pixel counts only as masked
         data = np.ones(SHAPE)
         data[12, 12] = np.nan
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = unit_mask
         mask[12, 12] = True
         flags = _flags(aper, data, mask=mask)
         assert flags == APERTURE_FLAGS.MASKED_PIXELS
 
-    def test_non_finite_error(self):
+    def test_non_finite_error(self, unit_data):
         """
         Test the non_finite_error flag.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         error = np.ones(SHAPE)
         error[12, 12] = np.inf
         aper = CircularAperture((12, 12), r=3.0)
@@ -308,11 +308,11 @@ class TestSegmentationFlags:
     """
 
     @pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
-    def test_neighbor_pixels(self, mask_method):
+    def test_neighbor_pixels(self, unit_data, mask_method):
         """
         Test the neighbor_pixels flag for all segmentation mask methods.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         segm = np.zeros(SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor pixel inside the aperture
@@ -328,11 +328,11 @@ class TestSegmentationFlags:
                        mask_method=mask_method)
         assert flags == 0
 
-    def test_uncorrected_pixels(self):
+    def test_uncorrected_pixels(self, unit_data):
         """
         Test the uncorrected_pixels flag with mask_method='correct'.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         segm = np.zeros(SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor; its mirror (12, 10) is source pixel
@@ -357,7 +357,7 @@ class TestMaskPathParity:
     """
 
     @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
-    def test_basic(self, method, subpixels):
+    def test_basic(self, unit_mask, method, subpixels):
         """
         Test that the mask-based code path produces flags identical to the
         batch Cython driver.
@@ -367,7 +367,7 @@ class TestMaskPathParity:
         data[13, 12] = np.nan
         error = np.ones(SHAPE)
         error[10, 12] = np.inf
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = unit_mask
         mask[12, 12] = True
 
         xy = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0), (24.5, 24.5),
@@ -384,11 +384,11 @@ class TestMaskPathParity:
                         result_nobatch.flux, rtol=1e-12,
                         equal_nan=True)
 
-    def test_segmentation(self):
+    def test_segmentation(self, unit_data):
         """
         Test batch/mask-path flag parity with segmentation masking.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         segm = np.zeros(SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2
@@ -409,7 +409,7 @@ class TestMaskPathParity:
     @pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
     @pytest.mark.parametrize('nan_pixel', [(12, 14), (12, 10)],
                              ids=['nan_neighbor', 'nan_mirror'])
-    def test_nonfinite_segmentation(self, mask_method, nan_pixel):
+    def test_nonfinite_segmentation(self, unit_data, mask_method, nan_pixel):
         """
         Test batch/mask-path parity when non-finite masking (the
         AperturePhotometry path) combines with segmentation masking.
@@ -420,7 +420,7 @@ class TestMaskPathParity:
         its neighbor uncorrectable with mask_method='correct', matching the
         batch kernel and ApertureStats.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         data[nan_pixel] = np.nan
         segm = np.zeros(SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
@@ -449,24 +449,24 @@ class TestFlagsAPI:
     Tests for how the flags are exposed by the photometry classes.
     """
 
-    def test_flag_combinations(self):
+    def test_flag_combinations(self, unit_data, unit_mask):
         """
         Test that multiple conditions combine bitwise.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         data[12, 6] = np.nan  # outside the r=3 aperture at (0, 12)
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = unit_mask
         mask[10, 1] = True
         aper = CircularAperture((0.0, 12.0), r=3.0)  # straddles left edge
         flags = _flags(aper, data, mask=mask)
         assert flags == (APERTURE_FLAGS.PARTIAL_OVERLAP
                          | APERTURE_FLAGS.MASKED_PIXELS)
 
-    def test_legacy_function_has_no_flags(self):
+    def test_legacy_function_has_no_flags(self, unit_data):
         """
         Test the AperturePhotometry flags.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         xy = [(12.0, 12.0), (-50.0, 12.0), (0.0, 12.0)]
         aper = CircularAperture(xy, r=3.0)
         phot = AperturePhotometry(data, aper)

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -44,60 +44,6 @@ def _make_wcs():
     return wcs
 
 
-def test_signed_polygon_area_ccw_positive():
-    verts = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
-    assert_allclose(_signed_polygon_area(verts), 1.0)
-
-
-def test_signed_polygon_area_cw_negative():
-    verts = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]])
-    assert_allclose(_signed_polygon_area(verts), -1.0)
-
-
-def test_vertices_centroid_square():
-    verts = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]])
-    assert_allclose(_vertices_centroid(verts), [2.0, 2.0])
-
-
-def test_validate_simple_polygon_reorders_clockwise():
-    cw = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]])
-    out = _validate_simple_polygon(cw)
-    # Expect CCW order
-    assert _signed_polygon_area(out) > 0
-
-
-def test_validate_simple_polygon_rejects_wrong_shape():
-    with pytest.raises(ValueError, match='must have shape'):
-        _validate_simple_polygon(np.array([1.0, 2.0, 3.0]))
-
-
-def test_validate_simple_polygon_rejects_too_few():
-    with pytest.raises(ValueError, match='at least 3 vertices'):
-        _validate_simple_polygon(np.array([[0.0, 0.0], [1.0, 0.0]]))
-
-
-def test_validate_simple_polygon_rejects_nonfinite():
-    bad = np.array([[0.0, 0.0], [np.nan, 0.0], [1.0, 1.0]])
-    with pytest.raises(ValueError, match='non-finite'):
-        _validate_simple_polygon(bad)
-
-
-def test_validate_simple_polygon_rejects_collinear():
-    bad = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
-    with pytest.raises(ValueError, match='degenerate'):
-        _validate_simple_polygon(bad)
-
-
-def test_validate_simple_polygon_accepts_nonconvex():
-    """
-    Test that a non-convex (L-shaped) polygon is accepted.
-    """
-    arrow = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 2.0],
-                      [2.0, 2.0], [2.0, 4.0], [0.0, 4.0]])
-    out = _validate_simple_polygon(arrow)
-    assert out.shape == arrow.shape
-
-
 def _pentagram():
     """
     A five-pointed (self-intersecting) star drawn by connecting every
@@ -118,125 +64,6 @@ def _concave_star():
     ang = np.pi / 2 + np.arange(10) * np.pi / 5
     radius = np.where(np.arange(10) % 2 == 0, 5.0, 2.0)
     return np.column_stack([radius * np.cos(ang), radius * np.sin(ang)])
-
-
-def test_polygon_is_simple_true_for_square():
-    assert _polygon_is_simple(SQUARE_OFFSETS)
-
-
-def test_polygon_is_simple_true_for_concave_star():
-    assert _polygon_is_simple(_concave_star())
-
-
-def test_polygon_is_simple_false_for_pentagram():
-    star = _pentagram()
-    # Sanity check: the pentagram has non-zero area, so it is not caught
-    # by the degeneracy check and must be rejected by the simplicity
-    # check.
-    assert _signed_polygon_area(star) != 0.0
-    assert not _polygon_is_simple(star)
-
-
-def test_validate_simple_polygon_rejects_self_intersecting():
-    with pytest.raises(ValueError, match='self-intersect'):
-        _validate_simple_polygon(_pentagram())
-
-
-def test_pixel_polygon_rejects_self_intersecting():
-    with pytest.raises(ValueError, match='self-intersect'):
-        PolygonAperture((0.0, 0.0), _pentagram())
-
-
-def test_sky_polygon_rejects_self_intersecting():
-    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-    with pytest.raises(ValueError, match='self-intersect'):
-        SkyPolygonAperture(pos, _pentagram() * u.arcsec)
-
-
-def test_pixel_polygon_accepts_concave_star():
-    aper = PolygonAperture((0.0, 0.0), _concave_star())
-    assert aper.vertex_offsets.shape == (10, 2)
-
-
-@pytest.mark.parametrize('n_spikes', [5, 6, 7, 8])
-def test_pixel_polygon_from_star(n_spikes):
-    """
-    Test that ``_from_star`` constructs a star-shaped polygon with the
-    correct area and that it raises for invalid parameters.
-    """
-    xypos = (5, 5)
-
-    match = 'must be at least 2'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture._from_star(xypos, 1, 5.0, 2.0)
-
-    match = 'must be a finite positive number'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture._from_star(xypos, 5, -2.0, 2.0)
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture._from_star(xypos, 5, 5.0, -2.0)
-
-    match = 'inner_radius must be less than outer_radius'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture._from_star(xypos, 5, 5.0, 6.0)
-
-    match = 'optimal_shape and collinear_edges cannot both be True'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture._from_star(xypos, 5, 5.0, 2.0, optimal_shape=True,
-                                   collinear_edges=True)
-
-    match = 'collinear_edges requires n_spikes'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture._from_star(xypos, 4, 3.0, 2.0, collinear_edges=True)
-
-    match = 'inner_radius must be provided'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture._from_star(xypos, 5, 3.0)
-
-    data = np.ones((11, 11))
-    outer_radius = 5.0
-    inner_radius = 2.0
-    aper = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
-                                      inner_radius)
-    phot = AperturePhotometry(data, aper, method='exact')
-    assert_allclose(phot.flux, aper.area)
-
-    aper1 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
-                                       inner_radius, theta=10 * u.deg)
-    phot = AperturePhotometry(data, aper1, method='exact')
-    assert_allclose(phot.flux, aper1.area)
-
-    aper2 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
-                                       optimal_shape=True)
-    phot = AperturePhotometry(data, aper2, method='exact')
-    assert_allclose(phot.flux, aper2.area)
-
-    aper3 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
-                                       collinear_edges=True)
-    phot = AperturePhotometry(data, aper3, method='exact')
-    assert_allclose(phot.flux, aper3.area)
-
-
-@pytest.mark.parametrize(
-    ('p1', 'p2', 'p3', 'p4', 'expected'),
-    [
-        # Proper crossing (segments straddle each other).
-        ((0.0, 0.0), (2.0, 2.0), (0.0, 2.0), (2.0, 0.0), True),
-        # Disjoint, non-collinear segments.
-        ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0), False),
-        # p1 lies on segment p3-p4 (d1 == 0).
-        ((1.0, 0.0), (1.0, 1.0), (0.0, 0.0), (2.0, 0.0), True),
-        # p2 lies on segment p3-p4 (d2 == 0).
-        ((1.0, 1.0), (1.0, 0.0), (0.0, 0.0), (2.0, 0.0), True),
-        # p3 lies on segment p1-p2 (d3 == 0).
-        ((0.0, 0.0), (2.0, 0.0), (1.0, 0.0), (1.0, 1.0), True),
-        # p4 lies on segment p1-p2 (d4 == 0).
-        ((0.0, 0.0), (2.0, 0.0), (1.0, 1.0), (1.0, 0.0), True),
-        # Collinear but non-overlapping segments.
-        ((0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0), False),
-    ])
-def test_segments_intersect(p1, p2, p3, p4, expected):
-    assert _segments_intersect(p1, p2, p3, p4) is expected
 
 
 class TestPolygonAperture(BaseTestAperture):
@@ -299,307 +126,6 @@ class TestPolygonAperture(BaseTestAperture):
             assert isinstance(patch, Patch)
 
 
-def test_construct_scalar():
-    aper = PolygonAperture((10.0, 20.0), SQUARE_OFFSETS)
-    assert aper.isscalar
-    assert aper.shape == ()
-    assert aper.vertex_offsets.shape == (4, 2)
-    assert_allclose(aper.area, 4.0)
-    assert aper._xy_extents == (1.0, 1.0)
-
-
-def test_construct_array_positions():
-    aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
-    assert not aper.isscalar
-    assert aper.shape == (4,)
-    assert len(aper) == 4
-    assert aper.vertices.shape == (4, 4, 2)
-    expected_first = np.asarray(POSITIONS[0]) + SQUARE_OFFSETS
-    assert_allclose(aper.vertices[0], expected_first)
-
-
-def test_vertices_scalar():
-    aper = PolygonAperture((10.0, 20.0), SQUARE_OFFSETS)
-    assert aper.vertices.shape == (4, 2)
-    assert_allclose(aper.vertices, np.array([10.0, 20.0]) + SQUARE_OFFSETS)
-
-
-def test_vertex_offsets_normalized_to_ccw():
-    cw = SQUARE_OFFSETS[::-1].copy()
-    aper = PolygonAperture((0, 0), cw)
-    assert _signed_polygon_area(aper.vertex_offsets) > 0
-
-
-def test_invalid_vertex_offsets_quantity_raises():
-    match = 'must not be a Quantity'
-    with pytest.raises(TypeError, match=match):
-        PolygonAperture((0, 0), SQUARE_OFFSETS * u.pix)
-
-
-def test_invalid_vertex_offsets_nonfinite_raises():
-    bad = np.array([[0.0, 0.0], [np.nan, 1.0], [1.0, 0.0]])
-    with pytest.raises(ValueError, match='non-finite'):
-        PolygonAperture((0, 0), bad)
-
-
-def test_polygon_aperture_accepts_nonconvex():
-    """
-    The aperture supports non-convex (L-shaped) polygons.
-    """
-    l_shape = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 2.0],
-                        [2.0, 2.0], [2.0, 4.0], [0.0, 4.0]])
-    aper = PolygonAperture((0.0, 0.0), l_shape)
-    assert aper.vertex_offsets.shape == (6, 2)
-    assert_allclose(aper.area, 12.0)
-    mask = aper.to_mask(method='exact')
-    assert_allclose(mask.data.sum(), 12.0, atol=1e-12)
-
-
-def test_invalid_vertex_offsets_too_few_raises():
-    match = 'at least 3 vertices'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture((0, 0), [[0.0, 0.0], [1.0, 1.0]])
-
-
-def test_invalid_vertex_offsets_unparseable():
-    match = 'must be convertible to a numeric'
-    with pytest.raises(TypeError, match=match):
-        PolygonAperture((0, 0), [['a', 'b'], ['c', 'd'], ['e', 'f']])
-
-
-def test_from_vertices_round_trip():
-    verts = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]])
-    aper = PolygonAperture.from_vertices(verts)
-    assert_allclose(aper.vertices, verts)
-
-
-def test_from_vertices_invalid_shape():
-    match = 'vertices must have shape'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture.from_vertices(np.array([1.0, 2.0]))
-
-
-def test_from_vertices_rejects_degenerate():
-    """
-    Test that ``from_vertices`` rejects collinear vertices.
-
-    The ``from_vertices`` method must raise a clean ValueError
-    rather than a ZeroDivisionError from the area-weighted centroid
-    computation.
-    """
-    match = 'degenerate'
-    with pytest.raises(ValueError, match=match):
-        PolygonAperture.from_vertices([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
-
-
-def test_to_mask_exact_matches_rectangle():
-    """
-    Test that exact polygon mask for a square equals the rectangular
-    result.
-    """
-    poly = PolygonAperture((5.0, 5.0), SQUARE_OFFSETS)
-    rect = RectangularAperture((5.0, 5.0), w=2.0, h=2.0)
-    assert_allclose(poly.to_mask(method='exact').data,
-                    rect.to_mask(method='exact').data)
-
-
-def test_to_mask_subpixel_approximates_exact():
-    poly = PolygonAperture((5.5, 5.5), TRIANGLE_OFFSETS)
-    exact = poly.to_mask(method='exact').data
-    sub = poly.to_mask(method='subpixel', subpixels=32).data
-    assert np.abs(exact - sub).max() < 0.05
-
-
-def test_to_mask_center_method():
-    poly = PolygonAperture((5.0, 5.0), SQUARE_OFFSETS)
-    mask = poly.to_mask(method='center').data
-    assert set(np.unique(mask)).issubset({0.0, 1.0})
-
-
-def test_to_mask_center_matches_rectangle():
-    """
-    Test that the ``center`` mask for a rectangle matches the equivalent
-    polygon.
-
-    A `RectangularAperture` and a `PolygonAperture` built from the same
-    four corners must produce identical ``center`` masks. This includes
-    pixel centers that lie exactly on the aperture boundary, which both
-    apertures must exclude.
-    """
-    shape = (12, 12)
-
-    # Axis-aligned rectangle whose edges fall exactly on pixel centers
-    # (x in [1, 5], y in [2, 4]), so many pixel centers lie on the
-    # boundary and must be excluded by both apertures.
-    rect = RectangularAperture((3.0, 3.0), w=4.0, h=2.0)
-    corners = [(1.0, 2.0), (5.0, 2.0), (5.0, 4.0), (1.0, 4.0)]
-    poly = PolygonAperture.from_vertices(corners)
-    rect_mask = rect.to_mask(method='center').to_image(shape)
-    poly_mask = poly.to_mask(method='center').to_image(shape)
-    assert_allclose(poly_mask, rect_mask)
-
-    # Boundary centers are excluded: only the strictly interior centers
-    # (x in {2, 3, 4}, y = 3) are counted.
-    assert rect_mask.sum() == 3
-
-    # Rotated rectangle, compared against the equivalent polygon.
-    theta = 0.6
-    cos_t, sin_t = np.cos(theta), np.sin(theta)
-    half_w, half_h = 2.5, 1.5
-    local = [(-half_w, -half_h), (half_w, -half_h),
-             (half_w, half_h), (-half_w, half_h)]
-    abs_corners = [(6.0 + x * cos_t - y * sin_t,
-                    6.0 + x * sin_t + y * cos_t) for x, y in local]
-    rect2 = RectangularAperture((6.0, 6.0), w=5.0, h=3.0, theta=theta)
-    poly2 = PolygonAperture.from_vertices(abs_corners)
-    rect2_mask = rect2.to_mask(method='center').to_image(shape)
-    poly2_mask = poly2.to_mask(method='center').to_image(shape)
-    assert_allclose(poly2_mask, rect2_mask)
-
-
-def test_to_mask_array_returns_list():
-    aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
-    masks = aper.to_mask(method='exact')
-    assert isinstance(masks, list)
-    assert len(masks) == len(POSITIONS)
-
-
-def test_indexing_and_iteration():
-    aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
-    one = aper[1]
-    assert one.isscalar
-    assert_allclose(one.positions, POSITIONS[1])
-    assert_allclose(one.vertex_offsets, aper.vertex_offsets)
-    assert list(aper)[0].isscalar
-    sliced = aper[0:2]
-    assert len(sliced) == 2
-
-
-def test_indexing_scalar_raises():
-    aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
-    match = 'cannot be indexed'
-    with pytest.raises(TypeError, match=match):
-        aper[0]
-    match = 'no len'
-    with pytest.raises(TypeError, match=match):
-        len(aper)
-
-
-def test_photometry():
-    data = np.ones((30, 30))
-    aper = PolygonAperture((10.0, 10.0), SQUARE_OFFSETS)
-    phot = AperturePhotometry(data, aper, method='exact')
-    assert_allclose(phot.flux, [4.0])
-
-
-def test_photometry_subpixel_on_horizontal_boundary():
-    """
-    Test that ``photometry`` excludes subpixel centers landing
-    exactly on a horizontal polygon edge.
-
-    This is the ``photometry`` counterpart of
-    ``test_polygon_overlap_subpixel_on_horizontal_boundary`` in
-    ``photutils/geometry/tests/test_polygon_overlap_grid.py``,
-    using the same wide rectangle (half-widths 2 in x, 1 in y) and
-    ``subpixels=3``.
-
-    At an integer position the subpixel centers fall on all multiples
-    of 1/3, so the horizontal edges at y = center +/- 1 coincide with
-    a row of subpixel centers and are excluded. The strictly interior
-    subpixel centers are the 11 x-positions and 5 y-positions inside the
-    open rectangle, giving 55 of every 9 subpixels, i.e., 55/9. Were the
-    on-boundary centers counted instead, the result would be 91/9.
-    """
-    data = np.ones((31, 31))
-    offsets = np.array([[-2.0, -1.0], [2.0, -1.0],
-                        [2.0, 1.0], [-2.0, 1.0]])
-    aper = PolygonAperture((15.0, 15.0), offsets)
-    phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
-    assert_allclose(phot.flux, [55.0 / 9.0])
-
-
-def test_photometry_subpixel_on_vertical_boundary():
-    """
-    Test that ``photometry`` excludes subpixel centers landing
-    exactly on a vertical polygon edge.
-
-    This is the ``photometry`` counterpart of
-    ``test_polygon_overlap_subpixel_on_vertical_boundary``, using
-    the same tall rectangle (half-widths 1 in x, 2 in y) and
-    ``subpixels=3``. The vertical edges at x = center +/- 1 coincide
-    with a column of subpixel centers and are excluded, giving 55/9 (the
-    boundary-included value would be 91/9).
-    """
-    data = np.ones((31, 31))
-    offsets = np.array([[-1.0, -2.0], [1.0, -2.0],
-                        [1.0, 2.0], [-1.0, 2.0]])
-    aper = PolygonAperture((15.0, 15.0), offsets)
-    phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
-    assert_allclose(phot.flux, [55.0 / 9.0])
-
-
-def test_photometry_subpixel_on_all_boundaries():
-    """
-    Test that ``photometry`` excludes subpixel centers on horizontal
-    edges, vertical edges, and at corners.
-
-    This is the ``photometry`` counterpart of
-    ``test_polygon_overlap_subpixel_on_all_boundaries``, using the same
-    unit square (half-widths 1 in both axes) and ``subpixels=3``. At
-    an integer position the four edges and four corners coincide with
-    subpixel centers and are all excluded, leaving the 5 x-positions
-    and 5 y-positions strictly inside the open square, i.e., 25/9 (the
-    boundary-included value would be 49/9).
-    """
-    data = np.ones((31, 31))
-    aper = PolygonAperture((15.0, 15.0), SQUARE_OFFSETS)
-    phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
-    assert_allclose(phot.flux, [25.0 / 9.0])
-
-
-@pytest.mark.parametrize(('method', 'kwargs'),
-                         [('exact', {}),
-                          ('subpixel', {'subpixels': 7}),
-                          ('center', {})])
-def test_array_photometry_matches_scalar(method, kwargs):
-    """
-    Test that multi-position polygon photometry (batch Cython driver)
-    matches the per-position mask-based (grid) result for the exact,
-    subpixel, and center methods, including for a non-convex polygon.
-
-    This exercises the batch driver's per-position buffer reuse and
-    confirms it is numerically identical to the ``polygon_overlap_grid``
-    code path used by ``to_mask``.
-    """
-    rng = np.random.default_rng(0)
-    data = rng.random((60, 60))
-    positions = [(15.0, 18.0), (30.0, 32.0), (45.0, 22.0)]
-    offsets = _concave_star()
-
-    aper = PolygonAperture(positions, offsets)
-    phot = AperturePhotometry(data, aper, method=method, **kwargs)
-
-    ref = [PolygonAperture(pos, offsets)
-           .to_mask(method=method, **kwargs).multiply(data).sum()
-           for pos in positions]
-    assert_allclose(phot.flux, ref, rtol=1e-12)
-
-
-def test_invalid_mask_method():
-    aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
-    match = 'Invalid mask method'
-    with pytest.raises(ValueError, match=match):
-        aper.to_mask(method='nonsense')
-
-
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-def test_to_patch_scalar():
-    import matplotlib.patches as mpatches
-    aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
-    patch = aper._to_patch()
-    assert isinstance(patch, mpatches.Polygon)
-
-
 class TestSkyPolygonAperture(BaseTestAperture):
     aperture = SkyPolygonAperture(SKYCOORD, SQUARE_OFFSETS * UNIT)
 
@@ -647,344 +173,6 @@ class TestSkyPolygonAperture(BaseTestAperture):
         assert_quantity_allclose(aper.perimeter, expected, rtol=1e-12)
 
 
-def test_sky_construct():
-    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-    offsets = TRIANGLE_OFFSETS * u.arcsec
-    aper = SkyPolygonAperture(pos, offsets)
-    assert aper.isscalar
-    assert aper.vertex_offsets.unit.is_equivalent(u.arcsec)
-
-
-def test_sky_invalid_offsets_not_quantity():
-    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-    match = 'angular Quantity'
-    with pytest.raises(TypeError, match=match):
-        SkyPolygonAperture(pos, TRIANGLE_OFFSETS)
-
-
-def test_sky_invalid_offsets_wrong_unit():
-    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-    match = 'angular units'
-    with pytest.raises(u.UnitsError, match=match):
-        SkyPolygonAperture(pos, TRIANGLE_OFFSETS * u.m)
-
-
-def test_sky_invalid_offsets_wrong_shape():
-    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-    match = 'shape'
-    with pytest.raises(ValueError, match=match):
-        SkyPolygonAperture(pos, TRIANGLE_OFFSETS.flatten() * u.arcsec)
-
-
-def test_sky_invalid_positions():
-    with pytest.raises(TypeError, match='SkyCoord'):
-        SkyPolygonAperture((1.0, 2.0), TRIANGLE_OFFSETS * u.arcsec)
-
-
-def test_sky_vertices_scalar():
-    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-    offsets = SQUARE_OFFSETS * u.arcsec
-    aper = SkyPolygonAperture(pos, offsets)
-    assert aper.vertices.shape == (4,)
-
-
-def test_sky_vertices_array():
-    pos = SkyCoord(ra=[180.0, 181.0], dec=[0.0, 1.0], unit='deg')
-    offsets = SQUARE_OFFSETS * u.arcsec
-    aper = SkyPolygonAperture(pos, offsets)
-    assert aper.vertices.shape == (2, 4)
-
-
-def test_sky_from_vertices_round_trip():
-    verts = SkyCoord(ra=[180.0, 180.001, 180.0],
-                     dec=[0.0, 0.0, 0.001], unit='deg')
-    aper = SkyPolygonAperture.from_vertices(verts)
-    assert_quantity_allclose(aper.vertices.ra, verts.ra, atol=1e-9 * u.deg)
-    assert_quantity_allclose(aper.vertices.dec, verts.dec, atol=1e-9 * u.deg)
-
-
-def test_sky_from_vertices_requires_skycoord():
-    with pytest.raises(TypeError, match='SkyCoord'):
-        SkyPolygonAperture.from_vertices(np.array([[0.0, 0.0], [1.0, 0.0],
-                                                   [1.0, 1.0]]))
-
-
-def test_pixel_to_sky_to_pixel_round_trip():
-    """
-    Test that round-trip through to_sky / to_pixel reproduces original.
-    """
-    wcs = _make_wcs()
-    aper = PolygonAperture([(50.0, 50.0), (60.0, 60.0)], SQUARE_OFFSETS)
-    sky = aper.to_sky(wcs)
-    back = sky.to_pixel(wcs)
-    assert_allclose(back.positions, aper.positions, atol=1e-9)
-    assert_allclose(back.vertex_offsets, aper.vertex_offsets, atol=1e-9)
-
-
-def test_pixel_to_sky_scalar():
-    wcs = _make_wcs()
-    aper = PolygonAperture((50.0, 50.0), SQUARE_OFFSETS)
-    sky = aper.to_sky(wcs)
-    assert sky.isscalar
-    back = sky.to_pixel(wcs)
-    assert_allclose(back.positions, aper.positions, atol=1e-9)
-
-
-def test_to_sky_vertices_match_pixel_to_world():
-    """
-    For a scalar polygon, the absolute sky vertices from ``to_sky``
-    match feeding the absolute pixel vertices directly to
-    ``wcs.pixel_to_world``.
-
-    The comparison is order-independent. The ``_make_wcs`` WCS flips
-    parity, so the counter-clockwise normalization applied when setting
-    ``vertex_offsets`` may reverse the vertex order relative to the
-    input. The two sets of vertices must still describe the same
-    polygon.
-    """
-    wcs = _make_wcs()
-    aper = PolygonAperture((50.0, 50.0), SQUARE_OFFSETS)
-
-    abs_pix = aper.vertices
-    direct = wcs.pixel_to_world(abs_pix[:, 0], abs_pix[:, 1])
-    got = aper.to_sky(wcs).vertices
-
-    # Each direct vertex must coincide with one of the to_sky vertices
-    nearest = [np.min(coord.separation(got).to_value(u.arcsec))
-               for coord in direct]
-    assert_allclose(nearest, 0.0, atol=1e-9)
-
-
-def test_sky_to_pixel_to_sky_round_trip():
-    """
-    Test that round-trip through to_pixel / to_sky reproduces the
-    original sky aperture.
-    """
-    wcs = _make_wcs()
-    positions = SkyCoord(ra=[180.0, 180.01], dec=[0.0, 0.01], unit='deg')
-    aper = SkyPolygonAperture(positions, SQUARE_OFFSETS * u.arcsec)
-    pixel = aper.to_pixel(wcs)
-    back = pixel.to_sky(wcs)
-    assert_quantity_allclose(back.positions.ra, aper.positions.ra,
-                             atol=1e-9 * u.deg)
-    assert_quantity_allclose(back.positions.dec, aper.positions.dec,
-                             atol=1e-9 * u.deg)
-    assert_quantity_allclose(back.vertex_offsets, aper.vertex_offsets,
-                             atol=1e-6 * u.arcsec)
-
-
-def test_polygon_matches_rotated_rectangle():
-    """
-    Test that the exact polygon mask for a rotated rectangle matches the
-    exact rectangular mask.
-
-    This is a non-trivial test of the polygon masking machinery, since
-    the rectangle vertices are not axis-aligned and thus require the
-    full generality of the polygon code.
-    """
-    rect = RectangularAperture((5.5, 5.5), w=4.0, h=2.0, theta=np.pi / 6)
-    # Build the equivalent polygon from the rotated rectangle vertices.
-    cos_t = np.cos(rect.theta.to_value(u.radian))
-    sin_t = np.sin(rect.theta.to_value(u.radian))
-    hw = rect.w / 2
-    hh = rect.h / 2
-    local = np.array([[-hw, -hh], [hw, -hh], [hw, hh], [-hw, hh]])
-    rot = np.column_stack([local[:, 0] * cos_t - local[:, 1] * sin_t,
-                           local[:, 0] * sin_t + local[:, 1] * cos_t])
-    poly = PolygonAperture((5.5, 5.5), rot)
-    assert_allclose(poly.to_mask(method='exact').data,
-                    rect.to_mask(method='exact').data)
-
-
-def test_sky_indexing():
-    pos = SkyCoord(ra=[180.0, 181.0], dec=[0.0, 1.0], unit='deg')
-    offsets = SQUARE_OFFSETS * u.arcsec
-    aper = SkyPolygonAperture(pos, offsets)
-    one = aper[0]
-    assert one.isscalar
-    assert_quantity_allclose(one.positions.ra, 180.0 * u.deg)
-
-
-def test_sky_vertex_offsets_reset_lazyproperties():
-    """
-    Test that changing vertex_offsets on a SkyPolygonAperture clears the
-    cached vertices, which are stored as a SkyCoord.
-    """
-    pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-    aper = SkyPolygonAperture(pos, SQUARE_OFFSETS * u.arcsec)
-    _ = aper.vertices  # cache it
-    aper.vertex_offsets = TRIANGLE_OFFSETS * u.arcsec
-    assert aper.vertices.shape == (3,)
-
-
-def test_pixel_vertex_offsets_reset_lazyproperties():
-    aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
-    _ = aper.vertices
-    aper.vertex_offsets = TRIANGLE_OFFSETS
-    assert aper.vertices.shape == (3, 2)
-
-
-@pytest.mark.parametrize('n_vertices', [3, 4, 5, 6, 8, 12])
-def test_pixel_from_regular_polygon_basic(n_vertices):
-    aper = PolygonAperture.from_regular_polygon((10.0, 20.0), n_vertices, 5.0)
-    assert aper.vertex_offsets.shape == (n_vertices, 2)
-    assert aper.n_vertices == n_vertices
-    assert aper.is_regular
-    assert_allclose(aper.outer_radius, 5.0)
-    expected_inner_radius = 5.0 * np.cos(np.pi / n_vertices)
-    assert_allclose(aper.inner_radius, expected_inner_radius)
-    expected_side = 2.0 * 5.0 * np.sin(np.pi / n_vertices)
-    assert_allclose(aper.side_length, expected_side)
-    assert_quantity_allclose(aper.interior_angle,
-                             ((n_vertices - 2) / n_vertices) * 180.0 * u.deg)
-    assert_quantity_allclose(aper.exterior_angle,
-                             (360.0 / n_vertices) * u.deg)
-    assert_allclose(aper.vertices[0], (10.0, 25.0), atol=1e-12)
-
-
-def test_pixel_from_regular_polygon_with_angle_quantity():
-    aper = PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 1.0,
-                                                theta=45.0 * u.deg)
-    assert aper.is_regular
-    expected = np.array([[-np.sqrt(2) / 2, np.sqrt(2) / 2],
-                         [-np.sqrt(2) / 2, -np.sqrt(2) / 2],
-                         [np.sqrt(2) / 2, -np.sqrt(2) / 2],
-                         [np.sqrt(2) / 2, np.sqrt(2) / 2]])
-    assert_allclose(aper.vertex_offsets, expected, atol=1e-12)
-
-
-def test_pixel_from_regular_polygon_with_angle_float():
-    aper = PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 1.0,
-                                                theta=np.pi / 4)
-    assert_allclose(aper.vertex_offsets[0],
-                    (-np.sqrt(2) / 2, np.sqrt(2) / 2), atol=1e-12)
-
-
-def test_pixel_from_regular_polygon_invalid_n_vertices():
-    with pytest.raises(ValueError, match='at least 3'):
-        PolygonAperture.from_regular_polygon((0.0, 0.0), 2, 1.0)
-
-
-def test_pixel_from_regular_polygon_invalid_radius():
-    with pytest.raises(ValueError, match='positive'):
-        PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 0.0)
-    with pytest.raises(ValueError, match='positive'):
-        PolygonAperture.from_regular_polygon((0.0, 0.0), 4, -1.0)
-    with pytest.raises(ValueError, match='positive'):
-        PolygonAperture.from_regular_polygon((0.0, 0.0), 4, np.nan)
-
-
-def test_pixel_is_regular_false_cases():
-    aper = PolygonAperture.from_vertices(
-        np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
-    assert not aper.is_regular
-
-    aper2 = PolygonAperture((0.0, 0.0),
-                            np.array([[1.0, 2.0], [-1.0, 2.0],
-                                      [-1.0, -2.0], [1.0, -2.0]]))
-    assert not aper2.is_regular
-
-    aper3 = PolygonAperture((0.0, 0.0),
-                            np.array([[0.0, 0.0], [4.0, 0.0],
-                                      [4.0, 2.0], [2.0, 2.0],
-                                      [2.0, 4.0], [0.0, 4.0]]))
-    assert not aper3.is_regular
-
-
-def test_pixel_regular_attrs_raise_when_not_regular():
-    aper = PolygonAperture.from_vertices(
-        np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
-    for attr in ('outer_radius', 'inner_radius', 'side_length',
-                 'interior_angle', 'exterior_angle'):
-        with pytest.raises(ValueError, match='regular polygon'):
-            getattr(aper, attr)
-
-
-def test_pixel_n_vertices_works_for_any_polygon():
-    aper = PolygonAperture.from_vertices(
-        np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
-    assert aper.n_vertices == 3
-
-
-@pytest.mark.parametrize('n_vertices', [3, 4, 5, 6])
-def test_sky_from_regular_polygon_basic(n_vertices):
-    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-    aper = SkyPolygonAperture.from_regular_polygon(pos, n_vertices,
-                                                   2.0 * u.arcsec)
-    assert aper.vertex_offsets.shape == (n_vertices, 2)
-    assert aper.n_vertices == n_vertices
-    assert aper.is_regular
-    assert_quantity_allclose(aper.outer_radius, 2.0 * u.arcsec)
-    assert_quantity_allclose(aper.inner_radius,
-                             2.0 * np.cos(np.pi / n_vertices) * u.arcsec)
-    assert_quantity_allclose(aper.side_length,
-                             2.0 * 2.0 * np.sin(np.pi / n_vertices)
-                             * u.arcsec)
-    assert_quantity_allclose(aper.interior_angle,
-                             ((n_vertices - 2) / n_vertices) * 180.0 * u.deg)
-    assert_quantity_allclose(aper.exterior_angle,
-                             (360.0 / n_vertices) * u.deg)
-
-
-def test_sky_from_regular_polygon_with_angle():
-    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-    aper = SkyPolygonAperture.from_regular_polygon(pos, 4,
-                                                   1.0 * u.arcmin,
-                                                   theta=45.0 * u.deg)
-    assert aper.is_regular
-    assert aper.vertex_offsets.unit == u.arcmin
-
-
-def test_sky_from_regular_polygon_invalid_n_vertices():
-    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-    with pytest.raises(ValueError, match='at least 3'):
-        SkyPolygonAperture.from_regular_polygon(pos, 2, 1.0 * u.arcsec)
-
-
-def test_sky_from_regular_polygon_invalid_radius():
-    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-    with pytest.raises(TypeError, match='angular Quantity'):
-        SkyPolygonAperture.from_regular_polygon(pos, 4, 1.0)
-    with pytest.raises(TypeError, match='angular Quantity'):
-        SkyPolygonAperture.from_regular_polygon(pos, 4, 1.0 * u.kg)
-    with pytest.raises(ValueError, match='positive'):
-        SkyPolygonAperture.from_regular_polygon(pos, 4, 0.0 * u.arcsec)
-    with pytest.raises(ValueError, match='positive'):
-        SkyPolygonAperture.from_regular_polygon(pos, 4, -1.0 * u.arcsec)
-
-
-def test_sky_from_regular_polygon_invalid_angle():
-    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-    with pytest.raises(TypeError, match='angular Quantity'):
-        SkyPolygonAperture.from_regular_polygon(pos, 4,
-                                                1.0 * u.arcsec,
-                                                theta=0.5)
-    with pytest.raises(TypeError, match='angular Quantity'):
-        SkyPolygonAperture.from_regular_polygon(pos, 4,
-                                                1.0 * u.arcsec,
-                                                theta=1.0 * u.kg)
-
-
-def test_sky_is_regular_false_and_attrs_raise():
-    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-    aper = SkyPolygonAperture(pos,
-                              np.array([[0.0, 0.0], [4.0, 0.0],
-                                        [4.0, 3.0]]) * u.arcsec)
-    assert not aper.is_regular
-    for attr in ('outer_radius', 'inner_radius', 'side_length',
-                 'interior_angle', 'exterior_angle'):
-        with pytest.raises(ValueError, match='regular polygon'):
-            getattr(aper, attr)
-
-
-def test_sky_n_vertices_works_for_any_polygon():
-    pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-    aper = SkyPolygonAperture(pos,
-                              np.array([[0.0, 0.0], [4.0, 0.0],
-                                        [4.0, 3.0]]) * u.arcsec)
-    assert aper.n_vertices == 3
-
-
 def _matches_up_to_cyclic_reversal(a, b, *, atol=1e-10):
     n = len(a)
     if len(b) != n:
@@ -995,22 +183,6 @@ def _matches_up_to_cyclic_reversal(a, b, *, atol=1e-10):
             if np.allclose(a, shifted, atol=atol):
                 return True
     return False
-
-
-@pytest.mark.skipif(not pytest.importorskip('regions', minversion='0.11'),
-                    reason='requires regions')
-def test_pixel_from_regular_polygon_matches_regions():
-    from regions import PixCoord, RegularPolygonPixelRegion
-
-    for n in (3, 5, 6, 8):
-        for angle in (0.0, 30.0, 90.0):
-            aper = PolygonAperture.from_regular_polygon(
-                (10.0, 20.0), n, 5.0, theta=angle * u.deg)
-            reg = RegularPolygonPixelRegion(
-                PixCoord(10.0, 20.0), n, 5.0, angle=angle * u.deg)
-            reg_xy = np.column_stack([reg.vertices.x, reg.vertices.y])
-            ours = aper.vertices
-            assert _matches_up_to_cyclic_reversal(ours, reg_xy)
 
 
 class TestPolygonApertureTheta:
@@ -1119,3 +291,824 @@ class TestSkyPolygonApertureTheta:
             SKYCOORD[0], n_vertices, 1.0 * u.arcsec, theta=0.0 * u.deg)
         assert_quantity_allclose(aper.theta, 0.0 * u.deg,
                                  atol=1e-10 * u.deg)
+
+
+class TestPolygonGeometryHelpers:
+    """
+    Tests for the module-level polygon geometry helper functions.
+    """
+
+    def test_signed_area_ccw_positive(self):
+        verts = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+        assert_allclose(_signed_polygon_area(verts), 1.0)
+
+    def test_signed_area_cw_negative(self):
+        verts = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]])
+        assert_allclose(_signed_polygon_area(verts), -1.0)
+
+    def test_centroid_square(self):
+        verts = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]])
+        assert_allclose(_vertices_centroid(verts), [2.0, 2.0])
+
+    @pytest.mark.parametrize(
+        ('p1', 'p2', 'p3', 'p4', 'expected'),
+        [
+            # Proper crossing (segments straddle each other).
+            ((0.0, 0.0), (2.0, 2.0), (0.0, 2.0), (2.0, 0.0), True),
+            # Disjoint, non-collinear segments.
+            ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0), False),
+            # p1 lies on segment p3-p4 (d1 == 0).
+            ((1.0, 0.0), (1.0, 1.0), (0.0, 0.0), (2.0, 0.0), True),
+            # p2 lies on segment p3-p4 (d2 == 0).
+            ((1.0, 1.0), (1.0, 0.0), (0.0, 0.0), (2.0, 0.0), True),
+            # p3 lies on segment p1-p2 (d3 == 0).
+            ((0.0, 0.0), (2.0, 0.0), (1.0, 0.0), (1.0, 1.0), True),
+            # p4 lies on segment p1-p2 (d4 == 0).
+            ((0.0, 0.0), (2.0, 0.0), (1.0, 1.0), (1.0, 0.0), True),
+            # Collinear but non-overlapping segments.
+            ((0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0), False),
+        ])
+    def test_segments_intersect(self, p1, p2, p3, p4, expected):
+        assert _segments_intersect(p1, p2, p3, p4) is expected
+
+    def test_is_simple_square(self):
+        assert _polygon_is_simple(SQUARE_OFFSETS)
+
+    def test_is_simple_concave_star(self):
+        assert _polygon_is_simple(_concave_star())
+
+    def test_is_simple_pentagram(self):
+        star = _pentagram()
+        # Sanity check: the pentagram has non-zero area, so it is not caught
+        # by the degeneracy check and must be rejected by the simplicity
+        # check.
+        assert _signed_polygon_area(star) != 0.0
+        assert not _polygon_is_simple(star)
+
+
+class TestPolygonValidation:
+    """
+    Tests for the simple-polygon validation applied when the vertex
+    offsets are set.
+    """
+
+    def test_reorders_clockwise(self):
+        cw = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]])
+        out = _validate_simple_polygon(cw)
+        # Expect CCW order
+        assert _signed_polygon_area(out) > 0
+
+    def test_rejects_wrong_shape(self):
+        with pytest.raises(ValueError, match='must have shape'):
+            _validate_simple_polygon(np.array([1.0, 2.0, 3.0]))
+
+    def test_rejects_too_few(self):
+        with pytest.raises(ValueError, match='at least 3 vertices'):
+            _validate_simple_polygon(np.array([[0.0, 0.0], [1.0, 0.0]]))
+
+    def test_rejects_nonfinite(self):
+        bad = np.array([[0.0, 0.0], [np.nan, 0.0], [1.0, 1.0]])
+        with pytest.raises(ValueError, match='non-finite'):
+            _validate_simple_polygon(bad)
+
+    def test_rejects_collinear(self):
+        bad = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
+        with pytest.raises(ValueError, match='degenerate'):
+            _validate_simple_polygon(bad)
+
+    def test_accepts_nonconvex(self):
+        """
+        Test that a non-convex (L-shaped) polygon is accepted.
+        """
+        arrow = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 2.0],
+                          [2.0, 2.0], [2.0, 4.0], [0.0, 4.0]])
+        out = _validate_simple_polygon(arrow)
+        assert out.shape == arrow.shape
+
+    def test_rejects_self_intersecting(self):
+        with pytest.raises(ValueError, match='self-intersect'):
+            _validate_simple_polygon(_pentagram())
+
+    def test_pixel_aperture_rejects_self_intersecting(self):
+        with pytest.raises(ValueError, match='self-intersect'):
+            PolygonAperture((0.0, 0.0), _pentagram())
+
+    def test_sky_aperture_rejects_self_intersecting(self):
+        pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+        with pytest.raises(ValueError, match='self-intersect'):
+            SkyPolygonAperture(pos, _pentagram() * u.arcsec)
+
+    def test_pixel_aperture_accepts_concave_star(self):
+        aper = PolygonAperture((0.0, 0.0), _concave_star())
+        assert aper.vertex_offsets.shape == (10, 2)
+
+
+class TestPolygonConstruction:
+    """
+    Tests for constructing a PolygonAperture and validating its
+    vertex offsets.
+    """
+
+    def test_construct_scalar(self):
+        aper = PolygonAperture((10.0, 20.0), SQUARE_OFFSETS)
+        assert aper.isscalar
+        assert aper.shape == ()
+        assert aper.vertex_offsets.shape == (4, 2)
+        assert_allclose(aper.area, 4.0)
+        assert aper._xy_extents == (1.0, 1.0)
+
+    def test_construct_array_positions(self):
+        aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
+        assert not aper.isscalar
+        assert aper.shape == (4,)
+        assert len(aper) == 4
+        assert aper.vertices.shape == (4, 4, 2)
+        expected_first = np.asarray(POSITIONS[0]) + SQUARE_OFFSETS
+        assert_allclose(aper.vertices[0], expected_first)
+
+    def test_vertices_scalar(self):
+        aper = PolygonAperture((10.0, 20.0), SQUARE_OFFSETS)
+        assert aper.vertices.shape == (4, 2)
+        assert_allclose(aper.vertices, np.array([10.0, 20.0]) + SQUARE_OFFSETS)
+
+    def test_vertex_offsets_normalized_to_ccw(self):
+        cw = SQUARE_OFFSETS[::-1].copy()
+        aper = PolygonAperture((0, 0), cw)
+        assert _signed_polygon_area(aper.vertex_offsets) > 0
+
+    def test_invalid_vertex_offsets_quantity_raises(self):
+        match = 'must not be a Quantity'
+        with pytest.raises(TypeError, match=match):
+            PolygonAperture((0, 0), SQUARE_OFFSETS * u.pix)
+
+    def test_invalid_vertex_offsets_nonfinite_raises(self):
+        bad = np.array([[0.0, 0.0], [np.nan, 1.0], [1.0, 0.0]])
+        with pytest.raises(ValueError, match='non-finite'):
+            PolygonAperture((0, 0), bad)
+
+    def test_accepts_nonconvex(self):
+        """
+        The aperture supports non-convex (L-shaped) polygons.
+        """
+        l_shape = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 2.0],
+                            [2.0, 2.0], [2.0, 4.0], [0.0, 4.0]])
+        aper = PolygonAperture((0.0, 0.0), l_shape)
+        assert aper.vertex_offsets.shape == (6, 2)
+        assert_allclose(aper.area, 12.0)
+        mask = aper.to_mask(method='exact')
+        assert_allclose(mask.data.sum(), 12.0, atol=1e-12)
+
+    def test_invalid_vertex_offsets_too_few_raises(self):
+        match = 'at least 3 vertices'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture((0, 0), [[0.0, 0.0], [1.0, 1.0]])
+
+    def test_invalid_vertex_offsets_unparseable(self):
+        match = 'must be convertible to a numeric'
+        with pytest.raises(TypeError, match=match):
+            PolygonAperture((0, 0), [['a', 'b'], ['c', 'd'], ['e', 'f']])
+
+    def test_from_vertices_round_trip(self):
+        verts = np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]])
+        aper = PolygonAperture.from_vertices(verts)
+        assert_allclose(aper.vertices, verts)
+
+    def test_from_vertices_invalid_shape(self):
+        match = 'vertices must have shape'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture.from_vertices(np.array([1.0, 2.0]))
+
+    def test_from_vertices_rejects_degenerate(self):
+        """
+        Test that ``from_vertices`` rejects collinear vertices.
+
+        The ``from_vertices`` method must raise a clean ValueError
+        rather than a ZeroDivisionError from the area-weighted centroid
+        computation.
+        """
+        match = 'degenerate'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture.from_vertices([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
+
+    def test_offsets_reset_lazyproperties(self):
+        aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+        _ = aper.vertices
+        aper.vertex_offsets = TRIANGLE_OFFSETS
+        assert aper.vertices.shape == (3, 2)
+
+
+class TestPolygonMasks:
+    """
+    Tests for the PolygonAperture aperture masks.
+    """
+
+    def test_to_mask_exact_matches_rectangle(self):
+        """
+        Test that exact polygon mask for a square equals the rectangular
+        result.
+        """
+        poly = PolygonAperture((5.0, 5.0), SQUARE_OFFSETS)
+        rect = RectangularAperture((5.0, 5.0), w=2.0, h=2.0)
+        assert_allclose(poly.to_mask(method='exact').data,
+                        rect.to_mask(method='exact').data)
+
+    def test_to_mask_subpixel_approximates_exact(self):
+        poly = PolygonAperture((5.5, 5.5), TRIANGLE_OFFSETS)
+        exact = poly.to_mask(method='exact').data
+        sub = poly.to_mask(method='subpixel', subpixels=32).data
+        assert np.abs(exact - sub).max() < 0.05
+
+    def test_to_mask_center_method(self):
+        poly = PolygonAperture((5.0, 5.0), SQUARE_OFFSETS)
+        mask = poly.to_mask(method='center').data
+        assert set(np.unique(mask)).issubset({0.0, 1.0})
+
+    def test_to_mask_center_matches_rectangle(self):
+        """
+        Test that the ``center`` mask for a rectangle matches the equivalent
+        polygon.
+
+        A `RectangularAperture` and a `PolygonAperture` built from the same
+        four corners must produce identical ``center`` masks. This includes
+        pixel centers that lie exactly on the aperture boundary, which both
+        apertures must exclude.
+        """
+        shape = (12, 12)
+
+        # Axis-aligned rectangle whose edges fall exactly on pixel centers
+        # (x in [1, 5], y in [2, 4]), so many pixel centers lie on the
+        # boundary and must be excluded by both apertures.
+        rect = RectangularAperture((3.0, 3.0), w=4.0, h=2.0)
+        corners = [(1.0, 2.0), (5.0, 2.0), (5.0, 4.0), (1.0, 4.0)]
+        poly = PolygonAperture.from_vertices(corners)
+        rect_mask = rect.to_mask(method='center').to_image(shape)
+        poly_mask = poly.to_mask(method='center').to_image(shape)
+        assert_allclose(poly_mask, rect_mask)
+
+        # Boundary centers are excluded: only the strictly interior centers
+        # (x in {2, 3, 4}, y = 3) are counted.
+        assert rect_mask.sum() == 3
+
+        # Rotated rectangle, compared against the equivalent polygon.
+        theta = 0.6
+        cos_t, sin_t = np.cos(theta), np.sin(theta)
+        half_w, half_h = 2.5, 1.5
+        local = [(-half_w, -half_h), (half_w, -half_h),
+                 (half_w, half_h), (-half_w, half_h)]
+        abs_corners = [(6.0 + x * cos_t - y * sin_t,
+                        6.0 + x * sin_t + y * cos_t) for x, y in local]
+        rect2 = RectangularAperture((6.0, 6.0), w=5.0, h=3.0, theta=theta)
+        poly2 = PolygonAperture.from_vertices(abs_corners)
+        rect2_mask = rect2.to_mask(method='center').to_image(shape)
+        poly2_mask = poly2.to_mask(method='center').to_image(shape)
+        assert_allclose(poly2_mask, rect2_mask)
+
+    def test_to_mask_array_returns_list(self):
+        aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
+        masks = aper.to_mask(method='exact')
+        assert isinstance(masks, list)
+        assert len(masks) == len(POSITIONS)
+
+    def test_invalid_mask_method(self):
+        aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+        match = 'Invalid mask method'
+        with pytest.raises(ValueError, match=match):
+            aper.to_mask(method='nonsense')
+
+
+class TestPolygonPhotometry:
+    """
+    Tests for photometry with a PolygonAperture, including pixel
+    centers lying exactly on a polygon boundary.
+    """
+
+    def test_photometry(self):
+        data = np.ones((30, 30))
+        aper = PolygonAperture((10.0, 10.0), SQUARE_OFFSETS)
+        phot = AperturePhotometry(data, aper, method='exact')
+        assert_allclose(phot.flux, [4.0])
+
+    def test_photometry_subpixel_on_horizontal_boundary(self):
+        """
+        Test that ``photometry`` excludes subpixel centers landing
+        exactly on a horizontal polygon edge.
+
+        This is the ``photometry`` counterpart of
+        ``test_polygon_overlap_subpixel_on_horizontal_boundary`` in
+        ``photutils/geometry/tests/test_polygon_overlap_grid.py``,
+        using the same wide rectangle (half-widths 2 in x, 1 in y) and
+        ``subpixels=3``.
+
+        At an integer position the subpixel centers fall on all multiples
+        of 1/3, so the horizontal edges at y = center +/- 1 coincide with
+        a row of subpixel centers and are excluded. The strictly interior
+        subpixel centers are the 11 x-positions and 5 y-positions inside the
+        open rectangle, giving 55 of every 9 subpixels, i.e., 55/9. Were the
+        on-boundary centers counted instead, the result would be 91/9.
+        """
+        data = np.ones((31, 31))
+        offsets = np.array([[-2.0, -1.0], [2.0, -1.0],
+                            [2.0, 1.0], [-2.0, 1.0]])
+        aper = PolygonAperture((15.0, 15.0), offsets)
+        phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
+        assert_allclose(phot.flux, [55.0 / 9.0])
+
+    def test_photometry_subpixel_on_vertical_boundary(self):
+        """
+        Test that ``photometry`` excludes subpixel centers landing
+        exactly on a vertical polygon edge.
+
+        This is the ``photometry`` counterpart of
+        ``test_polygon_overlap_subpixel_on_vertical_boundary``, using
+        the same tall rectangle (half-widths 1 in x, 2 in y) and
+        ``subpixels=3``. The vertical edges at x = center +/- 1 coincide
+        with a column of subpixel centers and are excluded, giving 55/9 (the
+        boundary-included value would be 91/9).
+        """
+        data = np.ones((31, 31))
+        offsets = np.array([[-1.0, -2.0], [1.0, -2.0],
+                            [1.0, 2.0], [-1.0, 2.0]])
+        aper = PolygonAperture((15.0, 15.0), offsets)
+        phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
+        assert_allclose(phot.flux, [55.0 / 9.0])
+
+    def test_photometry_subpixel_on_all_boundaries(self):
+        """
+        Test that ``photometry`` excludes subpixel centers on horizontal
+        edges, vertical edges, and at corners.
+
+        This is the ``photometry`` counterpart of
+        ``test_polygon_overlap_subpixel_on_all_boundaries``, using the same
+        unit square (half-widths 1 in both axes) and ``subpixels=3``. At
+        an integer position the four edges and four corners coincide with
+        subpixel centers and are all excluded, leaving the 5 x-positions
+        and 5 y-positions strictly inside the open square, i.e., 25/9 (the
+        boundary-included value would be 49/9).
+        """
+        data = np.ones((31, 31))
+        aper = PolygonAperture((15.0, 15.0), SQUARE_OFFSETS)
+        phot = AperturePhotometry(data, aper, method='subpixel', subpixels=3)
+        assert_allclose(phot.flux, [25.0 / 9.0])
+
+    @pytest.mark.parametrize(('method', 'kwargs'),
+                             [('exact', {}),
+                              ('subpixel', {'subpixels': 7}),
+                              ('center', {})])
+    def test_array_photometry_matches_scalar(self, method, kwargs):
+        """
+        Test that multi-position polygon photometry (batch Cython driver)
+        matches the per-position mask-based (grid) result for the exact,
+        subpixel, and center methods, including for a non-convex polygon.
+
+        This exercises the batch driver's per-position buffer reuse and
+        confirms it is numerically identical to the ``polygon_overlap_grid``
+        code path used by ``to_mask``.
+        """
+        rng = np.random.default_rng(0)
+        data = rng.random((60, 60))
+        positions = [(15.0, 18.0), (30.0, 32.0), (45.0, 22.0)]
+        offsets = _concave_star()
+
+        aper = PolygonAperture(positions, offsets)
+        phot = AperturePhotometry(data, aper, method=method, **kwargs)
+
+        ref = [PolygonAperture(pos, offsets)
+               .to_mask(method=method, **kwargs).multiply(data).sum()
+               for pos in positions]
+        assert_allclose(phot.flux, ref, rtol=1e-12)
+
+    def test_matches_rotated_rectangle(self):
+        """
+        Test that the exact polygon mask for a rotated rectangle matches the
+        exact rectangular mask.
+
+        This is a non-trivial test of the polygon masking machinery, since
+        the rectangle vertices are not axis-aligned and thus require the
+        full generality of the polygon code.
+        """
+        rect = RectangularAperture((5.5, 5.5), w=4.0, h=2.0, theta=np.pi / 6)
+        # Build the equivalent polygon from the rotated rectangle vertices.
+        cos_t = np.cos(rect.theta.to_value(u.radian))
+        sin_t = np.sin(rect.theta.to_value(u.radian))
+        hw = rect.w / 2
+        hh = rect.h / 2
+        local = np.array([[-hw, -hh], [hw, -hh], [hw, hh], [-hw, hh]])
+        rot = np.column_stack([local[:, 0] * cos_t - local[:, 1] * sin_t,
+                               local[:, 0] * sin_t + local[:, 1] * cos_t])
+        poly = PolygonAperture((5.5, 5.5), rot)
+        assert_allclose(poly.to_mask(method='exact').data,
+                        rect.to_mask(method='exact').data)
+
+
+class TestPolygonIndexing:
+    """
+    Tests for indexing, iteration, and plotting of a PolygonAperture.
+    """
+
+    def test_indexing_and_iteration(self):
+        aper = PolygonAperture(POSITIONS, SQUARE_OFFSETS)
+        one = aper[1]
+        assert one.isscalar
+        assert_allclose(one.positions, POSITIONS[1])
+        assert_allclose(one.vertex_offsets, aper.vertex_offsets)
+        assert list(aper)[0].isscalar
+        sliced = aper[0:2]
+        assert len(sliced) == 2
+
+    def test_indexing_scalar_raises(self):
+        aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+        match = 'cannot be indexed'
+        with pytest.raises(TypeError, match=match):
+            aper[0]
+        match = 'no len'
+        with pytest.raises(TypeError, match=match):
+            len(aper)
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_to_patch_scalar(self):
+        import matplotlib.patches as mpatches
+        aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+        patch = aper._to_patch()
+        assert isinstance(patch, mpatches.Polygon)
+
+
+class TestRegularPolygon:
+    """
+    Tests for the regular-polygon constructors and properties.
+    """
+
+    @pytest.mark.parametrize('n_vertices', [3, 4, 5, 6, 8, 12])
+    def test_from_regular_polygon(self, n_vertices):
+        aper = PolygonAperture.from_regular_polygon((10.0, 20.0),
+                                                    n_vertices, 5.0)
+        assert aper.vertex_offsets.shape == (n_vertices, 2)
+        assert aper.n_vertices == n_vertices
+        assert aper.is_regular
+        assert_allclose(aper.outer_radius, 5.0)
+        expected_inner_radius = 5.0 * np.cos(np.pi / n_vertices)
+        assert_allclose(aper.inner_radius, expected_inner_radius)
+        expected_side = 2.0 * 5.0 * np.sin(np.pi / n_vertices)
+        assert_allclose(aper.side_length, expected_side)
+        assert_quantity_allclose(aper.interior_angle,
+                                 ((n_vertices - 2) / n_vertices) * 180.0
+                                 * u.deg)
+        assert_quantity_allclose(aper.exterior_angle,
+                                 (360.0 / n_vertices) * u.deg)
+        assert_allclose(aper.vertices[0], (10.0, 25.0), atol=1e-12)
+
+    def test_angle_quantity(self):
+        aper = PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 1.0,
+                                                    theta=45.0 * u.deg)
+        assert aper.is_regular
+        expected = np.array([[-np.sqrt(2) / 2, np.sqrt(2) / 2],
+                             [-np.sqrt(2) / 2, -np.sqrt(2) / 2],
+                             [np.sqrt(2) / 2, -np.sqrt(2) / 2],
+                             [np.sqrt(2) / 2, np.sqrt(2) / 2]])
+        assert_allclose(aper.vertex_offsets, expected, atol=1e-12)
+
+    def test_angle_float(self):
+        aper = PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 1.0,
+                                                    theta=np.pi / 4)
+        assert_allclose(aper.vertex_offsets[0],
+                        (-np.sqrt(2) / 2, np.sqrt(2) / 2), atol=1e-12)
+
+    def test_invalid_n_vertices(self):
+        with pytest.raises(ValueError, match='at least 3'):
+            PolygonAperture.from_regular_polygon((0.0, 0.0), 2, 1.0)
+
+    def test_invalid_radius(self):
+        with pytest.raises(ValueError, match='positive'):
+            PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 0.0)
+        with pytest.raises(ValueError, match='positive'):
+            PolygonAperture.from_regular_polygon((0.0, 0.0), 4, -1.0)
+        with pytest.raises(ValueError, match='positive'):
+            PolygonAperture.from_regular_polygon((0.0, 0.0), 4, np.nan)
+
+    def test_is_regular_false_cases(self):
+        aper = PolygonAperture.from_vertices(
+            np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
+        assert not aper.is_regular
+
+        aper2 = PolygonAperture((0.0, 0.0),
+                                np.array([[1.0, 2.0], [-1.0, 2.0],
+                                          [-1.0, -2.0], [1.0, -2.0]]))
+        assert not aper2.is_regular
+
+        aper3 = PolygonAperture((0.0, 0.0),
+                                np.array([[0.0, 0.0], [4.0, 0.0],
+                                          [4.0, 2.0], [2.0, 2.0],
+                                          [2.0, 4.0], [0.0, 4.0]]))
+        assert not aper3.is_regular
+
+    def test_attrs_raise_when_not_regular(self):
+        aper = PolygonAperture.from_vertices(
+            np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
+        for attr in ('outer_radius', 'inner_radius', 'side_length',
+                     'interior_angle', 'exterior_angle'):
+            with pytest.raises(ValueError, match='regular polygon'):
+                getattr(aper, attr)
+
+    def test_n_vertices(self):
+        aper = PolygonAperture.from_vertices(
+            np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
+        assert aper.n_vertices == 3
+
+    @pytest.mark.skipif(not pytest.importorskip('regions', minversion='0.11'),
+                        reason='requires regions')
+    def test_matches_regions(self):
+        from regions import PixCoord, RegularPolygonPixelRegion
+
+        for n in (3, 5, 6, 8):
+            for angle in (0.0, 30.0, 90.0):
+                aper = PolygonAperture.from_regular_polygon(
+                    (10.0, 20.0), n, 5.0, theta=angle * u.deg)
+                reg = RegularPolygonPixelRegion(
+                    PixCoord(10.0, 20.0), n, 5.0, angle=angle * u.deg)
+                reg_xy = np.column_stack([reg.vertices.x, reg.vertices.y])
+                ours = aper.vertices
+                assert _matches_up_to_cyclic_reversal(ours, reg_xy)
+
+    @pytest.mark.parametrize('n_spikes', [5, 6, 7, 8])
+    def test_from_star(self, n_spikes):
+        """
+        Test that ``_from_star`` constructs a star-shaped polygon with the
+        correct area and that it raises for invalid parameters.
+        """
+        xypos = (5, 5)
+
+        match = 'must be at least 2'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture._from_star(xypos, 1, 5.0, 2.0)
+
+        match = 'must be a finite positive number'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture._from_star(xypos, 5, -2.0, 2.0)
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture._from_star(xypos, 5, 5.0, -2.0)
+
+        match = 'inner_radius must be less than outer_radius'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture._from_star(xypos, 5, 5.0, 6.0)
+
+        match = 'optimal_shape and collinear_edges cannot both be True'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture._from_star(xypos, 5, 5.0, 2.0, optimal_shape=True,
+                                       collinear_edges=True)
+
+        match = 'collinear_edges requires n_spikes'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture._from_star(xypos, 4, 3.0, 2.0,
+                                       collinear_edges=True)
+
+        match = 'inner_radius must be provided'
+        with pytest.raises(ValueError, match=match):
+            PolygonAperture._from_star(xypos, 5, 3.0)
+
+        data = np.ones((11, 11))
+        outer_radius = 5.0
+        inner_radius = 2.0
+        aper = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
+                                          inner_radius)
+        phot = AperturePhotometry(data, aper, method='exact')
+        assert_allclose(phot.flux, aper.area)
+
+        aper1 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
+                                           inner_radius, theta=10 * u.deg)
+        phot = AperturePhotometry(data, aper1, method='exact')
+        assert_allclose(phot.flux, aper1.area)
+
+        aper2 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
+                                           optimal_shape=True)
+        phot = AperturePhotometry(data, aper2, method='exact')
+        assert_allclose(phot.flux, aper2.area)
+
+        aper3 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
+                                           collinear_edges=True)
+        phot = AperturePhotometry(data, aper3, method='exact')
+        assert_allclose(phot.flux, aper3.area)
+
+
+class TestSkyPolygonConstruction:
+    """
+    Tests for constructing a SkyPolygonAperture and validating its
+    angular vertex offsets.
+    """
+
+    def test_construct(self):
+        pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+        offsets = TRIANGLE_OFFSETS * u.arcsec
+        aper = SkyPolygonAperture(pos, offsets)
+        assert aper.isscalar
+        assert aper.vertex_offsets.unit.is_equivalent(u.arcsec)
+
+    def test_offsets_not_quantity(self):
+        pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+        match = 'angular Quantity'
+        with pytest.raises(TypeError, match=match):
+            SkyPolygonAperture(pos, TRIANGLE_OFFSETS)
+
+    def test_offsets_wrong_unit(self):
+        pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+        match = 'angular units'
+        with pytest.raises(u.UnitsError, match=match):
+            SkyPolygonAperture(pos, TRIANGLE_OFFSETS * u.m)
+
+    def test_offsets_wrong_shape(self):
+        pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+        match = 'shape'
+        with pytest.raises(ValueError, match=match):
+            SkyPolygonAperture(pos, TRIANGLE_OFFSETS.flatten() * u.arcsec)
+
+    def test_invalid_positions(self):
+        with pytest.raises(TypeError, match='SkyCoord'):
+            SkyPolygonAperture((1.0, 2.0), TRIANGLE_OFFSETS * u.arcsec)
+
+    def test_vertices_scalar(self):
+        pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+        offsets = SQUARE_OFFSETS * u.arcsec
+        aper = SkyPolygonAperture(pos, offsets)
+        assert aper.vertices.shape == (4,)
+
+    def test_vertices_array(self):
+        pos = SkyCoord(ra=[180.0, 181.0], dec=[0.0, 1.0], unit='deg')
+        offsets = SQUARE_OFFSETS * u.arcsec
+        aper = SkyPolygonAperture(pos, offsets)
+        assert aper.vertices.shape == (2, 4)
+
+    def test_from_vertices_round_trip(self):
+        verts = SkyCoord(ra=[180.0, 180.001, 180.0],
+                         dec=[0.0, 0.0, 0.001], unit='deg')
+        aper = SkyPolygonAperture.from_vertices(verts)
+        assert_quantity_allclose(aper.vertices.ra, verts.ra, atol=1e-9 * u.deg)
+        assert_quantity_allclose(aper.vertices.dec, verts.dec,
+                                 atol=1e-9 * u.deg)
+
+    def test_from_vertices_requires_skycoord(self):
+        with pytest.raises(TypeError, match='SkyCoord'):
+            SkyPolygonAperture.from_vertices(np.array([[0.0, 0.0], [1.0, 0.0],
+                                                       [1.0, 1.0]]))
+
+    def test_indexing(self):
+        pos = SkyCoord(ra=[180.0, 181.0], dec=[0.0, 1.0], unit='deg')
+        offsets = SQUARE_OFFSETS * u.arcsec
+        aper = SkyPolygonAperture(pos, offsets)
+        one = aper[0]
+        assert one.isscalar
+        assert_quantity_allclose(one.positions.ra, 180.0 * u.deg)
+
+    def test_offsets_reset_lazyproperties(self):
+        """
+        Test that changing vertex_offsets on a SkyPolygonAperture clears the
+        cached vertices, which are stored as a SkyCoord.
+        """
+        pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
+        aper = SkyPolygonAperture(pos, SQUARE_OFFSETS * u.arcsec)
+        _ = aper.vertices  # cache it
+        aper.vertex_offsets = TRIANGLE_OFFSETS * u.arcsec
+        assert aper.vertices.shape == (3,)
+
+
+class TestSkyRegularPolygon:
+    """
+    Tests for the sky regular-polygon constructors and properties.
+    """
+
+    @pytest.mark.parametrize('n_vertices', [3, 4, 5, 6])
+    def test_from_regular_polygon(self, n_vertices):
+        pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+        aper = SkyPolygonAperture.from_regular_polygon(pos, n_vertices,
+                                                       2.0 * u.arcsec)
+        assert aper.vertex_offsets.shape == (n_vertices, 2)
+        assert aper.n_vertices == n_vertices
+        assert aper.is_regular
+        assert_quantity_allclose(aper.outer_radius, 2.0 * u.arcsec)
+        assert_quantity_allclose(aper.inner_radius,
+                                 2.0 * np.cos(np.pi / n_vertices) * u.arcsec)
+        assert_quantity_allclose(aper.side_length,
+                                 2.0 * 2.0 * np.sin(np.pi / n_vertices)
+                                 * u.arcsec)
+        assert_quantity_allclose(aper.interior_angle,
+                                 ((n_vertices - 2) / n_vertices) * 180.0
+                                 * u.deg)
+        assert_quantity_allclose(aper.exterior_angle,
+                                 (360.0 / n_vertices) * u.deg)
+
+    def test_angle(self):
+        pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+        aper = SkyPolygonAperture.from_regular_polygon(pos, 4,
+                                                       1.0 * u.arcmin,
+                                                       theta=45.0 * u.deg)
+        assert aper.is_regular
+        assert aper.vertex_offsets.unit == u.arcmin
+
+    def test_invalid_n_vertices(self):
+        pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+        with pytest.raises(ValueError, match='at least 3'):
+            SkyPolygonAperture.from_regular_polygon(pos, 2, 1.0 * u.arcsec)
+
+    def test_invalid_radius(self):
+        pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+        with pytest.raises(TypeError, match='angular Quantity'):
+            SkyPolygonAperture.from_regular_polygon(pos, 4, 1.0)
+        with pytest.raises(TypeError, match='angular Quantity'):
+            SkyPolygonAperture.from_regular_polygon(pos, 4, 1.0 * u.kg)
+        with pytest.raises(ValueError, match='positive'):
+            SkyPolygonAperture.from_regular_polygon(pos, 4, 0.0 * u.arcsec)
+        with pytest.raises(ValueError, match='positive'):
+            SkyPolygonAperture.from_regular_polygon(pos, 4, -1.0 * u.arcsec)
+
+    def test_invalid_angle(self):
+        pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+        with pytest.raises(TypeError, match='angular Quantity'):
+            SkyPolygonAperture.from_regular_polygon(pos, 4,
+                                                    1.0 * u.arcsec,
+                                                    theta=0.5)
+        with pytest.raises(TypeError, match='angular Quantity'):
+            SkyPolygonAperture.from_regular_polygon(pos, 4,
+                                                    1.0 * u.arcsec,
+                                                    theta=1.0 * u.kg)
+
+    def test_is_regular_false_and_attrs_raise(self):
+        pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+        aper = SkyPolygonAperture(pos,
+                                  np.array([[0.0, 0.0], [4.0, 0.0],
+                                            [4.0, 3.0]]) * u.arcsec)
+        assert not aper.is_regular
+        for attr in ('outer_radius', 'inner_radius', 'side_length',
+                     'interior_angle', 'exterior_angle'):
+            with pytest.raises(ValueError, match='regular polygon'):
+                getattr(aper, attr)
+
+    def test_n_vertices(self):
+        pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
+        aper = SkyPolygonAperture(pos,
+                                  np.array([[0.0, 0.0], [4.0, 0.0],
+                                            [4.0, 3.0]]) * u.arcsec)
+        assert aper.n_vertices == 3
+
+
+class TestPolygonPixelSkyConversion:
+    """
+    Tests for converting polygon apertures between pixel and sky
+    coordinates.
+    """
+
+    def test_pixel_sky_pixel(self):
+        """
+        Test that round-trip through to_sky / to_pixel reproduces original.
+        """
+        wcs = _make_wcs()
+        aper = PolygonAperture([(50.0, 50.0), (60.0, 60.0)], SQUARE_OFFSETS)
+        sky = aper.to_sky(wcs)
+        back = sky.to_pixel(wcs)
+        assert_allclose(back.positions, aper.positions, atol=1e-9)
+        assert_allclose(back.vertex_offsets, aper.vertex_offsets, atol=1e-9)
+
+    def test_pixel_to_sky_scalar(self):
+        wcs = _make_wcs()
+        aper = PolygonAperture((50.0, 50.0), SQUARE_OFFSETS)
+        sky = aper.to_sky(wcs)
+        assert sky.isscalar
+        back = sky.to_pixel(wcs)
+        assert_allclose(back.positions, aper.positions, atol=1e-9)
+
+    def test_vertices_match_pixel_to_world(self):
+        """
+        For a scalar polygon, the absolute sky vertices from ``to_sky``
+        match feeding the absolute pixel vertices directly to
+        ``wcs.pixel_to_world``.
+
+        The comparison is order-independent. The ``_make_wcs`` WCS flips
+        parity, so the counter-clockwise normalization applied when setting
+        ``vertex_offsets`` may reverse the vertex order relative to the
+        input. The two sets of vertices must still describe the same
+        polygon.
+        """
+        wcs = _make_wcs()
+        aper = PolygonAperture((50.0, 50.0), SQUARE_OFFSETS)
+
+        abs_pix = aper.vertices
+        direct = wcs.pixel_to_world(abs_pix[:, 0], abs_pix[:, 1])
+        got = aper.to_sky(wcs).vertices
+
+        # Each direct vertex must coincide with one of the to_sky vertices
+        nearest = [np.min(coord.separation(got).to_value(u.arcsec))
+                   for coord in direct]
+        assert_allclose(nearest, 0.0, atol=1e-9)
+
+    def test_sky_pixel_sky(self):
+        """
+        Test that round-trip through to_pixel / to_sky reproduces the
+        original sky aperture.
+        """
+        wcs = _make_wcs()
+        positions = SkyCoord(ra=[180.0, 180.01], dec=[0.0, 0.01], unit='deg')
+        aper = SkyPolygonAperture(positions, SQUARE_OFFSETS * u.arcsec)
+        pixel = aper.to_pixel(wcs)
+        back = pixel.to_sky(wcs)
+        assert_quantity_allclose(back.positions.ra, aper.positions.ra,
+                                 atol=1e-9 * u.deg)
+        assert_quantity_allclose(back.positions.dec, aper.positions.dec,
+                                 atol=1e-9 * u.deg)
+        assert_quantity_allclose(back.vertex_offsets, aper.vertex_offsets,
+                                 atol=1e-6 * u.arcsec)

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -16,8 +16,8 @@ from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularMaskMixin,
                                           SkyRectangularAnnulus,
                                           SkyRectangularAperture)
-from photutils.aperture.tests.test_aperture_common import BaseTestAperture
-from photutils.utils._optional_deps import HAS_MATPLOTLIB
+from photutils.aperture.tests.test_aperture_common import (
+    BaseTestAperture, BaseTestRotatedPixelAperture)
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
@@ -26,8 +26,10 @@ UNIT = u.arcsec
 RADII = (0.0, -1.0, -np.inf)
 
 
-class TestRectangularAperture(BaseTestAperture):
+class TestRectangularAperture(BaseTestRotatedPixelAperture):
     aperture = RectangularAperture(POSITIONS, w=10.0, h=5.0, theta=np.pi / 2.0)
+    copy_param = 'w'
+    copy_value = 20.0
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -40,28 +42,12 @@ class TestRectangularAperture(BaseTestAperture):
         with pytest.raises(ValueError, match=match):
             RectangularAperture(POSITIONS, w=10.0, h=radius, theta=np.pi / 2.0)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.w = 20.0
-        assert aper != self.aperture
 
-    def test_theta(self):
-        assert isinstance(self.aperture.theta, u.Quantity)
-        assert self.aperture.theta.unit == u.rad
-
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_to_patch_nonscalar(self):
-        """
-        Test that _to_patch returns a list for non-scalar apertures.
-        """
-        patches = self.aperture._to_patch()
-        assert isinstance(patches, list)
-
-
-class TestRectangularAnnulus(BaseTestAperture):
+class TestRectangularAnnulus(BaseTestRotatedPixelAperture):
     aperture = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
                                   theta=np.pi / 3)
+    copy_param = 'w_in'
+    copy_value = 2.0
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -86,16 +72,6 @@ class TestRectangularAnnulus(BaseTestAperture):
             RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
                                h_in=radius, theta=np.pi / 3)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.w_in = 2.0
-        assert aper != self.aperture
-
-    def test_theta(self):
-        assert isinstance(self.aperture.theta, u.Quantity)
-        assert self.aperture.theta.unit == u.rad
-
     def test_h_in_greater_than_h_out(self):
         """
         Test that a ValueError is raised when h_in >= h_out.
@@ -105,18 +81,12 @@ class TestRectangularAnnulus(BaseTestAperture):
             RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=5.0,
                                h_in=8.0, theta=np.pi / 3)
 
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_to_patch_nonscalar(self):
-        """
-        Test that _to_patch returns a list for non-scalar apertures.
-        """
-        patches = self.aperture._to_patch()
-        assert isinstance(patches, list)
-
 
 class TestSkyRectangularAperture(BaseTestAperture):
     aperture = SkyRectangularAperture(SKYCOORD, w=10.0 * UNIT, h=5.0 * UNIT,
                                       theta=30 * u.deg)
+    copy_param = 'w'
+    copy_value = 20.0 * UNIT
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -131,17 +101,13 @@ class TestSkyRectangularAperture(BaseTestAperture):
             SkyRectangularAperture(SKYCOORD, w=10.0 * UNIT, h=radius * UNIT,
                                    theta=30 * u.deg)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.w = 20.0 * UNIT
-        assert aper != self.aperture
-
 
 class TestSkyRectangularAnnulus(BaseTestAperture):
     aperture = SkyRectangularAnnulus(SKYCOORD, w_in=10.0 * UNIT,
                                      w_out=20.0 * UNIT, h_out=17.0 * UNIT,
                                      theta=60 * u.deg)
+    copy_param = 'w_in'
+    copy_value = 2.0 * UNIT
 
     @staticmethod
     @pytest.mark.parametrize('radius', RADII)
@@ -170,12 +136,6 @@ class TestSkyRectangularAnnulus(BaseTestAperture):
                                   w_out=20.0 * UNIT, h_out=17.0 * UNIT,
                                   h_in=radius * UNIT, theta=60 * u.deg)
 
-    def test_copy_eq(self):
-        aper = self.aperture.copy()
-        assert aper == self.aperture
-        aper.w_in = 2.0 * UNIT
-        assert aper != self.aperture
-
     def test_h_in_greater_than_h_out(self):
         """
         Test that a ValueError is raised when h_in >= h_out.
@@ -187,154 +147,161 @@ class TestSkyRectangularAnnulus(BaseTestAperture):
                                   h_in=8.0 * UNIT, theta=60 * u.deg)
 
 
-def test_rectangle_theta_quantity():
-    aper1 = RectangularAperture(POSITIONS, w=10.0, h=5.0, theta=np.pi / 2.0)
-    theta = u.Quantity(90 * u.deg)
-    aper2 = RectangularAperture(POSITIONS, w=10.0, h=5.0, theta=theta)
-    theta = Angle(90 * u.deg)
-    aper3 = RectangularAperture(POSITIONS, w=10.0, h=5.0, theta=theta)
-
-    assert_quantity_allclose(aper1.theta, aper2.theta)
-    assert_quantity_allclose(aper1.theta, aper3.theta)
-
-
-def test_rectangle_annulus_theta_quantity():
-    aper1 = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
-                               theta=np.pi / 3)
-    theta = u.Quantity(60 * u.deg)
-    aper2 = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
-                               theta=theta)
-    theta = Angle(60 * u.deg)
-    aper3 = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
-                               theta=theta)
-
-    assert_quantity_allclose(aper1.theta, aper2.theta)
-    assert_quantity_allclose(aper1.theta, aper3.theta)
-
-
-@pytest.mark.parametrize(('method', 'subpixels'),
-                         [('exact', 5), ('center', 5), ('subpixel', 8)])
-def test_deprecated_rectangular_mask_mixin(method, subpixels):
+class TestThetaQuantity:
     """
-    Test that the deprecated RectangularMaskMixin.to_mask method works
-    with the current _translate_mask_method signature and matches the
-    non-deprecated to_mask result.
+    Tests for a theta input as an angular Quantity.
     """
-    aper = RectangularAperture((10.0, 10.0), w=4.0, h=2.0, theta=0.5)
-    mask = RectangularMaskMixin.to_mask(aper, method=method,
-                                        subpixels=subpixels)
-    expected = aper.to_mask(method=method, subpixels=subpixels)
-    assert_quantity_allclose(mask.data, expected.data)
+
+    def test_aperture(self):
+        aper1 = RectangularAperture(POSITIONS, w=10.0, h=5.0,
+                                    theta=np.pi / 2.0)
+        theta = u.Quantity(90 * u.deg)
+        aper2 = RectangularAperture(POSITIONS, w=10.0, h=5.0, theta=theta)
+        theta = Angle(90 * u.deg)
+        aper3 = RectangularAperture(POSITIONS, w=10.0, h=5.0, theta=theta)
+
+        assert_quantity_allclose(aper1.theta, aper2.theta)
+        assert_quantity_allclose(aper1.theta, aper3.theta)
+
+    def test_annulus(self):
+        aper1 = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
+                                   theta=np.pi / 3)
+        theta = u.Quantity(60 * u.deg)
+        aper2 = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
+                                   theta=theta)
+        theta = Angle(60 * u.deg)
+        aper3 = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
+                                   theta=theta)
+
+        assert_quantity_allclose(aper1.theta, aper2.theta)
+        assert_quantity_allclose(aper1.theta, aper3.theta)
 
 
-def test_rectangular_aperture_to_polygon():
-    aper = RectangularAperture((10.0, 20.0), w=4.0, h=2.0)
-    poly = aper.to_polygon()
-    assert isinstance(poly, PolygonAperture)
-    assert poly.n_vertices == 4
-    # Area is exact (rectangle is itself a polygon)
-    assert_allclose(poly.area, aper.area)
-
-
-@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_rectangular_aperture_to_polygon_rotation(theta_deg):
-    aper = RectangularAperture((10.0, 20.0), w=4.0, h=2.0,
-                               theta=np.deg2rad(theta_deg))
-    poly = aper.to_polygon()
-    assert poly.n_vertices == 4
-    assert_allclose(poly.area, aper.area, rtol=1e-12)
-    # Bounding-box extents should match the rotated rectangle's.
-    expected_x_extent = (0.5 * abs(aper.w * np.cos(aper.theta.value))
-                         + 0.5 * abs(aper.h * np.sin(aper.theta.value)))
-    expected_y_extent = (0.5 * abs(aper.w * np.sin(aper.theta.value))
-                         + 0.5 * abs(aper.h * np.cos(aper.theta.value)))
-    assert_allclose(poly._xy_extents[0], expected_x_extent, rtol=1e-12)
-    assert_allclose(poly._xy_extents[1], expected_y_extent, rtol=1e-12)
-
-
-def test_rectangular_aperture_to_polygon_multi_position():
-    aper = RectangularAperture([(10.0, 20.0), (30.0, 40.0)],
-                               w=4.0, h=3.0, theta=0.5)
-    poly = aper.to_polygon()
-    assert poly.vertices.shape == (2, 4, 2)
-
-
-def test_sky_rectangular_aperture_to_polygon():
-    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
-    aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec)
-    poly = aper.to_polygon()
-    assert isinstance(poly, SkyPolygonAperture)
-    assert poly.n_vertices == 4
-    assert poly.vertices.shape == (4,)
-    # At theta=0, the width (4) is along +lat (d_lat) and the height (2)
-    # is along +lon (d_lon).
-    offsets = poly.vertex_offsets.to_value(u.arcsec)
-    assert_allclose(np.sort(np.abs(offsets[:, 0])), [1.0, 1.0, 1.0, 1.0])
-    assert_allclose(np.sort(np.abs(offsets[:, 1])), [2.0, 2.0, 2.0, 2.0])
-
-
-@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_sky_rectangular_aperture_to_polygon_rotation(theta_deg):
-    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
-    aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec,
-                                  theta=theta_deg * u.deg)
-    poly = aper.to_polygon()
-    assert poly.n_vertices == 4
-    # The perimeter and vertex distances are rotation-invariant.
-    assert_allclose(poly.perimeter.to_value(u.arcsec), 2 * (4.0 + 2.0))
-    radii = np.hypot(*poly.vertex_offsets.to_value(u.arcsec).T)
-    assert_allclose(radii, np.hypot(1.0, 2.0))
-
-
-def test_sky_rectangular_aperture_to_polygon_multi_position():
-    pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
-    aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=3.0 * u.arcsec,
-                                  theta=0.5 * u.rad)
-    poly = aper.to_polygon()
-    assert poly.vertices.shape == (2, 4)
-
-
-@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_sky_rectangular_aperture_to_polygon_wcs_round_trip(
-        theta_deg, tan_wcs):
+class TestDeprecatedMaskMixin:
     """
-    Test that converting a SkyRectangularAperture to a polygon and then
-    to pixels matches converting to pixels and then to a polygon for all
-    rotation angles.
-
-    The two pixel polygons share the same area and bounding-box extents.
+    Tests for the deprecated RectangularMaskMixin.
     """
-    pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
-    aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec,
-                                  theta=theta_deg * u.deg)
-    poly_from_sky = aper.to_polygon().to_pixel(tan_wcs)
-    poly_from_pix = aper.to_pixel(tan_wcs).to_polygon()
-    assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
-    assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
-                    rtol=1e-6)
+
+    @pytest.mark.parametrize(('method', 'subpixels'),
+                             [('exact', 5), ('center', 5), ('subpixel', 8)])
+    def test_to_mask(self, method, subpixels):
+        """
+        Test that the deprecated RectangularMaskMixin.to_mask method works
+        with the current _translate_mask_method signature and matches the
+        non-deprecated to_mask result.
+        """
+        aper = RectangularAperture((10.0, 10.0), w=4.0, h=2.0, theta=0.5)
+        mask = RectangularMaskMixin.to_mask(aper, method=method,
+                                            subpixels=subpixels)
+        expected = aper.to_mask(method=method, subpixels=subpixels)
+        assert_quantity_allclose(mask.data, expected.data)
 
 
-@pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
-def test_rectangular_aperture_to_polygon_to_sky_round_trip(theta_deg, tan_wcs):
+class TestToPolygon:
     """
-    Test that converting a RectangularAperture to a polygon and then to
-    sky matches converting to sky and then to a polygon for all rotation
-    angles.
+    Tests for converting rectangular apertures to polygon apertures.
     """
-    # The bounding-box orientation can differ at the ~1e-5 level because
-    # the sky shape parameters from ``to_sky`` are derived from a local
-    # linear (SVD) approximation, while the polygon ``to_sky`` maps
-    # each vertex exactly, so only rotation-invariant quantities are
-    # compared.
-    aper = RectangularAperture((50.0, 50.0), w=4.0, h=2.0,
-                               theta=np.deg2rad(theta_deg))
-    sky_from_poly = aper.to_polygon().to_sky(tan_wcs)
-    sky_from_aper = aper.to_sky(tan_wcs).to_polygon()
-    assert_allclose(sky_from_poly.positions.ra.deg,
-                    sky_from_aper.positions.ra.deg)
-    assert_allclose(sky_from_poly.positions.dec.deg,
-                    sky_from_aper.positions.dec.deg)
-    assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
-                    sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
-    assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
-                    sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)
+
+    def test_pixel(self):
+        aper = RectangularAperture((10.0, 20.0), w=4.0, h=2.0)
+        poly = aper.to_polygon()
+        assert isinstance(poly, PolygonAperture)
+        assert poly.n_vertices == 4
+        # Area is exact (rectangle is itself a polygon)
+        assert_allclose(poly.area, aper.area)
+
+    @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+    def test_pixel_rotation(self, theta_deg):
+        aper = RectangularAperture((10.0, 20.0), w=4.0, h=2.0,
+                                   theta=np.deg2rad(theta_deg))
+        poly = aper.to_polygon()
+        assert poly.n_vertices == 4
+        assert_allclose(poly.area, aper.area, rtol=1e-12)
+        # Bounding-box extents should match the rotated rectangle's.
+        expected_x_extent = (0.5 * abs(aper.w * np.cos(aper.theta.value))
+                             + 0.5 * abs(aper.h * np.sin(aper.theta.value)))
+        expected_y_extent = (0.5 * abs(aper.w * np.sin(aper.theta.value))
+                             + 0.5 * abs(aper.h * np.cos(aper.theta.value)))
+        assert_allclose(poly._xy_extents[0], expected_x_extent, rtol=1e-12)
+        assert_allclose(poly._xy_extents[1], expected_y_extent, rtol=1e-12)
+
+    def test_pixel_multi_position(self):
+        aper = RectangularAperture([(10.0, 20.0), (30.0, 40.0)],
+                                   w=4.0, h=3.0, theta=0.5)
+        poly = aper.to_polygon()
+        assert poly.vertices.shape == (2, 4, 2)
+
+    def test_sky(self):
+        pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+        aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec)
+        poly = aper.to_polygon()
+        assert isinstance(poly, SkyPolygonAperture)
+        assert poly.n_vertices == 4
+        assert poly.vertices.shape == (4,)
+        # At theta=0, the width (4) is along +lat (d_lat) and the height (2)
+        # is along +lon (d_lon).
+        offsets = poly.vertex_offsets.to_value(u.arcsec)
+        assert_allclose(np.sort(np.abs(offsets[:, 0])), [1.0, 1.0, 1.0, 1.0])
+        assert_allclose(np.sort(np.abs(offsets[:, 1])), [2.0, 2.0, 2.0, 2.0])
+
+    @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+    def test_sky_rotation(self, theta_deg):
+        pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+        aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec,
+                                      theta=theta_deg * u.deg)
+        poly = aper.to_polygon()
+        assert poly.n_vertices == 4
+        # The perimeter and vertex distances are rotation-invariant.
+        assert_allclose(poly.perimeter.to_value(u.arcsec), 2 * (4.0 + 2.0))
+        radii = np.hypot(*poly.vertex_offsets.to_value(u.arcsec).T)
+        assert_allclose(radii, np.hypot(1.0, 2.0))
+
+    def test_sky_multi_position(self):
+        pos = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
+        aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=3.0 * u.arcsec,
+                                      theta=0.5 * u.rad)
+        poly = aper.to_polygon()
+        assert poly.vertices.shape == (2, 4)
+
+    @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+    def test_sky_wcs_round_trip(self, theta_deg, tan_wcs):
+        """
+        Test that converting a SkyRectangularAperture to a polygon and then
+        to pixels matches converting to pixels and then to a polygon for all
+        rotation angles.
+
+        The two pixel polygons share the same area and bounding-box extents.
+        """
+        pos = SkyCoord(ra=10.0, dec=30.0, unit='deg')
+        aper = SkyRectangularAperture(pos, w=4.0 * u.arcsec, h=2.0 * u.arcsec,
+                                      theta=theta_deg * u.deg)
+        poly_from_sky = aper.to_polygon().to_pixel(tan_wcs)
+        poly_from_pix = aper.to_pixel(tan_wcs).to_polygon()
+        assert_allclose(poly_from_sky.area, poly_from_pix.area, rtol=1e-6)
+        assert_allclose(poly_from_sky._xy_extents, poly_from_pix._xy_extents,
+                        rtol=1e-6)
+
+    @pytest.mark.parametrize('theta_deg', [0.0, 30.0, 45.0, 90.0, 137.0])
+    def test_pixel_to_sky_round_trip(self, theta_deg, tan_wcs):
+        """
+        Test that converting a RectangularAperture to a polygon and then to
+        sky matches converting to sky and then to a polygon for all rotation
+        angles.
+        """
+        # The bounding-box orientation can differ at the ~1e-5 level because
+        # the sky shape parameters from ``to_sky`` are derived from a local
+        # linear (SVD) approximation, while the polygon ``to_sky`` maps
+        # each vertex exactly, so only rotation-invariant quantities are
+        # compared.
+        aper = RectangularAperture((50.0, 50.0), w=4.0, h=2.0,
+                                   theta=np.deg2rad(theta_deg))
+        sky_from_poly = aper.to_polygon().to_sky(tan_wcs)
+        sky_from_aper = aper.to_sky(tan_wcs).to_polygon()
+        assert_allclose(sky_from_poly.positions.ra.deg,
+                        sky_from_aper.positions.ra.deg)
+        assert_allclose(sky_from_poly.positions.dec.deg,
+                        sky_from_aper.positions.dec.deg)
+        assert_allclose(sky_from_poly.perimeter.to_value(u.arcsec),
+                        sky_from_aper.perimeter.to_value(u.arcsec), rtol=1e-6)
+        assert_allclose(sky_from_poly.to_pixel(tan_wcs).area,
+                        sky_from_aper.to_pixel(tan_wcs).area, rtol=1e-6)

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -46,23 +46,12 @@ class _NoneSpecCircular(CircularAperture):
         return None
 
 
-def test_mad_std_scale():
+class BaseApertureStatsData:
     """
-    Test that the hard-coded MAD-to-sigma scale factor matches
-    `astropy.stats.mad_std`.
-
-    The factor is duplicated in ``photutils.aperture.stats`` and
-    ``photutils.aperture._batch_stats`` (a Cython constant cannot be
-    shared directly); the fast-vs-mask regression tests cover the
-    Cython copy.
+    Shared data, aperture, and ApertureStats objects used by the
+    ApertureStats test classes below.
     """
-    rng = np.random.default_rng(0)
-    values = rng.normal(size=101)
-    mad = np.median(np.abs(values - np.median(values)))
-    assert_allclose(_MAD_STD_SCALE * mad, mad_std(values), rtol=1e-14)
 
-
-class TestApertureStats:
     data = make_100gaussians_image()
     error = np.sqrt(np.abs(data))
     wcs = make_wcs(data.shape)
@@ -82,6 +71,12 @@ class TestApertureStats:
     apstats2_units = ApertureStats(data * u.Jy, aperture,
                                    error=error * u.Jy, wcs=wcs,
                                    sigma_clip=sigclip)
+
+
+class TestProperties(BaseApertureStatsData):
+    """
+    Tests for the computed source properties.
+    """
 
     @pytest.mark.parametrize('with_units', [True, False])
     @pytest.mark.parametrize('with_sigmaclip', [True, False])
@@ -130,16 +125,6 @@ class TestApertureStats:
         with pytest.raises(ValueError, match=match):
             _ = ApertureStats(self.data, skyaper)
 
-    def test_lazyproperties_class_cache(self):
-        """
-        Test that _lazyproperties is cached on the class and shared
-        across instances.
-        """
-        apstats2 = ApertureStats(self.data, self.aperture)
-        result1 = self.apstats1._lazyproperties
-        result2 = apstats2._lazyproperties
-        assert result1 is result2
-
     def test_minimal_inputs(self):
         apstats = ApertureStats(self.data, self.aperture)
         props = ('sky_centroid', 'sky_centroid_icrs', 'error_sum_cutout')
@@ -150,6 +135,53 @@ class TestApertureStats:
 
         apstats = ApertureStats(self.data, self.aperture, sum_method='center')
         assert set(apstats._variance_cutout_center) == {None}
+
+    def test_tiny_source(self):
+        data = np.zeros((21, 21))
+        data[5, 5] = 1.0
+        aperture = CircularAperture(((5, 5), (15, 15)), r=1)
+        apstats = ApertureStats(data, aperture)
+        assert_allclose(apstats.sum, (1.0, 0.0))
+        assert_allclose(apstats[0].covariance,
+                        [(1 / 12, 0), (0, 1 / 12)] * u.pix**2)
+        assert_allclose(apstats[1].covariance,
+                        [(np.nan, np.nan), (np.nan, np.nan)] * u.pix**2)
+        assert_allclose(apstats.fwhm, [0.67977799, np.nan] * u.pix)
+
+    def test_data_dtype(self):
+        """
+        Regression test that input ``data`` with int dtype does not
+        raise UFuncTypeError due to subtraction of float array from int
+        array.
+        """
+        data = np.ones((25, 25), dtype=np.uint16)
+        aper = CircularAperture((12, 12), 5)
+        apstats = ApertureStats(data, aper)
+        assert apstats.min == 1.0
+        assert apstats.max == 1.0
+        assert apstats.mean == 1.0
+        assert apstats.x_centroid == 12.0
+        assert apstats.y_centroid == 12.0
+
+    def test_lazyproperties_class_cache(self):
+        """
+        Test that _lazyproperties is cached on the class and shared
+        across instances.
+        """
+        apstats2 = ApertureStats(self.data, self.aperture)
+        result1 = self.apstats1._lazyproperties
+        result2 = apstats2._lazyproperties
+        assert result1 is result2
+
+    def test_repr_str(self):
+        assert repr(self.apstats1) == str(self.apstats1)
+        assert 'Length: 3' in repr(self.apstats1)
+
+
+class TestSumMethod(BaseApertureStatsData):
+    """
+    Tests for the sum_method aperture-mask footprint.
+    """
 
     @pytest.mark.parametrize('sum_method', ['exact', 'subpixel'])
     def test_sum_method(self, sum_method):
@@ -183,6 +215,48 @@ class TestApertureStats:
                                       subpixels=subpixels)
             assert_allclose(apstats.sum, phot.flux)
             assert_allclose(apstats.sum_err, phot.flux_err)
+
+    def test_sum_aper_area_center_masked(self):
+        """
+        Regression test that ``sum_aper_area`` is consistent with
+        ``sum`` (and identical between the fast and mask-based code
+        paths) when all center-method pixels are masked but the
+        ``sum_method`` aperture still contains unmasked fractional
+        boundary pixels.
+
+        Previously, the mask-based path returned NaN for the area (via
+        the center-method all-masked flag) while returning a finite
+        ``sum`` from the same surviving fractional pixels.
+        """
+        data = np.ones((11, 11))
+        aperture = CircularAperture((5.0, 5.0), r=1.4)
+        # Mask exactly the center-method pixels. The fractional
+        # (exact-method) boundary pixels remain unmasked.
+        mask = aperture.to_mask(method='center').to_image(data.shape) > 0
+
+        fast = ApertureStats(data, aperture, mask=mask)
+        with patch.object(ApertureStats, '_batch_inputs',
+                          property(lambda _: None)):
+            slow = ApertureStats(data, aperture, mask=mask)
+            slow_sum = slow.sum
+            slow_area = slow.sum_aper_area
+
+        assert fast._fast_sum is not None
+        assert fast.sum > 0
+        # data is all ones, so the sum equals the surviving area
+        assert_allclose(fast.sum_aper_area.value, fast.sum)
+        assert_allclose(slow_sum, fast.sum)
+        assert_allclose(slow_area, fast.sum_aper_area)
+        # The center-method statistics remain all-masked (NaN)
+        assert np.isnan(fast.center_aper_area.value)
+        assert np.isnan(fast.mean)
+
+
+class TestMasking(BaseApertureStatsData):
+    """
+    Tests for the mask keyword, local background, and apertures
+    that do not overlap the data.
+    """
 
     def test_mask(self):
         mask = np.zeros(self.data.shape, dtype=bool)
@@ -267,6 +341,12 @@ class TestApertureStats:
         assert apstats[2].flags == (APERTURE_FLAGS.NO_OVERLAP
                                     | APERTURE_FLAGS.NO_PIXELS)
 
+
+class TestTable(BaseApertureStatsData):
+    """
+    Tests for the to_table output and the properties list.
+    """
+
     def test_to_table(self):
         tbl = self.apstats1.to_table()
         assert tbl.colnames == self.apstats1.default_columns
@@ -311,6 +391,12 @@ class TestApertureStats:
         with pytest.warns(AstropyDeprecationWarning, match=match):
             tbl = self.apstats1.to_table(columns='xcentroid')
         assert tbl.colnames == ['x_centroid']
+
+
+class TestIndexing(BaseApertureStatsData):
+    """
+    Tests for indexing, slicing, and scalar ApertureStats objects.
+    """
 
     def test_slicing(self):
         apstats = self.apstats1
@@ -399,7 +485,7 @@ class TestApertureStats:
                                         'cutout_centroid', 'centroid',
                                         'covariance_eigvals', 'data_cutout',
                                         'bbox', 'x_centroid'])
-    def test_scalar_slice_after_cached_dependency(self, cached):
+    def test_scalar_slice_after_cache(self, cached):
         """
         Test that per-source properties are computed correctly for a
         scalar instance obtained by slicing a multi-source instance when
@@ -437,6 +523,12 @@ class TestApertureStats:
             if prop in scalar_props:
                 continue
             assert_equal(getattr(scalar, prop), getattr(ref, prop))
+
+
+class TestDeprecations(BaseApertureStatsData):
+    """
+    Tests for the deprecated attributes and columns.
+    """
 
     def test_deprecated_attributes(self):
         """
@@ -484,6 +576,12 @@ class TestApertureStats:
         with pytest.warns(AstropyDeprecationWarning, match=match):
             assert scalar.ids == scalar.id
 
+
+class TestInputValidation(BaseApertureStatsData):
+    """
+    Tests for the input validation and NDData input.
+    """
+
     def test_invalid_inputs(self):
         match = 'aperture must be an Aperture or Region object'
         with pytest.raises(TypeError, match=match):
@@ -508,25 +606,6 @@ class TestApertureStats:
         match = 'data and error must have the same shape'
         with pytest.raises(ValueError, match=match):
             ApertureStats(self.data, self.aperture, error=np.ones((3, 3)))
-
-    def test_repr_str(self):
-        assert repr(self.apstats1) == str(self.apstats1)
-        assert 'Length: 3' in repr(self.apstats1)
-
-    def test_data_dtype(self):
-        """
-        Regression test that input ``data`` with int dtype does not
-        raise UFuncTypeError due to subtraction of float array from int
-        array.
-        """
-        data = np.ones((25, 25), dtype=np.uint16)
-        aper = CircularAperture((12, 12), 5)
-        apstats = ApertureStats(data, aper)
-        assert apstats.min == 1.0
-        assert apstats.max == 1.0
-        assert apstats.mean == 1.0
-        assert apstats.x_centroid == 12.0
-        assert apstats.y_centroid == 12.0
 
     @pytest.mark.parametrize('with_units', [True, False])
     def test_nddata_input(self, with_units):
@@ -563,17 +642,12 @@ class TestApertureStats:
         with pytest.warns(AstropyUserWarning, match=match):
             ApertureStats(nddata, self.aperture, mask=mask)
 
-    def test_tiny_source(self):
-        data = np.zeros((21, 21))
-        data[5, 5] = 1.0
-        aperture = CircularAperture(((5, 5), (15, 15)), r=1)
-        apstats = ApertureStats(data, aperture)
-        assert_allclose(apstats.sum, (1.0, 0.0))
-        assert_allclose(apstats[0].covariance,
-                        [(1 / 12, 0), (0, 1 / 12)] * u.pix**2)
-        assert_allclose(apstats[1].covariance,
-                        [(np.nan, np.nan), (np.nan, np.nan)] * u.pix**2)
-        assert_allclose(apstats.fwhm, [0.67977799, np.nan] * u.pix)
+
+class TestMaskPathParity(BaseApertureStatsData):
+    """
+    The mask-based code path must give the same results as the
+    fast batch code path.
+    """
 
     @pytest.mark.parametrize('aperture', [
         CircularAperture(((145.1, 168.3), (84.7, 224.1), (48.3, 200.3)), r=6),
@@ -594,7 +668,7 @@ class TestApertureStats:
         SigmaClip(sigma=2.5, cenfunc='mean', stdfunc='mad_std',
                   maxiters=None),
     ])
-    def test_fast_path_matches_mask_path(self, aperture, sigma_clip):
+    def test_fast_matches_mask(self, aperture, sigma_clip):
         """
         Regression test that the fast Cython statistics path produces the
         same results as the mask-based path for every property, including
@@ -637,7 +711,7 @@ class TestApertureStats:
         SigmaClip(sigma=3.0, stdfunc=np.nanstd),
         SigmaClip(sigma=3.0, grow=1.5),
     ])
-    def test_unsupported_sigma_clip_fallback(self, sigma_clip):
+    def test_sigma_clip_fallback(self, sigma_clip):
         """
         Test that a SigmaClip not supported by the fast clipping kernel
         (callable cenfunc/stdfunc or spatial growing) falls back to the
@@ -649,7 +723,7 @@ class TestApertureStats:
         assert np.all(np.isfinite(apstats.mean))
         assert np.all(np.isfinite(apstats.mean_err))
 
-    def test_sigma_clip_callable_matches_string(self):
+    def test_sigma_clip_callable(self):
         """
         Test that a SigmaClip with callable cenfunc/stdfunc (mask-based
         path) gives the same results as the equivalent string
@@ -667,7 +741,7 @@ class TestApertureStats:
             assert_allclose(getattr(fast, prop), getattr(slow, prop),
                             rtol=1e-7, equal_nan=True, err_msg=prop)
 
-    def test_aperture_batch_hook_fallback(self):
+    def test_batch_hook_fallback(self):
         """
         Test that apertures that do not opt into the batch driver (no
         own-class hook, or a hook returning None) use the mask-based
@@ -683,42 +757,7 @@ class TestApertureStats:
         assert_allclose(nohook.mean, ref.mean, equal_nan=True)
         assert_allclose(nospec.mean, ref.mean, equal_nan=True)
 
-    def test_sum_aper_area_center_masked(self):
-        """
-        Regression test that ``sum_aper_area`` is consistent with
-        ``sum`` (and identical between the fast and mask-based code
-        paths) when all center-method pixels are masked but the
-        ``sum_method`` aperture still contains unmasked fractional
-        boundary pixels.
-
-        Previously, the mask-based path returned NaN for the area (via
-        the center-method all-masked flag) while returning a finite
-        ``sum`` from the same surviving fractional pixels.
-        """
-        data = np.ones((11, 11))
-        aperture = CircularAperture((5.0, 5.0), r=1.4)
-        # Mask exactly the center-method pixels. The fractional
-        # (exact-method) boundary pixels remain unmasked.
-        mask = aperture.to_mask(method='center').to_image(data.shape) > 0
-
-        fast = ApertureStats(data, aperture, mask=mask)
-        with patch.object(ApertureStats, '_batch_inputs',
-                          property(lambda _: None)):
-            slow = ApertureStats(data, aperture, mask=mask)
-            slow_sum = slow.sum
-            slow_area = slow.sum_aper_area
-
-        assert fast._fast_sum is not None
-        assert fast.sum > 0
-        # data is all ones, so the sum equals the surviving area
-        assert_allclose(fast.sum_aper_area.value, fast.sum)
-        assert_allclose(slow_sum, fast.sum)
-        assert_allclose(slow_area, fast.sum_aper_area)
-        # The center-method statistics remain all-masked (NaN)
-        assert np.isnan(fast.center_aper_area.value)
-        assert np.isnan(fast.mean)
-
-    def test_unsupported_data_mask_fallback(self):
+    def test_data_mask_fallback(self):
         """
         Test that data/mask inputs not supported by the fast batch
         driver fall back to the mask-based code path.
@@ -821,7 +860,7 @@ class TestApertureStats:
             assert_allclose(getattr(fast, prop), getattr(slow, prop),
                             rtol=1e-7, equal_nan=True, err_msg=prop)
 
-    def test_fast_path_mask_with_nonfinite_data(self):
+    def test_mask_nonfinite_data(self):
         """
         Test that the fast batch driver correctly combines a
         user-supplied ``mask`` with the mask derived from non-finite
@@ -842,6 +881,12 @@ class TestApertureStats:
                      'median_err'):
             assert_allclose(getattr(fast, prop), getattr(slow, prop),
                             rtol=1e-7, equal_nan=True, err_msg=prop)
+
+
+class TestStandardErrors(BaseApertureStatsData):
+    """
+    Tests for the mean_err and median_err standard errors.
+    """
 
     def test_mean_err_median_err(self):
         """
@@ -875,6 +920,12 @@ class TestApertureStats:
                                 error=self.error * self.unit)
         assert apstats.mean_err.unit == self.unit
         assert apstats.median_err.unit == self.unit
+
+
+class TestDdof(BaseApertureStatsData):
+    """
+    Tests for the ddof keyword used by the var and std properties.
+    """
 
     @pytest.mark.parametrize('with_units', [False, True])
     def test_ddof(self, with_units):
@@ -943,56 +994,90 @@ class TestApertureStats:
                 ApertureStats(self.data, self.aperture, ddof=bad)
 
 
-@pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
-def test_aperture_stats_region():
-    from regions import CirclePixelRegion, PixCoord
-    region = CirclePixelRegion(center=PixCoord(5, 5), radius=3)
-    aperture = CircularAperture((5, 5), r=3)
-    data = np.ones((10, 10))
-    apstats1 = ApertureStats(data, region)
-    apstats2 = ApertureStats(data, aperture)
-    tbl = apstats1.to_table()
-    for colname in tbl.colnames:
-        val1 = getattr(apstats1, colname)
-        if val1 is not None:
-            assert_allclose(val1, getattr(apstats2, colname))
+class TestMadStdScale:
+    """
+    The mad_std scale factor must match astropy.stats.mad_std.
+    """
+
+    def test_scale(self):
+        """
+        Test that the hard-coded MAD-to-sigma scale factor matches
+        `astropy.stats.mad_std`.
+
+        The factor is duplicated in ``photutils.aperture.stats`` and
+        ``photutils.aperture._batch_stats`` (a Cython constant cannot be
+        shared directly); the fast-vs-mask regression tests cover the
+        Cython copy.
+        """
+        rng = np.random.default_rng(0)
+        values = rng.normal(size=101)
+        mad = np.median(np.abs(values - np.median(values)))
+        assert_allclose(_MAD_STD_SCALE * mad, mad_std(values), rtol=1e-14)
 
 
-def test_aperture_metadata():
-    x = [10, 20, 3]
-    y = [3, 5, 10]
-    xypos = list(zip(x, y, strict=False))
-    a1 = CircularAperture(xypos, r=3)
-    a2 = CircularAperture(xypos, r=4)
-    a3 = CircularAnnulus(xypos, 5, 10)
-    a4 = EllipticalAperture(xypos, 10, 5, theta=10 * u.deg)
-    a5 = EllipticalAnnulus(xypos, a_in=5, a_out=10, b_in=3, b_out=5,
-                           theta=20 * u.deg)
-    a6 = RectangularAperture(xypos, 10, 5, theta=30 * u.deg)
-    a7 = RectangularAnnulus(xypos, w_in=5, w_out=10, h_in=3, h_out=5,
-                            theta=40 * u.deg)
-    apers = (a1, a2, a3, a4, a5, a6, a7)
-    data = np.ones((50, 50))
+class TestRegionInput:
+    """
+    A regions.Region input must give the same results as the
+    equivalent aperture.
+    """
 
-    for aper in apers:
-        apstats = ApertureStats(data, aper)
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
+    def test_region_matches_aperture(self):
+        from regions import CirclePixelRegion, PixCoord
+        region = CirclePixelRegion(center=PixCoord(5, 5), radius=3)
+        aperture = CircularAperture((5, 5), r=3)
+        data = np.ones((10, 10))
+        apstats1 = ApertureStats(data, region)
+        apstats2 = ApertureStats(data, aperture)
+        tbl = apstats1.to_table()
+        for colname in tbl.colnames:
+            val1 = getattr(apstats1, colname)
+            if val1 is not None:
+                assert_allclose(val1, getattr(apstats2, colname))
+
+
+class TestApertureMetadata:
+    """
+    Tests for the aperture metadata stored in the output table.
+    """
+
+    def test_metadata(self):
+        x = [10, 20, 3]
+        y = [3, 5, 10]
+        xypos = list(zip(x, y, strict=False))
+        a1 = CircularAperture(xypos, r=3)
+        a2 = CircularAperture(xypos, r=4)
+        a3 = CircularAnnulus(xypos, 5, 10)
+        a4 = EllipticalAperture(xypos, 10, 5, theta=10 * u.deg)
+        a5 = EllipticalAnnulus(xypos, a_in=5, a_out=10, b_in=3, b_out=5,
+                               theta=20 * u.deg)
+        a6 = RectangularAperture(xypos, 10, 5, theta=30 * u.deg)
+        a7 = RectangularAnnulus(xypos, w_in=5, w_out=10, h_in=3, h_out=5,
+                                theta=40 * u.deg)
+        apers = (a1, a2, a3, a4, a5, a6, a7)
+        data = np.ones((50, 50))
+
+        for aper in apers:
+            apstats = ApertureStats(data, aper)
+            tbl = apstats.to_table()
+            assert tbl.meta['aperture'] == aper.__class__.__name__
+            params = aper._params
+            for param in params:
+                if param != 'positions':
+                    assert (tbl.meta[f'aperture_{param}']
+                            == getattr(aper, param))
+
+        wcs = make_wcs(data.shape)
+        skycoord = wcs.pixel_to_world(10, 10)
+        unit = u.arcsec
+        saper = SkyEllipticalAnnulus(skycoord, a_in=0.1 * unit,
+                                     a_out=0.2 * unit,
+                                     b_in=0.05 * unit, b_out=0.1 * unit,
+                                     theta=10 * u.deg)
+        apstats = ApertureStats(data, saper, wcs=wcs)
         tbl = apstats.to_table()
-        assert tbl.meta['aperture'] == aper.__class__.__name__
-        params = aper._params
-        for param in params:
-            if param != 'positions':
-                assert tbl.meta[f'aperture_{param}'] == getattr(aper, param)
-
-    wcs = make_wcs(data.shape)
-    skycoord = wcs.pixel_to_world(10, 10)
-    unit = u.arcsec
-    saper = SkyEllipticalAnnulus(skycoord, a_in=0.1 * unit, a_out=0.2 * unit,
-                                 b_in=0.05 * unit, b_out=0.1 * unit,
-                                 theta=10 * u.deg)
-    apstats = ApertureStats(data, saper, wcs=wcs)
-    tbl = apstats.to_table()
-    assert tbl.meta['aperture'] == saper.__class__.__name__
-    assert tbl.meta['aperture_a_in'] == saper.a_in
-    assert tbl.meta['aperture_a_out'] == saper.a_out
-    assert tbl.meta['aperture_b_out'] == saper.b_out
-    assert tbl.meta['aperture_theta'] == saper.theta
+        assert tbl.meta['aperture'] == saper.__class__.__name__
+        assert tbl.meta['aperture_a_in'] == saper.a_in
+        assert tbl.meta['aperture_a_out'] == saper.a_out
+        assert tbl.meta['aperture_b_out'] == saper.b_out
+        assert tbl.meta['aperture_theta'] == saper.theta

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -39,340 +39,6 @@ def maybe_mask_path(request):
             yield
 
 
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_no_flags():
-    """
-    Test that a clean interior source has no flags set.
-    """
-    data = np.ones(SHAPE)
-    aper = CircularAperture((12, 12), r=3.0)
-    stats = ApertureStats(data, aper)
-    assert stats.flags == 0  # scalar aperture gives a scalar flag
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_overlap_flags():
-    """
-    Test the no_overlap, partial_overlap, and no_pixels flags.
-    """
-    data = np.ones(SHAPE)
-    aper = CircularAperture([(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0)],
-                            r=3.0)
-    stats = ApertureStats(data, aper)
-    assert stats.flags[0] == 0
-    assert stats.flags[1] == APERTURE_FLAGS.PARTIAL_OVERLAP
-    assert stats.flags[2] == (APERTURE_FLAGS.NO_OVERLAP
-                              | APERTURE_FLAGS.NO_PIXELS)
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_no_pixels_center_footprint():
-    """
-    Test that an empty "center" footprint sets no_pixels even when the
-    default exact-method sum footprint is populated (the per-footprint
-    flag bits are combined with OR).
-    """
-    data = np.ones(SHAPE)
-    # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
-    aper = CircularAperture((12.5, 12.5), r=0.4)
-    stats = ApertureStats(data, aper)
-    assert stats.flags == APERTURE_FLAGS.NO_PIXELS
-    assert stats.sum > 0.0  # the exact-method sum is finite
-    assert np.isnan(stats.mean)  # center statistics are undefined
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_masked_pixels():
-    """
-    Test the masked_pixels and all_masked flags.
-    """
-    data = np.ones(SHAPE)
-    aper = CircularAperture((12, 12), r=3.0)
-
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[12, 12] = True
-    assert _stats_flags(data, aper,
-                        mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
-
-    # Masked pixel inside the bounding box but outside the aperture
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[9, 9] = True
-    assert _stats_flags(data, aper, mask=mask) == 0
-
-    # Fully masked aperture
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[8:17, 8:17] = True
-    assert _stats_flags(data, aper, mask=mask) == (
-        APERTURE_FLAGS.MASKED_PIXELS | APERTURE_FLAGS.ALL_MASKED)
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_masked_pixels_sum_footprint_only():
-    """
-    Test that a masked boundary pixel touched only by the exact-method
-    sum footprint (its center lies exactly on the aperture boundary)
-    sets masked_pixels in sum_flags but not in the value-statistics
-    flags.
-    """
-    data = np.ones(SHAPE)
-    aper = CircularAperture((12, 12), r=3.0)
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[15, 12] = True  # center at distance exactly 3.0 (boundary)
-    stats = ApertureStats(data, aper, mask=mask)
-    assert stats.sum_flags == APERTURE_FLAGS.MASKED_PIXELS
-    # The pixel is excluded from the center (value-statistics) footprint
-    assert stats.flags == 0
-    stats = ApertureStats(data, aper, mask=mask, sum_method='center')
-    assert stats.flags == 0
-    assert stats.sum_flags == 0
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_non_finite_data():
-    """
-    Test the non_finite_data flag.
-
-    In ApertureStats, non-finite data values are automatically masked,
-    so they contribute to all_masked (but not to masked_pixels, which
-    reflects only the input mask).
-    """
-    data = np.ones(SHAPE)
-    data[12, 12] = np.nan
-    aper = CircularAperture((12, 12), r=3.0)
-    assert _stats_flags(data, aper) == APERTURE_FLAGS.NON_FINITE_DATA
-
-    # All-NaN aperture: auto-masked, so also all_masked
-    data = np.full(SHAPE, np.nan)
-    assert _stats_flags(data, aper) == (APERTURE_FLAGS.NON_FINITE_DATA
-                                        | APERTURE_FLAGS.ALL_MASKED)
-
-    # A pixel that is both input-masked and non-finite counts only as
-    # masked
-    data = np.ones(SHAPE)
-    data[12, 12] = np.nan
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[12, 12] = True
-    assert _stats_flags(data, aper,
-                        mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_non_finite_error():
-    """
-    Test the non_finite_error flag (evaluated on the sum footprint).
-    """
-    data = np.ones(SHAPE)
-    error = np.ones(SHAPE)
-    error[12, 12] = np.nan
-    aper = CircularAperture((12, 12), r=3.0)
-    stats = ApertureStats(data, aper, error=error)
-    # non_finite_error is a sum-footprint flag, not a value-statistics
-    # flag, so it appears in sum_flags but not flags
-    assert stats.sum_flags == APERTURE_FLAGS.NON_FINITE_ERROR
-    assert stats.flags == 0
-    assert ApertureStats(data, aper).sum_flags == 0
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_sigma_clipped():
-    """
-    Test the sigma_clipped flag.
-    """
-    rng = np.random.default_rng(0)
-    data = rng.normal(1.0, 0.1, size=SHAPE)
-    data[12, 12] = 1000.0  # outlier
-    aper = CircularAperture((12, 12), r=3.0)
-    sigclip = SigmaClip(sigma=3.0, maxiters=10)
-    flags = _stats_flags(data, aper, sigma_clip=sigclip)
-    assert flags == APERTURE_FLAGS.SIGMA_CLIPPED
-
-    # Sigma-clip flags apply only to the value statistics, not sum_flags
-    stats = ApertureStats(data, aper, sigma_clip=sigclip)
-    assert not stats.sum_flags & APERTURE_FLAGS.SIGMA_CLIPPED
-
-    # Without clipping, no flag is set
-    assert _stats_flags(data, aper) == 0
-
-
-def test_all_clipped():
-    """
-    Test the all_clipped flag using a SigmaClip subclass that rejects
-    every pixel (only reachable via the mask-based path).
-    """
-    class _ClipAll(SigmaClip):
-        def __call__(self, data, **kwargs):  # noqa: ARG002
-            return np.ma.masked_array(data,
-                                      mask=np.ones(data.shape, dtype=bool))
-
-    data = np.ones(SHAPE)
-    aper = CircularAperture((12, 12), r=3.0)
-    # A callable cenfunc is not supported by the fast clipping kernel,
-    # forcing the mask-based path
-    sigclip = _ClipAll(cenfunc=np.ma.median)
-    stats = ApertureStats(data, aper, sigma_clip=sigclip)
-    assert stats.flags == (APERTURE_FLAGS.SIGMA_CLIPPED
-                           | APERTURE_FLAGS.ALL_CLIPPED)
-    assert np.isnan(stats.mean)
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_too_few_pixels():
-    """
-    Test the too_few_pixels flag with ddof.
-    """
-    data = np.ones(SHAPE)
-    # The r=1.1 center footprint contains exactly 5 pixels
-    aper = CircularAperture((12, 12), r=1.1)
-
-    stats = ApertureStats(data, aper, ddof=5)
-    assert stats.flags == APERTURE_FLAGS.TOO_FEW_PIXELS
-    assert np.isnan(stats.var)
-    assert np.isnan(stats.std)
-
-    assert _stats_flags(data, aper, ddof=1) == 0
-    assert _stats_flags(data, aper, ddof=0) == 0
-
-
-@pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_neighbor_pixels(mask_method):
-    """
-    Test the neighbor_pixels flag for all segmentation mask methods.
-    """
-    data = np.ones(SHAPE)
-    segm = np.zeros(SHAPE, dtype=int)
-    segm[10:15, 10:15] = 1
-    segm[12, 14] = 2  # neighbor pixel inside the aperture
-    aper = CircularAperture((12, 12), r=3.0)
-    flags = _stats_flags(data, aper, segmentation_image=segm, labels=1,
-                         mask_method=mask_method)
-    assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_uncorrected_pixels():
-    """
-    Test the uncorrected_pixels flag with mask_method='correct'.
-    """
-    data = np.ones(SHAPE)
-    segm = np.zeros(SHAPE, dtype=int)
-    segm[10:15, 10:15] = 1
-    segm[12, 14] = 2
-    segm[12, 10] = 2  # the mirror is also a neighbor: uncorrectable
-    aper = CircularAperture((12, 12), r=3.0)
-    flags = _stats_flags(data, aper, segmentation_image=segm, labels=1,
-                         mask_method='correct')
-    assert flags == (APERTURE_FLAGS.NEIGHBOR_PIXELS
-                     | APERTURE_FLAGS.UNCORRECTED_PIXELS)
-
-
-def test_fast_mask_path_parity():
-    """
-    Test that the fast batch path and the mask-based path produce
-    identical flags for a mix of conditions.
-    """
-    rng = np.random.default_rng(1)
-    data = rng.normal(1.0, 0.1, size=SHAPE)
-    data[13, 12] = np.nan
-    data[5, 5] = 100.0  # sigma-clip outlier
-    error = np.ones(SHAPE)
-    error[10, 12] = np.inf
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[12, 12] = True
-
-    xy = [(12.0, 12.0), (5.0, 5.0), (0.0, 12.0), (-50.0, 12.0),
-          (24.5, 24.5), (0.2, 12.0), (12.5, 3.5)]
-    aper = CircularAperture(xy, r=3.0)
-
-    for kwargs in ({}, {'error': error, 'mask': mask},
-                   {'sigma_clip': SigmaClip(sigma=3.0)},
-                   {'sum_method': 'center'},
-                   {'ddof': 1}):
-        fast = ApertureStats(data, aper, **kwargs)
-        assert fast._batch_inputs is not None
-        with _force_mask_path():
-            slow = ApertureStats(data, aper, **kwargs)
-            assert slow._batch_inputs is None
-            assert_array_equal(fast.flags, slow.flags)
-            assert_array_equal(fast.sum_flags, slow.sum_flags)
-
-
-def test_flags_in_table_and_properties():
-    """
-    Test that flags appears in the properties list and the default
-    to_table() columns.
-    """
-    data = np.ones(SHAPE)
-    aper = CircularAperture([(12, 12), (-50, 12)], r=3.0)
-    stats = ApertureStats(data, aper)
-    assert 'flags' in stats.properties
-    assert 'sum_flags' in stats.properties
-    tbl = stats.to_table()
-    assert 'flags' in tbl.colnames
-    assert 'sum_flags' in tbl.colnames
-    expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS]
-    assert_array_equal(tbl['flags'], expected)
-    assert_array_equal(tbl['sum_flags'], expected)
-
-
-def test_flags_slicing():
-    """
-    Test that flags are sliced correctly by __getitem__.
-    """
-    data = np.ones(SHAPE)
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[12, 12] = True
-    aper = CircularAperture([(12, 12), (0.0, 12.0)], r=3.0)
-    stats = ApertureStats(data, aper, mask=mask)
-    flags = stats.flags  # evaluate before slicing
-    assert stats[0].flags == flags[0]
-    assert stats[1].flags == flags[1]
-
-    # Also test slicing before evaluation
-    stats2 = ApertureStats(data, aper, mask=mask)
-    assert stats2[1].flags == flags[1]
-
-
-def test_decode_flags():
-    """
-    Test the decode_flags convenience method.
-    """
-    data = np.ones(SHAPE)
-    mask = np.zeros(SHAPE, dtype=bool)
-    mask[12, 12] = True
-    aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
-    stats = ApertureStats(data, aper, mask=mask)
-    decoded = stats.decode_flags()
-    assert decoded == [['masked_pixels'], ['partial_overlap']]
-
-    decoded = stats.decode_flags(return_bit_values=True)
-    assert decoded == [[APERTURE_FLAGS.MASKED_PIXELS],
-                       [APERTURE_FLAGS.PARTIAL_OVERLAP]]
-
-    # Decode the sum flags via the column keyword
-    decoded = stats.decode_flags(column='sum_flags')
-    assert decoded == [['masked_pixels'], ['partial_overlap']]
-
-    match = "column must be 'flags' or 'sum_flags'"
-    with pytest.raises(ValueError, match=match):
-        stats.decode_flags(column='invalid')
-
-    # Scalar ApertureStats also returns a list of lists
-    stats = ApertureStats(data, CircularAperture((0.0, 12.0), r=3.0))
-    assert stats.decode_flags() == [['partial_overlap']]
-    assert stats.decode_flags(column='sum_flags') == [['partial_overlap']]
-
-
-def test_flags_docstring():
-    """
-    Test that the flags docstring placeholder was substituted.
-    """
-    for prop in (ApertureStats.flags, ApertureStats.sum_flags):
-        docstring = prop.__doc__
-        assert '<flag_descriptions>' not in docstring
-        assert "**1** (``'no_overlap'``)" in docstring
-
-
 def _single_pixel_data():
     """
     Return data with a single bright pixel, giving a source whose
@@ -381,145 +47,6 @@ def _single_pixel_data():
     data = np.zeros(SHAPE)
     data[12, 12] = 100.0
     return data
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_singular_covariance_requires_shape_access():
-    """
-    Test that the singular_covariance bit is not set until a
-    covariance-derived property is accessed.
-    """
-    data = _single_pixel_data()
-    aper = CircularAperture((12.0, 12.0), r=5.0)
-    stats = ApertureStats(data, aper)
-
-    # Not set before any covariance-derived property is accessed
-    assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
-    assert 'singular_covariance' not in stats.decode_flags()[0]
-
-    # Accessing a shape property makes a reread include the bit
-    _ = stats.semimajor_axis
-    assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
-    assert 'singular_covariance' in stats.decode_flags()[0]
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_singular_covariance_triggered_by_covariance():
-    """
-    Test that the singular_covariance bit is set when the covariance
-    matrix is computed, even if no shape properties are accessed.
-    """
-    data = _single_pixel_data()
-    aper = CircularAperture((12.0, 12.0), r=5.0)
-    stats = ApertureStats(data, aper)
-    _ = stats.covariance
-    assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_singular_covariance_array_and_guards():
-    """
-    Test that the singular_covariance bit is set for an array of sources
-    and that the covariance computation is guarded against sources with
-    no overlap (undefined moments).
-    """
-    data = _single_pixel_data()
-    data[6, 6] = 100.0
-    yy, xx = np.mgrid[0:25, 0:25]
-    data = data + 50.0 * np.exp(-((xx - 18)**2 + (yy - 18)**2) / (2 * 2.5**2))
-    aper = CircularAperture([(6.0, 6.0), (18.0, 18.0), (-50.0, 12.0)], r=4.0)
-    stats = ApertureStats(data, aper)
-    _ = stats.semimajor_axis  # force the covariance computation
-    flags = stats.flags
-    covar_flag = APERTURE_FLAGS.SINGULAR_COVARIANCE
-    assert (flags[0] & covar_flag) != 0  # singular point source
-    assert (flags[1] & covar_flag) == 0  # extended source
-    assert (flags[2] & covar_flag) == 0  # no-overlap: not flagged singular
-    assert (flags[2] & APERTURE_FLAGS.NO_OVERLAP) != 0
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_singular_covariance_extended_source_not_flagged():
-    """
-    Test that a well-resolved source with a non-singular covariance
-    matrix is not flagged as singular.
-    """
-    yy, xx = np.mgrid[0:25, 0:25]
-    data = 100.0 * np.exp(-((xx - 12)**2 + (yy - 12)**2) / (2 * 3.0**2))
-    aper = CircularAperture((12.0, 12.0), r=6.0)
-    stats = ApertureStats(data, aper)
-    _ = stats.semimajor_axis
-    assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_singular_covariance_in_default_table():
-    """
-    Test that the singular_covariance bit is reflected in the default
-    to_table() output.
-    """
-    data = _single_pixel_data()
-    aper = CircularAperture((12.0, 12.0), r=5.0)
-    stats = ApertureStats(data, aper)
-    tbl = stats.to_table()
-    assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_to_table_evaluates_flags_last():
-    """
-    Test that requesting a shape column before 'flags' still yields a
-    flags column that reflects the singular_covariance bit.
-    """
-    data = _single_pixel_data()
-    aper = CircularAperture((12.0, 12.0), r=5.0)
-    stats = ApertureStats(data, aper)
-    columns = ['flags', 'semimajor_axis']
-    tbl = stats.to_table(columns=columns)
-    assert tbl.colnames == columns  # check order
-    assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_to_table_flags_only_no_singular_bit():
-    """
-    Test that requesting only the 'flags' column does not trigger the
-    covariance computation and so does not set the singular_covariance
-    bit.
-    """
-    data = _single_pixel_data()
-    aper = CircularAperture((12.0, 12.0), r=5.0)
-    stats = ApertureStats(data, aper)
-    tbl = stats.to_table(columns=['flags'])
-    assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_singular_covariance_in_properties():
-    """
-    Test that the singular_covariance bit is reflected in the properties
-    list even if no shape properties are accessed.
-    """
-    data = _single_pixel_data()
-    aper = CircularAperture((12.0, 12.0), r=5.0)
-    stats = ApertureStats(data, aper)
-    assert 'flags' in stats.properties
-
-
-@pytest.mark.usefixtures('maybe_mask_path')
-def test_singular_covariance_slicing():
-    """
-    Test that the singular_covariance bit is preserved when slicing an
-    array of ApertureStats objects.
-    """
-    data = _single_pixel_data()
-    data[6, 6] = 100.0
-    aper = CircularAperture([(6.0, 6.0), (12.0, 12.0)], r=4.0)
-    stats = ApertureStats(data, aper)
-    _ = stats.semimajor_axis
-    covar_flag = APERTURE_FLAGS.SINGULAR_COVARIANCE
-    assert (stats[0].flags & covar_flag) != 0
-    assert (stats[1].flags & covar_flag) != 0
 
 
 def _stats_with_injected_covariance(cov_xx, cov_yy, cov_xy):
@@ -544,40 +71,531 @@ def _stats_with_injected_covariance(cov_xx, cov_yy, cov_xy):
     return stats
 
 
-def test_singular_covariance_rank1_degeneracy():
+class TestOverlapFlags:
     """
-    Test that a rank-1 degenerate source is flagged as singular.
-
-    A rank-1 degenerate source has one unresolved axis and one extended
-    axis, so its covariance matrix has one tiny eigenvalue. The
-    singularity criterion is that the minor-axis variance is below a
-    floor of ``1/12`` (the variance of a uniform distribution over a
-    unit pixel). This is a more robust criterion than the determinant
-    test, which can be fooled by a rank-1 source with a large major-axis
-    variance.
+    Tests for the no_overlap, partial_overlap, and no_pixels flags.
     """
-    # Minor-axis variance 0.05 < 1/12, major-axis variance 0.5
-    stats = _stats_with_injected_covariance(cov_xx=0.5, cov_yy=0.05,
-                                            cov_xy=0.0)
-    delta = 1.0 / 12
-    assert delta**2 < 0.5 * 0.05  # determinant test alone would miss it
-    assert delta > 0.05  # minor-axis variance below the floor
-    assert stats._singular_covariance_mask[0]
 
-    # The bit is reflected in flags once a shape property is computed
-    _ = stats.semimajor_axis
-    assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_no_flags(self):
+        """
+        Test that a clean interior source has no flags set.
+        """
+        data = np.ones(SHAPE)
+        aper = CircularAperture((12, 12), r=3.0)
+        stats = ApertureStats(data, aper)
+        assert stats.flags == 0  # scalar aperture gives a scalar flag
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_overlap_flags(self):
+        """
+        Test the no_overlap, partial_overlap, and no_pixels flags.
+        """
+        data = np.ones(SHAPE)
+        aper = CircularAperture([(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0)],
+                                r=3.0)
+        stats = ApertureStats(data, aper)
+        assert stats.flags[0] == 0
+        assert stats.flags[1] == APERTURE_FLAGS.PARTIAL_OVERLAP
+        assert stats.flags[2] == (APERTURE_FLAGS.NO_OVERLAP
+                                  | APERTURE_FLAGS.NO_PIXELS)
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_no_pixels(self):
+        """
+        Test that an empty "center" footprint sets no_pixels even when the
+        default exact-method sum footprint is populated (the per-footprint
+        flag bits are combined with OR).
+        """
+        data = np.ones(SHAPE)
+        # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
+        aper = CircularAperture((12.5, 12.5), r=0.4)
+        stats = ApertureStats(data, aper)
+        assert stats.flags == APERTURE_FLAGS.NO_PIXELS
+        assert stats.sum > 0.0  # the exact-method sum is finite
+        assert np.isnan(stats.mean)  # center statistics are undefined
 
 
-def test_singular_covariance_not_positive_semidefinite():
+class TestMaskedAndNonFiniteFlags:
     """
-    Test that a covariance matrix that is not positive semidefinite is
-    flagged as singular.
+    Tests for the masked_pixels, all_masked, and non-finite flags.
     """
-    stats = _stats_with_injected_covariance(cov_xx=1.0, cov_yy=1.0,
-                                            cov_xy=2.0)
-    assert (1.0 * 1.0 - 2.0**2) < 0  # negative determinant
-    assert stats._singular_covariance_mask[0]
 
-    _ = stats.semimajor_axis
-    assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_masked_pixels(self):
+        """
+        Test the masked_pixels and all_masked flags.
+        """
+        data = np.ones(SHAPE)
+        aper = CircularAperture((12, 12), r=3.0)
+
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[12, 12] = True
+        assert _stats_flags(data, aper,
+                            mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
+
+        # Masked pixel inside the bounding box but outside the aperture
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[9, 9] = True
+        assert _stats_flags(data, aper, mask=mask) == 0
+
+        # Fully masked aperture
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[8:17, 8:17] = True
+        assert _stats_flags(data, aper, mask=mask) == (
+            APERTURE_FLAGS.MASKED_PIXELS | APERTURE_FLAGS.ALL_MASKED)
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_sum_footprint_only(self):
+        """
+        Test that a masked boundary pixel touched only by the exact-method
+        sum footprint (its center lies exactly on the aperture boundary)
+        sets masked_pixels in sum_flags but not in the value-statistics
+        flags.
+        """
+        data = np.ones(SHAPE)
+        aper = CircularAperture((12, 12), r=3.0)
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[15, 12] = True  # center at distance exactly 3.0 (boundary)
+        stats = ApertureStats(data, aper, mask=mask)
+        assert stats.sum_flags == APERTURE_FLAGS.MASKED_PIXELS
+        # The pixel is excluded from the center (value-statistics) footprint
+        assert stats.flags == 0
+        stats = ApertureStats(data, aper, mask=mask, sum_method='center')
+        assert stats.flags == 0
+        assert stats.sum_flags == 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_non_finite_data(self):
+        """
+        Test the non_finite_data flag.
+
+        In ApertureStats, non-finite data values are automatically masked,
+        so they contribute to all_masked (but not to masked_pixels, which
+        reflects only the input mask).
+        """
+        data = np.ones(SHAPE)
+        data[12, 12] = np.nan
+        aper = CircularAperture((12, 12), r=3.0)
+        assert _stats_flags(data, aper) == APERTURE_FLAGS.NON_FINITE_DATA
+
+        # All-NaN aperture: auto-masked, so also all_masked
+        data = np.full(SHAPE, np.nan)
+        assert _stats_flags(data, aper) == (APERTURE_FLAGS.NON_FINITE_DATA
+                                            | APERTURE_FLAGS.ALL_MASKED)
+
+        # A pixel that is both input-masked and non-finite counts only as
+        # masked
+        data = np.ones(SHAPE)
+        data[12, 12] = np.nan
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[12, 12] = True
+        assert _stats_flags(data, aper,
+                            mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_non_finite_error(self):
+        """
+        Test the non_finite_error flag (evaluated on the sum footprint).
+        """
+        data = np.ones(SHAPE)
+        error = np.ones(SHAPE)
+        error[12, 12] = np.nan
+        aper = CircularAperture((12, 12), r=3.0)
+        stats = ApertureStats(data, aper, error=error)
+        # non_finite_error is a sum-footprint flag, not a value-statistics
+        # flag, so it appears in sum_flags but not flags
+        assert stats.sum_flags == APERTURE_FLAGS.NON_FINITE_ERROR
+        assert stats.flags == 0
+        assert ApertureStats(data, aper).sum_flags == 0
+
+
+class TestSigmaClipFlags:
+    """
+    Tests for the sigma_clipped, all_clipped, and too_few_pixels flags.
+    """
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_sigma_clipped(self):
+        """
+        Test the sigma_clipped flag.
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(1.0, 0.1, size=SHAPE)
+        data[12, 12] = 1000.0  # outlier
+        aper = CircularAperture((12, 12), r=3.0)
+        sigclip = SigmaClip(sigma=3.0, maxiters=10)
+        flags = _stats_flags(data, aper, sigma_clip=sigclip)
+        assert flags == APERTURE_FLAGS.SIGMA_CLIPPED
+
+        # Sigma-clip flags apply only to the value statistics, not sum_flags
+        stats = ApertureStats(data, aper, sigma_clip=sigclip)
+        assert not stats.sum_flags & APERTURE_FLAGS.SIGMA_CLIPPED
+
+        # Without clipping, no flag is set
+        assert _stats_flags(data, aper) == 0
+
+    def test_all_clipped(self):
+        """
+        Test the all_clipped flag using a SigmaClip subclass that rejects
+        every pixel (only reachable via the mask-based path).
+        """
+        class _ClipAll(SigmaClip):
+            def __call__(self, data, **kwargs):  # noqa: ARG002
+                return np.ma.masked_array(data,
+                                          mask=np.ones(data.shape, dtype=bool))
+
+        data = np.ones(SHAPE)
+        aper = CircularAperture((12, 12), r=3.0)
+        # A callable cenfunc is not supported by the fast clipping kernel,
+        # forcing the mask-based path
+        sigclip = _ClipAll(cenfunc=np.ma.median)
+        stats = ApertureStats(data, aper, sigma_clip=sigclip)
+        assert stats.flags == (APERTURE_FLAGS.SIGMA_CLIPPED
+                               | APERTURE_FLAGS.ALL_CLIPPED)
+        assert np.isnan(stats.mean)
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_too_few_pixels(self):
+        """
+        Test the too_few_pixels flag with ddof.
+        """
+        data = np.ones(SHAPE)
+        # The r=1.1 center footprint contains exactly 5 pixels
+        aper = CircularAperture((12, 12), r=1.1)
+
+        stats = ApertureStats(data, aper, ddof=5)
+        assert stats.flags == APERTURE_FLAGS.TOO_FEW_PIXELS
+        assert np.isnan(stats.var)
+        assert np.isnan(stats.std)
+
+        assert _stats_flags(data, aper, ddof=1) == 0
+        assert _stats_flags(data, aper, ddof=0) == 0
+
+
+class TestSegmentationFlags:
+    """
+    Tests for the neighbor_pixels and uncorrected_pixels flags.
+    """
+
+    @pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_neighbor_pixels(self, mask_method):
+        """
+        Test the neighbor_pixels flag for all segmentation mask methods.
+        """
+        data = np.ones(SHAPE)
+        segm = np.zeros(SHAPE, dtype=int)
+        segm[10:15, 10:15] = 1
+        segm[12, 14] = 2  # neighbor pixel inside the aperture
+        aper = CircularAperture((12, 12), r=3.0)
+        flags = _stats_flags(data, aper, segmentation_image=segm, labels=1,
+                             mask_method=mask_method)
+        assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_uncorrected_pixels(self):
+        """
+        Test the uncorrected_pixels flag with mask_method='correct'.
+        """
+        data = np.ones(SHAPE)
+        segm = np.zeros(SHAPE, dtype=int)
+        segm[10:15, 10:15] = 1
+        segm[12, 14] = 2
+        segm[12, 10] = 2  # the mirror is also a neighbor: uncorrectable
+        aper = CircularAperture((12, 12), r=3.0)
+        flags = _stats_flags(data, aper, segmentation_image=segm, labels=1,
+                             mask_method='correct')
+        assert flags == (APERTURE_FLAGS.NEIGHBOR_PIXELS
+                         | APERTURE_FLAGS.UNCORRECTED_PIXELS)
+
+
+class TestMaskPathParity:
+    """
+    The mask-based code path must set the same flags as the batch
+    driver.
+    """
+
+    def test_parity(self):
+        """
+        Test that the fast batch path and the mask-based path produce
+        identical flags for a mix of conditions.
+        """
+        rng = np.random.default_rng(1)
+        data = rng.normal(1.0, 0.1, size=SHAPE)
+        data[13, 12] = np.nan
+        data[5, 5] = 100.0  # sigma-clip outlier
+        error = np.ones(SHAPE)
+        error[10, 12] = np.inf
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[12, 12] = True
+
+        xy = [(12.0, 12.0), (5.0, 5.0), (0.0, 12.0), (-50.0, 12.0),
+              (24.5, 24.5), (0.2, 12.0), (12.5, 3.5)]
+        aper = CircularAperture(xy, r=3.0)
+
+        for kwargs in ({}, {'error': error, 'mask': mask},
+                       {'sigma_clip': SigmaClip(sigma=3.0)},
+                       {'sum_method': 'center'},
+                       {'ddof': 1}):
+            fast = ApertureStats(data, aper, **kwargs)
+            assert fast._batch_inputs is not None
+            with _force_mask_path():
+                slow = ApertureStats(data, aper, **kwargs)
+                assert slow._batch_inputs is None
+                assert_array_equal(fast.flags, slow.flags)
+                assert_array_equal(fast.sum_flags, slow.sum_flags)
+
+
+class TestFlagsAPI:
+    """
+    Tests for how the flags are exposed by ApertureStats.
+    """
+
+    def test_flags_in_table_and_properties(self):
+        """
+        Test that flags appears in the properties list and the default
+        to_table() columns.
+        """
+        data = np.ones(SHAPE)
+        aper = CircularAperture([(12, 12), (-50, 12)], r=3.0)
+        stats = ApertureStats(data, aper)
+        assert 'flags' in stats.properties
+        assert 'sum_flags' in stats.properties
+        tbl = stats.to_table()
+        assert 'flags' in tbl.colnames
+        assert 'sum_flags' in tbl.colnames
+        expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS]
+        assert_array_equal(tbl['flags'], expected)
+        assert_array_equal(tbl['sum_flags'], expected)
+
+    def test_flags_slicing(self):
+        """
+        Test that flags are sliced correctly by __getitem__.
+        """
+        data = np.ones(SHAPE)
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[12, 12] = True
+        aper = CircularAperture([(12, 12), (0.0, 12.0)], r=3.0)
+        stats = ApertureStats(data, aper, mask=mask)
+        flags = stats.flags  # evaluate before slicing
+        assert stats[0].flags == flags[0]
+        assert stats[1].flags == flags[1]
+
+        # Also test slicing before evaluation
+        stats2 = ApertureStats(data, aper, mask=mask)
+        assert stats2[1].flags == flags[1]
+
+    def test_decode_flags(self):
+        """
+        Test the decode_flags convenience method.
+        """
+        data = np.ones(SHAPE)
+        mask = np.zeros(SHAPE, dtype=bool)
+        mask[12, 12] = True
+        aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
+        stats = ApertureStats(data, aper, mask=mask)
+        decoded = stats.decode_flags()
+        assert decoded == [['masked_pixels'], ['partial_overlap']]
+
+        decoded = stats.decode_flags(return_bit_values=True)
+        assert decoded == [[APERTURE_FLAGS.MASKED_PIXELS],
+                           [APERTURE_FLAGS.PARTIAL_OVERLAP]]
+
+        # Decode the sum flags via the column keyword
+        decoded = stats.decode_flags(column='sum_flags')
+        assert decoded == [['masked_pixels'], ['partial_overlap']]
+
+        match = "column must be 'flags' or 'sum_flags'"
+        with pytest.raises(ValueError, match=match):
+            stats.decode_flags(column='invalid')
+
+        # Scalar ApertureStats also returns a list of lists
+        stats = ApertureStats(data, CircularAperture((0.0, 12.0), r=3.0))
+        assert stats.decode_flags() == [['partial_overlap']]
+        assert stats.decode_flags(column='sum_flags') == [['partial_overlap']]
+
+    def test_flags_docstring(self):
+        """
+        Test that the flags docstring placeholder was substituted.
+        """
+        for prop in (ApertureStats.flags, ApertureStats.sum_flags):
+            docstring = prop.__doc__
+            assert '<flag_descriptions>' not in docstring
+            assert "**1** (``'no_overlap'``)" in docstring
+
+
+class TestSingularCovariance:
+    """
+    Tests for the singular_covariance flag, which is set only once a
+    covariance-derived shape property has been computed.
+    """
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_requires_shape(self):
+        """
+        Test that the singular_covariance bit is not set until a
+        covariance-derived property is accessed.
+        """
+        data = _single_pixel_data()
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+
+        # Not set before any covariance-derived property is accessed
+        assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
+        assert 'singular_covariance' not in stats.decode_flags()[0]
+
+        # Accessing a shape property makes a reread include the bit
+        _ = stats.semimajor_axis
+        assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+        assert 'singular_covariance' in stats.decode_flags()[0]
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_triggered_by_covariance(self):
+        """
+        Test that the singular_covariance bit is set when the covariance
+        matrix is computed, even if no shape properties are accessed.
+        """
+        data = _single_pixel_data()
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        _ = stats.covariance
+        assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_array_and_guards(self):
+        """
+        Test that the singular_covariance bit is set for an array of sources
+        and that the covariance computation is guarded against sources with
+        no overlap (undefined moments).
+        """
+        data = _single_pixel_data()
+        data[6, 6] = 100.0
+        yy, xx = np.mgrid[0:25, 0:25]
+        data = data + 50.0 * np.exp(-((xx - 18)**2 + (yy - 18)**2)
+                                    / (2 * 2.5**2))
+        aper = CircularAperture([(6.0, 6.0), (18.0, 18.0), (-50.0, 12.0)],
+                                r=4.0)
+        stats = ApertureStats(data, aper)
+        _ = stats.semimajor_axis  # force the covariance computation
+        flags = stats.flags
+        covar_flag = APERTURE_FLAGS.SINGULAR_COVARIANCE
+        assert (flags[0] & covar_flag) != 0  # singular point source
+        assert (flags[1] & covar_flag) == 0  # extended source
+        assert (flags[2] & covar_flag) == 0  # no-overlap: not flagged singular
+        assert (flags[2] & APERTURE_FLAGS.NO_OVERLAP) != 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_extended_source_not_flagged(self):
+        """
+        Test that a well-resolved source with a non-singular covariance
+        matrix is not flagged as singular.
+        """
+        yy, xx = np.mgrid[0:25, 0:25]
+        data = 100.0 * np.exp(-((xx - 12)**2 + (yy - 12)**2) / (2 * 3.0**2))
+        aper = CircularAperture((12.0, 12.0), r=6.0)
+        stats = ApertureStats(data, aper)
+        _ = stats.semimajor_axis
+        assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_in_default_table(self):
+        """
+        Test that the singular_covariance bit is reflected in the default
+        to_table() output.
+        """
+        data = _single_pixel_data()
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        tbl = stats.to_table()
+        assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_to_table_evaluates_flags_last(self):
+        """
+        Test that requesting a shape column before 'flags' still yields a
+        flags column that reflects the singular_covariance bit.
+        """
+        data = _single_pixel_data()
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        columns = ['flags', 'semimajor_axis']
+        tbl = stats.to_table(columns=columns)
+        assert tbl.colnames == columns  # check order
+        assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_to_table_flags_only_no_singular_bit(self):
+        """
+        Test that requesting only the 'flags' column does not trigger the
+        covariance computation and so does not set the singular_covariance
+        bit.
+        """
+        data = _single_pixel_data()
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        tbl = stats.to_table(columns=['flags'])
+        assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_in_properties(self):
+        """
+        Test that the singular_covariance bit is reflected in the properties
+        list even if no shape properties are accessed.
+        """
+        data = _single_pixel_data()
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        assert 'flags' in stats.properties
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_slicing(self):
+        """
+        Test that the singular_covariance bit is preserved when slicing an
+        array of ApertureStats objects.
+        """
+        data = _single_pixel_data()
+        data[6, 6] = 100.0
+        aper = CircularAperture([(6.0, 6.0), (12.0, 12.0)], r=4.0)
+        stats = ApertureStats(data, aper)
+        _ = stats.semimajor_axis
+        covar_flag = APERTURE_FLAGS.SINGULAR_COVARIANCE
+        assert (stats[0].flags & covar_flag) != 0
+        assert (stats[1].flags & covar_flag) != 0
+
+    def test_rank1_degeneracy(self):
+        """
+        Test that a rank-1 degenerate source is flagged as singular.
+
+        A rank-1 degenerate source has one unresolved axis and one extended
+        axis, so its covariance matrix has one tiny eigenvalue. The
+        singularity criterion is that the minor-axis variance is below a
+        floor of ``1/12`` (the variance of a uniform distribution over a
+        unit pixel). This is a more robust criterion than the determinant
+        test, which can be fooled by a rank-1 source with a large major-axis
+        variance.
+        """
+        # Minor-axis variance 0.05 < 1/12, major-axis variance 0.5
+        stats = _stats_with_injected_covariance(cov_xx=0.5, cov_yy=0.05,
+                                                cov_xy=0.0)
+        delta = 1.0 / 12
+        assert delta**2 < 0.5 * 0.05  # determinant test alone would miss it
+        assert delta > 0.05  # minor-axis variance below the floor
+        assert stats._singular_covariance_mask[0]
+
+        # The bit is reflected in flags once a shape property is computed
+        _ = stats.semimajor_axis
+        assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+    def test_not_positive_semidefinite(self):
+        """
+        Test that a covariance matrix that is not positive semidefinite is
+        flagged as singular.
+        """
+        stats = _stats_with_injected_covariance(cov_xx=1.0, cov_yy=1.0,
+                                                cov_xy=2.0)
+        assert (1.0 * 1.0 - 2.0**2) < 0  # negative determinant
+        assert stats._singular_covariance_mask[0]
+
+        _ = stats.semimajor_axis
+        assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -77,21 +77,21 @@ class TestOverlapFlags:
     """
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_no_flags(self):
+    def test_no_flags(self, unit_data):
         """
         Test that a clean interior source has no flags set.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = CircularAperture((12, 12), r=3.0)
         stats = ApertureStats(data, aper)
         assert stats.flags == 0  # scalar aperture gives a scalar flag
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_overlap_flags(self):
+    def test_overlap_flags(self, unit_data):
         """
         Test the no_overlap, partial_overlap, and no_pixels flags.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = CircularAperture([(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0)],
                                 r=3.0)
         stats = ApertureStats(data, aper)
@@ -101,13 +101,13 @@ class TestOverlapFlags:
                                   | APERTURE_FLAGS.NO_PIXELS)
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_no_pixels(self):
+    def test_no_pixels(self, unit_data):
         """
         Test that an empty "center" footprint sets no_pixels even when the
         default exact-method sum footprint is populated (the per-footprint
         flag bits are combined with OR).
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         # Nearest pixel centers are sqrt(0.5) ~ 0.707 away
         aper = CircularAperture((12.5, 12.5), r=0.4)
         stats = ApertureStats(data, aper)
@@ -122,11 +122,11 @@ class TestMaskedAndNonFiniteFlags:
     """
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_masked_pixels(self):
+    def test_masked_pixels(self, unit_data):
         """
         Test the masked_pixels and all_masked flags.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = CircularAperture((12, 12), r=3.0)
 
         mask = np.zeros(SHAPE, dtype=bool)
@@ -146,16 +146,16 @@ class TestMaskedAndNonFiniteFlags:
             APERTURE_FLAGS.MASKED_PIXELS | APERTURE_FLAGS.ALL_MASKED)
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_sum_footprint_only(self):
+    def test_sum_footprint_only(self, unit_data, unit_mask):
         """
         Test that a masked boundary pixel touched only by the exact-method
         sum footprint (its center lies exactly on the aperture boundary)
         sets masked_pixels in sum_flags but not in the value-statistics
         flags.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = CircularAperture((12, 12), r=3.0)
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = unit_mask
         mask[15, 12] = True  # center at distance exactly 3.0 (boundary)
         stats = ApertureStats(data, aper, mask=mask)
         assert stats.sum_flags == APERTURE_FLAGS.MASKED_PIXELS
@@ -166,7 +166,7 @@ class TestMaskedAndNonFiniteFlags:
         assert stats.sum_flags == 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_non_finite_data(self):
+    def test_non_finite_data(self, unit_mask):
         """
         Test the non_finite_data flag.
 
@@ -188,17 +188,17 @@ class TestMaskedAndNonFiniteFlags:
         # masked
         data = np.ones(SHAPE)
         data[12, 12] = np.nan
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = unit_mask
         mask[12, 12] = True
         assert _stats_flags(data, aper,
                             mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_non_finite_error(self):
+    def test_non_finite_error(self, unit_data):
         """
         Test the non_finite_error flag (evaluated on the sum footprint).
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         error = np.ones(SHAPE)
         error[12, 12] = np.nan
         aper = CircularAperture((12, 12), r=3.0)
@@ -235,7 +235,7 @@ class TestSigmaClipFlags:
         # Without clipping, no flag is set
         assert _stats_flags(data, aper) == 0
 
-    def test_all_clipped(self):
+    def test_all_clipped(self, unit_data):
         """
         Test the all_clipped flag using a SigmaClip subclass that rejects
         every pixel (only reachable via the mask-based path).
@@ -245,7 +245,7 @@ class TestSigmaClipFlags:
                 return np.ma.masked_array(data,
                                           mask=np.ones(data.shape, dtype=bool))
 
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = CircularAperture((12, 12), r=3.0)
         # A callable cenfunc is not supported by the fast clipping kernel,
         # forcing the mask-based path
@@ -256,11 +256,11 @@ class TestSigmaClipFlags:
         assert np.isnan(stats.mean)
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_too_few_pixels(self):
+    def test_too_few_pixels(self, unit_data):
         """
         Test the too_few_pixels flag with ddof.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         # The r=1.1 center footprint contains exactly 5 pixels
         aper = CircularAperture((12, 12), r=1.1)
 
@@ -280,11 +280,11 @@ class TestSegmentationFlags:
 
     @pytest.mark.parametrize('mask_method', ['mask', 'source_only', 'correct'])
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_neighbor_pixels(self, mask_method):
+    def test_neighbor_pixels(self, unit_data, mask_method):
         """
         Test the neighbor_pixels flag for all segmentation mask methods.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         segm = np.zeros(SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor pixel inside the aperture
@@ -294,11 +294,11 @@ class TestSegmentationFlags:
         assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_uncorrected_pixels(self):
+    def test_uncorrected_pixels(self, unit_data):
         """
         Test the uncorrected_pixels flag with mask_method='correct'.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         segm = np.zeros(SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2
@@ -316,7 +316,7 @@ class TestMaskPathParity:
     driver.
     """
 
-    def test_parity(self):
+    def test_parity(self, unit_mask):
         """
         Test that the fast batch path and the mask-based path produce
         identical flags for a mix of conditions.
@@ -327,7 +327,7 @@ class TestMaskPathParity:
         data[5, 5] = 100.0  # sigma-clip outlier
         error = np.ones(SHAPE)
         error[10, 12] = np.inf
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = unit_mask
         mask[12, 12] = True
 
         xy = [(12.0, 12.0), (5.0, 5.0), (0.0, 12.0), (-50.0, 12.0),
@@ -352,12 +352,12 @@ class TestFlagsAPI:
     Tests for how the flags are exposed by ApertureStats.
     """
 
-    def test_flags_in_table_and_properties(self):
+    def test_flags_in_table_and_properties(self, unit_data):
         """
         Test that flags appears in the properties list and the default
         to_table() columns.
         """
-        data = np.ones(SHAPE)
+        data = unit_data
         aper = CircularAperture([(12, 12), (-50, 12)], r=3.0)
         stats = ApertureStats(data, aper)
         assert 'flags' in stats.properties
@@ -369,12 +369,12 @@ class TestFlagsAPI:
         assert_array_equal(tbl['flags'], expected)
         assert_array_equal(tbl['sum_flags'], expected)
 
-    def test_flags_slicing(self):
+    def test_flags_slicing(self, unit_data, unit_mask):
         """
         Test that flags are sliced correctly by __getitem__.
         """
-        data = np.ones(SHAPE)
-        mask = np.zeros(SHAPE, dtype=bool)
+        data = unit_data
+        mask = unit_mask
         mask[12, 12] = True
         aper = CircularAperture([(12, 12), (0.0, 12.0)], r=3.0)
         stats = ApertureStats(data, aper, mask=mask)
@@ -386,12 +386,12 @@ class TestFlagsAPI:
         stats2 = ApertureStats(data, aper, mask=mask)
         assert stats2[1].flags == flags[1]
 
-    def test_decode_flags(self):
+    def test_decode_flags(self, unit_data, unit_mask):
         """
         Test the decode_flags convenience method.
         """
-        data = np.ones(SHAPE)
-        mask = np.zeros(SHAPE, dtype=bool)
+        data = unit_data
+        mask = unit_mask
         mask[12, 12] = True
         aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
         stats = ApertureStats(data, aper, mask=mask)


### PR DESCRIPTION
This PR reorganizes the aperture test suite to reduce duplication and improve maintainability. It shares common aperture tests through base classes, replaces setup_class with pytest fixtures, groups related tests into classes, and simplifies redundant test setup.