### PR TITLE
Add kernel validation for PSF matching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -389,6 +389,17 @@ Bug Fixes
     filter metadata is missing. The missing values left stray spaces in
     the title. [#2347]
 
+- ``photutils.psf_matching``
+
+  - ``make_wiener_kernel`` now validates a custom ``penalty`` array.
+    It must be 2D with odd dimensions in both axes, contain only finite
+    values, and not be all zeros. [#2372]
+
+  - ``make_kernel`` and ``make_wiener_kernel`` now raise a
+    ``ValueError`` if the computed kernel contains non-finite values,
+    which can occur when the Fourier-space denominator is zero at
+    frequencies where the numerator is also zero. [#2372]
+
 - ``photutils.isophote``
 
   - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -94,6 +94,22 @@ python benchmarks/bench_profiles.py
 python benchmarks/bench_profiles.py --which radii-scaling --n-radii-list 100,400,1600
 ```
 
+## PSF matching (`bench_psf_matching.py`)
+
+Benchmarks for the `photutils.psf_matching` subpackage:
+
+- the per-call cost of the kernel-making functions (`make_kernel`
+  with and without a window, and `make_wiener_kernel` for the
+  scalar, Laplacian, and biharmonic penalties)
+- the scaling of the kernel computation with the PSF size
+- the per-call cost of the window classes
+- `resize_psf` for down- and upsampling with each spline order
+
+```bash
+python benchmarks/bench_psf_matching.py
+python benchmarks/bench_psf_matching.py --which size-scaling --sizes 101,201,401
+```
+
 ## Background (`bench_background.py`)
 
 Benchmarks for the `photutils.background` subpackage:

--- a/benchmarks/bench_psf_matching.py
+++ b/benchmarks/bench_psf_matching.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for the photutils.psf_matching subpackage.
+
+The benchmarks cover the per-call cost of the kernel-making functions
+(``make_kernel`` and ``make_wiener_kernel`` for each penalty), the
+scaling of the kernel computation with the PSF size, the per-call
+cost of the window classes, and ``resize_psf`` for each spline
+order.
+
+Run ``python benchmarks/bench_psf_matching.py --help`` to see the
+available options.
+"""
+
+import argparse
+from functools import partial
+
+import numpy as np
+from astropy.modeling.models import Gaussian2D
+from bench_utils import print_environment, time_best
+
+from photutils.psf_matching import (CosineBellWindow, HanningWindow,
+                                    SplitCosineBellWindow, TopHatWindow,
+                                    TukeyWindow, make_kernel,
+                                    make_wiener_kernel, resize_psf)
+
+# The (label, function, kwargs) variants for the kernel benchmarks
+KERNEL_VARIANTS = (
+    ('make_kernel', make_kernel, {}),
+    ('make_kernel (window)', make_kernel,
+     {'window': SplitCosineBellWindow(alpha=0.15, beta=0.3)}),
+    ('make_wiener_kernel', make_wiener_kernel, {}),
+    ('make_wiener_kernel (laplacian)', make_wiener_kernel,
+     {'penalty': 'laplacian'}),
+    ('make_wiener_kernel (biharmonic)', make_wiener_kernel,
+     {'penalty': 'biharmonic'}),
+)
+
+
+def make_psf_pair(size, *, source_fraction=0.06, target_fraction=0.10):
+    """
+    Return centered, normalized source and target Gaussian PSFs.
+
+    The PSF widths scale with the array size so that the PSFs fill a
+    constant fraction of the array.
+
+    Parameters
+    ----------
+    size : int
+        The PSF array size; the arrays are ``(size, size)``. Must be
+        odd.
+
+    source_fraction : float, optional
+        The source Gaussian sigma as a fraction of the array size.
+
+    target_fraction : float, optional
+        The target Gaussian sigma as a fraction of the array size.
+
+    Returns
+    -------
+    source_psf : 2D `~numpy.ndarray`
+        The source (narrower) PSF.
+
+    target_psf : 2D `~numpy.ndarray`
+        The target (broader) PSF.
+    """
+    cen = (size - 1) / 2.0
+    yy, xx = np.mgrid[0:size, 0:size]
+    psfs = []
+    for fraction in (source_fraction, target_fraction):
+        sigma = fraction * size
+        psf = Gaussian2D(1.0, cen, cen, sigma, sigma)(xx, yy)
+        psfs.append(psf / psf.sum())
+    return tuple(psfs)
+
+
+def run_kernel(func, source_psf, target_psf, n_iter, **kwargs):
+    """
+    Compute a matching kernel repeatedly.
+
+    Parameters
+    ----------
+    func : callable
+        The kernel-making function.
+
+    source_psf : 2D `~numpy.ndarray`
+        The source PSF.
+
+    target_psf : 2D `~numpy.ndarray`
+        The target PSF.
+
+    n_iter : int
+        The number of calls.
+
+    **kwargs : dict, optional
+        Additional keyword arguments passed to ``func`` (e.g.,
+        ``window`` or ``penalty``).
+    """
+    for _ in range(n_iter):
+        func(source_psf, target_psf, **kwargs)
+
+
+def bench_kernels(*, size=101, n_iter=20, repeats=3):
+    """
+    Benchmark each kernel-making function variant.
+
+    Parameters
+    ----------
+    size : int, optional
+        The PSF array size; the arrays are ``(size, size)``. Must be
+        odd.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    source_psf, target_psf = make_psf_pair(size)
+
+    print(f'\n== kernel functions ({size}x{size} PSFs, per-call time) ==')
+    print(f'{"variant":>34}{"time":>12}')
+    for label, func, kwargs in KERNEL_VARIANTS:
+        bench = partial(run_kernel, func, source_psf, target_psf,
+                        n_iter, **kwargs)
+        t_call = time_best(bench, repeats=repeats) / n_iter
+        print(f'{label:>34}{f"{t_call * 1e3:.3f}ms":>12}')
+
+
+def bench_size_scaling(*, sizes=(25, 51, 101, 201), n_iter=20,
+                       repeats=3):
+    """
+    Benchmark the kernel computation versus the PSF size.
+
+    Parameters
+    ----------
+    sizes : tuple of int, optional
+        The PSF array sizes. Each must be odd.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    variants = (
+        ('make_kernel', make_kernel, {}),
+        ('make_wiener_kernel', make_wiener_kernel,
+         {'penalty': 'laplacian'}),
+    )
+
+    print('\n== scaling with the PSF size (per-call time) ==')
+    header = f'{"size":>8}'
+    for label, _, _ in variants:
+        header += f'{label:>22}'
+    print(header)
+    for size in sizes:
+        source_psf, target_psf = make_psf_pair(size)
+        cells = ''
+        for _, func, kwargs in variants:
+            bench = partial(run_kernel, func, source_psf, target_psf,
+                            n_iter, **kwargs)
+            t_call = time_best(bench, repeats=repeats) / n_iter
+            cells += f'{f"{t_call * 1e3:.3f}ms":>22}'
+        print(f'{size:>8}{cells}')
+
+
+def run_window(window, shape, n_iter):
+    """
+    Evaluate a window function repeatedly.
+
+    Parameters
+    ----------
+    window : callable
+        The window class instance.
+
+    shape : tuple of int
+        The array shape passed to the window.
+
+    n_iter : int
+        The number of calls.
+    """
+    for _ in range(n_iter):
+        window(shape)
+
+
+def bench_windows(*, size=101, n_iter=100, repeats=3):
+    """
+    Benchmark each window class.
+
+    Parameters
+    ----------
+    size : int, optional
+        The window array size; the arrays are ``(size, size)``.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    windows = (
+        SplitCosineBellWindow(alpha=0.4, beta=0.3),
+        TukeyWindow(alpha=0.5),
+        HanningWindow(),
+        CosineBellWindow(alpha=0.5),
+        TopHatWindow(beta=0.4),
+    )
+
+    shape = (size, size)
+    print(f'\n== window classes ({size}x{size} array, per-call time) ==')
+    print(f'{"class":>24}{"time":>12}')
+    for window in windows:
+        bench = partial(run_window, window, shape, n_iter)
+        t_call = time_best(bench, repeats=repeats) / n_iter
+        print(f'{window.__class__.__name__:>24}'
+              f'{f"{t_call * 1e3:.3f}ms":>12}')
+
+
+def run_resize(psf, ratio, order, n_iter):
+    """
+    Resize a PSF repeatedly.
+
+    Parameters
+    ----------
+    psf : 2D `~numpy.ndarray`
+        The PSF array.
+
+    ratio : float
+        The ratio of the input to output pixel scale.
+
+    order : int
+        The spline interpolation order.
+
+    n_iter : int
+        The number of calls.
+    """
+    for _ in range(n_iter):
+        resize_psf(psf, ratio, 1.0, order=order)
+
+
+def bench_resize(*, size=101, ratios=(0.5, 2.0), n_iter=20, repeats=3):
+    """
+    Benchmark resize_psf for each spline order.
+
+    Parameters
+    ----------
+    size : int, optional
+        The PSF array size; the array is ``(size, size)``. Must be
+        odd.
+
+    ratios : tuple of float, optional
+        The ratios of the input to output pixel scale (a ratio > 1
+        upsamples the PSF).
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    psf, _ = make_psf_pair(size)
+    orders = (1, 3, 5)
+
+    print(f'\n== resize_psf ({size}x{size} PSF, per-call time) ==')
+    header = f'{"ratio":>8}'
+    for order in orders:
+        header += f'{f"order={order}":>12}'
+    print(header)
+    for ratio in ratios:
+        cells = ''
+        for order in orders:
+            bench = partial(run_resize, psf, ratio, order, n_iter)
+            t_call = time_best(bench, repeats=repeats) / n_iter
+            cells += f'{f"{t_call * 1e3:.3f}ms":>12}'
+        print(f'{ratio:>8}{cells}')
+
+
+def parse_int_list(text):
+    """
+    Parse a comma-separated list of positive odd integers.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated integers (e.g., ``'25,101,201'``).
+
+    Returns
+    -------
+    result : list of int
+        The parsed integers.
+    """
+    values = [int(item) for item in text.split(',')]
+    if any(value < 1 or value % 2 == 0 for value in values):
+        msg = 'values must be positive odd integers'
+        raise ValueError(msg)
+    return values
+
+
+def main():
+    """
+    Run the photutils.psf_matching benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for the photutils.psf_matching '
+                    'subpackage.')
+    parser.add_argument('--size', type=int, default=101,
+                        help='PSF array size; must be odd '
+                             '(default: %(default)s)')
+    parser.add_argument('--sizes', type=parse_int_list,
+                        default=[25, 51, 101, 201],
+                        help='comma-separated PSF sizes for the '
+                             'scaling benchmark; each must be odd '
+                             '(default: 25,51,101,201)')
+    parser.add_argument('--n-iter', type=int, default=20,
+                        help='number of calls per timing '
+                             '(default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'kernels', 'size-scaling',
+                                 'windows', 'resize'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'kernels'):
+        bench_kernels(size=args.size, n_iter=args.n_iter,
+                      repeats=args.repeats)
+    if args.which in ('all', 'size-scaling'):
+        bench_size_scaling(sizes=args.sizes, n_iter=args.n_iter,
+                           repeats=args.repeats)
+    if args.which in ('all', 'windows'):
+        bench_windows(size=args.size, n_iter=args.n_iter * 5,
+                      repeats=args.repeats)
+    if args.which in ('all', 'resize'):
+        bench_resize(size=args.size, n_iter=args.n_iter,
+                     repeats=args.repeats)
+
+
+if __name__ == '__main__':
+    main()

--- a/photutils/psf/matching/__init__.py
+++ b/photutils/psf/matching/__init__.py
@@ -9,9 +9,10 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 import photutils.psf_matching as _psf_matching
 from photutils.psf_matching.fourier import __all__ as _fourier_all
+from photutils.psf_matching.utils import __all__ as _utils_all
 from photutils.psf_matching.windows import __all__ as _windows_all
 
-__all__ = list(_fourier_all) + list(_windows_all)
+__all__ = list(_fourier_all) + list(_utils_all) + list(_windows_all)
 
 _deprecation_msg = ('photutils.psf.matching is deprecated (since version '
                     '3.0) and will be removed in a future version. Use '

--- a/photutils/psf/tests/test_matching_deprecated.py
+++ b/photutils/psf/tests/test_matching_deprecated.py
@@ -1,0 +1,64 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the deprecated photutils.psf.matching subpackage.
+"""
+
+import pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from photutils import psf_matching
+from photutils.psf import matching as old_matching
+
+DEPRECATION_MATCH = 'photutils.psf.matching is deprecated'
+
+
+@pytest.mark.parametrize('name', old_matching.__all__)
+def test_deprecated_attribute_access(name):
+    """
+    Test that accessing each public name from the old location emits a
+    deprecation warning and returns the object from the new location.
+    """
+    with pytest.warns(AstropyDeprecationWarning, match=DEPRECATION_MATCH):
+        obj = getattr(old_matching, name)
+    assert obj is getattr(psf_matching, name)
+
+
+def test_deprecated_from_import():
+    """
+    Test that a from-import of a name public in photutils < 3.0 emits
+    a deprecation warning.
+    """
+    with pytest.warns(AstropyDeprecationWarning, match=DEPRECATION_MATCH):
+        from photutils.psf.matching import resize_psf
+    assert resize_psf is psf_matching.resize_psf
+
+
+def test_all_contains_old_public_names():
+    """
+    Test that every name public in photutils < 3.0 is still importable
+    from the old location.
+    """
+    old_public_names = ('create_matching_kernel', 'resize_psf',
+                        'CosineBellWindow', 'HanningWindow',
+                        'SplitCosineBellWindow', 'TopHatWindow',
+                        'TukeyWindow')
+    for name in old_public_names:
+        assert name in old_matching.__all__
+
+
+def test_invalid_attribute():
+    """
+    Test that an invalid attribute raises AttributeError without a
+    deprecation warning.
+    """
+    match = "module 'photutils.psf.matching' has no attribute 'invalid'"
+    with pytest.raises(AttributeError, match=match):
+        getattr(old_matching, 'invalid')  # noqa: B009
+
+
+def test_dir():
+    """
+    Test that dir() lists all public names.
+    """
+    assert sorted(dir(old_matching)) == sorted(old_matching.__all__)
+    assert 'resize_psf' in dir(old_matching)

--- a/photutils/psf_matching/fourier.py
+++ b/photutils/psf_matching/fourier.py
@@ -9,9 +9,78 @@ from scipy.fft import fft2, fftshift, ifft2
 
 from photutils.psf_matching.utils import (_apply_window_to_fourier,
                                           _convert_psf_to_otf,
+                                          _normalize_kernel,
                                           _validate_kernel_inputs)
 
 __all__ = ['create_matching_kernel', 'make_kernel', 'make_wiener_kernel']
+
+
+def _build_penalty_array(penalty):
+    """
+    Validate the penalty input and convert it to a 2D float array.
+
+    Parameters
+    ----------
+    penalty : `None`, ``'laplacian'``, ``'biharmonic'``, or 2D array-like
+        The regularization penalty operator.
+
+    Returns
+    -------
+    penalty_array : 2D `~numpy.ndarray` or `None`
+        The penalty operator as a float array, or `None` if ``penalty``
+        is `None`.
+
+    Raises
+    ------
+    ValueError
+        If ``penalty`` is an invalid string, cannot be converted to a
+        numeric array, is not 2D, has even dimensions, contains NaN or
+        Inf values, or is all zeros.
+    """
+    if penalty is None:
+        return None
+
+    if isinstance(penalty, str):
+        if penalty == 'laplacian':
+            return np.array([[+0, -1, +0],
+                             [-1, +4, -1],
+                             [+0, -1, +0]], dtype=float)
+        if penalty == 'biharmonic':
+            return np.array([[+0, +0, +1, +0, +0],
+                             [+0, +2, -8, +2, +0],
+                             [+1, -8, 20, -8, +1],
+                             [+0, +2, -8, +2, +0],
+                             [+0, +0, +1, +0, +0]], dtype=float)
+        msg = (f'Invalid penalty string {penalty!r}. '
+               'Must be "laplacian" or "biharmonic".')
+        raise ValueError(msg)
+
+    try:
+        penalty_array = np.asarray(penalty, dtype=float)
+    except (TypeError, ValueError) as exc:
+        msg = ("penalty must be None, 'laplacian', 'biharmonic', or a "
+               '2D array.')
+        raise ValueError(msg) from exc
+
+    if penalty_array.ndim != 2:
+        msg = 'penalty array must be 2D.'
+        raise ValueError(msg)
+
+    if (penalty_array.shape[0] % 2 == 0 or penalty_array.shape[1] % 2 == 0):
+        msg = (f'penalty array must have odd dimensions, got shape '
+               f'{penalty_array.shape}.')
+        raise ValueError(msg)
+
+    if not np.all(np.isfinite(penalty_array)):
+        msg = 'penalty array contains NaN or Inf values.'
+        raise ValueError(msg)
+
+    if np.all(penalty_array == 0):
+        msg = ('penalty array must not be all zeros because it would '
+               'apply no regularization.')
+        raise ValueError(msg)
+
+    return penalty_array
 
 
 def make_kernel(source_psf, target_psf, *, window=None, regularization=1e-4):
@@ -157,14 +226,7 @@ def make_kernel(source_psf, target_psf, *, window=None, regularization=1e-4):
         ratio = _apply_window_to_fourier(ratio, window, target_psf.shape)
 
     kernel = np.real(fftshift(ifft2(ratio)))
-    if np.sum(kernel) < 1e-30:
-        msg = ('The computed kernel sums to zero, which likely indicates '
-               'that the regularization threshold is too high. Try reducing '
-               'the regularization parameter or using a different window '
-               'function.')
-        raise ValueError(msg)
-
-    return kernel / kernel.sum()
+    return _normalize_kernel(kernel)
 
 
 def make_wiener_kernel(source_psf, target_psf, *, regularization=1e-4,
@@ -256,7 +318,7 @@ def make_wiener_kernel(source_psf, target_psf, *, regularization=1e-4,
         detail but may amplify noise. Must be a positive number.
 
     penalty : `None`, ``'laplacian'``, ``'biharmonic'``, or 2D \
-`~numpy.ndarray`, optional
+array-like, optional
         The regularization penalty operator. This controls the
         structure of the regularization term in the denominator:
 
@@ -287,10 +349,12 @@ def make_wiener_kernel(source_psf, target_psf, *, regularization=1e-4,
           of reduced accuracy in matching. Requires PSFs to be at least
           5x5.
 
-        * 2D `~numpy.ndarray`: A custom penalty operator array.
+        * 2D array-like: A custom penalty operator array.
           Its OTF will be computed and used in the denominator as
-          :math:`|S|^2 + \\lambda \\cdot |P|^2`. The PSFs must be at
-          least as large as the penalty array in both dimensions.
+          :math:`|S|^2 + \\lambda \\cdot |P|^2`. The array must have
+          odd dimensions in both axes, contain only finite values, and
+          not be all zeros. The PSFs must be at least as large as the
+          penalty array in both dimensions.
 
     window : callable, optional
         The window (taper) function or callable class instance used
@@ -327,9 +391,12 @@ def make_wiener_kernel(source_psf, target_psf, *, regularization=1e-4,
     ------
     ValueError
         If the PSFs are not 2D arrays, have even dimensions, do not have
-        the same shape, are too small for the specified penalty, if
-        ``regularization`` is not positive, or if ``penalty`` is not a
-        valid value.
+        the same shape, contain NaN or Inf values, have a zero sum, or
+        are too small for the specified penalty, if ``regularization``
+        is not positive, if ``penalty`` is not a valid value (see
+        above), if the window function output is invalid (not a 2D
+        array, wrong shape, or values outside [0, 1]), or if the
+        computed kernel is degenerate (non-finite or sums to zero).
 
     TypeError
         If the input ``window`` is not callable.
@@ -374,33 +441,7 @@ def make_wiener_kernel(source_psf, target_psf, *, regularization=1e-4,
         msg = 'regularization must be a positive number.'
         raise ValueError(msg)
 
-    # Validate and build the penalty term
-    if penalty is None:
-        penalty_array = None
-    elif isinstance(penalty, str):
-        if penalty == 'laplacian':
-            penalty_array = np.array([[+0, -1, +0],
-                                      [-1, +4, -1],
-                                      [+0, -1, +0]], dtype=float)
-        elif penalty == 'biharmonic':
-            penalty_array = np.array([[+0, +0, +1, +0, +0],
-                                      [+0, +2, -8, +2, +0],
-                                      [+1, -8, 20, -8, +1],
-                                      [+0, +2, -8, +2, +0],
-                                      [+0, +0, +1, +0, +0]], dtype=float)
-        else:
-            msg = (f'Invalid penalty string {penalty!r}. '
-                   'Must be "laplacian" or "biharmonic".')
-            raise ValueError(msg)
-    elif isinstance(penalty, np.ndarray):
-        if penalty.ndim != 2:
-            msg = 'penalty array must be 2D.'
-            raise ValueError(msg)
-        penalty_array = np.asarray(penalty, dtype=float)
-    else:
-        msg = ("penalty must be None, 'laplacian', 'biharmonic', or a 2D "
-               'numpy array.')
-        raise ValueError(msg)
+    penalty_array = _build_penalty_array(penalty)
 
     # Validate that PSF is large enough for the penalty
     if penalty_array is not None:
@@ -428,9 +469,13 @@ def make_wiener_kernel(source_psf, target_psf, *, regularization=1e-4,
         # the peak power in the source OTF
         reg_term = regularization * np.max(source_power)
 
-    # Compute the Wiener-regularized kernel in Fourier space
-    kernel_otf = (target_otf * np.conj(source_otf)
-                  / (source_power + reg_term))
+    # Compute the Wiener-regularized kernel in Fourier space. The
+    # denominator can be zero at frequencies where both the source OTF
+    # and the penalty OTF are zero. Any resulting non-finite values are
+    # caught by the kernel normalization below.
+    with np.errstate(invalid='ignore', divide='ignore'):
+        kernel_otf = (target_otf * np.conj(source_otf)
+                      / (source_power + reg_term))
 
     # Apply a window function in frequency space
     if window is not None:
@@ -438,14 +483,7 @@ def make_wiener_kernel(source_psf, target_psf, *, regularization=1e-4,
             kernel_otf, window, target_psf.shape)
 
     kernel = np.real(fftshift(ifft2(kernel_otf)))
-    if np.sum(kernel) < 1e-30:
-        msg = ('The computed kernel sums to zero, which likely indicates '
-               'that the regularization threshold is too high. Try reducing '
-               'the regularization parameter or using a different window '
-               'function.')
-        raise ValueError(msg)
-
-    return kernel / kernel.sum()
+    return _normalize_kernel(kernel)
 
 
 @deprecated('3.0', alternative='make_kernel')

--- a/photutils/psf_matching/fourier.py
+++ b/photutils/psf_matching/fourier.py
@@ -83,7 +83,7 @@ def _build_penalty_array(penalty):
     return penalty_array
 
 
-def make_kernel(source_psf, target_psf, *, window=None, regularization=1e-4):
+def make_kernel(source_psf, target_psf, *, regularization=1e-4, window=None):
     """
     Make a convolution kernel that matches an input PSF to a target PSF
     using the ratio of Fourier transforms.
@@ -129,6 +129,17 @@ def make_kernel(source_psf, target_psf, *, window=None, regularization=1e-4):
         ``target_psf`` must have the same shape and pixel scale. It is
         assumed to be centered on the central pixel.
 
+    regularization : float, optional
+        The regularization parameter that controls the OTF amplitude
+        threshold for the source OTF (Optical Transfer Function, the
+        Fourier transform of the PSF). At frequencies where the source
+        OTF amplitude is below ``regularization`` times the peak
+        amplitude, the Fourier ratio is set to zero to avoid division by
+        near-zero values. Must be in the range [0, 1), where 0 provides
+        no thresholding (only exact zeros are excluded) and values
+        closer to 1 apply more aggressive thresholding. A value of 1
+        would zero out all frequencies and produce a degenerate kernel.
+
     window : callable, optional
         The window (taper) function or callable class instance used
         to remove high frequency noise from the PSF matching kernel.
@@ -149,17 +160,6 @@ def make_kernel(source_psf, target_psf, *, window=None, regularization=1e-4):
         For more information on window functions, custom windows, and
         example usage, see :ref:`PSF Matching <psf_matching>`.
 
-    regularization : float, optional
-        The regularization parameter that controls the OTF amplitude
-        threshold for the source OTF (Optical Transfer Function, the
-        Fourier transform of the PSF). At frequencies where the source
-        OTF amplitude is below ``regularization`` times the peak
-        amplitude, the Fourier ratio is set to zero to avoid division by
-        near-zero values. Must be in the range [0, 1), where 0 provides
-        no thresholding (only exact zeros are excluded) and values
-        closer to 1 apply more aggressive thresholding. A value of 1
-        would zero out all frequencies and produce a degenerate kernel.
-
     Returns
     -------
     kernel : 2D `~numpy.ndarray`
@@ -169,10 +169,12 @@ def make_kernel(source_psf, target_psf, *, window=None, regularization=1e-4):
     Raises
     ------
     ValueError
-        If the PSFs are not 2D arrays, have even dimensions, or do not
-        have the same shape, if ``regularization`` is not in the range
-        [0, 1), or if the window function output is invalid (not a 2D
-        array, wrong shape, or values outside [0, 1]).
+        If the PSFs are not 2D arrays, have even dimensions, do not have
+        the same shape, contain NaN or Inf values, or have a zero sum,
+        if ``regularization`` is not in the range [0, 1), if the window
+        function output is invalid (not a 2D array, wrong shape, or
+        values outside [0, 1]), or if the computed kernel is degenerate
+        (non-finite or sums to zero).
 
     TypeError
         If the input ``window`` is not callable.
@@ -487,8 +489,8 @@ array-like, optional
 
 
 @deprecated('3.0', alternative='make_kernel')
-def create_matching_kernel(source_psf, target_psf, *, window=None,
-                           regularization=1e-4):
+def create_matching_kernel(source_psf, target_psf, *,
+                           regularization=1e-4, window=None):
     """
     Create a kernel to match 2D point spread functions (PSF).
 

--- a/photutils/psf_matching/tests/test_fourier.py
+++ b/photutils/psf_matching/tests/test_fourier.py
@@ -345,19 +345,81 @@ class TestMakeKernelWiener:
 
     def test_penalty_invalid_type(self, psf1, psf2):
         """
-        Test that an invalid penalty type raises ValueError.
+        Test that a penalty that cannot be converted to a numeric
+        array raises ValueError.
         """
         match = 'penalty must be None'
         with pytest.raises(ValueError, match=match):
-            make_wiener_kernel(psf1, psf2, penalty=42)
+            make_wiener_kernel(psf1, psf2, penalty={'bad': 1})
 
-    def test_penalty_non_2d_array(self, psf1, psf2):
+    @pytest.mark.parametrize('penalty', [42, np.ones(5), [1.0, 2.0, 3.0]])
+    def test_penalty_non_2d_array(self, psf1, psf2, penalty):
         """
         Test that a non-2D penalty array raises ValueError.
         """
         match = 'penalty array must be 2D'
         with pytest.raises(ValueError, match=match):
-            make_wiener_kernel(psf1, psf2, penalty=np.ones(5))
+            make_wiener_kernel(psf1, psf2, penalty=penalty)
+
+    def test_penalty_even_dimensions(self, psf1, psf2):
+        """
+        Test that a penalty array with even dimensions raises
+        ValueError.
+        """
+        match = 'penalty array must have odd dimensions'
+        with pytest.raises(ValueError, match=match):
+            make_wiener_kernel(psf1, psf2, penalty=np.ones((2, 2)))
+
+    def test_penalty_non_finite(self, psf1, psf2):
+        """
+        Test that a penalty array with NaN or Inf values raises
+        ValueError.
+        """
+        penalty = np.zeros((3, 3))
+        penalty[1, 1] = np.nan
+        match = 'penalty array contains NaN or Inf values'
+        with pytest.raises(ValueError, match=match):
+            make_wiener_kernel(psf1, psf2, penalty=penalty)
+
+        penalty[1, 1] = np.inf
+        with pytest.raises(ValueError, match=match):
+            make_wiener_kernel(psf1, psf2, penalty=penalty)
+
+    def test_penalty_all_zeros(self, psf1, psf2):
+        """
+        Test that an all-zero penalty array raises ValueError because
+        it would apply no regularization.
+        """
+        match = 'penalty array must not be all zeros'
+        with pytest.raises(ValueError, match=match):
+            make_wiener_kernel(psf1, psf2, penalty=np.zeros((3, 3)))
+
+    def test_penalty_array_like(self, psf1, psf2):
+        """
+        Test that an array-like penalty gives the same result as the
+        equivalent ndarray penalty.
+        """
+        laplacian = [[0, -1, 0], [-1, 4, -1], [0, -1, 0]]
+        kernel_list = make_wiener_kernel(psf1, psf2, penalty=laplacian)
+        kernel_arr = make_wiener_kernel(psf1, psf2,
+                                        penalty=np.array(laplacian))
+        assert_allclose(kernel_list, kernel_arr)
+
+    def test_non_finite_kernel_raises(self):
+        """
+        Test that a degenerate Fourier-space denominator raises
+        ValueError instead of silently returning a non-finite kernel.
+
+        A uniform source PSF and a uniform penalty operator both have
+        OTFs that are zero away from the DC frequency, so the Wiener
+        denominator is zero where the numerator is also zero (0/0).
+        """
+        source_psf = np.ones((3, 3)) / 9.0
+        target_psf = _make_gaussian_psf(3, 1.0)
+        penalty = np.ones((3, 3))
+        match = 'The computed kernel contains non-finite values'
+        with pytest.raises(ValueError, match=match):
+            make_wiener_kernel(source_psf, target_psf, penalty=penalty)
 
     def test_penalty_psf_too_small_for_laplacian(self):
         """

--- a/photutils/psf_matching/tests/test_thread_safety.py
+++ b/photutils/psf_matching/tests/test_thread_safety.py
@@ -1,0 +1,107 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests that the psf_matching tools are safe for concurrent use.
+
+The kernel-making functions are pure (they copy their inputs and hold no
+module-level mutable state) and the window classes are immutable after
+construction, so concurrent calls must produce results identical to
+serial calls and must not modify shared inputs.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from numpy.testing import assert_equal
+
+from photutils.psf_matching import (SplitCosineBellWindow, make_kernel,
+                                    make_wiener_kernel, resize_psf)
+
+N_THREADS = 8
+N_CALLS = 25
+
+
+def _run_concurrently(task, n_threads=N_THREADS):
+    """
+    Run ``task`` in ``n_threads`` threads and return all results.
+
+    A barrier maximizes the overlap of the concurrent calls.
+    """
+    barrier = threading.Barrier(n_threads)
+
+    def worker():
+        barrier.wait()
+        return [task() for _ in range(N_CALLS)]
+
+    with ThreadPoolExecutor(max_workers=n_threads) as executor:
+        futures = [executor.submit(worker) for _ in range(n_threads)]
+        return [result for future in futures for result in future.result()]
+
+
+def test_concurrent_make_kernel(psf1, psf2):
+    """
+    Test that concurrent make_kernel calls on shared input arrays
+    return results identical to a serial call and do not modify the
+    inputs.
+    """
+    window = SplitCosineBellWindow(alpha=0.2, beta=0.3)
+    psf1_orig = psf1.copy()
+    psf2_orig = psf2.copy()
+    expected = make_kernel(psf1, psf2, window=window)
+
+    def task():
+        return make_kernel(psf1, psf2, window=window)
+
+    for result in _run_concurrently(task):
+        assert_equal(result, expected)
+
+    assert_equal(psf1, psf1_orig)
+    assert_equal(psf2, psf2_orig)
+
+
+def test_concurrent_make_wiener_kernel(psf1, psf2):
+    """
+    Test that concurrent make_wiener_kernel calls with a penalty
+    return results identical to a serial call.
+    """
+    expected = make_wiener_kernel(psf1, psf2, penalty='laplacian')
+
+    def task():
+        return make_wiener_kernel(psf1, psf2, penalty='laplacian')
+
+    for result in _run_concurrently(task):
+        assert_equal(result, expected)
+
+
+def test_concurrent_resize_psf(psf1):
+    """
+    Test that concurrent resize_psf calls on a shared input array
+    return results identical to a serial call and do not modify the
+    input.
+    """
+    psf1_orig = psf1.copy()
+    expected = resize_psf(psf1, 0.1, 0.05)
+
+    def task():
+        return resize_psf(psf1, 0.1, 0.05)
+
+    for result in _run_concurrently(task):
+        assert_equal(result, expected)
+
+    assert_equal(psf1, psf1_orig)
+
+
+def test_concurrent_shared_window_instance():
+    """
+    Test that a single window instance shared across threads returns
+    identical results for concurrent calls with different shapes.
+    """
+    window = SplitCosineBellWindow(alpha=0.4, beta=0.3)
+    shapes = [(25, 25), (51, 51), (25, 51), (51, 25)]
+    expected = [window(shape) for shape in shapes]
+
+    def task():
+        return [window(shape) for shape in shapes]
+
+    for results in _run_concurrently(task):
+        for result, expect in zip(results, expected, strict=True):
+            assert_equal(result, expect)

--- a/photutils/psf_matching/utils.py
+++ b/photutils/psf_matching/utils.py
@@ -138,6 +138,47 @@ def _validate_window_array(window_array, expected_shape):
         raise ValueError(msg)
 
 
+def _normalize_kernel(kernel):
+    """
+    Normalize a matching kernel so that it sums to 1.
+
+    Parameters
+    ----------
+    kernel : 2D `~numpy.ndarray`
+        The matching kernel.
+
+    Returns
+    -------
+    kernel : 2D `~numpy.ndarray`
+        The normalized matching kernel.
+
+    Raises
+    ------
+    ValueError
+        If the kernel contains non-finite values or its sum is zero or
+        nearly zero.
+    """
+    kernel_sum = np.sum(kernel)
+
+    if not np.isfinite(kernel_sum):
+        msg = ('The computed kernel contains non-finite values. This '
+               'can occur when the Fourier-space denominator is zero '
+               'at frequencies where the numerator is also zero (e.g., '
+               'the source OTF and the penalty OTF are both zero at '
+               'the same frequency).')
+        raise ValueError(msg)
+
+    if np.isclose(kernel_sum, 0.0):
+        msg = ('The computed kernel sums to zero, which likely indicates '
+               'that the regularization is too aggressive or that the '
+               'window function suppressed all frequencies. Try reducing '
+               'the regularization parameter or using a different window '
+               'function.')
+        raise ValueError(msg)
+
+    return kernel / kernel_sum
+
+
 def _convert_psf_to_otf(psf, shape):
     """
     Convert a point-spread function to an optical transfer function.

--- a/photutils/psf_matching/utils.py
+++ b/photutils/psf_matching/utils.py
@@ -215,9 +215,6 @@ def _convert_psf_to_otf(psf, shape):
     otf : 2D `~numpy.ndarray`
         The optical transfer function (complex array).
     """
-    if np.all(psf == 0):
-        return np.zeros(shape, dtype=complex)
-
     if psf.ndim != 2:
         msg = 'psf must be a 2D array.'
         raise ValueError(msg)
@@ -225,6 +222,9 @@ def _convert_psf_to_otf(psf, shape):
     if psf.shape[0] % 2 == 0 or psf.shape[1] % 2 == 0:
         msg = f'psf must have odd dimensions, got shape {psf.shape}.'
         raise ValueError(msg)
+
+    if np.all(psf == 0):
+        return np.zeros(shape, dtype=complex)
 
     inshape = psf.shape
 
@@ -325,8 +325,9 @@ def resize_psf(psf, input_pixel_scale, output_pixel_scale, *, order=3):
     Raises
     ------
     ValueError
-        If ``psf`` is not a 2D array, has even dimensions, is not
-        centered, or if the pixel scales are not positive.
+        If ``psf`` is not a 2D array, has even dimensions, contains NaN
+        or Inf values, or has a zero sum, or if the pixel scales are not
+        positive.
     """
     psf = np.asarray(psf, dtype=float)
 

--- a/photutils/psf_matching/windows.py
+++ b/photutils/psf_matching/windows.py
@@ -59,11 +59,11 @@ class SplitCosineBellWindow:
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float
         The percentage of array values that are tapered. ``alpha`` must
         be between 0.0 and 1.0, inclusive.
 
-    beta : float, optional
+    beta : float
         The inner diameter as a fraction of the array size beyond
         which the taper begins. ``beta`` must be between 0.0 and 1.0,
         inclusive.
@@ -212,9 +212,6 @@ class HanningWindow(SplitCosineBellWindow):
     def __repr__(self):
         return f'{self.__class__.__name__}()'
 
-    def __str__(self):
-        return self.__repr__()
-
 
 class TukeyWindow(SplitCosineBellWindow):
     """
@@ -237,7 +234,7 @@ class TukeyWindow(SplitCosineBellWindow):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float
         The percentage of array values that are tapered. Must be
         between 0.0 and 1.0, inclusive. When ``alpha=0``, this
         becomes a `TopHatWindow`. When ``alpha=1``, this becomes a
@@ -283,9 +280,6 @@ class TukeyWindow(SplitCosineBellWindow):
         return (f'{self.__class__.__name__}'
                 f'(alpha={self.alpha!r})')
 
-    def __str__(self):
-        return self.__repr__()
-
 
 class CosineBellWindow(SplitCosineBellWindow):
     """
@@ -304,7 +298,7 @@ class CosineBellWindow(SplitCosineBellWindow):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float
         The percentage of array values that are tapered. Must be between
         0.0 and 1.0, inclusive. When ``alpha=1``, this becomes a
         `HanningWindow`.
@@ -348,9 +342,6 @@ class CosineBellWindow(SplitCosineBellWindow):
         return (f'{self.__class__.__name__}'
                 f'(alpha={self.alpha!r})')
 
-    def __str__(self):
-        return self.__repr__()
-
 
 class TopHatWindow(SplitCosineBellWindow):
     """
@@ -373,7 +364,7 @@ class TopHatWindow(SplitCosineBellWindow):
 
     Parameters
     ----------
-    beta : float, optional
+    beta : float
         The inner diameter as a fraction of the array size beyond
         which the window drops to zero. Must be between 0.0 and 1.0,
         inclusive.
@@ -416,6 +407,3 @@ class TopHatWindow(SplitCosineBellWindow):
     def __repr__(self):
         return (f'{self.__class__.__name__}'
                 f'(beta={self.beta!r})')
-
-    def __str__(self):
-        return self.__repr__()


### PR DESCRIPTION
This PR contains several fixes and improvements for the psf_matching subpackage:

* Fixed the `resize_psf` import from the deprecated `photutils.psf.matching` location and added tests for the deprecated namespace.
* `make_wiener_kernel` now validates a custom `penalty` array. It must be 2D with odd dimensions in both axes, contain only finite values, and not be all zeros.
* `make_kernel` and `make_wiener_kernel` now raise a `ValueError `if the computed kernel contains non-finite values, which can occur when the Fourier-space denominator is zero at frequencies where the numerator is also zero.
* Also adds docstring polish, thread-safety tests, and a benchmark script