### PR TITLE
Refactor SegmentationImage to a single data write path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -643,6 +643,11 @@ API Changes
     ``AstropyUserWarning``) instead of an ``AstropyUserWarning``.
     [#2378]
 
+  - ``SegmentationImage`` now requires a 2D input array. Previously,
+    arrays of other dimensions were accepted and raised a
+    ``ValueError`` only when the ``bbox`` attribute was accessed.
+    [#XXXX]
+
 - ``photutils.utils``
 
   - The ``ShepardIDWInterpolator`` ``ncoords`` attribute has been

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -648,6 +648,9 @@ API Changes
     ``ValueError`` only when the ``bbox`` attribute was accessed.
     [#XXXX]
 
+  - ``SegmentationImage`` now raises a ``TypeError`` for masked array
+    input. [#2381]
+
 - ``photutils.utils``
 
   - The ``ShepardIDWInterpolator`` ``ncoords`` attribute has been

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -643,11 +643,6 @@ API Changes
     ``AstropyUserWarning``) instead of an ``AstropyUserWarning``.
     [#2378]
 
-  - ``SegmentationImage`` now requires a 2D input array. Previously,
-    arrays of other dimensions were accepted and raised a
-    ``ValueError`` only when the ``bbox`` attribute was accessed.
-    [#XXXX]
-
   - ``SegmentationImage`` now raises a ``TypeError`` for masked array
     input. [#2381]
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -39,6 +39,33 @@ _SEGMENT_DEPRECATED_ATTRIBUTES = {
 }
 
 
+def _get_labels(array, *, return_counts=False):
+    """
+    Return the sorted non-zero values in ``array``.
+
+    Parameters
+    ----------
+    array : `~numpy.ndarray`
+        An array of label values. It may have any shape (e.g., a full
+        segmentation array or already-extracted values).
+
+    return_counts : bool, optional
+        If `True`, also return the number of occurrences of each
+        label.
+
+    Returns
+    -------
+    labels : `~numpy.ndarray`
+        The sorted non-zero label values. `numpy.unique` preserves the
+        input dtype.
+
+    counts : `~numpy.ndarray`, optional
+        The number of occurrences of each label, in the same order as
+        ``labels``. Only returned if ``return_counts`` is `True`.
+    """
+    return np.unique(array[array != 0], return_counts=return_counts)
+
+
 class SegmentationImage:
     """
     Class for a segmentation image.
@@ -346,9 +373,8 @@ class SegmentationImage:
             raise TypeError(msg)
 
         # A single pass over the non-zero pixels yields both the
-        # sorted labels and their pixel areas. np.unique preserves
-        # dtype and also sorts elements.
-        labels, areas = np.unique(value[value != 0], return_counts=True)
+        # sorted labels and their pixel areas
+        labels, areas = _get_labels(value, return_counts=True)
 
         # labels is sorted, so only the first element can be negative.
         # The size check also covers all-zero and zero-size arrays.
@@ -379,9 +405,8 @@ class SegmentationImage:
         The sorted non-zero labels in the segmentation array.
         """
         # Normally seeded by _set_data. This runs only when the array
-        # was set without known labels. np.unique preserves dtype and
-        # also sorts elements.
-        return np.unique(self._data[self._data != 0])
+        # was set without known labels.
+        return _get_labels(self._data)
 
     @cached_property
     def n_labels(self):
@@ -506,11 +531,10 @@ class SegmentationImage:
         returned array has a length equal to the number of labels and
         matches the order of the ``labels`` attribute.
         """
-        # Normally seeded by _set_data from the same np.unique pass
-        # that produces the labels. This runs only when the array was
-        # set without known areas.
-        data = self._data
-        return np.unique(data[data != 0], return_counts=True)[1]
+        # Normally seeded by _set_data from the same single pass that
+        # produces the labels. This runs only when the array was set
+        # without known areas.
+        return _get_labels(self._data, return_counts=True)[1]
 
     def get_area(self, label):
         """
@@ -1500,12 +1524,9 @@ class SegmentationImage:
         if mask.shape != self.shape:
             msg = 'mask must have the same shape as the segmentation array'
             raise ValueError(msg)
-        masked_data = self.data[mask]
-        remove_labels = np.unique(masked_data[masked_data != 0])
+        remove_labels = _get_labels(self.data[mask])
         if not partial_overlap:
-            interior_data = self.data[~mask]
-            interior_labels = np.unique(
-                interior_data[interior_data != 0])
+            interior_labels = _get_labels(self.data[~mask])
             remove_labels = list(set(remove_labels)
                                  - set(interior_labels))
         self.remove_labels(remove_labels, relabel=relabel)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -77,10 +77,9 @@ class SegmentationImage:
             msg = 'Input data must be a numpy array'
             raise TypeError(msg)
         self.data = data
-        self._deblend_label_map = {}  # set by source deblender
 
     @classmethod
-    def _from_data(cls, data, *, labels=None, slices=None,
+    def _from_data(cls, data, *, labels=None, areas=None, slices=None,
                    deblend_label_map=None):
         """
         Create a `SegmentationImage` from a pre-validated segmentation
@@ -101,6 +100,10 @@ class SegmentationImage:
             The sorted non-zero labels in ``data``, used to seed the
             ``labels`` cached property.
 
+        areas : `~numpy.ndarray`, optional
+            The pixel area of each label, in the same order as
+            ``labels``, used to seed the ``areas`` cached property.
+
         slices : list of tuple of slice, optional
             The slices for each label, used to seed the ``slices``
             cached property. The list order must match ``labels``.
@@ -115,14 +118,9 @@ class SegmentationImage:
             The new `SegmentationImage` instance.
         """
         segm = object.__new__(cls)
-        segm._data = data
-        if labels is not None:
-            segm.__dict__['labels'] = labels
-        if slices is not None:
-            segm.__dict__['slices'] = slices
-        segm._deblend_label_map = ({} if deblend_label_map is None
-                                   else deblend_label_map)
-        segm.info = {}
+        segm._set_data(data, labels=labels, areas=areas, slices=slices)
+        if deblend_label_map is not None:
+            segm._deblend_label_map = deblend_label_map
         return segm
 
     def __str__(self):
@@ -300,6 +298,57 @@ class SegmentationImage:
         for key in self._cached_properties:
             self.__dict__.pop(key, None)
 
+    def _set_data(self, data, *, labels=None, areas=None, slices=None):
+        """
+        Set the segmentation array and seed its derived properties.
+
+        This is the only method that assigns the ``_data`` attribute.
+        It performs no validation. The caller is responsible for
+        passing a valid 2D integer segmentation array.
+
+        Any derived value that is not supplied is computed on first
+        access. Supplied values are trusted and are not checked against
+        ``data``.
+
+        Parameters
+        ----------
+        data : 2D int `~numpy.ndarray`
+            The valid 2D segmentation array.
+
+        labels : 1D int `~numpy.ndarray`, optional
+            The sorted non-zero labels in ``data``.
+
+        areas : 1D int `~numpy.ndarray`, optional
+            The pixel area of each label, in the same order as
+            ``labels``.
+
+        slices : list of tuple of slice, optional
+            The minimal bounding slices of each label, in the same
+            order as ``labels``.
+        """
+        if '_data' in self.__dict__:
+            # Reset cached properties when data is reassigned, but not
+            # on init
+            self._reset_cached_properties()
+
+        # Bypass __setattr__, which rejects direct _data assignment
+        object.__setattr__(self, '_data', data)
+
+        # Seed the known derived values. functools.cached_property
+        # reads the instance dictionary first, so a seeded entry is
+        # returned as-is and an absent one falls through to the
+        # property body.
+        for name, value in (('labels', labels), ('areas', areas),
+                            ('slices', slices)):
+            if value is not None:
+                self.__dict__[name] = value
+
+        # Reset deblended labels and auxiliary info explicitly since
+        # _deblend_label_map and info are regular attributes, not
+        # cached properties cleared by _reset_cached_properties above.
+        self.__dict__['_deblend_label_map'] = {}
+        self.__dict__['info'] = {}
+
     @data.setter
     def data(self, value):
         if not np.issubdtype(value.dtype, np.integer):
@@ -311,18 +360,7 @@ class SegmentationImage:
             msg = 'The segmentation image cannot contain negative integers.'
             raise ValueError(msg)
 
-        if '_data' in self.__dict__:
-            # Reset cached properties when data is reassigned, but not on init
-            self._reset_cached_properties()
-
-        self._data = value  # pylint: disable=attribute-defined-outside-init
-        self.__dict__['labels'] = labels
-
-        # Reset deblended labels and auxiliary info explicitly since
-        # _deblend_label_map and info are regular attributes, not cached
-        # properties cleared by _reset_cached_properties above.
-        self.__dict__['_deblend_label_map'] = {}
-        self.__dict__['info'] = {}
+        self._set_data(value, labels=labels)
 
     @cached_property
     def data_masked(self):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -156,6 +156,20 @@ class SegmentationImage:
         msg = f'{key!r} is not a valid 2D slice object'
         raise TypeError(msg)
 
+    def __setattr__(self, name, value):
+        """
+        Set an attribute.
+
+        The segmentation array is write protected because the derived
+        cached properties must be reset whenever it changes. Use the
+        ``data`` attribute or :meth:`_set_data` instead.
+        """
+        if name == '_data':
+            msg = ('Direct assignment to _data is not allowed. Assign '
+                   'to the data attribute or call _set_data()')
+            raise AttributeError(msg)
+        super().__setattr__(name, value)
+
     def __array__(self):
         """
         Array representation of the segmentation array (e.g., for

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -464,15 +464,20 @@ class SegmentationImage:
         """
         Find the index of the input ``label``.
 
+        Array input is also accepted, in which case an array of
+        indices is returned. :meth:`get_indices` delegates to this
+        method.
+
         Parameters
         ----------
-        label : int
-            The label number to find.
+        label : int or 1D array_like (int)
+            The label number(s) to find.
 
         Returns
         -------
-        index : int
-            The array index.
+        index : int or 1D int `~numpy.ndarray`
+            The array index or indices. If ``label`` is a scalar, then
+            the returned index will also be a scalar.
 
         Raises
         ------

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -448,19 +448,6 @@ class SegmentationImage:
         return np.searchsorted(self.labels, labels)
 
     @cached_property
-    def _raw_slices(self):
-        """
-        A list of tuples, where each tuple contains two slices representing
-        the minimal box that contains the labeled region.
-
-        The list starts with the *non-zero* label. The returned list has
-        a length equal to the maximum label number and is indexed by
-        (label - 1). If a label is missing, then the corresponding list
-        element will be `None` instead of a slice.
-        """
-        return find_objects(self.data)
-
-    @cached_property
     def slices(self):
         """
         A list of tuples, where each tuple contains two slices
@@ -470,7 +457,29 @@ class SegmentationImage:
         a length equal to the number of labels and matches the order of
         the ``labels`` attribute.
         """
-        return [slc for slc in self._raw_slices if slc is not None]
+        return [slc for slc in find_objects(self._data)
+                if slc is not None]
+
+    def _get_slice(self, label):
+        """
+        Return the bounding slice for a single label.
+
+        The input ``label`` must already be known to be valid. Use
+        :meth:`check_labels` first if that is not guaranteed.
+
+        Parameters
+        ----------
+        label : int
+            The label number.
+
+        Returns
+        -------
+        slc : tuple of slice
+            The minimal bounding slice containing the labeled region.
+        """
+        # self.labels is sorted, so searchsorted gives the position in
+        # the slices list, which matches the labels order
+        return self.slices[np.searchsorted(self.labels, label)]
 
     @cached_property
     def bbox(self):
@@ -608,10 +617,8 @@ class SegmentationImage:
         segment : `Segment`
             The segment object.
         """
-        # _raw_slices is indexed by (label - 1) since it includes all
-        # labels up to max_label, even if some are missing
         label = self._data.dtype.type(label)
-        slc = self._raw_slices[label - 1]
+        slc = self._get_slice(label)
         bbox = BoundingBox(ixmin=slc[1].start, ixmax=slc[1].stop,
                            iymin=slc[0].start, iymax=slc[0].stop)
         area = np.count_nonzero(self._data[slc] == label)
@@ -1782,7 +1789,7 @@ class SegmentationImage:
         """
         labels = np.atleast_1d(labels)
         self.check_labels(labels)
-        return [self._make_polygon(label, self._raw_slices[label - 1])
+        return [self._make_polygon(label, self._get_slice(label))
                 for label in labels]
 
     @staticmethod
@@ -1976,7 +1983,7 @@ class SegmentationImage:
         patch_kwargs.update(kwargs)
         patches = []
         for label in labels:
-            poly = self._make_polygon(label, self._raw_slices[label - 1])
+            poly = self._make_polygon(label, self._get_slice(label))
             patches.append(self._convert_shapely_to_pathpatch(
                 poly, origin=origin, scale=scale, **patch_kwargs))
         return patches
@@ -2212,7 +2219,7 @@ class SegmentationImage:
         visual_kwargs = kwargs or None
         regions = []
         for label in labels:
-            poly = self._make_polygon(label, self._raw_slices[label - 1])
+            poly = self._make_polygon(label, self._get_slice(label))
             regions.append(_shapely_polygon_to_region(
                 poly, label=int(label), visual_kwargs=visual_kwargs))
         return regions

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -398,6 +398,9 @@ class SegmentationImage:
         if not isinstance(value, np.ndarray):
             msg = 'Input data must be a numpy array'
             raise TypeError(msg)
+        if isinstance(value, np.ma.MaskedArray):
+            msg = 'Input data must not be a numpy masked array'
+            raise TypeError(msg)
         if value.ndim != 2:
             msg = 'Input data must be a 2D array'
             raise ValueError(msg)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -166,33 +166,6 @@ class SegmentationImage:
         """
         return self._data
 
-    @staticmethod
-    def _get_labels(data):
-        """
-        Return a sorted array of the non-zero labels in the segmentation
-        image.
-
-        Parameters
-        ----------
-        data : array_like (int)
-            A segmentation array where source regions are labeled by
-            different positive integer values. A value of zero is
-            reserved for the background.
-
-        Returns
-        -------
-        result : `~numpy.ndarray`
-            An array of non-zero label numbers.
-
-        Notes
-        -----
-        This is a static method so it can be used in
-        :meth:`remove_masked_labels` on a masked version of the
-        segmentation array.
-        """
-        # np.unique preserves dtype and also sorts elements
-        return np.unique(data[data != 0])
-
     @cached_property
     def segments(self):
         """
@@ -1498,10 +1471,14 @@ class SegmentationImage:
         if mask.shape != self.shape:
             msg = 'mask must have the same shape as the segmentation array'
             raise ValueError(msg)
-        remove_labels = self._get_labels(self.data[mask])
+        masked_data = self.data[mask]
+        remove_labels = np.unique(masked_data[masked_data != 0])
         if not partial_overlap:
-            interior_labels = self._get_labels(self.data[~mask])
-            remove_labels = list(set(remove_labels) - set(interior_labels))
+            interior_data = self.data[~mask]
+            interior_labels = np.unique(
+                interior_data[interior_data != 0])
+            remove_labels = list(set(remove_labels)
+                                 - set(interior_labels))
         self.remove_labels(remove_labels, relabel=relabel)
 
     def make_source_mask(self, *, size=None, footprint=None):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -855,19 +855,24 @@ class SegmentationImage:
         """
         return self.make_cmap(background_color='#000000ff', seed=0)
 
-    def _update_deblend_label_map(self, relabel_map):
+    def _update_deblend_label_map(self, deblend_label_map, relabel_map):
         """
         Update the deblended label map based on the input
         ``relabel_map``.
 
         Parameters
         ----------
+        deblend_label_map : dict
+            The mapping of parent label numbers to deblended (child)
+            label numbers to update. This is passed explicitly because
+            :meth:`_set_data` resets the instance attribute.
+
         relabel_map : `~numpy.ndarray`
-            An array mapping the original label numbers to the new label
-            numbers.
+            An array mapping the original label numbers to the new
+            label numbers.
         """
         # child_labels are the deblended labels
-        for parent_label, child_labels in self._deblend_label_map.items():
+        for parent_label, child_labels in deblend_label_map.items():
             self._deblend_label_map[parent_label] = relabel_map[child_labels]
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
@@ -1040,9 +1045,11 @@ class SegmentationImage:
                 relabel_map = map2[relabel_map]
 
         data_new = relabel_map[self.data]
-        self._reset_cached_properties()  # reset all cached properties
-        self._data = data_new  # use _data to avoid validation
-        self._update_deblend_label_map(relabel_map)
+        # _set_data rebinds _deblend_label_map to a new dict, so this
+        # local reference still points at the old mapping
+        deblend_label_map = self._deblend_label_map
+        self._set_data(data_new)
+        self._update_deblend_label_map(deblend_label_map, relabel_map)
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def relabel_consecutive(self, start_label=1):
@@ -1089,18 +1096,21 @@ class SegmentationImage:
             return
 
         old_slices = self.__dict__.get('slices', None)
+        old_areas = self.__dict__.get('areas', None)
         dtype = self.data.dtype  # keep the original dtype
         new_labels = np.arange(self.n_labels, dtype=dtype) + start_label
         new_label_map = np.zeros(self.max_label + 1, dtype=dtype)
         new_label_map[self.labels] = new_labels
 
         data_new = new_label_map[self.data]
-        self._reset_cached_properties()  # reset all cached properties
-        self._data = data_new  # use _data to avoid validation
-        self.__dict__['labels'] = new_labels
-        if old_slices is not None:
-            self.__dict__['slices'] = old_slices  # slice order is unchanged
-        self._update_deblend_label_map(new_label_map)
+        # _set_data rebinds _deblend_label_map to a new dict, so this
+        # local reference still points at the old mapping
+        deblend_label_map = self._deblend_label_map
+        # Relabeling is order-preserving, so the areas and slices are
+        # unchanged and carry over under the new label numbers
+        self._set_data(data_new, labels=new_labels, areas=old_areas,
+                       slices=old_slices)
+        self._update_deblend_label_map(deblend_label_map, new_label_map)
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def keep_label(self, label, relabel=False):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -73,9 +73,6 @@ class SegmentationImage:
     """
 
     def __init__(self, data):
-        if not isinstance(data, np.ndarray):
-            msg = 'Input data must be a numpy array'
-            raise TypeError(msg)
         self.data = data
 
     @classmethod
@@ -324,6 +321,12 @@ class SegmentationImage:
 
     @data.setter
     def data(self, value):
+        if not isinstance(value, np.ndarray):
+            msg = 'Input data must be a numpy array'
+            raise TypeError(msg)
+        if value.ndim != 2:
+            msg = 'Input data must be a 2D array'
+            raise ValueError(msg)
         if not np.issubdtype(value.dtype, np.integer):
             msg = 'data must have integer type'
             raise TypeError(msg)
@@ -355,13 +358,6 @@ class SegmentationImage:
         The shape of the segmentation array.
         """
         return self._data.shape
-
-    @cached_property
-    def _ndim(self):
-        """
-        The number of array dimensions of the segmentation array.
-        """
-        return self._data.ndim
 
     @cached_property
     def labels(self):
@@ -468,10 +464,6 @@ class SegmentationImage:
         A list of `~photutils.aperture.BoundingBox` of the minimal
         bounding boxes containing the labeled regions.
         """
-        if self._ndim != 2:
-            msg = "The 'bbox' attribute requires a 2D segmentation image."
-            raise ValueError(msg)
-
         return [BoundingBox(ixmin=slc[1].start, ixmax=slc[1].stop,
                             iymin=slc[0].start, iymax=slc[0].stop)
                 for slc in self.slices]

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -333,7 +333,8 @@ class SegmentationImage:
         for key in self._cached_properties:
             self.__dict__.pop(key, None)
 
-    def _set_data(self, data, *, labels=None, areas=None, slices=None):
+    def _set_data(self, data, *, labels=None, areas=None, slices=None,
+                  preserve_info=False):
         """
         Set the segmentation array and seed its derived properties.
 
@@ -360,6 +361,12 @@ class SegmentationImage:
         slices : list of tuple of slice, optional
             The minimal bounding slices of each label, in the same
             order as ``labels``.
+
+        preserve_info : bool, optional
+            If `True`, keep the current ``info`` dictionary instead of
+            resetting it to an empty one. This is used by the
+            relabeling methods, where the change is an in-place
+            relabeling rather than a data reassignment.
         """
         if '_data' in self.__dict__:
             # Reset cached properties when data is reassigned, but not
@@ -378,11 +385,13 @@ class SegmentationImage:
             if value is not None:
                 self.__dict__[name] = value
 
-        # Reset deblended labels and auxiliary info explicitly since
-        # _deblend_label_map and info are regular attributes, not
-        # cached properties cleared by _reset_cached_properties above.
+        # Reset the deblended label map and auxiliary info explicitly
+        # since _deblend_label_map and info are regular attributes,
+        # not cached properties cleared by _reset_cached_properties
+        # above.
         self.__dict__['_deblend_label_map'] = {}
-        self.__dict__['info'] = {}
+        if not preserve_info:
+            self.__dict__['info'] = {}
 
     @data.setter
     def data(self, value):
@@ -1092,14 +1101,12 @@ class SegmentationImage:
                 relabel_map = map2[relabel_map]
 
         data_new = relabel_map[self.data]
-        # _set_data rebinds _deblend_label_map and info to new dicts,
-        # so these local references still point at the old ones.
         # Relabeling is an in-place change, not a data reassignment,
-        # so the auxiliary info is kept.
+        # so the auxiliary info and the deblending provenance are
+        # kept. The local reference is needed because _set_data
+        # rebinds _deblend_label_map to a new empty dict.
         deblend_label_map = self._deblend_label_map
-        info = self.info
-        self._set_data(data_new)
-        self.__dict__['info'] = info
+        self._set_data(data_new, preserve_info=True)
         self._deblend_label_map = _remap_deblend_label_map(
             deblend_label_map, relabel_map)
 
@@ -1155,17 +1162,15 @@ class SegmentationImage:
         new_label_map[self.labels] = new_labels
 
         data_new = new_label_map[self.data]
-        # _set_data rebinds _deblend_label_map and info to new dicts,
-        # so these local references still point at the old ones.
         # Relabeling is an in-place change, not a data reassignment,
-        # so the auxiliary info is kept.
+        # so the auxiliary info and the deblending provenance are
+        # kept. The local reference is needed because _set_data
+        # rebinds _deblend_label_map to a new empty dict.
         deblend_label_map = self._deblend_label_map
-        info = self.info
         # Relabeling is order-preserving, so the areas and slices are
         # unchanged and carry over under the new label numbers
         self._set_data(data_new, labels=new_labels, areas=old_areas,
-                       slices=old_slices)
-        self.__dict__['info'] = info
+                       slices=old_slices, preserve_info=True)
         self._deblend_label_map = _remap_deblend_label_map(
             deblend_label_map, new_label_map)
 

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -340,7 +340,7 @@ class SegmentationImage:
 
         This is the only method that assigns the ``_data`` attribute.
         It performs no validation. The caller is responsible for
-        passing a valid 2D integer segmentation array.
+        passing a valid integer segmentation array.
 
         Any derived value that is not supplied is computed on first
         access. Supplied values are trusted and are not checked against
@@ -401,9 +401,6 @@ class SegmentationImage:
         if isinstance(value, np.ma.MaskedArray):
             msg = 'Input data must not be a numpy masked array'
             raise TypeError(msg)
-        if value.ndim != 2:
-            msg = 'Input data must be a 2D array'
-            raise ValueError(msg)
         if not np.issubdtype(value.dtype, np.integer):
             msg = 'data must have integer type'
             raise TypeError(msg)
@@ -551,6 +548,10 @@ class SegmentationImage:
         A list of `~photutils.aperture.BoundingBox` of the minimal
         bounding boxes containing the labeled regions.
         """
+        if self._data.ndim != 2:
+            msg = "The 'bbox' attribute requires a 2D segmentation image."
+            raise ValueError(msg)
+
         return [BoundingBox(ixmin=slc[1].start, ixmax=slc[1].stop,
                             iymin=slc[0].start, iymax=slc[0].stop)
                 for slc in self.slices]

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -1064,10 +1064,14 @@ class SegmentationImage:
                 relabel_map = map2[relabel_map]
 
         data_new = relabel_map[self.data]
-        # _set_data rebinds _deblend_label_map to a new dict, so this
-        # local reference still points at the old mapping
+        # _set_data rebinds _deblend_label_map and info to new dicts,
+        # so these local references still point at the old ones.
+        # Relabeling is an in-place change, not a data reassignment,
+        # so the auxiliary info is kept.
         deblend_label_map = self._deblend_label_map
+        info = self.info
         self._set_data(data_new)
+        self.__dict__['info'] = info
         self._update_deblend_label_map(deblend_label_map, relabel_map)
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
@@ -1122,13 +1126,17 @@ class SegmentationImage:
         new_label_map[self.labels] = new_labels
 
         data_new = new_label_map[self.data]
-        # _set_data rebinds _deblend_label_map to a new dict, so this
-        # local reference still points at the old mapping
+        # _set_data rebinds _deblend_label_map and info to new dicts,
+        # so these local references still point at the old ones.
+        # Relabeling is an in-place change, not a data reassignment,
+        # so the auxiliary info is kept.
         deblend_label_map = self._deblend_label_map
+        info = self.info
         # Relabeling is order-preserving, so the areas and slices are
         # unchanged and carry over under the new label numbers
         self._set_data(data_new, labels=new_labels, areas=old_areas,
                        slices=old_slices)
+        self.__dict__['info'] = info
         self._update_deblend_label_map(deblend_label_map, new_label_map)
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -66,6 +66,30 @@ def _get_labels(array, *, return_counts=False):
     return np.unique(array[array != 0], return_counts=return_counts)
 
 
+def _remap_deblend_label_map(deblend_label_map, relabel_map):
+    """
+    Return a new deblend label map with remapped child labels.
+
+    Parameters
+    ----------
+    deblend_label_map : dict
+        The mapping of parent label numbers to arrays of deblended
+        (child) label numbers.
+
+    relabel_map : 1D `~numpy.ndarray`
+        An array mapping the original label numbers to the new label
+        numbers.
+
+    Returns
+    -------
+    result : dict
+        A new mapping with the same parent keys, where each array of
+        child labels has been translated through ``relabel_map``.
+    """
+    return {parent_label: relabel_map[child_labels]
+            for parent_label, child_labels in deblend_label_map.items()}
+
+
 class SegmentationImage:
     """
     Class for a segmentation image.
@@ -898,26 +922,6 @@ class SegmentationImage:
         """
         return self.make_cmap(background_color='#000000ff', seed=0)
 
-    def _update_deblend_label_map(self, deblend_label_map, relabel_map):
-        """
-        Update the deblended label map based on the input
-        ``relabel_map``.
-
-        Parameters
-        ----------
-        deblend_label_map : dict
-            The mapping of parent label numbers to deblended (child)
-            label numbers to update. This is passed explicitly because
-            :meth:`_set_data` resets the instance attribute.
-
-        relabel_map : `~numpy.ndarray`
-            An array mapping the original label numbers to the new
-            label numbers.
-        """
-        # child_labels are the deblended labels
-        for parent_label, child_labels in deblend_label_map.items():
-            self._deblend_label_map[parent_label] = relabel_map[child_labels]
-
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def reassign_label(self, label, new_label, relabel=False):
         """
@@ -1096,7 +1100,8 @@ class SegmentationImage:
         info = self.info
         self._set_data(data_new)
         self.__dict__['info'] = info
-        self._update_deblend_label_map(deblend_label_map, relabel_map)
+        self._deblend_label_map = _remap_deblend_label_map(
+            deblend_label_map, relabel_map)
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def relabel_consecutive(self, start_label=1):
@@ -1161,7 +1166,8 @@ class SegmentationImage:
         self._set_data(data_new, labels=new_labels, areas=old_areas,
                        slices=old_slices)
         self.__dict__['info'] = info
-        self._update_deblend_label_map(deblend_label_map, new_label_map)
+        self._deblend_label_map = _remap_deblend_label_map(
+            deblend_label_map, new_label_map)
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def keep_label(self, label, relabel=False):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -443,9 +443,7 @@ class SegmentationImage:
         ValueError
             If any input ``labels`` are invalid.
         """
-        self.check_labels(labels)
-        # self.labels is always sorted
-        return np.searchsorted(self.labels, labels)
+        return self.get_index(labels)
 
     @cached_property
     def slices(self):

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -355,12 +355,18 @@ class SegmentationImage:
             msg = 'data must have integer type'
             raise TypeError(msg)
 
-        labels = self._get_labels(value)  # array([]) if value all zeros
-        if labels.shape != (0,) and np.min(labels) < 0:
+        # A single pass over the non-zero pixels yields both the
+        # sorted labels and their pixel areas. np.unique preserves
+        # dtype and also sorts elements.
+        labels, areas = np.unique(value[value != 0], return_counts=True)
+
+        # labels is sorted, so only the first element can be negative.
+        # The size check also covers all-zero and zero-size arrays.
+        if labels.size and labels[0] < 0:
             msg = 'The segmentation image cannot contain negative integers.'
             raise ValueError(msg)
 
-        self._set_data(value, labels=labels)
+        self._set_data(value, labels=labels, areas=areas)
 
     @cached_property
     def data_masked(self):
@@ -389,16 +395,10 @@ class SegmentationImage:
         """
         The sorted non-zero labels in the segmentation array.
         """
-        if '_raw_slices' in self.__dict__:
-            labels_all = np.arange(len(self._raw_slices)) + 1
-            labels = []
-            # If a label is missing, raw_slices will be None instead of a slice
-            for label, slc in zip(labels_all, self._raw_slices, strict=True):
-                if slc is not None:
-                    labels.append(label)
-            return np.array(labels, dtype=self._data.dtype)
-
-        return self._get_labels(self.data)
+        # Normally seeded by _set_data. This runs only when the array
+        # was set without known labels. np.unique preserves dtype and
+        # also sorts elements.
+        return np.unique(self._data[self._data != 0])
 
     @cached_property
     def n_labels(self):
@@ -520,14 +520,11 @@ class SegmentationImage:
         returned array has a length equal to the number of labels and
         matches the order of the ``labels`` attribute.
         """
-        # NOTE: np.bincount was benchmarked but is slower for typical
-        # large images because its cost is O(total_pixels) whereas the
-        # per-bbox loop below is O(sum_of_bbox_areas), which is much
-        # smaller when segments occupy a small fraction of the image.
-        areas = []
-        for label, slices in zip(self.labels, self.slices, strict=True):
-            areas.append(np.count_nonzero(self._data[slices] == label))
-        return np.array(areas)
+        # Normally seeded by _set_data from the same np.unique pass
+        # that produces the labels. This runs only when the array was
+        # set without known areas.
+        data = self._data
+        return np.unique(data[data != 0], return_counts=True)[1]
 
     def get_area(self, label):
         """

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -15,7 +15,8 @@ from astropy.units import Quantity
 from scipy.ndimage import label as ndi_label
 from scipy.ndimage import sum_labels
 
-from photutils.segmentation.core import SegmentationImage, _get_labels
+from photutils.segmentation.core import (SegmentationImage, _get_labels,
+                                         _remap_deblend_label_map)
 from photutils.segmentation.detect import _detect_sources
 from photutils.segmentation.utils import _make_binary_structure
 from photutils.utils._deprecation import deprecated_renamed_argument
@@ -331,8 +332,8 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         relabel_map = _create_relabel_map(segm_deblended, start_label=1)
         if relabel_map is not None:
             segm_deblended = relabel_map[segm_deblended]
-            deblend_label_map = _update_deblend_label_map(deblend_label_map,
-                                                          relabel_map)
+            deblend_label_map = _remap_deblend_label_map(deblend_label_map,
+                                                         relabel_map)
 
     segm_img = SegmentationImage._from_data(
         segm_deblended, deblend_label_map=deblend_label_map)
@@ -693,27 +694,3 @@ def _create_relabel_map(array, *, start_label=1):
     relabel_map[labels] = np.arange(len(labels)) + start_label
 
     return relabel_map
-
-
-def _update_deblend_label_map(deblend_label_map, relabel_map):
-    """
-    Update the deblend_label_map to reflect the new labels that are
-    consecutive integers.
-
-    Parameters
-    ----------
-    deblend_label_map : dict
-        A dictionary mapping the original labels to the new deblended
-        labels.
-
-    relabel_map : 1D `~numpy.ndarray`
-        The array mapping the original labels to the new labels.
-
-    Returns
-    -------
-    deblend_label_map : dict
-        The updated deblend_label_map.
-    """
-    for old_label, new_labels in deblend_label_map.items():
-        deblend_label_map[old_label] = relabel_map[new_labels]
-    return deblend_label_map

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -15,7 +15,7 @@ from astropy.units import Quantity
 from scipy.ndimage import label as ndi_label
 from scipy.ndimage import sum_labels
 
-from photutils.segmentation.core import SegmentationImage
+from photutils.segmentation.core import SegmentationImage, _get_labels
 from photutils.segmentation.detect import _detect_sources
 from photutils.segmentation.utils import _make_binary_structure
 from photutils.utils._deprecation import deprecated_renamed_argument
@@ -656,24 +656,6 @@ class _SingleSourceDeblender:
         if relabel_map is not None:
             markers = relabel_map[markers]
         return markers
-
-
-def _get_labels(array):
-    """
-    Get the unique labels greater than zero in an array.
-
-    Parameters
-    ----------
-    array : `~numpy.ndarray`
-        The array to get the unique labels from.
-
-    Returns
-    -------
-    labels : int `~numpy.ndarray`
-        The unique labels in the array.
-    """
-    labels = np.unique(array)
-    return labels[labels != 0]
 
 
 def _create_relabel_map(array, *, start_label=1):

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -225,14 +225,19 @@ def _detect_sources(data, threshold, n_pixels, footprint, inverse_mask, *,
     slices = find_objects(segment_img)
     segm_labels = []
     segm_slices = []
+    segm_areas = []
     for label, slc in zip(labels, slices, strict=True):
         cutout = segment_img[slc]
         segment_mask = (cutout == label)
-        if np.count_nonzero(segment_mask) < n_pixels:
+        # The pixel count is the segment area, so it is kept to seed
+        # the SegmentationImage areas instead of being recomputed
+        area = np.count_nonzero(segment_mask)
+        if area < n_pixels:
             cutout[segment_mask] = 0
             continue
         segm_labels.append(label)
         segm_slices.append(slc)
+        segm_areas.append(area)
 
     if np.count_nonzero(segment_img) == 0:
         return None
@@ -253,6 +258,7 @@ def _detect_sources(data, threshold, n_pixels, footprint, inverse_mask, *,
 
     if return_segmimg:
         return SegmentationImage._from_data(segment_img, labels=labels,
+                                            areas=np.array(segm_areas),
                                             slices=segm_slices)
 
     # This is used by deblend_sources

--- a/photutils/segmentation/detect.py
+++ b/photutils/segmentation/detect.py
@@ -254,7 +254,9 @@ def _detect_sources(data, threshold, n_pixels, footprint, inverse_mask, *,
             label_map[segm_labels] = labels
             segment_img = label_map[segment_img]
     else:
-        labels = segm_labels
+        # Use an ndarray so that seeded labels are always an array,
+        # matching the relabel path
+        labels = np.asarray(segm_labels)
 
     if return_segmimg:
         return SegmentationImage._from_data(segment_img, labels=labels,

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -464,11 +464,10 @@ class TestSourceCatalog:
             SourceCatalog(self.data, segm)
 
         # Test 1D arrays
-        img1d = np.arange(4)
-        segm = SegmentationImage(img1d)
+        segm = SegmentationImage(np.arange(9).reshape((3, 3)))
         match = 'data must be a 2D array'
         with pytest.raises(ValueError, match=match):
-            SourceCatalog(img1d, segm)
+            SourceCatalog(np.arange(3), segm)
 
         wrong_shape = np.ones((3, 3), dtype=int)
         match = 'segmentation_image and data must have the same shape'

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -464,10 +464,11 @@ class TestSourceCatalog:
             SourceCatalog(self.data, segm)
 
         # Test 1D arrays
-        segm = SegmentationImage(np.arange(9).reshape((3, 3)))
+        img1d = np.arange(4)
+        segm = SegmentationImage(img1d)
         match = 'data must be a 2D array'
         with pytest.raises(ValueError, match=match):
-            SourceCatalog(np.arange(3), segm)
+            SourceCatalog(img1d, segm)
 
         wrong_shape = np.ones((3, 3), dtype=int)
         match = 'segmentation_image and data must have the same shape'

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -113,6 +113,40 @@ class TestSegmentationImage:
         segm.data = self.data[0:3, :].copy()
         assert_equal(segm.labels, [1, 3, 4])
 
+    def test_set_data_seeds_derived_state(self):
+        """
+        Test that _set_data seeds the derived cached properties and
+        resets the mutable attributes.
+        """
+        segm = SegmentationImage(self.data.copy())
+        segm.info['key'] = 'value'
+
+        data2 = np.array([[2, 2, 0], [0, 0, 5], [5, 5, 0]])
+        labels = np.array([2, 5])
+        areas = np.array([2, 3])
+        slices = [(slice(0, 1), slice(0, 2)), (slice(1, 3), slice(0, 3))]
+        segm._set_data(data2, labels=labels, areas=areas, slices=slices)
+
+        assert_equal(segm.data, data2)
+        assert_equal(segm.labels, labels)
+        assert_equal(segm.areas, areas)
+        assert segm.slices == slices
+        assert segm.info == {}
+        assert segm._deblend_label_map == {}
+
+    def test_set_data_without_seeds(self):
+        """
+        Test that _set_data computes the derived properties on demand
+        when they are not supplied.
+        """
+        segm = SegmentationImage(self.data.copy())
+        data2 = np.array([[2, 2, 0], [0, 0, 5], [5, 5, 0]])
+        segm._set_data(data2)
+
+        assert_equal(segm.labels, [2, 5])
+        assert_equal(segm.areas, [2, 3])
+        assert len(segm.slices) == 2
+
     def test_info(self):
         """
         Test that the info attribute always exists and is reset when the

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -151,6 +151,32 @@ class TestSegmentationImage:
         # Label 4 extends beyond the mask, so it is kept
         assert_equal(segm.labels, [3, 4, 5, 7])
 
+    def test_data_setter_validation(self):
+        """
+        Test that the data setter validates reassigned arrays.
+        """
+        segm = SegmentationImage(self.data.copy())
+
+        match = 'Input data must be a numpy array'
+        with pytest.raises(TypeError, match=match):
+            segm.data = [[1, 1], [0, 1]]
+
+        match = 'Input data must be a 2D array'
+        with pytest.raises(ValueError, match=match):
+            segm.data = np.ones(3, dtype=int)
+
+    def test_zero_size_data(self):
+        """
+        Test that a zero-size 2D array is still accepted.
+
+        This guards the negative-value check against raising a numpy
+        reduction error on an empty array.
+        """
+        segm = SegmentationImage(np.zeros((0, 0), dtype=int))
+        assert segm.n_labels == 0
+        assert_equal(segm.labels, [])
+        assert_equal(segm.areas, [])
+
     def test_set_data_seeds_derived_state(self):
         """
         Test that _set_data seeds the derived cached properties and
@@ -217,6 +243,16 @@ class TestSegmentationImage:
         data = [[1, 1], [0, 1]]
         match = 'Input data must be a numpy array'
         with pytest.raises(TypeError, match=match):
+            SegmentationImage(data)
+
+        # Is not 2D
+        data = np.ones(3, dtype=int)
+        match = 'Input data must be a 2D array'
+        with pytest.raises(ValueError, match=match):
+            SegmentationImage(data)
+
+        data = np.ones((2, 2, 2), dtype=int)
+        with pytest.raises(ValueError, match=match):
             SegmentationImage(data)
 
     @pytest.mark.parametrize('label', [0, -1, 2])
@@ -516,15 +552,6 @@ class TestSegmentationImage:
         bbox = self.segm.bbox[idx]
         assert isinstance(bbox, BoundingBox)
         assert (bbox.iymin, bbox.iymax, bbox.ixmin, bbox.ixmax) == expected
-
-    def test_bbox_1d(self):
-        """
-        Test bbox 1d.
-        """
-        segm = SegmentationImage(np.array([0, 0, 1, 1, 0, 2, 2, 0]))
-        match = "The 'bbox' attribute requires a 2D segmentation image"
-        with pytest.raises(ValueError, match=match):
-            _ = segm.bbox
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_reset_cmap(self):

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -162,9 +162,19 @@ class TestSegmentationImage:
         with pytest.raises(TypeError, match=match):
             segm.data = [[1, 1], [0, 1]]
 
-        match = 'Input data must be a 2D array'
+    def test_non_2d_data(self):
+        """
+        Test that non-2D input is accepted and the derived properties
+        work, but that the bbox attribute requires a 2D array.
+        """
+        segm = SegmentationImage(np.array([0, 1, 1, 0, 2, 2, 2]))
+        assert_equal(segm.labels, [1, 2])
+        assert_equal(segm.areas, [2, 3])
+        assert segm.slices == [(slice(1, 3),), (slice(4, 7),)]
+
+        match = "The 'bbox' attribute requires a 2D segmentation image"
         with pytest.raises(ValueError, match=match):
-            segm.data = np.ones(3, dtype=int)
+            _ = segm.bbox
 
     def test_zero_size_data(self):
         """
@@ -354,16 +364,6 @@ class TestSegmentationImage:
                                   mask=[[False, True], [False, False]])
         match = 'Input data must not be a numpy masked array'
         with pytest.raises(TypeError, match=match):
-            SegmentationImage(data)
-
-        # Is not 2D
-        data = np.ones(3, dtype=int)
-        match = 'Input data must be a 2D array'
-        with pytest.raises(ValueError, match=match):
-            SegmentationImage(data)
-
-        data = np.ones((2, 2, 2), dtype=int)
-        with pytest.raises(ValueError, match=match):
             SegmentationImage(data)
 
     @pytest.mark.parametrize('label', [0, -1, 2])

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -134,6 +134,23 @@ class TestSegmentationImage:
         _ = segm2.slices
         assert_equal(segm1.labels, segm2.labels)
 
+    def test_remove_masked_labels_partial_overlap(self):
+        """
+        Test remove_masked_labels for both partial_overlap settings.
+        """
+        mask = np.zeros(self.data.shape, dtype=bool)
+        mask[0, :] = True
+
+        segm = SegmentationImage(self.data.copy())
+        segm.remove_masked_labels(mask, partial_overlap=True)
+        # Labels 1 and 4 both touch the masked first row
+        assert_equal(segm.labels, [3, 5, 7])
+
+        segm = SegmentationImage(self.data.copy())
+        segm.remove_masked_labels(mask, partial_overlap=False)
+        # Label 4 extends beyond the mask, so it is kept
+        assert_equal(segm.labels, [3, 4, 5, 7])
+
     def test_set_data_seeds_derived_state(self):
         """
         Test that _set_data seeds the derived cached properties and

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -350,6 +350,13 @@ class TestSegmentationImage:
         with pytest.raises(TypeError, match=match):
             SegmentationImage(data)
 
+        # Is a masked array
+        data = np.ma.masked_array([[1, 1], [0, 1]],
+                                  mask=[[False, True], [False, False]])
+        match = 'Input data must not be a numpy masked array'
+        with pytest.raises(TypeError, match=match):
+            SegmentationImage(data)
+
         # Is not 2D
         data = np.ones(3, dtype=int)
         match = 'Input data must be a 2D array'

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -16,6 +16,7 @@ from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
 
+import photutils.segmentation.core as segm_core
 from photutils.segmentation.core import Segment, SegmentationImage
 from photutils.utils import circular_footprint
 from photutils.utils._optional_deps import (HAS_MATPLOTLIB, HAS_RASTERIO,
@@ -228,8 +229,6 @@ class TestSegmentationImage:
         Test that the bounding slices are computed only once, even
         when both slices and per-label segments are used.
         """
-        import photutils.segmentation.core as segm_core
-
         calls = []
         original = segm_core.find_objects
 

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -177,6 +177,32 @@ class TestSegmentationImage:
         assert_equal(segm.labels, [])
         assert_equal(segm.areas, [])
 
+    def test_relabel_consecutive_carries_areas(self):
+        """
+        Test that relabel_consecutive carries labels, areas, and
+        slices across without recomputing them.
+        """
+        segm = SegmentationImage(self.data.copy())
+        old_areas = segm.areas.copy()
+        _ = segm.slices
+
+        segm.relabel_consecutive()
+
+        assert_equal(segm.labels, np.arange(len(old_areas)) + 1)
+        assert 'areas' in segm.__dict__
+        assert_equal(segm.areas, old_areas)
+
+    def test_reassign_labels_areas_recomputed(self):
+        """
+        Test that reassign_labels leaves areas correct after labels
+        are merged.
+        """
+        segm = SegmentationImage(self.data.copy())
+        segm.reassign_label(label=3, new_label=1)
+        expected = np.unique(segm.data[segm.data != 0],
+                             return_counts=True)[1]
+        assert_equal(segm.areas, expected)
+
     def test_set_data_seeds_derived_state(self):
         """
         Test that _set_data seeds the derived cached properties and

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -257,6 +257,26 @@ class TestSegmentationImage:
         assert segm.get_indices(labels[0]) == segm.get_index(labels[0])
         assert np.ndim(segm.get_indices(labels[0])) == 0
 
+    def test_relabeling_preserves_info(self):
+        """
+        Test that relabeling keeps the auxiliary info dictionary.
+
+        Relabeling is an in-place change, not a data reassignment, so
+        the deblending provenance stored in info still applies.
+        """
+        for relabel in (lambda s: s.relabel_consecutive(),
+                        lambda s: s.reassign_label(label=3, new_label=1)):
+            segm = SegmentationImage(self.data.copy())
+            segm.info['nonposmin_labels'] = np.array([3, 5])
+            relabel(segm)
+            assert_equal(segm.info['nonposmin_labels'], [3, 5])
+
+        # Reassigning data does reset info
+        segm = SegmentationImage(self.data.copy())
+        segm.info['nonposmin_labels'] = np.array([3, 5])
+        segm.data = self.data.copy()
+        assert segm.info == {}
+
     def test_set_data_seeds_derived_state(self):
         """
         Test that _set_data seeds the derived cached properties and

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -298,6 +298,11 @@ class TestSegmentationImage:
         assert segm.info == {}
         assert segm._deblend_label_map == {}
 
+        # preserve_info keeps the info dictionary
+        segm.info['key'] = 'value'
+        segm._set_data(data2, preserve_info=True)
+        assert segm.info == {'key': 'value'}
+
     def test_set_data_without_seeds(self):
         """
         Test that _set_data computes the derived properties on demand

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -203,6 +203,16 @@ class TestSegmentationImage:
                              return_counts=True)[1]
         assert_equal(segm.areas, expected)
 
+    def test_data_attribute_is_write_protected(self):
+        """
+        Test that _data cannot be assigned directly, which would leave
+        the derived properties stale.
+        """
+        segm = SegmentationImage(self.data.copy())
+        match = 'Direct assignment to _data is not allowed'
+        with pytest.raises(AttributeError, match=match):
+            segm._data = np.zeros((3, 3), dtype=int)
+
     def test_set_data_seeds_derived_state(self):
         """
         Test that _set_data seeds the derived cached properties and
@@ -1231,8 +1241,7 @@ def test_geojson_polygons_int64_out_of_range():
     data = np.array([[0, 0, 0],
                      [0, np.iinfo(np.int32).max + 1, 0],
                      [0, 0, 0]], dtype=np.int64)
-    segm = SegmentationImage.__new__(SegmentationImage)
-    segm._data = data
+    segm = SegmentationImage._from_data(data)
     match = 'values outside the safe np.int32 range'
     with pytest.raises(ValueError, match=match):
         _ = segm._geojson_polygons

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -245,6 +245,18 @@ class TestSegmentationImage:
         _ = segm.get_segment(int(segm.labels[0]))
         assert len(calls) == 1
 
+    def test_get_index_and_get_indices_agree(self):
+        """
+        Test that get_index and get_indices return the same result for
+        both scalar and array inputs.
+        """
+        segm = SegmentationImage(self.data.copy())
+        labels = segm.labels
+
+        assert_equal(segm.get_indices(labels), segm.get_index(labels))
+        assert segm.get_indices(labels[0]) == segm.get_index(labels[0])
+        assert np.ndim(segm.get_indices(labels[0])) == 0
+
     def test_set_data_seeds_derived_state(self):
         """
         Test that _set_data seeds the derived cached properties and

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -213,6 +213,38 @@ class TestSegmentationImage:
         with pytest.raises(AttributeError, match=match):
             segm._data = np.zeros((3, 3), dtype=int)
 
+    def test_get_slice_matches_slices(self):
+        """
+        Test that _get_slice returns the same slice as indexing into
+        the slices list by label index.
+        """
+        segm = SegmentationImage(self.data.copy())
+        for label in segm.labels:
+            idx = segm.get_index(label)
+            assert segm._get_slice(label) == segm.slices[idx]
+
+    def test_find_objects_called_once(self, monkeypatch):
+        """
+        Test that the bounding slices are computed only once, even
+        when both slices and per-label segments are used.
+        """
+        import photutils.segmentation.core as segm_core
+
+        calls = []
+        original = segm_core.find_objects
+
+        def counting_find_objects(*args, **kwargs):
+            calls.append(1)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(segm_core, 'find_objects',
+                            counting_find_objects)
+
+        segm = SegmentationImage(self.data.copy())
+        _ = segm.slices
+        _ = segm.get_segment(int(segm.labels[0]))
+        assert len(calls) == 1
+
     def test_set_data_seeds_derived_state(self):
         """
         Test that _set_data seeds the derived cached properties and

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -79,19 +79,6 @@ class TestSegmentationImage:
         with pytest.raises(ValueError, match=match):
             self.segm[5:2, 0:3]
 
-    def test_labels_via_raw_slices(self):
-        """
-        Test that labels can be derived from _raw_slices when that
-        cached property is already cached.
-        """
-        segm = SegmentationImage(self.data.copy())
-        # Force _raw_slices to be cached
-        _ = segm._raw_slices
-        # Remove labels from instance dict to force the _raw_slices path
-        del segm.__dict__['labels']
-        labels = segm.labels
-        assert_equal(labels, [1, 3, 4, 5, 7])
-
     def test_data_all_zeros(self):
         """
         Test data all zeros.
@@ -112,6 +99,40 @@ class TestSegmentationImage:
         segm = SegmentationImage(self.data.copy())
         segm.data = self.data[0:3, :].copy()
         assert_equal(segm.labels, [1, 3, 4])
+
+    def test_labels_and_areas_seeded_together(self):
+        """
+        Test that assigning data seeds both labels and areas from a
+        single pass, without computing either on demand.
+        """
+        segm = SegmentationImage(self.data.copy())
+        assert 'labels' in segm.__dict__
+        assert 'areas' in segm.__dict__
+        assert_equal(segm.labels, [1, 3, 4, 5, 7])
+        assert_equal(segm.areas, [2, 2, 3, 6, 5])
+
+    def test_areas_computed_when_not_seeded(self):
+        """
+        Test that areas fall back to on-demand computation when they
+        are not seeded, and match the seeded values.
+        """
+        segm = SegmentationImage(self.data.copy())
+        expected = segm.areas.copy()
+
+        segm2 = SegmentationImage._from_data(self.data.copy())
+        assert 'areas' not in segm2.__dict__
+        assert_equal(segm2.areas, expected)
+        assert 'areas' in segm2.__dict__  # now cached
+
+    def test_labels_independent_of_slices_access(self):
+        """
+        Test that labels do not depend on whether slices have been
+        accessed.
+        """
+        segm1 = SegmentationImage(self.data.copy())
+        segm2 = SegmentationImage._from_data(self.data.copy())
+        _ = segm2.slices
+        assert_equal(segm1.labels, segm2.labels)
 
     def test_set_data_seeds_derived_state(self):
         """
@@ -1070,8 +1091,8 @@ def test_subclass(segm_data):
                       [70, 70, 0, 0],
                       [70, 70, 0, 1]])
     segm.data = data2
-    # Only _data, labels, _deblend_label_map, and info should remain
-    assert len(segm.__dict__) == 4
+    # Only _data, labels, areas, _deblend_label_map, and info remain
+    assert len(segm.__dict__) == 5
     assert_equal(segm.areas, [1, 2, 2, 4])
 
 

--- a/photutils/segmentation/tests/test_detect.py
+++ b/photutils/segmentation/tests/test_detect.py
@@ -157,6 +157,43 @@ class TestDetectThreshold:
             detect_threshold(DATA, 1.0, sigma_clip=10)
 
 
+def test_detect_sources_seeds_areas():
+    """
+    Test that detect_sources returns a SegmentationImage with the
+    areas already cached and correct.
+    """
+    data = np.zeros((10, 10))
+    data[2:5, 2:5] = 10.0
+    data[6:8, 6:9] = 10.0
+
+    segm = detect_sources(data, 1.0, 4)
+    assert 'areas' in segm.__dict__
+
+    expected = np.unique(segm.data[segm.data != 0],
+                         return_counts=True)[1]
+    assert_equal(segm.areas, expected)
+
+
+def test_detect_sources_seeded_areas_after_relabel():
+    """
+    Test that the seeded areas stay aligned with the labels when the
+    n_pixels cut removes sources and the remaining ones are relabeled.
+    """
+    data = np.zeros((20, 20))
+    data[1:2, 1:2] = 10.0  # 1 pixel, removed
+    data[4:7, 4:7] = 10.0  # 9 pixels, kept
+    data[9:10, 9:11] = 10.0  # 2 pixels, removed
+    data[12:16, 12:17] = 10.0  # 20 pixels, kept
+
+    segm = detect_sources(data, 1.0, 4)
+    assert_equal(segm.labels, [1, 2])
+    assert_equal(segm.areas, [9, 20])
+
+    expected = np.unique(segm.data[segm.data != 0],
+                         return_counts=True)[1]
+    assert_equal(segm.areas, expected)
+
+
 class TestDetectSources:
     def setup_class(self):
         self.data = np.array([[0, 1, 0], [0, 2, 0],


### PR DESCRIPTION
This PR refactors `SegmentationImage` so that every assignment of the internal `_data` array goes through a single method, `_set_data`, which resets and reseeds all derived state in one place. Direct `_data` assignment is blocked via `__setattr__`, so the stale-cache bug class is now impossible rather than merely avoided.

Main changes:

* The `labels` and `areas` attributes are computed from a single pass over the non-zero pixels and seeded at construction. `detect_sources` seeds the areas for free from its existing `n_pixels` filtering loop.
* The `_raw_slices` double bookkeeping was removed. Per-label slices are now looked up by label position, so `get_segment` no longer triggers a second full-image find_objects call.
* The relabeling methods route through _`set_data` and preserve the info dictionary and deblending provenance.
* Private helpers (`_get_labels`, `_remap_deblend_label_map`) are now shared between `core.py` and `deblend.py` instead of being duplicated.
* API change: masked array input now raises a `TypeError.` Previously it was accepted but produced labels and areas containing invalid masked entries.