### PR TITLE
Add option to multithread the Background2D fill-size map interpolation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ General
 
 - The minimum required astropy is now 6.1.7. [#2211]
 
-- The minimum required SciPy is now 1.14.1. [#2266, #2308]
+- The minimum required SciPy is now 1.15.0. [#2365]
 
 - The minimum required regions is now 0.10. [#2266]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -133,6 +133,13 @@ New Features
     batched ``ApertureStats`` kernels instead of a Python loop over the
     apertures. [#2364]
 
+  - The ``Background2D`` ``n_threads`` keyword also multithreads
+    the interpolation of the low-resolution meshes to the full-size maps
+    returned by the ``background`` and ``background_rms`` properties
+    (for the 'reflect' and 'mirror' interpolation boundary modes). The
+    multithreaded maps are identical to the single-threaded maps up to
+    floating-point rounding. [#2365]
+
 - ``photutils.detection``
 
   - Added validation of the ``StarFinderCatalogBase.to_table()``

--- a/benchmarks/bench_background.py
+++ b/benchmarks/bench_background.py
@@ -150,18 +150,23 @@ def bench_background2d(sizes, box_sizes, n_threads_list, *, repeats=3,
             print(row)
 
 
-def bench_maps(sizes, *, box_size=64, repeats=3, seed=0):
+def bench_maps(sizes, n_threads_list, *, box_size=64, repeats=3, seed=0):
     """
-    Benchmark full-size background and background RMS map generation.
+    Benchmark full-size background map generation.
 
     The ``background`` and ``background_rms`` properties are
     recalculated on each access, so their cost is paid every time
-    they are used.
+    they are used. The ``background`` access time is measured for
+    each ``n_threads`` value, with speedups reported relative to the
+    first value in ``n_threads_list``.
 
     Parameters
     ----------
     sizes : list of int
         The image sizes; each image is ``(size, size)``.
+
+    n_threads_list : list of int
+        The ``n_threads`` values to benchmark.
 
     box_size : int, optional
         The box size used for the Background2D instance.
@@ -172,17 +177,27 @@ def bench_maps(sizes, *, box_size=64, repeats=3, seed=0):
     seed : int, optional
         The random number generator seed.
     """
-    print(f'\n== Full-size map generation (box={box_size}) ==')
-    print(f'{"image":>12}{"background":>14}{"background_rms":>17}')
+    print(f'\n== Full-size background map generation (box={box_size}) ==')
+    header = f'{"image":>12}'
+    for n_threads in n_threads_list:
+        header += f'{f"n_threads={n_threads}":>19}'
+    print(header)
+
     for size in sizes:
         data = make_image((size, size), seed=seed)
-        bkg = Background2D(data, box_size)
-        t_bkg = time_best(partial(getattr, bkg, 'background'),
-                          repeats=repeats)
-        t_rms = time_best(partial(getattr, bkg, 'background_rms'),
-                          repeats=repeats)
-        print(f'{f"{size}x{size}":>12}{f"{t_bkg:.3f}s":>14}'
-              f'{f"{t_rms:.3f}s":>17}')
+        row = f'{f"{size}x{size}":>12}'
+        t_ref = None
+        for n_threads in n_threads_list:
+            bkg = Background2D(data, box_size, n_threads=n_threads)
+            t_bkg = time_best(partial(getattr, bkg, 'background'),
+                              repeats=repeats)
+            if t_ref is None:
+                t_ref = t_bkg
+                cell = f'{t_bkg:.3f}s'
+            else:
+                cell = f'{t_bkg:.3f}s ({t_ref / t_bkg:.2f}x)'
+            row += f'{cell:>19}'
+        print(row)
 
 
 def bench_estimators(*, size=2048, repeats=3, seed=0):
@@ -283,7 +298,8 @@ def main():
         bench_background2d(sizes, box_sizes, n_threads_list,
                            repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'maps'):
-        bench_maps(sizes, repeats=args.repeats, seed=args.seed)
+        bench_maps(sizes, n_threads_list, repeats=args.repeats,
+                   seed=args.seed)
     if args.which in ('all', 'estimators'):
         bench_estimators(repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'local'):

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -11,7 +11,7 @@ Photutils has the following strict requirements:
 
 * `NumPy <https://numpy.org/>`_ 2.0 or later
 
-* `SciPy <https://scipy.org/>`_ 1.14.1 or later
+* `SciPy <https://scipy.org/>`_ 1.15.0 or later
 
 * `Astropy`_ 6.1.7 or later
 

--- a/docs/user_guide/background.rst
+++ b/docs/user_guide/background.rst
@@ -501,14 +501,30 @@ interpreter lock (GIL), so threads can effectively run in parallel:
     >>> with ThreadPoolExecutor() as executor:
     ...     backgrounds = list(executor.map(estimate_background, images))
 
-In addition, the box statistics computed by
-`~photutils.background.Background2D` itself can be multithreaded by
-setting the ``n_threads`` keyword. The results are identical to the
-single-threaded computation. This is most beneficial for large images:
+In addition, the work done by `~photutils.background.Background2D`
+itself can be multithreaded by setting the ``n_threads`` keyword,
+which parallelizes both the box statistics and the interpolation
+of the low-resolution meshes to the full-size maps returned by the
+``background`` and ``background_rms`` properties. The box statistics are
+identical to the single-threaded computation and the full-size maps are
+identical up to floating-point rounding. This is most beneficial for
+large images:
 
 .. doctest-skip::
 
     >>> bkg = Background2D(data2, (15, 15), n_threads=4)
+
+Finally, when both the background and background RMS maps are needed,
+they can be computed concurrently (each property access recalculates its
+map, and the underlying interpolation releases the GIL):
+
+.. doctest-skip::
+
+    >>> with ThreadPoolExecutor(max_workers=2) as executor:
+    ...     bkg_future = executor.submit(getattr, bkg, 'background')
+    ...     rms_future = executor.submit(getattr, bkg, 'background_rms')
+    ...     bkg_image = bkg_future.result()
+    ...     rms_image = rms_future.result()
 
 
 Plotting Meshes

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -24,7 +24,7 @@ dependencies to provide users with access to the latest features and
 performance improvements. The minimum required versions are now:
 
 - Astropy: 6.1.7
-- SciPy: 1.14
+- SciPy: 1.15
 - Regions: 0.10
 - scikit-image: 0.24
 - gwcs: 0.22

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -189,11 +189,14 @@ class Background2D:
         `~photutils.background.StdBackgroundRMS`.
 
     n_threads : int, optional
-        The number of threads to use to compute the box statistics. The
-        default is 1 (no multithreading). When ``n_threads`` > 1, the
-        boxes are divided into chunks along the y axis and processed
-        concurrently. The results are identical to the single-threaded
-        computation. The underlying sigma-clipping and statistics
+        The number of threads to use to compute the box statistics
+        and to resize the low-resolution meshes to the full-size
+        maps returned by the ``background`` and ``background_rms``
+        properties. The default is 1 (no multithreading). When
+        ``n_threads`` > 1, the work is divided into chunks along the
+        y axis and processed concurrently. The box statistics are
+        identical to the single-threaded computation and the resized
+        maps are identical up to floating-point rounding. The underlying
         kernels release the Python global interpreter lock (GIL),
         so multithreading can significantly speed up the background
         estimation for large images. If a custom ``bkg_estimator`` or
@@ -340,7 +343,8 @@ class Background2D:
             interp_dtype = np.float32
         self._interp_kwargs = {'shape': self._data.shape,
                                'dtype': interp_dtype,
-                               'box_size': self.box_size}
+                               'box_size': self.box_size,
+                               'n_threads': self.n_threads}
 
         # Perform the initial calculations to avoid storing large data
         # arrays and to keep the memory usage minimal

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -3,6 +3,7 @@
 Tools for upsampling images for Background2D using interpolation.
 """
 
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
@@ -131,9 +132,17 @@ class _BkgZoomInterpolator:
 
         n_bands = min(n_threads, out_shape[0])
         band_edges = np.linspace(0, out_shape[0], n_bands + 1).astype(int)
-        with ThreadPoolExecutor(max_workers=n_bands) as executor:
-            list(executor.map(resample_band, band_edges[:-1],
-                              band_edges[1:]))
+        with warnings.catch_warnings():
+            # scipy < 1.16 emits a UserWarning noting that the behavior
+            # of affine_transform with a 1-D matrix changed in scipy
+            # 0.18. The 1-D (per-axis) matrix form is intentional here
+            # because it selects the fast separable code path.
+            warnings.filterwarnings('ignore', message='The behavior of '
+                                    'affine_transform with a 1-D array',
+                                    category=UserWarning)
+            with ThreadPoolExecutor(max_workers=n_bands) as executor:
+                list(executor.map(resample_band, band_edges[:-1],
+                                  band_edges[1:]))
 
         return result
 

--- a/photutils/background/interpolators.py
+++ b/photutils/background/interpolators.py
@@ -3,10 +3,12 @@
 Tools for upsampling images for Background2D using interpolation.
 """
 
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
 from astropy.units import Quantity
 from astropy.utils.decorators import deprecated
-from scipy.ndimage import zoom
+from scipy.ndimage import affine_transform, spline_filter, zoom
 
 from photutils.utils import ShepardIDWInterpolator
 from photutils.utils._repr import make_repr
@@ -50,6 +52,12 @@ class _BkgZoomInterpolator:
     `~scipy.ndimage.zoom` ``grid_mode`` is True). This makes
     zoom's behavior consistent with `scipy.ndimage.map_coordinates` and
     `skimage.transform.resize`
+
+    When called with an ``n_threads`` keyword larger than 1 (e.g.,
+    by `~photutils.background.Background2D`) and the ``mode`` is
+    'reflect' or 'mirror', the output is computed concurrently over
+    bands of rows. The multithreaded result is identical to the single
+    `~scipy.ndimage.zoom` call up to floating-point rounding.
     """
 
     def __init__(self, *, order=3, mode='reflect', cval=0.0, clip=True):
@@ -62,6 +70,73 @@ class _BkgZoomInterpolator:
         params = ('order', 'mode', 'cval', 'clip')
         return make_repr(self, params)
 
+    def _threaded_zoom(self, data, zoom_factor, n_threads):
+        """
+        Compute `~scipy.ndimage.zoom` (``grid_mode=True``) of a 2D array
+        using multiple threads over bands of output rows.
+
+        The spline prefilter is applied once to the (small) input mesh
+        exactly as `~scipy.ndimage.zoom` does. The output resampling,
+        which dominates the cost, is then evaluated concurrently
+        over row bands with `~scipy.ndimage.affine_transform` (which
+        releases the GIL and, for a diagonal transform, uses the
+        same fast separable code path as `~scipy.ndimage.zoom`)
+        using the same coordinate mapping as `~scipy.ndimage.zoom`
+        with ``grid_mode=True``. For the 'reflect' and 'mirror'
+        boundary modes, the result is identical to the single
+        `~scipy.ndimage.zoom` call up to floating-point rounding. Other
+        boundary modes have ``grid_mode``-specific edge handling that
+        `~scipy.ndimage.affine_transform` does not reproduce, so the
+        caller must not use this method for them.
+
+        Parameters
+        ----------
+        data : 2D `~numpy.ndarray`
+            The low-resolution 2D mesh array.
+
+        zoom_factor : tuple of int
+            The integer zoom factor along each axis.
+
+        n_threads : int
+            The number of threads to use.
+
+        Returns
+        -------
+        result : 2D `~numpy.ndarray`
+            The resized 2D array, with the same dtype as the input.
+        """
+        out_shape = (data.shape[0] * zoom_factor[0],
+                     data.shape[1] * zoom_factor[1])
+
+        # The same coordinate mapping as scipy.ndimage.zoom with
+        # grid_mode=True: input_coord = output_coord * ratio + offset
+        zoom_ratio = np.array(data.shape) / np.array(out_shape)
+        offset = 0.5 * zoom_ratio - 0.5
+
+        if self.order > 1:
+            filtered = spline_filter(data, self.order, output=np.float64,
+                                     mode=self.mode)
+        else:
+            filtered = data
+
+        result = np.empty(out_shape, dtype=data.dtype)
+
+        def resample_band(y0, y1):
+            band_offset = (y0 * zoom_ratio[0] + offset[0], offset[1])
+            affine_transform(filtered, zoom_ratio, offset=band_offset,
+                             output_shape=(y1 - y0, out_shape[1]),
+                             output=result[y0:y1], order=self.order,
+                             mode=self.mode, cval=self.cval,
+                             prefilter=False)
+
+        n_bands = min(n_threads, out_shape[0])
+        band_edges = np.linspace(0, out_shape[0], n_bands + 1).astype(int)
+        with ThreadPoolExecutor(max_workers=n_bands) as executor:
+            list(executor.map(resample_band, band_edges[:-1],
+                              band_edges[1:]))
+
+        return result
+
     def __call__(self, data, **kwargs):
         """
         Resize the 2D mesh array.
@@ -72,7 +147,9 @@ class _BkgZoomInterpolator:
             The low-resolution 2D mesh array.
 
         **kwargs : dict
-            Additional keyword arguments passed to the interpolator.
+            Additional keyword arguments passed to the interpolator,
+            including an optional ``n_threads`` value (see the class
+            Notes).
 
         Returns
         -------
@@ -96,8 +173,12 @@ class _BkgZoomInterpolator:
         # (i.e., zoom_factor should be an integer) and then cropped
         # back to the final data size.
         zoom_factor = kwargs['box_size']
-        result = zoom(data, zoom_factor, order=self.order, mode=self.mode,
-                      cval=self.cval, grid_mode=True)
+        n_threads = kwargs.get('n_threads', 1)
+        if n_threads > 1 and self.mode in ('reflect', 'mirror'):
+            result = self._threaded_zoom(data, zoom_factor, n_threads)
+        else:
+            result = zoom(data, zoom_factor, order=self.order,
+                          mode=self.mode, cval=self.cval, grid_mode=True)
         result = result[0:kwargs['shape'][0], 0:kwargs['shape'][1]]
 
         if self.clip:

--- a/photutils/background/tests/test_background_2d.py
+++ b/photutils/background/tests/test_background_2d.py
@@ -284,7 +284,11 @@ class TestBackground2D:
         assert_equal(bkg1.background_mesh, bkg2.background_mesh)
         assert_equal(bkg1.background_rms_mesh, bkg2.background_rms_mesh)
         assert_equal(bkg1.n_pixels_mesh, bkg2.n_pixels_mesh)
-        assert_equal(bkg1.background, bkg2.background)
+        # The multithreaded full-size interpolation is identical up to
+        # floating-point rounding
+        assert_allclose(bkg1.background, bkg2.background, rtol=1e-10)
+        assert_allclose(bkg1.background_rms, bkg2.background_rms,
+                        rtol=1e-10)
 
     def test_n_threads_no_sigma_clip(self):
         """

--- a/photutils/background/tests/test_interpolators.py
+++ b/photutils/background/tests/test_interpolators.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from numpy.testing import assert_allclose
 
 from photutils.background.background_2d import Background2D
 from photutils.background.interpolators import (BkgIDWInterpolator,
@@ -124,3 +125,80 @@ def test_idw_interp(test_data, test_mesh):
     # Test repr
     cls_repr = repr(interp)
     assert cls_repr.startswith(f'{interp.__class__.__name__}')
+
+
+class TestThreadedZoom:
+    """
+    Tests for the multithreaded row-band zoom in _BkgZoomInterpolator.
+    """
+
+    @staticmethod
+    def _make_kwargs(mesh_shape, box_size, *, crop=(0, 0), n_threads=1,
+                     dtype=np.float64):
+        shape = (mesh_shape[0] * box_size[0] - crop[0],
+                 mesh_shape[1] * box_size[1] - crop[1])
+        return {'shape': shape, 'dtype': dtype,
+                'box_size': np.array(box_size), 'n_threads': n_threads}
+
+    @pytest.mark.parametrize('order', [0, 1, 3, 5])
+    @pytest.mark.parametrize('mode', ['reflect', 'mirror'])
+    def test_threaded_matches_serial(self, order, mode):
+        """
+        Test that the multithreaded zoom matches the serial scipy zoom
+        up to floating-point rounding, including with uneven bands,
+        non-square meshes and boxes, and output cropping.
+        """
+        rng = np.random.default_rng(5)
+        mesh = rng.normal(10.0, 3.0, (17, 11))
+        interp = _BkgZoomInterpolator(order=order, mode=mode)
+
+        kwargs = self._make_kwargs((17, 11), (13, 7), crop=(4, 3))
+        ref = interp(mesh, **kwargs)
+        for n_threads in (2, 5, 16):
+            kwargs['n_threads'] = n_threads
+            result = interp(mesh, **kwargs)
+            assert result.shape == kwargs['shape']
+            assert_allclose(result, ref, rtol=1e-10)
+
+    def test_threaded_float32(self):
+        """
+        Test the multithreaded zoom with float32 mesh data.
+        """
+        rng = np.random.default_rng(5)
+        mesh = rng.normal(10.0, 3.0, (17, 11)).astype(np.float32)
+        interp = _BkgZoomInterpolator()
+        kwargs = self._make_kwargs((17, 11), (13, 7), crop=(4, 3),
+                                   dtype=np.float32)
+        ref = interp(mesh, **kwargs)
+        kwargs['n_threads'] = 8
+        result = interp(mesh, **kwargs)
+        assert result.dtype == np.float32
+        assert_allclose(result, ref, rtol=1e-5)
+
+    def test_unsupported_mode_falls_back(self):
+        """
+        Test that boundary modes with grid_mode-specific edge handling
+        fall back to the serial scipy zoom (identical results).
+        """
+        rng = np.random.default_rng(5)
+        mesh = rng.normal(10.0, 3.0, (9, 9))
+        interp = _BkgZoomInterpolator(mode='nearest')
+        kwargs = self._make_kwargs((9, 9), (10, 10))
+        ref = interp(mesh, **kwargs)
+        kwargs['n_threads'] = 8
+        result = interp(mesh, **kwargs)
+        assert_allclose(result, ref, rtol=0, atol=0)
+
+    def test_more_threads_than_rows(self):
+        """
+        Test that n_threads larger than the number of output rows is
+        clamped to the number of rows.
+        """
+        rng = np.random.default_rng(5)
+        mesh = rng.normal(10.0, 3.0, (2, 3))
+        interp = _BkgZoomInterpolator()
+        kwargs = self._make_kwargs((2, 3), (2, 2))
+        ref = interp(mesh, **kwargs)
+        kwargs['n_threads'] = 64  # only 4 output rows
+        result = interp(mesh, **kwargs)
+        assert_allclose(result, ref, rtol=1e-10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = '>=3.11'
 dependencies = [
     'astropy >= 6.1.7',
     'numpy >= 2.0',
-    'scipy >= 1.14.1',
+    'scipy >= 1.15.0',
 ]
 
 [project.urls]


### PR DESCRIPTION
With this PR \the ``Background2D`` ``n_threads`` keyword now also multithreads the interpolation of the low-resolution meshes to the full-size maps returned by the ``background`` and ``background_rms`` properties (for the 'reflect' and 'mirror' interpolation boundary modes). The multithreaded maps are identical to the single-threaded maps up to floating-point rounding.