### PR TITLE
Rename the aperture region conversion module

### DIFF
--- a/photutils/aperture/__init__.py
+++ b/photutils/aperture/__init__.py
@@ -5,7 +5,7 @@ Subpackage containing tools for performing aperture photometry.
 
 from .bounding_box import *  # noqa: F401, F403
 from .circle import *  # noqa: F401, F403
-from .converters import *  # noqa: F401, F403
+from .region_converters import *  # noqa: F401, F403
 from .core import *  # noqa: F401, F403
 from .ellipse import *  # noqa: F401, F403
 from .flags import *  # noqa: F401, F403

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -13,10 +13,10 @@ from photutils.aperture._common import (SCALAR_COLLAPSE_TYPES,
                                         collapse_scalar_value, unpack_nddata,
                                         validate_array, validate_mask_method)
 from photutils.aperture._segmentation import process_segmentation_inputs
-from photutils.aperture.converters import region_to_aperture
 from photutils.aperture.core import (Aperture, SkyAperture, _aperture_metadata,
                                      _update_method_subpixels_docstring)
 from photutils.aperture.flags import decode_aperture_flags
+from photutils.aperture.region_converters import region_to_aperture
 from photutils.utils._deprecation import (create_empty_deprecated_qtable,
                                           deprecated_positional_kwargs)
 from photutils.utils._misc import _get_meta

--- a/photutils/aperture/region_converters.py
+++ b/photutils/aperture/region_converters.py
@@ -445,7 +445,8 @@ def _shapely_polygon_to_region(polygon, *, label=None, visual_kwargs=None):
     Examples
     --------
     >>> from shapely import Polygon
-    >>> from photutils.aperture.converters import _shapely_polygon_to_region
+    >>> from photutils.aperture.region_converters import (
+    ...     _shapely_polygon_to_region)
     >>> polygon = Polygon([(1, 1), (3, 1), (2, 4), (1, 2)])
     >>> region = _shapely_polygon_to_region(polygon)
     >>> region

--- a/photutils/aperture/tests/test_region_converters.py
+++ b/photutils/aperture/tests/test_region_converters.py
@@ -18,10 +18,10 @@ from photutils.aperture import (CircularAnnulus, CircularAperture,
                                 SkyCircularAperture, SkyEllipticalAnnulus,
                                 SkyEllipticalAperture, SkyPolygonAperture,
                                 SkyRectangularAnnulus, SkyRectangularAperture)
-from photutils.aperture.converters import (_scalar_aperture_to_region,
-                                           _shapely_polygon_to_region,
-                                           aperture_to_region,
-                                           region_to_aperture)
+from photutils.aperture.region_converters import (_scalar_aperture_to_region,
+                                                  _shapely_polygon_to_region,
+                                                  aperture_to_region,
+                                                  region_to_aperture)
 from photutils.utils._optional_deps import HAS_REGIONS, HAS_SHAPELY
 
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -16,7 +16,7 @@ from scipy.ndimage import find_objects, grey_dilation
 from scipy.signal import fftconvolve
 
 from photutils.aperture import BoundingBox
-from photutils.aperture.converters import _shapely_polygon_to_region
+from photutils.aperture.region_converters import _shapely_polygon_to_region
 from photutils.utils._deprecation import (deprecated_getattr,
                                           deprecated_positional_kwargs)
 from photutils.utils._optional_deps import HAS_RASTERIO, HAS_SHAPELY


### PR DESCRIPTION
This PR renames the regions ↔ apertures converters to `region_converters.py` so it is not confused with the ASDF `converters` package. Individual package modules are considered private, so this does not need a deprecation.