### PR TITLE
Fix data_properties background units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -292,6 +292,13 @@ Bug Fixes
     also makes it consistent with ``ApertureStats.orientation`` and
     ``SourceCatalog.orientation``. [#2317]
 
+- ``photutils.morphology``
+
+  - Fixed ``data_properties`` so that a ``background`` input with
+    units is preserved. Previously, the units were stripped, and a
+    confusing units-mismatch error was raised when ``data`` was a
+    ``Quantity``. [#2370]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -62,6 +62,20 @@ python benchmarks/bench_geometry.py
 python benchmarks/bench_geometry.py --which polygon --n-vertices 8,64,512
 ```
 
+## Morphology (`bench_morphology.py`)
+
+Benchmarks for the `photutils.morphology` subpackage:
+
+- the per-call cost of `data_properties`: catalog construction alone
+  and with the morphological properties computed, with and without a
+  mask, background, and WCS
+- the scaling of `gini` with array size, with and without a mask
+
+```bash
+python benchmarks/bench_morphology.py
+python benchmarks/bench_morphology.py --which gini --sizes 256,1024,4096
+```
+
 ## Background (`bench_background.py`)
 
 Benchmarks for the `photutils.background` subpackage:

--- a/benchmarks/bench_morphology.py
+++ b/benchmarks/bench_morphology.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for the photutils.morphology subpackage.
+
+The benchmarks cover the per-call cost of data_properties (catalog
+construction alone and with the morphological properties computed,
+with and without a mask, background, and WCS) and the scaling of gini
+with array size, with and without a mask.
+
+Run ``python benchmarks/bench_morphology.py --help`` to see the
+available options.
+"""
+
+import argparse
+from functools import partial
+
+import numpy as np
+from astropy.modeling.models import Gaussian2D
+from astropy.stats import gaussian_fwhm_to_sigma
+from bench_utils import print_environment, time_best
+
+from photutils.datasets import make_wcs
+from photutils.morphology import data_properties, gini
+
+# The morphological properties accessed by the data_properties
+# benchmark (computing them is lazy, so construction is timed
+# separately from property access)
+PROPERTY_NAMES = ['x_centroid', 'y_centroid', 'semimajor_axis',
+                  'semiminor_axis', 'orientation', 'eccentricity',
+                  'area']
+
+BACKGROUND_PROPERTY_NAMES = ['background_mean', 'background_sum']
+
+
+def make_source_cutout(size, *, amplitude=100.0, noise_std=1.0, seed=0):
+    """
+    Return a cutout image containing a single Gaussian source.
+
+    The source FWHM scales with the cutout size so that the source
+    fills a constant fraction of the cutout.
+
+    Parameters
+    ----------
+    size : int
+        The cutout size; the cutout is ``(size, size)``.
+
+    amplitude : float, optional
+        The amplitude of the Gaussian source.
+
+    noise_std : float, optional
+        The standard deviation of the Gaussian noise.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        The cutout image.
+    """
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:size, 0:size]
+    xc = yc = (size - 1) / 2.0
+    sigma = (size / 8.0) * gaussian_fwhm_to_sigma
+    model = Gaussian2D(amplitude, xc, yc, sigma, sigma)
+    return model(xx, yy) + rng.normal(0.0, noise_std, (size, size))
+
+
+def run_data_properties(data, n_iter, property_names, **kwargs):
+    """
+    Call data_properties repeatedly and access the given properties.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The cutout image.
+
+    n_iter : int
+        The number of calls.
+
+    property_names : list of str
+        The names of the properties to access on each returned
+        catalog.
+
+    **kwargs : dict, optional
+        Keyword arguments passed to ``data_properties``.
+    """
+    for _ in range(n_iter):
+        props = data_properties(data, **kwargs)
+        for name in property_names:
+            getattr(props, name)
+
+
+def bench_data_properties(*, cutout_size=51, n_iter=10, repeats=3,
+                          seed=0):
+    """
+    Benchmark the per-call cost of data_properties.
+
+    Catalog construction alone is timed separately from construction
+    plus computing the morphological properties (the properties are
+    computed lazily), and the mask, background, and WCS variants are
+    timed with their relevant properties.
+
+    Parameters
+    ----------
+    cutout_size : int, optional
+        The cutout size; the cutout is ``(cutout_size, cutout_size)``.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data = make_source_cutout(cutout_size, seed=seed)
+    mask = data < 5.0  # isolate source pixels
+    background = 1.0
+    wcs = make_wcs(data.shape)
+
+    variants = [
+        ('construct only', {}, []),
+        ('+ properties', {}, PROPERTY_NAMES),
+        ('+ mask', {'mask': mask}, PROPERTY_NAMES),
+        ('+ background', {'background': background},
+         PROPERTY_NAMES + BACKGROUND_PROPERTY_NAMES),
+        ('+ wcs (sky_centroid)', {'wcs': wcs}, ['sky_centroid']),
+    ]
+
+    print(f'\n== data_properties ({cutout_size}x{cutout_size} cutout, '
+          f'per-call time) ==')
+    print(f'{"variant":>22}{"time":>12}')
+    for name, kwargs, property_names in variants:
+        bench = partial(run_data_properties, data, n_iter,
+                        property_names, **kwargs)
+        t_call = time_best(bench, repeats=repeats) / n_iter
+        print(f'{name:>22}{f"{t_call * 1e3:.3f}ms":>12}')
+
+
+def run_gini(data, n_iter, **kwargs):
+    """
+    Call gini repeatedly on the data.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The cutout image.
+
+    n_iter : int
+        The number of calls.
+
+    **kwargs : dict, optional
+        Keyword arguments passed to ``gini``.
+    """
+    for _ in range(n_iter):
+        gini(data, **kwargs)
+
+
+def bench_gini(*, sizes=(64, 256, 1024), n_iter=10, repeats=3, seed=0):
+    """
+    Benchmark gini across array sizes, with and without a mask.
+
+    Parameters
+    ----------
+    sizes : tuple of int, optional
+        The array sizes (pixels per side).
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    print('\n== gini vs array size (per-call time) ==')
+    print(f'{"size":>12}{"no mask":>12}{"with mask":>12}')
+    rng = np.random.default_rng(seed)
+    for size in sizes:
+        data = make_source_cutout(size, seed=seed)
+        # A sparse mask keeps the number of unmasked values comparable
+        # to the no-mask case, so the columns show the masking overhead
+        mask = rng.random(data.shape) < 0.01
+        cells = ''
+        for kwargs in ({}, {'mask': mask}):
+            bench = partial(run_gini, data, n_iter, **kwargs)
+            t_call = time_best(bench, repeats=repeats) / n_iter
+            cells += f'{f"{t_call * 1e3:.3f}ms":>12}'
+        print(f'{f"{size}x{size}":>12}{cells}')
+
+
+def parse_int_list(text):
+    """
+    Parse a comma-separated list of positive integers.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated integers (e.g., ``'64,256,1024'``).
+
+    Returns
+    -------
+    result : list of int
+        The parsed integers.
+    """
+    values = [int(item) for item in text.split(',')]
+    if any(value < 1 for value in values):
+        msg = 'values must be positive integers'
+        raise ValueError(msg)
+    return values
+
+
+def main():
+    """
+    Run the photutils.morphology benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for the photutils.morphology '
+                    'subpackage.')
+    parser.add_argument('--cutout-size', type=int, default=51,
+                        help='data_properties cutout size '
+                             '(default: %(default)s)')
+    parser.add_argument('--sizes', type=parse_int_list,
+                        default=[64, 256, 1024],
+                        help='comma-separated array sizes for the gini '
+                             'benchmark (default: 64,256,1024)')
+    parser.add_argument('--n-iter', type=int, default=10,
+                        help='number of calls per timing '
+                             '(default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'data-properties', 'gini'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'data-properties'):
+        bench_data_properties(cutout_size=args.cutout_size,
+                              n_iter=args.n_iter,
+                              repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'gini'):
+        bench_gini(sizes=args.sizes, n_iter=args.n_iter,
+                   repeats=args.repeats, seed=args.seed)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/user_guide/morphology.rst
+++ b/docs/user_guide/morphology.rst
@@ -133,9 +133,10 @@ coefficient.
 
 The :func:`~photutils.morphology.gini` function calculates the Gini
 coefficient of the distribution of absolute flux values of a single
-source using the values in a cutout image. The input array may be
-1D or 2D. Negative pixel values are used via their absolute value.
-Invalid values (NaN and inf) are automatically excluded from the
+source using the values in a cutout image. The input array may have any
+dimensionality (e.g., a 1D array or a 2D image), with its values treated
+as a flattened set. Negative pixel values are used via their absolute
+value. Invalid values (NaN and inf) are automatically excluded from the
 calculation. An optional boolean mask can be used to exclude pixels from
 the calculation.
 

--- a/photutils/morphology/core.py
+++ b/photutils/morphology/core.py
@@ -26,13 +26,14 @@ def data_properties(data, mask=None, background=None, wcs=None):
         value indicates the corresponding element of ``data`` is masked.
         Masked data are excluded from all calculations.
 
-    background : float or array_like, optional
+    background : float, array_like, or `~astropy.units.Quantity`, optional
         The background level previously present in the input ``data``.
         ``background`` may be a scalar value or a 2D array with the same
-        shape as ``data``. The input ``background`` is not subtracted
-        from ``data``, which should already be background-subtracted;
-        providing it only enables background-related properties to be
-        measured.
+        shape as ``data``. If ``data`` is a `~astropy.units.Quantity`,
+        then ``background`` must have the same units. The input
+        ``background`` is not subtracted from ``data``, which should
+        already be background-subtracted; providing it only enables
+        background-related properties to be measured.
 
     wcs : WCS object or `None`, optional
         A world coordinate system (WCS) transformation that
@@ -53,6 +54,9 @@ def data_properties(data, mask=None, background=None, wcs=None):
         If ``data`` is not a 2D array.
 
     ValueError
+        If ``data`` is empty.
+
+    ValueError
         If ``mask`` is provided and does not have the same shape as
         ``data``.
 
@@ -67,8 +71,11 @@ def data_properties(data, mask=None, background=None, wcs=None):
     from photutils.segmentation import SegmentationImage, SourceCatalog
 
     data = np.asanyarray(data)
-    if len(data.shape) != 2:
+    if data.ndim != 2:
         msg = 'data must be a 2D array'
+        raise ValueError(msg)
+    if data.size == 0:
+        msg = 'data must not be empty'
         raise ValueError(msg)
 
     seg_arr = np.ones(data.shape, dtype=int)
@@ -85,9 +92,11 @@ def data_properties(data, mask=None, background=None, wcs=None):
     segment_image = SegmentationImage(seg_arr)
 
     if background is not None:
-        background = np.asarray(background)
+        # asanyarray and the multiplication below preserve Quantity
+        # units
+        background = np.asanyarray(background)
         if background.ndim == 0:
-            background = np.full(data.shape, float(background))
+            background = np.full(data.shape, 1.0) * background
         elif background.shape != data.shape:
             msg = ('background must be a scalar or a 2D array '
                    'with the same shape as data')

--- a/photutils/morphology/non_parametric.py
+++ b/photutils/morphology/non_parametric.py
@@ -27,8 +27,8 @@ def gini(data, mask=None):
             \sum^{n}_{i} (2i - n - 1) \left | x_i \right |
 
     where :math:`\overline{|x|}` is the mean of the absolute value of
-    all pixel values :math:`x_i`. If the sum of all pixel values is
-    zero, the Gini coefficient is zero.
+    all pixel values :math:`x_i`. If all pixel values are zero, the Gini
+    coefficient is zero.
 
     The Gini coefficient is a way of measuring the inequality in a given
     set of values. In the context of galaxy morphology, it measures how
@@ -46,13 +46,15 @@ def gini(data, mask=None):
     Negative pixel values are used via their absolute value. Invalid
     values (NaN and inf) in the input are automatically excluded from
     the calculation. If only a single finite pixel remains after
-    filtering, the Gini coefficient is 0.0.
+    filtering, the Gini coefficient is 0.0. If no finite, unmasked
+    pixels remain, NaN is returned.
 
     Parameters
     ----------
     data : array_like
-        The 1D or 2D data array or object that can be converted to an
-        array.
+        The data array or object that can be converted to an array. The
+        array may have any dimensionality (e.g., a 1D array or a 2D
+        image), with its values treated as a flattened set.
 
     mask : array_like, optional
         A boolean mask with the same shape as ``data`` where `True`
@@ -62,7 +64,8 @@ def gini(data, mask=None):
     Returns
     -------
     result : float
-        The Gini coefficient of the input array.
+        The Gini coefficient of the input array. NaN is returned if
+        there are no finite, unmasked values.
 
     Raises
     ------

--- a/photutils/morphology/tests/test_core.py
+++ b/photutils/morphology/tests/test_core.py
@@ -77,6 +77,32 @@ def test_data_properties_bkg():
     assert props2.background_sum == 18.0
 
 
+def test_data_properties_quantity_bkg():
+    """
+    Test that a ``~astropy.units.Quantity`` background preserves its
+    units.
+    """
+    data = np.ones((3, 3)) * u.Jy
+    props = data_properties(data, background=1.0 * u.Jy)
+    assert props.background_sum == 9.0 * u.Jy
+
+    bkg_2d = np.full((3, 3), 2.0) * u.Jy
+    props2 = data_properties(data, background=bkg_2d)
+    assert props2.background_sum == 18.0 * u.Jy
+
+
+def test_data_properties_empty_data():
+    """
+    Test that empty data raises ``ValueError``.
+    """
+    match = 'data must not be empty'
+    with pytest.raises(ValueError, match=match):
+        data_properties(np.ones((0, 5)))
+
+    with pytest.raises(ValueError, match=match):
+        data_properties(np.ones((3, 0)))
+
+
 def test_data_properties_bkg_invalid():
     """
     Test that invalid background inputs raise ``ValueError``.

--- a/photutils/morphology/tests/test_non_parametric.py
+++ b/photutils/morphology/tests/test_non_parametric.py
@@ -31,6 +31,17 @@ def test_gini_1d():
     assert gini(data_1d) == 1.0
 
 
+def test_gini_nd():
+    """
+    Test that arrays of any dimensionality are accepted and treated as
+    a flattened set of values.
+    """
+    data_3d = np.zeros((3, 3, 3))
+    data_3d[1, 1, 1] = 1.0
+    assert gini(data_3d) == 1.0
+    assert gini(data_3d) == gini(data_3d.ravel())
+
+
 def test_gini_mask():
     """
     Test Gini coefficient calculation with a mask.

--- a/photutils/morphology/tests/test_thread_safety.py
+++ b/photutils/morphology/tests/test_thread_safety.py
@@ -1,0 +1,125 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests that the morphology functions are thread-safe and return
+identical results when run concurrently from multiple threads.
+
+Both ``data_properties`` and ``gini`` are pure functions with no
+module-level mutable state. Each call operates only on its inputs
+and local variables, and ``data_properties`` constructs a new
+``SourceCatalog`` per call.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from photutils.morphology import data_properties, gini
+
+N_THREADS = 8
+N_CALLS_PER_THREAD = 4
+
+DATA_PROPERTIES_COLUMNS = ['x_centroid', 'y_centroid', 'semimajor_axis',
+                           'semiminor_axis', 'orientation', 'area']
+
+
+def make_shared_inputs():
+    """
+    Return a shared image, mask, and background for the concurrent
+    calls.
+
+    Returns
+    -------
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    mask : 2D `~numpy.ndarray`
+        A boolean mask.
+
+    background : 2D `~numpy.ndarray`
+        A background image.
+    """
+    rng = np.random.default_rng(0)
+    data = rng.random((51, 51))
+    data[20:30, 20:30] += 50.0
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[10, 10] = True
+    background = np.full(data.shape, 0.5)
+    return data, mask, background
+
+
+def run_concurrently(task, expected):
+    """
+    Run ``task`` concurrently and check each result against
+    ``expected``.
+
+    Parameters
+    ----------
+    task : callable
+        The zero-argument callable to run in the thread pool.
+
+    expected : tuple
+        The expected result from a serial call.
+    """
+    with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+        futures = [executor.submit(task)
+                   for _ in range(N_THREADS * N_CALLS_PER_THREAD)]
+        for future in futures:
+            assert_array_equal(future.result(), expected)
+
+
+def test_concurrent_data_properties():
+    """
+    Test that concurrent data_properties calls on shared input arrays
+    return results identical to a serial call.
+    """
+    data, mask, background = make_shared_inputs()
+
+    def task():
+        props = data_properties(data, mask=mask, background=background)
+        values = [getattr(props, name).value
+                  for name in DATA_PROPERTIES_COLUMNS
+                  if name not in ('x_centroid', 'y_centroid')]
+        values += [props.x_centroid, props.y_centroid,
+                   props.background_sum]
+        return values
+
+    run_concurrently(task, task())
+
+
+def test_concurrent_gini():
+    """
+    Test that concurrent gini calls on shared input arrays return
+    results identical to a serial call.
+    """
+    data, mask, _ = make_shared_inputs()
+
+    def task():
+        return gini(data, mask=mask)
+
+    run_concurrently(task, task())
+
+
+def test_mixed_concurrent_calls():
+    """
+    Test data_properties and gini running interleaved in one thread
+    pool.
+    """
+    data, mask, _ = make_shared_inputs()
+
+    def gini_task():
+        return gini(data, mask=mask)
+
+    def props_task():
+        props = data_properties(data, mask=mask)
+        return [props.x_centroid, props.y_centroid, props.area.value]
+
+    tasks = {'gini': gini_task, 'data_properties': props_task}
+    expected = {name: task() for name, task in tasks.items()}
+
+    with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+        futures = [(name, executor.submit(task))
+                   for name, task in tasks.items()
+                   for _ in range(N_THREADS)]
+        for name, future in futures:
+            assert_array_equal(future.result(), expected[name])


### PR DESCRIPTION
This PR fixes ``data_properties`` so that a ``background`` input with units is preserved. Previously, the units were stripped, and a confusing units-mismatch error was raised when ``data`` was a ``Quantity``.

This PR also adds benchmarks for the `morphology` package.