### PR TITLE
Add multithreading to Background2D and fix background bugs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,13 @@ New Features
   - Added validation of the ``ApertureStats.to_table()`` ``columns``
     keyword. [#2329]
 
+- ``photutils.background``
+
+  - Updated ``LocalBackground`` so that ``Quantity`` input data is
+    supported, consistent with the background estimator classes and
+    ``Background2D``. The result is a ``Quantity`` with the same unit as
+    the input data. [#2363]
+
 - ``photutils.detection``
 
   - Added validation of the ``StarFinderCatalogBase.to_table()``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -210,6 +210,12 @@ Bug Fixes
     pixels was excluded, and ``exclude_percentile=0`` excluded all
     boxes, even fully unmasked ones. [#2363]
 
+  - ``Background2D`` now raises a clear ``TypeError`` if the input
+    ``mask`` or ``coverage_mask`` is not a boolean array. Previously,
+    a non-boolean ``coverage_mask`` raised a cryptic ``IndexError``
+    (or could silently select the wrong pixels) when the background
+    map was computed. [#2363]
+
 - ``photutils.detection``
 
   - Fixed ``DAOStarFinder`` and ``IRAFStarFinder`` ``orientation``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,13 @@ New Features
     ``Background2D``. The result is a ``Quantity`` with the same unit as
     the input data. [#2363]
 
+  - Added an ``n_threads`` keyword to ``Background2D`` to compute the
+    box statistics using multiple threads. The results are identical
+    to the single-threaded computation. The underlying sigma-clipping
+    and statistics kernels release the GIL, so multithreading can
+    significantly speed up the background estimation for large
+    images. [#2363]
+
 - ``photutils.detection``
 
   - Added validation of the ``StarFinderCatalogBase.to_table()``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -194,6 +194,15 @@ Bug Fixes
     shape parameter after construction validates the inner < outer
     invariant. [#2362]
 
+- ``photutils.background``
+
+  - Fixed the ``exclude_percentile`` box-exclusion criterion in
+    ``Background2D`` so that a box is excluded only if more than
+    ``exclude_percentile`` percent of its pixels are masked, as
+    documented. Previously, a box with exactly that percentage of masked
+    pixels was excluded, and ``exclude_percentile=0`` excluded all
+    boxes, even fully unmasked ones. [#2363]
+
 - ``photutils.detection``
 
   - Fixed ``DAOStarFinder`` and ``IRAFStarFinder`` ``orientation``

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,27 @@
+# Photutils Benchmarks
+
+This directory contains standalone benchmark scripts for photutils.
+They are not part of the installed package or the test suite.
+
+## Background (`bench_background.py`)
+
+Benchmarks for the `photutils.background` subpackage:
+
+- `Background2D` construction across image sizes, box sizes, and
+  `n_threads` values (with speedups relative to the first
+  `n_threads` value)
+- full-size background and background RMS map generation
+- the scalar background and background RMS estimator classes, with
+  and without sigma clipping
+- `LocalBackground` at many positions
+
+Examples:
+
+```bash
+# Run everything with the default settings
+python benchmarks/bench_background.py
+
+# Only the Background2D n_threads scaling benchmark
+python benchmarks/bench_background.py --which background2d \
+    --sizes 2048,4096 --box-sizes 64 --n-threads 1,2,4,8
+```

--- a/benchmarks/bench_background.py
+++ b/benchmarks/bench_background.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for the photutils.background subpackage.
+
+The benchmarks cover Background2D construction across image sizes,
+box sizes, and n_threads values; full-size background and background
+RMS map generation; the scalar background and background RMS
+estimator classes; and LocalBackground.
+
+Run ``python benchmarks/bench_background.py --help`` to see the
+available options.
+"""
+
+import argparse
+import os
+import platform
+import sys
+import time
+from functools import partial
+
+import numpy as np
+from astropy.stats import SigmaClip
+
+from photutils.background import (Background2D, BiweightLocationBackground,
+                                  BiweightScaleBackgroundRMS, LocalBackground,
+                                  MADStdBackgroundRMS, MeanBackground,
+                                  MedianBackground, MMMBackground,
+                                  ModeEstimatorBackground,
+                                  SExtractorBackground, StdBackgroundRMS)
+
+ESTIMATOR_CLASSES = [MeanBackground, MedianBackground,
+                     ModeEstimatorBackground, MMMBackground,
+                     SExtractorBackground, BiweightLocationBackground,
+                     StdBackgroundRMS, MADStdBackgroundRMS,
+                     BiweightScaleBackgroundRMS]
+
+
+def time_best(func, *, repeats=3):
+    """
+    Return the best wall-clock time of ``repeats`` calls to ``func``.
+
+    Parameters
+    ----------
+    func : callable
+        The zero-argument callable to time.
+
+    repeats : int, optional
+        The number of times to call ``func``.
+
+    Returns
+    -------
+    result : float
+        The best (minimum) wall-clock time in seconds.
+    """
+    best = np.inf
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        func()
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+def make_image(shape, *, seed=0):
+    """
+    Return a Gaussian-noise image of the given shape.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the output image.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        The noise image.
+    """
+    rng = np.random.default_rng(seed)
+    return rng.normal(100.0, 5.0, shape)
+
+
+def print_environment():
+    """
+    Print information about the runtime environment.
+    """
+    import astropy
+    import scipy
+
+    import photutils
+    from photutils.utils._optional_deps import HAS_BOTTLENECK
+
+    gil = getattr(sys, '_is_gil_enabled', lambda: True)()
+    print(f'python {platform.python_version()} (GIL enabled: {gil}), '
+          f'{os.cpu_count()} CPUs')
+    print(f'photutils {photutils.__version__}, numpy {np.__version__}, '
+          f'scipy {scipy.__version__}, astropy {astropy.__version__}, '
+          f'bottleneck: {HAS_BOTTLENECK}')
+
+
+def bench_background2d(sizes, box_sizes, n_threads_list, *, repeats=3,
+                       seed=0):
+    """
+    Benchmark Background2D construction.
+
+    The construction time is measured for each combination of image
+    size, box size, and number of threads. Speedups are reported
+    relative to the first value in ``n_threads_list``.
+
+    Parameters
+    ----------
+    sizes : list of int
+        The image sizes; each image is ``(size, size)``.
+
+    box_sizes : list of int
+        The box sizes; each box is ``(box_size, box_size)``.
+
+    n_threads_list : list of int
+        The ``n_threads`` values to benchmark.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print('\n== Background2D construction ==')
+    header = f'{"image":>12} {"box":>6}'
+    for n_threads in n_threads_list:
+        header += f'{f"n_threads={n_threads}":>19}'
+    print(header)
+
+    for size in sizes:
+        data = make_image((size, size), seed=seed)
+        for box_size in box_sizes:
+            row = f'{f"{size}x{size}":>12} {box_size:>6}'
+            t_ref = None
+            for n_threads in n_threads_list:
+                func = partial(Background2D, data, box_size,
+                               n_threads=n_threads)
+                t_best = time_best(func, repeats=repeats)
+                if t_ref is None:
+                    t_ref = t_best
+                    cell = f'{t_best:.3f}s'
+                else:
+                    cell = f'{t_best:.3f}s ({t_ref / t_best:.2f}x)'
+                row += f'{cell:>19}'
+            print(row)
+
+
+def bench_maps(sizes, *, box_size=64, repeats=3, seed=0):
+    """
+    Benchmark full-size background and background RMS map generation.
+
+    The ``background`` and ``background_rms`` properties are
+    recalculated on each access, so their cost is paid every time
+    they are used.
+
+    Parameters
+    ----------
+    sizes : list of int
+        The image sizes; each image is ``(size, size)``.
+
+    box_size : int, optional
+        The box size used for the Background2D instance.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print(f'\n== Full-size map generation (box={box_size}) ==')
+    print(f'{"image":>12}{"background":>14}{"background_rms":>17}')
+    for size in sizes:
+        data = make_image((size, size), seed=seed)
+        bkg = Background2D(data, box_size)
+        t_bkg = time_best(partial(getattr, bkg, 'background'),
+                          repeats=repeats)
+        t_rms = time_best(partial(getattr, bkg, 'background_rms'),
+                          repeats=repeats)
+        print(f'{f"{size}x{size}":>12}{f"{t_bkg:.3f}s":>14}'
+              f'{f"{t_rms:.3f}s":>17}')
+
+
+def bench_estimators(*, size=2048, repeats=3, seed=0):
+    """
+    Benchmark the scalar background and background RMS estimators.
+
+    Each estimator is timed on the full image, with and without
+    sigma clipping.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print(f'\n== Scalar estimators ({size}x{size} image) ==')
+    print(f'{"class":>28}{"no clipping":>14}{"sigma clipping":>17}')
+    data = make_image((size, size), seed=seed)
+    for cls in ESTIMATOR_CLASSES:
+        est_noclip = cls(sigma_clip=None)
+        est_clip = cls(sigma_clip=SigmaClip(sigma=3.0, maxiters=10))
+        t_noclip = time_best(partial(est_noclip, data), repeats=repeats)
+        t_clip = time_best(partial(est_clip, data), repeats=repeats)
+        print(f'{cls.__name__:>28}{f"{t_noclip:.3f}s":>14}'
+              f'{f"{t_clip:.3f}s":>17}')
+
+
+def bench_local_background(*, size=2048, n_positions=1000, repeats=3,
+                           seed=0):
+    """
+    Benchmark LocalBackground at many positions.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    n_positions : int, optional
+        The number of aperture positions.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print(f'\n== LocalBackground ({n_positions} positions, '
+          f'{size}x{size} image) ==')
+    data = make_image((size, size), seed=seed)
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(50, size - 50, n_positions)
+    y = rng.uniform(50, size - 50, n_positions)
+    local_bkg = LocalBackground(5, 10)
+    t_local = time_best(partial(local_bkg, data, x, y), repeats=repeats)
+    print(f'{t_local:.3f}s')
+
+
+def main():
+    """
+    Run the photutils.background benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for the photutils.background subpackage.')
+    parser.add_argument('--sizes', default='1024,2048,4096',
+                        help='comma-separated image sizes '
+                             '(default: %(default)s)')
+    parser.add_argument('--box-sizes', default='32,64,128',
+                        help='comma-separated box sizes '
+                             '(default: %(default)s)')
+    parser.add_argument('--n-threads', default='1,2,4,8',
+                        help='comma-separated n_threads values '
+                             '(default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'background2d', 'maps',
+                                 'estimators', 'local'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    sizes = [int(size) for size in args.sizes.split(',')]
+    box_sizes = [int(box) for box in args.box_sizes.split(',')]
+    n_threads_list = [int(nthr) for nthr in args.n_threads.split(',')]
+
+    print_environment()
+
+    if args.which in ('all', 'background2d'):
+        bench_background2d(sizes, box_sizes, n_threads_list,
+                           repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'maps'):
+        bench_maps(sizes, repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'estimators'):
+        bench_estimators(repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'local'):
+        bench_local_background(repeats=args.repeats, seed=args.seed)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/user_guide/background.rst
+++ b/docs/user_guide/background.rst
@@ -481,6 +481,36 @@ the background subtraction can be improved by masking the sources
 and/or through further iterations.
 
 
+Multithreading
+^^^^^^^^^^^^^^
+
+`~photutils.background.Background2D` instances are immutable
+after construction (aside from internal lazy-attribute caches),
+so a single instance is safe to share across threads and
+independent images can be processed concurrently, e.g., with a
+`~concurrent.futures.ThreadPoolExecutor`. The underlying sigma-clipping,
+statistics, and interpolation kernels release the Python global
+interpreter lock (GIL), so threads can effectively run in parallel:
+
+.. doctest-skip::
+
+    >>> from concurrent.futures import ThreadPoolExecutor
+    >>> from photutils.background import Background2D
+    >>> def estimate_background(data):
+    ...     return Background2D(data, (25, 25)).background
+    >>> with ThreadPoolExecutor() as executor:
+    ...     backgrounds = list(executor.map(estimate_background, images))
+
+In addition, the box statistics computed by
+`~photutils.background.Background2D` itself can be multithreaded by
+setting the ``n_threads`` keyword. The results are identical to the
+single-threaded computation. This is most beneficial for large images:
+
+.. doctest-skip::
+
+    >>> bkg = Background2D(data2, (15, 15), n_threads=4)
+
+
 Plotting Meshes
 ^^^^^^^^^^^^^^^
 

--- a/docs/user_guide/background.rst
+++ b/docs/user_guide/background.rst
@@ -205,6 +205,12 @@ keyword. The default is to perform sigma clipping with ``sigma=3``
 and ``maxiters=10``. Sigma clipping can be turned off by setting
 ``sigma_clip=None``.
 
+.. note::
+    `~astropy.stats.SigmaClip` instances store internal state while
+    clipping, so a single background or background RMS estimator
+    instance should not be called concurrently from multiple threads
+    when sigma clipping is enabled.
+
 After the background level has been determined in each of the boxes, the
 low-resolution background image can be median filtered, with a window
 of size of ``filter_size``, to suppress local under or over estimations
@@ -440,7 +446,6 @@ Finally, let's subtract the background from the image and plot it:
 
 .. doctest-skip::
 
-    >>> norm = ImageNormalize(stretch=SqrtStretch())
     >>> data_sub = data3 - bkg3.background
     >>> norm = simple_norm(data_sub, 'sqrt', percent=99.5)
     >>> fig, ax = plt.subplots()  # doctest: +SKIP

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -261,6 +261,28 @@ input order, the stacked table rows are in the same order as the input
 ``positions``.
 
 
+Multithreaded 2D Background Estimation
+======================================
+
+`~photutils.background.Background2D` now accepts an ``n_threads``
+keyword to compute the box statistics using multiple threads. The
+boxes are divided into chunks and processed concurrently, producing
+results identical to the single-threaded computation. The underlying
+sigma-clipping and statistics kernels release the Python global
+interpreter lock (GIL), so the threads run in parallel::
+
+    >>> import numpy as np
+    >>> from photutils.background import Background2D
+    >>> rng = np.random.default_rng(seed=0)
+    >>> data = rng.normal(100.0, 5.0, (4096, 4096))
+    >>> bkg = Background2D(data, (64, 64), n_threads=8)
+
+In addition, `~photutils.background.Background2D` instances are now
+immutable after construction (aside from internal lazy-attribute
+caches), so a single instance is safe to share across threads and
+independent images can be processed concurrently.
+
+
 Polygon Apertures
 =================
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -117,8 +117,8 @@ class Background2D:
         order. ``filter_size`` must be odd along both axes. A filter
         size of ``1`` (or ``(1, 1)``) means no filtering.
 
-    filter_threshold : int, optional
-        The threshold value for used for selective median filtering of
+    filter_threshold : float, optional
+        The threshold value used for selective median filtering of
         the low-resolution 2D background map. The median filter will
         be applied to only the background boxes with values larger
         than ``filter_threshold``. Set to `None` to filter all boxes
@@ -965,7 +965,7 @@ class Background2D:
 
         markersize : float, optional
             The box center marker size in ``points ** 2``
-            (typographical points are 1/72 inch) . The default is
+            (typographical points are 1/72 inch). The default is
             ``matplotlib.rcParams['lines.markersize'] ** 2``. If set to
             0, then the box center markers will not be plotted.
 

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -102,8 +102,8 @@ class Background2D:
         include those from the input ``mask`` and ``coverage_mask``,
         non-finite ``data`` values, any padded area at the data
         edges, and those resulting from any sigma clipping. Setting
-        ``exclude_percentile=0`` will exclude boxes that have any that
-        have any masked pixels. Note that completely masked boxes are
+        ``exclude_percentile=0`` will exclude boxes that have any
+        masked pixels. Note that completely masked boxes are
         always excluded. In general, ``exclude_percentile`` should be
         kept as low as possible to ensure there are a sufficient number
         of unmasked pixels in each box for reasonable statistical
@@ -399,9 +399,10 @@ class Background2D:
         The minimum number of required unmasked pixels in a box used for
         it to be included in the low-resolution map.
 
-        For exclude_percentile=0, only boxes where nmasked=0 will be
-        included. For exclude_percentile=100, all boxes will be included
-        *unless* they are completely masked.
+        A box is excluded if it contains fewer unmasked pixels than this
+        threshold. For exclude_percentile=0, only boxes with zero masked
+        pixels will be included. For exclude_percentile=100, all boxes
+        will be included unless they are completely masked.
 
         Boxes that are completely masked are always excluded.
         """
@@ -469,9 +470,11 @@ class Background2D:
         bkg = self.bkg_estimator(data, axis=axis)
         bkgrms = self.bkg_rms_estimator(data, axis=axis)
 
-        # Mask boxes with too few unmasked pixels
+        # Mask boxes with too few unmasked pixels. Completely masked
+        # boxes are always excluded.
         n_good = np.count_nonzero(~np.isnan(data), axis=axis)
-        box_mask = n_good <= self._good_n_pixels_threshold
+        box_mask = ((n_good < self._good_n_pixels_threshold)
+                    | (n_good == 0))
 
         if np.ndim(bkg) == 0:
             if box_mask:  # single corner box
@@ -589,11 +592,13 @@ class Background2D:
                 n_good = np.hstack([n_good, col_n_good])
 
         if np.all(np.isnan(bkg)):
-            msg = (f'All boxes contain <= {self._good_n_pixels_threshold} '
-                   f'unmasked or finite pixels ({self.box_size=}, '
-                   f'{self.exclude_percentile=}). Please check your data '
-                   'or increase "exclude_percentile" to allow more boxes to '
-                   'be included.')
+            msg = ('All boxes contain fewer than '
+                   f'{self._good_n_pixels_threshold} unmasked or finite '
+                   'pixels or are completely masked '
+                   f'(box_size={tuple(self.box_size)}, '
+                   f'exclude_percentile={self.exclude_percentile}). Please '
+                   'check your data or increase "exclude_percentile" to '
+                   'allow more boxes to be included.')
             raise ValueError(msg)
 
         # We no longer need the temporary input arrays

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -192,7 +192,10 @@ class Background2D:
                  bkg_estimator=None, bkg_rms_estimator=None,
                  interpolator=None):
 
-        if isinstance(data, (u.Quantity, NDData)):  # includes CCDData
+        if isinstance(data, u.Quantity):
+            self._unit = data.unit
+            data = data.value
+        elif isinstance(data, NDData):  # includes CCDData
             self._unit = data.unit
             data = data.data
         else:
@@ -203,7 +206,8 @@ class Background2D:
         self._data = self._validate_array(data, 'data', shape=False)
         self._data_dtype = self._data.dtype
         self._data_shape = self._data.shape
-        if np.all(~np.isfinite(self._data)):
+        nonfinite_mask = ~np.isfinite(self._data)
+        if np.all(nonfinite_mask):
             msg = ('Input data contains all non-finite (NaN or infinity) '
                    'values. Cannot compute a background.')
             raise ValueError(msg)
@@ -272,7 +276,7 @@ class Background2D:
         # arrays and to keep the memory usage minimal
         (self._bkg_stats,
          self._bkgrms_stats,
-         self._n_good) = self._calculate_stats()
+         self._n_good) = self._calculate_stats(nonfinite_mask)
 
         # This is used to selectively filter the low-resolution maps
         self._min_bkg_stats = nanmin(self._bkg_stats)
@@ -298,10 +302,8 @@ class Background2D:
 
         mask_repr = None if not self._has_mask else data_repr
 
-        if 'coverage_mask' in self.__dict__ and self.coverage_mask is None:
-            coverage_mask_repr = None
-        else:
-            coverage_mask_repr = data_repr
+        coverage_mask_repr = (None if self.coverage_mask is None
+                              else data_repr)
 
         overrides = {'data': data_repr, 'mask': mask_repr,
                      'coverage_mask': coverage_mask_repr}
@@ -324,6 +326,10 @@ class Background2D:
             array = None
         if array is not None:
             array = np.asanyarray(array)
+            if (name in ('mask', 'coverage_mask')
+                    and array.dtype != bool):
+                msg = f'{name} must be a boolean array'
+                raise TypeError(msg)
             if array.ndim != 2:
                 msg = f'{name} must be a 2D array'
                 raise ValueError(msg)
@@ -489,10 +495,16 @@ class Background2D:
 
         return bkg, bkgrms, n_good
 
-    def _calculate_stats(self):
+    def _calculate_stats(self, nonfinite_mask):
         """
         Calculate the background and background RMS statistics in each
         box.
+
+        Parameters
+        ----------
+        nonfinite_mask : 2D bool `~numpy.ndarray`
+            A mask of the non-finite (NaN or infinity) values in the
+            input data.
 
         Returns
         -------
@@ -511,7 +523,7 @@ class Background2D:
 
         # Automatically mask non-finite values that aren't already
         # masked and combine all masks
-        mask = self._combine_all_masks(~np.isfinite(self._data))
+        mask = self._combine_all_masks(nonfinite_mask)
 
         self._box_n_pixels = np.prod(self.box_size)
         n_boxes = self._data.shape // self.box_size

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -274,16 +274,15 @@ class Background2D:
 
         # Perform the initial calculations to avoid storing large data
         # arrays and to keep the memory usage minimal
-        (self._bkg_stats,
-         self._bkgrms_stats,
-         self._n_good) = self._calculate_stats(nonfinite_mask)
+        bkg_stats, bkgrms_stats, self._n_good = self._calculate_stats(
+            nonfinite_mask)
 
         # This is used to selectively filter the low-resolution maps
-        self._min_bkg_stats = nanmin(self._bkg_stats)
+        self._min_bkg_stats = nanmin(bkg_stats)
 
         # Store a mask of the excluded mesh values (NaNs) in the
         # low-resolution maps
-        self._mesh_nan_mask = np.isnan(self._bkg_stats)
+        self._mesh_nan_mask = np.isnan(bkg_stats)
 
         # Add keyword arguments needed for BkgZoomInterpolator.
         # BkgIDWInterpolator upscales the mesh based only on the good
@@ -291,6 +290,19 @@ class Background2D:
         if isinstance(self.interpolator, BkgIDWInterpolator):
             self._interp_kwargs['mesh_yxcen'] = self._calculate_mesh_yxcen()
             self._interp_kwargs['mesh_nan_mask'] = self._mesh_nan_mask
+
+        # Compute the low-resolution background and background RMS
+        # meshes. The mesh arrays are small, so this is inexpensive
+        # compared to the box statistics above, and computing them
+        # here keeps the instance immutable after construction. The
+        # unfiltered background mesh defines the pixels selected by
+        # filter_threshold for both meshes.
+        bkg_mesh = self._interpolate_grid(bkg_stats)
+        bkgrms_mesh = self._interpolate_grid(bkgrms_stats)
+        bkg_mesh_filt = self._filter_grid(bkg_mesh, bkg_mesh)
+        bkgrms_mesh_filt = self._filter_grid(bkgrms_mesh, bkg_mesh)
+        self._background_mesh = self._apply_units(bkg_mesh_filt)
+        self._background_rms_mesh = self._apply_units(bkgrms_mesh_filt)
 
     def _repr_str_params(self):
         params = ('data', 'box_size', 'mask', 'coverage_mask', 'fill_value',
@@ -678,7 +690,7 @@ class Background2D:
 
         return interp_data
 
-    def _selective_filter(self, data):
+    def _selective_filter(self, data, bkg_grid):
         """
         Filter only pixels above ``filter_threshold`` in a low-
         resolution 2D image.
@@ -693,13 +705,16 @@ class Background2D:
         data : 2D `~numpy.ndarray`
             A 2D array of mesh values.
 
+        bkg_grid : 2D `~numpy.ndarray`
+            The NaN-interpolated, unfiltered background mesh used to
+            select the pixels to filter.
+
         Returns
         -------
         result : 2D `~numpy.ndarray`
             The filtered 2D array of mesh values.
         """
-        bkg_stats_interp = self._interpolate_grid(self._bkg_stats)
-        above_threshold = bkg_stats_interp > self.filter_threshold
+        above_threshold = bkg_grid > self.filter_threshold
         if not np.any(above_threshold):
             return data
 
@@ -711,7 +726,7 @@ class Background2D:
                                   mode='constant', cval=np.nan)
         return np.where(above_threshold, filtered, data)
 
-    def _filter_grid(self, data):
+    def _filter_grid(self, data, bkg_grid):
         """
         Apply a 2D median filter to a low-resolution 2D image.
 
@@ -719,6 +734,11 @@ class Background2D:
         ----------
         data : 2D `~numpy.ndarray`
             A 2D array of mesh values.
+
+        bkg_grid : 2D `~numpy.ndarray`
+            The NaN-interpolated, unfiltered background mesh used to
+            select the pixels to filter when ``filter_threshold`` is
+            set.
 
         Returns
         -------
@@ -735,7 +755,7 @@ class Background2D:
                                       mode='constant', cval=np.nan)
         else:
             # Selectively filter the array
-            filtdata = self._selective_filter(data)
+            filtdata = self._selective_filter(data, bkg_grid)
 
         return filtdata
 
@@ -753,40 +773,7 @@ class Background2D:
         box_cen = (self.box_size - 1) / 2.0
         return (mesh_idx * self.box_size[:, None]) + box_cen[:, None]
 
-    def _try_free_bkg_stats(self, *, computed):
-        """
-        Free ``_bkg_stats`` when it is safe to do so.
-
-        ``_bkg_stats`` is always needed by ``background_mesh``
-        (via ``_interpolate_grid``). It is also needed by
-        ``_selective_filter`` (called from ``_filter_grid``) when
-        ``filter_threshold`` is not ``None``. It is therefore
-        safe to free it only after ``background_mesh`` has been
-        computed and either ``filter_threshold`` is ``None``
-        (so ``background_rms_mesh`` does not need it) or
-        ``background_rms_mesh`` has also been computed.
-
-        Because `~astropy.utils.lazyproperty` caches a value in the
-        instance ``__dict__`` only after its getter returns, the
-        property currently being computed must be identified via the
-        ``computed`` keyword.
-
-        Parameters
-        ----------
-        computed : {'background_mesh', 'background_rms_mesh'}
-            The name of the lazyproperty whose value has just been
-            computed by the caller.
-        """
-        have_mesh = ('background_mesh' in self.__dict__
-                     or computed == 'background_mesh')
-        if not have_mesh:
-            return
-        have_rms_mesh = ('background_rms_mesh' in self.__dict__
-                         or computed == 'background_rms_mesh')
-        if self.filter_threshold is None or have_rms_mesh:
-            self._bkg_stats = None  # delete to save memory
-
-    @lazyproperty
+    @property
     def background_mesh(self):
         """
         The low-resolution background image.
@@ -794,12 +781,9 @@ class Background2D:
         This image is equivalent to the low-resolution "MINIBACK"
         background map check image in SourceExtractor.
         """
-        data = self._interpolate_grid(self._bkg_stats)
-        result = self._apply_units(self._filter_grid(data))
-        self._try_free_bkg_stats(computed='background_mesh')
-        return result
+        return self._background_mesh
 
-    @lazyproperty
+    @property
     def background_rms_mesh(self):
         """
         The low-resolution background RMS image.
@@ -807,11 +791,7 @@ class Background2D:
         This image is equivalent to the low-resolution "MINIBACK_RMS"
         background rms map check image in SourceExtractor.
         """
-        data = self._interpolate_grid(self._bkgrms_stats)
-        result = self._apply_units(self._filter_grid(data))
-        self._bkgrms_stats = None  # delete to save memory
-        self._try_free_bkg_stats(computed='background_rms_mesh')
-        return result
+        return self._background_rms_mesh
 
     @property
     @deprecated(since='3.0', alternative='n_pixels_mesh', until='4.0')
@@ -886,7 +866,7 @@ class Background2D:
             median of the final interpolated mesh, not solely the median
             of directly measured mesh values.
         """
-        return self._apply_units(np.median(self.background_mesh))
+        return np.median(self.background_mesh)
 
     @lazyproperty
     def background_rms_median(self):
@@ -906,7 +886,7 @@ class Background2D:
             mesh, not solely the median of directly measured mesh
             values.
         """
-        return self._apply_units(np.median(self.background_rms_mesh))
+        return np.median(self.background_rms_mesh)
 
     def _calculate_image(self, data):
         """

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -53,7 +53,7 @@ class Background2D:
 
     Parameters
     ----------
-    data : array_like or `~astropy.nddata.NDData`
+    data : 2D `~numpy.ndarray` or `~astropy.nddata.NDData`
         The 2D array from which to estimate the background and/or
         background RMS map.
 
@@ -218,7 +218,7 @@ class Background2D:
 
         # box_size cannot be larger than the data array size
         self.box_size = as_pair('box_size', box_size, lower_bound=(0, 0),
-                                upper_bound=data.shape)
+                                upper_bound=self._data_shape)
 
         self.fill_value = fill_value
         if exclude_percentile < 0 or exclude_percentile > 100:

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -741,7 +741,7 @@ class Background2D:
         box_cen = (self.box_size - 1) / 2.0
         return (mesh_idx * self.box_size[:, None]) + box_cen[:, None]
 
-    def _try_free_bkg_stats(self):
+    def _try_free_bkg_stats(self, *, computed):
         """
         Free ``_bkg_stats`` when it is safe to do so.
 
@@ -750,14 +750,28 @@ class Background2D:
         ``_selective_filter`` (called from ``_filter_grid``) when
         ``filter_threshold`` is not ``None``. It is therefore
         safe to free it only after ``background_mesh`` has been
-        cached and either ``filter_threshold`` is ``None``
+        computed and either ``filter_threshold`` is ``None``
         (so ``background_rms_mesh`` does not need it) or
-        ``background_rms_mesh`` has also been cached.
+        ``background_rms_mesh`` has also been computed.
+
+        Because `~astropy.utils.lazyproperty` caches a value in the
+        instance ``__dict__`` only after its getter returns, the
+        property currently being computed must be identified via the
+        ``computed`` keyword.
+
+        Parameters
+        ----------
+        computed : {'background_mesh', 'background_rms_mesh'}
+            The name of the lazyproperty whose value has just been
+            computed by the caller.
         """
-        if 'background_mesh' not in self.__dict__:
+        have_mesh = ('background_mesh' in self.__dict__
+                     or computed == 'background_mesh')
+        if not have_mesh:
             return
-        if (self.filter_threshold is None
-                or 'background_rms_mesh' in self.__dict__):
+        have_rms_mesh = ('background_rms_mesh' in self.__dict__
+                         or computed == 'background_rms_mesh')
+        if self.filter_threshold is None or have_rms_mesh:
             self._bkg_stats = None  # delete to save memory
 
     @lazyproperty
@@ -770,7 +784,7 @@ class Background2D:
         """
         data = self._interpolate_grid(self._bkg_stats)
         result = self._apply_units(self._filter_grid(data))
-        self._try_free_bkg_stats()
+        self._try_free_bkg_stats(computed='background_mesh')
         return result
 
     @lazyproperty
@@ -782,9 +796,9 @@ class Background2D:
         background rms map check image in SourceExtractor.
         """
         data = self._interpolate_grid(self._bkgrms_stats)
-        self._bkgrms_stats = None  # delete to save memory
         result = self._apply_units(self._filter_grid(data))
-        self._try_free_bkg_stats()
+        self._bkgrms_stats = None  # delete to save memory
+        self._try_free_bkg_stats(computed='background_rms_mesh')
         return result
 
     @property

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -5,6 +5,7 @@ Tools for estimating the 2D background and background RMS in an image.
 
 import copy
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 
 import astropy.units as u
 import numpy as np
@@ -157,6 +158,17 @@ class Background2D:
         to define sigma clipping). The default is an instance of
         `~photutils.background.StdBackgroundRMS`.
 
+    n_threads : int, optional
+        The number of threads to use to compute the box statistics. The
+        default is 1 (no multithreading). When ``n_threads`` > 1, the
+        boxes are divided into chunks along the y axis and processed
+        concurrently. The results are identical to the single-threaded
+        computation. The underlying sigma-clipping and statistics
+        kernels release the Python global interpreter lock (GIL),
+        so multithreading can significantly speed up the background
+        estimation for large images. If a custom ``bkg_estimator`` or
+        ``bkg_rms_estimator`` callable is input, it must be thread-safe.
+
     interpolator : callable, optional
         A callable object (a function or object) used to interpolate
         the low-resolution background or background RMS image to the
@@ -189,7 +201,7 @@ class Background2D:
     def __init__(self, data, box_size, *, mask=None, coverage_mask=None,
                  fill_value=0.0, exclude_percentile=10.0, filter_size=(3, 3),
                  filter_threshold=None, sigma_clip=SIGMA_CLIP,
-                 bkg_estimator=None, bkg_rms_estimator=None,
+                 bkg_estimator=None, bkg_rms_estimator=None, n_threads=1,
                  interpolator=None):
 
         if isinstance(data, u.Quantity):
@@ -232,6 +244,11 @@ class Background2D:
         self.filter_size = as_pair('filter_size', filter_size,
                                    lower_bound=(0, 0), check_odd=True)
         self.filter_threshold = filter_threshold
+
+        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+            msg = 'n_threads must be a positive integer'
+            raise ValueError(msg)
+        self.n_threads = int(n_threads)
 
         if sigma_clip is SIGMA_CLIP:
             sigma_clip = create_default_sigmaclip(sigma=SIGMA_CLIP.sigma,
@@ -308,7 +325,7 @@ class Background2D:
         params = ('data', 'box_size', 'mask', 'coverage_mask', 'fill_value',
                   'exclude_percentile', 'filter_size', 'filter_threshold',
                   'sigma_clip', 'bkg_estimator', 'bkg_rms_estimator',
-                  'interpolator')
+                  'n_threads', 'interpolator')
 
         data_repr = f'<array; shape={self._interp_kwargs["shape"]}>'
 
@@ -426,7 +443,7 @@ class Background2D:
         """
         return (1 - (self.exclude_percentile / 100.0)) * self._box_n_pixels
 
-    def _sigmaclip_boxes(self, data, axis):
+    def _sigmaclip_boxes(self, data, *, axis, sigma_clip=None):
         """
         Sigma clip the boxes along the specified axis.
 
@@ -448,20 +465,22 @@ class Background2D:
         axis : int or tuple of int
             The axis or axes along which to sigma clip the data.
 
+        sigma_clip : `~astropy.stats.SigmaClip` or `None`
+            The sigma-clipping instance to apply. If `None`, no sigma
+            clipping is performed. `~astropy.stats.SigmaClip` stores
+            internal state on the instance during calls, so each thread
+            must use its own instance.
+
         Returns
         -------
         data : `~numpy.ndarray`
             The sigma-clipped data.
         """
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=AstropyUserWarning)
-            if self.sigma_clip is not None:
-                data = self.sigma_clip(data, axis=axis, masked=False,
-                                       copy=False)
-
+        if sigma_clip is not None:
+            data = sigma_clip(data, axis=axis, masked=False, copy=False)
         return data
 
-    def _compute_box_statistics(self, data, *, axis=None):
+    def _compute_box_statistics(self, data, *, sigma_clip=None, axis=None):
         """
         Compute the background and background RMS statistics in each
         box.
@@ -470,6 +489,10 @@ class Background2D:
         ----------
         data : `~numpy.ndarray`
             The 4D array of box data.
+
+        sigma_clip : `~astropy.stats.SigmaClip` or `None`
+            The sigma-clipping instance to apply to the box data. If
+            `None`, no sigma clipping is performed.
 
         axis : int or tuple of int, optional
             The axis or axes along which to compute the statistics.
@@ -482,7 +505,7 @@ class Background2D:
         bkgrms : 2D `~numpy.ndarray` or float
             The background RMS statistics in each box.
         """
-        data = self._sigmaclip_boxes(data, axis=axis)
+        data = self._sigmaclip_boxes(data, axis=axis, sigma_clip=sigma_clip)
 
         # Make 2D arrays of the box statistics
         bkg = self.bkg_estimator(data, axis=axis)
@@ -505,6 +528,58 @@ class Background2D:
             bkg[box_mask] = np.nan
             bkgrms[box_mask] = np.nan
 
+        return bkg, bkgrms, n_good
+
+    def _parallel_box_statistics(self, data):
+        """
+        Compute the statistics for the core boxes, optionally using
+        multiple threads.
+
+        When ``n_threads`` > 1, the boxes are divided into chunks along
+        the first (box row) axis and processed concurrently. The box
+        statistics are independent between boxes, so the results are
+        identical to the single-threaded computation. The underlying
+        sigma-clipping and statistics kernels release the GIL, allowing
+        the threads to run in parallel.
+
+        Parameters
+        ----------
+        data : 3D `~numpy.ndarray`
+            The array of box data, where the first two axes are the box
+            grid positions and the last axis contains the (flattened)
+            pixels within each box.
+
+        Returns
+        -------
+        bkg : 2D `~numpy.ndarray`
+            The background statistics in each box.
+
+        bkgrms : 2D `~numpy.ndarray`
+            The background RMS statistics in each box.
+
+        n_good : 2D `~numpy.ndarray`
+            The number of unmasked pixels in each box.
+        """
+        n_chunks = min(self.n_threads, data.shape[0])
+        if n_chunks == 1:
+            return self._compute_box_statistics(
+                data, axis=-1, sigma_clip=self.sigma_clip)
+
+        def worker(chunk):
+            # SigmaClip stores internal state on the instance during
+            # calls, so each thread needs its own copy
+            sigma_clip = (None if self.sigma_clip is None
+                          else copy.copy(self.sigma_clip))
+            return self._compute_box_statistics(chunk, axis=-1,
+                                                sigma_clip=sigma_clip)
+
+        chunks = np.array_split(data, n_chunks, axis=0)
+        with ThreadPoolExecutor(max_workers=n_chunks) as executor:
+            results = list(executor.map(worker, chunks))
+
+        bkg = np.vstack([result[0] for result in results])
+        bkgrms = np.vstack([result[1] for result in results])
+        n_good = np.vstack([result[2] for result in results])
         return bkg, bkgrms, n_good
 
     def _calculate_stats(self, nonfinite_mask):
@@ -541,79 +616,94 @@ class Background2D:
         n_boxes = self._data.shape // self.box_size
         y1, x1 = n_boxes * self.box_size
 
-        # Core boxes - the part of the data array that is an integer
-        # multiple of the box size.
-        # Combine the last two axes for performance.
-        # Below we transform both the data and mask arrays to avoid
-        # making multiple copies of the data (one to insert NaN and
-        # another for the reshape). Only one copy of the data and mask
-        # array is made (except for the extra corner). The boolean mask
-        # copy is much smaller than the data array.
-        # An explicit copy of the data array is needed to avoid
-        # modifying the original data array if the shape of the data
-        # array is (y1, x1) (i.e., box_size = data.shape).
-        core = reshape_as_blocks(self._data[:y1, :x1].copy(), self.box_size)
-        core_mask = reshape_as_blocks(mask[:y1, :x1], self.box_size)
-        core = core.reshape((*n_boxes, -1))
-        core_mask = core_mask.reshape((*n_boxes, -1))
-        core[core_mask] = np.nan
-        bkg, bkgrms, n_good = self._compute_box_statistics(core, axis=-1)
+        # Suppress the AstropyUserWarning issued by sigma clipping
+        # for the NaN values inserted for masked pixels. The warning
+        # filter is set once here, in the main thread, because
+        # warnings.catch_warnings manipulates global state and is not
+        # thread-safe.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=AstropyUserWarning)
 
-        extra_row = y1 < self._data.shape[0]
-        extra_col = x1 < self._data.shape[1]
-        if extra_row or extra_col:
+            # Core boxes - the part of the data array that is an
+            # integer multiple of the box size.
+            # Combine the last two axes for performance.
+            # Below we transform both the data and mask arrays to avoid
+            # making multiple copies of the data (one to insert NaN and
+            # another for the reshape). Only one copy of the data and
+            # mask array is made (except for the extra corner). The
+            # boolean mask copy is much smaller than the data array.
+            # An explicit copy of the data array is needed to avoid
+            # modifying the original data array if the shape of the
+            # data array is (y1, x1) (i.e., box_size = data.shape).
+            core = reshape_as_blocks(self._data[:y1, :x1].copy(),
+                                     self.box_size)
+            core_mask = reshape_as_blocks(mask[:y1, :x1], self.box_size)
+            core = core.reshape((*n_boxes, -1))
+            core_mask = core_mask.reshape((*n_boxes, -1))
+            core[core_mask] = np.nan
+            bkg, bkgrms, n_good = self._parallel_box_statistics(core)
+
+            extra_row = y1 < self._data.shape[0]
+            extra_col = x1 < self._data.shape[1]
             if extra_row:
                 # Extra row of boxes.
-                # Here we need to make a copy of the data array to avoid
-                # modifying the original data array.
-                # Move the axes and combine the last two for performance.
+                # Here we need to make a copy of the data array to
+                # avoid modifying the original data array.
+                # Move the axes and combine the last two for
+                # performance.
                 row_data = self._data[y1:, :x1].copy()
                 row_mask = mask[y1:, :x1]
                 row_data[row_mask] = np.nan
-                row_data = reshape_as_blocks(row_data, (1, self.box_size[1]))
+                row_data = reshape_as_blocks(row_data,
+                                             (1, self.box_size[1]))
                 row_data = np.moveaxis(row_data, 0, -1)
                 row_data = row_data.reshape((*row_data.shape[:-2], -1))
-                row_bkg, row_bkgrms, row_n_good = self._compute_box_statistics(
-                    row_data, axis=-1)
+                row_stats = self._compute_box_statistics(
+                    row_data, axis=-1, sigma_clip=self.sigma_clip)
+                row_bkg, row_bkgrms, row_n_good = row_stats
 
             if extra_col:
                 # Extra column of boxes.
-                # Here we need to make a copy of the data array to avoid
-                # modifying the original data array.
-                # Move the axes and combine the last two for performance.
+                # Here we need to make a copy of the data array to
+                # avoid modifying the original data array.
+                # Move the axes and combine the last two for
+                # performance.
                 col_data = self._data[:y1, x1:].copy()
                 col_mask = mask[:y1, x1:]
                 col_data[col_mask] = np.nan
-                col_data = reshape_as_blocks(col_data, (self.box_size[0], 1))
+                col_data = reshape_as_blocks(col_data,
+                                             (self.box_size[0], 1))
                 col_data = np.transpose(col_data, (0, 3, 1, 2))
                 col_data = col_data.reshape((*col_data.shape[:-2], -1))
-                col_bkg, col_bkgrms, col_n_good = self._compute_box_statistics(
-                    col_data, axis=-1)
+                col_stats = self._compute_box_statistics(
+                    col_data, axis=-1, sigma_clip=self.sigma_clip)
+                col_bkg, col_bkgrms, col_n_good = col_stats
 
             if extra_row and extra_col:
                 # Extra corner box -- append to extra column.
-                # Here we need to make a copy of the data array to avoid
-                # modifying the original data array.
+                # Here we need to make a copy of the data array to
+                # avoid modifying the original data array.
                 corner_data = self._data[y1:, x1:].copy()
                 corner_mask = mask[y1:, x1:]
                 corner_data[corner_mask] = np.nan
-                crn_bkg, crn_bkgrms, crn_n_good = self._compute_box_statistics(
-                    corner_data, axis=None)
+                crn_stats = self._compute_box_statistics(
+                    corner_data, axis=None, sigma_clip=self.sigma_clip)
+                crn_bkg, crn_bkgrms, crn_n_good = crn_stats
                 col_bkg = np.vstack((col_bkg, crn_bkg))
                 col_bkgrms = np.vstack((col_bkgrms, crn_bkgrms))
                 col_n_good = np.vstack((col_n_good, crn_n_good))
 
-            # Combine the core and extra boxes to construct the
-            # complete 2D bkg and bkgrms arrays
-            if extra_row:
-                bkg = np.vstack([bkg, row_bkg[:, 0]])
-                bkgrms = np.vstack([bkgrms, row_bkgrms[:, 0]])
-                n_good = np.vstack([n_good, row_n_good[:, 0]])
+        # Combine the core and extra boxes to construct the complete
+        # 2D bkg and bkgrms arrays
+        if extra_row:
+            bkg = np.vstack([bkg, row_bkg[:, 0]])
+            bkgrms = np.vstack([bkgrms, row_bkgrms[:, 0]])
+            n_good = np.vstack([n_good, row_n_good[:, 0]])
 
-            if extra_col:
-                bkg = np.hstack([bkg, col_bkg])
-                bkgrms = np.hstack([bkgrms, col_bkgrms])
-                n_good = np.hstack([n_good, col_n_good])
+        if extra_col:
+            bkg = np.hstack([bkg, col_bkg])
+            bkgrms = np.hstack([bkgrms, col_bkgrms])
+            n_good = np.hstack([n_good, col_n_good])
 
         if np.all(np.isnan(bkg)):
             msg = ('All boxes contain fewer than '

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -472,7 +472,10 @@ class SExtractorBackground(BackgroundBase):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
 
-            _median = np.atleast_1d(nanmedian(data, axis=axis))
+            _median = nanmedian(data, axis=axis)
+            # A scalar median means the reduction consumed all axes
+            is_scalar = np.ndim(_median) == 0
+            _median = np.atleast_1d(_median)
             _mean = np.atleast_1d(nanmean(data, axis=axis))
             _std = np.atleast_1d(nanstd(data, axis=axis))
             result = (2.5 * _median) - (1.5 * _mean)
@@ -488,8 +491,9 @@ class SExtractorBackground(BackgroundBase):
             mask = np.logical_and(med_mask, np.logical_not(mean_mask))
             result[mask] = _median[mask]
 
-            # If result is a scalar, return it as a float
-            if result.shape == (1,) and axis is None:
+            # If the reduction consumed all axes, return a scalar
+            # float, consistent with the other estimator classes
+            if is_scalar:
                 result = result[0]
 
         return _apply_masked(result, masked)

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -429,14 +429,12 @@ class MMMBackground(ModeEstimatorBackground):
 @_insert_sigma_clip_doc
 class SExtractorBackground(BackgroundBase):
     """
-    Class to calculate the background in an array using the Source
-    Extractor algorithm.
+    Class to calculate the background in an array using the
+    SourceExtractor algorithm.
 
     The background is calculated using a mode estimator of the form
     ``(2.5 * median) - (1.5 * mean)``. If ``(mean - median) / std >
     0.3`` then the median is used instead.
-
-    .. _SourceExtractor: https://sextractor.readthedocs.io/en/latest/
 
     Parameters
     ----------
@@ -615,10 +613,10 @@ class MADStdBackgroundRMS(BackgroundRMSBase):
 
     .. math::
 
-        \sigma \approx \frac{{\textrm{{MAD}}}}{{\Phi^{{-1}}(3/4)}}
-            \approx 1.4826 \ \textrm{{MAD}}
+        \sigma \approx \frac{\textrm{MAD}}{\Phi^{-1}(3/4)}
+            \approx 1.4826 \ \textrm{MAD}
 
-    where :math:`\Phi^{{-1}}(P)` is the normal inverse cumulative
+    where :math:`\Phi^{-1}(P)` is the normal inverse cumulative
     distribution function evaluated at probability :math:`P = 3/4`.
 
     Parameters

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -153,7 +153,7 @@ class BkgZoomInterpolator(_BkgZoomInterpolator):
 
 
 @deprecated(since='3.0', message=('BkgIDWInterpolator is deprecated and will '
-                                  'be removed in a version 4.0.'))
+                                  'be removed in version 4.0.'))
 class BkgIDWInterpolator:
     """
     Class to generate a full-sized background and background RMS images

--- a/photutils/background/local_background.py
+++ b/photutils/background/local_background.py
@@ -3,6 +3,7 @@
 Tools for estimating local background using a circular annulus aperture.
 """
 
+import astropy.units as u
 import numpy as np
 
 from photutils.aperture import CircularAnnulus
@@ -110,8 +111,11 @@ class LocalBackground:
         """
         x = np.atleast_1d(x)
         y = np.atleast_1d(y)
+        if x.shape != y.shape:
+            msg = 'x and y must have the same shape'
+            raise ValueError(msg)
 
-        positions = np.array(list(zip(x, y, strict=True)))
+        positions = np.column_stack((x, y))
         return CircularAnnulus(positions, self.inner_radius,
                                self.outer_radius)
 
@@ -122,7 +126,7 @@ class LocalBackground:
 
         Parameters
         ----------
-        data : 2D `~numpy.ndarray`
+        data : 2D `~numpy.ndarray` or `~astropy.units.Quantity`
             The 2D array on which to measure the local background.
 
         x, y : float or 1D float `~numpy.ndarray`
@@ -137,9 +141,11 @@ class LocalBackground:
         Returns
         -------
         value : float or 1D float `~numpy.ndarray`
-            The local background values. If all pixels in an annulus
-            are masked or outside the data bounds, the corresponding
-            value will be NaN.
+            The local background values. If ``data`` is
+            a `~astropy.units.Quantity`, the result is a
+            `~astropy.units.Quantity` with the same unit. If all pixels
+            in an annulus are masked or outside the data bounds, the
+            corresponding value will be NaN.
 
         Examples
         --------
@@ -161,6 +167,11 @@ class LocalBackground:
         >>> print(np.isnan(bkg))
         True
         """
+        unit = None
+        if isinstance(data, u.Quantity):
+            unit = data.unit
+            data = data.value
+
         apertures = self.to_aperture(x, y)
         apermasks = apertures.to_mask(method='center')
 
@@ -172,5 +183,7 @@ class LocalBackground:
 
         if bkg.size == 1:
             bkg = bkg[0]
+        if unit is not None:
+            bkg = bkg << unit
 
         return bkg

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -675,12 +675,12 @@ class TestBackground2D:
         match = 'data and mask must have the same shape'
         with pytest.raises(ValueError, match=match):
             Background2D(test_data, (25, 25), filter_size=(1, 1),
-                         mask=np.zeros((2, 2)))
+                         mask=np.zeros((2, 2), dtype=bool))
 
         match = 'mask must be a 2D array'
         with pytest.raises(ValueError, match=match):
             Background2D(test_data, (25, 25), filter_size=(1, 1),
-                         mask=np.zeros((2, 2, 2)))
+                         mask=np.zeros((2, 2, 2), dtype=bool))
 
     def test_invalid_coverage_mask(self, test_data):
         """
@@ -690,12 +690,24 @@ class TestBackground2D:
         match = 'data and coverage_mask must have the same shape'
         with pytest.raises(ValueError, match=match):
             Background2D(test_data, (25, 25), filter_size=(1, 1),
-                         coverage_mask=np.zeros((2, 2)))
+                         coverage_mask=np.zeros((2, 2), dtype=bool))
 
         match = 'coverage_mask must be a 2D array'
         with pytest.raises(ValueError, match=match):
             Background2D(test_data, (25, 25), filter_size=(1, 1),
-                         coverage_mask=np.zeros((2, 2, 2)))
+                         coverage_mask=np.zeros((2, 2, 2), dtype=bool))
+
+    @pytest.mark.parametrize('name', ['mask', 'coverage_mask'])
+    @pytest.mark.parametrize('dtype', [float, int])
+    def test_invalid_mask_dtype(self, name, dtype, test_data):
+        """
+        Test that an error is raised if the mask or coverage_mask is
+        not a boolean array.
+        """
+        mask = np.zeros(test_data.shape, dtype=dtype)
+        match = f'{name} must be a boolean array'
+        with pytest.raises(TypeError, match=match):
+            Background2D(test_data, (25, 25), **{name: mask})
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_plot_meshes(self, test_data):

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -246,6 +246,29 @@ class TestBackground2D:
         mesh = bkg.background_mesh
         assert rms_mesh.shape == mesh.shape
 
+    @pytest.mark.parametrize('filter_threshold', [None, 9.0])
+    def test_mesh_access_order_independent(self, filter_threshold):
+        """
+        Test that the background_mesh and background_rms_mesh values do
+        not depend on the order in which they are first accessed, with
+        and without filter_threshold.
+        """
+        data = np.ones((100, 100))
+        data[25:50, 50:75] = 10.0
+
+        bkg1 = Background2D(data, (25, 25), filter_size=(3, 3),
+                            filter_threshold=filter_threshold)
+        mesh1 = bkg1.background_mesh
+        rms_mesh1 = bkg1.background_rms_mesh
+
+        bkg2 = Background2D(data, (25, 25), filter_size=(3, 3),
+                            filter_threshold=filter_threshold)
+        rms_mesh2 = bkg2.background_rms_mesh
+        mesh2 = bkg2.background_mesh
+
+        assert_allclose(mesh1, mesh2)
+        assert_allclose(rms_mesh1, rms_mesh2)
+
     def test_no_sigma_clipping(self, test_data):
         """
         Test bkg_estimator inputs without sigma clipping.

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -500,6 +500,57 @@ class TestBackground2D:
         with ctx1, ctx2:
             Background2D(data, (10, 10))
 
+    def test_exclude_percentile_zero(self, test_data):
+        """
+        Test that exclude_percentile=0 keeps fully unmasked boxes and
+        excludes boxes with any masked pixels.
+        """
+        bkg = Background2D(test_data, (25, 25), filter_size=(1, 1),
+                           sigma_clip=None, exclude_percentile=0)
+        assert_allclose(bkg.background_mesh, np.ones((4, 4)))
+
+        # A box with a single masked pixel is excluded. Its mesh value
+        # is then interpolated from the other (unit-valued) boxes.
+        data = np.copy(test_data)
+        data[0:25, 0:25] = 5.0
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0, 0] = True
+        bkg = Background2D(data, (25, 25), filter_size=(1, 1),
+                           sigma_clip=None, mask=mask, exclude_percentile=0)
+        assert_allclose(bkg.background_mesh[0, 0], 1.0)
+
+        # The same box is included when exclude_percentile=100
+        bkg = Background2D(data, (25, 25), filter_size=(1, 1),
+                           sigma_clip=None, mask=mask,
+                           exclude_percentile=100)
+        assert_allclose(bkg.background_mesh[0, 0], 5.0)
+
+    def test_exclude_percentile_boundary(self):
+        """
+        Test that a box with exactly exclude_percentile percent masked
+        pixels is included.
+
+        Only boxes with more than exclude_percentile percent masked
+        pixels are excluded.
+        """
+        data = np.ones((10, 10))
+        data[0, 0:10] = 5.0
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[0, 0:10] = True  # Exactly 10% of the single box
+        bkg = Background2D(data, (10, 10), filter_size=(1, 1),
+                           sigma_clip=None, mask=mask,
+                           exclude_percentile=10.0)
+        assert_allclose(bkg.background_mesh, [[1.0]])
+        assert bkg.n_pixels_mesh[0, 0] == 90
+
+        # More than 10% masked excludes the only box
+        mask[1, 0] = True
+        match = 'All boxes contain fewer than'
+        with pytest.raises(ValueError, match=match):
+            Background2D(data, (10, 10), filter_size=(1, 1),
+                         sigma_clip=None, mask=mask,
+                         exclude_percentile=10.0)
+
     def test_filter_threshold(self, test_data, bkg_mesh):
         """
         Test that the filter_threshold parameter filters the correct

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -388,16 +388,15 @@ class TestBackground2D:
         assert_equal(bkg1.background_rms[:50, :50], fill_value)
 
         # Test that combined mask and coverage_mask gives the same
-        # results
+        # results. The input masks cover all of the non-finite values,
+        # so no warning should be issued.
         mask = np.zeros(test_data.shape, dtype=bool)
         coverage_mask = np.zeros(test_data.shape, dtype=bool)
         mask[:50, :25] = True
         coverage_mask[:50, 25:50] = True
-        match = r'Input data contains non-finite \(NaN or infinity\) values'
-        with pytest.warns(AstropyUserWarning, match=match):
-            bkg2 = Background2D(data, (25, 25), filter_size=(1, 1), mask=mask,
-                                coverage_mask=mask, fill_value=0.0,
-                                bkg_estimator=MeanBackground())
+        bkg2 = Background2D(data, (25, 25), filter_size=(1, 1), mask=mask,
+                            coverage_mask=coverage_mask, fill_value=0.0,
+                            bkg_estimator=MeanBackground())
         assert_allclose(bkg1.background_mesh, bkg2.background_mesh)
         assert_allclose(bkg1.background_rms_mesh, bkg2.background_rms_mesh)
 
@@ -761,10 +760,10 @@ class TestBackground2D:
         arr = np.arange(25.0).reshape(5, 5)
         arr_orig = arr.copy()
         mask = np.zeros(arr.shape, dtype=bool)
-        mask[0, 0] = np.nan
-        mask[-1, 0] = np.nan
-        mask[-1, -1] = np.nan
-        mask[0, -1] = np.nan
+        mask[0, 0] = True
+        mask[-1, 0] = True
+        mask[-1, -1] = True
+        mask[0, -1] = True
 
         box_size = (2, 2)
         exclude_percentile = 100

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -206,12 +206,7 @@ class TestBackground2D:
     def test_filter_threshold_rms_mesh_before_mesh(self):
         """
         Test that accessing background_rms_mesh before background_mesh
-        does not crash when filter_threshold is set.
-
-        Background2D._bkg_stats is used by _selective_filter, which
-        is called when filter_threshold is not None. It must still
-        be available when background_mesh is computed even if
-        background_rms_mesh was computed first.
+        gives sensible results when filter_threshold is set.
         """
         data = np.ones((100, 100))
         data[25:50, 50:75] = 10.0
@@ -230,11 +225,7 @@ class TestBackground2D:
     def test_rms_mesh_before_mesh_no_filter_threshold(self):
         """
         Test that accessing background_rms_mesh before background_mesh
-        does not crash when filter_threshold is None (the default).
-
-        _try_free_bkg_stats must not free _bkg_stats before
-        background_mesh has been computed, otherwise _interpolate_grid
-        receives None and raises a TypeError on np.isnan.
+        works when filter_threshold is None (the default).
         """
         data = np.ones((101, 101))
         coverage_mask = np.zeros(data.shape, dtype=bool)

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -260,6 +260,60 @@ class TestBackground2D:
         assert_allclose(mesh1, mesh2)
         assert_allclose(rms_mesh1, rms_mesh2)
 
+    @pytest.mark.parametrize('n_threads', [2, 8])
+    def test_n_threads(self, n_threads):
+        """
+        Test that multithreaded box statistics give identical results
+        to the single-threaded computation.
+
+        The data shape is not an integer multiple of the box size, so
+        the extra row, column, and corner boxes are also exercised.
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(1.0, 0.5, (121, 289))
+        data[50:60, 50:60] = 1000.0
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[50:60, 50:60] = True
+
+        bkg1 = Background2D(data, (25, 25), mask=mask)
+        bkg2 = Background2D(data, (25, 25), mask=mask, n_threads=n_threads)
+        assert bkg2.n_threads == n_threads
+        assert_equal(bkg1.background_mesh, bkg2.background_mesh)
+        assert_equal(bkg1.background_rms_mesh, bkg2.background_rms_mesh)
+        assert_equal(bkg1.n_pixels_mesh, bkg2.n_pixels_mesh)
+        assert_equal(bkg1.background, bkg2.background)
+
+    def test_n_threads_no_sigma_clip(self):
+        """
+        Test multithreading with sigma clipping disabled.
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(1.0, 0.5, (100, 100))
+        bkg1 = Background2D(data, (25, 25), sigma_clip=None)
+        bkg2 = Background2D(data, (25, 25), sigma_clip=None, n_threads=4)
+        assert_equal(bkg1.background_mesh, bkg2.background_mesh)
+        assert_equal(bkg1.background_rms_mesh, bkg2.background_rms_mesh)
+
+    def test_n_threads_single_box_row(self):
+        """
+        Test that n_threads larger than the number of box rows falls
+        back to a single-chunk (serial) computation.
+        """
+        data = np.ones((25, 100))
+        bkg = Background2D(data, (25, 25), n_threads=8)
+        assert bkg.background_mesh.shape == (1, 4)
+        assert_allclose(bkg.background, data)
+
+    def test_invalid_n_threads(self, test_data):
+        """
+        Test that an error is raised if n_threads is not a positive
+        integer.
+        """
+        match = 'n_threads must be a positive integer'
+        for n_threads in (0, -1, 2.5):
+            with pytest.raises(ValueError, match=match):
+                Background2D(test_data, (25, 25), n_threads=n_threads)
+
     def test_no_sigma_clipping(self, test_data):
         """
         Test bkg_estimator inputs without sigma clipping.

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -412,6 +412,15 @@ class TestBackground2D:
             bkg = Background2D(data, (25, 25), filter_size=(1, 1))
         assert_allclose(bkg.background, test_data, rtol=1e-5)
 
+        # A warning is also issued when an input mask is given that
+        # does not cover the non-finite values
+        mask = np.zeros(test_data.shape, dtype=bool)
+        mask[60:70, 60:70] = True
+        with pytest.warns(AstropyUserWarning, match=match):
+            bkg = Background2D(data, (25, 25), filter_size=(1, 1),
+                               mask=mask)
+        assert_allclose(bkg.background, test_data, rtol=1e-5)
+
     def test_mask_with_already_masked_nans(self, test_data):
         """
         Test masked invalid values.

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -153,6 +153,8 @@ class TestBackgroundEstimators:
         bkg = bkg_class(sigma_clip=None)
         bkg_val1 = bkg.calc_background(test_data, axis=None)
         bkg_val2 = bkg.calc_background(test_data, axis=(0, 1))
+        assert np.ndim(bkg_val1) == 0
+        assert np.ndim(bkg_val2) == 0
         assert_allclose(bkg_val1, bkg_val2)
 
     @pytest.mark.parametrize('bkg_class', BACKGROUND_CLASSES)
@@ -330,6 +332,24 @@ class TestSpecificEstimators:
         data[70:] = 1.0e7
         bkg = SExtractorBackground(sigma_clip=None)
         assert_allclose(bkg.calc_background(data), np.median(data))
+
+    def test_sextractor_scalar_result_with_axis(self):
+        """
+        Test that SExtractorBackground returns a scalar when the
+        reduction consumes all axes, consistent with the other
+        estimator classes.
+        """
+        rng = np.random.default_rng(0)
+        bkg = SExtractorBackground(sigma_clip=None)
+
+        data = rng.normal(10.0, 1.0, (10, 10))
+        result = bkg.calc_background(data, axis=(0, 1))
+        assert np.ndim(result) == 0
+
+        data1d = rng.normal(10.0, 1.0, 100)
+        result = bkg.calc_background(data1d, axis=0)
+        assert np.ndim(result) == 0
+        assert_allclose(result, bkg.calc_background(data1d, axis=None))
 
     @pytest.mark.parametrize(('median_factor', 'mean_factor'), [
         (3.0, 2.0),  # default

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -459,7 +459,7 @@ class TestBackgroundRMSEstimators:
         mask[0, 0:10] = True
         data = np.ma.MaskedArray(test_data, mask=mask)
         rms = bkgrms.calc_background_rms(data)
-        assert not np.ma.isMaskedArray(bkgrms)
+        assert not np.ma.isMaskedArray(rms)
         assert_allclose(rms, std_value, atol=0.004)
         assert_allclose(bkgrms(data), bkgrms.calc_background_rms(data))
 

--- a/photutils/background/tests/test_local_background.py
+++ b/photutils/background/tests/test_local_background.py
@@ -3,6 +3,7 @@
 Tests for the local_background module.
 """
 
+import astropy.units as u
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -77,6 +78,26 @@ def test_local_background():
     assert_allclose(bkg4, bkg)
 
 
+def test_local_background_units():
+    """
+    Test that Quantity input data returns a Quantity with the same unit.
+    """
+    data = np.ones((101, 101))
+    local_bkg = LocalBackground(5, 10)
+
+    bkg = local_bkg(data << u.Jy, 50, 50)
+    assert isinstance(bkg, u.Quantity)
+    assert bkg.unit == u.Jy
+    assert_allclose(bkg.value, local_bkg(data, 50, 50))
+
+    x = [30, 50, 70]
+    y = [30, 50, 70]
+    bkg2 = local_bkg(data << u.Jy, x, y)
+    assert isinstance(bkg2, u.Quantity)
+    assert bkg2.unit == u.Jy
+    assert_allclose(bkg2.value, local_bkg(data, x, y))
+
+
 def test_local_background_estimator_1d():
     """
     Test that the bkg_estimator can be a 1D function that takes an array
@@ -91,6 +112,16 @@ def test_local_background_estimator_1d():
     local_bkg = LocalBackground(3, 6, bkg_estimator=estimator)
     bkg = local_bkg(data, [10, 20], [10, 20])
     assert_allclose(bkg, np.ones(2))
+
+
+def test_to_aperture_mismatched_shapes():
+    """
+    Test that an error is raised if x and y have different shapes.
+    """
+    local_bkg = LocalBackground(5, 10)
+    match = 'x and y must have the same shape'
+    with pytest.raises(ValueError, match=match):
+        local_bkg.to_aperture([1, 2], [1, 2, 3])
 
 
 def test_to_aperture_scalar():

--- a/photutils/background/tests/test_positional_kwargs.py
+++ b/photutils/background/tests/test_positional_kwargs.py
@@ -6,12 +6,14 @@ positionally.
 
 import numpy as np
 import pytest
+from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.background import (BiweightLocationBackground,
                                   BiweightScaleBackgroundRMS, LocalBackground,
                                   MADStdBackgroundRMS, MeanBackground,
-                                  MedianBackground, ModeEstimatorBackground,
+                                  MedianBackground, MMMBackground,
+                                  ModeEstimatorBackground,
                                   SExtractorBackground, StdBackgroundRMS)
 
 BKG_CLASSES = [MeanBackground,
@@ -74,6 +76,30 @@ class TestBackgroundRMSBasePositionalKwargs:
     def test_call_keyword_no_warning(self, cls):
         bkgrms = cls()
         bkgrms(self.data, axis=None)
+
+
+class TestEstimatorInitPositionalKwargs:
+    """
+    Test that estimator __init__ methods warn for positional optional
+    args.
+    """
+
+    @pytest.mark.parametrize(('cls', 'args'), [
+        (ModeEstimatorBackground, (3.0, 2.0)),
+        (MMMBackground, (SigmaClip(sigma=3.0),)),
+        (BiweightLocationBackground, (6.0,)),
+        (BiweightScaleBackgroundRMS, (9.0,)),
+    ])
+    def test_init_positional_warns(self, cls, args):
+        match = '__init__'
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            cls(*args)
+
+    def test_init_keyword_no_warning(self):
+        ModeEstimatorBackground(median_factor=3.0, mean_factor=2.0)
+        MMMBackground(sigma_clip=SigmaClip(sigma=3.0))
+        BiweightLocationBackground(c=6.0, M=None)
+        BiweightScaleBackgroundRMS(c=9.0, M=None)
 
 
 class TestLocalBackgroundPositionalKwargs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,6 +336,10 @@ ignore = [
     'INP001',  # not a package
     'T201',  # print
 ]
+'benchmarks/*.py' = [
+    'INP001',  # not a package
+    'T201',  # print
+]
 'docs/conf.py' = [
     'ERA001',  # commented-out-code
     'INP001',  # implicit-namespace-package


### PR DESCRIPTION
This PR adds an `n_threads` keyword to `Background2D` for multithreaded box statistics, along with several related fixes and cleanups in the `background` subpackage.

Main changes:

- `Background2D` gains an `n_threads` keyword. Boxes are split into
  chunks and processed concurrently. The sigma-clipping and statistics
  kernels release the GIL, so threads run in parallel. Results are
  identical to the single-threaded computation.
- The box statistics are now computed eagerly in `__init__`, and
  instances are effectively immutable afterwards (aside from internal
  lazy-attribute caches), making a single instance safe to share
  across threads.
- `LocalBackground` now supports `Quantity` input, returning a
  `Quantity` with the same unit.

Bug fixes:

- Fixed the `exclude_percentile` box-exclusion boundary: a box is now
  excluded only if *more than* `exclude_percentile` percent of its
  pixels are masked. Previously `exclude_percentile=0` excluded all
  boxes, including fully unmasked ones.
- `Background2D` now raises a clear `TypeError` for non-boolean `mask`
  or `coverage_mask` input instead of a cryptic `IndexError`.