### PR TITLE
Handle path-like inputs in the STDPSF format identifiers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,10 @@ New Features
   - Added a ``STDPSFGrid.grid_shape`` property returning the ``(ny,
     nx)`` shape of the ePSF grid. [#2347]
 
+  - ``STDPSFGrid`` and the ``GriddedPSFModel`` ``read`` method now
+    accept path-like inputs (e.g., ``pathlib.Path``) in addition to
+    strings. [#2355]
+
 - ``photutils.segmentation``
 
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -791,7 +791,7 @@ class STDPSFGrid:
 
     Parameters
     ----------
-    filename : str
+    filename : str or path-like
         The name or URL of a STDPSF FITS file.
 
     Examples

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -116,7 +116,7 @@ def _read_stdpsf(filename):
 
     Parameters
     ----------
-    filename : str or `~astropy.io.fits.HDUList`
+    filename : str, path-like, or `~astropy.io.fits.HDUList`
         The name of the STDPSF FITS file, or an already-open
         `~astropy.io.fits.HDUList`.
 
@@ -125,6 +125,9 @@ def _read_stdpsf(filename):
     data : dict
         A dictionary containing the ePSF data and metadata.
     """
+    if isinstance(filename, os.PathLike):
+        filename = os.fspath(filename)
+
     is_hdulist = isinstance(filename, fits.HDUList)
     is_fileobj = (isinstance(filename, io.FileIO)
                   and filename.name.lower().endswith(_FITS_EXTENSIONS))
@@ -142,7 +145,7 @@ def _read_fits_stdpsf(filename):
 
     Parameters
     ----------
-    filename : str or `~astropy.io.fits.HDUList`
+    filename : str, path-like, or `~astropy.io.fits.HDUList`
         The name of the STDPSF FITS file, or an already-open
         `~astropy.io.fits.HDUList`.
 
@@ -427,7 +430,7 @@ def _get_metadata(filename, detector_id):
 
     Parameters
     ----------
-    filename : str
+    filename : str or path-like
         The name of the STDPSF FITS file.
 
     detector_id : int
@@ -440,6 +443,8 @@ def _get_metadata(filename, detector_id):
     """
     if isinstance(filename, io.FileIO):
         filename = filename.name
+    elif isinstance(filename, os.PathLike):
+        filename = os.fspath(filename)
 
     # Strip the file extension (e.g., '.fits' or '.fits.gz') before
     # splitting the filename into its underscore-separated fields.
@@ -500,7 +505,7 @@ def stdpsf_reader(filename, detector_id=None):
 
     Parameters
     ----------
-    filename : str
+    filename : str or path-like
         The name of the STDPSF FITS file. A URL can also be used.
 
     detector_id : `None` or int, optional
@@ -588,7 +593,7 @@ def webbpsf_reader(filename):
 
     Parameters
     ----------
-    filename : str
+    filename : str or path-like
         The name of the WebbPSF FITS file. A URL can also be used.
 
     Returns
@@ -654,7 +659,7 @@ def _has_fits_header_keys(filepath, keys):
 
     Parameters
     ----------
-    filepath : str or `None`
+    filepath : str, path-like, or `None`
         The file path of the FITS file.
 
     keys : tuple of str
@@ -666,6 +671,9 @@ def _has_fits_header_keys(filepath, keys):
         Returns `True` if the file is a FITS file containing all of the
         input keywords.
     """
+    if isinstance(filepath, os.PathLike):
+        filepath = os.fspath(filepath)
+
     if filepath is None or not filepath.lower().endswith(_FITS_EXTENSIONS):
         return False
 
@@ -686,7 +694,7 @@ def is_stdpsf(origin, filepath, fileobj, *args, **kwargs):
         A string indicating whether the file is to be opened for reading
         or writing.
 
-    filepath : str
+    filepath : str or path-like
         The file path of the FITS file.
 
     fileobj : file-like object
@@ -715,7 +723,7 @@ def is_webbpsf(origin, filepath, fileobj, *args, **kwargs):
         A string indicating whether the file is to be opened for reading
         or writing.
 
-    filepath : str
+    filepath : str or path-like
         The file path of the FITS file.
 
     fileobj : file-like object

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -5,6 +5,7 @@ Tests for the gridded_models module.
 
 import os.path as op
 from itertools import product
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -519,6 +520,13 @@ def test_stdpsfgrid(filename):
     assert psfgrid.data.shape[0] == len(psfgrid.grid_xypos)
     assert isinstance(psfgrid.grid_xypos, np.ndarray)
     assert psfgrid.grid_shape == (len(psfgrid._ygrid), len(psfgrid._xgrid))
+
+
+def test_stdpsfgrid_path():
+    filename = Path(__file__).parent / 'data' / STDPSF_FILENAMES[0]
+    psfgrid = STDPSFGrid(filename)
+    assert psfgrid.data.shape[0] == len(psfgrid.grid_xypos)
+    assert psfgrid.meta['STDPSF'] == str(filename)
 
 
 def test_stdpsfgrid_repr_str():

--- a/photutils/psf/tests/test_model_io.py
+++ b/photutils/psf/tests/test_model_io.py
@@ -6,6 +6,7 @@ Tests for the model_io module.
 import io
 import os.path as op
 from itertools import product
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -14,7 +15,8 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.psf import GriddedPSFModel
 from photutils.psf.model_io import (_get_metadata, _has_fits_header_keys,
-                                    _read_stdpsf, is_stdpsf, is_webbpsf)
+                                    _read_stdpsf, is_stdpsf, is_webbpsf,
+                                    stdpsf_reader)
 
 # The first file has a single detector, the rest have multiple detectors
 STDPSF_FILENAMES = ('STDPSF_NRCA1_F150W_mock.fits',
@@ -129,6 +131,23 @@ class TestSTDPSFReader:
         assert isinstance(psfmodel.meta['grid_xypos'], np.ndarray)
         assert_equal(psfmodel.oversampling, [4, 4])
         assert_equal(psfmodel.meta['oversampling'], psfmodel.oversampling)
+
+    def test_read_stdpsf_path(self):
+        """
+        Test STDPSF read with a pathlib.Path.
+
+        The reader is called directly because the astropy unified-I/O
+        registry converts a path-like input to a string before
+        dispatching to the reader.
+        """
+        filename = Path(get_data_filename('STDPSF_NRCA1_F150W_mock.fits'))
+        psfmodel = stdpsf_reader(filename)
+        assert psfmodel.data.shape[0] == len(psfmodel.meta['grid_xypos'])
+        assert_equal(psfmodel.oversampling, [4, 4])
+        assert psfmodel.meta['STDPSF'] == str(filename)
+
+        psfmodel2 = GriddedPSFModel.read(filename, format='stdpsf')
+        assert_equal(psfmodel2.data, psfmodel.data)
 
     @pytest.mark.parametrize('filename', STDPSF_FILENAMES[1:])
     @pytest.mark.parametrize('detector_id', [1, 2])
@@ -358,7 +377,13 @@ class TestFormatIdentifiers:
         assert is_webbpsf('read', filename, None)
         assert not is_stdpsf('read', filename, None)
 
-    @pytest.mark.parametrize('filepath', [None, 'filename.txt'])
+    def test_path_input(self):
+        filename = Path(get_data_filename('STDPSF_NRCA1_F150W_mock.fits'))
+        assert is_stdpsf('read', filename, None)
+        assert not is_webbpsf('read', filename, None)
+
+    @pytest.mark.parametrize('filepath', [None, 'filename.txt',
+                                          Path('filename.txt')])
     def test_not_a_fits_file(self, filepath):
         assert not is_stdpsf('read', filepath, None)
         assert not is_webbpsf('read', filepath, None)


### PR DESCRIPTION
With this PR, ``STDPSFGrid`` and the ``GriddedPSFModel`` ``read`` method now accept path-like inputs (e.g., ``pathlib.Path``) in addition to strings.