### PR TITLE
Reject unknown properties in the aperture ASDF schemas

### DIFF
--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -361,3 +361,21 @@ def test_pixel_angular_theta_accepted(stem):
                              {**sizes, 'theta': _quantity(0.5)})
     with asdf.open(yaml_to_asdf(f'aper: {example}')) as af:
         assert af['aper'].theta == 0.5 * u.arcsec
+
+
+@pytest.mark.parametrize('stem', list(SIZE_PARAMS))
+def test_unknown_property_rejected(stem):
+    """
+    Test that an aperture with an unknown property fails schema
+    validation when read.
+
+    Without ``additionalProperties: false`` an unknown key is accepted
+    and then silently dropped, so a misspelled parameter would read
+    back as an aperture with default values.
+    """
+    params = _sizes(SIZE_PARAMS[stem], sky=False)
+    params['not_a_parameter'] = '999.0'
+    example = _aperture_yaml(stem, PIXEL_POSITIONS, params)
+    with pytest.raises(ValidationError), \
+            asdf.open(yaml_to_asdf(f'aper: {example}')):
+        pass

--- a/photutils/resources/schemas/aperture/circular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/circular_annulus-1.0.0.yaml
@@ -85,6 +85,7 @@ properties:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 required: [positions, r_in, r_out]
+additionalProperties: false
 # CircularAnnulus and SkyCircularAnnulus share a tag, so this requires
 # a file to use pixel values or angular quantities consistently.
 oneOf:

--- a/photutils/resources/schemas/aperture/circular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/circular_aperture-1.0.0.yaml
@@ -71,6 +71,7 @@ properties:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 required: [positions, r]
+additionalProperties: false
 # CircularAperture and SkyCircularAperture share a tag, so this requires
 # a file to use pixel values or angular quantities consistently.
 oneOf:

--- a/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
@@ -118,6 +118,7 @@ properties:
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 required: [positions, a_in, a_out, b_out]
+additionalProperties: false
 # EllipticalAnnulus and SkyEllipticalAnnulus share a tag, so this
 # requires a file to use pixel values or angular quantities
 # consistently. ``theta`` is constrained only in the sky branch because

--- a/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
@@ -95,6 +95,7 @@ properties:
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 required: [positions, a, b]
+additionalProperties: false
 # EllipticalAperture and SkyEllipticalAperture share a tag, so this
 # requires a file to use pixel values or angular quantities
 # consistently. ``theta`` is constrained only in the sky branch because

--- a/photutils/resources/schemas/aperture/polygon_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/polygon_aperture-1.0.0.yaml
@@ -79,6 +79,7 @@ properties:
       - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 required: [positions, vertex_offsets]
+additionalProperties: false
 # PolygonAperture and SkyPolygonAperture share a tag, so this requires
 # a file to use pixel values or angular quantities consistently.
 oneOf:

--- a/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
@@ -132,6 +132,7 @@ properties:
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 required: [positions, w_in, w_out, h_out]
+additionalProperties: false
 # RectangularAnnulus and SkyRectangularAnnulus share a tag, so this
 # requires a file to use pixel values or angular quantities
 # consistently. ``theta`` is constrained only in the sky branch because

--- a/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
@@ -86,6 +86,7 @@ properties:
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
 required: [positions, w, h]
+additionalProperties: false
 # RectangularAperture and SkyRectangularAperture share a tag, so this
 # requires a file to use pixel values or angular quantities
 # consistently. ``theta`` is constrained only in the sky branch because


### PR DESCRIPTION
The aperture ASDF schemas did not set `additionalProperties: false`, so an unknown key in a file passed schema validation and was then silently dropped by the converter. A misspelled parameter therefore read back as an aperture using the default value for that parameter, with no indication that anything in the file had been ignored.

This PR adds `additionalProperties: false` to all seven aperture schemas, so an unknown key now raises a `ValidationError` when the file is read. 