### PR TITLE
Replace lazyproperty with cached_property

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,14 +31,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.11'
-            tox_env: 'py311-test-oldestdeps'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
-            python: '3.11'
-            tox_env: 'py311-test-alldeps'
+            python: '3.12'
+            tox_env: 'py312-test-oldestdeps'
             allow_failure: false
             prefix: ''
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 General
 ^^^^^^^
 
+- The minimum required Python is now 3.12. [#2366]
+
 - The minimum required astropy is now 6.1.7. [#2211]
 
 - The minimum required SciPy is now 1.15.0. [#2365]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ General
 
 - Added serialization to ASDF for all apertures. [#2341]
 
+- All lazily-computed class attributes now use
+  ``functools.cached_property`` instead of the astropy ``lazyproperty``
+  decorator. [#2366]
+
 New Features
 ^^^^^^^^^^^^
 

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -7,7 +7,7 @@ Requirements
 
 Photutils has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.11 or later
+* `Python <https://www.python.org/>`_ 3.12 or later
 
 * `NumPy <https://numpy.org/>`_ 2.0 or later
 

--- a/photutils/aperture/attributes.py
+++ b/photutils/aperture/attributes.py
@@ -47,7 +47,7 @@ class ApertureAttribute:
         self._validate_ordered_pairs(instance, value)
         # No need to reset if not already in the instance dict
         if self.name in instance.__dict__:
-            self._reset_lazyproperties(instance)
+            self._reset_cached_properties(instance)
         instance.__dict__[self.name] = value
 
     def _validate_ordered_pairs(self, instance, value):
@@ -76,11 +76,11 @@ class ApertureAttribute:
                     msg = f'{outer!r} must be greater than {inner!r}'
                     raise ValueError(msg)
 
-    def _reset_lazyproperties(self, instance):
-        # Reset lazyproperties (if they exist) for aperture parameter
+    def _reset_cached_properties(self, instance):
+        # Reset cached properties (if they exist) for aperture parameter
         # changes
         try:
-            for key in instance._lazyproperties:
+            for key in instance._cached_properties:
                 instance.__dict__.pop(key, None)
         except AttributeError:
             pass
@@ -111,7 +111,7 @@ class PixelPositions(ApertureAttribute):
         value = self._validate(value)  # np.ndarray
         # No need to reset if not already in the instance dict
         if self.name in instance.__dict__:
-            self._reset_lazyproperties(instance)
+            self._reset_cached_properties(instance)
         instance.__dict__[self.name] = value
 
     def _validate(self, value):
@@ -224,7 +224,7 @@ class ScalarAngleOrValue(ApertureAttribute):
         self._validate(value)
         # No need to reset if not already in the instance dict
         if self.name in instance.__dict__:
-            self._reset_lazyproperties(instance)
+            self._reset_cached_properties(instance)
 
         # If theta is not a Quantity, it is assumed to be in radians
         if not isinstance(value, u.Quantity):

--- a/photutils/aperture/circle.py
+++ b/photutils/aperture/circle.py
@@ -5,11 +5,11 @@ coordinates.
 """
 
 import math
+from functools import cached_property
 
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import Angle
-from astropy.utils import lazyproperty
 
 from photutils.aperture._batch_photometry import (SHAPE_CIRCLE,
                                                   SHAPE_CIRCULAR_ANNULUS)
@@ -173,14 +173,14 @@ class CircularAperture(PixelAperture):
         self.positions = positions
         self.r = r
 
-    @lazyproperty
+    @cached_property
     def _xy_extents(self):
         return self.r, self.r
 
     def _batch_shape_params(self):
         return SHAPE_CIRCLE, (self.r,)
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The exact geometric area of the aperture shape.
@@ -347,14 +347,14 @@ class CircularAnnulus(PixelAperture):
         self.r_in = r_in
         self.r_out = r_out
 
-    @lazyproperty
+    @cached_property
     def _xy_extents(self):
         return self.r_out, self.r_out
 
     def _batch_shape_params(self):
         return SHAPE_CIRCULAR_ANNULUS, (self.r_in, self.r_out)
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The exact geometric area of the aperture shape.

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -10,11 +10,11 @@ import textwrap
 import warnings
 from copy import deepcopy
 from dataclasses import dataclass
+from functools import cached_property
 
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
-from astropy.utils import lazyproperty
 
 from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
                                                   FLAG_COL_MASKED,
@@ -408,23 +408,23 @@ class Aperture(metaclass=abc.ABCMeta):
         return True
 
     @property
-    def _lazyproperties(self):
+    def _cached_properties(self):
         """
-        A list of all class lazyproperties (even in superclasses).
+        A list of all class cached properties (even in superclasses).
 
         The result depends only on the class, so it is computed once
         per class and cached (it is looked up on every aperture
         parameter reassignment).
         """
         cls = self.__class__
-        cached = cls.__dict__.get('_lazyproperties_cache')
+        cached = cls.__dict__.get('_cached_properties_cache')
         if cached is None:
-            def islazyproperty(obj):
-                return isinstance(obj, lazyproperty)
+            def is_cached_property(obj):
+                return isinstance(obj, cached_property)
 
             cached = [i[0] for i in inspect.getmembers(
-                cls, predicate=islazyproperty)]
-            cls._lazyproperties_cache = cached
+                cls, predicate=is_cached_property)]
+            cls._cached_properties_cache = cached
         return cached
 
     def copy(self):
@@ -448,7 +448,7 @@ class Aperture(metaclass=abc.ABCMeta):
         `~astropy.coordinates.SkyCoord`.
         """
 
-    @lazyproperty
+    @cached_property
     def shape(self):
         """
         The shape of the instance.
@@ -458,7 +458,7 @@ class Aperture(metaclass=abc.ABCMeta):
 
         return self.positions.shape[:-1]
 
-    @lazyproperty
+    @cached_property
     def isscalar(self):
         """
         Whether the instance is scalar (i.e., a single position).
@@ -471,13 +471,13 @@ class _RotatableApertureMixin:
     Mixin class for apertures that have a rotation angle ``theta``.
     """
 
-    @lazyproperty
+    @cached_property
     def _theta_rad(self):
         """
         The rotation angle in radians.
 
-        This is a lazyproperty so that it is invalidated together with
-        the other lazyproperties when ``theta`` is reassigned.
+        This is a cached property so that it is invalidated together
+        with the other cached properties when ``theta`` is reassigned.
         """
         return self.theta.to_value(u.radian)
 
@@ -492,7 +492,7 @@ class PixelAperture(Aperture):
     # batch driver only when this is their own class
     _batch_photometry_class = None
 
-    @lazyproperty
+    @cached_property
     def _default_patch_properties(self):
         """
         A dictionary of default matplotlib.patches.Patch properties.
@@ -561,14 +561,14 @@ class PixelAperture(Aperture):
         """
         return 0.0, 0.0
 
-    @lazyproperty
+    @cached_property
     def _positions(self):
         """
         The aperture positions, always as a 2D ndarray.
         """
         return np.atleast_2d(self.positions)
 
-    @lazyproperty
+    @cached_property
     def _bbox(self):
         """
         The minimal bounding box for the aperture, always as a list of
@@ -584,7 +584,7 @@ class PixelAperture(Aperture):
         return [BoundingBox.from_float(x0, x1, y0, y1)
                 for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax, strict=True)]
 
-    @lazyproperty
+    @cached_property
     def bbox(self):
         """
         The minimal bounding box for the aperture.
@@ -598,7 +598,7 @@ class PixelAperture(Aperture):
 
         return self._bbox
 
-    @lazyproperty
+    @cached_property
     def _centered_edges(self):
         """
         A list of ``(xmin, xmax, ymin, ymax)`` tuples, one for each

--- a/photutils/aperture/ellipse.py
+++ b/photutils/aperture/ellipse.py
@@ -5,11 +5,11 @@ coordinates.
 """
 
 import math
+from functools import cached_property
 
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import Angle
-from astropy.utils import lazyproperty
 
 from photutils.aperture._batch_photometry import (SHAPE_ELLIPSE,
                                                   SHAPE_ELLIPTICAL_ANNULUS)
@@ -246,7 +246,7 @@ class EllipticalAperture(_RotatableApertureMixin, PixelAperture):
         self.b = b
         self.theta = theta
 
-    @lazyproperty
+    @cached_property
     def _xy_extents(self):
         """
         The half of the bounding box extents of the ellipse in the x and
@@ -257,7 +257,7 @@ class EllipticalAperture(_RotatableApertureMixin, PixelAperture):
     def _batch_shape_params(self):
         return SHAPE_ELLIPSE, (self.a, self.b, self._theta_rad)
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The exact geometric area of the aperture shape.
@@ -467,7 +467,7 @@ class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
 
         self.theta = theta
 
-    @lazyproperty
+    @cached_property
     def _xy_extents(self):
         """
         The half of the bounding box extents of the outer ellipse in the
@@ -479,7 +479,7 @@ class EllipticalAnnulus(_RotatableApertureMixin, PixelAperture):
         return SHAPE_ELLIPTICAL_ANNULUS, (self.a_in, self.b_in, self.a_out,
                                           self.b_out, self._theta_rad)
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The exact geometric area of the aperture shape.

--- a/photutils/aperture/mask.py
+++ b/photutils/aperture/mask.py
@@ -4,10 +4,10 @@ Class for aperture masks.
 """
 
 import warnings
+from functools import cached_property
 
 import astropy.units as u
 import numpy as np
-from astropy.utils import lazyproperty
 
 from photutils.utils._deprecation import deprecated_positional_kwargs
 
@@ -38,7 +38,7 @@ class ApertureMask:
             raise ValueError(msg)
         self.bbox = bbox
 
-    @lazyproperty
+    @cached_property
     def _mask(self):
         """
         A boolean array that is `True` where the aperture mask weight

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -3,11 +3,12 @@
 Tools for performing aperture photometry.
 """
 
+from functools import cached_property
+
 import astropy.units as u
 import numpy as np
 from astropy.nddata import NDData
 from astropy.table import QTable
-from astropy.utils import lazyproperty
 
 from photutils.aperture._common import (SCALAR_COLLAPSE_TYPES,
                                         collapse_scalar_value, unpack_nddata,
@@ -149,10 +150,10 @@ class AperturePhotometry:
     flag (see `~photutils.aperture.decode_aperture_flags`).
 
     This class should be treated as immutable after
-    initialization (aside from the internal compute-once
-    `~astropy.utils.decorators.lazyproperty` cache), so a single
-    instance can be safely shared across threads. Do not reassign its
-    attributes after construction.
+    initialization (aside from the internal lazily-computed
+    `functools.cached_property` cache), so a single instance can be
+    safely shared across threads. Do not reassign its attributes after
+    construction.
 
     One caveat applies to apertures that are not supported by the
     compiled batch code path (e.g., a `~photutils.aperture.Aperture`
@@ -310,7 +311,7 @@ class AperturePhotometry:
         """
         return object.__getattribute__(self, name)
 
-    @lazyproperty
+    @cached_property
     def isscalar(self):
         """
         Whether the instance is scalar (i.e., a single aperture
@@ -318,7 +319,7 @@ class AperturePhotometry:
         """
         return self._pixel_apertures[0].isscalar
 
-    @lazyproperty
+    @cached_property
     def _photometry_results(self):
         """
         The per-aperture photometry result objects, one for each input
@@ -332,42 +333,42 @@ class AperturePhotometry:
             mask_nonfinite=True)
             for aper in self._pixel_apertures]
 
-    @lazyproperty
+    @cached_property
     def _positions(self):
         """
         The aperture positions in pixels, always as a 2D array.
         """
         return np.atleast_2d(self._pixel_apertures[0].positions)
 
-    @lazyproperty
+    @cached_property
     def n_positions(self):
         """
         The number of aperture positions.
         """
         return self._positions.shape[0]
 
-    @lazyproperty
+    @cached_property
     def id(self):
         """
         The aperture identification number(s).
         """
         return np.arange(self.n_positions) + 1
 
-    @lazyproperty
+    @cached_property
     def x_center(self):
         """
         The ``x`` pixel coordinate(s) of the aperture center(s).
         """
         return self._positions[:, 0]
 
-    @lazyproperty
+    @cached_property
     def y_center(self):
         """
         The ``y`` pixel coordinate(s) of the aperture center(s).
         """
         return self._positions[:, 1]
 
-    @lazyproperty
+    @cached_property
     def sky_center(self):
         """
         The sky coordinates of the aperture center(s), or `None` if no
@@ -395,7 +396,7 @@ class AperturePhotometry:
             return values[0]
         return np.stack(values, axis=1)
 
-    @lazyproperty
+    @cached_property
     def flux(self):
         """
         The sum of the (weighted) values within the aperture(s).
@@ -408,7 +409,7 @@ class AperturePhotometry:
             values <<= self._data_unit
         return values
 
-    @lazyproperty
+    @cached_property
     def flux_err(self):
         """
         The uncertainty in the `flux` values.
@@ -422,7 +423,7 @@ class AperturePhotometry:
             values <<= self._data_unit
         return values
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The total unmasked overlap area of the aperture(s) (in
@@ -439,7 +440,7 @@ class AperturePhotometry:
         stacked = np.stack([value.value for value in values], axis=1)
         return u.Quantity(stacked, u.pix**2)
 
-    @lazyproperty
+    @cached_property
     def flags(self):
         """
         The bitwise quality flags for the aperture(s).

--- a/photutils/aperture/polygon.py
+++ b/photutils/aperture/polygon.py
@@ -3,10 +3,11 @@
 Polygon apertures in both pixel and sky coordinates.
 """
 
+from functools import cached_property
+
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
-from astropy.utils import lazyproperty
 
 from photutils.aperture._batch_photometry import SHAPE_POLYGON
 from photutils.aperture.attributes import (ApertureAttribute, PixelPositions,
@@ -208,7 +209,7 @@ class PixelVertexOffsets(ApertureAttribute):
     def __set__(self, instance, value):
         value = self._validate(value)
         if self.name in instance.__dict__:
-            self._reset_lazyproperties(instance)
+            self._reset_cached_properties(instance)
         instance.__dict__[self.name] = value
 
     def _validate(self, value):
@@ -238,7 +239,7 @@ class SkyVertexOffsets(ApertureAttribute):
     def __set__(self, instance, value):
         value = self._validate(value)
         if self.name in instance.__dict__:
-            self._reset_lazyproperties(instance)
+            self._reset_cached_properties(instance)
         instance.__dict__[self.name] = value
 
     def _validate(self, value):
@@ -718,7 +719,7 @@ class PolygonAperture(PixelAperture):
 
         return cls(positions, offsets)
 
-    @lazyproperty
+    @cached_property
     def vertices(self):
         """
         The absolute pixel ``(x, y)`` vertices of the polygon at each
@@ -739,7 +740,7 @@ class PolygonAperture(PixelAperture):
         # positions shape: (n_positions, 2); result: (n_positions, n_v, 2)
         return self.positions[:, np.newaxis, :] + offsets[np.newaxis, :, :]
 
-    @lazyproperty
+    @cached_property
     def _xy_bounds(self):
         """
         The ``(xmin, xmax, ymin, ymax)`` offsets of the polygon's
@@ -749,7 +750,7 @@ class PolygonAperture(PixelAperture):
         return (float(offsets[:, 0].min()), float(offsets[:, 0].max()),
                 float(offsets[:, 1].min()), float(offsets[:, 1].max()))
 
-    @lazyproperty
+    @cached_property
     def _xy_extents(self):
         """
         Half the extents of the polygon's axis-aligned bounding box.
@@ -757,7 +758,7 @@ class PolygonAperture(PixelAperture):
         xmin, xmax, ymin, ymax = self._xy_bounds
         return 0.5 * (xmax - xmin), 0.5 * (ymax - ymin)
 
-    @lazyproperty
+    @cached_property
     def _xy_bbox_offset(self):
         """
         The (x, y) offset of the bounding box center from ``positions``.
@@ -775,14 +776,14 @@ class PolygonAperture(PixelAperture):
         # the batch Cython photometry driver.
         return SHAPE_POLYGON, tuple(self.vertex_offsets.ravel())
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The exact geometric area of the aperture shape.
         """
         return abs(_signed_polygon_area(self.vertex_offsets))
 
-    @lazyproperty
+    @cached_property
     def perimeter(self):
         """
         The perimeter of the polygon in pixels.
@@ -794,14 +795,14 @@ class PolygonAperture(PixelAperture):
         diff = np.roll(offsets, -1, axis=0) - offsets
         return float(np.sum(np.hypot(diff[:, 0], diff[:, 1])))
 
-    @lazyproperty
+    @cached_property
     def n_vertices(self):
         """
         The number of vertices of the polygon.
         """
         return int(self.vertex_offsets.shape[0])
 
-    @lazyproperty
+    @cached_property
     def _regular_geometry(self):
         """
         Helper that computes the regular-polygon geometric properties
@@ -809,7 +810,7 @@ class PolygonAperture(PixelAperture):
         """
         return _RegularPolygonGeometry(self.vertex_offsets)
 
-    @lazyproperty
+    @cached_property
     def is_regular(self):
         """
         `True` if the polygon is regular (equal-length sides and equal
@@ -824,7 +825,7 @@ class PolygonAperture(PixelAperture):
                    'aperture')
             raise ValueError(msg)
 
-    @lazyproperty
+    @cached_property
     def outer_radius(self):
         """
         The outer (circumscribed-circle) radius of the regular polygon
@@ -839,7 +840,7 @@ class PolygonAperture(PixelAperture):
         self._check_regular('outer_radius')
         return self._regular_geometry.outer_radius
 
-    @lazyproperty
+    @cached_property
     def inner_radius(self):
         """
         The inner (inscribed-circle) radius of the regular polygon in
@@ -855,7 +856,7 @@ class PolygonAperture(PixelAperture):
         self._check_regular('inner_radius')
         return self._regular_geometry.inner_radius
 
-    @lazyproperty
+    @cached_property
     def side_length(self):
         """
         The side length of the regular polygon, in pixels.
@@ -866,7 +867,7 @@ class PolygonAperture(PixelAperture):
         self._check_regular('side_length')
         return self._regular_geometry.side_length
 
-    @lazyproperty
+    @cached_property
     def interior_angle(self):
         """
         The interior angle of the regular polygon as an angular
@@ -878,7 +879,7 @@ class PolygonAperture(PixelAperture):
         self._check_regular('interior_angle')
         return self._regular_geometry.interior_angle
 
-    @lazyproperty
+    @cached_property
     def exterior_angle(self):
         """
         The exterior angle of the regular polygon as an angular
@@ -890,7 +891,7 @@ class PolygonAperture(PixelAperture):
         self._check_regular('exterior_angle')
         return self._regular_geometry.exterior_angle
 
-    @lazyproperty
+    @cached_property
     def theta(self):
         """
         The rotation angle of the regular polygon as an angular
@@ -1191,14 +1192,14 @@ class SkyPolygonAperture(SkyAperture):
 
         return cls(positions=positions, vertex_offsets=offsets)
 
-    @lazyproperty
+    @cached_property
     def n_vertices(self):
         """
         The number of vertices of the polygon.
         """
         return int(self.vertex_offsets.shape[0])
 
-    @lazyproperty
+    @cached_property
     def perimeter(self):
         """
         The angular perimeter of the polygon as a
@@ -1212,7 +1213,7 @@ class SkyPolygonAperture(SkyAperture):
         total = float(np.sum(np.hypot(diff[:, 0], diff[:, 1])))
         return total * u.arcsec
 
-    @lazyproperty
+    @cached_property
     def _regular_geometry(self):
         """
         Helper that computes the regular-polygon geometric properties
@@ -1221,7 +1222,7 @@ class SkyPolygonAperture(SkyAperture):
         return _RegularPolygonGeometry(
             self.vertex_offsets.to_value(u.arcsec))
 
-    @lazyproperty
+    @cached_property
     def is_regular(self):
         """
         `True` if the polygon is regular (equal-length sides and equal
@@ -1236,7 +1237,7 @@ class SkyPolygonAperture(SkyAperture):
                    'aperture')
             raise ValueError(msg)
 
-    @lazyproperty
+    @cached_property
     def outer_radius(self):
         """
         The angular outer (circumscribed-circle) radius of the regular
@@ -1252,7 +1253,7 @@ class SkyPolygonAperture(SkyAperture):
         self._check_regular('outer_radius')
         return self._regular_geometry.outer_radius * u.arcsec
 
-    @lazyproperty
+    @cached_property
     def inner_radius(self):
         """
         The angular inner (inscribed-circle) radius of the regular
@@ -1268,7 +1269,7 @@ class SkyPolygonAperture(SkyAperture):
         self._check_regular('inner_radius')
         return self._regular_geometry.inner_radius * u.arcsec
 
-    @lazyproperty
+    @cached_property
     def side_length(self):
         """
         The angular side length of the regular polygon as a
@@ -1280,7 +1281,7 @@ class SkyPolygonAperture(SkyAperture):
         self._check_regular('side_length')
         return self._regular_geometry.side_length * u.arcsec
 
-    @lazyproperty
+    @cached_property
     def interior_angle(self):
         """
         The interior angle of the regular polygon as an angular
@@ -1292,7 +1293,7 @@ class SkyPolygonAperture(SkyAperture):
         self._check_regular('interior_angle')
         return self._regular_geometry.interior_angle
 
-    @lazyproperty
+    @cached_property
     def exterior_angle(self):
         """
         The exterior angle of the regular polygon as an angular
@@ -1304,7 +1305,7 @@ class SkyPolygonAperture(SkyAperture):
         self._check_regular('exterior_angle')
         return self._regular_geometry.exterior_angle
 
-    @lazyproperty
+    @cached_property
     def theta(self):
         """
         The rotation angle of the regular polygon as an angular
@@ -1331,7 +1332,7 @@ class SkyPolygonAperture(SkyAperture):
         self._check_regular('theta')
         return self._regular_geometry.theta
 
-    @lazyproperty
+    @cached_property
     def vertices(self):
         """
         The absolute sky vertices of the polygon at each aperture

--- a/photutils/aperture/rectangle.py
+++ b/photutils/aperture/rectangle.py
@@ -5,11 +5,11 @@ coordinates.
 """
 
 import math
+from functools import cached_property
 
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import Angle
-from astropy.utils import lazyproperty
 
 from photutils.aperture._batch_photometry import (SHAPE_RECTANGLE,
                                                   SHAPE_RECTANGULAR_ANNULUS)
@@ -254,7 +254,7 @@ class RectangularAperture(_RotatableApertureMixin, PixelAperture):
         self.h = h
         self.theta = theta
 
-    @lazyproperty
+    @cached_property
     def _xy_extents(self):
         """
         The half-width and half-height of the bounding box of the
@@ -265,7 +265,7 @@ class RectangularAperture(_RotatableApertureMixin, PixelAperture):
     def _batch_shape_params(self):
         return SHAPE_RECTANGLE, (self.w, self.h, self._theta_rad)
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The exact geometric area of the aperture shape.
@@ -475,7 +475,7 @@ class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
 
         self.theta = theta
 
-    @lazyproperty
+    @cached_property
     def _xy_extents(self):
         """
         The half-width and half-height of the bounding box of the
@@ -487,7 +487,7 @@ class RectangularAnnulus(_RotatableApertureMixin, PixelAperture):
         return SHAPE_RECTANGULAR_ANNULUS, (self.w_in, self.h_in, self.w_out,
                                            self.h_out, self._theta_rad)
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The exact geometric area of the aperture shape.

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -6,6 +6,7 @@ Tools for calculating properties of sources defined by an Aperture.
 import inspect
 import warnings
 from copy import copy, deepcopy
+from functools import cached_property
 from typing import NamedTuple
 
 import astropy.units as u
@@ -13,7 +14,6 @@ import numpy as np
 from astropy.nddata import NDData
 from astropy.stats import (SigmaClip, biweight_location, biweight_midvariance,
                            mad_std)
-from astropy.utils import lazyproperty
 
 from photutils.aperture import Aperture, SkyAperture, region_to_aperture
 from photutils.aperture._batch_photometry import (FLAG_COL_BBOX_CLIPPED,
@@ -130,24 +130,24 @@ _SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'labels',
                              'segmentation_image'})
 
 
-class _UncachedLazyProperty(lazyproperty):
+class _UncachedProperty(cached_property):
     """
     A property that is discovered as a source property (like
-    `~astropy.utils.lazyproperty`) but is recomputed on every access
+    `functools.cached_property`) but is recomputed on every access
     instead of being cached.
 
     This is used for `ApertureStats.flags`, whose value can change
     over the object's lifetime. It reflects whether covariance-derived
     properties have been computed (see `ApertureStats.flags`). Caching
     would freeze the first-computed value, so the getter runs on every
-    access. Subclassing `~astropy.utils.lazyproperty` keeps it in the
+    access. Subclassing `functools.cached_property` keeps it in the
     `ApertureStats.properties` list and the ``to_table`` machinery.
     """
 
     def __get__(self, obj, owner=None):
         if obj is None:
             return self
-        return self.fget(obj)
+        return self.func(obj)
 
 
 @_update_method_subpixels_docstring
@@ -346,10 +346,10 @@ class ApertureStats:
                                 'data_sum_cutout', 'error_sum_cutout',
                                 'sum_flags')
 
-    # Cached lazyproperties that are not per-source sliceable: the
-    # packed gather buffers and their reductions. ``__getitem__`` drops
-    # these from the sliced object, which recomputes them lazily from
-    # its sliced inputs. Any new lazyproperty backed by the packed batch
+    # Cached properties that are not per-source sliceable: the packed
+    # gather buffers and their reductions. ``__getitem__`` drops these
+    # from the sliced object, which recomputes them lazily from its
+    # sliced inputs. Any new cached property backed by the packed batch
     # buffers must be added here, otherwise slicing will attempt to
     # index the packed buffer per source and fail or corrupt it.
     _NON_SLICEABLE_CACHES = frozenset({
@@ -465,23 +465,23 @@ class ApertureStats:
         return aperture
 
     @property
-    def _lazyproperties(self):
+    def _cached_properties(self):
         """
-        A list of all class lazyproperties (even in superclasses).
+        A list of all class cached properties (even in superclasses).
 
         The result is cached on the class to avoid repeated
         introspection via `inspect.getmembers`.
         """
         cls = self.__class__
-        attr = '_cached_lazyproperties'
-        # Subclasses get their own lazyproperty list
+        attr = '_cached_properties_cache'
+        # Subclasses get their own cached-property list
         if attr not in cls.__dict__:
-            def islazyproperty(obj):
-                return isinstance(obj, lazyproperty)
+            def is_cached_property(obj):
+                return isinstance(obj, cached_property)
 
             setattr(cls, attr,
                     [i[0] for i in inspect.getmembers(
-                        cls, predicate=islazyproperty)])
+                        cls, predicate=is_cached_property)])
         return getattr(cls, attr)
 
     @property
@@ -489,15 +489,15 @@ class ApertureStats:
         """
         A sorted list of the built-in source properties.
         """
-        lazyproperties = [name for name in self._lazyproperties if not
-                          name.startswith('_')]
+        cached_properties = [name for name in self._cached_properties
+                             if not name.startswith('_')]
         # isscalar and n_positions are scalar values for the whole
         # object, not per-source values, so they are not valid table
         # columns
-        lazyproperties.remove('isscalar')
-        lazyproperties.remove('n_positions')
-        lazyproperties.sort()
-        return lazyproperties
+        cached_properties.remove('isscalar')
+        cached_properties.remove('n_positions')
+        cached_properties.sort()
+        return cached_properties
 
     def __getitem__(self, index):
         if self.isscalar:
@@ -536,8 +536,8 @@ class ApertureStats:
         else:
             newcls._seg_labels = np.atleast_1d(self._seg_labels[index])
 
-        # Slice evaluated lazyproperty objects
-        keys = set(self.__dict__.keys()) & set(self._lazyproperties)
+        # Slice evaluated cached-property objects
+        keys = set(self.__dict__.keys()) & set(self._cached_properties)
         keys.add('_local_bkg')  # iterable defined in __init__
         # The packed gather buffers and their reductions are not
         # per-source sliceable; the sliced object recomputes them
@@ -643,7 +643,7 @@ class ApertureStats:
             return value[np.newaxis, ...]
         return [value]
 
-    @lazyproperty
+    @cached_property
     def isscalar(self):
         """
         Whether the instance is scalar (e.g., a single aperture
@@ -662,14 +662,14 @@ class ApertureStats:
         """
         return deepcopy(self)
 
-    @lazyproperty
+    @cached_property
     def _null_object(self):
         """
         Return `None` values.
         """
         return np.array([None] * self.n_positions)
 
-    @lazyproperty
+    @cached_property
     def _null_value(self):
         """
         Return np.nan values.
@@ -782,7 +782,7 @@ class ApertureStats:
             table_columns = self.default_columns
         else:
             # id is not included in self.properties because it is not
-            # a lazyproperty
+            # a cached property
             allowed_columns = set(self.properties) | set(self.default_columns)
             # Remove 2D cutout images from the allowed columns
             allowed_columns = {col for col in allowed_columns
@@ -837,7 +837,7 @@ class ApertureStats:
             tbl[canonical_column] = values_map[column]
         return tbl
 
-    @lazyproperty
+    @cached_property
     def n_positions(self):
         """
         The number of positions for the input aperture.
@@ -858,7 +858,7 @@ class ApertureStats:
         """
         return self.n_positions
 
-    @lazyproperty
+    @cached_property
     def _pixel_aperture(self):
         """
         The input aperture as a PixelAperture.
@@ -867,7 +867,7 @@ class ApertureStats:
             return self.aperture.to_pixel(self._wcs)
         return self.aperture
 
-    @lazyproperty
+    @cached_property
     def _batch_inputs(self):
         """
         The validated inputs for the fast Cython batch driver, or `None`.
@@ -932,7 +932,7 @@ class ApertureStats:
                 np.ascontiguousarray(self._local_bkg, dtype=np.float64),
                 seg_arr, labels_arr, seg_code, clip_spec)
 
-    @lazyproperty
+    @cached_property
     def _fast_gather(self):
         """
         The fast Cython "center"-method value gather, or `None`.
@@ -976,7 +976,7 @@ class ApertureStats:
             gather = self._apply_center_clip(gather, clip_spec)
         return gather
 
-    @lazyproperty
+    @cached_property
     def _fast_sum(self):
         """
         The fast Cython ``sum_method`` aperture gather, or `None`.
@@ -1092,7 +1092,7 @@ class ApertureStats:
                                sum_values=None, sum_fracs=None,
                                sum_errsq=None, sum_counts=None)
 
-    @lazyproperty
+    @cached_property
     def _sorted_values(self):
         """
         The packed per-source ascending-sorted center pixel values, or
@@ -1116,7 +1116,7 @@ class ApertureStats:
             return (gather.sorted_values, starts, counts)
         return (batch_sort_values(values, starts, counts), starts, counts)
 
-    @lazyproperty
+    @cached_property
     def _order_stats(self):
         """
         The per-source ``(min, max, median)`` arrays, or `None`.
@@ -1129,7 +1129,7 @@ class ApertureStats:
             return None
         return batch_order_stats(*sorted_values)
 
-    @lazyproperty
+    @cached_property
     def _mean_var(self):
         """
         The per-source ``(mean, var)`` arrays, or `None`.
@@ -1143,7 +1143,7 @@ class ApertureStats:
             return None
         return batch_mean_var(gather.values, gather.starts, gather.counts)
 
-    @lazyproperty
+    @cached_property
     def _mad(self):
         """
         The per-source unscaled median absolute deviation, or `None`.
@@ -1156,7 +1156,7 @@ class ApertureStats:
             return None
         return batch_mad(*sorted_values)
 
-    @lazyproperty
+    @cached_property
     def _biweight(self):
         """
         The per-source ``(biweight_location, biweight_midvariance)``
@@ -1172,7 +1172,7 @@ class ApertureStats:
         _, _, median = self._order_stats
         return batch_biweight(*sorted_values, median, self._mad)
 
-    @lazyproperty
+    @cached_property
     def _gini(self):
         """
         The per-source Gini coefficient, or `None`.
@@ -1222,7 +1222,7 @@ class ApertureStats:
                 result <<= unit
         return result
 
-    @lazyproperty
+    @cached_property
     def _aperture_masks_center(self):
         """
         The aperture masks (`ApertureMask`) generated with the 'center'
@@ -1233,7 +1233,7 @@ class ApertureStats:
             aperture_masks = (aperture_masks,)
         return aperture_masks
 
-    @lazyproperty
+    @cached_property
     def _aperture_masks(self):
         """
         The aperture masks (`ApertureMask`) generated with the
@@ -1245,7 +1245,7 @@ class ApertureStats:
             aperture_masks = (aperture_masks,)
         return aperture_masks
 
-    @lazyproperty
+    @cached_property
     def _overlap_slices(self):
         """
         The aperture mask overlap slices with the data, always as an
@@ -1260,7 +1260,7 @@ class ApertureStats:
             overlap_slices.append((slc_large, slc_small))
         return overlap_slices
 
-    @lazyproperty
+    @cached_property
     def _data_cutouts(self):
         """
         The local-background-subtracted unmasked data cutouts using the
@@ -1309,10 +1309,10 @@ class ApertureStats:
             `False`).
         """
         # Use a local copy of the SigmaClip instance because SigmaClip
-        # stores internal state on the instance # during calls. This
-        # method is reachable from two different # lazyproperties (the
-        # center- and sum-footprint cutouts), # which do not share a lock,
-        # so calling a shared instance from # multiple threads could
+        # stores internal state on the instance during calls. This
+        # method is reachable from two different cached properties (the
+        # center- and sum-footprint cutouts), which do not share a lock,
+        # so calling a shared instance from multiple threads could
         # silently corrupt the results.
         sigma_clip = copy(self.sigma_clip)
 
@@ -1456,7 +1456,7 @@ class ApertureStats:
                         weight_cutouts, overlaps, flag_counts, n_clipped,
                         strict=True))
 
-    @lazyproperty
+    @cached_property
     def _aperture_cutouts_center(self):
         """
         Aperture-weighted cutouts for the data, variance, total mask,
@@ -1464,7 +1464,7 @@ class ApertureStats:
         """
         return self._make_aperture_cutouts(self._aperture_masks_center)
 
-    @lazyproperty
+    @cached_property
     def _aperture_cutouts(self):
         """
         Aperture-weighted cutouts for the data, variance, total mask,
@@ -1478,7 +1478,7 @@ class ApertureStats:
         return self._make_aperture_cutouts(self._aperture_masks,
                                            count_clipped=False)
 
-    @lazyproperty
+    @cached_property
     def _mask_cutout_center(self):
         """
         Boolean mask cutouts representing the total mask.
@@ -1489,7 +1489,7 @@ class ApertureStats:
         """
         return list(zip(*self._aperture_cutouts_center, strict=True))[2]
 
-    @lazyproperty
+    @cached_property
     def _mask_cutout(self):
         """
         Boolean mask cutouts representing the total mask.
@@ -1521,7 +1521,7 @@ class ApertureStats:
         return [np.ma.masked_array(arr, mask=mask)
                 for arr, mask in zip(array, self._mask_cutout, strict=True)]
 
-    @lazyproperty
+    @cached_property
     def data_cutout(self):
         """
         A 2D aperture-weighted cutout from the data using the aperture
@@ -1538,7 +1538,7 @@ class ApertureStats:
         return self._make_masked_array_center(
             list(zip(*self._aperture_cutouts_center, strict=True))[0])
 
-    @lazyproperty
+    @cached_property
     def data_sum_cutout(self):
         """
         A 2D aperture-weighted cutout from the data using the aperture
@@ -1556,7 +1556,7 @@ class ApertureStats:
         return self._make_masked_array(list(zip(*self._aperture_cutouts,
                                                 strict=True))[0])
 
-    @lazyproperty
+    @cached_property
     def _variance_cutout_center(self):
         """
         A 2D aperture-weighted variance cutout using the aperture mask
@@ -1575,7 +1575,7 @@ class ApertureStats:
         return self._make_masked_array_center(
             list(zip(*self._aperture_cutouts_center, strict=True))[1])
 
-    @lazyproperty
+    @cached_property
     def _variance_cutout(self):
         """
         A 2D aperture-weighted variance cutout using the aperture mask
@@ -1595,7 +1595,7 @@ class ApertureStats:
         return self._make_masked_array(list(zip(*self._aperture_cutouts,
                                                 strict=True))[1])
 
-    @lazyproperty
+    @cached_property
     def error_sum_cutout(self):
         """
         A 2D aperture-weighted error cutout using the aperture mask with
@@ -1613,7 +1613,7 @@ class ApertureStats:
             return self._null_object
         return [np.sqrt(var) for var in self._variance_cutout]
 
-    @lazyproperty
+    @cached_property
     def _weight_cutout_center(self):
         """
         A 2D `~numpy.ma.MaskedArray` cutout from the aperture mask
@@ -1628,7 +1628,7 @@ class ApertureStats:
         return self._make_masked_array_center(
             list(zip(*self._aperture_cutouts_center, strict=True))[3])
 
-    @lazyproperty
+    @cached_property
     def _weight_cutout(self):
         """
         A 2D `~numpy.ma.MaskedArray` cutout from the aperture mask
@@ -1643,7 +1643,7 @@ class ApertureStats:
         return self._make_masked_array(list(zip(*self._aperture_cutouts,
                                                 strict=True))[3])
 
-    @lazyproperty
+    @cached_property
     def _moment_data_cutout(self):
         """
         A list of 2D `~numpy.ndarray` cutouts from the data.
@@ -1668,14 +1668,14 @@ class ApertureStats:
 
         return cutouts
 
-    @lazyproperty
+    @cached_property
     def _all_masked(self):
         """
         True if all pixels within the aperture are masked.
         """
         return np.array([np.all(mask) for mask in self._mask_cutout_center])
 
-    @lazyproperty
+    @cached_property
     def _overlap(self):
         """
         True if there is no overlap of the aperture with the data.
@@ -1745,7 +1745,7 @@ class ApertureStats:
             candidates=candidates)
         return _counts_to_flag_bits(flag_counts, overlap, w_out)
 
-    @lazyproperty
+    @cached_property
     def _base_flags(self):
         """
         The count-based value-statistics flag bits (1D int array).
@@ -1778,7 +1778,7 @@ class ApertureStats:
 
         return flags
 
-    @lazyproperty
+    @cached_property
     def _undefined_shape_mask(self):
         """
         Boolean mask (1D) marking sources whose net flux is not
@@ -1797,7 +1797,7 @@ class ApertureStats:
         n_pixels = self._center_n_pixels
         return np.isfinite(m00) & (m00 <= 0) & np.isfinite(n_pixels)
 
-    @lazyproperty
+    @cached_property
     def _singular_covariance_mask(self):
         """
         Boolean mask (1D) marking sources with a singular or nearly
@@ -1837,7 +1837,7 @@ class ApertureStats:
         finite = np.isfinite(covar_det) & np.isfinite(min_eigval)
         return finite & ((covar_det < delta**2) | (min_eigval < delta))
 
-    @_UncachedLazyProperty
+    @_UncachedProperty
     @_update_method_subpixels_docstring
     def flags(self):
         # numpydoc ignore: RT01
@@ -1883,7 +1883,7 @@ class ApertureStats:
                 APERTURE_FLAGS.SINGULAR_COVARIANCE)
         return flags
 
-    @lazyproperty
+    @cached_property
     @_update_method_subpixels_docstring
     def sum_flags(self):
         # numpydoc ignore: RT01
@@ -1970,7 +1970,7 @@ class ApertureStats:
         return [arr.compressed() if len(arr.compressed()) > 0
                 else np.array([np.nan]) for arr in array]
 
-    @lazyproperty
+    @cached_property
     def _data_values_center(self):
         """
         A 1D array of unmasked aperture-weighted data values using the
@@ -1981,7 +1981,7 @@ class ApertureStats:
         """
         return self._get_values(self.data_cutout)
 
-    @lazyproperty
+    @cached_property
     def moments(self):
         """
         Spatial moments up to 3rd order of the source.
@@ -2002,7 +2002,7 @@ class ApertureStats:
         return np.array([_image_moments(arr, order=3)
                          for arr in self._moment_data_cutout])
 
-    @lazyproperty
+    @cached_property
     def moments_central(self):
         """
         Central moments (translation invariant) of the source up to 3rd
@@ -2028,7 +2028,7 @@ class ApertureStats:
                          zip(self._moment_data_cutout, cutout_centroid[:, 0],
                              cutout_centroid[:, 1], strict=True)])
 
-    @lazyproperty
+    @cached_property
     def cutout_centroid(self):
         """
         The ``(x, y)`` coordinate, relative to the cutout data, of the
@@ -2046,7 +2046,7 @@ class ApertureStats:
             x_centroid = moments[:, 0, 1] / moments[:, 0, 0]
         return np.transpose((x_centroid, y_centroid))
 
-    @lazyproperty
+    @cached_property
     def centroid(self):
         """
         The ``(x, y)`` coordinate of the centroid.
@@ -2057,7 +2057,7 @@ class ApertureStats:
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.cutout_centroid + origin
 
-    @lazyproperty
+    @cached_property
     def x_centroid(self):
         """
         The ``x`` coordinate of the centroid.
@@ -2067,7 +2067,7 @@ class ApertureStats:
         """
         return np.transpose(self._array('centroid'))[0]
 
-    @lazyproperty
+    @cached_property
     def y_centroid(self):
         """
         The ``y`` coordinate of the centroid.
@@ -2077,7 +2077,7 @@ class ApertureStats:
         """
         return np.transpose(self._array('centroid'))[1]
 
-    @lazyproperty
+    @cached_property
     def sky_centroid(self):
         """
         The sky coordinate of the centroid of the unmasked pixels within
@@ -2092,7 +2092,7 @@ class ApertureStats:
             return self._null_object
         return self._wcs.pixel_to_world(self.x_centroid, self.y_centroid)
 
-    @lazyproperty
+    @cached_property
     def sky_centroid_icrs(self):
         """
         The sky coordinate in the International Celestial Reference
@@ -2106,7 +2106,7 @@ class ApertureStats:
             return self._null_object
         return self.sky_centroid.icrs
 
-    @lazyproperty
+    @cached_property
     def _bbox(self):
         """
         The `~photutils.aperture.BoundingBox` of the aperture, always as
@@ -2117,7 +2117,7 @@ class ApertureStats:
             apertures = (apertures,)
         return [aperture.bbox for aperture in apertures]
 
-    @lazyproperty
+    @cached_property
     def bbox(self):
         """
         The `~photutils.aperture.BoundingBox` of the aperture.
@@ -2128,7 +2128,7 @@ class ApertureStats:
         """
         return self._bbox
 
-    @lazyproperty
+    @cached_property
     def _bbox_bounds(self):
         """
         The bounding box x and y minimum and maximum bounds.
@@ -2140,14 +2140,14 @@ class ApertureStats:
                           bbox_.iymin, bbox_.iymax - 1)
                          for bbox_ in bbox], dtype=int).reshape(-1, 4)
 
-    @lazyproperty
+    @cached_property
     def bbox_xmin(self):
         """
         The minimum ``x``-pixel index of the bounding box.
         """
         return np.transpose(self._bbox_bounds)[0]
 
-    @lazyproperty
+    @cached_property
     def bbox_xmax(self):
         """
         The maximum ``x``-pixel index of the bounding box.
@@ -2156,14 +2156,14 @@ class ApertureStats:
         """
         return np.transpose(self._bbox_bounds)[1]
 
-    @lazyproperty
+    @cached_property
     def bbox_ymin(self):
         """
         The minimum ``y``-pixel index of the bounding box.
         """
         return np.transpose(self._bbox_bounds)[2]
 
-    @lazyproperty
+    @cached_property
     def bbox_ymax(self):
         """
         The maximum ``y``-pixel index of the bounding box.
@@ -2172,7 +2172,7 @@ class ApertureStats:
         """
         return np.transpose(self._bbox_bounds)[3]
 
-    @lazyproperty
+    @cached_property
     def _center_n_pixels(self):
         """
         The number of unmasked pixels within each aperture using the
@@ -2192,7 +2192,7 @@ class ApertureStats:
         n_pixels[self._all_masked] = np.nan
         return n_pixels
 
-    @lazyproperty
+    @cached_property
     def _sem(self):
         """
         The standard error of the mean for each aperture.
@@ -2217,7 +2217,7 @@ class ApertureStats:
         sem[mask] = np.sqrt(var[mask] / (n_pixels[mask] - 1.0))
         return sem
 
-    @lazyproperty
+    @cached_property
     def center_aper_area(self):
         """
         The total area of the unmasked pixels within the aperture using
@@ -2225,7 +2225,7 @@ class ApertureStats:
         """
         return self._center_n_pixels * (u.pix**2)
 
-    @lazyproperty
+    @cached_property
     def sum_aper_area(self):
         """
         The total area of the unmasked pixels within the aperture using
@@ -2246,7 +2246,7 @@ class ApertureStats:
         areas[areas == 0] = np.nan
         return areas << (u.pix**2)
 
-    @lazyproperty
+    @cached_property
     def sum(self):
         r"""
         The sum of the unmasked ``data`` values within the aperture.
@@ -2283,7 +2283,7 @@ class ApertureStats:
             result <<= self._data_unit
         return result
 
-    @lazyproperty
+    @cached_property
     def sum_err(self):
         r"""
         The uncertainty of `sum`, propagated from the input ``error``
@@ -2330,7 +2330,7 @@ class ApertureStats:
             err <<= self._data_unit
         return err
 
-    @lazyproperty
+    @cached_property
     def min(self):
         """
         The minimum of the unmasked pixel values within the aperture.
@@ -2338,7 +2338,7 @@ class ApertureStats:
         fast = None if self._order_stats is None else self._order_stats[0]
         return self._finalize_value_stat(fast, np.min)
 
-    @lazyproperty
+    @cached_property
     def max(self):
         """
         The maximum of the unmasked pixel values within the aperture.
@@ -2346,7 +2346,7 @@ class ApertureStats:
         fast = None if self._order_stats is None else self._order_stats[1]
         return self._finalize_value_stat(fast, np.max)
 
-    @lazyproperty
+    @cached_property
     def mean(self):
         """
         The mean of the unmasked pixel values within the aperture.
@@ -2354,7 +2354,7 @@ class ApertureStats:
         fast = None if self._mean_var is None else self._mean_var[0]
         return self._finalize_value_stat(fast, np.mean)
 
-    @lazyproperty
+    @cached_property
     def mean_err(self):
         r"""
         The standard error of the `mean`.
@@ -2378,7 +2378,7 @@ class ApertureStats:
             result <<= self._data_unit
         return result
 
-    @lazyproperty
+    @cached_property
     def median(self):
         """
         The median of the unmasked pixel values within the aperture.
@@ -2386,7 +2386,7 @@ class ApertureStats:
         fast = None if self._order_stats is None else self._order_stats[2]
         return self._finalize_value_stat(fast, np.median)
 
-    @lazyproperty
+    @cached_property
     def median_err(self):
         r"""
         The standard error of the `median`.
@@ -2413,7 +2413,7 @@ class ApertureStats:
             result <<= self._data_unit
         return result
 
-    @lazyproperty
+    @cached_property
     def mode(self):
         """
         The mode of the unmasked pixel values within the aperture.
@@ -2422,7 +2422,7 @@ class ApertureStats:
         """
         return 3.0 * self.median - 2.0 * self.mean
 
-    @lazyproperty
+    @cached_property
     def _variance(self):
         """
         The variance of the unmasked pixel values within each aperture
@@ -2446,7 +2446,7 @@ class ApertureStats:
                         / (n_pixels[mask] - self.ddof))
         return result
 
-    @lazyproperty
+    @cached_property
     def std(self):
         """
         The standard deviation of the unmasked pixel values within the
@@ -2461,7 +2461,7 @@ class ApertureStats:
             result <<= self._data_unit
         return result
 
-    @lazyproperty
+    @cached_property
     def mad_std(self):
         r"""
         The standard deviation calculated using
@@ -2481,7 +2481,7 @@ class ApertureStats:
         fast = None if self._mad is None else self._mad * _MAD_STD_SCALE
         return self._finalize_value_stat(fast, mad_std)
 
-    @lazyproperty
+    @cached_property
     def var(self):
         """
         The variance of the unmasked pixel values within the aperture.
@@ -2495,7 +2495,7 @@ class ApertureStats:
             result <<= self._data_unit**2
         return result
 
-    @lazyproperty
+    @cached_property
     def biweight_location(self):
         """
         The biweight location of the unmasked pixel values within the
@@ -2507,7 +2507,7 @@ class ApertureStats:
         fast = None if self._biweight is None else self._biweight[0]
         return self._finalize_value_stat(fast, biweight_location)
 
-    @lazyproperty
+    @cached_property
     def biweight_midvariance(self):
         """
         The biweight midvariance of the unmasked pixel values within the
@@ -2520,7 +2520,7 @@ class ApertureStats:
         return self._finalize_value_stat(fast, biweight_midvariance,
                                          square_unit=True)
 
-    @lazyproperty
+    @cached_property
     def inertia_tensor(self):
         """
         The inertia tensor of the source for the rotation around its
@@ -2533,7 +2533,7 @@ class ApertureStats:
         tensor = np.array([mu_02, mu_11, mu_11, mu_20]).swapaxes(0, 1)
         return tensor.reshape((tensor.shape[0], 2, 2)) * u.pix**2
 
-    @lazyproperty
+    @cached_property
     def _raw_covariance(self):
         """
         The raw ``(N, 2, 2)`` covariance matrix of the 2D Gaussian
@@ -2554,7 +2554,7 @@ class ApertureStats:
                           mu_norm[:, 1, 1], mu_norm[:, 2, 0]]).swapaxes(0, 1)
         return covar.reshape((covar.shape[0], 2, 2))
 
-    @lazyproperty
+    @cached_property
     def _covariance(self):
         """
         The covariance matrix of the 2D Gaussian function that has the
@@ -2597,7 +2597,7 @@ class ApertureStats:
             covar[idx, 1, 1] += delta
         return covar
 
-    @lazyproperty
+    @cached_property
     def covariance(self):
         """
         The covariance matrix of the 2D Gaussian function that has the
@@ -2605,7 +2605,7 @@ class ApertureStats:
         """
         return self._covariance * (u.pix**2)
 
-    @lazyproperty
+    @cached_property
     def covariance_eigvals(self):
         """
         The two eigenvalues of the `covariance` matrix in decreasing
@@ -2628,7 +2628,7 @@ class ApertureStats:
 
         return eigvals * u.pix**2
 
-    @lazyproperty
+    @cached_property
     def semimajor_axis(self):
         """
         The 1-sigma standard deviation along the semimajor axis of the
@@ -2638,7 +2638,7 @@ class ApertureStats:
         eigvals = self._array('covariance_eigvals')
         return np.sqrt(eigvals[:, 0])
 
-    @lazyproperty
+    @cached_property
     def semiminor_axis(self):
         """
         The 1-sigma standard deviation along the semiminor axis of the
@@ -2648,7 +2648,7 @@ class ApertureStats:
         eigvals = self._array('covariance_eigvals')
         return np.sqrt(eigvals[:, 1])
 
-    @lazyproperty
+    @cached_property
     def fwhm(self):
         r"""
         The circularized full width at half maximum (FWHM) of the 2D
@@ -2668,7 +2668,7 @@ class ApertureStats:
         return 2.0 * np.sqrt(np.log(2.0) * (self.semimajor_axis**2
                                             + self.semiminor_axis**2))
 
-    @lazyproperty
+    @cached_property
     def orientation(self):
         """
         The angle between the ``x`` axis and the major axis of the 2D
@@ -2683,7 +2683,7 @@ class ApertureStats:
                                           (covar[:, 0, 0] - covar[:, 1, 1]))
         return np.rad2deg(orient_radians) * u.deg
 
-    @lazyproperty
+    @cached_property
     def eccentricity(self):
         r"""
         The eccentricity of the 2D Gaussian function that has the same
@@ -2702,7 +2702,7 @@ class ApertureStats:
         semimajor_var, semiminor_var = np.transpose(self.covariance_eigvals)
         return np.sqrt(1.0 - (semiminor_var / semimajor_var))
 
-    @lazyproperty
+    @cached_property
     def elongation(self):
         r"""
         The ratio of the lengths of the semimajor and semiminor axes.
@@ -2716,7 +2716,7 @@ class ApertureStats:
         """
         return self.semimajor_axis / self.semiminor_axis
 
-    @lazyproperty
+    @cached_property
     def ellipticity(self):
         r"""
         1.0 minus the ratio of the lengths of the semiminor and
@@ -2733,7 +2733,7 @@ class ApertureStats:
         """
         return 1.0 - (self.semiminor_axis / self.semimajor_axis)
 
-    @lazyproperty
+    @cached_property
     def covariance_xx(self):
         r"""
         The ``(0, 0)`` element of the `covariance` matrix, representing
@@ -2741,7 +2741,7 @@ class ApertureStats:
         """
         return self._covariance[:, 0, 0] * u.pix**2
 
-    @lazyproperty
+    @cached_property
     def covariance_yy(self):
         r"""
         The ``(1, 1)`` element of the `covariance` matrix, representing
@@ -2749,7 +2749,7 @@ class ApertureStats:
         """
         return self._covariance[:, 1, 1] * u.pix**2
 
-    @lazyproperty
+    @cached_property
     def covariance_xy(self):
         r"""
         The ``(0, 1)`` and ``(1, 0)`` elements of the `covariance`
@@ -2758,7 +2758,7 @@ class ApertureStats:
         """
         return self._covariance[:, 0, 1] * u.pix**2
 
-    @lazyproperty
+    @cached_property
     def ellipse_cxx(self):
         r"""
         Coefficient for ``x**2`` in the generalized ellipse equation in
@@ -2780,7 +2780,7 @@ class ApertureStats:
         return ((np.cos(self.orientation) / self.semimajor_axis)**2
                 + (np.sin(self.orientation) / self.semiminor_axis)**2)
 
-    @lazyproperty
+    @cached_property
     def ellipse_cyy(self):
         r"""
         Coefficient for ``y**2`` in the generalized ellipse equation in
@@ -2802,7 +2802,7 @@ class ApertureStats:
         return ((np.sin(self.orientation) / self.semimajor_axis)**2
                 + (np.cos(self.orientation) / self.semiminor_axis)**2)
 
-    @lazyproperty
+    @cached_property
     def ellipse_cxy(self):
         r"""
         Coefficient for ``x * y`` in the generalized ellipse equation in
@@ -2825,7 +2825,7 @@ class ApertureStats:
                 * ((1.0 / self.semimajor_axis**2)
                    - (1.0 / self.semiminor_axis**2)))
 
-    @lazyproperty
+    @cached_property
     def gini(self):
         r"""
         The `Gini coefficient

--- a/photutils/aperture/tests/test_attributes.py
+++ b/photutils/aperture/tests/test_attributes.py
@@ -22,13 +22,13 @@ class MockBase:
     attr = ApertureAttribute(doc='a test attribute')
 
 
-class MockWithLazy:
+class MockWithCachedProperties:
     """
-    Minimal class with _lazyproperties for reset testing.
+    Minimal class with _cached_properties for reset testing.
     """
 
     attr = ApertureAttribute()
-    _lazyproperties = ['cached']  # noqa: RUF012
+    _cached_properties = ['cached']  # noqa: RUF012
 
 
 class MockPixelPos:
@@ -140,26 +140,26 @@ class TestApertureAttribute:
         obj.attr = val
         assert isinstance(obj.attr, SkyCoord)
 
-    def test_reset_lazyproperties(self):
+    def test_reset_cached_properties(self):
         """
-        Test that lazyproperties are cleared when the attribute is
+        Test that cached properties are cleared when the attribute is
         updated.
         """
-        obj = MockWithLazy()
+        obj = MockWithCachedProperties()
         obj.attr = 1.0
         obj.cached = 42
         assert 'cached' in obj.__dict__
-        obj.attr = 2.0  # second assignment triggers _reset_lazyproperties
+        obj.attr = 2.0  # second assignment triggers _reset_cached_properties
         assert 'cached' not in obj.__dict__
 
-    def test_reset_no_lazyproperties(self):
+    def test_reset_no_cached_properties(self):
         """
-        Test that AttributeError is silently caught when _lazyproperties
+        Test that AttributeError is silently caught when _cached_properties
         is absent.
         """
         obj = MockBase()
         obj.attr = 1.0
-        # Triggers _reset_lazyproperties; obj has no _lazyproperties
+        # Triggers _reset_cached_properties; obj has no _cached_properties
         obj.attr = 2.0
         assert obj.attr == 2.0
 
@@ -222,13 +222,13 @@ class TestPixelPositions:
         obj.positions = zip([1.0, 2.0], [3.0, 4.0], strict=False)
         assert obj.positions.shape == (2, 2)
 
-    def test_reset_lazyproperties(self):
+    def test_reset_cached_properties(self):
         """
-        Test that setting positions twice clears cached lazyproperties.
+        Test that setting positions twice clears cached properties.
         """
         obj = MockPixelPos()
         obj.positions = [(1, 2)]
-        obj._lazyproperties = ['cached']
+        obj._cached_properties = ['cached']
         obj.cached = 99
         obj.positions = [(3, 4)]  # triggers reset
         assert 'cached' not in obj.__dict__
@@ -518,13 +518,13 @@ class TestScalarAngleOrValue:
         assert obj.theta.unit == u.radian
         assert obj.theta.value == 1.5
 
-    def test_reset_lazyproperties(self):
+    def test_reset_cached_properties(self):
         """
-        Test that setting theta twice clears cached lazyproperties.
+        Test that setting theta twice clears cached properties.
         """
         obj = MockScalarAngleOrValue()
         obj.theta = 1.0
-        obj._lazyproperties = ['cached']
+        obj._cached_properties = ['cached']
         obj.cached = 42
         obj.theta = 2.0  # triggers reset
         assert 'cached' not in obj.__dict__

--- a/photutils/aperture/tests/test_batch_thread_safety.py
+++ b/photutils/aperture/tests/test_batch_thread_safety.py
@@ -14,6 +14,7 @@ modules.
 import importlib
 import sys
 import sysconfig
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
@@ -246,10 +247,10 @@ class TestApertureStatsThreadSafety:
         Test that a single shared ApertureStats instance can be read
         concurrently.
 
-        The instance is documented as immutable after construction, so
-        concurrent readers racing to fill the lazyproperty caches
-        (which are guarded by the astropy lazyproperty lock) must all
-        see identical values.
+        The instance is documented as immutable after construction,
+        so concurrent readers racing to fill the cached-property
+        caches (which fill without any locking) must all see
+        identical values.
         """
         data = make_100gaussians_image()
         error = np.sqrt(np.abs(data))
@@ -272,3 +273,52 @@ class TestApertureStatsThreadSafety:
             for name, values in result.items():
                 assert_allclose(values, expected[name], rtol=0, atol=0,
                                 equal_nan=True)
+
+    def test_no_cross_instance_serialization(self, monkeypatch):
+        """
+        Test that computing a cached property on one instance does not
+        block the same property on a different instance in another
+        thread.
+
+        The astropy lazyproperty descriptor holds one lock per
+        class attribute shared by all instances, which serialized
+        the entire computation across instances and threads. The
+        `functools.cached_property` descriptors used now have no lock,
+        so instance B must complete while instance A is still blocked
+        inside its getter. This test deadlocks instance B (until the
+        timeout) if a class-level lock is ever reintroduced.
+        """
+        import photutils.aperture.stats as stats_mod
+
+        data = np.ones((50, 50))
+        stats_a = ApertureStats(data, CircularAperture((25, 25), r=5.0))
+        stats_b = ApertureStats(data, CircularAperture((30, 30), r=5.0))
+
+        entered_a = threading.Event()
+        release_a = threading.Event()
+        real_gather = stats_mod.batch_aperture_gather
+
+        def blocking_gather(data_arr, mask, positions, *args):
+            # Block only instance A's gather; B's must run freely
+            if positions[0, 0] == 25.0:
+                entered_a.set()
+                assert release_a.wait(timeout=30)
+            return real_gather(data_arr, mask, positions, *args)
+
+        monkeypatch.setattr(stats_mod, 'batch_aperture_gather',
+                            blocking_gather)
+
+        with ThreadPoolExecutor(max_workers=2) as ex:
+            future_a = ex.submit(lambda: stats_a.median)
+            assert entered_a.wait(timeout=30)
+
+            # Instance A is now parked inside the median getter chain.
+            # Instance B's median must complete while A is blocked.
+            future_b = ex.submit(lambda: stats_b.median)
+            result_b = future_b.result(timeout=30)
+            assert not future_a.done()
+
+            release_a.set()
+            result_a = future_a.result(timeout=30)
+
+        assert_allclose(result_a, result_b)

--- a/photutils/aperture/tests/test_core.py
+++ b/photutils/aperture/tests/test_core.py
@@ -384,7 +384,7 @@ class TestApertureParameterMutation:
         """
         theta = 0.7
         aper = aperture_class(SCALAR_POS_20, theta=0.0, **params)
-        # Cache the lazyproperties derived from the original theta
+        # Cache the cached properties derived from the original theta
         aper.to_mask()
         aper.theta = theta
 
@@ -432,7 +432,7 @@ class TestApertureParameterMutation:
         theta = 35.0 * u.deg
         position = SkyCoord(ra=10.0, dec=30.0, unit='deg')
         aper = aperture_class(position, theta=0.0 * u.deg, **params)
-        # Cache the lazyproperties derived from the original theta
+        # Cache the cached properties derived from the original theta
         aper.to_pixel(tan_wcs)
         aper.theta = theta
 

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -931,7 +931,7 @@ class TestReprAndImmutability:
 
     def test_no_new_attributes_after_init(self, data):
         """
-        Only lazyproperty cache entries may appear after ``__init__``,
+        Only cached-property cache entries may appear after ``__init__``,
         which is required for the instance to be thread-safe.
         """
         aper = CircularAperture(((150, 25), (90, 60)), 8)
@@ -955,8 +955,10 @@ class TestReprAndImmutability:
     def test_concurrent_access(self, data):
         """
         Test that a single shared AperturePhotometry instance can be
-        read concurrently. The lazyproperty caches fill under contention
-        and every thread sees identical values.
+        read concurrently.
+
+        The cached-property caches fill under contention and every
+        thread sees identical values.
         """
         aper = CircularAperture(((150, 25), (90, 60)), 8)
         phot = AperturePhotometry(data, aper, error=np.ones_like(data))

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -491,7 +491,7 @@ class TestPolygonConstruction:
         with pytest.raises(ValueError, match=match):
             PolygonAperture.from_vertices([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
 
-    def test_offsets_reset_lazyproperties(self):
+    def test_offsets_reset_cached_properties(self):
         aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
         _ = aper.vertices
         aper.vertex_offsets = TRIANGLE_OFFSETS
@@ -1004,7 +1004,7 @@ class TestSkyPolygonConstruction:
         assert one.isscalar
         assert_quantity_allclose(one.positions.ra, 180.0 * u.deg)
 
-    def test_offsets_reset_lazyproperties(self):
+    def test_offsets_reset_cached_properties(self):
         """
         Test that changing vertex_offsets on a SkyPolygonAperture clears the
         cached vertices, which are stored as a SkyCoord.

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -81,7 +81,7 @@ class BaseApertureStatsData:
 
     The ``stats_data`` fixture builds the objects once per test class
     rather than at import time, so collection stays cheap and each test
-    class gets its own instances (no lazyproperty-cache state is shared
+    class gets its own instances (no cached-property state is shared
     across classes).
     """
 
@@ -176,14 +176,14 @@ class TestProperties(BaseApertureStatsData):
         assert apstats.x_centroid == 12.0
         assert apstats.y_centroid == 12.0
 
-    def test_lazyproperties_class_cache(self):
+    def test_cached_properties_class_cache(self):
         """
-        Test that _lazyproperties is cached on the class and shared
+        Test that _cached_properties is cached on the class and shared
         across instances.
         """
         apstats2 = ApertureStats(self.data, self.aperture)
-        result1 = self.apstats1._lazyproperties
-        result2 = apstats2._lazyproperties
+        result1 = self.apstats1._cached_properties
+        result2 = apstats2._cached_properties
         assert result1 is result2
 
     def test_repr_str(self):
@@ -1142,11 +1142,11 @@ class TestSigmaClipSharedInstance:
     Tests for calling a shared SigmaClip instance from the astropy
     fallback clipping path.
 
-    astropy SigmaClip stores internal state on the instance during
-    calls, and the fallback path is reachable from two different
-    lazyproperties (the center- and sum-footprint cutouts) that do not
-    share a lock. ApertureStats must therefore never call the user's
-    SigmaClip instance directly.
+    Astropy SigmaClip stores internal state on the instance during
+    calls, and the fallback path is reachable from two different cached
+    properties (the center- and sum-footprint cutouts) that do not share
+    a lock. ApertureStats must therefore never call the user's SigmaClip
+    instance directly.
     """
 
     def test_user_sigma_clip_instance_not_called(self, monkeypatch):

--- a/photutils/background/background_2d.py
+++ b/photutils/background/background_2d.py
@@ -6,13 +6,13 @@ Tools for estimating the 2D background and background RMS in an image.
 import copy
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from functools import cached_property
 from typing import NamedTuple
 
 import astropy.units as u
 import numpy as np
 from astropy.nddata import NDData, block_replicate, reshape_as_blocks
 from astropy.stats import SigmaClip
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from scipy.ndimage import generic_filter
 
@@ -485,7 +485,7 @@ class Background2D:
 
         return total_mask
 
-    @lazyproperty
+    @cached_property
     def _good_n_pixels_threshold(self):
         """
         The minimum number of required unmasked pixels in a box used for
@@ -1195,7 +1195,7 @@ class Background2D:
         return n_pixels_map[:self._interp_kwargs['shape'][0],
                             :self._interp_kwargs['shape'][1]]
 
-    @lazyproperty
+    @cached_property
     def background_median(self):
         """
         The median value of the 2D low-resolution background map.
@@ -1214,7 +1214,7 @@ class Background2D:
         """
         return np.median(self.background_mesh)
 
-    @lazyproperty
+    @cached_property
     def background_rms_median(self):
         """
         The median value of the low-resolution background RMS map.

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -11,11 +11,11 @@ import abc
 import inspect
 import math
 import warnings
+from functools import cached_property
 
 import astropy.units as u
 import numpy as np
 from astropy.stats import gaussian_fwhm_to_sigma
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.detection.peakfinder import find_peaks
@@ -295,7 +295,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         setattr(newcls, attr, np.atleast_2d(value))
 
         # Index/slice the remaining attributes
-        keys = set(self.__dict__.keys()) & set(self._lazyproperties)
+        keys = set(self.__dict__.keys()) & set(self._cached_properties)
         keys.add('id')
         for key in keys:
             value = self.__dict__[key]
@@ -323,23 +323,23 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
                 'cutout_shape', 'default_columns')
 
     @property
-    def _lazyproperties(self):
+    def _cached_properties(self):
         """
-        Return all lazyproperties (even in superclasses).
+        Return all cached properties (even in superclasses).
 
         The result is cached on the class to avoid repeated
         introspection via `inspect.getmembers`.
         """
         cls = self.__class__
-        attr = '_cached_lazyproperties'
-        # Subclasses get their own lazyproperty list
+        attr = '_cached_properties_cache'
+        # Subclasses get their own cached-property list
         if attr not in cls.__dict__:
-            def islazyproperty(obj):
-                return isinstance(obj, lazyproperty)
+            def is_cached_property(obj):
+                return isinstance(obj, cached_property)
 
             setattr(cls, attr,
                     [i[0] for i in inspect.getmembers(
-                        cls, predicate=islazyproperty)])
+                        cls, predicate=is_cached_property)])
         return getattr(cls, attr)
 
     @property
@@ -347,15 +347,15 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         """
         A sorted list of the built-in source properties.
         """
-        lazyproperties = [name for name in self._lazyproperties if not
-                          name.startswith('_')]
+        cached_properties = [name for name in self._cached_properties
+                             if not name.startswith('_')]
         # isscalar is a scalar value for the whole object, not a
         # per-source value, so it is not a valid table column
-        lazyproperties.remove('isscalar')
-        lazyproperties.sort()
-        return lazyproperties
+        cached_properties.remove('isscalar')
+        cached_properties.sort()
+        return cached_properties
 
-    @lazyproperty
+    @cached_property
     def isscalar(self):
         """
         Whether the instance is scalar (e.g., a single source).
@@ -392,7 +392,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
 
         return cutouts
 
-    @lazyproperty
+    @cached_property
     def cutout_data(self):
         """
         The cutout data arrays.
@@ -403,7 +403,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         """
         return self.make_cutouts(self.data)
 
-    @lazyproperty
+    @cached_property
     def moments(self):
         """
         The raw image moments.
@@ -419,7 +419,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         # M[n, p, q] = sum_jk data[n,j,k] * y[j]^p * x[k]^q
         return ypowers.T @ data @ xpowers
 
-    @lazyproperty
+    @cached_property
     def moments_central(self):
         """
         The central image moments.
@@ -442,7 +442,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
             warnings.simplefilter('ignore', RuntimeWarning)
             return moments / self.moments[:, 0, 0][:, np.newaxis, np.newaxis]
 
-    @lazyproperty
+    @cached_property
     def cutout_centroid(self):
         """
         The cutout centroids.
@@ -456,14 +456,14 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
             x_centroid = moments[:, 0, 1] / moments[:, 0, 0]
         return np.transpose((y_centroid, x_centroid))
 
-    @lazyproperty
+    @cached_property
     def cutout_x_centroid(self):
         """
         The cutout x centroids.
         """
         return np.transpose(self.cutout_centroid)[1]
 
-    @lazyproperty
+    @cached_property
     def cutout_y_centroid(self):
         """
         The cutout y centroids.
@@ -493,7 +493,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         return deprecated_getattr(self, name, _DEPRECATED_ATTRIBUTES,
                                   since='3.0', until='4.0')
 
-    @lazyproperty
+    @cached_property
     def mu_sum(self):
         """
         The sum of the central moments.
@@ -501,7 +501,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         return (self.moments_central[:, 0, 2]
                 + self.moments_central[:, 2, 0])
 
-    @lazyproperty
+    @cached_property
     def mu_diff(self):
         """
         The difference of the central moments.
@@ -509,14 +509,14 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         return (self.moments_central[:, 0, 2]
                 - self.moments_central[:, 2, 0])
 
-    @lazyproperty
+    @cached_property
     def fwhm(self):
         """
         The FWHM of the sources.
         """
         return 2.0 * np.sqrt(np.log(2.0) * self.mu_sum)
 
-    @lazyproperty
+    @cached_property
     def orientation(self):
         """
         The angle between the ``x`` axis and the major axis of the 2D
@@ -530,7 +530,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
                                  self.mu_diff)
         return np.rad2deg(angle) * u.deg
 
-    @lazyproperty
+    @cached_property
     def roundness(self):
         """
         The roundness of the sources.
@@ -541,21 +541,21 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
                             + 4.0 * self.moments_central[:, 1, 1]**2)
                     / self.mu_sum)
 
-    @lazyproperty
+    @cached_property
     def peak(self):
         """
         The peak pixel values.
         """
         return np.max(self.cutout_data, axis=(1, 2))
 
-    @lazyproperty
+    @cached_property
     def flux(self):
         """
         The instrumental fluxes.
         """
         return np.sum(self.cutout_data, axis=(1, 2))
 
-    @lazyproperty
+    @cached_property
     def mag(self):
         """
         The instrumental magnitudes.
@@ -728,7 +728,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
             table_columns = list(self.default_columns)
         else:
             # id is not included in self._properties because it is
-            # not a lazyproperty
+            # not a cached property
             allowed_columns = (set(self._properties) | {'id'}
                                | set(self.default_columns))
             table_columns = validate_table_columns(

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -4,10 +4,10 @@ DAOStarFinder class.
 """
 
 import warnings
+from functools import cached_property
 
 import astropy.units as u
 import numpy as np
-from astropy.utils import lazyproperty
 
 from photutils.detection.core import (_DEPR_DEFAULT, StarFinderBase,
                                       StarFinderCatalogBase,
@@ -505,7 +505,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
                 'peak_max', 'threshold_eff', 'cutout_shape',
                 'cutout_center', 'default_columns')
 
-    @lazyproperty
+    @cached_property
     def cutout_convdata(self):
         """
         The cutout of the convolved data centered on the source
@@ -513,7 +513,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return self.make_cutouts(self.convolved_data)
 
-    @lazyproperty
+    @cached_property
     def peak(self):
         """
         The peak pixel value of the source in the original (unconvolved)
@@ -522,7 +522,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         return self.cutout_data[:, self.cutout_center[0],
                                 self.cutout_center[1]]
 
-    @lazyproperty
+    @cached_property
     def convdata_peak(self):
         """
         The peak pixel value of the source in the convolved data.
@@ -530,7 +530,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         return self.cutout_convdata[:, self.cutout_center[0],
                                     self.cutout_center[1]]
 
-    @lazyproperty
+    @cached_property
     def roundness1(self):
         """
         The roundness of the source based on symmetry, defined as
@@ -576,7 +576,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
             warnings.simplefilter('ignore', RuntimeWarning)
             return 2.0 * sum2 / sum4
 
-    @lazyproperty
+    @cached_property
     def sharpness(self):
         """
         The sharpness of the source, defined as the ratio of the
@@ -895,7 +895,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
                                              kern_sums)
         return self._marginal_lstsq(kern_sums, data_sums, sigma, size)
 
-    @lazyproperty
+    @cached_property
     def dx_hx(self):
         """
         The fitted fractional shift (dx) and amplitude (hx) from the
@@ -903,7 +903,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return self.daofind_marginal_fit(axis=1)
 
-    @lazyproperty
+    @cached_property
     def dy_hy(self):
         """
         The fitted fractional shift (dy) and amplitude (hy) from the
@@ -911,7 +911,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return self.daofind_marginal_fit(axis=0)
 
-    @lazyproperty
+    @cached_property
     def dx(self):
         """
         The fitted fractional shift in x of the image centroid relative
@@ -919,7 +919,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return np.transpose(self.dx_hx)[0]
 
-    @lazyproperty
+    @cached_property
     def dy(self):
         """
         The fitted fractional shift in y of the image centroid relative
@@ -927,7 +927,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return np.transpose(self.dy_hy)[0]
 
-    @lazyproperty
+    @cached_property
     def hx(self):
         """
         The height of the best-fitting Gaussian to the marginal x
@@ -935,7 +935,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return np.transpose(self.dx_hx)[1]
 
-    @lazyproperty
+    @cached_property
     def hy(self):
         """
         The height of the best-fitting Gaussian to the marginal y
@@ -943,7 +943,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return np.transpose(self.dy_hy)[1]
 
-    @lazyproperty
+    @cached_property
     def x_centroid(self):
         """
         The fitted x centroid of the source, calculated as the sum of
@@ -952,7 +952,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return np.transpose(self.xypos)[0] + self.dx
 
-    @lazyproperty
+    @cached_property
     def y_centroid(self):
         """
         The fitted y centroid of the source, calculated as the sum of
@@ -961,7 +961,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return np.transpose(self.xypos)[1] + self.dy
 
-    @lazyproperty
+    @cached_property
     def roundness2(self):
         """
         The star roundness.
@@ -975,7 +975,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         return 2.0 * (self.hx - self.hy) / (self.hx + self.hy)
 
-    @lazyproperty
+    @cached_property
     def _threshold_eff_per_source(self):
         """
         Per-source effective threshold values.
@@ -994,7 +994,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         ypos = np.round(self.xypos[:, 1]).astype(int)
         return self.threshold_eff[ypos, xpos]
 
-    @lazyproperty
+    @cached_property
     def daofind_mag(self):
         """
         The "mag" parameter returned by the original DAOFIND algorithm.
@@ -1009,7 +1009,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
             return -2.5 * np.log10(self.convdata_peak
                                    / self._threshold_eff_per_source)
 
-    @lazyproperty
+    @cached_property
     def n_pixels(self):
         """
         The total number of pixels in the Gaussian kernel array.

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -4,9 +4,9 @@ IRAFStarFinder class.
 """
 
 import warnings
+from functools import cached_property
 
 import numpy as np
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.detection.core import (_DEPR_DEFAULT, StarFinderBase,
@@ -456,7 +456,7 @@ class _IRAFStarFinderCatalog(StarFinderCatalogBase):
                 'sharpness_range', 'roundness_range', 'n_brightest',
                 'peak_max', 'cutout_shape', 'default_columns')
 
-    @lazyproperty
+    @cached_property
     def sky(self):
         """
         Calculate the sky background level.
@@ -478,14 +478,14 @@ class _IRAFStarFinderCatalog(StarFinderCatalogBase):
 
         return sky
 
-    @lazyproperty
+    @cached_property
     def cutout_data_nosub(self):
         """
         The cutout data without sky subtraction or masking.
         """
         return self.make_cutouts(self.data)
 
-    @lazyproperty
+    @cached_property
     def cutout_data(self):
         """
         The cutout data with sky subtraction and masking applied.
@@ -498,7 +498,7 @@ class _IRAFStarFinderCatalog(StarFinderCatalogBase):
         data[data < 0] = 0.0
         return data
 
-    @lazyproperty
+    @cached_property
     def n_pixels(self):
         """
         The total number of (positive) unmasked pixels in the cutout
@@ -506,35 +506,35 @@ class _IRAFStarFinderCatalog(StarFinderCatalogBase):
         """
         return np.count_nonzero(self.cutout_data, axis=(1, 2))
 
-    @lazyproperty
+    @cached_property
     def cutout_xorigin(self):
         """
         The x pixel coordinate of the cutout origin.
         """
         return np.transpose(self.xypos)[0] - self.kernel.x_radius
 
-    @lazyproperty
+    @cached_property
     def cutout_yorigin(self):
         """
         The y pixel coordinate of the cutout origin.
         """
         return np.transpose(self.xypos)[1] - self.kernel.y_radius
 
-    @lazyproperty
+    @cached_property
     def x_centroid(self):
         """
         The x pixel coordinate of the object centroid.
         """
         return self.cutout_x_centroid + self.cutout_xorigin
 
-    @lazyproperty
+    @cached_property
     def y_centroid(self):
         """
         The y pixel coordinate of the object centroid.
         """
         return self.cutout_y_centroid + self.cutout_yorigin
 
-    @lazyproperty
+    @cached_property
     def sharpness(self):
         """
         The sharpness of the object.

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -4,9 +4,9 @@ StarFinder class.
 """
 
 import warnings
+from functools import cached_property
 
 import numpy as np
-from astropy.utils import lazyproperty
 
 from photutils.detection.core import (StarFinderBase, StarFinderCatalogBase,
                                       _validate_n_brightest)
@@ -272,7 +272,7 @@ class _StarFinderCatalog(StarFinderCatalogBase):
         return ('data', 'unit', 'kernel', 'n_brightest', 'peak_max',
                 'cutout_shape', 'default_columns')
 
-    @lazyproperty
+    @cached_property
     def cutout_data(self):
         """
         The cutout data arrays with negative values set to zero.
@@ -281,14 +281,14 @@ class _StarFinderCatalog(StarFinderCatalogBase):
         cutouts[cutouts < 0] = 0.0  # exclude negative pixels
         return cutouts
 
-    @lazyproperty
+    @cached_property
     def max_value(self):
         """
         The maximum pixel value in the cutout data.
         """
         return self.peak
 
-    @lazyproperty
+    @cached_property
     def x_centroid(self):
         """
         The x centroid of the source.
@@ -296,7 +296,7 @@ class _StarFinderCatalog(StarFinderCatalogBase):
         xoff = self.cutout_shape[1] // 2
         return self.cutout_x_centroid + self.xypos[:, 0] - xoff
 
-    @lazyproperty
+    @cached_property
     def y_centroid(self):
         """
         The y centroid of the source.

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -3,9 +3,10 @@
 Tests for the photutils.detection.core module.
 """
 
+from functools import cached_property
+
 import numpy as np
 import pytest
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.detection import DAOStarFinder
@@ -190,11 +191,11 @@ def _make_minimal_catalog_class():
 
     class _MinimalCatalog(StarFinderCatalogBase):
 
-        @lazyproperty
+        @cached_property
         def x_centroid(self):
             return self.cutout_x_centroid
 
-        @lazyproperty
+        @cached_property
         def y_centroid(self):
             return self.cutout_y_centroid
 
@@ -231,9 +232,9 @@ class TestStarFinderCatalogBase:
                     'cutout_shape', 'default_columns')
         assert cat._get_init_attributes() == expected
 
-    def test_lazyproperties_class_cache(self, minimal_catalog_cls):
+    def test_cached_properties_class_cache(self, minimal_catalog_cls):
         """
-        Test that _lazyproperties is cached on the class and shared
+        Test that _cached_properties is cached on the class and shared
         across instances.
         """
         data = np.zeros((11, 11))
@@ -242,8 +243,8 @@ class TestStarFinderCatalogBase:
         xypos = np.array([[5, 5]])
         cat1 = minimal_catalog_cls(data, xypos, kernel)
         cat2 = minimal_catalog_cls(data, xypos, kernel)
-        result1 = cat1._lazyproperties
-        result2 = cat2._lazyproperties
+        result1 = cat1._cached_properties
+        result2 = cat2._cached_properties
         assert result1 is result2
 
     def test_to_table_missing_default_columns(self, minimal_catalog_cls):
@@ -335,7 +336,7 @@ class TestStarFinderCatalogBase:
     def test_properties(self, minimal_catalog_cls):
         """
         Test that the _properties attribute returns a sorted list of
-        lazyproperty names.
+        cached-property names.
         """
         data = np.zeros((11, 11))
         data[5, 5] = 10.0
@@ -394,7 +395,7 @@ class TestStarFinderCatalogBase:
         xypos = np.array([[3, 3], [5, 5], [7, 7]])
         cat = minimal_catalog_cls(data, xypos, kernel)
 
-        # Force evaluation of a lazyproperty before slicing
+        # Force evaluation of a cached property before slicing
         _ = cat.flux
 
         mask = np.array([True, False, True])

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -5,9 +5,9 @@ Base class for profiles.
 
 import abc
 import warnings
+from functools import cached_property
 
 import numpy as np
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture.core import _update_method_subpixels_docstring
@@ -146,7 +146,7 @@ class ProfileBase(metaclass=abc.ABCMeta):
         ``(0,)`` is returned.
         """
 
-    @lazyproperty
+    @cached_property
     def _circular_apertures(self):
         """
         A list of `~photutils.aperture.CircularAperture` objects.
@@ -215,7 +215,7 @@ class ProfileBase(metaclass=abc.ABCMeta):
 
         return fluxes, flux_errs, areas
 
-    @lazyproperty
+    @cached_property
     def _photometry(self):
         """
         The aperture fluxes, flux errors, and areas as a function of
@@ -262,7 +262,7 @@ class ProfileBase(metaclass=abc.ABCMeta):
             # multiple times (e.g., different methods)
             self.normalization_value *= normalization
 
-            # Need to use __dict__ as these are lazy properties
+            # Need to use __dict__ as these are cached properties
             self.__dict__['profile'] = self.profile / normalization
             self.__dict__['profile_error'] = self.profile_error / normalization
             self._normalize_hook(normalization)

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -3,8 +3,9 @@
 Tools for generating curves of growth.
 """
 
+from functools import cached_property
+
 import numpy as np
-from astropy.utils import lazyproperty
 from scipy.interpolate import PchipInterpolator
 
 from photutils.aperture.core import _update_method_subpixels_docstring
@@ -219,7 +220,7 @@ class CurveOfGrowth(ProfileBase):
         super().__init__(data, xycen, radii, error=error, mask=mask,
                          method=method, subpixels=subpixels)
 
-    @lazyproperty
+    @cached_property
     def radius(self):
         """
         The profile radius in pixels as a 1D `~numpy.ndarray`.
@@ -233,7 +234,7 @@ class CurveOfGrowth(ProfileBase):
         """
         return self.radii
 
-    @lazyproperty
+    @cached_property
     def apertures(self):
         """
         A list of `~photutils.aperture.CircularAperture` objects used to
@@ -241,7 +242,7 @@ class CurveOfGrowth(ProfileBase):
         """
         return self._circular_apertures
 
-    @lazyproperty
+    @cached_property
     def _photometry(self):
         """
         The aperture fluxes, flux errors, and areas as a function of
@@ -249,14 +250,14 @@ class CurveOfGrowth(ProfileBase):
         """
         return self._compute_photometry(self.apertures)
 
-    @lazyproperty
+    @cached_property
     def profile(self):
         """
         The curve-of-growth profile as a 1D `~numpy.ndarray`.
         """
         return self._photometry[0]
 
-    @lazyproperty
+    @cached_property
     def profile_error(self):
         """
         The curve-of-growth profile errors as a 1D `~numpy.ndarray`.
@@ -266,7 +267,7 @@ class CurveOfGrowth(ProfileBase):
         """
         return self._photometry[1]
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The unmasked area in each circular aperture as a function of
@@ -513,7 +514,7 @@ class EnsquaredCurveOfGrowth(ProfileBase):
                 f'n_half_sizes={n_half_sizes}, '
                 f'normalized={normalized})')
 
-    @lazyproperty
+    @cached_property
     def half_size(self):
         """
         The profile half-sizes (half side lengths) in pixels as a 1D
@@ -529,7 +530,7 @@ class EnsquaredCurveOfGrowth(ProfileBase):
         """
         return self.half_sizes
 
-    @lazyproperty
+    @cached_property
     def radius(self):
         """
         The profile half-sizes (half side lengths) in pixels as a 1D
@@ -539,7 +540,7 @@ class EnsquaredCurveOfGrowth(ProfileBase):
         """
         return self.half_sizes
 
-    @lazyproperty
+    @cached_property
     def apertures(self):
         """
         A list of `~photutils.aperture.RectangularAperture` objects used
@@ -550,7 +551,7 @@ class EnsquaredCurveOfGrowth(ProfileBase):
         return [RectangularAperture(self.xycen, 2 * hs, 2 * hs)
                 for hs in self.half_sizes]
 
-    @lazyproperty
+    @cached_property
     def _photometry(self):
         """
         The aperture fluxes, flux errors, and areas as a function of
@@ -558,14 +559,14 @@ class EnsquaredCurveOfGrowth(ProfileBase):
         """
         return self._compute_photometry(self.apertures)
 
-    @lazyproperty
+    @cached_property
     def profile(self):
         """
         The ensquared curve-of-growth profile as a 1D `~numpy.ndarray`.
         """
         return self._photometry[0]
 
-    @lazyproperty
+    @cached_property
     def profile_error(self):
         """
         The ensquared curve-of-growth profile errors as a 1D
@@ -576,7 +577,7 @@ class EnsquaredCurveOfGrowth(ProfileBase):
         """
         return self._photometry[1]
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The unmasked area in each square aperture as a function of size
@@ -845,7 +846,7 @@ class EllipticalCurveOfGrowth(ProfileBase):
         super().__init__(data, xycen, radii, error=error, mask=mask,
                          method=method, subpixels=subpixels)
 
-    @lazyproperty
+    @cached_property
     def radius(self):
         """
         The profile semimajor-axis lengths in pixels as a 1D
@@ -859,7 +860,7 @@ class EllipticalCurveOfGrowth(ProfileBase):
         """
         return self.radii
 
-    @lazyproperty
+    @cached_property
     def apertures(self):
         """
         A list of `~photutils.aperture.EllipticalAperture` objects used
@@ -871,7 +872,7 @@ class EllipticalCurveOfGrowth(ProfileBase):
                                    theta=self.theta)
                 for a in self.radii]
 
-    @lazyproperty
+    @cached_property
     def _photometry(self):
         """
         The aperture fluxes, flux errors, and areas as a function of
@@ -879,14 +880,14 @@ class EllipticalCurveOfGrowth(ProfileBase):
         """
         return self._compute_photometry(self.apertures)
 
-    @lazyproperty
+    @cached_property
     def profile(self):
         """
         The elliptical curve-of-growth profile as a 1D `~numpy.ndarray`.
         """
         return self._photometry[0]
 
-    @lazyproperty
+    @cached_property
     def profile_error(self):
         """
         The elliptical curve-of-growth profile errors as a 1D
@@ -897,7 +898,7 @@ class EllipticalCurveOfGrowth(ProfileBase):
         """
         return self._photometry[1]
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The unmasked area in each elliptical aperture as a function of

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -4,12 +4,12 @@ Tools for generating radial profiles.
 """
 
 import warnings
+from functools import cached_property
 
 import numpy as np
 from astropy.modeling.fitting import TRFLSQFitter
 from astropy.modeling.models import Gaussian1D, Moffat1D
 from astropy.stats import gaussian_sigma_to_fwhm
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture.core import _update_method_subpixels_docstring
@@ -283,7 +283,7 @@ class RadialProfile(ProfileBase):
                        'gaussian_profile', 'gaussian_fwhm', 'moffat_fit',
                        'moffat_profile', 'moffat_fwhm')
 
-    @lazyproperty
+    @cached_property
     def radius(self):
         """
         The profile radius (bin centers) in pixels as a 1D
@@ -299,7 +299,7 @@ class RadialProfile(ProfileBase):
         # Define the radial bin centers from the radial bin edges
         return (self.radii[:-1] + self.radii[1:]) / 2
 
-    @lazyproperty
+    @cached_property
     def apertures(self):
         """
         A list of the circular annulus apertures used to measure the
@@ -325,21 +325,21 @@ class RadialProfile(ProfileBase):
 
         return apertures
 
-    @lazyproperty
+    @cached_property
     def _flux(self):
         """
         The flux in a circular annulus.
         """
         return np.diff(self._photometry[0])
 
-    @lazyproperty
+    @cached_property
     def _flux_err(self):
         """
         The flux error in a circular annulus.
         """
         return np.sqrt(np.diff(self._photometry[1] ** 2))
 
-    @lazyproperty
+    @cached_property
     def area(self):
         """
         The unmasked area in each circular annulus (or aperture) as a
@@ -347,7 +347,7 @@ class RadialProfile(ProfileBase):
         """
         return np.diff(self._photometry[2])
 
-    @lazyproperty
+    @cached_property
     def profile(self):
         """
         The radial profile as a 1D `~numpy.ndarray`.
@@ -357,7 +357,7 @@ class RadialProfile(ProfileBase):
             warnings.simplefilter('ignore', RuntimeWarning)
             return self._flux / self.area
 
-    @lazyproperty
+    @cached_property
     def profile_error(self):
         """
         The radial profile errors as a 1D `~numpy.ndarray`.
@@ -373,11 +373,11 @@ class RadialProfile(ProfileBase):
             warnings.simplefilter('ignore', RuntimeWarning)
             return self._flux_err / self.area
 
-    @lazyproperty
+    @cached_property
     def _profile_nanmask(self):
         return np.isfinite(self.profile)
 
-    @lazyproperty
+    @cached_property
     def gaussian_fit(self):
         """
         The fitted 1D Gaussian to the radial profile as a
@@ -418,7 +418,7 @@ class RadialProfile(ProfileBase):
 
         return gaussian_fit
 
-    @lazyproperty
+    @cached_property
     def gaussian_profile(self):
         """
         The fitted 1D Gaussian profile to the radial profile as a 1D
@@ -434,7 +434,7 @@ class RadialProfile(ProfileBase):
             return None
         return self.gaussian_fit(self.radius)
 
-    @lazyproperty
+    @cached_property
     def gaussian_fwhm(self):
         """
         The full-width at half-maximum (FWHM) in pixels of the 1D
@@ -450,7 +450,7 @@ class RadialProfile(ProfileBase):
             return None
         return self.gaussian_fit.stddev.value * gaussian_sigma_to_fwhm
 
-    @lazyproperty
+    @cached_property
     def moffat_fit(self):
         """
         The fitted 1D Moffat to the radial profile as a
@@ -491,7 +491,7 @@ class RadialProfile(ProfileBase):
         fitter = TRFLSQFitter()
         return fitter(m_init, radius, profile)
 
-    @lazyproperty
+    @cached_property
     def moffat_profile(self):
         """
         The fitted 1D Moffat profile to the radial profile as a 1D
@@ -507,7 +507,7 @@ class RadialProfile(ProfileBase):
             return None
         return self.moffat_fit(self.radius)
 
-    @lazyproperty
+    @cached_property
     def moffat_fwhm(self):
         """
         The full-width at half-maximum (FWHM) in pixels of the 1D Moffat
@@ -523,7 +523,7 @@ class RadialProfile(ProfileBase):
             return None
         return self.moffat_fit.fwhm
 
-    @lazyproperty
+    @cached_property
     def _data_profile(self):
         """
         The raw data profile returned as 1D arrays (`~numpy.ndarray`) of
@@ -560,14 +560,14 @@ class RadialProfile(ProfileBase):
 
         return radii, data_values
 
-    @lazyproperty
+    @cached_property
     def data_radius(self):
         """
         The radii of the raw data profile as a 1D `~numpy.ndarray`.
         """
         return self._data_profile[0]
 
-    @lazyproperty
+    @cached_property
     def data_profile(self):
         """
         The raw data profile as a 1D `~numpy.ndarray`.
@@ -576,7 +576,7 @@ class RadialProfile(ProfileBase):
 
     def _invalidate_fit_cache(self):
         """
-        Remove cached Gaussian and Moffat fit lazy properties so they
+        Remove the cached Gaussian and Moffat fit properties so they
         are recomputed on next access using the current profile.
         """
         for key in self._fit_properties:

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -533,7 +533,7 @@ class TestRadialProfile:
         assert mfit.gamma.value > 0
         assert mfit.alpha.value >= 1
 
-    def test_moffat_lazyproperty(self, profile_data):
+    def test_moffat_cached_property(self, profile_data):
         """
         Test that ``moffat_fit``, ``moffat_profile``, and
         ``moffat_fwhm`` are lazily computed and cached.

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -5,12 +5,12 @@ cutouts for fitting and building ePSFs.
 """
 
 import warnings
+from functools import cached_property
 
 import numpy as np
 from astropy.nddata import (NDData, NoOverlapError, PartialOverlapError,
                             StdDevUncertainty, overlap_slices)
 from astropy.table import Table
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from photutils.aperture import BoundingBox
@@ -229,7 +229,7 @@ class EPSFStar:
         """
         return self.cutout_center + self.origin
 
-    @lazyproperty
+    @cached_property
     def slices(self):
         """
         A tuple of two slices representing the cutout region with
@@ -238,7 +238,7 @@ class EPSFStar:
         return (slice(self.origin[1], self.origin[1] + self.shape[1]),
                 slice(self.origin[0], self.origin[0] + self.shape[0]))
 
-    @lazyproperty
+    @cached_property
     def bbox(self):
         """
         The minimal `~photutils.aperture.BoundingBox` for the cutout
@@ -322,7 +322,7 @@ class EPSFStar:
         y_centered = yidx[~self.mask].ravel() - self.cutout_center[1]
         return x_centered, y_centered
 
-    @lazyproperty
+    @cached_property
     def _data_values_normalized(self):
         """
         1D array of unmasked cutout data values, normalized by the
@@ -427,7 +427,7 @@ class EPSFStars:
         """
         return np.array([star.center for star in self.all_stars])
 
-    @lazyproperty
+    @cached_property
     def all_stars(self):
         """
         A list of all `EPSFStar` objects stored in this object,
@@ -456,7 +456,7 @@ class EPSFStars:
             stars.append(star)
         return stars
 
-    @lazyproperty
+    @cached_property
     def n_stars(self):
         """
         The total number of stars.
@@ -465,7 +465,7 @@ class EPSFStars:
         """
         return len(self._data)
 
-    @lazyproperty
+    @cached_property
     def n_all_stars(self):
         """
         The total number of `EPSFStar` objects, including all the linked

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -6,12 +6,12 @@ Gridded PSF models.
 import bisect
 import copy
 import itertools
+from functools import cached_property
 
 import numpy as np
 from astropy.io import registry
 from astropy.modeling import Fittable2DModel, Parameter
 from astropy.nddata import NDData
-from astropy.utils.decorators import lazyproperty
 from scipy.interpolate import RectBivariateSpline
 
 from photutils.psf.model_io import (GriddedPSFModelRead, _get_metadata,
@@ -465,7 +465,7 @@ class GriddedPSFModel(Fittable2DModel):
         """
         return self._calc_bounding_box()
 
-    @lazyproperty
+    @cached_property
     def origin(self):
         """
         A 1D `~numpy.ndarray` (x, y) pixel coordinates within the
@@ -476,7 +476,7 @@ class GriddedPSFModel(Fittable2DModel):
         xyorigin = (np.array(self.data.shape[1:]) - 1) / 2
         return xyorigin[::-1]
 
-    @lazyproperty
+    @cached_property
     def _interp_xyidx(self):
         """
         The x and y indices for the interpolator.
@@ -518,7 +518,7 @@ class GriddedPSFModel(Fittable2DModel):
 
         return interp
 
-    @lazyproperty
+    @cached_property
     def _xgrid_list(self):
         """
         A plain Python list of the sorted unique x grid positions.
@@ -528,7 +528,7 @@ class GriddedPSFModel(Fittable2DModel):
         """
         return [float(v) for v in self._xgrid]
 
-    @lazyproperty
+    @cached_property
     def _ygrid_list(self):
         """
         A plain Python list of the sorted unique y grid positions.
@@ -538,7 +538,7 @@ class GriddedPSFModel(Fittable2DModel):
         """
         return [float(v) for v in self._ygrid]
 
-    @lazyproperty
+    @cached_property
     def _bounding_lookup(self):
         """
         A precomputed lookup table mapping grid-cell indices to the

--- a/photutils/psf/groupers.py
+++ b/photutils/psf/groupers.py
@@ -4,9 +4,9 @@ Tools for performing grouping of stars.
 """
 
 from collections import defaultdict
+from functools import cached_property
 
 import numpy as np
-from astropy.utils import lazyproperty
 from scipy.cluster.hierarchy import fclusterdata
 
 from photutils.aperture import CircularAperture
@@ -108,7 +108,7 @@ class SourceGroups:
         """
         return self.n_sources
 
-    @lazyproperty
+    @cached_property
     def size_map(self):
         """
         Mapping of group ID to group size.
@@ -122,7 +122,7 @@ class SourceGroups:
         return dict(zip(self._unique_groups.tolist(),
                         self._group_counts.tolist(), strict=True))
 
-    @lazyproperty
+    @cached_property
     def sizes(self):
         """
         Size of each group for each source.
@@ -136,7 +136,7 @@ class SourceGroups:
         """
         return np.array([self.size_map[group] for group in self.groups])
 
-    @lazyproperty
+    @cached_property
     def group_centers(self):
         """
         Centroid coordinates of each group.

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -4,10 +4,10 @@ Image-based PSF models.
 """
 
 import copy
+from functools import cached_property
 
 import numpy as np
 from astropy.modeling import Fittable2DModel, Parameter
-from astropy.utils.decorators import lazyproperty
 from scipy.interpolate import RectBivariateSpline
 
 from photutils.utils._parameters import as_pair
@@ -323,7 +323,7 @@ class ImagePSF(Fittable2DModel):
                 raise ValueError(msg)
         self._origin = origin
 
-    @lazyproperty
+    @cached_property
     def interpolator(self):
         """
         The interpolating spline function.

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -9,12 +9,12 @@ import inspect
 import math
 import warnings
 from copy import deepcopy
+from functools import cached_property
 
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
-from astropy.utils import lazyproperty
 from scipy.ndimage import map_coordinates
 from scipy.optimize import root_scalar
 
@@ -518,18 +518,18 @@ class SourceCatalog:
     @property
     def _properties(self):
         """
-        A list of all class properties, include lazyproperties (even in
-        superclasses).
+        A list of all class properties, including cached properties
+        (even in superclasses).
 
         The result is cached on the class to avoid repeated
         introspection via `inspect.getmembers`.
         """
         cls = self.__class__
-        attr = '_cached_properties'
+        attr = '_properties_cache'
         # Subclasses get their own property list
         if attr not in cls.__dict__:
             def isproperty(obj):
-                return isinstance(obj, property)
+                return isinstance(obj, (property, cached_property))
 
             setattr(cls, attr,
                     [i[0] for i in inspect.getmembers(
@@ -541,32 +541,32 @@ class SourceCatalog:
         """
         A list of built-in source properties.
         """
-        lazyproperties = [name for name in self._lazyproperties if not
-                          name.startswith('_')]
-        lazyproperties.remove('isscalar')
-        lazyproperties.remove('n_labels')
-        lazyproperties.extend(['label', 'labels', 'slices'])
-        lazyproperties.sort()
-        return lazyproperties
+        cached_properties = [name for name in self._cached_properties
+                             if not name.startswith('_')]
+        cached_properties.remove('isscalar')
+        cached_properties.remove('n_labels')
+        cached_properties.extend(['label', 'labels', 'slices'])
+        cached_properties.sort()
+        return cached_properties
 
     @property
-    def _lazyproperties(self):
+    def _cached_properties(self):
         """
-        A list of all class lazyproperties (even in superclasses).
+        A list of all class cached properties (even in superclasses).
 
         The result is cached on the class to avoid repeated
         introspection via `inspect.getmembers`.
         """
         cls = self.__class__
-        attr = '_cached_lazyproperties'
-        # Subclasses get their own lazyproperty list
+        attr = '_cached_properties_cache'
+        # Subclasses get their own cached-property list
         if attr not in cls.__dict__:
-            def islazyproperty(obj):
-                return isinstance(obj, lazyproperty)
+            def is_cached_property(obj):
+                return isinstance(obj, cached_property)
 
             setattr(cls, attr,
                     [i[0] for i in inspect.getmembers(
-                        cls, predicate=islazyproperty)])
+                        cls, predicate=is_cached_property)])
         return getattr(cls, attr)
 
     @staticmethod
@@ -639,9 +639,10 @@ class SourceCatalog:
                                      for key, value
                                      in self._flux_radius_cache.items()}
 
-        # Evaluated lazyproperty objects and extra properties
+        # Evaluated cached-property objects and extra properties
         keys = (set(self.__dict__.keys())
-                & (set(self._lazyproperties) | set(self._custom_properties)))
+                & (set(self._cached_properties)
+                   | set(self._custom_properties)))
         for key in keys:
             value = self.__dict__[key]
 
@@ -652,7 +653,7 @@ class SourceCatalog:
                 continue
 
             try:
-                # Keep private ('_'-prefixed) lazyproperties as length-1
+                # Keep private ('_'-prefixed) cached properties as length-1
                 # iterables. Such properties are never collapsed by
                 # __getattribute__ and internal code relies on them
                 # always being iterable.
@@ -760,7 +761,7 @@ class SourceCatalog:
             return value[np.newaxis, ...]
         return [value]
 
-    @lazyproperty
+    @cached_property
     def isscalar(self):
         """
         Whether the instance is scalar (e.g., a single source).
@@ -929,7 +930,7 @@ class SourceCatalog:
         self.custom_properties.remove(new_name)
         self.custom_properties.insert(idx, new_name)
 
-    @lazyproperty
+    @cached_property
     def _null_objects(self):
         """
         Return `None` values.
@@ -939,7 +940,7 @@ class SourceCatalog:
         """
         return np.array([None] * self.n_labels)
 
-    @lazyproperty
+    @cached_property
     def _null_values(self):
         """
         Return np.nan values.
@@ -951,14 +952,14 @@ class SourceCatalog:
         values.fill(np.nan)
         return values
 
-    @lazyproperty
+    @cached_property
     def _data_cutouts(self):
         """
         A list of data cutouts using the segmentation image slices.
         """
         return [self._data[slc] for slc in self._slices_iter]
 
-    @lazyproperty
+    @cached_property
     def _segmentation_image_cutouts(self):
         """
         A list of segmentation image cutouts using the segmentation
@@ -967,7 +968,7 @@ class SourceCatalog:
         return [self._segmentation_image.data[slc]
                 for slc in self._slices_iter]
 
-    @lazyproperty
+    @cached_property
     def _mask_cutouts(self):
         """
         A list of mask cutouts using the segmentation image slices.
@@ -978,7 +979,7 @@ class SourceCatalog:
             return self._null_objects
         return [self._mask[slc] for slc in self._slices_iter]
 
-    @lazyproperty
+    @cached_property
     def _error_cutouts(self):
         """
         A list of error cutouts using the segmentation image slices.
@@ -989,7 +990,7 @@ class SourceCatalog:
             return self._null_objects
         return [self._error[slc] for slc in self._slices_iter]
 
-    @lazyproperty
+    @cached_property
     def _convdata_cutouts(self):
         """
         A list of convolved data cutouts using the segmentation image
@@ -997,7 +998,7 @@ class SourceCatalog:
         """
         return [self._convolved_data[slc] for slc in self._slices_iter]
 
-    @lazyproperty
+    @cached_property
     def _background_cutouts(self):
         """
         A list of background cutouts using the segmentation image
@@ -1030,7 +1031,7 @@ class SourceCatalog:
                                                           mask_cutout))
         return data_masks
 
-    @lazyproperty
+    @cached_property
     def _cutout_segment_masks(self):
         """
         Cutout boolean mask for source segment.
@@ -1044,7 +1045,7 @@ class SourceCatalog:
                        self._segmentation_image_cutouts,
                        strict=True)]
 
-    @lazyproperty
+    @cached_property
     def _cutout_data_masks(self):
         """
         Cutout boolean mask of non-finite ``data`` values combined with
@@ -1056,7 +1057,7 @@ class SourceCatalog:
         return self._make_cutout_data_masks(self._data_cutouts,
                                             self._mask_cutouts)
 
-    @lazyproperty
+    @cached_property
     def _cutout_total_masks(self):
         """
         Boolean mask representing the combination of
@@ -1071,7 +1072,7 @@ class SourceCatalog:
             masks.append(mask1 | mask2)
         return masks
 
-    @lazyproperty
+    @cached_property
     def _moment_data_cutouts(self):
         """
         A list of 2D `~numpy.ndarray` cutouts from the (convolved) data.
@@ -1237,7 +1238,7 @@ class SourceCatalog:
             tbl[canonical_column] = values
         return tbl
 
-    @lazyproperty
+    @cached_property
     def n_labels(self):
         """
         The number of source labels.
@@ -1282,7 +1283,7 @@ class SourceCatalog:
         """
         return self._slices
 
-    @lazyproperty
+    @cached_property
     def _slices_iter(self):
         """
         A tuple of slice objects defining the minimal bounding box of
@@ -1293,7 +1294,7 @@ class SourceCatalog:
             _slices = (_slices,)
         return _slices
 
-    @lazyproperty
+    @cached_property
     def segment_cutout(self):
         """
         A 2D `~numpy.ndarray` cutout of the segmentation image using the
@@ -1306,7 +1307,7 @@ class SourceCatalog:
             self._segmentation_image_cutouts, units=False,
             masked=False)
 
-    @lazyproperty
+    @cached_property
     def segment_cutout_masked(self):
         """
         A 2D `~numpy.ma.MaskedArray` cutout of the segmentation image
@@ -1323,7 +1324,7 @@ class SourceCatalog:
             self._segmentation_image_cutouts, units=False,
             masked=True)
 
-    @lazyproperty
+    @cached_property
     def data_cutout(self):
         """
         A 2D `~numpy.ndarray` cutout from the data using the minimal
@@ -1335,7 +1336,7 @@ class SourceCatalog:
         return self._prepare_cutouts(self._data_cutouts, units=True,
                                      masked=False, dtype=float)
 
-    @lazyproperty
+    @cached_property
     def data_cutout_masked(self):
         """
         A 2D `~numpy.ma.MaskedArray` cutout from the data using the
@@ -1351,7 +1352,7 @@ class SourceCatalog:
         return self._prepare_cutouts(self._data_cutouts, units=False,
                                      masked=True, dtype=float)
 
-    @lazyproperty
+    @cached_property
     def conv_data_cutout(self):
         """
         A 2D `~numpy.ndarray` cutout from the convolved data using the
@@ -1363,7 +1364,7 @@ class SourceCatalog:
         return self._prepare_cutouts(self._convdata_cutouts, units=True,
                                      masked=False, dtype=float)
 
-    @lazyproperty
+    @cached_property
     def conv_data_cutout_masked(self):
         """
         A 2D `~numpy.ma.MaskedArray` cutout from the convolved data
@@ -1379,7 +1380,7 @@ class SourceCatalog:
         return self._prepare_cutouts(self._convdata_cutouts, units=False,
                                      masked=True, dtype=float)
 
-    @lazyproperty
+    @cached_property
     def error_cutout(self):
         """
         A 2D `~numpy.ndarray` cutout from the error array using the
@@ -1393,7 +1394,7 @@ class SourceCatalog:
         return self._prepare_cutouts(self._error_cutouts, units=True,
                                      masked=False)
 
-    @lazyproperty
+    @cached_property
     def error_cutout_masked(self):
         """
         A 2D `~numpy.ma.MaskedArray` cutout from the error array using
@@ -1411,7 +1412,7 @@ class SourceCatalog:
         return self._prepare_cutouts(self._error_cutouts, units=False,
                                      masked=True)
 
-    @lazyproperty
+    @cached_property
     def background_cutout(self):
         """
         A 2D `~numpy.ndarray` cutout from the background array using the
@@ -1425,7 +1426,7 @@ class SourceCatalog:
         return self._prepare_cutouts(self._background_cutouts, units=True,
                                      masked=False)
 
-    @lazyproperty
+    @cached_property
     def background_cutout_masked(self):
         """
         A 2D `~numpy.ma.MaskedArray` cutout from the background array.
@@ -1443,7 +1444,7 @@ class SourceCatalog:
         return self._prepare_cutouts(self._background_cutouts, units=False,
                                      masked=True)
 
-    @lazyproperty
+    @cached_property
     def _all_masked(self):
         """
         True if all pixels over the source segment are masked.
@@ -1500,7 +1501,7 @@ class SourceCatalog:
             concat = transform(concat)
         return ufunc.reduceat(concat, splits), sizes
 
-    @lazyproperty
+    @cached_property
     def _data_values(self):
         """
         A 1D array of unmasked data values.
@@ -1510,7 +1511,7 @@ class SourceCatalog:
         """
         return self._get_values(self._array('data_cutout_masked'))
 
-    @lazyproperty
+    @cached_property
     def _error_values(self):
         """
         A 1D array of unmasked error values.
@@ -1522,7 +1523,7 @@ class SourceCatalog:
             return self._null_objects
         return self._get_values(self._array('error_cutout_masked'))
 
-    @lazyproperty
+    @cached_property
     def _background_values(self):
         """
         A 1D array of unmasked background values.
@@ -1534,7 +1535,7 @@ class SourceCatalog:
             return self._null_objects
         return self._get_values(self._array('background_cutout_masked'))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def moments(self):
         """
@@ -1550,7 +1551,7 @@ class SourceCatalog:
             result.append(yp.T @ arr @ xp)
         return np.array(result)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def moments_central(self):
         """
@@ -1570,7 +1571,7 @@ class SourceCatalog:
             result.append(yp.T @ arr @ xp)
         return np.array(result)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def cutout_centroid(self):
         """
@@ -1589,7 +1590,7 @@ class SourceCatalog:
             x_centroid = moments[:, 0, 1] / moments[:, 0, 0]
         return np.transpose((x_centroid, y_centroid))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def centroid(self):
         """
@@ -1602,7 +1603,7 @@ class SourceCatalog:
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.cutout_centroid + origin
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def x_centroid(self):
         """
@@ -1614,7 +1615,7 @@ class SourceCatalog:
         """
         return self._array('centroid')[:, 0]
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def y_centroid(self):
         """
@@ -1626,7 +1627,7 @@ class SourceCatalog:
         """
         return self._array('centroid')[:, 1]
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def centroid_win(self):
         """
@@ -1837,7 +1838,7 @@ class SourceCatalog:
 
         return np.transpose((xcen_win, ycen_win))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def x_centroid_win(self):
         """
@@ -1850,7 +1851,7 @@ class SourceCatalog:
         """
         return self._array('centroid_win')[:, 0]
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def y_centroid_win(self):
         """
@@ -1863,7 +1864,7 @@ class SourceCatalog:
         """
         return self._array('centroid_win')[:, 1]
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def cutout_centroid_win(self):
         """
@@ -1878,7 +1879,7 @@ class SourceCatalog:
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.centroid_win - origin
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def cutout_centroid_quad(self):
         """
@@ -1988,7 +1989,7 @@ class SourceCatalog:
 
         return centroid_quad
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def centroid_quad(self):
         """
@@ -2016,7 +2017,7 @@ class SourceCatalog:
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.cutout_centroid_quad + origin
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def x_centroid_quad(self):
         """
@@ -2026,7 +2027,7 @@ class SourceCatalog:
         """
         return self._array('centroid_quad')[:, 0]
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def y_centroid_quad(self):
         """
@@ -2036,7 +2037,7 @@ class SourceCatalog:
         """
         return self._array('centroid_quad')[:, 1]
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def sky_centroid(self):
         """
@@ -2051,7 +2052,7 @@ class SourceCatalog:
             return self._null_objects
         return self.wcs.pixel_to_world(self.x_centroid, self.y_centroid)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def sky_centroid_icrs(self):
         """
@@ -2065,7 +2066,7 @@ class SourceCatalog:
             return self._null_objects
         return self.sky_centroid.icrs
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def sky_centroid_win(self):
         """
@@ -2082,7 +2083,7 @@ class SourceCatalog:
         return self.wcs.pixel_to_world(self.x_centroid_win,
                                        self.y_centroid_win)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def sky_centroid_quad(self):
         """
@@ -2099,7 +2100,7 @@ class SourceCatalog:
         return self.wcs.pixel_to_world(self.x_centroid_quad,
                                        self.y_centroid_quad)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _bbox(self):
         """
@@ -2110,7 +2111,7 @@ class SourceCatalog:
                             iymin=slc[0].start, iymax=slc[0].stop)
                 for slc in self._slices_iter]
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def bbox(self):
         """
@@ -2122,7 +2123,7 @@ class SourceCatalog:
         """
         return self._bbox
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def bbox_xmin(self):
         """
@@ -2131,7 +2132,7 @@ class SourceCatalog:
         """
         return np.array([slc[1].start for slc in self._slices_iter])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def bbox_xmax(self):
         """
@@ -2142,7 +2143,7 @@ class SourceCatalog:
         """
         return np.array([slc[1].stop - 1 for slc in self._slices_iter])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def bbox_ymin(self):
         """
@@ -2151,7 +2152,7 @@ class SourceCatalog:
         """
         return np.array([slc[0].start for slc in self._slices_iter])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def bbox_ymax(self):
         """
@@ -2162,7 +2163,7 @@ class SourceCatalog:
         """
         return np.array([slc[0].stop - 1 for slc in self._slices_iter])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _bbox_corner_ll(self):
         """
@@ -2171,7 +2172,7 @@ class SourceCatalog:
         return np.array([(bbox_.ixmin - 0.5, bbox_.iymin - 0.5)
                          for bbox_ in self._bbox])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _bbox_corner_ul(self):
         """
@@ -2180,7 +2181,7 @@ class SourceCatalog:
         return np.array([(bbox_.ixmin - 0.5, bbox_.iymax + 0.5)
                          for bbox_ in self._bbox])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _bbox_corner_lr(self):
         """
@@ -2189,7 +2190,7 @@ class SourceCatalog:
         return np.array([(bbox_.ixmax + 0.5, bbox_.iymin - 0.5)
                          for bbox_ in self._bbox])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _bbox_corner_ur(self):
         """
@@ -2198,7 +2199,7 @@ class SourceCatalog:
         return np.array([(bbox_.ixmax + 0.5, bbox_.iymax + 0.5)
                          for bbox_ in self._bbox])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def sky_bbox_ll(self):
         """
@@ -2216,7 +2217,7 @@ class SourceCatalog:
             return self._null_objects
         return self.wcs.pixel_to_world(*np.transpose(self._bbox_corner_ll))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def sky_bbox_ul(self):
         """
@@ -2234,7 +2235,7 @@ class SourceCatalog:
             return self._null_objects
         return self.wcs.pixel_to_world(*np.transpose(self._bbox_corner_ul))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def sky_bbox_lr(self):
         """
@@ -2252,7 +2253,7 @@ class SourceCatalog:
             return self._null_objects
         return self.wcs.pixel_to_world(*np.transpose(self._bbox_corner_lr))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def sky_bbox_ur(self):
         """
@@ -2270,7 +2271,7 @@ class SourceCatalog:
             return self._null_objects
         return self.wcs.pixel_to_world(*np.transpose(self._bbox_corner_ur))
 
-    @lazyproperty
+    @cached_property
     def min_value(self):
         """
         The minimum pixel value of the ``data`` within the source
@@ -2282,7 +2283,7 @@ class SourceCatalog:
             values <<= self._data_unit
         return values
 
-    @lazyproperty
+    @cached_property
     def max_value(self):
         """
         The maximum pixel value of the ``data`` within the source
@@ -2294,7 +2295,7 @@ class SourceCatalog:
             values <<= self._data_unit
         return values
 
-    @lazyproperty
+    @cached_property
     def cutout_min_value_index(self):
         """
         The ``(y, x)`` coordinate, relative to the cutout data, of the
@@ -2312,7 +2313,7 @@ class SourceCatalog:
                 idx.append(np.unravel_index(np.argmin(arr), arr.shape))
         return np.array(idx)
 
-    @lazyproperty
+    @cached_property
     def cutout_max_value_index(self):
         """
         The ``(y, x)`` coordinate, relative to the cutout data, of the
@@ -2330,7 +2331,7 @@ class SourceCatalog:
                 idx.append(np.unravel_index(np.argmax(arr), arr.shape))
         return np.array(idx)
 
-    @lazyproperty
+    @cached_property
     def min_value_index(self):
         """
         The ``(y, x)`` coordinate of the minimum pixel value of the
@@ -2345,7 +2346,7 @@ class SourceCatalog:
             out.append((idx[0] + slc[0].start, idx[1] + slc[1].start))
         return np.array(out)
 
-    @lazyproperty
+    @cached_property
     def max_value_index(self):
         """
         The ``(y, x)`` coordinate of the maximum pixel value of the
@@ -2360,7 +2361,7 @@ class SourceCatalog:
             out.append((idx[0] + slc[0].start, idx[1] + slc[1].start))
         return np.array(out)
 
-    @lazyproperty
+    @cached_property
     def min_value_xindex(self):
         """
         The ``x`` coordinate of the minimum pixel value of the ``data``
@@ -2371,7 +2372,7 @@ class SourceCatalog:
         """
         return self._array('min_value_index')[:, 1]
 
-    @lazyproperty
+    @cached_property
     def min_value_yindex(self):
         """
         The ``y`` coordinate of the minimum pixel value of the ``data``
@@ -2382,7 +2383,7 @@ class SourceCatalog:
         """
         return self._array('min_value_index')[:, 0]
 
-    @lazyproperty
+    @cached_property
     def max_value_xindex(self):
         """
         The ``x`` coordinate of the maximum pixel value of the ``data``
@@ -2393,7 +2394,7 @@ class SourceCatalog:
         """
         return self._array('max_value_index')[:, 1]
 
-    @lazyproperty
+    @cached_property
     def max_value_yindex(self):
         """
         The ``y`` coordinate of the maximum pixel value of the ``data``
@@ -2404,7 +2405,7 @@ class SourceCatalog:
         """
         return self._array('max_value_index')[:, 0]
 
-    @lazyproperty
+    @cached_property
     def segment_flux(self):
         r"""
         The sum of the unmasked ``data`` values within the source
@@ -2430,7 +2431,7 @@ class SourceCatalog:
             source_sum <<= self._data_unit
         return source_sum
 
-    @lazyproperty
+    @cached_property
     def segment_flux_err(self):
         r"""
         The uncertainty of `segment_flux`, propagated from the input
@@ -2463,7 +2464,7 @@ class SourceCatalog:
             err <<= self._data_unit
         return err
 
-    @lazyproperty
+    @cached_property
     def background_sum(self):
         """
         The sum of ``background`` values within the source segment.
@@ -2482,7 +2483,7 @@ class SourceCatalog:
             bkg_sum <<= self._data_unit
         return bkg_sum
 
-    @lazyproperty
+    @cached_property
     def background_mean(self):
         """
         The mean of ``background`` values within the source segment.
@@ -2502,7 +2503,7 @@ class SourceCatalog:
             bkg_mean <<= self._data_unit
         return bkg_mean
 
-    @lazyproperty
+    @cached_property
     def background_centroid(self):
         """
         The value of the per-pixel ``background`` at the position of the
@@ -2529,7 +2530,7 @@ class SourceCatalog:
             bkg <<= self._data_unit
         return bkg
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def segment_area(self):
         """
@@ -2547,7 +2548,7 @@ class SourceCatalog:
                 self._segmentation_image[slices] == label))
         return np.array(areas) << (u.pix**2)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def area(self):
         """
@@ -2561,7 +2562,7 @@ class SourceCatalog:
         areas[self._all_masked] = np.nan
         return areas << (u.pix**2)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def equivalent_radius(self):
         """
@@ -2570,7 +2571,7 @@ class SourceCatalog:
         """
         return np.sqrt(self.area / np.pi)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def perimeter(self):
         """
@@ -2630,7 +2631,7 @@ class SourceCatalog:
 
         return np.array(perimeter) * u.pix
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def inertia_tensor(self):
         """
@@ -2644,7 +2645,7 @@ class SourceCatalog:
         tensor = np.array([mu_02, mu_11, mu_11, mu_20]).swapaxes(0, 1)
         return tensor.reshape((tensor.shape[0], 2, 2)) * u.pix**2
 
-    @lazyproperty
+    @cached_property
     def _raw_covariance(self):
         """
         The raw ``(N, 2, 2)`` covariance matrix of the 2D Gaussian
@@ -2665,7 +2666,7 @@ class SourceCatalog:
                           mu_norm[:, 1, 1], mu_norm[:, 2, 0]]).swapaxes(0, 1)
         return covar.reshape((covar.shape[0], 2, 2))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _covariance(self):
         """
@@ -2709,7 +2710,7 @@ class SourceCatalog:
             covar[idx, 1, 1] += delta
         return covar
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def covariance(self):
         """
@@ -2718,7 +2719,7 @@ class SourceCatalog:
         """
         return self._covariance * (u.pix**2)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def covariance_eigvals(self):
         """
@@ -2742,7 +2743,7 @@ class SourceCatalog:
 
         return eigvals * u.pix**2
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def semimajor_axis(self):
         """
@@ -2754,7 +2755,7 @@ class SourceCatalog:
         # This matches SourceExtractor's A parameter
         return np.sqrt(eigvals[:, 0])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def semiminor_axis(self):
         """
@@ -2766,7 +2767,7 @@ class SourceCatalog:
         # This matches SourceExtractor's B parameter
         return np.sqrt(eigvals[:, 1])
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def fwhm(self):
         r"""
@@ -2787,7 +2788,7 @@ class SourceCatalog:
         return 2.0 * np.sqrt(np.log(2.0) * (self.semimajor_axis**2
                                             + self.semiminor_axis**2))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def orientation(self):
         """
@@ -2803,7 +2804,7 @@ class SourceCatalog:
                                           (covar[:, 0, 0] - covar[:, 1, 1]))
         return np.rad2deg(orient_radians) * u.deg
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def eccentricity(self):
         r"""
@@ -2823,7 +2824,7 @@ class SourceCatalog:
         semimajor_var, semiminor_var = np.transpose(self.covariance_eigvals)
         return np.sqrt(1.0 - (semiminor_var / semimajor_var))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def elongation(self):
         r"""
@@ -2838,7 +2839,7 @@ class SourceCatalog:
         """
         return self.semimajor_axis / self.semiminor_axis
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def ellipticity(self):
         r"""
@@ -2854,7 +2855,7 @@ class SourceCatalog:
         """
         return 1.0 - (self.semiminor_axis / self.semimajor_axis)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def covariance_xx(self):
         r"""
@@ -2863,7 +2864,7 @@ class SourceCatalog:
         """
         return self._covariance[:, 0, 0] * u.pix**2
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def covariance_yy(self):
         r"""
@@ -2872,7 +2873,7 @@ class SourceCatalog:
         """
         return self._covariance[:, 1, 1] * u.pix**2
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def covariance_xy(self):
         r"""
@@ -2882,7 +2883,7 @@ class SourceCatalog:
         """
         return self._covariance[:, 0, 1] * u.pix**2
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def ellipse_cxx(self):
         r"""
@@ -2905,7 +2906,7 @@ class SourceCatalog:
         return ((np.cos(self.orientation) / self.semimajor_axis)**2
                 + (np.sin(self.orientation) / self.semiminor_axis)**2)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def ellipse_cyy(self):
         r"""
@@ -2928,7 +2929,7 @@ class SourceCatalog:
         return ((np.sin(self.orientation) / self.semimajor_axis)**2
                 + (np.cos(self.orientation) / self.semiminor_axis)**2)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def ellipse_cxy(self):
         r"""
@@ -2952,7 +2953,7 @@ class SourceCatalog:
                 * ((1.0 / self.semimajor_axis**2)
                    - (1.0 / self.semiminor_axis**2)))
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def gini(self):
         r"""
@@ -2981,7 +2982,7 @@ class SourceCatalog:
         """
         return np.array([gini_func(arr) for arr in self._data_values])
 
-    @lazyproperty
+    @cached_property
     def _local_background_apertures(self):
         """
         The `~photutils.aperture.RectangularAnnulus` aperture used to
@@ -3004,7 +3005,7 @@ class SourceCatalog:
                                                 h_in=height_in, theta=0.0))
         return apertures
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def local_background_aperture(self):
         """
@@ -3016,7 +3017,7 @@ class SourceCatalog:
         """
         return self._local_background_apertures
 
-    @lazyproperty
+    @cached_property
     def _local_background(self):
         """
         The local background value (per pixel) estimated using a
@@ -3069,7 +3070,7 @@ class SourceCatalog:
         local_bkgs[self._all_masked] = np.nan
         return local_bkgs
 
-    @lazyproperty
+    @cached_property
     def local_background(self):
         """
         The local background value (per pixel) estimated using a
@@ -3378,7 +3379,7 @@ class SourceCatalog:
 
         return aperture
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _measured_kron_radius(self):
         r"""
@@ -3563,7 +3564,7 @@ class SourceCatalog:
 
         return kron_radius << u.pix
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def kron_radius(self):
         r"""
@@ -3637,7 +3638,7 @@ class SourceCatalog:
         scale = kron_radius.value * kron_params[0]
         return self._make_elliptical_apertures(scale=scale)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def kron_aperture(self):
         r"""
@@ -4038,7 +4039,7 @@ class SourceCatalog:
 
         return kron_flux, kron_flux_err
 
-    @lazyproperty
+    @cached_property
     def _kron_photometry(self):
         """
         The flux and flux error in the Kron aperture (without units).
@@ -4053,7 +4054,7 @@ class SourceCatalog:
         """
         return np.transpose(self._calc_kron_photometry(kron_params=None))
 
-    @lazyproperty
+    @cached_property
     def kron_flux(self):
         """
         The flux in the Kron aperture.
@@ -4071,7 +4072,7 @@ class SourceCatalog:
             kron_flux <<= self._data_unit
         return kron_flux
 
-    @lazyproperty
+    @cached_property
     def kron_flux_err(self):
         """
         The flux error in the Kron aperture.
@@ -4089,7 +4090,7 @@ class SourceCatalog:
             kron_flux_err <<= self._data_unit
         return kron_flux_err
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _max_circular_kron_radius(self):
         """
@@ -4119,7 +4120,7 @@ class SourceCatalog:
         flux = np.sum(clean_data * weights)
         return 1.0 - (flux / normflux)
 
-    @lazyproperty
+    @cached_property
     @use_detcat
     def _flux_radius_optimizer_args(self):
         kron_flux = self._kron_photometry[:, 0]  # unitless

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -8,9 +8,9 @@ import inspect
 import warnings
 from collections import defaultdict
 from copy import copy, deepcopy
+from functools import cached_property
 
 import numpy as np
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from scipy.ndimage import find_objects, grey_dilation
 from scipy.signal import fftconvolve
@@ -137,7 +137,7 @@ class SegmentationImage:
         # np.unique preserves dtype and also sorts elements
         return np.unique(data[data != 0])
 
-    @lazyproperty
+    @cached_property
     def segments(self):
         """
         A list of `Segment` objects.
@@ -165,7 +165,7 @@ class SegmentationImage:
 
         return segments
 
-    @lazyproperty
+    @cached_property
     def deblended_labels(self):
         """
         A sorted 1D array of deblended label numbers.
@@ -177,7 +177,7 @@ class SegmentationImage:
             return np.array([], dtype=self._data.dtype)
         return np.sort(np.concatenate(list(self._deblend_label_map.values())))
 
-    @lazyproperty
+    @cached_property
     def deblended_label_to_parent(self):
         """
         A dictionary mapping deblended label numbers to the original
@@ -196,7 +196,7 @@ class SegmentationImage:
                 inverse_map[value] = key
         return inverse_map
 
-    @lazyproperty
+    @cached_property
     def parent_to_deblended_labels(self):
         """
         A dictionary mapping the original parent label numbers to the
@@ -219,27 +219,27 @@ class SegmentationImage:
         return self._data
 
     @property
-    def _lazyproperties(self):
+    def _cached_properties(self):
         """
-        A list of all class lazyproperties (even in superclasses).
+        A list of all class cached properties (even in superclasses).
 
         The result is cached on the class to avoid repeated
         introspection via `inspect.getmembers`.
         """
         cls = self.__class__
-        attr = '_cached_lazyproperties'
-        # Subclasses get their own lazyproperty list
+        attr = '_cached_properties_cache'
+        # Subclasses get their own cached-property list
         if attr not in cls.__dict__:
-            def islazyproperty(obj):
-                return isinstance(obj, lazyproperty)
+            def is_cached_property(obj):
+                return isinstance(obj, cached_property)
 
             setattr(cls, attr,
                     [i[0] for i in inspect.getmembers(
-                        cls, predicate=islazyproperty)])
+                        cls, predicate=is_cached_property)])
         return getattr(cls, attr)
 
-    def _reset_lazyproperties(self):
-        for key in self._lazyproperties:
+    def _reset_cached_properties(self):
+        for key in self._cached_properties:
             self.__dict__.pop(key, None)
 
     @data.setter
@@ -255,17 +255,17 @@ class SegmentationImage:
 
         if '_data' in self.__dict__:
             # Reset cached properties when data is reassigned, but not on init
-            self._reset_lazyproperties()
+            self._reset_cached_properties()
 
         self._data = value  # pylint: disable=attribute-defined-outside-init
         self.__dict__['labels'] = labels
 
         # Reset deblended labels explicitly since _deblend_label_map
-        # is a regular attribute, not a lazyproperty cleared by
-        # _reset_lazyproperties above.
+        # is a regular attribute, not a cached property cleared by
+        # _reset_cached_properties above.
         self.__dict__['_deblend_label_map'] = {}
 
-    @lazyproperty
+    @cached_property
     def data_masked(self):
         """
         A `~numpy.ma.MaskedArray` version of the segmentation array
@@ -273,21 +273,21 @@ class SegmentationImage:
         """
         return np.ma.masked_where(self.data == 0, self.data)
 
-    @lazyproperty
+    @cached_property
     def shape(self):
         """
         The shape of the segmentation array.
         """
         return self._data.shape
 
-    @lazyproperty
+    @cached_property
     def _ndim(self):
         """
         The number of array dimensions of the segmentation array.
         """
         return self._data.ndim
 
-    @lazyproperty
+    @cached_property
     def labels(self):
         """
         The sorted non-zero labels in the segmentation array.
@@ -303,14 +303,14 @@ class SegmentationImage:
 
         return self._get_labels(self.data)
 
-    @lazyproperty
+    @cached_property
     def n_labels(self):
         """
         The number of non-zero labels in the segmentation array.
         """
         return len(self.labels)
 
-    @lazyproperty
+    @cached_property
     def max_label(self):
         """
         The maximum label in the segmentation array.
@@ -367,7 +367,7 @@ class SegmentationImage:
         # self.labels is always sorted
         return np.searchsorted(self.labels, labels)
 
-    @lazyproperty
+    @cached_property
     def _raw_slices(self):
         """
         A list of tuples, where each tuple contains two slices representing
@@ -380,7 +380,7 @@ class SegmentationImage:
         """
         return find_objects(self.data)
 
-    @lazyproperty
+    @cached_property
     def slices(self):
         """
         A list of tuples, where each tuple contains two slices
@@ -392,7 +392,7 @@ class SegmentationImage:
         """
         return [slc for slc in self._raw_slices if slc is not None]
 
-    @lazyproperty
+    @cached_property
     def bbox(self):
         """
         A list of `~photutils.aperture.BoundingBox` of the minimal
@@ -406,14 +406,14 @@ class SegmentationImage:
                             iymin=slc[0].start, iymax=slc[0].stop)
                 for slc in self.slices]
 
-    @lazyproperty
+    @cached_property
     def background_area(self):
         """
         The area (in pixel**2) of the background (label=0) region.
         """
         return self._data.size - np.count_nonzero(self._data)
 
-    @lazyproperty
+    @cached_property
     def areas(self):
         """
         A 1D array of areas (in pixel**2) of the non-zero labeled
@@ -607,7 +607,7 @@ class SegmentationImage:
         self.check_labels(labels)
         return [self._make_segment(label) for label in labels]
 
-    @lazyproperty
+    @cached_property
     def is_consecutive(self):
         """
         Boolean value indicating whether the non-zero labels in the
@@ -618,7 +618,7 @@ class SegmentationImage:
         return ((self.labels[-1] - self.labels[0] + 1) == self.n_labels
                 and self.labels[0] == 1)
 
-    @lazyproperty
+    @cached_property
     def missing_labels(self):
         """
         A 1D `~numpy.ndarray` of the sorted non-zero labels that are
@@ -786,7 +786,7 @@ class SegmentationImage:
         """
         self.cmap = self.make_cmap(background_color='#000000ff', seed=seed)
 
-    @lazyproperty
+    @cached_property
     def cmap(self):
         """
         A matplotlib colormap consisting of (random) muted colors.
@@ -980,7 +980,7 @@ class SegmentationImage:
                 relabel_map = map2[relabel_map]
 
         data_new = relabel_map[self.data]
-        self._reset_lazyproperties()  # reset all cached properties
+        self._reset_cached_properties()  # reset all cached properties
         self._data = data_new  # use _data to avoid validation
         self._update_deblend_label_map(relabel_map)
 
@@ -1035,7 +1035,7 @@ class SegmentationImage:
         new_label_map[self.labels] = new_labels
 
         data_new = new_label_map[self.data]
-        self._reset_lazyproperties()  # reset all cached properties
+        self._reset_cached_properties()  # reset all cached properties
         self._data = data_new  # use _data to avoid validation
         self.__dict__['labels'] = new_labels
         if old_slices is not None:
@@ -1517,7 +1517,7 @@ class SegmentationImage:
         # https://www.researchgate.net/publication/238778666_DILATION_AND_EROSION_OF_GRAY_IMAGES_WITH_SPHERICAL_MASKS
         return fftconvolve(mask, footprint, 'same') > 0.5
 
-    @lazyproperty
+    @cached_property
     def _geojson_polygons(self):
         """
         A dictionary of GeoJSON-like polygons representing each source
@@ -1598,7 +1598,7 @@ class SegmentationImage:
 
         return polygon_dict
 
-    @lazyproperty
+    @cached_property
     def polygons(self):
         """
         A list of `Shapely <https://shapely.readthedocs.io/en/stable/>`_
@@ -2390,7 +2390,7 @@ class Segment:
         """
         return self.data
 
-    @lazyproperty
+    @cached_property
     def data(self):
         """
         A cutout array of the segment using the minimal bounding box,
@@ -2403,7 +2403,7 @@ class Segment:
 
         return cutout
 
-    @lazyproperty
+    @cached_property
     def data_masked(self):
         """
         A `~numpy.ma.MaskedArray` cutout array of the segment using the

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -7,12 +7,11 @@ image.
 import warnings
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
-from functools import partial
+from functools import cached_property, partial
 from multiprocessing import cpu_count, get_context
 
 import numpy as np
 from astropy.units import Quantity
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from scipy.ndimage import label as ndi_label
 from scipy.ndimage import sum_labels
@@ -387,7 +386,7 @@ class _SingleSourceDeblender:
         self.source_sum = nansum(data_values)
         self.warnings = {}
 
-    @lazyproperty
+    @cached_property
     def linear_thresholds(self):
         """
         Linearly spaced thresholds between the source minimum and
@@ -398,7 +397,7 @@ class _SingleSourceDeblender:
         """
         return np.linspace(self.source_min, self.source_max, self.n_levels + 2)
 
-    @lazyproperty
+    @cached_property
     def normalized_thresholds(self):
         """
         Normalized thresholds (from 0 to 1) between the source minimum

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1034,7 +1034,7 @@ class TestSourceCatalog:
             # Built-in property
             cat.add_property('label', segment_snr)
         with pytest.raises(ValueError, match=match):
-            # Built-in lazyproperty
+            # Built-in cached property
             cat.add_property('area', segment_snr)
 
         cat.add_property('segment_snr', segment_snr)
@@ -1114,14 +1114,14 @@ class TestSourceCatalog:
         for attr in attrs:
             assert attr in self.cat.properties
 
-    def test_lazyproperties_class_cache(self):
+    def test_cached_properties_class_cache(self):
         """
-        Test that _lazyproperties is cached on the class and shared
+        Test that _cached_properties is cached on the class and shared
         across instances.
         """
         cat2 = SourceCatalog(self.data, self.segm)
-        result1 = self.cat._lazyproperties
-        result2 = cat2._lazyproperties
+        result1 = self.cat._cached_properties
+        result2 = cat2._cached_properties
         assert result1 is result2
 
     def test_properties_class_cache(self):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -5,11 +5,11 @@ Tests for the core module.
 
 import sys
 from collections import defaultdict
+from functools import cached_property
 from unittest.mock import PropertyMock, patch
 
 import numpy as np
 import pytest
-from astropy.utils import lazyproperty
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
@@ -80,7 +80,7 @@ class TestSegmentationImage:
     def test_labels_via_raw_slices(self):
         """
         Test that labels can be derived from _raw_slices when that
-        lazyproperty is already cached.
+        cached property is already cached.
         """
         segm = SegmentationImage(self.data.copy())
         # Force _raw_slices to be cached
@@ -283,18 +283,18 @@ class TestSegmentationImage:
 
     def test_shape(self):
         """
-        Test that the shape lazyproperty returns the correct shape.
+        Test that the shape cached property returns the correct shape.
         """
         assert self.segm.shape == (6, 6)
 
-    def test_lazyproperties_class_cache(self):
+    def test_cached_properties_class_cache(self):
         """
-        Test that _lazyproperties is cached on the class and shared
+        Test that _cached_properties is cached on the class and shared
         across instances.
         """
         segm2 = SegmentationImage(self.data.copy())
-        result1 = self.segm._lazyproperties
-        result2 = segm2._lazyproperties
+        result1 = self.segm._cached_properties
+        result2 = segm2._cached_properties
         assert result1 is result2
 
     def test_labels(self):
@@ -990,7 +990,7 @@ class TestSegmentationImage:
 
 
 class CustomSegm(SegmentationImage):
-    @lazyproperty
+    @cached_property
     def value(self):
         return np.median(self.data)
 

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -3,9 +3,10 @@
 Tools for generating 2D image cutouts.
 """
 
+from functools import cached_property
+
 import numpy as np
 from astropy.nddata import extract_array, overlap_slices
-from astropy.utils import lazyproperty
 
 from photutils.utils._deprecation import deprecated_positional_kwargs
 
@@ -149,7 +150,7 @@ class CutoutImage:
         return (f'{self.__class__.__name__}(position={self.position}, '
                 f'shape={self.shape})')
 
-    @lazyproperty
+    @cached_property
     def slices_original(self):
         """
         A tuple of slice objects in axis order for the minimal bounding
@@ -160,7 +161,7 @@ class CutoutImage:
         """
         return self._overlap_slices[0]
 
-    @lazyproperty
+    @cached_property
     def slices_cutout(self):
         """
         A tuple of slice objects in axis order for the minimal bounding
@@ -187,7 +188,7 @@ class CutoutImage:
         return BoundingBox(ixmin=slices[1].start, ixmax=slices[1].stop,
                            iymin=slices[0].start, iymax=slices[0].stop)
 
-    @lazyproperty
+    @cached_property
     def bbox_original(self):
         """
         The `~photutils.aperture.BoundingBox` of the minimal rectangular
@@ -198,7 +199,7 @@ class CutoutImage:
         """
         return self._calc_bbox(self.slices_original)
 
-    @lazyproperty
+    @cached_property
     def bbox_cutout(self):
         """
         The `~photutils.aperture.BoundingBox` of the minimal rectangular
@@ -233,7 +234,7 @@ class CutoutImage:
 
         return np.array((xorigin, yorigin))
 
-    @lazyproperty
+    @cached_property
     def xyorigin(self):
         """
         A `~numpy.ndarray` containing the ``(x, y)`` integer index of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Astronomy',
 ]
 dynamic = ['version']
-requires-python = '>=3.11'
+requires-python = '>=3.12'
 dependencies = [
     'astropy >= 6.1.7',
     'numpy >= 2.0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{311,312}-test-oldestdeps
-    py{311,312,313,314}-test{,-alldeps,-devdeps,-predeps,-devinfra}{,-cov}
+    py{312}-test-oldestdeps
+    py{312,313,314}-test{,-alldeps,-devdeps,-predeps,-devinfra}{,-cov}
     oldest_cython
     build_docs
     linkcheck
@@ -79,7 +79,7 @@ install_command =
 
 # oldestdeps includes oldest build dependencies (e.g., Cython).
 commands_pre =
-    oldestdeps: python -c "import sys; assert (3,11) <= sys.version_info < (3,13), 'Requires Python 3.11 or 3.12'"
+    oldestdeps: python -c "import sys; assert (3,12) <= sys.version_info < (3,13), 'Requires Python 3.12'"
 
     oldestdeps-!alldeps: python {toxinidir}/scripts/pin_minimum_requirements.py --path {envdir}
     oldestdeps-!alldeps: python -m pip install -r {envdir}/photutils_oldest_deps.txt
@@ -157,7 +157,7 @@ description = Check Cython compilation with the oldest supported Cython version
 deps =
     packaging
 commands_pre =
-    python -c "import sys; assert (3,11) <= sys.version_info < (3,13), 'Requires Python 3.11 or 3.12'"
+    python -c "import sys; assert (3,12) <= sys.version_info < (3,13), 'Requires Python 3.12'"
     python {toxinidir}/scripts/pin_minimum_requirements.py --path {envdir}
     python -m pip install -r {envdir}/photutils_oldest_deps.txt
 commands =


### PR DESCRIPTION
The astropy `lazyproperty` descriptor holds one `threading.RLock` per class attribute (shared by ALL instances) for the entire duration of the getter. Any two instances computing the same property from two threads therefore serialize on that class-level lock. `functools.cached_property` has no lock on Python >= 3.12 (Python removed it for exactly this reason). Note that with this change concurrent first accesses on the same instance may run a getter more than once (equal values; last store wins). This is the same trade Python made in 3.12.

This change enables cross-instance thread parallelism for `ApertureStats` and `AperturePhotometry`.