### PR TITLE
Fix bugs and improve validation in detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -310,6 +310,13 @@ Bug Fixes
     also makes it consistent with ``ApertureStats.orientation`` and
     ``SourceCatalog.orientation``. [#2317]
 
+  - Fixed integer indexing of the star finder catalog classes when
+    multidimensional per-source attributes (e.g., image moments or
+    cutouts) had already been computed. Previously, the integer index
+    dropped the leading source axis of those cached arrays, and
+    accessing dependent properties on the indexed catalog raised an
+    ``IndexError``. [#2377]
+
 - ``photutils.morphology``
 
   - Fixed ``data_properties`` so that a ``background`` input with

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -321,6 +321,14 @@ Bug Fixes
     if any input ``xycoords`` position is outside the bounds of the
     input data. [#2377]
 
+  - Fixed ``find_peaks`` (and the star finder classes, which use it)
+    so that masked pixels can no longer suppress nearby peaks within
+    the local region. Masked pixels are now replaced by the minimum
+    finite data value before peak detection, the same treatment already
+    applied to NaN pixels. Previously, a masked pixel (e.g., a flagged
+    cosmic ray or hot pixel) with a value larger than a nearby true peak
+    prevented that peak from being detected. [#2377]
+
 - ``photutils.morphology``
 
   - Fixed ``data_properties`` so that a ``background`` input with

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -329,6 +329,10 @@ Bug Fixes
     cosmic ray or hot pixel) with a value larger than a nearby true peak
     prevented that peak from being detected. [#2377]
 
+  - ``StarFinder`` now validates the input ``kernel`` values. The
+    kernel must contain only finite values and have a positive
+    maximum. [#2377]
+
 - ``photutils.morphology``
 
   - Fixed ``data_properties`` so that a ``background`` input with

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -317,6 +317,10 @@ Bug Fixes
     accessing dependent properties on the indexed catalog raised an
     ``IndexError``. [#2377]
 
+  - ``DAOStarFinder`` and ``IRAFStarFinder`` now raise a ``ValueError``
+    if any input ``xycoords`` position is outside the bounds of the
+    input data. [#2377]
+
 - ``photutils.morphology``
 
   - Fixed ``data_properties`` so that a ``background`` input with

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -130,6 +130,32 @@ python benchmarks/bench_datasets.py
 python benchmarks/bench_datasets.py --which model-image --n-sources-list 500,2000
 ```
 
+## Detection (`bench_detection.py`)
+
+Benchmarks for the `photutils.detection` subpackage:
+
+- the star finder classes (`DAOStarFinder`, `IRAFStarFinder`, and
+  `StarFinder`) for full detection runs and, for the DAOFIND-style
+  finders, catalog-only runs with the source positions given via
+  `xycoords`
+- the `find_peaks` detection modes (`box_size`, `footprint`,
+  `min_separation`, and centroiding)
+- the fast circular (`min_separation`) peak detection versus the
+  equivalent circular-footprint maximum filter (with speedups)
+- concurrent `find_stars` calls on a shared `DAOStarFinder` instance
+  across thread counts (with speedups relative to the first thread
+  count)
+
+Examples:
+
+```bash
+# Run everything with the default settings
+python benchmarks/bench_detection.py
+
+# Only the min-separation speedup benchmark
+python benchmarks/bench_detection.py --which min-separation --radii 10,50
+```
+
 ## Background (`bench_background.py`)
 
 Benchmarks for the `photutils.background` subpackage:

--- a/benchmarks/bench_detection.py
+++ b/benchmarks/bench_detection.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for the photutils.detection subpackage.
+
+The benchmarks cover the star finder classes (DAOStarFinder,
+IRAFStarFinder, and StarFinder) for both source detection and
+catalog-only (xycoords) runs, the find_peaks detection modes, the
+fast circular (min_separation) peak detection versus the equivalent
+circular-footprint maximum filter, and concurrent find_stars calls on
+a shared finder instance across thread counts.
+
+Run ``python benchmarks/bench_detection.py --help`` to see the
+available options.
+"""
+
+import argparse
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+
+import numpy as np
+from astropy.modeling.models import Gaussian2D
+from astropy.stats import gaussian_fwhm_to_sigma
+from bench_helpers import (format_sweep_cells, parse_thread_counts,
+                           print_environment, time_best)
+
+from photutils.centroids import centroid_com
+from photutils.detection import (DAOStarFinder, IRAFStarFinder, StarFinder,
+                                 find_peaks)
+from photutils.utils.exceptions import NoDetectionsWarning
+
+FWHM = 4.0
+THRESHOLD = 10.0
+
+
+def make_star_image(n_sources, *, spacing=25, fwhm=FWHM, amplitude=100.0,
+                    noise_std=1.0, seed=0):
+    """
+    Return an image with a grid of Gaussian stars and their positions.
+
+    Parameters
+    ----------
+    n_sources : int
+        The number of stars. The image is a square grid of
+        ``spacing``-sized cells with one star per cell, so the image
+        size is ``ceil(sqrt(n_sources)) * spacing`` per side.
+
+    spacing : int, optional
+        The grid cell size in pixels.
+
+    fwhm : float, optional
+        The FWHM of the Gaussian stars in pixels.
+
+    amplitude : float, optional
+        The amplitude of the Gaussian stars.
+
+    noise_std : float, optional
+        The standard deviation of the Gaussian noise.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    xypos : Nx2 `~numpy.ndarray`
+        The (x, y) star positions.
+    """
+    n_grid = int(np.ceil(np.sqrt(n_sources)))
+    size = n_grid * spacing
+    rng = np.random.default_rng(seed)
+    data = rng.normal(0.0, noise_std, (size, size))
+
+    sigma = fwhm * gaussian_fwhm_to_sigma
+    yy, xx = np.mgrid[0:spacing, 0:spacing]
+    xypos = np.empty((n_sources, 2))
+    for i in range(n_sources):
+        gy, gx = divmod(i, n_grid)
+        xc = (spacing - 1) / 2.0 + rng.uniform(-0.5, 0.5)
+        yc = (spacing - 1) / 2.0 + rng.uniform(-0.5, 0.5)
+        model = Gaussian2D(amplitude, xc, yc, sigma, sigma)
+        x0 = gx * spacing
+        y0 = gy * spacing
+        data[y0:y0 + spacing, x0:x0 + spacing] += model(xx, yy)
+        xypos[i] = (x0 + xc, y0 + yc)
+
+    return data, xypos
+
+
+def make_gaussian_kernel(size, *, fwhm=FWHM):
+    """
+    Return a 2D Gaussian kernel array for StarFinder.
+
+    Parameters
+    ----------
+    size : int
+        The kernel size; the kernel is ``(size, size)``.
+
+    fwhm : float, optional
+        The FWHM of the Gaussian kernel in pixels.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        The kernel array.
+    """
+    cen = (size - 1) / 2.0
+    sigma = fwhm * gaussian_fwhm_to_sigma
+    yy, xx = np.mgrid[0:size, 0:size]
+    model = Gaussian2D(1.0, cen, cen, sigma, sigma)
+    return model(xx, yy)
+
+
+def make_finders(xypos=None):
+    """
+    Return the star finder name and instance pairs.
+
+    Parameters
+    ----------
+    xypos : Nx2 `~numpy.ndarray` or `None`, optional
+        If not `None`, the DAOStarFinder and IRAFStarFinder instances
+        are configured with these source positions (skipping the
+        source-finding step).
+
+    Returns
+    -------
+    result : list of (str, finder) tuples
+        The finder name and instance pairs.
+    """
+    kwargs = {}
+    if xypos is not None:
+        kwargs['xycoords'] = np.round(xypos).astype(int)
+    finders = [
+        ('DAOStarFinder', DAOStarFinder(THRESHOLD, FWHM, **kwargs)),
+        ('IRAFStarFinder', IRAFStarFinder(THRESHOLD, FWHM, **kwargs)),
+    ]
+    if xypos is None:  # StarFinder does not support xycoords
+        kernel = make_gaussian_kernel(11)
+        finders.append(('StarFinder', StarFinder(THRESHOLD, kernel)))
+    return finders
+
+
+def bench_star_finders(*, n_sources=1000, repeats=3, seed=0):
+    """
+    Benchmark the star finder classes.
+
+    Each finder is timed for a full detection run and, for the
+    DAOFIND-style finders, a catalog-only run with the source
+    positions given via ``xycoords`` (skipping the source-finding
+    step).
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The number of stars in the image.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, xypos = make_star_image(n_sources, seed=seed)
+    print(f'\n== Star finders ({n_sources} stars, '
+          f'{data.shape[0]}x{data.shape[1]} image) ==')
+    print(f'{"finder":>16}{"detect":>12}{"catalog-only":>14}{"n_found":>9}')
+
+    catalog_times = {name: 'n/a' for name, _ in make_finders()}
+    for name, finder in make_finders(xypos=xypos):
+        t_best = time_best(partial(finder, data), repeats=repeats)
+        catalog_times[name] = f'{t_best:.4f}s'
+
+    for name, finder in make_finders():
+        tbl = finder(data)
+        t_best = time_best(partial(finder, data), repeats=repeats)
+        print(f'{name:>16}{f"{t_best:.4f}s":>12}'
+              f'{catalog_times[name]:>14}{len(tbl):>9}')
+
+
+def bench_find_peaks(*, n_sources=1000, repeats=3, seed=0):
+    """
+    Benchmark the find_peaks detection modes.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The number of stars in the image.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, _ = make_star_image(n_sources, seed=seed)
+    print(f'\n== find_peaks ({n_sources} stars, '
+          f'{data.shape[0]}x{data.shape[1]} image) ==')
+    print(f'{"mode":>34}{"time":>12}{"n_peaks":>9}')
+
+    modes = [
+        ('box_size=3', {'box_size': 3}),
+        ('box_size=11', {'box_size': 11}),
+        ('footprint=ones((11, 11))', {'footprint': np.ones((11, 11))}),
+        ('min_separation=10', {'min_separation': 10}),
+        ('box_size=3 + centroid_com', {'box_size': 3,
+                                       'centroid_func': centroid_com}),
+    ]
+    for name, kwargs in modes:
+        tbl = find_peaks(data, THRESHOLD, **kwargs)
+        bench = partial(find_peaks, data, THRESHOLD, **kwargs)
+        t_best = time_best(bench, repeats=repeats)
+        print(f'{name:>34}{f"{t_best:.4f}s":>12}{len(tbl):>9}')
+
+
+def bench_min_separation(*, n_sources=1000, radii=(5, 10, 25, 50),
+                         repeats=3, seed=0):
+    """
+    Benchmark the fast circular (min_separation) peak detection
+    against the equivalent circular-footprint maximum filter.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The number of stars in the image.
+
+    radii : tuple of int, optional
+        The circular-region radii in pixels.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, _ = make_star_image(n_sources, seed=seed)
+    print(f'\n== find_peaks min_separation vs circular footprint '
+          f'({n_sources} stars, {data.shape[0]}x{data.shape[1]} '
+          'image) ==')
+    print(f'{"radius":>8}{"footprint":>12}{"min_separation":>16}'
+          f'{"speedup":>9}')
+
+    for radius in radii:
+        idx = np.arange(-radius, radius + 1)
+        xx, yy = np.meshgrid(idx, idx)
+        footprint = np.array((xx**2 + yy**2) <= radius**2, dtype=int)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', NoDetectionsWarning)
+            bench_ref = partial(find_peaks, data, THRESHOLD,
+                                footprint=footprint)
+            t_ref = time_best(bench_ref, repeats=repeats)
+            bench_fast = partial(find_peaks, data, THRESHOLD,
+                                 min_separation=radius)
+            t_fast = time_best(bench_fast, repeats=repeats)
+
+        print(f'{radius:>8}{f"{t_ref:.4f}s":>12}{f"{t_fast:.4f}s":>16}'
+              f'{f"{t_ref / t_fast:.1f}x":>9}')
+
+
+def run_finder_concurrent(finder, data, n_calls, n_threads):
+    """
+    Run concurrent find_stars calls on a shared finder instance.
+
+    Parameters
+    ----------
+    finder : `~photutils.detection.StarFinderBase`
+        The shared star finder instance.
+
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    n_calls : int
+        The total number of calls.
+
+    n_threads : int
+        The number of worker threads.
+    """
+    with ThreadPoolExecutor(max_workers=n_threads) as executor:
+        futures = [executor.submit(finder, data) for _ in range(n_calls)]
+        for future in futures:
+            future.result()
+
+
+def bench_finder_threads(*, n_sources=1000, n_calls=8,
+                         thread_counts=(1, 2, 4, 8), repeats=3, seed=0):
+    """
+    Benchmark concurrent find_stars calls on a shared DAOStarFinder.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The number of stars in the image.
+
+    n_calls : int, optional
+        The total number of find_stars calls per timing.
+
+    thread_counts : tuple of int, optional
+        The numbers of worker threads.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, _ = make_star_image(n_sources, seed=seed)
+    finder = DAOStarFinder(THRESHOLD, FWHM)
+    finder(data)  # warm up
+
+    times = []
+    for n_threads in thread_counts:
+        bench = partial(run_finder_concurrent, finder, data, n_calls,
+                        n_threads)
+        times.append(time_best(bench, repeats=repeats))
+
+    print(f'\n== DAOStarFinder thread scaling ({n_sources} stars, '
+          f'{data.shape[0]}x{data.shape[1]} image, {n_calls} concurrent '
+          'calls on a shared instance) ==')
+    header = ''.join(f'{f"{n} thr":>18}' for n in thread_counts)
+    print(header)
+    print(''.join(f'{cell:>18}' for cell in format_sweep_cells(times)))
+
+
+def parse_int_list(text):
+    """
+    Parse a comma-separated list of positive integers.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated integers (e.g., ``'5,10,25'``).
+
+    Returns
+    -------
+    result : list of int
+        The parsed integers.
+    """
+    values = [int(item) for item in text.split(',')]
+    if any(value < 1 for value in values):
+        msg = 'values must be positive integers'
+        raise ValueError(msg)
+    return values
+
+
+def main():
+    """
+    Run the photutils.detection benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for the photutils.detection subpackage.')
+    parser.add_argument('--n-sources', type=int, default=1000,
+                        help='number of stars in the image '
+                             '(default: %(default)s)')
+    parser.add_argument('--radii', type=parse_int_list,
+                        default=[5, 10, 25, 50],
+                        help='comma-separated radii for the '
+                             'min-separation benchmark '
+                             '(default: 5,10,25,50)')
+    parser.add_argument('--n-calls', type=int, default=8,
+                        help='number of concurrent find_stars calls for '
+                             'the thread-scaling benchmark '
+                             '(default: %(default)s)')
+    parser.add_argument('--threads', type=parse_thread_counts,
+                        default=[1, 2, 4, 8],
+                        help='comma-separated thread counts for the '
+                             'thread-scaling benchmark (default: 1,2,4,8)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'finders', 'find-peaks',
+                                 'min-separation', 'threads'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'finders'):
+        bench_star_finders(n_sources=args.n_sources, repeats=args.repeats,
+                           seed=args.seed)
+    if args.which in ('all', 'find-peaks'):
+        bench_find_peaks(n_sources=args.n_sources, repeats=args.repeats,
+                         seed=args.seed)
+    if args.which in ('all', 'min-separation'):
+        bench_min_separation(n_sources=args.n_sources, radii=args.radii,
+                             repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'threads'):
+        bench_finder_threads(n_sources=args.n_sources, n_calls=args.n_calls,
+                             thread_counts=args.threads,
+                             repeats=args.repeats, seed=args.seed)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/user_guide/detection.rst
+++ b/docs/user_guide/detection.rst
@@ -57,12 +57,12 @@ as :class:`~photutils.detection.DAOStarFinder` shown below. Replace
 the class name and adjust the parameters (e.g., ``fwhm`` and
 ``kernel``) as needed. Note that the ``scale_threshold`` parameter
 is specific to :class:`~photutils.detection.DAOStarFinder`.
-Note also that each class returns different output columns.
-For example, :class:`~photutils.detection.DAOStarFinder`
-includes ``daofind_mag`` and ``sharpness`` columns, while
+Note also that each class returns different output columns. For
+example, :class:`~photutils.detection.DAOStarFinder` includes
+``roundness1``, ``roundness2``, and ``daofind_mag`` columns, while
 :class:`~photutils.detection.IRAFStarFinder` includes ``fwhm`` and
-``pa`` (position angle) columns. See each class's API documentation for
-the full list of output columns.
+``orientation`` columns. See each class's API documentation for the full
+list of output columns.
 
 As an example, let's load a simulated HST star image and add Gaussian
 noise. We will then estimate the background and background noise using

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -954,6 +954,37 @@ def _validate_n_brightest(n_brightest):
     return n_brightest
 
 
+def _validate_xycoords_bounds(xycoords, shape):
+    """
+    Validate that ``xycoords`` positions are within the data shape.
+
+    Positions are interpreted as pixel coordinates, where pixel centers
+    are at integer values and the image footprint spans ``(-0.5, nx -
+    0.5)`` in x and ``(-0.5, ny - 0.5)`` in y.
+
+    Parameters
+    ----------
+    xycoords : Nx2 `~numpy.ndarray`
+        The (x, y) pixel coordinates of sources.
+
+    shape : tuple of 2 int
+        The ``(ny, nx)`` shape of the data array.
+
+    Raises
+    ------
+    ValueError
+        If any position is outside the bounds of the data.
+    """
+    ny, nx = shape
+    xpos = xycoords[:, 0]
+    ypos = xycoords[:, 1]
+    if np.any((xpos <= -0.5) | (xpos >= nx - 0.5)
+              | (ypos <= -0.5) | (ypos >= ny - 0.5)):
+        msg = ('xycoords must be within the bounds of the input data '
+               f'with shape {tuple(shape)}')
+        raise ValueError(msg)
+
+
 def _handle_deprecated_range(old_lower, old_upper, new_range,
                              old_name, new_name, default_range):
     """

--- a/photutils/detection/core.py
+++ b/photutils/detection/core.py
@@ -274,12 +274,20 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
         """
         Index or slice the catalog.
 
-        This method should be overridden in subclasses to handle
-        class-specific attributes.
+        Class-specific attributes to copy are declared by overriding
+        the ``_get_init_attributes`` method in subclasses.
         """
         # NOTE: we allow indexing/slicing of scalar (self.isscalar = True)
         #       instances in order to perform catalog filtering even for
         #       a single source
+
+        # Normalize an integer index to a one-element fancy index so
+        # that the leading source axis is always preserved, including
+        # for cached multidimensional per-source arrays (e.g., moments
+        # and cutouts).
+        if (isinstance(index, (int, np.integer))
+                and not isinstance(index, bool)):
+            index = [index]
 
         newcls = object.__new__(self.__class__)
 
@@ -289,10 +297,8 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
             setattr(newcls, attr, getattr(self, attr))
 
         # xypos determines ordering and isscalar
-        # NOTE: always keep as 2D array, even for a single source
         attr = 'xypos'
-        value = getattr(self, attr)[index]
-        setattr(newcls, attr, np.atleast_2d(value))
+        setattr(newcls, attr, getattr(self, attr)[index])
 
         # Index/slice the remaining attributes
         keys = set(self.__dict__.keys()) & set(self._cached_properties)
@@ -305,11 +311,7 @@ class StarFinderCatalogBase(metaclass=abc.ABCMeta):
             if np.isscalar(value):
                 continue
 
-            # Ensure value is always at least a 1D array, even for a
-            # single source
-            value = np.atleast_1d(value[index])
-
-            newcls.__dict__[key] = value
+            newcls.__dict__[key] = value[index]
 
         return newcls
 

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -1025,10 +1025,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         """
         attrs = ('x_centroid', 'y_centroid', 'hx', 'hy', 'sharpness',
                  'roundness1', 'roundness2', 'peak', 'flux')
-        skip = ()
-        if np.all(self._threshold_eff_per_source == 0):
-            skip = ('flux',)
-        newcat = self._filter_finite(attrs, skip_attrs=skip)
+        newcat = self._filter_finite(attrs)
         if newcat is None:
             return None
 

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -455,7 +455,7 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         The ``(lower, upper)`` inclusive bounds on roundness for object
         detection. Objects with roundness outside this range will be
         rejected. Both ``roundness1`` and ``roundness2`` are tested
-        against this range.
+        against this range. The default is ``(-1.0, 1.0)``.
 
     n_brightest : int, None, optional
         The number of brightest objects to keep after sorting the source
@@ -470,6 +470,12 @@ class _DAOStarFinderCatalog(StarFinderCatalogBase):
         `~astropy.units.Quantity` array, then ``peak_max`` must have the
         same units. If ``peak_max`` is set to `None`, then no peak pixel
         value filtering will be performed.
+
+    scale_threshold : bool, optional
+        If `True` (default), the input ``threshold`` is multiplied by
+        the kernel relative error to compute the effective threshold
+        used by ``daofind_mag``. If `False`, the input ``threshold`` is
+        used directly.
     """
 
     def __init__(self, data, convolved_data, xypos, threshold, kernel, *,

--- a/photutils/detection/daofinder.py
+++ b/photutils/detection/daofinder.py
@@ -12,7 +12,8 @@ import numpy as np
 from photutils.detection.core import (_DEPR_DEFAULT, StarFinderBase,
                                       StarFinderCatalogBase,
                                       _handle_deprecated_range,
-                                      _StarFinderKernel, _validate_n_brightest)
+                                      _StarFinderKernel, _validate_n_brightest,
+                                      _validate_xycoords_bounds)
 from photutils.utils._convolution import _filter_data
 from photutils.utils._deprecation import (deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
@@ -139,7 +140,8 @@ class DAOStarFinder(StarFinderBase):
     xycoords : `None` or Nx2 `~numpy.ndarray`, optional
         The (x, y) pixel coordinates of the approximate centroid
         positions of identified sources. If ``xycoords`` are input, the
-        algorithm will skip the source-finding step.
+        algorithm will skip the source-finding step. The positions must
+        be within the bounds of the input ``data``.
 
     min_separation : `None` or float, optional
         The minimum separation (in pixels) for detected objects. If
@@ -336,6 +338,7 @@ class DAOStarFinder(StarFinderBase):
                                      min_separation=self.min_separation,
                                      exclude_border=self.exclude_border)
         else:
+            _validate_xycoords_bounds(self.xycoords, data.shape)
             xypos = self.xycoords
 
         if xypos is None:

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -408,12 +408,12 @@ class _IRAFStarFinderCatalog(StarFinderCatalogBase):
     sharpness_range : tuple of 2 floats, optional
         The ``(lower, upper)`` inclusive bounds on sharpness for object
         detection. Objects with sharpness outside this range will be
-        rejected.
+        rejected. The default is ``(0.5, 2.0)``.
 
     roundness_range : tuple of 2 floats, optional
         The ``(lower, upper)`` inclusive bounds on roundness for object
         detection. Objects with roundness outside this range will be
-        rejected.
+        rejected. The default is ``(0.0, 0.2)``.
 
     n_brightest : int, None, optional
         The number of brightest objects to keep after sorting the source
@@ -431,7 +431,7 @@ class _IRAFStarFinderCatalog(StarFinderCatalogBase):
     """
 
     def __init__(self, data, convolved_data, xypos, kernel, *,
-                 sharpness_range=(0.2, 1.0), roundness_range=(-1.0, 1.0),
+                 sharpness_range=(0.5, 2.0), roundness_range=(0.0, 0.2),
                  n_brightest=None, peak_max=None):
 
         # Validate the units, but do not strip them

--- a/photutils/detection/irafstarfinder.py
+++ b/photutils/detection/irafstarfinder.py
@@ -12,7 +12,8 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from photutils.detection.core import (_DEPR_DEFAULT, StarFinderBase,
                                       StarFinderCatalogBase,
                                       _handle_deprecated_range,
-                                      _StarFinderKernel, _validate_n_brightest)
+                                      _StarFinderKernel, _validate_n_brightest,
+                                      _validate_xycoords_bounds)
 from photutils.utils._convolution import _filter_data
 from photutils.utils._deprecation import (deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
@@ -106,7 +107,8 @@ class IRAFStarFinder(StarFinderBase):
     xycoords : `None` or Nx2 `~numpy.ndarray`, optional
         The (x, y) pixel coordinates of the approximate centroid
         positions of identified sources. If ``xycoords`` are input, the
-        algorithm will skip the source-finding step.
+        algorithm will skip the source-finding step. The positions must
+        be within the bounds of the input ``data``.
 
     min_separation : `None` or float, optional
         The minimum separation (in pixels) for detected objects. If
@@ -306,6 +308,7 @@ class IRAFStarFinder(StarFinderBase):
                                      mask=mask,
                                      exclude_border=self.exclude_border)
         else:
+            _validate_xycoords_bounds(self.xycoords, data.shape)
             xypos = self.xycoords
 
         if xypos is None:

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -231,6 +231,15 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
     mask : array_like, bool, optional
         A boolean mask with the same shape as ``data``, where a `True`
         value indicates the corresponding element of ``data`` is masked.
+        Masked pixels can neither be detected as peaks nor suppress
+        nearby peaks within the local region (they are treated the same
+        as NaN pixels).
+
+        .. versionchanged:: 3.1
+            Masked pixels no longer suppress nearby peaks within the
+            local region. Previously, a masked pixel with a value larger
+            than a nearby true peak prevented that peak from being
+            detected.
 
     border_width : int, array_like of int, or None, optional
         The width in pixels to exclude around the border of the
@@ -314,9 +323,10 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
     image boundary are treated as zero. For images with all-negative
     values, this may suppress legitimate peaks near the borders.
 
-    Any NaN values in the input ``data`` are replaced with the minimum
-    finite value before peak detection, and the corresponding pixels are
-    automatically excluded from the results.
+    Masked pixels and any NaN values in the input ``data`` are replaced
+    with the minimum finite data value before peak detection, so they
+    can neither be detected as peaks nor suppress nearby peaks. NaN
+    pixels are automatically excluded from the results.
 
     The output column names (``x_peak``, ``y_peak``, ``peak_value``)
     differ from the star finder classes (e.g.,
@@ -352,14 +362,23 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
         border_width = as_pair('border_width', border_width,
                                lower_bound=(0, 1), upper_bound=data.shape)
 
-    # Remove NaN values to avoid runtime warnings and exclude NaN pixels
-    # from peak detection
+    # Combine the input mask with a mask of NaN pixels. Masked and
+    # NaN pixels are replaced by the minimum finite data value before
+    # peak detection so that they can neither be detected as peaks nor
+    # suppress nearby peaks within the local region.
     nan_mask = np.isnan(data)
-    if np.any(nan_mask):
-        data = np.copy(data)  # ndarray
-        data[nan_mask] = nanmin(data)
-        mask = (nan_mask if mask is None
-                else np.asanyarray(mask) | nan_mask)
+    if mask is not None:
+        mask = np.asanyarray(mask, dtype=bool)
+        if data.shape != mask.shape:
+            msg = 'data and mask must have the same shape'
+            raise ValueError(msg)
+        mask = mask | nan_mask
+    elif np.any(nan_mask):
+        mask = nan_mask
+
+    if mask is not None and np.any(mask):
+        data = np.copy(data)  # do not mutate the input data
+        data[mask] = nanmin(data)
 
     # peak_goodmask: good pixels are True
     if min_separation is not None and min_separation > 0:
@@ -375,10 +394,6 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
 
     # Exclude peaks that are masked
     if mask is not None:
-        mask = np.asanyarray(mask, dtype=bool)
-        if data.shape != mask.shape:
-            msg = 'data and mask must have the same shape'
-            raise ValueError(msg)
         peak_goodmask = np.logical_and(peak_goodmask, ~mask)
 
     # Exclude peaks that are too close to the border

--- a/photutils/detection/peakfinder.py
+++ b/photutils/detection/peakfinder.py
@@ -250,9 +250,11 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
         integers.
 
     n_peaks : int, optional
-        The maximum number of peaks to return. When the number of
-        detected peaks exceeds ``n_peaks``, the peaks with the highest
-        peak intensities will be returned.
+        The maximum number of peaks to return. It must be a positive
+        integer or `numpy.inf` (the default, meaning all peaks
+        are returned). When the number of detected peaks exceeds
+        ``n_peaks``, the peaks with the highest peak intensities will be
+        returned.
 
     min_separation : float or None, optional
         The minimum allowed separation (in pixels) between detected
@@ -338,6 +340,10 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
     data, threshold, error = arrays
     data = np.asanyarray(data)
 
+    if data.size == 0:
+        msg = 'data must not be empty'
+        raise ValueError(msg)
+
     if centroid_func is not None and not callable(centroid_func):
         msg = 'centroid_func must be a callable object'
         raise TypeError(msg)
@@ -345,6 +351,19 @@ def find_peaks(data, threshold, *, box_size=3, footprint=None, mask=None,
     if min_separation is not None and min_separation < 0:
         msg = 'min_separation must be >= 0'
         raise ValueError(msg)
+
+    if n_peaks != np.inf:
+        if isinstance(n_peaks, bool):
+            msg = 'n_peaks must be an integer'
+            raise TypeError(msg)
+        if n_peaks <= 0:
+            msg = 'n_peaks must be > 0'
+            raise ValueError(msg)
+        n_peaks_int = int(n_peaks)
+        if n_peaks_int != n_peaks:
+            msg = 'n_peaks must be an integer'
+            raise ValueError(msg)
+        n_peaks = n_peaks_int
 
     if np.all(data == data.flat[0]):
         msg = 'Input data is constant. No local peaks can be found.'

--- a/photutils/detection/starfinder.py
+++ b/photutils/detection/starfinder.py
@@ -34,7 +34,8 @@ class StarFinder(StarFinderBase):
         the same units.
 
     kernel : `~numpy.ndarray`
-        A 2D array of the PSF kernel.
+        A 2D array of the PSF kernel. The kernel values must be finite
+        and its maximum value must be positive.
 
     min_separation : `None` or float, optional
         The minimum separation (in pixels) for detected objects. If
@@ -96,6 +97,12 @@ class StarFinder(StarFinderBase):
         kernel = np.asarray(kernel)
         if kernel.ndim != 2:
             msg = 'kernel must be a 2D array'
+            raise ValueError(msg)
+        if not np.all(np.isfinite(kernel)):
+            msg = 'kernel must contain only finite values'
+            raise ValueError(msg)
+        if np.max(kernel) <= 0:
+            msg = 'kernel must have a positive maximum value'
             raise ValueError(msg)
         self.kernel = kernel
 

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -3,11 +3,14 @@
 Tests for the photutils.detection.core module.
 """
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from functools import cached_property
 
 import numpy as np
 import pytest
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from numpy.testing import assert_array_equal
 
 from photutils.detection import DAOStarFinder
 from photutils.detection.core import (_DEPR_DEFAULT, StarFinderCatalogBase,
@@ -447,7 +450,7 @@ class TestStarFinderCatalogBase:
 
         assert cutouts.shape == (1, 3, 3)
         expected = data[4:7, 4:7]
-        np.testing.assert_array_equal(cutouts[0], expected)
+        assert_array_equal(cutouts[0], expected)
 
     def test_select_brightest(self, make_catalog):
         """
@@ -476,7 +479,7 @@ class TestStarFinderCatalogBase:
         sub = cat[1:]
         assert sub.id[0] == 2
         sub.reset_ids()
-        np.testing.assert_array_equal(sub.id, [1, 2])
+        assert_array_equal(sub.id, [1, 2])
 
     def test_apply_all_filters(self, make_catalog):
         """
@@ -488,7 +491,7 @@ class TestStarFinderCatalogBase:
         assert result is not None
         assert len(result) == 2
         # IDs should be reset to [1, 2]
-        np.testing.assert_array_equal(result.id, [1, 2])
+        assert_array_equal(result.id, [1, 2])
 
     def test_getitem_negative_index(self, make_catalog):
         """
@@ -541,9 +544,8 @@ class TestStarFinderCatalogBase:
         assert sub.moments.shape == (1, 2, 2)
         assert sub.cutout_data.shape == (1, 3, 3)
         assert sub.cutout_centroid.shape == (1, 2)
-        np.testing.assert_array_equal(sub.moments[0], cat.moments[i])
-        np.testing.assert_array_equal(sub.cutout_data[0],
-                                      cat.cutout_data[i])
+        assert_array_equal(sub.moments[0], cat.moments[i])
+        assert_array_equal(sub.cutout_data[0], cat.cutout_data[i])
 
         # Dependent properties must be computable from the sliced
         # cached values
@@ -592,6 +594,94 @@ class TestStarFinderCatalogBase:
         assert sub.default_columns == ('id', 'x_centroid', 'y_centroid')
 
 
+class TestThreadSafety:
+    """
+    Thread-safety tests for the star finder and catalog classes.
+    """
+
+    def test_concurrent_find_stars_shared_finder(self, data):
+        """
+        Test that concurrent find_stars calls on a shared finder
+        instance give results identical to a serial call.
+
+        Finder instances are immutable after construction and create a
+        fresh catalog per call, so concurrent calls must not interfere.
+        """
+        finder = DAOStarFinder(threshold=5.0, fwhm=2.0)
+        expected = finder(data)
+
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+
+        def worker(_):
+            barrier.wait()
+            return finder(data)
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(worker, range(n_threads)))
+
+        for tbl in results:
+            assert len(tbl) == len(expected)
+            for col in expected.colnames:
+                assert_array_equal(tbl[col], expected[col])
+
+    def test_concurrent_cached_property_access(self, make_catalog):
+        """
+        Test concurrent first access of cached properties on a shared
+        catalog.
+
+        cached_property does not lock, so concurrent first accesses
+        may run a getter more than once, but every thread must see
+        values identical to the serial computation.
+        """
+        expected = make_catalog(n_sources=3)
+        cat = make_catalog(n_sources=3)
+
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+
+        def worker(_):
+            barrier.wait()
+            return (cat.flux, cat.moments, cat.cutout_centroid)
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(worker, range(n_threads)))
+
+        for flux, moments, cutout_centroid in results:
+            assert_array_equal(flux, expected.flux)
+            assert_array_equal(moments, expected.moments)
+            assert_array_equal(cutout_centroid, expected.cutout_centroid)
+
+    def test_concurrent_cached_properties_introspection(self):
+        """
+        Test concurrent first access of the class-level
+        _cached_properties introspection cache on a fresh class.
+
+        The lazy class-level cache is written without a lock. The race
+        is benign because the computed list is identical for every
+        thread.
+        """
+        cls = _make_minimal_catalog_class()
+        data = np.zeros((11, 11))
+        data[5, 5] = 10.0
+        kernel = np.ones((3, 3))
+        xypos = np.array([[5, 5]])
+        cats = [cls(data, xypos, kernel) for _ in range(8)]
+
+        n_threads = len(cats)
+        barrier = threading.Barrier(n_threads)
+
+        def worker(cat):
+            barrier.wait()
+            return cat._cached_properties
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(worker, cats))
+
+        assert all(result == results[0] for result in results)
+        assert 'flux' in results[0]
+
+
 class TestStarFinderBaseCall:
     """
     Test that StarFinderBase.__call__ delegates to find_stars.
@@ -606,7 +696,7 @@ class TestStarFinderBaseCall:
         tbl_find = finder.find_stars(data)
         assert len(tbl_call) == len(tbl_find)
         for col in tbl_call.colnames:
-            np.testing.assert_array_equal(tbl_call[col], tbl_find[col])
+            assert_array_equal(tbl_call[col], tbl_find[col])
 
 
 def test_deprecated_attr(data):

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -550,6 +550,19 @@ class TestStarFinderCatalogBase:
         assert sub.cutout_x_centroid[0] == cat.cutout_x_centroid[i]
         assert sub.peak[0] == cat.peak[i]
 
+    def test_filter_finite_skip_attrs(self, make_catalog):
+        """
+        Test that _filter_finite skips attributes listed in
+        skip_attrs.
+        """
+        cat = make_catalog(n_sources=3)
+        # Inject a cached flux with a non-finite value
+        cat.__dict__['flux'] = np.array([1.0, np.nan, 2.0])
+        result = cat._filter_finite(('flux',), skip_attrs=('flux',))
+        assert len(result) == 3
+        result = cat._filter_finite(('flux',))
+        assert len(result) == 2
+
     def test_filter_bounds_none_range(self, make_catalog):
         """
         Test that _filter_bounds skips filtering when a range is None.

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -519,6 +519,37 @@ class TestStarFinderCatalogBase:
         assert sub.xypos[0, 0] == 15
         assert sub.xypos[1, 0] == 5
 
+    @pytest.mark.parametrize('index', [0, 1, -1, np.int64(2)])
+    def test_getitem_int_index_cached_multidim(self, make_catalog, index):
+        """
+        Regression test for integer indexing with cached
+        multidimensional per-source arrays.
+
+        Previously, an integer index dropped the leading source axis
+        of cached >=2D per-source arrays (e.g., moments and cutouts),
+        and accessing dependent properties on the indexed catalog
+        raised an IndexError.
+        """
+        cat = make_catalog(n_sources=3)
+        # Cache multidimensional per-source arrays before indexing
+        _ = cat.moments
+        _ = cat.cutout_data
+        _ = cat.cutout_centroid
+
+        sub = cat[index]
+        i = int(index) % len(cat)
+        assert sub.moments.shape == (1, 2, 2)
+        assert sub.cutout_data.shape == (1, 3, 3)
+        assert sub.cutout_centroid.shape == (1, 2)
+        np.testing.assert_array_equal(sub.moments[0], cat.moments[i])
+        np.testing.assert_array_equal(sub.cutout_data[0],
+                                      cat.cutout_data[i])
+
+        # Dependent properties must be computable from the sliced
+        # cached values
+        assert sub.cutout_x_centroid[0] == cat.cutout_x_centroid[i]
+        assert sub.peak[0] == cat.peak[i]
+
     def test_filter_bounds_none_range(self, make_catalog):
         """
         Test that _filter_bounds skips filtering when a range is None.

--- a/photutils/detection/tests/test_core.py
+++ b/photutils/detection/tests/test_core.py
@@ -214,186 +214,156 @@ def fixture_minimal_catalog_cls():
     return _make_minimal_catalog_class()
 
 
+@pytest.fixture(name='make_catalog')
+def fixture_make_catalog(minimal_catalog_cls):
+    """
+    Factory fixture for minimal catalogs with common single-source
+    (11x11 image) and three-source (21x21 image) layouts.
+    """
+    def _make(n_sources=1, **kwargs):
+        kernel = np.ones((3, 3))
+        if n_sources == 1:
+            data = np.zeros((11, 11))
+            data[5, 5] = 10.0
+            xypos = np.array([[5, 5]])
+        else:
+            data = np.zeros((21, 21))
+            data[5, 5] = 10.0
+            data[10, 10] = 50.0
+            data[15, 15] = 30.0
+            xypos = np.array([[5, 5], [10, 10], [15, 15]])
+        return minimal_catalog_cls(data, xypos, kernel, **kwargs)
+
+    return _make
+
+
 class TestStarFinderCatalogBase:
     """
     Tests for the StarFinderCatalogBase base-class methods.
     """
 
-    def test_get_init_attributes(self, minimal_catalog_cls):
+    def test_get_init_attributes(self, make_catalog):
         """
         Test base _get_init_attributes returns expected tuple.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         expected = ('data', 'unit', 'kernel', 'n_brightest', 'peak_max',
                     'cutout_shape', 'default_columns')
         assert cat._get_init_attributes() == expected
 
-    def test_cached_properties_class_cache(self, minimal_catalog_cls):
+    def test_cached_properties_class_cache(self, make_catalog):
         """
         Test that _cached_properties is cached on the class and shared
         across instances.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat1 = minimal_catalog_cls(data, xypos, kernel)
-        cat2 = minimal_catalog_cls(data, xypos, kernel)
+        cat1 = make_catalog()
+        cat2 = make_catalog()
         result1 = cat1._cached_properties
         result2 = cat2._cached_properties
         assert result1 is result2
 
-    def test_to_table_missing_default_columns(self, minimal_catalog_cls):
+    def test_to_table_missing_default_columns(self, make_catalog):
         """
         Test that to_table raises when default_columns is not set.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         match = 'default_columns attribute is not set'
         with pytest.raises(AttributeError, match=match):
             cat.to_table()
 
-    def test_to_table_explicit_columns(self, minimal_catalog_cls):
+    def test_to_table_explicit_columns(self, make_catalog):
         """
         Test that to_table works with explicit column names.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         columns = ('id', 'x_centroid', 'y_centroid')
         tbl = cat.to_table(columns=columns)
         assert len(tbl) == 1
         assert tbl.colnames == list(columns)
 
-    def test_to_table_invalid_column(self, minimal_catalog_cls):
+    def test_to_table_invalid_column(self, make_catalog):
         """
         Regression test for invalid column names not being validated
         in to_table (e.g., ``data`` is an attribute, but not a valid
         column name).
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         match = 'Invalid column name'
         with pytest.raises(ValueError, match=match):
             cat.to_table(columns=('id', 'data'))
 
-    def test_to_table_scalar_column(self, minimal_catalog_cls):
+    def test_to_table_scalar_column(self, make_catalog):
         """
         Regression test to ensure that ``isscalar`` (a scalar value
         for the whole object, not a per-source value) is not a valid
         ``to_table`` column.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         match = 'Invalid column name'
         with pytest.raises(ValueError, match=match):
             cat.to_table(columns='isscalar')
 
-    def test_to_table_deprecated_column(self, minimal_catalog_cls):
+    def test_to_table_deprecated_column(self, make_catalog):
         """
         Regression test to ensure that deprecated column names are still
         accepted by ``to_table``, not rejected by the new column-name
         validation.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         match = "'xcentroid' attribute was deprecated"
         with pytest.warns(AstropyDeprecationWarning, match=match):
             tbl = cat.to_table(columns='xcentroid')
         assert tbl.colnames == ['x_centroid']
 
-    def test_to_table_str_column(self, minimal_catalog_cls):
+    def test_to_table_str_column(self, make_catalog):
         """
         Regression test to ensure that a single string column name (not
         wrapped in a list) is accepted by ``to_table``.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         tbl = cat.to_table(columns='id')
         assert tbl.colnames == ['id']
 
-    def test_properties(self, minimal_catalog_cls):
+    def test_properties(self, make_catalog):
         """
         Test that the _properties attribute returns a sorted list of
         cached-property names.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         assert cat._properties == sorted(cat._properties)
         assert 'x_centroid' in cat._properties
         assert 'y_centroid' in cat._properties
         assert 'data' not in cat._properties
         assert 'isscalar' not in cat._properties
 
-    def test_getitem_integer_index(self, minimal_catalog_cls):
+    def test_getitem_integer_index(self, make_catalog):
         """
         Test indexing the catalog with an integer index.
         """
-        data = np.zeros((11, 11))
-        data[3, 3] = 10.0
-        data[7, 7] = 20.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[3, 3], [7, 7]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
-        assert len(cat) == 2
+        cat = make_catalog(n_sources=3)
+        assert len(cat) == 3
 
         sub = cat[0]
         assert len(sub) == 1
-        assert sub.xypos[0, 0] == 3
+        assert sub.xypos[0, 0] == 5
 
-    def test_getitem_slice(self, minimal_catalog_cls):
+    def test_getitem_slice(self, make_catalog):
         """
         Test slicing the catalog.
         """
-        data = np.zeros((11, 11))
-        data[3, 3] = 10.0
-        data[5, 5] = 15.0
-        data[7, 7] = 20.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[3, 3], [5, 5], [7, 7]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
         assert len(cat) == 3
 
         sub = cat[1:]
         assert len(sub) == 2
-        assert sub.xypos[0, 0] == 5
-        assert sub.xypos[1, 0] == 7
+        assert sub.xypos[0, 0] == 10
+        assert sub.xypos[1, 0] == 15
 
-    def test_getitem_fancy_index(self, minimal_catalog_cls):
+    def test_getitem_fancy_index(self, make_catalog):
         """
         Test indexing with a boolean mask (fancy indexing).
         """
-        data = np.zeros((11, 11))
-        data[3, 3] = 10.0
-        data[5, 5] = 15.0
-        data[7, 7] = 20.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[3, 3], [5, 5], [7, 7]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
 
         # Force evaluation of a cached property before slicing
         _ = cat.flux
@@ -401,8 +371,8 @@ class TestStarFinderCatalogBase:
         mask = np.array([True, False, True])
         sub = cat[mask]
         assert len(sub) == 2
-        assert sub.xypos[0, 0] == 3
-        assert sub.xypos[1, 0] == 7
+        assert sub.xypos[0, 0] == 5
+        assert sub.xypos[1, 0] == 15
 
     def test_roundness(self, minimal_catalog_cls):
         """
@@ -420,28 +390,20 @@ class TestStarFinderCatalogBase:
         # roundness should be finite for a well-defined source
         assert np.isfinite(cat.roundness[0])
 
-    def test_repr(self, minimal_catalog_cls):
+    def test_repr(self, make_catalog):
         """
         Test the __repr__ of StarFinderCatalogBase subclass.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [3, 3]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
         r = repr(cat)
         assert '_MinimalCatalog(' in r
-        assert 'n_sources=2' in r
+        assert 'n_sources=3' in r
 
-    def test_str(self, minimal_catalog_cls):
+    def test_str(self, make_catalog):
         """
         Test the __str__ of StarFinderCatalogBase subclass.
         """
-        data = np.zeros((11, 11))
-        data[5, 5] = 10.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog()
         s = str(cat)
         assert '_MinimalCatalog' in s
         assert 'n_sources: 1' in s
@@ -487,158 +449,100 @@ class TestStarFinderCatalogBase:
         expected = data[4:7, 4:7]
         np.testing.assert_array_equal(cutouts[0], expected)
 
-    def test_select_brightest(self, minimal_catalog_cls):
+    def test_select_brightest(self, make_catalog):
         """
         Test select_brightest selects the top sources by flux.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        data[15, 15] = 30.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10], [15, 15]])
-        cat = minimal_catalog_cls(data, xypos, kernel, n_brightest=2)
+        cat = make_catalog(n_sources=3, n_brightest=2)
         newcat = cat.select_brightest()
         assert len(newcat) == 2
         # Brightest first
         assert newcat.flux[0] >= newcat.flux[1]
 
-    def test_select_brightest_none(self, minimal_catalog_cls):
+    def test_select_brightest_none(self, make_catalog):
         """
         Test that select_brightest with n_brightest=None keeps all sources.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        data[15, 15] = 30.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10], [15, 15]])
-        cat = minimal_catalog_cls(data, xypos, kernel, n_brightest=None)
+        cat = make_catalog(n_sources=3, n_brightest=None)
         newcat = cat.select_brightest()
         assert len(newcat) == 3
 
-    def test_reset_ids(self, minimal_catalog_cls):
+    def test_reset_ids(self, make_catalog):
         """
         Test that reset_ids renumbers the catalog consecutively.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        data[15, 15] = 30.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10], [15, 15]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
         # Slice to drop the first source
         sub = cat[1:]
         assert sub.id[0] == 2
         sub.reset_ids()
         np.testing.assert_array_equal(sub.id, [1, 2])
 
-    def test_apply_all_filters(self, minimal_catalog_cls):
+    def test_apply_all_filters(self, make_catalog):
         """
         Test apply_all_filters chains apply_filters, select_brightest,
         and reset_ids.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        data[15, 15] = 30.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10], [15, 15]])
-        cat = minimal_catalog_cls(data, xypos, kernel, n_brightest=2)
+        cat = make_catalog(n_sources=3, n_brightest=2)
         result = cat.apply_all_filters()
         assert result is not None
         assert len(result) == 2
         # IDs should be reset to [1, 2]
         np.testing.assert_array_equal(result.id, [1, 2])
 
-    def test_getitem_negative_index(self, minimal_catalog_cls):
+    def test_getitem_negative_index(self, make_catalog):
         """
         Test indexing with a negative integer index.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        data[15, 15] = 30.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10], [15, 15]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
         sub = cat[-1]
         assert len(sub) == 1
         assert sub.xypos[0, 0] == 15
 
-    def test_getitem_empty_boolean_mask(self, minimal_catalog_cls):
+    def test_getitem_empty_boolean_mask(self, make_catalog):
         """
         Test indexing with an all-False boolean mask.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
-        mask = np.array([False, False])
+        cat = make_catalog(n_sources=3)
+        mask = np.array([False, False, False])
         sub = cat[mask]
         assert len(sub) == 0
 
-    def test_getitem_integer_array(self, minimal_catalog_cls):
+    def test_getitem_integer_array(self, make_catalog):
         """
         Test indexing with an integer array (fancy indexing).
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        data[15, 15] = 30.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10], [15, 15]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
         idx = np.array([2, 0])
         sub = cat[idx]
         assert len(sub) == 2
         assert sub.xypos[0, 0] == 15
         assert sub.xypos[1, 0] == 5
 
-    def test_filter_bounds_none_range(self, minimal_catalog_cls):
+    def test_filter_bounds_none_range(self, make_catalog):
         """
         Test that _filter_bounds skips filtering when a range is None.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        data[15, 15] = 30.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10], [15, 15]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
         bounds = [('flux', None)]
         result = cat._filter_bounds(bounds)
         assert len(result) == 3
 
-    def test_filter_bounds_initial_mask(self, minimal_catalog_cls):
+    def test_filter_bounds_initial_mask(self, make_catalog):
         """
         Test _filter_bounds with an initial_mask.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        data[15, 15] = 30.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10], [15, 15]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
         # Pre-exclude the first source
         initial_mask = np.array([False, True, True])
         result = cat._filter_bounds([], initial_mask=initial_mask)
         assert len(result) == 2
 
-    def test_default_columns_preserved_on_slice(self, minimal_catalog_cls):
+    def test_default_columns_preserved_on_slice(self, make_catalog):
         """
         Test that default_columns is preserved when slicing.
         """
-        data = np.zeros((21, 21))
-        data[5, 5] = 10.0
-        data[10, 10] = 50.0
-        kernel = np.ones((3, 3))
-        xypos = np.array([[5, 5], [10, 10]])
-        cat = minimal_catalog_cls(data, xypos, kernel)
+        cat = make_catalog(n_sources=3)
         cat.default_columns = ('id', 'x_centroid', 'y_centroid')
         sub = cat[0]
         assert sub.default_columns == ('id', 'x_centroid', 'y_centroid')

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -156,6 +156,24 @@ class TestDAOStarFinder:
         tbl1 = finder1(data)
         assert_array_equal(tbl0, tbl1)
 
+    @pytest.mark.parametrize('xycoords', [[[500, 50]], [[50, 500]],
+                                          [[-50, 50]], [[50, -50]]])
+    def test_xycoords_out_of_bounds(self, data, xycoords):
+        """
+        Test that out-of-bounds xycoords raise a ValueError.
+        """
+        match = 'xycoords must be within the bounds'
+        finder = DAOStarFinder(threshold=5.0, fwhm=2.0,
+                               xycoords=np.array(xycoords))
+        with pytest.raises(ValueError, match=match):
+            finder(data)
+
+        # 2D threshold uses per-source threshold lookups
+        finder = DAOStarFinder(threshold=np.full(data.shape, 5.0),
+                               fwhm=2.0, xycoords=np.array(xycoords))
+        with pytest.raises(ValueError, match=match):
+            finder(data)
+
     def test_min_separation(self, data):
         """
         Test the min_separation parameter.

--- a/photutils/detection/tests/test_daofinder.py
+++ b/photutils/detection/tests/test_daofinder.py
@@ -326,6 +326,27 @@ class TestDAOStarFinder:
         flux = cat.flux[0]  # evaluate the flux so it can be sliced
         assert cat[0].flux == flux
 
+    def test_getitem_int_index_cached_multidim(self, data):
+        """
+        Regression test for integer indexing of the catalog after
+        multidimensional per-source arrays (e.g., the cutouts and
+        marginal-fit results) have been computed.
+
+        Previously, the integer index dropped the leading source axis
+        of those cached arrays, and accessing dependent properties
+        (e.g., ``peak``) on the indexed catalog raised an IndexError.
+        """
+        finder = DAOStarFinder(threshold=5.0, fwhm=2.0)
+        cat = finder._get_raw_catalog(data)
+        _ = cat.cutout_data
+        _ = cat.dx_hx
+
+        sub = cat[0]
+        assert sub.cutout_data.shape == (1, *cat.cutout_shape)
+        assert sub.dx_hx.shape == (1, 2)
+        assert sub.peak[0] == cat.peak[0]
+        assert sub.x_centroid[0] == cat.x_centroid[0]
+
     def test_interval_ends_included(self):
         """
         Test that filter interval endpoints are inclusive.

--- a/photutils/detection/tests/test_irafstarfinder.py
+++ b/photutils/detection/tests/test_irafstarfinder.py
@@ -122,6 +122,18 @@ class TestIRAFStarFinder:
         tbl1 = finder1(data)
         assert_array_equal(tbl0, tbl1)
 
+    @pytest.mark.parametrize('xycoords', [[[500, 50]], [[50, 500]],
+                                          [[-50, 50]], [[50, -50]]])
+    def test_xycoords_out_of_bounds(self, data, xycoords):
+        """
+        Test that out-of-bounds xycoords raise a ValueError.
+        """
+        match = 'xycoords must be within the bounds'
+        finder = IRAFStarFinder(threshold=5.0, fwhm=2.0,
+                                xycoords=np.array(xycoords))
+        with pytest.raises(ValueError, match=match):
+            finder(data)
+
     def test_min_separation(self, data):
         """
         Test the min_separation parameter.

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -147,6 +147,40 @@ class TestFindPeaks:
         tbl = find_peaks(data, 0.1, box_size=3, n_peaks=1)
         assert len(tbl) == 1
 
+    def test_n_peaks_integral_float(self, data):
+        """
+        Test that an integral float n_peaks works like the integer.
+        """
+        tbl1 = find_peaks(data, 0.1, box_size=3, n_peaks=5)
+        tbl2 = find_peaks(data, 0.1, box_size=3, n_peaks=5.0)
+        assert_array_equal(tbl1, tbl2)
+
+    @pytest.mark.parametrize('n_peaks', [0, -1, 5.5])
+    def test_n_peaks_invalid(self, data, n_peaks):
+        """
+        Test that non-positive or non-integral n_peaks values raise a
+        ValueError.
+        """
+        match = 'n_peaks must be'
+        with pytest.raises(ValueError, match=match):
+            find_peaks(data, 0.1, box_size=3, n_peaks=n_peaks)
+
+    def test_n_peaks_bool(self, data):
+        """
+        Test that a boolean n_peaks raises a TypeError.
+        """
+        match = 'n_peaks must be an integer'
+        with pytest.raises(TypeError, match=match):
+            find_peaks(data, 0.1, box_size=3, n_peaks=True)
+
+    def test_empty_data(self):
+        """
+        Test that empty input data raises a ValueError.
+        """
+        match = 'data must not be empty'
+        with pytest.raises(ValueError, match=match):
+            find_peaks(np.empty((0, 0)), 0.0)
+
     def test_border_width(self, data):
         """
         Test border exclusion.

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -551,10 +551,15 @@ class TestFindPeaks:
                     dist = np.sqrt((x[i] - x[j])**2 + (y[i] - y[j])**2)
                     assert dist > 10
 
-    def test_min_separation_matches_circular_footprint(self):
+    @pytest.mark.parametrize('radius', [2.5, 5, 7.3, 10, 12.5, 25, 50])
+    def test_min_separation_matches_circular_footprint(self, radius):
         """
         Test that min_separation produces the same peaks as an
         equivalent circular footprint passed to maximum_filter.
+
+        The fractional radii exercise the even-sized-footprint branch
+        of the fast algorithm, which is the default star finder path
+        (min_separation = 2.5 * fwhm).
         """
         rng = np.random.default_rng(42)
         data = rng.standard_normal((200, 200))
@@ -563,25 +568,21 @@ class TestFindPeaks:
         data[30, 170] = 15.0
         threshold = 3.0
 
-        for radius in (5, 10, 25, 50):
-            # Reference: actual circular footprint (slow but correct)
-            idx = np.arange(-radius, radius + 1)
-            xx, yy = np.meshgrid(idx, idx)
-            fp = np.array((xx**2 + yy**2) <= radius**2, dtype=int)
-            tbl_ref = find_peaks(data, threshold, footprint=fp)
+        # Reference uses the actual circular footprint (slow but correct)
+        idx = np.arange(-radius, radius + 1)
+        xx, yy = np.meshgrid(idx, idx)
+        fp = np.array((xx**2 + yy**2) <= radius**2, dtype=int)
+        tbl_ref = find_peaks(data, threshold, footprint=fp)
 
-            tbl_fast = find_peaks(data, threshold, min_separation=radius)
+        tbl_fast = find_peaks(data, threshold, min_separation=radius)
 
-            if tbl_ref is None:
-                assert tbl_fast is None
-            else:
-                ref_xy = set(zip(tbl_ref['x_peak'].tolist(),
-                                 tbl_ref['y_peak'].tolist(),
-                                 strict=True))
-                fast_xy = set(zip(tbl_fast['x_peak'].tolist(),
-                                  tbl_fast['y_peak'].tolist(),
-                                  strict=True))
-                assert ref_xy == fast_xy
+        ref_xy = set(zip(tbl_ref['x_peak'].tolist(),
+                         tbl_ref['y_peak'].tolist(),
+                         strict=True))
+        fast_xy = set(zip(tbl_fast['x_peak'].tolist(),
+                          tbl_fast['y_peak'].tolist(),
+                          strict=True))
+        assert ref_xy == fast_xy
 
     def test_min_separation_rejects_non_maxima(self):
         """

--- a/photutils/detection/tests/test_peakfinder.py
+++ b/photutils/detection/tests/test_peakfinder.py
@@ -73,6 +73,57 @@ class TestFindPeaks:
         tbl_int = find_peaks(data, 0.1, box_size=3, mask=int_mask)
         assert_array_equal(tbl_bool, tbl_int)
 
+    def test_masked_pixels_do_not_suppress_peaks(self):
+        """
+        Test that a masked pixel brighter than a nearby true peak does
+        not suppress that peak.
+        """
+        data = np.zeros((20, 20))
+        data[10, 10] = 100.0  # bad pixel (masked)
+        data[10, 12] = 50.0  # real peak, 2 pixels away
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[10, 10] = True
+
+        tbl = find_peaks(data, 1.0, box_size=5, mask=mask)
+        assert len(tbl) == 1
+        assert tbl['x_peak'][0] == 12
+        assert tbl['y_peak'][0] == 10
+
+    def test_masked_pixels_min_separation(self):
+        """
+        Test that masked pixels do not suppress nearby peaks with the
+        fast circular (min_separation) peak detection.
+        """
+        data = np.zeros((40, 40))
+        data[20, 20] = 100.0  # bad pixel (masked)
+        data[20, 24] = 50.0  # real peak, 4 pixels away
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[20, 20] = True
+
+        tbl = find_peaks(data, 1.0, min_separation=6, mask=mask)
+        assert len(tbl) == 1
+        assert tbl['x_peak'][0] == 24
+        assert tbl['y_peak'][0] == 20
+
+    def test_mask_equivalent_to_nan(self):
+        """
+        Test that masking a pixel gives the same result as setting it
+        to NaN.
+        """
+        rng = np.random.default_rng(0)
+        data = rng.normal(0.0, 1.0, (50, 50))
+        data[25, 25] = 100.0
+        data[25, 27] = 50.0
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[25, 25] = True
+
+        data_nan = data.copy()
+        data_nan[25, 25] = np.nan
+
+        tbl_mask = find_peaks(data, 10.0, box_size=5, mask=mask)
+        tbl_nan = find_peaks(data_nan, 10.0, box_size=5)
+        assert_array_equal(tbl_mask, tbl_nan)
+
     def test_maskshape(self, data):
         """
         Test if mask shape doesn't match data shape.

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -111,8 +111,11 @@ class TestStarFinder:
         tbl1 = starfinder(data)
         tbl2 = starfinder(data, mask=mask)
         assert len(tbl1) == 25
-        assert len(tbl2) == 13
-        assert min(tbl2['y_centroid']) > 50
+        # The 14 sources include one whose unmasked peak pixel lies at
+        # the mask boundary (its centroid falls just below it). Masked
+        # pixels do not suppress nearby peaks.
+        assert len(tbl2) == 14
+        assert min(tbl2['y_centroid']) > 49.5
 
     def test_mask_int(self, data, kernel):
         """

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -106,7 +106,7 @@ class TestStarFinder:
             tbl = finder(-data)
         assert tbl is None
 
-    def test_exclude_border(self, data, kernel):
+    def test_exclude_border(self):
         """
         Test that border sources are excluded.
         """

--- a/photutils/detection/tests/test_starfinder.py
+++ b/photutils/detection/tests/test_starfinder.py
@@ -69,6 +69,26 @@ class TestStarFinder:
         with pytest.raises(ValueError, match=match):
             StarFinder(1, bad_kernel)
 
+    def test_kernel_nonpositive(self):
+        """
+        Test that kernels without a positive maximum raise ValueError.
+        """
+        match = 'kernel must have a positive maximum value'
+        for bad_kernel in (np.zeros((3, 3)), -np.ones((3, 3))):
+            with pytest.raises(ValueError, match=match):
+                StarFinder(1, bad_kernel)
+
+    def test_kernel_nonfinite(self):
+        """
+        Test that kernels with non-finite values raise ValueError.
+        """
+        match = 'kernel must contain only finite values'
+        for bad_value in (np.nan, np.inf):
+            kernel = np.ones((3, 3))
+            kernel[1, 1] = bad_value
+            with pytest.raises(ValueError, match=match):
+                StarFinder(1, kernel)
+
     def test_nosources(self, data, kernel):
         """
         Test that no sources returns None with a warning.


### PR DESCRIPTION
This PR contains bug fixes, input validation improvements, and test/documentation updates for the detection package:

* Fixed integer indexing of star finder catalogs when cached multidimensional per-source attributes (e.g., moments, cutouts) had already been computed. Previously, accessing dependent properties on the indexed catalog raised an `IndexError`
* `find_peaks` (and the star finder classes, which use it) now treats masked pixels like NaN pixels, so a large-valued masked pixel (e.g., a flagged cosmic ray or hot pixel) no longer suppresses nearby true peaks
* Removed an outdated threshold-zero flux skip in DAO catalog filtering
* `DAOStarFinder` and `IRAFStarFinder` now raise a ValueError if any `xycoords `position is outside the data bounds
* `StarFinder` now validates kernel values (must be finite with a positive maximum)
* `find_peaks` now validates empty data and `n_peaks` inputs
