### PR TITLE
Speed up isophote tests

### DIFF
--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -18,11 +18,11 @@ from photutils.isophote.geometry import EllipseGeometry
 from photutils.isophote.isophote import Isophote, IsophoteList
 from photutils.isophote.tests.make_test_data import make_test_image
 
-# define an off-center position and a tilted sma
+# Define an off-center position and a tilted sma
 POS = 384
 PA = np.deg2rad(10.0)
 
-# build off-center test data. It's fine to have a single np array to use
+# Build off-center test data. It's fine to have a single np array to use
 # in all tests that need it, but do not use a single instance of
 # EllipseGeometry. The code may eventually modify it's contents. The safe
 # bet is to build it wherever it's needed. The cost is negligible.
@@ -32,7 +32,7 @@ OFFSET_GALAXY = make_test_image(x0=POS, y0=POS, pa=PA, noise=1.0e-12,
 
 class TestEllipse:
     def setup_class(self):
-        # centered, tilted galaxy
+        # Centered, tilted galaxy
         self.data = make_test_image(pa=PA, seed=0)
 
     @pytest.mark.remote_data
@@ -56,21 +56,24 @@ class TestEllipse:
         assert len(isophote_list) > 1
         assert isinstance(isophote_list[0], Isophote)
 
-        # verify that the list is properly sorted in sem-major axis length
+        # Verify that the list is properly sorted in sem-major axis length
         assert isophote_list[-1] > isophote_list[0]
 
-        # the fit should stop where gradient loses reliability.
+        # The fit should stop where gradient loses reliability
         assert len(isophote_list) == 69
         assert isophote_list[-1].stop_code == 1
 
     def test_linear(self):
         ellipse = Ellipse(self.data)
-        isophote_list = ellipse.fit_image(linear=True, step=2.0)
+        # maxsma limits the runtime. The linear spacing checks below
+        # do not depend on the outer extent of the fit.
+        isophote_list = ellipse.fit_image(linear=True, step=2.0,
+                                          maxsma=80.0)
 
-        # verify that the list is properly sorted in sem-major axis length
+        # Verify that the list is properly sorted in sem-major axis length
         assert isophote_list[-1] > isophote_list[0]
 
-        # difference in sma between successive isohpotes must be constant.
+        # Difference in sma between successive isohpotes must be constant
         step = isophote_list[-1].sma - isophote_list[-2].sma
         assert math.isclose((isophote_list[-2].sma - isophote_list[-3].sma),
                             step, rel_tol=0.01)
@@ -88,8 +91,8 @@ class TestEllipse:
 
     def test_offcenter_fail(self):
         # A first guess ellipse that is centered in the image frame.
-        # This should result in failure since the real galaxy
-        # image is off-center by a large offset.
+        # This should result in failure since the real galaxy image is
+        # off-center by a large offset.
         ellipse = Ellipse(OFFSET_GALAXY)
 
         match = 'No meaningful fit was possible'
@@ -98,30 +101,30 @@ class TestEllipse:
         assert len(isophote_list) == 0
 
     def test_offcenter_fit(self):
-        # A first guess ellipse that is roughly centered on the
-        # offset galaxy image.
+        # A first guess ellipse that is roughly centered on the offset
+        # galaxy image.
         g = EllipseGeometry(POS + 5, POS + 5, 10.0, eps=0.2, pa=PA, astep=0.1)
         ellipse = Ellipse(OFFSET_GALAXY, geometry=g)
         isophote_list = ellipse.fit_image()
 
-        # the fit should stop when too many potential sample
-        # points fall outside the image frame.
+        # The fit should stop when too many potential sample points fall
+        # outside the image frame.
         assert len(isophote_list) == 63
         assert isophote_list[-1].stop_code == 1
 
     def test_offcenter_go_beyond_frame(self):
-        # Same as before, but now force the fit to goo
-        # beyond the image frame limits.
+        # Same as before, but now force the fit to go beyond the image
+        # frame limits.
         g = EllipseGeometry(POS + 5, POS + 5, 10.0, eps=0.2, pa=PA, astep=0.1)
         ellipse = Ellipse(OFFSET_GALAXY, geometry=g)
         isophote_list = ellipse.fit_image(maxsma=400.0)
 
-        # the fit should go to maxsma, but with fixed geometry
+        # The fit should go to maxsma, but with fixed geometry
         assert len(isophote_list) == 71
         assert isophote_list[-1].stop_code == 4
 
-        # check that no zero-valued intensities were left behind
-        # in the sample arrays when sampling outside the image.
+        # Check that no zero-valued intensities were left behind in the
+        # sample arrays when sampling outside the image.
         for iso in isophote_list:
             assert not np.any(iso.sample.values[2] == 0)
 

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -48,8 +48,14 @@ def test_model():
     assert np.abs(np.mean(residual)) <= 5.0
 
 
-@pytest.mark.parametrize('sma_interval', [0.05, 0.1])
-def test_model_simulated_data(sma_interval):
+@pytest.fixture(name='simulated_isolist', scope='module')
+def fixture_simulated_isolist():
+    """
+    Fit isophotes to a simulated galaxy image.
+
+    The fit does not depend on the model-building parameters, so it is
+    performed only once and shared across tests.
+    """
     data = make_test_image(nx=200, ny=200, i0=10.0, sma=5.0, eps=0.5,
                            pa=np.pi / 3.0, noise=0.05, seed=0)
 
@@ -62,6 +68,12 @@ def test_model_simulated_data(sma_interval):
         warnings.simplefilter('ignore', RuntimeWarning)
         isophote_list = ellipse.fit_image()
 
+    return data, isophote_list
+
+
+@pytest.mark.parametrize('sma_interval', [0.05, 0.1])
+def test_model_simulated_data(simulated_isolist, sma_interval):
+    data, isophote_list = simulated_isolist
     model = build_ellipse_model(data.shape, isophote_list,
                                 fill=np.mean(data[0:50, 0:50]),
                                 sma_interval=sma_interval)

--- a/photutils/isophote/tests/test_positional_kwargs.py
+++ b/photutils/isophote/tests/test_positional_kwargs.py
@@ -22,17 +22,19 @@ class TestEllipsePositionalKwargs:
     """
 
     def setup_method(self):
-        self.data = make_test_image(seed=0)
+        # A small image with a capped fit is sufficient (and fast)
+        # for testing the deprecation warnings
+        self.data = make_test_image(nx=128, ny=128, sma=10.0, seed=0)
 
     def test_init_positional_warns(self):
-        geometry = EllipseGeometry(x0=256, y0=256, sma=10, eps=0.2,
+        geometry = EllipseGeometry(x0=64, y0=64, sma=10, eps=0.2,
                                    pa=np.pi / 2)
         match = '__init__'
         with pytest.warns(AstropyDeprecationWarning, match=match):
             Ellipse(self.data, geometry)
 
     def test_init_keyword_no_warning(self):
-        geometry = EllipseGeometry(x0=256, y0=256, sma=10, eps=0.2,
+        geometry = EllipseGeometry(x0=64, y0=64, sma=10, eps=0.2,
                                    pa=np.pi / 2)
         Ellipse(self.data, geometry=geometry)
 
@@ -40,21 +42,21 @@ class TestEllipsePositionalKwargs:
         ellipse = Ellipse(self.data)
         match = 'fit_image'
         with pytest.warns(AstropyDeprecationWarning, match=match):
-            ellipse.fit_image(10.0)
+            ellipse.fit_image(10.0, maxsma=15.0)
 
     def test_fit_image_keyword_no_warning(self):
         ellipse = Ellipse(self.data)
-        ellipse.fit_image(sma0=10.0)
+        ellipse.fit_image(sma0=10.0, maxsma=15.0)
 
     def test_fit_isophote_positional_warns(self):
         ellipse = Ellipse(self.data)
         match = 'fit_isophote'
         with pytest.warns(AstropyDeprecationWarning, match=match):
-            ellipse.fit_isophote(40.0, 0.1)
+            ellipse.fit_isophote(10.0, 0.1)
 
     def test_fit_isophote_keyword_no_warning(self):
         ellipse = Ellipse(self.data)
-        ellipse.fit_isophote(40.0, step=0.1)
+        ellipse.fit_isophote(10.0, step=0.1)
 
 
 class TestEllipseGeometryPositionalKwargs:
@@ -85,24 +87,35 @@ class TestEllipseGeometryPositionalKwargs:
         geometry.find_center(data, threshold=0.5)
 
 
+@pytest.fixture(name='small_isolist', scope='module')
+def fixture_small_isolist():
+    """
+    Fit isophotes to a small simulated galaxy image.
+
+    A small image with a capped fit is sufficient (and fast) for
+    testing the deprecation warnings, and the fit is shared across
+    tests.
+    """
+    data = make_test_image(nx=128, ny=128, sma=10.0, seed=0)
+    ellipse = Ellipse(data)
+    isolist = ellipse.fit_image(sma0=10.0, maxsma=15.0)
+    return data.shape, isolist
+
+
 class TestBuildEllipseModelPositionalKwargs:
     """
     Test build_ellipse_model.
     """
 
-    def test_positional_warns(self):
-        data = make_test_image(seed=0)
-        ellipse = Ellipse(data)
-        isolist = ellipse.fit_image(sma0=10.0)
+    def test_positional_warns(self, small_isolist):
+        shape, isolist = small_isolist
         match = 'build_ellipse_model'
         with pytest.warns(AstropyDeprecationWarning, match=match):
-            build_ellipse_model(data.shape, isolist, 0.0)
+            build_ellipse_model(shape, isolist, 0.0)
 
-    def test_keyword_no_warning(self):
-        data = make_test_image(seed=0)
-        ellipse = Ellipse(data)
-        isolist = ellipse.fit_image(sma0=10.0)
-        build_ellipse_model(data.shape, isolist, fill=0.0)
+    def test_keyword_no_warning(self, small_isolist):
+        shape, isolist = small_isolist
+        build_ellipse_model(shape, isolist, fill=0.0)
 
 
 class TestEllipseSamplePositionalKwargs:


### PR DESCRIPTION
This PR reduces the runtime of the isophote tests without changing what is tested. Running locally, the tests go from ~32s to ~10s (no remote data) and ~42s to ~19s for `--remote-data`.