### PR TITLE
Add get_label_mapping method to SegmentationImage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -221,6 +221,12 @@ New Features
     affected by deblending warnings under ``'nonposmin_labels'`` and
     ``'n_markers_labels'`` keys. [#2378]
 
+  - Added a ``get_label_mapping`` method to ``SegmentationImage`` to find
+    the mapping of labels to another segmentation image defined on the
+    same pixel grid, e.g., mapping the original (parent) labels to the
+    deblended (child) labels between segmentation images made before
+    and after deblending. [#2382]
+
 - ``photutils.utils``
 
   - Added a new ``DeblendWarning`` class, a subclass of astropy's

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -2271,6 +2271,103 @@ class SegmentationImage:
                 poly, label=int(label), visual_kwargs=visual_kwargs))
         return regions
 
+    def get_label_mapping(self, other, *, labels=None):
+        """
+        Find the mapping of labels between this segmentation image
+        and another one defined on the same pixel grid.
+
+        For each label in this segmentation image, find the labels in
+        ``other`` that cover any of the same pixels. The typical use
+        case is comparing segmentation images of the same sources
+        before and after deblending, where the result maps each
+        original (parent) label to the deblended (child) labels that
+        replaced it.
+
+        Parameters
+        ----------
+        other : `SegmentationImage`
+            The segmentation image to which the labels are mapped. It
+            must have the same shape as this segmentation image.
+
+        labels : int or 1D array_like (int), optional
+            The label number(s) to map. If `None` (default), all
+            labels are mapped.
+
+        Returns
+        -------
+        mapping : dict
+            A dictionary mapping each label number in this
+            segmentation image to a sorted 1D array of the label
+            numbers in ``other`` that share pixels with it.
+
+        Notes
+        -----
+        The two segmentation images are usually assumed to have
+        identical non-zero footprints. That assumption is not
+        checked. If ``other`` contains background (zero) pixels
+        within a labeled region of this segmentation image, then 0
+        will be included in the mapped labels for that label.
+
+        For segmentation images deblended in the current session, the
+        :attr:`parent_to_deblended_labels` and
+        :attr:`deblended_label_to_parent` attributes already provide
+        the label mapping. This method is the general tool for two
+        segmentation images without that provenance, e.g., images
+        read from files. The inverse mapping can be computed with
+        ``other.get_label_mapping(self)``.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from photutils.segmentation import SegmentationImage
+        >>> segm1 = SegmentationImage(np.array([[1, 1, 0, 2],
+        ...                                     [0, 1, 0, 2]]))
+        >>> segm2 = SegmentationImage(np.array([[1, 3, 0, 2],
+        ...                                     [0, 3, 0, 2]]))
+        >>> segm1.get_label_mapping(segm2)
+        {1: array([1, 3]), 2: array([2])}
+        >>> segm1.get_label_mapping(segm2, labels=1)
+        {1: array([1, 3])}
+        """
+        if not isinstance(other, SegmentationImage):
+            msg = ('The other segmentation image must be a '
+                   'SegmentationImage instance')
+            raise TypeError(msg)
+
+        if other.shape != self.shape:
+            msg = ('The other segmentation image must have the same '
+                   'shape as this one')
+            raise ValueError(msg)
+
+        mask = self._data > 0
+        parents = self._data[mask].astype(np.int64)
+        children = other._data[mask].astype(np.int64)
+
+        if parents.size == 0:
+            mapping = {}
+        else:
+            # Pack each (parent, child) label pair into a single
+            # int64 key so that one sorting pass finds all unique
+            # pairs. This is safe from overflow for label values
+            # below 2**31.
+            mult = np.int64(other.max_label) + 1
+            pairs = np.unique(parents * mult + children)
+            parents = pairs // mult
+            children = (pairs % mult).astype(other._data.dtype)
+
+            unique_parents, starts = np.unique(parents,
+                                               return_index=True)
+            mapping = dict(zip(unique_parents.tolist(),
+                               np.split(children, starts[1:]),
+                               strict=True))
+
+        if labels is not None:
+            self.check_labels(labels)
+            mapping = {int(label): mapping[int(label)]
+                       for label in np.atleast_1d(labels)}
+
+        return mapping
+
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def imshow(self, ax=None, figsize=None, dpi=None, cmap=None, alpha=None):
         """

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -1467,6 +1467,155 @@ def test_imshow_map_no_background():
     assert np.max(np.asarray(im.get_array())) == len(labels) - 1
 
 
+class TestGetLabelMapping:
+    """
+    Tests for the get_label_mapping method.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, segm_data):
+        self.parent = SegmentationImage(segm_data)
+        # A deblend-like version of segm_data with the identical
+        # non-zero footprint: label 5 is split into labels 8 and 9,
+        # and label 7 is split into labels 10 and 11
+        child_data = np.array([[1, 1, 0, 0, 4, 4],
+                               [0, 0, 0, 0, 0, 4],
+                               [0, 0, 3, 3, 0, 0],
+                               [10, 0, 0, 0, 0, 8],
+                               [10, 10, 0, 8, 8, 9],
+                               [10, 11, 0, 0, 9, 9]])
+        self.child = SegmentationImage(child_data)
+
+    def test_basic(self):
+        """
+        Test the full parent-to-child mapping.
+        """
+        mapping = self.parent.get_label_mapping(self.child)
+        expected = {1: [1], 3: [3], 4: [4], 5: [8, 9], 7: [10, 11]}
+        assert list(mapping.keys()) == list(expected.keys())
+        for label, child_labels in expected.items():
+            assert_equal(mapping[label], child_labels)
+
+    def test_key_and_value_types(self):
+        """
+        Test that the keys are Python ints and the values are sorted
+        arrays with the dtype of the other segmentation image.
+        """
+        mapping = self.parent.get_label_mapping(self.child)
+        assert all(isinstance(key, int) for key in mapping)
+        for value in mapping.values():
+            assert isinstance(value, np.ndarray)
+            assert value.dtype == self.child.data.dtype
+            assert_equal(value, np.sort(value))
+
+    def test_identity(self):
+        """
+        Test that mapping a segmentation image to itself maps every
+        label to itself.
+        """
+        mapping = self.parent.get_label_mapping(self.parent)
+        for label, mapped in mapping.items():
+            assert_equal(mapped, [label])
+
+    def test_inverse(self):
+        """
+        Test the child-to-parent mapping.
+        """
+        mapping = self.child.get_label_mapping(self.parent)
+        expected = {1: [1], 3: [3], 4: [4], 8: [5], 9: [5], 10: [7],
+                    11: [7]}
+        assert list(mapping.keys()) == list(expected.keys())
+        for label, parent_labels in expected.items():
+            assert_equal(mapping[label], parent_labels)
+
+    def test_labels_scalar(self):
+        """
+        Test mapping a single scalar label.
+        """
+        mapping = self.parent.get_label_mapping(self.child, labels=5)
+        assert list(mapping.keys()) == [5]
+        assert_equal(mapping[5], [8, 9])
+
+    def test_labels_subset(self):
+        """
+        Test that a labels subset preserves the input label order.
+        """
+        mapping = self.parent.get_label_mapping(self.child, labels=[7, 1])
+        assert list(mapping.keys()) == [7, 1]
+        assert_equal(mapping[7], [10, 11])
+        assert_equal(mapping[1], [1])
+
+    def test_labels_empty(self):
+        """
+        Test that an empty labels list returns an empty dict.
+        """
+        assert self.parent.get_label_mapping(self.child, labels=[]) == {}
+
+    def test_labels_invalid(self):
+        """
+        Test that invalid labels raise a ValueError.
+        """
+        match = r'label \[2\] is invalid'
+        with pytest.raises(ValueError, match=match):
+            self.parent.get_label_mapping(self.child, labels=2)
+
+    def test_labels_positional(self):
+        """
+        Test that labels cannot be passed as a positional argument.
+        """
+        match = 'positional argument'
+        with pytest.raises(TypeError, match=match):
+            self.parent.get_label_mapping(self.child, [5])
+
+    def test_other_invalid_type(self):
+        """
+        Test that a non-SegmentationImage other raises a TypeError.
+        """
+        match = 'must be a SegmentationImage instance'
+        with pytest.raises(TypeError, match=match):
+            self.parent.get_label_mapping(self.child.data)
+
+    def test_other_shape_mismatch(self):
+        """
+        Test that a shape mismatch raises a ValueError.
+        """
+        segm = SegmentationImage(np.array([[1, 1], [0, 2]]))
+        match = 'must have the same shape'
+        with pytest.raises(ValueError, match=match):
+            self.parent.get_label_mapping(segm)
+
+    def test_all_zeros(self):
+        """
+        Test that a segmentation image with no labels returns an empty
+        dict.
+        """
+        segm = SegmentationImage(np.zeros((6, 6), dtype=int))
+        assert segm.get_label_mapping(self.child) == {}
+
+    def test_other_all_zeros(self):
+        """
+        Test that every label maps to the background when the other
+        segmentation image is all zeros.
+        """
+        segm = SegmentationImage(np.zeros((6, 6), dtype=int))
+        mapping = self.parent.get_label_mapping(segm)
+        assert list(mapping.keys()) == [1, 3, 4, 5, 7]
+        for mapped in mapping.values():
+            assert_equal(mapped, [0])
+
+    def test_footprint_mismatch(self):
+        """
+        Test that zero appears in the mapped labels where the other
+        segmentation image has background pixels within a labeled
+        region.
+        """
+        child_data = self.child.data.copy()
+        child_data[0, 0] = 0
+        child = SegmentationImage(child_data)
+        mapping = self.parent.get_label_mapping(child)
+        assert_equal(mapping[1], [0, 1])
+
+
 class TestGetSegment:
     """
     Tests for get_segment and get_segments methods.


### PR DESCRIPTION
This PR adds a `get_label_mapping` method to `SegmentationImage` that maps each label to the labels in another segmentation image that cover any of the same pixels. The typical use case is comparing segmentation images made before and after deblending to find the parent/child label mapping when the deblending provenance is not available (e.g., segmentation images read from files).