### PR TITLE
Merge ApertureStats sum_flags into a single flags property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,12 +95,13 @@ New Features
 
   - Added per-source bitwise quality flags to aperture photometry and
     statistics. The ``AperturePhotometry`` and ``ApertureStats``
-    classes provide a ``flags`` attribute (and a ``'flags'`` column,
-    or ``'flags_<i>'`` columns for multiple apertures, in their
-    default ``to_table()`` output), and ``ApertureStats`` also
-    provides a ``sum_flags`` attribute for the sum properties. A new
-    ``decode_aperture_flags`` function decodes the flag values into
-    human-readable names. [#2327, #2328, #2362]
+    classes provide a ``flags`` attribute (and a ``'flags'`` column, or
+    ``'flags_<i>'`` columns for multiple apertures, in their default
+    ``to_table()`` output). The ``ApertureStats.flags`` property reports
+    conditions from both the "center"-method footprint used by the
+    value statistics and the ``sum_method`` footprint used by the sum
+    properties. A new ``decode_aperture_flags`` function decodes the
+    flag values into human-readable names. [#2327, #2328, #2362, #2379]
 
   - Added validation of the ``ApertureStats.to_table()`` ``columns``
     keyword. [#2329]
@@ -500,8 +501,8 @@ API Changes
     will be removed in version 4.0. Use the new ``AperturePhotometry``
     class instead. [#2324, #2328]
 
-  - The default ``ApertureStats.to_table()`` columns now include
-    ``'flags'`` and ``'sum_flags'`` columns. [#2327]
+  - The default ``ApertureStats.to_table()`` columns now include a
+    ``'flags'`` column. [#2327, #2379]
 
   - The ``ApertureStats.ids`` attribute is now deprecated and will
     be removed in version 4.0. Use the ``ApertureStats.id`` attribute

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -753,28 +753,23 @@ method::
     ['partial_overlap']
     ['no_overlap', 'no_pixels']
 
-For `~photutils.aperture.ApertureStats`, the value statistics
-and the sum properties are measured on two different
-footprints, so they have separate flag columns. The
-:attr:`~photutils.aperture.ApertureStats.flags` property reports the
-flags for the value statistics (e.g., ``mean``, ``median``, ``std``),
-evaluated on the ``'center'``-method footprint, and includes the
-``'sigma_clipped'``, ``'all_clipped'``, and ``'too_few_pixels'`` flags.
-The :attr:`~photutils.aperture.ApertureStats.sum_flags` property
-reports the flags for the sum properties (``sum``, ``sum_err``, and
-``sum_aper_area``), evaluated on the ``sum_method`` footprint, and
-includes the ``'non_finite_error'`` flag. Only ``flags`` reports whether
-clipping occurred (via the ``'sigma_clipped'``, ``'all_clipped'``, and
-``'too_few_pixels'`` bits). ``sum_flags`` never sets those bits, even
-though the sum-related properties are computed from the sigma-clipped
-``sum_method`` footprint.
-
-Both columns are included in the default ``to_table()``
-output, and either can be decoded by passing
-``column='flags'`` (the default) or ``column='sum_flags'`` to
-:meth:`~photutils.aperture.ApertureStats.decode_flags`. To check for
-any quality issue across both footprints, combine the two flag columns
-with a bitwise OR, e.g., ``aperstats.flags | aperstats.sum_flags``.
+For `~photutils.aperture.ApertureStats`, the value statistics and
+the sum properties are measured on two different footprints, and
+the single :attr:`~photutils.aperture.ApertureStats.flags` property
+reports the quality conditions from both. The footprint-based flags
+(e.g., ``'masked_pixels'``, ``'non_finite_data'``, and the overlap
+flags) are evaluated on the union of the ``'center'``-method footprint
+used by the value statistics (e.g., ``mean``, ``median``, ``std``)
+and the ``sum_method`` footprint used by the sum properties (``sum``,
+``sum_err``, and ``sum_aper_area``). The ``'non_finite_error'``
+flag is evaluated on the ``sum_method`` footprint, while the
+``'sigma_clipped'``, ``'all_clipped'``, and ``'too_few_pixels'``
+flags are evaluated on the value-statistics footprint. The
+``'undefined_shape'`` and ``'singular_covariance'`` flags are always
+evaluated. Accessing ``flags`` computes the sum, moment, and covariance
+quantities if they have not already been computed (the results are
+cached and shared with the corresponding properties), so the flag values
+never depend on which properties were accessed first.
 
 Because non-finite values are automatically masked in
 both :class:`~photutils.aperture.AperturePhotometry` and
@@ -844,7 +839,7 @@ annulus aperture to estimate the local background level. Sigma clipping
 is applied independently on the "center" and ``sum_method`` footprints
 described above, so the sum-related properties are also computed from
 sigma-clipped data; see :ref:`aperture_flags` for how this affects the
-``flags`` and ``sum_flags`` properties.
+``flags`` property.
 
 Here is a simple example using a circular aperture at one position.
 Note that like :class:`~photutils.aperture.AperturePhotometry`,

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -428,15 +428,14 @@ Aperture Photometry Quality Flags
 Aperture photometry and statistics now provide
 per-source bitwise quality flags, unified across
 the `~photutils.aperture.AperturePhotometry` and
-`~photutils.aperture.ApertureStats` classes. (e.g., new
-:attr:`~photutils.aperture.ApertureStats.flags` and
-:attr:`~photutils.aperture.ApertureStats.sum_flags` properties,
+`~photutils.aperture.ApertureStats` classes (e.g., a new
+:attr:`~photutils.aperture.ApertureStats.flags` property,
 included in the default ``to_table()`` columns). In
-`~photutils.aperture.ApertureStats`, ``flags`` reports the flags for the
-value statistics (the ``'center'``-method footprint) and ``sum_flags``
-reports the flags for the sum properties (the ``sum_method`` footprint).
-A flag value of 0 means that no issues were detected. The flags indicate
-conditions such as:
+`~photutils.aperture.ApertureStats`, ``flags`` reports conditions from
+both the ``'center'``-method footprint used by the value statistics and
+the ``sum_method`` footprint used by the sum properties. A flag value of
+0 means that no issues were detected. The flags indicate conditions such
+as:
 
 * the aperture is partially (``'partial_overlap'``) or fully
   (``'no_overlap'``) outside the data

--- a/photutils/aperture/flags.py
+++ b/photutils/aperture/flags.py
@@ -159,12 +159,8 @@ class _ApertureFlags(FlagRegistry):
                                   'not positive, so the centroid and '
                                   'the covariance-derived shape '
                                   'properties (e.g., ``centroid``, '
-                                  '``semimajor_axis``, '
-                                  '``orientation``) are undefined or '
-                                  'unreliable. This is a stats-only '
-                                  'flag that is set only when a '
-                                  'moment-derived property has been '
-                                  'computed.'),
+                                  '``semimajor_axis``, ``orientation``)'
+                                  ' are undefined or unreliable.'),
         ),
         FlagDefinition(
             bit_value=8192,
@@ -176,13 +172,10 @@ class _ApertureFlags(FlagRegistry):
                                   '``1/12``, the variance of a uniform '
                                   'distribution across a single pixel), '
                                   'so covariance-derived shape '
-                                  'properties (e.g., '
-                                  '``semimajor_axis``, ``orientation``, '
-                                  '``eccentricity``) are ill-defined '
-                                  'and have been regularized or set to '
-                                  'NaN. This is a stats-only flag that '
-                                  'is set only when a covariance-derived '
-                                  'property has been computed.'),
+                                  'properties (e.g., ``semimajor_axis``, '
+                                  '``orientation``, ``eccentricity``) are '
+                                  'ill-defined and have been regularized '
+                                  'or set to NaN.'),
         ),
     ]
 

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -131,26 +131,6 @@ _SCALAR_EXCLUDE = frozenset({'default_columns', 'isscalar', 'labels',
                              'segmentation_image'})
 
 
-class _UncachedProperty(cached_property):
-    """
-    A property that is discovered as a source property (like
-    `functools.cached_property`) but is recomputed on every access
-    instead of being cached.
-
-    This is used for `ApertureStats.flags`, whose value can change
-    over the object's lifetime. It reflects whether covariance-derived
-    properties have been computed (see `ApertureStats.flags`). Caching
-    would freeze the first-computed value, so the getter runs on every
-    access. Subclassing `functools.cached_property` keeps it in the
-    `ApertureStats.properties` list and the ``to_table`` machinery.
-    """
-
-    def __get__(self, obj, owner=None):
-        if obj is None:
-            return self
-        return self.func(obj)
-
-
 @_update_method_subpixels_docstring
 class ApertureStats:
     # numpydoc ignore: PR01,PR02,PR04,PR07
@@ -308,11 +288,9 @@ class ApertureStats:
     of ``sum_method``. The default is ``sum_method='exact'``, which
     produces exact aperture-weighted photometry.
 
-    The sum-related properties have their own separate `sum_flags`
-    quality flags, distinct from the `flags` property used by all
-    other properties. To check for any quality issue across both
-    footprints, combine the two flag columns with a bitwise OR, e.g.,
-    ``aperstats.flags | aperstats.sum_flags``.
+    The `flags` property reports quality conditions from both the
+    "center"-method footprint and the ``sum_method`` footprint (see the
+    `flags` docstring for the per-bit details).
 
     The calculated statistics are always float64, regardless of the
     input ``data`` dtype (`~astropy.units.Quantity` values with float64
@@ -358,8 +336,7 @@ class ApertureStats:
     # footprint (set by the ``sum_method``/``subpixels`` keywords).
     # All other properties use the "center" aperture-mask method.
     SUM_FOOTPRINT_PROPERTIES = ('sum', 'sum_err', 'sum_aper_area',
-                                'data_sum_cutout', 'error_sum_cutout',
-                                'sum_flags')
+                                'data_sum_cutout', 'error_sum_cutout')
 
     # Cached properties that are not per-source sliceable: the packed
     # gather buffers and their reductions. ``__getitem__`` drops these
@@ -451,11 +428,11 @@ class ApertureStats:
         self._ids = np.arange(self.n_positions) + 1
         self.default_columns = ['id', 'x_centroid', 'y_centroid',
                                 'sky_centroid', 'sum', 'sum_err',
-                                'sum_aper_area', 'sum_flags',
-                                'center_aper_area', 'min', 'max', 'mean',
-                                'median', 'mode', 'std', 'mad_std', 'var',
-                                'biweight_location', 'biweight_midvariance',
-                                'fwhm', 'semimajor_axis', 'semiminor_axis',
+                                'sum_aper_area', 'center_aper_area',
+                                'min', 'max', 'mean', 'median', 'mode',
+                                'std', 'mad_std', 'var', 'biweight_location',
+                                'biweight_midvariance', 'fwhm',
+                                'semimajor_axis', 'semiminor_axis',
                                 'orientation', 'eccentricity', 'flags']
 
         self.meta = _get_meta()
@@ -827,35 +804,19 @@ class ApertureStats:
 
         tbl.meta.update(self.meta)  # keep tbl.meta type
 
-        # Evaluate the flag columns last (while preserving the
-        # requested column order in the output table). The ``flags``
-        # column reports the ``'singular_covariance'`` bit only if a
-        # covariance-derived shape property has already been computed
-        # (see `flags`). Evaluating the flag columns after all other
-        # columns ensures that any shape columns present in the same
-        # table are computed first, so the table's ``flags`` column
-        # consistently reflects the other columns it is shown alongside.
-        flag_columns = {'flags', 'sum_flags'}
-        eval_order = ([col for col in table_columns
-                       if col not in flag_columns]
-                      + [col for col in table_columns if col in flag_columns])
-        values_map = {}
-        for column in eval_order:
+        for column in table_columns:
             values = getattr(self, column)
 
             # Column assignment requires an object with a length
             if self.isscalar:
                 values = (values,)
 
-            values_map[column] = values
-
-        for column in table_columns:
             # Use the canonical (non-deprecated) column name so that
             # assigning into ``tbl`` does not trigger a second,
             # redundant deprecation warning (the deprecated attribute
             # access above already warned once).
             canonical_column = _DEPRECATED_ATTRIBUTES.get(column, column)
-            tbl[canonical_column] = values_map[column]
+            tbl[canonical_column] = values
         return tbl
 
     @cached_property
@@ -2063,16 +2024,15 @@ class ApertureStats:
         """
         The count-based value-statistics flag bits (1D int array).
 
-        These are the flag bits that do not depend on any lazily
-        computed moment or covariance property: the "center"-method
-        footprint bits plus the sigma-clip and ``ddof`` bits. The
-        ``undefined_shape`` and ``singular_covariance`` bits are
-        folded in by the `flags` property only if a moment-derived or
-        covariance-derived property, respectively, has been computed.
+        These are the "center"-method footprint bits plus the sigma-clip
+        and ``ddof`` bits. The `flags` property combines them with the
+        ``sum_method`` footprint bits and the ``undefined_shape`` and
+        ``singular_covariance`` bits.
         """
         # The gather kernel and the center-method cutouts do not
-        # evaluate error values, so the non-finite-error bit is defined
-        # by the sum footprint only (see `sum_flags`).
+        # evaluate error values, so the non-finite-error bit is stripped
+        # here. `flags` picks it up from the sum footprint, the only
+        # footprint where error values are evaluated.
         flags = (self._footprint_flags('center')
                  & ~APERTURE_FLAGS.NON_FINITE_ERROR)
 
@@ -2150,91 +2110,50 @@ class ApertureStats:
         finite = np.isfinite(covar_det) & np.isfinite(min_eigval)
         return finite & ((covar_det < delta**2) | (min_eigval < delta))
 
-    @_UncachedProperty
+    @cached_property
     @_update_method_subpixels_docstring
     def flags(self):
         # numpydoc ignore: RT01
         """
-        The bitwise quality flags for the value statistics.
+        The bitwise quality flags.
 
-        The flags are evaluated on the "center"-method footprint used
-        by the value statistics (e.g., ``mean``, ``median``, ``std``).
-        The sum properties (``sum``, ``sum_err``, and ``sum_aper_area``)
-        have their own separate `sum_flags`. The ``'sigma_clipped'``,
+        The footprint-based flags (e.g., ``'masked_pixels'``,
+        ``'non_finite_data'``, and the overlap flags) are evaluated
+        on the union of the "center"-method footprint used by the
+        value statistics and the ``sum_method`` footprint used by the
+        sum properties. The ``'non_finite_error'`` flag is evaluated
+        on the ``sum_method`` footprint. The ``'sigma_clipped'``,
         ``'all_clipped'``, and ``'too_few_pixels'`` flags are evaluated
-        on this footprint. To check for any quality issue across both
-        footprints, combine the two flag columns with a bitwise OR
-        (e.g., ``flags | sum_flags``).
-
-        The ``'undefined_shape'`` and ``'singular_covariance'`` bits
-        are special. They report conditions that are only knowable
-        once a moment-derived property (e.g., ``centroid``) or a
-        covariance-derived shape property (e.g., ``semimajor_axis``,
-        ``orientation``, ``eccentricity``) has been computed. To avoid
-        forcing those computations, each bit is included only if such a
-        property has already been evaluated on this object. Otherwise
-        it is omitted. This means the value of ``flags`` reflects the
-        measurements requested so far, so accessing a shape property and
-        then re-reading ``flags`` may set additional bits. The default
-        `to_table` always evaluates the moment and shape properties, so
-        its ``flags`` column always reflects both bits.
+        on the value-statistics footprint. The ``'undefined_shape'`` and
+        ``'singular_covariance'`` flags are always evaluated. Accessing
+        ``flags`` computes the moment and covariance properties if they
+        have not already been computed (the results are cached and
+        shared with the corresponding shape properties).
 
         See `~photutils.aperture.decode_aperture_flags` for decoding
         flag values. The flags are:
 
         <flag_descriptions>
         """
-        # A fresh array is returned on every access (never mutating the
-        # cached `_base_flags`), so concurrent readers and previously
-        # returned arrays are never modified in place.
-        flags = self._base_flags.copy()
-        if 'moments' in self.__dict__:
-            flags[self._undefined_shape_mask] |= (
-                APERTURE_FLAGS.UNDEFINED_SHAPE)
-        if '_covariance' in self.__dict__:
-            flags[self._singular_covariance_mask] |= (
-                APERTURE_FLAGS.SINGULAR_COVARIANCE)
+        # The | allocates a new array, so the in-place |= below never
+        # mutates the cached `_base_flags`
+        flags = self._base_flags | self._footprint_flags('sum')
+        flags[self._undefined_shape_mask] |= (
+            APERTURE_FLAGS.UNDEFINED_SHAPE)
+        flags[self._singular_covariance_mask] |= (
+            APERTURE_FLAGS.SINGULAR_COVARIANCE)
         return flags
 
-    @cached_property
-    @_update_method_subpixels_docstring
-    def sum_flags(self):
-        # numpydoc ignore: RT01
-        """
-        The bitwise quality flags for the sum properties.
-
-        The flags are evaluated on the ``sum_method`` footprint
-        used by the sum properties (``sum``, ``sum_err``, and
-        ``sum_aper_area``). The value statistics have their own separate
-        `flags`. The ``'non_finite_error'`` flag is evaluated on this
-        footprint. The ``'sigma_clipped'``, ``'all_clipped'``, and
-        ``'too_few_pixels'`` flags apply only to the value statistics
-        and are never set here. To check for any quality issue across
-        both footprints, combine the two flag columns with a bitwise OR
-        (e.g., ``flags | sum_flags``).
-
-        See `~photutils.aperture.decode_aperture_flags` for decoding
-        flag values. The flags are:
-
-        <flag_descriptions>
-        """
-        return self._footprint_flags('sum')
-
-    def decode_flags(self, *, column='flags', return_bit_values=False):
+    def decode_flags(self, *, return_bit_values=False):
         """
         Decode the source quality flags into individual components.
 
         This is a convenience method that calls
-        `~photutils.aperture.decode_aperture_flags` with the `flags` or
-        `sum_flags` property.
+        `~photutils.aperture.decode_aperture_flags` with the `flags`
+        property.
 
         Parameters
         ----------
-        column : {'flags', 'sum_flags'}, optional
-            Which quality flags to decode: ``'flags'`` for the value
-            statistics (default) or ``'sum_flags'`` for the sum
-            properties.
-
         return_bit_values : bool, optional
             If `True`, return the decoded bit flags (integers) instead
             of the flag names (strings).
@@ -2263,11 +2182,7 @@ class ApertureStats:
         ['masked_pixels']
         ['partial_overlap']
         """
-        if column not in ('flags', 'sum_flags'):
-            msg = "column must be 'flags' or 'sum_flags'"
-            raise ValueError(msg)
-
-        return decode_aperture_flags(self._array(column),
+        return decode_aperture_flags(self._array('flags'),
                                      return_bit_values=return_bit_values)
 
     def _get_values(self, array):

--- a/photutils/aperture/tests/test_batch_thread_safety.py
+++ b/photutils/aperture/tests/test_batch_thread_safety.py
@@ -261,7 +261,7 @@ class TestApertureStatsThreadSafety:
 
         def read():
             return {name: np.asarray(getattr(stats, name))
-                    for name in (*_STATS_PROPERTIES, 'sum_flags')}
+                    for name in (*_STATS_PROPERTIES, 'flags')}
 
         with ThreadPoolExecutor(max_workers=N_THREADS) as ex:
             futures = [ex.submit(read)

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -820,7 +820,7 @@ class TestReadOnlyInputs:
                               mask_method='correct')
         for attr in ('sum', 'sum_err', 'mean', 'median', 'std', 'mad_std',
                      'biweight_location', 'gini', 'centroid',
-                     'semimajor_axis', 'fwhm', 'flags', 'sum_flags'):
+                     'semimajor_axis', 'fwhm', 'flags'):
             _ = getattr(stats, attr)
         assert np.isfinite(stats.mean)
         _ = stats.to_table()

--- a/photutils/aperture/tests/test_photometry_flags.py
+++ b/photutils/aperture/tests/test_photometry_flags.py
@@ -197,7 +197,6 @@ class TestPolygonOverlapFlags:
         assert result.flags == 0
         stats = ApertureStats(data, aper, sum_method=method,
                               subpixels=subpixels)
-        assert stats.sum_flags == 0
         assert stats.flags == 0
 
     @pytest.mark.parametrize(('method', 'subpixels'), METHODS)
@@ -218,7 +217,7 @@ class TestPolygonOverlapFlags:
         assert result.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
         stats = ApertureStats(data, aper, sum_method=method,
                               subpixels=subpixels)
-        assert stats.sum_flags == APERTURE_FLAGS.PARTIAL_OVERLAP
+        assert stats.flags == APERTURE_FLAGS.PARTIAL_OVERLAP
 
 
 class TestMaskedAndNonFiniteFlags:

--- a/photutils/aperture/tests/test_stats.py
+++ b/photutils/aperture/tests/test_stats.py
@@ -230,7 +230,7 @@ class TestSumMethod(BaseApertureStatsData):
         for prop in apstats1.properties:
             if prop in scalar_props:
                 continue
-            if 'sum' in prop and prop != 'sum_flags':
+            if 'sum' in prop:
                 # The sum-footprint properties must differ between the
                 # two sum methods
                 equal = True
@@ -310,7 +310,7 @@ class TestMasking(BaseApertureStatsData):
         assert apstats[1].sum_err < self.apstats1[1].sum_err
 
         exclude = ('isscalar', 'n_positions', 'sky_centroid',
-                   'sky_centroid_icrs', 'flags', 'sum_flags')
+                   'sky_centroid_icrs', 'flags')
         apstats1 = apstats[2]
         for prop in apstats1.properties:
             if (prop in exclude or 'bbox' in prop or 'cutout' in prop
@@ -391,7 +391,7 @@ class TestMasking(BaseApertureStatsData):
         assert_equal(apstats._overlap, [True, True, False])
 
         exclude = ('isscalar', 'n_positions', 'sky_centroid',
-                   'sky_centroid_icrs', 'flags', 'sum_flags')
+                   'sky_centroid_icrs', 'flags')
         apstats1 = apstats[2]
         for prop in apstats1.properties:
             if (prop in exclude or 'bbox' in prop or 'cutout' in prop
@@ -1443,7 +1443,7 @@ class TestNThreads:
                   'mask_method': 'mask'}
         stats1 = ApertureStats(data, aper, **kwargs)
         stats2 = ApertureStats(data, aper, n_threads=3, **kwargs)
-        for prop in ('sum', 'mean', 'median', 'flags', 'sum_flags'):
+        for prop in ('sum', 'mean', 'median', 'flags'):
             assert_equal(getattr(stats1, prop), getattr(stats2, prop))
 
     def test_more_threads_than_positions(self):

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -221,10 +221,10 @@ class TestSigmaClipFlags:
         flags = _stats_flags(data, aper, sigma_clip=sigclip)
         assert flags == APERTURE_FLAGS.SIGMA_CLIPPED
 
-        # Without clipping, the sigma_clipped flag is not set (the
-        # unclipped outlier makes the source point-like, so the
-        # always-evaluated singular_covariance bit may be set)
-        assert not _stats_flags(data, aper) & APERTURE_FLAGS.SIGMA_CLIPPED
+        # Without clipping, the sigma_clipped flag is not set. The
+        # unclipped outlier dominates the moments, making the source
+        # point-like, so the singular_covariance bit is set instead.
+        assert _stats_flags(data, aper) == APERTURE_FLAGS.SINGULAR_COVARIANCE
 
     def test_all_clipped(self, unit_data):
         """

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -145,24 +145,21 @@ class TestMaskedAndNonFiniteFlags:
             APERTURE_FLAGS.MASKED_PIXELS | APERTURE_FLAGS.ALL_MASKED)
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_sum_footprint_only(self, unit_data, unit_mask):
+    def test_sum_footprint_masked(self, unit_data, unit_mask):
         """
         Test that a masked boundary pixel touched only by the exact-method
         sum footprint (its center lies exactly on the aperture boundary)
-        sets masked_pixels in sum_flags but not in the value-statistics
-        flags.
+        sets masked_pixels in the merged flags.
         """
         data = unit_data
         aper = CircularAperture((12, 12), r=3.0)
         mask = unit_mask
         mask[15, 12] = True  # center at distance exactly 3.0 (boundary)
         stats = ApertureStats(data, aper, mask=mask)
-        assert stats.sum_flags == APERTURE_FLAGS.MASKED_PIXELS
-        # The pixel is excluded from the center (value-statistics) footprint
-        assert stats.flags == 0
+        assert stats.flags == APERTURE_FLAGS.MASKED_PIXELS
+        # With sum_method='center' both footprints exclude the pixel
         stats = ApertureStats(data, aper, mask=mask, sum_method='center')
         assert stats.flags == 0
-        assert stats.sum_flags == 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
     def test_non_finite_data(self, unit_mask):
@@ -202,11 +199,8 @@ class TestMaskedAndNonFiniteFlags:
         error[12, 12] = np.nan
         aper = CircularAperture((12, 12), r=3.0)
         stats = ApertureStats(data, aper, error=error)
-        # non_finite_error is a sum-footprint flag, not a value-statistics
-        # flag, so it appears in sum_flags but not flags
-        assert stats.sum_flags == APERTURE_FLAGS.NON_FINITE_ERROR
-        assert stats.flags == 0
-        assert ApertureStats(data, aper).sum_flags == 0
+        assert stats.flags == APERTURE_FLAGS.NON_FINITE_ERROR
+        assert ApertureStats(data, aper).flags == 0
 
 
 class TestSigmaClipFlags:
@@ -227,12 +221,10 @@ class TestSigmaClipFlags:
         flags = _stats_flags(data, aper, sigma_clip=sigclip)
         assert flags == APERTURE_FLAGS.SIGMA_CLIPPED
 
-        # Sigma-clip flags apply only to the value statistics, not sum_flags
-        stats = ApertureStats(data, aper, sigma_clip=sigclip)
-        assert not stats.sum_flags & APERTURE_FLAGS.SIGMA_CLIPPED
-
-        # Without clipping, no flag is set
-        assert _stats_flags(data, aper) == 0
+        # Without clipping, the sigma_clipped flag is not set (the
+        # unclipped outlier makes the source point-like, so the
+        # always-evaluated singular_covariance bit may be set)
+        assert not _stats_flags(data, aper) & APERTURE_FLAGS.SIGMA_CLIPPED
 
     def test_all_clipped(self, unit_data):
         """
@@ -343,7 +335,6 @@ class TestMaskPathParity:
                 slow = ApertureStats(data, aper, **kwargs)
                 assert slow._batch_inputs is None
                 assert_array_equal(fast.flags, slow.flags)
-                assert_array_equal(fast.sum_flags, slow.sum_flags)
 
 
 class TestFlagsAPI:
@@ -360,13 +351,31 @@ class TestFlagsAPI:
         aper = CircularAperture([(12, 12), (-50, 12)], r=3.0)
         stats = ApertureStats(data, aper)
         assert 'flags' in stats.properties
-        assert 'sum_flags' in stats.properties
+        assert 'sum_flags' not in stats.properties
         tbl = stats.to_table()
         assert 'flags' in tbl.colnames
-        assert 'sum_flags' in tbl.colnames
+        assert 'sum_flags' not in tbl.colnames
         expected = [0, APERTURE_FLAGS.NO_OVERLAP | APERTURE_FLAGS.NO_PIXELS]
         assert_array_equal(tbl['flags'], expected)
-        assert_array_equal(tbl['sum_flags'], expected)
+
+    def test_flags_deterministic(self, unit_data, unit_mask):
+        """
+        Test that flags is stable regardless of property access order
+        and includes the shape bits without prior shape access.
+        """
+        data = unit_data.copy()
+        data[12, 12] = -100.0  # non-positive net flux for source 1
+        mask = unit_mask
+        mask[18, 18] = True
+        aper = CircularAperture([(12.0, 12.0), (18.0, 18.0)], r=3.0)
+        stats = ApertureStats(data, aper, mask=mask)
+        flags1 = stats.flags.copy()
+        assert (flags1[0] & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
+        assert (flags1[1] & APERTURE_FLAGS.MASKED_PIXELS) != 0
+        _ = stats.semimajor_axis
+        _ = stats.eccentricity
+        _ = stats.sum
+        assert_array_equal(stats.flags, flags1)
 
     def test_flags_slicing(self, unit_data, unit_mask):
         """
@@ -401,65 +410,48 @@ class TestFlagsAPI:
         assert decoded == [[APERTURE_FLAGS.MASKED_PIXELS],
                            [APERTURE_FLAGS.PARTIAL_OVERLAP]]
 
-        # Decode the sum flags via the column keyword
-        decoded = stats.decode_flags(column='sum_flags')
-        assert decoded == [['masked_pixels'], ['partial_overlap']]
-
-        match = "column must be 'flags' or 'sum_flags'"
-        with pytest.raises(ValueError, match=match):
-            stats.decode_flags(column='invalid')
-
         # Scalar ApertureStats also returns a list of lists
         stats = ApertureStats(data, CircularAperture((0.0, 12.0), r=3.0))
         assert stats.decode_flags() == [['partial_overlap']]
-        assert stats.decode_flags(column='sum_flags') == [['partial_overlap']]
+
+    def test_decode_flags_no_column_keyword(self, unit_data):
+        """
+        Test that decode_flags no longer accepts a column keyword.
+        """
+        data = unit_data
+        aper = CircularAperture((12.0, 12.0), r=3.0)
+        stats = ApertureStats(data, aper)
+        match = 'unexpected keyword'
+        with pytest.raises(TypeError, match=match):
+            stats.decode_flags(column='flags')
+        assert stats.decode_flags() == [[]]
 
     def test_flags_docstring(self):
         """
         Test that the flags docstring placeholder was substituted.
         """
-        for prop in (ApertureStats.flags, ApertureStats.sum_flags):
-            docstring = prop.__doc__
-            assert '<flag_descriptions>' not in docstring
-            assert "**1** (``'no_overlap'``)" in docstring
+        docstring = ApertureStats.flags.__doc__
+        assert '<flag_descriptions>' not in docstring
+        assert "**1** (``'no_overlap'``)" in docstring
 
 
 class TestSingularCovariance:
     """
-    Tests for the singular_covariance flag, which is set only once a
-    covariance-derived shape property has been computed.
+    Tests for the singular_covariance flag, which is always evaluated
+    by the flags property.
     """
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_requires_shape(self):
+    def test_set_without_shape_access(self):
         """
-        Test that the singular_covariance bit is not set until a
-        covariance-derived property is accessed.
+        Test that the singular_covariance bit is set without any prior
+        covariance-derived property access.
         """
         data = _single_pixel_data()
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
-
-        # Not set before any covariance-derived property is accessed
-        assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
-        assert 'singular_covariance' not in stats.decode_flags()[0]
-
-        # Accessing a shape property makes a reread include the bit
-        _ = stats.semimajor_axis
         assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
         assert 'singular_covariance' in stats.decode_flags()[0]
-
-    @pytest.mark.usefixtures('maybe_mask_path')
-    def test_triggered_by_covariance(self):
-        """
-        Test that the singular_covariance bit is set when the covariance
-        matrix is computed, even if no shape properties are accessed.
-        """
-        data = _single_pixel_data()
-        aper = CircularAperture((12.0, 12.0), r=5.0)
-        stats = ApertureStats(data, aper)
-        _ = stats.covariance
-        assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
     def test_array_and_guards(self):
@@ -476,7 +468,6 @@ class TestSingularCovariance:
         aper = CircularAperture([(6.0, 6.0), (18.0, 18.0), (-50.0, 12.0)],
                                 r=4.0)
         stats = ApertureStats(data, aper)
-        _ = stats.semimajor_axis  # force the covariance computation
         flags = stats.flags
         covar_flag = APERTURE_FLAGS.SINGULAR_COVARIANCE
         assert (flags[0] & covar_flag) != 0  # singular point source
@@ -494,7 +485,6 @@ class TestSingularCovariance:
         data = 100.0 * np.exp(-((xx - 12)**2 + (yy - 12)**2) / (2 * 3.0**2))
         aper = CircularAperture((12.0, 12.0), r=6.0)
         stats = ApertureStats(data, aper)
-        _ = stats.semimajor_axis
         assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
@@ -510,31 +500,16 @@ class TestSingularCovariance:
         assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_to_table_evaluates_flags_last(self):
+    def test_to_table_flags_only(self):
         """
-        Test that requesting a shape column before 'flags' still yields a
-        flags column that reflects the singular_covariance bit.
-        """
-        data = _single_pixel_data()
-        aper = CircularAperture((12.0, 12.0), r=5.0)
-        stats = ApertureStats(data, aper)
-        columns = ['flags', 'semimajor_axis']
-        tbl = stats.to_table(columns=columns)
-        assert tbl.colnames == columns  # check order
-        assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
-
-    @pytest.mark.usefixtures('maybe_mask_path')
-    def test_to_table_flags_only_no_singular_bit(self):
-        """
-        Test that requesting only the 'flags' column does not trigger the
-        covariance computation and so does not set the singular_covariance
-        bit.
+        Test that requesting only the 'flags' column reports the
+        singular_covariance bit.
         """
         data = _single_pixel_data()
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
         tbl = stats.to_table(columns=['flags'])
-        assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) == 0
+        assert (tbl['flags'][0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
     def test_in_properties(self):
@@ -557,7 +532,6 @@ class TestSingularCovariance:
         data[6, 6] = 100.0
         aper = CircularAperture([(6.0, 6.0), (12.0, 12.0)], r=4.0)
         stats = ApertureStats(data, aper)
-        _ = stats.semimajor_axis
         covar_flag = APERTURE_FLAGS.SINGULAR_COVARIANCE
         assert (stats[0].flags & covar_flag) != 0
         assert (stats[1].flags & covar_flag) != 0
@@ -581,9 +555,6 @@ class TestSingularCovariance:
         assert delta**2 < 0.5 * 0.05  # determinant test alone would miss it
         assert delta > 0.05  # minor-axis variance below the floor
         assert stats._singular_covariance_mask[0]
-
-        # The bit is reflected in flags once a shape property is computed
-        _ = stats.semimajor_axis
         assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
 
     def test_not_positive_semidefinite(self):
@@ -595,37 +566,27 @@ class TestSingularCovariance:
                                                 cov_xy=2.0)
         assert (1.0 * 1.0 - 2.0**2) < 0  # negative determinant
         assert stats._singular_covariance_mask[0]
-
-        _ = stats.semimajor_axis
         assert (stats.flags[0] & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
 
 
 class TestUndefinedShape:
     """
     Tests for the undefined_shape flag, which marks sources whose net
-    flux is not positive and is set only once a moment-derived property
-    has been computed.
+    flux is not positive and is always evaluated by the flags property.
     """
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_requires_moments(self):
+    def test_set_without_moment_access(self):
         """
-        Test that the undefined_shape bit is not set until a
-        moment-derived property is accessed.
+        Test that the undefined_shape bit is set without any prior
+        moment-derived property access.
         """
         data = np.zeros(UNIT_SHAPE)
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
-
-        # Not set before any moment-derived property is accessed
-        assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) == 0
-        assert 'undefined_shape' not in stats.decode_flags()[0]
-
-        # Accessing the centroid makes a reread include the bit
-        _ = stats.centroid
-        assert np.all(np.isnan(stats.centroid))
         assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
         assert 'undefined_shape' in stats.decode_flags()[0]
+        assert np.all(np.isnan(stats.centroid))
 
     @pytest.mark.usefixtures('maybe_mask_path')
     @pytest.mark.parametrize('value', [0.0, -1.0])
@@ -637,7 +598,6 @@ class TestUndefinedShape:
         data = np.full(UNIT_SHAPE, value)
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
-        _ = stats.centroid
         assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
@@ -648,7 +608,6 @@ class TestUndefinedShape:
         data = np.ones(UNIT_SHAPE)
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
-        _ = stats.centroid
         assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) == 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
@@ -666,7 +625,6 @@ class TestUndefinedShape:
         aper = CircularAperture([(6.0, 18.0), (18.0, 18.0), (6.0, 6.0),
                                  (-50.0, 12.0)], r=4.0)
         stats = ApertureStats(data, aper, mask=mask)
-        _ = stats.centroid
         flags = stats.flags
         shape_flag = APERTURE_FLAGS.UNDEFINED_SHAPE
         assert (flags[0] & shape_flag) != 0  # zero-flux source
@@ -689,17 +647,16 @@ class TestUndefinedShape:
         assert (tbl['flags'][0] & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
-    def test_to_table_flags_only_no_shape_bit(self):
+    def test_to_table_flags_only(self):
         """
-        Test that requesting only the 'flags' column does not trigger
-        the moments computation and so does not set the undefined_shape
-        bit.
+        Test that requesting only the 'flags' column reports the
+        undefined_shape bit.
         """
         data = np.zeros(UNIT_SHAPE)
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
         tbl = stats.to_table(columns=['flags'])
-        assert (tbl['flags'][0] & APERTURE_FLAGS.UNDEFINED_SHAPE) == 0
+        assert (tbl['flags'][0] & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
 
     @pytest.mark.usefixtures('maybe_mask_path')
     def test_slicing(self):
@@ -711,7 +668,6 @@ class TestUndefinedShape:
         data[18, 18] = 100.0
         aper = CircularAperture([(6.0, 6.0), (18.0, 18.0)], r=4.0)
         stats = ApertureStats(data, aper)
-        _ = stats.centroid
         shape_flag = APERTURE_FLAGS.UNDEFINED_SHAPE
         assert (stats[0].flags & shape_flag) != 0
         assert (stats[1].flags & shape_flag) == 0
@@ -726,7 +682,6 @@ class TestUndefinedShape:
         data[12, 12] = -100.0
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
-        _ = stats.semimajor_axis
         flags = stats.flags
         assert (flags & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
         assert (flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0


### PR DESCRIPTION
This PR removes `ApertureStats.sum_flags` and makes `flags` a single deterministic, cached property that reports every flag condition.

The merged semantics are:

- The footprint-based flags (masked, non-finite data, and overlap
  bits) are the union (bitwise OR) of the "center"-method footprint
  used by the value statistics and the `sum_method` footprint used by
  the sum properties.
- `non_finite_error` is evaluated on the `sum_method` footprint (the
  only footprint where error values are evaluated); `sigma_clipped`,
  `all_clipped`, and `too_few_pixels` on the value-statistics
  footprint, as before.
- `undefined_shape` and `singular_covariance` are now always
  evaluated. Accessing `flags` computes the moment and covariance
  quantities if needed (cached and shared with the shape properties),
  so the flag values never depend on property access order.