### PR TITLE
Add GriddedfPSFModel grid_shape property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,8 +126,8 @@ New Features
 
   - Added a ``GriddedPSFModel.grid_shape`` property returning the
     ``(ny, nx)`` shape of the ePSF grid, matching the ``STDPSFGrid``
-    property of the same name. It contains the same information as the
-    ``grid_shape`` metadata key. [#2360]
+    property of the same name. It replaces the ``grid_shape`` metadata
+    key, which has been removed. [#2360]
 
   - ``STDPSFGrid`` and the ``GriddedPSFModel`` ``read`` method now
     accept path-like inputs (e.g., ``pathlib.Path``) in addition to
@@ -137,7 +137,6 @@ New Features
 
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``
     keyword. [#2329]
-
 
 Bug Fixes
 ^^^^^^^^^
@@ -309,9 +308,13 @@ API Changes
 
   - The ``nxpsfs`` and ``nypsfs`` metadata keys of the
     ``GriddedPSFModel`` returned when reading a STDPSF file have been
-    removed. They were redundant with the ``grid_shape`` metadata key,
-    which is always set and contains the same information as
-    ``(nypsfs, nxpsfs)``. [#2344]
+    removed. They were redundant with the ``grid_shape`` attribute,
+    which contains the same information as ``(nypsfs, nxpsfs)``.
+    [#2344]
+
+  - The ``'grid_shape'`` key has been removed from the
+    ``GriddedPSFModel`` ``meta`` dictionary. Use the new
+    ``GriddedPSFModel.grid_shape`` attribute instead. [#2360]
 
   - The ``grid_xypos``, ``oversampling``, and ``grid_shape`` keys have
     been removed from the ``STDPSFGrid`` ``meta`` dictionary. The

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,11 @@ New Features
   - Added a ``STDPSFGrid.grid_shape`` property returning the ``(ny,
     nx)`` shape of the ePSF grid. [#2347]
 
+  - Added a ``GriddedPSFModel.grid_shape`` property returning the
+    ``(ny, nx)`` shape of the ePSF grid, matching the ``STDPSFGrid``
+    property of the same name. It contains the same information as the
+    ``grid_shape`` metadata key. [#2360]
+
   - ``STDPSFGrid`` and the ``GriddedPSFModel`` ``read`` method now
     accept path-like inputs (e.g., ``pathlib.Path``) in addition to
     strings. [#2355]

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -540,6 +540,14 @@ now always stores ``'grid_xypos'`` as the sorted array of grid
 positions and ``'oversampling'`` as a normalized ``(y, x)`` tuple, so
 that both always match the attributes of the same name.
 
+``GriddedPSFModel`` ``'grid_shape'`` Metadata Key
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``'grid_shape'`` key has been removed from the
+`~photutils.psf.GriddedPSFModel` ``meta`` dictionary. Use the new
+``grid_shape`` attribute instead, i.e., ``psfmodel.grid_shape`` instead
+of ``psfmodel.meta['grid_shape']``.
+
 Deblending ``n_markers`` Warning Key
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -70,11 +70,10 @@ class GriddedPSFModelConverter(TransformConverterBase):
         }
 
         # Preserve any additional meta items (e.g., 'STDPSF', 'detector',
-        # 'filter'). 'grid_xypos' and 'oversampling' are stored above and
-        # 'grid_shape' is recomputed when the model is initialized.
+        # 'filter'). 'grid_xypos' and 'oversampling' are stored above.
         node['meta'] = {
             key: value for key, value in model.meta.items()
-            if key not in ('grid_xypos', 'oversampling', 'grid_shape')
+            if key not in ('grid_xypos', 'oversampling')
         }
 
         return node

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -144,7 +144,6 @@ class GriddedPSFModel(Fittable2DModel):
         self._xgrid = np.unique(self.grid_xypos[:, 0])  # sorted
         self._ygrid = np.unique(self.grid_xypos[:, 1])  # sorted
         self._grid_shape = (len(self._ygrid), len(self._xgrid))
-        self.meta['grid_shape'] = self._grid_shape
         # Store the sorted grid positions so that meta always matches
         # the grid_xypos attribute, regardless of the input form
         self.meta['grid_xypos'] = self.grid_xypos

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -143,7 +143,8 @@ class GriddedPSFModel(Fittable2DModel):
 
         self._xgrid = np.unique(self.grid_xypos[:, 0])  # sorted
         self._ygrid = np.unique(self.grid_xypos[:, 1])  # sorted
-        self.meta['grid_shape'] = (len(self._ygrid), len(self._xgrid))
+        self._grid_shape = (len(self._ygrid), len(self._xgrid))
+        self.meta['grid_shape'] = self._grid_shape
         # Store the sorted grid positions so that meta always matches
         # the grid_xypos attribute, regardless of the input form
         self.meta['grid_xypos'] = self.grid_xypos
@@ -301,7 +302,7 @@ class GriddedPSFModel(Fittable2DModel):
                 keywords.append((name, self.meta[key]))
 
         keywords.extend([('Number of PSFs', len(self.grid_xypos)),
-                         ('Grid shape', self.meta['grid_shape']),
+                         ('Grid shape', self.grid_shape),
                          ('Grid positions', self.grid_xypos.tolist()),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
@@ -336,6 +337,13 @@ class GriddedPSFModel(Fittable2DModel):
         grid.
         """
         return self._grid_xypos
+
+    @property
+    def grid_shape(self):
+        """
+        The ``(ny, nx)`` shape of the ePSF grid.
+        """
+        return self._grid_shape
 
     def copy(self):
         """

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -136,6 +136,27 @@ class TestGriddedPSFModel:
         with pytest.raises(AttributeError, match=match):
             psfmodel.grid_xypos = [[0, 0], [1, 1]]
 
+    def test_grid_shape(self, psfmodel):
+        assert psfmodel.grid_shape == (4, 4)
+        assert all(isinstance(value, int) for value in psfmodel.grid_shape)
+        assert psfmodel.meta['grid_shape'] == psfmodel.grid_shape
+
+        match = 'object has no setter'
+        with pytest.raises(AttributeError, match=match):
+            psfmodel.grid_shape = (2, 2)
+
+    def test_grid_shape_rectangular(self):
+        """
+        Test that grid_shape is in (ny, nx) order.
+        """
+        xgrid = [0, 10, 20]
+        ygrid = [0, 5, 15, 25]
+        meta = {'grid_xypos': list(product(xgrid, ygrid)),
+                'oversampling': 1}
+        data = np.ones((len(xgrid) * len(ygrid), 5, 5))
+        psfmodel = GriddedPSFModel(NDData(data, meta=meta))
+        assert psfmodel.grid_shape == (len(ygrid), len(xgrid))
+
     def test_repr_str(self, psfmodel):
         repr_str = repr(psfmodel)
         assert 'GriddedPSFModel' in repr_str
@@ -444,6 +465,7 @@ class TestGriddedPSFModel:
         keys = ('Grid shape', 'Number of PSFs', 'PSF shape', 'Oversampling')
         for key in keys:
             assert key in model_str
+        assert 'Grid shape: (4, 4)' in model_str
         for param in psfmodel.param_names:
             assert param in model_str
 

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -139,7 +139,7 @@ class TestGriddedPSFModel:
     def test_grid_shape(self, psfmodel):
         assert psfmodel.grid_shape == (4, 4)
         assert all(isinstance(value, int) for value in psfmodel.grid_shape)
-        assert psfmodel.meta['grid_shape'] == psfmodel.grid_shape
+        assert 'grid_shape' not in psfmodel.meta
 
         match = 'object has no setter'
         with pytest.raises(AttributeError, match=match):
@@ -434,6 +434,7 @@ class TestGriddedPSFModel:
         assert_equal(model_copy.grid_xypos, psfmodel.grid_xypos)
         assert_equal(model_copy.oversampling, psfmodel.oversampling)
         assert_equal(model_copy.meta, psfmodel.meta)
+        assert model_copy.grid_shape == psfmodel.grid_shape
         assert model_copy.flux.value == psfmodel.flux.value
         assert model_copy.x_0.value == psfmodel.x_0.value
         assert model_copy.y_0.value == psfmodel.y_0.value

--- a/photutils/psf/tests/test_model_io.py
+++ b/photutils/psf/tests/test_model_io.py
@@ -252,7 +252,7 @@ class TestWebbPSFReader:
         psfmodel = GriddedPSFModel.read(filename, format='webbpsf')
         assert_equal(np.unique(psfmodel.grid_xypos[:, 0]), xgrid)
         assert_equal(np.unique(psfmodel.grid_xypos[:, 1]), ygrid)
-        assert psfmodel.meta['grid_shape'] == (len(ygrid), len(xgrid))
+        assert psfmodel.grid_shape == (len(ygrid), len(xgrid))
 
         for (x, y), plane in zip(psfmodel.grid_xypos, psfmodel.data,
                                  strict=True):

--- a/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
@@ -86,9 +86,8 @@ allOf:
         description: |
           Additional metadata describing the ePSF grid, such as the
           telescope, instrument, detector, or filter. The ``grid_xypos``
-          and ``oversampling`` items are stored as separate properties
-          and the ``grid_shape`` item is recomputed when the model is
-          initialized, so none of them appear here.
+          and ``oversampling`` items are stored as separate properties,
+          so neither appears here.
       # The properties of the referenced transform schema are repeated
       # here because "additionalProperties" applies only to the
       # properties defined in the same subschema.


### PR DESCRIPTION
This PR adds a ``GriddedPSFModel.grid_shape`` property returning the ``(ny, nx)`` shape of the ePSF grid, matching the ``STDPSFGrid`` property of the same name. It replaces the ``grid_shape`` metadata key, which has been removed.