### PR TITLE
Fix round-trip fidelity issues in the ASDF PSF converters

### DIFF
--- a/photutils/converters/functional_models.py
+++ b/photutils/converters/functional_models.py
@@ -54,11 +54,24 @@ class _PSFModelConverter(TransformConverterBase):
         names = ('flux', 'x_0', 'y_0', *self.model_params)
         params = {name: node[name] for name in names}
 
-        return self._model_class()(
+        model = self._model_class()(
             **params,
             **optional_params(node, *self.optional_model_params,
                               'bbox_factor'),
         )
+
+        # The file stores only the fixed=True entries and the non-empty
+        # bounds, relative to a baseline of fixed=False and bounds of
+        # (None, None). The photutils models default their shape
+        # parameters to fixed=True with bounds set, so the constraints
+        # are reset to that baseline here. The caller then applies the
+        # stored constraints on top, which reconstructs the saved state
+        # exactly.
+        for name in model.param_names:
+            model.fixed[name] = False
+            model.bounds[name] = (None, None)
+
+        return model
 
 
 class AiryDiskPSFConverter(_PSFModelConverter):

--- a/photutils/converters/image_models.py
+++ b/photutils/converters/image_models.py
@@ -111,7 +111,7 @@ class STDPSFGridConverter(Converter):
         # in its meta attribute.
         return {
             'data': model.data,
-            'grid_xypos': np.array(model.grid_xypos),
+            'grid_xypos': np.asarray(model.grid_xypos),
             'grid_shape': model.grid_shape,
             'oversampling': tuple(int(value)
                                   for value in model.oversampling),
@@ -125,6 +125,11 @@ class STDPSFGridConverter(Converter):
         # Load the lazily-read grid positions into memory
         meta['grid_xypos'] = np.asarray(node['grid_xypos'])
         meta['grid_shape'] = node['grid_shape']
-        meta['oversampling'] = node['oversampling']
+        if 'oversampling' in node:
+            # The schema does not require this key. When it is absent
+            # the class supplies its default.
+            meta['oversampling'] = node['oversampling']
 
-        return STDPSFGrid._from_asdf(node['data'], meta)
+        # Load the lazily-read data into memory so that the returned
+        # object remains usable after the file is closed
+        return STDPSFGrid._from_asdf(np.asarray(node['data']), meta)

--- a/photutils/converters/tests/examples.py
+++ b/photutils/converters/tests/examples.py
@@ -19,8 +19,7 @@ from photutils.psf import (AiryDiskPSF, CircularGaussianPRF,
                            GaussianPRF, GaussianPSF, GriddedPSFModel, ImagePSF,
                            MoffatPSF, STDPSFGrid)
 
-# The directory holding the STDPSF test files. STDPSFGrid accepts only
-# a string filename, so the paths are converted where they are used.
+# The directory holding the STDPSF test files
 PSF_DATA_DIR = Path(__file__).resolve().parents[2] / 'psf' / 'tests' / 'data'
 
 parameters = {
@@ -88,7 +87,7 @@ def circular_gaussian_prf():
 
 def circular_gaussian_sigma_prf_units():
     """
-    Return a CircularGaussianPRF with units.
+    Return a CircularGaussianSigmaPRF with units.
     """
     return (CircularGaussianSigmaPRF(flux=71.4 * u.Jy,
                                      x_0=24.3 * u.pix, y_0=25.2 * u.pix,
@@ -98,7 +97,7 @@ def circular_gaussian_sigma_prf_units():
 
 def circular_gaussian_sigma_prf():
     """
-    Return a CircularGaussianPRF without units.
+    Return a CircularGaussianSigmaPRF without units.
     """
     return (CircularGaussianSigmaPRF(flux=71.4, x_0=24.3, y_0=25.2,
                                      sigma=5.1),
@@ -218,7 +217,7 @@ def stdpsf_single_detector():
     """
     Return a STDPSFGrid object read from a FITS STDPSF file.
     """
-    psfgrid = STDPSFGrid(str(PSF_DATA_DIR / 'STDPSF_NRCA1_F150W_mock.fits'))
+    psfgrid = STDPSFGrid(PSF_DATA_DIR / 'STDPSF_NRCA1_F150W_mock.fits')
     return psfgrid, parameters['STDPSFGrid']
 
 

--- a/photutils/converters/tests/test_apertures.py
+++ b/photutils/converters/tests/test_apertures.py
@@ -61,9 +61,12 @@ def _check_roundtrip(tmp_path, aperture, params):
 
     with asdf.open(filename) as af:
         aperture2 = af['aper']
-        for param in params:
-            assert_array_equal(getattr(aperture, param),
-                               getattr(aperture2, param))
+
+    # The comparisons are made after the file is closed so that they
+    # also check that no lazily-loaded arrays leak into the object
+    for param in params:
+        assert_array_equal(getattr(aperture, param),
+                           getattr(aperture2, param))
 
 
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -58,8 +58,11 @@ def test_psf_converters(tmp_path, example):
 
     with asdf.open(filename) as af:
         psf2 = af['psf']
-        for param in params:
-            assert_array_equal(getattr(psf, param), getattr(psf2, param))
+
+    # The comparisons are made after the file is closed so that they
+    # also check that no lazily-loaded arrays leak into the object
+    for param in params:
+        assert_array_equal(getattr(psf, param), getattr(psf2, param))
 
 
 # Examples of every PSF model (STDPSFGrid is not a model, so it has
@@ -144,8 +147,9 @@ def test_gridded_psf_converter_preserves_modified_oversampling(tmp_path):
 
     with asdf.open(filename) as af:
         psf2 = af['psf']
-        assert_array_equal(psf2.oversampling, (2, 3))
-        assert psf2.meta['oversampling'] == (2, 3)
+
+    assert_array_equal(psf2.oversampling, (2, 3))
+    assert psf2.meta['oversampling'] == (2, 3)
 
 
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
@@ -203,12 +207,13 @@ def test_stdpsf_grid_converter_preserves_oversampling(tmp_path):
 
     with asdf.open(filename) as af:
         psfgrid2 = af['psf']
-        assert_array_equal(psfgrid2.oversampling, (8, 8))
-        assert psfgrid2.meta['instrument'] == 'test-instrument'
-        assert psfgrid2.meta['custom'] == {'value': 42}
-        assert 'grid_xypos' not in psfgrid2.meta
-        assert 'oversampling' not in psfgrid2.meta
-        assert 'grid_shape' not in psfgrid2.meta
+
+    assert_array_equal(psfgrid2.oversampling, (8, 8))
+    assert psfgrid2.meta['instrument'] == 'test-instrument'
+    assert psfgrid2.meta['custom'] == {'value': 42}
+    assert 'grid_xypos' not in psfgrid2.meta
+    assert 'oversampling' not in psfgrid2.meta
+    assert 'grid_shape' not in psfgrid2.meta
 
 
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
@@ -229,9 +234,10 @@ def test_stdpsf_grid_converter_repeated_grid_coordinate(tmp_path):
 
     with asdf.open(asdf_filename) as af:
         psfgrid2 = af['psf']
-        assert psfgrid2._grid_shape == psfgrid._grid_shape
-        assert_array_equal(psfgrid2.grid_xypos, psfgrid.grid_xypos)
-        assert_array_equal(psfgrid2._xgrid, psfgrid._xgrid)
-        assert_array_equal(psfgrid2._ygrid, psfgrid._ygrid)
-        assert_array_equal(psfgrid2.data, psfgrid.data)
-        assert repr(psfgrid2) == repr(psfgrid)
+
+    assert psfgrid2._grid_shape == psfgrid._grid_shape
+    assert_array_equal(psfgrid2.grid_xypos, psfgrid.grid_xypos)
+    assert_array_equal(psfgrid2._xgrid, psfgrid._xgrid)
+    assert_array_equal(psfgrid2._ygrid, psfgrid._ygrid)
+    assert_array_equal(psfgrid2.data, psfgrid.data)
+    assert repr(psfgrid2) == repr(psfgrid)

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -224,7 +224,7 @@ def test_stdpsf_grid_converter_repeated_grid_coordinate(tmp_path):
     repeated where the two detectors abut.
     """
     filename = examples.PSF_DATA_DIR / 'STDPSF_ACSWFC_F814W_mock.fits'
-    psfgrid = STDPSFGrid(str(filename))
+    psfgrid = STDPSFGrid(filename)
     assert psfgrid._grid_shape == (10, 9)
 
     asdf_filename = tmp_path / 'psf.asdf'

--- a/photutils/converters/tests/test_psf.py
+++ b/photutils/converters/tests/test_psf.py
@@ -62,6 +62,54 @@ def test_psf_converters(tmp_path, example):
             assert_array_equal(getattr(psf, param), getattr(psf2, param))
 
 
+# Examples of every PSF model (STDPSFGrid is not a model, so it has
+# no fitting state)
+MODEL_EXAMPLES = [
+    examples.airy_disk,
+    examples.circular_gaussian_prf,
+    examples.circular_gaussian_psf,
+    examples.circular_gaussian_sigma_prf,
+    examples.gaussian_prf,
+    examples.gaussian_psf,
+    examples.moffat_psf,
+    examples.image_psf,
+    examples.gridded_psf,
+]
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('example', MODEL_EXAMPLES, ids=_example_id)
+def test_psf_converters_preserve_fitting_state(tmp_path, example):
+    """
+    Test that non-default fixed, bounds, and name states survive a
+    round trip.
+
+    The file stores only the fixed=True entries and the non-empty
+    bounds, so parameters whose class defaults differ from that
+    baseline (e.g., the shape parameters, which default to fixed=True
+    with a lower bound) must be reset when reading.
+    """
+    psf, _ = example()
+    for name in psf.param_names:
+        psf.fixed[name] = not psf.fixed[name]
+        psf.bounds[name] = (None, None)
+    psf.bounds[psf.param_names[0]] = (0.5, 100.0)
+    psf.name = 'my-psf'
+
+    filename = tmp_path / 'psf.asdf'
+    with asdf.AsdfFile() as af:
+        af['psf'] = psf
+        af.write_to(filename)
+
+    with asdf.open(filename) as af:
+        psf2 = af['psf']
+
+    assert psf2.name == psf.name
+    assert psf2.fixed == psf.fixed
+    assert psf2.bounds == psf.bounds
+
+
 @pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
                     reason='asdf-astropy is not installed')
 def test_psf_examples_cover_all_converters():

--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -530,6 +530,48 @@ def test_optional_stdpsf_grid_params_use_defaults():
     assert_array_equal(grid.oversampling, (4, 4))
 
 
+# The oversampling form not otherwise exercised by each model's
+# round-trip tests. The converters write an ndarray for ImagePSF and
+# GriddedPSFModel and a plain integer array for STDPSFGrid.
+OTHER_OVERSAMPLING_FORMS = {
+    'image_psf': '[2, 2]',
+    'gridded_psf_model': '[1, 1]',
+    'stdpsf_grid': '!core/ndarray-1.1.0 [4, 4]',
+}
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+@pytest.mark.parametrize('stem', list(OTHER_OVERSAMPLING_FORMS))
+def test_oversampling_forms_accepted(stem):
+    """
+    Test that ``oversampling`` may be a plain integer array or an
+    ndarray in every image-based PSF schema.
+    """
+    params = {**REQUIRED_PSF_PARAMS[stem],
+              'oversampling': OTHER_OVERSAMPLING_FORMS[stem]}
+    model = _read_psf(stem, params)
+    expected = yaml.safe_load(
+        OTHER_OVERSAMPLING_FORMS[stem].removeprefix('!core/ndarray-1.1.0'))
+    assert_array_equal(model.oversampling, expected)
+
+
+@pytest.mark.parametrize('stem', list(OTHER_OVERSAMPLING_FORMS))
+def test_float_oversampling_rejected(stem):
+    """
+    Test that a non-integer ``oversampling`` array fails schema
+    validation when read.
+
+    The oversampling factors must be integers, so rejecting floats in
+    the schema reports the problem as a validation error instead of a
+    model initialization error.
+    """
+    params = {**REQUIRED_PSF_PARAMS[stem], 'oversampling': '[2.5, 2.5]'}
+    with pytest.raises(ValidationError), \
+            asdf.open(yaml_to_asdf(f'psf: {_psf_yaml(stem, params)}')):
+        pass
+
+
 @pytest.mark.parametrize('stem', list(REQUIRED_PSF_PARAMS))
 def test_unknown_psf_property_rejected(stem):
     """

--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -404,7 +404,8 @@ GRID_XYPOS = _ndarray(GRID_XYPOS_VALUES)
 
 # The parameters that each PSF schema requires. The remaining
 # parameters are optional; ``bbox_factor`` is optional in every
-# functional-model schema, as is ``theta`` for the elliptical Gaussians.
+# functional-model schema, as is ``theta`` for the elliptical Gaussians
+# and ``oversampling`` for the STDPSF grid.
 REQUIRED_PSF_PARAMS = {
     'airy_disk_psf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0, 'radius': 4.0},
     'circular_gaussian_prf': {'flux': 1.0, 'x_0': 2.0, 'y_0': 3.0,
@@ -427,7 +428,6 @@ REQUIRED_PSF_PARAMS = {
     'stdpsf_grid': {'data': PSF_GRID,
                     'grid_xypos': GRID_XYPOS,
                     'grid_shape': '[2, 2]',
-                    'oversampling': '[4, 4]',
                     'meta': '{}'},
 }
 
@@ -511,6 +511,23 @@ def test_optional_gridded_psf_model_params_use_defaults():
     assert_array_equal(model.data, PSF_GRID_VALUES)
     for name in ('flux', 'x_0', 'y_0', 'fill_value'):
         assert getattr(model, name) == getattr(reference, name)
+
+
+@pytest.mark.skipif(not _ASDF_ASTROPY_INSTALLED,
+                    reason='asdf-astropy is not installed')
+def test_optional_stdpsf_grid_params_use_defaults():
+    """
+    Test that a STDPSFGrid file containing only the parameters
+    required by its schema is read using the default oversampling.
+
+    ``oversampling`` is optional in the schema, and STDPSFGrid assumes
+    a factor of 4 along both axes when it is absent.
+    """
+    grid = _read_psf('stdpsf_grid', REQUIRED_PSF_PARAMS['stdpsf_grid'])
+
+    assert_array_equal(grid.data, PSF_GRID_VALUES)
+    assert_array_equal(grid.grid_xypos, GRID_XYPOS_VALUES)
+    assert_array_equal(grid.oversampling, (4, 4))
 
 
 @pytest.mark.parametrize('stem', list(REQUIRED_PSF_PARAMS))

--- a/photutils/converters/tests/test_schemas.py
+++ b/photutils/converters/tests/test_schemas.py
@@ -167,6 +167,17 @@ def test_manifest_schemas_are_registered():
         assert schema['id'] == schema_uri, tag_uri
 
 
+def _check_example_tag(schema_uri, index, tag):
+    """
+    Check that a schema example carries the manifest tag of the schema
+    that contains it.
+    """
+    assert tag is not None, f'{schema_uri} example {index} is untagged'
+    assert tag in MANIFEST_TAGS, f'{tag} is not defined in the manifest'
+    assert MANIFEST_TAGS[tag] == schema_uri, (
+        f'{tag} is defined by a different schema')
+
+
 @pytest.mark.parametrize(('schema_uri', 'index', 'tag'), EXAMPLE_TAGS,
                          ids=EXAMPLE_IDS)
 def test_example_tag_in_manifest(schema_uri, index, tag):
@@ -179,10 +190,7 @@ def test_example_tag_in_manifest(schema_uri, index, tag):
     tag selects no schema at all, which makes the example self-test pass
     without validating anything.
     """
-    assert tag is not None, f'{schema_uri} example {index} is untagged'
-    assert tag in MANIFEST_TAGS, f'{tag} is not defined in the manifest'
-    assert MANIFEST_TAGS[tag] == schema_uri, (
-        f'{tag} is defined by a different schema')
+    _check_example_tag(schema_uri, index, tag)
 
 
 @pytest.mark.parametrize(('example_tag', 'match'), [
@@ -203,7 +211,7 @@ def test_invalid_example_tag_is_detected(example_tag, match):
     assert tag == example_tag
 
     with pytest.raises(AssertionError, match=match):
-        test_example_tag_in_manifest(schema['id'], index, tag)
+        _check_example_tag(schema['id'], index, tag)
 
 
 def _quantity(value):

--- a/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/gridded_psf_model-1.0.0.yaml
@@ -70,7 +70,13 @@ allOf:
           Assign value to pixels outside the input pixel grid
           to avoid extrapolation.
       oversampling:
-        tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
+        anyOf:
+          - type: array
+            items:
+              type: integer
+            minItems: 2
+            maxItems: 2
+          - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
         description: |
           The integer oversampling factor of the input ePSF images
           along each axis, in numpy ``(y, x)`` order.

--- a/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/image_psf-1.0.0.yaml
@@ -83,7 +83,7 @@ allOf:
         anyOf:
           - type: array
             items:
-              type: number
+              type: integer
             minItems: 2
             maxItems: 2
           - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'

--- a/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
+++ b/photutils/resources/schemas/psf/stdpsf_grid-1.0.0.yaml
@@ -51,14 +51,16 @@ properties:
     minItems: 2
     maxItems: 2
   oversampling:
-    type: array
+    anyOf:
+      - type: array
+        items:
+          type: integer
+        minItems: 2
+        maxItems: 2
+      - tag: 'tag:stsci.edu:asdf/core/ndarray-1.*'
     description: |
       The integer oversampling factor of the ePSF images along each
       axis, in numpy ``(y, x)`` order.
-    items:
-      type: integer
-    minItems: 2
-    maxItems: 2
   meta:
     type: object
     description: |


### PR DESCRIPTION
This PR cleans up several issues in the ASDF converters and schemas for the PSF models so that objects round-trip through ASDF exactly.

* Preserve non-default `fixed` and `bounds` parameter constraints when serializing the functional PSF models. The file stores constraints relative to the asdf-astropy baseline (`fixed=False`, bounds of (None, None)), so the converters now reset the model to that baseline on read and let the stored constraints be applied on top, reconstructing the saved state exactly.
* Fix the `STDPSFGrid` converter to load the lazily-read data and grid positions into memory so the returned object remains usable after the file is closed, and make oversampling optional on read, with the class supplying its default when the key is absent.
* Make oversampling validation consistent across the image-based PSF schemas (`image_psf`, `gridded_psf_model`, and `stdpsf_grid`): each now accepts either a 2-element integer array or an ndarray.

All parameters, including optional ones such as oversampling, are always written to the file, so previously saved objects are unaffected if a class default ever changes. The optional keys matter only when reading files written by other tools.