### PR TITLE
Add an n_threads keyword to AperturePhotometry, ApertureStats, and LocalBackground

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,12 @@ New Features
     construction, so instances are thread-safe and independent frames
     can be processed concurrently. [#2328, #2331]
 
+  - Added an ``n_threads`` keyword to ``AperturePhotometry`` to
+    compute the aperture sums using multiple threads. The aperture
+    positions are divided into chunks and processed concurrently,
+    producing results identical to the single-threaded computation.
+    [#2367]
+
   - Rectangular apertures now support the ``method='exact'`` mask mode.
     Previously this fell back to a 32x subpixel approximation. [#2291]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,11 +44,11 @@ New Features
     construction, so instances are thread-safe and independent frames
     can be processed concurrently. [#2328, #2331]
 
-  - Added an ``n_threads`` keyword to ``AperturePhotometry`` to
-    compute the aperture sums using multiple threads. The aperture
-    positions are divided into chunks and processed concurrently,
-    producing results identical to the single-threaded computation.
-    [#2367]
+  - Added an ``n_threads`` keyword to ``AperturePhotometry`` and
+    ``ApertureStats`` to compute the aperture sums and statistics
+    using multiple threads. The aperture positions are divided into
+    chunks and processed concurrently, producing results identical
+    to the single-threaded computation. [#2367]
 
   - Rectangular apertures now support the ``method='exact'`` mask mode.
     Previously this fell back to a 32x subpixel approximation. [#2291]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -123,6 +123,13 @@ New Features
     significantly speed up the background estimation for large
     images. [#2363]
 
+  - The ``Background2D`` ``n_threads`` keyword also multithreads
+    the interpolation of the low-resolution meshes to the full-size maps
+    returned by the ``background`` and ``background_rms`` properties
+    (for the 'reflect' and 'mirror' interpolation boundary modes). The
+    multithreaded maps are identical to the single-threaded maps up to
+    floating-point rounding. [#2365]
+
   - Significantly improved the performance of ``Background2D`` by
     computing the sigma clipping and the box statistics in a
     single combined pass in compiled code when the ``sigma_clip``,
@@ -145,12 +152,10 @@ New Features
     batched ``ApertureStats`` kernels instead of a Python loop over the
     apertures. [#2364]
 
-  - The ``Background2D`` ``n_threads`` keyword also multithreads
-    the interpolation of the low-resolution meshes to the full-size maps
-    returned by the ``background`` and ``background_rms`` properties
-    (for the 'reflect' and 'mirror' interpolation boundary modes). The
-    multithreaded maps are identical to the single-threaded maps up to
-    floating-point rounding. [#2365]
+  - Added an ``n_threads`` keyword to ``LocalBackground``, passed
+    through to its internal ``ApertureStats`` computation to measure
+    the local backgrounds using multiple threads. The results are
+    identical to the single-threaded computation. [#2367]
 
 - ``photutils.detection``
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,34 @@
 # Photutils Benchmarks
 
 This directory contains standalone benchmark scripts for photutils.
-They are not part of the installed package or the test suite.
+They are not part of the installed package or the test suite. Helper
+functions shared by the scripts live in `bench_utils.py`.
+
+## Aperture statistics (`bench_aperture_stats.py`)
+
+Benchmarks for `ApertureStats`:
+
+- computing the median and all properties for all of the pixel-based
+  aperture types, with and without sigma clipping
+- the cold cost of each individual property (including its lazy
+  dependencies) for a circular aperture, sorted by decreasing
+  sigma-clipped time
+
+```bash
+python benchmarks/bench_aperture_stats.py
+python benchmarks/bench_aperture_stats.py --which types --n-sources 10000
+```
+
+## Aperture photometry (`bench_aperture_photometry.py`)
+
+Benchmarks for `AperturePhotometry`: computing the flux (with an
+error array) for all of the pixel-based aperture types and each
+overlap method (exact, center, and subpixel).
+
+```bash
+python benchmarks/bench_aperture_photometry.py
+python benchmarks/bench_aperture_photometry.py --n-sources 100000
+```
 
 ## Background (`bench_background.py`)
 

--- a/benchmarks/bench_aperture_photometry.py
+++ b/benchmarks/bench_aperture_photometry.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for AperturePhotometry in the photutils.aperture
+subpackage.
+
+The benchmarks cover computing the flux (with an error array) for all
+of the pixel-based aperture types and each aperture overlap method
+(exact, center, and subpixel), and the thread scaling of the
+``n_threads`` keyword.
+
+Run ``python benchmarks/bench_aperture_photometry.py --help`` to see
+the available options.
+"""
+
+import argparse
+from functools import partial
+
+from bench_utils import (format_sweep_cells, make_aperture_inputs,
+                         make_apertures, parse_thread_counts,
+                         print_environment, time_best)
+
+from photutils.aperture import AperturePhotometry
+
+
+def _compute_flux(data, aperture, *, error=None, method='exact',
+                  n_threads=1):
+    """
+    Construct an AperturePhotometry instance and compute the flux.
+    """
+    return AperturePhotometry(data, aperture, error=error,
+                              method=method, n_threads=n_threads).flux
+
+
+def bench_photometry(size, n_sources, *, repeats=3, seed=0):
+    """
+    Benchmark AperturePhotometry for all pixel-based aperture types.
+
+    For each aperture type, the time to compute the flux (with an
+    error array) is measured for each aperture overlap method.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    n_sources : int
+        The number of aperture positions.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print(f'\n== AperturePhotometry '
+          f'({n_sources} sources, {size}x{size} image) ==')
+    print(f'{"aperture":>22}{"exact":>10}{"center":>10}{"subpixel":>10}')
+    data, error, _, positions = make_aperture_inputs(size, n_sources,
+                                                     seed=seed)
+
+    for name, aperture in make_apertures(positions):
+        row = f'{name:>22}'
+        for method in ('exact', 'center', 'subpixel'):
+            t_flux = time_best(
+                partial(_compute_flux, data, aperture, error=error,
+                        method=method), repeats=repeats)
+            row += f'{f"{t_flux:.3f}s":>10}'
+        print(row)
+
+
+def bench_thread_scaling(size, n_sources, n_threads_list, *, repeats=3,
+                         seed=0):
+    """
+    Benchmark AperturePhotometry thread scaling for all pixel-based
+    aperture types.
+
+    For each aperture type, the time to compute the flux (with an
+    error array and the 'exact' method) is measured for each thread
+    count. Speedups are relative to the first thread count.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    n_sources : int
+        The number of aperture positions.
+
+    n_threads_list : list of int
+        The thread counts to sweep.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print(f'\n== AperturePhotometry n_threads sweep '
+          f'({n_sources} sources, {size}x{size} image, exact method) ==')
+    header = f'{"aperture":>22}'
+    header += ''.join(f'{f"n={n}":>16}' for n in n_threads_list)
+    print(header)
+    data, error, _, positions = make_aperture_inputs(size, n_sources,
+                                                     seed=seed)
+
+    for name, aperture in make_apertures(positions):
+        times = [time_best(partial(_compute_flux, data, aperture,
+                                   error=error, n_threads=n_threads),
+                           repeats=repeats)
+                 for n_threads in n_threads_list]
+        row = f'{name:>22}'
+        row += ''.join(f'{cell:>16}' for cell in format_sweep_cells(times))
+        print(row)
+
+
+def main():
+    """
+    Run the AperturePhotometry benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for AperturePhotometry.')
+    parser.add_argument('--size', type=int, default=2048,
+                        help='image size (default: %(default)s)')
+    parser.add_argument('--n-sources', type=int, default=10000,
+                        help='number of sources (default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'types', 'threads'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    parser.add_argument('--n-threads', type=parse_thread_counts,
+                        default='1,2,4,8',
+                        help='comma-separated thread counts for the '
+                             'threads benchmark (default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'types'):
+        bench_photometry(args.size, args.n_sources, repeats=args.repeats,
+                         seed=args.seed)
+    if args.which in ('all', 'threads'):
+        bench_thread_scaling(args.size, args.n_sources, args.n_threads,
+                             repeats=args.repeats, seed=args.seed)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/bench_aperture_stats.py
+++ b/benchmarks/bench_aperture_stats.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for ApertureStats in the photutils.aperture subpackage.
+
+The benchmarks cover computing all ApertureStats properties for all
+of the pixel-based aperture types, with and without sigma clipping,
+the cold cost of each individual ApertureStats property (including
+its lazy dependencies) for a circular aperture, and the thread
+scaling of the ``n_threads`` keyword.
+
+Run ``python benchmarks/bench_aperture_stats.py --help`` to see the
+available options.
+"""
+
+import argparse
+from functools import partial
+
+from astropy.stats import SigmaClip
+from bench_utils import (format_sweep_cells, make_aperture_inputs,
+                         make_apertures, parse_thread_counts,
+                         print_environment, time_best)
+
+from photutils.aperture import ApertureStats, CircularAperture
+
+
+def _compute_all_properties(data, aperture, *, error=None, wcs=None,
+                            sigma_clip=None, n_threads=1):
+    """
+    Construct an ApertureStats instance and compute every property.
+    """
+    apstats = ApertureStats(data, aperture, error=error, wcs=wcs,
+                            sigma_clip=sigma_clip, n_threads=n_threads)
+    for prop in apstats.properties:
+        getattr(apstats, prop)
+
+
+def _compute_median(data, aperture, *, error=None, wcs=None,
+                    sigma_clip=None, n_threads=1):
+    """
+    Construct an ApertureStats instance and compute the median.
+    """
+    return ApertureStats(data, aperture, error=error, wcs=wcs,
+                         sigma_clip=sigma_clip, n_threads=n_threads).median
+
+
+def _compute_property(data, aperture, prop, *, error=None, wcs=None,
+                      sigma_clip=None, n_threads=1):
+    """
+    Construct an ApertureStats instance and compute one property.
+    """
+    apstats = ApertureStats(data, aperture, error=error, wcs=wcs,
+                            sigma_clip=sigma_clip, n_threads=n_threads)
+    return getattr(apstats, prop)
+
+
+def bench_aperture_types(size, n_sources, n_threads_list, *, repeats=3,
+                         seed=0):
+    """
+    Benchmark ApertureStats for all pixel-based aperture types.
+
+    For each aperture type, the time to compute the median and the
+    time to compute all ApertureStats properties are measured, with
+    and without sigma clipping. When more than one thread count is
+    requested, additional tables sweep the all-properties timings
+    over the thread counts, with speedups relative to the first
+    thread count.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    n_sources : int
+        The number of aperture positions.
+
+    n_threads_list : list of int
+        The thread counts to sweep.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print(f'\n== ApertureStats aperture types '
+          f'({n_sources} sources, {size}x{size} image) ==')
+    print(f'{"aperture":>22}{"median":>10}{"all props":>12}'
+          f'{"all props+clip":>16}')
+    (data, error, wcs,
+     positions) = make_aperture_inputs(size, n_sources, seed=seed)
+    sigma_clip = SigmaClip(sigma=3.0, maxiters=10)
+
+    for name, aperture in make_apertures(positions):
+        t_median = time_best(
+            partial(_compute_median, data, aperture, error=error,
+                    wcs=wcs), repeats=repeats)
+        t_all = time_best(
+            partial(_compute_all_properties, data, aperture, error=error,
+                    wcs=wcs), repeats=repeats)
+        t_all_clip = time_best(
+            partial(_compute_all_properties, data, aperture, error=error,
+                    wcs=wcs, sigma_clip=sigma_clip), repeats=repeats)
+        print(f'{name:>22}{f"{t_median:.3f}s":>10}'
+              f'{f"{t_all:.3f}s":>12}{f"{t_all_clip:.3f}s":>16}')
+
+    if len(n_threads_list) == 1:
+        return
+
+    for label, sigclip in (('all properties', None),
+                           ('all properties + sigma clip', sigma_clip)):
+        print(f'\n== ApertureStats aperture types n_threads sweep: '
+              f'{label} ({n_sources} sources, {size}x{size} image) ==')
+        header = f'{"aperture":>22}'
+        header += ''.join(f'{f"n={n}":>18}' for n in n_threads_list)
+        print(header)
+
+        for name, aperture in make_apertures(positions):
+            times = [time_best(
+                partial(_compute_all_properties, data, aperture,
+                        error=error, wcs=wcs, sigma_clip=sigclip,
+                        n_threads=n_threads),
+                repeats=repeats) for n_threads in n_threads_list]
+            row = f'{name:>22}'
+            row += ''.join(f'{cell:>18}'
+                           for cell in format_sweep_cells(times))
+            print(row)
+
+
+def bench_properties(size, n_sources, n_threads_list, *, repeats=3,
+                     seed=0):
+    """
+    Benchmark each ApertureStats property for a circular aperture.
+
+    Each property is timed on a fresh ApertureStats instance for
+    each thread count, so a timing includes the cost of the
+    property's uncomputed lazy dependencies (e.g., the pixel gather
+    and sigma clipping). Two tables are printed (without and with
+    sigma clipping), with the properties listed by decreasing
+    single-threaded time. Speedups are relative to the first thread
+    count.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    n_sources : int
+        The number of aperture positions.
+
+    n_threads_list : list of int
+        The thread counts to sweep.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    (data, error, wcs,
+     positions) = make_aperture_inputs(size, n_sources, seed=seed)
+    aperture = CircularAperture(positions, r=8.0)
+    sigma_clip = SigmaClip(sigma=3.0, maxiters=10)
+    prop_names = ApertureStats(data, aperture).properties
+
+    for label, sigclip in (('no sigma clipping', None),
+                           ('sigma clipping', sigma_clip)):
+        print(f'\n== ApertureStats properties, {label} (cold, incl. '
+              f'dependencies; CircularAperture r=8, {n_sources} '
+              f'sources) ==')
+        header = f'{"property":>24}'
+        header += ''.join(f'{f"n={n}":>18}' for n in n_threads_list)
+        print(header)
+
+        results = []
+        for prop in prop_names:
+            times = [time_best(
+                partial(_compute_property, data, aperture, prop,
+                        error=error, wcs=wcs, sigma_clip=sigclip,
+                        n_threads=n_threads),
+                repeats=repeats) for n_threads in n_threads_list]
+            results.append((prop, times))
+
+        results.sort(key=lambda result: result[1][0], reverse=True)
+        for prop, times in results:
+            row = f'{prop:>24}'
+            row += ''.join(f'{cell:>18}'
+                           for cell in format_sweep_cells(times))
+            print(row)
+
+
+def bench_thread_scaling(size, n_sources, n_threads_list, *, repeats=3,
+                         seed=0):
+    """
+    Benchmark ApertureStats thread scaling for all pixel-based
+    aperture types.
+
+    Two sweeps are measured for each aperture type: the aperture
+    ``sum`` (with an error array), which runs entirely in the
+    threaded ``sum_method`` gather, and the sigma-clipped ``median``,
+    whose pixel gather and sigma clipping are threaded (the clipped
+    order statistics reuse the clip kernel's sorted values).
+    Properties dominated by the serial per-source reductions (e.g.,
+    the image moments) benefit less. Speedups are relative to the
+    first thread count.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    n_sources : int
+        The number of aperture positions.
+
+    n_threads_list : list of int
+        The thread counts to sweep.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    (data, error, wcs,
+     positions) = make_aperture_inputs(size, n_sources, seed=seed)
+    sigma_clip = SigmaClip(sigma=3.0, maxiters=10)
+    sweeps = (('sum', 'sum', None),
+              ('sigma-clipped median', 'median', sigma_clip))
+
+    for label, prop, sigclip in sweeps:
+        print(f'\n== ApertureStats n_threads sweep: {label} '
+              f'({n_sources} sources, {size}x{size} image) ==')
+        header = f'{"aperture":>22}'
+        header += ''.join(f'{f"n={n}":>16}' for n in n_threads_list)
+        print(header)
+
+        for name, aperture in make_apertures(positions):
+            times = [time_best(
+                partial(_compute_property, data, aperture, prop,
+                        error=error, wcs=wcs, sigma_clip=sigclip,
+                        n_threads=n_threads),
+                repeats=repeats) for n_threads in n_threads_list]
+            row = f'{name:>22}'
+            row += ''.join(f'{cell:>16}'
+                           for cell in format_sweep_cells(times))
+            print(row)
+
+
+def main():
+    """
+    Run the aperture benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for ApertureStats.')
+    parser.add_argument('--size', type=int, default=2048,
+                        help='image size (default: %(default)s)')
+    parser.add_argument('--n-sources', type=int, default=1000,
+                        help='number of sources (default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'types', 'properties', 'threads'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    parser.add_argument('--n-threads', type=parse_thread_counts,
+                        default='1,2,4,8',
+                        help='comma-separated thread counts for the '
+                             'threads benchmark (default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'types'):
+        bench_aperture_types(args.size, args.n_sources, args.n_threads,
+                             repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'properties'):
+        bench_properties(args.size, args.n_sources, args.n_threads,
+                         repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'threads'):
+        bench_thread_scaling(args.size, args.n_sources, args.n_threads,
+                             repeats=args.repeats, seed=args.seed)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/bench_background.py
+++ b/benchmarks/bench_background.py
@@ -13,14 +13,11 @@ available options.
 """
 
 import argparse
-import os
-import platform
-import sys
-import time
 from functools import partial
 
 import numpy as np
 from astropy.stats import SigmaClip
+from bench_utils import make_image, print_environment, time_best
 
 from photutils.background import (Background2D, BiweightLocationBackground,
                                   BiweightScaleBackgroundRMS, LocalBackground,
@@ -34,70 +31,6 @@ ESTIMATOR_CLASSES = [MeanBackground, MedianBackground,
                      SExtractorBackground, BiweightLocationBackground,
                      StdBackgroundRMS, MADStdBackgroundRMS,
                      BiweightScaleBackgroundRMS]
-
-
-def time_best(func, *, repeats=3):
-    """
-    Return the best wall-clock time of ``repeats`` calls to ``func``.
-
-    Parameters
-    ----------
-    func : callable
-        The zero-argument callable to time.
-
-    repeats : int, optional
-        The number of times to call ``func``.
-
-    Returns
-    -------
-    result : float
-        The best (minimum) wall-clock time in seconds.
-    """
-    best = np.inf
-    for _ in range(repeats):
-        t0 = time.perf_counter()
-        func()
-        best = min(best, time.perf_counter() - t0)
-    return best
-
-
-def make_image(shape, *, seed=0):
-    """
-    Return a Gaussian-noise image of the given shape.
-
-    Parameters
-    ----------
-    shape : tuple of int
-        The shape of the output image.
-
-    seed : int, optional
-        The random number generator seed.
-
-    Returns
-    -------
-    result : 2D `~numpy.ndarray`
-        The noise image.
-    """
-    rng = np.random.default_rng(seed)
-    return rng.normal(100.0, 5.0, shape)
-
-
-def print_environment():
-    """
-    Print information about the runtime environment.
-    """
-    import astropy
-    import scipy
-
-    import photutils
-    from photutils.utils._optional_deps import HAS_BOTTLENECK
-
-    gil = getattr(sys, '_is_gil_enabled', lambda: True)()
-    print(f'python {platform.python_version()} (GIL enabled: {gil}), '
-          f'{os.cpu_count()} CPUs')
-    print(f'photutils {photutils.__version__}, numpy {np.__version__}, '
-          f'scipy {scipy.__version__}, astropy {astropy.__version__}, '
-          f'bottleneck: {HAS_BOTTLENECK}')
 
 
 def bench_background2d(sizes, box_sizes, n_threads_list, *, repeats=3,

--- a/benchmarks/bench_background.py
+++ b/benchmarks/bench_background.py
@@ -17,7 +17,8 @@ from functools import partial
 
 import numpy as np
 from astropy.stats import SigmaClip
-from bench_utils import make_image, print_environment, time_best
+from bench_utils import (format_sweep_cells, make_image, print_environment,
+                         time_best)
 
 from photutils.background import (Background2D, BiweightLocationBackground,
                                   BiweightScaleBackgroundRMS, LocalBackground,
@@ -163,13 +164,19 @@ def bench_estimators(*, size=2048, repeats=3, seed=0):
               f'{f"{t_clip:.3f}s":>17}')
 
 
-def bench_local_background(*, size=2048, n_positions=1000, repeats=3,
-                           seed=0):
+def bench_local_background(n_threads_list, *, size=2048, n_positions=1000,
+                           repeats=3, seed=0):
     """
-    Benchmark LocalBackground at many positions.
+    Benchmark LocalBackground at many positions for each thread
+    count.
+
+    Speedups are relative to the first thread count.
 
     Parameters
     ----------
+    n_threads_list : list of int
+        The thread counts to sweep.
+
     size : int, optional
         The image size; the image is ``(size, size)``.
 
@@ -184,13 +191,20 @@ def bench_local_background(*, size=2048, n_positions=1000, repeats=3,
     """
     print(f'\n== LocalBackground ({n_positions} positions, '
           f'{size}x{size} image) ==')
+    header = ''.join(f'{f"n={n}":>18}' for n in n_threads_list)
+    print(header)
     data = make_image((size, size), seed=seed)
     rng = np.random.default_rng(seed)
     x = rng.uniform(50, size - 50, n_positions)
     y = rng.uniform(50, size - 50, n_positions)
-    local_bkg = LocalBackground(5, 10)
-    t_local = time_best(partial(local_bkg, data, x, y), repeats=repeats)
-    print(f'{t_local:.3f}s')
+
+    times = []
+    for n_threads in n_threads_list:
+        local_bkg = LocalBackground(5, 10, n_threads=n_threads)
+        times.append(time_best(partial(local_bkg, data, x, y),
+                               repeats=repeats))
+    row = ''.join(f'{cell:>18}' for cell in format_sweep_cells(times))
+    print(row)
 
 
 def main():
@@ -236,7 +250,8 @@ def main():
     if args.which in ('all', 'estimators'):
         bench_estimators(repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'local'):
-        bench_local_background(repeats=args.repeats, seed=args.seed)
+        bench_local_background(n_threads_list, repeats=args.repeats,
+                               seed=args.seed)
 
 
 if __name__ == '__main__':

--- a/benchmarks/bench_utils.py
+++ b/benchmarks/bench_utils.py
@@ -1,0 +1,196 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Shared helper functions for the photutils benchmark scripts.
+"""
+
+import os
+import platform
+import sys
+import time
+
+import numpy as np
+
+from photutils.aperture import (CircularAnnulus, CircularAperture,
+                                EllipticalAnnulus, EllipticalAperture,
+                                PolygonAperture, RectangularAnnulus,
+                                RectangularAperture)
+from photutils.datasets import make_wcs
+
+
+def time_best(func, *, repeats=3):
+    """
+    Return the best wall-clock time of ``repeats`` calls to ``func``.
+
+    Parameters
+    ----------
+    func : callable
+        The zero-argument callable to time.
+
+    repeats : int, optional
+        The number of times to call ``func``.
+
+    Returns
+    -------
+    result : float
+        The best (minimum) wall-clock time in seconds.
+    """
+    best = np.inf
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        func()
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+def make_image(shape, *, seed=0):
+    """
+    Return a Gaussian-noise image of the given shape.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the output image.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        The noise image.
+    """
+    rng = np.random.default_rng(seed)
+    return rng.normal(100.0, 5.0, shape)
+
+
+def print_environment():
+    """
+    Print information about the runtime environment.
+    """
+    import astropy
+    import scipy
+
+    import photutils
+    from photutils.utils._optional_deps import HAS_BOTTLENECK
+
+    gil = getattr(sys, '_is_gil_enabled', lambda: True)()
+    print(f'python {platform.python_version()} (GIL enabled: {gil}), '
+          f'{os.cpu_count()} CPUs')
+    print(f'photutils {photutils.__version__}, numpy {np.__version__}, '
+          f'scipy {scipy.__version__}, astropy {astropy.__version__}, '
+          f'bottleneck: {HAS_BOTTLENECK}')
+
+
+def parse_thread_counts(text):
+    """
+    Parse a comma-separated list of thread counts.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated thread counts (e.g., ``'1,2,4,8'``).
+
+    Returns
+    -------
+    result : list of int
+        The thread counts.
+    """
+    counts = [int(item) for item in text.split(',')]
+    if any(count < 1 for count in counts):
+        msg = 'thread counts must be positive integers'
+        raise ValueError(msg)
+    return counts
+
+
+def format_sweep_cells(times):
+    """
+    Format thread-sweep times, with speedups relative to the first
+    time.
+
+    Parameters
+    ----------
+    times : list of float
+        The wall-clock times in seconds, one per thread count.
+
+    Returns
+    -------
+    result : list of str
+        The formatted cells (e.g., ``['0.3270s', '0.1700s (1.9x)']``).
+    """
+    cells = [f'{times[0]:.4f}s']
+    cells.extend(f'{t:.4f}s ({times[0] / t:.1f}x)' for t in times[1:])
+    return cells
+
+
+def make_apertures(positions):
+    """
+    Return all of the pixel-based aperture types at the given
+    positions, with roughly comparable sizes.
+
+    Parameters
+    ----------
+    positions : 2D `~numpy.ndarray`
+        The (x, y) aperture positions.
+
+    Returns
+    -------
+    result : list of (str, aperture) tuples
+        The aperture name and instance pairs.
+    """
+    theta = 0.5
+    return [
+        ('CircularAperture', CircularAperture(positions, r=8.0)),
+        ('CircularAnnulus',
+         CircularAnnulus(positions, r_in=5.0, r_out=10.0)),
+        ('EllipticalAperture',
+         EllipticalAperture(positions, a=10.0, b=6.0, theta=theta)),
+        ('EllipticalAnnulus',
+         EllipticalAnnulus(positions, a_in=6.0, a_out=12.0, b_out=8.0,
+                           theta=theta)),
+        ('RectangularAperture',
+         RectangularAperture(positions, w=14.0, h=10.0, theta=theta)),
+        ('RectangularAnnulus',
+         RectangularAnnulus(positions, w_in=8.0, w_out=16.0, h_out=12.0,
+                            theta=theta)),
+        ('PolygonAperture',
+         PolygonAperture.from_regular_polygon(positions, n_vertices=6,
+                                              radius=8.0)),
+    ]
+
+
+def make_aperture_inputs(size, n_sources, *, seed=0):
+    """
+    Return the data, error, wcs, and aperture positions used by the
+    aperture benchmark scripts.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    n_sources : int
+        The number of aperture positions.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    data, error : 2D `~numpy.ndarray`
+        The image and its error array.
+
+    wcs : `~astropy.wcs.WCS`
+        A WCS for the image.
+
+    positions : 2D `~numpy.ndarray`
+        The (x, y) aperture positions.
+    """
+    data = make_image((size, size), seed=seed)
+    error = np.sqrt(np.abs(data))
+    wcs = make_wcs(data.shape)
+    rng = np.random.default_rng(seed)
+    margin = 20.0
+    positions = np.column_stack(
+        [rng.uniform(margin, size - margin, n_sources),
+         rng.uniform(margin, size - margin, n_sources)])
+    return data, error, wcs, positions

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -19,10 +19,12 @@ smaller improvements and bug fixes, which are described in the full
 Dependency Version Updates
 ==========================
 
-Photutils 3.1 bumps the minimum required versions of several key
-dependencies to provide users with access to the latest features and
-performance improvements. The minimum required versions are now:
+Photutils 3.1 bumps the minimum required versions of Python and
+several key dependencies to provide users with access to the latest
+features and performance improvements. The minimum required versions
+are now:
 
+- Python: 3.12
 - Astropy: 6.1.7
 - SciPy: 1.15
 - Regions: 0.10
@@ -232,33 +234,37 @@ making it safe to call concurrently from multiple threads. The compiled
 extensions are also declared compatible with free-threaded CPython
 builds, so threads can run the computation truly in parallel.
 
-For example, photometry of many apertures on a large image can be
-parallelized across threads by splitting the source positions into
-chunks::
+The simplest way to use multiple threads is the new ``n_threads``
+keyword of `~photutils.aperture.AperturePhotometry` and
+`~photutils.aperture.ApertureStats`. The aperture positions are divided
+into chunks and processed concurrently, producing results identical to
+the single-threaded computation::
 
-    >>> from concurrent.futures import ThreadPoolExecutor
     >>> import numpy as np
-    >>> from astropy.table import vstack
     >>> from photutils.aperture import (AperturePhotometry,
-    ...                                 CircularAperture)
+    ...                                 ApertureStats, CircularAperture)
     >>> rng = np.random.default_rng(seed=0)
     >>> data = rng.random((4096, 4096))
     >>> positions = rng.uniform(0, 4096, (100_000, 2))
-    >>> n_workers = 10
-    >>> chunks = [CircularAperture(pos, r=5.0)
-    ...           for pos in np.array_split(positions, n_workers)]
-    >>> with ThreadPoolExecutor(max_workers=n_workers) as executor:
-    ...     results = list(executor.map(
-    ...         lambda aper: AperturePhotometry(data, aper), chunks))
-    >>> tables = [result.to_table() for result in results]
-    >>> phot_table = vstack(tables)
-    >>> phot_table['id'] = np.arange(1, len(phot_table) + 1)
+    >>> aperture = CircularAperture(positions, r=5.0)
+    >>> phot = AperturePhotometry(data, aperture, n_threads=8)
+    >>> stats = ApertureStats(data, aperture, n_threads=8)
 
-Note that the ``id`` column of each chunk's table is numbered starting
-from 1, so the last line renumbers the stacked ``id`` column to match
-the input source order. Because ``executor.map`` returns results in
-input order, the stacked table rows are in the same order as the input
-``positions``.
+For more advanced workflows, independent images can also be processed
+concurrently with a thread pool, one instance per frame::
+
+    >>> from concurrent.futures import ThreadPoolExecutor
+    >>> frames = [rng.random((1024, 1024)) for _ in range(8)]
+    >>> aperture = CircularAperture(rng.uniform(0, 1024, (1000, 2)),
+    ...                             r=5.0)
+    >>> with ThreadPoolExecutor(max_workers=8) as executor:
+    ...     results = list(executor.map(
+    ...         lambda frame: AperturePhotometry(frame, aperture),
+    ...         frames))
+    >>> tables = [result.to_table() for result in results]
+
+Because ``executor.map`` returns results in input order, the tables are
+in the same order as the input ``frames``.
 
 
 Multithreaded 2D Background Estimation

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -250,6 +250,14 @@ the single-threaded computation::
     >>> phot = AperturePhotometry(data, aperture, n_threads=8)
     >>> stats = ApertureStats(data, aperture, n_threads=8)
 
+The aperture sums, sigma clipping, and per-source statistic reductions
+(e.g., the sorts, order statistics, robust estimators, and moments)
+all run in the threads, so both classes scale nearly linearly with the
+thread count for large numbers of positions. For the example above,
+measured speedups are ~2x with 2 threads and ~8-10x with 12 threads,
+for the aperture fluxes and sums as well as for statistics such as the
+median, MAD standard deviation, and the biweight estimators.
+
 For more advanced workflows, independent images can also be processed
 concurrently with a thread pool, one instance per frame::
 

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -8,6 +8,7 @@ import inspect
 import re
 import textwrap
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import cached_property
@@ -933,7 +934,8 @@ class PixelAperture(Aperture):
 
     def _batch_photometry(self, data, *, error, mask, method, subpixels,
                           segmentation=None, labels=None,
-                          mask_method='none', mask_nonfinite=False):
+                          mask_method='none', mask_nonfinite=False,
+                          n_threads=1):
         """
         Perform aperture photometry using the batch Cython driver.
 
@@ -962,6 +964,15 @@ class PixelAperture(Aperture):
             where they corrupt the sum (the 3.0.0 behavior, used by the
             legacy `aperture_photometry` function). In both cases, the
             non-finite pixels are flagged as ``non_finite_data``.
+
+        n_threads : int, optional
+            The number of threads to use to compute the aperture sums.
+            When ``n_threads`` > 1, the aperture positions are divided
+            into chunks that are processed concurrently. The per-source
+            results are independent, so they are identical to the
+            single-threaded computation. The per-image preprocessing
+            (e.g., the non-finite mask plane) is computed once and
+            shared read-only across the workers.
 
         Returns
         -------
@@ -1004,12 +1015,37 @@ class PixelAperture(Aperture):
         ext_x, ext_y = self._xy_extents
         off_x, off_y = self._xy_bbox_offset
 
-        sums, sum_var, area, overlap, *_, fcounts = batch_aperture_sums(
-            np.ascontiguousarray(data, dtype=np.float64), error, mask,
-            np.ascontiguousarray(self._positions, dtype=np.float64),
-            shape_code, np.array(params, dtype=np.float64),
-            float(ext_x), float(ext_y), float(off_x), float(off_y),
-            use_exact, subpixels, seg_arr, labels_arr, seg_code)
+        data = np.ascontiguousarray(data, dtype=np.float64)
+        positions = np.ascontiguousarray(self._positions, dtype=np.float64)
+        params = np.array(params, dtype=np.float64)
+
+        def run_sums(pos, src_labels):
+            return batch_aperture_sums(
+                data, error, mask, pos, shape_code, params,
+                float(ext_x), float(ext_y), float(off_x), float(off_y),
+                use_exact, subpixels, seg_arr, src_labels, seg_code)
+
+        n_chunks = min(n_threads, positions.shape[0])
+        if n_chunks > 1:
+            # Row slices of the C-contiguous positions and labels
+            # arrays are themselves C-contiguous, so the chunks can be
+            # passed directly to the Cython driver.
+            pos_chunks = np.array_split(positions, n_chunks)
+            if labels_arr is None:
+                labels_chunks = [None] * n_chunks
+            else:
+                labels_chunks = np.array_split(labels_arr, n_chunks)
+            with ThreadPoolExecutor(max_workers=n_chunks) as executor:
+                results = list(executor.map(run_sums, pos_chunks,
+                                            labels_chunks))
+            sums = np.concatenate([result[0] for result in results])
+            sum_var = np.concatenate([result[1] for result in results])
+            area = np.concatenate([result[2] for result in results])
+            overlap = np.concatenate([result[3] for result in results])
+            fcounts = np.concatenate([result[-1] for result in results])
+        else:
+            sums, sum_var, area, overlap, *_, fcounts = run_sums(
+                positions, labels_arr)
 
         if error is None:
             # Match the mask-based path, which returns an all-NaN error
@@ -1024,7 +1060,7 @@ class PixelAperture(Aperture):
     @_update_method_subpixels_docstring
     def _photometry(self, data, *, error=None, mask=None, method='exact',
                     subpixels=5, segmentation_image=None, labels=None,
-                    mask_method='none', mask_nonfinite=False):
+                    mask_method='none', mask_nonfinite=False, n_threads=1):
         # numpydoc ignore: PR01,PR02,PR04,PR07
         """
         Perform aperture photometry on the input data.
@@ -1057,6 +1093,11 @@ class PixelAperture(Aperture):
             where they corrupt the sum (the 3.0.0 behavior, used by the
             legacy `aperture_photometry` function). In both cases, the
             non-finite pixels are flagged as ``non_finite_data``.
+
+        n_threads : int, optional
+            The number of threads to use to compute the aperture sums
+            on the batch code path (see `_batch_photometry`). The
+            mask-based code path is always serial.
 
         Returns
         -------
@@ -1128,7 +1169,8 @@ class PixelAperture(Aperture):
         result = self._batch_photometry(
             data, error=error, mask=mask, method=method, subpixels=subpixels,
             segmentation=segmentation, labels=labels,
-            mask_method=mask_method, mask_nonfinite=mask_nonfinite)
+            mask_method=mask_method, mask_nonfinite=mask_nonfinite,
+            n_threads=n_threads)
 
         if result is not None:
             flux, flux_err, area, fcounts, overlap = result

--- a/photutils/aperture/core.py
+++ b/photutils/aperture/core.py
@@ -570,10 +570,17 @@ class PixelAperture(Aperture):
         return np.atleast_2d(self.positions)
 
     @cached_property
-    def _bbox(self):
+    def _bbox_bounds(self):
         """
-        The minimal bounding box for the aperture, always as a list of
-        `~photutils.aperture.BoundingBox` instances.
+        The integer bounding-box bounds, as an ``(n_positions, 4)``
+        array of ``(ixmin, ixmax, iymin, iymax)`` values.
+
+        The bounds follow the same pixel-index arithmetic as
+        `BoundingBox.from_float` (upper bounds exclusive), computed
+        vectorized over the positions. Performance-sensitive consumers
+        (e.g., `~photutils.aperture.ApertureStats`) use this array
+        directly so that no per-position `BoundingBox` objects need to
+        be created.
         """
         x_delta, y_delta = self._xy_extents
         off_x, off_y = self._xy_bbox_offset
@@ -582,8 +589,22 @@ class PixelAperture(Aperture):
         ymin = self._positions[:, 1] + off_y - y_delta
         ymax = self._positions[:, 1] + off_y + y_delta
 
-        return [BoundingBox.from_float(x0, x1, y0, y1)
-                for x0, x1, y0, y1 in zip(xmin, xmax, ymin, ymax, strict=True)]
+        bounds = np.empty((self._positions.shape[0], 4), dtype=int)
+        bounds[:, 0] = np.floor(xmin + 0.5)
+        bounds[:, 1] = np.ceil(xmax + 0.5)
+        bounds[:, 2] = np.floor(ymin + 0.5)
+        bounds[:, 3] = np.ceil(ymax + 0.5)
+        return bounds
+
+    @cached_property
+    def _bbox(self):
+        """
+        The minimal bounding box for the aperture, always as a list of
+        `~photutils.aperture.BoundingBox` instances.
+        """
+        return [BoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin,
+                            iymax=iymax)
+                for ixmin, ixmax, iymin, iymax in self._bbox_bounds]
 
     @cached_property
     def bbox(self):

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -115,6 +115,18 @@ class AperturePhotometry:
 
     <segmentation_descriptions>
 
+    n_threads : int, optional
+        The number of threads to use to compute the aperture sums.
+        The default is 1 (no multithreading). When ``n_threads`` > 1,
+        the aperture positions are divided into chunks and processed
+        concurrently. The per-position results are independent, so
+        they are identical to the single-threaded computation. The
+        underlying kernels release the Python global interpreter
+        lock (GIL), so multithreading can significantly speed up the
+        photometry for many aperture positions. Multithreading is
+        used only for apertures supported by the fast batch code
+        path. Otherwise, the computation is serial.
+
     See Also
     --------
     photutils.aperture.ApertureStats : Per-source statistics (e.g.,
@@ -187,11 +199,11 @@ class AperturePhotometry:
         3  9286.709206410273 1.417963080724414
     """
 
-    _repr_params = ('method', 'subpixels', 'mask_method')
+    _repr_params = ('method', 'subpixels', 'mask_method', 'n_threads')
 
     def __init__(self, data, apertures, *, error=None, mask=None, wcs=None,
                  method='exact', subpixels=5, segmentation_image=None,
-                 labels=None, mask_method='none'):
+                 labels=None, mask_method='none', n_threads=1):
 
         if isinstance(data, NDData):
             data, error, mask, wcs = unpack_nddata(data, error, mask, wcs)
@@ -212,6 +224,11 @@ class AperturePhotometry:
         self.method = method
         self.subpixels = subpixels
         self.mask_method = mask_method
+
+        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+            msg = 'n_threads must be a positive integer'
+            raise ValueError(msg)
+        self.n_threads = int(n_threads)
 
         single_aperture = False
         if not isinstance(apertures, (list, tuple, np.ndarray)):
@@ -267,7 +284,8 @@ class AperturePhotometry:
         # Define output table metadata
         self.meta = _get_meta()
         calling_args = (f"method='{method}', subpixels={subpixels}, "
-                        f"mask_method='{mask_method}'")
+                        f"mask_method='{mask_method}', "
+                        f'n_threads={self.n_threads}')
         self.meta['aperture_photometry_args'] = calling_args
         self.meta.update(aper_meta)
 
@@ -330,7 +348,7 @@ class AperturePhotometry:
             method=self.method, subpixels=self.subpixels,
             segmentation_image=self._segmentation,
             labels=self._seg_labels, mask_method=self.mask_method,
-            mask_nonfinite=True)
+            mask_nonfinite=True, n_threads=self.n_threads)
             for aper in self._pixel_apertures]
 
     @cached_property

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -369,7 +369,8 @@ class ApertureStats:
     # index the packed buffer per source and fail or corrupt it.
     _NON_SLICEABLE_CACHES = frozenset({
         '_batch_inputs', '_fast_gather', '_fast_sum', '_sorted_values',
-        '_order_stats', '_mean_var', '_mad', '_biweight', '_gini'})
+        '_order_stats', '_mean_var', '_mad', '_biweight', '_gini',
+        '_fast_cutouts_center'})
 
     def __init__(self, data, aperture, *, error=None, mask=None, wcs=None,
                  sigma_clip=None, sum_method='exact', subpixels=5, ddof=0,
@@ -1691,6 +1692,9 @@ class ApertureStats:
         non-finite ``data`` values, the cutout aperture mask using the
         "center" method, and the sigma-clip mask.
         """
+        fast = self._fast_cutouts_center
+        if fast is not None:
+            return fast[2]
         return list(zip(*self._aperture_cutouts_center, strict=True))[2]
 
     @cached_property
@@ -1703,6 +1707,102 @@ class ApertureStats:
         ``sum_method`` method, and the sigma-clip mask.
         """
         return list(zip(*self._aperture_cutouts, strict=True))[2]
+
+    @cached_property
+    def _fast_cutouts_center(self):
+        """
+        The center-method cutout arrays reconstructed from the packed
+        gather buffers, or `None`.
+
+        Returns a ``(data, variance, mask, weight)`` tuple of
+        per-source cutout lists identical to the mask-based
+        `_aperture_cutouts_center` values. The packed buffer holds
+        exactly the surviving pixels (unmasked, finite, inside the
+        center-method aperture, segmentation-kept, and sigma-clip
+        surviving) together with their cutout coordinates, so the total
+        mask is `True` for every pixel absent from the buffer, and the
+        data, variance, and weight cutouts are zero there (matching
+        the mask-based arrays). Sources whose bounding box does not
+        overlap the data get the same single-NaN sentinel arrays as the
+        mask-based path.
+
+        `None` is returned (and the mask-based path is used) when
+        the fast gather is unavailable or when segmentation neighbor
+        correction is applied: ``mask_method='correct'`` replaces
+        neighbor-pixel data *and error* values with their mirrored
+        values, and the mirrored error values are not recoverable from
+        the packed buffers.
+        """
+        gather = self._fast_gather
+        if gather is None or (self._segmentation is not None
+                              and self.mask_method == 'correct'):
+            return None
+
+        # The kernel's per-source cutout origin is the bounding box
+        # clipped to the data, using the same integer bounds as
+        # ``PixelAperture._bbox_bounds`` (upper bounds exclusive).
+        bounds = self._pixel_aperture._bbox_bounds
+        ny, nx = self._data.shape
+        x0 = np.maximum(bounds[:, 0], 0)
+        x1 = np.minimum(bounds[:, 1], nx)
+        y0 = np.maximum(bounds[:, 2], 0)
+        y1 = np.minimum(bounds[:, 3], ny)
+        overlaps = ((bounds[:, 0] < nx) & (bounds[:, 1] > 0)
+                    & (bounds[:, 2] < ny) & (bounds[:, 3] > 0))
+
+        error = self._error
+        starts, counts = gather.starts, gather.counts
+        values = gather.values
+        local_x, local_y = gather.local_x, gather.local_y
+
+        data_cutouts = []
+        variance_cutouts = []
+        mask_cutouts = []
+        weight_cutouts = []
+        for idx, overlap in enumerate(overlaps):
+            if not overlap:
+                # Match the mask-based no-overlap sentinels
+                data_cutouts.append(np.array([np.nan]))
+                variance_cutouts.append(np.array([np.nan]))
+                mask_cutouts.append(np.array([False]))
+                weight_cutouts.append(np.array([np.nan]))
+                continue
+
+            shape = (y1[idx] - y0[idx], x1[idx] - x0[idx])
+            slc = (slice(y0[idx], y1[idx]), slice(x0[idx], x1[idx]))
+            i0 = starts[idx]
+            i1 = i0 + counts[idx]
+            lx = local_x[i0:i1]
+            ly = local_y[i0:i1]
+
+            data_cutout = np.zeros(shape)
+            data_cutout[ly, lx] = values[i0:i1]
+            if self.sigma_clip is None:
+                # The mask-based path multiplies the data by the
+                # boolean masks, so non-finite pixels are NaN in the
+                # cutout data instead of zero. (With sigma clipping
+                # it instead fills every masked pixel with zero.)
+                data_cutout[~np.isfinite(self._data[slc])] = np.nan
+
+            mask_cutout = np.ones(shape, dtype=bool)
+            mask_cutout[ly, lx] = False
+            weight_cutout = np.zeros(shape)
+            weight_cutout[ly, lx] = 1.0
+            if error is None:
+                variance_cutout = None
+            else:
+                # Multiplying the full variance cutout by the weights
+                # replicates the mask-based arithmetic exactly,
+                # including NaN for masked non-finite error values.
+                variance_cutout = error[slc] ** 2 * weight_cutout
+
+            data_cutouts.append(data_cutout)
+            variance_cutouts.append(variance_cutout)
+            mask_cutouts.append(mask_cutout)
+            weight_cutouts.append(weight_cutout)
+
+        return (data_cutouts, variance_cutouts, mask_cutouts,
+                weight_cutouts)
 
     def _make_masked_array_center(self, array):
         """
@@ -1739,6 +1839,9 @@ class ApertureStats:
         within the aperture, and pixels where the aperture mask has zero
         weight.
         """
+        fast = self._fast_cutouts_center
+        if fast is not None:
+            return self._make_masked_array_center(fast[0])
         return self._make_masked_array_center(
             list(zip(*self._aperture_cutouts_center, strict=True))[0])
 
@@ -1776,6 +1879,9 @@ class ApertureStats:
         """
         if self._error is None:
             return self._null_object
+        fast = self._fast_cutouts_center
+        if fast is not None:
+            return self._make_masked_array_center(fast[1])
         return self._make_masked_array_center(
             list(zip(*self._aperture_cutouts_center, strict=True))[1])
 
@@ -1829,6 +1935,9 @@ class ApertureStats:
         from the input ``mask``, non-finite ``data`` values (NaN and
         inf), and sigma-clipped pixels.
         """
+        fast = self._fast_cutouts_center
+        if fast is not None:
+            return self._make_masked_array_center(fast[3])
         return self._make_masked_array_center(
             list(zip(*self._aperture_cutouts_center, strict=True))[3])
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -256,11 +256,13 @@ class ApertureStats:
 
     n_threads : int, optional
         The number of threads to use to gather the aperture pixel
-        values and compute the aperture sums. The default is 1 (no
-        multithreading). When ``n_threads`` > 1, the aperture positions
-        are divided into chunks and processed concurrently. The
-        per-source results are independent, so they are identical to
-        the single-threaded computation. The underlying kernels release
+        values, compute the aperture sums, and reduce the per-source
+        statistics (e.g., the sorts, order statistics, robust
+        estimators, and moments). The default is 1 (no multithreading).
+        When ``n_threads`` > 1, the aperture positions are divided
+        into chunks and processed concurrently. The per-source
+        results are independent, so they are identical to the
+        single-threaded computation. The underlying kernels release
         the Python global interpreter lock (GIL), so multithreading
         can significantly speed up the statistics for many aperture
         positions. Multithreading is used only on the fast batch code
@@ -1148,6 +1150,70 @@ class ApertureStats:
             overlap=np.concatenate([g.overlap for g in gathers]),
             flag_counts=np.concatenate([g.flag_counts for g in gathers]))
 
+    def _threaded_reduction(self, func, buffers, starts, counts,
+                            per_source=()):
+        """
+        Run a per-source packed-buffer reduction, dividing the sources
+        into chunks that are processed concurrently.
+
+        The kernel is called as ``func(*buffers, starts, counts,
+        *per_source)``. When ``n_threads`` > 1, the sources are
+        divided into contiguous ranges; each worker receives the
+        corresponding packed-buffer regions (with the ``starts``
+        rebased to the region) and per-source array slices, so the
+        kernels run concurrently on disjoint data. The per-chunk
+        outputs are concatenated, making the result identical to the
+        single-chunk call. A kernel returning a packed buffer (e.g.,
+        ``batch_sort_values``) also concatenates correctly because the
+        chunk regions partition the buffer in order.
+
+        Parameters
+        ----------
+        func : callable
+            The reduction kernel.
+
+        buffers : tuple of `~numpy.ndarray`
+            The packed per-pixel buffers (equal lengths), passed as
+            the leading kernel arguments.
+
+        starts, counts : `~numpy.ndarray`
+            The per-source start offsets into the buffers and the
+            per-source pixel counts.
+
+        per_source : tuple of `~numpy.ndarray`, optional
+            Additional per-source arrays, passed as the trailing
+            kernel arguments.
+
+        Returns
+        -------
+        result : `~numpy.ndarray` or tuple of `~numpy.ndarray`
+            The kernel output(s), concatenated over the chunks.
+        """
+        n_src = len(counts)
+        n_chunks = min(self.n_threads, n_src)
+        if n_chunks <= 1:  # 0 for empty positions
+            return func(*buffers, starts, counts, *per_source)
+
+        buffer_len = len(buffers[0])
+        src_edges = np.arange(n_chunks + 1) * n_src // n_chunks
+
+        def reduce_chunk(i0, i1):
+            buf0 = starts[i0]
+            buf1 = starts[i1] if i1 < n_src else buffer_len
+            chunk_buffers = [buffer[buf0:buf1] for buffer in buffers]
+            return func(*chunk_buffers, starts[i0:i1] - buf0,
+                        counts[i0:i1],
+                        *[arr[i0:i1] for arr in per_source])
+
+        with ThreadPoolExecutor(max_workers=n_chunks) as executor:
+            results = list(executor.map(reduce_chunk, src_edges[:-1],
+                                        src_edges[1:]))
+
+        if isinstance(results[0], tuple):
+            return tuple(np.concatenate(parts)
+                         for parts in zip(*results, strict=True))
+        return np.concatenate(results)
+
     def _fast_clip_spec(self):
         """
         The fast sigma-clip parameters, or `None`.
@@ -1232,6 +1298,9 @@ class ApertureStats:
         kernel are reused directly (the clipping already sorts each
         source's values to compute the clip bounds). `None` is returned
         when the fast path is unavailable.
+
+        When ``n_threads`` > 1, the per-source sorts run concurrently
+        (see `_threaded_reduction`).
         """
         gather = self._fast_gather
         if gather is None:
@@ -1239,7 +1308,9 @@ class ApertureStats:
         values, starts, counts = gather.values, gather.starts, gather.counts
         if gather.sorted_values is not None:
             return (gather.sorted_values, starts, counts)
-        return (batch_sort_values(values, starts, counts), starts, counts)
+        sorted_values = self._threaded_reduction(
+            batch_sort_values, (values,), starts, counts)
+        return (sorted_values, starts, counts)
 
     @cached_property
     def _order_stats(self):
@@ -1252,7 +1323,9 @@ class ApertureStats:
         sorted_values = self._sorted_values
         if sorted_values is None:
             return None
-        return batch_order_stats(*sorted_values)
+        values, starts, counts = sorted_values
+        return self._threaded_reduction(batch_order_stats, (values,),
+                                        starts, counts)
 
     @cached_property
     def _mean_var(self):
@@ -1266,7 +1339,8 @@ class ApertureStats:
         gather = self._fast_gather
         if gather is None:
             return None
-        return batch_mean_var(gather.values, gather.starts, gather.counts)
+        return self._threaded_reduction(batch_mean_var, (gather.values,),
+                                        gather.starts, gather.counts)
 
     @cached_property
     def _mad(self):
@@ -1279,7 +1353,8 @@ class ApertureStats:
         sorted_values = self._sorted_values
         if sorted_values is None:
             return None
-        return batch_mad(*sorted_values)
+        values, starts, counts = sorted_values
+        return self._threaded_reduction(batch_mad, (values,), starts, counts)
 
     @cached_property
     def _biweight(self):
@@ -1295,7 +1370,10 @@ class ApertureStats:
         if sorted_values is None:
             return None
         _, _, median = self._order_stats
-        return batch_biweight(*sorted_values, median, self._mad)
+        values, starts, counts = sorted_values
+        return self._threaded_reduction(batch_biweight, (values,),
+                                        starts, counts,
+                                        per_source=(median, self._mad))
 
     @cached_property
     def _gini(self):
@@ -1308,7 +1386,8 @@ class ApertureStats:
         gather = self._fast_gather
         if gather is None:
             return None
-        return batch_gini(gather.values, gather.starts, gather.counts)
+        return self._threaded_reduction(batch_gini, (gather.values,),
+                                        gather.starts, gather.counts)
 
     def _finalize_value_stat(self, fast_result, stat_func, *,
                              square_unit=False, apply_unit=True):
@@ -2115,9 +2194,10 @@ class ApertureStats:
         if gather is not None:
             overlap = gather.overlap
             zeros = np.zeros(self.n_positions)
-            mom = batch_moments(gather.values, gather.local_x,
-                                gather.local_y, gather.starts,
-                                gather.counts, zeros, zeros)
+            mom = self._threaded_reduction(
+                batch_moments,
+                (gather.values, gather.local_x, gather.local_y),
+                gather.starts, gather.counts, per_source=(zeros, zeros))
             # No-overlap sources have NaN moments (the mask-based path
             # uses an all-NaN cutout); all-masked overlapping sources
             # have zero moments (an all-zero cutout).
@@ -2139,9 +2219,10 @@ class ApertureStats:
         if gather is not None:
             cen_x = np.ascontiguousarray(cutout_centroid[:, 0])
             cen_y = np.ascontiguousarray(cutout_centroid[:, 1])
-            mom = batch_moments(gather.values, gather.local_x,
-                                gather.local_y, gather.starts,
-                                gather.counts, cen_x, cen_y)
+            mom = self._threaded_reduction(
+                batch_moments,
+                (gather.values, gather.local_x, gather.local_y),
+                gather.starts, gather.counts, per_source=(cen_x, cen_y))
             # Empty sources (no overlap or fully masked) have a NaN
             # centroid, so their central moments are NaN (matching the
             # mask-based path).

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -41,7 +41,7 @@ from photutils.aperture._common import (SCALAR_COLLAPSE_TYPES,
                                         validate_array, validate_mask_method)
 from photutils.aperture._segmentation import (make_segmentation_exclusion,
                                               process_segmentation_inputs)
-from photutils.aperture.core import (_aperture_metadata,
+from photutils.aperture.core import (PixelAperture, _aperture_metadata,
                                      _update_method_subpixels_docstring)
 from photutils.aperture.flags import (APERTURE_FLAGS, _counts_to_flag_bits,
                                       decode_aperture_flags)
@@ -2337,8 +2337,20 @@ class ApertureStats:
     @cached_property
     def _bbox_bounds(self):
         """
-        The bounding box x and y minimum and maximum bounds.
+        The bounding box x and y minimum and maximum (inclusive)
+        bounds, as an ``(n_positions, 4)`` array.
+
+        When the aperture uses the default ``bbox`` implementation,
+        the bounds are taken from the aperture's vectorized integer
+        bounds, so no per-position `~photutils.aperture.BoundingBox`
+        objects are created. An aperture subclass that overrides
+        ``bbox`` falls back to reading the per-position objects.
         """
+        aper = self._pixel_aperture
+        if type(aper).bbox is PixelAperture.bbox:
+            # Convert the exclusive upper bounds to inclusive
+            return aper._bbox_bounds - [0, 1, 0, 1]
+
         bbox = self._array('bbox')
         # The reshape preserves the (n_positions, 4) shape when there
         # are zero positions

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -5,6 +5,7 @@ Tools for calculating properties of sources defined by an Aperture.
 
 import inspect
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from copy import copy, deepcopy
 from functools import cached_property
 from typing import NamedTuple
@@ -253,6 +254,18 @@ class ApertureStats:
 
     <segmentation_descriptions>
 
+    n_threads : int, optional
+        The number of threads to use to gather the aperture pixel
+        values and compute the aperture sums. The default is 1 (no
+        multithreading). When ``n_threads`` > 1, the aperture positions
+        are divided into chunks and processed concurrently. The
+        per-source results are independent, so they are identical to
+        the single-threaded computation. The underlying kernels release
+        the Python global interpreter lock (GIL), so multithreading
+        can significantly speed up the statistics for many aperture
+        positions. Multithreading is used only on the fast batch code
+        path. Otherwise, the computation is serial.
+
     Notes
     -----
     ``data`` should be background-subtracted for accurate source
@@ -359,7 +372,7 @@ class ApertureStats:
     def __init__(self, data, aperture, *, error=None, mask=None, wcs=None,
                  sigma_clip=None, sum_method='exact', subpixels=5, ddof=0,
                  local_bkg=None, segmentation_image=None, labels=None,
-                 mask_method='none'):
+                 mask_method='none', n_threads=1):
 
         if isinstance(data, NDData):
             data, error, mask, wcs = unpack_nddata(data, error, mask, wcs)
@@ -406,6 +419,11 @@ class ApertureStats:
             msg = 'ddof must be a non-negative integer'
             raise ValueError(msg)
         self.ddof = ddof
+
+        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+            msg = 'n_threads must be a positive integer'
+            raise ValueError(msg)
+        self.n_threads = int(n_threads)
 
         self._local_bkg = np.zeros(self.n_positions)  # no local bkg
         if local_bkg is not None:
@@ -511,8 +529,8 @@ class ApertureStats:
         # new class
         init_attr = ('_data', '_data_unit', '_error', '_mask', '_wcs',
                      'sigma_clip', 'sum_method', 'subpixels', 'ddof',
-                     'default_columns', 'meta', '_segmentation',
-                     'segmentation_image', 'mask_method')
+                     'n_threads', 'default_columns', 'meta',
+                     '_segmentation', 'segmentation_image', 'mask_method')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
 
@@ -956,6 +974,10 @@ class ApertureStats:
         (``values``, ``local_x``, ``local_y``, ``starts``, ``counts``),
         ``overlap``, and ``flag_counts`` populated. The ``sum_method``
         fields are `None`.
+
+        When ``n_threads`` > 1, the positions are divided into chunks
+        that are gathered (and sigma clipped) concurrently and then
+        merged (see `_merge_center_gathers`).
         """
         inputs = self._batch_inputs
         if inputs is None:
@@ -964,17 +986,26 @@ class ApertureStats:
          off_x, off_y, _sum_use_exact, _sum_subpixels, local_bkg, seg_arr,
          labels_arr, seg_code, clip_spec) = inputs
 
-        (values, lx, ly, starts, counts, overlap,
-         flag_counts) = batch_aperture_gather(
-            data, mask, positions, shape_code, params, ext_x, ext_y,
-            off_x, off_y, local_bkg, seg_arr, labels_arr, seg_code)
-        gather = _BatchGather(values=values, local_x=lx, local_y=ly,
-                              starts=starts, counts=counts, overlap=overlap,
-                              flag_counts=flag_counts)
+        def gather_chunk(pos, bkg, labels):
+            (values, lx, ly, starts, counts, overlap,
+             flag_counts) = batch_aperture_gather(
+                data, mask, pos, shape_code, params, ext_x, ext_y,
+                off_x, off_y, bkg, seg_arr, labels, seg_code)
+            gather = _BatchGather(values=values, local_x=lx, local_y=ly,
+                                  starts=starts, counts=counts,
+                                  overlap=overlap, flag_counts=flag_counts)
 
-        if clip_spec is not None:
-            gather = self._apply_center_clip(gather, clip_spec)
-        return gather
+            if clip_spec is not None:
+                gather = self._apply_center_clip(gather, clip_spec)
+            return gather
+
+        chunks = self._batch_chunks(positions, local_bkg, labels_arr)
+        if chunks is None:
+            return gather_chunk(positions, local_bkg, labels_arr)
+
+        with ThreadPoolExecutor(max_workers=len(chunks[0])) as executor:
+            gathers = list(executor.map(gather_chunk, *chunks))
+        return self._merge_center_gathers(gathers)
 
     @cached_property
     def _fast_sum(self):
@@ -999,6 +1030,11 @@ class ApertureStats:
         ``var_aper``, ``sum_area``, ``starts``, ``overlap``, and
         ``flag_counts`` fields populated. The center-value fields are
         `None`.
+
+        When ``n_threads`` > 1, the positions are divided into chunks
+        that are computed (and sigma clipped) concurrently and then
+        merged. The merged result keeps only the flat per-source outputs
+        (see `_merge_sum_gathers`).
         """
         inputs = self._batch_inputs
         if inputs is None:
@@ -1008,20 +1044,109 @@ class ApertureStats:
          labels_arr, seg_code, clip_spec) = inputs
 
         emit_sum = 1 if clip_spec is not None else 0
-        (sums, sum_var, area, overlap, starts, sum_values, sum_fracs,
-         sum_errsq, scounts, flag_counts) = batch_aperture_sums(
-            data, error, mask, positions, shape_code, params, ext_x, ext_y,
-            off_x, off_y, sum_use_exact, sum_subpixels, seg_arr, labels_arr,
-            seg_code, local_bkg, emit_sum)
-        gather = _BatchGather(starts=starts, sum_aper=sums, var_aper=sum_var,
-                              sum_area=area, overlap=overlap,
-                              sum_values=sum_values, sum_fracs=sum_fracs,
-                              sum_errsq=sum_errsq, sum_counts=scounts,
-                              flag_counts=flag_counts)
 
-        if clip_spec is not None:
-            gather = self._apply_sum_clip(gather, clip_spec)
-        return gather
+        def sum_chunk(pos, bkg, labels):
+            (sums, sum_var, area, overlap, starts, sum_values, sum_fracs,
+             sum_errsq, scounts, flag_counts) = batch_aperture_sums(
+                data, error, mask, pos, shape_code, params, ext_x, ext_y,
+                off_x, off_y, sum_use_exact, sum_subpixels, seg_arr,
+                labels, seg_code, bkg, emit_sum)
+            gather = _BatchGather(starts=starts, sum_aper=sums,
+                                  var_aper=sum_var, sum_area=area,
+                                  overlap=overlap, sum_values=sum_values,
+                                  sum_fracs=sum_fracs, sum_errsq=sum_errsq,
+                                  sum_counts=scounts,
+                                  flag_counts=flag_counts)
+
+            if clip_spec is not None:
+                gather = self._apply_sum_clip(gather, clip_spec)
+            return gather
+
+        chunks = self._batch_chunks(positions, local_bkg, labels_arr)
+        if chunks is None:
+            return sum_chunk(positions, local_bkg, labels_arr)
+
+        with ThreadPoolExecutor(max_workers=len(chunks[0])) as executor:
+            gathers = list(executor.map(sum_chunk, *chunks))
+        return self._merge_sum_gathers(gathers)
+
+    def _batch_chunks(self, positions, local_bkg, labels_arr):
+        """
+        Split the per-source batch-driver inputs into per-thread chunks,
+        or return `None` for a single-chunk (serial) computation.
+
+        The number of chunks is ``min(n_threads, n_sources)``. Row
+        slices of the C-contiguous input arrays are themselves
+        C-contiguous, so the chunks can be passed directly to the Cython
+        drivers.
+
+        Returns
+        -------
+        chunks : tuple of list or `None`
+            A ``(positions, local_bkg, labels)`` tuple of per-chunk
+            lists, or `None` when only one chunk would be used.
+        """
+        n_chunks = min(self.n_threads, positions.shape[0])
+        if n_chunks <= 1:  # 0 for empty positions
+            return None
+        pos_chunks = np.array_split(positions, n_chunks)
+        bkg_chunks = np.array_split(local_bkg, n_chunks)
+        if labels_arr is None:
+            labels_chunks = [None] * n_chunks
+        else:
+            labels_chunks = np.array_split(labels_arr, n_chunks)
+        return pos_chunks, bkg_chunks, labels_chunks
+
+    @staticmethod
+    def _merge_center_gathers(gathers):
+        """
+        Merge per-chunk center-value gathers into a single
+        `_BatchGather` equivalent to a single-chunk gather.
+
+        The packed buffers (``values``, ``local_x``, ``local_y``, and
+        ``sorted_values`` when sigma clipping is applied) and the
+        per-source arrays are concatenated. The per-source ``starts``
+        are offset by the cumulative packed-buffer length of the
+        preceding chunks.
+        """
+        starts = []
+        offset = 0
+        for gather in gathers:
+            starts.append(gather.starts + offset)
+            offset += gather.values.shape[0]
+
+        sorted_values = None
+        if gathers[0].sorted_values is not None:
+            sorted_values = np.concatenate(
+                [gather.sorted_values for gather in gathers])
+
+        return _BatchGather(
+            values=np.concatenate([g.values for g in gathers]),
+            local_x=np.concatenate([g.local_x for g in gathers]),
+            local_y=np.concatenate([g.local_y for g in gathers]),
+            starts=np.concatenate(starts),
+            counts=np.concatenate([g.counts for g in gathers]),
+            overlap=np.concatenate([g.overlap for g in gathers]),
+            flag_counts=np.concatenate([g.flag_counts for g in gathers]),
+            sorted_values=sorted_values)
+
+    @staticmethod
+    def _merge_sum_gathers(gathers):
+        """
+        Merge per-chunk ``sum_method`` gathers into a single
+        `_BatchGather`.
+
+        Only the flat per-source outputs are kept. The packed member
+        buffers and their ``starts`` are dropped (`None`). They are
+        consumed within each chunk (by the sigma clipping) and no
+        downstream consumer reads them from the merged result.
+        """
+        return _BatchGather(
+            sum_aper=np.concatenate([g.sum_aper for g in gathers]),
+            var_aper=np.concatenate([g.var_aper for g in gathers]),
+            sum_area=np.concatenate([g.sum_area for g in gathers]),
+            overlap=np.concatenate([g.overlap for g in gathers]),
+            flag_counts=np.concatenate([g.flag_counts for g in gathers]))
 
     def _fast_clip_spec(self):
         """

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -1111,6 +1111,17 @@ class TestNThreads:
         phot = AperturePhotometry(data, aper, n_threads=4)
         assert_allclose(phot.flux, ref.flux, equal_nan=True)
 
+    def test_empty_positions(self):
+        """
+        Test that an aperture with zero positions works with n_threads >
+        1 (zero chunks must fall back to the serial path).
+        """
+        data = np.ones((11, 11))
+        aper = CircularAperture(np.empty((0, 2)), r=3.0)
+        phot = AperturePhotometry(data, aper, n_threads=4)
+        assert phot.n_positions == 0
+        assert phot.flux.shape == (0,)
+
     def test_invalid_n_threads(self):
         """
         Test that an error is raised if n_threads is not a positive

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -1000,3 +1000,137 @@ class TestRegionInput:
         phot = AperturePhotometry(data, region)
         ref = AperturePhotometry(data, aper)
         assert_allclose(phot.flux, ref.flux)
+
+
+class TestNThreads:
+    """
+    Tests for the n_threads keyword.
+    """
+
+    @staticmethod
+    def make_inputs():
+        """
+        Build a deterministic image (with non-finite values), error,
+        mask, and positions (including off-edge positions).
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(100.0, 5.0, (120, 130))
+        data[3, 3] = np.nan
+        data[50, 50] = np.inf
+        error = np.abs(rng.normal(5.0, 0.5, data.shape)) + 0.1
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[60:65, 85:90] = True
+        positions = np.column_stack(
+            [rng.uniform(-5, data.shape[1] + 5, 57),
+             rng.uniform(-5, data.shape[0] + 5, 57)])
+        return data, error, mask, positions
+
+    @pytest.mark.parametrize('n_threads', [2, 8])
+    def test_identical_results(self, n_threads):
+        """
+        Test that multithreaded photometry gives results identical to
+        the single-threaded computation, including for off-edge
+        positions, masked pixels, and non-finite data values.
+        """
+        data, error, mask, positions = self.make_inputs()
+        aper = CircularAperture(positions, r=7.0)
+        phot1 = AperturePhotometry(data, aper, error=error, mask=mask)
+        phot2 = AperturePhotometry(data, aper, error=error, mask=mask,
+                                   n_threads=n_threads)
+        assert phot2.n_threads == n_threads
+        assert_equal(phot1.flux, phot2.flux)
+        assert_equal(phot1.flux_err, phot2.flux_err)
+        assert_equal(phot1.area, phot2.area)
+        assert_equal(phot1.flags, phot2.flags)
+
+    def test_more_threads_than_positions(self):
+        """
+        Test that n_threads larger than the number of positions gives
+        identical results.
+        """
+        data = np.ones((40, 40))
+        aper = CircularAperture([(20, 20), (10, 10), (30, 25)], r=5.0)
+        phot1 = AperturePhotometry(data, aper)
+        phot2 = AperturePhotometry(data, aper, n_threads=8)
+        assert_equal(phot1.flux, phot2.flux)
+        assert_equal(phot1.flags, phot2.flags)
+
+    def test_scalar_position(self):
+        """
+        Test that a scalar aperture position with n_threads > 1 falls
+        back to a single-chunk (serial) computation.
+        """
+        data = np.ones((40, 40))
+        aper = CircularAperture((20, 20), r=5.0)
+        phot1 = AperturePhotometry(data, aper)
+        phot2 = AperturePhotometry(data, aper, n_threads=4)
+        assert_equal(phot1.flux, phot2.flux)
+
+    def test_aperture_list(self):
+        """
+        Test multithreading with a list of input apertures.
+        """
+        data, error, mask, positions = self.make_inputs()
+        apers = [CircularAperture(positions, r=r) for r in (3.0, 7.0)]
+        phot1 = AperturePhotometry(data, apers, error=error, mask=mask)
+        phot2 = AperturePhotometry(data, apers, error=error, mask=mask,
+                                   n_threads=4)
+        assert_equal(phot1.flux, phot2.flux)
+        assert_equal(phot1.flux_err, phot2.flux_err)
+        assert_equal(phot1.area, phot2.area)
+        assert_equal(phot1.flags, phot2.flags)
+
+    def test_segmentation_masking(self):
+        """
+        Test that per-source segmentation labels are chunked together
+        with the positions.
+        """
+        data, segm = make_scene()
+        positions = [(21.0, 21.0), (28.0, 22.0), (21.0, 21.5),
+                     (28.5, 22.0), (20.5, 21.0)]
+        labels = [1, 2, 1, 2, 1]
+        aper = CircularAperture(positions, r=8.0)
+        phot1 = AperturePhotometry(data, aper, segmentation_image=segm,
+                                   labels=labels, mask_method='mask')
+        phot2 = AperturePhotometry(data, aper, segmentation_image=segm,
+                                   labels=labels, mask_method='mask',
+                                   n_threads=3)
+        assert_equal(phot1.flux, phot2.flux)
+        assert_equal(phot1.area, phot2.area)
+        assert_equal(phot1.flags, phot2.flags)
+
+    def test_mask_based_fallback(self):
+        """
+        Test that apertures that do not support the batch code path
+        give correct results with n_threads > 1 (the mask-based code
+        path stays serial).
+        """
+        data, _, _, positions = self.make_inputs()
+        aper = NoBatchCircularAperture(positions, r=7.0)
+        ref = AperturePhotometry(data, CircularAperture(positions, r=7.0))
+        phot = AperturePhotometry(data, aper, n_threads=4)
+        assert_allclose(phot.flux, ref.flux, equal_nan=True)
+
+    def test_invalid_n_threads(self):
+        """
+        Test that an error is raised if n_threads is not a positive
+        integer.
+        """
+        data = np.ones((40, 40))
+        aper = CircularAperture((20, 20), r=5.0)
+        match = 'n_threads must be a positive integer'
+        for n_threads in (0, -1, 2.5):
+            with pytest.raises(ValueError, match=match):
+                AperturePhotometry(data, aper, n_threads=n_threads)
+
+    def test_repr_and_meta(self):
+        """
+        Test that n_threads appears in the repr and in the table
+        metadata calling arguments.
+        """
+        data = np.ones((40, 40))
+        aper = CircularAperture((20, 20), r=5.0)
+        phot = AperturePhotometry(data, aper, n_threads=4)
+        assert 'n_threads=4' in repr(phot)
+        assert 'n_threads=4' in phot.to_table().meta[
+            'aperture_photometry_args']

--- a/photutils/aperture/tests/test_polygon.py
+++ b/photutils/aperture/tests/test_polygon.py
@@ -360,21 +360,27 @@ class TestPolygonValidation:
         assert _signed_polygon_area(out) > 0
 
     def test_rejects_wrong_shape(self):
-        with pytest.raises(ValueError, match='must have shape'):
+        match = r"'vertex_offsets' must have shape \(n_vertices, 2\)"
+        with pytest.raises(ValueError, match=match):
             _validate_simple_polygon(np.array([1.0, 2.0, 3.0]))
 
     def test_rejects_too_few(self):
-        with pytest.raises(ValueError, match='at least 3 vertices'):
+        match = ("'vertex_offsets' must define a polygon with at "
+                 'least 3 vertices')
+        with pytest.raises(ValueError, match=match):
             _validate_simple_polygon(np.array([[0.0, 0.0], [1.0, 0.0]]))
 
     def test_rejects_nonfinite(self):
         bad = np.array([[0.0, 0.0], [np.nan, 0.0], [1.0, 1.0]])
-        with pytest.raises(ValueError, match='non-finite'):
+        match = "'vertex_offsets' must not contain any non-finite values"
+        with pytest.raises(ValueError, match=match):
             _validate_simple_polygon(bad)
 
     def test_rejects_collinear(self):
         bad = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
-        with pytest.raises(ValueError, match='degenerate'):
+        match = ("'vertex_offsets' defines a degenerate polygon with "
+                 r'zero area \(vertices are collinear or coincident\)')
+        with pytest.raises(ValueError, match=match):
             _validate_simple_polygon(bad)
 
     def test_accepts_nonconvex(self):
@@ -387,16 +393,22 @@ class TestPolygonValidation:
         assert out.shape == arrow.shape
 
     def test_rejects_self_intersecting(self):
-        with pytest.raises(ValueError, match='self-intersect'):
+        match = ("'vertex_offsets' must define a simple polygon, but "
+                 'its edges self-intersect')
+        with pytest.raises(ValueError, match=match):
             _validate_simple_polygon(_pentagram())
 
     def test_pixel_aperture_rejects_self_intersecting(self):
-        with pytest.raises(ValueError, match='self-intersect'):
+        match = ("'vertex_offsets' must define a simple polygon, but "
+                 'its edges self-intersect')
+        with pytest.raises(ValueError, match=match):
             PolygonAperture((0.0, 0.0), _pentagram())
 
     def test_sky_aperture_rejects_self_intersecting(self):
         pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-        with pytest.raises(ValueError, match='self-intersect'):
+        match = ("'vertex_offsets' must define a simple polygon, but "
+                 'its edges self-intersect')
+        with pytest.raises(ValueError, match=match):
             SkyPolygonAperture(pos, _pentagram() * u.arcsec)
 
     def test_pixel_aperture_accepts_concave_star(self):
@@ -438,13 +450,14 @@ class TestPolygonConstruction:
         assert _signed_polygon_area(aper.vertex_offsets) > 0
 
     def test_invalid_vertex_offsets_quantity_raises(self):
-        match = 'must not be a Quantity'
+        match = "'vertex_offsets' must not be a Quantity"
         with pytest.raises(TypeError, match=match):
             PolygonAperture((0, 0), SQUARE_OFFSETS * u.pix)
 
     def test_invalid_vertex_offsets_nonfinite_raises(self):
         bad = np.array([[0.0, 0.0], [np.nan, 1.0], [1.0, 0.0]])
-        with pytest.raises(ValueError, match='non-finite'):
+        match = "'vertex_offsets' must not contain any non-finite values"
+        with pytest.raises(ValueError, match=match):
             PolygonAperture((0, 0), bad)
 
     def test_accepts_nonconvex(self):
@@ -460,12 +473,14 @@ class TestPolygonConstruction:
         assert_allclose(mask.data.sum(), 12.0, atol=1e-12)
 
     def test_invalid_vertex_offsets_too_few_raises(self):
-        match = 'at least 3 vertices'
+        match = ("'vertex_offsets' must define a polygon with at "
+                 'least 3 vertices')
         with pytest.raises(ValueError, match=match):
             PolygonAperture((0, 0), [[0.0, 0.0], [1.0, 1.0]])
 
     def test_invalid_vertex_offsets_unparseable(self):
-        match = 'must be convertible to a numeric'
+        match = ("'vertex_offsets' must be convertible to a numeric "
+                 r'\(n_vertices, 2\) array')
         with pytest.raises(TypeError, match=match):
             PolygonAperture((0, 0), [['a', 'b'], ['c', 'd'], ['e', 'f']])
 
@@ -475,7 +490,7 @@ class TestPolygonConstruction:
         assert_allclose(aper.vertices, verts)
 
     def test_from_vertices_invalid_shape(self):
-        match = 'vertices must have shape'
+        match = r'vertices must have shape \(n_vertices, 2\)'
         with pytest.raises(ValueError, match=match):
             PolygonAperture.from_vertices(np.array([1.0, 2.0]))
 
@@ -487,7 +502,8 @@ class TestPolygonConstruction:
         rather than a ZeroDivisionError from the area-weighted centroid
         computation.
         """
-        match = 'degenerate'
+        match = ("'vertices' defines a degenerate polygon with zero "
+                 r'area \(vertices are collinear or coincident\)')
         with pytest.raises(ValueError, match=match):
             PolygonAperture.from_vertices([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
 
@@ -617,7 +633,7 @@ class TestPolygonMasks:
 
     def test_invalid_mask_method(self):
         aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
-        match = 'Invalid mask method'
+        match = "Invalid mask method: 'nonsense'"
         with pytest.raises(ValueError, match=match):
             aper.to_mask(method='nonsense')
 
@@ -763,10 +779,10 @@ class TestPolygonIndexing:
 
     def test_indexing_scalar_raises(self):
         aper = PolygonAperture((0.0, 0.0), SQUARE_OFFSETS)
-        match = 'cannot be indexed'
+        match = "A scalar 'PolygonAperture' object cannot be indexed"
         with pytest.raises(TypeError, match=match):
             aper[0]
-        match = 'no len'
+        match = r"A scalar 'PolygonAperture' object has no len\(\)"
         with pytest.raises(TypeError, match=match):
             len(aper)
 
@@ -819,15 +835,17 @@ class TestRegularPolygon:
                         (-np.sqrt(2) / 2, np.sqrt(2) / 2), atol=1e-12)
 
     def test_invalid_n_vertices(self):
-        with pytest.raises(ValueError, match='at least 3'):
+        match = 'n_vertices must be at least 3, got 2'
+        with pytest.raises(ValueError, match=match):
             PolygonAperture.from_regular_polygon((0.0, 0.0), 2, 1.0)
 
     def test_invalid_radius(self):
-        with pytest.raises(ValueError, match='positive'):
+        match = 'radius must be a finite positive number'
+        with pytest.raises(ValueError, match=match):
             PolygonAperture.from_regular_polygon((0.0, 0.0), 4, 0.0)
-        with pytest.raises(ValueError, match='positive'):
+        with pytest.raises(ValueError, match=match):
             PolygonAperture.from_regular_polygon((0.0, 0.0), 4, -1.0)
-        with pytest.raises(ValueError, match='positive'):
+        with pytest.raises(ValueError, match=match):
             PolygonAperture.from_regular_polygon((0.0, 0.0), 4, np.nan)
 
     def test_is_regular_false_cases(self):
@@ -851,7 +869,9 @@ class TestRegularPolygon:
             np.array([[0.0, 0.0], [4.0, 0.0], [4.0, 3.0]]))
         for attr in ('outer_radius', 'inner_radius', 'side_length',
                      'interior_angle', 'exterior_angle'):
-            with pytest.raises(ValueError, match='regular polygon'):
+            match = (f'{attr!r} is only defined for a regular polygon '
+                     'aperture')
+            with pytest.raises(ValueError, match=match):
                 getattr(aper, attr)
 
     def test_n_vertices(self):
@@ -882,17 +902,19 @@ class TestRegularPolygon:
         """
         xypos = (5, 5)
 
-        match = 'must be at least 2'
+        match = 'n_spikes must be at least 2, got 1'
         with pytest.raises(ValueError, match=match):
             PolygonAperture._from_star(xypos, 1, 5.0, inner_radius=2.0)
 
-        match = 'must be a finite positive number'
+        match = 'outer_radius must be a finite positive number, got -2.0'
         with pytest.raises(ValueError, match=match):
             PolygonAperture._from_star(xypos, 5, -2.0, inner_radius=2.0)
+        match = 'inner_radius must be a finite positive number, got -2.0'
         with pytest.raises(ValueError, match=match):
             PolygonAperture._from_star(xypos, 5, 5.0, inner_radius=-2.0)
 
-        match = 'inner_radius must be less than outer_radius'
+        match = (r'inner_radius must be less than outer_radius '
+                 r'\(6.0 >= 5.0\)')
         with pytest.raises(ValueError, match=match):
             PolygonAperture._from_star(xypos, 5, 5.0, inner_radius=6.0)
 
@@ -902,12 +924,13 @@ class TestRegularPolygon:
                                        optimal_shape=True,
                                        collinear_edges=True)
 
-        match = 'collinear_edges requires n_spikes'
+        match = 'collinear_edges requires n_spikes >= 5, got 4'
         with pytest.raises(ValueError, match=match):
             PolygonAperture._from_star(xypos, 4, 3.0, inner_radius=2.0,
                                        collinear_edges=True)
 
-        match = 'inner_radius must be provided'
+        match = ('inner_radius must be provided if both optimal_shape '
+                 'and collinear_edges are False')
         with pytest.raises(ValueError, match=match):
             PolygonAperture._from_star(xypos, 5, 3.0)
 
@@ -951,24 +974,26 @@ class TestSkyPolygonConstruction:
 
     def test_offsets_not_quantity(self):
         pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-        match = 'angular Quantity'
+        match = ("'vertex_offsets' must be an angular Quantity with "
+                 r'shape \(n_vertices, 2\)')
         with pytest.raises(TypeError, match=match):
             SkyPolygonAperture(pos, TRIANGLE_OFFSETS)
 
     def test_offsets_wrong_unit(self):
         pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-        match = 'angular units'
+        match = "'vertex_offsets' must have angular units"
         with pytest.raises(u.UnitsError, match=match):
             SkyPolygonAperture(pos, TRIANGLE_OFFSETS * u.m)
 
     def test_offsets_wrong_shape(self):
         pos = SkyCoord(ra=180.0, dec=0.0, unit='deg')
-        match = 'shape'
+        match = r"'vertex_offsets' must have shape \(n_vertices, 2\)"
         with pytest.raises(ValueError, match=match):
             SkyPolygonAperture(pos, TRIANGLE_OFFSETS.flatten() * u.arcsec)
 
     def test_invalid_positions(self):
-        with pytest.raises(TypeError, match='SkyCoord'):
+        match = "'positions' must be a SkyCoord instance"
+        with pytest.raises(TypeError, match=match):
             SkyPolygonAperture((1.0, 2.0), TRIANGLE_OFFSETS * u.arcsec)
 
     def test_vertices_scalar(self):
@@ -992,7 +1017,8 @@ class TestSkyPolygonConstruction:
                                  atol=1e-9 * u.deg)
 
     def test_from_vertices_requires_skycoord(self):
-        with pytest.raises(TypeError, match='SkyCoord'):
+        match = 'vertices must be a 1-D SkyCoord with at least 3 vertices'
+        with pytest.raises(TypeError, match=match):
             SkyPolygonAperture.from_vertices(np.array([[0.0, 0.0], [1.0, 0.0],
                                                        [1.0, 1.0]]))
 
@@ -1051,27 +1077,31 @@ class TestSkyRegularPolygon:
 
     def test_invalid_n_vertices(self):
         pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-        with pytest.raises(ValueError, match='at least 3'):
+        match = 'n_vertices must be at least 3, got 2'
+        with pytest.raises(ValueError, match=match):
             SkyPolygonAperture.from_regular_polygon(pos, 2, 1.0 * u.arcsec)
 
     def test_invalid_radius(self):
         pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-        with pytest.raises(TypeError, match='angular Quantity'):
+        match = 'radius must be an angular Quantity'
+        with pytest.raises(TypeError, match=match):
             SkyPolygonAperture.from_regular_polygon(pos, 4, 1.0)
-        with pytest.raises(TypeError, match='angular Quantity'):
+        with pytest.raises(TypeError, match=match):
             SkyPolygonAperture.from_regular_polygon(pos, 4, 1.0 * u.kg)
-        with pytest.raises(ValueError, match='positive'):
+        match = 'radius must be a finite positive Quantity'
+        with pytest.raises(ValueError, match=match):
             SkyPolygonAperture.from_regular_polygon(pos, 4, 0.0 * u.arcsec)
-        with pytest.raises(ValueError, match='positive'):
+        with pytest.raises(ValueError, match=match):
             SkyPolygonAperture.from_regular_polygon(pos, 4, -1.0 * u.arcsec)
 
     def test_invalid_angle(self):
         pos = SkyCoord(ra=10.0 * u.deg, dec=30.0 * u.deg)
-        with pytest.raises(TypeError, match='angular Quantity'):
+        match = 'theta must be an angular Quantity'
+        with pytest.raises(TypeError, match=match):
             SkyPolygonAperture.from_regular_polygon(pos, 4,
                                                     1.0 * u.arcsec,
                                                     theta=0.5)
-        with pytest.raises(TypeError, match='angular Quantity'):
+        with pytest.raises(TypeError, match=match):
             SkyPolygonAperture.from_regular_polygon(pos, 4,
                                                     1.0 * u.arcsec,
                                                     theta=1.0 * u.kg)
@@ -1084,7 +1114,9 @@ class TestSkyRegularPolygon:
         assert not aper.is_regular
         for attr in ('outer_radius', 'inner_radius', 'side_length',
                      'interior_angle', 'exterior_angle'):
-            with pytest.raises(ValueError, match='regular polygon'):
+            match = (f'{attr!r} is only defined for a regular polygon '
+                     'aperture')
+            with pytest.raises(ValueError, match=match):
                 getattr(aper, attr)
 
     def test_n_vertices(self):

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -4,6 +4,7 @@ Tests for the stats module.
 """
 
 import sys
+from functools import cached_property
 from unittest.mock import patch
 
 import astropy.units as u
@@ -15,6 +16,7 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
 
+from photutils.aperture.bounding_box import BoundingBox
 from photutils.aperture.circle import CircularAnnulus, CircularAperture
 from photutils.aperture.core import _enable_batch_photometry
 from photutils.aperture.ellipse import (EllipticalAnnulus, EllipticalAperture,
@@ -71,6 +73,25 @@ def stats_data(request):
                                        error=cls.error * cls.unit,
                                        wcs=cls.wcs,
                                        sigma_clip=cls.sigclip)
+
+
+class _ExpandedBboxCircular(CircularAperture):
+    """
+    A `CircularAperture` subclass whose ``bbox`` is expanded by one
+    pixel on each side, overriding the default implementation.
+
+    Used to test that the ``ApertureStats`` bounding-box bounds honor a
+    ``bbox`` override instead of using the vectorized fast path.
+    """
+
+    @cached_property
+    def bbox(self):
+        boxes = [BoundingBox(ixmin=box.ixmin - 1, ixmax=box.ixmax + 1,
+                             iymin=box.iymin - 1, iymax=box.iymax + 1)
+                 for box in self._bbox]
+        if self.isscalar:
+            return boxes[0]
+        return boxes
 
 
 @pytest.mark.usefixtures('stats_data')
@@ -502,6 +523,17 @@ class TestIndexing(BaseApertureStatsData):
         match = '-1 is not a valid source ID number'
         with pytest.raises(ValueError, match=match):
             apstat0 = apstats.select_ids([-1, 0])
+
+    def test_fancy_slicing_list_cache(self):
+        """
+        Test fancy-index slicing of an evaluated list-valued cached
+        property (e.g., the ``bbox`` BoundingBox list), which cannot
+        be indexed directly with an array index.
+        """
+        apstats = self.apstats1.copy()
+        bbox = apstats.bbox  # cache the per-source BoundingBox list
+        sliced = apstats[[2, 1, 0]]
+        assert sliced.bbox == [bbox[2], bbox[1], bbox[0]]
 
     def test_scalar_aperture_stats(self):
         apstats = self.apstats1[0]
@@ -1487,3 +1519,22 @@ class TestNThreads:
         for n_threads in (0, -1, 2.5):
             with pytest.raises(ValueError, match=match):
                 ApertureStats(data, aper, n_threads=n_threads)
+
+
+def test_overridden_bbox_fallback():
+    """
+    Test that the bounding-box bounds honor an aperture subclass that
+    overrides ``bbox``.
+
+    The bounds are normally computed from the aperture's vectorized
+    integer bounds without creating per-position BoundingBox objects;
+    an overridden ``bbox`` must fall back to reading the objects.
+    """
+    data = np.ones((60, 60))
+    positions = [(20.0, 20.0), (35.5, 24.2), (10.1, 40.7)]
+    stats1 = ApertureStats(data, CircularAperture(positions, r=5.0))
+    stats2 = ApertureStats(data, _ExpandedBboxCircular(positions, r=5.0))
+    assert_equal(stats2.bbox_xmin, stats1.bbox_xmin - 1)
+    assert_equal(stats2.bbox_xmax, stats1.bbox_xmax + 1)
+    assert_equal(stats2.bbox_ymin, stats1.bbox_ymin - 1)
+    assert_equal(stats2.bbox_ymax, stats1.bbox_ymax + 1)

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -1538,3 +1538,138 @@ def test_overridden_bbox_fallback():
     assert_equal(stats2.bbox_xmax, stats1.bbox_xmax + 1)
     assert_equal(stats2.bbox_ymin, stats1.bbox_ymin - 1)
     assert_equal(stats2.bbox_ymax, stats1.bbox_ymax + 1)
+
+
+class TestCenterCutoutParity:
+    """
+    The center-method cutouts reconstructed from the packed gather
+    buffers must match the mask-based cutouts exactly, including the
+    masked-pixel data values.
+    """
+
+    @staticmethod
+    def make_inputs():
+        """
+        Build a deterministic image (with non-finite data and error
+        values), error, mask, and positions (including partial-overlap
+        and no-overlap positions).
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(100.0, 5.0, (80, 90))
+        data[10, 10] = np.nan
+        data[40, 41] = np.inf
+        error = np.abs(rng.normal(5.0, 0.5, data.shape)) + 0.1
+        error[12, 12] = np.inf
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[30:35, 30:35] = True
+        positions = [(5.0, 5.0), (-20.0, -20.0), (33.0, 32.0),
+                     (45.5, 41.2), (88.0, 3.0), (12.3, 11.1)]
+        return data, error, mask, positions
+
+    @staticmethod
+    def assert_cutout_lists_equal(fast_list, slow_list):
+        """
+        Assert two per-source cutout lists are exactly equal,
+        including the data values under the mask.
+        """
+        for fast, slow in zip(fast_list, slow_list, strict=True):
+            assert_equal(np.ma.getdata(fast), np.ma.getdata(slow))
+            assert_equal(np.ma.getmaskarray(fast),
+                         np.ma.getmaskarray(slow))
+
+    @staticmethod
+    def get_cutouts(stats):
+        """
+        Return the center-method cutout lists of an instance.
+        """
+        return {'data': stats.data_cutout,
+                'variance': stats._variance_cutout_center,
+                'mask': stats._mask_cutout_center,
+                'weight': stats._weight_cutout_center}
+
+    @pytest.mark.parametrize('use_sigma_clip', [False, True])
+    @pytest.mark.parametrize('use_error', [False, True])
+    def test_matches_mask_path(self, use_sigma_clip, use_error):
+        """
+        Test that the buffer-reconstructed cutouts equal the
+        mask-based cutouts, including non-finite pixels, partial
+        overlaps, and the no-overlap sentinel arrays.
+        """
+        data, error, mask, positions = self.make_inputs()
+        sigma_clip = (SigmaClip(sigma=2.0, maxiters=10) if use_sigma_clip
+                      else None)
+        kwargs = {'error': error if use_error else None, 'mask': mask,
+                  'sigma_clip': sigma_clip,
+                  'local_bkg': np.linspace(-1.0, 1.0, len(positions))}
+        aperture = CircularAperture(positions, r=6.0)
+
+        fast = ApertureStats(data, aperture, **kwargs)
+        assert fast._fast_cutouts_center is not None
+        fast_cutouts = self.get_cutouts(fast)
+
+        with patch.object(ApertureStats, '_batch_inputs',
+                          property(lambda _: None)):
+            slow = ApertureStats(data, aperture, **kwargs)
+            assert slow._fast_cutouts_center is None
+            # The mask-based path multiplies non-finite data values by
+            # the boolean masks (NaN * 0), which emits a numpy
+            # RuntimeWarning
+            with np.errstate(invalid='ignore'):
+                slow_cutouts = self.get_cutouts(slow)
+
+        for key in fast_cutouts:
+            if not use_error and key == 'variance':
+                assert all(value is None for value in fast_cutouts[key])
+                assert all(value is None for value in slow_cutouts[key])
+                continue
+            self.assert_cutout_lists_equal(fast_cutouts[key],
+                                           slow_cutouts[key])
+
+    @pytest.mark.parametrize('mask_method', ['mask', 'source_only'])
+    def test_segmentation_masking(self, mask_method):
+        """
+        Test that segmentation-excluded pixels land in the cutout mask
+        identically to the mask-based path.
+        """
+        data = np.ones((50, 50))
+        segm = np.zeros((50, 50), dtype=int)
+        data[18:25, 18:25] = 10.0
+        segm[18:25, 18:25] = 1
+        data[20:25, 26:32] = 100.0
+        segm[20:25, 26:32] = 2
+        aperture = CircularAperture([(21.0, 21.0), (28.0, 22.0)], r=8.0)
+        kwargs = {'segmentation_image': segm, 'labels': [1, 2],
+                  'mask_method': mask_method}
+
+        fast = ApertureStats(data, aperture, **kwargs)
+        assert fast._fast_cutouts_center is not None
+        fast_data = fast.data_cutout
+
+        with patch.object(ApertureStats, '_batch_inputs',
+                          property(lambda _: None)):
+            slow = ApertureStats(data, aperture, **kwargs)
+            slow_data = slow.data_cutout
+
+        self.assert_cutout_lists_equal(fast_data, slow_data)
+
+    def test_correct_mode_fallback(self):
+        """
+        Test that mask_method='correct' uses the mask-based cutout
+        path (the mirrored error values are not recoverable from the
+        packed buffers) and still produces the corrected cutouts.
+        """
+        data = np.ones((50, 50))
+        segm = np.zeros((50, 50), dtype=int)
+        data[18:25, 18:25] = 10.0
+        segm[18:25, 18:25] = 1
+        data[20:25, 26:32] = 100.0
+        segm[20:25, 26:32] = 2
+        aperture = CircularAperture([(21.0, 21.0)], r=8.0)
+        stats = ApertureStats(data, aperture, segmentation_image=segm,
+                              labels=[1], mask_method='correct')
+        assert stats._fast_gather is not None
+        assert stats._fast_cutouts_center is None
+        # The bright neighbor pixel values must not leak into the
+        # cutout (they are replaced by their mirrored values)
+        cutout = stats.data_cutout[0]
+        assert np.ma.getdata(cutout).max() <= 10.0

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -1307,3 +1307,183 @@ def test_sigma_clip_sorted_values_reuse(monkeypatch):
     apstats2 = ApertureStats(data, aper, sigma_clip=sigclip)
     for prop, result1 in zip(props, results1, strict=True):
         assert_allclose(result1, getattr(apstats2, prop), rtol=1e-10)
+
+
+class TestNThreads:
+    """
+    Tests for the n_threads keyword.
+    """
+
+    @staticmethod
+    def make_inputs():
+        """
+        Build a deterministic image (with non-finite values), error,
+        mask, and positions (including off-edge positions).
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(100.0, 5.0, (120, 130))
+        data[3, 3] = np.nan
+        data[50, 50] = np.inf
+        error = np.abs(rng.normal(5.0, 0.5, data.shape)) + 0.1
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[60:65, 85:90] = True
+        positions = np.column_stack(
+            [rng.uniform(-5, data.shape[1] + 5, 57),
+             rng.uniform(-5, data.shape[0] + 5, 57)])
+        return data, error, mask, positions
+
+    @staticmethod
+    def assert_stats_equal(stats1, stats2):
+        """
+        Assert that all (non-cutout) properties of two ApertureStats
+        instances are exactly equal.
+        """
+        for prop in stats1.properties:
+            value1 = getattr(stats1, prop)
+            value2 = getattr(stats2, prop)
+            if prop.endswith('cutout'):
+                for arr1, arr2 in zip(value1, value2, strict=True):
+                    arr1 = np.ma.filled(arr1, np.nan)
+                    arr2 = np.ma.filled(arr2, np.nan)
+                    assert_equal(arr1, arr2)
+            elif prop.startswith('sky_'):
+                # SkyCoord without a wcs is None or an array of None
+                if hasattr(value1, 'ra'):
+                    assert_equal(value1.ra.deg, value2.ra.deg)
+                    assert_equal(value1.dec.deg, value2.dec.deg)
+                else:
+                    assert_equal(value1, value2)
+            else:
+                assert_equal(value1, value2)
+
+    @pytest.mark.parametrize('n_threads', [2, 8])
+    @pytest.mark.parametrize('use_sigma_clip', [False, True])
+    def test_identical_results(self, n_threads, use_sigma_clip):
+        """
+        Test that multithreaded statistics are identical to the
+        single-threaded computation for every property, including for
+        off-edge positions, masked pixels, and non-finite data values.
+        """
+        data, error, mask, positions = self.make_inputs()
+        wcs = make_wcs(data.shape)
+        sigma_clip = (SigmaClip(sigma=3.0, maxiters=10) if use_sigma_clip
+                      else None)
+        aper = CircularAperture(positions, r=7.0)
+        stats1 = ApertureStats(data, aper, error=error, mask=mask,
+                               wcs=wcs, sigma_clip=sigma_clip)
+        stats2 = ApertureStats(data, aper, error=error, mask=mask,
+                               wcs=wcs, sigma_clip=sigma_clip,
+                               n_threads=n_threads)
+        assert stats2.n_threads == n_threads
+        self.assert_stats_equal(stats1, stats2)
+
+    def test_local_bkg_ddof_sum_method(self):
+        """
+        Test that the per-source local background values are chunked
+        together with the positions.
+        """
+        data, error, _, positions = self.make_inputs()
+        local_bkg = np.linspace(-1.0, 1.0, positions.shape[0])
+        aper = CircularAperture(positions, r=6.0)
+        kwargs = {'error': error, 'local_bkg': local_bkg, 'ddof': 1,
+                  'sum_method': 'center'}
+        stats1 = ApertureStats(data, aper, **kwargs)
+        stats2 = ApertureStats(data, aper, n_threads=4, **kwargs)
+        for prop in ('sum', 'sum_err', 'std', 'median', 'mean'):
+            assert_equal(getattr(stats1, prop), getattr(stats2, prop))
+
+    def test_segmentation_masking(self):
+        """
+        Test that the per-source segmentation labels are chunked
+        together with the positions.
+        """
+        data = np.ones((50, 50))
+        segm = np.zeros((50, 50), dtype=int)
+        data[18:25, 18:25] = 10.0
+        segm[18:25, 18:25] = 1
+        data[20:25, 26:32] = 100.0
+        segm[20:25, 26:32] = 2
+        positions = [(21.0, 21.0), (28.0, 22.0), (21.0, 21.5),
+                     (28.5, 22.0), (20.5, 21.0)]
+        labels = [1, 2, 1, 2, 1]
+        aper = CircularAperture(positions, r=8.0)
+        kwargs = {'segmentation_image': segm, 'labels': labels,
+                  'mask_method': 'mask'}
+        stats1 = ApertureStats(data, aper, **kwargs)
+        stats2 = ApertureStats(data, aper, n_threads=3, **kwargs)
+        for prop in ('sum', 'mean', 'median', 'flags', 'sum_flags'):
+            assert_equal(getattr(stats1, prop), getattr(stats2, prop))
+
+    def test_more_threads_than_positions(self):
+        """
+        Test that n_threads larger than the number of positions gives
+        identical results.
+        """
+        data = np.ones((40, 40))
+        aper = CircularAperture([(20, 20), (10, 10), (30, 25)], r=5.0)
+        stats1 = ApertureStats(data, aper)
+        stats2 = ApertureStats(data, aper, n_threads=8)
+        self.assert_stats_equal(stats1, stats2)
+
+    def test_scalar_aperture(self):
+        """
+        Test that a scalar aperture position with n_threads > 1 falls
+        back to a single-chunk (serial) computation.
+        """
+        data = np.ones((40, 40))
+        aper = CircularAperture((20, 20), r=5.0)
+        stats1 = ApertureStats(data, aper)
+        stats2 = ApertureStats(data, aper, n_threads=4)
+        assert_equal(stats1.sum, stats2.sum)
+        assert_equal(stats1.median, stats2.median)
+
+    def test_mask_based_fallback(self):
+        """
+        Test that apertures that do not support the batch code path
+        give correct results with n_threads > 1 (the mask-based code
+        path stays serial).
+        """
+        data, error, _, positions = self.make_inputs()
+        aper = NoBatchCircularAperture(positions, r=7.0)
+        stats = ApertureStats(data, aper, error=error, n_threads=4)
+        assert stats._batch_inputs is None
+        ref = ApertureStats(data, CircularAperture(positions, r=7.0),
+                            error=error)
+        assert_allclose(stats.sum, ref.sum, equal_nan=True)
+        assert_allclose(stats.median, ref.median, equal_nan=True)
+
+    def test_empty_positions(self):
+        """
+        Test that an aperture with zero positions works with
+        n_threads > 1 (regression test for the chunking helper, which
+        must fall back to the serial path for zero chunks).
+        """
+        data = np.ones((11, 11))
+        aper = CircularAperture(np.empty((0, 2)), r=3.0)
+        stats = ApertureStats(data, aper, n_threads=4)
+        assert stats.n_positions == 0
+        assert stats.sum.shape == (0,)
+        assert stats.median.shape == (0,)
+
+    def test_indexing_preserves_n_threads(self):
+        """
+        Test that slicing an ApertureStats instance preserves the
+        n_threads value.
+        """
+        data = np.ones((40, 40))
+        aper = CircularAperture([(20, 20), (10, 10), (30, 25)], r=5.0)
+        stats = ApertureStats(data, aper, n_threads=4)
+        assert stats[1:].n_threads == 4
+        assert stats[0].n_threads == 4
+
+    def test_invalid_n_threads(self):
+        """
+        Test that an error is raised if n_threads is not a positive
+        integer.
+        """
+        data = np.ones((40, 40))
+        aper = CircularAperture((20, 20), r=5.0)
+        match = 'n_threads must be a positive integer'
+        for n_threads in (0, -1, 2.5):
+            with pytest.raises(ValueError, match=match):
+                ApertureStats(data, aper, n_threads=n_threads)

--- a/photutils/background/local_background.py
+++ b/photutils/background/local_background.py
@@ -41,6 +41,17 @@ class LocalBackground:
         `~photutils.background.MedianBackground` with sigma clipping
         (i.e., sigma-clipped median).
 
+    n_threads : int, optional
+        The number of threads to use to measure the local backgrounds.
+        The default is 1 (no multithreading). The value is passed
+        through to the internal `~photutils.aperture.ApertureStats`
+        computation, which divides the annulus positions into chunks
+        that are processed concurrently, producing results identical
+        to the single-threaded computation. Multithreading is used
+        only for the standard photutils estimator classes (see
+        ``bkg_estimator``). A custom estimator callable uses the serial
+        per-aperture loop.
+
     Examples
     --------
     >>> import numpy as np
@@ -60,7 +71,8 @@ class LocalBackground:
     """
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
-    def __init__(self, inner_radius, outer_radius, bkg_estimator=None):
+    def __init__(self, inner_radius, outer_radius, bkg_estimator=None, *,
+                 n_threads=1):
         if inner_radius <= 0:
             msg = 'inner_radius must be positive.'
             raise ValueError(msg)
@@ -77,8 +89,14 @@ class LocalBackground:
             bkg_estimator = MedianBackground()
         self.bkg_estimator = bkg_estimator
 
+        if not isinstance(n_threads, (int, np.integer)) or n_threads < 1:
+            msg = 'n_threads must be a positive integer'
+            raise ValueError(msg)
+        self.n_threads = int(n_threads)
+
     def __repr__(self):
-        params = ('inner_radius', 'outer_radius', 'bkg_estimator')
+        params = ('inner_radius', 'outer_radius', 'bkg_estimator',
+                  'n_threads')
         return make_repr(self, params)
 
     def _fast_estimator_spec(self):
@@ -155,7 +173,8 @@ class LocalBackground:
         kind, median_factor, mean_factor = spec
         apstats = ApertureStats(data, apertures, mask=mask,
                                 sigma_clip=self.bkg_estimator.sigma_clip,
-                                sum_method='center')
+                                sum_method='center',
+                                n_threads=self.n_threads)
 
         if kind == 'mean':
             result = apstats.mean

--- a/photutils/background/tests/test_local_background.py
+++ b/photutils/background/tests/test_local_background.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from photutils.aperture import CircularAnnulus
 from photutils.background import (BiweightLocationBackground,
@@ -285,3 +285,32 @@ class TestFastLocalBackground:
             local_bkg = LocalBackground(5, 10, bkg_estimator=estimator)
             assert local_bkg._fast_estimator_spec() is None
             assert np.isfinite(local_bkg(data, 25, 25))
+
+    def test_n_threads_identical(self):
+        """
+        Test that n_threads (passed through to ApertureStats) gives
+        results identical to the single-threaded computation.
+        """
+        local_bkg1 = LocalBackground(5, 10)
+        local_bkg4 = LocalBackground(5, 10, n_threads=4)
+        assert local_bkg4.n_threads == 4
+        bkg1 = local_bkg1(self.data, self.x, self.y, mask=self.mask)
+        bkg4 = local_bkg4(self.data, self.x, self.y, mask=self.mask)
+        assert_equal(bkg1, bkg4)
+
+    def test_n_threads_repr(self):
+        """
+        Test that n_threads appears in the repr.
+        """
+        local_bkg = LocalBackground(5, 10, n_threads=4)
+        assert 'n_threads=4' in repr(local_bkg)
+
+    def test_invalid_n_threads(self):
+        """
+        Test that an error is raised if n_threads is not a positive
+        integer.
+        """
+        match = 'n_threads must be a positive integer'
+        for n_threads in (0, -1, 2.5):
+            with pytest.raises(ValueError, match=match):
+                LocalBackground(5, 10, n_threads=n_threads)


### PR DESCRIPTION
This PR adds an `n_threads` keyword to `AperturePhotometry`, `ApertureStats`, and `LocalBackground` to compute aperture sums and statistics using multiple threads. The aperture positions are divided into chunks that are processed concurrently, producing results identical to the single-threaded computation.

The aperture sums, sigma clipping, and the per-source statistic reductions (sorts, order statistics, robust estimators, and moments) all run in the threads, so both classes scale nearly linearly with the thread count for large numbers of positions. For 100,000 circular apertures on a 4096x4096 image, the measured speedups are ~2x with 2 threads and ~8-10x with 12 threads.