### PR TITLE
Use tight bounding boxes for PolygonAperture

### DIFF
--- a/photutils/aperture/_batch_overlap.pxd
+++ b/photutils/aperture/_batch_overlap.pxd
@@ -77,6 +77,7 @@ cdef inline Py_ssize_t _round_half_away(double x) noexcept nogil:
 
 cdef inline bint _source_grid_setup(double cx, double cy,
                                     double ext_x, double ext_y,
+                                    double off_x, double off_y,
                                     Py_ssize_t nx_data, Py_ssize_t ny_data,
                                     double *gxmin, double *gymin,
                                     double *dx, double *dy,
@@ -109,6 +110,11 @@ cdef inline bint _source_grid_setup(double cx, double cy,
         Half the width and half the height of the aperture's bounding
         box, in pixels.
 
+    off_x, off_y : double
+        The (x, y) offset of the bounding-box center from the aperture
+        center, in pixels. This is zero for an aperture whose bounding
+        box is centered on the aperture position.
+
     nx_data, ny_data : Py_ssize_t
         The shape of the data array in the x and y direction.
 
@@ -139,10 +145,10 @@ cdef inline bint _source_grid_setup(double cx, double cy,
         Otherwise, returns `True` and writes the grid and bounding-box
         values described above through the output pointers.
     """
-    cdef double ixmin_d = floor(cx - ext_x + 0.5)
-    cdef double ixmax_d = ceil(cx + ext_x + 0.5)
-    cdef double iymin_d = floor(cy - ext_y + 0.5)
-    cdef double iymax_d = ceil(cy + ext_y + 0.5)
+    cdef double ixmin_d = floor(cx + off_x - ext_x + 0.5)
+    cdef double ixmax_d = ceil(cx + off_x + ext_x + 0.5)
+    cdef double iymin_d = floor(cy + off_y - ext_y + 0.5)
+    cdef double iymax_d = ceil(cy + off_y + ext_y + 0.5)
     cdef double gxmax, gymax
     cdef Py_ssize_t grid_nx, grid_ny
 
@@ -172,6 +178,7 @@ cdef inline bint _source_grid_setup(double cx, double cy,
 
 cdef inline Py_ssize_t _presize_packed_offsets(
         const double[:, ::1] positions, double ext_x, double ext_y,
+        double off_x, double off_y,
         Py_ssize_t nx_data, Py_ssize_t ny_data,
         Py_ssize_t[::1] starts) noexcept nogil:
     """
@@ -198,6 +205,10 @@ cdef inline Py_ssize_t _presize_packed_offsets(
         Half the width and half the height of the aperture's bounding
         box, in pixels. All sources share the same extent.
 
+    off_x, off_y : double
+        The (x, y) offset of the bounding-box center from the aperture
+        center, in pixels. All sources share the same offset.
+
     nx_data, ny_data : Py_ssize_t
         The shape of the data array in the x and y direction.
 
@@ -216,10 +227,10 @@ cdef inline Py_ssize_t _presize_packed_offsets(
     for k in range(positions.shape[0]):
         cx = positions[k, 0]
         cy = positions[k, 1]
-        ixmin_d = floor(cx - ext_x + 0.5)
-        ixmax_d = ceil(cx + ext_x + 0.5)
-        iymin_d = floor(cy - ext_y + 0.5)
-        iymax_d = ceil(cy + ext_y + 0.5)
+        ixmin_d = floor(cx + off_x - ext_x + 0.5)
+        ixmax_d = ceil(cx + off_x + ext_x + 0.5)
+        iymin_d = floor(cy + off_y - ext_y + 0.5)
+        iymax_d = ceil(cy + off_y + ext_y + 0.5)
         starts[k] = total
         if (ixmin_d >= <double>nx_data or ixmax_d <= 0.0
                 or iymin_d >= <double>ny_data or iymax_d <= 0.0):

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -68,6 +68,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                         const unsigned char[:, ::1] mask,
                         const double[:, ::1] positions, int shape_code,
                         const double[::1] params, double ext_x, double ext_y,
+                        double off_x, double off_y,
                         int use_exact, int subpixels,
                         const Py_ssize_t[:, ::1] segmentation=None,
                         const Py_ssize_t[::1] labels=None, int seg_method=0,
@@ -127,6 +128,11 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     ext_x, ext_y : float
         The half-extents of the aperture minimal bounding box in the x
         and y directions (i.e., ``Aperture._xy_extents``).
+
+    off_x, off_y : float
+        The (x, y) offset of the bounding-box center from each source
+        position (i.e., ``Aperture._xy_bbox_offset``). This is zero for
+        an aperture whose bounding box is centered on its position.
 
     use_exact : int
         Whether to compute exact overlap fractions (1) or use subpixel
@@ -399,7 +405,8 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     if emit_sum:
         with nogil:
             total = _presize_packed_offsets(positions, ext_x, ext_y,
-                                            nx_data, ny_data, starts)
+                                            off_x, off_y, nx_data, ny_data,
+                                            starts)
 
     cdef Py_ssize_t sum_cap = total if emit_sum else 0
     sum_values_arr = np.empty(sum_cap, dtype=np.float64)
@@ -427,9 +434,9 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             # Bounding box, overlap test, and pixel grid, replicated
             # from the mask-based path (see ``_source_grid_setup``); the
             # sums stay NaN when there is no overlap.
-            if not _source_grid_setup(cx, cy, ext_x, ext_y, nx_data,
-                                      ny_data, &gxmin, &gymin, &dx, &dy,
-                                      &pixel_radius, &norm, &ixmin,
+            if not _source_grid_setup(cx, cy, ext_x, ext_y, off_x, off_y,
+                                      nx_data, ny_data, &gxmin, &gymin,
+                                      &dx, &dy, &pixel_radius, &norm, &ixmin,
                                       &iymin, &ix0, &ix1, &iy0, &iy1):
                 continue
             overlap[k] = 1
@@ -574,8 +581,8 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
             # caller resolves this to the precise outside-weight test
             # (nonzero aperture weights outside the data) only for
             # these sources; unclipped interior sources are exactly 0.
-            ixmax_full = <Py_ssize_t>ceil(cx + ext_x + 0.5)
-            iymax_full = <Py_ssize_t>ceil(cy + ext_y + 0.5)
+            ixmax_full = <Py_ssize_t>ceil(cx + off_x + ext_x + 0.5)
+            iymax_full = <Py_ssize_t>ceil(cy + off_y + ext_y + 0.5)
             if (ixmin < ix0 or ixmax_full > ix1
                     or iymin < iy0 or iymax_full > iy1):
                 w_out = 1  # bounding box clipped by data edge

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -203,7 +203,8 @@ def batch_aperture_gather(const double[:, ::1] data,
                           const unsigned char[:, ::1] mask,
                           const double[:, ::1] positions, int shape_code,
                           const double[::1] params, double ext_x,
-                          double ext_y, const double[::1] local_bkg=None,
+                          double ext_y, double off_x, double off_y,
+                          const double[::1] local_bkg=None,
                           const Py_ssize_t[:, ::1] segmentation=None,
                           const Py_ssize_t[::1] labels=None,
                           int seg_method=0):
@@ -252,6 +253,10 @@ def batch_aperture_gather(const double[:, ::1] data,
 
     ext_x, ext_y : float
         The aperture bounding-box half-extents.
+
+    off_x, off_y : float
+        The (x, y) offset of the bounding-box center from each source
+        position (see `_batch_photometry`).
 
     local_bkg : 1D ndarray of float64 (C-contiguous) or `None`
         The per-source local background to subtract. If `None`, no
@@ -448,8 +453,8 @@ def batch_aperture_gather(const double[:, ::1] data,
     # bounding-box arithmetic; it does not iterate over or evaluate
     # individual pixels.
     with nogil:
-        total = _presize_packed_offsets(positions, ext_x, ext_y, nx_data,
-                                        ny_data, starts)
+        total = _presize_packed_offsets(positions, ext_x, ext_y, off_x, off_y,
+                                        nx_data, ny_data, starts)
 
     values_arr = np.empty(total, dtype=np.float64)
     lx_arr = np.empty(total, dtype=np.int32)
@@ -476,9 +481,9 @@ def batch_aperture_gather(const double[:, ::1] data,
 
             # Bounding box, overlap test, and pixel grid, replicated
             # from the mask-based path (see ``_source_grid_setup``).
-            if not _source_grid_setup(cx, cy, ext_x, ext_y, nx_data,
-                                      ny_data, &gxmin, &gymin, &dx, &dy,
-                                      &pixel_radius, &norm, &ixmin,
+            if not _source_grid_setup(cx, cy, ext_x, ext_y, off_x, off_y,
+                                      nx_data, ny_data, &gxmin, &gymin,
+                                      &dx, &dy, &pixel_radius, &norm, &ixmin,
                                       &iymin, &ix0, &ix1, &iy0, &iy1):
                 continue
             overlap[k] = 1
@@ -589,8 +594,8 @@ def batch_aperture_gather(const double[:, ::1] data,
             # caller resolves this to the precise outside-weight test
             # (nonzero aperture weights outside the data) only for these
             # sources; unclipped interior sources are exactly 0.
-            ixmax_full = <Py_ssize_t>ceil(cx + ext_x + 0.5)
-            iymax_full = <Py_ssize_t>ceil(cy + ext_y + 0.5)
+            ixmax_full = <Py_ssize_t>ceil(cx + off_x + ext_x + 0.5)
+            iymax_full = <Py_ssize_t>ceil(cy + off_y + ext_y + 0.5)
             if (ixmin < ix0 or ixmax_full > ix1
                     or iymin < iy0 or iymax_full > iy1):
                 w_out = 1  # bounding box clipped by a data edge

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -486,6 +486,17 @@ class PixelAperture(Aperture):
         minimal bounding box size in each dimension.
         """
 
+    @property
+    def _xy_bbox_offset(self):
+        """
+        The (x, y) offset of the bounding box center from ``positions``.
+
+        This is zero for an aperture whose minimal bounding box is
+        centered on ``positions``, which is the case for every aperture
+        whose shape is symmetric about its position.
+        """
+        return 0.0, 0.0
+
     @lazyproperty
     def _positions(self):
         """
@@ -500,10 +511,11 @@ class PixelAperture(Aperture):
         `~photutils.aperture.BoundingBox` instances.
         """
         x_delta, y_delta = self._xy_extents
-        xmin = self._positions[:, 0] - x_delta
-        xmax = self._positions[:, 0] + x_delta
-        ymin = self._positions[:, 1] - y_delta
-        ymax = self._positions[:, 1] + y_delta
+        off_x, off_y = self._xy_bbox_offset
+        xmin = self._positions[:, 0] + off_x - x_delta
+        xmax = self._positions[:, 0] + off_x + x_delta
+        ymin = self._positions[:, 1] + off_y - y_delta
+        ymax = self._positions[:, 1] + off_y + y_delta
 
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax, strict=True)]
@@ -929,13 +941,14 @@ class PixelAperture(Aperture):
         if error is not None:
             error = np.ascontiguousarray(error, dtype=np.float64)
         ext_x, ext_y = self._xy_extents
+        off_x, off_y = self._xy_bbox_offset
 
         sums, sum_var, area, overlap, *_, fcounts = batch_aperture_sums(
             np.ascontiguousarray(data, dtype=np.float64), error, mask,
             np.ascontiguousarray(self._positions, dtype=np.float64),
             shape_code, np.array(params, dtype=np.float64),
-            float(ext_x), float(ext_y), use_exact, subpixels,
-            seg_arr, labels_arr, seg_code)
+            float(ext_x), float(ext_y), float(off_x), float(off_y),
+            use_exact, subpixels, seg_arr, labels_arr, seg_code)
 
         if error is None:
             # Match the mask-based path, which returns an all-NaN error

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -419,15 +419,6 @@ class PixelAperture(Aperture):
     Abstract base class for apertures defined in pixel coordinates.
     """
 
-    # Whether the minimal bounding box is tight, i.e., whether the
-    # aperture is tangent to each side of its bounding box. This holds
-    # for any aperture whose ``_xy_extents`` are the true half-extents
-    # of its shape, which is the case for all of the built-in apertures
-    # except `~photutils.aperture.PolygonAperture` (whose extents are
-    # symmetric about ``positions``, while the polygon itself need not
-    # be). See `_resolve_outside_weights`.
-    _bbox_is_tight = True
-
     @lazyproperty
     def _default_patch_properties(self):
         """
@@ -1166,17 +1157,14 @@ class PixelAperture(Aperture):
             Whether each aperture has one or more pixels with nonzero
             aperture weight outside the data.
         """
-        # For the 'exact' method, if the bounding box is tight (the
-        # aperture is tangent to each bbox side), then a bbox that
+        # For the 'exact' method the minimal bounding box is tight
+        # (the aperture is tangent to each bbox side), so a bbox that
         # is clipped by a data edge always leaves a positive-area
         # portion of the aperture outside the data. The precise
         # outside-weight test therefore agrees exactly with the
-        # bbox-clipped candidates, and no per-source aperture masks
-        # need to be built. An aperture with a non-tight bounding box
-        # (e.g., an off-center polygon) can have a clipped bbox with no
-        # aperture area outside the data, so it must use the precise
-        # test below.
-        if method == 'exact' and self._bbox_is_tight:
+        # bbox-clipped candidates, and no per-source aperture masks need
+        # to be built.
+        if method == 'exact':
             return candidates.copy()
 
         w_out = np.zeros(candidates.shape, dtype=bool)

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -437,11 +437,6 @@ class PolygonAperture(PixelAperture):
         'The (n_vertices, 2) array of pixel offsets of the polygon '
         'vertices, measured relative to ``positions``.')
 
-    # The bounding box is symmetric about ``positions`` (see
-    # ``_xy_extents``), so it is not tight for a polygon whose vertices
-    # are not symmetric about ``positions``.
-    _bbox_is_tight = False
-
     def __init__(self, positions, vertex_offsets):
         self.positions = positions
         self.vertex_offsets = vertex_offsets
@@ -736,13 +731,34 @@ class PolygonAperture(PixelAperture):
         return self.positions[:, np.newaxis, :] + offsets[np.newaxis, :, :]
 
     @lazyproperty
+    def _xy_bounds(self):
+        """
+        The ``(xmin, xmax, ymin, ymax)`` offsets of the polygon's
+        axis-aligned bounding box, relative to ``positions``.
+        """
+        offsets = self.vertex_offsets
+        return (float(offsets[:, 0].min()), float(offsets[:, 0].max()),
+                float(offsets[:, 1].min()), float(offsets[:, 1].max()))
+
+    @lazyproperty
     def _xy_extents(self):
         """
         Half the extents of the polygon's axis-aligned bounding box.
         """
-        x_extent = float(np.max(np.abs(self.vertex_offsets[:, 0])))
-        y_extent = float(np.max(np.abs(self.vertex_offsets[:, 1])))
-        return x_extent, y_extent
+        xmin, xmax, ymin, ymax = self._xy_bounds
+        return 0.5 * (xmax - xmin), 0.5 * (ymax - ymin)
+
+    @lazyproperty
+    def _xy_bbox_offset(self):
+        """
+        The (x, y) offset of the bounding box center from ``positions``.
+
+        A polygon's vertices need not be symmetric about ``positions``,
+        so its minimal bounding box is generally not centered on the
+        aperture position.
+        """
+        xmin, xmax, ymin, ymax = self._xy_bounds
+        return 0.5 * (xmin + xmax), 0.5 * (ymin + ymax)
 
     def _batch_shape_params(self):
         # The vertex offsets are counter-clockwise (normalized when the

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -865,6 +865,7 @@ class ApertureStats:
         sum_use_exact, sum_subpixels = aper._translate_mask_method(
             self.sum_method, self.subpixels)
         ext_x, ext_y = aper._xy_extents
+        off_x, off_y = aper._xy_bbox_offset
 
         if error is not None:
             error = np.ascontiguousarray(error, dtype=np.float64)
@@ -872,7 +873,8 @@ class ApertureStats:
         return (np.ascontiguousarray(data, dtype=np.float64), error, mask,
                 np.ascontiguousarray(aper._positions, dtype=np.float64),
                 shape_code, np.array(params, dtype=np.float64),
-                float(ext_x), float(ext_y), sum_use_exact, sum_subpixels,
+                float(ext_x), float(ext_y), float(off_x), float(off_y),
+                sum_use_exact, sum_subpixels,
                 np.ascontiguousarray(self._local_bkg, dtype=np.float64),
                 seg_arr, labels_arr, seg_code, clip_spec)
 
@@ -907,13 +909,13 @@ class ApertureStats:
         if inputs is None:
             return None
         (data, _error, mask, positions, shape_code, params, ext_x, ext_y,
-         _sum_use_exact, _sum_subpixels, local_bkg, seg_arr, labels_arr,
-         seg_code, clip_spec) = inputs
+         off_x, off_y, _sum_use_exact, _sum_subpixels, local_bkg, seg_arr,
+         labels_arr, seg_code, clip_spec) = inputs
 
         (values, lx, ly, starts, counts, overlap,
          flag_counts) = batch_aperture_gather(
             data, mask, positions, shape_code, params, ext_x, ext_y,
-            local_bkg, seg_arr, labels_arr, seg_code)
+            off_x, off_y, local_bkg, seg_arr, labels_arr, seg_code)
         gather = (values, lx, ly, starts, counts, None, None, None, overlap,
                   None, None, None, None, flag_counts)
 
@@ -949,15 +951,15 @@ class ApertureStats:
         if inputs is None:
             return None
         (data, error, mask, positions, shape_code, params, ext_x, ext_y,
-         sum_use_exact, sum_subpixels, local_bkg, seg_arr, labels_arr,
-         seg_code, clip_spec) = inputs
+         off_x, off_y, sum_use_exact, sum_subpixels, local_bkg, seg_arr,
+         labels_arr, seg_code, clip_spec) = inputs
 
         emit_sum = 1 if clip_spec is not None else 0
         (sums, sum_var, area, overlap, starts, sum_values, sum_fracs,
          sum_errsq, scounts, flag_counts) = batch_aperture_sums(
             data, error, mask, positions, shape_code, params, ext_x, ext_y,
-            sum_use_exact, sum_subpixels, seg_arr, labels_arr, seg_code,
-            local_bkg, emit_sum)
+            off_x, off_y, sum_use_exact, sum_subpixels, seg_arr, labels_arr,
+            seg_code, local_bkg, emit_sum)
         gather = (None, None, None, starts, None, sums, sum_var, area,
                   overlap, sum_values, sum_fracs, sum_errsq, scounts,
                   flag_counts)

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -33,8 +33,8 @@ def _sums_fcounts(data, positions, radius, *, error=None, mask=None,
     params = np.array([radius], dtype=np.float64)
     result = batch_aperture_sums(
         np.ascontiguousarray(data, dtype=np.float64), error, mask,
-        positions, SHAPE_CIRCLE, params, radius, radius, use_exact,
-        subpixels, segmentation, labels, seg_method)
+        positions, SHAPE_CIRCLE, params, radius, radius, 0.0, 0.0,
+        use_exact, subpixels, segmentation, labels, seg_method)
     return result[-1]
 
 
@@ -48,8 +48,8 @@ def _gather_fcounts(data, positions, radius, *, mask=None,
     params = np.array([radius], dtype=np.float64)
     result = batch_aperture_gather(
         np.ascontiguousarray(data, dtype=np.float64), mask, positions,
-        SHAPE_CIRCLE, params, radius, radius, None, segmentation,
-        labels, seg_method)
+        SHAPE_CIRCLE, params, radius, radius, 0.0, 0.0, None,
+        segmentation, labels, seg_method)
     return result[-1]
 
 

--- a/photutils/aperture/tests/test_batch_photometry_driver.py
+++ b/photutils/aperture/tests/test_batch_photometry_driver.py
@@ -69,14 +69,14 @@ class TestBatchApertureSums:
         params = np.array([8.0], dtype=np.float64)
 
         expected = batch_aperture_sums(data, error, mask, positions,
-                                       SHAPE_CIRCLE,
-                                       params, 8.0, 8.0, use_exact, 8)
+                                       SHAPE_CIRCLE, params, 8.0, 8.0,
+                                       0.0, 0.0, use_exact, 8)
 
         for arr in (data, error, positions, params):
             arr.setflags(write=False)
         result = batch_aperture_sums(data, error, mask, positions,
-                                     SHAPE_CIRCLE,
-                                     params, 8.0, 8.0, use_exact, 8)
+                                     SHAPE_CIRCLE, params, 8.0, 8.0,
+                                     0.0, 0.0, use_exact, 8)
 
         for res_arr, exp_arr in zip(result, expected, strict=True):
             assert_array_equal(res_arr, exp_arr)
@@ -91,7 +91,7 @@ class TestBatchApertureSums:
         def fn():
             return batch_aperture_sums(data, error, mask, positions,
                                        shape_code, params, ext_x, ext_y,
-                                       use_exact, 8)
+                                       0.0, 0.0, use_exact, 8)
 
         expected = fn()
         with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
@@ -117,7 +117,7 @@ class TestBatchApertureSums:
             params = np.array(params, dtype=np.float64)
             return batch_aperture_sums(data, error, mask, positions,
                                        shape_code, params, ext_x, ext_y,
-                                       1, 5)
+                                       0.0, 0.0, 1, 5)
 
         expected = {spec[0]: task(spec) for spec in _BATCH_SPECS}
 

--- a/photutils/aperture/tests/test_batch_thread_safety.py
+++ b/photutils/aperture/tests/test_batch_thread_safety.py
@@ -151,10 +151,10 @@ class TestBatchApertureGather:
 
         none_result = batch_aperture_gather(data, mask, positions,
                                             SHAPE_CIRCLE, params, 8.0, 8.0,
-                                            None)
+                                            0.0, 0.0, None)
         zero_result = batch_aperture_gather(data, mask, positions,
                                             SHAPE_CIRCLE, params, 8.0, 8.0,
-                                            zeros)
+                                            0.0, 0.0, zeros)
 
         _assert_gather_equal(none_result, zero_result)
 
@@ -167,7 +167,8 @@ class TestBatchApertureGather:
 
         def fn():
             return batch_aperture_gather(data, mask, positions, shape_code,
-                                         params, ext_x, ext_y, local_bkg)
+                                         params, ext_x, ext_y, 0.0, 0.0,
+                                         local_bkg)
 
         expected = fn()
         with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
@@ -191,7 +192,8 @@ class TestBatchApertureGather:
             shape_code, params, ext_x, ext_y = spec
             params = np.array(params, dtype=np.float64)
             return batch_aperture_gather(data, mask, positions, shape_code,
-                                         params, ext_x, ext_y, local_bkg)
+                                         params, ext_x, ext_y, 0.0, 0.0,
+                                         local_bkg)
 
         expected = {spec[0]: task(spec) for spec in _GATHER_SPECS}
 

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -175,24 +175,28 @@ class TestOverlapFlags:
 
 class TestPolygonOverlapFlags:
     """
-    A polygon bounding box is symmetric about its positions, so it can
-    be clipped by a data edge while the polygon is fully inside.
+    A polygon whose vertices are not centered on its positions still has
+    a tight bounding box, so the partial_overlap flag tracks the polygon
+    itself rather than the box.
     """
 
     @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
     def test_offcenter_inside(self, method, subpixels):
         """
         Test that a polygon lying entirely inside the data is not flagged as
-        partial_overlap even though its bounding box, which is symmetric
-        about ``positions``, is clipped by a data edge.
+        partial_overlap.
         """
         data = np.ones((12, 12))
-        # The centroid of this triangle is well off-center, so the symmetric
-        # bounding box extends outside the data on two sides
+        # The centroid of this triangle is well off-center from the
+        # vertices, so its bounding box is not centered on ``positions``
         aper = PolygonAperture.from_vertices([(1.0, 1.0), (9.0, 1.0),
                                               (9.0, 9.0)])
+        # The tight bounding box lies entirely within the data
         bbox = aper.bbox
-        assert bbox.ixmax > data.shape[1] or bbox.iymin < 0
+        assert bbox.ixmin >= 0
+        assert bbox.ixmax <= data.shape[1]
+        assert bbox.iymin >= 0
+        assert bbox.iymax <= data.shape[0]
 
         result = AperturePhotometry(data, aper, method=method,
                                     subpixels=subpixels)
@@ -209,8 +213,12 @@ class TestPolygonOverlapFlags:
         partial_overlap.
         """
         data = np.ones((12, 12))
-        aper = PolygonAperture.from_vertices([(-2.0, 1.0), (9.0, 1.0),
+        # The part of this triangle beyond the left data edge contains
+        # whole pixels, so every mask method sees weight outside the data
+        aper = PolygonAperture.from_vertices([(-3.0, 4.0), (9.0, 1.0),
                                               (9.0, 9.0)])
+        assert aper.bbox.ixmin < 0
+
         result = AperturePhotometry(data, aper, method=method,
                                     subpixels=subpixels)
         assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -11,6 +11,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
+from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.photometry import AperturePhotometry
 from photutils.aperture.polygon import (PolygonAperture, SkyPolygonAperture,
                                         _polygon_is_simple,
@@ -495,6 +496,51 @@ class TestPolygonConstruction:
         _ = aper.vertices
         aper.vertex_offsets = TRIANGLE_OFFSETS
         assert aper.vertices.shape == (3, 2)
+
+
+class TestPolygonBoundingBox:
+    """
+    Tests for the PolygonAperture minimal bounding box.
+    """
+
+    def test_bbox_is_tight(self):
+        """
+        Test that the bounding box of a polygon whose vertices are not
+        centered on ``positions`` is the minimal box enclosing the
+        polygon.
+        """
+        aper = PolygonAperture.from_vertices([(1.0, 1.0), (9.0, 1.0),
+                                              (9.0, 9.0)])
+        assert aper.bbox == BoundingBox(ixmin=1, ixmax=10, iymin=1, iymax=10)
+
+    def test_bbox_offset(self):
+        """
+        Test the bounding-box extents and center offset of an off-center
+        polygon.
+        """
+        # A triangle whose centroid is at (2, 1), giving vertex offsets
+        # spanning x in [-2, 4] and y in [-1, 2]
+        aper = PolygonAperture.from_vertices([(0.0, 0.0), (6.0, 0.0),
+                                              (0.0, 3.0)])
+        assert_allclose(aper.positions, (2.0, 1.0))
+        assert_allclose(aper._xy_extents, (3.0, 1.5))
+        assert_allclose(aper._xy_bbox_offset, (1.0, 0.5))
+        assert aper.bbox == BoundingBox(ixmin=0, ixmax=7, iymin=0, iymax=4)
+
+    def test_bbox_offset_zero_for_symmetric_polygon(self):
+        aper = PolygonAperture((10.0, 20.0), SQUARE_OFFSETS)
+        assert_allclose(aper._xy_bbox_offset, (0.0, 0.0))
+        assert aper.bbox == BoundingBox(ixmin=9, ixmax=12, iymin=19, iymax=22)
+
+    def test_bbox_offset_resets_with_offsets(self):
+        aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
+        assert_allclose(aper._xy_bbox_offset, (0.0, 0.0))
+        aper.vertex_offsets = TRIANGLE_OFFSETS
+        assert_allclose(aper._xy_bbox_offset,
+                        (0.5 * (TRIANGLE_OFFSETS[:, 0].min()
+                                + TRIANGLE_OFFSETS[:, 0].max()),
+                         0.5 * (TRIANGLE_OFFSETS[:, 1].min()
+                                + TRIANGLE_OFFSETS[:, 1].max())))
 
 
 class TestPolygonMasks:

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -272,13 +272,13 @@ class TestBatchDriverSegmentation:
 
         sums = batch_aperture_sums(
             data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
-            1, 8, segm, labels, 1)[0]
+            0.0, 0.0, 1, 8, segm, labels, 1)[0]
 
         # Reference via global mask
         manual_mask = ((segm > 0) & (segm != 1)).astype(np.uint8)
         ref = batch_aperture_sums(
             data, error, manual_mask, positions, SHAPE_CIRCLE, params,
-            8.0, 8.0, 1, 8)[0]
+            8.0, 8.0, 0.0, 0.0, 1, 8)[0]
         assert_allclose(sums, ref)
 
     def test_source_only_method(self):
@@ -295,12 +295,12 @@ class TestBatchDriverSegmentation:
 
         sums = batch_aperture_sums(
             data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
-            1, 8, segm, labels, 2)[0]
+            0.0, 0.0, 1, 8, segm, labels, 2)[0]
 
         manual_mask = (segm != 1).astype(np.uint8)
         ref = batch_aperture_sums(
             data, error, manual_mask, positions, SHAPE_CIRCLE, params,
-            8.0, 8.0, 1, 8)[0]
+            8.0, 8.0, 0.0, 0.0, 1, 8)[0]
         assert_allclose(sums, ref)
 
     def test_label0_disables(self):
@@ -318,10 +318,10 @@ class TestBatchDriverSegmentation:
 
         sums = batch_aperture_sums(
             data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
-            1, 8, segm, labels, 1)[0]
+            0.0, 0.0, 1, 8, segm, labels, 1)[0]
         ref = batch_aperture_sums(
             data, error, mask, positions, SHAPE_CIRCLE, params, 8.0, 8.0,
-            1, 8)[0]
+            0.0, 0.0, 1, 8)[0]
         assert_allclose(sums, ref)
 
     def test_correct_method_matches_mask_path(self):


### PR DESCRIPTION
This PR updates polygon apertures to use minimal bounding boxes around their vertices, including support for off-center polygons in batch photometry and statistics calculations.