### PR TITLE
Profiles fixes, batched photometry, and thread-safe normalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -299,6 +299,19 @@ Bug Fixes
     confusing units-mismatch error was raised when ``data`` was a
     ``Quantity``. [#2370]
 
+- ``photutils.profiles``
+
+  - Fixed ``RadialProfile.data_profile`` so that its values are always
+    consistent with the current profile normalization. Previously, if
+    ``normalize`` was called before ``data_profile`` was first accessed,
+    the raw (unnormalized) values were returned, and a subsequent
+    ``unnormalize`` call then incorrectly multiplied those raw values by
+    the normalization. [#2371]
+
+  - Fixed ``RadialProfile.data_profile`` to return a ``Quantity``
+    when the input data is a ``Quantity``, consistent with the
+    ``profile`` attribute. [#2371]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -187,6 +187,10 @@ New Features
     one area calculation per radius. Profile construction is now ~3x
     faster. [#2371]
 
+  - The profile classes are now thread-safe. All lazily-computed
+    attributes cache raw (unnormalized) values that are immutable
+    once computed. [#2371]
+
 - ``photutils.psf``
 
   - Improved ``GriddedPSFModel`` evaluation performance by ~20-25%

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -318,6 +318,10 @@ Bug Fixes
     such pixels were excluded on the upper-x and upper-y sides of the
     center. [#2371]
 
+  - Fixed the profile ``plot`` method so that the y-axis label no
+    longer includes the data unit after the profile has been normalized
+    (a normalized profile is dimensionless). [#2371]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,14 @@ New Features
     keyword. Also restored the ``npix_e`` and ``npix_c`` properties to
     the ``columns='all'`` output. [#2329]
 
+- ``photutils.profiles``
+
+  - Improved the performance of the profile classes by computing the
+    aperture photometry and unmasked areas for all radii in a single
+    batched ``AperturePhotometry`` call instead of one photometry and
+    one area calculation per radius. Profile construction is now ~3x
+    faster. [#2371]
+
 - ``photutils.psf``
 
   - Improved ``GriddedPSFModel`` evaluation performance by ~20-25%

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -322,6 +322,13 @@ Bug Fixes
     longer includes the data unit after the profile has been normalized
     (a normalized profile is dimensionless). [#2371]
 
+  - A ``Quantity`` ``radii`` (or ``half_sizes``) input to the profile
+    classes now raises a ``TypeError``. Previously, the units were
+    silently dropped. [#2371]
+
+  - The ``EnsquaredCurveOfGrowth`` input validation error messages now
+    refer to the ``half_sizes`` parameter instead of ``radii``. [#xxxx]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -312,6 +312,12 @@ Bug Fixes
     when the input data is a ``Quantity``, consistent with the
     ``profile`` attribute. [#2371]
 
+  - Fixed the ``RadialProfile`` ``data_radius`` and ``data_profile``
+    attributes so that pixels whose centers lie exactly at the maximum
+    input radius are included on all sides of the center. Previously,
+    such pixels were excluded on the upper-x and upper-y sides of the
+    center. [#2371]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -76,6 +76,24 @@ python benchmarks/bench_morphology.py
 python benchmarks/bench_morphology.py --which gini --sizes 256,1024,4096
 ```
 
+## Profiles (`bench_profiles.py`)
+
+Benchmarks for the `photutils.profiles` subpackage:
+
+- the per-call cost of constructing each profile class
+  (`RadialProfile`, `CurveOfGrowth`, `EnsquaredCurveOfGrowth`, and
+  `EllipticalCurveOfGrowth`) and computing its profile, errors, and
+  areas, for each overlap method (exact, center, and subpixel)
+- the scaling of the profile computation with the number of radial
+  bins
+- the cost of the extra lazily-computed `RadialProfile` attributes
+  (`data_profile`, `gaussian_fit`, and `moffat_fit`)
+
+```bash
+python benchmarks/bench_profiles.py
+python benchmarks/bench_profiles.py --which radii-scaling --n-radii-list 100,400,1600
+```
+
 ## Background (`bench_background.py`)
 
 Benchmarks for the `photutils.background` subpackage:

--- a/benchmarks/bench_profiles.py
+++ b/benchmarks/bench_profiles.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for the photutils.profiles subpackage.
+
+The benchmarks cover the per-call cost of constructing each profile
+class and computing its profile for each aperture overlap method, the
+scaling of the profile computation with the number of radial bins,
+and the cost of the RadialProfile extras (the raw data profile and
+the Gaussian and Moffat model fits).
+
+Run ``python benchmarks/bench_profiles.py --help`` to see the
+available options.
+"""
+
+import argparse
+from functools import partial
+
+import numpy as np
+from astropy.modeling.models import Gaussian2D
+from astropy.stats import gaussian_fwhm_to_sigma
+from bench_utils import print_environment, time_best
+
+from photutils.profiles import (CurveOfGrowth, EllipticalCurveOfGrowth,
+                                EnsquaredCurveOfGrowth, RadialProfile)
+
+# The overlap methods used by the profile-classes benchmark
+METHODS = ('exact', 'center', 'subpixel')
+
+
+def make_source_image(size, *, amplitude=100.0, noise_std=1.0, seed=0):
+    """
+    Return an image with a single Gaussian source and an error array.
+
+    The source FWHM scales with the image size so that the source
+    fills a constant fraction of the image.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    amplitude : float, optional
+        The amplitude of the Gaussian source.
+
+    noise_std : float, optional
+        The standard deviation of the Gaussian noise.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    error : 2D `~numpy.ndarray`
+        The error array.
+
+    xycen : tuple of float
+        The ``(x, y)`` source center.
+    """
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:size, 0:size]
+    xc = yc = (size - 1) / 2.0
+    sigma = (size / 8.0) * gaussian_fwhm_to_sigma
+    model = Gaussian2D(amplitude, xc, yc, sigma, sigma)
+    data = model(xx, yy) + rng.normal(0.0, noise_std, (size, size))
+    error = np.full((size, size), noise_std)
+    return data, error, (xc, yc)
+
+
+def make_profile(profile_class, data, error, xycen, n_radii, max_radius,
+                 **kwargs):
+    """
+    Construct a profile instance covering the given radial range.
+
+    Parameters
+    ----------
+    profile_class : class
+        The profile class to construct.
+
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    error : 2D `~numpy.ndarray`
+        The error array.
+
+    xycen : tuple of float
+        The ``(x, y)`` source center.
+
+    n_radii : int
+        The number of radial bins.
+
+    max_radius : float
+        The maximum radius (or half-size) in pixels.
+
+    **kwargs : dict, optional
+        Additional keyword arguments passed to the profile class
+        (e.g., ``method`` or ``axis_ratio``).
+
+    Returns
+    -------
+    result : `~photutils.profiles.ProfileBase`
+        The profile instance.
+    """
+    if profile_class is RadialProfile:
+        radii = np.linspace(0.0, max_radius, n_radii + 1)
+    else:
+        radii = np.linspace(1.0, max_radius, n_radii)
+    if profile_class is EllipticalCurveOfGrowth:
+        kwargs.setdefault('axis_ratio', 0.5)
+        kwargs.setdefault('theta', 0.5)
+    return profile_class(data, xycen, radii, error=error, **kwargs)
+
+
+def run_profile(profile_class, data, error, xycen, n_radii, max_radius,
+                n_iter, **kwargs):
+    """
+    Construct a profile and compute its outputs repeatedly.
+
+    Each call constructs a new instance and accesses the ``profile``,
+    ``profile_error``, and ``area`` attributes (the computation is
+    lazy and cached per instance).
+
+    Parameters
+    ----------
+    profile_class : class
+        The profile class to construct.
+
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    error : 2D `~numpy.ndarray`
+        The error array.
+
+    xycen : tuple of float
+        The ``(x, y)`` source center.
+
+    n_radii : int
+        The number of radial bins.
+
+    max_radius : float
+        The maximum radius (or half-size) in pixels.
+
+    n_iter : int
+        The number of calls.
+
+    **kwargs : dict, optional
+        Additional keyword arguments passed to the profile class.
+    """
+    for _ in range(n_iter):
+        profile = make_profile(profile_class, data, error, xycen,
+                               n_radii, max_radius, **kwargs)
+        for name in ('profile', 'profile_error', 'area'):
+            getattr(profile, name)
+
+
+def bench_classes(*, size=501, n_radii=100, n_iter=5, repeats=3, seed=0):
+    """
+    Benchmark each profile class for each overlap method.
+
+    Each timing includes profile construction and the computation of
+    the ``profile``, ``profile_error``, and ``area`` attributes.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    n_radii : int, optional
+        The number of radial bins.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, error, xycen = make_source_image(size, seed=seed)
+    max_radius = size / 4.0
+
+    classes = (RadialProfile, CurveOfGrowth, EnsquaredCurveOfGrowth,
+               EllipticalCurveOfGrowth)
+
+    print(f'\n== profile classes ({size}x{size} image, {n_radii} radii, '
+          'per-call time) ==')
+    header = f'{"class":>24}'
+    for method in METHODS:
+        header += f'{method:>12}'
+    print(header)
+    for profile_class in classes:
+        cells = ''
+        for method in METHODS:
+            bench = partial(run_profile, profile_class, data, error,
+                            xycen, n_radii, max_radius, n_iter,
+                            method=method)
+            t_call = time_best(bench, repeats=repeats) / n_iter
+            cells += f'{f"{t_call * 1e3:.2f}ms":>12}'
+        print(f'{profile_class.__name__:>24}{cells}')
+
+
+def bench_radii_scaling(*, size=501, n_radii_list=(25, 100, 400),
+                        n_iter=5, repeats=3, seed=0):
+    """
+    Benchmark the profile computation versus the number of radii.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    n_radii_list : tuple of int, optional
+        The numbers of radial bins.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, error, xycen = make_source_image(size, seed=seed)
+    max_radius = size / 4.0
+
+    classes = (RadialProfile, CurveOfGrowth)
+
+    print(f'\n== scaling with the number of radii ({size}x{size} image, '
+          'per-call time) ==')
+    header = f'{"n_radii":>12}'
+    for profile_class in classes:
+        header += f'{profile_class.__name__:>16}'
+    print(header)
+    for n_radii in n_radii_list:
+        cells = ''
+        for profile_class in classes:
+            bench = partial(run_profile, profile_class, data, error,
+                            xycen, n_radii, max_radius, n_iter)
+            t_call = time_best(bench, repeats=repeats) / n_iter
+            cells += f'{f"{t_call * 1e3:.2f}ms":>16}'
+        print(f'{n_radii:>12}{cells}')
+
+
+def run_radial_extra(data, error, xycen, n_radii, max_radius, n_iter,
+                     attributes):
+    """
+    Construct a RadialProfile and access the given attributes.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    error : 2D `~numpy.ndarray`
+        The error array.
+
+    xycen : tuple of float
+        The ``(x, y)`` source center.
+
+    n_radii : int
+        The number of radial bins.
+
+    max_radius : float
+        The maximum radius in pixels.
+
+    n_iter : int
+        The number of calls.
+
+    attributes : list of str
+        The names of the attributes to access on each instance.
+    """
+    for _ in range(n_iter):
+        profile = make_profile(RadialProfile, data, error, xycen,
+                               n_radii, max_radius)
+        for name in ['profile', *attributes]:
+            getattr(profile, name)
+
+
+def bench_radial_extras(*, size=501, n_radii=100, n_iter=5, repeats=3,
+                        seed=0):
+    """
+    Benchmark the extra lazily-computed RadialProfile attributes.
+
+    The baseline row times construction plus the ``profile``
+    computation alone; the remaining rows add one extra attribute
+    each.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    n_radii : int, optional
+        The number of radial bins.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, error, xycen = make_source_image(size, seed=seed)
+    max_radius = size / 4.0
+
+    variants = [
+        ('profile only', []),
+        ('+ data_profile', ['data_profile']),
+        ('+ gaussian_fit', ['gaussian_fit']),
+        ('+ moffat_fit', ['moffat_fit']),
+    ]
+
+    print(f'\n== RadialProfile extras ({size}x{size} image, {n_radii} '
+          'radii, per-call time) ==')
+    print(f'{"variant":>18}{"time":>12}')
+    for name, attributes in variants:
+        bench = partial(run_radial_extra, data, error, xycen, n_radii,
+                        max_radius, n_iter, attributes)
+        t_call = time_best(bench, repeats=repeats) / n_iter
+        print(f'{name:>18}{f"{t_call * 1e3:.2f}ms":>12}')
+
+
+def parse_int_list(text):
+    """
+    Parse a comma-separated list of positive integers.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated integers (e.g., ``'25,100,400'``).
+
+    Returns
+    -------
+    result : list of int
+        The parsed integers.
+    """
+    values = [int(item) for item in text.split(',')]
+    if any(value < 1 for value in values):
+        msg = 'values must be positive integers'
+        raise ValueError(msg)
+    return values
+
+
+def main():
+    """
+    Run the photutils.profiles benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for the photutils.profiles subpackage.')
+    parser.add_argument('--size', type=int, default=501,
+                        help='image size (default: %(default)s)')
+    parser.add_argument('--n-radii', type=int, default=100,
+                        help='number of radial bins '
+                             '(default: %(default)s)')
+    parser.add_argument('--n-radii-list', type=parse_int_list,
+                        default=[25, 100, 400],
+                        help='comma-separated numbers of radial bins '
+                             'for the scaling benchmark '
+                             '(default: 25,100,400)')
+    parser.add_argument('--n-iter', type=int, default=5,
+                        help='number of calls per timing '
+                             '(default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'classes', 'radii-scaling',
+                                 'radial-extras'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'classes'):
+        bench_classes(size=args.size, n_radii=args.n_radii,
+                      n_iter=args.n_iter, repeats=args.repeats,
+                      seed=args.seed)
+    if args.which in ('all', 'radii-scaling'):
+        bench_radii_scaling(size=args.size,
+                            n_radii_list=args.n_radii_list,
+                            n_iter=args.n_iter, repeats=args.repeats,
+                            seed=args.seed)
+    if args.which in ('all', 'radial-extras'):
+        bench_radial_extras(size=args.size, n_radii=args.n_radii,
+                            n_iter=args.n_iter, repeats=args.repeats,
+                            seed=args.seed)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/user_guide/curves_of_growth.rst
+++ b/docs/user_guide/curves_of_growth.rst
@@ -115,7 +115,7 @@ radius. The curve-of-growth profile can be normalized using the
 :meth:`~photutils.profiles.CurveOfGrowth.normalize` method. By default
 (``method='max'``), the profile is normalized such that its maximum
 value is 1. Setting ``method='sum'`` can also be used to normalize the
-profile such that its sum (integral) is 1::
+profile such that the sum of its values is 1::
 
     >>> cog.normalize(method='max')
 

--- a/docs/user_guide/radial_profiles.rst
+++ b/docs/user_guide/radial_profiles.rst
@@ -163,7 +163,7 @@ If desired, the radial profile can be normalized using the
 :meth:`~photutils.profiles.RadialProfile.normalize` method. By default
 (``method='max'``), the profile is normalized such that its maximum
 value is 1. Setting ``method='sum'`` can be used to normalize the
-profile such that its sum (integral) is 1::
+profile such that the sum of its values is 1::
 
     >>> rp.normalize(method='max')
 

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -83,6 +83,14 @@ class ProfileBase(metaclass=abc.ABCMeta):
         self.mask = self._compute_mask(data, error, mask)
         self.method = method
         self.subpixels = subpixels
+
+        # The total normalization applied to the profile. This is the
+        # only mutable state of the class. All normalization-dependent
+        # attributes (e.g., ``profile``) are derived from immutable
+        # cached values divided by this value, and `normalize` and
+        # `unnormalize` update it with a single atomic attribute
+        # store, making the class safe for concurrent reads during
+        # normalization changes.
         self.normalization_value = 1.0
 
     def _validate_radii(self, radii):
@@ -143,20 +151,41 @@ class ProfileBase(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def profile(self):
+    def _raw_profile(self):
         """
-        The radial profile as a 1D `~numpy.ndarray`.
+        The raw (unnormalized) profile as a 1D `~numpy.ndarray`.
         """
 
     @property
     @abc.abstractmethod
-    def profile_error(self):
+    def _raw_profile_error(self):
         """
-        The profile errors as a 1D `~numpy.ndarray`.
+        The raw (unnormalized) profile errors as a 1D `~numpy.ndarray`.
 
         If no ``error`` array was provided, an empty array with shape
         ``(0,)`` is returned.
         """
+
+    @property
+    def profile(self):
+        """
+        The profile as a 1D `~numpy.ndarray`.
+
+        The returned values reflect the current profile normalization
+        (see `normalize`).
+        """
+        return self._raw_profile / self.normalization_value
+
+    @property
+    def profile_error(self):
+        """
+        The profile errors as a 1D `~numpy.ndarray`.
+
+        The returned values reflect the current profile normalization
+        (see `normalize`). If no ``error`` array was provided, an empty
+        array with shape ``(0,)`` is returned.
+        """
+        return self._raw_profile_error / self.normalization_value
 
     @cached_property
     def _circular_apertures(self):
@@ -235,6 +264,12 @@ class ProfileBase(metaclass=abc.ABCMeta):
         """
         Normalize the profile.
 
+        The normalization is computed from the raw (unnormalized)
+        profile values, so repeated calls do not accumulate. The
+        most recent call determines the normalization. Because both
+        normalization methods scale linearly with the profile values,
+        this is equivalent to normalizing an already-normalized profile.
+
         Parameters
         ----------
         method : {'max', 'sum'}, optional
@@ -249,69 +284,33 @@ class ProfileBase(metaclass=abc.ABCMeta):
               is 1.
         """
         if method == 'max':
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', RuntimeWarning)
-                normalization = nanmax(self.profile)
+            func = nanmax
         elif method == 'sum':
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', RuntimeWarning)
-                normalization = nansum(self.profile)
+            func = nansum
         else:
             msg = "invalid method, must be 'max' or 'sum'"
             raise ValueError(msg)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            normalization = func(self._raw_profile)
 
         if normalization == 0 or not np.isfinite(normalization):
             msg = ('The profile cannot be normalized because the max or '
                    'sum is zero or non-finite.')
             warnings.warn(msg, AstropyUserWarning)
         else:
-            # normalization_values accumulate if normalize is run
-            # multiple times (e.g., different methods)
-            self.normalization_value *= normalization
-
-            # Need to use __dict__ as these are cached properties
-            self.__dict__['profile'] = self.profile / normalization
-            self.__dict__['profile_error'] = self.profile_error / normalization
-            self._normalize_hook(normalization)
-
-    def _normalize_hook(self, normalization):  # noqa: B027
-        """
-        Hook called by `normalize` after normalizing ``profile`` and
-        ``profile_error``.
-
-        This hook is only called when normalization succeeds (i.e., when
-        the normalization value is non-zero and finite).
-
-        Subclasses can override this to invalidate or rescale additional
-        cached properties that depend on the profile normalization
-        (e.g., ``data_profile``).
-
-        Parameters
-        ----------
-        normalization : float
-            The normalization value applied to the profile.
-        """
+            # A single atomic attribute store. Concurrent readers see
+            # either the old or the new normalization, never a mixed
+            # state.
+            self.normalization_value = normalization
 
     def unnormalize(self):
         """
         Unnormalize the profile back to the original state before any
         calls to `normalize`.
         """
-        self.__dict__['profile'] = self.profile * self.normalization_value
-        self.__dict__['profile_error'] = (self.profile_error
-                                          * self.normalization_value)
-        self._unnormalize_hook()
         self.normalization_value = 1.0
-
-    def _unnormalize_hook(self):  # noqa: B027
-        """
-        Hook called by `unnormalize` after unnormalizing ``profile`` and
-        ``profile_error``, but before resetting ``normalization_value``.
-
-        Subclasses can override this to invalidate or rescale additional
-        cached properties that depend on the profile normalization
-        (e.g., ``data_profile``).
-        """
 
     @staticmethod
     def _trim_to_monotonic(xarr, profile, name):

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -7,6 +7,7 @@ import abc
 import warnings
 from functools import cached_property
 
+import astropy.units as u
 import numpy as np
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -393,11 +394,19 @@ class ProfileBase(metaclass=abc.ABCMeta):
         if ax is None:
             ax = plt.gca()
 
-        lines = ax.plot(self.radius, self.profile, **kwargs)
+        profile = self.profile
+        unit = None
+        if isinstance(profile, u.Quantity):
+            unit = profile.unit
+            profile = profile.value
+
+        lines = ax.plot(self.radius, profile, **kwargs)
         ax.set_xlabel(self._xlabel)
         ylabel = self._ylabel
-        if self.unit is not None:
-            ylabel = f'{ylabel} ({self.unit})'
+        # A normalized profile is dimensionless, so the unit is
+        # included only when the profile has a physical unit
+        if unit is not None and unit != u.dimensionless_unscaled:
+            ylabel = f'{ylabel} ({unit})'
         ax.set_ylabel(ylabel)
 
         return lines
@@ -444,8 +453,9 @@ class ProfileBase(metaclass=abc.ABCMeta):
 
         profile = self.profile
         profile_error = self.profile_error
-        if self.unit is not None:
+        if isinstance(profile, u.Quantity):
             profile = profile.value
+        if isinstance(profile_error, u.Quantity):
             profile_error = profile_error.value
         ymin = profile - profile_error
         ymax = profile + profile_error

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -250,8 +250,8 @@ class ProfileBase(metaclass=abc.ABCMeta):
               1.
 
             * ``'sum'``:
-              The profile is normalized such that its sum (integral) is
-              1.
+              The profile is normalized such that the sum of its values
+              is 1.
         """
         if method == 'max':
             with warnings.catch_warnings():

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -275,8 +275,9 @@ class ProfileBase(metaclass=abc.ABCMeta):
         This hook is only called when normalization succeeds (i.e., when
         the normalization value is non-zero and finite).
 
-        Subclasses can override this to normalize additional lazy
-        properties (e.g., ``data_profile``).
+        Subclasses can override this to invalidate or rescale additional
+        cached properties that depend on the profile normalization
+        (e.g., ``data_profile``).
 
         Parameters
         ----------
@@ -300,8 +301,9 @@ class ProfileBase(metaclass=abc.ABCMeta):
         Hook called by `unnormalize` after unnormalizing ``profile`` and
         ``profile_error``, but before resetting ``normalization_value``.
 
-        Subclasses can override this to unnormalize additional lazy
-        properties (e.g., ``data_profile``).
+        Subclasses can override this to invalidate or rescale additional
+        cached properties that depend on the profile normalization
+        (e.g., ``data_profile``).
         """
 
     @staticmethod

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -178,14 +178,15 @@ class ProfileBase(metaclass=abc.ABCMeta):
     def _compute_photometry(self, apertures):
         """
         Compute aperture fluxes, flux errors, and areas for the given
-        apertures.
+        apertures using a single batched photometry call.
 
         Parameters
         ----------
         apertures : list
-            A list of aperture objects. Elements may be `None`, in which
-            case the corresponding flux, error, and area are set to
-            zero.
+            A list of aperture objects sharing the same position.
+            Leading elements may be `None` (e.g., for a zero radius), in
+            which case the corresponding flux, error, and area are set
+            to zero.
 
         Returns
         -------
@@ -198,32 +199,26 @@ class ProfileBase(metaclass=abc.ABCMeta):
         areas : `~numpy.ndarray`
             The aperture areas.
         """
-        fluxes = []
-        flux_errs = []
-        areas = []
-        for aperture in apertures:
-            if aperture is None:
-                flux, flux_err = 0.0, 0.0
-                area = 0.0
-            else:
-                result = AperturePhotometry(
-                    self.data, aperture, error=self.error, mask=self.mask,
-                    method=self.method, subpixels=self.subpixels)
-                flux, flux_err = result.flux, result.flux_err
-                area = aperture.area_overlap(self.data, mask=self.mask,
-                                             method=self.method,
-                                             subpixels=self.subpixels)
-            fluxes.append(flux)
-            if self.error is not None:
-                flux_errs.append(flux_err)
-            areas.append(area)
+        n_none = sum(aperture is None for aperture in apertures)
+        result = AperturePhotometry(
+            self.data, apertures[n_none:], error=self.error,
+            mask=self.mask, method=self.method, subpixels=self.subpixels)
 
-        fluxes = np.array(fluxes)
-        flux_errs = np.array(flux_errs)
-        areas = np.array(areas)
+        fluxes = result.flux
+        areas = result.area.to_value(u.pix ** 2)
+        flux_errs = (result.flux_err if self.error is not None
+                     else np.array([]))
+
+        if n_none > 0:
+            zeros = np.zeros(n_none)
+            fluxes = np.concatenate((zeros, fluxes))
+            areas = np.concatenate((zeros, areas))
+            if self.error is not None:
+                flux_errs = np.concatenate((zeros, flux_errs))
+
         if self.unit is not None:
-            fluxes <<= self.unit
-            flux_errs <<= self.unit
+            fluxes = fluxes << self.unit
+            flux_errs = flux_errs << self.unit
 
         return fluxes, flux_errs, areas
 

--- a/photutils/profiles/core.py
+++ b/photutils/profiles/core.py
@@ -60,6 +60,11 @@ class ProfileBase(metaclass=abc.ABCMeta):
     _xlabel = 'Radius (pixels)'
     _ylabel = 'Profile'
 
+    # The user-facing name of the ``radii`` parameter, used in
+    # validation error messages. Subclasses that rename the parameter
+    # (e.g., ``half_sizes``) may override this.
+    _radii_name = 'radii'
+
     def __init__(self, data, xycen, radii, *, error=None, mask=None,
                  method='exact', subpixels=5):
 
@@ -84,16 +89,22 @@ class ProfileBase(metaclass=abc.ABCMeta):
         """
         Validate and return the radii array.
         """
+        name = self._radii_name
+        if isinstance(radii, u.Quantity):
+            msg = (f'{name} must be a plain array of pixel values, '
+                   'not a Quantity')
+            raise TypeError(msg)
+
         radii = np.array(radii)
         if radii.ndim != 1 or radii.size < 2:
-            msg = 'radii must be a 1D array and have at least two values'
+            msg = f'{name} must be a 1D array and have at least two values'
             raise ValueError(msg)
         if radii.min() < 0:
-            msg = 'minimum radii must be >= 0'
+            msg = f'minimum {name} must be >= 0'
             raise ValueError(msg)
 
         if not np.all(radii[1:] > radii[:-1]):
-            msg = 'radii must be strictly increasing'
+            msg = f'{name} must be strictly increasing'
             raise ValueError(msg)
 
         return radii

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -40,16 +40,18 @@ class _CurveOfGrowthBase(ProfileBase):
         return self._compute_photometry(self.apertures)
 
     @cached_property
-    def profile(self):
+    def _raw_profile(self):
         """
-        The curve-of-growth profile as a 1D `~numpy.ndarray`.
+        The raw (unnormalized) curve-of-growth profile as a 1D
+        `~numpy.ndarray`.
         """
         return self._photometry[0]
 
     @cached_property
-    def profile_error(self):
+    def _raw_profile_error(self):
         """
-        The curve-of-growth profile errors as a 1D `~numpy.ndarray`.
+        The raw (unnormalized) curve-of-growth profile errors as a 1D
+        `~numpy.ndarray`.
 
         If no ``error`` array was provided, an empty array with shape
         ``(0,)`` is returned.

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -3,6 +3,7 @@
 Tools for generating curves of growth.
 """
 
+import abc
 from functools import cached_property
 
 import numpy as np
@@ -15,8 +16,57 @@ __all__ = ['CurveOfGrowth', 'EllipticalCurveOfGrowth',
            'EnsquaredCurveOfGrowth']
 
 
+class _CurveOfGrowthBase(ProfileBase):
+    """
+    Base class for curve-of-growth profile classes.
+
+    Curve-of-growth profiles measure the cumulative flux directly
+    within the apertures defined by the ``apertures`` property.
+    """
+
+    @property
+    @abc.abstractmethod
+    def apertures(self):
+        """
+        A list of the aperture objects used to measure the profile.
+        """
+
+    @cached_property
+    def _photometry(self):
+        """
+        The aperture fluxes, flux errors, and areas as a function of
+        radius.
+        """
+        return self._compute_photometry(self.apertures)
+
+    @cached_property
+    def profile(self):
+        """
+        The curve-of-growth profile as a 1D `~numpy.ndarray`.
+        """
+        return self._photometry[0]
+
+    @cached_property
+    def profile_error(self):
+        """
+        The curve-of-growth profile errors as a 1D `~numpy.ndarray`.
+
+        If no ``error`` array was provided, an empty array with shape
+        ``(0,)`` is returned.
+        """
+        return self._photometry[1]
+
+    @cached_property
+    def area(self):
+        """
+        The unmasked area within each aperture as a function of radius
+        as a 1D `~numpy.ndarray`.
+        """
+        return self._photometry[2]
+
+
 @_update_method_subpixels_docstring
-class CurveOfGrowth(ProfileBase):
+class CurveOfGrowth(_CurveOfGrowthBase):
     # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Class to create a curve of growth using concentric circular
@@ -242,39 +292,6 @@ class CurveOfGrowth(ProfileBase):
         """
         return self._circular_apertures
 
-    @cached_property
-    def _photometry(self):
-        """
-        The aperture fluxes, flux errors, and areas as a function of
-        radius.
-        """
-        return self._compute_photometry(self.apertures)
-
-    @cached_property
-    def profile(self):
-        """
-        The curve-of-growth profile as a 1D `~numpy.ndarray`.
-        """
-        return self._photometry[0]
-
-    @cached_property
-    def profile_error(self):
-        """
-        The curve-of-growth profile errors as a 1D `~numpy.ndarray`.
-
-        If no ``error`` array was provided, an empty array with shape
-        ``(0,)`` is returned.
-        """
-        return self._photometry[1]
-
-    @cached_property
-    def area(self):
-        """
-        The unmasked area in each circular aperture as a function of
-        radius as a 1D `~numpy.ndarray`.
-        """
-        return self._photometry[2]
-
     def calc_ee_at_radius(self, radius):
         """
         Calculate the encircled energy at a given radius using a cubic
@@ -332,7 +349,7 @@ class CurveOfGrowth(ProfileBase):
 
 
 @_update_method_subpixels_docstring
-class EnsquaredCurveOfGrowth(ProfileBase):
+class EnsquaredCurveOfGrowth(_CurveOfGrowthBase):
     # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Class to create a curve of growth using concentric square
@@ -507,7 +524,8 @@ class EnsquaredCurveOfGrowth(ProfileBase):
 
         super().__init__(data, xycen, half_sizes, error=error, mask=mask,
                          method=method, subpixels=subpixels)
-        # self.radii is set by the parent class
+        # Alias the validated sizes under the user-facing name. The
+        # inherited ``radii`` attribute holds the same array.
         self.half_sizes = self.radii
 
     def __repr__(self):
@@ -554,40 +572,6 @@ class EnsquaredCurveOfGrowth(ProfileBase):
 
         return [RectangularAperture(self.xycen, 2 * hs, 2 * hs)
                 for hs in self.half_sizes]
-
-    @cached_property
-    def _photometry(self):
-        """
-        The aperture fluxes, flux errors, and areas as a function of
-        size.
-        """
-        return self._compute_photometry(self.apertures)
-
-    @cached_property
-    def profile(self):
-        """
-        The ensquared curve-of-growth profile as a 1D `~numpy.ndarray`.
-        """
-        return self._photometry[0]
-
-    @cached_property
-    def profile_error(self):
-        """
-        The ensquared curve-of-growth profile errors as a 1D
-        `~numpy.ndarray`.
-
-        If no ``error`` array was provided, an empty array with shape
-        ``(0,)`` is returned.
-        """
-        return self._photometry[1]
-
-    @cached_property
-    def area(self):
-        """
-        The unmasked area in each square aperture as a function of size
-        as a 1D `~numpy.ndarray`.
-        """
-        return self._photometry[2]
 
     def calc_ee_at_half_size(self, half_size):
         """
@@ -648,7 +632,7 @@ class EnsquaredCurveOfGrowth(ProfileBase):
 
 
 @_update_method_subpixels_docstring
-class EllipticalCurveOfGrowth(ProfileBase):
+class EllipticalCurveOfGrowth(_CurveOfGrowthBase):
     # numpydoc ignore: PR01,PR02,PR04,PR07
     """
     Class to create a curve of growth using concentric elliptical
@@ -883,40 +867,6 @@ class EllipticalCurveOfGrowth(ProfileBase):
         return [EllipticalAperture(self.xycen, a, a * self.axis_ratio,
                                    theta=self.theta)
                 for a in self.radii]
-
-    @cached_property
-    def _photometry(self):
-        """
-        The aperture fluxes, flux errors, and areas as a function of
-        semimajor axis.
-        """
-        return self._compute_photometry(self.apertures)
-
-    @cached_property
-    def profile(self):
-        """
-        The elliptical curve-of-growth profile as a 1D `~numpy.ndarray`.
-        """
-        return self._photometry[0]
-
-    @cached_property
-    def profile_error(self):
-        """
-        The elliptical curve-of-growth profile errors as a 1D
-        `~numpy.ndarray`.
-
-        If no ``error`` array was provided, an empty array with shape
-        ``(0,)`` is returned.
-        """
-        return self._photometry[1]
-
-    @cached_property
-    def area(self):
-        """
-        The unmasked area in each elliptical aperture as a function of
-        semimajor axis as a 1D `~numpy.ndarray`.
-        """
-        return self._photometry[2]
 
     def calc_ee_at_radius(self, radius):
         """

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -494,6 +494,10 @@ class EnsquaredCurveOfGrowth(ProfileBase):
     _xlabel = 'Half-Size (pixels)'
     _ylabel = 'Ensquared Curve of Growth'
 
+    # The user-facing name of the sizes parameter, used in validation
+    # error messages
+    _radii_name = 'half_sizes'
+
     def __init__(self, data, xycen, half_sizes, *, error=None, mask=None,
                  method='exact', subpixels=5):
 

--- a/photutils/profiles/curve_of_growth.py
+++ b/photutils/profiles/curve_of_growth.py
@@ -850,6 +850,14 @@ class EllipticalCurveOfGrowth(ProfileBase):
         super().__init__(data, xycen, radii, error=error, mask=mask,
                          method=method, subpixels=subpixels)
 
+    def __repr__(self):
+        cls_name = self.__class__.__name__
+        n_radii = len(self.radii)
+        normalized = self.normalization_value != 1.0
+        return (f'{cls_name}(xycen={self.xycen}, n_radii={n_radii}, '
+                f'axis_ratio={self.axis_ratio}, theta={self.theta}, '
+                f'normalized={normalized})')
+
     @cached_property
     def radius(self):
         """

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -526,8 +526,8 @@ class RadialProfile(ProfileBase):
     @cached_property
     def _data_profile(self):
         """
-        The raw data profile returned as 1D arrays (`~numpy.ndarray`) of
-        radii and data values.
+        The raw (unnormalized) data profile returned as 1D arrays
+        (`~numpy.ndarray`) of radii and data values.
 
         Returns the radii and values of the unmasked data points within
         the maximum radius defined by the input radii. Pixels flagged
@@ -557,6 +557,8 @@ class RadialProfile(ProfileBase):
         valid = ~self.mask[yidx_sub, xidx_sub]
         radii = radii[valid]
         data_values = self.data[yidx_sub[valid], xidx_sub[valid]]
+        if self.unit is not None:
+            data_values = data_values << self.unit
 
         return radii, data_values
 
@@ -571,8 +573,13 @@ class RadialProfile(ProfileBase):
     def data_profile(self):
         """
         The raw data profile as a 1D `~numpy.ndarray`.
+
+        The values reflect the current profile normalization. If
+        `~photutils.profiles.ProfileBase.normalize` has been called, the
+        raw data values are divided by the same normalization applied to
+        ``profile``.
         """
-        return self._data_profile[1]
+        return self._data_profile[1] / self.normalization_value
 
     def _invalidate_fit_cache(self):
         """
@@ -582,21 +589,20 @@ class RadialProfile(ProfileBase):
         for key in self._fit_properties:
             self.__dict__.pop(key, None)
 
-    def _normalize_hook(self, normalization):
+    def _normalize_hook(self, normalization):  # noqa: ARG002
         """
-        Also normalize ``data_profile`` if it has been computed, and
-        invalidate fit caches so they are recomputed on next access.
+        Invalidate the cached ``data_profile`` and fit properties
+        so they are recomputed on next access using the current
+        normalization.
         """
-        if 'data_profile' in self.__dict__:
-            self.__dict__['data_profile'] = self.data_profile / normalization
+        self.__dict__.pop('data_profile', None)
         self._invalidate_fit_cache()
 
     def _unnormalize_hook(self):
         """
-        Also unnormalize ``data_profile`` if it has been computed, and
-        invalidate fit caches so they are recomputed on next access.
+        Invalidate the cached ``data_profile`` and fit properties
+        so they are recomputed on next access using the current
+        normalization.
         """
-        if 'data_profile' in self.__dict__:
-            self.__dict__['data_profile'] = (self.data_profile
-                                             * self.normalization_value)
+        self.__dict__.pop('data_profile', None)
         self._invalidate_fit_cache()

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -276,13 +276,6 @@ class RadialProfile(ProfileBase):
     # Define y-axis label used by `~photutils.profiles.ProfileBase.plot`
     _ylabel = 'Radial Profile'
 
-    # Define the fit properties that should be invalidated when the
-    # profile normalization is changed, so they are always consistent
-    # with the current profile.
-    _fit_properties = ('_profile_nanmask', 'gaussian_fit',
-                       'gaussian_profile', 'gaussian_fwhm', 'moffat_fit',
-                       'moffat_profile', 'moffat_fwhm')
-
     @cached_property
     def radius(self):
         """
@@ -348,9 +341,9 @@ class RadialProfile(ProfileBase):
         return np.diff(self._photometry[2])
 
     @cached_property
-    def profile(self):
+    def _raw_profile(self):
         """
-        The radial profile as a 1D `~numpy.ndarray`.
+        The raw (unnormalized) radial profile as a 1D `~numpy.ndarray`.
         """
         # Ignore divide-by-zero RuntimeWarning
         with warnings.catch_warnings():
@@ -358,9 +351,10 @@ class RadialProfile(ProfileBase):
             return self._flux / self.area
 
     @cached_property
-    def profile_error(self):
+    def _raw_profile_error(self):
         """
-        The radial profile errors as a 1D `~numpy.ndarray`.
+        The raw (unnormalized) radial profile errors as a 1D
+        `~numpy.ndarray`.
 
         If no ``error`` array was provided, an empty array with shape
         ``(0,)`` is returned.
@@ -375,19 +369,15 @@ class RadialProfile(ProfileBase):
 
     @cached_property
     def _profile_nanmask(self):
-        return np.isfinite(self.profile)
+        return np.isfinite(self._raw_profile)
 
     @cached_property
-    def gaussian_fit(self):
+    def _raw_gaussian_fit(self):
         """
-        The fitted 1D Gaussian to the radial profile as a
-        `~astropy.modeling.functional_models.Gaussian1D` model.
-
-        The cached fit is automatically invalidated when the profile
-        normalization is changed, so the fit is always consistent with
-        the current profile.
+        The 1D Gaussian fitted to the raw (unnormalized) radial profile,
+        or `None` if the profile is entirely non-finite or masked.
         """
-        profile = self.profile[self._profile_nanmask]
+        profile = self._raw_profile[self._profile_nanmask]
         radius = self.radius[self._profile_nanmask]
 
         if len(profile) == 0:
@@ -418,49 +408,74 @@ class RadialProfile(ProfileBase):
 
         return gaussian_fit
 
-    @cached_property
+    @property
+    def gaussian_fit(self):
+        """
+        The fitted 1D Gaussian to the radial profile as a
+        `~astropy.modeling.functional_models.Gaussian1D` model.
+
+        The model amplitude reflects the current profile normalization
+        (the Gaussian amplitude scales linearly with the profile
+        values). The mean and standard deviation are independent of the
+        normalization.
+
+        Returns `None` if the fit failed (e.g., the profile is entirely
+        non-finite or masked).
+        """
+        raw_fit = self._raw_gaussian_fit
+        if raw_fit is None:
+            return None
+        fit = raw_fit.copy()
+        fit.amplitude = raw_fit.amplitude.value / self.normalization_value
+        return fit
+
+    @property
     def gaussian_profile(self):
         """
         The fitted 1D Gaussian profile to the radial profile as a 1D
         `~numpy.ndarray`.
 
-        The cached profile is automatically invalidated when the profile
-        normalization is changed.
+        The values reflect the current profile normalization.
 
         Returns `None` if the fit failed (e.g., the profile is entirely
         non-finite or masked).
         """
-        if self.gaussian_fit is None:
+        if self._raw_gaussian_profile is None:
             return None
-        return self.gaussian_fit(self.radius)
+        return self._raw_gaussian_profile / self.normalization_value
 
     @cached_property
+    def _raw_gaussian_profile(self):
+        """
+        The raw-fit 1D Gaussian evaluated at the profile radii, or
+        `None` if the fit failed.
+        """
+        if self._raw_gaussian_fit is None:
+            return None
+        return self._raw_gaussian_fit(self.radius)
+
+    @property
     def gaussian_fwhm(self):
         """
         The full-width at half-maximum (FWHM) in pixels of the 1D
         Gaussian fitted to the radial profile.
 
-        The cached value is automatically invalidated when the profile
-        normalization is changed.
+        The FWHM is independent of the profile normalization.
 
         Returns `None` if the fit failed (e.g., the profile is entirely
         non-finite or masked).
         """
-        if self.gaussian_fit is None:
+        if self._raw_gaussian_fit is None:
             return None
-        return self.gaussian_fit.stddev.value * gaussian_sigma_to_fwhm
+        return self._raw_gaussian_fit.stddev.value * gaussian_sigma_to_fwhm
 
     @cached_property
-    def moffat_fit(self):
+    def _raw_moffat_fit(self):
         """
-        The fitted 1D Moffat to the radial profile as a
-        `~astropy.modeling.functional_models.Moffat1D` model.
-
-        The cached fit is automatically invalidated when the profile
-        normalization is changed, so the fit is always consistent with
-        the current profile.
+        The 1D Moffat fitted to the raw (unnormalized) radial profile,
+        or `None` if the profile is entirely non-finite or masked.
         """
-        profile = self.profile[self._profile_nanmask]
+        profile = self._raw_profile[self._profile_nanmask]
         radius = self.radius[self._profile_nanmask]
 
         if len(profile) == 0:
@@ -491,37 +506,66 @@ class RadialProfile(ProfileBase):
         fitter = TRFLSQFitter()
         return fitter(m_init, radius, profile)
 
-    @cached_property
+    @property
+    def moffat_fit(self):
+        """
+        The fitted 1D Moffat to the radial profile as a
+        `~astropy.modeling.functional_models.Moffat1D` model.
+
+        The model amplitude reflects the current profile normalization
+        (the Moffat amplitude scales linearly with the profile
+        values). The core width and power index are independent of the
+        normalization.
+
+        Returns `None` if the fit failed (e.g., the profile is entirely
+        non-finite or masked).
+        """
+        raw_fit = self._raw_moffat_fit
+        if raw_fit is None:
+            return None
+        fit = raw_fit.copy()
+        fit.amplitude = raw_fit.amplitude.value / self.normalization_value
+        return fit
+
+    @property
     def moffat_profile(self):
         """
         The fitted 1D Moffat profile to the radial profile as a 1D
         `~numpy.ndarray`.
 
-        The cached profile is automatically invalidated when the profile
-        normalization is changed.
+        The values reflect the current profile normalization.
 
         Returns `None` if the fit failed (e.g., the profile is entirely
         non-finite or masked).
         """
-        if self.moffat_fit is None:
+        if self._raw_moffat_profile is None:
             return None
-        return self.moffat_fit(self.radius)
+        return self._raw_moffat_profile / self.normalization_value
 
     @cached_property
+    def _raw_moffat_profile(self):
+        """
+        The raw-fit 1D Moffat evaluated at the profile radii, or
+        `None` if the fit failed.
+        """
+        if self._raw_moffat_fit is None:
+            return None
+        return self._raw_moffat_fit(self.radius)
+
+    @property
     def moffat_fwhm(self):
         """
         The full-width at half-maximum (FWHM) in pixels of the 1D Moffat
         fitted to the radial profile.
 
-        The cached value is automatically invalidated when the profile
-        normalization is changed.
+        The FWHM is independent of the profile normalization.
 
         Returns `None` if the fit failed (e.g., the profile is entirely
         non-finite or masked).
         """
-        if self.moffat_fit is None:
+        if self._raw_moffat_fit is None:
             return None
-        return self.moffat_fit.fwhm
+        return self._raw_moffat_fit.fwhm
 
     @cached_property
     def _data_profile(self):
@@ -572,7 +616,7 @@ class RadialProfile(ProfileBase):
         """
         return self._data_profile[0]
 
-    @cached_property
+    @property
     def data_profile(self):
         """
         The raw data profile as a 1D `~numpy.ndarray`.
@@ -583,29 +627,3 @@ class RadialProfile(ProfileBase):
         ``profile``.
         """
         return self._data_profile[1] / self.normalization_value
-
-    def _invalidate_fit_cache(self):
-        """
-        Remove the cached Gaussian and Moffat fit properties so they
-        are recomputed on next access using the current profile.
-        """
-        for key in self._fit_properties:
-            self.__dict__.pop(key, None)
-
-    def _normalize_hook(self, normalization):  # noqa: ARG002
-        """
-        Invalidate the cached ``data_profile`` and fit properties
-        so they are recomputed on next access using the current
-        normalization.
-        """
-        self.__dict__.pop('data_profile', None)
-        self._invalidate_fit_cache()
-
-    def _unnormalize_hook(self):
-        """
-        Invalidate the cached ``data_profile`` and fit properties
-        so they are recomputed on next access using the current
-        normalization.
-        """
-        self.__dict__.pop('data_profile', None)
-        self._invalidate_fit_cache()

--- a/photutils/profiles/radial_profile.py
+++ b/photutils/profiles/radial_profile.py
@@ -536,10 +536,13 @@ class RadialProfile(ProfileBase):
         """
         shape = self.data.shape
         max_radius = np.max(self.radii)
+        # The bounding box must include the pixels whose centers lie
+        # exactly at max_radius, so the (exclusive) upper slice bounds
+        # are floor(center + max_radius) + 1
         x_min = int(max(np.floor(self.xycen[0] - max_radius), 0))
-        x_max = int(min(np.ceil(self.xycen[0] + max_radius), shape[1]))
+        x_max = int(min(np.floor(self.xycen[0] + max_radius) + 1, shape[1]))
         y_min = int(max(np.floor(self.xycen[1] - max_radius), 0))
-        y_max = int(min(np.ceil(self.xycen[1] + max_radius), shape[0]))
+        y_max = int(min(np.floor(self.xycen[1] + max_radius) + 1, shape[0]))
         yidx, xidx = np.indices((y_max - y_min, x_max - x_min))
         xidx += x_min
         yidx += y_min

--- a/photutils/profiles/tests/test_curve_of_growth.py
+++ b/photutils/profiles/tests/test_curve_of_growth.py
@@ -124,7 +124,7 @@ class TestCurveOfGrowth:
         with pytest.raises(ValueError, match=match):
             cg1.normalize(method='invalid')
 
-        cg1.__dict__['profile'] -= np.nanmax(cg1.__dict__['profile'])
+        cg1.__dict__['_raw_profile'] = cg1.profile - np.nanmax(cg1.profile)
         match = 'The profile cannot be normalized'
         with pytest.warns(AstropyUserWarning, match=match):
             cg1.normalize(method='max')
@@ -170,7 +170,7 @@ class TestCurveOfGrowth:
         # elements
         profile = cg1.profile.copy()
         profile[0] = profile[1]
-        cg1.__dict__['profile'] = profile
+        cg1.__dict__['_raw_profile'] = profile
 
         match = 'The curve-of-growth profile is not monotonically increasing'
         with pytest.raises(ValueError, match=match):
@@ -435,7 +435,7 @@ class TestEnsquaredCurveOfGrowth:
         with pytest.raises(ValueError, match=match):
             ecg1.normalize(method='invalid')
 
-        ecg1.__dict__['profile'] -= np.nanmax(ecg1.__dict__['profile'])
+        ecg1.__dict__['_raw_profile'] = ecg1.profile - np.nanmax(ecg1.profile)
         match = 'The profile cannot be normalized'
         with pytest.warns(AstropyUserWarning, match=match):
             ecg1.normalize(method='max')
@@ -477,7 +477,7 @@ class TestEnsquaredCurveOfGrowth:
         # Force non-monotonicity at the first point
         profile = ecg1.profile.copy()
         profile[0] = profile[1]
-        ecg1.__dict__['profile'] = profile
+        ecg1.__dict__['_raw_profile'] = profile
 
         match = 'The ensquared curve-of-growth profile is not monotonically'
         with pytest.raises(ValueError, match=match):
@@ -722,7 +722,7 @@ class TestEllipticalCurveOfGrowth:
         with pytest.raises(ValueError, match=match):
             ecg1.normalize(method='invalid')
 
-        ecg1.__dict__['profile'] -= np.nanmax(ecg1.__dict__['profile'])
+        ecg1.__dict__['_raw_profile'] = ecg1.profile - np.nanmax(ecg1.profile)
         match = 'The profile cannot be normalized'
         with pytest.warns(AstropyUserWarning, match=match):
             ecg1.normalize(method='max')
@@ -765,7 +765,7 @@ class TestEllipticalCurveOfGrowth:
         # Force non-monotonicity at the first point
         profile = ecg1.profile.copy()
         profile[0] = profile[1]
-        ecg1.__dict__['profile'] = profile
+        ecg1.__dict__['_raw_profile'] = profile
 
         match = 'The elliptical curve-of-growth profile is not monotonically'
         with pytest.raises(ValueError, match=match):

--- a/photutils/profiles/tests/test_curve_of_growth.py
+++ b/photutils/profiles/tests/test_curve_of_growth.py
@@ -495,7 +495,7 @@ class TestEnsquaredCurveOfGrowth:
             EnsquaredCurveOfGrowth(data, xycen, half_sizes, error=None,
                                    mask=None)
 
-        match = 'radii must be a 1D array and have at least two values'
+        match = 'half_sizes must be a 1D array and have at least two values'
         with pytest.raises(ValueError, match=match):
             EnsquaredCurveOfGrowth(data, xycen, [1], error=None, mask=None)
         with pytest.raises(ValueError, match=match):
@@ -503,9 +503,15 @@ class TestEnsquaredCurveOfGrowth:
                                    np.arange(1, 7).reshape(2, 3),
                                    error=None, mask=None)
 
-        match = 'radii must be strictly increasing'
+        match = 'half_sizes must be strictly increasing'
         half_sizes = np.arange(1, 10)[::-1]
         with pytest.raises(ValueError, match=match):
+            EnsquaredCurveOfGrowth(data, xycen, half_sizes, error=None,
+                                   mask=None)
+
+        match = 'half_sizes must be a plain array of pixel values'
+        half_sizes = np.arange(1, 10) << u.pix
+        with pytest.raises(TypeError, match=match):
             EnsquaredCurveOfGrowth(data, xycen, half_sizes, error=None,
                                    mask=None)
 

--- a/photutils/profiles/tests/test_curve_of_growth.py
+++ b/photutils/profiles/tests/test_curve_of_growth.py
@@ -879,9 +879,12 @@ class TestEllipticalCurveOfGrowth:
         xycen, data, _, _ = profile_data
 
         radii = np.arange(1, 36)
-        ecg = EllipticalCurveOfGrowth(data, xycen, radii, axis_ratio=0.5)
+        ecg = EllipticalCurveOfGrowth(data, xycen, radii, axis_ratio=0.5,
+                                      theta=0.7)
         r = repr(ecg)
         assert 'EllipticalCurveOfGrowth' in r
         assert f'xycen={xycen}' in r
         assert f'n_radii={len(radii)}' in r
+        assert 'axis_ratio=0.5' in r
+        assert 'theta=0.7' in r
         assert 'normalized=False' in r

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -631,10 +631,13 @@ class TestRadialProfile:
         assert mfit.gamma.value > 0
         assert mfit.alpha.value >= 1
 
-    def test_moffat_cached_property(self, profile_data):
+    def test_moffat_repeated_access(self, profile_data):
         """
-        Test that ``moffat_fit``, ``moffat_profile``, and
-        ``moffat_fwhm`` are lazily computed and cached.
+        Test that repeated access to ``moffat_fit``, ``moffat_profile``,
+        and ``moffat_fwhm`` returns consistent values.
+
+        The underlying fit is computed once and the returned values are
+        derived from it.
         """
         xycen, data, _, _ = profile_data
 
@@ -643,11 +646,11 @@ class TestRadialProfile:
 
         fit1 = rp.moffat_fit
         fit2 = rp.moffat_fit
-        assert fit1 is fit2
+        assert_equal(fit1.parameters, fit2.parameters)
 
         prof1 = rp.moffat_profile
         prof2 = rp.moffat_profile
-        assert prof1 is prof2
+        assert_equal(prof1, prof2)
 
         fwhm1 = rp.moffat_fwhm
         fwhm2 = rp.moffat_fwhm
@@ -655,8 +658,7 @@ class TestRadialProfile:
 
     def test_moffat_normalized(self, profile_data):
         """
-        Test that normalizing the profile invalidates the Moffat fit
-        cache and the fit is recomputed on the normalized profile.
+        Test that the Moffat fit reflects the profile normalization.
         """
         xycen, data, _, _ = profile_data
 
@@ -711,11 +713,10 @@ class TestRadialProfile:
         assert isinstance(rp.moffat_fit, Moffat1D)
         assert rp.moffat_fwhm > 0
 
-    def test_gaussian_fit_invalidated_on_normalize(self, profile_data):
+    def test_gaussian_fit_updated_on_normalize(self, profile_data):
         """
-        Test that Gaussian fit properties are invalidated when the
-        profile is normalized, and the recomputed fit matches the
-        normalized profile.
+        Test that the Gaussian fit properties reflect the profile
+        normalization after normalize is called.
         """
         xycen, data, _, _ = profile_data
 
@@ -747,11 +748,10 @@ class TestRadialProfile:
         fwhm_after = rp.gaussian_fwhm
         assert_allclose(fwhm_after, fwhm_before, rtol=0.1)
 
-    def test_moffat_fit_invalidated_on_normalize(self, profile_data):
+    def test_moffat_fit_updated_on_normalize(self, profile_data):
         """
-        Test that Moffat fit properties are invalidated when the profile
-        is normalized, and the recomputed fit matches the normalized
-        profile.
+        Test that the Moffat fit properties reflect the profile
+        normalization after normalize is called.
         """
         xycen, data, _, _ = profile_data
 
@@ -766,7 +766,7 @@ class TestRadialProfile:
 
         rp.normalize()
 
-        # The fit should be a new object (recomputed)
+        # The fit should be a new, recomputed object
         mfit_after = rp.moffat_fit
         assert mfit_after is not mfit_before
 
@@ -782,11 +782,10 @@ class TestRadialProfile:
         fwhm_after = rp.moffat_fwhm
         assert_allclose(fwhm_after, fwhm_before, rtol=0.1)
 
-    def test_fit_invalidated_on_unnormalize(self, profile_data):
+    def test_fits_updated_on_unnormalize(self, profile_data):
         """
-        Test that Gaussian and Moffat fits are invalidated when
-        unnormalize is called, and the recomputed fits match the
-        original (unnormalized) profile.
+        Test that the Gaussian and Moffat fits match the original
+        (unnormalized) profile after unnormalize is called.
         """
         xycen, data, _, _ = profile_data
 

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -104,6 +104,56 @@ class TestRadialProfile:
         assert np.all(np.isfinite(rp3.data_profile))
         assert len(rp3.data_profile) < len(rp1.data_profile)
 
+    def test_data_profile_access_after_normalize(self, profile_data):
+        """
+        Test that data_profile is consistent with the profile
+        normalization when it is first accessed after normalize, and
+        that unnormalize restores the raw values.
+        """
+        xycen, data, _, _ = profile_data
+
+        edge_radii = np.arange(36)
+        rp1 = RadialProfile(data, xycen, edge_radii)
+        raw = rp1.data_profile.copy()
+        normalization = np.max(rp1.profile)
+
+        # Access data_profile for the first time after normalizing
+        rp2 = RadialProfile(data, xycen, edge_radii)
+        rp2.normalize()
+        assert_allclose(rp2.data_profile, raw / normalization)
+
+        # Unnormalizing must restore the raw values
+        rp2.unnormalize()
+        assert_allclose(rp2.data_profile, raw)
+
+        # Repeated normalize calls must compound consistently
+        rp2.normalize(method='max')
+        rp2.normalize(method='sum')
+        assert_allclose(rp2.data_profile, raw / rp2.normalization_value)
+        rp2.unnormalize()
+        assert_allclose(rp2.data_profile, raw)
+
+    def test_data_profile_units(self, profile_data):
+        """
+        Test that data_profile is a Quantity when the input data is a
+        Quantity, and is dimensionless after normalization.
+        """
+        xycen, data, error, _ = profile_data
+
+        unit = u.Jy
+        edge_radii = np.arange(36)
+        rp = RadialProfile(data << unit, xycen, edge_radii,
+                           error=error << unit)
+        assert rp.data_profile.unit == unit
+        assert not isinstance(rp.data_radius, u.Quantity)
+
+        rp.normalize()
+        assert rp.profile.unit == u.dimensionless_unscaled
+        assert rp.data_profile.unit == u.dimensionless_unscaled
+
+        rp.unnormalize()
+        assert rp.data_profile.unit == unit
+
     def test_inputs(self, profile_data):
         """
         Test RadialProfile input validation.

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -196,6 +196,11 @@ class TestRadialProfile:
         with pytest.raises(ValueError, match=match):
             RadialProfile(data, xycen, edge_radii, error=None, mask=None)
 
+        match = 'radii must be a plain array of pixel values'
+        edge_radii = np.arange(10) << u.pix
+        with pytest.raises(TypeError, match=match):
+            RadialProfile(data, xycen, edge_radii, error=None, mask=None)
+
         match = 'error must have the same shape as data'
         edge_radii = np.arange(10)
         with pytest.raises(ValueError, match=match):

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -394,6 +394,32 @@ class TestRadialProfile:
         rp3.plot_error()
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_plot_ylabel_units(self, profile_data):
+        """
+        Test that the plot y-axis label includes the data unit only
+        when the profile has a physical unit.
+
+        A normalized profile is dimensionless.
+        """
+        xycen, data, error, _ = profile_data
+        edge_radii = np.arange(36)
+
+        rp1 = RadialProfile(data, xycen, edge_radii)
+        lines = rp1.plot()
+        assert lines[0].axes.get_ylabel() == 'Radial Profile'
+
+        unit = u.Jy
+        rp2 = RadialProfile(data << unit, xycen, edge_radii,
+                            error=error << unit)
+        lines = rp2.plot()
+        assert lines[0].axes.get_ylabel() == 'Radial Profile (Jy)'
+
+        rp2.normalize()
+        lines = rp2.plot()
+        assert lines[0].axes.get_ylabel() == 'Radial Profile'
+        rp2.plot_error()
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_plot_error_none(self, profile_data):
         """
         Test that ``plot_error()`` returns ``None`` when no errors were

--- a/photutils/profiles/tests/test_radial_profile.py
+++ b/photutils/profiles/tests/test_radial_profile.py
@@ -104,6 +104,23 @@ class TestRadialProfile:
         assert np.all(np.isfinite(rp3.data_profile))
         assert len(rp3.data_profile) < len(rp1.data_profile)
 
+    def test_data_boundary_pixels(self):
+        """
+        Test that pixels whose centers lie exactly at the maximum radius
+        are included in the data profile on all sides of the center.
+        """
+        data = np.ones((101, 101))
+        xycen = (50.0, 50.0)
+        max_radius = 25
+        rp = RadialProfile(data, xycen, np.arange(max_radius + 1))
+
+        yy, xx = np.mgrid[0:101, 0:101]
+        dist = np.hypot(xx - xycen[0], yy - xycen[1])
+        assert len(rp.data_radius) == np.sum(dist <= max_radius)
+
+        n_boundary = np.sum(rp.data_radius == max_radius)
+        assert n_boundary == np.sum(dist == max_radius)
+
     def test_data_profile_access_after_normalize(self, profile_data):
         """
         Test that data_profile is consistent with the profile

--- a/photutils/profiles/tests/test_thread_safety.py
+++ b/photutils/profiles/tests/test_thread_safety.py
@@ -1,0 +1,167 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests that the profile classes are safe for concurrent use.
+
+All lazily-computed attributes cache raw (unnormalized) values
+that are immutable once computed, and the only mutable state is
+the scalar ``normalization_value`` attribute, which ``normalize``
+and ``unnormalize`` update with a single atomic attribute store.
+Normalization-dependent attributes are derived on access by dividing
+the raw values by ``normalization_value``, so a concurrent reader sees
+values consistent with either the old or the new normalization, never a
+mixture within one returned array.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+from numpy.testing import assert_equal
+
+from photutils.profiles import CurveOfGrowth, RadialProfile
+
+N_THREADS = 8
+N_TOGGLES = 200
+N_READS = 500
+
+
+def test_concurrent_cold_access(profile_data):
+    """
+    Test that concurrent first accesses of the lazy attributes on a
+    single shared instance return results identical to a serial
+    computation.
+    """
+    xycen, data, error, _ = profile_data
+
+    edge_radii = np.arange(36)
+    rp = RadialProfile(data, xycen, edge_radii, error=error)
+    reference = RadialProfile(data, xycen, edge_radii, error=error)
+    expected = (reference.profile, reference.profile_error,
+                reference.area)
+
+    barrier = threading.Barrier(N_THREADS)
+
+    def task():
+        barrier.wait()
+        return rp.profile, rp.profile_error, rp.area
+
+    with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+        futures = [executor.submit(task) for _ in range(N_THREADS)]
+        for future in futures:
+            for result, expect in zip(future.result(), expected,
+                                      strict=True):
+                assert_equal(result, expect)
+
+
+def test_concurrent_normalize_and_read(profile_data):
+    """
+    Test that profile reads concurrent with normalize/unnormalize
+    toggling always return one of the two consistent states, never a
+    mixed state.
+    """
+    xycen, data, _, _ = profile_data
+
+    radii = np.arange(1, 36)
+    cog = CurveOfGrowth(data, xycen, radii)
+    raw = cog.profile.copy()
+    cog.normalize()
+    normalized = cog.profile.copy()
+    cog.unnormalize()
+
+    barrier = threading.Barrier(N_THREADS)
+
+    def writer():
+        barrier.wait()
+        for _ in range(N_TOGGLES):
+            cog.normalize()
+            cog.unnormalize()
+
+    def reader():
+        barrier.wait()
+        return [cog.profile for _ in range(N_READS)]
+
+    with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+        writer_future = executor.submit(writer)
+        reader_futures = [executor.submit(reader)
+                          for _ in range(N_THREADS - 1)]
+        writer_future.result()
+        for future in reader_futures:
+            for snapshot in future.result():
+                assert (np.array_equal(snapshot, raw)
+                        or np.array_equal(snapshot, normalized))
+
+
+def test_concurrent_normalize_methods(profile_data):
+    """
+    Test that concurrent normalize calls with different methods leave
+    the instance in one of the valid states, with the profile consistent
+    with the final normalization value.
+    """
+    xycen, data, _, _ = profile_data
+
+    radii = np.arange(1, 36)
+    cog = CurveOfGrowth(data, xycen, radii)
+    raw = cog.profile.copy()
+
+    expected_values = set()
+    for method in ('max', 'sum'):
+        twin = CurveOfGrowth(data, xycen, radii)
+        twin.normalize(method=method)
+        expected_values.add(twin.normalization_value)
+
+    barrier = threading.Barrier(N_THREADS)
+
+    def task(method):
+        barrier.wait()
+        for _ in range(N_TOGGLES):
+            cog.normalize(method=method)
+
+    methods = ['max' if i % 2 == 0 else 'sum' for i in range(N_THREADS)]
+    with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+        futures = [executor.submit(task, method) for method in methods]
+        for future in futures:
+            future.result()
+
+    assert cog.normalization_value in expected_values
+    assert_equal(cog.profile, raw / cog.normalization_value)
+
+
+def test_concurrent_fit_access_during_normalize(profile_data):
+    """
+    Test that the fit properties read concurrently with
+    normalize/unnormalize toggling are always consistent with one of the
+    two normalization states, and that the FWHM is unaffected.
+    """
+    xycen, data, _, _ = profile_data
+
+    edge_radii = np.arange(36)
+    rp = RadialProfile(data, xycen, edge_radii)
+    raw_amplitude = rp.gaussian_fit.amplitude.value
+    raw_fwhm = rp.gaussian_fwhm
+    rp.normalize()
+    norm_amplitude = rp.gaussian_fit.amplitude.value
+    rp.unnormalize()
+
+    n_workers = 4
+    barrier = threading.Barrier(n_workers)
+
+    def writer():
+        barrier.wait()
+        for _ in range(N_TOGGLES):
+            rp.normalize()
+            rp.unnormalize()
+
+    def reader():
+        barrier.wait()
+        return [(rp.gaussian_fit.amplitude.value, rp.gaussian_fwhm)
+                for _ in range(100)]
+
+    with ThreadPoolExecutor(max_workers=n_workers) as executor:
+        writer_future = executor.submit(writer)
+        reader_futures = [executor.submit(reader)
+                          for _ in range(n_workers - 1)]
+        writer_future.result()
+        for future in reader_futures:
+            for amplitude, fwhm in future.result():
+                assert amplitude in (raw_amplitude, norm_amplitude)
+                assert fwhm == raw_fwhm


### PR DESCRIPTION
This PR fixes `data_profile` normalization, units, and bounding-box handling in `RadialProfile`, plus several small API and docstring cleanups. It also batches the profile aperture photometry into a single call and restructures normalization to be thread-safe, with new benchmark and thread-safety tests.