### PR TITLE
Require consistent pixel or sky parameters in aperture ASDF schemas

### DIFF
--- a/photutils/converters/apertures.py
+++ b/photutils/converters/apertures.py
@@ -17,6 +17,18 @@ __all__ = [
 ]
 
 
+def _optional_theta(node):
+    """
+    Return ``theta`` as a keyword dict, or an empty dict if it is
+    absent.
+
+    ``theta`` is optional in the aperture schemas. It is omitted instead
+    of being passed as `None` because its default differs between the
+    pixel and sky apertures.
+    """
+    return {'theta': node['theta']} if 'theta' in node else {}
+
+
 class CircularApertureConverter(Converter):
     """
     ASDF converter for circular apertures.
@@ -115,7 +127,7 @@ class EllipticalApertureConverter(Converter):
             positions=node['positions'],
             a=node['a'],
             b=node['b'],
-            theta=node['theta'],
+            **_optional_theta(node),
         )
 
 
@@ -153,9 +165,9 @@ class EllipticalAnnulusConverter(Converter):
             positions=node['positions'],
             a_in=node['a_in'],
             a_out=node['a_out'],
-            b_in=node['b_in'],
+            b_in=node.get('b_in'),
             b_out=node['b_out'],
-            theta=node['theta'],
+            **_optional_theta(node),
         )
 
 
@@ -223,7 +235,7 @@ class RectangularApertureConverter(Converter):
             positions=node['positions'],
             w=node['w'],
             h=node['h'],
-            theta=node['theta'],
+            **_optional_theta(node),
         )
 
 
@@ -261,7 +273,7 @@ class RectangularAnnulusConverter(Converter):
             positions=node['positions'],
             w_in=node['w_in'],
             w_out=node['w_out'],
-            h_in=node['h_in'],
+            h_in=node.get('h_in'),
             h_out=node['h_out'],
-            theta=node['theta'],
+            **_optional_theta(node),
         )

--- a/photutils/converters/tests/test_apertures.py
+++ b/photutils/converters/tests/test_apertures.py
@@ -28,11 +28,11 @@ aper_params = pytest.mark.parametrize('aperobj', [
     'circular_annulus_multi_pos',
     'polygon_aperture',
     'polygon_aperture_vertices',
-    'sky_polygon_aperture',
     'sky_circular_annulus',
     'sky_circular_aperture',
     'sky_elliptical_annulus',
     'sky_elliptical_aperture',
+    'sky_polygon_aperture',
     'sky_rectangular_aperture',
     'sky_rectangular_annulus',
 ], indirect=True)

--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -12,7 +12,9 @@ import yaml
 from asdf import get_config, treeutil
 from asdf.exceptions import ValidationError
 from asdf.testing.helpers import yaml_to_asdf
+from astropy import units as u
 
+from photutils.converters import _ASDF_ASTROPY_INSTALLED
 from photutils.extension import PHOTUTILS_MANIFEST_URIS
 
 # Matches the top-level YAML tag that opens a schema example.
@@ -265,3 +267,61 @@ def test_mixed_pixel_and_sky_rejected(example):
     with pytest.raises(ValidationError), \
             asdf.open(yaml_to_asdf(f'aper: {example}')):
         pass
+
+
+# The size parameters that each aperture schema requires. The remaining
+# parameters of these apertures (``theta`` for all of them, plus the
+# inner size of the annuli) are optional.
+REQUIRED_SIZE_PARAMS = {
+    'elliptical_aperture': ('a', 'b'),
+    'elliptical_annulus': ('a_in', 'a_out', 'b_out'),
+    'rectangular_aperture': ('w', 'h'),
+    'rectangular_annulus': ('w_in', 'w_out', 'h_out'),
+}
+
+
+def _read_minimal_aperture(stem, *, sky):
+    """
+    Read an aperture from a file containing only its required
+    parameters.
+    """
+    example = _aperture_yaml(stem,
+                             SKY_POSITIONS if sky else PIXEL_POSITIONS,
+                             _sizes(REQUIRED_SIZE_PARAMS[stem], sky=sky))
+    with asdf.open(yaml_to_asdf(f'aper: {example}')) as af:
+        return af['aper']
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('sky', [False, True], ids=['pixel', 'sky'])
+@pytest.mark.parametrize('stem', list(REQUIRED_SIZE_PARAMS))
+def test_optional_theta_uses_default(stem, sky):
+    """
+    Test that an aperture file that omits ``theta`` is read using the
+    default rotation angle of its aperture class.
+
+    ``theta`` is optional in both the aperture classes and the schemas,
+    and its default differs between the pixel and sky apertures.
+    """
+    aperture = _read_minimal_aperture(stem, sky=sky)
+    assert aperture.theta == (0.0 * u.deg if sky else 0.0)
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('sky', [False, True], ids=['pixel', 'sky'])
+def test_optional_inner_size_uses_default(sky):
+    """
+    Test that an annulus file that omits its inner size is read using
+    the inner size derived by its aperture class.
+
+    ``b_in`` and ``h_in`` are optional in both the aperture classes and
+    the schemas.
+    """
+    ellipse = _read_minimal_aperture('elliptical_annulus', sky=sky)
+    assert ellipse.b_in == ellipse.b_out * ellipse.a_in / ellipse.a_out
+
+    rectangle = _read_minimal_aperture('rectangular_annulus', sky=sky)
+    assert (rectangle.h_in
+            == rectangle.w_in * rectangle.h_out / rectangle.w_out)

--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -6,14 +6,47 @@ Tests for the photutils ASDF manifests and schemas.
 import re
 import textwrap
 
+import asdf
 import pytest
 import yaml
 from asdf import get_config, treeutil
+from asdf.exceptions import ValidationError
+from asdf.testing.helpers import yaml_to_asdf
 
 from photutils.extension import PHOTUTILS_MANIFEST_URIS
 
 # Matches the top-level YAML tag that opens a schema example.
 EXAMPLE_TAG_PATTERN = re.compile(r'!<([^>]+)>')
+
+PIXEL_POSITIONS = '[10.0, 20.0]'
+
+SKY_POSITIONS = """!<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
+      dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0>
+        {unit: !unit/unit-1.0.0 deg, value: 20.0}
+      frame: icrs
+      ra: !<tag:astropy.org:astropy/coordinates/longitude-1.2.0>
+        {unit: !unit/unit-1.0.0 deg, value: 10.0,
+         wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+           {unit: !unit/unit-1.0.0 deg, value: 360.0}}
+      representation_type: spherical"""
+
+VERTICES = '[[5.0, 0.0], [0.0, 5.0], [-5.0, 0.0]]'
+PIXEL_OFFSETS = f'!core/ndarray-1.1.0 {VERTICES}'
+SKY_OFFSETS = ('!unit/quantity-1.3.0 {unit: !unit/unit-1.0.0 arcsec, '
+               f'value: !core/ndarray-1.1.0 {VERTICES}}}')
+
+# The parameters of each aperture that must agree with ``positions``.
+# ``theta`` is excluded because the pixel apertures also accept an
+# angular quantity.
+SIZE_PARAMS = {
+    'circular_aperture': ('r',),
+    'circular_annulus': ('r_in', 'r_out'),
+    'elliptical_aperture': ('a', 'b'),
+    'elliptical_annulus': ('a_in', 'a_out', 'b_in', 'b_out'),
+    'polygon_aperture': ('vertex_offsets',),
+    'rectangular_aperture': ('w', 'h'),
+    'rectangular_annulus': ('w_in', 'w_out', 'h_in', 'h_out'),
+}
 
 
 def _load_resource(uri):
@@ -165,3 +198,70 @@ def test_invalid_example_tag_is_detected(example_tag, match):
 
     with pytest.raises(AssertionError, match=match):
         test_example_tag_in_manifest(schema['id'], index, tag)
+
+
+def _quantity(value):
+    """
+    Build the YAML for a scalar angular quantity.
+    """
+    return ('!unit/quantity-1.3.0 '
+            f'{{unit: !unit/unit-1.0.0 arcsec, value: {value}}}')
+
+
+def _sizes(names, *, sky=False):
+    """
+    Build the size parameters of an aperture in pixel or sky form.
+    """
+    values = {}
+    for index, name in enumerate(names):
+        if name == 'vertex_offsets':
+            values[name] = SKY_OFFSETS if sky else PIXEL_OFFSETS
+        elif sky:
+            values[name] = _quantity(index + 3.0)
+        else:
+            values[name] = f'{index + 3.0}'
+    return values
+
+
+def _aperture_yaml(stem, positions, sizes):
+    """
+    Build the tagged YAML for a photutils aperture.
+    """
+    params = {'positions': positions, **sizes}
+    body = '\n'.join(f'  {key}: {value}' for key, value in params.items())
+    return f'!<tag:astropy.org:photutils/aperture/{stem}-1.0.0>\n{body}'
+
+
+def _mixed_apertures():
+    """
+    Build apertures that mix pixel values with angular quantities.
+    """
+    mixed = []
+    for stem, names in SIZE_PARAMS.items():
+        mixed.append((f'{stem}-sky-positions',
+                      _aperture_yaml(stem, SKY_POSITIONS,
+                                     _sizes(names, sky=False))))
+        mixed.append((f'{stem}-sky-sizes',
+                      _aperture_yaml(stem, PIXEL_POSITIONS,
+                                     _sizes(names, sky=True))))
+    return mixed
+
+
+MIXED_APERTURES = _mixed_apertures()
+
+
+@pytest.mark.parametrize('example', [case[1] for case in MIXED_APERTURES],
+                         ids=[case[0] for case in MIXED_APERTURES])
+def test_mixed_pixel_and_sky_rejected(example):
+    """
+    Test that an aperture mixing pixel values with angular quantities
+    fails schema validation when read.
+
+    The pixel and sky variants of each aperture share a tag, so this
+    combination is excluded only by the ``oneOf`` in the schema. Valid
+    pixel and sky files are covered by the round-trip tests in
+    ``test_apertures.py``.
+    """
+    with pytest.raises(ValidationError), \
+            asdf.open(yaml_to_asdf(f'aper: {example}')):
+        pass

--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -325,3 +325,39 @@ def test_optional_inner_size_uses_default(sky):
     rectangle = _read_minimal_aperture('rectangular_annulus', sky=sky)
     assert (rectangle.h_in
             == rectangle.w_in * rectangle.h_out / rectangle.w_out)
+
+
+@pytest.mark.parametrize('stem', list(REQUIRED_SIZE_PARAMS))
+def test_sky_numeric_theta_rejected(stem):
+    """
+    Test that a sky aperture with a numeric ``theta`` fails schema
+    validation when read.
+
+    The sky apertures require an angular ``theta``, so a number is
+    excluded by the sky branch of the ``oneOf`` in the schema.
+    """
+    sizes = _sizes(REQUIRED_SIZE_PARAMS[stem], sky=True)
+    example = _aperture_yaml(stem, SKY_POSITIONS,
+                             {**sizes, 'theta': '0.5'})
+    with pytest.raises(ValidationError), \
+            asdf.open(yaml_to_asdf(f'aper: {example}')):
+        pass
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('stem', list(REQUIRED_SIZE_PARAMS))
+def test_pixel_angular_theta_accepted(stem):
+    """
+    Test that a pixel aperture with an angular ``theta`` is read
+    without error.
+
+    The pixel apertures accept either a number or an angular quantity,
+    so ``theta`` is constrained only in the sky branch of the ``oneOf``
+    in the schema.
+    """
+    sizes = _sizes(REQUIRED_SIZE_PARAMS[stem], sky=False)
+    example = _aperture_yaml(stem, PIXEL_POSITIONS,
+                             {**sizes, 'theta': _quantity(0.5)})
+    with asdf.open(yaml_to_asdf(f'aper: {example}')) as af:
+        assert af['aper'].theta == 0.5 * u.arcsec

--- a/photutils/resources/schemas/aperture/circular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/circular_annulus-1.0.0.yaml
@@ -85,4 +85,25 @@ properties:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 required: [positions, r_in, r_out]
+# CircularAnnulus and SkyCircularAnnulus share a tag, so this requires
+# a file to use pixel values or angular quantities consistently.
+oneOf:
+  - title: Pixel coordinates
+    properties:
+      positions:
+        anyOf:
+          - type: array
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      r_in:
+        type: number
+      r_out:
+        type: number
+  - title: Sky coordinates
+    properties:
+      positions:
+        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      r_in:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      r_out:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 ...

--- a/photutils/resources/schemas/aperture/circular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/circular_aperture-1.0.0.yaml
@@ -71,4 +71,21 @@ properties:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 required: [positions, r]
+# CircularAperture and SkyCircularAperture share a tag, so this requires
+# a file to use pixel values or angular quantities consistently.
+oneOf:
+  - title: Pixel coordinates
+    properties:
+      positions:
+        anyOf:
+          - type: array
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      r:
+        type: number
+  - title: Sky coordinates
+    properties:
+      positions:
+        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      r:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 ...

--- a/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
@@ -118,4 +118,35 @@ properties:
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 required: [positions, a_in, a_out, b_out]
+# EllipticalAnnulus and SkyEllipticalAnnulus share a tag, so this
+# requires a file to use pixel values or angular quantities
+# consistently. ``theta`` is excluded because EllipticalAnnulus also
+# accepts an angular quantity.
+oneOf:
+  - title: Pixel coordinates
+    properties:
+      positions:
+        anyOf:
+          - type: array
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      a_in:
+        type: number
+      a_out:
+        type: number
+      b_in:
+        type: number
+      b_out:
+        type: number
+  - title: Sky coordinates
+    properties:
+      positions:
+        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      a_in:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      a_out:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      b_in:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      b_out:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 ...

--- a/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
@@ -120,8 +120,8 @@ properties:
 required: [positions, a_in, a_out, b_out]
 # EllipticalAnnulus and SkyEllipticalAnnulus share a tag, so this
 # requires a file to use pixel values or angular quantities
-# consistently. ``theta`` is excluded because EllipticalAnnulus also
-# accepts an angular quantity.
+# consistently. ``theta`` is constrained only in the sky branch because
+# EllipticalAnnulus also accepts an angular quantity.
 oneOf:
   - title: Pixel coordinates
     properties:
@@ -149,4 +149,8 @@ oneOf:
         tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       b_out:
         tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      theta:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 ...

--- a/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
@@ -95,4 +95,27 @@ properties:
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 required: [positions, a, b]
+# EllipticalAperture and SkyEllipticalAperture share a tag, so this
+# requires a file to use pixel values or angular quantities
+# consistently. ``theta`` is excluded because EllipticalAperture also
+# accepts an angular quantity.
+oneOf:
+  - title: Pixel coordinates
+    properties:
+      positions:
+        anyOf:
+          - type: array
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      a:
+        type: number
+      b:
+        type: number
+  - title: Sky coordinates
+    properties:
+      positions:
+        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      a:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      b:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 ...

--- a/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
@@ -97,8 +97,8 @@ properties:
 required: [positions, a, b]
 # EllipticalAperture and SkyEllipticalAperture share a tag, so this
 # requires a file to use pixel values or angular quantities
-# consistently. ``theta`` is excluded because EllipticalAperture also
-# accepts an angular quantity.
+# consistently. ``theta`` is constrained only in the sky branch because
+# EllipticalAperture also accepts an angular quantity.
 oneOf:
   - title: Pixel coordinates
     properties:
@@ -118,4 +118,8 @@ oneOf:
         tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       b:
         tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      theta:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 ...

--- a/photutils/resources/schemas/aperture/polygon_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/polygon_aperture-1.0.0.yaml
@@ -79,4 +79,21 @@ properties:
       - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 required: [positions, vertex_offsets]
+# PolygonAperture and SkyPolygonAperture share a tag, so this requires
+# a file to use pixel values or angular quantities consistently.
+oneOf:
+  - title: Pixel coordinates
+    properties:
+      positions:
+        anyOf:
+          - type: array
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      vertex_offsets:
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+  - title: Sky coordinates
+    properties:
+      positions:
+        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      vertex_offsets:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 ...

--- a/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
@@ -132,4 +132,35 @@ properties:
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 required: [positions, w_in, w_out, h_out]
+# RectangularAnnulus and SkyRectangularAnnulus share a tag, so this
+# requires a file to use pixel values or angular quantities
+# consistently. ``theta`` is excluded because RectangularAnnulus also
+# accepts an angular quantity.
+oneOf:
+  - title: Pixel coordinates
+    properties:
+      positions:
+        anyOf:
+          - type: array
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      w_in:
+        type: number
+      w_out:
+        type: number
+      h_in:
+        type: number
+      h_out:
+        type: number
+  - title: Sky coordinates
+    properties:
+      positions:
+        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      w_in:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      w_out:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      h_in:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      h_out:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 ...

--- a/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
@@ -134,8 +134,8 @@ properties:
 required: [positions, w_in, w_out, h_out]
 # RectangularAnnulus and SkyRectangularAnnulus share a tag, so this
 # requires a file to use pixel values or angular quantities
-# consistently. ``theta`` is excluded because RectangularAnnulus also
-# accepts an angular quantity.
+# consistently. ``theta`` is constrained only in the sky branch because
+# RectangularAnnulus also accepts an angular quantity.
 oneOf:
   - title: Pixel coordinates
     properties:
@@ -163,4 +163,8 @@ oneOf:
         tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       h_out:
         tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      theta:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 ...

--- a/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
@@ -86,4 +86,27 @@ properties:
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 required: [positions, w, h]
+# RectangularAperture and SkyRectangularAperture share a tag, so this
+# requires a file to use pixel values or angular quantities
+# consistently. ``theta`` is excluded because RectangularAperture also
+# accepts an angular quantity.
+oneOf:
+  - title: Pixel coordinates
+    properties:
+      positions:
+        anyOf:
+          - type: array
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      w:
+        type: number
+      h:
+        type: number
+  - title: Sky coordinates
+    properties:
+      positions:
+        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      w:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      h:
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 ...

--- a/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
@@ -88,8 +88,8 @@ properties:
 required: [positions, w, h]
 # RectangularAperture and SkyRectangularAperture share a tag, so this
 # requires a file to use pixel values or angular quantities
-# consistently. ``theta`` is excluded because RectangularAperture also
-# accepts an angular quantity.
+# consistently. ``theta`` is constrained only in the sky branch because
+# RectangularAperture also accepts an angular quantity.
 oneOf:
   - title: Pixel coordinates
     properties:
@@ -109,4 +109,8 @@ oneOf:
         tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       h:
         tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      theta:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 ...


### PR DESCRIPTION
The pixel and sky variant of each aperture share one ASDF tag, so a single schema describes both. This PR:

- Adds a top-level `oneOf` to each aperture schema so a file must use pixel values or angular quantities consistently. Previously a `SkyCoord` position with pixel radii validated fine. `theta` is excluded, since the pixel apertures also accept an angular quantity.
  
- Stops the converters from requiring `theta`, `b_in`, and `h_in`, which the schemas list as optional. Omitting any of them raised a `KeyError` instead of using the aperture class default.