### PR TITLE
Aperture cleanup: validation, API consistency, and expanded tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,7 +88,7 @@ New Features
     default ``to_table()`` output), and ``ApertureStats`` also
     provides a ``sum_flags`` attribute for the sum properties. A new
     ``decode_aperture_flags`` function decodes the flag values into
-    human-readable names. [#2327, #2328]
+    human-readable names. [#2327, #2328, #2362]
 
   - Added validation of the ``ApertureStats.to_table()`` ``columns``
     keyword. [#2329]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -302,6 +302,9 @@ API Changes
     ``area_overlap`` method must now be a boolean array (or `None`).
     [#2362]
 
+  - The ``PixelAperture.plot`` method now returns a list of patches
+    for scalar apertures, as documented, instead of a tuple. [#2362]
+
 - ``photutils.detection``
 
   - The ``repr`` and ``str`` output of ``StarFinderCatalogBase`` now

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -294,6 +294,10 @@ API Changes
     ``BoundingBox``, so that comparing a ``BoundingBox`` to another
     type returns `False` rather than raising. [#2348]
 
+  - The ``mask`` input to aperture photometry and the aperture
+    ``area_overlap`` method must now be a boolean array (or `None`).
+    [#2362]
+
 - ``photutils.detection``
 
   - The ``repr`` and ``str`` output of ``StarFinderCatalogBase`` now

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -190,6 +190,10 @@ Bug Fixes
     the data of the aperture mask it creates when a ``mask`` is input.
     [#2348]
 
+  - Fixed the annulus apertures so that reassigning an inner or outer
+    shape parameter after construction validates the inner < outer
+    invariant. [#2362]
+
 - ``photutils.detection``
 
   - Fixed ``DAOStarFinder`` and ``IRAFStarFinder`` ``orientation``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -280,6 +280,11 @@ API Changes
     be removed in version 4.0. Use the ``ApertureStats.id`` attribute
     instead. [#2331]
 
+  - The ``ApertureStats.n_apertures`` attribute is now deprecated
+    and will be removed in version 4.0. Use the new
+    ``ApertureStats.n_positions`` attribute instead, which matches
+    ``AperturePhotometry.n_positions``. [#2362]
+
   - ``AperturePhotometry`` and ``ApertureStats`` now validate the
     ``method``/``sum_method`` and ``subpixels`` keywords when the
     object is created instead of when a measured attribute is first

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -334,9 +334,10 @@ one of three methods:
   aperture, and 0 otherwise.
 
 * ``'subpixel'``:
-  Pixels are divided into a sub-grid of :math:`N×N` subpixels (where
-  :math:`N` is set by the ``'subpixels'`` keyword). The pixel weight is
-  the fraction of subpixel centers that fall within the aperture.
+  Pixels are divided into a sub-grid of :math:`N \times N` subpixels
+  (where :math:`N` is set by the ``'subpixels'`` keyword). The pixel
+  weight is the fraction of subpixel centers that fall within the
+  aperture.
 
 .. note::
 
@@ -543,13 +544,13 @@ Aperture Photometry on a 3D Data Cube
 image. To measure a source in a 3D data cube --- for example, a time
 series of images of the same field or a spectroscopic integral field
 unit (IFU) data cube --- apply the same aperture to each 2D image in the
-stack and collect the measurements into into an output array or table.
-For a time series of images, these measurements form a light curve.
+stack and collect the measurements into an output array or table. For a
+time series of images, these measurements form a light curve.
 
 Here we create a small stack of five images in which a single source
 varies in brightness from frame to frame, and measure its flux and
 uncertainty in each frame using the same circular aperture. Build the
-list of results objects first (a single photometry pass per frame), then
+list of result objects first (a single photometry pass per frame), then
 read as many attributes as needed::
 
     >>> import numpy as np

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -485,6 +485,15 @@ been renamed to ``n_coords`` for naming consistency within photutils.
 The old ``ncoords`` name is deprecated and will be removed in version
 4.0.
 
+``ApertureStats.n_apertures`` Renamed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `~photutils.aperture.ApertureStats` ``n_apertures``
+attribute has been renamed to ``n_positions``, matching the
+`~photutils.aperture.AperturePhotometry` attribute of the same name
+(both count the aperture positions). The old ``n_apertures`` name is
+deprecated and will be removed in version 4.0.
+
 
 Removed Deprecations
 --------------------

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -415,6 +415,11 @@ conditions such as:
 * sigma-clipped pixels within the aperture (``'sigma_clipped'``,
   ``'all_clipped'``) and too few pixels to compute a statistic
   (``'too_few_pixels'``) in `~photutils.aperture.ApertureStats`
+* sources whose net flux is not positive (``'undefined_shape'``)
+  or whose covariance matrix is singular or nearly singular
+  (``'singular_covariance'``), so that the centroid and shape
+  properties are undefined or unreliable, in
+  `~photutils.aperture.ApertureStats`
 
 The overlap flags are precise. They are based on the pixels with
 nonzero aperture weight, not simply the aperture bounding box. The

--- a/photutils/aperture/_batch_overlap.pxd
+++ b/photutils/aperture/_batch_overlap.pxd
@@ -75,6 +75,112 @@ cdef inline Py_ssize_t _round_half_away(double x) noexcept nogil:
     return <Py_ssize_t>ceil(x - 0.5)
 
 
+cdef inline bint _resolve_seg_pixel(const Py_ssize_t *segmentation,
+                                    const unsigned char *mask,
+                                    Py_ssize_t nx_data, int seg_method,
+                                    Py_ssize_t label,
+                                    Py_ssize_t ix, Py_ssize_t iy,
+                                    Py_ssize_t ix0, Py_ssize_t ix1,
+                                    Py_ssize_t iy0, Py_ssize_t iy1,
+                                    Py_ssize_t ccx, Py_ssize_t ccy,
+                                    Py_ssize_t *six, Py_ssize_t *siy,
+                                    Py_ssize_t *n_seg_px,
+                                    Py_ssize_t *n_uncorr) noexcept nogil:
+    """
+    Apply the segmentation masking method to a single unmasked pixel.
+
+    This is the segmentation-masking step shared by the per-pixel
+    loops of ``_batch_photometry.batch_aperture_sums`` and
+    ``_batch_stats.batch_aperture_gather``. The caller must invoke it
+    only when a segmentation array is present and ``label`` is nonzero.
+
+    Parameters
+    ----------
+    segmentation : const Py_ssize_t *
+        The C-contiguous segmentation array data.
+
+    mask : const unsigned char *
+        The C-contiguous mask-plane data, or NULL if there is no mask.
+        Used only by the symmetric 'correct' method (``seg_method`` 3)
+        to reject mirror pixels that are masked or non-finite.
+
+    nx_data : Py_ssize_t
+        The row stride (number of columns) of the data arrays.
+
+    seg_method : int
+        The segmentation masking method code: 1 excludes neighbor-source
+        pixels, 2 excludes all pixels not assigned to the target source,
+        and 3 replaces neighbor-source pixels with the values mirrored
+        across the aperture center (see ``batch_aperture_sums``).
+
+    label : Py_ssize_t
+        The target source label (nonzero).
+
+    ix, iy : Py_ssize_t
+        The pixel coordinates.
+
+    ix0, ix1, iy0, iy1 : Py_ssize_t
+        The bounding-box limits, clipped to the image. For method 3, a
+        mirror pixel outside these limits cannot be used.
+
+    ccx, ccy : Py_ssize_t
+        The rounded aperture center used by the method-3 mirror.
+
+    six, siy : Py_ssize_t *
+        Output. The coordinates of the pixel whose value contributes.
+        Overwritten (with the mirror pixel) only by a successful
+        method-3 correction.
+
+    n_seg_px : Py_ssize_t *
+        In/out. Incremented when the pixel is excluded, restricted, or
+        corrected due to a neighboring source.
+
+    n_uncorr : Py_ssize_t *
+        In/out. Incremented when a method-3 neighbor pixel could not be
+        corrected (the mirror pixel was unavailable).
+
+    Returns
+    -------
+    contributes : bint
+        `True` if the pixel contributes to the aperture (reading its
+        value from ``(siy[0], six[0])``); `False` if it is excluded.
+    """
+    cdef Py_ssize_t seg_val = segmentation[iy * nx_data + ix]
+    cdef Py_ssize_t xm, ym, mseg
+
+    if seg_method == 1:
+        if seg_val != 0 and seg_val != label:
+            n_seg_px[0] += 1
+            return False
+    elif seg_method == 2:
+        if seg_val != label:
+            # Only neighbor-source pixels (not background pixels)
+            # count toward the neighbor-pixels flag.
+            if seg_val != 0:
+                n_seg_px[0] += 1
+            return False
+    elif seg_method == 3:
+        if seg_val != 0 and seg_val != label:
+            # Neighbor pixel: replace its value with the pixel
+            # mirrored across the center.
+            n_seg_px[0] += 1
+            xm = 2 * ccx - ix
+            ym = 2 * ccy - iy
+            if xm < ix0 or xm >= ix1 or ym < iy0 or ym >= iy1:
+                n_uncorr[0] += 1
+                return False
+            mseg = segmentation[ym * nx_data + xm]
+            if mseg != 0 and mseg != label:
+                n_uncorr[0] += 1
+                return False
+            if mask != NULL and mask[ym * nx_data + xm]:
+                n_uncorr[0] += 1
+                return False
+            six[0] = xm
+            siy[0] = ym
+    return True
+
+
 cdef inline bint _source_grid_setup(double cx, double cy,
                                     double ext_x, double ext_y,
                                     double off_x, double off_y,

--- a/photutils/aperture/_batch_overlap.pxd
+++ b/photutils/aperture/_batch_overlap.pxd
@@ -2,7 +2,7 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """
 Shared per-pixel aperture overlap helpers for the batch Cython drivers
-for aperture photometry.
+for aperture photometry and statistics.
 
 Each helper returns the fraction of a single pixel that overlaps an
 aperture shape centered on the origin, using exactly the same arithmetic

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -25,7 +25,7 @@ from photutils.aperture._batch_overlap cimport (
     _circular_annulus_pixel_frac, _ellipse_pixel_frac,
     _elliptical_annulus_pixel_frac, _polygon_pixel_frac,
     _presize_packed_offsets, _rect_pixel_frac, _rectangular_annulus_pixel_frac,
-    _round_half_away, _source_grid_setup)
+    _resolve_seg_pixel, _round_half_away, _source_grid_setup)
 from photutils.geometry._polygon_overlap cimport (convex_edge_normals,
                                                   polygon_work_partition,
                                                   polygon_work_size)
@@ -272,7 +272,16 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     cdef bint has_mask = mask is not None
     cdef bint has_seg = segmentation is not None
     cdef bint has_bkg = local_bkg is not None
-    cdef Py_ssize_t lbl = 0, seg_val
+    cdef Py_ssize_t lbl = 0
+
+    # Base pointers for the C-contiguous segmentation and mask planes,
+    # used by the shared per-pixel segmentation helper
+    cdef const Py_ssize_t *seg_ptr = NULL
+    cdef const unsigned char *mask_ptr = NULL
+    if has_seg:
+        seg_ptr = &segmentation[0, 0]
+    if has_mask:
+        mask_ptr = &mask[0, 0]
 
     # Aperture shape parameters (constant over all source positions)
     cdef double r_in = 0.0, r_out = 0.0
@@ -390,7 +399,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
 
     cdef Py_ssize_t k, ix, iy, ix0, ix1, iy0, iy1
     cdef Py_ssize_t ixmin, iymin
-    cdef Py_ssize_t six, siy, xm, ym, ccx = 0, ccy = 0, mseg
+    cdef Py_ssize_t six, siy, ccx = 0, ccy = 0
     cdef double cx, cy, lbk = 0.0
     cdef double gxmin, gymin
     cdef double dx, dy, pixel_radius, norm
@@ -522,40 +531,12 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                             continue
                     six = ix
                     siy = iy
-                    if has_seg and lbl != 0:
-                        seg_val = segmentation[iy, ix]
-                        if seg_method == 1:
-                            if seg_val != 0 and seg_val != lbl:
-                                n_seg_px += 1
-                                continue
-                        elif seg_method == 2:
-                            if seg_val != lbl:
-                                # Only neighbor-source pixels (not
-                                # background pixels) count toward the
-                                # neighbor-pixels flag.
-                                if seg_val != 0:
-                                    n_seg_px += 1
-                                continue
-                        elif seg_method == 3:
-                            if seg_val != 0 and seg_val != lbl:
-                                # Neighbor pixel: replace its value with
-                                # the pixel mirrored across the center.
-                                n_seg_px += 1
-                                xm = 2 * ccx - ix
-                                ym = 2 * ccy - iy
-                                if (xm < ix0 or xm >= ix1
-                                        or ym < iy0 or ym >= iy1):
-                                    n_uncorr += 1
-                                    continue
-                                mseg = segmentation[ym, xm]
-                                if mseg != 0 and mseg != lbl:
-                                    n_uncorr += 1
-                                    continue
-                                if has_mask and mask[ym, xm]:
-                                    n_uncorr += 1
-                                    continue
-                                six = xm
-                                siy = ym
+                    if (has_seg and lbl != 0
+                            and not _resolve_seg_pixel(
+                                seg_ptr, mask_ptr, nx_data, seg_method,
+                                lbl, ix, iy, ix0, ix1, iy0, iy1, ccx,
+                                ccy, &six, &siy, &n_seg_px, &n_uncorr)):
+                        continue
 
                     val = data[siy, six] - lbk
                     n_valid += 1

--- a/photutils/aperture/_batch_photometry.pyx
+++ b/photutils/aperture/_batch_photometry.pyx
@@ -63,6 +63,10 @@ FLAG_COL_UNCORRECTED = 5
 FLAG_COL_VALID = 6
 FLAG_COL_BBOX_CLIPPED = 7
 
+# The total number of ``flag_counts`` columns. Every producer of a
+# per-source flag-count array must allocate this many columns
+N_FLAG_COLS = 8
+
 
 def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
                         const unsigned char[:, ::1] mask,
@@ -256,7 +260,7 @@ def batch_aperture_sums(const double[:, ::1] data, const double[:, ::1] error,
     areas_arr = np.full(n_src, np.nan)
     overlap_arr = np.zeros(n_src, dtype=np.uint8)
     starts_arr = np.zeros(n_src, dtype=np.intp)
-    fcounts_arr = np.zeros((n_src, 8), dtype=np.intp)
+    fcounts_arr = np.zeros((n_src, N_FLAG_COLS), dtype=np.intp)
     cdef double[::1] sums = sums_arr
     cdef double[::1] sum_vars = vars_arr
     cdef double[::1] areas = areas_arr

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -29,7 +29,7 @@ from photutils.aperture._batch_overlap cimport (
     _circular_annulus_pixel_frac, _ellipse_pixel_frac,
     _elliptical_annulus_pixel_frac, _polygon_pixel_frac,
     _presize_packed_offsets, _rect_pixel_frac, _rectangular_annulus_pixel_frac,
-    _round_half_away, _source_grid_setup)
+    _resolve_seg_pixel, _round_half_away, _source_grid_setup)
 from photutils.geometry._polygon_overlap cimport (convex_edge_normals,
                                                   polygon_work_partition,
                                                   polygon_work_size)
@@ -327,7 +327,16 @@ def batch_aperture_gather(const double[:, ::1] data,
     cdef bint has_mask = mask is not None
     cdef bint has_bkg = local_bkg is not None
     cdef bint has_seg = segmentation is not None
-    cdef Py_ssize_t lbl = 0, seg_val
+    cdef Py_ssize_t lbl = 0
+
+    # Base pointers for the C-contiguous segmentation and mask planes,
+    # used by the shared per-pixel segmentation helper
+    cdef const Py_ssize_t *seg_ptr = NULL
+    cdef const unsigned char *mask_ptr = NULL
+    if has_seg:
+        seg_ptr = &segmentation[0, 0]
+    if has_mask:
+        mask_ptr = &mask[0, 0]
 
     starts_arr = np.zeros(n_src, dtype=np.intp)
     counts_arr = np.zeros(n_src, dtype=np.intp)
@@ -439,7 +448,7 @@ def batch_aperture_gather(const double[:, ::1] data,
 
     cdef Py_ssize_t k, ix, iy, ix0, ix1, iy0, iy1
     cdef Py_ssize_t ixmin, iymin
-    cdef Py_ssize_t six, siy, xm, ym, ccx = 0, ccy = 0, mseg
+    cdef Py_ssize_t six, siy, ccx = 0, ccy = 0
     cdef double cx, cy, lbk
     cdef double gxmin, gymin
     cdef double dx, dy, pixel_radius, norm
@@ -553,38 +562,12 @@ def batch_aperture_gather(const double[:, ::1] data,
                             continue
                     six = ix
                     siy = iy
-                    if has_seg and lbl != 0:
-                        seg_val = segmentation[iy, ix]
-                        if seg_method == 1:
-                            if seg_val != 0 and seg_val != lbl:
-                                n_seg_px += 1
-                                continue
-                        elif seg_method == 2:
-                            if seg_val != lbl:
-                                # Only neighbor-source pixels (not
-                                # background pixels) count toward the
-                                # neighbor-pixels flag.
-                                if seg_val != 0:
-                                    n_seg_px += 1
-                                continue
-                        elif seg_method == 3:
-                            if seg_val != 0 and seg_val != lbl:
-                                n_seg_px += 1
-                                xm = 2 * ccx - ix
-                                ym = 2 * ccy - iy
-                                if (xm < ix0 or xm >= ix1
-                                        or ym < iy0 or ym >= iy1):
-                                    n_uncorr += 1
-                                    continue
-                                mseg = segmentation[ym, xm]
-                                if mseg != 0 and mseg != lbl:
-                                    n_uncorr += 1
-                                    continue
-                                if has_mask and mask[ym, xm]:
-                                    n_uncorr += 1
-                                    continue
-                                six = xm
-                                siy = ym
+                    if (has_seg and lbl != 0
+                            and not _resolve_seg_pixel(
+                                seg_ptr, mask_ptr, nx_data, seg_method,
+                                lbl, ix, iy, ix0, ix1, iy0, iy1, ccx,
+                                ccy, &six, &siy, &n_seg_px, &n_uncorr)):
+                        continue
 
                     values[pos] = data[siy, six] - lbk
                     local_x[pos] = <int>(ix - ix0)

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -21,6 +21,8 @@ free-threaded Python builds.
 
 import numpy as np
 
+from photutils.aperture._batch_photometry import N_FLAG_COLS
+
 from photutils.aperture._batch_overlap cimport (
     _CIRCLE, _CIRCULAR_ANNULUS, _ELLIPSE, _ELLIPTICAL_ANNULUS, _POLYGON,
     _RECTANGLE, _RECTANGULAR_ANNULUS, _circle_pixel_frac,
@@ -330,7 +332,7 @@ def batch_aperture_gather(const double[:, ::1] data,
     starts_arr = np.zeros(n_src, dtype=np.intp)
     counts_arr = np.zeros(n_src, dtype=np.intp)
     overlap_arr = np.zeros(n_src, dtype=np.uint8)
-    fcounts_arr = np.zeros((n_src, 8), dtype=np.intp)
+    fcounts_arr = np.zeros((n_src, N_FLAG_COLS), dtype=np.intp)
     cdef Py_ssize_t[::1] starts = starts_arr
     cdef Py_ssize_t[::1] counts = counts_arr
     cdef unsigned char[::1] overlap = overlap_arr

--- a/photutils/aperture/_segmentation.py
+++ b/photutils/aperture/_segmentation.py
@@ -103,6 +103,9 @@ def process_segmentation_inputs(segmentation_image, labels,
         raise ValueError(msg)
 
     labels = np.atleast_1d(labels)
+    if labels.ndim != 1:
+        msg = 'labels must be a 1D array'
+        raise ValueError(msg)
     if labels.shape[0] != n_positions:
         msg = ('labels must have the same length as the number of '
                'aperture positions')

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -44,10 +44,37 @@ class ApertureAttribute:
         self._validate(value)
         if not isinstance(value, (u.Quantity, SkyCoord)):
             value = float(value)
+        self._validate_ordered_pairs(instance, value)
         # No need to reset if not already in the instance dict
         if self.name in instance.__dict__:
             self._reset_lazyproperties(instance)
         instance.__dict__[self.name] = value
+
+    def _validate_ordered_pairs(self, instance, value):
+        """
+        Validate the ordering invariants between related parameters
+        declared by the owner class in ``_ordered_pairs``.
+
+        ``_ordered_pairs`` is a tuple of ``(inner, outer)`` parameter
+        name pairs, where the inner value must be strictly less than the
+        outer value (e.g., an annulus inner and outer radius). The check
+        runs whenever either parameter of a pair is assigned, comparing
+        the new value against the other parameter's current value. It is
+        skipped while the other parameter is not yet set (e.g., partway
+        through ``__init__``). The check runs before the new value is
+        stored, so a failed assignment leaves the instance unchanged.
+        """
+        for inner, outer in getattr(instance, '_ordered_pairs', ()):
+            if self.name == inner:
+                other = instance.__dict__.get(outer)
+                if other is not None and not other > value:
+                    msg = f'{outer!r} must be greater than {inner!r}'
+                    raise ValueError(msg)
+            elif self.name == outer:
+                other = instance.__dict__.get(inner)
+                if other is not None and not value > other:
+                    msg = f'{outer!r} must be greater than {inner!r}'
+                    raise ValueError(msg)
 
     def _reset_lazyproperties(self, instance):
         # Reset lazyproperties (if they exist) for aperture parameter
@@ -131,8 +158,17 @@ class PositiveScalar(ApertureAttribute):
     """
 
     def _validate(self, value):
-        if not np.isscalar(value) or value <= 0:
-            msg = f'{self.name!r} must be a positive scalar'
+        msg = f'{self.name!r} must be a positive scalar'
+        if not np.isscalar(value):
+            raise ValueError(msg)
+        try:
+            # NaN compares False, so it is also rejected here
+            positive = value > 0
+        except TypeError:
+            # Non-numeric scalars (e.g., strings) do not support
+            # comparison with 0
+            raise TypeError(msg) from None
+        if not positive:
             raise ValueError(msg)
 
 
@@ -167,7 +203,8 @@ class PositiveScalarAngle(ScalarAngle):
     def _validate(self, value):
         super()._validate(value)
 
-        if value <= 0:
+        # NaN compares False, so it is also rejected here
+        if not value > 0:
             msg = f'{self.name!r} must be greater than zero'
             raise ValueError(msg)
 

--- a/photutils/aperture/bounding_box.py
+++ b/photutils/aperture/bounding_box.py
@@ -142,9 +142,19 @@ class BoundingBox:
         return hash((self.ixmin, self.ixmax, self.iymin, self.iymax))
 
     def __or__(self, other):
+        # NotImplemented (instead of the TypeError raised by ``union``)
+        # lets Python try the reflected operation and raise its standard
+        # unsupported-operand TypeError.
+        if not isinstance(other, BoundingBox):
+            return NotImplemented
         return self.union(other)
 
     def __and__(self, other):
+        # NotImplemented (instead of the TypeError raised by
+        # ``intersection``) lets Python try the reflected operation and
+        # raise its standard unsupported-operand TypeError.
+        if not isinstance(other, BoundingBox):
+            return NotImplemented
         return self.intersection(other)
 
     def __repr__(self):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -17,6 +17,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            PositiveScalarAngle,
                                            SkyCoordPositions)
 from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _enable_batch_photometry,
                                      _update_method_subpixels_docstring)
 from photutils.aperture.mask import ApertureMask
 from photutils.aperture.polygon import PolygonAperture, SkyPolygonAperture
@@ -126,6 +127,7 @@ class CircularMaskMixin:  # pragma: no cover
         return masks
 
 
+@_enable_batch_photometry
 class CircularAperture(PixelAperture):
     """
     A circular aperture defined in pixel coordinates.
@@ -289,6 +291,7 @@ class CircularAperture(PixelAperture):
         return PolygonAperture._from_simple_offsets(self.positions, offsets)
 
 
+@_enable_batch_photometry
 class CircularAnnulus(PixelAperture):
     """
     A circular annulus aperture defined in pixel coordinates.

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -68,7 +68,7 @@ def _circular_polygon_offsets(r, n_vertices):
     return np.column_stack([np.cos(theta), np.sin(theta)]) * r
 
 
-@deprecated('3.0')
+@deprecated('3.0', until='3.2')
 class CircularMaskMixin:  # pragma: no cover
     """
     Mixin class to create masks for circular and circular-annulus

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -286,7 +286,7 @@ class CircularAperture(PixelAperture):
             A polygon aperture that approximates the circle.
         """
         offsets = _circular_polygon_offsets(self.r, n_vertices)
-        return PolygonAperture._from_convex_offsets(self.positions, offsets)
+        return PolygonAperture._from_simple_offsets(self.positions, offsets)
 
 
 class CircularAnnulus(PixelAperture):
@@ -542,7 +542,7 @@ class SkyCircularAperture(SkyAperture):
             A sky polygon aperture that approximates the circle.
         """
         offsets = _circular_polygon_offsets(self.r, n_vertices)
-        return SkyPolygonAperture._from_convex_offsets(self.positions,
+        return SkyPolygonAperture._from_simple_offsets(self.positions,
                                                        offsets)
 
 

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -148,7 +148,7 @@ class CircularAperture(PixelAperture):
     Raises
     ------
     ValueError : `ValueError`
-        If the input radius, ``r``, is negative.
+        If the input radius, ``r``, is not positive.
 
     Examples
     --------
@@ -314,11 +314,11 @@ class CircularAnnulus(PixelAperture):
     Raises
     ------
     ValueError : `ValueError`
-        If inner radius (``r_in``) is greater than outer radius
+        If the inner radius (``r_in``) is not less than the outer radius
         (``r_out``).
 
     ValueError : `ValueError`
-        If inner radius (``r_in``) is negative.
+        If either radius (``r_in`` or ``r_out``) is not positive.
 
     Examples
     --------

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -334,15 +334,12 @@ class CircularAnnulus(PixelAperture):
     """
 
     _params = ('positions', 'r_in', 'r_out')
+    _ordered_pairs = (('r_in', 'r_out'),)
     positions = PixelPositions('The center pixel position(s).')
     r_in = PositiveScalar('The inner radius in pixels.')
     r_out = PositiveScalar('The outer radius in pixels.')
 
     def __init__(self, positions, r_in, r_out):
-        if not r_out > r_in:
-            msg = "'r_out' must be greater than 'r_in'"
-            raise ValueError(msg)
-
         self.positions = positions
         self.r_in = r_in
         self.r_out = r_out
@@ -578,15 +575,12 @@ class SkyCircularAnnulus(SkyAperture):
     """
 
     _params = ('positions', 'r_in', 'r_out')
+    _ordered_pairs = (('r_in', 'r_out'),)
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     r_in = PositiveScalarAngle('The inner radius in angular units.')
     r_out = PositiveScalarAngle('The outer radius in angular units.')
 
     def __init__(self, positions, r_in, r_out):
-        if not r_out > r_in:
-            msg = "'r_out' must be greater than 'r_in'"
-            raise ValueError(msg)
-
         self.positions = positions
         self.r_in = r_in
         self.r_out = r_out

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -1038,11 +1038,13 @@ class PixelAperture(Aperture):
 
             - ``area`` : `~astropy.units.Quantity`
               The total unmasked overlap area of each aperture (in
-              ``pix**2``), taking into account the aperture mask
-              method, masked data pixels, segmentation masking, and
-              partial/no overlap of the aperture with the data. This
-              is equivalent to `area_overlap` computed with the same
-              inputs. The value is ``NaN`` where the aperture does not
+              ``pix**2``), taking into account the aperture mask method,
+              masked data pixels, segmentation masking, and partial/no
+              overlap of the aperture with the data. This is equivalent
+              to `area_overlap` computed with the same inputs when
+              no segmentation masking is applied and there are no
+              non-finite data values (`area_overlap` takes neither into
+              account). The value is ``NaN`` where the aperture does not
               overlap the data.
 
             - ``flags`` : `~numpy.ndarray`

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -210,6 +210,37 @@ def _update_method_subpixels_docstring(obj):
     return obj
 
 
+def _validate_mask(mask, shape):
+    """
+    Validate that ``mask`` is a boolean array with the given shape.
+
+    Parameters
+    ----------
+    mask : array_like (bool) or `None`
+        The input mask.
+
+    shape : tuple of int
+        The required mask shape (i.e., the data shape).
+
+    Returns
+    -------
+    mask : `~numpy.ndarray` (bool) or `None`
+        The validated mask as a boolean array, or `None` if ``mask`` is
+        `None`.
+    """
+    if mask is None:
+        return None
+
+    mask = np.asanyarray(mask)
+    if mask.dtype != bool:
+        msg = 'mask must be a boolean array'
+        raise TypeError(msg)
+    if mask.shape != shape:
+        msg = 'mask and data must have the same shape'
+        raise ValueError(msg)
+    return mask
+
+
 @dataclass(frozen=True)
 class _ApertureResults:
     """
@@ -606,11 +637,7 @@ class PixelAperture(Aperture):
         if self.isscalar:
             apermasks = (apermasks,)
 
-        if mask is not None:
-            mask = np.asarray(mask)
-            if mask.shape != data.shape:
-                msg = 'mask and data must have the same shape'
-                raise ValueError(msg)
+        mask = _validate_mask(mask, data.shape)
 
         areas = []
         for apermask in apermasks:
@@ -1029,6 +1056,8 @@ class PixelAperture(Aperture):
             if error.shape != data.shape:
                 msg = 'error and data must have the same shape'
                 raise ValueError(msg)
+
+        mask = _validate_mask(mask, data.shape)
 
         # Check Quantity inputs
         unit = {getattr(arr, 'unit', None) for arr in (data, error)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -288,14 +288,17 @@ class Aperture(metaclass=abc.ABCMeta):
                    'indexed')
             raise TypeError(msg)
 
-        kwargs = {}
+        # Transplant the already-validated shape parameters directly
+        # into the new instance instead of re-validating them through
+        # __init__ (e.g., the polygon simple-polygon check is O(n^2) in
+        # the number of vertices). Only the sliced positions are set
+        # through their descriptor.
+        newobj = self.__class__.__new__(self.__class__)
+        newobj.positions = self.positions[index]
         for param in self._params:
-            if param == 'positions':
-                # Slice the positions array
-                kwargs[param] = getattr(self, param)[index]
-            else:
-                kwargs[param] = getattr(self, param)
-        return self.__class__(**kwargs)
+            if param != 'positions':
+                newobj.__dict__[param] = getattr(self, param)
+        return newobj
 
     def __iter__(self):
         for i in range(len(self)):
@@ -383,12 +386,21 @@ class Aperture(metaclass=abc.ABCMeta):
     def _lazyproperties(self):
         """
         A list of all class lazyproperties (even in superclasses).
-        """
-        def islazyproperty(obj):
-            return isinstance(obj, lazyproperty)
 
-        return [i[0] for i in inspect.getmembers(self.__class__,
-                                                 predicate=islazyproperty)]
+        The result depends only on the class, so it is computed once
+        per class and cached (it is looked up on every aperture
+        parameter reassignment).
+        """
+        cls = self.__class__
+        cached = cls.__dict__.get('_lazyproperties_cache')
+        if cached is None:
+            def islazyproperty(obj):
+                return isinstance(obj, lazyproperty)
+
+            cached = [i[0] for i in inspect.getmembers(
+                cls, predicate=islazyproperty)]
+            cls._lazyproperties_cache = cached
+        return cached
 
     def copy(self):
         """

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -376,12 +376,6 @@ class Aperture(metaclass=abc.ABCMeta):
 
         return True
 
-    def __ne__(self, other):
-        """
-        Inequality operator for `Aperture`.
-        """
-        return not self == other
-
     @property
     def _lazyproperties(self):
         """
@@ -1344,7 +1338,7 @@ class PixelAperture(Aperture):
 
         patches = self._to_patch(origin=origin, **kwargs)
         if self.isscalar:
-            patches = (patches,)
+            patches = [patches]
 
         for patch in patches:
             ax.add_patch(patch)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -23,7 +23,7 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_NONFINITE_ERROR,
                                                   FLAG_COL_SEG,
                                                   FLAG_COL_UNCORRECTED,
-                                                  FLAG_COL_VALID,
+                                                  FLAG_COL_VALID, N_FLAG_COLS,
                                                   batch_aperture_sums)
 from photutils.aperture._common import (batch_inputs_supported,
                                         batch_mask_plane,
@@ -775,7 +775,7 @@ class PixelAperture(Aperture):
         aperture_sums = []
         aperture_sum_errs = []
         areas = []
-        flag_counts = np.zeros((n_src, 8), dtype=np.intp)
+        flag_counts = np.zeros((n_src, N_FLAG_COLS), dtype=np.intp)
         overlap = np.zeros(n_src, dtype=bool)
         with warnings.catch_warnings():
             # Ignore multiplication with non-finite data values

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -231,7 +231,10 @@ def _validate_mask(mask, shape):
     if mask is None:
         return None
 
-    mask = np.asanyarray(mask)
+    # asarray demotes ndarray subclasses (e.g., a boolean MaskedArray)
+    # to a plain array of the underlying data, which the batch and
+    # mask-based code paths handle identically.
+    mask = np.asarray(mask)
     if mask.dtype != bool:
         msg = 'mask must be a boolean array'
         raise TypeError(msg)

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -244,6 +244,34 @@ def _validate_mask(mask, shape):
     return mask
 
 
+def _enable_batch_photometry(cls):
+    """
+    Class decorator that opts a `PixelAperture` subclass in to the
+    batch Cython photometry driver.
+
+    The decorator records the decorated class itself, and the batch
+    driver is used only when an instance's own class was decorated
+    (see ``PixelAperture._batch_photometry``). The opt-in therefore
+    does not propagate to subclasses. An undecorated subclass may
+    override behavior (e.g., ``to_mask``) that the batch driver would
+    not honor, so it uses the mask-based code path unless it is
+    explicitly decorated as well. A decorated class must provide the
+    ``_batch_shape_params`` hook (which may be inherited).
+
+    Parameters
+    ----------
+    cls : type
+        The aperture class to opt in.
+
+    Returns
+    -------
+    cls : type
+        The input class, with the opt-in recorded.
+    """
+    cls._batch_photometry_class = cls
+    return cls
+
+
 @dataclass(frozen=True)
 class _ApertureResults:
     """
@@ -458,6 +486,11 @@ class PixelAperture(Aperture):
     """
     Abstract base class for apertures defined in pixel coordinates.
     """
+
+    # The class (if any) that opted in to the batch photometry driver
+    # via the _enable_batch_photometry decorator; instances use the
+    # batch driver only when this is their own class
+    _batch_photometry_class = None
 
     @lazyproperty
     def _default_patch_properties(self):
@@ -725,9 +758,9 @@ class PixelAperture(Aperture):
         the segmentation masking methods for such apertures. All
         of the built-in apertures opt in to the batch driver, so
         this path is reached only for an unsupported input (see
-        `~photutils.aperture._common.batch_inputs_supported`)
-        or for an `Aperture` subclass that does not define the
-        ``_batch_shape_params`` hook in its own class.
+        `~photutils.aperture._common.batch_inputs_supported`) or
+        for an `Aperture` subclass that is not decorated with
+        ``_enable_batch_photometry``.
 
         Parameters
         ----------
@@ -891,10 +924,10 @@ class PixelAperture(Aperture):
 
         Notes
         -----
-        The batch driver is used only if this hook is defined in the
-        aperture instance's own class (see `_batch_photometry`),
-        so subclasses must define this method (e.g., by calling
-        ``super()``) to opt in to the batch code path.
+        The batch driver is used only for classes decorated with
+        ``_enable_batch_photometry`` (see `_batch_photometry`). The
+        opt-in does not propagate to subclasses, so a subclass must
+        itself be decorated to use the batch code path.
         """
         return
 
@@ -944,11 +977,12 @@ class PixelAperture(Aperture):
             that the caller must resolve to the precise outside-weight
             test (see `_resolve_outside_weights`).
         """
-        # Use the batch driver only if the aperture's own class defines
-        # the _batch_shape_params hook. Subclasses that do not define
-        # it may override other behavior (e.g., to_mask) that the batch
-        # driver would not honor, so they use the mask-based code path.
-        if '_batch_shape_params' not in type(self).__dict__:
+        # Use the batch driver only if the instance's own class opted
+        # in via the _enable_batch_photometry decorator. Undecorated
+        # subclasses may override other behavior (e.g., to_mask) that
+        # the batch driver would not honor, so they use the mask-based
+        # code path.
+        if type(self)._batch_photometry_class is not type(self):
             return None
 
         spec = self._batch_shape_params()

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -369,7 +369,7 @@ class EllipticalAperture(_RotatableApertureMixin, PixelAperture):
         """
         offsets = _elliptical_polygon_offsets(
             self.a, self.b, self.theta.to_value(u.radian), n_vertices)
-        return PolygonAperture._from_convex_offsets(self.positions, offsets)
+        return PolygonAperture._from_simple_offsets(self.positions, offsets)
 
 
 class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
@@ -701,7 +701,7 @@ class SkyEllipticalAperture(_RotatableApertureMixin, SkyAperture):
         offsets = _elliptical_polygon_offsets(
             self.a.to_value(unit), self.b.to_value(unit),
             self.theta.to_value(u.radian), n_vertices, swap_axes=True) * unit
-        return SkyPolygonAperture._from_convex_offsets(self.positions, offsets)
+        return SkyPolygonAperture._from_simple_offsets(self.positions, offsets)
 
 
 class SkyEllipticalAnnulus(_RotatableApertureMixin, SkyAperture):

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -211,7 +211,7 @@ class EllipticalAperture(_RotatableApertureMixin, PixelAperture):
     Raises
     ------
     ValueError : `ValueError`
-        If either axis (``a`` or ``b``) is negative.
+        If either axis (``a`` or ``b``) is not positive.
 
     Examples
     --------
@@ -414,12 +414,14 @@ class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
     Raises
     ------
     ValueError : `ValueError`
-        If inner semimajor axis (``a_in``) is greater than outer semimajor
-        axis (``a_out``).
+        If the inner semimajor axis (``a_in``) is not less than the
+        outer semimajor axis (``a_out``), or if the inner semiminor axis
+        (``b_in``), when given, is not less than the outer semiminor
+        axis (``b_out``).
 
     ValueError : `ValueError`
-        If either the inner semimajor axis (``a_in``) or the outer semiminor
-        axis (``b_out``) is negative.
+        If any of the axes (``a_in``, ``a_out``, ``b_in``, or ``b_out``)
+        is not positive.
 
     Examples
     --------

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -18,6 +18,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            ScalarAngleOrValue,
                                            SkyCoordPositions)
 from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _enable_batch_photometry,
                                      _RotatableApertureMixin,
                                      _update_method_subpixels_docstring)
 from photutils.aperture.mask import ApertureMask
@@ -180,6 +181,7 @@ def _calc_ellipse_extents(semimajor_axis, semiminor_axis, theta_rad):
     return x_extent, y_extent
 
 
+@_enable_batch_photometry
 class EllipticalAperture(_RotatableApertureMixin, PixelAperture):
     """
     An elliptical aperture defined in pixel coordinates.
@@ -372,6 +374,7 @@ class EllipticalAperture(_RotatableApertureMixin, PixelAperture):
         return PolygonAperture._from_simple_offsets(self.positions, offsets)
 
 
+@_enable_batch_photometry
 class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
     r"""
     An elliptical annulus aperture defined in pixel coordinates.

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -95,7 +95,7 @@ def _elliptical_polygon_offsets(a, b, theta, n_vertices, *, swap_axes=False):
                             x * sin_t + y * cos_t])
 
 
-@deprecated('3.0', until='4.0')
+@deprecated('3.0', until='3.2')
 class EllipticalMaskMixin:  # pragma: no cover
     """
     Mixin class to create masks for elliptical and elliptical-annulus

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -439,6 +439,7 @@ class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
     """
 
     _params = ('positions', 'a_in', 'a_out', 'b_in', 'b_out', 'theta')
+    _ordered_pairs = (('a_in', 'a_out'), ('b_in', 'b_out'))
     positions = PixelPositions('The center pixel position(s).')
     a_in = PositiveScalar('The inner semimajor axis in pixels.')
     a_out = PositiveScalar('The outer semimajor axis in pixels.')
@@ -450,10 +451,6 @@ class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def __init__(self, positions, a_in, a_out, b_out, b_in=None, theta=0.0):
-        if not a_out > a_in:
-            msg = "'a_out' must be greater than 'a_in'"
-            raise ValueError(msg)
-
         self.positions = positions
         self.a_in = a_in
         self.a_out = a_out
@@ -461,9 +458,6 @@ class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
 
         if b_in is None:
             b_in = self.b_out * self.a_in / self.a_out
-        elif not b_out > b_in:
-            msg = "'b_out' must be greater than 'b_in'"
-            raise ValueError(msg)
         self.b_in = b_in
 
         self.theta = theta
@@ -756,6 +750,7 @@ class SkyEllipticalAnnulus(_RotatableApertureMixin, SkyAperture):
     """
 
     _params = ('positions', 'a_in', 'a_out', 'b_in', 'b_out', 'theta')
+    _ordered_pairs = (('a_in', 'a_out'), ('b_in', 'b_out'))
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     a_in = PositiveScalarAngle('The inner semimajor axis in angular units.')
     a_out = PositiveScalarAngle('The outer semimajor axis in angular units.')
@@ -767,10 +762,6 @@ class SkyEllipticalAnnulus(_RotatableApertureMixin, SkyAperture):
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def __init__(self, positions, a_in, a_out, b_out, b_in=None,
                  theta=0.0 * u.deg):
-        if not a_out > a_in:
-            msg = "'a_out' must be greater than 'a_in'"
-            raise ValueError(msg)
-
         self.positions = positions
         self.a_in = a_in
         self.a_out = a_out
@@ -778,9 +769,6 @@ class SkyEllipticalAnnulus(_RotatableApertureMixin, SkyAperture):
 
         if b_in is None:
             b_in = self.b_out * self.a_in / self.a_out
-        elif not b_out > b_in:
-            msg = "'b_out' must be greater than 'b_in'"
-            raise ValueError(msg)
         self.b_in = b_in
 
         self.theta = theta

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -151,6 +151,23 @@ class _ApertureFlags(FlagRegistry):
         ),
         FlagDefinition(
             bit_value=4096,
+            name='undefined_shape',
+            description='non-positive net flux; shape properties undefined',
+            detailed_description=('The net flux within the aperture '
+                                  '(the zeroth image moment of the '
+                                  'unmasked "center"-method pixels) is '
+                                  'not positive, so the centroid and '
+                                  'the covariance-derived shape '
+                                  'properties (e.g., ``centroid``, '
+                                  '``semimajor_axis``, '
+                                  '``orientation``) are undefined or '
+                                  'unreliable. This is a stats-only '
+                                  'flag that is set only when a '
+                                  'moment-derived property has been '
+                                  'computed.'),
+        ),
+        FlagDefinition(
+            bit_value=8192,
             name='singular_covariance',
             description='singular or nearly singular source covariance',
             detailed_description=('The source covariance matrix is '

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -7,6 +7,7 @@ import warnings
 
 import astropy.units as u
 import numpy as np
+from astropy.utils import lazyproperty
 
 from photutils.utils._deprecation import deprecated_positional_kwargs
 
@@ -36,7 +37,14 @@ class ApertureMask:
             msg = 'mask data and bounding box must have the same shape'
             raise ValueError(msg)
         self.bbox = bbox
-        self._mask = (self.data == 0)
+
+    @lazyproperty
+    def _mask(self):
+        """
+        A boolean array that is `True` where the aperture mask weight
+        is zero.
+        """
+        return self.data == 0
 
     # NumPy calls `obj.__array__(dtype)` positionally with
     # `np.asarray(obj, dtype=int)`, so dtype must remain a positional
@@ -139,11 +147,11 @@ class ApertureMask:
             not overlap with the input ``data``. The default is 0.
 
         copy : bool, optional
-            If `True` then the returned cutout array will always be hold
-            a copy of the input ``data``. If `False` and the mask is
-            fully within the input ``data``, then the returned cutout
-            array will be a view into the input ``data``. In cases where
-            the mask partially overlaps or has no overlap with the input
+            If `True` then the returned cutout array will always hold a
+            copy of the input ``data``. If `False` and the mask is fully
+            within the input ``data``, then the returned cutout array
+            will be a view into the input ``data``. In cases where the
+            mask partially overlaps or has no overlap with the input
             ``data``, the returned cutout array will always hold a copy
             of the input ``data`` (i.e., this keyword has no effect).
 
@@ -178,7 +186,7 @@ class ApertureMask:
             return cutout
 
         # Cutout is always a copy for partial overlap
-        dtype = float if ~np.isfinite(fill_value) else data.dtype
+        dtype = float if not np.isfinite(fill_value) else data.dtype
         cutout = np.zeros(self.shape, dtype=dtype)
         cutout[:] = fill_value
         cutout[slices_small] = data[slices_large]
@@ -304,17 +312,21 @@ class ApertureMask:
 
         Returns
         -------
-        result : `~numpy.ndarray`
+        result : `~numpy.ndarray` or `~astropy.units.Quantity`
             A 1D array of mask-weighted pixel values from the input
             ``data``. If there is no overlap of the aperture with the
             input ``data``, the result will be an empty array with shape
-            (0,).
+            (0,). If ``data`` is a `~astropy.units.Quantity`, the result
+            is a `~astropy.units.Quantity` with the same units.
         """
         slc_large, aper_weights, pixel_mask = self._get_overlap_cutouts(
             data.shape, mask=mask)
 
         if slc_large is None:
-            return np.array([])
+            values = np.array([])
+            if isinstance(data, u.Quantity):
+                values <<= data.unit
+            return values
 
         # Ignore multiplication with non-finite data values
         with warnings.catch_warnings():

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -38,7 +38,10 @@ _DEPRECATED_COLUMNS: dict = {
 # instance because they are not per-position output values (see
 # ``AperturePhotometry.__getattribute__``). ``segmentation_image`` and
 # ``labels`` are the inputs echoed back to the user, and the others
-# describe the whole object.
+# describe the whole object. Any new public attribute that is a list,
+# tuple, ndarray, or SkyCoord but is not a per-position value must be
+# added here, otherwise a length-1 value will be silently collapsed to
+# its first element for a scalar instance.
 _SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'labels',
                              'n_positions', 'segmentation_image'})
 

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -213,6 +213,9 @@ class AperturePhotometry:
         if not isinstance(apertures, (list, tuple, np.ndarray)):
             single_aperture = True
             apertures = (apertures,)
+        elif len(apertures) == 0:
+            msg = 'apertures must not be empty'
+            raise ValueError(msg)
         self._single_aperture = single_aperture
 
         # Create table metadata using the input apertures, not the
@@ -472,7 +475,8 @@ class AperturePhotometry:
         Raises
         ------
         ValueError
-            If any name in ``columns`` is not a valid column name.
+            If any name in ``columns`` is not a valid column name, or if
+            ``'sky_center'`` is requested but no WCS was input.
         """
         allowed_columns = ('id', 'x_center', 'y_center', 'sky_center',
                            'flux', 'flux_err', 'area', 'flags')
@@ -480,6 +484,12 @@ class AperturePhotometry:
             table_columns = self.default_columns
         else:
             table_columns = validate_table_columns(columns, allowed_columns)
+
+        if ('sky_center' in table_columns
+                and self._array('sky_center') is None):
+            msg = ("the 'sky_center' column requires a WCS, which must "
+                   'be defined by the input data or the wcs keyword')
+            raise ValueError(msg)
 
         tbl = QTable()
         tbl.meta.update(self.meta)

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -559,10 +559,14 @@ class PolygonAperture(PixelAperture):
         return cls(positions, offsets)
 
     @classmethod
-    def _from_star(cls, positions, n_spikes, outer_radius, inner_radius=None,
-                   *, theta=0.0, optimal_shape=False, collinear_edges=False):
+    def _from_star(cls, positions, n_spikes, outer_radius, *,
+                   inner_radius=None, theta=0.0, optimal_shape=False,
+                   collinear_edges=False):
         """
         Construct a star-shaped `PolygonAperture`.
+
+        This private constructor exists to generate non-convex simple
+        polygons for internal testing. It is not part of the public API.
 
         The star has ``n_spikes`` spikes, with vertices alternating
         between ``outer_radius`` and ``inner_radius``. The first (outer)
@@ -599,10 +603,10 @@ class PolygonAperture(PixelAperture):
             If `True`, compute ``inner_radius`` automatically to
             produce a star with naturally-proportioned geometry. The
             spike angle (the angular width at each point) is set to
-            180°/``n_spikes``, which is the exterior angle of a
-            regular ``n_spikes``-gon. This creates a balanced, visually
-            appealing star where the indentations between spikes are
-            symmetric and proportional to the spikes themselves.
+            180°/``n_spikes``, which is the exterior angle of a regular
+            ``n_spikes``-gon. This creates a balanced star where the
+            indentations between spikes are symmetric and proportional
+            to the spikes themselves.
 
             The formula is:
 

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -12,6 +12,7 @@ from photutils.aperture._batch_photometry import SHAPE_POLYGON
 from photutils.aperture.attributes import (ApertureAttribute, PixelPositions,
                                            SkyCoordPositions)
 from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _enable_batch_photometry,
                                      _update_method_subpixels_docstring)
 from photutils.geometry._polygon_overlap import polygon_overlap_grid
 
@@ -383,6 +384,7 @@ class _RegularPolygonGeometry:
         return (np.degrees(theta_rad) % 360.0) * u.deg
 
 
+@_enable_batch_photometry
 class PolygonAperture(PixelAperture):
     """
     A polygon aperture defined in pixel coordinates.

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -442,7 +442,7 @@ class PolygonAperture(PixelAperture):
         self.vertex_offsets = vertex_offsets
 
     @classmethod
-    def _from_convex_offsets(cls, positions, offsets):
+    def _from_simple_offsets(cls, positions, offsets):
         """
         Construct a `PolygonAperture` from vertex offsets that are
         known to define a simple polygon, skipping the ``O(n^2)``
@@ -491,14 +491,17 @@ class PolygonAperture(PixelAperture):
                    f'got {verts.shape}')
             raise ValueError(msg)
 
-        # Validate before computing the centroid: the area-weighted
+        # Validate before computing the centroid. The area-weighted
         # centroid formula divides by the polygon area, which is zero
-        # for a degenerate (collinear or coincident) polygon.
+        # for a degenerate (collinear or coincident) polygon. The
+        # offsets are a pure translation of the validated vertices, so
+        # the O(n^2) self-intersection check does not need to be
+        # repeated on them.
         verts = _validate_simple_polygon(verts, name='vertices')
         center = _vertices_centroid(verts)
         offsets = verts - center
 
-        return cls(tuple(center), offsets)
+        return cls._from_simple_offsets(tuple(center), offsets)
 
     @classmethod
     def from_regular_polygon(cls, positions, n_vertices, radius, *, theta=0.0):
@@ -1043,7 +1046,7 @@ class SkyPolygonAperture(SkyAperture):
         self.vertex_offsets = vertex_offsets
 
     @classmethod
-    def _from_convex_offsets(cls, positions, offsets):
+    def _from_simple_offsets(cls, positions, offsets):
         """
         Construct a `SkyPolygonAperture` from angular vertex offsets
         that are known to define a simple polygon, skipping the

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -448,6 +448,7 @@ class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
     """
 
     _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')
+    _ordered_pairs = (('w_in', 'w_out'), ('h_in', 'h_out'))
     positions = PixelPositions('The center pixel position(s).')
     w_in = PositiveScalar('The inner full width in pixels.')
     w_out = PositiveScalar('The outer full width in pixels.')
@@ -459,10 +460,6 @@ class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def __init__(self, positions, w_in, w_out, h_out, h_in=None, theta=0.0):
-        if not w_out > w_in:
-            msg = "'w_out' must be greater than 'w_in'"
-            raise ValueError(msg)
-
         self.positions = positions
         self.w_in = w_in
         self.w_out = w_out
@@ -470,9 +467,6 @@ class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
 
         if h_in is None:
             h_in = self.w_in * self.h_out / self.w_out
-        elif not h_out > h_in:
-            msg = "'h_out' must be greater than 'h_in'"
-            raise ValueError(msg)
         self.h_in = h_in
 
         self.theta = theta
@@ -777,6 +771,7 @@ class SkyRectangularAnnulus(_RotatableApertureMixin, SkyAperture):
     """
 
     _params = ('positions', 'w_in', 'w_out', 'h_in', 'h_out', 'theta')
+    _ordered_pairs = (('w_in', 'w_out'), ('h_in', 'h_out'))
     positions = SkyCoordPositions('The center position(s) in sky coordinates.')
     w_in = PositiveScalarAngle('The inner full width in angular units.')
     w_out = PositiveScalarAngle('The outer full width in angular units.')
@@ -788,10 +783,6 @@ class SkyRectangularAnnulus(_RotatableApertureMixin, SkyAperture):
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def __init__(self, positions, w_in, w_out, h_out, h_in=None,
                  theta=0.0 * u.deg):
-        if not w_out > w_in:
-            msg = "'w_out' must be greater than 'w_in'"
-            raise ValueError(msg)
-
         self.positions = positions
         self.w_in = w_in
         self.w_out = w_out
@@ -799,9 +790,6 @@ class SkyRectangularAnnulus(_RotatableApertureMixin, SkyAperture):
 
         if h_in is None:
             h_in = self.w_in * self.h_out / self.w_out
-        elif not h_out > h_in:
-            msg = "'h_out' must be greater than 'h_in'"
-            raise ValueError(msg)
         self.h_in = h_in
 
         self.theta = theta

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -219,7 +219,7 @@ class RectangularAperture(_RotatableApertureMixin, PixelAperture):
     Raises
     ------
     ValueError : `ValueError`
-        If either width (``w``) or height (``h``) is negative.
+        If either width (``w``) or height (``h``) is not positive.
 
     Examples
     --------
@@ -423,12 +423,13 @@ class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
     Raises
     ------
     ValueError : `ValueError`
-        If inner width (``w_in``) is greater than outer width
-        (``w_out``).
+        If the inner width (``w_in``) is not less than the outer width
+        (``w_out``), or if the inner height (``h_in``), when given, is
+        not less than the outer height (``h_out``).
 
     ValueError : `ValueError`
-        If either the inner width (``w_in``) or the outer height
-        (``h_out``) is negative.
+        If any of the widths or heights (``w_in``, ``w_out``, ``h_in``,
+        or ``h_out``) is not positive.
 
     Examples
     --------

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -72,7 +72,7 @@ def _rectangular_polygon_offsets(half_x, half_y, theta):
     return corners @ rot_mat.T
 
 
-@deprecated('3.0', until='4.0')
+@deprecated('3.0', until='3.2')
 class RectangularMaskMixin:  # pragma: no cover
     """
     Mixin class to create masks for rectangular or rectangular-annulus

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -374,7 +374,7 @@ class RectangularAperture(_RotatableApertureMixin, PixelAperture):
         """
         offsets = _rectangular_polygon_offsets(
             0.5 * self.w, 0.5 * self.h, self.theta.to_value(u.radian))
-        return PolygonAperture._from_convex_offsets(self.positions, offsets)
+        return PolygonAperture._from_simple_offsets(self.positions, offsets)
 
 
 class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
@@ -715,7 +715,7 @@ class SkyRectangularAperture(_RotatableApertureMixin, SkyAperture):
         offsets = _rectangular_polygon_offsets(
             0.5 * self.h.to_value(unit), 0.5 * self.w.to_value(unit),
             self.theta.to_value(u.radian)) * unit
-        return SkyPolygonAperture._from_convex_offsets(self.positions, offsets)
+        return SkyPolygonAperture._from_simple_offsets(self.positions, offsets)
 
 
 class SkyRectangularAnnulus(_RotatableApertureMixin, SkyAperture):

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -18,6 +18,7 @@ from photutils.aperture.attributes import (PixelPositions, PositiveScalar,
                                            ScalarAngleOrValue,
                                            SkyCoordPositions)
 from photutils.aperture.core import (PixelAperture, SkyAperture,
+                                     _enable_batch_photometry,
                                      _RotatableApertureMixin,
                                      _update_method_subpixels_docstring)
 from photutils.aperture.mask import ApertureMask
@@ -186,6 +187,7 @@ def _calc_lower_left_positions(positions, width, height, theta_rad):
     return np.atleast_2d(positions) + np.array([xshift, yshift])
 
 
+@_enable_batch_photometry
 class RectangularAperture(_RotatableApertureMixin, PixelAperture):
     """
     A rectangular aperture defined in pixel coordinates.
@@ -377,6 +379,7 @@ class RectangularAperture(_RotatableApertureMixin, PixelAperture):
         return PolygonAperture._from_simple_offsets(self.positions, offsets)
 
 
+@_enable_batch_photometry
 class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
     r"""
     A rectangular annulus aperture defined in pixel coordinates.

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -1732,10 +1732,11 @@ class ApertureStats:
         The count-based value-statistics flag bits (1D int array).
 
         These are the flag bits that do not depend on any lazily
-        computed covariance property: the "center"-method
+        computed moment or covariance property: the "center"-method
         footprint bits plus the sigma-clip and ``ddof`` bits. The
-        ``singular_covariance`` bit is folded in by the `flags` property
-        only if a covariance-derived property has been computed.
+        ``undefined_shape`` and ``singular_covariance`` bits are
+        folded in by the `flags` property only if a moment-derived or
+        covariance-derived property, respectively, has been computed.
         """
         # The gather kernel and the center-method cutouts do not
         # evaluate error values, so the non-finite-error bit is defined
@@ -1757,6 +1758,25 @@ class ApertureStats:
                   & (n_kept <= self.ddof)] |= APERTURE_FLAGS.TOO_FEW_PIXELS
 
         return flags
+
+    @lazyproperty
+    def _undefined_shape_mask(self):
+        """
+        Boolean mask (1D) marking sources whose net flux is not
+        positive.
+
+        The net flux is the zeroth image moment of the unmasked
+        "center"-method pixels. When it is zero or negative, the
+        centroid and the covariance-derived shape properties are
+        undefined or unreliable. Sources with no valid pixels (no
+        overlap, fully masked, or fully sigma clipped) are not flagged
+        here. They are already reported by the overlap, masking, and
+        clipping bits.
+        """
+        m00 = self._array('moments')[:, 0, 0]
+        # NaN where a source has no valid pixels
+        n_pixels = self._center_n_pixels
+        return np.isfinite(m00) & (m00 <= 0) & np.isfinite(n_pixels)
 
     @lazyproperty
     def _singular_covariance_mask(self):
@@ -1814,19 +1834,18 @@ class ApertureStats:
         footprints, combine the two flag columns with a bitwise OR
         (e.g., ``flags | sum_flags``).
 
-        The ``'singular_covariance'`` bit is special. It reports whether
-        a source's covariance matrix is singular or nearly singular,
-        a condition that is only knowable once a covariance-derived
-        shape property (e.g., ``semimajor_axis``, ``orientation``,
-        ``eccentricity``) has been computed. To avoid forcing that
-        computation, the bit is included only if such a property has
-        already been evaluated on this object; otherwise it is omitted.
-        This means the value of ``flags`` reflects the measurements
-        requested so far, so accessing a shape property and then
-        re-reading ``flags`` may set additional bits. The default
-        `to_table` always evaluates the shape properties, so its
-        ``flags`` column always reflects the ``'singular_covariance'``
-        bit.
+        The ``'undefined_shape'`` and ``'singular_covariance'`` bits
+        are special. They report conditions that are only knowable
+        once a moment-derived property (e.g., ``centroid``) or a
+        covariance-derived shape property (e.g., ``semimajor_axis``,
+        ``orientation``, ``eccentricity``) has been computed. To avoid
+        forcing those computations, each bit is included only if such a
+        property has already been evaluated on this object. Otherwise
+        it is omitted. This means the value of ``flags`` reflects the
+        measurements requested so far, so accessing a shape property and
+        then re-reading ``flags`` may set additional bits. The default
+        `to_table` always evaluates the moment and shape properties, so
+        its ``flags`` column always reflects both bits.
 
         See `~photutils.aperture.decode_aperture_flags` for decoding
         flag values. The flags are:
@@ -1837,6 +1856,9 @@ class ApertureStats:
         # cached `_base_flags`), so concurrent readers and previously
         # returned arrays are never modified in place.
         flags = self._base_flags.copy()
+        if 'moments' in self.__dict__:
+            flags[self._undefined_shape_mask] |= (
+                APERTURE_FLAGS.UNDEFINED_SHAPE)
         if '_covariance' in self.__dict__:
             flags[self._singular_covariance_mask] |= (
                 APERTURE_FLAGS.SINGULAR_COVARIANCE)

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -83,7 +83,10 @@ _DEPRECATED_ATTRIBUTES: dict = {
 
 # Public attributes that are never collapsed to a scalar for a scalar
 # instance because they describe the whole object rather than a single
-# per-source value (see ``ApertureStats.__getattribute__``).
+# per-source value (see ``ApertureStats.__getattribute__``). Any new
+# public attribute that is a list, tuple, ndarray, or SkyCoord but is
+# not a per-source value must be added here, otherwise a length-1 value
+# will be silently collapsed to its first element for a scalar instance.
 _SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'labels',
                              'n_apertures', 'properties',
                              'segmentation_image'})
@@ -320,7 +323,7 @@ class ApertureStats:
 
         self._data = validate_array(data, 'data')
         self._data_unit = unit
-        self._input_aperture = self._validate_aperture(aperture)
+        self._validate_aperture(aperture)
         aperture_meta = _aperture_metadata(aperture)  # use input aperture
 
         if isinstance(aperture, SkyAperture) and wcs is None:
@@ -533,9 +536,7 @@ class ApertureStats:
 
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
-        with np.printoptions(threshold=25, edgeitems=5):
-            fmt = [f'Length: {self.n_apertures}']
-        return f'{cls_name}\n' + '\n'.join(fmt)
+        return f'{cls_name}\nLength: {self.n_apertures}'
 
     def __repr__(self):
         return self.__str__()

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -120,7 +120,7 @@ class ApertureStats:
     ``data`` values within the aperture. It does not convert data
     in surface brightness units to flux or counts. Conversion from
     surface-brightness units should be performed before using this
-    function.
+    class.
 
     Parameters
     ----------
@@ -1417,9 +1417,9 @@ class ApertureStats:
         """
         Boolean mask cutouts representing the total mask.
 
-        The total mask is combination of the input ``mask``, non-finite
-        ``data`` values, the cutout aperture mask using the "center"
-        method, and the sigma-clip mask.
+        The total mask is a combination of the input ``mask``,
+        non-finite ``data`` values, the cutout aperture mask using the
+        "center" method, and the sigma-clip mask.
         """
         return list(zip(*self._aperture_cutouts_center, strict=True))[2]
 
@@ -1428,7 +1428,7 @@ class ApertureStats:
         """
         Boolean mask cutouts representing the total mask.
 
-        The total mask is combination of the input ``mask``,
+        The total mask is a combination of the input ``mask``,
         non-finite ``data`` values, the cutout aperture mask using the
         ``sum_method`` method, and the sigma-clip mask.
         """
@@ -1448,7 +1448,7 @@ class ApertureStats:
     def _make_masked_array(self, array):
         """
         Return a list of cutout masked arrays using the
-        ``_mask_sumcutout`` mask.
+        ``_mask_cutout`` mask.
 
         Units are not applied.
         """

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -123,7 +123,7 @@ class _BatchGather(NamedTuple):
 # not a per-source value must be added here, otherwise a length-1 value
 # will be silently collapsed to its first element for a scalar instance.
 _SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'labels',
-                             'n_apertures', 'properties',
+                             'n_positions', 'properties',
                              'segmentation_image'})
 
 
@@ -404,7 +404,7 @@ class ApertureStats:
             raise ValueError(msg)
         self.ddof = ddof
 
-        self._local_bkg = np.zeros(self.n_apertures)  # no local bkg
+        self._local_bkg = np.zeros(self.n_positions)  # no local bkg
         if local_bkg is not None:
             local_bkg = np.atleast_1d(local_bkg)
             if local_bkg.ndim != 1:
@@ -412,11 +412,11 @@ class ApertureStats:
                 raise ValueError(msg)
 
             n_local_bkg = len(local_bkg)
-            if n_local_bkg not in (1, self.n_apertures):
+            if n_local_bkg not in (1, self.n_positions):
                 msg = ('local_bkg must be scalar or have the same length '
                        'as the input aperture')
                 raise ValueError(msg)
-            local_bkg = np.broadcast_to(local_bkg, self.n_apertures)
+            local_bkg = np.broadcast_to(local_bkg, self.n_positions)
 
             if np.any(~np.isfinite(local_bkg)):
                 msg = ('local_bkg must not contain any non-finite '
@@ -424,7 +424,7 @@ class ApertureStats:
                 raise ValueError(msg)
             self._local_bkg = local_bkg  # always an iterable
 
-        self._ids = np.arange(self.n_apertures) + 1
+        self._ids = np.arange(self.n_positions) + 1
         self.default_columns = ['id', 'x_centroid', 'y_centroid',
                                 'sky_centroid', 'sum', 'sum_err',
                                 'sum_aper_area', 'sum_flags',
@@ -488,11 +488,11 @@ class ApertureStats:
         """
         lazyproperties = [name for name in self._lazyproperties if not
                           name.startswith('_')]
-        # isscalar and n_apertures are scalar values for the whole
+        # isscalar and n_positions are scalar values for the whole
         # object, not per-source values, so they are not valid table
         # columns
         lazyproperties.remove('isscalar')
-        lazyproperties.remove('n_apertures')
+        lazyproperties.remove('n_positions')
         lazyproperties.sort()
         return lazyproperties
 
@@ -544,7 +544,7 @@ class ApertureStats:
             value = self.__dict__[key]
 
             # Do not insert attributes that are always scalar (e.g.,
-            # isscalar, n_apertures), i.e., not an array/list for each
+            # isscalar, n_positions), i.e., not an array/list for each
             # source
             if np.isscalar(value):
                 continue
@@ -573,7 +573,7 @@ class ApertureStats:
 
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
-        return f'{cls_name}\nLength: {self.n_apertures}'
+        return f'{cls_name}\nLength: {self.n_positions}'
 
     def __repr__(self):
         return self.__str__()
@@ -582,7 +582,7 @@ class ApertureStats:
         if self.isscalar:
             msg = f'Scalar {self.__class__.__name__!r} object has no len()'
             raise TypeError(msg)
-        return self.n_apertures
+        return self.n_positions
 
     def __iter__(self):
         for item in range(len(self)):
@@ -664,14 +664,14 @@ class ApertureStats:
         """
         Return `None` values.
         """
-        return np.array([None] * self.n_apertures)
+        return np.array([None] * self.n_positions)
 
     @lazyproperty
     def _null_value(self):
         """
         Return np.nan values.
         """
-        values = np.empty(self.n_apertures)
+        values = np.empty(self.n_positions)
         values.fill(np.nan)
         return values
 
@@ -835,13 +835,25 @@ class ApertureStats:
         return tbl
 
     @lazyproperty
-    def n_apertures(self):
+    def n_positions(self):
         """
         The number of positions for the input aperture.
         """
         if self.isscalar:
             return 1
         return len(self._pixel_aperture)
+
+    @property
+    @deprecated('3.1', alternative="the 'n_positions' attribute",
+                until='4.0')
+    def n_apertures(self):
+        """
+        The number of positions for the input aperture.
+
+        .. deprecated:: 3.1
+            Use the `n_positions` attribute instead.
+        """
+        return self.n_positions
 
     @lazyproperty
     def _pixel_aperture(self):
@@ -1936,7 +1948,7 @@ class ApertureStats:
         gather = self._fast_gather
         if gather is not None:
             overlap = gather.overlap
-            zeros = np.zeros(self.n_apertures)
+            zeros = np.zeros(self.n_positions)
             mom = batch_moments(gather.values, gather.local_x,
                                 gather.local_y, gather.starts,
                                 gather.counts, zeros, zeros)
@@ -2155,7 +2167,7 @@ class ApertureStats:
             var = np.array([np.var(values)
                             for values in self._data_values_center])
         n_pixels = self._center_n_pixels
-        sem = np.full(self.n_apertures, np.nan)
+        sem = np.full(self.n_positions, np.nan)
         mask = n_pixels >= 2
         # var is the population (ddof=0) variance, so var / (N - 1)
         # equals the squared standard error of the mean.
@@ -2385,7 +2397,7 @@ class ApertureStats:
         if self.ddof == 0:
             return var
         n_pixels = self._center_n_pixels
-        result = np.full(self.n_apertures, np.nan)
+        result = np.full(self.n_positions, np.nan)
         mask = n_pixels > self.ddof
         result[mask] = (var[mask] * n_pixels[mask]
                         / (n_pixels[mask] - self.ddof))
@@ -2556,7 +2568,7 @@ class ApertureStats:
         The two eigenvalues of the `covariance` matrix in decreasing
         order.
         """
-        eigvals = np.full((self.n_apertures, 2), np.nan)
+        eigvals = np.full((self.n_positions, 2), np.nan)
         # np.linalg.eigvalsh requires that every element of a covariance
         # matrix be finite, so select only the wholly finite matrices
         idx = np.flatnonzero(np.isfinite(self._covariance).all(axis=(1, 2)))

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -839,9 +839,10 @@ class ApertureStats:
 
         aper = self._pixel_aperture
 
-        # Use the batch driver only if the aperture's own class defines
-        # the _batch_shape_params hook (see _batch_photometry).
-        if '_batch_shape_params' not in type(aper).__dict__:
+        # Use the batch driver only if the aperture's own class
+        # opted in via the _enable_batch_photometry decorator (see
+        # PixelAperture._batch_photometry).
+        if type(aper)._batch_photometry_class is not type(aper):
             return None
         spec = aper._batch_shape_params()
         if spec is None:

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -2093,9 +2093,11 @@ class ApertureStats:
         The bounding box x and y minimum and maximum bounds.
         """
         bbox = self._array('bbox')
+        # The reshape preserves the (n_positions, 4) shape when there
+        # are zero positions
         return np.array([(bbox_.ixmin, bbox_.ixmax - 1,
                           bbox_.iymin, bbox_.iymax - 1)
-                         for bbox_ in bbox])
+                         for bbox_ in bbox], dtype=int).reshape(-1, 4)
 
     @lazyproperty
     def bbox_xmin(self):

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -6,6 +6,7 @@ Tools for calculating properties of sources defined by an Aperture.
 import inspect
 import warnings
 from copy import deepcopy
+from typing import NamedTuple
 
 import astropy.units as u
 import numpy as np
@@ -79,6 +80,40 @@ _DEPRECATED_ATTRIBUTES: dict = {
     'xcentroid': 'x_centroid',
     'ycentroid': 'y_centroid',
 }
+
+
+class _BatchGather(NamedTuple):
+    """
+    Container for the fast Cython batch-driver results shared by
+    `ApertureStats._fast_gather` and `ApertureStats._fast_sum`.
+
+    Each instance populates only the fields relevant to its footprint;
+    the remaining fields are `None`:
+
+    * center-value gather (``_fast_gather``): ``values``, ``local_x``,
+      ``local_y``, ``starts``, ``counts``, ``overlap``, and
+      ``flag_counts``
+
+    * ``sum_method`` gather (``_fast_sum``): ``sum_aper``, ``var_aper``,
+      ``sum_area``, ``starts``, ``overlap``, and ``flag_counts``,
+      plus the packed member buffers (``sum_values``, ``sum_fracs``,
+      ``sum_errsq``, and ``sum_counts``) while sigma clipping is applied
+    """
+
+    values: np.ndarray = None
+    local_x: np.ndarray = None
+    local_y: np.ndarray = None
+    starts: np.ndarray = None
+    counts: np.ndarray = None
+    sum_aper: np.ndarray = None
+    var_aper: np.ndarray = None
+    sum_area: np.ndarray = None
+    overlap: np.ndarray = None
+    sum_values: np.ndarray = None
+    sum_fracs: np.ndarray = None
+    sum_errsq: np.ndarray = None
+    sum_counts: np.ndarray = None
+    flag_counts: np.ndarray = None
 
 
 # Public attributes that are never collapsed to a scalar for a scalar
@@ -308,6 +343,16 @@ class ApertureStats:
                                 'data_sum_cutout', 'error_sum_cutout',
                                 'sum_flags')
 
+    # Cached lazyproperties that are not per-source sliceable: the
+    # packed gather buffers and their reductions. ``__getitem__`` drops
+    # these from the sliced object, which recomputes them lazily from
+    # its sliced inputs. Any new lazyproperty backed by the packed batch
+    # buffers must be added here, otherwise slicing will attempt to
+    # index the packed buffer per source and fail or corrupt it.
+    _NON_SLICEABLE_CACHES = frozenset({
+        '_batch_inputs', '_fast_gather', '_fast_sum', '_sorted_values',
+        '_order_stats', '_mean_var', '_mad', '_biweight', '_gini'})
+
     def __init__(self, data, aperture, *, error=None, mask=None, wcs=None,
                  sigma_clip=None, sum_method='exact', subpixels=5, ddof=0,
                  local_bkg=None, segmentation_image=None, labels=None,
@@ -494,15 +539,7 @@ class ApertureStats:
         # The packed gather buffers and their reductions are not
         # per-source sliceable; the sliced object recomputes them
         # lazily from its sliced inputs.
-        keys.discard('_batch_inputs')
-        keys.discard('_fast_gather')
-        keys.discard('_fast_sum')
-        keys.discard('_sorted_values')
-        keys.discard('_order_stats')
-        keys.discard('_mean_var')
-        keys.discard('_mad')
-        keys.discard('_biweight')
-        keys.discard('_gini')
+        keys -= self._NON_SLICEABLE_CACHES
         for key in keys:
             value = self.__dict__[key]
 
@@ -900,12 +937,10 @@ class ApertureStats:
         `None` is returned (and the mask-based code path is used) when
         the fast batch driver is unavailable (see `_batch_inputs`).
 
-        The result is a tuple ``(values, local_x, local_y, starts,
-        counts, sum_aper, var_aper, sum_area, overlap, ...)`` (a
-        14-tuple shared with `_fast_sum`, whose last entry is the
-        per-source flag-count array). Only the center-value entries
-        (indices 0-4), ``overlap`` (index 8), and the flag counts (index
-        13) are populated here. The ``sum_method`` entries are `None`.
+        The result is a `_BatchGather` with the center-value fields
+        (``values``, ``local_x``, ``local_y``, ``starts``, ``counts``),
+        ``overlap``, and ``flag_counts`` populated. The ``sum_method``
+        fields are `None`.
         """
         inputs = self._batch_inputs
         if inputs is None:
@@ -918,8 +953,9 @@ class ApertureStats:
          flag_counts) = batch_aperture_gather(
             data, mask, positions, shape_code, params, ext_x, ext_y,
             off_x, off_y, local_bkg, seg_arr, labels_arr, seg_code)
-        gather = (values, lx, ly, starts, counts, None, None, None, overlap,
-                  None, None, None, None, flag_counts)
+        gather = _BatchGather(values=values, local_x=lx, local_y=ly,
+                              starts=starts, counts=counts, overlap=overlap,
+                              flag_counts=flag_counts)
 
         if clip_spec is not None:
             gather = self._apply_center_clip(gather, clip_spec)
@@ -944,10 +980,10 @@ class ApertureStats:
         `None` is returned (and the mask-based code path is used) when
         the fast batch driver is unavailable (see `_batch_inputs`).
 
-        The result is a tuple with the same layout as `_fast_gather`;
-        only the ``sum_aper`` (index 5), ``var_aper`` (index 6),
-        ``sum_area`` (index 7), and ``overlap`` (index 8) entries are
-        populated.
+        The result is a `_BatchGather` with the ``sum_aper``,
+        ``var_aper``, ``sum_area``, ``starts``, ``overlap``, and
+        ``flag_counts`` fields populated. The center-value fields are
+        `None`.
         """
         inputs = self._batch_inputs
         if inputs is None:
@@ -962,9 +998,11 @@ class ApertureStats:
             data, error, mask, positions, shape_code, params, ext_x, ext_y,
             off_x, off_y, sum_use_exact, sum_subpixels, seg_arr, labels_arr,
             seg_code, local_bkg, emit_sum)
-        gather = (None, None, None, starts, None, sums, sum_var, area,
-                  overlap, sum_values, sum_fracs, sum_errsq, scounts,
-                  flag_counts)
+        gather = _BatchGather(starts=starts, sum_aper=sums, var_aper=sum_var,
+                              sum_area=area, overlap=overlap,
+                              sum_values=sum_values, sum_fracs=sum_fracs,
+                              sum_errsq=sum_errsq, sum_counts=scounts,
+                              flag_counts=flag_counts)
 
         if clip_spec is not None:
             gather = self._apply_sum_clip(gather, clip_spec)
@@ -1004,39 +1042,37 @@ class ApertureStats:
 
     def _apply_center_clip(self, gather, clip_spec):
         """
-        Sigma-clip the packed center buffer and return a gather tuple
-        with the same layout whose center buffer reflects the per-source
-        clipped data.
+        Sigma-clip the packed center buffer and return a `_BatchGather`
+        whose center buffer reflects the per-source clipped data.
         """
         sigma_lower, sigma_upper, maxiters, cenfunc, stdfunc = clip_spec
-        (values, local_x, local_y, starts, counts, _sum, _var, _area,
-         overlap, _sv, _sf, _se, _sc, flag_counts) = gather
 
         (cvalues, clx, cly, cstarts, ccounts) = batch_sigma_clip_center(
-            values, local_x, local_y, starts, counts, sigma_lower,
-            sigma_upper, maxiters, cenfunc, stdfunc)
+            gather.values, gather.local_x, gather.local_y, gather.starts,
+            gather.counts, sigma_lower, sigma_upper, maxiters, cenfunc,
+            stdfunc)
 
-        return (cvalues, clx, cly, cstarts, ccounts, _sum, _var, _area,
-                overlap, None, None, None, None, flag_counts)
+        return gather._replace(values=cvalues, local_x=clx, local_y=cly,
+                               starts=cstarts, counts=ccounts)
 
     def _apply_sum_clip(self, gather, clip_spec):
         """
-        Sigma-clip the packed ``sum_method`` member buffers and return a
-        gather tuple with the same layout whose aperture sum, variance,
-        and area reflect the per-source clipped data.
+        Sigma-clip the packed ``sum_method`` member buffers and return
+        a `_BatchGather` whose aperture sum, variance, and area reflect
+        the per-source clipped data. The packed member buffers are
+        dropped (set to `None`) so their memory can be reclaimed.
         """
         sigma_lower, sigma_upper, maxiters, cenfunc, stdfunc = clip_spec
-        (values, local_x, local_y, starts, counts, _sum, _var, _area,
-         overlap, sum_values, sum_fracs, sum_errsq, sum_counts,
-         flag_counts) = gather
 
         has_error = 1 if self._error is not None else 0
         (csum, cvar, carea) = batch_sigma_clip_sum(
-            sum_values, sum_fracs, sum_errsq, starts, sum_counts,
-            sigma_lower, sigma_upper, maxiters, cenfunc, stdfunc, has_error)
+            gather.sum_values, gather.sum_fracs, gather.sum_errsq,
+            gather.starts, gather.sum_counts, sigma_lower, sigma_upper,
+            maxiters, cenfunc, stdfunc, has_error)
 
-        return (values, local_x, local_y, starts, counts, csum, cvar, carea,
-                overlap, None, None, None, None, flag_counts)
+        return gather._replace(sum_aper=csum, var_aper=cvar, sum_area=carea,
+                               sum_values=None, sum_fracs=None,
+                               sum_errsq=None, sum_counts=None)
 
     @lazyproperty
     def _sorted_values(self):
@@ -1054,7 +1090,7 @@ class ApertureStats:
         gather = self._fast_gather
         if gather is None:
             return None
-        values, starts, counts = gather[0], gather[3], gather[4]
+        values, starts, counts = gather.values, gather.starts, gather.counts
         return (batch_sort_values(values, starts, counts), starts, counts)
 
     @lazyproperty
@@ -1082,8 +1118,7 @@ class ApertureStats:
         gather = self._fast_gather
         if gather is None:
             return None
-        values, starts, counts = gather[0], gather[3], gather[4]
-        return batch_mean_var(values, starts, counts)
+        return batch_mean_var(gather.values, gather.starts, gather.counts)
 
     @lazyproperty
     def _mad(self):
@@ -1125,8 +1160,7 @@ class ApertureStats:
         gather = self._fast_gather
         if gather is None:
             return None
-        values, starts, counts = gather[0], gather[3], gather[4]
-        return batch_gini(values, starts, counts)
+        return batch_gini(gather.values, gather.starts, gather.counts)
 
     def _finalize_value_stat(self, fast_result, stat_func, *,
                              square_unit=False, apply_unit=True):
@@ -1645,13 +1679,13 @@ class ApertureStats:
         if footprint == 'center':
             gather = self._fast_gather
             if gather is not None:
-                return (gather[13], np.asarray(gather[8]),
-                        np.asarray(gather[4]))
+                return (gather.flag_counts, np.asarray(gather.overlap),
+                        np.asarray(gather.counts))
             cutouts = self._aperture_cutouts_center
         else:
             gather = self._fast_sum
             if gather is not None:
-                return gather[13], np.asarray(gather[8]), None
+                return gather.flag_counts, np.asarray(gather.overlap), None
             cutouts = self._aperture_cutouts
 
         flag_counts = np.array([cut[5] for cut in cutouts])
@@ -1901,10 +1935,11 @@ class ApertureStats:
         """
         gather = self._fast_gather
         if gather is not None:
-            values, lx, ly, starts, counts = gather[:5]
-            overlap = gather[8]
+            overlap = gather.overlap
             zeros = np.zeros(self.n_apertures)
-            mom = batch_moments(values, lx, ly, starts, counts, zeros, zeros)
+            mom = batch_moments(gather.values, gather.local_x,
+                                gather.local_y, gather.starts,
+                                gather.counts, zeros, zeros)
             # No-overlap sources have NaN moments (the mask-based path
             # uses an all-NaN cutout); all-masked overlapping sources
             # have zero moments (an all-zero cutout).
@@ -1924,14 +1959,15 @@ class ApertureStats:
 
         gather = self._fast_gather
         if gather is not None:
-            values, lx, ly, starts, counts = gather[:5]
             cen_x = np.ascontiguousarray(cutout_centroid[:, 0])
             cen_y = np.ascontiguousarray(cutout_centroid[:, 1])
-            mom = batch_moments(values, lx, ly, starts, counts, cen_x, cen_y)
+            mom = batch_moments(gather.values, gather.local_x,
+                                gather.local_y, gather.starts,
+                                gather.counts, cen_x, cen_y)
             # Empty sources (no overlap or fully masked) have a NaN
             # centroid, so their central moments are NaN (matching the
             # mask-based path).
-            mom[counts == 0] = np.nan
+            mom[gather.counts == 0] = np.nan
             return mom
 
         return np.array([_image_moments(arr, center=(xcen_, ycen_), order=3)
@@ -2092,7 +2128,7 @@ class ApertureStats:
         """
         gather = self._fast_gather
         if gather is not None:
-            counts = gather[4]
+            counts = gather.counts
             n_pixels = counts.astype(float)
             n_pixels[counts == 0] = np.nan
             return n_pixels
@@ -2142,7 +2178,7 @@ class ApertureStats:
         """
         gather = self._fast_sum
         if gather is not None:
-            area, overlap = gather[7].copy(), gather[8]
+            area, overlap = gather.sum_area.copy(), gather.overlap
             area[overlap & (area == 0)] = np.nan
             return area << (u.pix**2)
         areas = np.array([np.sum(weight.filled(0.0))
@@ -2173,7 +2209,9 @@ class ApertureStats:
         """
         gather = self._fast_sum
         if gather is not None:
-            result, area, overlap = gather[5].copy(), gather[7], gather[8]
+            result = gather.sum_aper.copy()
+            area = gather.sum_area
+            overlap = gather.overlap
             # No sum-method survivors -> NaN (matches the mask-based
             # path, which returns NaN for an all-masked aperture).
             result[overlap & (area == 0)] = np.nan
@@ -2218,9 +2256,9 @@ class ApertureStats:
         else:
             gather = self._fast_sum
             if gather is not None:
-                variance = gather[6].copy()
-                area = gather[7]
-                overlap = gather[8]
+                variance = gather.var_aper.copy()
+                area = gather.sum_area
+                overlap = gather.overlap
                 variance[overlap & (area == 0)] = np.nan
                 err = np.sqrt(variance)
             else:

--- a/photutils/aperture/tests/conftest.py
+++ b/photutils/aperture/tests/conftest.py
@@ -1,16 +1,49 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Shared pytest fixtures for the aperture tests.
+Shared pytest fixtures and helpers for the aperture tests.
 """
 
 import numpy as np
 import pytest
 from astropy.wcs import WCS
 
+from photutils.aperture import CircularAperture
 from photutils.datasets import make_4gaussians_image
 
 # The shape of the small uniform image used by the quality-flag tests
 UNIT_SHAPE = (25, 25)
+
+
+class NoBatchCircularAperture(CircularAperture):
+    """
+    A `CircularAperture` subclass that does not opt in to the batch
+    Cython driver (it is not decorated with
+    ``_enable_batch_photometry``), forcing the mask-based code path.
+    """
+
+
+def make_scene():
+    """
+    Build a deterministic scene with a target source (label 1) and a
+    bright neighbor source (label 2), on a nonzero background.
+
+    Returns
+    -------
+    data, segm : 2D `~numpy.ndarray`
+        The image and the matching segmentation image.
+    """
+    data = np.ones((50, 50))
+    segm = np.zeros((50, 50), dtype=int)
+
+    # Target source (label 1)
+    data[18:25, 18:25] = 10.0
+    segm[18:25, 18:25] = 1
+
+    # Bright neighbor source (label 2)
+    data[20:25, 26:32] = 100.0
+    segm[20:25, 26:32] = 2
+
+    return data, segm
 
 
 @pytest.fixture(name='data')

--- a/photutils/aperture/tests/test_aperture_common.py
+++ b/photutils/aperture/tests/test_aperture_common.py
@@ -110,6 +110,19 @@ class BaseTestPixelAperture(BaseTestAperture):
         ax.legend(patches, list(range(len(patches))))
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_plot_scalar_returns_list(self):
+        """
+        Test that plot returns a list containing a single patch for a
+        scalar aperture.
+        """
+        from matplotlib.patches import Patch
+
+        patches = self.aperture[0].plot()
+        assert isinstance(patches, list)
+        assert len(patches) == 1
+        assert isinstance(patches[0], Patch)
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_to_patch_nonscalar(self):
         """
         Test that _to_patch returns a list for non-scalar apertures.

--- a/photutils/aperture/tests/test_aperture_common.py
+++ b/photutils/aperture/tests/test_aperture_common.py
@@ -130,3 +130,44 @@ class BaseTestRotatedPixelAperture(BaseTestPixelAperture):
         """
         assert isinstance(self.aperture.theta, u.Quantity)
         assert self.aperture.theta.unit == u.rad
+
+
+class BaseTestAnnulusMutation:
+    """
+    Tests for the inner/outer parameter ordering invariants of annulus
+    apertures, mixed into the annulus test classes.
+    """
+
+    def test_ordered_pairs_mutation(self):
+        """
+        Test that reassigning a parameter of an inner/outer pair to a
+        value violating the ordering invariant raises a ValueError and
+        leaves the aperture unchanged.
+        """
+        aper = self.aperture.copy()
+        for inner, outer in aper._ordered_pairs:
+            inner_value = getattr(aper, inner)
+            outer_value = getattr(aper, outer)
+            match = f'{outer!r} must be greater than {inner!r}'
+            with pytest.raises(ValueError, match=match):
+                setattr(aper, inner, outer_value)
+            with pytest.raises(ValueError, match=match):
+                setattr(aper, inner, outer_value * 2)
+            with pytest.raises(ValueError, match=match):
+                setattr(aper, outer, inner_value / 2)
+            assert getattr(aper, inner) == inner_value
+            assert getattr(aper, outer) == outer_value
+
+    def test_ordered_pairs_valid_mutation(self):
+        """
+        Test that reassigning inner/outer pair parameters to values
+        satisfying the ordering invariant works.
+        """
+        aper = self.aperture.copy()
+        for inner, outer in aper._ordered_pairs:
+            new_outer = getattr(aper, outer) * 2
+            new_inner = getattr(aper, inner) * 1.5
+            setattr(aper, outer, new_outer)
+            setattr(aper, inner, new_inner)
+            assert getattr(aper, inner) == new_inner
+            assert getattr(aper, outer) == new_outer

--- a/photutils/aperture/tests/test_attributes.py
+++ b/photutils/aperture/tests/test_attributes.py
@@ -366,6 +366,25 @@ class TestPositiveScalar:
         with pytest.raises(ValueError, match=match):
             obj.r = np.array([1.0, 2.0])
 
+    def test_non_numeric_error(self):
+        """
+        Test that a non-numeric scalar (e.g., a string) raises
+        TypeError with the intended message.
+        """
+        obj = MockPositiveScalar()
+        match = "'r' must be a positive scalar"
+        with pytest.raises(TypeError, match=match):
+            obj.r = 'abc'
+
+    def test_nan_error(self):
+        """
+        Test that NaN raises ValueError.
+        """
+        obj = MockPositiveScalar()
+        match = "'r' must be a positive scalar"
+        with pytest.raises(ValueError, match=match):
+            obj.r = np.nan
+
 
 class TestScalarAngle:
     """
@@ -447,6 +466,15 @@ class TestPositiveScalarAngle:
         with pytest.raises(ValueError, match=match):
             # Single-element array passes > 0 check but fails isscalar
             obj.angle = np.array([5.0]) * u.arcsec
+
+    def test_nan_error(self):
+        """
+        Test that a NaN angle raises ValueError.
+        """
+        obj = MockPositiveScalarAngle()
+        match = "'angle' must be greater than zero"
+        with pytest.raises(ValueError, match=match):
+            obj.angle = np.nan * u.arcsec
 
     def test_non_angle_units_error(self):
         """

--- a/photutils/aperture/tests/test_batch_flag_counts.py
+++ b/photutils/aperture/tests/test_batch_flag_counts.py
@@ -18,8 +18,7 @@ from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_VALID, SHAPE_CIRCLE,
                                                   batch_aperture_sums)
 from photutils.aperture._batch_stats import batch_aperture_gather
-
-SHAPE = (25, 25)
+from photutils.aperture.tests.conftest import UNIT_SHAPE
 
 
 def _sums_fcounts(data, positions, radius, *, error=None, mask=None,
@@ -93,7 +92,7 @@ class TestPixelCounts:
         data = unit_data
 
         # Pixel inside the aperture
-        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask = np.zeros(UNIT_SHAPE, dtype=np.uint8)
         mask[12, 12] = 1
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
                            use_exact=use_exact)[0]
@@ -102,7 +101,7 @@ class TestPixelCounts:
 
         # Pixel inside the bounding box but outside the aperture (bbox
         # corner)
-        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask = np.zeros(UNIT_SHAPE, dtype=np.uint8)
         mask[9, 9] = 1
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
                            use_exact=use_exact)[0]
@@ -115,7 +114,7 @@ class TestPixelCounts:
         data, with bit 1 taking precedence.
         """
         data = unit_data
-        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask = np.zeros(UNIT_SHAPE, dtype=np.uint8)
         mask[12, 12] = 1  # input-masked
         mask[12, 13] = 2  # non-finite data
         mask[13, 12] = 3  # both; masked wins
@@ -131,9 +130,9 @@ class TestPixelCounts:
         with the "center" method.
         """
         rng = np.random.default_rng(1)
-        data = rng.normal(size=SHAPE)
+        data = rng.normal(size=UNIT_SHAPE)
         data[11, 12] = np.nan
-        user_mask = np.zeros(SHAPE, dtype=bool)
+        user_mask = np.zeros(UNIT_SHAPE, dtype=bool)
         user_mask[12, 13] = True
 
         xy = np.array([(12.0, 12.0), (0.5, 3.0), (24.0, 24.0)])
@@ -178,13 +177,13 @@ class TestNonFiniteCounts:
         counted.
         """
         data = unit_data
-        error = np.ones(SHAPE)
+        error = np.ones(UNIT_SHAPE)
         error[12, 12] = np.nan
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error)[0]
         assert fc[FLAG_COL_NONFINITE_ERROR] == 1
 
         # A masked pixel with non-finite error is not counted
-        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask = np.zeros(UNIT_SHAPE, dtype=np.uint8)
         mask[12, 12] = 1
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0, error=error, mask=mask)[0]
         assert fc[FLAG_COL_NONFINITE_ERROR] == 0
@@ -239,7 +238,7 @@ class TestBboxClipped:
             apertures = CircularAperture(xy, r=radius)
             masks = apertures.to_mask(method=method)
             for fc, apermask in zip(fcs, masks, strict=True):
-                slc_large, slc_small = apermask.get_overlap_slices(SHAPE)
+                slc_large, slc_small = apermask.get_overlap_slices(UNIT_SHAPE)
                 if slc_large is None:
                     assert_array_equal(fc, 0)
                     continue
@@ -261,7 +260,7 @@ class TestSegmentationCounts:
         source_only, and correct methods.
         """
         data = unit_data
-        segm = np.zeros(SHAPE, dtype=np.intp)
+        segm = np.zeros(UNIT_SHAPE, dtype=np.intp)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor pixel inside the aperture
         labels = np.array([1], dtype=np.intp)
@@ -296,7 +295,7 @@ class TestSegmentationCounts:
         assert fc[FLAG_COL_UNCORRECTED] == 2
 
         # Method 3 with a masked mirror pixel: uncorrectable
-        mask = np.zeros(SHAPE, dtype=np.uint8)
+        mask = np.zeros(UNIT_SHAPE, dtype=np.uint8)
         mask[12, 10] = 1
         fc = _sums_fcounts(data, (12.0, 12.0), 3.0, mask=mask,
                            segmentation=segm, labels=labels, seg_method=3)[0]

--- a/photutils/aperture/tests/test_batch_photometry.py
+++ b/photutils/aperture/tests/test_batch_photometry.py
@@ -12,7 +12,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from photutils.aperture.circle import CircularAnnulus, CircularAperture
-from photutils.aperture.core import PixelAperture
+from photutils.aperture.core import PixelAperture, _enable_batch_photometry
 from photutils.aperture.ellipse import EllipticalAnnulus, EllipticalAperture
 from photutils.aperture.polygon import PolygonAperture
 from photutils.aperture.rectangle import (RectangularAnnulus,
@@ -303,17 +303,17 @@ class TestFallback:
         assert_allclose(result.flux_err, expected.flux_err, rtol=1e-12,
                         equal_nan=True)
 
-    def test_subclass_without_hook(self):
+    def test_undecorated_subclass(self):
         """
-        Test that aperture subclasses that do not themselves define
-        _batch_shape_params fall back to the mask-based code path in
-        photometry, so that any overridden behavior (e.g., to_mask) is
-        honored.
+        Test that aperture subclasses that are not decorated with
+        _enable_batch_photometry fall back to the mask-based code path
+        in photometry, so that any overridden behavior (e.g., to_mask)
+        is honored.
         """
 
         class MyAperture(CircularAperture):
-            # Inherits _batch_shape_params, but does not define it in its
-            # own class, so the batch driver must not be used.
+            # Inherits _batch_photometry_class pointing at
+            # CircularAperture, so the batch driver must not be used.
             pass
 
         aperture = MyAperture(POSITIONS, r=5.5)
@@ -323,15 +323,15 @@ class TestFallback:
         result2 = CircularAperture(POSITIONS, r=5.5)._photometry(DATA)
         assert_allclose(result.flux, result2.flux, rtol=1e-12, equal_nan=True)
 
-    def test_subclass_with_hook(self):
+    def test_decorated_subclass(self):
         """
-        Test that aperture subclasses that define the _batch_shape_params
-        hook in their own class opt in to the batch code path.
+        Test that aperture subclasses decorated with
+        _enable_batch_photometry opt in to the batch code path.
         """
 
+        @_enable_batch_photometry
         class MyAperture(CircularAperture):
-            def _batch_shape_params(self):
-                return super()._batch_shape_params()
+            pass
 
         aperture = MyAperture(POSITIONS, r=5.5)
         result = aperture._batch_photometry(DATA, error=None, mask=None,
@@ -341,9 +341,8 @@ class TestFallback:
 
     def test_base_hook_none(self):
         """
-        Test that when a subclass defines _batch_shape_params (opting in)
-        but the method returns None, _batch_photometry falls back to
-        None.
+        Test that when a decorated subclass's _batch_shape_params hook
+        returns None, _batch_photometry falls back to None.
 
         This covers:
         - PixelAperture._batch_shape_params (the base ``return`` on its own
@@ -351,11 +350,12 @@ class TestFallback:
         - the ``if spec is None: return None`` branch in _batch_photometry.
         """
 
+        @_enable_batch_photometry
         class MyAperture(CircularAperture):
             def _batch_shape_params(self):
-                # Explicitly delegate to the base PixelAperture hook, which
-                # returns None, signalling that the batch driver is not
-                # supported for this subclass.
+                # Explicitly delegate to the base PixelAperture hook,
+                # which returns None, signalling that the batch driver
+                # is not supported for this subclass.
                 return PixelAperture._batch_shape_params(self)
 
         aperture = MyAperture(POSITIONS, r=5.5)

--- a/photutils/aperture/tests/test_batch_thread_safety.py
+++ b/photutils/aperture/tests/test_batch_thread_safety.py
@@ -240,3 +240,35 @@ class TestApertureStatsThreadSafety:
                 for name in _STATS_PROPERTIES:
                     assert_allclose(result[name], expected[name],
                                     rtol=0, atol=0, equal_nan=True)
+
+    def test_shared_instance(self):
+        """
+        Test that a single shared ApertureStats instance can be read
+        concurrently.
+
+        The instance is documented as immutable after construction, so
+        concurrent readers racing to fill the lazyproperty caches
+        (which are guarded by the astropy lazyproperty lock) must all
+        see identical values.
+        """
+        data = make_100gaussians_image()
+        error = np.sqrt(np.abs(data))
+        positions = ((145.1, 168.3), (84.7, 224.1), (48.3, 200.3),
+                     (200.0, 100.0))
+        aperture = CircularAperture(positions, r=6.0)
+        stats = ApertureStats(data, aperture, error=error)
+
+        def read():
+            return {name: np.asarray(getattr(stats, name))
+                    for name in (*_STATS_PROPERTIES, 'sum_flags')}
+
+        with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
+            futures = [ex.submit(read)
+                       for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
+            results = [future.result() for future in futures]
+
+        expected = read()
+        for result in results:
+            for name, values in result.items():
+                assert_allclose(values, expected[name], rtol=0, atol=0,
+                                equal_nan=True)

--- a/photutils/aperture/tests/test_bounding_box.py
+++ b/photutils/aperture/tests/test_bounding_box.py
@@ -176,6 +176,18 @@ class TestSetOperations:
 
         assert bbox1.intersection(BoundingBox(30, 40, 50, 60)) is None
 
+    def test_operators_invalid_type(self):
+        """
+        Test that the | and & operators raise the standard TypeError
+        for a non-BoundingBox operand.
+        """
+        bbox = BoundingBox(1, 10, 2, 20)
+        match = 'unsupported operand type'
+        with pytest.raises(TypeError, match=match):
+            bbox | (5, 21, 7, 32)
+        with pytest.raises(TypeError, match=match):
+            bbox & (5, 21, 7, 32)
+
 
 @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
 class TestPlotting:

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -200,6 +200,11 @@ class TestAreaOverlap:
         with pytest.raises(ValueError, match=match):
             aper.area_overlap(data, mask=mask)
 
+        mask = np.zeros(data.shape, dtype=int)
+        match = 'mask must be a boolean array'
+        with pytest.raises(TypeError, match=match):
+            aper.area_overlap(data, mask=mask)
+
 
 class TestToPolygon:
     """

--- a/photutils/aperture/tests/test_circle.py
+++ b/photutils/aperture/tests/test_circle.py
@@ -13,7 +13,7 @@ from photutils.aperture import PolygonAperture, SkyPolygonAperture
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAnnulus, SkyCircularAperture)
 from photutils.aperture.tests.test_aperture_common import (
-    BaseTestAperture, BaseTestPixelAperture)
+    BaseTestAnnulusMutation, BaseTestAperture, BaseTestPixelAperture)
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
@@ -35,7 +35,7 @@ class TestCircularAperture(BaseTestPixelAperture):
             CircularAperture(POSITIONS, radius)
 
 
-class TestCircularAnnulus(BaseTestPixelAperture):
+class TestCircularAnnulus(BaseTestAnnulusMutation, BaseTestPixelAperture):
     aperture = CircularAnnulus(POSITIONS, r_in=3.0, r_out=7.0)
     copy_param = 'r_in'
     copy_value = 2.0
@@ -47,9 +47,20 @@ class TestCircularAnnulus(BaseTestPixelAperture):
         with pytest.raises(ValueError, match=match):
             CircularAnnulus(POSITIONS, r_in=radius, r_out=7.0)
 
-        match = "'r_out' must be greater than 'r_in'"
+        match = "'r_out' must be a positive scalar"
         with pytest.raises(ValueError, match=match):
             CircularAnnulus(POSITIONS, r_in=3.0, r_out=radius)
+
+    @staticmethod
+    def test_r_out_not_greater_than_r_in():
+        """
+        Test that a ValueError is raised when r_out <= r_in.
+        """
+        match = "'r_out' must be greater than 'r_in'"
+        with pytest.raises(ValueError, match=match):
+            CircularAnnulus(POSITIONS, r_in=7.0, r_out=3.0)
+        with pytest.raises(ValueError, match=match):
+            CircularAnnulus(POSITIONS, r_in=3.0, r_out=3.0)
 
 
 class TestSkyCircularAperture(BaseTestAperture):
@@ -65,7 +76,7 @@ class TestSkyCircularAperture(BaseTestAperture):
             SkyCircularAperture(SKYCOORD, r=radius * UNIT)
 
 
-class TestSkyCircularAnnulus(BaseTestAperture):
+class TestSkyCircularAnnulus(BaseTestAnnulusMutation, BaseTestAperture):
     aperture = SkyCircularAnnulus(SKYCOORD, r_in=3.0 * UNIT, r_out=7.0 * UNIT)
     copy_param = 'r_in'
     copy_value = 2.0 * UNIT
@@ -77,7 +88,7 @@ class TestSkyCircularAnnulus(BaseTestAperture):
         with pytest.raises(ValueError, match=match):
             SkyCircularAnnulus(SKYCOORD, r_in=radius * UNIT, r_out=7.0 * UNIT)
 
-        match = "'r_out' must be greater than 'r_in'"
+        match = "'r_out' must be greater than zero"
         with pytest.raises(ValueError, match=match):
             SkyCircularAnnulus(SKYCOORD, r_in=3.0 * UNIT, r_out=radius * UNIT)
 

--- a/photutils/aperture/tests/test_ellipse.py
+++ b/photutils/aperture/tests/test_ellipse.py
@@ -15,7 +15,7 @@ from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus,
                                         SkyEllipticalAperture)
 from photutils.aperture.tests.test_aperture_common import (
-    BaseTestAperture, BaseTestRotatedPixelAperture)
+    BaseTestAnnulusMutation, BaseTestAperture, BaseTestRotatedPixelAperture)
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
@@ -41,7 +41,8 @@ class TestEllipticalAperture(BaseTestRotatedPixelAperture):
             EllipticalAperture(POSITIONS, a=10.0, b=radius, theta=np.pi / 2.0)
 
 
-class TestEllipticalAnnulus(BaseTestRotatedPixelAperture):
+class TestEllipticalAnnulus(BaseTestAnnulusMutation,
+                            BaseTestRotatedPixelAperture):
     aperture = EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=17.0,
                                  theta=np.pi / 3)
     copy_param = 'a_in'
@@ -55,7 +56,7 @@ class TestEllipticalAnnulus(BaseTestRotatedPixelAperture):
             EllipticalAnnulus(POSITIONS, a_in=radius, a_out=20.0, b_out=17.0,
                               theta=np.pi / 3)
 
-        match = "'a_out' must be greater than 'a_in'"
+        match = "'a_out' must be a positive scalar"
         with pytest.raises(ValueError, match=match):
             EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=radius, b_out=17.0,
                               theta=np.pi / 3)
@@ -79,6 +80,15 @@ class TestEllipticalAnnulus(BaseTestRotatedPixelAperture):
             EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=20.0, b_out=5.0,
                               b_in=8.0, theta=np.pi / 3)
 
+    def test_a_in_greater_than_a_out(self):
+        """
+        Test that a ValueError is raised when a_in >= a_out.
+        """
+        match = "'a_out' must be greater than 'a_in'"
+        with pytest.raises(ValueError, match=match):
+            EllipticalAnnulus(POSITIONS, a_in=10.0, a_out=8.0, b_out=5.0,
+                              theta=np.pi / 3)
+
 
 class TestSkyEllipticalAperture(BaseTestAperture):
     aperture = SkyEllipticalAperture(SKYCOORD, a=10.0 * UNIT, b=5.0 * UNIT,
@@ -100,7 +110,7 @@ class TestSkyEllipticalAperture(BaseTestAperture):
                                   theta=30 * u.deg)
 
 
-class TestSkyEllipticalAnnulus(BaseTestAperture):
+class TestSkyEllipticalAnnulus(BaseTestAnnulusMutation, BaseTestAperture):
     aperture = SkyEllipticalAnnulus(SKYCOORD, a_in=10.0 * UNIT,
                                     a_out=20.0 * UNIT, b_out=17.0 * UNIT,
                                     theta=60 * u.deg)
@@ -116,7 +126,7 @@ class TestSkyEllipticalAnnulus(BaseTestAperture):
                                  a_out=20.0 * UNIT, b_out=17.0 * UNIT,
                                  theta=60 * u.deg)
 
-        match = "'a_out' must be greater than 'a_in'"
+        match = "'a_out' must be greater than zero"
         with pytest.raises(ValueError, match=match):
             SkyEllipticalAnnulus(SKYCOORD, a_in=10.0 * UNIT,
                                  a_out=radius * UNIT, b_out=17.0 * UNIT,
@@ -142,6 +152,15 @@ class TestSkyEllipticalAnnulus(BaseTestAperture):
             SkyEllipticalAnnulus(SKYCOORD, a_in=10.0 * UNIT, a_out=20.0 * UNIT,
                                  b_out=5.0 * UNIT, b_in=8.0 * UNIT,
                                  theta=60 * u.deg)
+
+    def test_a_in_greater_than_a_out(self):
+        """
+        Test that a ValueError is raised when a_in >= a_out.
+        """
+        match = "'a_out' must be greater than 'a_in'"
+        with pytest.raises(ValueError, match=match):
+            SkyEllipticalAnnulus(SKYCOORD, a_in=10.0 * UNIT, a_out=8.0 * UNIT,
+                                 b_out=5.0 * UNIT, theta=60 * u.deg)
 
 
 class TestThetaQuantity:

--- a/photutils/aperture/tests/test_flags.py
+++ b/photutils/aperture/tests/test_flags.py
@@ -23,7 +23,8 @@ EXPECTED_FLAGS = {
     'sigma_clipped': 512,
     'all_clipped': 1024,
     'too_few_pixels': 2048,
-    'singular_covariance': 4096,
+    'undefined_shape': 4096,
+    'singular_covariance': 8192,
 }
 
 

--- a/photutils/aperture/tests/test_mask.py
+++ b/photutils/aperture/tests/test_mask.py
@@ -247,6 +247,22 @@ class TestGetValues:
         values = aper.to_mask().get_values(data)
         assert values.shape == (0,)
 
+    def test_get_values_units(self):
+        """
+        Test that the result is a Quantity with the data units for both
+        the overlap and no-overlap cases.
+        """
+        data = np.ones((51, 51)) * u.Jy
+        values = CircularAperture((25, 25), r=3).to_mask().get_values(data)
+        assert isinstance(values, u.Quantity)
+        assert values.unit == u.Jy
+
+        values = CircularAperture((-100, -100), r=3).to_mask().get_values(
+            data)
+        assert isinstance(values, u.Quantity)
+        assert values.unit == u.Jy
+        assert values.shape == (0,)
+
     def test_get_values_mask(self):
         aper = CircularAperture((24.5, 24.5), r=10.0)
         data = np.ones((51, 51))

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -58,148 +58,101 @@ def fixture_ones_data():
     return np.ones((40, 40), dtype=float)
 
 
-class BaseTestAperturePhotometry:
+def _shape_aperture_specs():
     """
-    Tests shared by the shape-specific aperture photometry classes.
+    Build the ``(aperture, area)`` pairs used by the shape-specific
+    photometry tests, where ``area`` is the analytic aperture area.
+    """
+    r = 10.0
+    r_in, r_out = 8.0, 10.0
+    a, b = 10.0, 5.0
+    a_in, a_out, b_out = 5.0, 8.0, 5.0
+    b_in = a_in * b_out / a_out
+    w, h = 8.0, 5.0
+    w_in, w_out, h_out = 8.0, 12.0, 8.0
+    h_in = w_in * h_out / w_out
+    polygon = PolygonAperture.from_regular_polygon(POSITION, 5, 6.0,
+                                                   theta=30 * u.deg)
+    return [
+        pytest.param(CircularAperture(POSITION, r),
+                     np.pi * r**2, id='circle'),
+        pytest.param(CircularAperture(POSITIONS, r),
+                     np.full(len(POSITIONS), np.pi * r**2),
+                     id='circle-array'),
+        pytest.param(CircularAnnulus(POSITION, r_in, r_out),
+                     np.pi * (r_out**2 - r_in**2), id='circular-annulus'),
+        pytest.param(CircularAnnulus(POSITIONS, r_in, r_out),
+                     np.full(len(POSITIONS), np.pi * (r_out**2 - r_in**2)),
+                     id='circular-annulus-array'),
+        pytest.param(EllipticalAperture(POSITION, a, b, theta=-np.pi / 4.0),
+                     np.pi * a * b, id='ellipse'),
+        pytest.param(EllipticalAnnulus(POSITION, a_in, a_out, b_out,
+                                       theta=-np.pi / 4.0),
+                     np.pi * (a_out * b_out - a_in * b_in),
+                     id='elliptical-annulus'),
+        pytest.param(RectangularAperture(POSITION, w, h, theta=np.pi / 4.0),
+                     w * h, id='rectangle'),
+        pytest.param(RectangularAnnulus(POSITION, w_in, w_out, h_out,
+                                        theta=np.pi / 8.0),
+                     w_out * h_out - w_in * h_in, id='rectangular-annulus'),
+        pytest.param(polygon, polygon.area, id='polygon'),
+    ]
 
-    Each subclass defines the ``aperture`` to measure, along with its
-    true ``area`` and ``true_flux`` in an image of ones. A subclass that
-    masks a data pixel also overrides the ``mask`` fixture.
+
+class TestShapePhotometry:
+    """
+    Shape-specific photometry tests on an image of ones, comparing the
+    center, subpixel, and exact methods against the analytic aperture
+    area.
     """
 
-    @pytest.fixture(name='mask')
-    def fixture_mask(self):
+    @staticmethod
+    def _check_photometry(data, aperture, area, *, mask=None, n_masked=0):
         """
-        The data mask, `None` unless a subclass overrides it.
+        Compare the center, subpixel, and exact photometry of ``data``
+        (an image of ones) against the analytic ``area``, of which
+        ``n_masked`` unit pixels are masked by ``mask``.
         """
-        return
+        error = np.ones(data.shape, dtype=float)
+        true_flux = area - n_masked
+        true_error = np.sqrt(area - n_masked)
 
-    def test_array_error(self, ones_data, mask):
-        # Array error
-        error = np.ones(ones_data.shape, dtype=float)
-        if mask is None:
-            true_error = np.sqrt(self.area)
-        else:
-            # 1 masked pixel
-            true_error = np.sqrt(self.area - 1)
-
-        table1 = aperture_photometry(ones_data,
-                                     self.aperture, method='center',
+        table1 = aperture_photometry(data, aperture, method='center',
                                      mask=mask, error=error)
-        table2 = aperture_photometry(ones_data,
-                                     self.aperture,
-                                     method='subpixel', subpixels=12,
-                                     mask=mask, error=error)
-        table3 = aperture_photometry(ones_data,
-                                     self.aperture, method='exact',
+        table2 = aperture_photometry(data, aperture, method='subpixel',
+                                     subpixels=12, mask=mask, error=error)
+        table3 = aperture_photometry(data, aperture, method='exact',
                                      mask=mask, error=error)
 
-        if not isinstance(self.aperture, (RectangularAperture,
-                                          RectangularAnnulus)):
-            assert_allclose(table3['aperture_sum'], self.true_flux)
+        if not isinstance(aperture, (RectangularAperture,
+                                     RectangularAnnulus)):
+            assert_allclose(table3['aperture_sum'], true_flux)
             assert_allclose(table2['aperture_sum'], table3['aperture_sum'],
                             atol=0.1)
         assert np.all(table1['aperture_sum'] < table3['aperture_sum'])
 
-        if not isinstance(self.aperture, (RectangularAperture,
-                                          RectangularAnnulus)):
+        if not isinstance(aperture, (RectangularAperture,
+                                     RectangularAnnulus)):
             assert_allclose(table3['aperture_sum_err'], true_error)
             assert_allclose(table2['aperture_sum_err'],
                             table3['aperture_sum_err'], atol=0.1)
         assert np.all(table1['aperture_sum_err'] < table3['aperture_sum_err'])
 
+    @pytest.mark.parametrize(('aperture', 'area'), _shape_aperture_specs())
+    def test_array_error(self, ones_data, aperture, area):
+        self._check_photometry(ones_data, aperture, area)
 
-class TestCircular(BaseTestAperturePhotometry):
-    r = 10.0
-    aperture = CircularAperture(POSITION, r)
-    area = np.pi * r * r
-    true_flux = area
-
-
-class TestCircularArray(BaseTestAperturePhotometry):
-    r = 10.0
-    aperture = CircularAperture(POSITIONS, r)
-    area = np.full(len(POSITIONS), np.pi * r * r)
-    true_flux = area
-
-
-class TestCircularAnnulus(BaseTestAperturePhotometry):
-    r_in = 8.0
-    r_out = 10.0
-    aperture = CircularAnnulus(POSITION, r_in, r_out)
-    area = np.pi * (r_out * r_out - r_in * r_in)
-    true_flux = area
-
-
-class TestCircularAnnulusArray(BaseTestAperturePhotometry):
-    r_in = 8.0
-    r_out = 10.0
-    aperture = CircularAnnulus(POSITIONS, r_in, r_out)
-    area = np.full(len(POSITIONS), np.pi * (r_out * r_out - r_in * r_in))
-    true_flux = area
-
-
-class TestElliptical(BaseTestAperturePhotometry):
-    a = 10.0
-    b = 5.0
-    aperture = EllipticalAperture(POSITION, a, b, theta=-np.pi / 4.0)
-    area = np.pi * a * b
-    true_flux = area
-
-
-class TestEllipticalAnnulus(BaseTestAperturePhotometry):
-    a_in = 5.0
-    a_out = 8.0
-    b_out = 5.0
-    aperture = EllipticalAnnulus(POSITION, a_in, a_out, b_out,
-                                 theta=-np.pi / 4.0)
-    area = (np.pi * (a_out * b_out)
-            - np.pi * (a_in * b_out * a_in / a_out))
-    true_flux = area
-
-
-class TestRectangularAperture(BaseTestAperturePhotometry):
-    w = 8.0
-    h = 5.0
-    aperture = RectangularAperture(POSITION, w, h, theta=np.pi / 4.0)
-    area = h * w
-    true_flux = area
-
-
-class TestRectangularAnnulus(BaseTestAperturePhotometry):
-    w_in = 8.0
-    w_out = 12.0
-    h_out = 8.0
-    h_in = w_in * h_out / w_out
-    aperture = RectangularAnnulus(POSITION, w_in, w_out, h_out,
-                                  theta=np.pi / 8.0)
-    area = h_out * w_out - h_in * w_in
-    true_flux = area
-
-
-class TestPolygon(BaseTestAperturePhotometry):
-    n_vertices = 5
-    radius = 6.0
-    aperture = PolygonAperture.from_regular_polygon(POSITION, n_vertices,
-                                                    radius, theta=30 * u.deg)
-    area = aperture.area
-    true_flux = area
-
-
-class TestMaskedSkipCircular(BaseTestAperturePhotometry):
-    r = 10.0
-    aperture = CircularAperture(POSITION, r)
-    area = np.pi * r * r
-    true_flux = area - 1
-
-    @pytest.fixture(name='mask')
-    def fixture_mask(self, ones_data):
+    def test_masked_pixel(self, ones_data):
         """
-        A mask with the single pixel at the aperture center masked.
+        A masked pixel at the aperture center reduces the flux and the
+        error accordingly.
         """
+        r = 10.0
+        aperture = CircularAperture(POSITION, r)
         mask = np.zeros(ones_data.shape, dtype=bool)
         mask[20, 20] = True
-        return mask
+        self._check_photometry(ones_data, aperture, np.pi * r**2,
+                               mask=mask, n_masked=1)
 
 
 class TestInputNDData:

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -507,10 +507,14 @@ class TestPlots:
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     @pytest.mark.parametrize(('aperture_class', 'params'), TEST_APERTURES)
     def test_plots(self, aperture_class, params):
-        # This test should run without any errors, and there is no return
-        # value.
+        import matplotlib.pyplot as plt
+
         aperture = aperture_class((20.0, 20.0), **params)
-        aperture.plot()
+        try:
+            patches = aperture.plot()
+            assert len(patches) == 1
+        finally:
+            plt.close('all')
 
 
 class TestWcsInput:
@@ -989,10 +993,10 @@ class TestInputValidation:
         data = np.ones((11, 11))
         aper = CircularAperture((5, 5), r=3)
         match = 'subpixels must be a strictly positive integer'
-        with pytest.raises(ValueError, match=match):
-            aperture_photometry(data, aper, method='subpixel', subpixels=0)
-        with pytest.raises(ValueError, match=match):
-            aperture_photometry(data, aper, method='subpixel', subpixels=-1)
+        for subpixels in (0, -1, 2.5, True):
+            with pytest.raises(ValueError, match=match):
+                aperture_photometry(data, aper, method='subpixel',
+                                    subpixels=subpixels)
 
     def test_mask_validation(self):
         """

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -988,6 +988,30 @@ class TestInputValidation:
         with pytest.raises(ValueError, match=match):
             aperture_photometry(data, aper, method='subpixel', subpixels=-1)
 
+    def test_mask_validation(self):
+        """
+        Test that the mask must be a boolean array with the same shape
+        as the data.
+        """
+        data = np.ones((11, 11))
+        aper = CircularAperture((5, 5), r=3)
+
+        # A nested list of bools is converted to a boolean array
+        mask_list = [[False] * 11 for _ in range(11)]
+        tbl1 = aperture_photometry(data, aper, mask=np.array(mask_list))
+        tbl2 = aperture_photometry(data, aper, mask=mask_list)
+        assert_allclose(tbl2['aperture_sum'], tbl1['aperture_sum'])
+
+        match = 'mask must be a boolean array'
+        with pytest.raises(TypeError, match=match):
+            aperture_photometry(data, aper, mask=np.zeros(data.shape,
+                                                          dtype=int))
+
+        match = 'mask and data must have the same shape'
+        with pytest.raises(ValueError, match=match):
+            aperture_photometry(data, aper,
+                                mask=np.zeros((3, 3), dtype=bool))
+
     @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
     def test_unsupported_region_input(self):
         from regions import LinePixelRegion, PixCoord

--- a/photutils/aperture/tests/test_photometry.py
+++ b/photutils/aperture/tests/test_photometry.py
@@ -419,12 +419,18 @@ class TestArrayBounds:
                             atol=0.1)
 
     def test_pixel_positions(self):
+        """
+        A scalar position yields a (2,) positions array, while a list
+        containing one position yields a (1, 2) array.
+        """
         pos1 = (10, 20)
         pos2 = [(10, 20)]
         r = 3
         ap1 = CircularAperture(pos1, r)
         ap2 = CircularAperture(pos2, r)
-        assert not np.array_equal(ap1.positions, ap2.positions)
+        assert ap1.positions.shape == (2,)
+        assert ap2.positions.shape == (1, 2)
+        assert_allclose(ap1.positions, ap2.positions[0])
 
     def test_partial_overlap(self):
         data = np.ones((20, 20))

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -15,6 +15,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture.circle import (CircularAnnulus, CircularAperture,
                                        SkyCircularAperture)
+from photutils.aperture.flags import APERTURE_FLAGS
 from photutils.aperture.photometry import (AperturePhotometry,
                                            aperture_photometry)
 from photutils.aperture.polygon import PolygonAperture
@@ -266,12 +267,33 @@ class TestSegmentationMasking:
         ref = AperturePhotometry(data, aper)
         assert_allclose(phot.flux, ref.flux)
 
-    def test_correct_matches_neighbor(self):
+    def test_correct_matches_manual_mirror(self):
+        """
+        Test that mask_method='correct' reproduces plain photometry on
+        a manually mirror-corrected image.
+
+        The scene is constructed so that the mirror of every neighbor
+        pixel is an unmasked non-neighbor pixel, so every neighbor pixel
+        is corrected (none are excluded).
+        """
         data, segm = make_scene()
-        aper = CircularAperture([(21, 21)], r=10)
-        none_phot = AperturePhotometry(data, aper, mask_method='none')
+        xycen = (21, 21)
+        aper = CircularAperture([xycen], r=10)
         corr_phot = AperturePhotometry(data, aper, segmentation_image=segm,
                                        labels=[1], mask_method='correct')
+
+        # Replace every neighbor pixel with its value mirrored across
+        # the aperture center. Pixels outside the aperture have zero
+        # weight, so correcting them globally does not change the flux.
+        corrected = data.copy()
+        yidx, xidx = np.nonzero((segm > 0) & (segm != 1))
+        corrected[yidx, xidx] = data[2 * xycen[1] - yidx,
+                                     2 * xycen[0] - xidx]
+        ref_phot = AperturePhotometry(corrected, aper)
+        assert_allclose(corr_phot.flux, ref_phot.flux, rtol=1e-12)
+
+        # The correction changes the flux relative to no masking
+        none_phot = AperturePhotometry(data, aper, mask_method='none')
         assert corr_phot.flux[0] != none_phot.flux[0]
 
     def test_polygon_mask_path(self):
@@ -365,7 +387,7 @@ class TestFlagsAndArea:
         data = np.ones((25, 25), dtype=float)
         aper = CircularAperture((0, 12), r=5.0)
         phot = AperturePhotometry(data, aper)
-        assert phot.flags != 0
+        assert phot.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
 
     def test_decode_flags(self):
         data = np.ones((25, 25))

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -3,6 +3,7 @@
 Tests for the AperturePhotometry class.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 import astropy.units as u
@@ -680,8 +681,19 @@ class TestInputValidation:
     def test_unit_mismatch(self):
         data = np.ones((11, 11)) * u.Jy
         aper = CircularAperture((5, 5), r=3)
-        with pytest.raises(ValueError, match='must all have the same units'):
+        match = 'must all have the same units'
+        with pytest.raises(ValueError, match=match):
             AperturePhotometry(data, aper, error=np.ones((11, 11)))
+
+        # The converse: unitless data with a unit error
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(np.ones((11, 11)), aper,
+                               error=np.ones((11, 11)) * u.Jy)
+
+        # Same-dimension but different units are also rejected
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, aper,
+                               error=np.ones((11, 11)) * u.mJy)
 
     @pytest.mark.parametrize('method', ['exact ', 'Exact', 'invalid'])
     def test_invalid_method_at_init(self, method):
@@ -749,6 +761,42 @@ class TestInputValidation:
         with pytest.raises(ValueError, match=match):
             ApertureStats(data, aper, segmentation_image=segm,
                           labels=np.array([[1, 2]]), mask_method='mask')
+
+
+class TestEmptyPositions:
+    """
+    Regression tests for apertures with zero positions, which must
+    flow through both classes (including the batch Cython drivers) and
+    the legacy function, returning empty outputs.
+    """
+
+    def test_aperture_photometry_class(self):
+        data = np.ones((11, 11))
+        aper = CircularAperture(np.empty((0, 2)), r=3)
+        phot = AperturePhotometry(data, aper, error=np.ones_like(data))
+        assert phot.n_positions == 0
+        assert phot.flux.shape == (0,)
+        assert phot.flux_err.shape == (0,)
+        assert phot.area.shape == (0,)
+        assert phot.flags.shape == (0,)
+        assert len(phot.to_table()) == 0
+
+    def test_aperture_stats(self):
+        data = np.ones((11, 11))
+        aper = CircularAperture(np.empty((0, 2)), r=3)
+        stats = ApertureStats(data, aper)
+        assert stats.n_positions == 0
+        assert stats.mean.shape == (0,)
+        assert stats.median.shape == (0,)
+        assert stats.sum.shape == (0,)
+        assert stats.flags.shape == (0,)
+        assert len(stats.to_table()) == 0
+
+    def test_legacy_function(self):
+        data = np.ones((11, 11))
+        aper = CircularAperture(np.empty((0, 2)), r=3)
+        tbl = aperture_photometry(data, aper)
+        assert len(tbl) == 0
 
 
 class TestSegmentationAttributes:
@@ -839,8 +887,6 @@ class TestReprAndImmutability:
         assert new_keys.issubset(lazy_names)
 
     def test_concurrent_access(self, data):
-        from concurrent.futures import ThreadPoolExecutor
-
         aper = CircularAperture(((150, 25), (90, 60)), 8)
         phot = AperturePhotometry(data, aper)
         with ThreadPoolExecutor(max_workers=4) as executor:

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -341,6 +341,17 @@ class TestToTable:
         assert 'aperture_photometry_args' in tbl.meta
         assert tbl.meta['aperture'] == 'CircularAperture'
 
+    def test_sky_center_requires_wcs(self, data):
+        """
+        Test that requesting the sky_center column without a WCS raises
+        a clear error.
+        """
+        aper = CircularAperture((150, 25), 8)
+        phot = AperturePhotometry(data, aper)
+        match = "the 'sky_center' column requires a WCS"
+        with pytest.raises(ValueError, match=match):
+            phot.to_table(columns=['id', 'sky_center'])
+
 
 class TestFlagsAndArea:
     def test_area_matches_area_overlap(self):
@@ -688,6 +699,34 @@ class TestInputValidation:
             AperturePhotometry(data, aper, mask_method='invalid')
         with pytest.raises(ValueError, match=match):
             ApertureStats(data, aper, mask_method='invalid')
+
+    @pytest.mark.parametrize('apertures', [[], (), np.array([])])
+    def test_empty_aperture_list(self, apertures):
+        """
+        Test that an empty aperture list is reported at construction.
+        """
+        data = np.ones((11, 11))
+        match = 'apertures must not be empty'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, apertures)
+
+    def test_labels_not_1d(self):
+        """
+        Test that a 2D labels array is reported at construction rather
+        than failing later in the batch driver.
+        """
+        data = np.ones((11, 11))
+        segm = np.zeros(data.shape, dtype=int)
+        segm[4:7, 4:7] = 1
+        aper = CircularAperture((5, 5), r=3)
+        match = 'labels must be a 1D array'
+        with pytest.raises(ValueError, match=match):
+            AperturePhotometry(data, aper, segmentation_image=segm,
+                               labels=np.array([[1, 2]]),
+                               mask_method='mask')
+        with pytest.raises(ValueError, match=match):
+            ApertureStats(data, aper, segmentation_image=segm,
+                          labels=np.array([[1, 2]]), mask_method='mask')
 
 
 class TestSegmentationAttributes:

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -21,28 +21,10 @@ from photutils.aperture.photometry import (AperturePhotometry,
                                            aperture_photometry)
 from photutils.aperture.polygon import PolygonAperture
 from photutils.aperture.stats import ApertureStats
+from photutils.aperture.tests.conftest import make_scene
 from photutils.datasets import make_wcs
 from photutils.segmentation import SegmentationImage
 from photutils.utils._optional_deps import HAS_REGIONS
-
-
-def make_scene():
-    """
-    Build a deterministic scene with a target source (label 1) and a
-    bright neighbor source (label 2), on a nonzero background.
-    """
-    data = np.ones((50, 50))
-    segm = np.zeros((50, 50), dtype=int)
-
-    # Target source (label 1)
-    data[18:25, 18:25] = 10.0
-    segm[18:25, 18:25] = 1
-
-    # Bright neighbor source (label 2)
-    data[20:25, 26:32] = 100.0
-    segm[20:25, 26:32] = 2
-
-    return data, segm
 
 
 class TestAperturePhotometryParity:

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData, StdDevUncertainty
+from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
 
@@ -21,7 +22,8 @@ from photutils.aperture.photometry import (AperturePhotometry,
                                            aperture_photometry)
 from photutils.aperture.polygon import PolygonAperture
 from photutils.aperture.stats import ApertureStats
-from photutils.aperture.tests.conftest import make_scene
+from photutils.aperture.tests.conftest import (NoBatchCircularAperture,
+                                               make_scene)
 from photutils.datasets import make_wcs
 from photutils.segmentation import SegmentationImage
 from photutils.utils._optional_deps import HAS_REGIONS
@@ -745,6 +747,88 @@ class TestInputValidation:
                           labels=np.array([[1, 2]]), mask_method='mask')
 
 
+class TestReadOnlyInputs:
+    """
+    End-to-end tests that both classes accept read-only (non-writeable)
+    input arrays on both the batch and mask-based code paths, and that
+    the inputs are never modified.
+    """
+
+    @staticmethod
+    def _make_readonly_inputs():
+        """
+        Build a full set of read-only input arrays, including a masked
+        pixel and a non-finite data value.
+        """
+        data, segm = make_scene()
+        rng = np.random.default_rng(7)
+        data = data + rng.normal(0.0, 0.1, data.shape)
+        data[30, 5] = np.nan
+        error = np.full(data.shape, 0.1)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[20, 20] = True
+        arrays = {'data': data, 'error': error, 'mask': mask,
+                  'segmentation_image': segm.astype(np.intp),
+                  'labels': np.array([1]),
+                  'local_bkg': np.array([1.0]),
+                  'positions': np.array([(21.0, 21.0)])}
+        for arr in arrays.values():
+            arr.setflags(write=False)
+        return arrays
+
+    @pytest.mark.parametrize('aper_cls', [CircularAperture,
+                                          NoBatchCircularAperture])
+    @pytest.mark.parametrize('mask_method', ['none', 'mask', 'source_only',
+                                             'correct'])
+    def test_aperture_photometry(self, aper_cls, mask_method):
+        arrays = self._make_readonly_inputs()
+        originals = {key: arr.copy() for key, arr in arrays.items()}
+
+        kwargs = {}
+        if mask_method != 'none':
+            kwargs = {'segmentation_image': arrays['segmentation_image'],
+                      'labels': arrays['labels'],
+                      'mask_method': mask_method}
+        aper = aper_cls(arrays['positions'], r=10)
+        phot = AperturePhotometry(arrays['data'], aper,
+                                  error=arrays['error'],
+                                  mask=arrays['mask'], **kwargs)
+        assert np.isfinite(phot.flux[0])
+        for attr in ('flux_err', 'area', 'flags'):
+            _ = getattr(phot, attr)
+        _ = phot.to_table()
+
+        for key, arr in arrays.items():
+            assert_equal(arr, originals[key])
+
+    @pytest.mark.parametrize('aper_cls', [CircularAperture,
+                                          NoBatchCircularAperture])
+    @pytest.mark.parametrize('with_sigma_clip', [False, True])
+    def test_aperture_stats(self, aper_cls, with_sigma_clip):
+        arrays = self._make_readonly_inputs()
+        originals = {key: arr.copy() for key, arr in arrays.items()}
+
+        sigma_clip = (SigmaClip(sigma=3.0, maxiters=5) if with_sigma_clip
+                      else None)
+        aper = aper_cls(arrays['positions'], r=10)
+        stats = ApertureStats(arrays['data'], aper, error=arrays['error'],
+                              mask=arrays['mask'], sigma_clip=sigma_clip,
+                              local_bkg=arrays['local_bkg'],
+                              segmentation_image=(
+                                  arrays['segmentation_image']),
+                              labels=arrays['labels'],
+                              mask_method='correct')
+        for attr in ('sum', 'sum_err', 'mean', 'median', 'std', 'mad_std',
+                     'biweight_location', 'gini', 'centroid',
+                     'semimajor_axis', 'fwhm', 'flags', 'sum_flags'):
+            _ = getattr(stats, attr)
+        assert np.isfinite(stats.mean)
+        _ = stats.to_table()
+
+        for key, arr in arrays.items():
+            assert_equal(arr, originals[key])
+
+
 class TestEmptyPositions:
     """
     Regression tests for apertures with zero positions, which must
@@ -869,12 +953,23 @@ class TestReprAndImmutability:
         assert new_keys.issubset(lazy_names)
 
     def test_concurrent_access(self, data):
+        """
+        Test that a single shared AperturePhotometry instance can be
+        read concurrently. The lazyproperty caches fill under contention
+        and every thread sees identical values.
+        """
         aper = CircularAperture(((150, 25), (90, 60)), 8)
-        phot = AperturePhotometry(data, aper)
+        phot = AperturePhotometry(data, aper, error=np.ones_like(data))
+
+        def read(_):
+            return {attr: np.asarray(getattr(phot, attr))
+                    for attr in ('flux', 'flux_err', 'flags', 'id')}
+
         with ThreadPoolExecutor(max_workers=4) as executor:
-            results = list(executor.map(lambda _: phot.flux, range(8)))
+            results = list(executor.map(read, range(16)))
         for result in results:
-            assert_allclose(result, results[0])
+            for attr, values in result.items():
+                assert_allclose(values, results[0][attr])
 
 
 @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -14,8 +14,8 @@ from photutils.aperture import (APERTURE_FLAGS, AperturePhotometry,
                                 PolygonAperture, RectangularAperture,
                                 aperture_photometry)
 from photutils.aperture.flags import _counts_to_flag_bits
-
-SHAPE = (25, 25)
+from photutils.aperture.tests.conftest import (UNIT_SHAPE,
+                                               NoBatchCircularAperture)
 
 APERTURE_FACTORIES = [
     lambda xy: CircularAperture(xy, r=3.0),
@@ -25,13 +25,6 @@ APERTURE_FACTORIES = [
 ]
 
 METHODS = [('exact', 5), ('center', 1), ('subpixel', 4)]
-
-
-class _NoBatchCircularAperture(CircularAperture):
-    """
-    A CircularAperture subclass that does not opt in to the batch
-    Cython driver, forcing the mask-based code path.
-    """
 
 
 def _flags(aperture, data, **kwargs):
@@ -241,7 +234,7 @@ class TestMaskedAndNonFiniteFlags:
         data = unit_data
 
         # One masked pixel inside the aperture
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = np.zeros(UNIT_SHAPE, dtype=bool)
         mask[12, 12] = True
         aper = CircularAperture((12, 12), r=3.0)
         flags = _flags(aper, data, mask=mask, method=method,
@@ -249,14 +242,14 @@ class TestMaskedAndNonFiniteFlags:
         assert flags == APERTURE_FLAGS.MASKED_PIXELS
 
         # Masked pixel inside the bounding box but outside the aperture
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = np.zeros(UNIT_SHAPE, dtype=bool)
         mask[9, 9] = True
         flags = _flags(aper, data, mask=mask, method=method,
                        subpixels=subpixels)
         assert flags == 0
 
         # Fully masked aperture
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = np.zeros(UNIT_SHAPE, dtype=bool)
         mask[8:17, 8:17] = True
         flags = _flags(aper, data, mask=mask, method=method,
                        subpixels=subpixels)
@@ -275,7 +268,7 @@ class TestMaskedAndNonFiniteFlags:
         with the non-finite value instead of masking it out, unlike
         `AperturePhotometry`.
         """
-        data = np.ones(SHAPE)
+        data = np.ones(UNIT_SHAPE)
         data[12, 12] = np.nan
         aper = CircularAperture((12, 12), r=3.0)
         result = aper._photometry(data)
@@ -284,12 +277,12 @@ class TestMaskedAndNonFiniteFlags:
 
         # An all-NaN aperture is still non_finite_data only (the pixels
         # contribute, so all_masked is not set)
-        data = np.full(SHAPE, np.nan)
+        data = np.full(UNIT_SHAPE, np.nan)
         result = aper._photometry(data)
         assert result.flags[0] == APERTURE_FLAGS.NON_FINITE_DATA
 
         # A masked non-finite pixel counts only as masked
-        data = np.ones(SHAPE)
+        data = np.ones(UNIT_SHAPE)
         data[12, 12] = np.nan
         mask = unit_mask
         mask[12, 12] = True
@@ -301,7 +294,7 @@ class TestMaskedAndNonFiniteFlags:
         Test the non_finite_error flag.
         """
         data = unit_data
-        error = np.ones(SHAPE)
+        error = np.ones(UNIT_SHAPE)
         error[12, 12] = np.inf
         aper = CircularAperture((12, 12), r=3.0)
         flags = _flags(aper, data, error=error)
@@ -322,7 +315,7 @@ class TestSegmentationFlags:
         Test the neighbor_pixels flag for all segmentation mask methods.
         """
         data = unit_data
-        segm = np.zeros(SHAPE, dtype=int)
+        segm = np.zeros(UNIT_SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor pixel inside the aperture
         aper = CircularAperture((12, 12), r=3.0)
@@ -331,7 +324,7 @@ class TestSegmentationFlags:
         assert flags == APERTURE_FLAGS.NEIGHBOR_PIXELS
 
         # Without any neighbor pixels inside the aperture, no flag is set
-        segm2 = np.zeros(SHAPE, dtype=int)
+        segm2 = np.zeros(UNIT_SHAPE, dtype=int)
         segm2[10:15, 10:15] = 1
         flags = _flags(aper, data, segmentation_image=segm2, labels=1,
                        mask_method=mask_method)
@@ -342,7 +335,7 @@ class TestSegmentationFlags:
         Test the uncorrected_pixels flag with mask_method='correct'.
         """
         data = unit_data
-        segm = np.zeros(SHAPE, dtype=int)
+        segm = np.zeros(UNIT_SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor; its mirror (12, 10) is source pixel
         segm[12, 10] = 2  # make the mirror a neighbor too: uncorrectable
@@ -372,9 +365,9 @@ class TestMaskPathParity:
         batch Cython driver.
         """
         rng = np.random.default_rng(0)
-        data = rng.normal(1.0, 0.1, size=SHAPE)
+        data = rng.normal(1.0, 0.1, size=UNIT_SHAPE)
         data[13, 12] = np.nan
-        error = np.ones(SHAPE)
+        error = np.ones(UNIT_SHAPE)
         error[10, 12] = np.inf
         mask = unit_mask
         mask[12, 12] = True
@@ -382,7 +375,7 @@ class TestMaskPathParity:
         xy = [(12.0, 12.0), (0.0, 12.0), (-50.0, 12.0), (24.5, 24.5),
               (0.2, 12.0), (-1.2, 12.0)]
         batch_aper = CircularAperture(xy, r=3.0)
-        nobatch_aper = _NoBatchCircularAperture(xy, r=3.0)
+        nobatch_aper = NoBatchCircularAperture(xy, r=3.0)
 
         kwargs = {'error': error, 'mask': mask, 'method': method,
                   'subpixels': subpixels}
@@ -398,7 +391,7 @@ class TestMaskPathParity:
         Test batch/mask-path flag parity with segmentation masking.
         """
         data = unit_data
-        segm = np.zeros(SHAPE, dtype=int)
+        segm = np.zeros(UNIT_SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2
         segm[12, 10] = 2
@@ -410,7 +403,7 @@ class TestMaskPathParity:
             flags_batch = CircularAperture(xy, r=3.0)._photometry(
                 data, segmentation_image=segm, labels=labels,
                 mask_method=mask_method).flags
-            flags_nobatch = _NoBatchCircularAperture(xy, r=3.0)._photometry(
+            flags_nobatch = NoBatchCircularAperture(xy, r=3.0)._photometry(
                 data, segmentation_image=segm, labels=labels,
                 mask_method=mask_method).flags
             assert_array_equal(flags_batch, flags_nobatch)
@@ -431,14 +424,14 @@ class TestMaskPathParity:
         """
         data = unit_data
         data[nan_pixel] = np.nan
-        segm = np.zeros(SHAPE, dtype=int)
+        segm = np.zeros(UNIT_SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor pixel; its mirror is (12, 10)
 
         kwargs = {'segmentation_image': segm, 'labels': [1],
                   'mask_method': mask_method}
         batch_aper = CircularAperture((12.0, 12.0), r=3.0)
-        nobatch_aper = _NoBatchCircularAperture((12.0, 12.0), r=3.0)
+        nobatch_aper = NoBatchCircularAperture((12.0, 12.0), r=3.0)
         result_batch = AperturePhotometry(data, batch_aper, **kwargs)
         result_nobatch = AperturePhotometry(data, nobatch_aper, **kwargs)
         assert_array_equal(result_batch.flags, result_nobatch.flags)
@@ -505,7 +498,7 @@ class TestFlagsAPI:
         """
         Test that flags are also set for Quantity inputs.
         """
-        data = np.ones(SHAPE) * u.Jy
+        data = np.ones(UNIT_SHAPE) * u.Jy
         data[12, 12] = np.nan * u.Jy
         aper = CircularAperture((12, 12), r=3.0)
         phot = AperturePhotometry(data, aper)
@@ -564,7 +557,7 @@ class TestResolveOutsideWeights:
         mask-based outside-weight test for a mix of interior, edge, corner,
         and fully off-image positions.
         """
-        ny, nx = SHAPE
+        ny, nx = UNIT_SHAPE
         xy = [(12.0, 12.0),  # interior (not a candidate)
               (0.0, 12.0), (nx - 1.0, 12.0),  # left/right edges
               (12.0, 0.0), (12.0, ny - 1.0),  # bottom/top edges
@@ -574,11 +567,11 @@ class TestResolveOutsideWeights:
               (-50.0, 12.0)]  # fully off-image (not a candidate)
         aper = factory(xy)
 
-        candidates = _bbox_clipped_candidates(aper, SHAPE)
-        gated = aper._resolve_outside_weights(SHAPE, method='exact',
+        candidates = _bbox_clipped_candidates(aper, UNIT_SHAPE)
+        gated = aper._resolve_outside_weights(UNIT_SHAPE, method='exact',
                                               subpixels=5,
                                               candidates=candidates)
-        brute = _bruteforce_outside_weights(aper, SHAPE, method='exact',
+        brute = _bruteforce_outside_weights(aper, UNIT_SHAPE, method='exact',
                                             subpixels=5, candidates=candidates)
 
         # The gated path returns the candidates unchanged.
@@ -592,8 +585,8 @@ class TestResolveOutsideWeights:
         candidates array.
         """
         aper = CircularAperture([(0.0, 12.0), (12.0, 12.0)], r=3.0)
-        candidates = _bbox_clipped_candidates(aper, SHAPE)
-        w_out = aper._resolve_outside_weights(SHAPE, method='exact',
+        candidates = _bbox_clipped_candidates(aper, UNIT_SHAPE)
+        w_out = aper._resolve_outside_weights(UNIT_SHAPE, method='exact',
                                               subpixels=5,
                                               candidates=candidates)
         assert w_out is not candidates

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -11,7 +11,8 @@ from numpy.testing import assert_allclose, assert_array_equal
 from photutils.aperture import (APERTURE_FLAGS, AperturePhotometry,
                                 ApertureStats, CircularAnnulus,
                                 CircularAperture, EllipticalAperture,
-                                PolygonAperture, RectangularAperture)
+                                PolygonAperture, RectangularAperture,
+                                aperture_photometry)
 from photutils.aperture.flags import _counts_to_flag_bits
 
 SHAPE = (25, 25)
@@ -470,9 +471,10 @@ class TestFlagsAPI:
         assert flags == (APERTURE_FLAGS.PARTIAL_OVERLAP
                          | APERTURE_FLAGS.MASKED_PIXELS)
 
-    def test_legacy_function_has_no_flags(self, unit_data):
+    def test_flags_multiple_apertures(self, unit_data):
         """
-        Test the AperturePhotometry flags.
+        Test the AperturePhotometry flags for multiple positions and a
+        list of apertures (2D flags).
         """
         data = unit_data
         xy = [(12.0, 12.0), (-50.0, 12.0), (0.0, 12.0)]
@@ -487,6 +489,17 @@ class TestFlagsAPI:
         phot = AperturePhotometry(data, [aper, aper2])
         assert_array_equal(phot.flags[:, 0], expected)
         assert_array_equal(phot.flags[:, 1], expected)
+
+    def test_legacy_function_has_no_flags(self, unit_data):
+        """
+        Test that the legacy aperture_photometry function output table
+        contains no flags or area columns.
+        """
+        xy = [(12.0, 12.0), (0.0, 12.0)]
+        aper = CircularAperture(xy, r=3.0)
+        tbl = aperture_photometry(unit_data, aper)
+        assert tbl.colnames == ['id', 'x_center', 'y_center',
+                                'aperture_sum']
 
     def test_flags_with_units(self):
         """

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -884,26 +884,27 @@ class TestRegularPolygon:
 
         match = 'must be at least 2'
         with pytest.raises(ValueError, match=match):
-            PolygonAperture._from_star(xypos, 1, 5.0, 2.0)
+            PolygonAperture._from_star(xypos, 1, 5.0, inner_radius=2.0)
 
         match = 'must be a finite positive number'
         with pytest.raises(ValueError, match=match):
-            PolygonAperture._from_star(xypos, 5, -2.0, 2.0)
+            PolygonAperture._from_star(xypos, 5, -2.0, inner_radius=2.0)
         with pytest.raises(ValueError, match=match):
-            PolygonAperture._from_star(xypos, 5, 5.0, -2.0)
+            PolygonAperture._from_star(xypos, 5, 5.0, inner_radius=-2.0)
 
         match = 'inner_radius must be less than outer_radius'
         with pytest.raises(ValueError, match=match):
-            PolygonAperture._from_star(xypos, 5, 5.0, 6.0)
+            PolygonAperture._from_star(xypos, 5, 5.0, inner_radius=6.0)
 
         match = 'optimal_shape and collinear_edges cannot both be True'
         with pytest.raises(ValueError, match=match):
-            PolygonAperture._from_star(xypos, 5, 5.0, 2.0, optimal_shape=True,
+            PolygonAperture._from_star(xypos, 5, 5.0, inner_radius=2.0,
+                                       optimal_shape=True,
                                        collinear_edges=True)
 
         match = 'collinear_edges requires n_spikes'
         with pytest.raises(ValueError, match=match):
-            PolygonAperture._from_star(xypos, 4, 3.0, 2.0,
+            PolygonAperture._from_star(xypos, 4, 3.0, inner_radius=2.0,
                                        collinear_edges=True)
 
         match = 'inner_radius must be provided'
@@ -914,12 +915,13 @@ class TestRegularPolygon:
         outer_radius = 5.0
         inner_radius = 2.0
         aper = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
-                                          inner_radius)
+                                          inner_radius=inner_radius)
         phot = AperturePhotometry(data, aper, method='exact')
         assert_allclose(phot.flux, aper.area)
 
         aper1 = PolygonAperture._from_star(xypos, n_spikes, outer_radius,
-                                           inner_radius, theta=10 * u.deg)
+                                           inner_radius=inner_radius,
+                                           theta=10 * u.deg)
         phot = AperturePhotometry(data, aper1, method='exact')
         assert_allclose(phot.flux, aper1.area)
 

--- a/photutils/aperture/tests/test_rectangle.py
+++ b/photutils/aperture/tests/test_rectangle.py
@@ -17,7 +17,7 @@ from photutils.aperture.rectangle import (RectangularAnnulus,
                                           SkyRectangularAnnulus,
                                           SkyRectangularAperture)
 from photutils.aperture.tests.test_aperture_common import (
-    BaseTestAperture, BaseTestRotatedPixelAperture)
+    BaseTestAnnulusMutation, BaseTestAperture, BaseTestRotatedPixelAperture)
 
 POSITIONS = [(10, 20), (30, 40), (50, 60), (70, 80)]
 RA, DEC = np.transpose(POSITIONS)
@@ -43,7 +43,8 @@ class TestRectangularAperture(BaseTestRotatedPixelAperture):
             RectangularAperture(POSITIONS, w=10.0, h=radius, theta=np.pi / 2.0)
 
 
-class TestRectangularAnnulus(BaseTestRotatedPixelAperture):
+class TestRectangularAnnulus(BaseTestAnnulusMutation,
+                             BaseTestRotatedPixelAperture):
     aperture = RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=17,
                                   theta=np.pi / 3)
     copy_param = 'w_in'
@@ -57,7 +58,7 @@ class TestRectangularAnnulus(BaseTestRotatedPixelAperture):
             RectangularAnnulus(POSITIONS, w_in=radius, w_out=20.0, h_out=17,
                                theta=np.pi / 3)
 
-        match = "'w_out' must be greater than 'w_in'"
+        match = "'w_out' must be a positive scalar"
         with pytest.raises(ValueError, match=match):
             RectangularAnnulus(POSITIONS, w_in=10.0, w_out=radius, h_out=17,
                                theta=np.pi / 3)
@@ -81,6 +82,15 @@ class TestRectangularAnnulus(BaseTestRotatedPixelAperture):
             RectangularAnnulus(POSITIONS, w_in=10.0, w_out=20.0, h_out=5.0,
                                h_in=8.0, theta=np.pi / 3)
 
+    def test_w_in_greater_than_w_out(self):
+        """
+        Test that a ValueError is raised when w_in >= w_out.
+        """
+        match = "'w_out' must be greater than 'w_in'"
+        with pytest.raises(ValueError, match=match):
+            RectangularAnnulus(POSITIONS, w_in=10.0, w_out=8.0, h_out=5.0,
+                               theta=np.pi / 3)
+
 
 class TestSkyRectangularAperture(BaseTestAperture):
     aperture = SkyRectangularAperture(SKYCOORD, w=10.0 * UNIT, h=5.0 * UNIT,
@@ -102,7 +112,7 @@ class TestSkyRectangularAperture(BaseTestAperture):
                                    theta=30 * u.deg)
 
 
-class TestSkyRectangularAnnulus(BaseTestAperture):
+class TestSkyRectangularAnnulus(BaseTestAnnulusMutation, BaseTestAperture):
     aperture = SkyRectangularAnnulus(SKYCOORD, w_in=10.0 * UNIT,
                                      w_out=20.0 * UNIT, h_out=17.0 * UNIT,
                                      theta=60 * u.deg)
@@ -118,7 +128,7 @@ class TestSkyRectangularAnnulus(BaseTestAperture):
                                   w_out=20.0 * UNIT, h_out=17.0 * UNIT,
                                   theta=60 * u.deg)
 
-        match = "'w_out' must be greater than 'w_in'"
+        match = "'w_out' must be greater than zero"
         with pytest.raises(ValueError, match=match):
             SkyRectangularAnnulus(SKYCOORD, w_in=10.0 * UNIT,
                                   w_out=radius * UNIT, h_out=17.0 * UNIT,
@@ -145,6 +155,16 @@ class TestSkyRectangularAnnulus(BaseTestAperture):
             SkyRectangularAnnulus(SKYCOORD, w_in=10.0 * UNIT,
                                   w_out=20.0 * UNIT, h_out=5.0 * UNIT,
                                   h_in=8.0 * UNIT, theta=60 * u.deg)
+
+    def test_w_in_greater_than_w_out(self):
+        """
+        Test that a ValueError is raised when w_in >= w_out.
+        """
+        match = "'w_out' must be greater than 'w_in'"
+        with pytest.raises(ValueError, match=match):
+            SkyRectangularAnnulus(SKYCOORD, w_in=10.0 * UNIT,
+                                  w_out=8.0 * UNIT, h_out=5.0 * UNIT,
+                                  theta=60 * u.deg)
 
 
 class TestThetaQuantity:

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -97,6 +97,13 @@ class TestProcessSegmentationInputs:
             process_segmentation_inputs(segm, [1, 2], 'mask', [(21, 21)],
                                         data.shape)
 
+    def test_labels_not_1d(self):
+        data, segm = make_scene()
+        match = 'labels must be a 1D array'
+        with pytest.raises(ValueError, match=match):
+            process_segmentation_inputs(segm, [[1, 2]], 'mask', [(21, 21)],
+                                        data.shape)
+
     def test_labels_required(self):
         data, segm = make_scene()
         match = 'labels must be input when segmentation_image is input'

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -15,26 +15,8 @@ from photutils.aperture._segmentation import (make_segmentation_exclusion,
 from photutils.aperture.circle import CircularAperture
 from photutils.aperture.photometry import AperturePhotometry
 from photutils.aperture.stats import ApertureStats
+from photutils.aperture.tests.conftest import make_scene
 from photutils.segmentation import SegmentationImage
-
-
-def make_scene():
-    """
-    Build a deterministic scene with a target source (label 1) and a
-    bright neighbor source (label 2), on a nonzero background.
-    """
-    data = np.ones((50, 50))
-    segm = np.zeros((50, 50), dtype=int)
-
-    # Target source (label 1)
-    data[18:25, 18:25] = 10.0
-    segm[18:25, 18:25] = 1
-
-    # Bright neighbor source (label 2)
-    data[20:25, 26:32] = 100.0
-    segm[20:25, 26:32] = 2
-
-    return data, segm
 
 
 class TestProcessSegmentationInputs:

--- a/photutils/aperture/tests/test_segmentation_masking.py
+++ b/photutils/aperture/tests/test_segmentation_masking.py
@@ -6,7 +6,7 @@ Tests for segmentation-based masking of aperture photometry, shared by
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from photutils.aperture._batch_photometry import (SHAPE_CIRCLE,
                                                   batch_aperture_sums)
@@ -186,18 +186,18 @@ class TestMakeSegmentationExclusion:
         segm = np.array([[0, 1], [2, 1]])
         _, _, exclude, affected = make_segmentation_exclusion('mask', segm, 1)
         expected = np.array([[False, False], [True, False]])
-        assert_allclose(exclude, expected)
-        assert_allclose(affected, expected)
+        assert_array_equal(exclude, expected)
+        assert_array_equal(affected, expected)
 
     def test_source_only_method(self):
         segm = np.array([[0, 1], [2, 1]])
         _, _, exclude, affected = make_segmentation_exclusion(
             'source_only', segm, 1)
         expected = np.array([[True, False], [True, False]])
-        assert_allclose(exclude, expected)
+        assert_array_equal(exclude, expected)
         # Background exclusions are not marked as affected
         expected_affected = np.array([[False, False], [True, False]])
-        assert_allclose(affected, expected_affected)
+        assert_array_equal(affected, expected_affected)
 
     def test_correct_replaces_neighbor(self):
         # 5x5 cutout, center (2, 2). A neighbor pixel at (1, 2) [x=1, y=2]

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -199,10 +199,15 @@ class TestSumMethod(BaseApertureStatsData):
             if prop in scalar_props:
                 continue
             if 'sum' in prop and prop != 'sum_flags':
-                # Test that these properties are not equal
-                with pytest.raises(AssertionError):
+                # The sum-footprint properties must differ between the
+                # two sum methods
+                equal = True
+                try:
                     assert_equal(getattr(apstats1, prop),
                                  getattr(apstats2, prop))
+                except AssertionError:
+                    equal = False
+                assert not equal, f'{prop} is unexpectedly equal'
             else:
                 assert_equal(getattr(apstats1, prop), getattr(apstats2, prop))
 
@@ -324,6 +329,29 @@ class TestMasking(BaseApertureStatsData):
         with pytest.raises(ValueError, match=match):
             _ = ApertureStats(data, self.aperture[0:2],
                               local_bkg=np.ones((3, 3)))
+
+    def test_local_bkg_units(self):
+        """
+        Test that local_bkg must carry the same units as a Quantity
+        ``data`` input and that the results match the unitless case.
+        """
+        unit = u.Jy
+        data = np.ones(self.data.shape) * 100.0
+        local_bkg = (10, 20, 30)
+        apstats1 = ApertureStats(data << unit, self.aperture,
+                                 local_bkg=local_bkg * unit)
+        apstats2 = ApertureStats(data, self.aperture, local_bkg=local_bkg)
+        assert apstats1.sum.unit == unit
+        assert_allclose(apstats1.sum.value, apstats2.sum)
+
+        match = 'must all have the same units'
+        with pytest.raises(ValueError, match=match):
+            ApertureStats(data << unit, self.aperture, local_bkg=local_bkg)
+        with pytest.raises(ValueError, match=match):
+            ApertureStats(data << unit, self.aperture,
+                          local_bkg=local_bkg * u.mJy)
+        with pytest.raises(ValueError, match=match):
+            ApertureStats(data, self.aperture, local_bkg=local_bkg * unit)
 
     def test_no_aperture_overlap(self):
         aperture = CircularAperture(((0, 0), (100, 100), (-100, -100)), r=5)

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -92,7 +92,7 @@ class TestProperties(BaseApertureStatsData):
 
         idx = 1
 
-        scalar_props = ('isscalar', 'n_apertures')
+        scalar_props = ('isscalar', 'n_positions')
 
         # Evaluate (cache) properties before slice
         for prop in apstats1.properties:
@@ -192,7 +192,7 @@ class TestSumMethod(BaseApertureStatsData):
         apstats2 = ApertureStats(self.data, self.aperture, error=self.error,
                                  sum_method=sum_method, subpixels=4)
 
-        scalar_props = ('isscalar', 'n_apertures')
+        scalar_props = ('isscalar', 'n_positions')
 
         # Evaluate (cache) properties before slice
         for prop in apstats1.properties:
@@ -272,7 +272,7 @@ class TestMasking(BaseApertureStatsData):
         assert apstats[1].sum < self.apstats1[1].sum
         assert apstats[1].sum_err < self.apstats1[1].sum_err
 
-        exclude = ('isscalar', 'n_apertures', 'sky_centroid',
+        exclude = ('isscalar', 'n_positions', 'sky_centroid',
                    'sky_centroid_icrs', 'flags', 'sum_flags')
         apstats1 = apstats[2]
         for prop in apstats1.properties:
@@ -330,7 +330,7 @@ class TestMasking(BaseApertureStatsData):
         apstats = ApertureStats(self.data, aperture)
         assert_equal(apstats._overlap, [True, True, False])
 
-        exclude = ('isscalar', 'n_apertures', 'sky_centroid',
+        exclude = ('isscalar', 'n_positions', 'sky_centroid',
                    'sky_centroid_icrs', 'flags', 'sum_flags')
         apstats1 = apstats[2]
         for prop in apstats1.properties:
@@ -366,7 +366,7 @@ class TestTable(BaseApertureStatsData):
     @pytest.mark.parametrize('columns', ['invalid',
                                          'sum_method',
                                          'isscalar',
-                                         'n_apertures',
+                                         'n_positions',
                                          ['id', 'subpixels']])
     def test_invalid_column(self, columns):
         match = 'Invalid column name'
@@ -375,13 +375,13 @@ class TestTable(BaseApertureStatsData):
 
     def test_properties_excludes_scalar_attrs(self):
         """
-        Regression test to ensure that ``isscalar`` and ``n_apertures``
+        Regression test to ensure that ``isscalar`` and ``n_positions``
         (scalar values for the whole object, not per-source values) are
         not included in ``properties`` and so are not valid ``to_table``
         columns.
         """
         assert 'isscalar' not in self.apstats1.properties
-        assert 'n_apertures' not in self.apstats1.properties
+        assert 'n_positions' not in self.apstats1.properties
 
     def test_deprecated_column(self):
         """
@@ -404,10 +404,10 @@ class TestIndexing(BaseApertureStatsData):
         apstats = self.apstats1
         _ = apstats.to_table()
         apstat0 = apstats[1]
-        assert apstat0.n_apertures == 1
+        assert apstat0.n_positions == 1
         assert apstat0.id == np.array([2])
         apstat1 = apstats.select_id(2)
-        assert apstat1.n_apertures == 1
+        assert apstat1.n_positions == 1
         assert apstat0.sum_aper_area == apstat1.sum_aper_area
 
         apstat0 = apstats[0:1]
@@ -466,7 +466,7 @@ class TestIndexing(BaseApertureStatsData):
 
     def test_scalar_aperture_stats(self):
         apstats = self.apstats1[0]
-        assert apstats.n_apertures == 1
+        assert apstats.n_positions == 1
         assert apstats.id == np.array([1])
         tbl = apstats.to_table()
         assert len(tbl) == 1
@@ -508,7 +508,7 @@ class TestIndexing(BaseApertureStatsData):
         the parent, slices to a scalar, and checks that every property
         matches the same scalar computed from scratch.
         """
-        scalar_props = ('isscalar', 'n_apertures')
+        scalar_props = ('isscalar', 'n_positions')
 
         # Reference scalar instance that recomputes every property from
         # scratch (nothing cached on the parent before slicing).
@@ -577,6 +577,17 @@ class TestDeprecations(BaseApertureStatsData):
         scalar = apstats[0]
         with pytest.warns(AstropyDeprecationWarning, match=match):
             assert scalar.ids == scalar.id
+
+    def test_deprecated_n_apertures(self):
+        """
+        Test that the ``n_apertures`` attribute is deprecated and
+        returns the same value as the ``n_positions`` attribute.
+        """
+        apstats = ApertureStats(self.data, self.aperture)
+        match = 'deprecated in version 3.1'
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            old_val = apstats.n_apertures
+        assert old_val == apstats.n_positions
 
 
 class TestInputValidation(BaseApertureStatsData):

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -16,6 +16,7 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture.circle import CircularAnnulus, CircularAperture
+from photutils.aperture.core import _enable_batch_photometry
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
                                         SkyEllipticalAnnulus)
 from photutils.aperture.flags import APERTURE_FLAGS
@@ -29,17 +30,18 @@ from photutils.utils._optional_deps import HAS_REGIONS
 
 class _NoBatchCircular(CircularAperture):
     """
-    A `CircularAperture` subclass that does not define the
-    ``_batch_shape_params`` hook in its own class, so the fast batch
-    driver is not used and the mask-based code path is exercised.
+    A `CircularAperture` subclass that is not decorated with
+    ``_enable_batch_photometry``, so the fast batch driver is not used
+    and the mask-based code path is exercised.
     """
 
 
+@_enable_batch_photometry
 class _NoneSpecCircular(CircularAperture):
     """
-    A `CircularAperture` subclass that defines the ``_batch_shape_params``
-    hook in its own class but returns `None`, so the fast batch driver is
-    not used and the mask-based code path is exercised.
+    A `CircularAperture` subclass that opts in to the fast batch driver
+    but whose ``_batch_shape_params`` hook returns `None`, so the batch
+    driver is not used and the mask-based code path is exercised.
     """
 
     def _batch_shape_params(self):

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -24,16 +24,9 @@ from photutils.aperture.photometry import AperturePhotometry
 from photutils.aperture.rectangle import (RectangularAnnulus,
                                           RectangularAperture)
 from photutils.aperture.stats import _MAD_STD_SCALE, ApertureStats
+from photutils.aperture.tests.conftest import NoBatchCircularAperture
 from photutils.datasets import make_100gaussians_image, make_wcs
 from photutils.utils._optional_deps import HAS_REGIONS
-
-
-class _NoBatchCircular(CircularAperture):
-    """
-    A `CircularAperture` subclass that is not decorated with
-    ``_enable_batch_photometry``, so the fast batch driver is not used
-    and the mask-based code path is exercised.
-    """
 
 
 @_enable_batch_photometry
@@ -48,31 +41,49 @@ class _NoneSpecCircular(CircularAperture):
         return None
 
 
+@pytest.fixture(scope='class')
+def stats_data(request):
+    """
+    Build the shared data and ApertureStats objects on the test class.
+    """
+    cls = request.cls
+    cls.data = make_100gaussians_image()
+    cls.error = np.sqrt(np.abs(cls.data))
+    cls.wcs = make_wcs(cls.data.shape)
+    cls.positions = ((145.1, 168.3), (84.7, 224.1), (48.3, 200.3))
+    cls.aperture = CircularAperture(cls.positions, r=5)
+
+    cls.sigclip = SigmaClip(sigma=3.0, maxiters=10)
+    cls.apstats1 = ApertureStats(cls.data, cls.aperture,
+                                 error=cls.error, wcs=cls.wcs,
+                                 sigma_clip=None)
+    cls.apstats2 = ApertureStats(cls.data, cls.aperture,
+                                 error=cls.error, wcs=cls.wcs,
+                                 sigma_clip=cls.sigclip)
+
+    cls.unit = u.Jy
+    cls.apstats1_units = ApertureStats(cls.data * cls.unit,
+                                       cls.aperture,
+                                       error=cls.error * cls.unit,
+                                       wcs=cls.wcs, sigma_clip=None)
+    cls.apstats2_units = ApertureStats(cls.data * cls.unit,
+                                       cls.aperture,
+                                       error=cls.error * cls.unit,
+                                       wcs=cls.wcs,
+                                       sigma_clip=cls.sigclip)
+
+
+@pytest.mark.usefixtures('stats_data')
 class BaseApertureStatsData:
     """
     Shared data, aperture, and ApertureStats objects used by the
     ApertureStats test classes below.
+
+    The ``stats_data`` fixture builds the objects once per test class
+    rather than at import time, so collection stays cheap and each test
+    class gets its own instances (no lazyproperty-cache state is shared
+    across classes).
     """
-
-    data = make_100gaussians_image()
-    error = np.sqrt(np.abs(data))
-    wcs = make_wcs(data.shape)
-    positions = ((145.1, 168.3), (84.7, 224.1), (48.3, 200.3))
-    aperture = CircularAperture(positions, r=5)
-
-    sigclip = SigmaClip(sigma=3.0, maxiters=10)
-    apstats1 = ApertureStats(data, aperture, error=error, wcs=wcs,
-                             sigma_clip=None)
-    apstats2 = ApertureStats(data, aperture, error=error, wcs=wcs,
-                             sigma_clip=sigclip)
-
-    unit = u.Jy
-    apstats1_units = ApertureStats(data * u.Jy, aperture,
-                                   error=error * u.Jy, wcs=wcs,
-                                   sigma_clip=None)
-    apstats2_units = ApertureStats(data * u.Jy, aperture,
-                                   error=error * u.Jy, wcs=wcs,
-                                   sigma_clip=sigclip)
 
 
 class TestProperties(BaseApertureStatsData):
@@ -789,7 +800,7 @@ class TestMaskPathParity(BaseApertureStatsData):
         path and give the same results as the fast path.
         """
         nohook = ApertureStats(self.data,
-                               _NoBatchCircular(self.positions, r=5))
+                               NoBatchCircularAperture(self.positions, r=5))
         nospec = ApertureStats(self.data,
                                _NoneSpecCircular(self.positions, r=5))
         assert nohook._fast_gather is None
@@ -826,7 +837,7 @@ class TestMaskPathParity(BaseApertureStatsData):
             error = error * self.unit
         fast = ApertureStats(data, CircularAperture(positions, r=5),
                              error=error, sum_method=sum_method)
-        slow = ApertureStats(data, _NoBatchCircular(positions, r=5),
+        slow = ApertureStats(data, NoBatchCircularAperture(positions, r=5),
                              error=error, sum_method=sum_method)
         assert fast._fast_gather is not None
         assert slow._fast_gather is None
@@ -847,7 +858,7 @@ class TestMaskPathParity(BaseApertureStatsData):
         helpers.
         """
         slow = ApertureStats(self.data,
-                             _NoBatchCircular(self.positions[0], r=5),
+                             NoBatchCircularAperture(self.positions[0], r=5),
                              error=self.error)
         fast = ApertureStats(self.data,
                              CircularAperture(self.positions[0], r=5),
@@ -876,7 +887,7 @@ class TestMaskPathParity(BaseApertureStatsData):
                   'mask_method': 'mask'}
         fast = ApertureStats(data, CircularAperture(positions, r=6),
                              **kwargs)
-        slow = ApertureStats(data, _NoBatchCircular(positions, r=6),
+        slow = ApertureStats(data, NoBatchCircularAperture(positions, r=6),
                              **kwargs)
         assert slow._fast_gather is None
         for prop in ('sum', 'mean', 'median', 'std', 'mean_err',
@@ -893,7 +904,8 @@ class TestMaskPathParity(BaseApertureStatsData):
         mask = rng.random(self.data.shape) > 0.7
         fast = ApertureStats(self.data, CircularAperture(self.positions, r=5),
                              error=self.error, mask=mask)
-        slow = ApertureStats(self.data, _NoBatchCircular(self.positions, r=5),
+        slow_aper = NoBatchCircularAperture(self.positions, r=5)
+        slow = ApertureStats(self.data, slow_aper,
                              error=self.error, mask=mask)
         assert slow._fast_gather is None
         for prop in ('sum', 'mean', 'median', 'std', 'mean_err',
@@ -915,7 +927,8 @@ class TestMaskPathParity(BaseApertureStatsData):
         fast = ApertureStats(data, CircularAperture(self.positions, r=5),
                              error=self.error, mask=mask)
         assert fast._batch_inputs is not None
-        slow = ApertureStats(data, _NoBatchCircular(self.positions, r=5),
+        slow_aper = NoBatchCircularAperture(self.positions, r=5)
+        slow = ApertureStats(data, slow_aper,
                              error=self.error, mask=mask)
         assert slow._fast_gather is None
         for prop in ('sum', 'mean', 'median', 'std', 'mean_err',
@@ -1005,8 +1018,8 @@ class TestDdof(BaseApertureStatsData):
         """
         fast = ApertureStats(self.data, CircularAperture(self.positions, r=5),
                              ddof=1)
-        slow = ApertureStats(self.data, _NoBatchCircular(self.positions, r=5),
-                             ddof=1)
+        slow_aper = NoBatchCircularAperture(self.positions, r=5)
+        slow = ApertureStats(self.data, slow_aper, ddof=1)
         assert slow._fast_gather is None
         assert_allclose(fast.var, slow.var, equal_nan=True)
         assert_allclose(fast.std, slow.std, equal_nan=True)

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -115,7 +115,7 @@ class TestProperties(BaseApertureStatsData):
         skyaper = self.aperture.to_sky(self.wcs)
         sky_apstats = ApertureStats(self.data, skyaper, wcs=self.wcs)
 
-        exclude_props = ('bbox', 'error_sum_cutout', 'sum_error',
+        exclude_props = ('bbox', 'error_sum_cutout', 'sum_err',
                          'sky_centroid', 'sky_centroid_icrs')
         for prop in pix_apstats.properties:
             if prop in exclude_props:

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -11,8 +11,7 @@ from astropy.stats import SigmaClip
 from numpy.testing import assert_array_equal
 
 from photutils.aperture import APERTURE_FLAGS, ApertureStats, CircularAperture
-
-SHAPE = (25, 25)
+from photutils.aperture.tests.conftest import UNIT_SHAPE
 
 
 def _stats_flags(data, aperture, **kwargs):
@@ -44,7 +43,7 @@ def _single_pixel_data():
     Return data with a single bright pixel, giving a source whose
     covariance matrix is singular (zero spatial extent).
     """
-    data = np.zeros(SHAPE)
+    data = np.zeros(UNIT_SHAPE)
     data[12, 12] = 100.0
     return data
 
@@ -129,18 +128,18 @@ class TestMaskedAndNonFiniteFlags:
         data = unit_data
         aper = CircularAperture((12, 12), r=3.0)
 
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = np.zeros(UNIT_SHAPE, dtype=bool)
         mask[12, 12] = True
         assert _stats_flags(data, aper,
                             mask=mask) == APERTURE_FLAGS.MASKED_PIXELS
 
         # Masked pixel inside the bounding box but outside the aperture
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = np.zeros(UNIT_SHAPE, dtype=bool)
         mask[9, 9] = True
         assert _stats_flags(data, aper, mask=mask) == 0
 
         # Fully masked aperture
-        mask = np.zeros(SHAPE, dtype=bool)
+        mask = np.zeros(UNIT_SHAPE, dtype=bool)
         mask[8:17, 8:17] = True
         assert _stats_flags(data, aper, mask=mask) == (
             APERTURE_FLAGS.MASKED_PIXELS | APERTURE_FLAGS.ALL_MASKED)
@@ -174,19 +173,19 @@ class TestMaskedAndNonFiniteFlags:
         so they contribute to all_masked (but not to masked_pixels, which
         reflects only the input mask).
         """
-        data = np.ones(SHAPE)
+        data = np.ones(UNIT_SHAPE)
         data[12, 12] = np.nan
         aper = CircularAperture((12, 12), r=3.0)
         assert _stats_flags(data, aper) == APERTURE_FLAGS.NON_FINITE_DATA
 
         # All-NaN aperture: auto-masked, so also all_masked
-        data = np.full(SHAPE, np.nan)
+        data = np.full(UNIT_SHAPE, np.nan)
         assert _stats_flags(data, aper) == (APERTURE_FLAGS.NON_FINITE_DATA
                                             | APERTURE_FLAGS.ALL_MASKED)
 
         # A pixel that is both input-masked and non-finite counts only as
         # masked
-        data = np.ones(SHAPE)
+        data = np.ones(UNIT_SHAPE)
         data[12, 12] = np.nan
         mask = unit_mask
         mask[12, 12] = True
@@ -199,7 +198,7 @@ class TestMaskedAndNonFiniteFlags:
         Test the non_finite_error flag (evaluated on the sum footprint).
         """
         data = unit_data
-        error = np.ones(SHAPE)
+        error = np.ones(UNIT_SHAPE)
         error[12, 12] = np.nan
         aper = CircularAperture((12, 12), r=3.0)
         stats = ApertureStats(data, aper, error=error)
@@ -221,7 +220,7 @@ class TestSigmaClipFlags:
         Test the sigma_clipped flag.
         """
         rng = np.random.default_rng(0)
-        data = rng.normal(1.0, 0.1, size=SHAPE)
+        data = rng.normal(1.0, 0.1, size=UNIT_SHAPE)
         data[12, 12] = 1000.0  # outlier
         aper = CircularAperture((12, 12), r=3.0)
         sigclip = SigmaClip(sigma=3.0, maxiters=10)
@@ -285,7 +284,7 @@ class TestSegmentationFlags:
         Test the neighbor_pixels flag for all segmentation mask methods.
         """
         data = unit_data
-        segm = np.zeros(SHAPE, dtype=int)
+        segm = np.zeros(UNIT_SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2  # neighbor pixel inside the aperture
         aper = CircularAperture((12, 12), r=3.0)
@@ -299,7 +298,7 @@ class TestSegmentationFlags:
         Test the uncorrected_pixels flag with mask_method='correct'.
         """
         data = unit_data
-        segm = np.zeros(SHAPE, dtype=int)
+        segm = np.zeros(UNIT_SHAPE, dtype=int)
         segm[10:15, 10:15] = 1
         segm[12, 14] = 2
         segm[12, 10] = 2  # the mirror is also a neighbor: uncorrectable
@@ -322,10 +321,10 @@ class TestMaskPathParity:
         identical flags for a mix of conditions.
         """
         rng = np.random.default_rng(1)
-        data = rng.normal(1.0, 0.1, size=SHAPE)
+        data = rng.normal(1.0, 0.1, size=UNIT_SHAPE)
         data[13, 12] = np.nan
         data[5, 5] = 100.0  # sigma-clip outlier
-        error = np.ones(SHAPE)
+        error = np.ones(UNIT_SHAPE)
         error[10, 12] = np.inf
         mask = unit_mask
         mask[12, 12] = True

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -598,3 +598,135 @@ class TestSingularCovariance:
 
         _ = stats.semimajor_axis
         assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
+
+
+class TestUndefinedShape:
+    """
+    Tests for the undefined_shape flag, which marks sources whose net
+    flux is not positive and is set only once a moment-derived property
+    has been computed.
+    """
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_requires_moments(self):
+        """
+        Test that the undefined_shape bit is not set until a
+        moment-derived property is accessed.
+        """
+        data = np.zeros(UNIT_SHAPE)
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+
+        # Not set before any moment-derived property is accessed
+        assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) == 0
+        assert 'undefined_shape' not in stats.decode_flags()[0]
+
+        # Accessing the centroid makes a reread include the bit
+        _ = stats.centroid
+        assert np.all(np.isnan(stats.centroid))
+        assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
+        assert 'undefined_shape' in stats.decode_flags()[0]
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    @pytest.mark.parametrize('value', [0.0, -1.0])
+    def test_non_positive_flux(self, value):
+        """
+        Test that both zero and negative net flux set the
+        undefined_shape bit.
+        """
+        data = np.full(UNIT_SHAPE, value)
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        _ = stats.centroid
+        assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_positive_flux_not_flagged(self):
+        """
+        Test that a source with positive net flux is not flagged.
+        """
+        data = np.ones(UNIT_SHAPE)
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        _ = stats.centroid
+        assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) == 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_array_and_guards(self):
+        """
+        Test the undefined_shape bit for an array of sources, and that
+        sources with no valid pixels (no overlap or fully masked) are
+        not flagged (they are reported by the overlap and masking
+        bits).
+        """
+        data = np.zeros(UNIT_SHAPE)
+        data[16:21, 16:21] = 50.0  # positive-flux source at (18, 18)
+        mask = np.zeros(UNIT_SHAPE, dtype=bool)
+        mask[0:12, 0:12] = True  # fully mask the third aperture
+        aper = CircularAperture([(6.0, 18.0), (18.0, 18.0), (6.0, 6.0),
+                                 (-50.0, 12.0)], r=4.0)
+        stats = ApertureStats(data, aper, mask=mask)
+        _ = stats.centroid
+        flags = stats.flags
+        shape_flag = APERTURE_FLAGS.UNDEFINED_SHAPE
+        assert (flags[0] & shape_flag) != 0  # zero-flux source
+        assert (flags[1] & shape_flag) == 0  # positive-flux source
+        assert (flags[2] & shape_flag) == 0  # fully masked: not flagged
+        assert (flags[2] & APERTURE_FLAGS.ALL_MASKED) != 0
+        assert (flags[3] & shape_flag) == 0  # no overlap: not flagged
+        assert (flags[3] & APERTURE_FLAGS.NO_OVERLAP) != 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_in_default_table(self):
+        """
+        Test that the undefined_shape bit is reflected in the default
+        to_table() output, which evaluates the moment-derived columns.
+        """
+        data = np.zeros(UNIT_SHAPE)
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        tbl = stats.to_table()
+        assert (tbl['flags'][0] & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_to_table_flags_only_no_shape_bit(self):
+        """
+        Test that requesting only the 'flags' column does not trigger
+        the moments computation and so does not set the undefined_shape
+        bit.
+        """
+        data = np.zeros(UNIT_SHAPE)
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        tbl = stats.to_table(columns=['flags'])
+        assert (tbl['flags'][0] & APERTURE_FLAGS.UNDEFINED_SHAPE) == 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_slicing(self):
+        """
+        Test that the undefined_shape bit is preserved when slicing an
+        ApertureStats object.
+        """
+        data = np.zeros(UNIT_SHAPE)
+        data[18, 18] = 100.0
+        aper = CircularAperture([(6.0, 6.0), (18.0, 18.0)], r=4.0)
+        stats = ApertureStats(data, aper)
+        _ = stats.centroid
+        shape_flag = APERTURE_FLAGS.UNDEFINED_SHAPE
+        assert (stats[0].flags & shape_flag) != 0
+        assert (stats[1].flags & shape_flag) == 0
+
+    @pytest.mark.usefixtures('maybe_mask_path')
+    def test_with_singular_covariance(self):
+        """
+        Test that a single negative pixel sets both the undefined_shape
+        and singular_covariance bits once the covariance is computed.
+        """
+        data = np.zeros(UNIT_SHAPE)
+        data[12, 12] = -100.0
+        aper = CircularAperture((12.0, 12.0), r=5.0)
+        stats = ApertureStats(data, aper)
+        _ = stats.semimajor_axis
+        flags = stats.flags
+        assert (flags & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
+        assert (flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0


### PR DESCRIPTION
This PR is a broad cleanup pass over `photutils.aperture`, covering input validation, API consistency, internal simplification, and test coverage. No changes to photometry or statistics results other than the bug fix noted below.

### Bug fixes
- Annulus apertures now validate the inner < outer invariant when a shape
  parameter is reassigned after construction, not just at construction.

### API changes
- `ApertureStats.n_apertures` is deprecated in favor of `n_positions`, which
  matches `AperturePhotometry.n_positions`.
- `PixelAperture.plot` now returns a list of patches for scalar apertures, as
  documented, instead of a tuple.
- Added an `undefined_shape` quality flag to `ApertureStats` for sources with
  non-positive net flux (affects dev version only)
- Photometry/stats inputs are validated earlier with clearer error messages.
- The aperture mask mixin classes are scheduled for removal in 3.2.