### PR TITLE
Fix several photutils.utils bugs and inconsistencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -511,6 +511,11 @@ API Changes
     labels the number of sources as ``n_sources`` instead of
     ``nsources`` for naming consistency. [#2338]
 
+  - The star-finder cutout centers used for the shape and flux
+    measurements now round half-integer pixel positions half away
+    from zero instead of half to even, consistent with the rounding
+    convention used elsewhere in photutils. [#2375]
+
 - ``photutils.geometry``
 
   - The ``circular_overlap_grid``, ``elliptical_overlap_grid``, and

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -429,6 +429,9 @@ Bug Fixes
     result attributes now always reflect only the most recent call.
     [#2375]
 
+  - Fixed a crash in ``calc_total_error`` when the input ``data`` array
+    has an integer data type. [#2375]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -424,6 +424,11 @@ Bug Fixes
   - Fixed a thread-safety issue in ``ImageDepth`` by using a copy of the
     user's SigmaClip instance. [#2364]
 
+  - Fixed ``ImageDepth`` so that repeated calls on the same instance
+    no longer accumulate the ``fluxes`` attribute across calls. The
+    result attributes now always reflect only the most recent call.
+    [#2375]
+
 API Changes
 ^^^^^^^^^^^
 
@@ -563,6 +568,11 @@ API Changes
     renamed to ``n_coords``, consistent with the ``n_*`` naming used
     elsewhere in photutils. The old ``ncoords`` name is deprecated and
     will be removed in version 4.0. [#2346]
+
+  - ``ImageDepth`` now creates a fresh random generator initialized
+    with ``seed`` on every call instead of consuming a generator shared
+    across calls. With a fixed seed, every call on the same instance now
+    produces identical results. [#2375]
 
 
 3.0.0 (2026-04-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -558,6 +558,9 @@ API Changes
     ``STDPSFGrid`` output now labels the grid shape as ``Grid shape``
     instead of ``Grid_shape``. [#2344]
 
+  - ``decode_psf_flags`` now raises a ``TypeError`` for boolean flag
+    values instead of treating `True` as bit value 1. [#2375]
+
 - ``photutils.segmentation``
 
   - The ``deblend_sources`` "too many markers" warning key stored in

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -580,6 +580,11 @@ API Changes
     across calls. With a fixed seed, every call on the same instance now
     produces identical results. [#2375]
 
+  - ``ShepardIDWInterpolator`` now returns a NumPy scalar for a
+    single input position when ``n_neighbors=1``, consistent with the
+    ``n_neighbors > 1`` case. Previously it returned a Python float.
+    [#2375]
+
 
 3.0.0 (2026-04-17)
 ------------------

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,7 +2,7 @@
 
 This directory contains standalone benchmark scripts for photutils.
 They are not part of the installed package or the test suite. Helper
-functions shared by the scripts live in `bench_utils.py`.
+functions shared by the scripts live in `bench_helpers.py`.
 
 ## Aperture statistics (`bench_aperture_stats.py`)
 
@@ -151,4 +151,31 @@ python benchmarks/bench_background.py
 # Only the Background2D n_threads scaling benchmark
 python benchmarks/bench_background.py --which background2d \
     --sizes 2048,4096 --box-sizes 64 --n-threads 1,2,4,8
+```
+
+## Utils (`bench_utils.py`)
+
+Benchmarks for the `photutils.utils` subpackage:
+
+- `ImageDepth` versus the number of apertures, in the overlapping
+  and non-overlapping modes
+- concurrent `ImageDepth` calls on a shared instance across thread
+  counts (with speedups relative to the first thread count)
+- `ShepardIDWInterpolator` construction and evaluation versus the
+  numbers of data points, query positions, and neighbors
+- cutout generation with `_make_cutouts` and `CutoutImage`
+- `calc_total_error` versus image size, with scalar and 2D gains
+- the NaN-ignoring statistics functions on float64 (bottleneck) and
+  float32 (NumPy) arrays
+- `make_random_xycoords` with and without a minimum separation
+- the per-call cost of the local WCS helper functions
+
+Examples:
+
+```bash
+# Run everything with the default settings
+python benchmarks/bench_utils.py
+
+# Only the ImageDepth thread-scaling benchmark
+python benchmarks/bench_utils.py --which depth-threads --threads 1,4,8
 ```

--- a/benchmarks/bench_aperture_photometry.py
+++ b/benchmarks/bench_aperture_photometry.py
@@ -16,9 +16,9 @@ the available options.
 import argparse
 from functools import partial
 
-from bench_utils import (format_sweep_cells, make_aperture_inputs,
-                         make_apertures, parse_thread_counts,
-                         print_environment, time_best)
+from bench_helpers import (format_sweep_cells, make_aperture_inputs,
+                           make_apertures, parse_thread_counts,
+                           print_environment, time_best)
 
 from photutils.aperture import AperturePhotometry
 

--- a/benchmarks/bench_aperture_stats.py
+++ b/benchmarks/bench_aperture_stats.py
@@ -17,9 +17,9 @@ import argparse
 from functools import partial
 
 from astropy.stats import SigmaClip
-from bench_utils import (format_sweep_cells, make_aperture_inputs,
-                         make_apertures, parse_thread_counts,
-                         print_environment, time_best)
+from bench_helpers import (format_sweep_cells, make_aperture_inputs,
+                           make_apertures, parse_thread_counts,
+                           print_environment, time_best)
 
 from photutils.aperture import ApertureStats, CircularAperture
 

--- a/benchmarks/bench_background.py
+++ b/benchmarks/bench_background.py
@@ -17,8 +17,8 @@ from functools import partial
 
 import numpy as np
 from astropy.stats import SigmaClip
-from bench_utils import (format_sweep_cells, make_image, print_environment,
-                         time_best)
+from bench_helpers import (format_sweep_cells, make_image, print_environment,
+                           time_best)
 
 from photutils.background import (Background2D, BiweightLocationBackground,
                                   BiweightScaleBackgroundRMS, LocalBackground,

--- a/benchmarks/bench_centroids.py
+++ b/benchmarks/bench_centroids.py
@@ -17,7 +17,7 @@ from functools import partial
 import numpy as np
 from astropy.modeling.models import Gaussian2D
 from astropy.stats import gaussian_fwhm_to_sigma
-from bench_utils import print_environment, time_best
+from bench_helpers import print_environment, time_best
 
 from photutils.centroids import (centroid_1dg, centroid_2dg, centroid_com,
                                  centroid_quadratic, centroid_sources)

--- a/benchmarks/bench_datasets.py
+++ b/benchmarks/bench_datasets.py
@@ -17,7 +17,7 @@ from functools import partial
 
 import numpy as np
 from astropy.modeling.models import Gaussian2D
-from bench_utils import print_environment, time_best
+from bench_helpers import print_environment, time_best
 
 from photutils.datasets import (apply_poisson_noise, make_4gaussians_image,
                                 make_100gaussians_image, make_gwcs,

--- a/benchmarks/bench_geometry.py
+++ b/benchmarks/bench_geometry.py
@@ -18,7 +18,7 @@ import argparse
 from functools import partial
 
 import numpy as np
-from bench_utils import print_environment, time_best
+from bench_helpers import print_environment, time_best
 
 from photutils.geometry import (circular_overlap_grid, elliptical_overlap_grid,
                                 rectangular_overlap_grid)

--- a/benchmarks/bench_helpers.py
+++ b/benchmarks/bench_helpers.py
@@ -1,0 +1,196 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Shared helper functions for the photutils benchmark scripts.
+"""
+
+import os
+import platform
+import sys
+import time
+
+import numpy as np
+
+from photutils.aperture import (CircularAnnulus, CircularAperture,
+                                EllipticalAnnulus, EllipticalAperture,
+                                PolygonAperture, RectangularAnnulus,
+                                RectangularAperture)
+from photutils.datasets import make_wcs
+
+
+def time_best(func, *, repeats=3):
+    """
+    Return the best wall-clock time of ``repeats`` calls to ``func``.
+
+    Parameters
+    ----------
+    func : callable
+        The zero-argument callable to time.
+
+    repeats : int, optional
+        The number of times to call ``func``.
+
+    Returns
+    -------
+    result : float
+        The best (minimum) wall-clock time in seconds.
+    """
+    best = np.inf
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        func()
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+def make_image(shape, *, seed=0):
+    """
+    Return a Gaussian-noise image of the given shape.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the output image.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        The noise image.
+    """
+    rng = np.random.default_rng(seed)
+    return rng.normal(100.0, 5.0, shape)
+
+
+def print_environment():
+    """
+    Print information about the runtime environment.
+    """
+    import astropy
+    import scipy
+
+    import photutils
+    from photutils.utils._optional_deps import HAS_BOTTLENECK
+
+    gil = getattr(sys, '_is_gil_enabled', lambda: True)()
+    print(f'python {platform.python_version()} (GIL enabled: {gil}), '
+          f'{os.cpu_count()} CPUs')
+    print(f'photutils {photutils.__version__}, numpy {np.__version__}, '
+          f'scipy {scipy.__version__}, astropy {astropy.__version__}, '
+          f'bottleneck: {HAS_BOTTLENECK}')
+
+
+def parse_thread_counts(text):
+    """
+    Parse a comma-separated list of thread counts.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated thread counts (e.g., ``'1,2,4,8'``).
+
+    Returns
+    -------
+    result : list of int
+        The thread counts.
+    """
+    counts = [int(item) for item in text.split(',')]
+    if any(count < 1 for count in counts):
+        msg = 'thread counts must be positive integers'
+        raise ValueError(msg)
+    return counts
+
+
+def format_sweep_cells(times):
+    """
+    Format thread-sweep times, with speedups relative to the first
+    time.
+
+    Parameters
+    ----------
+    times : list of float
+        The wall-clock times in seconds, one per thread count.
+
+    Returns
+    -------
+    result : list of str
+        The formatted cells (e.g., ``['0.3270s', '0.1700s (1.9x)']``).
+    """
+    cells = [f'{times[0]:.4f}s']
+    cells.extend(f'{t:.4f}s ({times[0] / t:.1f}x)' for t in times[1:])
+    return cells
+
+
+def make_apertures(positions):
+    """
+    Return all of the pixel-based aperture types at the given
+    positions, with roughly comparable sizes.
+
+    Parameters
+    ----------
+    positions : 2D `~numpy.ndarray`
+        The (x, y) aperture positions.
+
+    Returns
+    -------
+    result : list of (str, aperture) tuples
+        The aperture name and instance pairs.
+    """
+    theta = 0.5
+    return [
+        ('CircularAperture', CircularAperture(positions, r=8.0)),
+        ('CircularAnnulus',
+         CircularAnnulus(positions, r_in=5.0, r_out=10.0)),
+        ('EllipticalAperture',
+         EllipticalAperture(positions, a=10.0, b=6.0, theta=theta)),
+        ('EllipticalAnnulus',
+         EllipticalAnnulus(positions, a_in=6.0, a_out=12.0, b_out=8.0,
+                           theta=theta)),
+        ('RectangularAperture',
+         RectangularAperture(positions, w=14.0, h=10.0, theta=theta)),
+        ('RectangularAnnulus',
+         RectangularAnnulus(positions, w_in=8.0, w_out=16.0, h_out=12.0,
+                            theta=theta)),
+        ('PolygonAperture',
+         PolygonAperture.from_regular_polygon(positions, n_vertices=6,
+                                              radius=8.0)),
+    ]
+
+
+def make_aperture_inputs(size, n_sources, *, seed=0):
+    """
+    Return the data, error, wcs, and aperture positions used by the
+    aperture benchmark scripts.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    n_sources : int
+        The number of aperture positions.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    data, error : 2D `~numpy.ndarray`
+        The image and its error array.
+
+    wcs : `~astropy.wcs.WCS`
+        A WCS for the image.
+
+    positions : 2D `~numpy.ndarray`
+        The (x, y) aperture positions.
+    """
+    data = make_image((size, size), seed=seed)
+    error = np.sqrt(np.abs(data))
+    wcs = make_wcs(data.shape)
+    rng = np.random.default_rng(seed)
+    margin = 20.0
+    positions = np.column_stack(
+        [rng.uniform(margin, size - margin, n_sources),
+         rng.uniform(margin, size - margin, n_sources)])
+    return data, error, wcs, positions

--- a/benchmarks/bench_morphology.py
+++ b/benchmarks/bench_morphology.py
@@ -18,7 +18,7 @@ from functools import partial
 import numpy as np
 from astropy.modeling.models import Gaussian2D
 from astropy.stats import gaussian_fwhm_to_sigma
-from bench_utils import print_environment, time_best
+from bench_helpers import print_environment, time_best
 
 from photutils.datasets import make_wcs
 from photutils.morphology import data_properties, gini

--- a/benchmarks/bench_profiles.py
+++ b/benchmarks/bench_profiles.py
@@ -19,7 +19,7 @@ from functools import partial
 import numpy as np
 from astropy.modeling.models import Gaussian2D
 from astropy.stats import gaussian_fwhm_to_sigma
-from bench_utils import print_environment, time_best
+from bench_helpers import print_environment, time_best
 
 from photutils.profiles import (CurveOfGrowth, EllipticalCurveOfGrowth,
                                 EnsquaredCurveOfGrowth, RadialProfile)

--- a/benchmarks/bench_psf_matching.py
+++ b/benchmarks/bench_psf_matching.py
@@ -18,7 +18,7 @@ from functools import partial
 
 import numpy as np
 from astropy.modeling.models import Gaussian2D
-from bench_utils import print_environment, time_best
+from bench_helpers import print_environment, time_best
 
 from photutils.psf_matching import (CosineBellWindow, HanningWindow,
                                     SplitCosineBellWindow, TopHatWindow,

--- a/benchmarks/bench_utils.py
+++ b/benchmarks/bench_utils.py
@@ -1,196 +1,544 @@
+#!/usr/bin/env python3
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Shared helper functions for the photutils benchmark scripts.
+Benchmarks for the photutils.utils subpackage.
+
+The benchmarks cover the scaling of ``ImageDepth`` with the number
+of apertures (including the non-overlapping mode and concurrent
+calls from multiple threads), ``ShepardIDWInterpolator`` construction
+and evaluation, cutout generation, ``calc_total_error``, the
+NaN-ignoring statistics functions, random-coordinate generation with
+a minimum separation, and the local WCS helper functions.
+
+Run ``python benchmarks/bench_utils.py --help`` to see the available
+options.
 """
 
-import os
-import platform
-import sys
-import time
+import argparse
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 
 import numpy as np
+from astropy.utils.exceptions import AstropyUserWarning
+from bench_helpers import (format_sweep_cells, make_image, parse_thread_counts,
+                           print_environment, time_best)
 
-from photutils.aperture import (CircularAnnulus, CircularAperture,
-                                EllipticalAnnulus, EllipticalAperture,
-                                PolygonAperture, RectangularAnnulus,
-                                RectangularAperture)
 from photutils.datasets import make_wcs
+from photutils.utils import (CutoutImage, ImageDepth, ShepardIDWInterpolator,
+                             calc_total_error)
+from photutils.utils._coords import make_random_xycoords
+from photutils.utils._stats import (nanmax, nanmean, nanmedian, nanmin, nanstd,
+                                    nansum, nanvar)
+from photutils.utils._wcs_helpers import (compute_local_wcs_jacobian,
+                                          wcs_pixel_scale_angle)
+from photutils.utils.cutouts import _make_cutouts
+
+APER_RADIUS = 4.0
 
 
-def time_best(func, *, repeats=3):
+def make_depth_inputs(size, *, seed=0):
     """
-    Return the best wall-clock time of ``repeats`` calls to ``func``.
+    Return a noise image and a source mask for the ImageDepth
+    benchmarks.
 
-    Parameters
-    ----------
-    func : callable
-        The zero-argument callable to time.
-
-    repeats : int, optional
-        The number of times to call ``func``.
-
-    Returns
-    -------
-    result : float
-        The best (minimum) wall-clock time in seconds.
-    """
-    best = np.inf
-    for _ in range(repeats):
-        t0 = time.perf_counter()
-        func()
-        best = min(best, time.perf_counter() - t0)
-    return best
-
-
-def make_image(shape, *, seed=0):
-    """
-    Return a Gaussian-noise image of the given shape.
-
-    Parameters
-    ----------
-    shape : tuple of int
-        The shape of the output image.
-
-    seed : int, optional
-        The random number generator seed.
-
-    Returns
-    -------
-    result : 2D `~numpy.ndarray`
-        The noise image.
-    """
-    rng = np.random.default_rng(seed)
-    return rng.normal(100.0, 5.0, shape)
-
-
-def print_environment():
-    """
-    Print information about the runtime environment.
-    """
-    import astropy
-    import scipy
-
-    import photutils
-    from photutils.utils._optional_deps import HAS_BOTTLENECK
-
-    gil = getattr(sys, '_is_gil_enabled', lambda: True)()
-    print(f'python {platform.python_version()} (GIL enabled: {gil}), '
-          f'{os.cpu_count()} CPUs')
-    print(f'photutils {photutils.__version__}, numpy {np.__version__}, '
-          f'scipy {scipy.__version__}, astropy {astropy.__version__}, '
-          f'bottleneck: {HAS_BOTTLENECK}')
-
-
-def parse_thread_counts(text):
-    """
-    Parse a comma-separated list of thread counts.
-
-    Parameters
-    ----------
-    text : str
-        The comma-separated thread counts (e.g., ``'1,2,4,8'``).
-
-    Returns
-    -------
-    result : list of int
-        The thread counts.
-    """
-    counts = [int(item) for item in text.split(',')]
-    if any(count < 1 for count in counts):
-        msg = 'thread counts must be positive integers'
-        raise ValueError(msg)
-    return counts
-
-
-def format_sweep_cells(times):
-    """
-    Format thread-sweep times, with speedups relative to the first
-    time.
-
-    Parameters
-    ----------
-    times : list of float
-        The wall-clock times in seconds, one per thread count.
-
-    Returns
-    -------
-    result : list of str
-        The formatted cells (e.g., ``['0.3270s', '0.1700s (1.9x)']``).
-    """
-    cells = [f'{times[0]:.4f}s']
-    cells.extend(f'{t:.4f}s ({times[0] / t:.1f}x)' for t in times[1:])
-    return cells
-
-
-def make_apertures(positions):
-    """
-    Return all of the pixel-based aperture types at the given
-    positions, with roughly comparable sizes.
-
-    Parameters
-    ----------
-    positions : 2D `~numpy.ndarray`
-        The (x, y) aperture positions.
-
-    Returns
-    -------
-    result : list of (str, aperture) tuples
-        The aperture name and instance pairs.
-    """
-    theta = 0.5
-    return [
-        ('CircularAperture', CircularAperture(positions, r=8.0)),
-        ('CircularAnnulus',
-         CircularAnnulus(positions, r_in=5.0, r_out=10.0)),
-        ('EllipticalAperture',
-         EllipticalAperture(positions, a=10.0, b=6.0, theta=theta)),
-        ('EllipticalAnnulus',
-         EllipticalAnnulus(positions, a_in=6.0, a_out=12.0, b_out=8.0,
-                           theta=theta)),
-        ('RectangularAperture',
-         RectangularAperture(positions, w=14.0, h=10.0, theta=theta)),
-        ('RectangularAnnulus',
-         RectangularAnnulus(positions, w_in=8.0, w_out=16.0, h_out=12.0,
-                            theta=theta)),
-        ('PolygonAperture',
-         PolygonAperture.from_regular_polygon(positions, n_vertices=6,
-                                              radius=8.0)),
-    ]
-
-
-def make_aperture_inputs(size, n_sources, *, seed=0):
-    """
-    Return the data, error, wcs, and aperture positions used by the
-    aperture benchmark scripts.
+    The mask contains compact square "sources" covering ~5% of the
+    image, so that plenty of unmasked area remains after the mask is
+    dilated by the aperture radius.
 
     Parameters
     ----------
     size : int
         The image size; the image is ``(size, size)``.
 
-    n_sources : int
-        The number of aperture positions.
-
     seed : int, optional
         The random number generator seed.
 
     Returns
     -------
-    data, error : 2D `~numpy.ndarray`
-        The image and its error array.
+    data : 2D `~numpy.ndarray`
+        The noise image.
 
-    wcs : `~astropy.wcs.WCS`
-        A WCS for the image.
-
-    positions : 2D `~numpy.ndarray`
-        The (x, y) aperture positions.
+    mask : 2D bool `~numpy.ndarray`
+        The source mask.
     """
     data = make_image((size, size), seed=seed)
-    error = np.sqrt(np.abs(data))
-    wcs = make_wcs(data.shape)
     rng = np.random.default_rng(seed)
-    margin = 20.0
+    mask = np.zeros(data.shape, dtype=bool)
+    blob_size = 20
+    n_blobs = max(1, (size * size) // (20 * blob_size**2))
+    for _ in range(n_blobs):
+        y = rng.integers(0, size - blob_size)
+        x = rng.integers(0, size - blob_size)
+        mask[y:y + blob_size, x:x + blob_size] = True
+    return data, mask
+
+
+def make_depth(n_apertures, *, overlap=True):
+    """
+    Return a seeded ImageDepth instance for the benchmarks.
+
+    Parameters
+    ----------
+    n_apertures : int
+        The number of circular apertures.
+
+    overlap : bool, optional
+        Whether to allow the apertures to overlap.
+
+    Returns
+    -------
+    depth : `~photutils.utils.ImageDepth`
+        The ImageDepth instance.
+    """
+    return ImageDepth(APER_RADIUS, n_sigma=5.0, n_apertures=n_apertures,
+                      n_iters=2, mask_pad=2, overlap=overlap, seed=0,
+                      progress_bar=False)
+
+
+def run_image_depth(depth, data, mask, n_iter):
+    """
+    Run an ImageDepth calculation repeatedly.
+
+    Parameters
+    ----------
+    depth : `~photutils.utils.ImageDepth`
+        The ImageDepth instance.
+
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    mask : 2D bool `~numpy.ndarray`
+        The source mask.
+
+    n_iter : int
+        The number of calls.
+    """
+    with warnings.catch_warnings():
+        # The non-overlapping mode may warn when fewer apertures than
+        # requested can be placed; that is irrelevant for timing
+        warnings.simplefilter('ignore', AstropyUserWarning)
+        for _ in range(n_iter):
+            depth(data, mask)
+
+
+def bench_image_depth(*, size=1000, n_apertures_list=(100, 500, 2000),
+                      n_iter=1, repeats=3):
+    """
+    Benchmark ImageDepth versus the number of apertures.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    n_apertures_list : tuple of int, optional
+        The numbers of apertures to place.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    data, mask = make_depth_inputs(size)
+    run_image_depth(make_depth(50), data, mask, 1)  # warm up
+
+    print(f'\n== ImageDepth ({size}x{size} image, radius '
+          f'{APER_RADIUS}, 2 iterations, per-call time) ==')
+    print(f'{"n_apertures":>12}{"overlap":>16}{"no overlap":>16}')
+    for n_apertures in n_apertures_list:
+        times = []
+        for overlap in (True, False):
+            depth = make_depth(n_apertures, overlap=overlap)
+            bench = partial(run_image_depth, depth, data, mask, n_iter)
+            times.append(time_best(bench, repeats=repeats) / n_iter)
+        print(f'{n_apertures:>12}'
+              f'{f"{times[0] * 1e3:.2f}ms":>16}'
+              f'{f"{times[1] * 1e3:.2f}ms":>16}')
+
+
+def run_image_depth_concurrent(depth, data, mask, n_calls, n_threads):
+    """
+    Run concurrent ImageDepth calls on a shared instance.
+
+    Parameters
+    ----------
+    depth : `~photutils.utils.ImageDepth`
+        The shared ImageDepth instance.
+
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    mask : 2D bool `~numpy.ndarray`
+        The source mask.
+
+    n_calls : int
+        The total number of calls.
+
+    n_threads : int
+        The number of worker threads.
+    """
+    with ThreadPoolExecutor(max_workers=n_threads) as executor:
+        futures = [executor.submit(depth, data, mask)
+                   for _ in range(n_calls)]
+        for future in futures:
+            future.result()
+
+
+def bench_depth_threads(*, size=500, n_apertures=500, n_calls=8,
+                        thread_counts=(1, 2, 4, 8), repeats=3):
+    """
+    Benchmark concurrent ImageDepth calls on a shared instance.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    n_apertures : int, optional
+        The number of circular apertures.
+
+    n_calls : int, optional
+        The total number of ImageDepth calls per timing.
+
+    thread_counts : tuple of int, optional
+        The numbers of worker threads.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    data, mask = make_depth_inputs(size)
+    depth = make_depth(n_apertures)
+    depth(data, mask)  # warm up
+
+    times = []
+    for n_threads in thread_counts:
+        bench = partial(run_image_depth_concurrent, depth, data, mask,
+                        n_calls, n_threads)
+        times.append(time_best(bench, repeats=repeats))
+
+    print(f'\n== ImageDepth thread scaling ({size}x{size} image, '
+          f'{n_apertures} apertures, {n_calls} concurrent calls on a '
+          'shared instance) ==')
+    header = ''.join(f'{f"{n} thr":>18}' for n in thread_counts)
+    print(header)
+    print(''.join(f'{cell:>18}' for cell in format_sweep_cells(times)))
+
+
+def bench_idw(*, n_coords_list=(1_000, 10_000, 100_000),
+              n_positions_list=(100, 1_000, 10_000),
+              n_neighbors_list=(1, 8, 64), repeats=3):
+    """
+    Benchmark ShepardIDWInterpolator construction and evaluation.
+
+    Parameters
+    ----------
+    n_coords_list : tuple of int, optional
+        The numbers of known data points for the construction
+        benchmark.
+
+    n_positions_list : tuple of int, optional
+        The numbers of query positions for the evaluation benchmark.
+
+    n_neighbors_list : tuple of int, optional
+        The numbers of neighbors for the evaluation benchmark.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    rng = np.random.default_rng(0)
+
+    print('\n== ShepardIDWInterpolator construction (2D coords) ==')
+    print(f'{"n_coords":>12}{"time":>12}')
+    for n_coords in n_coords_list:
+        coords = rng.random((n_coords, 2))
+        values = np.sin(coords[:, 0] + coords[:, 1])
+        bench = partial(ShepardIDWInterpolator, coords, values)
+        t_call = time_best(bench, repeats=repeats)
+        print(f'{n_coords:>12}{f"{t_call * 1e3:.2f}ms":>12}')
+
+    n_coords = 10_000
+    coords = rng.random((n_coords, 2))
+    values = np.sin(coords[:, 0] + coords[:, 1])
+    interp = ShepardIDWInterpolator(coords, values)
+
+    print(f'\n== ShepardIDWInterpolator evaluation ({n_coords} coords, '
+          '8 neighbors) ==')
+    print(f'{"n_positions":>12}{"time":>12}{"per-pos":>12}')
+    for n_positions in n_positions_list:
+        positions = rng.random((n_positions, 2))
+        bench = partial(interp, positions)
+        t_call = time_best(bench, repeats=repeats)
+        print(f'{n_positions:>12}{f"{t_call * 1e3:.2f}ms":>12}'
+              f'{f"{t_call / n_positions * 1e6:.1f}us":>12}')
+
+    n_positions = 1000
+    positions = rng.random((n_positions, 2))
+    print(f'\n== ShepardIDWInterpolator evaluation ({n_coords} coords, '
+          f'{n_positions} positions) ==')
+    print(f'{"n_neighbors":>12}{"time":>12}')
+    for n_neighbors in n_neighbors_list:
+        bench = partial(interp, positions, n_neighbors=n_neighbors)
+        t_call = time_best(bench, repeats=repeats)
+        print(f'{n_neighbors:>12}{f"{t_call * 1e3:.2f}ms":>12}')
+
+
+def run_cutout_image(data, positions, shape, n_iter):
+    """
+    Create single cutouts repeatedly with CutoutImage.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    positions : 2D `~numpy.ndarray`
+        The (y, x) cutout positions.
+
+    shape : 2-tuple of int
+        The cutout shape.
+
+    n_iter : int
+        The number of passes over the positions.
+    """
+    for _ in range(n_iter):
+        for position in positions:
+            CutoutImage(data, position, shape, mode='partial')
+
+
+def bench_cutouts(*, size=1000, n_sources_list=(100, 1_000, 10_000),
+                  cutout_shape=(11, 11), repeats=3):
+    """
+    Benchmark cutout generation.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    n_sources_list : tuple of int, optional
+        The numbers of cutout positions.
+
+    cutout_shape : 2-tuple of int, optional
+        The cutout shape.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    data = make_image((size, size))
+    rng = np.random.default_rng(0)
+
+    ny, nx = cutout_shape
+    print(f'\n== _make_cutouts ({size}x{size} image, {ny}x{nx} '
+          'cutouts) ==')
+    print(f'{"n_sources":>12}{"time":>12}{"per-source":>14}')
+    for n_sources in n_sources_list:
+        xpos = rng.uniform(0, size - 1, n_sources)
+        ypos = rng.uniform(0, size - 1, n_sources)
+        bench = partial(_make_cutouts, data, xpos, ypos, cutout_shape)
+        t_call = time_best(bench, repeats=repeats)
+        print(f'{n_sources:>12}{f"{t_call * 1e3:.2f}ms":>12}'
+              f'{f"{t_call / n_sources * 1e6:.1f}us":>14}')
+
+    n_sources = 1000
     positions = np.column_stack(
-        [rng.uniform(margin, size - margin, n_sources),
-         rng.uniform(margin, size - margin, n_sources)])
-    return data, error, wcs, positions
+        [rng.uniform(0, size - 1, n_sources),
+         rng.uniform(0, size - 1, n_sources)])
+    n_iter = 3
+    bench = partial(run_cutout_image, data, positions, (25, 25), n_iter)
+    t_call = time_best(bench, repeats=repeats) / (n_iter * n_sources)
+    print('\n== CutoutImage (25x25 cutouts, per-cutout time) ==')
+    print(f'{f"{t_call * 1e6:.1f}us":>12}')
+
+
+def bench_total_error(*, sizes=(500, 1000, 2000), n_iter=3, repeats=3):
+    """
+    Benchmark calc_total_error versus image size.
+
+    Parameters
+    ----------
+    sizes : tuple of int, optional
+        The image sizes.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    print('\n== calc_total_error (per-call time) ==')
+    print(f'{"size":>12}{"scalar gain":>14}{"2D gain":>14}')
+    for size in sizes:
+        data = make_image((size, size))
+        bkg_error = np.sqrt(np.abs(data))
+        gain_image = np.full(data.shape, 2.0)
+        times = []
+        for gain in (2.0, gain_image):
+            def run(data=data, bkg_error=bkg_error, gain=gain):
+                for _ in range(n_iter):
+                    calc_total_error(data, bkg_error, gain)
+
+            times.append(time_best(run, repeats=repeats) / n_iter)
+        print(f'{size:>12}'
+              f'{f"{times[0] * 1e3:.2f}ms":>14}'
+              f'{f"{times[1] * 1e3:.2f}ms":>14}')
+
+
+def bench_nan_stats(*, size=2000, n_iter=3, repeats=3):
+    """
+    Benchmark the NaN-ignoring statistics functions.
+
+    Float64 arrays dispatch to bottleneck (if installed); other
+    dtypes use NumPy.
+
+    Parameters
+    ----------
+    size : int, optional
+        The array size; the array is ``(size, size)``.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    data = make_image((size, size))
+    rng = np.random.default_rng(0)
+    nan_mask = rng.random(data.shape) < 0.01
+    data[nan_mask] = np.nan
+    data32 = data.astype(np.float32)
+
+    funcs = [('nansum', nansum), ('nanmin', nanmin), ('nanmax', nanmax),
+             ('nanmean', nanmean), ('nanmedian', nanmedian),
+             ('nanstd', nanstd), ('nanvar', nanvar)]
+
+    print(f'\n== NaN-ignoring statistics ({size}x{size} array, 1% NaN, '
+          'per-call time) ==')
+    print(f'{"function":>12}{"float64":>12}{"float32":>12}')
+    for name, func in funcs:
+        times = []
+        for arr in (data, data32):
+            def run(func=func, arr=arr):
+                for _ in range(n_iter):
+                    func(arr)
+
+            times.append(time_best(run, repeats=repeats) / n_iter)
+        print(f'{name:>12}'
+              f'{f"{times[0] * 1e3:.2f}ms":>12}'
+              f'{f"{times[1] * 1e3:.2f}ms":>12}')
+
+
+def bench_random_coords(*, size=1000, n_coords_list=(1_000, 10_000),
+                        min_separations=(0.0, 5.0), repeats=3):
+    """
+    Benchmark make_random_xycoords with and without a minimum
+    separation.
+
+    Parameters
+    ----------
+    size : int, optional
+        The coordinate range; coordinates span ``(0, size)`` in x
+        and y.
+
+    n_coords_list : tuple of int, optional
+        The numbers of coordinates to generate.
+
+    min_separations : tuple of float, optional
+        The minimum separations to apply.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    print('\n== make_random_xycoords (per-call time) ==')
+    header = f'{"n_coords":>12}'
+    header += ''.join(f'{f"min_sep={ms:g}":>16}' for ms in min_separations)
+    print(header)
+    for n_coords in n_coords_list:
+        cells = [f'{n_coords:>12}']
+        for min_separation in min_separations:
+            bench = partial(make_random_xycoords, n_coords, (0, size),
+                            (0, size), min_separation=min_separation,
+                            seed=0)
+            t_call = time_best(bench, repeats=repeats)
+            cells.append(f'{f"{t_call * 1e3:.2f}ms":>16}')
+        print(''.join(cells))
+
+
+def bench_wcs_helpers(*, n_iter=100, repeats=3):
+    """
+    Benchmark the per-call cost of the local WCS helper functions.
+
+    Parameters
+    ----------
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    wcs = make_wcs((1000, 1000))
+    skycoord = wcs.pixel_to_world(500.0, 500.0)
+
+    funcs = [('local Jacobian', compute_local_wcs_jacobian),
+             ('scale/angle', wcs_pixel_scale_angle)]
+
+    print('\n== WCS helpers (TAN WCS, per-call time) ==')
+    print(f'{"function":>16}{"time":>12}')
+    for name, func in funcs:
+        def run(func=func):
+            for _ in range(n_iter):
+                func(skycoord, wcs)
+
+        t_call = time_best(run, repeats=repeats) / n_iter
+        print(f'{name:>16}{f"{t_call * 1e6:.1f}us":>12}')
+
+
+def main():
+    """
+    Run the photutils.utils benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for the photutils.utils subpackage.')
+    parser.add_argument('--size', type=int, default=1000,
+                        help='image size for the ImageDepth and cutout '
+                             'benchmarks (default: %(default)s)')
+    parser.add_argument('--threads', type=parse_thread_counts,
+                        default=[1, 2, 4, 8],
+                        help='comma-separated thread counts for the '
+                             'ImageDepth thread-scaling benchmark '
+                             '(default: 1,2,4,8)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'image-depth', 'depth-threads',
+                                 'idw', 'cutouts', 'total-error',
+                                 'nan-stats', 'random-coords', 'wcs'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'image-depth'):
+        bench_image_depth(size=args.size, repeats=args.repeats)
+    if args.which in ('all', 'depth-threads'):
+        bench_depth_threads(thread_counts=args.threads,
+                            repeats=args.repeats)
+    if args.which in ('all', 'idw'):
+        bench_idw(repeats=args.repeats)
+    if args.which in ('all', 'cutouts'):
+        bench_cutouts(size=args.size, repeats=args.repeats)
+    if args.which in ('all', 'total-error'):
+        bench_total_error(repeats=args.repeats)
+    if args.which in ('all', 'nan-stats'):
+        bench_nan_stats(repeats=args.repeats)
+    if args.which in ('all', 'random-coords'):
+        bench_random_coords(repeats=args.repeats)
+    if args.which in ('all', 'wcs'):
+        bench_wcs_helpers(repeats=args.repeats)
+
+
+if __name__ == '__main__':
+    main()

--- a/photutils/utils/_flags.py
+++ b/photutils/utils/_flags.py
@@ -338,7 +338,8 @@ def decode_flags(flags, registry, *, return_bit_values=False):
         """
         Decode a single integer flag value.
         """
-        if not isinstance(flag_value, (int, np.integer)):
+        if (not isinstance(flag_value, (int, np.integer))
+                or isinstance(flag_value, bool)):
             msg = 'Flag value must be an integer'
             raise TypeError(msg)
 

--- a/photutils/utils/_parameters.py
+++ b/photutils/utils/_parameters.py
@@ -116,7 +116,7 @@ def as_pair(name, value, *, lower_bound=None, upper_bound=None,
     if len(value) == 1:
         value = np.array((value[0], value[0]))
 
-    if value.dtype.kind != 'i':
+    if value.dtype.kind not in 'iu':
         msg = f'{name} must have integer values'
         raise ValueError(msg)
     if check_odd and np.any(value % 2 != 1):

--- a/photutils/utils/_round.py
+++ b/photutils/utils/_round.py
@@ -21,7 +21,8 @@ def round_half_away(a):
     result : int, float, or array_like
         The rounded values. Finite inputs are returned as integers.
         Non-finite inputs (NaN or infinity) are returned as floats,
-        preserving the NaN or infinity value.
+        preserving the NaN or infinity value. Scalar and 0-d array
+        inputs return a scalar.
 
     Notes
     -----
@@ -33,9 +34,9 @@ def round_half_away(a):
     rounded = np.where(data >= 0, np.floor(data + 0.5),
                        np.ceil(data - 0.5))
 
-    if np.isscalar(a):
+    if np.ndim(a) == 0:
         val = rounded[0]
-        if not np.isfinite(a):
+        if not np.isfinite(val):
             return val
         return int(val)
 

--- a/photutils/utils/cutouts.py
+++ b/photutils/utils/cutouts.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.nddata import extract_array, overlap_slices
 
 from photutils.utils._deprecation import deprecated_positional_kwargs
+from photutils.utils._round import round_half_away
 
 __all__ = ['CutoutImage']
 
@@ -251,8 +252,9 @@ def _make_cutouts(data, xpos, ypos, cutout_shape, *, fill_value=0.0):
     """
     Make 2D cutouts from a data array at the given positions.
 
-    Positions are rounded to the nearest integer pixel. Pixels that fall
-    outside the image boundary are filled with ``fill_value``.
+    Positions are rounded to the nearest integer pixel, with ties
+    rounding half away from zero. Pixels that fall outside the image
+    boundary are filled with ``fill_value``.
 
     Parameters
     ----------
@@ -314,8 +316,8 @@ def _make_cutouts(data, xpos, ypos, cutout_shape, *, fill_value=0.0):
     ky, kx = cutout_shape
     hy, hx = ky // 2, kx // 2
 
-    yc = np.round(ypos).astype(int)
-    xc = np.round(xpos).astype(int)
+    yc = round_half_away(ypos)
+    xc = round_half_away(xpos)
 
     # Build index grids: shape (n_sources, ky, kx)
     dy = np.arange(ky) - hy

--- a/photutils/utils/depths.py
+++ b/photutils/utils/depths.py
@@ -86,8 +86,9 @@ class ImageDepth:
     seed : int, optional
         A seed to initialize the `numpy.random.BitGenerator`. If `None`,
         then fresh, unpredictable entropy will be pulled from the OS.
-        Separate function calls with the same ``seed`` will generate the
-        same results.
+        Each call to the object creates a fresh generator initialized
+        with ``seed``, so all calls with the same ``seed`` generate
+        identical results.
 
     zeropoint : float, optional
         The zeropoint used to calculate the magnitude limit from the
@@ -157,6 +158,12 @@ class ImageDepth:
 
         m_{\mathrm{lim}} = -2.5 \log_{10} f_{\mathrm{lim}}
             + \mathrm{zeropoint}
+
+    Instances are safe to call concurrently from multiple threads.
+    Each call uses only local state, including a fresh random
+    generator initialized with ``seed``. The result attributes
+    (``apertures``, ``n_apertures_used``, ``fluxes``, ``flux_limits``,
+    and ``mag_limits``) reflect the most recently completed call.
 
     Examples
     --------
@@ -237,6 +244,12 @@ class ImageDepth:
         if mask_pad < 0:
             msg = 'mask_pad must be >= 0'
             raise ValueError(msg)
+        if n_apertures < 1:
+            msg = 'n_apertures must be >= 1'
+            raise ValueError(msg)
+        if n_iters < 1:
+            msg = 'n_iters must be >= 1'
+            raise ValueError(msg)
 
         self.aper_radius = aper_radius
         self.n_sigma = n_sigma
@@ -256,7 +269,6 @@ class ImageDepth:
         self.sigma_clip = sigma_clip
         self.progress_bar = progress_bar
 
-        self.rng = np.random.default_rng(self.seed)
         self.dilate_radius = int(np.ceil(self.aper_radius + self.mask_pad))
         self.dilate_footprint = circular_footprint(radius=self.dilate_radius)
 
@@ -327,7 +339,12 @@ class ImageDepth:
             iter_range = add_progress_bar(iter_range,
                                           desc=desc)
 
-        flux_limits = []
+        # Use a fresh, local random generator so that calls use no
+        # shared mutable state and are safe to run concurrently from
+        # multiple threads. With a fixed seed, every call produces
+        # identical results.
+        rng = np.random.default_rng(self.seed)
+
         # Use a local copy of the SigmaClip instance because SigmaClip
         # stores internal state on the instance during calls, so a
         # shared instance is not safe to call concurrently from multiple
@@ -335,13 +352,16 @@ class ImageDepth:
         sigma_clip = copy(self.sigma_clip)
 
         apertures = []
+        all_fluxes = []
+        flux_limits = []
         for _ in iter_range:
             if self.overlap:
-                xycoords = self._make_coords(all_xycoords, n_apertures)
+                xycoords = self._make_coords(all_xycoords, n_apertures,
+                                             rng=rng)
             else:
                 # Cut the number of coords (only need to input ~10x)
                 xycoords = self._make_coords(all_xycoords,
-                                             n_apertures * 10)
+                                             n_apertures * 10, rng=rng)
                 min_separation = self.aper_radius * 2.0
                 xycoords = apply_separation(xycoords, min_separation)
                 xycoords = xycoords[0:self.n_apertures]
@@ -351,12 +371,10 @@ class ImageDepth:
             fluxes = AperturePhotometry(data, apers).flux
             if sigma_clip is not None:
                 fluxes = sigma_clip(fluxes, masked=False)  # ndarray
-            self.fluxes.append(fluxes)
+            all_fluxes.append(fluxes)
             flux_limits.append(self.n_sigma * np.std(fluxes))
 
-        self.apertures = apertures
         n_apertures_used = np.array([len(apers) for apers in apertures])
-        self.n_apertures_used = n_apertures_used
         if np.any(n_apertures_used < self.n_apertures):
             msg = (f'Unable to generate {self.n_apertures} '
                    'non-overlapping apertures in unmasked regions. '
@@ -371,12 +389,12 @@ class ImageDepth:
 
         if isinstance(flux_limits[0], u.Quantity):
             units = True
-            self.flux_limits = u.Quantity(flux_limits)
+            flux_limits = u.Quantity(flux_limits)
         else:
             units = False
-            self.flux_limits = np.array(flux_limits)
-        flux_limit = np.mean(self.flux_limits)
-        if np.any(self.flux_limits == 0):
+            flux_limits = np.array(flux_limits)
+        flux_limit = np.mean(flux_limits)
+        if np.any(flux_limits == 0):
             msg = ('One or more flux_limit values was zero. This is '
                    'likely due to constant image values. Check the '
                    'input mask.')
@@ -385,13 +403,21 @@ class ImageDepth:
         # Ignore divide-by-zero RuntimeWarning in log10
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            flux_limits = self.flux_limits
+            flux_limit_values = flux_limits
             flux_limit_ = flux_limit
             if units:
-                flux_limits = flux_limits.value
+                flux_limit_values = flux_limits.value
                 flux_limit_ = flux_limit.value
-            self.mag_limits = -2.5 * np.log10(flux_limits) + self.zeropoint
+            mag_limits = -2.5 * np.log10(flux_limit_values) + self.zeropoint
             mag_limit = -2.5 * np.log10(flux_limit_) + self.zeropoint
+
+        # Store the per-iteration results computed above. The result
+        # attributes reflect the most recently completed call.
+        self.apertures = apertures
+        self.n_apertures_used = n_apertures_used
+        self.fluxes = all_fluxes
+        self.flux_limits = flux_limits
+        self.mag_limits = mag_limits
 
         return flux_limit, mag_limit
 
@@ -553,7 +579,8 @@ class ImageDepth:
 
         return np.column_stack((xi, yi))
 
-    def _make_coords(self, xycoords, n_apertures):
+    @staticmethod
+    def _make_coords(xycoords, n_apertures, *, rng):
         """
         Randomly choose ``n_apertures`` (without replacement) coordinates
         from the input ``xycoords``.
@@ -565,8 +592,12 @@ class ImageDepth:
         ----------
         xycoords : 2xN `~numpy.ndarray`
             The (x, y) coordinates.
+
         n_apertures : int
             The number of aperture to make.
+
+        rng : `~numpy.random.Generator`
+            The random number generator.
 
         Returns
         -------
@@ -577,10 +608,10 @@ class ImageDepth:
             msg = 'Too many apertures for given unmasked area'
             raise ValueError(msg)
 
-        idx = self.rng.choice(xycoords.shape[0], n_apertures, replace=False)
+        idx = rng.choice(xycoords.shape[0], n_apertures, replace=False)
         xycoords = xycoords[idx, :].astype(float)
 
-        shift = self.rng.uniform(-0.5, 0.5, size=xycoords.shape)
+        shift = rng.uniform(-0.5, 0.5, size=xycoords.shape)
         xycoords += shift
 
         return xycoords

--- a/photutils/utils/errors.py
+++ b/photutils/utils/errors.py
@@ -184,8 +184,10 @@ def calc_total_error(data, bkg_error, effective_gain):
         data = data.value
         effective_gain = effective_gain.value
 
-    # Do not include source variance where effective_gain = 0
-    source_variance = data.copy()
+    # Do not include source variance where effective_gain = 0. Use a
+    # float array so that integer input data does not raise an error
+    # from the in-place division.
+    source_variance = data.astype(float)
     mask = effective_gain != 0
     source_variance[mask] /= effective_gain[mask]
     source_variance[~mask] = 0.0

--- a/photutils/utils/interpolation.py
+++ b/photutils/utils/interpolation.py
@@ -302,7 +302,7 @@ class ShepardIDWInterpolator:
 
         if n_neighbors == 1:
             result = self.values[idx]
-            return result.item() if n_positions == 1 else result
+            return result[0] if n_positions == 1 else result
 
         if dtype is None:
             dtype = self.values.dtype

--- a/photutils/utils/tests/test_cutouts.py
+++ b/photutils/utils/tests/test_cutouts.py
@@ -213,6 +213,18 @@ class TestMakeCutouts:
         # No overlap
         assert not mask[2].any()
 
+    def test_half_pixel_positions(self):
+        """
+        Test that half-integer positions round half away from zero.
+        """
+        xpos = np.array([2.5])
+        ypos = np.array([3.5])
+        cutouts, mask = _make_cutouts(self.data, xpos, ypos, (3, 3))
+        assert mask[0].all()
+        # Centers round to (y, x) = (4, 3)
+        expected = self.data[3:6, 2:5]
+        np.testing.assert_array_equal(cutouts[0], expected)
+
     def test_even_shaped_cutout(self):
         """
         Test _make_cutouts with an even-shaped cutout.

--- a/photutils/utils/tests/test_deprecation.py
+++ b/photutils/utils/tests/test_deprecation.py
@@ -4,6 +4,7 @@ Tests for the _deprecation module.
 """
 
 import warnings
+from copy import deepcopy
 
 import numpy as np
 import pytest
@@ -223,6 +224,33 @@ class TestDeprecatedColumn:
 
         # Missing column: no warning
         assert 'missing' not in table
+
+    def test_deepcopy_preserves_deprecation(self, raw_data):
+        """
+        Test that deepcopy() preserves deprecation behavior and copies
+        the data and metadata.
+        """
+        table = create_deprecated_table_from_data(
+            raw_data, DEPRECATION_MAP, since='3.0', until='4.0')
+        table.meta['key'] = [1, 2]
+        copied = deepcopy(table)
+
+        assert isinstance(copied, DeprecatedColumnTable)
+        match = "'old' was deprecated"
+        with pytest.warns(AstropyDeprecationWarning, match=match) as record:
+            col = copied['old']
+        assert np.all(col == [3, 2, 1])
+        msg = str(record[0].message)
+        assert 'in version 3.0' in msg
+        assert 'version 4.0' in msg
+
+        # Ensure the column data are deep-copied
+        table['new'][0] = 999
+        assert copied['new'][0] == 3
+
+        # Ensure the metadata are deep-copied
+        table.meta['key'].append(3)
+        assert copied.meta['key'] == [1, 2]
 
     def test_copy_preserves_deprecation(self, raw_data):
         """

--- a/photutils/utils/tests/test_depths.py
+++ b/photutils/utils/tests/test_depths.py
@@ -180,10 +180,49 @@ class TestImageDepth:
                        mask_pad=-7.1, overlap=True, seed=123, zeropoint=23.9,
                        progress_bar=False)
 
+        match = 'n_apertures must be >= 1'
+        with pytest.raises(ValueError, match=match):
+            ImageDepth(4.0, n_sigma=5.0, n_apertures=0, n_iters=2,
+                       progress_bar=False)
+
+        match = 'n_iters must be >= 1'
+        with pytest.raises(ValueError, match=match):
+            ImageDepth(4.0, n_sigma=5.0, n_apertures=500, n_iters=0,
+                       progress_bar=False)
+
         match = 'sigma_clip must be a callable'
         with pytest.raises(TypeError, match=match):
             ImageDepth(4.0, n_sigma=5.0, n_apertures=500, n_iters=2,
                        sigma_clip='not_callable', progress_bar=False)
+
+    def test_repeated_calls(self):
+        """
+        Test that repeated calls with a fixed seed produce identical
+        results and do not accumulate state from previous calls.
+        """
+        depth = ImageDepth(4, n_sigma=5.0, n_apertures=100, n_iters=2,
+                           mask_pad=5, overlap=True, seed=123,
+                           zeropoint=23.9, progress_bar=False)
+        limits1 = depth(self.data, self.mask)
+        fluxes1 = depth.fluxes
+        apertures1 = depth.apertures
+
+        limits2 = depth(self.data, self.mask)
+        assert_allclose(limits2, limits1)
+
+        # The result attributes reflect only the most recent call
+        assert len(depth.fluxes) == 2
+        assert len(depth.apertures) == 2
+        assert len(depth.flux_limits) == 2
+        assert len(depth.mag_limits) == 2
+        assert len(depth.n_apertures_used) == 2
+
+        # A fresh per-call generator makes calls idempotent
+        for fluxes_a, fluxes_b in zip(fluxes1, depth.fluxes, strict=True):
+            assert_allclose(fluxes_a, fluxes_b)
+        for apers_a, apers_b in zip(apertures1, depth.apertures,
+                                    strict=True):
+            assert_allclose(apers_a.positions, apers_b.positions)
 
     def test_repr(self):
         """

--- a/photutils/utils/tests/test_errors.py
+++ b/photutils/utils/tests/test_errors.py
@@ -55,6 +55,20 @@ def test_gain_scalar():
     assert_allclose(error_tot, np.sqrt(2.0) * BKG_ERROR)
 
 
+def test_integer_data():
+    """
+    Test calc_total_error with integer data and bkg_error inputs.
+    """
+    data_int = (DATA * 5).astype(int)
+    error_tot = calc_total_error(data_int, BKG_ERROR, 2.0)
+    assert error_tot.dtype == float
+    expected = calc_total_error(data_int.astype(float), BKG_ERROR, 2.0)
+    assert_allclose(error_tot, expected)
+
+    error_tot = calc_total_error(data_int, BKG_ERROR.astype(int), 2.0)
+    assert_allclose(error_tot, expected)
+
+
 def test_gain_array():
     """
     Test calc_total_error with an array effective_gain.

--- a/photutils/utils/tests/test_flags.py
+++ b/photutils/utils/tests/test_flags.py
@@ -1,0 +1,315 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the _flags module.
+"""
+
+from typing import ClassVar
+
+import numpy as np
+import pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from photutils.utils._flags import (FlagDefinition, FlagRegistry, decode_flags,
+                                    define_flag_docstring,
+                                    update_flag_docstring)
+
+
+class _ExampleFlags(FlagRegistry):
+    """
+    A minimal flag registry for testing the shared machinery.
+    """
+
+    FLAG_DEFINITIONS: ClassVar = [
+        FlagDefinition(1, 'one', 'first flag', 'The first flag.'),
+        FlagDefinition(2, 'two', 'second flag', 'The second flag.'),
+        FlagDefinition(4, 'four', 'third flag', 'The third flag.'),
+    ]
+    domain: ClassVar = 'example'
+    _DEPRECATED_FLAG_NAMES: ClassVar = {'old_one': 'one'}
+    _DEPRECATED_CONSTANT_NAMES: ClassVar = {'OLD_ONE': 'ONE'}
+    _DEPRECATED_SINCE: ClassVar = '3.0'
+    _DEPRECATED_UNTIL: ClassVar = '4.0'
+
+
+@pytest.fixture
+def registry():
+    """
+    Provide an example flag registry instance.
+    """
+    return _ExampleFlags()
+
+
+class TestFlagRegistry:
+    """
+    Tests for the FlagRegistry base class.
+    """
+
+    def test_constants(self, registry):
+        """
+        Test that uppercase constants are created for each flag.
+        """
+        assert registry.ONE == 1
+        assert registry.TWO == 2
+        assert registry.FOUR == 4
+
+    def test_all_flags(self, registry):
+        """
+        Test that all_flags returns a copy of the flag definitions.
+        """
+        flags = registry.all_flags
+        assert flags == _ExampleFlags.FLAG_DEFINITIONS
+        flags.append(None)
+        assert len(registry.all_flags) == 3
+
+    def test_bit_values(self, registry):
+        """
+        Test the bit_values property.
+        """
+        assert registry.bit_values == [1, 2, 4]
+
+    def test_names(self, registry):
+        """
+        Test the names property.
+        """
+        assert registry.names == ['one', 'two', 'four']
+
+    def test_flag_dict(self, registry):
+        """
+        Test the flag_dict property.
+        """
+        assert registry.flag_dict == {1: 'one', 2: 'two', 4: 'four'}
+
+    def test_get_definition_by_bit_value(self, registry):
+        """
+        Test get_definition with int and numpy integer bit values.
+        """
+        assert registry.get_definition(2).name == 'two'
+        assert registry.get_definition(np.int64(4)).name == 'four'
+
+    def test_get_definition_by_name(self, registry):
+        """
+        Test get_definition with a flag name.
+        """
+        definition = registry.get_definition('one')
+        assert definition.bit_value == 1
+        assert definition.description == 'first flag'
+
+    def test_get_definition_deprecated_name(self, registry):
+        """
+        Test that a deprecated flag name warns and resolves to the new
+        name.
+        """
+        match = "'old_one' is deprecated"
+        with pytest.warns(AstropyDeprecationWarning, match=match) as record:
+            definition = registry.get_definition('old_one')
+        assert definition.name == 'one'
+        msg = str(record[0].message)
+        assert 'version 3.0' in msg
+        assert 'version 4.0' in msg
+
+    def test_get_definition_unknown_bit_value(self, registry):
+        """
+        Test that an unknown bit value raises KeyError.
+        """
+        match = 'No flag with bit value 8'
+        with pytest.raises(KeyError, match=match):
+            registry.get_definition(8)
+
+    def test_get_definition_unknown_name(self, registry):
+        """
+        Test that an unknown flag name raises KeyError.
+        """
+        match = "No flag with name 'unknown'"
+        with pytest.raises(KeyError, match=match):
+            registry.get_definition('unknown')
+
+    @pytest.mark.parametrize('identifier', [1.5, True, None, [1]])
+    def test_get_definition_invalid_type(self, registry, identifier):
+        """
+        Test that non-int, non-str identifiers raise TypeError.
+        """
+        match = 'identifier must be int'
+        with pytest.raises(TypeError, match=match):
+            registry.get_definition(identifier)
+
+    def test_get_name(self, registry):
+        """
+        Test get_name.
+        """
+        assert registry.get_name(2) == 'two'
+
+    def test_get_bit_value(self, registry):
+        """
+        Test get_bit_value.
+        """
+        assert registry.get_bit_value('two') == 2
+
+    def test_get_description(self, registry):
+        """
+        Test get_description.
+        """
+        assert registry.get_description(4) == 'third flag'
+
+    def test_get_detailed_description(self, registry):
+        """
+        Test get_detailed_description.
+        """
+        assert registry.get_detailed_description(4) == 'The third flag.'
+
+    def test_deprecated_constant(self, registry):
+        """
+        Test that a deprecated constant name warns and resolves to the
+        new constant.
+        """
+        match = "'OLD_ONE' attribute was deprecated"
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            assert registry.OLD_ONE == 1
+
+    def test_unknown_attribute(self, registry):
+        """
+        Test that an unknown attribute raises AttributeError.
+        """
+        match = "no attribute 'UNKNOWN'"
+        with pytest.raises(AttributeError, match=match):
+            _ = registry.UNKNOWN
+
+
+class TestDefineFlagDocstring:
+    """
+    Tests for the define_flag_docstring function.
+    """
+
+    def test_bullet_list(self, registry):
+        """
+        Test the generated bullet list content.
+        """
+        lines = define_flag_docstring(registry)
+        assert lines[0] == ''
+        assert lines[1] == '* **0** : No flags set.'
+        assert lines[2] == "* **1** (``'one'``) : The first flag."
+        assert len(lines) == 5
+
+    def test_indent(self, registry):
+        """
+        Test the indent keyword.
+        """
+        lines = define_flag_docstring(registry, indent=4)
+        assert lines[1] == '    * **0** : No flags set.'
+
+    def test_invalid_registry(self):
+        """
+        Test that a non-FlagRegistry input raises TypeError.
+        """
+        match = 'registry must be an instance of FlagRegistry'
+        with pytest.raises(TypeError, match=match):
+            define_flag_docstring('not_a_registry')
+
+
+class TestUpdateFlagDocstring:
+    """
+    Tests for the update_flag_docstring function.
+    """
+
+    def test_placeholder_replaced(self, registry):
+        """
+        Test that the placeholder is replaced with the bullet list.
+        """
+        def func():
+            """
+            Flags.
+
+            <flag_descriptions>
+            """
+
+        func = update_flag_docstring(func, registry)
+        assert '<flag_descriptions>' not in func.__doc__
+        assert "* **1** (``'one'``) : The first flag." in func.__doc__
+
+    def test_no_placeholder(self, registry):
+        """
+        Test that a docstring without the placeholder is unchanged.
+        """
+        def func():
+            """
+            Flags.
+            """
+
+        docstring = func.__doc__
+        func = update_flag_docstring(func, registry)
+        assert func.__doc__ == docstring
+
+    def test_no_docstring(self, registry):
+        """
+        Test that a function without a docstring is returned unchanged.
+        """
+        def func():
+            pass
+
+        func = update_flag_docstring(func, registry)
+        assert func.__doc__ is None
+
+
+class TestDecodeFlags:
+    """
+    Tests for the decode_flags function.
+    """
+
+    def test_scalar_zero(self, registry):
+        """
+        Test that a zero flag value decodes to an empty list.
+        """
+        assert decode_flags(0, registry) == []
+
+    def test_scalar(self, registry):
+        """
+        Test decoding scalar flag values.
+        """
+        assert decode_flags(1, registry) == ['one']
+        assert decode_flags(5, registry) == ['one', 'four']
+        assert decode_flags(7, registry) == ['one', 'two', 'four']
+
+    def test_return_bit_values(self, registry):
+        """
+        Test the return_bit_values keyword.
+        """
+        assert decode_flags(5, registry, return_bit_values=True) == [1, 4]
+
+    def test_0d_array(self, registry):
+        """
+        Test decoding a 0-d array flag value.
+        """
+        assert decode_flags(np.array(3), registry) == ['one', 'two']
+
+    def test_1d_array(self, registry):
+        """
+        Test decoding a 1D array of flag values.
+        """
+        decoded = decode_flags(np.array([0, 1, 6]), registry)
+        assert decoded == [[], ['one'], ['two', 'four']]
+
+    def test_2d_array(self, registry):
+        """
+        Test that decoding a 2D array preserves the input shape as
+        nested lists.
+        """
+        flags = np.array([[0, 1], [2, 5]])
+        decoded = decode_flags(flags, registry)
+        assert decoded == [[[], ['one']], [['two'], ['one', 'four']]]
+
+    def test_negative_flag(self, registry):
+        """
+        Test that a negative flag value raises ValueError.
+        """
+        match = 'Flag value must be a non-negative integer'
+        with pytest.raises(ValueError, match=match):
+            decode_flags(-1, registry)
+
+    @pytest.mark.parametrize('flag_value', [1.5, True, np.True_])
+    def test_invalid_type(self, registry, flag_value):
+        """
+        Test that non-integer flag values (including bools) raise
+        TypeError.
+        """
+        match = 'Flag value must be an integer'
+        with pytest.raises(TypeError, match=match):
+            decode_flags(flag_value, registry)

--- a/photutils/utils/tests/test_interpolation.py
+++ b/photutils/utils/tests/test_interpolation.py
@@ -134,6 +134,17 @@ class TestShepardIDWInterpolator:
         assert np.isscalar(result)
         assert_allclose(result, 0.479334, rtol=3e-7)
 
+    def test_scalar_return_type(self):
+        """
+        Test that single-position calls return the same scalar type for
+        n_neighbors=1 and n_neighbors>1.
+        """
+        result1 = self.f(0.5, n_neighbors=1)
+        result8 = self.f(0.5, n_neighbors=8)
+        assert np.isscalar(result1)
+        assert np.isscalar(result8)
+        assert type(result1) is type(result8)
+
     def test_n_neighbors_negative(self):
         """
         Test that negative n_neighbors raises ValueError.

--- a/photutils/utils/tests/test_parameters.py
+++ b/photutils/utils/tests/test_parameters.py
@@ -44,6 +44,16 @@ class TestAsPairBasic:
         with pytest.raises(ValueError, match=match):
             as_pair('pair', 1.5)
 
+    def test_unsigned_integer_dtype(self):
+        result = as_pair('p', np.array([3, 4], dtype=np.uint8))
+        assert_equal(result, (3, 4))
+
+    def test_bool_dtype(self):
+        value = True
+        match = 'must have integer values'
+        with pytest.raises(ValueError, match=match):
+            as_pair('p', value)
+
     @pytest.mark.parametrize('value', [(1, np.nan), (1, np.inf)])
     def test_non_finite(self, value):
         match = 'must be a finite value'

--- a/photutils/utils/tests/test_round.py
+++ b/photutils/utils/tests/test_round.py
@@ -41,6 +41,24 @@ def test_round_scalar():
     assert ar == -1
 
 
+def test_round_0d_array():
+    """
+    Test round_half_away with 0D array inputs.
+    """
+    ar = round_half_away(np.array(1.5))
+    assert np.isscalar(ar)
+    assert isinstance(ar, int)
+    assert ar == 2
+
+    ar = round_half_away(np.float64(-2.5))
+    assert isinstance(ar, int)
+    assert ar == -3
+
+    ar = round_half_away(np.array(np.nan))
+    assert isinstance(ar, float)
+    assert np.isnan(ar)
+
+
 def test_round_nan():
     """
     Test round_half_away with NaN inputs.

--- a/photutils/utils/tests/test_stats.py
+++ b/photutils/utils/tests/test_stats.py
@@ -85,11 +85,16 @@ def test_nan_funcs_no_bottleneck():
     Test that the functions work when bottleneck is not available by
     reloading the module with HAS_BOTTLENECK mocked to False.
     """
-    with patch('photutils.utils._optional_deps.HAS_BOTTLENECK',
-               new=False):
-        import photutils.utils._stats as stats_mod
-        importlib.reload(stats_mod)
+    import photutils.utils._stats as stats_mod
 
-        arr = np.ones((5, 3))
-        result = stats_mod.nansum(arr)
-        assert_equal(result, np.nansum(arr))
+    try:
+        with patch('photutils.utils._optional_deps.HAS_BOTTLENECK',
+                   new=False):
+            importlib.reload(stats_mod)
+
+            arr = np.ones((5, 3))
+            result = stats_mod.nansum(arr)
+            assert_equal(result, np.nansum(arr))
+    finally:
+        # Reload again to restore the original state
+        importlib.reload(stats_mod)

--- a/photutils/utils/tests/test_thread_safety.py
+++ b/photutils/utils/tests/test_thread_safety.py
@@ -1,0 +1,137 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests that the utils tools are safe for concurrent use.
+
+``ImageDepth.__call__`` uses only local state (a fresh per-call random
+generator and a local copy of the SigmaClip instance), so concurrent
+calls on a shared, seeded instance must produce results identical to
+serial calls. The interpolator and coordinate tools are read-only or
+pure, so concurrent calls must also match serial results.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+from astropy.stats import SigmaClip
+from numpy.testing import assert_equal
+
+from photutils.utils import ImageDepth, ShepardIDWInterpolator
+from photutils.utils._coords import make_random_xycoords
+
+N_THREADS = 8
+N_CALLS = 3
+
+
+def _run_concurrently(task, *, n_threads=N_THREADS, n_calls=N_CALLS):
+    """
+    Run ``task`` in ``n_threads`` threads and return all results.
+
+    A barrier maximizes the overlap of the concurrent calls.
+    """
+    barrier = threading.Barrier(n_threads)
+
+    def worker():
+        barrier.wait()
+        return [task() for _ in range(n_calls)]
+
+    with ThreadPoolExecutor(max_workers=n_threads) as executor:
+        futures = [executor.submit(worker) for _ in range(n_threads)]
+        return [result for future in futures for result in future.result()]
+
+
+def _make_depth_inputs():
+    """
+    Return a noise image and a source mask for the ImageDepth tests.
+    """
+    rng = np.random.default_rng(1)
+    data = rng.normal(0.0, 1.0, (150, 150))
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[60:80, 40:70] = True
+    return data, mask
+
+
+def test_concurrent_image_depth_shared_instance():
+    """
+    Test that concurrent calls on a shared, seeded ImageDepth instance
+    return results identical to a serial call and leave the result
+    attributes consistent.
+    """
+    data, mask = _make_depth_inputs()
+    n_iters = 2
+    depth = ImageDepth(3, n_sigma=5.0, n_apertures=50, n_iters=n_iters,
+                       mask_pad=2, overlap=True, seed=123, zeropoint=23.9,
+                       progress_bar=False)
+    expected = depth(data, mask)
+    expected_fluxes = depth.fluxes
+
+    def task():
+        return depth(data, mask)
+
+    for result in _run_concurrently(task):
+        assert_equal(result, expected)
+
+    # The result attributes reflect a single completed call
+    assert len(depth.fluxes) == n_iters
+    assert len(depth.apertures) == n_iters
+    assert len(depth.flux_limits) == n_iters
+    for fluxes, fluxes_exp in zip(depth.fluxes, expected_fluxes, strict=True):
+        assert_equal(fluxes, fluxes_exp)
+
+
+def test_concurrent_image_depth_shared_sigma_clip():
+    """
+    Test that ImageDepth instances sharing a user-input SigmaClip
+    instance can run concurrently, producing results identical to
+    serial calls (each call must use a local copy of the SigmaClip
+    instance).
+    """
+    data, mask = _make_depth_inputs()
+    sigma_clip = SigmaClip(sigma=3.0, maxiters=5)
+
+    def make_depth():
+        return ImageDepth(3, n_sigma=5.0, n_apertures=50, n_iters=1,
+                          mask_pad=2, overlap=True, seed=42,
+                          sigma_clip=sigma_clip, progress_bar=False)
+
+    expected = make_depth()(data, mask)
+
+    def task():
+        return make_depth()(data, mask)
+
+    for result in _run_concurrently(task):
+        assert_equal(result, expected)
+
+
+def test_concurrent_idw_interpolator():
+    """
+    Test that concurrent queries of a shared ShepardIDWInterpolator
+    return results identical to a serial call.
+    """
+    rng = np.random.default_rng(0)
+    coords = rng.random((500, 2))
+    values = np.sin(coords[:, 0] + coords[:, 1])
+    interp = ShepardIDWInterpolator(coords, values)
+    positions = rng.random((100, 2))
+    expected = interp(positions)
+
+    def task():
+        return interp(positions)
+
+    for result in _run_concurrently(task, n_calls=10):
+        assert_equal(result, expected)
+
+
+def test_concurrent_make_random_xycoords():
+    """
+    Test that concurrent seeded make_random_xycoords calls return
+    results identical to a serial call.
+    """
+    kwargs = {'min_separation': 2.0, 'seed': 7}
+    expected = make_random_xycoords(100, (0, 500), (0, 300), **kwargs)
+
+    def task():
+        return make_random_xycoords(100, (0, 500), (0, 300), **kwargs)
+
+    for result in _run_concurrently(task, n_calls=10):
+        assert_equal(result, expected)


### PR DESCRIPTION
This PR fixes a collection of bugs and API inconsistencies found while reviewing photutils.utils, and expands its test and benchmark coverage.

* `ImageDepth` calls are now stateless and reproducible.Tthe fluxes attribute no longer accumulates across repeated calls, and a fresh random generator is created from seed on every call, so a fixed seed gives identical results each call.
* `calc_total_error` no longer crashes when the input data array has an integer dtype.
* Star-finder cutout centers now round half-integer positions half away from zero, matching the rounding convention used elsewhere in photutils (_round.py also returns a scalar for 0D inputs).