### PR TITLE
Speed up sigma-clipped background and aperture statistics with combined Cython kernels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,14 +108,15 @@ New Features
     images. [#2363]
 
   - Significantly improved the performance of ``Background2D`` by
-    computing the sigma clipping and the box statistics in a single
-    pass in compiled code when the ``sigma_clip``, ``bkg_estimator``,
-    and ``bkg_rms_estimator`` inputs are among the standard supported
-    options. The combined kernel releases the GIL and composes with the
-    ``n_threads`` keyword. Unsupported inputs (e.g., custom estimator
-    callables or the biweight-based estimators) fall back to the
-    previous implementation and produce the same results as before.
-    [#2364]
+    computing the sigma clipping and the box statistics in a
+    single combined pass in compiled code when the ``sigma_clip``,
+    ``bkg_estimator``, and ``bkg_rms_estimator`` inputs are among the
+    standard supported options. This includes all of the standard
+    photutils background and background RMS estimator classes. The
+    Cython code releases the GIL and composes with the ``n_threads``
+    keyword. Unsupported inputs (e.g., custom estimator callables) fall
+    back to the previous implementation and produce the same results as
+    before. [#2364]
 
 - ``photutils.detection``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -123,6 +123,12 @@ New Features
     and a supported ``sigma_clip``, by routing the sigma clipping
     through astropy's fast C implementation. [#2364]
 
+  - Significantly improved the performance of ``LocalBackground``
+    when the ``bkg_estimator`` is a standard photutils estimator class,
+    by computing the local backgrounds for all positions with the
+    batched ``ApertureStats`` kernels instead of a Python loop over the
+    apertures. [#2364]
+
 - ``photutils.detection``
 
   - Added validation of the ``StarFinderCatalogBase.to_table()``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,16 @@ New Features
     significantly speed up the background estimation for large
     images. [#2363]
 
+  - Significantly improved the performance of ``Background2D`` by
+    computing the sigma clipping and the box statistics in a single
+    pass in compiled code when the ``sigma_clip``, ``bkg_estimator``,
+    and ``bkg_rms_estimator`` inputs are among the standard supported
+    options. The combined kernel releases the GIL and composes with the
+    ``n_threads`` keyword. Unsupported inputs (e.g., custom estimator
+    callables or the biweight-based estimators) fall back to the
+    previous implementation and produce the same results as before.
+    [#2364]
+
 - ``photutils.detection``
 
   - Added validation of the ``StarFinderCatalogBase.to_table()``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -208,6 +208,9 @@ Bug Fixes
     shape parameter after construction validates the inner < outer
     invariant. [#2362]
 
+  - Fixed a thread-safety issue in ``ApertureStats`` by using a copy of
+    the user's SigmaClip instance. [#2364]
+
 - ``photutils.background``
 
   - Fixed the ``exclude_percentile`` box-exclusion criterion in
@@ -292,6 +295,11 @@ Bug Fixes
 
   - Fixed ``EllipseSample`` not resetting ``EllipseGeometry`` cached
     attributes when overriding ``sma``. [#2280]
+
+- ``photutils.utils``
+
+  - Fixed a thread-safety issue in ``ImageDepth`` by using a copy of the
+    user's SigmaClip instance. [#2364]
 
 API Changes
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,10 @@ New Features
   - Added validation of the ``ApertureStats.to_table()`` ``columns``
     keyword. [#2329]
 
+  - Improved the performance of the sigma-clipped ``ApertureStats``
+    order statistics (``min``, ``max``, ``median``), ``mad_std``,
+    and biweight properties. [#2364]
+
 - ``photutils.background``
 
   - Updated ``LocalBackground`` so that ``Quantity`` input data is

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,11 @@ New Features
     back to the previous implementation and produce the same results as
     before. [#2364]
 
+  - Improved the performance of the background and background RMS
+    estimator classes when called with ``axis=None`` (the default)
+    and a supported ``sigma_clip``, by routing the sigma clipping
+    through astropy's fast C implementation. [#2364]
+
 - ``photutils.detection``
 
   - Added validation of the ``StarFinderCatalogBase.to_table()``

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -1234,10 +1234,115 @@ def batch_sigma_clip_sum(const double[::1] sum_values,
     return (sum_arr, var_arr, area_arr)
 
 
+cdef inline double _biweight_location_range(double *s, Py_ssize_t lo,
+                                            Py_ssize_t hi, double anchor,
+                                            double c,
+                                            double mad) noexcept nogil:
+    """
+    Biweight location of the ascending-sorted values ``s[lo:hi]``.
+
+    The convention matches `astropy.stats.biweight_location` with
+    a scalar location anchor (``M``) and a nonzero unscaled median
+    absolute deviation (``mad``). The caller must handle the ``mad ==
+    0`` case (astropy returns the anchor). If every value is rejected
+    (``|u| >= 1``), NaN is returned via the IEEE 0/0 division, matching
+    astropy.
+
+    Parameters
+    ----------
+    s : double *
+        The ascending-sorted values.
+
+    lo, hi : Py_ssize_t
+        The half-open index range of the values to use.
+
+    anchor : double
+        The location anchor (``M``; the median if not input).
+
+    c : double
+        The tuning constant.
+
+    mad : double
+        The unscaled median absolute deviation about the median.
+
+    Returns
+    -------
+    result : double
+        The biweight location.
+    """
+    cdef Py_ssize_t i
+    cdef double d, u, weight
+    cdef double num = 0.0, den = 0.0
+
+    for i in range(lo, hi):
+        d = s[i] - anchor
+        u = d / (c * mad)
+        if fabs(u) < 1.0:
+            weight = 1.0 - u * u
+            weight *= weight
+            num += d * weight
+            den += weight
+    return anchor + num / den
+
+
+cdef inline double _biweight_midvar_range(double *s, Py_ssize_t lo,
+                                          Py_ssize_t hi, double anchor,
+                                          double c,
+                                          double mad) noexcept nogil:
+    """
+    Biweight midvariance of the ascending-sorted values ``s[lo:hi]``.
+
+    The convention matches `astropy.stats.biweight_midvariance` with
+    ``modify_sample_size=False``, a scalar location anchor (``M``), and
+    a nonzero unscaled median absolute deviation (``mad``). The caller
+    must handle the ``mad == 0`` case (astropy returns 0). If every
+    value is rejected (``u**2 >= 1``), NaN is returned via the IEEE 0/0
+    division, matching astropy.
+
+    Parameters
+    ----------
+    s : double *
+        The ascending-sorted values.
+
+    lo, hi : Py_ssize_t
+        The half-open index range of the values to use.
+
+    anchor : double
+        The location anchor (``M``; the median if not input).
+
+    c : double
+        The tuning constant.
+
+    mad : double
+        The unscaled median absolute deviation about the median.
+
+    Returns
+    -------
+    result : double
+        The biweight midvariance.
+    """
+    cdef Py_ssize_t i, cnt = hi - lo
+    cdef double d, u2, omu
+    cdef double f1 = 0.0, f2 = 0.0
+
+    for i in range(lo, hi):
+        d = s[i] - anchor
+        u2 = d / (c * mad)
+        u2 = u2 * u2
+        if u2 < 1.0:
+            omu = 1.0 - u2
+            f1 += d * d * omu * omu * omu * omu
+            f2 += omu * (1.0 - 5.0 * u2)
+    return cnt * f1 / (f2 * f2)
+
+
 def batch_sigma_clip_stats(double[:, ::1] sorted_data, double sigma_lower,
                            double sigma_upper, Py_ssize_t maxiters,
                            int cenfunc_code, int stdfunc_code,
-                           bint do_clip, bint compute_mad):
+                           bint do_clip, bint compute_mad,
+                           bint compute_biloc, double biloc_c,
+                           double biloc_m, bint compute_biscale,
+                           double biscale_c, double biscale_m):
     """
     Compute fused sigma-clipped statistics for each row of a 2D array.
 
@@ -1245,8 +1350,10 @@ def batch_sigma_clip_stats(double[:, ::1] sorted_data, double sigma_lower,
     `astropy.stats.SigmaClip` (no-axis, no-grow case; see
     ``_sigma_clip_bounds``), and the mean, median, and population
     standard deviation of the surviving values are computed directly,
-    without generating a clipped copy of the input. Optionally, the MAD
-    standard deviation (`astropy.stats.mad_std`) is also computed.
+    without generating a clipped copy of the input. Optionally, the
+    MAD standard deviation (`astropy.stats.mad_std`), the biweight
+    location (`astropy.stats.biweight_location`), and the biweight scale
+    (`astropy.stats.biweight_scale`) are also computed.
 
     Each row must be ascending-sorted with any NaN values placed last,
     as done by `numpy.sort`. Sorting is delegated to the caller because
@@ -1284,9 +1391,29 @@ def batch_sigma_clip_stats(double[:, ::1] sorted_data, double sigma_lower,
         Whether to compute the MAD standard deviation. If False, the
         returned ``madstd`` values are all NaN.
 
+    compute_biloc : bool
+        Whether to compute the biweight location
+        (`astropy.stats.biweight_location`). If False, the returned
+        ``biloc`` values are all NaN.
+
+    biloc_c, biloc_m : float
+        The biweight location tuning constant and scalar location
+        anchor (``M``). A NaN ``biloc_m`` means no anchor was input
+        (the median is used). Ignored if ``compute_biloc`` is False.
+
+    compute_biscale : bool
+        Whether to compute the biweight scale
+        (`astropy.stats.biweight_scale`). If False, the returned
+        ``biscale`` values are all NaN.
+
+    biscale_c, biscale_m : float
+        The biweight scale tuning constant and scalar location anchor
+        (``M``). A NaN ``biscale_m`` means no anchor was input (the
+        median is used). Ignored if ``compute_biscale`` is False.
+
     Returns
     -------
-    mean, median, std, madstd : 1D ndarray of float64
+    mean, median, std, madstd, biloc, biscale : 1D ndarray of float64
         The per-row statistics of the surviving values. NaN for rows
         with no surviving values.
 
@@ -1300,22 +1427,28 @@ def batch_sigma_clip_stats(double[:, ::1] sorted_data, double sigma_lower,
     median_arr = np.full(n_rows, np.nan, dtype=np.float64)
     std_arr = np.full(n_rows, np.nan, dtype=np.float64)
     madstd_arr = np.full(n_rows, np.nan, dtype=np.float64)
+    biloc_arr = np.full(n_rows, np.nan, dtype=np.float64)
+    biscale_arr = np.full(n_rows, np.nan, dtype=np.float64)
     n_kept_arr = np.zeros(n_rows, dtype=np.intp)
     cdef double[::1] mean_out = mean_arr
     cdef double[::1] median_out = median_arr
     cdef double[::1] std_out = std_arr
     cdef double[::1] madstd_out = madstd_arr
+    cdef double[::1] biloc_out = biloc_arr
+    cdef double[::1] biscale_out = biscale_arr
     cdef Py_ssize_t[::1] n_kept_out = n_kept_arr
 
     if n_rows == 0 or n_cols == 0:
-        return mean_arr, median_arr, std_arr, madstd_arr, n_kept_arr
+        return (mean_arr, median_arr, std_arr, madstd_arr, biloc_arr,
+                biscale_arr, n_kept_arr)
 
     # Scratch buffer for the MAD computations
     work_arr = np.empty(n_cols, dtype=np.float64)
     cdef double[::1] w = work_arr
 
+    cdef bint need_mad = compute_mad or compute_biloc or compute_biscale
     cdef Py_ssize_t k, i, n, lo, hi, cnt
-    cdef double v, minv, maxv, mu, ss, med
+    cdef double v, minv, maxv, mu, ss, med, madk, anchor
     cdef double *s
 
     with nogil:
@@ -1362,10 +1495,33 @@ def batch_sigma_clip_stats(double[:, ::1] sorted_data, double sigma_lower,
             median_out[k] = med
             n_kept_out[k] = cnt
 
-            if compute_mad:
+            if need_mad:
+                # Unscaled MAD about the median of the survivors
                 for i in range(lo, hi):
                     w[i - lo] = fabs(s[i] - med)
                 qsort(&w[0], <size_t>cnt, sizeof(double), &_cmp_double)
-                madstd_out[k] = _median_sorted(&w[0], cnt) * _MAD_STD_SCALE
+                madk = _median_sorted(&w[0], cnt)
 
-    return mean_arr, median_arr, std_arr, madstd_arr, n_kept_arr
+                if compute_mad:
+                    madstd_out[k] = madk * _MAD_STD_SCALE
+
+                if compute_biloc:
+                    anchor = biloc_m if biloc_m == biloc_m else med
+                    if madk == 0.0:
+                        # astropy returns the anchor for zero MAD
+                        biloc_out[k] = anchor
+                    else:
+                        biloc_out[k] = _biweight_location_range(
+                            s, lo, hi, anchor, biloc_c, madk)
+
+                if compute_biscale:
+                    anchor = biscale_m if biscale_m == biscale_m else med
+                    if madk == 0.0:
+                        # astropy returns zero variance for zero MAD
+                        biscale_out[k] = 0.0
+                    else:
+                        biscale_out[k] = sqrt(_biweight_midvar_range(
+                            s, lo, hi, anchor, biscale_c, madk))
+
+    return (mean_arr, median_arr, std_arr, madstd_arr, biloc_arr,
+            biscale_arr, n_kept_arr)

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -94,12 +94,14 @@ cdef inline double _median_sorted(double *s, Py_ssize_t n) noexcept nogil:
 
 
 # Sigma-clip center/scale function codes (must match the ``cenfunc`` and
-# ``stdfunc`` mapping in ``ApertureStats``).
+# ``stdfunc`` mappings in ``ApertureStats`` and ``Background2D``).
 cdef enum:
     _CEN_MEDIAN = 0
     _CEN_MEAN = 1
+    _CEN_BIWEIGHT = 2
     _STD_STD = 0
     _STD_MADSTD = 1
+    _STD_BIWEIGHT = 2
 
 
 cdef inline void _sigma_clip_bounds(double *s, double *work, Py_ssize_t n,
@@ -116,6 +118,15 @@ cdef inline void _sigma_clip_bounds(double *s, double *work, Py_ssize_t n,
     value ``v`` satisfies ``not (v < out_min) and not (v > out_max)``,
     so NaN bounds keep every value, matching astropy's degenerate
     empty-set behavior.
+
+    For the biweight center/scale codes (astropy's 'biweight' string
+    options, which use astropy's Python clipping code paths), the
+    returned bounds are the extrema of the final kept window rather
+    than the last computed clipping limits. The Python code paths clip
+    accumulatively (a value clipped in any iteration stays clipped), so
+    reapplying the last limits could otherwise re-include values that
+    were clipped in an earlier iteration. Equal values always share the
+    same fate, so the window extrema reproduce the kept set exactly.
 
     Parameters
     ----------
@@ -146,10 +157,13 @@ cdef inline void _sigma_clip_bounds(double *s, double *work, Py_ssize_t n,
     """
     cdef Py_ssize_t lo = 0, hi = n, new_lo, new_hi, cnt, i, iteration = 0
     cdef Py_ssize_t nchanged = 1
-    cdef double cen, std, mu, ss, med2, minv, maxv
+    cdef double cen, std, mu, ss, med2, mad2, minv, maxv
+    cdef bint biweight = (cenfunc_code == _CEN_BIWEIGHT
+                          or stdfunc_code == _STD_BIWEIGHT)
 
     minv = NAN
     maxv = NAN
+    mad2 = NAN
     while nchanged != 0 and (maxiters < 0 or iteration < maxiters):
         iteration += 1
         cnt = hi - lo
@@ -158,9 +172,27 @@ cdef inline void _sigma_clip_bounds(double *s, double *work, Py_ssize_t n,
             maxv = NAN
             break
 
+        # The biweight center and scale need the median and the
+        # unscaled MAD of the current values
+        if biweight:
+            med2 = _median_sorted(&s[lo], cnt)
+            for i in range(lo, hi):
+                work[i] = fabs(s[i] - med2)
+            qsort(&work[lo], <size_t>cnt, sizeof(double), &_cmp_double)
+            mad2 = _median_sorted(&work[lo], cnt)
+
         # Center.
         if cenfunc_code == _CEN_MEDIAN:
             cen = _median_sorted(&s[lo], cnt)
+        elif cenfunc_code == _CEN_BIWEIGHT:
+            # astropy biweight_location with the default tuning
+            # constant (c=6) and the median anchor. The median is
+            # returned for zero MAD.
+            if mad2 == 0.0:
+                cen = med2
+            else:
+                cen = _biweight_location_range(s, lo, hi, med2, 6.0,
+                                               mad2)
         else:
             mu = 0.0
             for i in range(lo, hi):
@@ -177,6 +209,15 @@ cdef inline void _sigma_clip_bounds(double *s, double *work, Py_ssize_t n,
             for i in range(lo, hi):
                 ss += (s[i] - mu) * (s[i] - mu)
             std = sqrt(ss / cnt)
+        elif stdfunc_code == _STD_BIWEIGHT:
+            # astropy biweight_scale with the default tuning constant
+            # (c=9) and the median anchor. Zero is returned for zero
+            # MAD.
+            if mad2 == 0.0:
+                std = 0.0
+            else:
+                std = sqrt(_biweight_midvar_range(s, lo, hi, med2, 9.0,
+                                                  mad2))
         else:
             med2 = _median_sorted(&s[lo], cnt)
             for i in range(lo, hi):
@@ -196,6 +237,13 @@ cdef inline void _sigma_clip_bounds(double *s, double *work, Py_ssize_t n,
         nchanged = (hi - lo) - (new_hi - new_lo)
         lo = new_lo
         hi = new_hi
+
+    if biweight and hi > lo:
+        # Match the accumulative clipping of astropy's Python code
+        # paths (see the docstring). The effective bounds are the
+        # extrema of the final kept window.
+        minv = s[lo]
+        maxv = s[hi - 1]
 
     out_min[0] = minv
     out_max[0] = maxv

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -1099,7 +1099,13 @@ def batch_sigma_clip_center(const double[::1] values,
     (no-axis, no-grow case), and the surviving pixels are written to a
     new packed buffer that reuses the input ``starts`` offsets. The
     output can be fed directly to the packed-buffer reductions (e.g.,
-    ``batch_mean_var``, ``batch_sort_values``, and ``batch_moments``).
+    ``batch_mean_var`` and ``batch_moments``).
+
+    Because computing the clip bounds requires sorting each source's
+    values, the ascending-sorted surviving values are also returned
+    (the survivors form a contiguous window of the sorted buffer), so
+    callers do not need to sort the clipped values again for the
+    order statistics.
 
     Parameters
     ----------
@@ -1128,15 +1134,21 @@ def batch_sigma_clip_center(const double[::1] values,
     values, local_x, local_y, starts, counts : 1D ndarray
         The clipped packed buffer (``starts`` is the input array,
         unchanged) and the per-source surviving pixel counts.
+
+    sorted_values : 1D ndarray of float64
+        The packed buffer of ascending-sorted surviving values, using
+        the same ``starts`` offsets and ``counts`` lengths.
     """
     cdef Py_ssize_t n_src = starts.shape[0]
     out_values_arr = np.empty(values.shape[0], dtype=np.float64)
     out_lx_arr = np.empty(values.shape[0], dtype=np.int32)
     out_ly_arr = np.empty(values.shape[0], dtype=np.int32)
+    out_sorted_arr = np.empty(values.shape[0], dtype=np.float64)
     counts2_arr = np.zeros(n_src, dtype=np.intp)
     cdef double[::1] out_values = out_values_arr
     cdef int[::1] out_lx = out_lx_arr
     cdef int[::1] out_ly = out_ly_arr
+    cdef double[::1] out_sorted = out_sorted_arr
     cdef Py_ssize_t[::1] counts2 = counts2_arr
 
     cdef Py_ssize_t maxn = 0, k
@@ -1145,14 +1157,14 @@ def batch_sigma_clip_center(const double[::1] values,
             maxn = counts[k]
     if maxn == 0:
         return (out_values_arr, out_lx_arr, out_ly_arr, np.asarray(starts),
-                counts2_arr)
+                counts2_arr, out_sorted_arr)
 
     sort_arr = np.empty(maxn, dtype=np.float64)
     work_arr = np.empty(maxn, dtype=np.float64)
     cdef double[::1] s = sort_arr
     cdef double[::1] w = work_arr
 
-    cdef Py_ssize_t start, count, i, j
+    cdef Py_ssize_t start, count, i, j, lo, hi
     cdef double minv, maxv, v
 
     with nogil:
@@ -1177,8 +1189,21 @@ def batch_sigma_clip_center(const double[::1] values,
                     j += 1
             counts2[k] = j
 
+            # The survivors form a contiguous window of the sorted
+            # buffer (equal values always share the same fate). Emit
+            # them sorted so that callers do not need to sort the
+            # clipped values again.
+            lo = 0
+            hi = count
+            while lo < count and s[lo] < minv:
+                lo += 1
+            while hi > lo and s[hi - 1] > maxv:
+                hi -= 1
+            for i in range(lo, hi):
+                out_sorted[start + (i - lo)] = s[i]
+
     return (out_values_arr, out_lx_arr, out_ly_arr, np.asarray(starts),
-            counts2_arr)
+            counts2_arr, out_sorted_arr)
 
 
 def batch_sigma_clip_sum(const double[::1] sum_values,

--- a/photutils/aperture/_batch_stats.pyx
+++ b/photutils/aperture/_batch_stats.pyx
@@ -38,7 +38,7 @@ from photutils.geometry.rectangle_overlap cimport rect_vertices
 __all__ = ['batch_aperture_gather', 'batch_moments', 'batch_sort_values',
            'batch_order_stats', 'batch_mean_var', 'batch_mad',
            'batch_biweight', 'batch_gini', 'batch_sigma_clip_center',
-           'batch_sigma_clip_sum']
+           'batch_sigma_clip_stats', 'batch_sigma_clip_sum']
 
 
 cdef extern from "math.h" nogil:
@@ -1232,3 +1232,140 @@ def batch_sigma_clip_sum(const double[::1] sum_values,
                 var_aper[k] = s_var
 
     return (sum_arr, var_arr, area_arr)
+
+
+def batch_sigma_clip_stats(double[:, ::1] sorted_data, double sigma_lower,
+                           double sigma_upper, Py_ssize_t maxiters,
+                           int cenfunc_code, int stdfunc_code,
+                           bint do_clip, bint compute_mad):
+    """
+    Compute fused sigma-clipped statistics for each row of a 2D array.
+
+    For each row, the finite values are sigma-clipped following
+    `astropy.stats.SigmaClip` (no-axis, no-grow case; see
+    ``_sigma_clip_bounds``), and the mean, median, and population
+    standard deviation of the surviving values are computed directly,
+    without generating a clipped copy of the input. Optionally, the MAD
+    standard deviation (`astropy.stats.mad_std`) is also computed.
+
+    Each row must be ascending-sorted with any NaN values placed last,
+    as done by `numpy.sort`. Sorting is delegated to the caller because
+    ``numpy.sort`` is much faster than a comparator-based C ``qsort``
+    for the large rows this function is designed for. The input array is
+    not modified.
+
+    The rows are typically the flattened pixels of the boxes of a
+    regular grid (e.g., the `~photutils.background.Background2D`
+    low-resolution mesh), with NaN values marking masked pixels.
+
+    Parameters
+    ----------
+    sorted_data : 2D ndarray of float64
+        The row data, ascending-sorted along the last axis with NaN
+        values last. NaN values are ignored.
+
+    sigma_lower, sigma_upper : float
+        The lower and upper clipping limits in units of the scale.
+
+    maxiters : int
+        The maximum number of clipping iterations, or a negative value
+        to iterate until convergence.
+
+    cenfunc_code, stdfunc_code : int
+        The center and scale function codes (``0`` = median/std,
+        ``1`` = mean/mad_std).
+
+    do_clip : bool
+        Whether to apply sigma clipping. If False, the statistics are
+        computed from all finite values and the clipping parameters
+        are ignored.
+
+    compute_mad : bool
+        Whether to compute the MAD standard deviation. If False, the
+        returned ``madstd`` values are all NaN.
+
+    Returns
+    -------
+    mean, median, std, madstd : 1D ndarray of float64
+        The per-row statistics of the surviving values. NaN for rows
+        with no surviving values.
+
+    n_kept : 1D ndarray of intp
+        The per-row number of surviving values.
+    """
+    cdef Py_ssize_t n_rows = sorted_data.shape[0]
+    cdef Py_ssize_t n_cols = sorted_data.shape[1]
+
+    mean_arr = np.full(n_rows, np.nan, dtype=np.float64)
+    median_arr = np.full(n_rows, np.nan, dtype=np.float64)
+    std_arr = np.full(n_rows, np.nan, dtype=np.float64)
+    madstd_arr = np.full(n_rows, np.nan, dtype=np.float64)
+    n_kept_arr = np.zeros(n_rows, dtype=np.intp)
+    cdef double[::1] mean_out = mean_arr
+    cdef double[::1] median_out = median_arr
+    cdef double[::1] std_out = std_arr
+    cdef double[::1] madstd_out = madstd_arr
+    cdef Py_ssize_t[::1] n_kept_out = n_kept_arr
+
+    if n_rows == 0 or n_cols == 0:
+        return mean_arr, median_arr, std_arr, madstd_arr, n_kept_arr
+
+    # Scratch buffer for the MAD computations
+    work_arr = np.empty(n_cols, dtype=np.float64)
+    cdef double[::1] w = work_arr
+
+    cdef Py_ssize_t k, i, n, lo, hi, cnt
+    cdef double v, minv, maxv, mu, ss, med
+    cdef double *s
+
+    with nogil:
+        for k in range(n_rows):
+            # The finite values are s[0:n]; NaN values sort last
+            n = n_cols
+            while n > 0:
+                v = sorted_data[k, n - 1]
+                if v == v:  # not NaN
+                    break
+                n -= 1
+            if n == 0:
+                continue
+            s = &sorted_data[k, 0]
+
+            lo = 0
+            hi = n
+            if do_clip:
+                _sigma_clip_bounds(s, &w[0], n, sigma_lower,
+                                   sigma_upper, maxiters, cenfunc_code,
+                                   stdfunc_code, &minv, &maxv)
+                # A value survives if not (v < minv) and not
+                # (v > maxv), so NaN bounds keep every value, matching
+                # astropy's degenerate empty-set behavior
+                while lo < n and s[lo] < minv:
+                    lo += 1
+                while hi > lo and s[hi - 1] > maxv:
+                    hi -= 1
+            cnt = hi - lo
+            if cnt == 0:
+                continue
+
+            mu = 0.0
+            for i in range(lo, hi):
+                mu += s[i]
+            mu /= cnt
+            ss = 0.0
+            for i in range(lo, hi):
+                ss += (s[i] - mu) * (s[i] - mu)
+            med = _median_sorted(&s[lo], cnt)
+
+            mean_out[k] = mu
+            std_out[k] = sqrt(ss / cnt)
+            median_out[k] = med
+            n_kept_out[k] = cnt
+
+            if compute_mad:
+                for i in range(lo, hi):
+                    w[i - lo] = fabs(s[i] - med)
+                qsort(&w[0], <size_t>cnt, sizeof(double), &_cmp_double)
+                madstd_out[k] = _median_sorted(&w[0], cnt) * _MAD_STD_SCALE
+
+    return mean_arr, median_arr, std_arr, madstd_arr, n_kept_arr

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -92,7 +92,9 @@ class _BatchGather(NamedTuple):
 
     * center-value gather (``_fast_gather``): ``values``, ``local_x``,
       ``local_y``, ``starts``, ``counts``, ``overlap``, and
-      ``flag_counts``
+      ``flag_counts``, plus ``sorted_values`` (the packed
+      ascending-sorted surviving values) when sigma clipping is
+      applied
 
     * ``sum_method`` gather (``_fast_sum``): ``sum_aper``, ``var_aper``,
       ``sum_area``, ``starts``, ``overlap``, and ``flag_counts``,
@@ -114,6 +116,7 @@ class _BatchGather(NamedTuple):
     sum_errsq: np.ndarray = None
     sum_counts: np.ndarray = None
     flag_counts: np.ndarray = None
+    sorted_values: np.ndarray = None
 
 
 # Public attributes that are never collapsed to a scalar for a scalar
@@ -1060,13 +1063,15 @@ class ApertureStats:
         """
         sigma_lower, sigma_upper, maxiters, cenfunc, stdfunc = clip_spec
 
-        (cvalues, clx, cly, cstarts, ccounts) = batch_sigma_clip_center(
+        (cvalues, clx, cly, cstarts, ccounts,
+         csorted) = batch_sigma_clip_center(
             gather.values, gather.local_x, gather.local_y, gather.starts,
             gather.counts, sigma_lower, sigma_upper, maxiters, cenfunc,
             stdfunc)
 
         return gather._replace(values=cvalues, local_x=clx, local_y=cly,
-                               starts=cstarts, counts=ccounts)
+                               starts=cstarts, counts=ccounts,
+                               sorted_values=csorted)
 
     def _apply_sum_clip(self, gather, clip_spec):
         """
@@ -1097,13 +1102,18 @@ class ApertureStats:
         source's packed pixel values are sorted once. The sorted buffer
         is cached and shared by the order statistics (``min``, ``max``,
         ``median``), ``mad_std``, and the biweight estimators, so the
-        per-source sort is performed only once. `None` is returned when
-        the fast path is unavailable.
+        per-source sort is performed only once. When sigma clipping is
+        applied, the sorted surviving values produced by the clipping
+        kernel are reused directly (the clipping already sorts each
+        source's values to compute the clip bounds). `None` is returned
+        when the fast path is unavailable.
         """
         gather = self._fast_gather
         if gather is None:
             return None
         values, starts, counts = gather.values, gather.starts, gather.counts
+        if gather.sorted_values is not None:
+            return (gather.sorted_values, starts, counts)
         return (batch_sort_values(values, starts, counts), starts, counts)
 
     @lazyproperty

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -1028,17 +1028,18 @@ class ApertureStats:
         stdfunc_code)`` when ``sigma_clip`` is a `SigmaClip` instance
         supported by the fast clipping kernel, and `None` otherwise (in
         which case the mask-based path is used). The fast path supports
-        the string ``cenfunc`` values 'median'/'mean', the string
-        ``stdfunc`` values 'std'/'mad_std', and no spatial growing.
+        the string ``cenfunc`` values 'median'/'mean'/'biweight', the
+        string ``stdfunc`` values 'std'/'mad_std'/'biweight', and no
+        spatial growing.
         """
         sc = self.sigma_clip
         if sc is None or not isinstance(sc, SigmaClip):
             return None
-        if not (isinstance(sc.cenfunc, str) and sc.cenfunc in ('median',
-                                                               'mean')):
+        if not (isinstance(sc.cenfunc, str)
+                and sc.cenfunc in ('median', 'mean', 'biweight')):
             return None
-        if not (isinstance(sc.stdfunc, str) and sc.stdfunc in ('std',
-                                                               'mad_std')):
+        if not (isinstance(sc.stdfunc, str)
+                and sc.stdfunc in ('std', 'mad_std', 'biweight')):
             return None
         if sc.grow:  # False or 0 is supported; spatial growing is not
             return None
@@ -1047,8 +1048,8 @@ class ApertureStats:
             maxiters = -1
         else:
             maxiters = int(maxiters)
-        cenfunc_code = 0 if sc.cenfunc == 'median' else 1
-        stdfunc_code = 0 if sc.stdfunc == 'std' else 1
+        cenfunc_code = {'median': 0, 'mean': 1, 'biweight': 2}[sc.cenfunc]
+        stdfunc_code = {'std': 0, 'mad_std': 1, 'biweight': 2}[sc.stdfunc]
         return (float(sc.sigma_lower), float(sc.sigma_upper), maxiters,
                 cenfunc_code, stdfunc_code)
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -5,7 +5,7 @@ Tools for calculating properties of sources defined by an Aperture.
 
 import inspect
 import warnings
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import NamedTuple
 
 import astropy.units as u
@@ -1297,6 +1297,14 @@ class ApertureStats:
             sigma-clipped pixels (always 0 when ``count_clipped`` is
             `False`).
         """
+        # Use a local copy of the SigmaClip instance because SigmaClip
+        # stores internal state on the instance # during calls. This
+        # method is reachable from two different # lazyproperties (the
+        # center- and sum-footprint cutouts), # which do not share a lock,
+        # so calling a shared instance from # multiple threads could
+        # silently corrupt the results.
+        sigma_clip = copy(self.sigma_clip)
+
         data_cutouts = []
         variance_cutouts = []
         mask_cutouts = []
@@ -1393,14 +1401,14 @@ class ApertureStats:
                 mask_cutout = (aperweight_cutout == 0) | data_mask
 
                 data_cutout = data_cutout.copy()
-                if self.sigma_clip is None:
+                if sigma_clip is None:
                     # data_cutout will have zeros where mask_cutout is True
                     data_cutout *= ~mask_cutout
                 else:
                     # To input a mask, SigmaClip needs a MaskedArray
                     data_cutout_ma = np.ma.masked_array(data_cutout,
                                                         mask=mask_cutout)
-                    data_sigclip = self.sigma_clip(data_cutout_ma)
+                    data_sigclip = sigma_clip(data_cutout_ma)
 
                     # Define a mask of only the sigma-clipped pixels
                     sigclip_mask = data_sigclip.mask & ~mask_cutout

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -1281,3 +1281,29 @@ class TestSigmaClipBiweightStrings:
         assert_allclose(mean1, apstats2.mean, rtol=1e-10)
         assert_allclose(std1, apstats2.std, rtol=1e-10)
         assert_allclose(sum1, apstats2.sum, rtol=1e-10)
+
+
+def test_sigma_clip_sorted_values_reuse(monkeypatch):
+    """
+    Test that the order statistics computed from the sigma-clip kernel's
+    sorted output (reused by _sorted_values instead of re-sorting the
+    clipped values) match the mask-based fallback path.
+    """
+    rng = np.random.default_rng(0)
+    data = rng.normal(10.0, 2.0, (101, 101))
+    data[::5, ::5] = 200.0  # outliers
+    positions = [(20.0, 20.0), (50.0, 50.0), (80.5, 80.5), (3.0, 3.0)]
+    aper = CircularAperture(positions, r=12)
+    sigclip = SigmaClip(sigma=2.0, maxiters=10)
+
+    apstats1 = ApertureStats(data, aper, sigma_clip=sigclip)
+    props = ('min', 'max', 'median', 'mad_std', 'biweight_location',
+             'std', 'mean')
+    results1 = [getattr(apstats1, prop) for prop in props]
+
+    # Force the mask-based fallback path
+    monkeypatch.setattr(ApertureStats, '_fast_clip_spec',
+                        lambda _self: None)
+    apstats2 = ApertureStats(data, aper, sigma_clip=sigclip)
+    for prop, result1 in zip(props, results1, strict=True):
+        assert_allclose(result1, getattr(apstats2, prop), rtol=1e-10)

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -1135,3 +1135,86 @@ class TestApertureMetadata:
         assert tbl.meta['aperture_a_out'] == saper.a_out
         assert tbl.meta['aperture_b_out'] == saper.b_out
         assert tbl.meta['aperture_theta'] == saper.theta
+
+
+class TestSigmaClipSharedInstance:
+    """
+    Tests for calling a shared SigmaClip instance from the astropy
+    fallback clipping path.
+
+    astropy SigmaClip stores internal state on the instance during
+    calls, and the fallback path is reachable from two different
+    lazyproperties (the center- and sum-footprint cutouts) that do not
+    share a lock. ApertureStats must therefore never call the user's
+    SigmaClip instance directly.
+    """
+
+    def test_user_sigma_clip_instance_not_called(self, monkeypatch):
+        """
+        Test that the user's SigmaClip instance is never called directly
+        (an internal copy must be used).
+        """
+        data = np.ones((51, 51))
+        data[20:30, 20:30] = 100.0
+        aper = CircularAperture([(25, 25), (10, 10)], r=8)
+        # A callable cenfunc is unsupported by the batch clipping
+        # kernels and forces the astropy SigmaClip fallback path.
+        sigclip = SigmaClip(sigma=3.0, maxiters=5, cenfunc=np.nanmedian)
+
+        called_ids = []
+        orig_call = SigmaClip.__call__
+
+        def spy(self, *args, **kwargs):
+            called_ids.append(id(self))
+            return orig_call(self, *args, **kwargs)
+
+        monkeypatch.setattr(SigmaClip, '__call__', spy)
+        apstats = ApertureStats(data, aper, sigma_clip=sigclip,
+                                sum_method='exact')
+        _ = apstats.mean
+        _ = apstats.sum
+
+        assert len(called_ids) > 0  # the fallback path was exercised
+        assert id(sigclip) not in called_ids
+
+    def test_fallback_thread_safety(self):
+        """
+        Test that computing a center-footprint and a sum-footprint
+        property concurrently on the same instance gives the same
+        results as the serial computation.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        rng = np.random.default_rng(0)
+        n_src = 200
+        ny = 51
+        yc = ny // 2
+        xs = np.arange(25, 25 + 50 * n_src, 50)
+        data = rng.normal(0.0, 1.0, (ny, 50 * n_src + 50))
+        for i, x in enumerate(xs):
+            # Strong per-source scale differences make any clipping
+            # bound contamination between sources visible
+            scale = 10.0 ** (i % 6)
+            data[:, x - 20:x + 20] = rng.normal(scale, scale / 10.0,
+                                                (ny, 40))
+            data[yc - 2:yc + 2, x - 2:x + 2] = scale * 50.0  # outliers
+
+        positions = np.column_stack([xs, np.full(n_src, yc)])
+        aper = CircularAperture(positions, r=15)
+        sigclip = SigmaClip(sigma=2.0, maxiters=10, cenfunc=np.nanmedian)
+
+        ref = ApertureStats(data, aper, sigma_clip=sigclip,
+                            sum_method='exact')
+        ref_mean = ref.mean
+        ref_sum = ref.sum
+
+        for _ in range(3):
+            apstats = ApertureStats(data, aper, sigma_clip=sigclip,
+                                    sum_method='exact')
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                mean_future = executor.submit(getattr, apstats, 'mean')
+                sum_future = executor.submit(getattr, apstats, 'sum')
+                mean = mean_future.result()
+                total = sum_future.result()
+            assert_allclose(mean, ref_mean)
+            assert_allclose(total, ref_sum)

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -10,7 +10,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.nddata import NDData, StdDevUncertainty
-from astropy.stats import SigmaClip, mad_std
+from astropy.stats import SigmaClip, biweight_location, biweight_scale, mad_std
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
@@ -1218,3 +1218,66 @@ class TestSigmaClipSharedInstance:
                 total = sum_future.result()
             assert_allclose(mean, ref_mean)
             assert_allclose(total, ref_sum)
+
+
+class TestSigmaClipBiweightStrings:
+    """
+    Tests for the SigmaClip 'biweight' cenfunc/stdfunc string options in
+    the fast clipping kernels.
+    """
+
+    @staticmethod
+    def _make_sigma_clip_biweight(**kwargs):
+        """
+        Create a SigmaClip instance using the 'biweight' cenfunc and
+        stdfunc string options, emulating them on astropy versions that
+        do not support these options.
+        """
+
+        def nanbiloc(data, axis=None):
+            return biweight_location(data, axis=axis, ignore_nan=True)
+
+        def nanbiscale(data, axis=None):
+            return biweight_scale(data, axis=axis, ignore_nan=True)
+
+        try:
+            return SigmaClip(cenfunc='biweight', stdfunc='biweight',
+                             **kwargs)
+        except ValueError:
+            sigma_clip = SigmaClip(**kwargs)
+            sigma_clip.cenfunc = 'biweight'
+            sigma_clip.stdfunc = 'biweight'
+            sigma_clip._cenfunc_parsed = nanbiloc
+            sigma_clip._stdfunc_parsed = nanbiscale
+            return sigma_clip
+
+    def test_biweight_matches_fallback(self, monkeypatch):
+        """
+        Test that the 'biweight' string options are accepted by the fast
+        clipping kernels and match the mask-based fallback path, which
+        clips using the astropy SigmaClip instance.
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(10.0, 2.0, (101, 101))
+        data[::7, ::7] = 200.0  # outliers
+        positions = [(20.0, 20.0), (50.0, 50.0), (80.5, 80.5)]
+        aper = CircularAperture(positions, r=12)
+        sigclip = self._make_sigma_clip_biweight(sigma=2.0, maxiters=5)
+
+        apstats1 = ApertureStats(data, aper, sigma_clip=sigclip,
+                                 sum_method='exact')
+        assert apstats1._fast_clip_spec() is not None
+        mean1 = apstats1.mean
+        std1 = apstats1.std
+        sum1 = apstats1.sum
+
+        # Force the mask-based fallback path
+        monkeypatch.setattr(ApertureStats, '_fast_clip_spec',
+                            lambda _self: None)
+        apstats2 = ApertureStats(data, aper, sigma_clip=sigclip,
+                                 sum_method='exact')
+        assert apstats2._fast_clip_spec() is None
+
+        assert_allclose(mean1, apstats2.mean, rtol=1e-10)
+        assert_allclose(std1, apstats2.std, rtol=1e-10)
+        assert_allclose(sum1, apstats2.sum, rtol=1e-10)

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -18,9 +18,11 @@ from scipy.ndimage import generic_filter
 
 from photutils.aperture import RectangularAperture
 from photutils.aperture._batch_stats import batch_sigma_clip_stats
-from photutils.background.core import (SIGMA_CLIP, MADStdBackgroundRMS,
-                                       MeanBackground, MedianBackground,
-                                       MMMBackground, ModeEstimatorBackground,
+from photutils.background.core import (SIGMA_CLIP, BiweightLocationBackground,
+                                       BiweightScaleBackgroundRMS,
+                                       MADStdBackgroundRMS, MeanBackground,
+                                       MedianBackground, MMMBackground,
+                                       ModeEstimatorBackground,
                                        SExtractorBackground, StdBackgroundRMS)
 from photutils.background.interpolators import (BkgIDWInterpolator,
                                                 _BkgZoomInterpolator)
@@ -52,7 +54,11 @@ class _BoxStatsSpec(NamedTuple):
     bkg_kind: str
     median_factor: float
     mean_factor: float
+    biloc_c: float
+    biloc_m: float
     rms_kind: str
+    biscale_c: float
+    biscale_m: float
 
 
 class Background2D:
@@ -217,10 +223,10 @@ class Background2D:
     When the ``sigma_clip`` input is `None` or uses the string
     ``cenfunc`` and ``stdfunc`` options, and the ``bkg_estimator``
     and ``bkg_rms_estimator`` inputs are standard photutils estimator
-    classes (except the biweight-based ones), the sigma clipping and
-    box statistics are computed together using a fast fused kernel in
-    compiled code. Otherwise, a generic path that calls ``sigma_clip``
-    and the estimators is used. Both paths produce the same results.
+    classes, the sigma clipping and box statistics are computed
+    together in compiled code. Otherwise, a generic path that calls
+    ``sigma_clip`` and the estimators is used. Both paths produce the
+    same results.
 
     If there is only one background box element (i.e., ``box_size`` is
     the same size as (or larger than) the ``data``), then the background
@@ -501,8 +507,9 @@ class Background2D:
         on `astropy.stats.SigmaClip` and the estimator callables is
         used). The fast path supports the string ``cenfunc`` values
         'median'/'mean', the string ``stdfunc`` values 'std'/'mad_std',
-        no spatial growing, and the standard photutils estimator classes
-        (except the biweight-based ones).
+        no spatial growing, and the standard photutils estimator
+        classes. For the biweight-based estimators, the ``M`` location
+        anchor must be `None` or a finite scalar.
         """
         sigma_clip = self.sigma_clip
         if sigma_clip is None:
@@ -532,6 +539,7 @@ class Background2D:
 
         bkg_estimator = self.bkg_estimator
         median_factor = mean_factor = 0.0
+        biloc_c = biloc_m = np.nan
         if type(bkg_estimator) is MeanBackground:
             bkg_kind = 'mean'
         elif type(bkg_estimator) is MedianBackground:
@@ -543,14 +551,31 @@ class Background2D:
             mean_factor = float(bkg_estimator.mean_factor)
         elif type(bkg_estimator) is SExtractorBackground:
             bkg_kind = 'sextractor'
+        elif type(bkg_estimator) is BiweightLocationBackground:
+            m_value = bkg_estimator.M
+            if m_value is not None and (np.ndim(m_value) != 0
+                                        or not np.isfinite(m_value)):
+                return None
+            bkg_kind = 'biweight_location'
+            biloc_c = float(bkg_estimator.c)
+            biloc_m = np.nan if m_value is None else float(m_value)
         else:
             return None
 
         rms_estimator = self.bkg_rms_estimator
+        biscale_c = biscale_m = np.nan
         if type(rms_estimator) is StdBackgroundRMS:
             rms_kind = 'std'
         elif type(rms_estimator) is MADStdBackgroundRMS:
             rms_kind = 'mad_std'
+        elif type(rms_estimator) is BiweightScaleBackgroundRMS:
+            m_value = rms_estimator.M
+            if m_value is not None and (np.ndim(m_value) != 0
+                                        or not np.isfinite(m_value)):
+                return None
+            rms_kind = 'biweight_scale'
+            biscale_c = float(rms_estimator.c)
+            biscale_m = np.nan if m_value is None else float(m_value)
         else:
             return None
 
@@ -560,7 +585,9 @@ class Background2D:
                              stdfunc_code=stdfunc_code, do_clip=do_clip,
                              bkg_kind=bkg_kind,
                              median_factor=median_factor,
-                             mean_factor=mean_factor, rms_kind=rms_kind)
+                             mean_factor=mean_factor, biloc_c=biloc_c,
+                             biloc_m=biloc_m, rms_kind=rms_kind,
+                             biscale_c=biscale_c, biscale_m=biscale_m)
 
     def _fast_box_statistics(self, data, *, axis=None):
         """
@@ -607,12 +634,14 @@ class Background2D:
         # requires ascending-sorted rows.
         data2d = np.sort(data2d.astype(np.float64, copy=False), axis=-1)
 
-        (mean, median, std, madstd,
-         n_good) = batch_sigma_clip_stats(data2d, spec.sigma_lower,
-                                          spec.sigma_upper, spec.maxiters,
-                                          spec.cenfunc_code,
-                                          spec.stdfunc_code, spec.do_clip,
-                                          spec.rms_kind == 'mad_std')
+        (mean, median, std, madstd, biloc,
+         biscale, n_good) = batch_sigma_clip_stats(
+            data2d, spec.sigma_lower, spec.sigma_upper, spec.maxiters,
+            spec.cenfunc_code, spec.stdfunc_code, spec.do_clip,
+            spec.rms_kind == 'mad_std',
+            spec.bkg_kind == 'biweight_location', spec.biloc_c,
+            spec.biloc_m, spec.rms_kind == 'biweight_scale',
+            spec.biscale_c, spec.biscale_m)
 
         if spec.bkg_kind == 'mean':
             bkg = mean
@@ -621,6 +650,8 @@ class Background2D:
         elif spec.bkg_kind == 'mode':
             bkg = ((spec.median_factor * median)
                    - (spec.mean_factor * mean))
+        elif spec.bkg_kind == 'biweight_location':
+            bkg = biloc
         else:  # 'sextractor'
             bkg = (2.5 * median) - (1.5 * mean)
 
@@ -636,7 +667,12 @@ class Background2D:
             mask = np.logical_and(med_mask, np.logical_not(mean_mask))
             bkg[mask] = median[mask]
 
-        bkgrms = madstd if spec.rms_kind == 'mad_std' else std
+        if spec.rms_kind == 'std':
+            bkgrms = std
+        elif spec.rms_kind == 'mad_std':
+            bkgrms = madstd
+        else:  # 'biweight_scale'
+            bkgrms = biscale
 
         # Preserve the (float) dtype of the input box data
         if data.dtype != np.float64:

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -506,10 +506,10 @@ class Background2D:
         and `None` otherwise (in which case the generic path based
         on `astropy.stats.SigmaClip` and the estimator callables is
         used). The fast path supports the string ``cenfunc`` values
-        'median'/'mean', the string ``stdfunc`` values 'std'/'mad_std',
-        no spatial growing, and the standard photutils estimator
-        classes. For the biweight-based estimators, the ``M`` location
-        anchor must be `None` or a finite scalar.
+        'median'/'mean'/'biweight', the string ``stdfunc`` values
+        'std'/'mad_std'/'biweight', no spatial growing, and the standard
+        photutils estimator classes. For the biweight-based estimators,
+        the ``M`` location anchor must be `None` or a finite scalar.
         """
         sigma_clip = self.sigma_clip
         if sigma_clip is None:
@@ -521,9 +521,11 @@ class Background2D:
             # Spatial growing (``grow``) is not supported
             if (not isinstance(sigma_clip, SigmaClip)
                     or not (isinstance(sigma_clip.cenfunc, str)
-                            and sigma_clip.cenfunc in ('median', 'mean'))
+                            and sigma_clip.cenfunc in ('median', 'mean',
+                                                       'biweight'))
                     or not (isinstance(sigma_clip.stdfunc, str)
-                            and sigma_clip.stdfunc in ('std', 'mad_std'))
+                            and sigma_clip.stdfunc in ('std', 'mad_std',
+                                                       'biweight'))
                     or sigma_clip.grow):
                 return None
             do_clip = True
@@ -534,8 +536,10 @@ class Background2D:
                 maxiters = -1
             else:
                 maxiters = int(maxiters)
-            cenfunc_code = 0 if sigma_clip.cenfunc == 'median' else 1
-            stdfunc_code = 0 if sigma_clip.stdfunc == 'std' else 1
+            cenfunc_code = {'median': 0, 'mean': 1,
+                            'biweight': 2}[sigma_clip.cenfunc]
+            stdfunc_code = {'std': 0, 'mad_std': 1,
+                            'biweight': 2}[sigma_clip.stdfunc]
 
         bkg_estimator = self.bkg_estimator
         median_factor = mean_factor = 0.0

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -6,17 +6,22 @@ Tools for estimating the 2D background and background RMS in an image.
 import copy
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from typing import NamedTuple
 
 import astropy.units as u
 import numpy as np
 from astropy.nddata import NDData, block_replicate, reshape_as_blocks
+from astropy.stats import SigmaClip
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from scipy.ndimage import generic_filter
 
 from photutils.aperture import RectangularAperture
-from photutils.background.core import (SIGMA_CLIP, SExtractorBackground,
-                                       StdBackgroundRMS)
+from photutils.aperture._batch_stats import batch_sigma_clip_stats
+from photutils.background.core import (SIGMA_CLIP, MADStdBackgroundRMS,
+                                       MeanBackground, MedianBackground,
+                                       MMMBackground, ModeEstimatorBackground,
+                                       SExtractorBackground, StdBackgroundRMS)
 from photutils.background.interpolators import (BkgIDWInterpolator,
                                                 _BkgZoomInterpolator)
 from photutils.utils import ShepardIDWInterpolator
@@ -29,6 +34,25 @@ from photutils.utils._stats import nanmedian, nanmin
 __all__ = ['Background2D']
 
 __doctest_skip__ = ['Background2D']
+
+
+class _BoxStatsSpec(NamedTuple):
+    """
+    Parameters for the fused sigma-clipped box-statistics kernel.
+
+    See ``Background2D._make_box_stats_spec``.
+    """
+
+    sigma_lower: float
+    sigma_upper: float
+    maxiters: int
+    cenfunc_code: int
+    stdfunc_code: int
+    do_clip: bool
+    bkg_kind: str
+    median_factor: float
+    mean_factor: float
+    rms_kind: str
 
 
 class Background2D:
@@ -190,6 +214,14 @@ class Background2D:
     while minimizing memory usage. Float input data produce background
     and background RMS outputs with the same dtype as the input data.
 
+    When the ``sigma_clip`` input is `None` or uses the string
+    ``cenfunc`` and ``stdfunc`` options, and the ``bkg_estimator``
+    and ``bkg_rms_estimator`` inputs are standard photutils estimator
+    classes (except the biweight-based ones), the sigma clipping and
+    box statistics are computed together using a fast fused kernel in
+    compiled code. Otherwise, a generic path that calls ``sigma_clip``
+    and the estimators is used. Both paths produce the same results.
+
     If there is only one background box element (i.e., ``box_size`` is
     the same size as (or larger than) the ``data``), then the background
     map will simply be a constant image.
@@ -213,6 +245,14 @@ class Background2D:
         else:
             self._unit = None
 
+        # For masked-array input, extract the data values. The data mask
+        # is combined with the input mask below.
+        data_mask = None
+        if isinstance(data, np.ma.MaskedArray):
+            if data.mask is not np.ma.nomask:
+                data_mask = np.asarray(data.mask, dtype=bool)
+            data = data.data
+
         # self._data is a temporary instance variable to store the input
         # data (the variable is deleted in self._calculate_stats)
         self._data = self._validate_array(data, 'data', shape=False)
@@ -228,6 +268,11 @@ class Background2D:
         # mask array (deleted in self._calculate_stats); self._has_mask
         # records whether a mask was provided for use after deletion.
         self._mask = self._validate_array(mask, 'mask')
+        if data_mask is not None:
+            if self._mask is None:
+                self._mask = data_mask
+            else:
+                self._mask = np.logical_or(self._mask, data_mask)
         self._has_mask = self._mask is not None
         self.coverage_mask = self._validate_array(coverage_mask,
                                                   'coverage_mask')
@@ -277,6 +322,8 @@ class Background2D:
             bkg_rms_estimator.sigma_clip = None
         self.bkg_estimator = bkg_estimator
         self.bkg_rms_estimator = bkg_rms_estimator
+
+        self._box_stats_spec = self._make_box_stats_spec()
 
         self._box_n_pixels = None
 
@@ -443,6 +490,166 @@ class Background2D:
         """
         return (1 - (self.exclude_percentile / 100.0)) * self._box_n_pixels
 
+    def _make_box_stats_spec(self):
+        """
+        The fused box-statistics kernel parameters, or `None`.
+
+        Returns a `_BoxStatsSpec` when the ``sigma_clip``,
+        ``bkg_estimator``, and ``bkg_rms_estimator`` inputs are all
+        supported by the fused sigma-clipping and statistics kernel,
+        and `None` otherwise (in which case the generic path based
+        on `astropy.stats.SigmaClip` and the estimator callables is
+        used). The fast path supports the string ``cenfunc`` values
+        'median'/'mean', the string ``stdfunc`` values 'std'/'mad_std',
+        no spatial growing, and the standard photutils estimator classes
+        (except the biweight-based ones).
+        """
+        sigma_clip = self.sigma_clip
+        if sigma_clip is None:
+            do_clip = False
+            sigma_lower = sigma_upper = 0.0
+            maxiters = 0
+            cenfunc_code = stdfunc_code = 0
+        else:
+            # Spatial growing (``grow``) is not supported
+            if (not isinstance(sigma_clip, SigmaClip)
+                    or not (isinstance(sigma_clip.cenfunc, str)
+                            and sigma_clip.cenfunc in ('median', 'mean'))
+                    or not (isinstance(sigma_clip.stdfunc, str)
+                            and sigma_clip.stdfunc in ('std', 'mad_std'))
+                    or sigma_clip.grow):
+                return None
+            do_clip = True
+            sigma_lower = float(sigma_clip.sigma_lower)
+            sigma_upper = float(sigma_clip.sigma_upper)
+            maxiters = sigma_clip.maxiters
+            if maxiters is None or np.isinf(maxiters):
+                maxiters = -1
+            else:
+                maxiters = int(maxiters)
+            cenfunc_code = 0 if sigma_clip.cenfunc == 'median' else 1
+            stdfunc_code = 0 if sigma_clip.stdfunc == 'std' else 1
+
+        bkg_estimator = self.bkg_estimator
+        median_factor = mean_factor = 0.0
+        if type(bkg_estimator) is MeanBackground:
+            bkg_kind = 'mean'
+        elif type(bkg_estimator) is MedianBackground:
+            bkg_kind = 'median'
+        elif type(bkg_estimator) in (ModeEstimatorBackground,
+                                     MMMBackground):
+            bkg_kind = 'mode'
+            median_factor = float(bkg_estimator.median_factor)
+            mean_factor = float(bkg_estimator.mean_factor)
+        elif type(bkg_estimator) is SExtractorBackground:
+            bkg_kind = 'sextractor'
+        else:
+            return None
+
+        rms_estimator = self.bkg_rms_estimator
+        if type(rms_estimator) is StdBackgroundRMS:
+            rms_kind = 'std'
+        elif type(rms_estimator) is MADStdBackgroundRMS:
+            rms_kind = 'mad_std'
+        else:
+            return None
+
+        return _BoxStatsSpec(sigma_lower=sigma_lower,
+                             sigma_upper=sigma_upper, maxiters=maxiters,
+                             cenfunc_code=cenfunc_code,
+                             stdfunc_code=stdfunc_code, do_clip=do_clip,
+                             bkg_kind=bkg_kind,
+                             median_factor=median_factor,
+                             mean_factor=mean_factor, rms_kind=rms_kind)
+
+    def _fast_box_statistics(self, data, *, axis=None):
+        """
+        Compute the background, background RMS, and surviving pixel
+        count in each box using the fused sigma-clipping and statistics
+        kernel.
+
+        The kernel operates on the finite values of each box in a
+        single pass, without generating a sigma-clipped copy of the box
+        data, and produces the same results as sequentially applying
+        `astropy.stats.SigmaClip` and the estimator classes. The kernel
+        releases the GIL, so this method can run in parallel threads.
+
+        Parameters
+        ----------
+        data : `~numpy.ndarray`
+            The array of box data, where NaN values mark masked pixels.
+
+        axis : int or `None`, optional
+            The axis along which to compute the statistics. Must be the
+            last axis (``-1``). If `None`, the entire array is treated
+            as a single box and scalar values are returned.
+
+        Returns
+        -------
+        bkg : `~numpy.ndarray` or float
+            The background statistics in each box.
+
+        bkgrms : `~numpy.ndarray` or float
+            The background RMS statistics in each box.
+
+        n_good : `~numpy.ndarray` or int
+            The number of surviving (unmasked and unclipped) pixels in
+            each box.
+        """
+        spec = self._box_stats_spec
+
+        if axis is None:
+            data2d = data.reshape(1, -1)
+        else:
+            data2d = data.reshape(-1, data.shape[-1])
+
+        # Sort each box (NaN values are placed last). The kernel
+        # requires ascending-sorted rows.
+        data2d = np.sort(data2d.astype(np.float64, copy=False), axis=-1)
+
+        (mean, median, std, madstd,
+         n_good) = batch_sigma_clip_stats(data2d, spec.sigma_lower,
+                                          spec.sigma_upper, spec.maxiters,
+                                          spec.cenfunc_code,
+                                          spec.stdfunc_code, spec.do_clip,
+                                          spec.rms_kind == 'mad_std')
+
+        if spec.bkg_kind == 'mean':
+            bkg = mean
+        elif spec.bkg_kind == 'median':
+            bkg = median
+        elif spec.bkg_kind == 'mode':
+            bkg = ((spec.median_factor * median)
+                   - (spec.mean_factor * mean))
+        else:  # 'sextractor'
+            bkg = (2.5 * median) - (1.5 * mean)
+
+            # Set the background to the mean where the std is zero
+            mean_mask = std == 0
+            bkg[mean_mask] = mean[mean_mask]
+
+            # Set the background to the median when the absolute
+            # difference between the mean and median divided by the
+            # standard deviation is greater than or equal to 0.3.
+            with np.errstate(divide='ignore', invalid='ignore'):
+                med_mask = (np.abs(mean - median) / std) >= 0.3
+            mask = np.logical_and(med_mask, np.logical_not(mean_mask))
+            bkg[mask] = median[mask]
+
+        bkgrms = madstd if spec.rms_kind == 'mad_std' else std
+
+        # Preserve the (float) dtype of the input box data
+        if data.dtype != np.float64:
+            bkg = bkg.astype(data.dtype)
+            bkgrms = bkgrms.astype(data.dtype)
+
+        if axis is None:
+            return bkg[0], bkgrms[0], n_good[0]
+
+        out_shape = data.shape[:-1]
+        return (bkg.reshape(out_shape), bkgrms.reshape(out_shape),
+                n_good.reshape(out_shape))
+
     def _sigmaclip_boxes(self, data, *, axis, sigma_clip=None):
         """
         Sigma clip the boxes along the specified axis.
@@ -505,15 +712,20 @@ class Background2D:
         bkgrms : 2D `~numpy.ndarray` or float
             The background RMS statistics in each box.
         """
-        data = self._sigmaclip_boxes(data, axis=axis, sigma_clip=sigma_clip)
+        if self._box_stats_spec is not None:
+            bkg, bkgrms, n_good = self._fast_box_statistics(data,
+                                                            axis=axis)
+        else:
+            data = self._sigmaclip_boxes(data, axis=axis,
+                                         sigma_clip=sigma_clip)
 
-        # Make 2D arrays of the box statistics
-        bkg = self.bkg_estimator(data, axis=axis)
-        bkgrms = self.bkg_rms_estimator(data, axis=axis)
+            # Make 2D arrays of the box statistics
+            bkg = self.bkg_estimator(data, axis=axis)
+            bkgrms = self.bkg_rms_estimator(data, axis=axis)
+            n_good = np.count_nonzero(~np.isnan(data), axis=axis)
 
         # Mask boxes with too few unmasked pixels. Completely masked
         # boxes are always excluded.
-        n_good = np.count_nonzero(~np.isnan(data), axis=axis)
         box_mask = ((n_good < self._good_n_pixels_threshold)
                     | (n_good == 0))
 

--- a/photutils/background/core.py
+++ b/photutils/background/core.py
@@ -83,6 +83,34 @@ def _validate_sigma_clip(sigma_clip):
     return sigma_clip
 
 
+def _use_fast_flat_clip(sigma_clip):
+    """
+    Whether an ``axis=None`` sigma clip can be routed through astropy's
+    fast C implementation.
+
+    astropy dispatches ``axis=None`` clipping to its slower Python code
+    path even when the ``cenfunc`` and ``stdfunc`` options are supported
+    by its fast C implementation, which requires an axis. When this
+    function returns `True`, `_prepare_data` instead clips the raveled
+    data along ``axis=0`` to use the fast C path.
+
+    Parameters
+    ----------
+    sigma_clip : `~astropy.stats.SigmaClip`
+        The sigma-clipping instance.
+
+    Returns
+    -------
+    result : bool
+        Whether the fast C clipping path can be used.
+    """
+    return (isinstance(sigma_clip.cenfunc, str)
+            and sigma_clip.cenfunc in ('median', 'mean')
+            and isinstance(sigma_clip.stdfunc, str)
+            and sigma_clip.stdfunc in ('std', 'mad_std')
+            and not sigma_clip.grow)
+
+
 def _prepare_data(sigma_clip, data, axis):
     """
     Prepare input data for a background estimation step.
@@ -106,10 +134,16 @@ def _prepare_data(sigma_clip, data, axis):
     Returns
     -------
     data : `~numpy.ndarray`
-        The prepared data array, with masked or clipped values replaced
-        by NaN.
+        The prepared data array, with masked or clipped values removed
+        or replaced by NaN.
     """
     if sigma_clip is not None:
+        if axis is None and _use_fast_flat_clip(sigma_clip):
+            # Clip the raveled data along axis=0 to use astropy's
+            # fast C implementation. Clipped values are replaced by
+            # NaN (rather than removed), which is equivalent for the
+            # NaN-aware statistics used by the estimator classes.
+            return sigma_clip(np.ravel(data), axis=0, masked=False)
         return sigma_clip(data, axis=axis, masked=False)
 
     if isinstance(data, np.ma.MaskedArray):

--- a/photutils/background/local_background.py
+++ b/photutils/background/local_background.py
@@ -6,8 +6,13 @@ Tools for estimating local background using a circular annulus aperture.
 import astropy.units as u
 import numpy as np
 
-from photutils.aperture import CircularAnnulus
-from photutils.background import MedianBackground
+from photutils.aperture import ApertureStats, CircularAnnulus
+from photutils.background.core import (BiweightLocationBackground,
+                                       BiweightScaleBackgroundRMS,
+                                       MADStdBackgroundRMS, MeanBackground,
+                                       MedianBackground, MMMBackground,
+                                       ModeEstimatorBackground,
+                                       SExtractorBackground, StdBackgroundRMS)
 from photutils.utils._deprecation import deprecated_positional_kwargs
 from photutils.utils._repr import make_repr
 
@@ -75,6 +80,118 @@ class LocalBackground:
     def __repr__(self):
         params = ('inner_radius', 'outer_radius', 'bkg_estimator')
         return make_repr(self, params)
+
+    def _fast_estimator_spec(self):
+        """
+        The fast batched estimator specification, or `None`.
+
+        Returns ``(kind, median_factor, mean_factor)`` when
+        ``bkg_estimator`` is a standard photutils estimator
+        class whose statistic can be computed with the batched
+        `~photutils.aperture.ApertureStats` machinery, and `None`
+        otherwise (in which case the per-aperture loop is used). The
+        biweight-based estimators are supported only with their default
+        tuning constants and location anchors, because the batched
+        biweight kernel uses fixed conventions.
+        """
+        estimator = self.bkg_estimator
+        median_factor = mean_factor = 0.0
+        if type(estimator) is MeanBackground:
+            kind = 'mean'
+        elif type(estimator) is MedianBackground:
+            kind = 'median'
+        elif type(estimator) in (ModeEstimatorBackground, MMMBackground):
+            kind = 'mode'
+            median_factor = float(estimator.median_factor)
+            mean_factor = float(estimator.mean_factor)
+        elif type(estimator) is SExtractorBackground:
+            kind = 'sextractor'
+        elif type(estimator) is BiweightLocationBackground:
+            if estimator.c != 6.0 or estimator.M is not None:
+                return None
+            kind = 'biweight_location'
+        elif type(estimator) is StdBackgroundRMS:
+            kind = 'std'
+        elif type(estimator) is MADStdBackgroundRMS:
+            kind = 'mad_std'
+        elif type(estimator) is BiweightScaleBackgroundRMS:
+            if estimator.c != 9.0 or estimator.M is not None:
+                return None
+            kind = 'biweight_scale'
+        else:
+            return None
+
+        return (kind, median_factor, mean_factor)
+
+    def _fast_background(self, data, apertures, mask, spec):
+        """
+        Measure the local backgrounds for all positions using the
+        batched `~photutils.aperture.ApertureStats` machinery.
+
+        This computes the same sigma-clipped statistic as calling the
+        estimator on each annulus, but gathers, clips, and reduces the
+        pixels of all apertures in compiled batch kernels instead of
+        looping over the apertures in Python.
+
+        Parameters
+        ----------
+        data : 2D `~numpy.ndarray`
+            The data array (without units).
+
+        apertures : `~photutils.aperture.CircularAnnulus`
+            The annulus apertures.
+
+        mask : 2D bool `~numpy.ndarray` or `None`
+            The data mask.
+
+        spec : tuple
+            The estimator specification from `_fast_estimator_spec`.
+
+        Returns
+        -------
+        result : 1D float `~numpy.ndarray`
+            The local background values.
+        """
+        kind, median_factor, mean_factor = spec
+        apstats = ApertureStats(data, apertures, mask=mask,
+                                sigma_clip=self.bkg_estimator.sigma_clip,
+                                sum_method='center')
+
+        if kind == 'mean':
+            result = apstats.mean
+        elif kind == 'median':
+            result = apstats.median
+        elif kind == 'mode':
+            result = ((median_factor * apstats.median)
+                      - (mean_factor * apstats.mean))
+        elif kind == 'sextractor':
+            mean = apstats.mean
+            median = apstats.median
+            std = apstats.std
+            result = (2.5 * median) - (1.5 * mean)
+
+            # Set the background to the mean where the std is zero
+            mean_mask = std == 0
+            result[mean_mask] = mean[mean_mask]
+
+            # Set the background to the median when the absolute
+            # difference between the mean and median divided by the
+            # standard deviation is greater than or equal to 0.3
+            with np.errstate(divide='ignore', invalid='ignore'):
+                med_mask = (np.abs(mean - median) / std) >= 0.3
+            med_mask = np.logical_and(med_mask, np.logical_not(mean_mask))
+            result[med_mask] = median[med_mask]
+        elif kind == 'biweight_location':
+            result = apstats.biweight_location
+        elif kind == 'std':
+            result = apstats.std
+        elif kind == 'mad_std':
+            result = apstats.mad_std
+        else:  # 'biweight_scale'
+            with np.errstate(invalid='ignore'):
+                result = np.sqrt(apstats.biweight_midvariance)
+
+        return np.asarray(result, dtype=float)
 
     def to_aperture(self, x, y):
         """
@@ -173,13 +290,17 @@ class LocalBackground:
             data = data.value
 
         apertures = self.to_aperture(x, y)
-        apermasks = apertures.to_mask(method='center')
 
-        n_apertures = len(apermasks)
-        bkg = np.empty(n_apertures)
-        for i, apermask in enumerate(apermasks):
-            values = apermask.get_values(data, mask=mask)
-            bkg[i] = self.bkg_estimator(values)
+        spec = self._fast_estimator_spec()
+        if spec is not None:
+            bkg = self._fast_background(data, apertures, mask, spec)
+        else:
+            apermasks = apertures.to_mask(method='center')
+            n_apertures = len(apermasks)
+            bkg = np.empty(n_apertures)
+            for i, apermask in enumerate(apermasks):
+                values = apermask.get_values(data, mask=mask)
+                bkg[i] = self.bkg_estimator(values)
 
         if bkg.size == 1:
             bkg = bkg[0]

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -1094,15 +1094,18 @@ class TestFastBoxStatistics:
         cls.data = data
         cls.mask = mask
 
-    def _compare_paths(self, monkeypatch, **kwargs):
+    def _compare_paths(self, monkeypatch, *, data=None, **kwargs):
         """
         Compare the fast and generic box-statistics paths.
         """
+        if data is None:
+            data = self.data
         kwargs = {'filter_size': (1, 1), 'exclude_percentile': 100.0,
-                  'mask': self.mask, **kwargs}
-        bkg_fast = Background2D(self.data, (25, 25), **kwargs)
+                  'mask': self.mask[:data.shape[0], :data.shape[1]],
+                  **kwargs}
+        bkg_fast = Background2D(data, (25, 25), **kwargs)
         assert bkg_fast._box_stats_spec is not None
-        bkg_generic = _make_generic_background2d(monkeypatch, self.data,
+        bkg_generic = _make_generic_background2d(monkeypatch, data,
                                                  (25, 25), **kwargs)
         assert_allclose(bkg_fast.background_mesh,
                         bkg_generic.background_mesh, rtol=1e-10)
@@ -1113,9 +1116,11 @@ class TestFastBoxStatistics:
     @pytest.mark.parametrize('bkg_estimator', [
         MeanBackground(), MedianBackground(),
         ModeEstimatorBackground(median_factor=2.5, mean_factor=1.5),
-        MMMBackground(), SExtractorBackground()])
+        MMMBackground(), SExtractorBackground(),
+        BiweightLocationBackground()])
     @pytest.mark.parametrize('rms_estimator', [StdBackgroundRMS(),
-                                               MADStdBackgroundRMS()])
+                                               MADStdBackgroundRMS(),
+                                               BiweightScaleBackgroundRMS()])
     def test_estimators_match_generic(self, bkg_estimator, rms_estimator,
                                       monkeypatch):
         """
@@ -1124,6 +1129,41 @@ class TestFastBoxStatistics:
         """
         self._compare_paths(monkeypatch, bkg_estimator=bkg_estimator,
                             bkg_rms_estimator=rms_estimator)
+
+    @pytest.mark.parametrize('bkg_estimator', [
+        BiweightLocationBackground(c=5.0),
+        BiweightLocationBackground(M=2.0)])
+    @pytest.mark.parametrize('rms_estimator', [
+        BiweightScaleBackgroundRMS(c=8.0),
+        BiweightScaleBackgroundRMS(M=2.0)])
+    def test_biweight_variants_match_generic(self, bkg_estimator,
+                                             rms_estimator, monkeypatch):
+        """
+        Test that the biweight estimators with non-default tuning
+        constants and scalar location anchors match the generic path.
+
+        The test data include constant boxes, for which the biweight
+        statistics are defined by the location anchor (zero MAD).
+        The data are trimmed to an integer number of boxes because
+        the generic path raises an ``AttributeError`` for a float
+        ``M`` anchor when a corner box is computed (an astropy
+        ``biweight_location`` bug for scalar ``M`` with ``axis=None``).
+        The fast path handles it.
+        """
+        self._compare_paths(monkeypatch, data=self.data[:100, :275],
+                            bkg_estimator=bkg_estimator,
+                            bkg_rms_estimator=rms_estimator)
+
+    def test_biweight_nonfinite_m_falls_back(self, test_data):
+        """
+        Test that a non-finite biweight location anchor (M) falls
+        back to the generic path, where the all-NaN result raises an
+        error, rather than silently computing median-anchored values.
+        """
+        bkg_estimator = BiweightLocationBackground(M=np.nan)
+        match = 'All boxes contain fewer than'
+        with pytest.raises(ValueError, match=match):
+            Background2D(test_data, (25, 25), bkg_estimator=bkg_estimator)
 
     @pytest.mark.parametrize('sigma_clip', [
         None,
@@ -1167,15 +1207,21 @@ class TestFastBoxStatistics:
         def bkg_func(data, *, axis=None):
             return np.nanmean(data, axis=axis)
 
+        def rms_func(data, *, axis=None):
+            return np.nanstd(data, axis=axis)
+
         unsupported = [
             {'sigma_clip': UnknownClip()},
             {'sigma_clip': SigmaClip(cenfunc=np.nanmedian)},
             {'sigma_clip': SigmaClip(stdfunc=np.nanstd)},
             {'sigma_clip': SigmaClip(grow=1.0)},
-            {'bkg_estimator': BiweightLocationBackground()},
             {'bkg_estimator': MySExtractorBackground()},
             {'bkg_estimator': bkg_func},
-            {'bkg_rms_estimator': BiweightScaleBackgroundRMS()},
+            {'bkg_estimator':
+                BiweightLocationBackground(M=np.array([1.0]))},
+            {'bkg_rms_estimator': rms_func},
+            {'bkg_rms_estimator':
+                BiweightScaleBackgroundRMS(M=np.array([1.0]))},
         ]
         for kwargs in unsupported:
             bkg = Background2D(test_data, (25, 25), **kwargs)

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -7,7 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.nddata import CCDData, NDData
-from astropy.stats import SigmaClip
+from astropy.stats import SigmaClip, biweight_location, biweight_scale
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
@@ -1058,6 +1058,36 @@ def test_deprecations(test_data):
         assert bkg.npixels_map.shape == data.shape
 
 
+def _make_sigma_clip_biweight(cenfunc='biweight', stdfunc='biweight',
+                              **kwargs):
+    """
+    Create a SigmaClip instance using the 'biweight' cenfunc/stdfunc
+    string options, emulating them on astropy versions that do not
+    support these options.
+    """
+
+    def nanbiloc(data, axis=None):
+        return biweight_location(data, axis=axis, ignore_nan=True)
+
+    def nanbiscale(data, axis=None):
+        return biweight_scale(data, axis=axis, ignore_nan=True)
+
+    try:
+        return SigmaClip(cenfunc=cenfunc, stdfunc=stdfunc, **kwargs)
+    except ValueError:
+        init_cenfunc = 'median' if cenfunc == 'biweight' else cenfunc
+        init_stdfunc = 'std' if stdfunc == 'biweight' else stdfunc
+        sigma_clip = SigmaClip(cenfunc=init_cenfunc, stdfunc=init_stdfunc,
+                               **kwargs)
+        sigma_clip.cenfunc = cenfunc
+        sigma_clip.stdfunc = stdfunc
+        if cenfunc == 'biweight':
+            sigma_clip._cenfunc_parsed = nanbiloc
+        if stdfunc == 'biweight':
+            sigma_clip._stdfunc_parsed = nanbiscale
+        return sigma_clip
+
+
 def _make_generic_background2d(monkeypatch, *args, **kwargs):
     """
     Create a Background2D instance that uses the generic (non-fused)
@@ -1154,11 +1184,27 @@ class TestFastBoxStatistics:
                             bkg_estimator=bkg_estimator,
                             bkg_rms_estimator=rms_estimator)
 
+    @pytest.mark.parametrize(('cenfunc', 'stdfunc'), [
+        ('biweight', 'biweight'),
+        ('biweight', 'std'),
+        ('median', 'biweight')])
+    def test_biweight_sigma_clip_matches_generic(self, cenfunc, stdfunc,
+                                                 monkeypatch):
+        """
+        Test that the SigmaClip 'biweight' cenfunc/stdfunc string
+        options are supported by the fused kernel and match the generic
+        path (astropy's Python clipping code paths).
+        """
+        sigma_clip = _make_sigma_clip_biweight(cenfunc=cenfunc,
+                                               stdfunc=stdfunc,
+                                               sigma=2.0, maxiters=5)
+        self._compare_paths(monkeypatch, sigma_clip=sigma_clip)
+
     def test_biweight_nonfinite_m_falls_back(self, test_data):
         """
-        Test that a non-finite biweight location anchor (M) falls
-        back to the generic path, where the all-NaN result raises an
-        error, rather than silently computing median-anchored values.
+        Test that a non-finite biweight location anchor (M) falls back
+        to the generic path, where the all-NaN result raises an error,
+        rather than silently computing median-anchored values.
         """
         bkg_estimator = BiweightLocationBackground(M=np.nan)
         match = 'All boxes contain fewer than'
@@ -1193,8 +1239,8 @@ class TestFastBoxStatistics:
 
     def test_unsupported_inputs_fall_back(self, test_data):
         """
-        Test that unsupported sigma_clip and estimator inputs fall
-        back to the generic path and still produce finite results.
+        Test that unsupported sigma_clip and estimator inputs fall back
+        to the generic path and still produce finite results.
         """
 
         class UnknownClip:

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -12,9 +12,12 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
 
-from photutils.background import (Background2D, BkgZoomInterpolator,
+from photutils.background import (Background2D, BiweightLocationBackground,
+                                  BiweightScaleBackgroundRMS,
+                                  BkgZoomInterpolator, MADStdBackgroundRMS,
                                   MeanBackground, MedianBackground,
-                                  SExtractorBackground)
+                                  MMMBackground, ModeEstimatorBackground,
+                                  SExtractorBackground, StdBackgroundRMS)
 from photutils.utils._optional_deps import HAS_MATPLOTLIB
 
 
@@ -1053,3 +1056,213 @@ def test_deprecations(test_data):
         assert bkg.npixels_mesh.shape == (4, 4)
     with pytest.warns(AstropyDeprecationWarning, match=match):
         assert bkg.npixels_map.shape == data.shape
+
+
+def _make_generic_background2d(monkeypatch, *args, **kwargs):
+    """
+    Create a Background2D instance that uses the generic (non-fused)
+    box-statistics path.
+    """
+    monkeypatch.setattr(Background2D, '_make_box_stats_spec',
+                        lambda _self: None)
+    bkg = Background2D(*args, **kwargs)
+    monkeypatch.undo()
+    assert bkg._box_stats_spec is None
+    return bkg
+
+
+class TestFastBoxStatistics:
+    """
+    Tests for the fused sigma-clipping and box-statistics fast path.
+
+    The fast path must produce the same results as the generic path
+    based on `astropy.stats.SigmaClip` and the estimator callables.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        rng = np.random.default_rng(0)
+        # Shape that is not an integer multiple of the box size, so
+        # the extra row, column, and corner boxes are also exercised
+        data = rng.normal(1.0, 0.5, (121, 289))
+        data[10:40, 10:40] += 100.0  # outliers to clip
+        data[50:75, 50:75] = 7.0  # constant boxes (zero std)
+        data[0:25, 250:275] = rng.exponential(10.0, (25, 25))  # skewed
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[80:105, 80:105] = True  # fully masked box
+        mask[0:10, 25:50] = True  # partially masked boxes
+        cls.data = data
+        cls.mask = mask
+
+    def _compare_paths(self, monkeypatch, **kwargs):
+        """
+        Compare the fast and generic box-statistics paths.
+        """
+        kwargs = {'filter_size': (1, 1), 'exclude_percentile': 100.0,
+                  'mask': self.mask, **kwargs}
+        bkg_fast = Background2D(self.data, (25, 25), **kwargs)
+        assert bkg_fast._box_stats_spec is not None
+        bkg_generic = _make_generic_background2d(monkeypatch, self.data,
+                                                 (25, 25), **kwargs)
+        assert_allclose(bkg_fast.background_mesh,
+                        bkg_generic.background_mesh, rtol=1e-10)
+        assert_allclose(bkg_fast.background_rms_mesh,
+                        bkg_generic.background_rms_mesh, rtol=1e-10)
+        assert_equal(bkg_fast.n_pixels_mesh, bkg_generic.n_pixels_mesh)
+
+    @pytest.mark.parametrize('bkg_estimator', [
+        MeanBackground(), MedianBackground(),
+        ModeEstimatorBackground(median_factor=2.5, mean_factor=1.5),
+        MMMBackground(), SExtractorBackground()])
+    @pytest.mark.parametrize('rms_estimator', [StdBackgroundRMS(),
+                                               MADStdBackgroundRMS()])
+    def test_estimators_match_generic(self, bkg_estimator, rms_estimator,
+                                      monkeypatch):
+        """
+        Test that all supported estimator combinations match the
+        generic path.
+        """
+        self._compare_paths(monkeypatch, bkg_estimator=bkg_estimator,
+                            bkg_rms_estimator=rms_estimator)
+
+    @pytest.mark.parametrize('sigma_clip', [
+        None,
+        SigmaClip(sigma=2.0, maxiters=5),
+        SigmaClip(sigma_lower=2.0, sigma_upper=4.0, maxiters=None),
+        SigmaClip(sigma=3.0, maxiters=10, cenfunc='mean'),
+        SigmaClip(sigma=3.0, maxiters=10, stdfunc='mad_std'),
+        SigmaClip(sigma=2.5, maxiters=1)])
+    def test_sigma_clip_variants_match_generic(self, sigma_clip,
+                                               monkeypatch):
+        """
+        Test that all supported sigma_clip variants match the generic
+        path.
+        """
+        self._compare_paths(monkeypatch, sigma_clip=sigma_clip)
+
+    def test_fast_path_used_by_default(self, test_data):
+        """
+        Test that the fast path is used with the default inputs.
+        """
+        bkg = Background2D(test_data, (25, 25))
+        spec = bkg._box_stats_spec
+        assert spec is not None
+        assert spec.bkg_kind == 'sextractor'
+        assert spec.rms_kind == 'std'
+        assert spec.do_clip
+
+    def test_unsupported_inputs_fall_back(self, test_data):
+        """
+        Test that unsupported sigma_clip and estimator inputs fall
+        back to the generic path and still produce finite results.
+        """
+
+        class UnknownClip:
+            def __call__(self, data, **_kwargs):
+                return np.asarray(data)
+
+        class MySExtractorBackground(SExtractorBackground):
+            pass
+
+        def bkg_func(data, *, axis=None):
+            return np.nanmean(data, axis=axis)
+
+        unsupported = [
+            {'sigma_clip': UnknownClip()},
+            {'sigma_clip': SigmaClip(cenfunc=np.nanmedian)},
+            {'sigma_clip': SigmaClip(stdfunc=np.nanstd)},
+            {'sigma_clip': SigmaClip(grow=1.0)},
+            {'bkg_estimator': BiweightLocationBackground()},
+            {'bkg_estimator': MySExtractorBackground()},
+            {'bkg_estimator': bkg_func},
+            {'bkg_rms_estimator': BiweightScaleBackgroundRMS()},
+        ]
+        for kwargs in unsupported:
+            bkg = Background2D(test_data, (25, 25), **kwargs)
+            assert bkg._box_stats_spec is None
+            assert np.all(np.isfinite(bkg.background_mesh))
+
+    def test_degenerate_clip_keeps_all(self, monkeypatch):
+        """
+        Test the degenerate case where sigma clipping converges to an
+        empty set.
+
+        Astropy then keeps every value (NaN bounds), and the fast path
+        must match.
+        """
+        data = np.ones((2, 4))
+        data[0:2, 2:4] = [[0.0, 0.0], [100.0, 100.0]]
+        sigma_clip = SigmaClip(sigma=0.1, maxiters=10)
+        kwargs = {'box_size': (2, 2), 'filter_size': (1, 1),
+                  'exclude_percentile': 100.0, 'sigma_clip': sigma_clip}
+
+        bkg_fast = Background2D(data, **kwargs)
+        # The generic path (astropy's gufunc) emits a numpy
+        # RuntimeWarning for the NaN bound comparisons in this
+        # degenerate case. The fast path does not.
+        with np.errstate(invalid='ignore'):
+            bkg_generic = _make_generic_background2d(monkeypatch, data,
+                                                     **kwargs)
+        assert_equal(bkg_fast.n_pixels_mesh, bkg_generic.n_pixels_mesh)
+        assert bkg_fast.n_pixels_mesh[0, 1] == 4  # all values kept
+        assert_allclose(bkg_fast.background_mesh,
+                        bkg_generic.background_mesh, rtol=1e-10)
+
+    def test_float32_matches_generic(self, monkeypatch):
+        """
+        Test that float32 input uses the fast path, preserves the
+        dtype, and matches the generic path.
+        """
+        data = self.data.astype(np.float32)
+        bkg_fast = Background2D(data, (25, 25), filter_size=(1, 1),
+                                exclude_percentile=100.0)
+        assert bkg_fast._box_stats_spec is not None
+        assert bkg_fast.background_mesh.dtype == np.float32
+        bkg_generic = _make_generic_background2d(
+            monkeypatch, data, (25, 25), filter_size=(1, 1),
+            exclude_percentile=100.0)
+        assert bkg_generic.background_mesh.dtype == np.float32
+        assert_allclose(bkg_fast.background_mesh,
+                        bkg_generic.background_mesh, rtol=2e-6)
+        assert_allclose(bkg_fast.background_rms_mesh,
+                        bkg_generic.background_rms_mesh, rtol=1e-3,
+                        atol=1e-5)
+
+    def test_n_threads_fast_path(self):
+        """
+        Test that the multithreaded fast path gives identical results
+        to the single-threaded fast path.
+        """
+        bkg1 = Background2D(self.data, (25, 25), mask=self.mask,
+                            exclude_percentile=100.0)
+        bkg2 = Background2D(self.data, (25, 25), mask=self.mask,
+                            exclude_percentile=100.0, n_threads=4)
+        assert_equal(bkg1.background_mesh, bkg2.background_mesh)
+        assert_equal(bkg1.background_rms_mesh, bkg2.background_rms_mesh)
+        assert_equal(bkg1.n_pixels_mesh, bkg2.n_pixels_mesh)
+
+    def test_masked_array_data_mask(self):
+        """
+        Test that the mask of masked-array input data is respected
+        and combined with the input mask.
+        """
+        data_values = np.ones((100, 100))
+        data_values[0:25, 0:25] = 1e6
+        data_values[25:50, 25:50] = 1e6
+        data_mask = np.zeros(data_values.shape, dtype=bool)
+        data_mask[0:25, 0:25] = True
+        data_ma = np.ma.MaskedArray(data_values, mask=data_mask)
+
+        # Without an input mask, the data mask alone is used
+        mask = np.zeros(data_values.shape, dtype=bool)
+        mask[25:50, 25:50] = True
+        bkg = Background2D(data_ma, (25, 25), filter_size=(1, 1),
+                           mask=mask)
+        assert_allclose(bkg.background_mesh, 1.0)
+        assert bkg.n_pixels_mesh[0, 0] == 0
+        assert bkg.n_pixels_mesh[1, 1] == 0
+
+        # A masked array with no masked values (nomask)
+        data_nomask = np.ma.MaskedArray(np.ones((100, 100)))
+        bkg = Background2D(data_nomask, (25, 25), filter_size=(1, 1))
+        assert_allclose(bkg.background_mesh, 1.0)

--- a/photutils/background/tests/test_core.py
+++ b/photutils/background/tests/test_core.py
@@ -663,3 +663,66 @@ class TestInputNotMutated:
         bkgrms.calc_background_rms(data_ma)
         assert_equal(data_ma.data, data_values_orig)
         assert_equal(data_ma.mask, mask_orig)
+
+
+class TestFastFlatClip:
+    """
+    Tests for routing axis=None sigma clipping through astropy's fast
+    C implementation.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        rng = np.random.default_rng(0)
+        data = rng.normal(10.0, 2.0, (301, 199))
+        data[10:20, 10:20] = 200.0  # outliers to clip
+        cls.data = data
+
+    @pytest.mark.parametrize('est_class',
+                             BACKGROUND_CLASSES + BACKGROUND_RMS_CLASSES)
+    @pytest.mark.parametrize('sigma_clip', [
+        SigmaClip(sigma=2.5, maxiters=10),
+        SigmaClip(sigma_lower=2.0, sigma_upper=4.0, maxiters=None),
+        SigmaClip(sigma=3.0, maxiters=5, cenfunc='mean'),
+        SigmaClip(sigma=3.0, maxiters=5, stdfunc='mad_std')])
+    def test_matches_slow_path(self, est_class, sigma_clip, monkeypatch):
+        """
+        Test that the rerouted fast clipping gives the same results as
+        the previous axis=None code path for all estimator classes.
+        """
+        estimator = est_class(sigma_clip=sigma_clip)
+        result_fast = estimator(self.data)
+
+        monkeypatch.setattr('photutils.background.core._use_fast_flat_clip',
+                            lambda _sigma_clip: False)
+        result_slow = estimator(self.data)
+        assert_allclose(result_fast, result_slow, rtol=1e-12)
+
+    def test_all_clipped_consistent_with_axis(self):
+        """
+        Test that when sigma clipping rejects all values, the
+        axis=None result is consistent with the axis-based result
+        (astropy keeps all values in this degenerate case).
+        Previously, the axis=None path returned NaN.
+        """
+        data = np.array([0.0, 100.0])
+        sigma_clip = SigmaClip(sigma=0.1, maxiters=10)
+        bkg = MeanBackground(sigma_clip=sigma_clip)
+        # astropy's C implementation emits a numpy RuntimeWarning for
+        # the NaN bound comparisons in this degenerate case
+        with np.errstate(invalid='ignore'):
+            value = bkg.calc_background(data)
+            value_axis = bkg.calc_background(data[np.newaxis, :], axis=1)
+        assert_allclose(value, 50.0)
+        assert_allclose(value, value_axis[0])
+
+    def test_unsupported_sigma_clip_uses_slow_path(self):
+        """
+        Test that a sigma_clip with a callable cenfunc (unsupported by
+        the fast C path) still works via the previous code path.
+        """
+        sigma_clip = SigmaClip(sigma=2.5, maxiters=10,
+                               cenfunc=np.nanmedian)
+        bkg1 = MeanBackground(sigma_clip=sigma_clip)
+        bkg2 = MeanBackground(sigma_clip=SigmaClip(sigma=2.5, maxiters=10))
+        assert_allclose(bkg1(self.data), bkg2(self.data), rtol=1e-12)

--- a/photutils/background/tests/test_local_background.py
+++ b/photutils/background/tests/test_local_background.py
@@ -6,10 +6,17 @@ Tests for the local_background module.
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.stats import SigmaClip
+from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
 
 from photutils.aperture import CircularAnnulus
-from photutils.background import LocalBackground, MedianBackground
+from photutils.background import (BiweightLocationBackground,
+                                  BiweightScaleBackgroundRMS, LocalBackground,
+                                  MADStdBackgroundRMS, MeanBackground,
+                                  MedianBackground, MMMBackground,
+                                  ModeEstimatorBackground,
+                                  SExtractorBackground, StdBackgroundRMS)
 
 
 def test_local_background_invalid_radii():
@@ -169,3 +176,112 @@ def test_to_aperture_array():
     y = list(y)
     aperture2 = local_bkg.to_aperture(x, y)
     assert aperture == aperture2
+
+
+class TestFastLocalBackground:
+    """
+    Tests that the batched ApertureStats-based fast path gives the
+    same results as the per-aperture estimator loop.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        rng = np.random.default_rng(0)
+        data = rng.normal(10.0, 2.0, (151, 151))
+        data[40:60, 40:60] += 100.0  # outliers to clip
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[100:130, 100:130] = True  # fully masks one annulus
+        cls.data = data
+        cls.mask = mask
+        # Interior, clipped-outlier, near-mask, fully-masked,
+        # edge-clipped, and off-image positions
+        cls.x = np.array([30.0, 50.0, 75.0, 115.0, 3.0, -50.0])
+        cls.y = np.array([30.0, 50.0, 75.0, 115.0, 3.0, -50.0])
+
+    def _run_both_paths(self, local_bkg, monkeypatch, data=None):
+        if data is None:
+            data = self.data
+        fast = local_bkg(data, self.x, self.y, mask=self.mask)
+        assert local_bkg._fast_estimator_spec() is not None
+        monkeypatch.setattr(LocalBackground, '_fast_estimator_spec',
+                            lambda _self: None)
+        slow = local_bkg(data, self.x, self.y, mask=self.mask)
+        monkeypatch.undo()
+        return fast, slow
+
+    @pytest.mark.parametrize('estimator', [
+        MeanBackground(), MedianBackground(),
+        ModeEstimatorBackground(median_factor=2.5, mean_factor=1.5),
+        MMMBackground(), SExtractorBackground(),
+        BiweightLocationBackground(), StdBackgroundRMS(),
+        MADStdBackgroundRMS(), BiweightScaleBackgroundRMS()])
+    def test_matches_slow_path(self, estimator, monkeypatch):
+        """
+        Test that all supported estimator classes match the per-aperture
+        loop, including for edge-clipped, fully-masked, and
+        non-overlapping apertures (NaN).
+        """
+        local_bkg = LocalBackground(5, 10, bkg_estimator=estimator)
+        fast, slow = self._run_both_paths(local_bkg, monkeypatch)
+        assert np.isnan(fast[3])  # fully masked annulus
+        assert np.isnan(fast[5])  # no overlap with the data
+        assert_allclose(fast, slow, rtol=1e-12)
+
+    @pytest.mark.parametrize('sigma_clip', [
+        None,
+        SigmaClip(sigma=2.0, maxiters=5),
+        SigmaClip(sigma=3.0, maxiters=10, cenfunc='mean',
+                  stdfunc='mad_std')])
+    def test_sigma_clip_variants_match_slow_path(self, sigma_clip,
+                                                 monkeypatch):
+        """
+        Test that estimator sigma_clip variants match the per-aperture
+        loop.
+        """
+        estimator = MedianBackground(sigma_clip=sigma_clip)
+        local_bkg = LocalBackground(5, 10, bkg_estimator=estimator)
+        fast, slow = self._run_both_paths(local_bkg, monkeypatch)
+        assert_allclose(fast, slow, rtol=1e-12)
+
+    def test_nonfinite_data_matches_slow_path(self, monkeypatch):
+        """
+        Test that non-finite data values are excluded, matching the
+        per-aperture loop (where sigma clipping removes them with a
+        warning; the fast path masks them silently).
+        """
+        data = self.data.copy()
+        data[30:34, 36:40] = np.nan  # inside the annulus at (30, 30)
+        local_bkg = LocalBackground(5, 10)
+
+        fast = local_bkg(data, self.x, self.y, mask=self.mask)
+        monkeypatch.setattr(LocalBackground, '_fast_estimator_spec',
+                            lambda _self: None)
+        match = 'Input data contains invalid values'
+        with pytest.warns(AstropyUserWarning, match=match):
+            slow = local_bkg(data, self.x, self.y, mask=self.mask)
+        assert_allclose(fast, slow, rtol=1e-12)
+
+    def test_unsupported_estimators_fall_back(self):
+        """
+        Test that unsupported estimators fall back to the per-aperture
+        loop and still produce finite results.
+        """
+
+        class MyMedianBackground(MedianBackground):
+            pass
+
+        def estimator_func(values):
+            return np.nanmedian(values)
+
+        # Note: np.float64 anchors are used because a Python float M
+        # triggers an astropy biweight_location bug
+        unsupported = [BiweightLocationBackground(c=5.0),
+                       BiweightLocationBackground(M=np.float64(1.0)),
+                       BiweightScaleBackgroundRMS(c=8.0),
+                       BiweightScaleBackgroundRMS(M=np.float64(1.0)),
+                       MyMedianBackground(), estimator_func]
+        data = np.ones((51, 51))
+        for estimator in unsupported:
+            local_bkg = LocalBackground(5, 10, bkg_estimator=estimator)
+            assert local_bkg._fast_estimator_spec() is None
+            assert np.isfinite(local_bkg(data, 25, 25))

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -4,6 +4,7 @@ Tools for calculating limiting fluxes.
 """
 
 import warnings
+from copy import copy
 
 import astropy.units as u
 import numpy as np
@@ -327,6 +328,12 @@ class ImageDepth:
                                           desc=desc)
 
         flux_limits = []
+        # Use a local copy of the SigmaClip instance because SigmaClip
+        # stores internal state on the instance during calls, so a
+        # shared instance is not safe to call concurrently from multiple
+        # threads.
+        sigma_clip = copy(self.sigma_clip)
+
         apertures = []
         for _ in iter_range:
             if self.overlap:
@@ -342,8 +349,8 @@ class ImageDepth:
             apers = CircularAperture(xycoords, r=self.aper_radius)
             apertures.append(apers)
             fluxes = AperturePhotometry(data, apers).flux
-            if self.sigma_clip is not None:
-                fluxes = self.sigma_clip(fluxes, masked=False)  # ndarray
+            if sigma_clip is not None:
+                fluxes = sigma_clip(fluxes, masked=False)  # ndarray
             self.fluxes.append(fluxes)
             flux_limits.append(self.n_sigma * np.std(fluxes))
 

--- a/photutils/utils/tests/test_depths.py
+++ b/photutils/utils/tests/test_depths.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.convolution import convolve
+from astropy.stats import SigmaClip
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
@@ -216,3 +217,31 @@ class TestImageDepth:
         match = 'attribute was deprecated'
         with pytest.warns(AstropyDeprecationWarning, match=match):
             _ = depth.napers
+
+    def test_user_sigma_clip_instance_not_called(self, monkeypatch):
+        """
+        Test that the user's SigmaClip instance is never called directly
+        (an internal copy must be used).
+
+        astropy SigmaClip stores internal state on the instance during
+        calls, so a shared instance is not safe to call concurrently
+        from multiple threads.
+        """
+        sigclip = SigmaClip(sigma=3.0, maxiters=5)
+        depth = ImageDepth(4, n_sigma=5.0, n_apertures=50, n_iters=1,
+                           mask_pad=5, overlap=True, seed=123,
+                           sigma_clip=sigclip, progress_bar=False)
+
+        called_ids = []
+        orig_call = SigmaClip.__call__
+
+        def spy(self, *args, **kwargs):
+            called_ids.append(id(self))
+            return orig_call(self, *args, **kwargs)
+
+        monkeypatch.setattr(SigmaClip, '__call__', spy)
+        limits = depth(self.data, self.mask)
+
+        assert np.isfinite(limits[0])
+        assert len(called_ids) > 0  # sigma clipping was exercised
+        assert id(sigclip) not in called_ids


### PR DESCRIPTION
This PR significantly improves the performance of sigma-clipped statistics across `photutils.background` and `photutils.aperture` by computing the sigma clipping and the summary statistics together in a single pass of compiled, GIL-releasing code.

This PR also fixes thread-safety issues in `ApertureStats` and `ImageDepth` by operating on a copy of the user-supplied `SigmaClip` instance.

Also, `LocalBackground` now computes the local backgrounds for all positions with the batched `ApertureStats` kernels instead of a Python loop over apertures, when `bkg_estimator` is a standard photutils estimator class.