### PR TITLE
Hide private base classes from the rendered "Bases:" line

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,3 +208,81 @@ linkcheck_ignore = [
     r'https://doi.org/*',
 ]
 linkcheck_timeout = 180
+
+
+# -- Hide private base classes from the rendered "Bases:" line ----------------
+def _public_ancestors(cls):
+    """
+    Yield the nearest public ancestors of a private base class.
+
+    Parameters
+    ----------
+    cls : type
+        The private base class to resolve.
+
+    Yields
+    ------
+    ancestor : type
+        Each nearest public ancestor of ``cls``, in method resolution
+        order. Private ancestors are replaced by their own nearest
+        public ancestors.
+    """
+    for base in cls.__bases__:
+        if base.__name__.startswith('_'):
+            yield from _public_ancestors(base)
+        else:
+            yield base
+
+
+def _hide_private_bases(app, name, obj, options, bases):  # noqa: ARG001
+    """
+    Replace private base classes with their nearest public ancestors.
+
+    A private base class is rendered as unlinked plain text in the
+    "Bases:" line of a class page, because it has no documentation to
+    link to. This handler substitutes the nearest public ancestors
+    instead, so that implementation-detail mixins and common base
+    classes stay out of the public API documentation.
+
+    Parameters
+    ----------
+    app : `sphinx.application.Sphinx`
+        The Sphinx application object.
+
+    name : str
+        The fully qualified name of the class being documented.
+
+    obj : type
+        The class being documented.
+
+    options : `sphinx.ext.autodoc.Options`
+        The options given to the class directive.
+
+    bases : list of type
+        The base classes to render. This list is modified in place.
+    """
+    public = []
+    for base in bases:
+        replacements = ([base] if not base.__name__.startswith('_')
+                        else _public_ancestors(base))
+        for cls in replacements:
+            if cls not in public:
+                public.append(cls)
+
+    # Drop the implicit object base unless it is the only one left
+    if len(public) > 1:
+        public = [cls for cls in public if cls is not object]
+
+    bases[:] = public
+
+
+def setup(app):
+    """
+    Connect the photutils-specific Sphinx event handlers.
+
+    Parameters
+    ----------
+    app : `sphinx.application.Sphinx`
+        The Sphinx application object.
+    """
+    app.connect('autodoc-process-bases', _hide_private_bases)


### PR DESCRIPTION
Sphinx renders a private base class as unlinked plain text in the "Bases:" line of a class page, because it has no documentation to link to. This affects three public class pages:

* photutils.background.BackgroundBase:     _BackgroundCommonBase, ABC
* photutils.background.BackgroundRMSBase:  _BackgroundCommonBase, ABC
* photutils.background.BkgZoomInterpolator:  _BkgZoomInterpolator

plus all of the elliptical and rectangular aperture classes (that have a `theta` parameter).

This PR hides the private base classes from the "Bases:" line in the docs.