### PR TITLE
Segmentation fixes and improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -214,6 +214,11 @@ New Features
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``
     keyword. [#2329]
 
+  - ``SegmentationImage`` objects now always have an ``info``
+    attribute, a dictionary containing auxiliary information.
+    Segmentation images returned by ``deblend_sources`` store any
+    deblending warnings under a ``'warnings'`` key. [#2378]
+
 Bug Fixes
 ^^^^^^^^^
 
@@ -377,6 +382,29 @@ Bug Fixes
     degrees (which only ever produced values in the disjoint ranges
     [0, 90] and (270, 360)). This also makes it consistent with
     ``ApertureStats.orientation``. [#2317]
+
+  - ``SegmentationImage.remove_border_labels`` now raises a
+    ``ValueError`` for non-positive ``border_width`` values. Previously,
+    ``border_width=0`` (and negative widths) silently removed every
+    label because the entire array was treated as the border region.
+    [#2378]
+
+  - Fixed ``SourceCatalog`` slicing so that the sliced catalog no
+    longer shares its custom-properties list (and other mutable
+    containers, such as ``meta``) with the parent catalog. [#2378]
+
+  - Fixed ``SourceCatalog.segment_flux`` so that the local-background
+    subtraction uses the number of unmasked pixels actually summed.
+    Previously, with a ``detection_catalog`` input and a different mask,
+    the local background was multiplied by the detection catalog's
+    ``area``, oversubtracting the background. [#2378]
+
+  - ``deblend_sources`` with ``contrast=1`` (no deblending) now
+    honors ``relabel=True``, relabeling non-consecutive input labels
+    like every other code path. [#2378]
+
+  - ``SourceCatalog.add_property`` now raises a ``ValueError`` for
+    names of built-in methods (e.g., ``to_table``). [#2378]
 
 - ``photutils.psf``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -214,10 +214,18 @@ New Features
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``
     keyword. [#2329]
 
-  - ``SegmentationImage`` objects now always have an ``info``
-    attribute, a dictionary containing auxiliary information.
-    Segmentation images returned by ``deblend_sources`` store any
-    deblending warnings under a ``'warnings'`` key. [#2378]
+  - ``SegmentationImage`` objects now always have an ``info`` attribute,
+    a dictionary containing auxiliary information. Segmentation
+    images returned by ``deblend_sources`` store the input labels
+    affected by deblending warnings under ``'nonposmin_labels'`` and
+    ``'n_markers_labels'`` keys. [#2378]
+
+- ``photutils.utils``
+
+  - Added a new ``DeblendWarning`` class, a subclass of astropy's
+    ``AstropyUserWarning``, which is raised by ``deblend_sources``
+    when the deblending mode is changed to "linear" for one or more
+    sources. [#2378]
 
 Bug Fixes
 ^^^^^^^^^
@@ -623,6 +631,16 @@ API Changes
     the returned ``SegmentationImage.info['warnings']`` dictionary has
     been renamed from ``'nmarkers'`` to ``'n_markers'``, consistent
     with the ``n_*`` naming used elsewhere in photutils. [#2346]
+
+  - The deblending warning information stored by ``deblend_sources``
+    in the returned ``SegmentationImage`` ``info`` dictionary has been
+    restructured. The affected input labels are now stored as arrays
+    directly under ``'nonposmin_labels'`` and ``'n_markers_labels'``
+    keys. The nested ``info['warnings']`` dictionary, including
+    its ``'message'`` entries, has been removed. The emitted
+    warning is now a ``DeblendWarning`` (a subclass of astropy's
+    ``AstropyUserWarning``) instead of an ``AstropyUserWarning``.
+    [#2378]
 
 - ``photutils.utils``
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -156,6 +156,41 @@ python benchmarks/bench_detection.py
 python benchmarks/bench_detection.py --which min-separation --radii 10,50
 ```
 
+## Segmentation (`bench_segmentation.py`)
+
+Benchmarks for the `photutils.segmentation` subpackage, using an
+image of blended Gaussian-source pairs so that deblending has work to
+do:
+
+- source detection (`detect_threshold` and `detect_sources` with
+  4- and 8-connectivity)
+- source deblending (`deblend_sources`) across the threshold modes
+  (`linear`, `exponential`, and `sinh`) and `n_processes` values
+- the combined `SourceFinder` class with and without deblending
+- `SegmentationImage` operations (cached properties, relabeling,
+  border-label removal, square and circular source masks, and
+  polygons)
+- all `SourceCatalog` properties (from the catalog `properties`
+  attribute, computed with convolved data, error, background, and
+  WCS inputs) plus the method-based measurements (`flux_radius`,
+  `circular_photometry`, `kron_photometry`, and `to_table`), each on
+  a fresh catalog (times include dependent properties, e.g.,
+  `centroid_win` includes the Kron flux and `flux_radius` it depends
+  on)
+- concurrent `SourceCatalog` measurement jobs across thread counts
+  (with speedups relative to the first thread count)
+
+Examples:
+
+```bash
+# Run everything with the default settings
+python benchmarks/bench_segmentation.py
+
+# Only the deblending benchmark with a larger image
+python benchmarks/bench_segmentation.py --which deblend \
+    --n-sources 4000 --n-processes 1,4,8
+```
+
 ## Background (`bench_background.py`)
 
 Benchmarks for the `photutils.background` subpackage:

--- a/benchmarks/bench_segmentation.py
+++ b/benchmarks/bench_segmentation.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for the photutils.segmentation subpackage.
+
+The benchmarks cover source detection (detect_threshold and
+detect_sources), source deblending (deblend_sources) across the
+threshold modes and process counts, the combined SourceFinder class,
+SegmentationImage operations (relabeling, border-label removal,
+source masks, and polygons), SourceCatalog property calculations, and
+concurrent SourceCatalog runs across thread counts.
+
+Run ``python benchmarks/bench_segmentation.py --help`` to see the
+available options.
+"""
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from operator import attrgetter
+
+import numpy as np
+from astropy.convolution import convolve
+from astropy.modeling.models import Gaussian2D
+from astropy.stats import gaussian_fwhm_to_sigma
+from bench_helpers import (format_sweep_cells, parse_thread_counts,
+                           print_environment, time_best)
+
+from photutils.datasets import make_wcs
+from photutils.segmentation import (SegmentationImage, SourceCatalog,
+                                    SourceFinder, deblend_sources,
+                                    detect_sources, detect_threshold,
+                                    make_2dgaussian_kernel)
+from photutils.utils import circular_footprint
+from photutils.utils._optional_deps import (HAS_RASTERIO, HAS_SHAPELY,
+                                            HAS_SKIMAGE)
+
+FWHM = 4.0
+THRESHOLD = 5.0
+N_PIXELS = 10
+
+
+def make_source_image(n_sources, *, spacing=25, fwhm=FWHM, offset=6.0,
+                      noise_std=1.0, seed=0):
+    """
+    Return an image with a grid of blended Gaussian-source pairs.
+
+    Each grid cell contains a pair of overlapping Gaussian sources
+    separated by ``offset`` pixels, so that each detected segment can
+    be deblended into two sources.
+
+    Parameters
+    ----------
+    n_sources : int
+        The total number of Gaussian sources. The number of grid
+        cells is ``ceil(n_sources / 2)``.
+
+    spacing : int, optional
+        The grid cell size in pixels.
+
+    fwhm : float, optional
+        The FWHM of the Gaussian sources in pixels.
+
+    offset : float, optional
+        The separation of the two sources within a cell in pixels.
+
+    noise_std : float, optional
+        The standard deviation of the Gaussian noise.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    data : 2D `~numpy.ndarray`
+        The image.
+    """
+    n_cells = (n_sources + 1) // 2
+    n_grid = int(np.ceil(np.sqrt(n_cells)))
+    size = n_grid * spacing
+    rng = np.random.default_rng(seed)
+    data = rng.normal(0.0, noise_std, (size, size))
+
+    sigma = fwhm * gaussian_fwhm_to_sigma
+    yy, xx = np.mgrid[0:spacing, 0:spacing]
+    cen = (spacing - 1) / 2.0
+    half = offset / 2.0
+    for i in range(n_sources):
+        cell, pair = divmod(i, 2)
+        gy, gx = divmod(cell, n_grid)
+        sign = 1.0 if pair == 0 else -1.0
+        amplitude = 100.0 if pair == 0 else 60.0
+        xc = cen + sign * half + rng.uniform(-0.5, 0.5)
+        yc = cen + sign * half + rng.uniform(-0.5, 0.5)
+        model = Gaussian2D(amplitude, xc, yc, sigma, sigma)
+        x0 = gx * spacing
+        y0 = gy * spacing
+        data[y0:y0 + spacing, x0:x0 + spacing] += model(xx, yy)
+
+    return data
+
+
+def make_inputs(n_sources, *, seed=0):
+    """
+    Return the image, convolved image, and segmentation image.
+
+    Parameters
+    ----------
+    n_sources : int
+        The total number of Gaussian sources.
+
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    data : 2D `~numpy.ndarray`
+        The image.
+
+    convolved_data : 2D `~numpy.ndarray`
+        The convolved image.
+
+    segm : `~photutils.segmentation.SegmentationImage`
+        The segmentation image from detect_sources.
+    """
+    data = make_source_image(n_sources, seed=seed)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    segm = detect_sources(convolved_data, THRESHOLD, N_PIXELS)
+    return data, convolved_data, segm
+
+
+def bench_detect(*, n_sources=1000, repeats=3, seed=0):
+    """
+    Benchmark detect_threshold and detect_sources.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources in the image.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data = make_source_image(n_sources, seed=seed)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+
+    print(f'\n== detect_threshold / detect_sources ({n_sources} sources, '
+          f'{data.shape[0]}x{data.shape[1]} image) ==')
+    print(f'{"benchmark":>34}{"time":>12}{"n_labels":>10}')
+
+    bench = partial(detect_threshold, data, 2.0)
+    t_best = time_best(bench, repeats=repeats)
+    print(f'{"detect_threshold(n_sigma=2)":>34}{f"{t_best:.4f}s":>12}'
+          f'{"n/a":>10}')
+
+    for connectivity in (4, 8):
+        segm = detect_sources(convolved_data, THRESHOLD, N_PIXELS,
+                              connectivity=connectivity)
+        bench = partial(detect_sources, convolved_data, THRESHOLD,
+                        N_PIXELS, connectivity=connectivity)
+        t_best = time_best(bench, repeats=repeats)
+        name = f'detect_sources(connectivity={connectivity})'
+        print(f'{name:>34}{f"{t_best:.4f}s":>12}{segm.n_labels:>10}')
+
+
+def bench_deblend(*, n_sources=1000, process_counts=(1, 4), repeats=3,
+                  seed=0):
+    """
+    Benchmark deblend_sources across modes and process counts.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources in the image.
+
+    process_counts : tuple of int, optional
+        The n_processes values (for mode='exponential').
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    if not HAS_SKIMAGE:
+        print('\n== deblend_sources: skipped (scikit-image required) ==')
+        return
+
+    data, convolved_data, segm = make_inputs(n_sources, seed=seed)
+
+    print(f'\n== deblend_sources ({n_sources} sources, '
+          f'{segm.n_labels} segments, {data.shape[0]}x{data.shape[1]} '
+          'image) ==')
+    print(f'{"benchmark":>36}{"time":>12}{"n_labels":>10}')
+
+    for mode in ('linear', 'exponential', 'sinh'):
+        segm_deblended = deblend_sources(convolved_data, segm, N_PIXELS,
+                                         mode=mode, progress_bar=False)
+        bench = partial(deblend_sources, convolved_data, segm, N_PIXELS,
+                        mode=mode, progress_bar=False)
+        t_best = time_best(bench, repeats=repeats)
+        name = f'mode={mode}'
+        print(f'{name:>36}{f"{t_best:.4f}s":>12}'
+              f'{segm_deblended.n_labels:>10}')
+
+    for n_processes in process_counts:
+        if n_processes == 1:
+            continue
+        bench = partial(deblend_sources, convolved_data, segm, N_PIXELS,
+                        mode='exponential', n_processes=n_processes,
+                        progress_bar=False)
+        t_best = time_best(bench, repeats=repeats)
+        name = f'mode=exponential, n_processes={n_processes}'
+        print(f'{name:>36}{f"{t_best:.4f}s":>12}{"":>10}')
+
+
+def bench_finder(*, n_sources=1000, repeats=3, seed=0):
+    """
+    Benchmark the SourceFinder class (detection plus deblending).
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources in the image.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data = make_source_image(n_sources, seed=seed)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+
+    print(f'\n== SourceFinder ({n_sources} sources, '
+          f'{data.shape[0]}x{data.shape[1]} image) ==')
+    print(f'{"benchmark":>24}{"time":>12}{"n_labels":>10}')
+
+    deblend_options = [False]
+    if HAS_SKIMAGE:
+        deblend_options.append(True)
+    for deblend in deblend_options:
+        finder = SourceFinder(n_pixels=N_PIXELS, deblend=deblend,
+                              progress_bar=False)
+        segm = finder(convolved_data, THRESHOLD)
+        bench = partial(finder, convolved_data, THRESHOLD)
+        t_best = time_best(bench, repeats=repeats)
+        name = f'deblend={deblend}'
+        print(f'{name:>24}{f"{t_best:.4f}s":>12}{segm.n_labels:>10}')
+
+
+def bench_segmentation_image(*, n_sources=1000, repeats=3, seed=0):
+    """
+    Benchmark SegmentationImage operations.
+
+    Each timing constructs a fresh SegmentationImage so that cached
+    properties are recomputed and mutating methods start from the same
+    state.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources in the image.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    _, _, segm = make_inputs(n_sources, seed=seed)
+    segm_data = segm.data
+    # Non-consecutive labels for the relabel benchmark
+    segm_data_gaps = segm_data * 2
+
+    print(f'\n== SegmentationImage operations ({segm.n_labels} segments, '
+          f'{segm_data.shape[0]}x{segm_data.shape[1]} image) ==')
+    print(f'{"benchmark":>36}{"time":>12}')
+
+    footprint = circular_footprint(radius=5)
+
+    def _run_properties():
+        segm = SegmentationImage(segm_data.copy())
+        _ = segm.slices, segm.areas, segm.bbox
+
+    def _run_relabel():
+        SegmentationImage(segm_data_gaps.copy()).relabel_consecutive()
+
+    def _run_remove_border():
+        segm = SegmentationImage(segm_data.copy())
+        segm.remove_border_labels(border_width=10)
+
+    def _run_source_mask_square():
+        SegmentationImage(segm_data).make_source_mask(size=11)
+
+    def _run_source_mask_circular():
+        SegmentationImage(segm_data).make_source_mask(footprint=footprint)
+
+    benchmarks = [
+        ('labels + slices + areas + bbox', _run_properties),
+        ('relabel_consecutive', _run_relabel),
+        ('remove_border_labels(10)', _run_remove_border),
+        ('make_source_mask(size=11)', _run_source_mask_square),
+        ('make_source_mask(circular r=5)', _run_source_mask_circular),
+    ]
+
+    if HAS_RASTERIO and HAS_SHAPELY:
+        def _run_polygons():
+            _ = SegmentationImage(segm_data).polygons
+
+        benchmarks.append(('polygons', _run_polygons))
+
+    for name, func in benchmarks:
+        t_best = time_best(func, repeats=repeats)
+        print(f'{name:>36}{f"{t_best:.4f}s":>12}')
+
+
+def bench_catalog(*, n_sources=1000, repeats=3, seed=0):
+    """
+    Benchmark all SourceCatalog property calculations.
+
+    Every property listed by the SourceCatalog ``properties``
+    attribute is timed, followed by the method-based measurements
+    (flux_radius, circular_photometry, kron_photometry, and
+    to_table). The catalog is constructed with convolved data, error,
+    background, and WCS inputs so that all properties compute real
+    values.
+
+    Each timing constructs a fresh SourceCatalog so that cached
+    properties are recomputed; the reported times therefore include
+    the computation of any dependent properties (e.g., centroid_win
+    includes the Kron flux and flux_radius it depends on).
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources in the image.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, convolved_data, segm = make_inputs(n_sources, seed=seed)
+    error = np.ones_like(data)
+    background = np.full(data.shape, 0.1)
+    wcs = make_wcs(data.shape)
+
+    def _make_catalog():
+        return SourceCatalog(data, segm, convolved_data=convolved_data,
+                             error=error, background=background, wcs=wcs)
+
+    catalog = _make_catalog()  # warm up shared segmentation-image caches
+
+    print(f'\n== SourceCatalog ({segm.n_labels} segments, '
+          f'{data.shape[0]}x{data.shape[1]} image; times include '
+          'dependent properties) ==')
+    print(f'{"benchmark":>32}{"time":>12}')
+
+    benchmarks = [('constructor', lambda _cat: None)]
+    benchmarks.extend((name, attrgetter(name))
+                      for name in catalog.properties)
+    benchmarks.extend([
+        ('flux_radius(0.5)', lambda cat: cat.flux_radius(0.5)),
+        ('circular_photometry(5)',
+         lambda cat: cat.circular_photometry(5.0)),
+        ('kron_photometry((2.5, 1.4))',
+         lambda cat: cat.kron_photometry((2.5, 1.4))),
+        ('to_table (default columns)', lambda cat: cat.to_table()),
+    ])
+
+    for name, func in benchmarks:
+        def _bench(func=func):
+            func(_make_catalog())
+
+        t_best = time_best(_bench, repeats=repeats)
+        print(f'{name:>32}{f"{t_best:.4f}s":>12}')
+
+
+def run_catalog_concurrent(make_catalog, n_calls, n_threads):
+    """
+    Run concurrent SourceCatalog measurement jobs.
+
+    Parameters
+    ----------
+    make_catalog : callable
+        The zero-argument callable returning a fresh SourceCatalog.
+
+    n_calls : int
+        The total number of jobs.
+
+    n_threads : int
+        The number of worker threads.
+    """
+    def _job():
+        make_catalog().to_table()
+
+    with ThreadPoolExecutor(max_workers=n_threads) as executor:
+        futures = [executor.submit(_job) for _ in range(n_calls)]
+        for future in futures:
+            future.result()
+
+
+def bench_catalog_threads(*, n_sources=1000, n_calls=8,
+                          thread_counts=(1, 2, 4, 8), repeats=3, seed=0):
+    """
+    Benchmark concurrent SourceCatalog measurement runs.
+
+    Each job constructs a fresh SourceCatalog over shared input arrays
+    and computes the default to_table columns.
+
+    Parameters
+    ----------
+    n_sources : int, optional
+        The total number of Gaussian sources in the image.
+
+    n_calls : int, optional
+        The total number of catalog jobs per timing.
+
+    thread_counts : tuple of int, optional
+        The numbers of worker threads.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data, convolved_data, segm = make_inputs(n_sources, seed=seed)
+    error = np.ones_like(data)
+
+    def _make_catalog():
+        return SourceCatalog(data, segm, convolved_data=convolved_data,
+                             error=error)
+
+    _make_catalog().to_table()  # warm up
+
+    times = []
+    for n_threads in thread_counts:
+        bench = partial(run_catalog_concurrent, _make_catalog, n_calls,
+                        n_threads)
+        times.append(time_best(bench, repeats=repeats))
+
+    print(f'\n== SourceCatalog thread scaling ({segm.n_labels} segments, '
+          f'{data.shape[0]}x{data.shape[1]} image, {n_calls} concurrent '
+          'to_table jobs) ==')
+    header = ''.join(f'{f"{n} thr":>18}' for n in thread_counts)
+    print(header)
+    print(''.join(f'{cell:>18}' for cell in format_sweep_cells(times)))
+
+
+def parse_int_list(text):
+    """
+    Parse a comma-separated list of positive integers.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated integers (e.g., ``'1,4'``).
+
+    Returns
+    -------
+    result : list of int
+        The parsed integers.
+    """
+    values = [int(item) for item in text.split(',')]
+    if any(value < 1 for value in values):
+        msg = 'values must be positive integers'
+        raise ValueError(msg)
+    return values
+
+
+def main():
+    """
+    Run the photutils.segmentation benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for the photutils.segmentation subpackage.')
+    parser.add_argument('--n-sources', type=int, default=1000,
+                        help='total number of Gaussian sources in the '
+                             'image (default: %(default)s)')
+    parser.add_argument('--n-processes', type=parse_int_list, default=[1, 4],
+                        help='comma-separated n_processes values for the '
+                             'deblending benchmark (default: 1,4)')
+    parser.add_argument('--n-calls', type=int, default=8,
+                        help='number of concurrent catalog jobs for the '
+                             'thread-scaling benchmark '
+                             '(default: %(default)s)')
+    parser.add_argument('--threads', type=parse_thread_counts,
+                        default=[1, 2, 4, 8],
+                        help='comma-separated thread counts for the '
+                             'thread-scaling benchmark (default: 1,2,4,8)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'detect', 'deblend', 'finder',
+                                 'segmimage', 'catalog', 'threads'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'detect'):
+        bench_detect(n_sources=args.n_sources, repeats=args.repeats,
+                     seed=args.seed)
+    if args.which in ('all', 'deblend'):
+        bench_deblend(n_sources=args.n_sources,
+                      process_counts=args.n_processes,
+                      repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'finder'):
+        bench_finder(n_sources=args.n_sources, repeats=args.repeats,
+                     seed=args.seed)
+    if args.which in ('all', 'segmimage'):
+        bench_segmentation_image(n_sources=args.n_sources,
+                                 repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'catalog'):
+        bench_catalog(n_sources=args.n_sources, repeats=args.repeats,
+                      seed=args.seed)
+    if args.which in ('all', 'threads'):
+        bench_catalog_threads(n_sources=args.n_sources,
+                              n_calls=args.n_calls,
+                              thread_counts=args.threads,
+                              repeats=args.repeats, seed=args.seed)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -466,8 +466,8 @@ subset of labels is needed::
     1 47
 
     >>> segments = segment_map.get_segments([1, 5, 10])
-    >>> [segment.label for segment in segments]
-    [np.int32(1), np.int32(5), np.int32(10)]
+    >>> [int(segment.label) for segment in segments]
+    [1, 5, 10]
 
 A `~photutils.segmentation.Segment` can provide cutout arrays
 of the segment data and of arbitrary data arrays via its
@@ -665,7 +665,6 @@ that was subtracted from the data into the ``background`` keyword
 of :class:`~photutils.segmentation.SourceCatalog`, the background
 properties for each source will also be calculated:
 
-.. doctest-requires:: scipy >= 1.8
 .. doctest-requires:: skimage
 
     >>> cat = SourceCatalog(data, segment_map, background=bkg.background)
@@ -719,7 +718,6 @@ calculated. `~photutils.segmentation.SourceCatalog.segment_flux`
 and `~photutils.segmentation.SourceCatalog.segment_flux_err` are the
 instrumental flux and propagated flux error within the source segments:
 
-.. doctest-requires:: scipy >= 1.8
 .. doctest-requires:: skimage
 
     >>> from photutils.utils import calc_total_error
@@ -739,13 +737,13 @@ instrumental flux and propagated flux error within the source segments:
     ...     tbl5[col].info.format = '%.8g'  # for consistent table output
     >>> print(tbl5)
     label x_centroid y_centroid segment_flux segment_flux_err
-    ----- --------- --------- ------------ ----------------
-        1 235.24302 1.1928271    433.35463        14.167067
-        5 257.82267 12.228232    489.96534        18.998371
-       20 347.15384 66.417567    625.96683        22.475065
-       50 380.94448 174.57181    249.01701        15.261334
-       75 74.413068 259.76066     836.4803        17.193721
-       80 14.920217 60.024006     666.6014        19.605394
+    ----- ---------- ---------- ------------ ----------------
+        1  235.24302  1.1928271    433.35462        14.167067
+        5  257.82267  12.228232    489.96532        18.998371
+       20  347.15384  66.417567    625.96682        22.475065
+       50  380.94448  174.57181    249.01701        15.261334
+       75  74.413068  259.76066     836.4803        17.193721
+       80  14.920217  60.024006    666.60139        19.605394
 
 
 Pixel Masking

--- a/docs/user_guide/utils.rst
+++ b/docs/user_guide/utils.rst
@@ -30,6 +30,9 @@ Some functions and classes of note include:
   colormap consisting of random muted colors. This type of colormap is
   useful for plotting segmentation images.
 
+* :class:`~photutils.utils.DeblendWarning`: Warning class to indicate
+  issues encountered while deblending sources.
+
 * :class:`~photutils.utils.NoDetectionsWarning`: Warning class to
   indicate no sources were detected.
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -598,10 +598,14 @@ The ``'grid_shape'`` key has been removed from the
 ``grid_shape`` attribute instead, i.e., ``psfmodel.grid_shape`` instead
 of ``psfmodel.meta['grid_shape']``.
 
-Deblending ``n_markers`` Warning Key
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Deblending Warning Information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The "too many markers" warning entry recorded by
-`~photutils.segmentation.deblend_sources` in the returned
-`~photutils.segmentation.SegmentationImage` ``info['warnings']``
-dictionary has been renamed from ``'nmarkers'`` to ``'n_markers'``.
+`~photutils.segmentation.deblend_sources` now emits a
+`~photutils.utils.DeblendWarning` (a subclass of astropy's
+``AstropyUserWarning``) when the deblending mode is changed to "linear"
+for one or more sources. The affected input labels are now stored as
+arrays directly under ``'nonposmin_labels'`` and ``'n_markers_labels'``
+keys in the returned `~photutils.segmentation.SegmentationImage`
+``info`` dictionary, replacing the nested ``info['warnings']``
+dictionary.

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1449,8 +1449,13 @@ class SourceCatalog:
         An array with a single NaN is returned for completely-masked
         sources.
         """
-        return [arr.compressed() if len(arr.compressed()) > 0
-                else np.array([np.nan]) for arr in array]
+        values = []
+        for arr in array:
+            compressed = arr.compressed()
+            if len(compressed) == 0:
+                compressed = np.array([np.nan])
+            values.append(compressed)
+        return values
 
     @staticmethod
     def _reduceat(values, ufunc, *, transform=None):
@@ -4115,6 +4120,10 @@ class SourceCatalog:
     @cached_property
     @use_detcat
     def _flux_radius_optimizer_args(self):
+        # NOTE: this cached property snapshots the current
+        # _aperture_mask_kwargs['flux_radius'] settings. Changing them
+        # (e.g., via _set_semode) after the first flux_radius call has
+        # no effect.
         kron_flux = self._kron_photometry[:, 0]  # unitless
         max_radius = self._max_circular_kron_radius
         kwargs = self._aperture_mask_kwargs['flux_radius']
@@ -4277,7 +4286,7 @@ class SourceCatalog:
 
             clean_data, grid_params, kronflux, max_radius = flux_radius_args
             normflux = kronflux * fraction
-            args = (clean_data, grid_params, normflux)
+            fcn_args = (clean_data, grid_params, normflux)
 
             # Try to find the root of self._flux_radius_func, which
             # is bracketed by a min and max radius. A ValueError is
@@ -4297,8 +4306,9 @@ class SourceCatalog:
             while max_radius > min_radius and found is False:
                 try:
                     bracket = [min_radius, max_radius]
-                    result = root_scalar(self._flux_radius_fcn, args=args,
-                                         bracket=bracket, method='brentq')
+                    result = root_scalar(self._flux_radius_fcn,
+                                         args=fcn_args, bracket=bracket,
+                                         method='brentq')
                     result = result.root
                     found = True
                 except ValueError:

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -614,10 +614,19 @@ class SourceCatalog:
         init_attr = ('_data', '_segmentation_image', '_error', '_mask',
                      '_background', 'wcs', '_data_unit', '_convolved_data',
                      'local_bkg_width', 'aperture_mask_method',
-                     'kron_params', 'default_columns', '_custom_properties',
-                     'meta', '_aperture_mask_kwargs', 'progress_bar')
+                     'kron_params', 'progress_bar')
         for attr in init_attr:
             setattr(newcls, attr, getattr(self, attr))
+
+        # Copy mutable containers so that mutating the sliced catalog
+        # (e.g., via add_property) does not also mutate the parent
+        # catalog (and vice versa).
+        newcls.default_columns = self.default_columns.copy()
+        newcls._custom_properties = self._custom_properties.copy()
+        newcls.meta = self.meta.copy()
+        newcls._aperture_mask_kwargs = {
+            key: value.copy()
+            for key, value in self._aperture_mask_kwargs.items()}
 
         # _labels determines ordering and isscalar
         attr = '_labels'

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -515,27 +515,6 @@ class SourceCatalog:
         }
 
     @property
-    def _properties(self):
-        """
-        A list of all class properties, including cached properties
-        (even in superclasses).
-
-        The result is cached on the class to avoid repeated
-        introspection via `inspect.getmembers`.
-        """
-        cls = self.__class__
-        attr = '_properties_cache'
-        # Subclasses get their own property list
-        if attr not in cls.__dict__:
-            def isproperty(obj):
-                return isinstance(obj, (property, cached_property))
-
-            setattr(cls, attr,
-                    [i[0] for i in inspect.getmembers(
-                        cls, predicate=isproperty)])
-        return getattr(cls, attr)
-
-    @property
     def properties(self):
         """
         A list of built-in source properties.
@@ -830,8 +809,11 @@ class SourceCatalog:
         overwrite : bool, option
             If `True`, will overwrite the existing property ``name``.
         """
+        # dir() includes all class-level attributes (properties, cached
+        # properties, and methods), so built-in methods (e.g., to_table)
+        # cannot be clobbered even with overwrite=True
         internal_attributes = ((set(self.__dict__.keys())
-                               | set(self._properties))
+                                | set(dir(self.__class__)))
                                - set(self.custom_properties))
         if name in internal_attributes:
             msg = f'{name} cannot be set because it is a built-in attribute'

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2430,11 +2430,13 @@ class SourceCatalog:
         Non-finite pixel values (NaN and inf) are excluded
         (automatically masked).
         """
-        localbkg = self._local_background
-        if self.isscalar:
-            localbkg = localbkg[0]
-        source_sum, _ = self._reduceat(self._data_values, np.add)
-        source_sum -= self.area.value * localbkg
+        source_sum, sizes = self._reduceat(self._data_values, np.add)
+        # Subtract the local background over the number of unmasked
+        # pixels actually included in the sum. The "area" property is
+        # not used here because it is taken from the detection catalog
+        # (if input), whose pixel count can differ when the data masks
+        # differ.
+        source_sum -= sizes * self._local_background
         if self._data_unit is not None:
             source_sum <<= self._data_unit
         return source_sum

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -180,12 +180,11 @@ class SourceCatalog:
         values (NaN and inf) in the input ``data`` are automatically
         masked.
 
-    background : float, 2D `~numpy.ndarray`, or `~astropy.units.Quantity`, \
-            optional
-        The background level that was *previously* present in the input
-        ``data``. ``background`` may either be a scalar value or a 2D
-        image with the same shape as the input ``data``. If ``data``
-        is a `~astropy.units.Quantity` array then ``background`` must
+    background : 2D `~numpy.ndarray` or `~astropy.units.Quantity`, optional
+        The background level that was *previously* present in the
+        input ``data``. ``background`` must be a 2D image with
+        the same shape as the input ``data``. If ``data`` is a
+        `~astropy.units.Quantity` array then ``background`` must
         be a `~astropy.units.Quantity` array (and vice versa) with
         identical units. Inputing the ``background`` merely allows
         for its properties to be measured within each source segment.

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1270,7 +1270,9 @@ class SegmentationImage:
         Parameters
         ----------
         border_width : int
-            The width of the border region in pixels.
+            The width of the border region in pixels. It must be
+            positive and smaller than half the array size in any
+            dimension.
 
         partial_overlap : bool, optional
             If this is set to `True` (the default), a segment that
@@ -1319,6 +1321,9 @@ class SegmentationImage:
                [7, 7, 0, 5, 5, 5],
                [7, 7, 0, 0, 5, 5]])
         """
+        if border_width <= 0:
+            msg = 'border_width must be a positive integer'
+            raise ValueError(msg)
         if border_width >= min(self.shape) / 2:
             msg = ('border_width must be smaller than half the array size '
                    'in any dimension')

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -51,6 +51,16 @@ class SegmentationImage:
         for the background. The segmentation image must have integer
         type.
 
+    Attributes
+    ----------
+    info : dict
+        A dictionary containing auxiliary information about the
+        segmentation image. For example, segmentation images returned
+        by :func:`~photutils.segmentation.deblend_sources` store any
+        deblending warnings under a ``'warnings'`` key. The dictionary
+        is empty if there is no auxiliary information. It is reset to an
+        empty dictionary when the ``data`` attribute is reassigned.
+
     Notes
     -----
     The `SegmentationImage` instance may be sliced, but note that the
@@ -66,6 +76,52 @@ class SegmentationImage:
             raise TypeError(msg)
         self.data = data
         self._deblend_label_map = {}  # set by source deblender
+
+    @classmethod
+    def _from_data(cls, data, *, labels=None, slices=None,
+                   deblend_label_map=None):
+        """
+        Create a `SegmentationImage` from a pre-validated segmentation
+        array, optionally seeding cached properties.
+
+        This bypasses the input validation performed by ``__init__``
+        and is used internally where the input array is already
+        known to be a valid segmentation image (e.g., the
+        outputs of `~photutils.segmentation.detect_sources` and
+        `~photutils.segmentation.deblend_sources`).
+
+        Parameters
+        ----------
+        data : 2D int `~numpy.ndarray`
+            The valid 2D segmentation array.
+
+        labels : `~numpy.ndarray`, optional
+            The sorted non-zero labels in ``data``, used to seed the
+            ``labels`` cached property.
+
+        slices : list of tuple of slice, optional
+            The slices for each label, used to seed the ``slices``
+            cached property. The list order must match ``labels``.
+
+        deblend_label_map : dict, optional
+            The mapping of parent label numbers to deblended label
+            numbers. If `None`, an empty mapping is used.
+
+        Returns
+        -------
+        segment_img : `SegmentationImage`
+            The new `SegmentationImage` instance.
+        """
+        segm = object.__new__(cls)
+        segm._data = data
+        if labels is not None:
+            segm.__dict__['labels'] = labels
+        if slices is not None:
+            segm.__dict__['slices'] = slices
+        segm._deblend_label_map = ({} if deblend_label_map is None
+                                   else deblend_label_map)
+        segm.info = {}
+        return segm
 
     def __str__(self):
         cls_name = f'<{self.__class__.__module__}.{self.__class__.__name__}>'
@@ -260,10 +316,11 @@ class SegmentationImage:
         self._data = value  # pylint: disable=attribute-defined-outside-init
         self.__dict__['labels'] = labels
 
-        # Reset deblended labels explicitly since _deblend_label_map
-        # is a regular attribute, not a cached property cleared by
-        # _reset_cached_properties above.
+        # Reset deblended labels and auxiliary info explicitly since
+        # _deblend_label_map and info are regular attributes, not cached
+        # properties cleared by _reset_cached_properties above.
         self.__dict__['_deblend_label_map'] = {}
+        self.__dict__['info'] = {}
 
     @cached_property
     def data_masked(self):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -740,7 +740,8 @@ class SegmentationImage:
         bad_labels.update(labels[~valid_mask])
 
         if bad_labels:
-            bad_labels = sorted(bad_labels)
+            # Convert numpy scalars to Python ints for a clean message
+            bad_labels = sorted(int(label) for label in bad_labels)
             label_str = 'label'
             conj_str = 'is'
             if len(bad_labels) > 1:

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -56,10 +56,12 @@ class SegmentationImage:
     info : dict
         A dictionary containing auxiliary information about the
         segmentation image. For example, segmentation images returned
-        by :func:`~photutils.segmentation.deblend_sources` store any
-        deblending warnings under a ``'warnings'`` key. The dictionary
-        is empty if there is no auxiliary information. It is reset to an
-        empty dictionary when the ``data`` attribute is reassigned.
+        by :func:`~photutils.segmentation.deblend_sources` store the
+        input labels affected by deblending warnings under
+        ``'nonposmin_labels'`` and ``'n_markers_labels'`` keys. The
+        dictionary is empty if there is no auxiliary information. It is
+        reset to an empty dictionary when the ``data`` attribute is
+        reassigned.
 
     Notes
     -----

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -2359,7 +2359,9 @@ class SegmentationImage:
                        alpha=alpha, vmin=vmin, vmax=vmax)
 
         cbar_info = None
-        cbar_labels = np.hstack((0, self.labels))
+        # The unique data values are the colorbar tick labels. 0 is
+        # included only if background pixels are present.
+        cbar_labels = data
         if len(cbar_labels) <= max_labels:
             cbar_ticks = np.arange(len(cbar_labels))
             cbar = ax.figure.colorbar(im, ax=ax, ticks=cbar_ticks)

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -12,7 +12,6 @@ from multiprocessing import cpu_count, get_context
 
 import numpy as np
 from astropy.units import Quantity
-from astropy.utils.exceptions import AstropyUserWarning
 from scipy.ndimage import label as ndi_label
 from scipy.ndimage import sum_labels
 
@@ -22,6 +21,7 @@ from photutils.segmentation.utils import _make_binary_structure
 from photutils.utils._deprecation import deprecated_renamed_argument
 from photutils.utils._progress_bars import add_progress_bar, tqdm
 from photutils.utils._stats import nanmax, nanmin, nansum
+from photutils.utils.exceptions import DeblendWarning
 
 __all__ = ['deblend_sources']
 
@@ -137,11 +137,21 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
     -------
     segment_image : `~photutils.segmentation.SegmentationImage`
         A segmentation image, with the same shape as ``data``, where
-        sources are marked by different positive integer values. A value
-        of zero is reserved for the background. The ``info`` attribute
-        of the returned segmentation image is a dictionary that contains
-        a ``'warnings'`` key if any deblending warnings occurred. It is
-        empty otherwise.
+        sources are marked by different positive integer values. A
+        value of zero is reserved for the background. The ``info``
+        attribute of the returned segmentation image is a dictionary
+        that stores the input labels for which the deblending mode was
+        changed to "linear" as arrays under ``'nonposmin_labels'``
+        (non-positive minimum data values) and ``'n_markers_labels'``
+        (too many potential deblended sources) keys. The dictionary is
+        empty if no mode fallbacks occurred.
+
+    Warns
+    -----
+    DeblendWarning
+        If the deblending mode for one or more sources was changed from
+        ``mode`` to "linear" due to non-positive minimum data values or
+        too many potential deblended sources.
 
     See Also
     --------
@@ -310,28 +320,12 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
                 deblend_label_map[label] = new_labels
                 max_label += len(new_labels)
 
-    # Process any warnings during deblending
-    warning_info = {}
     if nonposmin_labels or n_markers_labels:
         msg = ('The deblending mode of one or more source labels from the '
                f'input segmentation image was changed from "{mode}" to '
-               '"linear". See the "info" attribute for the list of affected '
-               'input labels.')
-        warnings.warn(msg, AstropyUserWarning)
-
-        if nonposmin_labels:
-            nonposmin_labels = np.array(nonposmin_labels)
-            msg = (f'Deblending mode changed from {mode} to linear due to '
-                   'non-positive minimum data values.')
-            warn = {'message': msg, 'input_labels': nonposmin_labels}
-            warning_info['nonposmin'] = warn
-
-        if n_markers_labels:
-            n_markers_labels = np.array(n_markers_labels)
-            msg = (f'Deblending mode changed from {mode} to linear due to '
-                   'too many potential deblended sources.')
-            warn = {'message': msg, 'input_labels': n_markers_labels}
-            warning_info['n_markers'] = warn
+               '"linear". See the "info" attribute of the returned '
+               'segmentation image for the affected input labels.')
+        warnings.warn(msg, DeblendWarning)
 
     if relabel:
         relabel_map = _create_relabel_map(segm_deblended, start_label=1)
@@ -343,9 +337,12 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
     segm_img = SegmentationImage._from_data(
         segm_deblended, deblend_label_map=deblend_label_map)
 
-    # Store any warnings in the info attribute
-    if warning_info:
-        segm_img.info['warnings'] = warning_info
+    # Store the input labels affected by deblending mode fallbacks in
+    # the info attribute
+    if nonposmin_labels:
+        segm_img.info['nonposmin_labels'] = np.array(nonposmin_labels)
+    if n_markers_labels:
+        segm_img.info['n_markers_labels'] = np.array(n_markers_labels)
 
     return segm_img
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -138,7 +138,10 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
     segment_image : `~photutils.segmentation.SegmentationImage`
         A segmentation image, with the same shape as ``data``, where
         sources are marked by different positive integer values. A value
-        of zero is reserved for the background.
+        of zero is reserved for the background. The ``info`` attribute
+        of the returned segmentation image is a dictionary that contains
+        a ``'warnings'`` key if any deblending warnings occurred. It is
+        empty otherwise.
 
     See Also
     --------
@@ -326,13 +329,12 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
             deblend_label_map = _update_deblend_label_map(deblend_label_map,
                                                           relabel_map)
 
-    segm_img = object.__new__(SegmentationImage)
-    segm_img._data = segm_deblended
-    segm_img._deblend_label_map = deblend_label_map
+    segm_img = SegmentationImage._from_data(
+        segm_deblended, deblend_label_map=deblend_label_map)
 
-    # Store the warnings in the output SegmentationImage info attribute
+    # Store any warnings in the info attribute
     if warning_info:
-        segm_img.info = {'warnings': warning_info}
+        segm_img.info['warnings'] = warning_info
 
     return segm_img
 

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -159,6 +159,14 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         msg = 'segmentation_image must have the same shape as data'
         raise ValueError(msg)
 
+    if segmentation_image.n_labels == 0:
+        msg = 'segmentation_image must have at least one non-zero label'
+        raise ValueError(msg)
+
+    if (n_pixels <= 0) or (int(n_pixels) != n_pixels):
+        msg = f'n_pixels must be a positive integer, got {n_pixels!r}'
+        raise ValueError(msg)
+
     if n_levels < 1:
         msg = 'n_levels must be >= 1'
         raise ValueError(msg)
@@ -166,12 +174,15 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         msg = 'contrast must be >= 0 and <= 1'
         raise ValueError(msg)
 
-    if contrast == 1:  # no deblending
-        return segmentation_image.copy()
-
     if mode not in ('exponential', 'linear', 'sinh'):
         msg = "mode must be 'exponential', 'linear', or 'sinh'"
         raise ValueError(msg)
+
+    if contrast == 1:  # no deblending
+        segm_img = segmentation_image.copy()
+        if relabel:
+            segm_img.relabel_consecutive()
+        return segm_img
 
     if labels is None:
         labels = segmentation_image.labels

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -252,12 +252,8 @@ def _detect_sources(data, threshold, n_pixels, footprint, inverse_mask, *,
         labels = segm_labels
 
     if return_segmimg:
-        segm = object.__new__(SegmentationImage)
-        segm._data = segment_img
-        segm.__dict__['labels'] = labels
-        segm.__dict__['slices'] = segm_slices
-        segm.__dict__['_deblend_label_map'] = {}
-        return segm
+        return SegmentationImage._from_data(segment_img, labels=labels,
+                                            slices=segm_slices)
 
     # This is used by deblend_sources
     if len(labels) == 1:

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -173,7 +173,7 @@ def _detect_sources(data, threshold, n_pixels, footprint, inverse_mask, *,
     footprint : array_like
         A footprint that defines feature connections. As an example,
         for connectivity along pixel edges only, the footprint is
-        ``np.array([[0, 1, 0]], [1, 1, 1], [0, 1, 0]])``.
+        ``np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])``.
 
     inverse_mask : 2D bool `~numpy.ndarray`
         A boolean mask, with the same shape as the input ``data``, where
@@ -386,7 +386,7 @@ def detect_sources(data, threshold, n_pixels, *, connectivity=8, mask=None):
 
     if segm is None:
         msg = ('No sources were found. Try lowering the threshold or '
-               'pixels parameters.')
+               'n_pixels parameters.')
         warnings.warn(msg, NoDetectionsWarning)
 
     return segm

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -689,6 +689,37 @@ class TestSourceCatalog:
         with pytest.raises(ValueError, match=match):
             SourceCatalog(self.data, self.segm, detection_catalog=cat)
 
+    def test_detection_catalog_segment_flux_localbkg(self):
+        """
+        Test that the segment_flux local-background subtraction uses
+        the measurement catalog's unmasked pixel count when a detection
+        catalog with a different mask is input.
+
+        Regression test for a bug where the local background was
+        multiplied by the detection catalog's "area" property, which
+        counts pixels that are masked (and thus not summed) in the
+        measurement catalog.
+        """
+        yy, xx = np.mgrid[0:101, 0:101]
+        g1 = Gaussian2D(100, 50, 50, 5, 5)
+        data = g1(xx, yy)
+        segm = detect_sources(data, 10.0, n_pixels=5)
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[48:52, 48:52] = True
+
+        det_cat = SourceCatalog(data, segm, local_bkg_width=4)
+        meas_cat = SourceCatalog(data + 3.0, segm, mask=mask,
+                                 local_bkg_width=4,
+                                 detection_catalog=det_cat)
+
+        # The detection-catalog area includes the masked pixels
+        n_pixels = len(meas_cat._data_values[0])
+        assert meas_cat.area.value[0] > n_pixels
+
+        localbkg = meas_cat._local_background[0]
+        expected = np.sum(meas_cat._data_values[0]) - n_pixels * localbkg
+        assert_allclose(meas_cat.segment_flux[0], expected)
+
     def test_kron_minradius(self):
         """
         Test kron minradius.

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1071,6 +1071,9 @@ class TestSourceCatalog:
         with pytest.raises(ValueError, match=match):
             # Built-in cached property
             cat.add_property('area', segment_snr)
+        with pytest.raises(ValueError, match=match):
+            # Built-in method; must raise even with overwrite=True
+            cat.add_property('to_table', segment_snr, overwrite=True)
 
         cat.add_property('segment_snr', segment_snr)
 
@@ -1191,16 +1194,6 @@ class TestSourceCatalog:
         cat2 = SourceCatalog(self.data, self.segm)
         result1 = self.cat._cached_properties
         result2 = cat2._cached_properties
-        assert result1 is result2
-
-    def test_properties_class_cache(self):
-        """
-        Test that _properties is cached on the class and shared across
-        instances.
-        """
-        cat2 = SourceCatalog(self.data, self.segm)
-        result1 = self.cat._properties
-        result2 = cat2._properties
         assert result1 is result2
 
     def test_copy(self):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -3,6 +3,8 @@
 Tests for the catalog module.
 """
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 from unittest.mock import patch
 
@@ -1408,6 +1410,97 @@ class TestSourceCatalog:
         assert_allclose(cat[1].covariance,
                         [(np.nan, np.nan), (np.nan, np.nan)] * u.pix**2)
         assert_allclose(cat.fwhm, [0.67977799, np.nan] * u.pix)
+
+
+class TestThreadSafety:
+    """
+    Thread-safety tests for the SourceCatalog class.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        yy, xx = np.mgrid[0:101, 0:101]
+        g1 = Gaussian2D(100, 50, 50, 5, 5)
+        g2 = Gaussian2D(80, 30, 30, 4, 4)
+        g3 = Gaussian2D(60, 70, 30, 3, 3)
+        self.data = g1(xx, yy) + g2(xx, yy) + g3(xx, yy)
+        self.segm = detect_sources(self.data, 10.0, n_pixels=5)
+
+    def test_concurrent_cached_property_access(self):
+        """
+        Test concurrent first access of cached properties on a shared
+        catalog.
+
+        cached_property does not lock, so concurrent first accesses may
+        run a getter more than once, but every thread must see values
+        identical to the serial computation.
+        """
+        expected = SourceCatalog(self.data, self.segm)
+        cat = SourceCatalog(self.data, self.segm)
+
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+
+        def worker(_):
+            barrier.wait()
+            return (cat.segment_flux, cat.centroid, cat.kron_flux)
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(worker, range(n_threads)))
+
+        for segment_flux, centroid, kron_flux in results:
+            assert_equal(segment_flux, expected.segment_flux)
+            assert_equal(centroid, expected.centroid)
+            assert_equal(kron_flux, expected.kron_flux)
+
+    def test_concurrent_flux_radius(self):
+        """
+        Test concurrent first flux_radius calls on a shared catalog.
+
+        The _flux_radius_cache dict uses an unlocked check-then-set, so
+        concurrent first calls may compute more than once, but every
+        thread must see values identical to the serial computation.
+        """
+        expected = SourceCatalog(self.data, self.segm).flux_radius(0.5)
+        cat = SourceCatalog(self.data, self.segm)
+
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+
+        def worker(_):
+            barrier.wait()
+            return cat.flux_radius(0.5)
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(worker, range(n_threads)))
+
+        for radius in results:
+            assert_allclose(radius.value, expected.value)
+
+    def test_concurrent_slice_add_property(self):
+        """
+        Test that threads slicing a shared catalog and adding custom
+        properties to their own slices do not interfere with each other
+        or with the parent catalog.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+
+        def worker(index):
+            barrier.wait()
+            obj = cat[index % cat.n_labels]
+            obj.add_property(f'prop{index}', float(index))
+            return obj
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(worker, range(n_threads)))
+
+        assert cat.custom_properties == []
+        for index, obj in enumerate(results):
+            assert obj.custom_properties == [f'prop{index}']
+            assert getattr(obj, f'prop{index}') == float(index)
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -481,6 +481,10 @@ class TestSourceCatalog:
         with pytest.raises(ValueError, match=match):
             SourceCatalog(self.data, self.segm, background=wrong_shape)
 
+        match = 'background must be a 2D array'
+        with pytest.raises(ValueError, match=match):
+            SourceCatalog(self.data, self.segm, background=5.1)
+
         match = 'data and mask must have the same shape'
         with pytest.raises(ValueError, match=match):
             SourceCatalog(self.data, self.segm, mask=wrong_shape)

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1082,6 +1082,40 @@ class TestSourceCatalog:
         cat.add_property('segment_snr4', segment_snr, overwrite=True)
         cat.add_property('segment_snr4', segment_snr, overwrite=True)
 
+    def test_sliced_catalog_state_isolation(self):
+        """
+        Test that a sliced catalog does not share mutable state with its
+        parent catalog.
+
+        Regression test for a bug where ``__getitem__`` copied the
+        ``_custom_properties`` list (and other mutable containers) by
+        reference, so adding a custom property to a slice polluted the
+        parent's ``custom_properties`` list, breaking ``add_property``
+        and ``to_table`` on the parent for that name.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        obj = cat[0]
+        obj.add_property('foo', 1.0)
+        assert 'foo' in obj.custom_properties
+        assert 'foo' not in cat.custom_properties
+
+        # The parent must still be able to add and use the same name
+        cat.add_property('foo', np.arange(cat.n_labels))
+        tbl = cat.to_table(columns='foo')
+        assert_equal(tbl['foo'], np.arange(cat.n_labels))
+
+        # Parent additions must not leak into existing slices
+        cat.add_property('bar', np.arange(cat.n_labels))
+        assert 'bar' not in obj.custom_properties
+
+        # Other mutable containers must also be isolated
+        obj.meta['extra'] = 1
+        assert 'extra' not in cat.meta
+        obj.default_columns.append('foo')
+        assert 'foo' not in cat.default_columns
+        obj._aperture_mask_kwargs['circ']['method'] = 'center'
+        assert cat._aperture_mask_kwargs['circ']['method'] == 'exact'
+
     def test_custom_properties_invalid(self):
         """
         Test custom properties invalid.

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -111,6 +111,18 @@ class TestSegmentationImage:
         segm.data = self.data[0:3, :].copy()
         assert_equal(segm.labels, [1, 3, 4])
 
+    def test_info(self):
+        """
+        Test that the info attribute always exists and is reset when the
+        data attribute is reassigned.
+        """
+        segm = SegmentationImage(self.data.copy())
+        assert segm.info == {}
+
+        segm.info['key'] = 'value'
+        segm.data = self.data[0:3, :].copy()
+        assert segm.info == {}
+
     def test_invalid_data(self):
         """
         Test invalid data.
@@ -1020,7 +1032,8 @@ def test_subclass(segm_data):
                       [70, 70, 0, 0],
                       [70, 70, 0, 1]])
     segm.data = data2
-    assert len(segm.__dict__) == 3
+    # Only _data, labels, _deblend_label_map, and info should remain
+    assert len(segm.__dict__) == 4
     assert_equal(segm.areas, [1, 2, 2, 4])
 
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -159,8 +159,10 @@ class TestSegmentationImage:
     def test_invalid_label_array(self):
         """
         Test invalid label array.
+
+        The message must show plain integers, not numpy scalar reprs.
         """
-        match = 'are invalid'
+        match = r'labels \[-1, 0, 2\] are invalid'
         with pytest.raises(ValueError, match=match):
             self.segm.check_labels([0, -1, 2])
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -611,6 +611,18 @@ class TestSegmentationImage:
         with pytest.raises(ValueError, match=match):
             segm.remove_border_labels(border_width=3)
 
+    @pytest.mark.parametrize('border_width', [0, -1])
+    def test_remove_border_labels_nonpositive_border_width(self,
+                                                           border_width):
+        """
+        Test that remove_border_labels raises for non-positive border
+        widths instead of removing every label.
+        """
+        segm = SegmentationImage(self.data.copy())
+        match = 'border_width must be a positive integer'
+        with pytest.raises(ValueError, match=match):
+            segm.remove_border_labels(border_width=border_width)
+
     def test_remove_border_labels_no_remaining_segments(self):
         """
         Test remove border labels no remaining segments.

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -4,7 +4,9 @@ Tests for the core module.
 """
 
 import sys
+import threading
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from functools import cached_property
 from unittest.mock import PropertyMock, patch
 
@@ -1732,6 +1734,72 @@ class TestGetRegion:
         regions = self.segm.to_regions()
         for region in regions:
             assert not region.visual
+
+
+class TestThreadSafety:
+    """
+    Thread-safety tests for the SegmentationImage class.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, segm_data):
+        self.data = segm_data
+
+    def test_concurrent_cached_property_access(self):
+        """
+        Test concurrent first access of cached properties on a shared
+        segmentation image.
+
+        cached_property does not lock, so concurrent first accesses may
+        run a getter more than once, but every thread must see values
+        identical to the serial computation.
+        """
+        expected = SegmentationImage(self.data.copy())
+        segm = SegmentationImage(self.data.copy())
+
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+
+        def worker(_):
+            barrier.wait()
+            return (segm.labels, segm.areas, segm.slices,
+                    segm.missing_labels)
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(worker, range(n_threads)))
+
+        for labels, areas, slices, missing_labels in results:
+            assert_equal(labels, expected.labels)
+            assert_equal(areas, expected.areas)
+            assert slices == expected.slices
+            assert_equal(missing_labels, expected.missing_labels)
+
+    def test_concurrent_cached_properties_introspection(self):
+        """
+        Test concurrent first access of the class-level
+        _cached_properties introspection cache on a fresh subclass.
+
+        The lazy class-level cache is written without a lock; the race
+        is benign because the computed list is identical for every
+        thread.
+        """
+        class FreshSegm(SegmentationImage):
+            pass
+
+        segms = [FreshSegm(self.data.copy()) for _ in range(8)]
+
+        n_threads = len(segms)
+        barrier = threading.Barrier(n_threads)
+
+        def worker(segm):
+            barrier.wait()
+            return segm._cached_properties
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(worker, segms))
+
+        assert all(result == results[0] for result in results)
+        assert 'areas' in results[0]
 
 
 def test_segment_deprecations(segm_data):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -1225,6 +1225,34 @@ def test_imshow_map_cbar_labelsize(segm_data):
     _im, cbar_info = segm.imshow_map(cbar_labelsize=8)
     assert cbar_info is not None
 
+    _cbar, ticks, labels = cbar_info
+    assert_equal(labels, [0, 1, 3, 4, 5, 7])
+    assert_equal(ticks, np.arange(len(labels)))
+
+
+@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+def test_imshow_map_no_background():
+    """
+    Test imshow_map colorbar labels for a segmentation image with no
+    background (zero) pixels.
+
+    Regression test for a bug where 0 was unconditionally prepended to
+    the colorbar tick labels, shifting every label by one position when
+    the segmentation image contained no background pixels.
+    """
+    data = np.array([[1, 1, 2, 2],
+                     [1, 1, 2, 2],
+                     [5, 5, 9, 9],
+                     [5, 5, 9, 9]])
+    segm = SegmentationImage(data)
+    im, cbar_info = segm.imshow_map()
+    assert cbar_info is not None
+
+    _cbar, ticks, labels = cbar_info
+    assert_equal(labels, [1, 2, 5, 9])
+    assert_equal(ticks, np.arange(len(labels)))
+    assert np.max(np.asarray(im.get_array())) == len(labels) - 1
+
 
 class TestGetSegment:
     """

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -16,6 +16,7 @@ from photutils.segmentation import (SegmentationImage, deblend_sources,
 from photutils.segmentation.deblend import (_DeblendParams,
                                             _SingleSourceDeblender)
 from photutils.utils._optional_deps import HAS_SKIMAGE
+from photutils.utils.exceptions import DeblendWarning
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
@@ -345,10 +346,11 @@ class TestDeblendSources:
         data = self.data.copy()
         data -= 20
         match = 'The deblending mode of one or more source labels from the'
-        with pytest.warns(AstropyUserWarning, match=match):
+        with pytest.warns(DeblendWarning, match=match):
             segm = deblend_sources(data, self.segm, self.n_pixels,
                                    progress_bar=False)
-        assert segm.info['warnings']['nonposmin']['input_labels'] == 1
+        assert list(segm.info) == ['nonposmin_labels']
+        assert_equal(segm.info['nonposmin_labels'], [1])
 
     def test_source_zero_min(self):
         """
@@ -357,10 +359,10 @@ class TestDeblendSources:
         data = self.data.copy()
         data -= data[self.segm.data > 0].min()
         match = 'The deblending mode of one or more source labels from the'
-        with pytest.warns(AstropyUserWarning, match=match):
+        with pytest.warns(DeblendWarning, match=match):
             segm = deblend_sources(data, self.segm, self.n_pixels,
                                    progress_bar=False)
-        assert segm.info['warnings']['nonposmin']['input_labels'] == 1
+        assert_equal(segm.info['nonposmin_labels'], [1])
 
     def test_connectivity(self):
         """
@@ -507,11 +509,9 @@ def test_n_markers_fallback():
 
     segm = detect_sources(data, 0.01, 10)
     match = 'The deblending mode of one or more source labels from the'
-    with pytest.warns(AstropyUserWarning, match=match):
+    with pytest.warns(DeblendWarning, match=match):
         segm2 = deblend_sources(data, segm, 1, mode='exponential')
-    assert segm2.info['warnings']['n_markers']['input_labels'][0] == 1
-    mesg = segm2.info['warnings']['n_markers']['message']
-    assert mesg.startswith('Deblending mode changed')
+    assert segm2.info['n_markers_labels'][0] == 1
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
@@ -536,18 +536,21 @@ def test_n_markers_fallback_multiproc():
 
     segm = detect_sources(data, 0.01, 10)
     match = 'The deblending mode of one or more source labels from the'
-    with pytest.warns(AstropyUserWarning, match=match):
+    with pytest.warns(DeblendWarning, match=match):
         segm2 = deblend_sources(data, segm, 1, mode='exponential',
                                 n_processes=2)
-    assert segm2.info['warnings']['n_markers']['input_labels'][0] == 1
+    assert segm2.info['n_markers_labels'][0] == 1
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_nonposmin_multiproc():
     """
     Test nonposmin warning via multiprocessing (n_processes=2).
+
     This covers the multiprocessing result-processing block for
-    nonposmin.
+    nonposmin. The warning is caught as an AstropyUserWarning to check
+    that DeblendWarning is a subclass of it, so existing warning filters
+    continue to work.
     """
     g1 = Gaussian2D(100, 50, 50, 8, 8)
     g2 = Gaussian2D(100, 35, 50, 8, 8)
@@ -559,7 +562,7 @@ def test_nonposmin_multiproc():
     with pytest.warns(AstropyUserWarning, match=match):
         segm2 = deblend_sources(data, segm, 5, progress_bar=False,
                                 n_processes=2)
-    assert 'nonposmin' in segm2.info['warnings']
+    assert 'nonposmin_labels' in segm2.info
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -421,6 +421,19 @@ class TestDeblendSources:
         markers = single_debl.make_markers(return_all=True)
         assert len(markers) == 19
 
+    def test_info_empty_without_warnings(self):
+        """
+        Test that the returned segmentation image always has an info
+        attribute, which is an empty dict when no deblending warnings
+        occurred.
+        """
+        result = deblend_sources(self.data, self.segm, self.n_pixels,
+                                 progress_bar=False)
+        assert result.info == {}
+
+        # detect_sources output must also have an info attribute
+        assert self.segm.info == {}
+
     def test_deblend_progress_bar(self):
         """
         Test deblend_sources with progress_bar=True (serial).

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -257,6 +257,41 @@ class TestDeblendSources:
             deblend_sources(self.data, segm_wrong, self.n_pixels,
                             progress_bar=False)
 
+    @pytest.mark.parametrize('relabel', [False, True])
+    def test_contrast_one_relabel(self, relabel):
+        """
+        Test that contrast=1 (no deblending) honors the relabel keyword
+        for non-consecutive input labels.
+        """
+        segm = self.segm.copy()
+        segm.reassign_label(1, 1000)
+        result = deblend_sources(self.data, segm, self.n_pixels,
+                                 contrast=1, relabel=relabel,
+                                 progress_bar=False)
+        expected = [1] if relabel else [1000]
+        assert_equal(result.labels, expected)
+
+    def test_empty_segmentation_image(self):
+        """
+        Test that a segmentation image with no non-zero labels raises a
+        ValueError.
+        """
+        segm = SegmentationImage(np.zeros(self.data.shape, dtype=int))
+        match = 'segmentation_image must have at least one non-zero label'
+        with pytest.raises(ValueError, match=match):
+            deblend_sources(self.data, segm, self.n_pixels,
+                            progress_bar=False)
+
+    @pytest.mark.parametrize('n_pixels', [0, -5, 2.5])
+    def test_invalid_n_pixels(self, n_pixels):
+        """
+        Test that invalid n_pixels values raise a ValueError.
+        """
+        match = 'n_pixels must be a positive integer'
+        with pytest.raises(ValueError, match=match):
+            deblend_sources(self.data, self.segm, n_pixels,
+                            progress_bar=False)
+
     def test_invalid_n_levels(self):
         """
         Test invalid n_levels.

--- a/photutils/utils/exceptions.py
+++ b/photutils/utils/exceptions.py
@@ -3,12 +3,19 @@
 Custom exceptions.
 """
 
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyUserWarning, AstropyWarning
 
-__all__ = ['NoDetectionsWarning']
+__all__ = ['DeblendWarning', 'NoDetectionsWarning']
 
 
 class NoDetectionsWarning(AstropyWarning):
     """
     A warning class to indicate no sources were detected.
+    """
+
+
+class DeblendWarning(AstropyUserWarning):
+    """
+    A warning class to indicate issues encountered while deblending
+    sources.
     """


### PR DESCRIPTION
This PR collects a set of bug fixes, API improvements, and test/benchmark
additions for the segmentation subpackage.

### Bug Fixes

- `SegmentationImage.remove_border_labels` now raises a `ValueError` for
  non-positive `border_width` values. Previously, `border_width=0` (and
  negative widths) silently removed every label.
- `SourceCatalog` slicing no longer shares mutable state (the
  custom-properties list, `meta`, etc.) with the parent catalog.
- `SourceCatalog.segment_flux` local-background subtraction now uses the
  number of unmasked pixels actually summed. Previously, with a
  `detection_catalog` input and a different mask, the background was
  oversubtracted.
- `deblend_sources` with `contrast=1` (no deblending) now honors
  `relabel=True`, relabeling non-consecutive input labels like every
  other code path.
- `SourceCatalog.add_property` now raises a `ValueError` when the name
  would clobber a built-in method (e.g., `to_table`).
- Fixed `SegmentationImage.imshow_map` colorbar labels when the image
  contains no background pixels.

### New Features / API Changes

- `SegmentationImage` objects now always have an `info` attribute.
  Segmentation images returned by `deblend_sources` store the input
  labels affected by deblending warnings under `'nonposmin_labels'` and
  `'n_markers_labels'` keys, replacing the nested `info['warnings']`
  dictionary.
- Added a new `DeblendWarning` class (subclass of astropy's
  `AstropyUserWarning`), raised by `deblend_sources` when the deblending
  mode falls back to "linear" for one or more sources.
- `deblend_sources` inputs are now validated.