### PR TITLE
ASDF converters and schemas followup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,21 @@ repos:
             (.*\/)?(codeql\.yml|dependabot\.yml)$
           )
 
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        name: yamllint (ASDF resources)
+        # Prettier does not reach inside the block scalars that hold the
+        # schema examples, so the line length is enforced here. The tag
+        # and schema URIs cannot be wrapped, so a value that is a single
+        # long word is exempt.
+        files: ^photutils/resources/.*\.yaml$
+        args:
+          - '-d'
+          - '{rules: {line-length: {max: 79,
+            allow-non-breakable-inline-mappings: true}}}'
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,11 +98,10 @@ repos:
       - id: prettier
         types_or: [css, rst, json, yaml, toml, markdown]
         args: ['--single-quote']
-        # Exclude codeql.yml, dependabot.yml, and schemas/**/*.yaml
+        # Exclude codeql.yml and dependabot.yml
         exclude: |
           (?x)^(
-            (.*\/)?(codeql\.yml|dependabot\.yml)$|
-            .*schemas\/.*\.yaml$
+            (.*\/)?(codeql\.yml|dependabot\.yml)$
           )
 
   - repo: https://github.com/codespell-project/codespell

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -30,11 +30,15 @@ Photutils also optionally depends on other packages for some features:
   Required in `~photutils.datasets.make_gwcs` to create a simple celestial
   gwcs object.
 
-* `asdf-astropy <https://asdf-astropy.readthedocs.io/en/latest/>`_ 0.10
-  or later:
-  Required to serialize objects to the `Advanced Scientific Data Format
-  (ASDF) <https://www.asdf-format.org/projects/asdf/en/latest/>`_
+* `asdf <https://asdf.readthedocs.io/>`_ 3.3 or later: Required to
+  serialize apertures and PSF models to the `Advanced Scientific Data
+  Format (ASDF) <https://www.asdf-format.org/projects/asdf/en/latest/>`_
   format.
+
+* `asdf-astropy <https://asdf-astropy.readthedocs.io/en/latest/>`_ 0.10
+  or later: Required to serialize objects that store a
+  `~astropy.units.Quantity` or a `~astropy.coordinates.SkyCoord` to
+  ASDF, which includes all PSF models and all sky apertures.
 
 * `Bottleneck <https://github.com/pydata/bottleneck>`_ 1.4 or later:
   Improves the performance of sigma clipping and other functionality that

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -618,12 +618,18 @@ class TestMethodSubpixelsDocstring:
     def test_no_placeholder_noop(self):
         """
         Test that the decorator is a no-op if no placeholder is present.
-        """
-        @_update_method_subpixels_docstring
-        def func():
-            """Summary with no placeholder."""
 
-        assert func.__doc__ == 'Summary with no placeholder.'
+        The docstring is assigned manually to avoid the compile-time
+        docstring dedenting introduced in Python 3.13.
+        """
+        def func():
+            pass
+
+        docstring = '\n        Summary with no placeholder.\n        '
+        func.__doc__ = docstring
+
+        assert _update_method_subpixels_docstring(func) is func
+        assert func.__doc__ == docstring
 
     def test_none_docstring_noop(self):
         """

--- a/photutils/converters/__init__.py
+++ b/photutils/converters/__init__.py
@@ -23,51 +23,41 @@ except ImportError:
 __all__ = []
 
 if _ASDF_INSTALLED:
-    from .apertures import (
-        CircularAnnulusConverter,
-        CircularApertureConverter,
-        EllipticalAnnulusConverter,
-        EllipticalApertureConverter,
-        PolygonApertureConverter,
-        RectangularAnnulusConverter,
-        RectangularApertureConverter,
-    )
+    from .apertures import (CircularAnnulusConverter,
+                            CircularApertureConverter,
+                            EllipticalAnnulusConverter,
+                            EllipticalApertureConverter,
+                            PolygonApertureConverter,
+                            RectangularAnnulusConverter,
+                            RectangularApertureConverter)
 
-    __all__ += [
-        'CircularAnnulusConverter',
-        'CircularApertureConverter',
-        'EllipticalAnnulusConverter',
-        'EllipticalApertureConverter',
-        'PolygonApertureConverter',
-        'RectangularAnnulusConverter',
-        'RectangularApertureConverter',
-    ]
+    __all__ += ['CircularAnnulusConverter',
+                'CircularApertureConverter',
+                'EllipticalAnnulusConverter',
+                'EllipticalApertureConverter',
+                'PolygonApertureConverter',
+                'RectangularAnnulusConverter',
+                'RectangularApertureConverter',
+                ]
 
 if _ASDF_ASTROPY_INSTALLED:
-    from .functional_models import (
-        AiryDiskPSFConverter,
-        CircularGaussianPRFConverter,
-        CircularGaussianPSFConverter,
-        CircularGaussianSigmaPRFConverter,
-        GaussianPRFConverter,
-        GaussianPSFConverter,
-        MoffatPSFConverter,
-    )
-    from .image_models import (
-        GriddedPSFModelConverter,
-        ImagePSFConverter,
-        STDPSFGridConverter,
-    )
+    from .functional_models import (AiryDiskPSFConverter,
+                                    CircularGaussianPRFConverter,
+                                    CircularGaussianPSFConverter,
+                                    CircularGaussianSigmaPRFConverter,
+                                    GaussianPRFConverter, GaussianPSFConverter,
+                                    MoffatPSFConverter)
+    from .image_models import (GriddedPSFModelConverter, ImagePSFConverter,
+                               STDPSFGridConverter)
 
-    __all__ += [
-        'AiryDiskPSFConverter',
-        'CircularGaussianPRFConverter',
-        'CircularGaussianPSFConverter',
-        'CircularGaussianSigmaPRFConverter',
-        'GaussianPRFConverter',
-        'GaussianPSFConverter',
-        'GriddedPSFModelConverter',
-        'ImagePSFConverter',
-        'MoffatPSFConverter',
-        'STDPSFGridConverter',
-    ]
+    __all__ += ['AiryDiskPSFConverter',
+                'CircularGaussianPRFConverter',
+                'CircularGaussianPSFConverter',
+                'CircularGaussianSigmaPRFConverter',
+                'GaussianPRFConverter',
+                'GaussianPSFConverter',
+                'GriddedPSFModelConverter',
+                'ImagePSFConverter',
+                'MoffatPSFConverter',
+                'STDPSFGridConverter',
+                ]

--- a/photutils/converters/__init__.py
+++ b/photutils/converters/__init__.py
@@ -1,25 +1,49 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 ASDF converters.
+
+The aperture converters need only ``asdf``. The PSF converters are built
+on the ``asdf-astropy`` transform machinery, so they are defined only
+when that optional dependency is installed.
 """
 
+_ASDF_INSTALLED = True
 _ASDF_ASTROPY_INSTALLED = True
 
 try:
-    import asdf_astropy  # noqa: F401 -- needed to register the converters
+    import asdf  # noqa: F401
+except ImportError:
+    _ASDF_INSTALLED = False
+
+try:
+    import asdf_astropy  # noqa: F401
 except ImportError:
     _ASDF_ASTROPY_INSTALLED = False
 
-if _ASDF_ASTROPY_INSTALLED:
+__all__ = []
+
+if _ASDF_INSTALLED:
     from .apertures import (
-        CircularApertureConverter,
         CircularAnnulusConverter,
-        EllipticalApertureConverter,
+        CircularApertureConverter,
         EllipticalAnnulusConverter,
+        EllipticalApertureConverter,
         PolygonApertureConverter,
-        RectangularApertureConverter,
         RectangularAnnulusConverter,
+        RectangularApertureConverter,
     )
+
+    __all__ += [
+        'CircularAnnulusConverter',
+        'CircularApertureConverter',
+        'EllipticalAnnulusConverter',
+        'EllipticalApertureConverter',
+        'PolygonApertureConverter',
+        'RectangularAnnulusConverter',
+        'RectangularApertureConverter',
+    ]
+
+if _ASDF_ASTROPY_INSTALLED:
     from .functional_models import (
         AiryDiskPSFConverter,
         CircularGaussianPRFConverter,
@@ -35,23 +59,15 @@ if _ASDF_ASTROPY_INSTALLED:
         STDPSFGridConverter,
     )
 
-
-__all__ = [
-    'AiryDiskPSFConverter',
-    'CircularAnnulusConverter',
-    'CircularApertureConverter',
-    'CircularGaussianPRFConverter',
-    'CircularGaussianPSFConverter',
-    'CircularGaussianSigmaPRFConverter',
-    'EllipticalAnnulusConverter',
-    'EllipticalApertureConverter',
-    'GaussianPRFConverter',
-    'GaussianPSFConverter',
-    'GriddedPSFModelConverter',
-    'ImagePSFConverter',
-    'MoffatPSFConverter',
-    'PolygonApertureConverter',
-    'RectangularAnnulusConverter',
-    'RectangularApertureConverter',
-    'STDPSFGridConverter',
-]
+    __all__ += [
+        'AiryDiskPSFConverter',
+        'CircularGaussianPRFConverter',
+        'CircularGaussianPSFConverter',
+        'CircularGaussianSigmaPRFConverter',
+        'GaussianPRFConverter',
+        'GaussianPSFConverter',
+        'GriddedPSFModelConverter',
+        'ImagePSFConverter',
+        'MoffatPSFConverter',
+        'STDPSFGridConverter',
+    ]

--- a/photutils/converters/_utils.py
+++ b/photutils/converters/_utils.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Helpers shared by the photutils ASDF converters.
+"""
+
+
+def optional_params(node, *names):
+    """
+    Return the optional parameters present in a YAML tree as a keyword
+    dictionary.
+
+    A parameter that is absent from ``node`` is omitted from the result
+    instead of being returned as `None`, so that the class supplies its
+    own default. This is required because the defaults are not always
+    `None` and may differ between related classes (e.g., the ``theta``
+    default differs between the pixel and sky apertures).
+
+    Parameters
+    ----------
+    node : dict
+        The YAML tree of a tagged object.
+
+    *names : str
+        The names of the optional parameters.
+
+    Returns
+    -------
+    params : dict
+        The subset of ``names`` that is present in ``node``, mapped to
+        the corresponding values.
+    """
+    return {name: node[name] for name in names if name in node}

--- a/photutils/converters/apertures.py
+++ b/photutils/converters/apertures.py
@@ -6,6 +6,8 @@ Converters to and from the ASDF data format for photutils apertures.
 from asdf.extension import Converter
 from astropy.coordinates import SkyCoord
 
+from photutils.converters._utils import optional_params
+
 __all__ = [
     'CircularAnnulusConverter',
     'CircularApertureConverter',
@@ -15,18 +17,6 @@ __all__ = [
     'RectangularAnnulusConverter',
     'RectangularApertureConverter',
 ]
-
-
-def _optional_theta(node):
-    """
-    Return ``theta`` as a keyword dict, or an empty dict if it is
-    absent.
-
-    ``theta`` is optional in the aperture schemas. It is omitted instead
-    of being passed as `None` because its default differs between the
-    pixel and sky apertures.
-    """
-    return {'theta': node['theta']} if 'theta' in node else {}
 
 
 class CircularApertureConverter(Converter):
@@ -127,7 +117,7 @@ class EllipticalApertureConverter(Converter):
             positions=node['positions'],
             a=node['a'],
             b=node['b'],
-            **_optional_theta(node),
+            **optional_params(node, 'theta'),
         )
 
 
@@ -165,9 +155,8 @@ class EllipticalAnnulusConverter(Converter):
             positions=node['positions'],
             a_in=node['a_in'],
             a_out=node['a_out'],
-            b_in=node.get('b_in'),
             b_out=node['b_out'],
-            **_optional_theta(node),
+            **optional_params(node, 'b_in', 'theta'),
         )
 
 
@@ -235,7 +224,7 @@ class RectangularApertureConverter(Converter):
             positions=node['positions'],
             w=node['w'],
             h=node['h'],
-            **_optional_theta(node),
+            **optional_params(node, 'theta'),
         )
 
 
@@ -273,7 +262,6 @@ class RectangularAnnulusConverter(Converter):
             positions=node['positions'],
             w_in=node['w_in'],
             w_out=node['w_out'],
-            h_in=node.get('h_in'),
             h_out=node['h_out'],
-            **_optional_theta(node),
+            **optional_params(node, 'h_in', 'theta'),
         )

--- a/photutils/converters/apertures.py
+++ b/photutils/converters/apertures.py
@@ -19,7 +19,57 @@ __all__ = [
 ]
 
 
-class CircularApertureConverter(Converter):
+class _ApertureConverter(Converter):
+    """
+    Base class for the photutils aperture converters.
+
+    The pixel and sky variants of an aperture share a tag, so a single
+    converter handles both. Subclasses list the pixel class first and
+    the sky class second in ``types``, and name the aperture parameters
+    that accompany ``positions``.
+
+    Every parameter is written to the file. Those in
+    ``optional_aperture_params`` may be absent when reading, in which
+    case the aperture class supplies its default. They are omitted
+    rather than passed as `None` because the defaults are not always
+    `None` and differ between the pixel and sky apertures.
+    """
+
+    aperture_params = ()
+    optional_aperture_params = ()
+
+    def _aperture_class(self, positions):
+        """
+        Return the pixel or sky aperture class for ``positions``.
+        """
+        from photutils import aperture
+
+        index = 1 if isinstance(positions, SkyCoord) else 0
+        return getattr(aperture, self.types[index].rsplit('.', 1)[-1])
+
+    def to_yaml_tree(self, obj, tag, ctx):  # noqa: ARG002
+        positions = obj.positions
+        if not isinstance(positions, SkyCoord) and positions.shape == (2,):
+            # store a single pixel position as a plain (x, y) pair
+            positions = positions.tolist()
+
+        node = {'positions': positions}
+        for name in (*self.aperture_params, *self.optional_aperture_params):
+            node[name] = getattr(obj, name)
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
+        positions = node['positions']
+        params = {name: node[name] for name in self.aperture_params}
+
+        return self._aperture_class(positions)(
+            positions=positions,
+            **params,
+            **optional_params(node, *self.optional_aperture_params),
+        )
+
+
+class CircularApertureConverter(_ApertureConverter):
     """
     ASDF converter for circular apertures.
     """
@@ -28,30 +78,10 @@ class CircularApertureConverter(Converter):
     types = ('photutils.aperture.CircularAperture',
              'photutils.aperture.SkyCircularAperture',
              )
-
-    def to_yaml_tree(self, obj, tag, ctx):  # noqa: ARG002
-        pos = obj.positions
-        if not isinstance(pos, SkyCoord) and obj.positions.shape == (2,):
-            pos = obj.positions.tolist()
-
-        return {
-            'positions': pos,
-            'r': obj.r,
-        }
-
-    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
-        if isinstance(node['positions'], SkyCoord):
-            from photutils.aperture import SkyCircularAperture as Aper
-        else:
-            from photutils.aperture import CircularAperture as Aper
-
-        return Aper(
-            positions=node['positions'],
-            r=node['r'],
-        )
+    aperture_params = ('r',)
 
 
-class CircularAnnulusConverter(Converter):
+class CircularAnnulusConverter(_ApertureConverter):
     """
     ASDF converter for circular annulus apertures.
     """
@@ -60,32 +90,10 @@ class CircularAnnulusConverter(Converter):
     types = ('photutils.aperture.CircularAnnulus',
              'photutils.aperture.SkyCircularAnnulus',
              )
-
-    def to_yaml_tree(self, obj, tag, ctx):  # noqa: ARG002
-        pos = obj.positions
-        if not isinstance(pos, SkyCoord) and obj.positions.shape == (2,):
-            pos = obj.positions.tolist()
-
-        return {
-            'positions': pos,
-            'r_in': obj.r_in,
-            'r_out': obj.r_out,
-        }
-
-    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
-        if isinstance(node['positions'], SkyCoord):
-            from photutils.aperture import SkyCircularAnnulus as Aper
-        else:
-            from photutils.aperture import CircularAnnulus as Aper
-
-        return Aper(
-            positions=node['positions'],
-            r_in=node['r_in'],
-            r_out=node['r_out'],
-        )
+    aperture_params = ('r_in', 'r_out')
 
 
-class EllipticalApertureConverter(Converter):
+class EllipticalApertureConverter(_ApertureConverter):
     """
     ASDF converter for elliptical apertures.
     """
@@ -94,34 +102,11 @@ class EllipticalApertureConverter(Converter):
     types = ('photutils.aperture.EllipticalAperture',
              'photutils.aperture.SkyEllipticalAperture',
              )
-
-    def to_yaml_tree(self, obj, tag, ctx):  # noqa: ARG002
-        pos = obj.positions
-        if not isinstance(pos, SkyCoord) and obj.positions.shape == (2,):
-            pos = obj.positions.tolist()
-
-        return {
-            'positions': pos,
-            'a': obj.a,
-            'b': obj.b,
-            'theta': obj.theta,
-        }
-
-    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
-        if isinstance(node['positions'], SkyCoord):
-            from photutils.aperture import SkyEllipticalAperture as Aper
-        else:
-            from photutils.aperture import EllipticalAperture as Aper
-
-        return Aper(
-            positions=node['positions'],
-            a=node['a'],
-            b=node['b'],
-            **optional_params(node, 'theta'),
-        )
+    aperture_params = ('a', 'b')
+    optional_aperture_params = ('theta',)
 
 
-class EllipticalAnnulusConverter(Converter):
+class EllipticalAnnulusConverter(_ApertureConverter):
     """
     ASDF converter for elliptical annulus apertures.
     """
@@ -130,37 +115,11 @@ class EllipticalAnnulusConverter(Converter):
     types = ('photutils.aperture.EllipticalAnnulus',
              'photutils.aperture.SkyEllipticalAnnulus',
              )
-
-    def to_yaml_tree(self, obj, tag, ctx):  # noqa: ARG002
-        pos = obj.positions
-        if not isinstance(pos, SkyCoord) and obj.positions.shape == (2,):
-            pos = obj.positions.tolist()
-
-        return {
-            'positions': pos,
-            'a_in': obj.a_in,
-            'a_out': obj.a_out,
-            'b_in': obj.b_in,
-            'b_out': obj.b_out,
-            'theta': obj.theta,
-        }
-
-    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
-        if isinstance(node['positions'], SkyCoord):
-            from photutils.aperture import SkyEllipticalAnnulus as Aper
-        else:
-            from photutils.aperture import EllipticalAnnulus as Aper
-
-        return Aper(
-            positions=node['positions'],
-            a_in=node['a_in'],
-            a_out=node['a_out'],
-            b_out=node['b_out'],
-            **optional_params(node, 'b_in', 'theta'),
-        )
+    aperture_params = ('a_in', 'a_out', 'b_out')
+    optional_aperture_params = ('b_in', 'theta')
 
 
-class PolygonApertureConverter(Converter):
+class PolygonApertureConverter(_ApertureConverter):
     """
     ASDF converter for polygon apertures.
     """
@@ -169,30 +128,10 @@ class PolygonApertureConverter(Converter):
     types = ('photutils.aperture.PolygonAperture',
              'photutils.aperture.SkyPolygonAperture',
              )
-
-    def to_yaml_tree(self, obj, tag, ctx):  # noqa: ARG002
-        pos = obj.positions
-        if not isinstance(pos, SkyCoord) and obj.positions.shape == (2,):
-            pos = obj.positions.tolist()
-
-        return {
-            'positions': pos,
-            'vertex_offsets': obj.vertex_offsets,
-        }
-
-    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
-        if isinstance(node['positions'], SkyCoord):
-            from photutils.aperture import SkyPolygonAperture as Aper
-        else:
-            from photutils.aperture import PolygonAperture as Aper
-
-        return Aper(
-            positions=node['positions'],
-            vertex_offsets=node['vertex_offsets'],
-        )
+    aperture_params = ('vertex_offsets',)
 
 
-class RectangularApertureConverter(Converter):
+class RectangularApertureConverter(_ApertureConverter):
     """
     ASDF converter for rectangular apertures.
     """
@@ -201,34 +140,11 @@ class RectangularApertureConverter(Converter):
     types = ('photutils.aperture.RectangularAperture',
              'photutils.aperture.SkyRectangularAperture',
              )
-
-    def to_yaml_tree(self, obj, tag, ctx):  # noqa: ARG002
-        pos = obj.positions
-        if not isinstance(pos, SkyCoord) and obj.positions.shape == (2,):
-            pos = obj.positions.tolist()
-
-        return {
-            'positions': pos,
-            'w': obj.w,
-            'h': obj.h,
-            'theta': obj.theta,
-        }
-
-    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
-        if isinstance(node['positions'], SkyCoord):
-            from photutils.aperture import SkyRectangularAperture as Aper
-        else:
-            from photutils.aperture import RectangularAperture as Aper
-
-        return Aper(
-            positions=node['positions'],
-            w=node['w'],
-            h=node['h'],
-            **optional_params(node, 'theta'),
-        )
+    aperture_params = ('w', 'h')
+    optional_aperture_params = ('theta',)
 
 
-class RectangularAnnulusConverter(Converter):
+class RectangularAnnulusConverter(_ApertureConverter):
     """
     ASDF converter for rectangular annulus apertures.
     """
@@ -237,31 +153,5 @@ class RectangularAnnulusConverter(Converter):
     types = ('photutils.aperture.RectangularAnnulus',
              'photutils.aperture.SkyRectangularAnnulus',
              )
-
-    def to_yaml_tree(self, obj, tag, ctx):  # noqa: ARG002
-        pos = obj.positions
-        if not isinstance(pos, SkyCoord) and obj.positions.shape == (2,):
-            pos = obj.positions.tolist()
-
-        return {
-            'positions': pos,
-            'w_in': obj.w_in,
-            'w_out': obj.w_out,
-            'h_in': obj.h_in,
-            'h_out': obj.h_out,
-            'theta': obj.theta,
-        }
-
-    def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
-        if isinstance(node['positions'], SkyCoord):
-            from photutils.aperture import SkyRectangularAnnulus as Aper
-        else:
-            from photutils.aperture import RectangularAnnulus as Aper
-
-        return Aper(
-            positions=node['positions'],
-            w_in=node['w_in'],
-            w_out=node['w_out'],
-            h_out=node['h_out'],
-            **optional_params(node, 'h_in', 'theta'),
-        )
+    aperture_params = ('w_in', 'w_out', 'h_out')
+    optional_aperture_params = ('h_in', 'theta')

--- a/photutils/converters/apertures.py
+++ b/photutils/converters/apertures.py
@@ -8,15 +8,14 @@ from astropy.coordinates import SkyCoord
 
 from photutils.converters._utils import optional_params
 
-__all__ = [
-    'CircularAnnulusConverter',
-    'CircularApertureConverter',
-    'EllipticalAnnulusConverter',
-    'EllipticalApertureConverter',
-    'PolygonApertureConverter',
-    'RectangularAnnulusConverter',
-    'RectangularApertureConverter',
-]
+__all__ = ['CircularAnnulusConverter',
+           'CircularApertureConverter',
+           'EllipticalAnnulusConverter',
+           'EllipticalApertureConverter',
+           'PolygonApertureConverter',
+           'RectangularAnnulusConverter',
+           'RectangularApertureConverter',
+           ]
 
 
 class _ApertureConverter(Converter):

--- a/photutils/converters/functional_models.py
+++ b/photutils/converters/functional_models.py
@@ -18,212 +18,116 @@ __all__ = ['AiryDiskPSFConverter',
            ]
 
 
-class AiryDiskPSFConverter(TransformConverterBase):
+class _PSFModelConverter(TransformConverterBase):
     """
-    Converter for AiryDiskPSF.
+    Base class for the photutils PSF model converters.
+
+    Subclasses name the model parameters that describe the profile;
+    ``flux``, ``x_0``, ``y_0``, and ``bbox_factor`` are common to every
+    model and are handled here.
+
+    Every parameter is written to the file. Those in
+    ``optional_model_params``, and ``bbox_factor``, may be absent when
+    reading, in which case the model class supplies its default.
+    """
+
+    model_params = ()
+    optional_model_params = ()
+
+    def _model_class(self):
+        """
+        Return the model class handled by this converter.
+        """
+        from photutils import psf
+
+        return getattr(psf, self.types[0].rsplit('.', 1)[-1])
+
+    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
+        names = ('flux', 'x_0', 'y_0', *self.model_params,
+                 *self.optional_model_params)
+        node = {name: parameter_to_value(getattr(model, name))
+                for name in names}
+        node['bbox_factor'] = model.bbox_factor
+        return node
+
+    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
+        names = ('flux', 'x_0', 'y_0', *self.model_params)
+        params = {name: node[name] for name in names}
+
+        return self._model_class()(
+            **params,
+            **optional_params(node, *self.optional_model_params,
+                              'bbox_factor'),
+        )
+
+
+class AiryDiskPSFConverter(_PSFModelConverter):
+    """
+    ASDF converter for the AiryDiskPSF model.
     """
 
     tags = ('tag:astropy.org:photutils/psf/airy_disk_psf-*',)
     types = ('photutils.psf.AiryDiskPSF',)
-
-    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
-        return {
-            'flux': parameter_to_value(model.flux),
-            'x_0': parameter_to_value(model.x_0),
-            'y_0': parameter_to_value(model.y_0),
-            'radius': parameter_to_value(model.radius),
-            'bbox_factor': model.bbox_factor,
-        }
-
-    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
-        from photutils.psf import AiryDiskPSF
-
-        return AiryDiskPSF(
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            radius=node['radius'],
-            **optional_params(node, 'bbox_factor'),
-        )
+    model_params = ('radius',)
 
 
-class CircularGaussianPRFConverter(TransformConverterBase):
+class CircularGaussianPRFConverter(_PSFModelConverter):
     """
-    ASDF converter for CircularGaussianPRF model.
+    ASDF converter for the CircularGaussianPRF model.
     """
 
     tags = ('tag:astropy.org:photutils/psf/circular_gaussian_prf-*',)
     types = ('photutils.psf.CircularGaussianPRF',)
-
-    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
-        return {
-            'flux': parameter_to_value(model.flux),
-            'x_0': parameter_to_value(model.x_0),
-            'y_0': parameter_to_value(model.y_0),
-            'fwhm': parameter_to_value(model.fwhm),
-            'bbox_factor': model.bbox_factor,
-        }
-
-    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
-        from photutils.psf import CircularGaussianPRF
-
-        return CircularGaussianPRF(
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            fwhm=node['fwhm'],
-            **optional_params(node, 'bbox_factor'),
-        )
+    model_params = ('fwhm',)
 
 
-class CircularGaussianPSFConverter(TransformConverterBase):
+class CircularGaussianPSFConverter(_PSFModelConverter):
     """
-    ASDF converter for CircularGaussianPSF model.
+    ASDF converter for the CircularGaussianPSF model.
     """
 
     tags = ('tag:astropy.org:photutils/psf/circular_gaussian_psf-*',)
     types = ('photutils.psf.CircularGaussianPSF',)
-
-    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
-        return {
-            'flux': parameter_to_value(model.flux),
-            'x_0': parameter_to_value(model.x_0),
-            'y_0': parameter_to_value(model.y_0),
-            'fwhm': parameter_to_value(model.fwhm),
-            'bbox_factor': model.bbox_factor,
-        }
-
-    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
-        from photutils.psf import CircularGaussianPSF
-
-        return CircularGaussianPSF(
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            fwhm=node['fwhm'],
-            **optional_params(node, 'bbox_factor'),
-        )
+    model_params = ('fwhm',)
 
 
-class CircularGaussianSigmaPRFConverter(TransformConverterBase):
+class CircularGaussianSigmaPRFConverter(_PSFModelConverter):
     """
-    ASDF converter for CircularGaussianSigmaPRF model.
+    ASDF converter for the CircularGaussianSigmaPRF model.
     """
 
     tags = ('tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-*',)
     types = ('photutils.psf.CircularGaussianSigmaPRF',)
-
-    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
-        return {
-            'flux': parameter_to_value(model.flux),
-            'x_0': parameter_to_value(model.x_0),
-            'y_0': parameter_to_value(model.y_0),
-            'sigma': parameter_to_value(model.sigma),
-            'bbox_factor': model.bbox_factor,
-        }
-
-    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
-        from photutils.psf import CircularGaussianSigmaPRF
-
-        return CircularGaussianSigmaPRF(
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            sigma=node['sigma'],
-            **optional_params(node, 'bbox_factor'),
-        )
+    model_params = ('sigma',)
 
 
-class GaussianPRFConverter(TransformConverterBase):
+class GaussianPRFConverter(_PSFModelConverter):
     """
-    ASDF converter for GaussianPRF model.
+    ASDF converter for the GaussianPRF model.
     """
 
     tags = ('tag:astropy.org:photutils/psf/gaussian_prf-*',)
     types = ('photutils.psf.GaussianPRF',)
-
-    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
-        return {
-            'flux': parameter_to_value(model.flux),
-            'x_0': parameter_to_value(model.x_0),
-            'y_0': parameter_to_value(model.y_0),
-            'x_fwhm': parameter_to_value(model.x_fwhm),
-            'y_fwhm': parameter_to_value(model.y_fwhm),
-            'theta': parameter_to_value(model.theta),
-            'bbox_factor': model.bbox_factor,
-        }
-
-    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
-        from photutils.psf import GaussianPRF
-
-        return GaussianPRF(
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            x_fwhm=node['x_fwhm'],
-            y_fwhm=node['y_fwhm'],
-            **optional_params(node, 'theta', 'bbox_factor'),
-        )
+    model_params = ('x_fwhm', 'y_fwhm')
+    optional_model_params = ('theta',)
 
 
-class GaussianPSFConverter(TransformConverterBase):
+class GaussianPSFConverter(_PSFModelConverter):
     """
-    ASDF converter for GaussianPSF model.
+    ASDF converter for the GaussianPSF model.
     """
 
     tags = ('tag:astropy.org:photutils/psf/gaussian_psf-*',)
     types = ('photutils.psf.GaussianPSF',)
-
-    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
-        return {
-            'flux': parameter_to_value(model.flux),
-            'x_0': parameter_to_value(model.x_0),
-            'y_0': parameter_to_value(model.y_0),
-            'x_fwhm': parameter_to_value(model.x_fwhm),
-            'y_fwhm': parameter_to_value(model.y_fwhm),
-            'theta': parameter_to_value(model.theta),
-            'bbox_factor': model.bbox_factor,
-        }
-
-    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
-        from photutils.psf import GaussianPSF
-
-        return GaussianPSF(
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            x_fwhm=node['x_fwhm'],
-            y_fwhm=node['y_fwhm'],
-            **optional_params(node, 'theta', 'bbox_factor'),
-        )
+    model_params = ('x_fwhm', 'y_fwhm')
+    optional_model_params = ('theta',)
 
 
-class MoffatPSFConverter(TransformConverterBase):
+class MoffatPSFConverter(_PSFModelConverter):
     """
-    ASDF converter for MoffatPSF model.
+    ASDF converter for the MoffatPSF model.
     """
 
     tags = ('tag:astropy.org:photutils/psf/moffat_psf-*',)
     types = ('photutils.psf.MoffatPSF',)
-
-    def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
-        return {
-            'flux': parameter_to_value(model.flux),
-            'x_0': parameter_to_value(model.x_0),
-            'y_0': parameter_to_value(model.y_0),
-            'alpha': parameter_to_value(model.alpha),
-            'beta': parameter_to_value(model.beta),
-            'bbox_factor': model.bbox_factor,
-        }
-
-    def from_yaml_tree_transform(self, node, tag, ctx):  # noqa: ARG002
-        from photutils.psf import MoffatPSF
-
-        return MoffatPSF(
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            alpha=node['alpha'],
-            beta=node['beta'],
-            **optional_params(node, 'bbox_factor'),
-        )
+    model_params = ('alpha', 'beta')

--- a/photutils/converters/functional_models.py
+++ b/photutils/converters/functional_models.py
@@ -3,13 +3,8 @@
 Converters to and from the ASDF format for photutils.psf.functional_models.
 """
 
-from . import _ASDF_ASTROPY_INSTALLED
-
-if _ASDF_ASTROPY_INSTALLED:
-    from asdf_astropy.converters.transform.core import (TransformConverterBase,
-                                                        parameter_to_value)
-else:
-    TransformConverterBase = object
+from asdf_astropy.converters.transform.core import (TransformConverterBase,
+                                                    parameter_to_value)
 
 __all__ = ['AiryDiskPSFConverter',
            'CircularGaussianPRFConverter',

--- a/photutils/converters/functional_models.py
+++ b/photutils/converters/functional_models.py
@@ -63,7 +63,7 @@ class _PSFModelConverter(TransformConverterBase):
 
 class AiryDiskPSFConverter(_PSFModelConverter):
     """
-    ASDF converter for the AiryDiskPSF model.
+    ASDF converter for AiryDiskPSF.
     """
 
     tags = ('tag:astropy.org:photutils/psf/airy_disk_psf-*',)
@@ -73,7 +73,7 @@ class AiryDiskPSFConverter(_PSFModelConverter):
 
 class CircularGaussianPRFConverter(_PSFModelConverter):
     """
-    ASDF converter for the CircularGaussianPRF model.
+    ASDF converter for CircularGaussianPRF.
     """
 
     tags = ('tag:astropy.org:photutils/psf/circular_gaussian_prf-*',)
@@ -83,7 +83,7 @@ class CircularGaussianPRFConverter(_PSFModelConverter):
 
 class CircularGaussianPSFConverter(_PSFModelConverter):
     """
-    ASDF converter for the CircularGaussianPSF model.
+    ASDF converter for CircularGaussianPSF.
     """
 
     tags = ('tag:astropy.org:photutils/psf/circular_gaussian_psf-*',)
@@ -93,7 +93,7 @@ class CircularGaussianPSFConverter(_PSFModelConverter):
 
 class CircularGaussianSigmaPRFConverter(_PSFModelConverter):
     """
-    ASDF converter for the CircularGaussianSigmaPRF model.
+    ASDF converter for CircularGaussianSigmaPRF.
     """
 
     tags = ('tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-*',)
@@ -103,7 +103,7 @@ class CircularGaussianSigmaPRFConverter(_PSFModelConverter):
 
 class GaussianPRFConverter(_PSFModelConverter):
     """
-    ASDF converter for the GaussianPRF model.
+    ASDF converter for GaussianPRF.
     """
 
     tags = ('tag:astropy.org:photutils/psf/gaussian_prf-*',)
@@ -114,7 +114,7 @@ class GaussianPRFConverter(_PSFModelConverter):
 
 class GaussianPSFConverter(_PSFModelConverter):
     """
-    ASDF converter for the GaussianPSF model.
+    ASDF converter for GaussianPSF.
     """
 
     tags = ('tag:astropy.org:photutils/psf/gaussian_psf-*',)
@@ -125,7 +125,7 @@ class GaussianPSFConverter(_PSFModelConverter):
 
 class MoffatPSFConverter(_PSFModelConverter):
     """
-    ASDF converter for the MoffatPSF model.
+    ASDF converter for MoffatPSF.
     """
 
     tags = ('tag:astropy.org:photutils/psf/moffat_psf-*',)

--- a/photutils/converters/functional_models.py
+++ b/photutils/converters/functional_models.py
@@ -6,6 +6,8 @@ Converters to and from the ASDF format for photutils.psf.functional_models.
 from asdf_astropy.converters.transform.core import (TransformConverterBase,
                                                     parameter_to_value)
 
+from photutils.converters._utils import optional_params
+
 __all__ = ['AiryDiskPSFConverter',
            'CircularGaussianPRFConverter',
            'CircularGaussianPSFConverter',
@@ -41,7 +43,7 @@ class AiryDiskPSFConverter(TransformConverterBase):
             x_0=node['x_0'],
             y_0=node['y_0'],
             radius=node['radius'],
-            bbox_factor=node['bbox_factor'],
+            **optional_params(node, 'bbox_factor'),
         )
 
 
@@ -70,7 +72,7 @@ class CircularGaussianPRFConverter(TransformConverterBase):
             x_0=node['x_0'],
             y_0=node['y_0'],
             fwhm=node['fwhm'],
-            bbox_factor=node['bbox_factor'],
+            **optional_params(node, 'bbox_factor'),
         )
 
 
@@ -99,7 +101,7 @@ class CircularGaussianPSFConverter(TransformConverterBase):
             x_0=node['x_0'],
             y_0=node['y_0'],
             fwhm=node['fwhm'],
-            bbox_factor=node['bbox_factor'],
+            **optional_params(node, 'bbox_factor'),
         )
 
 
@@ -128,7 +130,7 @@ class CircularGaussianSigmaPRFConverter(TransformConverterBase):
             x_0=node['x_0'],
             y_0=node['y_0'],
             sigma=node['sigma'],
-            bbox_factor=node['bbox_factor'],
+            **optional_params(node, 'bbox_factor'),
         )
 
 
@@ -160,8 +162,7 @@ class GaussianPRFConverter(TransformConverterBase):
             y_0=node['y_0'],
             x_fwhm=node['x_fwhm'],
             y_fwhm=node['y_fwhm'],
-            theta=node['theta'],
-            bbox_factor=node['bbox_factor'],
+            **optional_params(node, 'theta', 'bbox_factor'),
         )
 
 
@@ -193,8 +194,7 @@ class GaussianPSFConverter(TransformConverterBase):
             y_0=node['y_0'],
             x_fwhm=node['x_fwhm'],
             y_fwhm=node['y_fwhm'],
-            theta=node['theta'],
-            bbox_factor=node['bbox_factor'],
+            **optional_params(node, 'theta', 'bbox_factor'),
         )
 
 
@@ -225,5 +225,5 @@ class MoffatPSFConverter(TransformConverterBase):
             y_0=node['y_0'],
             alpha=node['alpha'],
             beta=node['beta'],
-            bbox_factor=node['bbox_factor'],
+            **optional_params(node, 'bbox_factor'),
         )

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 Converters to and from the ASDF format for photutils.psf.image_models
 and photutils.psf.gridded_models.
 """
+
 import numpy as np
 from asdf.extension import Converter
 from asdf_astropy.converters.transform.core import (TransformConverterBase,
@@ -19,7 +19,7 @@ __all__ = ['GriddedPSFModelConverter',
 
 class ImagePSFConverter(TransformConverterBase):
     """
-    ASDF converter for ImagePSF model.
+    ASDF converter for ImagePSF.
     """
 
     tags = ('tag:astropy.org:photutils/psf/image_psf-*',)

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -5,17 +5,9 @@ Converters to and from the ASDF format for photutils.psf.image_models
 and photutils.psf.gridded_models.
 """
 import numpy as np
-
-from . import _ASDF_ASTROPY_INSTALLED
-
-if _ASDF_ASTROPY_INSTALLED:
-    from asdf.extension import Converter
-    from asdf_astropy.converters.transform.core import (TransformConverterBase,
-                                                        parameter_to_value)
-else:
-    TransformConverterBase = object
-    Converter = object
-
+from asdf.extension import Converter
+from asdf_astropy.converters.transform.core import (TransformConverterBase,
+                                                    parameter_to_value)
 
 __all__ = ['GriddedPSFModelConverter',
            'ImagePSFConverter',

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -57,7 +57,7 @@ class GriddedPSFModelConverter(TransformConverterBase):
     ASDF converter for GriddedPSFModel.
     """
 
-    tags = ('tag:astropy.org:photutils/psf/gridded_psf-*',)
+    tags = ('tag:astropy.org:photutils/psf/gridded_psf_model-*',)
     types = ('photutils.psf.GriddedPSFModel',)
 
     def to_yaml_tree_transform(self, model, tag, ctx):  # noqa: ARG002
@@ -106,7 +106,7 @@ class STDPSFGridConverter(Converter):
     ASDF converter for STDPSFGrid.
     """
 
-    tags = ('tag:astropy.org:photutils/psf/stdpsf-*',)
+    tags = ('tag:astropy.org:photutils/psf/stdpsf_grid-*',)
     types = ('photutils.psf.STDPSFGrid',)
 
     def to_yaml_tree(self, model, tag, ctx):  # noqa: ARG002

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -9,6 +9,8 @@ from asdf.extension import Converter
 from asdf_astropy.converters.transform.core import (TransformConverterBase,
                                                     parameter_to_value)
 
+from photutils.converters._utils import optional_params
+
 __all__ = ['GriddedPSFModelConverter',
            'ImagePSFConverter',
            'STDPSFGridConverter',
@@ -43,12 +45,8 @@ class ImagePSFConverter(TransformConverterBase):
             # because the validation in ImagePSF happens before "data"
             # is assigned.
             data=np.array(node['data']),
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            oversampling=node['oversampling'],
-            fill_value=node['fill_value'],
-            origin=node['origin'],
+            **optional_params(node, 'flux', 'x_0', 'y_0', 'oversampling',
+                              'fill_value', 'origin'),
         )
 
 
@@ -94,10 +92,7 @@ class GriddedPSFModelConverter(TransformConverterBase):
 
         return GriddedPSFModel(
             nddata=nd_data,
-            flux=node['flux'],
-            x_0=node['x_0'],
-            y_0=node['y_0'],
-            fill_value=node['fill_value'],
+            **optional_params(node, 'flux', 'x_0', 'y_0', 'fill_value'),
         )
 
 

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -105,21 +105,27 @@ class STDPSFGridConverter(Converter):
     types = ('photutils.psf.STDPSFGrid',)
 
     def to_yaml_tree(self, model, tag, ctx):  # noqa: ARG002
-        meta = dict(model.meta)
-        meta.update({
-            'oversampling': tuple(int(value)
-                                  for value in model.oversampling),
-            'grid_shape': model.grid_shape,
-            'grid_xypos': np.array(model.grid_xypos),
-        })
+        # The grid structure is stored as separate properties, as it is
+        # for GriddedPSFModel, leaving 'meta' for the remaining metadata
+        # (e.g., 'STDPSF', 'detector', 'filter'). STDPSFGrid consumes
+        # these three items when it is initialized, so they never appear
+        # in its meta attribute.
         return {
             'data': model.data,
-            'meta': meta,
+            'grid_xypos': np.array(model.grid_xypos),
+            'grid_shape': model.grid_shape,
+            'oversampling': tuple(int(value)
+                                  for value in model.oversampling),
+            'meta': dict(model.meta),
         }
 
     def from_yaml_tree(self, node, tag, ctx):  # noqa: ARG002
         from photutils.psf import STDPSFGrid
 
+        meta = dict(node['meta'])
         # Load the lazily-read grid positions into memory
-        node['meta']['grid_xypos'] = np.asarray(node['meta']['grid_xypos'])
-        return STDPSFGrid._from_asdf(node['data'], node['meta'])
+        meta['grid_xypos'] = np.asarray(node['grid_xypos'])
+        meta['grid_shape'] = node['grid_shape']
+        meta['oversampling'] = node['oversampling']
+
+        return STDPSFGrid._from_asdf(node['data'], meta)

--- a/photutils/converters/tests/conftest.py
+++ b/photutils/converters/tests/conftest.py
@@ -36,12 +36,12 @@ def circular_gaussian_prf():
 
 @pytest.fixture
 def circular_gaussian_sigma_prf_units():
-    return examples.circular_gaussian_prf_units()
+    return examples.circular_gaussian_sigma_prf_units()
 
 
 @pytest.fixture
 def circular_gaussian_sigma_prf():
-    return examples.circular_gaussian_prf()
+    return examples.circular_gaussian_sigma_prf()
 
 
 @pytest.fixture

--- a/photutils/converters/tests/conftest.py
+++ b/photutils/converters/tests/conftest.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 Fixtures for the photutils ASDF converters.
 
@@ -7,6 +6,7 @@ Object fixtures return a photutils object and parameter names for
 round-trip comparisons. The ``theta`` fixture supplies rotation-angle
 values for parametrized aperture fixtures.
 """
+
 import pytest
 from astropy import units as u
 from astropy.coordinates import Angle

--- a/photutils/converters/tests/conftest.py
+++ b/photutils/converters/tests/conftest.py
@@ -136,7 +136,12 @@ def sky_circular_aperture():
 
 @pytest.fixture(params=[0.23, 0.5 * u.deg, Angle(80, 'deg')])
 def theta(request):
-    """Used to test different types of rotation angles."""
+    """
+    Fixture that returns a rotation angle value.
+
+    The fixture is parametrized with three different types of rotation
+    angles: a float, a Quantity, and an Angle.
+    """
     return request.param
 
 

--- a/photutils/converters/tests/examples.py
+++ b/photutils/converters/tests/examples.py
@@ -48,24 +48,27 @@ parameters = {
 }
 
 
-# PSF examples
-
-
 def airy_disk_units():
-    """Return an AiryDiskPSF with units."""
+    """
+    Return an AiryDiskPSF with units.
+    """
     return (AiryDiskPSF(flux=1 * u.Jy, x_0=0 * u.arcsec, y_0=0 * u.arcsec,
                         radius=1 * u.arcsec, bbox_factor=2),
             parameters['AiryDiskPSF'])
 
 
 def airy_disk():
-    """Return an AiryDiskPSF without units."""
+    """
+    Return an AiryDiskPSF without units.
+    """
     return (AiryDiskPSF(flux=2, x_0=1, y_0=1, radius=2, bbox_factor=3),
             parameters['AiryDiskPSF'])
 
 
 def circular_gaussian_prf_units():
-    """Return a CircularGaussianPRF with units."""
+    """
+    Return a CircularGaussianPRF with units.
+    """
     return (CircularGaussianPRF(flux=1 * u.Jy,
                                 x_0=0 * u.arcsec, y_0=0 * u.arcsec,
                                 fwhm=1 * u.arcsec, bbox_factor=2),
@@ -73,13 +76,17 @@ def circular_gaussian_prf_units():
 
 
 def circular_gaussian_prf():
-    """Return a CircularGaussianPRF without units."""
+    """
+    Return a CircularGaussianPRF without units.
+    """
     return (CircularGaussianPRF(flux=2, x_0=1, y_0=1, fwhm=2, bbox_factor=3),
             parameters['CircularGaussianPRF'])
 
 
 def circular_gaussian_sigma_prf_units():
-    """Return a CircularGaussianPRF with units."""
+    """
+    Return a CircularGaussianPRF with units.
+    """
     return (CircularGaussianSigmaPRF(flux=71.4 * u.Jy,
                                      x_0=24.3 * u.pix, y_0=25.2 * u.pix,
                                      sigma=5.1 * u.pix),
@@ -87,14 +94,18 @@ def circular_gaussian_sigma_prf_units():
 
 
 def circular_gaussian_sigma_prf():
-    """Return a CircularGaussianPRF without units."""
+    """
+    Return a CircularGaussianPRF without units.
+    """
     return (CircularGaussianSigmaPRF(flux=71.4, x_0=24.3, y_0=25.2,
                                      sigma=5.1),
             parameters['CircularGaussianSigmaPRF'])
 
 
 def circular_gaussian_psf_units():
-    """Return a CircularGaussianPSF with units."""
+    """
+    Return a CircularGaussianPSF with units.
+    """
     return (CircularGaussianPSF(flux=1 * u.Jy,
                                 x_0=0 * u.arcsec, y_0=0 * u.arcsec,
                                 fwhm=1 * u.arcsec, bbox_factor=2),
@@ -102,14 +113,18 @@ def circular_gaussian_psf_units():
 
 
 def circular_gaussian_psf():
-    """Return a CircularGaussianPSF without units."""
+    """
+    Return a CircularGaussianPSF without units.
+    """
     return (CircularGaussianPSF(flux=2, x_0=1, y_0=1, fwhm=2,
                                 bbox_factor=3),
             parameters['CircularGaussianPSF'])
 
 
 def gaussian_prf_units():
-    """Return a GaussianPRF with units."""
+    """
+    Return a GaussianPRF with units.
+    """
     return (GaussianPRF(flux=1 * u.Jy,
                         x_0=0 * u.arcsec, y_0=0 * u.arcsec,
                         x_fwhm=1 * u.arcsec, y_fwhm=1 * u.arcsec,
@@ -118,7 +133,9 @@ def gaussian_prf_units():
 
 
 def gaussian_prf():
-    """Return a GaussianPRF without units."""
+    """
+    Return a GaussianPRF without units.
+    """
     return (GaussianPRF(flux=2, x_0=1, y_0=1, x_fwhm=2, y_fwhm=2,
                         theta=0,
                         bbox_factor=3),
@@ -126,7 +143,9 @@ def gaussian_prf():
 
 
 def gaussian_psf_units():
-    """Return a GaussianPSF with units."""
+    """
+    Return a GaussianPSF with units.
+    """
     return (GaussianPSF(flux=1 * u.Jy, x_0=0 * u.arcsec, y_0=0 * u.arcsec,
                         x_fwhm=1 * u.arcsec, y_fwhm=1 * u.arcsec,
                         theta=0 * u.deg, bbox_factor=2),
@@ -134,7 +153,9 @@ def gaussian_psf_units():
 
 
 def gaussian_psf():
-    """Return a GaussianPSF without units."""
+    """
+    Return a GaussianPSF without units.
+    """
     return (GaussianPSF(flux=2, x_0=1, y_0=1,
                         x_fwhm=2, y_fwhm=2,
                         theta=0, bbox_factor=3),
@@ -142,7 +163,9 @@ def gaussian_psf():
 
 
 def moffat_psf_units():
-    """Return a MoffatPSF with units."""
+    """
+    Return a MoffatPSF with units.
+    """
     return (MoffatPSF(flux=71.4 * u.Jy,
                       x_0=24.3 * u.pix, y_0=25.2 * u.pix,
                       alpha=5.1 * u.pix, beta=3.2),
@@ -150,13 +173,17 @@ def moffat_psf_units():
 
 
 def moffat_psf():
-    """Return a MoffatPSF without units."""
+    """
+    Return a MoffatPSF without units.
+    """
     return (MoffatPSF(flux=71.4, x_0=24.3, y_0=25.2, alpha=5.1, beta=3.2),
             parameters['MoffatPSF'])
 
 
 def image_psf():
-    """Return an ImagePSF without units."""
+    """
+    Return an ImagePSF without units.
+    """
     return (ImagePSF(data=np.arange(36).reshape((6, 6)),
                      flux=6,
                      x_0=0.5, y_0=0.5,
@@ -167,7 +194,9 @@ def image_psf():
 
 
 def gridded_psf():
-    """Return a GriddedPSFModel without units."""
+    """
+    Return a GriddedPSFModel without units.
+    """
     nd_data = NDData(data=np.arange(180).reshape((5, 6, 6)),
                      meta={'oversampling': 1,
                            'grid_xypos': [(2, 2),
@@ -184,7 +213,9 @@ def gridded_psf():
 
 
 def stdpsf_single_detector():
-    """Return a STDPSFGrid object read from a FITS STDPSF file."""
+    """
+    Return a STDPSFGrid object read from a FITS STDPSF file.
+    """
     filename = 'STDPSF_NRCA1_F150W_mock.fits'
 
     filename = op.join(Path(__file__).resolve().parent.parent.parent,
@@ -193,54 +224,67 @@ def stdpsf_single_detector():
     return psfgrid, parameters['STDPSF']
 
 
-# Aperture examples
-
 def circular_aperture_single_pos():
-    """Circular Aperture with a single position."""
+    """
+    Circular Aperture with a single position.
+    """
     return (aperture.CircularAperture(positions=(5, 6), r=7),
             parameters['CircularAperture'])
 
 
 def circular_aperture_multi_pos():
-    """Circular aperture with multiple positions."""
+    """
+    Circular aperture with multiple positions.
+    """
     return (aperture.CircularAperture(positions=[(1, 2), (3, 4)], r=5),
             parameters['CircularAperture'])
 
 
 def circular_annulus_single_pos():
-    """Circular annulus aperture with a single position and theta=0."""
+    """
+    Circular annulus aperture with a single position and theta=0.
+    """
     return (aperture.CircularAnnulus([10.0, 20.0], 3.0, 5.0),
             parameters['CircularAnnulus'])
 
 
 def circular_annulus_single_pos_tuple():
-    """Circular annulus aperture with a single position as a tuple."""
+    """
+    Circular annulus aperture with a single position as a tuple.
+    """
     return (aperture.CircularAnnulus((10.0, 20.0), 3.0, 5.0),
             parameters['CircularAnnulus'])
 
 
 def circular_annulus_multi_pos():
-    """Circular annulus aperture with multiple positions."""
+    """
+    Circular annulus aperture with multiple positions.
+    """
     return (aperture.CircularAnnulus([(10, 20), (30, 40)], 3, 5),
             parameters['CircularAnnulus'])
 
 
 def sky_circular_annulus():
-    """Circular annulus aperture on the sky."""
+    """
+    Circular annulus aperture on the sky.
+    """
     sky = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
     return (aperture.SkyCircularAnnulus(sky, 3.0 * u.arcsec, 5.0 * u.arcsec),
             parameters['CircularAnnulus'])
 
 
 def sky_circular_aperture():
-    """Circular aperture on the sky."""
+    """
+    Circular aperture on the sky.
+    """
     sky = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
     return (aperture.SkyCircularAperture(sky, 3.0 * u.arcsec),
             parameters['CircularAperture'])
 
 
 def elliptical_aperture(theta):
-    """Elliptical aperture in pix coordinates with several values of theta.
+    """
+    Elliptical aperture in pix coordinates with several values of theta.
 
     Parameters
     ----------
@@ -253,7 +297,9 @@ def elliptical_aperture(theta):
 
 
 def sky_elliptical_aperture():
-    """Elliptical aperture on the sky."""
+    """
+    Elliptical aperture on the sky.
+    """
     sky = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
 
     return (aperture.SkyEllipticalAperture(sky,
@@ -264,7 +310,8 @@ def sky_elliptical_aperture():
 
 
 def elliptical_annulus(theta):
-    """Elliptical annulus aperture in pixel space.
+    """
+    Elliptical annulus aperture in pixel space.
 
     Parameters
     ----------
@@ -277,7 +324,9 @@ def elliptical_annulus(theta):
 
 
 def sky_elliptical_annulus():
-    """Elliptical annulus aperture on the sky."""
+    """
+    Elliptical annulus aperture on the sky.
+    """
     sky = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
     return (aperture.SkyEllipticalAnnulus(sky,
             a_in=3 * u.arcsec,
@@ -288,7 +337,9 @@ def sky_elliptical_annulus():
 
 
 def polygon_aperture():
-    """Polygon aperture on pixel space."""
+    """
+    Polygon aperture on pixel space.
+    """
     theta = np.linspace(0.0, 2 * np.pi, 6, endpoint=False)
     offsets = np.column_stack([5.0 * np.cos(theta),
                                5.0 * np.sin(theta)])
@@ -297,14 +348,18 @@ def polygon_aperture():
 
 
 def polygon_aperture_vertices():
-    """Polygon aperture in pixel space from vertices."""
+    """
+    Polygon aperture in pixel space from vertices.
+    """
     verts = [(0.0, 0.0), (4.0, 0.0), (4.0, 3.0)]
     return (aperture.PolygonAperture.from_vertices(verts),
             parameters['PolygonAperture'])
 
 
 def sky_polygon_aperture():
-    """Polygon aperture on the sky."""
+    """
+    Polygon aperture on the sky.
+    """
     sky = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
     theta = np.linspace(0, 2 * np.pi, 5, endpoint=False)
     r = 1.0
@@ -315,7 +370,8 @@ def sky_polygon_aperture():
 
 
 def rectangular_aperture(theta):
-    """Rectangular aperture in pixel space.
+    """
+    Rectangular aperture in pixel space.
 
     Parameters
     ----------
@@ -327,7 +383,9 @@ def rectangular_aperture(theta):
 
 
 def sky_rectangular_aperture():
-    """Rectangular aperture on the sky."""
+    """
+    Rectangular aperture on the sky.
+    """
     positions = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
     return (aperture.SkyRectangularAperture(positions,
                                             1.0 * u.arcsec,
@@ -336,7 +394,8 @@ def sky_rectangular_aperture():
 
 
 def rectangular_annulus(theta):
-    """Rectangular annulus aperture in pixel space.
+    """
+    Rectangular annulus aperture in pixel space.
 
     Parameters
     ----------
@@ -349,7 +408,9 @@ def rectangular_annulus(theta):
 
 
 def sky_rectangular_annulus():
-    """Rectangular annulus aperture on the sky."""
+    """
+    Rectangular annulus aperture on the sky.
+    """
     positions = SkyCoord(ra=[10.0, 20.0], dec=[30.0, 40.0], unit='deg')
     theta = Angle(80, 'deg')
     return (aperture.SkyRectangularAnnulus(positions,

--- a/photutils/converters/tests/examples.py
+++ b/photutils/converters/tests/examples.py
@@ -6,7 +6,6 @@ Examples for testing the photutils ASDF converters.
 Each example returns a tuple containing a photutils object and the list
 of parameter names to compare in round-trip tests.
 """
-import os.path as op
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +18,10 @@ from photutils.psf import (AiryDiskPSF, CircularGaussianPRF,
                            CircularGaussianPSF, CircularGaussianSigmaPRF,
                            GaussianPRF, GaussianPSF, GriddedPSFModel, ImagePSF,
                            MoffatPSF, STDPSFGrid)
+
+# The directory holding the STDPSF test files. STDPSFGrid accepts only
+# a string filename, so the paths are converted where they are used.
+PSF_DATA_DIR = Path(__file__).resolve().parents[2] / 'psf' / 'tests' / 'data'
 
 parameters = {
     'AiryDiskPSF': ['flux', 'x_0', 'y_0', 'radius', 'bbox_factor'],
@@ -197,12 +200,11 @@ def gridded_psf():
     """
     Return a GriddedPSFModel without units.
     """
-    nd_data = NDData(data=np.arange(180).reshape((5, 6, 6)),
+    nd_data = NDData(data=np.arange(144).reshape((4, 6, 6)),
                      meta={'oversampling': 1,
                            'grid_xypos': [(2, 2),
+                                          (65, 2),
                                           (2, 65),
-                                          (65, 2),
-                                          (65, 2),
                                           (65, 65)],
                            },
                      )
@@ -216,11 +218,7 @@ def stdpsf_single_detector():
     """
     Return a STDPSFGrid object read from a FITS STDPSF file.
     """
-    filename = 'STDPSF_NRCA1_F150W_mock.fits'
-
-    filename = op.join(Path(__file__).resolve().parent.parent.parent,
-                       'psf', 'tests', 'data', filename)
-    psfgrid = STDPSFGrid(filename)
+    psfgrid = STDPSFGrid(str(PSF_DATA_DIR / 'STDPSF_NRCA1_F150W_mock.fits'))
     return psfgrid, parameters['STDPSFGrid']
 
 

--- a/photutils/converters/tests/examples.py
+++ b/photutils/converters/tests/examples.py
@@ -33,9 +33,9 @@ parameters = {
     'MoffatPSF': ['flux', 'x_0', 'y_0', 'alpha', 'beta', 'bbox_factor'],
     'ImagePSF': ['data', 'flux', 'x_0', 'y_0', 'oversampling',
                  'fill_value', 'origin'],
-    'GriddedPSF': ['data', 'flux', 'x_0', 'y_0', 'oversampling',
-                   'fill_value', 'grid_xypos'],
-    'STDPSF': ['data', 'grid_xypos', 'oversampling'],
+    'GriddedPSFModel': ['data', 'flux', 'x_0', 'y_0', 'oversampling',
+                        'fill_value', 'grid_xypos'],
+    'STDPSFGrid': ['data', 'grid_xypos', 'oversampling'],
     'CircularAperture': ['positions', 'r'],
     'CircularAnnulus': ['positions', 'r_in', 'r_out'],
     'EllipticalAperture': ['positions', 'a', 'b', 'theta'],
@@ -209,7 +209,7 @@ def gridded_psf():
     return (GriddedPSFModel(nddata=nd_data, flux=6,
                             x_0=0.5, y_0=0.5,
                             fill_value=np.nan),
-            parameters['GriddedPSF'])
+            parameters['GriddedPSFModel'])
 
 
 def stdpsf_single_detector():
@@ -221,7 +221,7 @@ def stdpsf_single_detector():
     filename = op.join(Path(__file__).resolve().parent.parent.parent,
                        'psf', 'tests', 'data', filename)
     psfgrid = STDPSFGrid(filename)
-    return psfgrid, parameters['STDPSF']
+    return psfgrid, parameters['STDPSFGrid']
 
 
 def circular_aperture_single_pos():

--- a/photutils/converters/tests/examples.py
+++ b/photutils/converters/tests/examples.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 Examples for testing the photutils ASDF converters.
 
 Each example returns a tuple containing a photutils object and the list
 of parameter names to compare in round-trip tests.
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/photutils/converters/tests/test_apertures.py
+++ b/photutils/converters/tests/test_apertures.py
@@ -19,7 +19,7 @@ def aperobj(request):
     return request.getfixturevalue(request.param)
 
 
-# fixtures without parameters
+# Fixtures without parameters
 aper_params = pytest.mark.parametrize('aperobj', [
     'circular_aperture_single_pos',
     'circular_aperture_multi_pos',
@@ -38,7 +38,7 @@ aper_params = pytest.mark.parametrize('aperobj', [
 ], indirect=True)
 
 
-# a parameter ``theta`` is passed to these fixtures
+# Fixtures with a ``theta`` parameter
 aper_theta = pytest.mark.parametrize('aperobj', [
     'elliptical_annulus',
     'elliptical_aperture',
@@ -70,7 +70,9 @@ def test_aperture_converters(tmp_path, aperobj):
 
 
 def _run(tmp_path, aper):
-    """Run the comparison test."""
+    """
+    Run the comparison test.
+    """
     aperture, pars = aper
     with asdf.AsdfFile() as af:
         af['aper'] = aperture

--- a/photutils/converters/tests/test_apertures.py
+++ b/photutils/converters/tests/test_apertures.py
@@ -8,6 +8,8 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from photutils.converters import _ASDF_ASTROPY_INSTALLED
+from photutils.converters.tests import examples
+from photutils.extension import PHOTUTILS_APERTURE_CONVERTERS
 
 
 @pytest.fixture
@@ -19,8 +21,8 @@ def aperobj(request):
     return request.getfixturevalue(request.param)
 
 
-# Fixtures without parameters
-aper_params = pytest.mark.parametrize('aperobj', [
+# Examples that take no rotation angle
+APERTURE_EXAMPLE_NAMES = [
     'circular_aperture_single_pos',
     'circular_aperture_multi_pos',
     'circular_annulus_single_pos',
@@ -35,16 +37,20 @@ aper_params = pytest.mark.parametrize('aperobj', [
     'sky_polygon_aperture',
     'sky_rectangular_aperture',
     'sky_rectangular_annulus',
-], indirect=True)
+]
 
-
-# Fixtures with a ``theta`` parameter
-aper_theta = pytest.mark.parametrize('aperobj', [
+# Examples that take a rotation angle
+THETA_EXAMPLE_NAMES = [
     'elliptical_annulus',
     'elliptical_aperture',
     'rectangular_annulus',
     'rectangular_aperture',
-], indirect=True)
+]
+
+aper_params = pytest.mark.parametrize('aperobj', APERTURE_EXAMPLE_NAMES,
+                                      indirect=True)
+aper_theta = pytest.mark.parametrize('aperobj', THETA_EXAMPLE_NAMES,
+                                     indirect=True)
 
 
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
@@ -83,3 +89,46 @@ def _run(tmp_path, aper):
             for parameter in pars:
                 assert_array_equal(getattr(aperture, parameter),
                                    getattr(aperture2, parameter))
+
+
+@pytest.mark.parametrize('name', APERTURE_EXAMPLE_NAMES)
+def test_aperture_fixture_matches_example(request, name):
+    """
+    Test that each fixture returns the example of the same name.
+
+    The fixtures wrap the example functions, so a fixture wired to the
+    wrong function would silently drop an aperture from the round-trip
+    test.
+    """
+    expected, expected_params = getattr(examples, name)()
+    aper, params = request.getfixturevalue(name)
+    assert type(aper) is type(expected)
+    assert params == expected_params
+
+
+@pytest.mark.parametrize('name', THETA_EXAMPLE_NAMES)
+def test_aperture_theta_fixture_matches_example(request, name, theta):
+    """
+    Test that each rotated-aperture fixture returns the example of the
+    same name, using the rotation angle of the ``theta`` fixture.
+    """
+    expected, expected_params = getattr(examples, name)(theta)
+    aper, params = request.getfixturevalue(name)
+    assert type(aper) is type(expected)
+    assert aper.theta == expected.theta
+    assert params == expected_params
+
+
+def test_aperture_examples_cover_all_converters():
+    """
+    Test that the round-trip test exercises every type handled by an
+    aperture converter.
+    """
+    covered = {type(getattr(examples, name)()[0]).__name__
+               for name in APERTURE_EXAMPLE_NAMES}
+    covered |= {type(getattr(examples, name)(0.0)[0]).__name__
+                for name in THETA_EXAMPLE_NAMES}
+    handled = {name.rsplit('.', 1)[-1]
+               for converter in PHOTUTILS_APERTURE_CONVERTERS
+               for name in converter.types}
+    assert covered == handled

--- a/photutils/converters/tests/test_extension.py
+++ b/photutils/converters/tests/test_extension.py
@@ -1,0 +1,137 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the photutils ASDF extension.
+"""
+
+import yaml
+from asdf import get_config
+from asdf.extension import Converter, ExtensionProxy, ManifestExtension
+
+from photutils import converters
+from photutils.converters import _ASDF_ASTROPY_INSTALLED
+from photutils.extension import (PHOTUTILS_APERTURE_CONVERTERS,
+                                 PHOTUTILS_CONVERTERS, PHOTUTILS_MANIFEST_URIS,
+                                 PHOTUTILS_PSF_CONVERTERS, get_extensions,
+                                 get_resource_mappings)
+
+
+def _manifest_tags():
+    """
+    Return the set of tag URIs defined by the photutils manifests.
+    """
+    resource_manager = get_config().resource_manager
+    tags = set()
+    for manifest_uri in PHOTUTILS_MANIFEST_URIS:
+        manifest = yaml.safe_load(resource_manager[manifest_uri])
+        tags.update(tag['tag_uri'] for tag in manifest['tags'])
+    return tags
+
+
+def _converter_tag_prefixes(converters_):
+    """
+    Return the set of unversioned tag URIs handled by ``converters_``.
+    """
+    return {tag.removesuffix('-*')
+            for converter in converters_ for tag in converter.tags}
+
+
+def test_converters_implement_asdf_interface():
+    """
+    Test that every registered converter implements the asdf Converter
+    interface.
+
+    asdf rejects an entire extension that contains a converter which
+    does not, so a single invalid converter would disable all photutils
+    ASDF support.
+    """
+    assert PHOTUTILS_CONVERTERS
+    for converter in PHOTUTILS_CONVERTERS:
+        assert isinstance(converter, Converter)
+
+
+def test_extension_loads():
+    """
+    Test that the photutils extension is accepted by asdf.
+    """
+    extensions = get_extensions()
+    assert len(extensions) == len(PHOTUTILS_MANIFEST_URIS)
+    for extension in extensions:
+        proxy = ExtensionProxy(extension)
+        assert len(proxy.converters) == len(PHOTUTILS_CONVERTERS)
+
+
+def test_aperture_converters_do_not_need_asdf_astropy():
+    """
+    Test that the aperture converters alone form a valid extension.
+
+    The aperture converters need only asdf, so they remain available
+    when the optional asdf-astropy package is not installed.
+    """
+    assert PHOTUTILS_APERTURE_CONVERTERS
+    extension = ManifestExtension.from_uri(
+        PHOTUTILS_MANIFEST_URIS[0], converters=PHOTUTILS_APERTURE_CONVERTERS)
+    proxy = ExtensionProxy(extension)
+    assert len(proxy.converters) == len(PHOTUTILS_APERTURE_CONVERTERS)
+
+
+def test_psf_converters_require_asdf_astropy():
+    """
+    Test that the PSF converters are registered only when asdf-astropy
+    is installed.
+    """
+    if _ASDF_ASTROPY_INSTALLED:
+        assert PHOTUTILS_PSF_CONVERTERS
+    else:
+        assert PHOTUTILS_PSF_CONVERTERS == []
+
+
+def test_converter_tags_are_defined_by_the_manifest():
+    """
+    Test that every tag handled by a converter is defined by a manifest.
+    """
+    assert _converter_tag_prefixes(PHOTUTILS_CONVERTERS)
+    manifest_tags = _manifest_tags()
+    for prefix in _converter_tag_prefixes(PHOTUTILS_CONVERTERS):
+        assert any(tag.startswith(prefix) for tag in manifest_tags), prefix
+
+
+def test_manifest_tags_all_have_converters():
+    """
+    Test that every tag defined by a manifest has a converter.
+    """
+    if not _ASDF_ASTROPY_INSTALLED:
+        # the PSF tags are intentionally left without a converter
+        return
+
+    prefixes = _converter_tag_prefixes(PHOTUTILS_CONVERTERS)
+    for tag in _manifest_tags():
+        assert any(tag.startswith(prefix) for prefix in prefixes), tag
+
+
+def test_resource_mappings_register_all_files():
+    """
+    Test that every schema and manifest file is registered with asdf and
+    resolves to a resource with a matching ``id``.
+    """
+    resource_manager = get_config().resource_manager
+
+    uris = set()
+    for mapping in get_resource_mappings():
+        uris.update(mapping)
+    assert uris
+
+    for uri in uris:
+        assert uri in resource_manager
+        assert yaml.safe_load(resource_manager[uri])['id'] == uri
+
+
+def test_public_names_are_importable():
+    """
+    Test that every name in ``__all__`` is defined.
+
+    The converters are imported conditionally, so ``__all__`` must be
+    built to match.
+    """
+    assert converters.__all__
+    for name in converters.__all__:
+        assert hasattr(converters, name)

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -3,8 +3,6 @@
 Tests for the photutils PSF converters.
 """
 
-import os.path as op
-
 import asdf
 import numpy as np
 import pytest
@@ -12,6 +10,8 @@ from numpy.testing import assert_array_equal
 
 from photutils.converters import _ASDF_ASTROPY_INSTALLED
 from photutils.converters.image_models import GriddedPSFModelConverter
+from photutils.converters.tests import examples
+from photutils.extension import PHOTUTILS_PSF_CONVERTERS
 from photutils.psf import STDPSFGrid
 
 
@@ -24,7 +24,7 @@ def psfobj(request):
     return request.getfixturevalue(request.param)
 
 
-psf_params = pytest.mark.parametrize('psfobj', [
+PSF_EXAMPLE_NAMES = [
     'airy_disk_units',
     'airy_disk',
     'circular_gaussian_prf_units',
@@ -42,7 +42,41 @@ psf_params = pytest.mark.parametrize('psfobj', [
     'image_psf',
     'gridded_psf',
     'stdpsf_single_detector',
-], indirect=True)
+]
+
+psf_params = pytest.mark.parametrize('psfobj', PSF_EXAMPLE_NAMES,
+                                     indirect=True)
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('name', PSF_EXAMPLE_NAMES)
+def test_psf_fixture_matches_example(request, name):
+    """
+    Test that each fixture returns the example of the same name.
+
+    The fixtures wrap the example functions, so a fixture wired to the
+    wrong function would silently drop a model from the round-trip test.
+    """
+    expected, expected_params = getattr(examples, name)()
+    psf, params = request.getfixturevalue(name)
+    assert type(psf) is type(expected)
+    assert params == expected_params
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+def test_psf_examples_cover_all_converters():
+    """
+    Test that the round-trip test exercises every type handled by a PSF
+    converter.
+    """
+    covered = {type(getattr(examples, name)()[0]).__name__
+               for name in PSF_EXAMPLE_NAMES}
+    handled = {name.rsplit('.', 1)[-1]
+               for converter in PHOTUTILS_PSF_CONVERTERS
+               for name in converter.types}
+    assert covered == handled
 
 
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
@@ -128,9 +162,8 @@ def test_stdpsf_grid_converter_repeated_grid_coordinate(tmp_path):
     Test a round trip for an ACS/WFC grid, whose y coordinates are
     repeated where the two detectors abut.
     """
-    filename = op.join(op.dirname(op.abspath(__file__)), '..', '..', 'psf',
-                       'tests', 'data', 'STDPSF_ACSWFC_F814W_mock.fits')
-    psfgrid = STDPSFGrid(filename)
+    filename = examples.PSF_DATA_DIR / 'STDPSF_ACSWFC_F814W_mock.fits'
+    psfgrid = STDPSFGrid(str(filename))
     assert psfgrid._grid_shape == (10, 9)
 
     asdf_filename = tmp_path / 'psf.asdf'

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -126,6 +126,36 @@ def test_gridded_psf_converter_preserves_modified_oversampling(tmp_path,
 
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
                     reason='asdf-astropy is not installed')
+@pytest.mark.parametrize(('name', 'converter_name', 'method'), [
+    # GriddedPSFModel is an astropy model, so its converter builds the
+    # tree in to_yaml_tree_transform; STDPSFGrid is not a model, so its
+    # converter uses to_yaml_tree.
+    ('gridded_psf', 'GriddedPSFModelConverter', 'to_yaml_tree_transform'),
+    ('stdpsf_single_detector', 'STDPSFGridConverter', 'to_yaml_tree'),
+])
+def test_grid_structure_is_stored_outside_meta(name, converter_name, method):
+    """
+    Test that both grid converters store the grid structure as
+    top-level properties rather than inside ``meta``.
+
+    GriddedPSFModel keeps the grid structure in its meta attribute
+    and STDPSFGrid keeps it in private attributes, so the converters
+    normalize it to a single layout in the file.
+    """
+    from photutils.converters import image_models
+
+    obj, _ = getattr(examples, name)()
+    converter = getattr(image_models, converter_name)()
+    node = getattr(converter, method)(obj, None, None)
+
+    for key in ('grid_xypos', 'oversampling'):
+        assert key in node
+        assert key not in node['meta']
+    assert 'grid_shape' not in node['meta']
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
 def test_stdpsf_grid_converter_preserves_oversampling(tmp_path):
     """
     Test that a non-default oversampling value survives a round trip.

--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -425,8 +425,10 @@ REQUIRED_PSF_PARAMS = {
                           'grid_xypos': GRID_XYPOS,
                           'meta': '{}'},
     'stdpsf_grid': {'data': PSF_GRID,
-                    'meta': ('{oversampling: [4, 4], grid_shape: [2, 2], '
-                             f'grid_xypos: {GRID_XYPOS}}}')},
+                    'grid_xypos': GRID_XYPOS,
+                    'grid_shape': '[2, 2]',
+                    'oversampling': '[4, 4]',
+                    'meta': '{}'},
 }
 
 # The models whose parameters are all plain numbers, so that a reference

--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -7,15 +7,19 @@ import re
 import textwrap
 
 import asdf
+import numpy as np
 import pytest
 import yaml
 from asdf import get_config, treeutil
 from asdf.exceptions import ValidationError
 from asdf.testing.helpers import yaml_to_asdf
 from astropy import units as u
+from astropy.nddata import NDData
+from numpy.testing import assert_array_equal
 
 from photutils.converters import _ASDF_ASTROPY_INSTALLED
 from photutils.extension import PHOTUTILS_MANIFEST_URIS
+from photutils.psf import ImagePSF
 
 # Matches the top-level YAML tag that opens a schema example.
 EXAMPLE_TAG_PATTERN = re.compile(r'!<([^>]+)>')
@@ -379,3 +383,166 @@ def test_unknown_property_rejected(stem):
     with pytest.raises(ValidationError), \
             asdf.open(yaml_to_asdf(f'aper: {example}')):
         pass
+
+
+def _ndarray(values):
+    """
+    Build the inline YAML for an ndarray.
+    """
+    return f'!core/ndarray-1.1.0 {np.asarray(values).tolist()}'
+
+
+# A 4x4 image, the smallest accepted by the image-based PSF models,
+# four copies of it (one per grid position), and the grid positions.
+PSF_IMAGE_VALUES = np.arange(16.0).reshape((4, 4))
+PSF_GRID_VALUES = np.repeat(PSF_IMAGE_VALUES[np.newaxis], 4, axis=0)
+GRID_XYPOS_VALUES = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]
+
+PSF_IMAGE = _ndarray(PSF_IMAGE_VALUES)
+PSF_GRID = _ndarray(PSF_GRID_VALUES)
+GRID_XYPOS = _ndarray(GRID_XYPOS_VALUES)
+
+# The parameters that each PSF schema requires. The remaining
+# parameters are optional; ``bbox_factor`` is optional in every
+# functional-model schema, as is ``theta`` for the elliptical Gaussians.
+REQUIRED_PSF_PARAMS = {
+    'airy_disk_psf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0, 'radius': 4.0},
+    'circular_gaussian_prf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0,
+                              'fwhm': 4.0},
+    'circular_gaussian_psf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0,
+                              'fwhm': 4.0},
+    'circular_gaussian_sigma_prf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0,
+                                    'sigma': 4.0},
+    'gaussian_prf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0, 'x_fwhm': 4.0,
+                     'y_fwhm': 5.0},
+    'gaussian_psf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0, 'x_fwhm': 4.0,
+                     'y_fwhm': 5.0},
+    'moffat_psf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0, 'alpha': 4.0,
+                   'beta': 5.0},
+    'image_psf': {'data': PSF_IMAGE},
+    'gridded_psf_model': {'data': PSF_GRID,
+                          'oversampling': '!core/ndarray-1.1.0 [1, 1]',
+                          'grid_xypos': GRID_XYPOS,
+                          'meta': '{}'},
+    'stdpsf_grid': {'data': PSF_GRID,
+                    'meta': ('{oversampling: [4, 4], grid_shape: [2, 2], '
+                             f'grid_xypos: {GRID_XYPOS}}}')},
+}
+
+# The models whose parameters are all plain numbers, so that a reference
+# model can be built from the same required parameters.
+FUNCTIONAL_PSF_STEMS = list(REQUIRED_PSF_PARAMS)[:7]
+
+
+def _psf_yaml(stem, params):
+    """
+    Build the tagged YAML for a photutils PSF model.
+    """
+    body = '\n'.join(f'  {key}: {value}' for key, value in params.items())
+    return f'!<tag:astropy.org:photutils/psf/{stem}-1.0.0>\n{body}'
+
+
+def _read_psf(stem, params):
+    """
+    Read a PSF model from a file containing only ``params``.
+    """
+    with asdf.open(yaml_to_asdf(f'psf: {_psf_yaml(stem, params)}')) as af:
+        return af['psf']
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('stem', FUNCTIONAL_PSF_STEMS)
+def test_optional_psf_params_use_defaults(stem):
+    """
+    Test that a PSF file containing only the parameters required by its
+    schema is read using the defaults of its model class.
+
+    ``bbox_factor`` is optional in every functional-model schema, as is
+    ``theta`` for the elliptical Gaussian models, so a schema-valid file
+    may omit them.
+    """
+    params = REQUIRED_PSF_PARAMS[stem]
+    model = _read_psf(stem, params)
+    reference = type(model)(**params)
+
+    for name, value in params.items():
+        assert getattr(model, name) == value
+    assert model.bbox_factor == reference.bbox_factor
+    if hasattr(model, 'theta'):
+        assert model.theta == reference.theta
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+def test_optional_image_psf_params_use_defaults():
+    """
+    Test that an ImagePSF file containing only ``data`` is read using
+    the defaults of the model class.
+    """
+    model = _read_psf('image_psf', REQUIRED_PSF_PARAMS['image_psf'])
+    reference = ImagePSF(data=PSF_IMAGE_VALUES)
+
+    assert_array_equal(model.data, PSF_IMAGE_VALUES)
+    for name in ('flux', 'x_0', 'y_0', 'fill_value'):
+        assert getattr(model, name) == getattr(reference, name)
+    assert_array_equal(model.oversampling, reference.oversampling)
+    assert_array_equal(model.origin, reference.origin)
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+def test_optional_gridded_psf_model_params_use_defaults():
+    """
+    Test that a GriddedPSFModel file containing only the parameters
+    required by its schema is read using the defaults of the model
+    class.
+    """
+    from photutils.psf import GriddedPSFModel
+
+    model = _read_psf('gridded_psf_model',
+                      REQUIRED_PSF_PARAMS['gridded_psf_model'])
+    nddata = NDData(data=PSF_GRID_VALUES,
+                    meta={'oversampling': 1, 'grid_xypos': GRID_XYPOS_VALUES})
+    reference = GriddedPSFModel(nddata=nddata)
+
+    assert_array_equal(model.data, PSF_GRID_VALUES)
+    for name in ('flux', 'x_0', 'y_0', 'fill_value'):
+        assert getattr(model, name) == getattr(reference, name)
+
+
+@pytest.mark.parametrize('stem', list(REQUIRED_PSF_PARAMS))
+def test_unknown_psf_property_rejected(stem):
+    """
+    Test that a PSF model with an unknown property fails schema
+    validation when read.
+
+    Without ``additionalProperties: false`` an unknown key is accepted
+    and then silently dropped, so a misspelled parameter would read back
+    as a model with default values. The properties of the transform
+    schema referenced by the PSF models are repeated in each schema so
+    that they remain allowed.
+    """
+    params = {**REQUIRED_PSF_PARAMS[stem], 'not_a_parameter': '999.0'}
+    with pytest.raises(ValidationError), \
+            asdf.open(yaml_to_asdf(f'psf: {_psf_yaml(stem, params)}')):
+        pass
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('stem', FUNCTIONAL_PSF_STEMS)
+def test_transform_properties_accepted(stem):
+    """
+    Test that the properties of the referenced transform schema are
+    accepted by the PSF schemas.
+
+    They are repeated in each schema so that ``additionalProperties``
+    rejects only unknown keys.
+    """
+    params = {**REQUIRED_PSF_PARAMS[stem], 'name': 'psf',
+              'inputs': '[x, y]', 'outputs': '[z]'}
+    model = _read_psf(stem, params)
+    assert model.name == 'psf'
+    assert model.inputs == ('x', 'y')
+    assert model.outputs == ('z',)

--- a/photutils/extension.py
+++ b/photutils/extension.py
@@ -7,25 +7,15 @@ import importlib.resources as importlib_resources
 from asdf.extension import ManifestExtension
 from asdf.resource import DirectoryResourceMapping
 
-from .converters import apertures, functional_models, image_models
+from .converters import _ASDF_ASTROPY_INSTALLED, apertures
 
 __all__ = [
     'PHOTUTILS_APERTURE_CONVERTERS',
+    'PHOTUTILS_CONVERTERS',
     'PHOTUTILS_MANIFEST_URIS',
     'PHOTUTILS_PSF_CONVERTERS',
-]
-
-PHOTUTILS_PSF_CONVERTERS = [
-    functional_models.AiryDiskPSFConverter(),
-    functional_models.CircularGaussianPRFConverter(),
-    functional_models.CircularGaussianPSFConverter(),
-    functional_models.CircularGaussianSigmaPRFConverter(),
-    functional_models.GaussianPRFConverter(),
-    functional_models.GaussianPSFConverter(),
-    functional_models.MoffatPSFConverter(),
-    image_models.ImagePSFConverter(),
-    image_models.GriddedPSFModelConverter(),
-    image_models.STDPSFGridConverter(),
+    'get_extensions',
+    'get_resource_mappings',
 ]
 
 PHOTUTILS_APERTURE_CONVERTERS = [
@@ -37,6 +27,29 @@ PHOTUTILS_APERTURE_CONVERTERS = [
     apertures.RectangularApertureConverter(),
     apertures.RectangularAnnulusConverter(),
 ]
+
+# The PSF converters are built on the asdf-astropy transform machinery.
+# asdf rejects an entire extension that contains a converter which does
+# not implement its interface, so registering the PSF converters when
+# asdf-astropy is missing would also disable the aperture converters,
+# which need only asdf.
+if _ASDF_ASTROPY_INSTALLED:
+    from .converters import functional_models, image_models
+
+    PHOTUTILS_PSF_CONVERTERS = [
+        functional_models.AiryDiskPSFConverter(),
+        functional_models.CircularGaussianPRFConverter(),
+        functional_models.CircularGaussianPSFConverter(),
+        functional_models.CircularGaussianSigmaPRFConverter(),
+        functional_models.GaussianPRFConverter(),
+        functional_models.GaussianPSFConverter(),
+        functional_models.MoffatPSFConverter(),
+        image_models.ImagePSFConverter(),
+        image_models.GriddedPSFModelConverter(),
+        image_models.STDPSFGridConverter(),
+    ]
+else:
+    PHOTUTILS_PSF_CONVERTERS = []
 
 PHOTUTILS_CONVERTERS = PHOTUTILS_PSF_CONVERTERS + PHOTUTILS_APERTURE_CONVERTERS
 
@@ -51,11 +64,12 @@ PHOTUTILS_MANIFEST_URIS = [
 def get_extensions():
     """
     Get the photutils extension.
+
     This method is registered with the asdf.extensions entry point.
 
     Returns
     -------
-    list
+    extensions : list
         A list of ASDF extensions.
     """
     return [
@@ -69,14 +83,16 @@ def get_extensions():
 
 def get_resource_mappings():
     """
-    Get the resource mapping instances for the photutils schemas
-    and manifests.  This method is registered with the
-    asdf.resource_mappings entry point.
+    Get the resource mapping instances for the photutils schemas and
+    manifests.
+
+    This method is registered with the asdf.resource_mappings entry
+    point.
 
     Returns
     -------
-    list
-        A list of collections.abc.Mapping of ASDF resource mappings.
+    mappings : list
+        A list of `collections.abc.Mapping` of ASDF resource mappings.
     """
     from . import resources
 

--- a/photutils/extension.py
+++ b/photutils/extension.py
@@ -2,6 +2,7 @@
 """
 ASDF extension for photutils.
 """
+
 import importlib.resources as importlib_resources
 
 from asdf.extension import ManifestExtension

--- a/photutils/resources/manifests/photutils-1.0.0.yaml
+++ b/photutils/resources/manifests/photutils-1.0.0.yaml
@@ -6,32 +6,32 @@ description: |-
 tags:
   - tag_uri: tag:astropy.org:photutils/aperture/circular_aperture-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/aperture/circular_aperture-1.0.0
-    title: Circular apertures
-    description: Circular aperture with one or more positions.
+    title: Circular aperture
+    description: A circular aperture in pixel or sky coordinates.
   - tag_uri: tag:astropy.org:photutils/aperture/circular_annulus-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/aperture/circular_annulus-1.0.0
-    title: Circular annulus apertures
-    description: CircularAnnulus aperture with one or more positions.
+    title: Circular annulus aperture
+    description: A circular annulus aperture in pixel or sky coordinates.
   - tag_uri: tag:astropy.org:photutils/aperture/elliptical_aperture-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/aperture/elliptical_aperture-1.0.0
-    title: Elliptical apertures
-    description: Elliptical aperture with one or more positions.
+    title: Elliptical aperture
+    description: An elliptical aperture in pixel or sky coordinates.
   - tag_uri: tag:astropy.org:photutils/aperture/elliptical_annulus-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/aperture/elliptical_annulus-1.0.0
-    title: Elliptical annulus apertures
-    description: Elliptical annulus aperture with one or more positions.
+    title: Elliptical annulus aperture
+    description: An elliptical annulus aperture in pixel or sky coordinates.
   - tag_uri: tag:astropy.org:photutils/aperture/polygon_aperture-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/aperture/polygon_aperture-1.0.0
-    title: Polygon apertures
-    description: Polygon aperture with one or more positions.
+    title: Polygon aperture
+    description: A polygon aperture in pixel or sky coordinates.
   - tag_uri: tag:astropy.org:photutils/aperture/rectangular_aperture-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/aperture/rectangular_aperture-1.0.0
-    title: Rectangular apertures
-    description: Rectangular aperture with one or more positions.
+    title: Rectangular aperture
+    description: A rectangular aperture in pixel or sky coordinates.
   - tag_uri: tag:astropy.org:photutils/aperture/rectangular_annulus-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/aperture/rectangular_annulus-1.0.0
-    title: Rectangular annulus
-    description: Rectangular annulus with one or more positions.
+    title: Rectangular annulus aperture
+    description: A rectangular annulus aperture in pixel or sky coordinates.
   - tag_uri: tag:astropy.org:photutils/psf/airy_disk_psf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/airy_disk_psf-1.0.0
     title: AiryDiskPSF
@@ -39,36 +39,36 @@ tags:
   - tag_uri: tag:astropy.org:photutils/psf/circular_gaussian_prf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/circular_gaussian_prf-1.0.0
     title: CircularGaussianPRF
-    description: CircularGaussianPRF model.
+    description: A circular 2D Gaussian PRF model.
   - tag_uri: tag:astropy.org:photutils/psf/circular_gaussian_psf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/circular_gaussian_psf-1.0.0
     title: CircularGaussianPSF
-    description: CircularGaussianPSF model.
+    description: A circular 2D Gaussian PSF model.
   - tag_uri: tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/circular_gaussian_sigma_prf-1.0.0
     title: CircularGaussianSigmaPRF
-    description: CircularGaussianSigmaPRF model.
+    description: A circular 2D Gaussian PRF model parameterized by sigma.
   - tag_uri: tag:astropy.org:photutils/psf/gaussian_prf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/gaussian_prf-1.0.0
     title: GaussianPRF
-    description: A 2D GaussianPRF model.
+    description: A 2D Gaussian PRF model.
   - tag_uri: tag:astropy.org:photutils/psf/gaussian_psf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/gaussian_psf-1.0.0
     title: GaussianPSF
-    description: A 2D GaussianPSF model.
+    description: A 2D Gaussian PSF model.
   - tag_uri: tag:astropy.org:photutils/psf/gridded_psf_model-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/gridded_psf_model-1.0.0
     title: GriddedPSFModel
-    description: GriddedPSFModel model.
+    description: A grid of 2D ePSF models.
   - tag_uri: tag:astropy.org:photutils/psf/image_psf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/image_psf-1.0.0
     title: ImagePSF
-    description: A 2D ImagePSF model.
+    description: A 2D image PSF model.
   - tag_uri: tag:astropy.org:photutils/psf/moffat_psf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/moffat_psf-1.0.0
     title: MoffatPSF
-    description: A 2D MoffatPSF model.
+    description: A 2D Moffat PSF model.
   - tag_uri: tag:astropy.org:photutils/psf/stdpsf_grid-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/stdpsf_grid-1.0.0
     title: STDPSFGrid
-    description: STDPSFGrid container.
+    description: A grid of 2D ePSF models in the STDPSF format.

--- a/photutils/resources/manifests/photutils-1.0.0.yaml
+++ b/photutils/resources/manifests/photutils-1.0.0.yaml
@@ -56,10 +56,10 @@ tags:
     schema_uri: asdf://astropy.org/photutils/schemas/psf/gaussian_psf-1.0.0
     title: GaussianPSF
     description: A 2D GaussianPSF model.
-  - tag_uri: tag:astropy.org:photutils/psf/gridded_psf-1.0.0
-    schema_uri: asdf://astropy.org/photutils/schemas/psf/gridded_psf-1.0.0
-    title: GriddedPSF
-    description: GriddedPSF model.
+  - tag_uri: tag:astropy.org:photutils/psf/gridded_psf_model-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/gridded_psf_model-1.0.0
+    title: GriddedPSFModel
+    description: GriddedPSFModel model.
   - tag_uri: tag:astropy.org:photutils/psf/image_psf-1.0.0
     schema_uri: asdf://astropy.org/photutils/schemas/psf/image_psf-1.0.0
     title: ImagePSF
@@ -68,7 +68,7 @@ tags:
     schema_uri: asdf://astropy.org/photutils/schemas/psf/moffat_psf-1.0.0
     title: MoffatPSF
     description: A 2D MoffatPSF model.
-  - tag_uri: tag:astropy.org:photutils/psf/stdpsf-1.0.0
-    schema_uri: asdf://astropy.org/photutils/schemas/psf/stdpsf-1.0.0
-    title: STDPSF
-    description: STDPSF grid container.
+  - tag_uri: tag:astropy.org:photutils/psf/stdpsf_grid-1.0.0
+    schema_uri: asdf://astropy.org/photutils/schemas/psf/stdpsf_grid-1.0.0
+    title: STDPSFGrid
+    description: STDPSFGrid container.

--- a/photutils/resources/schemas/aperture/circular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/circular_annulus-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/aperture/circular_annulus-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/aperture/circular_annulus-1.0.0'
 title: Circular annulus aperture
 description: |
   ASDF schema for serializing a circular annulus aperture with one or more
   positions, in pixel or sky coordinates.
 
 examples:
-  -
-    - |
+  - - |
       A CircularAnnulus aperture with a single position, an inner radius
       of 3 pixels, and an outer radius of 5.1 pixels.
     - |
@@ -17,8 +16,7 @@ examples:
         positions: [10.0, 20.0]
         r_in: 3.0
         r_out: 5.1
-  -
-    - |
+  - - |
       A SkyCircularAnnulus aperture with two positions, an inner radius
       of 0.5 arcsec, and an outer radius of 1 arcsec.
     - |
@@ -39,11 +37,19 @@ examples:
               datatype: float64
               byteorder: little
               shape: [2]
-            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64,
-              unit: !unit/unit-1.0.0 deg, value: 360.0}
+            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+              datatype: float64
+              unit: !unit/unit-1.0.0 deg
+              value: 360.0
           representation_type: spherical
-        r_in: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 0.5}
-        r_out: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 1.0}
+        r_in: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 0.5
+        r_out: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 1.0
 
 type: object
 properties:
@@ -67,8 +73,8 @@ properties:
           type: number
         maxItems: 2
         minItems: 2
-      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
   r_in:
     title: Inner radius.
     description: |
@@ -77,7 +83,7 @@ properties:
       sky in angular units.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   r_out:
     title: Outer radius.
     description: |
@@ -86,7 +92,7 @@ properties:
       sky in angular units.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
 required: [positions, r_in, r_out]
 additionalProperties: false
 # CircularAnnulus and SkyCircularAnnulus share a tag, so this requires
@@ -97,7 +103,7 @@ oneOf:
       positions:
         anyOf:
           - type: array
-          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
       r_in:
         type: number
       r_out:
@@ -105,9 +111,9 @@ oneOf:
   - title: Sky coordinates
     properties:
       positions:
-        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+        tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
       r_in:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       r_out:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
 ...

--- a/photutils/resources/schemas/aperture/circular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/circular_annulus-1.0.0.yaml
@@ -2,15 +2,16 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/aperture/circular_annulus-1.0.0"
-title: Circular annulus
+title: Circular annulus aperture
 description: |
-  ASDF schema for serializing a circular annulus aperture in pixel
-  or sky coordinates.
+  ASDF schema for serializing a circular annulus aperture with one or more
+  positions, in pixel or sky coordinates.
+
 examples:
   -
     - |
-      A CircularAnnulus aperture with a single position, inner radius of 3.0,
-      and outer radius of 5.1.
+      A CircularAnnulus aperture with a single position, an inner radius
+      of 3 pixels, and an outer radius of 5.1 pixels.
     - |
       !<tag:astropy.org:photutils/aperture/circular_annulus-1.0.0>
         positions: [10.0, 20.0]
@@ -18,8 +19,8 @@ examples:
         r_out: 5.1
   -
     - |
-        A SkyCircularAnnulus aperture with 2 positions, inner radius of
-        0.5 arcsec and outer radius of 1 arcsec.
+      A SkyCircularAnnulus aperture with two positions, an inner radius
+      of 0.5 arcsec, and an outer radius of 1 arcsec.
     - |
       !<tag:astropy.org:photutils/aperture/circular_annulus-1.0.0>
         positions: !<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
@@ -49,13 +50,15 @@ properties:
   positions:
     title: Aperture position(s).
     description: |
-      The coordinates of the aperture center(s) in one of the following formats.
+      The coordinates of the aperture center(s) in one of the following
+      formats.
+
       If a CircularAnnulus in pixel coordinates:
 
         * single ``(x, y)`` pair as an array
         * `numpy.ndarray` of ``(x, y)`` pairs
 
-      If a SkyCircularAnnulus
+      If a SkyCircularAnnulus:
 
         * `astropy.coordinates.SkyCoord` object
     anyOf:

--- a/photutils/resources/schemas/aperture/circular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/circular_aperture-1.0.0.yaml
@@ -1,23 +1,21 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/aperture/circular_aperture-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/aperture/circular_aperture-1.0.0'
 title: Circular aperture
 description: |
   ASDF schema for serializing a circular aperture with one or more
   positions, in pixel or sky coordinates.
 
 examples:
-  -
-    - |
+  - - |
       A CircularAperture with a single position and a radius of
       5 pixels.
     - |
       !<tag:astropy.org:photutils/aperture/circular_aperture-1.0.0>
         positions: [1.0, 2.0]
         r: 5.0
-  -
-    - |
+  - - |
       A SkyCircularAperture with two positions and a radius of 5 arcsec.
     - |
       !<tag:astropy.org:photutils/aperture/circular_aperture-1.0.0>
@@ -37,10 +35,15 @@ examples:
               datatype: float64
               byteorder: little
               shape: [2]
-            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64,
-              unit: !unit/unit-1.0.0 deg, value: 360.0}
+            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+              datatype: float64
+              unit: !unit/unit-1.0.0 deg
+              value: 360.0
           representation_type: spherical
-        r: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 5.0}
+        r: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 5.0
 
 type: object
 properties:
@@ -64,8 +67,8 @@ properties:
           type: number
         maxItems: 2
         minItems: 2
-      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
   r:
     title: Aperture radius.
     description: |
@@ -74,7 +77,7 @@ properties:
       angular units.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
 required: [positions, r]
 additionalProperties: false
 # CircularAperture and SkyCircularAperture share a tag, so this requires
@@ -85,13 +88,13 @@ oneOf:
       positions:
         anyOf:
           - type: array
-          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
       r:
         type: number
   - title: Sky coordinates
     properties:
       positions:
-        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+        tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
       r:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
 ...

--- a/photutils/resources/schemas/aperture/circular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/circular_aperture-1.0.0.yaml
@@ -4,18 +4,21 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/aperture/circular_aperture-1.0.0"
 title: Circular aperture
 description: |
-  ASDF schema for serializing a circular aperture with one or more positions
-  in pixel or sky coordinates.
+  ASDF schema for serializing a circular aperture with one or more
+  positions, in pixel or sky coordinates.
+
 examples:
   -
-    - A CircularAperture with a single position and radius of 5 pixels.
+    - |
+      A CircularAperture with a single position and a radius of
+      5 pixels.
     - |
       !<tag:astropy.org:photutils/aperture/circular_aperture-1.0.0>
         positions: [1.0, 2.0]
         r: 5.0
   -
-    - A SkyCircularAperture aperture with a single position and radius of
-      0.5 arcsec.
+    - |
+      A SkyCircularAperture with two positions and a radius of 5 arcsec.
     - |
       !<tag:astropy.org:photutils/aperture/circular_aperture-1.0.0>
         positions: !<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
@@ -44,13 +47,15 @@ properties:
   positions:
     title: Aperture position(s).
     description: |
-      The pixel coordinates of the aperture center(s) in one of the following formats.
+      The coordinates of the aperture center(s) in one of the following
+      formats.
+
       If a CircularAperture in pixel coordinates:
 
         * single ``(x, y)`` pair as an array
         * `numpy.ndarray` of ``(x, y)`` pairs
 
-      If a SkyCircularAperture
+      If a SkyCircularAperture:
 
         * `astropy.coordinates.SkyCoord` object
     anyOf:

--- a/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
@@ -2,17 +2,18 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/aperture/elliptical_annulus-1.0.0"
-title: EllipticalAnnulus
+title: Elliptical annulus aperture
 description: |
-  ASDF schema for serializing an elliptical annulus aperture in pixel
-  and sky coordinates.
+  ASDF schema for serializing an elliptical annulus aperture with one or more
+  positions, in pixel or sky coordinates.
+
 examples:
   -
     - |
-      An EllipticalAnnulus aperture with a single position, with inner
-      semimajor axis of 0.5 arcsec, outer semimajor axis of 2 arcsec,
-      inner semiminor axis of 0.25 arcsec, outer semiminor axis of 1 arcsec,
-      and rotation angle of 0.
+      An EllipticalAnnulus aperture with a single position, inner
+      semimajor and semiminor axes of 0.5 and 0.25 pixels, outer
+      semimajor and semiminor axes of 2 and 1 pixels, and a rotation
+      angle of 0 radians.
     - |
       !<tag:astropy.org:photutils/aperture/elliptical_annulus-1.0.0>
         a_in: 0.5
@@ -23,7 +24,10 @@ examples:
         theta: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 rad, value: 0.0}
   -
     - |
-      SkyEllipticalAnnulus aperture with a single position.
+      A SkyEllipticalAnnulus aperture with a single position, inner
+      semimajor and semiminor axes of 0.5 and 0.25 arcsec, outer
+      semimajor and semiminor axes of 2 and 1 arcsec, and a position
+      angle of 0 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/elliptical_annulus-1.0.0>
         a_in: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 0.5}
@@ -43,19 +47,20 @@ examples:
           representation_type: spherical
         theta: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 deg, value: 0.0}
 
-
 type: object
 properties:
   positions:
     title: Aperture position(s).
     description: |
-      The coordinates of the aperture center(s) in one of the following formats.
-      If an EllipticalAnnulus in pixel coordinates:
+      The coordinates of the aperture center(s) in one of the following
+      formats.
+
+      If a EllipticalAnnulus in pixel coordinates:
 
         * single ``(x, y)`` pair as an array
         * `numpy.ndarray` of ``(x, y)`` pairs
 
-      If a SkyEllipticalAnnulus
+      If a SkyEllipticalAnnulus:
 
         * `astropy.coordinates.SkyCoord` object
     anyOf:
@@ -103,16 +108,15 @@ properties:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   theta:
-    title: Rotation angle of the ellipse.
+    title: Rotation angle.
     description: |
-      EllipticalAnnulus:
-        The rotation angle as an angular quantity from the positive ``x`` axis.
-        The rotation angle increases counterclockwise. If a number, it's assumed
-        to be in radians.
-      SkyEllipticalAnnulus:
-        The position angle (in angular units) of the ellipse semimajor
-        axis. For a right-handed world coordinate system, the position
-        angle increases counterclockwise from North (PA=0).
+      EllipticalAnnulus: the rotation angle of the ellipse from the
+      positive ``x`` axis, as an angular quantity or as a number in
+      radians. The rotation angle increases counterclockwise.
+      SkyEllipticalAnnulus: the position angle (in angular units) of the
+      ellipse semimajor axis. For a right-handed world coordinate
+      system, the position angle increases counterclockwise from North
+      (PA=0).
     anyOf:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"

--- a/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_annulus-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/aperture/elliptical_annulus-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/aperture/elliptical_annulus-1.0.0'
 title: Elliptical annulus aperture
 description: |
   ASDF schema for serializing an elliptical annulus aperture with one or more
   positions, in pixel or sky coordinates.
 
 examples:
-  -
-    - |
+  - - |
       An EllipticalAnnulus aperture with a single position, inner
       semimajor and semiminor axes of 0.5 and 0.25 pixels, outer
       semimajor and semiminor axes of 2 and 1 pixels, and a rotation
@@ -21,31 +20,52 @@ examples:
         b_in: 0.25
         b_out: 1.0
         positions: [10.0, 20.0]
-        theta: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 rad, value: 0.0}
-  -
-    - |
+        theta: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 rad
+          value: 0.0
+  - - |
       A SkyEllipticalAnnulus aperture with a single position, inner
       semimajor and semiminor axes of 0.5 and 0.25 arcsec, outer
       semimajor and semiminor axes of 2 and 1 arcsec, and a position
       angle of 0 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/elliptical_annulus-1.0.0>
-        a_in: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 0.5}
-        a_out: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 2.0}
-        b_in: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 0.25}
-        b_out: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 1.0}
+        a_in: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 0.5
+        a_out: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 2.0
+        b_in: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 0.25
+        b_out: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 1.0
         positions: !<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
-          dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0> {datatype: float64,
-            unit: !unit/unit-1.0.0 deg, value: 30.0}
+          dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0>
+            datatype: float64
+            unit: !unit/unit-1.0.0 deg
+            value: 30.0
           frame: icrs
           ra: !<tag:astropy.org:astropy/coordinates/longitude-1.2.0>
             datatype: float64
             unit: !unit/unit-1.0.0 deg
             value: 10.0
-            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64,
-              unit: !unit/unit-1.0.0 deg, value: 360.0}
+            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+              datatype: float64
+              unit: !unit/unit-1.0.0 deg
+              value: 360.0
           representation_type: spherical
-        theta: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 deg, value: 0.0}
+        theta: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 deg
+          value: 0.0
 
 type: object
 properties:
@@ -69,8 +89,8 @@ properties:
           type: number
         maxItems: 2
         minItems: 2
-      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
   a_in:
     title: Inner semimajor axis.
     description: |
@@ -79,7 +99,7 @@ properties:
       SkyEllipticalAnnulus: in angular units
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   a_out:
     title: Outer semimajor axis.
     description: |
@@ -88,7 +108,7 @@ properties:
       SkyEllipticalAnnulus: in angular units
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   b_in:
     title: Inner semiminor axis.
     description: |
@@ -97,7 +117,7 @@ properties:
       SkyEllipticalAnnulus: in angular units
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   b_out:
     title: Outer semiminor axis.
     description: |
@@ -106,7 +126,7 @@ properties:
       SkyEllipticalAnnulus: in angular units
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   theta:
     title: Rotation angle.
     description: |
@@ -119,8 +139,8 @@ properties:
       (PA=0).
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/angle-1.*'
 required: [positions, a_in, a_out, b_out]
 additionalProperties: false
 # EllipticalAnnulus and SkyEllipticalAnnulus share a tag, so this
@@ -133,7 +153,7 @@ oneOf:
       positions:
         anyOf:
           - type: array
-          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
       a_in:
         type: number
       a_out:
@@ -145,17 +165,17 @@ oneOf:
   - title: Sky coordinates
     properties:
       positions:
-        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+        tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
       a_in:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       a_out:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       b_in:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       b_out:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       theta:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-          - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
+          - tag: 'tag:astropy.org:astropy/coordinates/angle-1.*'
 ...

--- a/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
@@ -2,15 +2,17 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/aperture/elliptical_aperture-1.0.0"
-title: EllipticalAperture
+title: Elliptical aperture
 description: |
-  ASDF schema for serializing an elliptical aperture with one
-  or more positions in pixel or sky coordinates.
+  ASDF schema for serializing an elliptical aperture with one or more
+  positions, in pixel or sky coordinates.
+
 examples:
   -
     - |
-      An EllipticalAperture with a single position, semimajor axis of 5 pixels,
-      semiminor axis of 3 pixels and rotation angle of 0.2 radians.
+      An EllipticalAperture with a single position, a semimajor axis of
+      5 pixels, a semiminor axis of 3 pixels, and a rotation angle of
+      0.2 radians.
     - |
       !<tag:astropy.org:photutils/aperture/elliptical_aperture-1.0.0>
         a: 5.0
@@ -19,8 +21,9 @@ examples:
         theta: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 rad, value: 0.2}
   -
     - |
-      A SkyEllipticalAperture with a semimajor axis of 5 arcsec and
-      semiminor axis of 3 arcsec.
+      A SkyEllipticalAperture with a single position, a semimajor axis
+      of 5 arcsec, a semiminor axis of 3 arcsec, and a position angle of
+      0 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/elliptical_aperture-1.0.0>
         a: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 5.0}
@@ -43,13 +46,15 @@ properties:
   positions:
     title: Aperture position(s).
     description: |
-      The coordinates of the aperture center(s) in one of the following formats.
-      If an EllipticalAperture in pixel coordinates:
+      The coordinates of the aperture center(s) in one of the following
+      formats.
+
+      If a EllipticalAperture in pixel coordinates:
 
         * single ``(x, y)`` pair as an array
         * `numpy.ndarray` of ``(x, y)`` pairs
 
-      If a SkyEllipticalAperture
+      If a SkyEllipticalAperture:
 
         * `astropy.coordinates.SkyCoord` object
     anyOf:
@@ -79,17 +84,15 @@ properties:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   theta:
-    title: Rotation angle of the ellipse.
+    title: Rotation angle.
     description: |
-      EllipticalAperture:
-      The rotation angle as an angular quantity from the positive ``x`` axis.
-      The rotation angle increases counterclockwise. If a number, it's assumed
-      to be in radians.
-
-      SkyEllipticalAperture:
-        The position angle (in angular units) of the ellipse semimajor
-        axis. For a right-handed world coordinate system, the position
-        angle increases counterclockwise from North (PA=0).
+      EllipticalAperture: the rotation angle of the ellipse from the
+      positive ``x`` axis, as an angular quantity or as a number in
+      radians. The rotation angle increases counterclockwise.
+      SkyEllipticalAperture: the position angle (in angular units) of
+      the ellipse semimajor axis. For a right-handed world coordinate
+      system, the position angle increases counterclockwise from North
+      (PA=0).
     anyOf:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"

--- a/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/elliptical_aperture-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/aperture/elliptical_aperture-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/aperture/elliptical_aperture-1.0.0'
 title: Elliptical aperture
 description: |
   ASDF schema for serializing an elliptical aperture with one or more
   positions, in pixel or sky coordinates.
 
 examples:
-  -
-    - |
+  - - |
       An EllipticalAperture with a single position, a semimajor axis of
       5 pixels, a semiminor axis of 3 pixels, and a rotation angle of
       0.2 radians.
@@ -18,28 +17,43 @@ examples:
         a: 5.0
         b: 3.0
         positions: [20.0, 30.0]
-        theta: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 rad, value: 0.2}
-  -
-    - |
+        theta: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 rad
+          value: 0.2
+  - - |
       A SkyEllipticalAperture with a single position, a semimajor axis
       of 5 arcsec, a semiminor axis of 3 arcsec, and a position angle of
       0 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/elliptical_aperture-1.0.0>
-        a: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 5.0}
-        b: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 3.0}
+        a: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 5.0
+        b: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 3.0
         positions: !<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
-          dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0> {datatype: float64,
-            unit: !unit/unit-1.0.0 deg, value: 30.0}
+          dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0>
+            datatype: float64
+            unit: !unit/unit-1.0.0 deg
+            value: 30.0
           frame: icrs
           ra: !<tag:astropy.org:astropy/coordinates/longitude-1.2.0>
             datatype: float64
             unit: !unit/unit-1.0.0 deg
             value: 10.0
-            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64,
-              unit: !unit/unit-1.0.0 deg, value: 360.0}
+            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+              datatype: float64
+              unit: !unit/unit-1.0.0 deg
+              value: 360.0
           representation_type: spherical
-        theta: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 deg, value: 0.0}
+        theta: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 deg
+          value: 0.0
 
 type: object
 properties:
@@ -63,8 +77,8 @@ properties:
           type: number
         maxItems: 2
         minItems: 2
-      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
   a:
     title: Semimajor axis.
     description: |
@@ -73,7 +87,7 @@ properties:
       in angular units.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   b:
     title: Semiminor axis.
     description: |
@@ -82,7 +96,7 @@ properties:
       in angular units.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   theta:
     title: Rotation angle.
     description: |
@@ -95,8 +109,8 @@ properties:
       (PA=0).
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/angle-1.*'
 required: [positions, a, b]
 additionalProperties: false
 # EllipticalAperture and SkyEllipticalAperture share a tag, so this
@@ -109,7 +123,7 @@ oneOf:
       positions:
         anyOf:
           - type: array
-          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
       a:
         type: number
       b:
@@ -117,13 +131,13 @@ oneOf:
   - title: Sky coordinates
     properties:
       positions:
-        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+        tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
       a:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       b:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       theta:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-          - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
+          - tag: 'tag:astropy.org:astropy/coordinates/angle-1.*'
 ...

--- a/photutils/resources/schemas/aperture/polygon_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/polygon_aperture-1.0.0.yaml
@@ -4,12 +4,14 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/aperture/polygon_aperture-1.0.0"
 title: Polygon aperture
 description: |
-  ASDF schema for serializing a polygon aperture with one or more positions
-  in pixel or sky coordinates.
+  ASDF schema for serializing a polygon aperture with one or more
+  positions, in pixel or sky coordinates.
+
 examples:
   -
     - |
-      A PolygonAperture in pixel space at position [10, 20].
+      A PolygonAperture with a single position and four vertex offsets
+      in pixels.
     - |
       !<tag:astropy.org:photutils/aperture/polygon_aperture-1.0.0>
         positions: [10.0, 20.0]
@@ -20,7 +22,8 @@ examples:
           shape: [4, 2]
   -
     - |
-      A SkyPolygonAperture with a single position and vertex offsets
+      A SkyPolygonAperture with a single position and five vertex
+      offsets in arcsec.
     - |
       !<tag:astropy.org:photutils/aperture/polygon_aperture-1.0.0>
         positions: !<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
@@ -47,13 +50,15 @@ properties:
   positions:
     title: Aperture position(s).
     description: |
-      The coordinates of the aperture center(s) in one of the following formats.
+      The coordinates of the aperture center(s) in one of the following
+      formats.
+
       If a PolygonAperture in pixel coordinates:
 
         * single ``(x, y)`` pair as an array
         * `numpy.ndarray` of ``(x, y)`` pairs
 
-      If a SkyPolygonAperture
+      If a SkyPolygonAperture:
 
         * `astropy.coordinates.SkyCoord` object
     anyOf:

--- a/photutils/resources/schemas/aperture/polygon_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/polygon_aperture-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/aperture/polygon_aperture-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/aperture/polygon_aperture-1.0.0'
 title: Polygon aperture
 description: |
   ASDF schema for serializing a polygon aperture with one or more
   positions, in pixel or sky coordinates.
 
 examples:
-  -
-    - |
+  - - |
       A PolygonAperture with a single position and four vertex offsets
       in pixels.
     - |
@@ -20,22 +19,25 @@ examples:
           datatype: float64
           byteorder: little
           shape: [4, 2]
-  -
-    - |
+  - - |
       A SkyPolygonAperture with a single position and five vertex
       offsets in arcsec.
     - |
       !<tag:astropy.org:photutils/aperture/polygon_aperture-1.0.0>
         positions: !<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
-          dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0> {datatype: float64,
-            unit: !unit/unit-1.0.0 deg, value: 30.0}
+          dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0>
+            datatype: float64
+            unit: !unit/unit-1.0.0 deg
+            value: 30.0
           frame: icrs
           ra: !<tag:astropy.org:astropy/coordinates/longitude-1.2.0>
             datatype: float64
             unit: !unit/unit-1.0.0 deg
             value: 10.0
-            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64,
-              unit: !unit/unit-1.0.0 deg, value: 360.0}
+            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+              datatype: float64
+              unit: !unit/unit-1.0.0 deg
+              value: 360.0
           representation_type: spherical
         vertex_offsets: !unit/quantity-1.3.0
           unit: !unit/unit-1.0.0 arcsec
@@ -67,8 +69,8 @@ properties:
           type: number
         maxItems: 2
         minItems: 2
-      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
   vertex_offsets:
     title: Offsets of the polygon vertices from the positions.
     description: |
@@ -81,8 +83,8 @@ properties:
         The offsets are in angular units and are applied
         as spherical offsets on the local tangent plane.
     anyOf:
-      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
 required: [positions, vertex_offsets]
 additionalProperties: false
 # PolygonAperture and SkyPolygonAperture share a tag, so this requires
@@ -93,13 +95,13 @@ oneOf:
       positions:
         anyOf:
           - type: array
-          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
       vertex_offsets:
-        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
   - title: Sky coordinates
     properties:
       positions:
-        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+        tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
       vertex_offsets:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
 ...

--- a/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
@@ -2,14 +2,17 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/aperture/rectangular_annulus-1.0.0"
-title: Rectangular annulus apertures
+title: Rectangular annulus aperture
 description: |
-  ASDF schema for serializing a rectangular annulus aperture in pixel
-  or sky coordinates.
+  ASDF schema for serializing a rectangular annulus aperture with one or more
+  positions, in pixel or sky coordinates.
+
 examples:
   -
     - |
-      A RectangularAnnulus aperture with a single position,
+      A RectangularAnnulus aperture with a single position, inner full
+      width and height of 3 and 2 pixels, outer full width and height of
+      5 and 4 pixels, and a rotation angle of 80 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/rectangular_annulus-1.0.0>
         h_in: 2.0
@@ -21,7 +24,9 @@ examples:
         w_out: 5.0
   -
     - |
-      A SkyRectangularAnnulus aperture with a single position
+      A SkyRectangularAnnulus aperture with two positions, inner full
+      width and height of 3 and 2 arcsec, outer full width and height of
+      5 and 4 arcsec, and a position angle of 80 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/rectangular_annulus-1.0.0>
         h_in: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 2.0}
@@ -55,13 +60,15 @@ properties:
   positions:
     title: Aperture position(s).
     description: |
-      The coordinates of the aperture center(s) in one of the following formats.
+      The coordinates of the aperture center(s) in one of the following
+      formats.
+
       If a RectangularAnnulus in pixel coordinates:
 
         * single ``(x, y)`` pair as an array
         * `numpy.ndarray` of ``(x, y)`` pairs
 
-      If a SkyRectangularAnnulus
+      If a SkyRectangularAnnulus:
 
         * `astropy.coordinates.SkyCoord` object
     anyOf:
@@ -117,16 +124,15 @@ properties:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   theta:
-    title: Rotation angle
+    title: Rotation angle.
     description: |
-      RectangularAnnulus:
-        The rotation angle as an angular quantity
-        (`~astropy.units.Quantity` or `~astropy.coordinates.Angle`) or
-        value in radians (as a float) from the positive ``x`` axis. The
-        rotation angle increases counterclockwise.
-      SkyRectangularAnnulus:
-        For a right-handed world coordinate system, the position
-        angle increases counterclockwise from North (PA=0).
+      RectangularAnnulus: the rotation angle of the rectangle from the
+      positive ``x`` axis, as an angular quantity or as a number in
+      radians. The rotation angle increases counterclockwise.
+      SkyRectangularAnnulus: the position angle (in angular units) of
+      the rectangle "width" side. For a right-handed world coordinate
+      system, the position angle increases counterclockwise from North
+      (PA=0).
     anyOf:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"

--- a/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/aperture/rectangular_annulus-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/aperture/rectangular_annulus-1.0.0'
 title: Rectangular annulus aperture
 description: |
   ASDF schema for serializing a rectangular annulus aperture with one or more
   positions, in pixel or sky coordinates.
 
 examples:
-  -
-    - |
+  - - |
       A RectangularAnnulus aperture with a single position, inner full
       width and height of 3 and 2 pixels, outer full width and height of
       5 and 4 pixels, and a rotation angle of 80 degrees.
@@ -18,19 +17,26 @@ examples:
         h_in: 2.0
         h_out: 4.0
         positions: [10.0, 20.0]
-        theta: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64, unit: !unit/unit-1.0.0 deg,
-          value: 80.0}
+        theta: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+          datatype: float64
+          unit: !unit/unit-1.0.0 deg
+          value: 80.0
         w_in: 3.0
         w_out: 5.0
-  -
-    - |
+  - - |
       A SkyRectangularAnnulus aperture with two positions, inner full
       width and height of 3 and 2 arcsec, outer full width and height of
       5 and 4 arcsec, and a position angle of 80 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/rectangular_annulus-1.0.0>
-        h_in: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 2.0}
-        h_out: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 4.0}
+        h_in: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 2.0
+        h_out: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 4.0
         positions: !<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
           dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0>
             unit: !unit/unit-1.0.0 deg
@@ -47,13 +53,23 @@ examples:
               datatype: float64
               byteorder: little
               shape: [2]
-            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64,
-              unit: !unit/unit-1.0.0 deg, value: 360.0}
+            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+              datatype: float64
+              unit: !unit/unit-1.0.0 deg
+              value: 360.0
           representation_type: spherical
-        theta: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64, unit: !unit/unit-1.0.0 deg,
-          value: 80.0}
-        w_in: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 3.0}
-        w_out: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 5.0}
+        theta: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+          datatype: float64
+          unit: !unit/unit-1.0.0 deg
+          value: 80.0
+        w_in: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 3.0
+        w_out: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 5.0
 
 type: object
 properties:
@@ -77,8 +93,8 @@ properties:
           type: number
         maxItems: 2
         minItems: 2
-      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
   w_in:
     title: Inner width.
     description: |
@@ -89,7 +105,7 @@ properties:
       the North-South axis.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   w_out:
     title: Outer width.
     description: |
@@ -100,7 +116,7 @@ properties:
       the North-South axis.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   h_in:
     title: Inner height.
     description: |
@@ -111,7 +127,7 @@ properties:
       side is along the East-West axis.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   h_out:
     title: Outer height.
     description: |
@@ -122,7 +138,7 @@ properties:
       side is along the East-West axis.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   theta:
     title: Rotation angle.
     description: |
@@ -135,8 +151,8 @@ properties:
       (PA=0).
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/angle-1.*'
 required: [positions, w_in, w_out, h_out]
 additionalProperties: false
 # RectangularAnnulus and SkyRectangularAnnulus share a tag, so this
@@ -149,7 +165,7 @@ oneOf:
       positions:
         anyOf:
           - type: array
-          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
       w_in:
         type: number
       w_out:
@@ -161,17 +177,17 @@ oneOf:
   - title: Sky coordinates
     properties:
       positions:
-        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+        tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
       w_in:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       w_out:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       h_in:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       h_out:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       theta:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-          - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
+          - tag: 'tag:astropy.org:astropy/coordinates/angle-1.*'
 ...

--- a/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_annulus-1.0.0.yaml
@@ -73,13 +73,13 @@ properties:
       - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
       - tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
   w_in:
-    title: Inner radius.
+    title: Inner width.
     description: |
       RectangularAnnulus: the inner full width of the rectangular
       annulus in pixels.
       SkyRectangularAnnulus: the inner full width of the rectangular
-      annulus in angular units. For ``theta=0`` the width side is along the North-South
-      axis.
+      annulus in angular units. For ``theta=0`` the width side is along
+      the North-South axis.
     anyOf:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
@@ -108,7 +108,7 @@ properties:
   h_out:
     title: Outer height.
     description: |
-      RectangularAnnulus: the outer height of the rectangular
+      RectangularAnnulus: the outer full height of the rectangular
       annulus in pixels.
       SkyRectangularAnnulus: the outer full height of the rectangular
       annulus in angular units. For ``theta=0`` the height

--- a/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
@@ -4,12 +4,15 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/aperture/rectangular_aperture-1.0.0"
 title: Rectangular aperture
 description: |
-  ASDF schema for serializing a rectangular aperture with one or more positions
-  in pixel or sky coordinates.
+  ASDF schema for serializing a rectangular aperture with one or more
+  positions, in pixel or sky coordinates.
+
 examples:
   -
     - |
-      A RectangularAperture
+      A RectangularAperture with a single position, a full width of
+      5 pixels, a full height of 3 pixels, and a rotation angle of
+      80 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/rectangular_aperture-1.0.0>
         h: 3.0
@@ -18,7 +21,10 @@ examples:
           value: 80.0}
         w: 5.0
   -
-    - SkyRectangularAperture
+    - |
+      A SkyRectangularAperture with a single position, a full width of
+      1 arcsec, a full height of 0.5 arcsec, and a position angle of
+      0 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/rectangular_aperture-1.0.0>
         h: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 0.5}
@@ -41,13 +47,15 @@ properties:
   positions:
     title: Aperture position(s).
     description: |
-      The coordinates of the aperture center(s) in one of the following formats.
+      The coordinates of the aperture center(s) in one of the following
+      formats.
+
       If a RectangularAperture in pixel coordinates:
 
         * single ``(x, y)`` pair as an array
         * `numpy.ndarray` of ``(x, y)`` pairs
 
-      If a SkyRectangularAperture
+      If a SkyRectangularAperture:
 
         * `astropy.coordinates.SkyCoord` object
     anyOf:
@@ -61,26 +69,35 @@ properties:
   w:
     title: Full width.
     description: |
-      The full width of the rectangle in pixels. For ``theta=0`` the
-        width side is along the ``x`` axis.
+      RectangularAperture: the full width of the rectangle in pixels.
+      For ``theta=0`` the width side is along the ``x`` axis.
+      SkyRectangularAperture: the full width of the rectangle in angular
+      units. For ``theta=0`` the width side is along the North-South
+      axis.
     anyOf:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   h:
     title: Full height.
     description: |
-      The full height of the rectangle in pixels. For ``theta=0`` the
-      height side is along the ``y`` axis.
+      RectangularAperture: the full height of the rectangle in pixels.
+      For ``theta=0`` the height side is along the ``y`` axis.
+      SkyRectangularAperture: the full height of the rectangle in
+      angular units. For ``theta=0`` the height side is along the
+      East-West axis.
     anyOf:
-        - type: number
-        - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - type: number
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   theta:
-    title: Rotation angle
+    title: Rotation angle.
     description: |
-      The rotation angle as an angular quantity
-      (`~astropy.units.Quantity` or `~astropy.coordinates.Angle`) or
-      value in radians (as a float) from the positive ``x`` axis. The
-      rotation angle increases counterclockwise.
+      RectangularAperture: the rotation angle of the rectangle from the
+      positive ``x`` axis, as an angular quantity or as a number in
+      radians. The rotation angle increases counterclockwise.
+      SkyRectangularAperture: the position angle (in angular units) of
+      the rectangle "width" side. For a right-handed world coordinate
+      system, the position angle increases counterclockwise from North
+      (PA=0).
     anyOf:
       - type: number
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"

--- a/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
+++ b/photutils/resources/schemas/aperture/rectangular_aperture-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/aperture/rectangular_aperture-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/aperture/rectangular_aperture-1.0.0'
 title: Rectangular aperture
 description: |
   ASDF schema for serializing a rectangular aperture with one or more
   positions, in pixel or sky coordinates.
 
 examples:
-  -
-    - |
+  - - |
       A RectangularAperture with a single position, a full width of
       5 pixels, a full height of 3 pixels, and a rotation angle of
       80 degrees.
@@ -17,30 +16,44 @@ examples:
       !<tag:astropy.org:photutils/aperture/rectangular_aperture-1.0.0>
         h: 3.0
         positions: [10.0, 20.0]
-        theta: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64, unit: !unit/unit-1.0.0 deg,
-          value: 80.0}
+        theta: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+          datatype: float64
+          unit: !unit/unit-1.0.0 deg
+          value: 80.0
         w: 5.0
-  -
-    - |
+  - - |
       A SkyRectangularAperture with a single position, a full width of
       1 arcsec, a full height of 0.5 arcsec, and a position angle of
       0 degrees.
     - |
       !<tag:astropy.org:photutils/aperture/rectangular_aperture-1.0.0>
-        h: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 0.5}
+        h: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 0.5
         positions: !<tag:astropy.org:astropy/coordinates/skycoord-1.0.0>
-          dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0> {datatype: float64,
-            unit: !unit/unit-1.0.0 deg, value: 30.0}
+          dec: !<tag:astropy.org:astropy/coordinates/latitude-1.2.0>
+            datatype: float64
+            unit: !unit/unit-1.0.0 deg
+            value: 30.0
           frame: icrs
           ra: !<tag:astropy.org:astropy/coordinates/longitude-1.2.0>
             datatype: float64
             unit: !unit/unit-1.0.0 deg
             value: 10.0
-            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0> {datatype: float64,
-              unit: !unit/unit-1.0.0 deg, value: 360.0}
+            wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.2.0>
+              datatype: float64
+              unit: !unit/unit-1.0.0 deg
+              value: 360.0
           representation_type: spherical
-        theta: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 deg, value: 0.0}
-        w: !unit/quantity-1.3.0 {datatype: float64, unit: !unit/unit-1.0.0 arcsec, value: 1.0}
+        theta: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 deg
+          value: 0.0
+        w: !unit/quantity-1.3.0
+          datatype: float64
+          unit: !unit/unit-1.0.0 arcsec
+          value: 1.0
 
 type: object
 properties:
@@ -64,8 +77,8 @@ properties:
           type: number
         maxItems: 2
         minItems: 2
-      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
   w:
     title: Full width.
     description: |
@@ -76,7 +89,7 @@ properties:
       axis.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   h:
     title: Full height.
     description: |
@@ -87,7 +100,7 @@ properties:
       East-West axis.
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
   theta:
     title: Rotation angle.
     description: |
@@ -100,8 +113,8 @@ properties:
       (PA=0).
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-      - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
+      - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
+      - tag: 'tag:astropy.org:astropy/coordinates/angle-1.*'
 required: [positions, w, h]
 additionalProperties: false
 # RectangularAperture and SkyRectangularAperture share a tag, so this
@@ -114,7 +127,7 @@ oneOf:
       positions:
         anyOf:
           - type: array
-          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
       w:
         type: number
       h:
@@ -122,13 +135,13 @@ oneOf:
   - title: Sky coordinates
     properties:
       positions:
-        tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+        tag: 'tag:astropy.org:astropy/coordinates/skycoord-1.0.0'
       w:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       h:
-        tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+        tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
       theta:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-          - tag: "tag:astropy.org:astropy/coordinates/angle-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
+          - tag: 'tag:astropy.org:astropy/coordinates/angle-1.*'
 ...

--- a/photutils/resources/schemas/psf/airy_disk_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/airy_disk_psf-1.0.0.yaml
@@ -4,12 +4,15 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/airy_disk_psf-1.0.0"
 title: AiryDiskPSF
 description: |
-  ASDF schema for serializing a 2D Airy disk PSF model.
+  ASDF schema for serializing an AiryDiskPSF model, a 2D Airy disk PSF
+  defined by the total flux, center coordinates, and radius.
 
 examples:
   -
-    - An AiryDiskPSF with a flux of 71.4, centered at (24.3, 25.2) pixels, and a radius of 5 pixels.
-      psf.AiryDiskPSF(flux=71.4, x_0=24.3, y_0=25.2, radius=5)
+    - |
+      An AiryDiskPSF with a flux of 71.4, centered at (24.3, 25.2)
+      pixels, and a radius of 5 pixels:
+      AiryDiskPSF(flux=71.4, x_0=24.3, y_0=25.2, radius=5)
     - |
       !<tag:astropy.org:photutils/psf/airy_disk_psf-1.0.0>
         bbox_factor: 10.0
@@ -32,22 +35,26 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: Total integrated flux of the PSF.
+        description: |
+          Total integrated flux of the PSF.
       x_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "X coordinate of the PSF center (pixel coordinates)."
+        description: |
+          Position of the peak along the x axis.
       y_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "Y coordinate of the PSF center (pixel coordinates)."
+        description: |
+          Position of the peak along the y axis.
       radius:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "Characteristic radius of the Airy disk (e.g. first dark ring) in pixels."
+        description: |
+          Radius of the Airy disk at the first zero, in pixels.
       bbox_factor:
         type: number
         description: |

--- a/photutils/resources/schemas/psf/airy_disk_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/airy_disk_psf-1.0.0.yaml
@@ -51,6 +51,18 @@ allOf:
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
 
+    additionalProperties: false
     required: [flux, x_0, y_0, radius]
 ...

--- a/photutils/resources/schemas/psf/airy_disk_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/airy_disk_psf-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/airy_disk_psf-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/airy_disk_psf-1.0.0'
 title: AiryDiskPSF
 description: |
   ASDF schema for serializing an AiryDiskPSF model, a 2D Airy disk PSF
   defined by the total flux, center coordinates, and radius.
 
 examples:
-  -
-    - |
+  - - |
       An AiryDiskPSF with a flux of 71.4, centered at (24.3, 25.2)
       pixels, and a radius of 5 pixels:
       AiryDiskPSF(flux=71.4, x_0=24.3, y_0=25.2, radius=5)
@@ -26,32 +25,31 @@ examples:
         x_0: 24.3
         y_0: 25.2
 
-
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       flux:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Total integrated flux of the PSF.
       x_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the x axis.
       y_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the y axis.
       radius:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Radius of the Airy disk at the first zero, in pixels.

--- a/photutils/resources/schemas/psf/airy_disk_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/airy_disk_psf-1.0.0.yaml
@@ -50,7 +50,8 @@ allOf:
         description: "Characteristic radius of the Airy disk (e.g. first dark ring) in pixels."
       bbox_factor:
         type: number
-        description: Factor by which to multiply the radius to determine the size of the bounding box.
+        description: |
+          The multiple of the FWHM used to define the bounding box limits.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
@@ -51,6 +51,18 @@ allOf:
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
 
+    additionalProperties: false
     required: [flux, x_0, y_0, fwhm]
 ...

--- a/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
@@ -50,7 +50,9 @@ allOf:
         description: "Full width at half maximum of the Gaussian profile in pixels."
       bbox_factor:
         type: number
-        description: Factor by which to multiply the radius to determine the size of the bounding box.
+        description: |
+          The multiple of the standard deviation (sigma) used to define
+          the bounding box limits.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
@@ -4,12 +4,16 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_prf-1.0.0"
 title: CircularGaussianPRF
 description: |
-  ASDF schema for serializing a photutils CircularGaussianPRF.
+  ASDF schema for serializing a CircularGaussianPRF model, a circular
+  2D Gaussian PSF integrated over pixels, defined by the total flux,
+  center coordinates, and FWHM.
 
 examples:
   -
-    - A CircularGaussianPRF with a flux of 71.4, centered at (24.3, 25.2) pixels, and a FWHM of 5 pixels.
-      psf.CircularGaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=5)
+    - |
+      A CircularGaussianPRF with a flux of 71.4, centered at
+      (24.3, 25.2) pixels, and a FWHM of 5 pixels:
+      CircularGaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=5)
     - |
       !<tag:astropy.org:photutils/psf/circular_gaussian_prf-1.0.0>
         bbox_factor: 10.0
@@ -32,22 +36,27 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: Total integrated flux of the PSF.
+        description: |
+          Total integrated flux of the PSF.
       x_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "X coordinate of the PSF center (pixel coordinates)."
+        description: |
+          Position of the peak along the x axis.
       y_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "Y coordinate of the PSF center (pixel coordinates)."
+        description: |
+          Position of the peak along the y axis.
       fwhm:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "Full width at half maximum of the Gaussian profile in pixels."
+        description: |
+          Full width at half maximum of the Gaussian profile, in
+          pixels.
       bbox_factor:
         type: number
         description: |

--- a/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_prf-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_prf-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/circular_gaussian_prf-1.0.0'
 title: CircularGaussianPRF
 description: |
   ASDF schema for serializing a CircularGaussianPRF model, a circular
@@ -9,8 +9,7 @@ description: |
   center coordinates, and FWHM.
 
 examples:
-  -
-    - |
+  - - |
       A CircularGaussianPRF with a flux of 71.4, centered at
       (24.3, 25.2) pixels, and a FWHM of 5 pixels:
       CircularGaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=5)
@@ -27,32 +26,31 @@ examples:
         x_0: 24.3
         y_0: 25.2
 
-
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       flux:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Total integrated flux of the PSF.
       x_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the x axis.
       y_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the y axis.
       fwhm:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Full width at half maximum of the Gaussian profile, in

--- a/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
@@ -57,6 +57,18 @@ allOf:
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
 
+    additionalProperties: false
     required: [flux, x_0, y_0, fwhm]
 ...

--- a/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
@@ -56,7 +56,9 @@ allOf:
         description: "Full width at half maximum of the Gaussian profile in pixels."
       bbox_factor:
         type: number
-        description: Factor by which to multiply the radius to determine the size of the bounding box.
+        description: |
+          The multiple of the standard deviation (sigma) used to define
+          the bounding box limits.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_psf-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/circular_gaussian_psf-1.0.0'
 title: CircularGaussianPSF
 description: |
   ASDF schema for serializing a CircularGaussianPSF model, a circular
@@ -9,8 +9,7 @@ description: |
   FWHM.
 
 examples:
-  -
-    - |
+  - - |
       A CircularGaussianPSF with a flux of 71.4, centered at
       (24.3, 25.2) pixels, and a FWHM of 5 pixels:
       CircularGaussianPSF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=5)
@@ -27,32 +26,31 @@ examples:
         x_0: 24.3
         y_0: 25.2
 
-
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       flux:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Total integrated flux of the PSF.
       x_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the x axis.
       y_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the y axis.
       fwhm:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Full width at half maximum of the Gaussian profile, in

--- a/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_psf-1.0.0.yaml
@@ -2,20 +2,18 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_psf-1.0.0"
-title: A circular 2D Gaussian PSF model.
+title: CircularGaussianPSF
 description: |
-  ASDF schema for serializing a photutils CircularGaussianPSF.
-  This model is a circular 2D Gaussian PSF defined by the total flux,
-  center coordinates, and FWHM.
-
-  This model is evaluated by sampling the 2D Gaussian at the input
-  coordinates. The Gaussian is normalized such that the analytical
-  integral over the entire 2D plane is equal to the total flux.
+  ASDF schema for serializing a CircularGaussianPSF model, a circular
+  2D Gaussian PSF defined by the total flux, center coordinates, and
+  FWHM.
 
 examples:
   -
-    - A CircularGaussianPSF with a flux of 71.4, centered at (24.3, 25.2) pixels, and a FWHM of 5 pixels.
-      psf.CircularGaussianPSF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=5)
+    - |
+      A CircularGaussianPSF with a flux of 71.4, centered at
+      (24.3, 25.2) pixels, and a FWHM of 5 pixels:
+      CircularGaussianPSF(flux=71.4, x_0=24.3, y_0=25.2, fwhm=5)
     - |
       !<tag:astropy.org:photutils/psf/circular_gaussian_psf-1.0.0>
         bbox_factor: 10.0
@@ -38,22 +36,27 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: Total integrated flux of the PSF.
+        description: |
+          Total integrated flux of the PSF.
       x_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "X coordinate of the PSF center (pixel coordinates)."
+        description: |
+          Position of the peak along the x axis.
       y_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "Y coordinate of the PSF center (pixel coordinates)."
+        description: |
+          Position of the peak along the y axis.
       fwhm:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "Full width at half maximum of the Gaussian profile in pixels."
+        description: |
+          Full width at half maximum of the Gaussian profile, in
+          pixels.
       bbox_factor:
         type: number
         description: |

--- a/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
@@ -52,6 +52,18 @@ allOf:
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
 
+    additionalProperties: false
     required: [flux, x_0, y_0, sigma]
 ...

--- a/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
@@ -51,7 +51,9 @@ allOf:
         description: "Standard deviation of the Gaussian profile in pixels."
       bbox_factor:
         type: number
-        description: Factor by which to multiply the radius to determine the size of the bounding box.
+        description: |
+          The multiple of the standard deviation (sigma) used to define
+          the bounding box limits.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_sigma_prf-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/circular_gaussian_sigma_prf-1.0.0'
 title: CircularGaussianSigmaPRF
 description: |
   ASDF schema for serializing a CircularGaussianSigmaPRF model, a
@@ -9,8 +9,7 @@ description: |
   flux, center coordinates, and standard deviation.
 
 examples:
-  -
-    - |
+  - - |
       A CircularGaussianSigmaPRF with a flux of 71.4, centered at
       (24.3, 25.2) pixels, and a standard deviation of 5.1 pixels:
       CircularGaussianSigmaPRF(flux=71.4, x_0=24.3, y_0=25.2, sigma=5.1)
@@ -27,32 +26,31 @@ examples:
         x_0: 24.3
         y_0: 25.2
 
-
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       flux:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Total integrated flux of the PSF.
       x_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the x axis.
       y_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the y axis.
       sigma:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Standard deviation of the Gaussian profile, in pixels.

--- a/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/circular_gaussian_sigma_prf-1.0.0.yaml
@@ -4,13 +4,16 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/circular_gaussian_sigma_prf-1.0.0"
 title: CircularGaussianSigmaPRF
 description: |
-  ASDF schema for serializing a photutils CircularGaussianSigmaPRF.
+  ASDF schema for serializing a CircularGaussianSigmaPRF model, a
+  circular 2D Gaussian PSF integrated over pixels, defined by the total
+  flux, center coordinates, and standard deviation.
 
 examples:
   -
-    - A CircularGaussianSigmaPRF with a flux of 71.4, centered at (24.3, 25.2) pixels,
-      and a standard deviation of the Gaussian of 5.1 pixels.
-      psf.CircularGaussianSigmaPRF(flux=71.4, x_0=24.3, y_0=25.2, sigma=5.1)
+    - |
+      A CircularGaussianSigmaPRF with a flux of 71.4, centered at
+      (24.3, 25.2) pixels, and a standard deviation of 5.1 pixels:
+      CircularGaussianSigmaPRF(flux=71.4, x_0=24.3, y_0=25.2, sigma=5.1)
     - |
       !<tag:astropy.org:photutils/psf/circular_gaussian_sigma_prf-1.0.0>
         bbox_factor: 5.5
@@ -33,22 +36,26 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: Total integrated flux of the PSF.
+        description: |
+          Total integrated flux of the PSF.
       x_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "X coordinate of the PSF center (pixel coordinates)."
+        description: |
+          Position of the peak along the x axis.
       y_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "Y coordinate of the PSF center (pixel coordinates)."
+        description: |
+          Position of the peak along the y axis.
       sigma:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: "Standard deviation of the Gaussian profile in pixels."
+        description: |
+          Standard deviation of the Gaussian profile, in pixels.
       bbox_factor:
         type: number
         description: |

--- a/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
@@ -73,7 +73,9 @@ allOf:
           measured counter-clockwise from the positive x axis in degrees."
       bbox_factor:
         type: number
-        description: Factor by which to multiply the radius to determine the size of the bounding box.
+        description: |
+          The multiple of the x and y standard deviations (sigma) used
+          to define the bounding box limits.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
@@ -4,16 +4,18 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/gaussian_prf-1.0.0"
 title: GaussianPRF
 description: |
-  ASDF schema for serializing a 2D Gaussian PSF model integrated over pixels.
-
-
+  ASDF schema for serializing a GaussianPRF model, a 2D Gaussian PSF
+  integrated over pixels, defined by the total flux, center
+  coordinates, FWHMs, and rotation angle.
 
 examples:
   -
-    - A GaussianPRF with a flux of 71.4, centered at (24.3, 25.2) pixels,
-      and a FWHM of 5 pixels along the x axis, and 6 pixels along the y axis,
-      with a rotation angle of 21.7 degrees.
-      psf.GaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, x_fwhm=5, y_fwhm=6, theta=21.7)
+    - |
+      A GaussianPRF with a flux of 71.4, centered at (24.3, 25.2)
+      pixels, with FWHMs of 5 pixels along the x axis and 6 pixels along
+      the y axis, and a rotation angle of 21.7 degrees:
+      GaussianPRF(flux=71.4, x_0=24.3, y_0=25.2, x_fwhm=5, y_fwhm=6,
+                  theta=21.7)
     - |
       !<tag:astropy.org:photutils/psf/gaussian_prf-1.0.0>
         bbox_factor: 5.5
@@ -39,38 +41,42 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: Total integrated flux of the PSF.
+        description: |
+          Total integrated flux of the PSF.
       x_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          X coordinate of the PSF center (pixel coordinates).
+          Position of the peak along the x axis.
       y_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Y coordinate of the PSF center (pixel coordinates).
+          Position of the peak along the y axis.
       x_fwhm:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Full width at half maximum of the Gaussian profile along the x axis in pixels.
+          Full width at half maximum of the Gaussian profile along
+          the x axis, in pixels.
       y_fwhm:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Full width at half maximum of the Gaussian profile along the y axis in pixels.
+          Full width at half maximum of the Gaussian profile along
+          the y axis, in pixels.
       theta:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Rotation angle of the Gaussian profile in degrees. The angle is
-          measured counter-clockwise from the positive x axis in degrees."
+          Rotation angle of the Gaussian profile, either as a number in
+          degrees or as an angular quantity. The angle is measured
+          counterclockwise from the positive x axis.
       bbox_factor:
         type: number
         description: |

--- a/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/gaussian_prf-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/gaussian_prf-1.0.0'
 title: GaussianPRF
 description: |
   ASDF schema for serializing a GaussianPRF model, a 2D Gaussian PSF
@@ -9,8 +9,7 @@ description: |
   coordinates, FWHMs, and rotation angle.
 
 examples:
-  -
-    - |
+  - - |
       A GaussianPRF with a flux of 71.4, centered at (24.3, 25.2)
       pixels, with FWHMs of 5 pixels along the x axis and 6 pixels along
       the y axis, and a rotation angle of 21.7 degrees:
@@ -32,46 +31,45 @@ examples:
         y_0: 25.2
         y_fwhm: 6.0
 
-
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       flux:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Total integrated flux of the PSF.
       x_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the x axis.
       y_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the y axis.
       x_fwhm:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Full width at half maximum of the Gaussian profile along
           the x axis, in pixels.
       y_fwhm:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Full width at half maximum of the Gaussian profile along
           the y axis, in pixels.
       theta:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Rotation angle of the Gaussian profile, either as a number in

--- a/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_prf-1.0.0.yaml
@@ -74,6 +74,18 @@ allOf:
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
 
+    additionalProperties: false
     required: [flux, x_0, y_0, x_fwhm, y_fwhm]
 ...

--- a/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
@@ -73,7 +73,9 @@ allOf:
           measured counter-clockwise from the positive x axis in degrees."
       bbox_factor:
         type: number
-        description: Factor by which to multiply the radius to determine the size of the bounding box.
+        description: |
+          The multiple of the x and y standard deviations (sigma) used
+          to define the bounding box limits.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
@@ -4,16 +4,18 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/gaussian_psf-1.0.0"
 title: GaussianPSF
 description: |
-  ASDF schema for serializing a 2D Gaussian PSF model.
-
-
+  ASDF schema for serializing a GaussianPSF model, a 2D Gaussian PSF
+  defined by the total flux, center coordinates, FWHMs, and rotation
+  angle.
 
 examples:
   -
-    - A GaussianPSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
-      and a FWHM of 5 pixels along the x axis, and 6 pixels along the y axis,
-      with a rotation angle of 21.7 degrees.
-      psf.GaussianPSF(flux=71.4, x_0=24.3, y_0=25.2, x_fwhm=5, y_fwhm=6, theta=21.7)
+    - |
+      A GaussianPSF with a flux of 71.4, centered at (24.3, 25.2)
+      pixels, with FWHMs of 5 pixels along the x axis and 6 pixels along
+      the y axis, and a rotation angle of 21.7 degrees:
+      GaussianPSF(flux=71.4, x_0=24.3, y_0=25.2, x_fwhm=5, y_fwhm=6,
+                  theta=21.7)
     - |
       !<tag:astropy.org:photutils/psf/gaussian_psf-1.0.0>
         bbox_factor: 5.5
@@ -39,38 +41,42 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: Total integrated flux of the PSF.
+        description: |
+          Total integrated flux of the PSF.
       x_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          X coordinate of the PSF center (pixel coordinates).
+          Position of the peak along the x axis.
       y_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Y coordinate of the PSF center (pixel coordinates).
+          Position of the peak along the y axis.
       x_fwhm:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Full width at half maximum of the Gaussian profile along the x axis in pixels.
+          Full width at half maximum of the Gaussian profile along
+          the x axis, in pixels.
       y_fwhm:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Full width at half maximum of the Gaussian profile along the y axis in pixels.
+          Full width at half maximum of the Gaussian profile along
+          the y axis, in pixels.
       theta:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
-          Rotation angle of the Gaussian profile in degrees. The angle is
-          measured counter-clockwise from the positive x axis in degrees."
+          Rotation angle of the Gaussian profile, either as a number in
+          degrees or as an angular quantity. The angle is measured
+          counterclockwise from the positive x axis.
       bbox_factor:
         type: number
         description: |

--- a/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
@@ -74,6 +74,18 @@ allOf:
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
 
+    additionalProperties: false
     required: [flux, x_0, y_0, x_fwhm, y_fwhm]
 ...

--- a/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gaussian_psf-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/gaussian_psf-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/gaussian_psf-1.0.0'
 title: GaussianPSF
 description: |
   ASDF schema for serializing a GaussianPSF model, a 2D Gaussian PSF
@@ -9,8 +9,7 @@ description: |
   angle.
 
 examples:
-  -
-    - |
+  - - |
       A GaussianPSF with a flux of 71.4, centered at (24.3, 25.2)
       pixels, with FWHMs of 5 pixels along the x axis and 6 pixels along
       the y axis, and a rotation angle of 21.7 degrees:
@@ -32,46 +31,45 @@ examples:
         y_0: 25.2
         y_fwhm: 6.0
 
-
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       flux:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Total integrated flux of the PSF.
       x_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the x axis.
       y_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the y axis.
       x_fwhm:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Full width at half maximum of the Gaussian profile along
           the x axis, in pixels.
       y_fwhm:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Full width at half maximum of the Gaussian profile along
           the y axis, in pixels.
       theta:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Rotation angle of the Gaussian profile, either as a number in

--- a/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
@@ -88,5 +88,18 @@ allOf:
           instrument, detector, or filter. The grid_xypos and oversampling items
           are stored as separate properties and the grid_shape item is recomputed
           when the model is initialized, so none of them appear here.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
+
+    additionalProperties: false
     required: [data, oversampling, grid_xypos, meta]
 ...

--- a/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
@@ -4,26 +4,29 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/gridded_psf_model-1.0.0"
 title: GriddedPSFModel
 description: |
-  ASDF schema for serializing a 2D Gridded PSF model.
+  ASDF schema for serializing a GriddedPSFModel, a grid of 2D ePSF
+  models defined at fiducial detector locations that form a rectangular
+  grid.
 
 examples:
   -
-    - A GriddedPSF model example.
-
+    - |
+      A GriddedPSFModel with four 6x6 ePSF images on a 2x2 grid, a flux
+      of 6, and an oversampling factor of 1 along both axes.
     - |
       !<tag:astropy.org:photutils/psf/gridded_psf_model-1.0.0>
         data: !core/ndarray-1.1.0
           source: 0
           datatype: int64
           byteorder: little
-          shape: [5, 6, 6]
+          shape: [4, 6, 6]
         fill_value: .nan
         flux: 6.0
         grid_xypos: !core/ndarray-1.1.0
           source: 2
           datatype: int64
           byteorder: little
-          shape: [5, 2]
+          shape: [4, 2]
         inputs: [x, y]
         meta:
           detector: NRCA1
@@ -45,24 +48,23 @@ allOf:
       data:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
-          A 3D array of shape (N, My, Mx) containing N ePSF
-          images of shape (My, Mx).
+          A 3D array of shape (N, My, Mx) containing the N ePSF images
+          of shape (My, Mx).
       flux:
         type: number
         description: |
-          Intensity scaling factor for the ePSF.
-          This is the total flux of the source, assuming the input
-          ePSF images are properly normalized.
+          The flux scaling factor, which corresponds to the total source
+          flux assuming that the input image is properly normalized.
       x_0:
         type: number
         description: |
-          x position in the output coordinate grid where the model
-          is evaluated.
+          The x coordinate of the ePSF peak in the output coordinate
+          grid where the model is evaluated.
       y_0:
         type: number
         description: |
-          y position in the output coordinate grid where the model
-          is evaluated.
+          The y coordinate of the ePSF peak in the output coordinate
+          grid where the model is evaluated.
       fill_value:
         type: number
         description: |
@@ -71,23 +73,23 @@ allOf:
       oversampling:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
-          The integer oversampling factor(s) of the input ePSF images along each axis.
-          It is in Python order - "(y, x)".
+          The integer oversampling factor of the input ePSF images
+          along each axis, in numpy ``(y, x)`` order.
       grid_xypos:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
-          A list of the (x, y) grid positions of each reference ePSF. The order of
-          positions should match the first axis of the 3D `~numpy.ndarray` of ePSFs.
-          In other words, ``grid_xypos[i]`` should be the (x, y) position of the
-          reference ePSF defined in ``nddata.data[i]``. The grid positions must form
-          a rectangular grid.
+          The ``(x, y)`` grid position of each reference ePSF, in the
+          same order as the first axis of ``data``; that is,
+          ``grid_xypos[i]`` is the position of the ePSF in ``data[i]``.
+          The grid positions must form a rectangular grid.
       meta:
         type: object
         description: |
-          Additional metadata describing the ePSF grid, such as the telescope,
-          instrument, detector, or filter. The grid_xypos and oversampling items
-          are stored as separate properties and the grid_shape item is recomputed
-          when the model is initialized, so none of them appear here.
+          Additional metadata describing the ePSF grid, such as the
+          telescope, instrument, detector, or filter. The ``grid_xypos``
+          and ``oversampling`` items are stored as separate properties
+          and the ``grid_shape`` item is recomputed when the model is
+          initialized, so none of them appear here.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/gridded_psf_model-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/gridded_psf_model-1.0.0'
 title: GriddedPSFModel
 description: |
   ASDF schema for serializing a GriddedPSFModel, a grid of 2D ePSF
@@ -9,8 +9,7 @@ description: |
   grid.
 
 examples:
-  -
-    - |
+  - - |
       A GriddedPSFModel with four 6x6 ePSF images on a 2x2 grid, a flux
       of 6, and an oversampling factor of 1 along both axes.
     - |
@@ -42,11 +41,11 @@ examples:
         y_0: 0.5
 
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       data:
-        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
         description: |
           A 3D array of shape (N, My, Mx) containing the N ePSF images
           of shape (My, Mx).
@@ -71,12 +70,12 @@ allOf:
           Assign value to pixels outside the input pixel grid
           to avoid extrapolation.
       oversampling:
-        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
         description: |
           The integer oversampling factor of the input ePSF images
           along each axis, in numpy ``(y, x)`` order.
       grid_xypos:
-        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
         description: |
           The ``(x, y)`` grid position of each reference ePSF, in the
           same order as the first axis of ``data``; that is,

--- a/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
@@ -1,8 +1,8 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/gridded_psf-1.0.0"
-title: GriddedPSF
+id: "asdf://astropy.org/photutils/schemas/psf/gridded_psf_model-1.0.0"
+title: GriddedPSFModel
 description: |
   ASDF schema for serializing a 2D Gridded PSF model.
 
@@ -11,7 +11,7 @@ examples:
     - A GriddedPSF model example.
 
     - |
-      !<tag:astropy.org:photutils/psf/gridded_psf-1.0.0>
+      !<tag:astropy.org:photutils/psf/gridded_psf_model-1.0.0>
         data: !core/ndarray-1.1.0
           source: 0
           datatype: int64

--- a/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
@@ -4,13 +4,15 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/image_psf-1.0.0"
 title: ImagePSF
 description: |
-  ASDF schema for serializing a 2D Image PSF model.
+  ASDF schema for serializing an ImagePSF model, a 2D image PSF that is
+  evaluated at arbitrary positions by spline interpolation.
 
 examples:
   -
-    - An ImagePSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
-      and an image of shape (11, 11).
-      psf.ImagePSF(data=np.ones((11, 11)), flux=71.4, x_0=24.3, y_0=25.2)
+    - |
+      An ImagePSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
+      and an image of shape (11, 11):
+      ImagePSF(data=np.ones((11, 11)), flux=71.4, x_0=24.3, y_0=25.2)
     - |
       !<tag:astropy.org:photutils/psf/image_psf-1.0.0>
         data: !core/ndarray-1.1.0
@@ -43,17 +45,25 @@ allOf:
     properties:
       data:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        description: |
+          A 2D array containing the PSF image.
       flux:
         type: number
-        description: Total integrated flux of the PSF.
+        description: |
+          The flux scaling factor, which corresponds to the total source
+          flux assuming that the input image is properly normalized.
       x_0:
         type: number
         description: |
-          Position of the peak along the x axis.
+          The x position of a feature in the image, typically the PSF
+          peak, in the output coordinate grid where the model is
+          evaluated.
       y_0:
         type: number
         description: |
-          Position of the peak along the y axis.
+          The y position of a feature in the image, typically the PSF
+          peak, in the output coordinate grid where the model is
+          evaluated.
       origin:
         anyOf:
         - type: array
@@ -79,7 +89,8 @@ allOf:
           maxItems: 2
         - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
-          The integer oversampling factor(s) of the input PSF image in (y, x) order.
+          The integer oversampling factor of the input PSF image along
+          each axis, in numpy ``(y, x)`` order.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
@@ -80,5 +80,18 @@ allOf:
         - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
           The integer oversampling factor(s) of the input PSF image in (y, x) order.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
+
+    additionalProperties: false
     required: [data]
 ...

--- a/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/image_psf-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/image_psf-1.0.0'
 title: ImagePSF
 description: |
   ASDF schema for serializing an ImagePSF model, a 2D image PSF that is
   evaluated at arbitrary positions by spline interpolation.
 
 examples:
-  -
-    - |
+  - - |
       An ImagePSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
       and an image of shape (11, 11):
       ImagePSF(data=np.ones((11, 11)), flux=71.4, x_0=24.3, y_0=25.2)
@@ -40,11 +39,11 @@ examples:
         y_0: 25.2
 
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       data:
-        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
         description: |
           A 2D array containing the PSF image.
       flux:
@@ -66,12 +65,12 @@ allOf:
           evaluated.
       origin:
         anyOf:
-        - type: array
-          items:
-            type: number
-          minItems: 2
-          maxItems: 2
-        - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
         description: |
           The ``(x, y)`` coordinate with respect to the input image data
           array that represents the reference pixel of the input data.
@@ -82,12 +81,12 @@ allOf:
           to avoid extrapolation.
       oversampling:
         anyOf:
-        - type: array
-          items:
-            type: number
-          minItems: 2
-          maxItems: 2
-        - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
         description: |
           The integer oversampling factor of the input PSF image along
           each axis, in numpy ``(y, x)`` order.

--- a/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/moffat_psf-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/moffat_psf-1.0.0'
 title: MoffatPSF
 description: |
   ASDF schema for serializing a MoffatPSF model, a 2D Moffat PSF
@@ -9,8 +9,7 @@ description: |
   parameters.
 
 examples:
-  -
-    - |
+  - - |
       A MoffatPSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
       with an alpha of 5.1 and a beta of 3.2:
       MoffatPSF(flux=71.4, x_0=24.3, y_0=25.2, alpha=5.1, beta=3.2)
@@ -30,30 +29,30 @@ examples:
         beta: 3.2
 
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - $ref: 'http://stsci.edu/schemas/asdf/transform/transform-1.4.0'
   - type: object
     properties:
       flux:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Total integrated flux of the PSF.
       x_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the x axis.
       y_0:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Position of the peak along the y axis.
       alpha:
         anyOf:
-          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+          - tag: 'tag:stsci.edu:asdf/unit/quantity-1.*'
           - type: number
         description: |
           Characteristic radius of the Moffat profile.

--- a/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
@@ -61,7 +61,8 @@ allOf:
           Power-law index of the Moffat profile.
       bbox_factor:
         type: number
-        description: Factor by which to multiply the radius to determine the size of the bounding box.
+        description: |
+          The multiple of the FWHM used to define the bounding box limits.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.

--- a/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
@@ -62,6 +62,18 @@ allOf:
       bbox_factor:
         type: number
         description: Factor by which to multiply the radius to determine the size of the bounding box.
+      # The properties of the referenced transform schema are repeated
+      # here because "additionalProperties" applies only to the
+      # properties defined in the same subschema.
+      bounding_box: {}
+      bounds: {}
+      fixed: {}
+      input_units_equivalencies: {}
+      inputs: {}
+      inverse: {}
+      name: {}
+      outputs: {}
 
+    additionalProperties: false
     required: [flux, x_0, y_0, alpha, beta]
 ...

--- a/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/moffat_psf-1.0.0.yaml
@@ -4,15 +4,16 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/moffat_psf-1.0.0"
 title: MoffatPSF
 description: |
-  ASDF schema for serializing a 2D Moffat PSF model.
-
-
+  ASDF schema for serializing a MoffatPSF model, a 2D Moffat PSF
+  defined by the total flux, center coordinates, and the alpha and beta
+  parameters.
 
 examples:
   -
-    - A MoffatPSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
-      and alpha of 5.1 and beta of 3.2
-      psf.MoffatPSF(flux=71.4, x_0=24.3, y_0=25.2, alpha=5.1, beta=3.2)
+    - |
+      A MoffatPSF with a flux of 71.4, centered at (24.3, 25.2) pixels,
+      with an alpha of 5.1 and a beta of 3.2:
+      MoffatPSF(flux=71.4, x_0=24.3, y_0=25.2, alpha=5.1, beta=3.2)
     - |
       !<tag:astropy.org:photutils/psf/moffat_psf-1.0.0>
         bbox_factor: 10.0
@@ -36,7 +37,8 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
-        description: Total integrated flux of the PSF.
+        description: |
+          Total integrated flux of the PSF.
       x_0:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"

--- a/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
@@ -4,14 +4,14 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "asdf://astropy.org/photutils/schemas/psf/stdpsf_grid-1.0.0"
 title: STDPSFGrid
 description: |
-  Schema for serializing "STDPSF" format ePSF grids to ASDF.
-
-  By convention the model is saved under a key "stdpsf".
-
+  ASDF schema for serializing a STDPSFGrid, a grid of 2D ePSF models
+  read from a file in the STDPSF format.
 
 examples:
   -
-    - An STDPSF ASDF file.
+    - |
+      A STDPSFGrid with nine 101x101 ePSF images on a 3x3 grid, read
+      from a WFC3/IR F153M STDPSF file.
     - |
       !<tag:astropy.org:photutils/psf/stdpsf_grid-1.0.0>
         data: !core/ndarray-1.1.0
@@ -31,40 +31,50 @@ examples:
             shape: [9, 2]
           oversampling: [4, 4]
 
-
 type: object
 properties:
   data:
     tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
     description: |
-      A 3D array with PSFs.
+      A 3D array of shape (N, My, Mx) containing the N ePSF images of
+      shape (My, Mx).
   meta:
     type: object
     properties:
       STDPSF:
         type: string
-        title: The name of the file containing the PSFs.
+        description: |
+          The name of the STDPSF file that the ePSFs were read from.
       oversampling:
         type: array
         description: |
-          Oversampling factor(s), as a 2-element (y, x) array.
+          The integer oversampling factor of the ePSF images along each
+          axis, in numpy ``(y, x)`` order.
         items:
           type: integer
         minItems: 2
         maxItems: 2
       detector:
         type: string
-        title: The name of the detector
+        description: |
+          The name of the detector.
       filter:
         type: string
-        title: The name of the filter.
+        description: |
+          The name of the filter.
       grid_shape:
         type: array
-        description: The shape of the array of PSFS in numpy order.
+        description: |
+          The shape of the ePSF grid in numpy ``(ny, nx)`` order.
+        items:
+          type: integer
+        minItems: 2
+        maxItems: 2
       grid_xypos:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
         description: |
-          A list of the fiducial positions of the PSFs in the detector frame.
+          The ``(x, y)`` fiducial detector position of each ePSF, in the
+          same order as the first axis of ``data``.
     required: [oversampling, grid_shape, grid_xypos]
 
 required: [data, meta]

--- a/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
@@ -1,15 +1,14 @@
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/stdpsf_grid-1.0.0"
+$schema: 'http://stsci.edu/schemas/yaml-schema/draft-01'
+id: 'asdf://astropy.org/photutils/schemas/psf/stdpsf_grid-1.0.0'
 title: STDPSFGrid
 description: |
   ASDF schema for serializing a STDPSFGrid, a grid of 2D ePSF models
   read from a file in the STDPSF format.
 
 examples:
-  -
-    - |
+  - - |
       A STDPSFGrid with nine 101x101 ePSF images on a 3x3 grid, read
       from a WFC3/IR F153M STDPSF file.
     - |
@@ -34,7 +33,7 @@ examples:
 type: object
 properties:
   data:
-    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
     description: |
       A 3D array of shape (N, My, Mx) containing the N ePSF images of
       shape (My, Mx).
@@ -71,7 +70,7 @@ properties:
         minItems: 2
         maxItems: 2
       grid_xypos:
-        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+        tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
         description: |
           The ``(x, y)`` fiducial detector position of each ePSF, in the
           same order as the first axis of ``data``.

--- a/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
@@ -18,17 +18,17 @@ examples:
           datatype: float32
           byteorder: big
           shape: [9, 101, 101]
+        grid_shape: [3, 3]
+        grid_xypos: !core/ndarray-1.1.0
+          source: 1
+          datatype: int64
+          byteorder: little
+          shape: [9, 2]
         meta:
           STDPSF: STDPSF_WFC3IR_F153M.fits
           detector: WFC3IR
           filter: F153M
-          grid_shape: [3, 3]
-          grid_xypos: !core/ndarray-1.1.0
-            source: 1
-            datatype: int64
-            byteorder: little
-            shape: [9, 2]
-          oversampling: [4, 4]
+        oversampling: [4, 4]
 
 type: object
 properties:
@@ -37,22 +37,40 @@ properties:
     description: |
       A 3D array of shape (N, My, Mx) containing the N ePSF images of
       shape (My, Mx).
+  grid_xypos:
+    tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+    description: |
+      The ``(x, y)`` fiducial detector position of each ePSF, in the
+      same order as the first axis of ``data``.
+  grid_shape:
+    type: array
+    description: |
+      The shape of the ePSF grid in numpy ``(ny, nx)`` order.
+    items:
+      type: integer
+    minItems: 2
+    maxItems: 2
+  oversampling:
+    type: array
+    description: |
+      The integer oversampling factor of the ePSF images along each
+      axis, in numpy ``(y, x)`` order.
+    items:
+      type: integer
+    minItems: 2
+    maxItems: 2
   meta:
     type: object
+    description: |
+      Additional metadata describing the ePSF grid, such as the STDPSF
+      file it was read from, the detector, or the filter. The
+      ``grid_xypos``, ``grid_shape``, and ``oversampling`` items are
+      stored as separate properties, so none of them appear here.
     properties:
       STDPSF:
         type: string
         description: |
           The name of the STDPSF file that the ePSFs were read from.
-      oversampling:
-        type: array
-        description: |
-          The integer oversampling factor of the ePSF images along each
-          axis, in numpy ``(y, x)`` order.
-        items:
-          type: integer
-        minItems: 2
-        maxItems: 2
       detector:
         type: string
         description: |
@@ -61,21 +79,6 @@ properties:
         type: string
         description: |
           The name of the filter.
-      grid_shape:
-        type: array
-        description: |
-          The shape of the ePSF grid in numpy ``(ny, nx)`` order.
-        items:
-          type: integer
-        minItems: 2
-        maxItems: 2
-      grid_xypos:
-        tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
-        description: |
-          The ``(x, y)`` fiducial detector position of each ePSF, in the
-          same order as the first axis of ``data``.
-    required: [oversampling, grid_shape, grid_xypos]
-
-required: [data, meta]
+required: [data, grid_xypos, grid_shape, meta]
 additionalProperties: false
 ...

--- a/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
@@ -68,4 +68,5 @@ properties:
     required: [oversampling, grid_shape, grid_xypos]
 
 required: [data, meta]
+additionalProperties: false
 ...

--- a/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
@@ -1,8 +1,8 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://astropy.org/photutils/schemas/psf/stdpsf-1.0.0"
-title: STDPSF
+id: "asdf://astropy.org/photutils/schemas/psf/stdpsf_grid-1.0.0"
+title: STDPSFGrid
 description: |
   Schema for serializing "STDPSF" format ePSF grids to ASDF.
 
@@ -13,7 +13,7 @@ examples:
   -
     - An STDPSF ASDF file.
     - |
-      !<tag:astropy.org:photutils/psf/stdpsf-1.0.0>
+      !<tag:astropy.org:photutils/psf/stdpsf_grid-1.0.0>
         data: !core/ndarray-1.1.0
           source: 0
           datatype: float32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ Documentation = 'https://photutils.readthedocs.io/en/stable/'
 
 [project.optional-dependencies]
 all = [
+    'asdf >= 3.3',
     'asdf-astropy >= 0.10',
     'bottleneck >= 1.4',
     'gwcs >= 0.22',
@@ -59,6 +60,7 @@ all = [
     'tqdm >= 4.67',
 ]
 test = [
+    'asdf >= 3.3',
     'asdf-astropy >= 0.10',
     'pytest-asdf-plugin',
     'pytest-astropy >= 0.11',


### PR DESCRIPTION
This PR is a follow-up to the ASDF serialization work, assisted by an LLM review.

FIxes:
- Schema-valid PSF files raised `KeyError`. The converters indexed parameters their schemas do not require (`bbox_factor` everywhere, `theta` for the Gaussians, and nearly everything for `ImagePSF` and `GriddedPSFModel`). Optional parameters now fall back to the model default.
- `from photutils.converters import *` raised `AttributeError` when `asdf-astropy` was missing.
- `CircularGaussianSigmaPRF` was never round-tripped: its fixtures returned the `CircularGaussianPRF` examples.
- The PSF schemas silently accepted misspelled parameters; they now set `additionalProperties: false`, as the aperture schemas do.

Other:
- asdf is now as explicit optional dependency
- Base classes remove the duplicated converter bodies. 
- The schemas are no longer excluded from `prettier`, with a `yamllint` hook for the line length inside the example block scalars that prettier cannot reach.