### PR TITLE
Fix PSFPhotometry grouper mutation and user-mask merging bugs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -396,6 +396,10 @@ Bug Fixes
     table containing a ``group_id`` column permanently disabled the
     grouper for all subsequent calls on the same instance. [#2383]
 
+  - Fixed a bug where non-finite data values were not merged into a
+    user-provided mask, causing fit failures in ``fit_2dgaussian``,
+    ``fit_fwhm``, and ``PSFPhotometry``. [#2383]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -390,6 +390,12 @@ Bug Fixes
   - The ``EnsquaredCurveOfGrowth`` input validation error messages now
     refer to the ``half_sizes`` parameter instead of ``radii``. [#xxxx]
 
+- ``photutils.psf``
+
+  - Fixed a bug where calling ``PSFPhotometry`` with an ``init_params``
+    table containing a ``group_id`` column permanently disabled the
+    grouper for all subsequent calls on the same instance. [#2383]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -82,14 +82,14 @@ class _PSFParameterMapper:
             names in the PSF model. The keys are 'x', 'y', 'flux', and
             any additional parameters defined in the model.
         """
-        # the order of the main parameters is important; it defines
-        # the order of table outputs
+        # The order of the main parameters is important. It defines
+        # the order of table outputs.
         main_params = _get_psf_model_main_params(self.psf_model)
         params_map = dict(zip(self.MAIN_ALIASES, main_params, strict=True))
 
-        # extra parameters that are not 'x', 'y', or 'flux', but
+        # Extra parameters that are not 'x', 'y', or 'flux', but
         # are free to be fit (fixed = False), are added to the map
-        # with their own aliases
+        # with their own aliases.
         fitted_params = [
             param for param in self.psf_model.param_names
             if not self.psf_model.fixed[param]
@@ -179,7 +179,7 @@ class _PSFParameterMapper:
         try:
             valid_names = self.VALID_INIT_COLNAMES[param_alias]
         except KeyError:
-            # valid names for extra parameters are more limited
+            # Valid names for extra parameters are more limited
             valid_names = (f'{param_alias}_init', param_alias,
                            f'{param_alias}_fit')
 
@@ -420,7 +420,7 @@ class PSFPhotometry:
             self._param_mapper, self.fit_shape, xy_bounds=self.xy_bounds,
         )
 
-        # used by the __repr__ method and the output table metadata
+        # Used by the __repr__ method and the output table metadata
         self._attrs = ('psf_model', 'fit_shape', 'finder', 'grouper', 'fitter',
                        'fitter_maxiters', 'xy_bounds', 'aperture_radius',
                        'local_bkg_estimator', 'group_warning_threshold',
@@ -438,11 +438,11 @@ class PSFPhotometry:
         self.results = None
         self.fit_info = []
 
-        # sync data_unit with components
+        # Sync data_unit with components
         if hasattr(self, '_data_processor'):
             self._data_processor.data_unit = None
 
-        # internal state container
+        # Internal state container
         self._state = {
             'valid_mask_by_id': None,
             'fit_param_errs': None,
@@ -491,20 +491,20 @@ class PSFPhotometry:
         only the parameter values, fixed flags, and bounds that are
         needed for the results table.
         """
-        # get all parameter names from the PSF model
+        # Get all parameter names from the PSF model
         model_params = list(self.psf_model.param_names)
 
-        # initialize parameter value storage
+        # Initialize parameter value storage
         param_data = {}
         for model_param in model_params:
-            # initialize all parameters with np.nan (for invalid sources)
+            # Initialize all parameters with np.nan (for invalid sources)
             param_data[model_param] = np.full(n_sources,
                                               self._DEFAULT_PARAM_VALUE)
             param_data[f'{model_param}_fixed'] = [None] * n_sources
             param_data[f'{model_param}_bounds'] = [None] * n_sources
 
-        # add placehold IDs column -- this will be updated later to
-        # match IDs in init_params
+        # Add placehold IDs column. This will be updated later to
+        # match IDs in init_params.
         param_data['id'] = np.arange(1, n_sources + 1)
 
         self._state['model_param_data'] = param_data
@@ -798,22 +798,19 @@ class PSFPhotometry:
         init_params : `~astropy.table.Table`
             The table of initial parameters with a 'group_id' column.
         """
-        if 'group_id' in init_params.colnames:
-            # user-provided group_id takes precedence
-            self.grouper = None
+        # A user-provided group_id column takes precedence for this
+        # call
+        if 'group_id' not in init_params.colnames:
+            if self.grouper is not None:
+                x_col = self._param_mapper.init_colnames['x']
+                y_col = self._param_mapper.init_colnames['y']
+                init_params['group_id'] = self.grouper(
+                    init_params[x_col], init_params[y_col])
+            else:
+                # No grouper provided, so each source is its own group
+                init_params['group_id'] = init_params['id'].copy()
 
-        elif self.grouper is not None:
-            # use the grouper to group sources
-            x_col = self._param_mapper.init_colnames['x']
-            y_col = self._param_mapper.init_colnames['y']
-            init_params['group_id'] = self.grouper(init_params[x_col],
-                                                   init_params[y_col])
-
-        else:
-            # no grouper provided, so each source is its own group
-            init_params['group_id'] = init_params['id'].copy()
-
-        # ensure group_id contains only positive (> 0) integers
+        # Ensure group_id contains only positive (> 0) integers
         group_id = init_params['group_id']
         if np.any(~np.isfinite(group_id)):
             msg = 'group_id must be finite'
@@ -855,7 +852,7 @@ class PSFPhotometry:
         if init_params is None:
             return None
 
-        # strip any units from the x/y position columns
+        # Strip any units from the x/y position columns
         for axis in ('x', 'y'):
             colname = self._param_mapper.init_colnames[axis]
             if isinstance(init_params[colname], u.Quantity):
@@ -865,7 +862,7 @@ class PSFPhotometry:
         init_params = add_flux_bkg(data, mask, init_params)
         init_params = self._group_sources(init_params)
 
-        # check for large group sizes after grouping is complete
+        # Check for large group sizes after grouping is complete
         warn_size = self.group_warning_threshold
         if 'group_id' in init_params.colnames:
             _, counts = np.unique(init_params['group_id'], return_counts=True)
@@ -947,7 +944,7 @@ class PSFPhotometry:
         (data, error), unit = process_quantities((data, error),
                                                  ('data', 'error'))
         self.data_unit = unit
-        self._sync_data_unit()  # Sync with components
+        self._sync_data_unit()  # sync with components
 
         data = self._data_processor.validate_array(data, 'data')
         error = self._data_processor.validate_array(error, 'error',
@@ -960,7 +957,7 @@ class PSFPhotometry:
         init_params = self._build_initial_parameters(data, mask, init_params)
 
         if init_params is None:
-            # no sources found
+            # No sources found
             return None, None, None, None
 
         return data, mask, error, init_params
@@ -1114,24 +1111,24 @@ class PSFPhotometry:
         reduced_chi2 = np.full(n_sources, np.nan, dtype=float)
 
         if residuals is not None:
-            # convert to numpy arrays for vectorized operations
+            # Convert to numpy arrays for vectorized operations
             valid_mask_arr = np.array(valid_mask, dtype=bool)
             n_pixels_fit_arr = np.array(n_pixels_fit_full)
             cen_index_arr = np.array(cen_index_full)
 
-            # get valid source indices
+            # Get valid source indices
             valid_indices = np.where(valid_mask_arr)[0]
             if len(valid_indices) > 0:
                 n_pixels_valid = n_pixels_fit_arr[valid_indices]
 
-                # calculate cumulative pixel positions
+                # Calculate cumulative pixel positions
                 cumsum_n_pixels = np.concatenate(
                     ([0], np.cumsum(n_pixels_valid)))
 
-                # get the number of fitted parameters
+                # Get the number of fitted parameters
                 n_fit_params = len(self._param_mapper.fitted_param_names)
 
-                # process all valid sources
+                # Process all valid sources
                 for idx, valid_idx in enumerate(valid_indices):
                     start_pos = cumsum_n_pixels[idx]
                     end_pos = cumsum_n_pixels[idx + 1]
@@ -1149,17 +1146,18 @@ class PSFPhotometry:
                         yi_source = yi_all[idx]
                         error_vals = error[yi_source, xi_source]
 
-                        # Convert weighted residuals to raw residuals:
-                        # multiply by error
+                        # Multiply by error to convert weighted
+                        # residuals to raw residuals
                         if (np.all(error_vals > 0)
                                 and np.all(np.isfinite(error_vals))):
                             raw_residuals = source_residuals * error_vals
 
-                    # sum of absolute residuals
+                    # Sum of absolute residuals
                     sum_abs_residuals[valid_idx] = float(
                         np.abs(raw_residuals).sum())
 
-                    # center residual
+                    # Residual at the center pixel (cen_index) for this
+                    # source
                     cen_idx = cen_index_arr[valid_idx]
                     if np.isfinite(cen_idx):
                         cen_residuals[valid_idx] = float(
@@ -1220,7 +1218,7 @@ class PSFPhotometry:
         y_offsets, x_offsets = self._data_processor.get_fit_offsets()
         n_fit_params_per_source = len(self._param_mapper.fitted_param_names)
 
-        # sources are fit by groups in group ID order
+        # Sources are fit by groups in group ID order
         for source_group in source_groups:
             group_size = len(source_group)
             xi_all = []
@@ -1350,7 +1348,7 @@ class PSFPhotometry:
         fitted_models_table = self._build_fitted_models_table()
         fit_params = self._create_fit_results(fitted_models_table)
 
-        # store results in state for other methods that need them
+        # Store results in state for other methods that need them
         self._state['fit_error_indices'] = fit_error_indices
         self._state['fitted_models_table'] = fitted_models_table
         self._state['fit_params'] = fit_params
@@ -1381,7 +1379,7 @@ class PSFPhotometry:
             The table of fitted parameters and fit quality metrics for
             each source.
         """
-        # add row index for stable mapping
+        # Add row index for stable mapping
         if '_row_index' not in init_params.colnames:
             init_params['_row_index'] = np.arange(len(init_params))
         self._initialize_source_state_storage(len(init_params))
@@ -1389,7 +1387,7 @@ class PSFPhotometry:
         source_groups = init_params.group_by('group_id').groups
         self._fit_source_groups(source_groups, data, mask, error)
 
-        # clean up temporary row index column
+        # Clean up temporary row index column
         if '_row_index' in init_params.colnames:
             init_params.remove_column('_row_index')
 
@@ -1429,7 +1427,7 @@ class PSFPhotometry:
 
         This method delegates to the results assembler component.
         """
-        # prepare metadata attributes
+        # Prepare metadata attributes
         class_attrs = {'psf_model', 'finder', 'grouper', 'fitter',
                        'local_bkg_estimator'}
         metadata_attrs = {}
@@ -1490,36 +1488,36 @@ class PSFPhotometry:
 
     @_create_call_docstring(iterative=False)
     def __call__(self, data, *, mask=None, error=None, init_params=None):
-        # reset state from previous runs
+        # Reset state from previous runs
         self._reset_results()
 
         try:
-            # handle NDData input
+            # Handle NDData input
             if isinstance(data, NDData):
                 data, mask, error = self._coerce_nddata(data)
 
-            # prepare all inputs for sources to be fit
+            # Prepare all inputs for sources to be fit
             data, mask, error, init_params = self._prepare_fit_inputs(
                 data, mask=mask, error=error, init_params=init_params,
             )
 
-            # handle the case where no sources were found
+            # Handle the case where no sources were found
             if init_params is None:
                 return None
 
             self.init_params = init_params
 
-            # fit sources defined in init_params
+            # Fit sources defined in init_params
             fit_params = self._fit_sources(data, init_params, error=error,
                                            mask=mask)
 
-            # assemble the final results table
+            # Assemble the final results table
             # Note: _assemble_results_table handles _state cleanup
             self.results = self._assemble_results_table(
                 init_params, fit_params, data.shape)
 
         except Exception:
-            # ensure state cleanup even if an exception occurs
+            # Ensure state cleanup even if an exception occurs
             self._reset_state()
             raise
 

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -143,7 +143,7 @@ def test_invalid_inputs():
     with pytest.raises(ValueError, match=match):
         _ = psfphot(data, init_params=tbl)
 
-    # test no finder or init_params
+    # Test no finder or init_params
     match = 'finder must be defined if init_params is not input'
     psfphot = PSFPhotometry(model, (3, 3), aperture_radius=5)
     data = np.ones((11, 11))
@@ -213,18 +213,18 @@ def test_psf_photometry(test_data):
     assert isinstance(resid_data, np.ndarray)
     assert resid_data.shape == data.shape
     assert phot.colnames[:4] == ['id', 'group_id', 'group_size', 'local_bkg']
-    # test that error columns are ordered correctly
+    # Test that error columns are ordered correctly
     assert phot['x_err'].max() > 0.0062
     assert phot['y_err'].max() > 0.0065
     assert phot['flux_err'].max() > 2.5
 
     assert isinstance(psfphot.fit_info, list)
 
-    # test that repeated calls reset the results
+    # Test that repeated calls reset the results
     phot = psfphot(data, error=error)
     assert len(psfphot.fit_info) == len(phot)
 
-    # test units
+    # Test units
     unit = u.Jy
     finderu = DAOStarFinder(6.0 * unit, 2.0)
     psfphotu = PSFPhotometry(psf_model, fit_shape, finder=finderu,
@@ -284,7 +284,7 @@ def test_psf_photometry_nddata(test_data):
     fit_shape = (5, 5)
     finder = DAOStarFinder(6.0, 2.0)
 
-    # test NDData input
+    # Test NDData input
     uncertainty = StdDevUncertainty(error)
     nddata = NDData(data, uncertainty=uncertainty)
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
@@ -299,7 +299,7 @@ def test_psf_photometry_nddata(test_data):
     assert resid_data2.data.shape == data.shape
     assert_allclose(resid_data1, resid_data2.data)
 
-    # test NDData input with units
+    # Test NDData input with units
     unit = u.Jy
     finderu = DAOStarFinder(6.0 * unit, 2.0)
     psfphotu = PSFPhotometry(psf_model, fit_shape, finder=finderu,
@@ -406,8 +406,8 @@ def test_model_residual_image_nonfinite_localbkg(test_data):
     assert np.all(np.isfinite(model_without_bkg))
 
     # For sources with non-finite local_bkg, the model with and without
-    # local_bkg should be identical (since non-finite is treated as 0)
-    # Check this by comparing the models at source positions
+    # local_bkg should be identical (since non-finite is treated as 0).
+    # Check this by comparing the models at source positions.
     for i in range(min(3, len(phot))):
         if not np.isfinite(phot['local_bkg'][i]):
             x_fit = int(phot['x_fit'][i])
@@ -440,7 +440,8 @@ def test_residual_image_localbkg_invalid_sources(test_data):
     sources['x_centroid'][-3] = 1000
     sources['y_centroid'][-3] = 1000
 
-    # Perform PSF photometry with init_params containing non-finite local_bkg
+    # Perform PSF photometry with init_params containing non-finite
+    # local_bkg
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                             aperture_radius=4)
     psfphot(data, error=error, init_params=sources)
@@ -481,7 +482,7 @@ def test_psf_photometry_compound_psfmodel(test_data, fit_stddev):
         for colname in colnames:
             assert colname in phot.colnames
 
-    # test model and residual images
+    # Test model and residual images
     psf_shape = (9, 9)
     model1 = psfphot.make_model_image(data.shape, psf_shape=psf_shape,
                                       include_local_bkg=False)
@@ -498,7 +499,7 @@ def test_psf_photometry_compound_psfmodel(test_data, fit_stddev):
     assert_equal(data - model1, resid1)
     assert_equal(data - model2, resid2)
 
-    # test with init_params
+    # Test with init_params
     init_params = psfphot.results_to_init_params()
     phot = psfphot(data, error=error, init_params=init_params)
     assert isinstance(phot, QTable)
@@ -511,7 +512,7 @@ def test_psf_photometry_compound_psfmodel(test_data, fit_stddev):
         for colname in colnames:
             assert colname in phot.colnames
 
-    # test results when fit does not converge (fitter_maxiters=3)
+    # Test results when fit does not converge (fitter_maxiters=3)
     match = r'One or more fit\(s\) may not have converged.'
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                             aperture_radius=4, fitter_maxiters=3)
@@ -529,12 +530,12 @@ def test_psf_photometry_mask(test_data):
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                             aperture_radius=4)
 
-    # test np.ma.nomask
+    # Test np.ma.nomask
     phot = psfphot(data, error=error, mask=None)
     photm = psfphot(data, error=error, mask=np.ma.nomask)
     assert np.all(phot == photm)
 
-    # masked near source at ~(63, 49)
+    # Masked near source at ~(63, 49)
     data_orig = data.copy()
     data = data.copy()
     data[55, 60:70] = np.nan
@@ -548,7 +549,7 @@ def test_psf_photometry_mask(test_data):
     phot2 = psfphot(data, error=error, mask=mask)
     assert np.all(phot1 == phot2)
 
-    # unmasked NaN with mask not None
+    # Unmasked NaN with mask not None
     match = 'Input data contains unmasked non-finite values'
     mask = ~np.isfinite(data)
     mask[55, 65] = False
@@ -556,13 +557,13 @@ def test_psf_photometry_mask(test_data):
         phot = psfphot(data, error=error, mask=mask)
     assert len(phot) == len(sources)
 
-    # mask all True; finder returns no sources
+    # With mask all True, the finder should return no sources
     match = 'No sources were found'
     mask = np.ones(data.shape, dtype=bool)
     with pytest.warns(NoDetectionsWarning, match=match):
         psfphot(data, mask=mask)
 
-    # completely masked source should return NaNs and not raise
+    # Completely masked source should return NaNs and not raise
     init_params = QTable()
     init_params['x'] = [63]
     init_params['y'] = [49]
@@ -576,10 +577,10 @@ def test_psf_photometry_mask(test_data):
         assert np.isnan(phot_masked[col][0])
     assert phot_masked['n_pixels_fit'][0] == 0
     assert phot_masked['group_size'][0] == 1
-    # new flag 128 for fully masked
+    # New flag 128 for fully masked
     assert (phot_masked['flags'][0] & 128) == 128
 
-    # masked central pixel
+    # Masked central pixel
     init_params = QTable()
     init_params['x'] = [63]
     init_params['y'] = [49]
@@ -589,7 +590,7 @@ def test_psf_photometry_mask(test_data):
     assert len(phot) == 1
     assert np.isnan(phot['cfit'][0])
 
-    # this should not raise a warning because the non-finite pixel was
+    # This should not raise a warning because the non-finite pixel was
     # explicitly masked
     psfphot = PSFPhotometry(psf_model, (3, 3), aperture_radius=3)
     data = np.ones((11, 11))
@@ -657,7 +658,7 @@ def test_psf_photometry_init_params(test_data):
     colnames = ('x_fit', 'y_fit', 'flux_fit', 'x_err', 'y_err', 'flux_err',
                 'qfit', 'cfit', 'reduced_chi2')
 
-    # no-overlap source should return NaNs and not raise; also test
+    # No-overlap source should return NaNs and not raise; also test
     # too-few-pixels
     init_params = QTable()
     init_params['x'] = [-63]
@@ -669,10 +670,10 @@ def test_psf_photometry_init_params(test_data):
         assert np.isnan(phot_no_overlap[col][0])
     assert phot_no_overlap['n_pixels_fit'][0] == 0
     assert phot_no_overlap['group_size'][0] == 1
-    # new flag 64 for no overlap
+    # New flag 64 for no overlap
     assert (phot_no_overlap['flags'][0] & 64) == 64
 
-    # too-few pixels (unmasking only 2 pixels < 3 free params) should
+    # Too-few pixels (unmasking only 2 pixels < 3 free params) should
     # give NaNs
     init_params = QTable()
     init_params['x'] = [63]
@@ -686,10 +687,10 @@ def test_psf_photometry_init_params(test_data):
         assert np.isnan(phot_few[col][0])
     assert phot_few['n_pixels_fit'][0] == 2
     assert phot_few['group_size'][0] == 1
-    # new flag 256 for too few pixels
+    # New flag 256 for too few pixels
     assert (phot_few['flags'][0] & 256) == 256
 
-    # check that the first matching column name is used
+    # Check that the first matching column name is used
     init_params = QTable()
     x = 63
     y = 49
@@ -741,7 +742,7 @@ def test_psf_photometry_init_params_units(test_data):
         assert isinstance(resid, u.Quantity)
         assert resid.unit == unit
 
-    # test invalid units
+    # Test invalid units
     colnames = ('flux', 'local_bkg')
     for col in colnames:
         init_params2 = init_params.copy()
@@ -839,7 +840,7 @@ def test_grouper_init_params(test_data):
     assert_equal(phot1['group_size'],
                  np.ones(n_sources, dtype=int) * n_sources)
 
-    # test with grouper=None
+    # Test with grouper=None
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                             grouper=None, aperture_radius=4)
     phot2 = psfphot(data, error=error, init_params=init_params)
@@ -847,6 +848,30 @@ def test_grouper_init_params(test_data):
     assert_equal(phot1['group_id'], np.ones(n_sources, dtype=int))
     assert_equal(phot1['group_size'],
                  np.ones(n_sources, dtype=int) * n_sources)
+
+
+def test_grouper_not_mutated_by_group_id():
+    """
+    Regression test that a call with init_params['group_id'] does
+    not disable the grouper for subsequent calls.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, true_params = make_psf_model_image(
+        (80, 80), model, 10, model_shape=(9, 9), flux=(500, 700),
+        min_separation=3, seed=0)
+    init = Table({'x': true_params['x_0'], 'y': true_params['y_0']})
+    grouper = SourceGrouper(min_separation=10)
+    psfphot = PSFPhotometry(model, (5, 5), grouper=grouper,
+                            aperture_radius=4)
+    phot1 = psfphot(data, init_params=init)
+
+    init2 = init.copy()
+    init2['group_id'] = np.ones(len(init2), dtype=int)
+    psfphot(data, init_params=init2)
+    assert psfphot.grouper is grouper
+
+    phot3 = psfphot(data, init_params=init)
+    assert_equal(phot1['group_id'], phot3['group_id'])
 
 
 def test_large_group_warning():
@@ -1011,7 +1036,7 @@ def test_fit_warning(test_data):
     fit_shape = (5, 5)
     fitter = LMLSQFitter()  # uses "status" instead of "ierr"
     finder = DAOStarFinder(6.0, 2.0)
-    # set fitter_maxiters = 1 so that the fit error status is set
+    # Set fitter_maxiters = 1 so that the fit error status is set
     psfphot = PSFPhotometry(psf_model, fit_shape, fitter=fitter,
                             fitter_maxiters=1, finder=finder,
                             aperture_radius=4)
@@ -1020,7 +1045,7 @@ def test_fit_warning(test_data):
     with pytest.warns(AstropyUserWarning, match=match):
         phot = psfphot(data)
 
-    # check that flag=8 is set for these sources
+    # Check that flag=8 is set for these sources
     assert_equal(phot['flags'][0] & 8, np.ones(len(phot)) * 8)
 
 
@@ -1094,7 +1119,7 @@ def test_xy_bounds(test_data):
     assert phot['y_fit'] < 48.7
     assert phot['flags'] == 0
 
-    # test invalid inputs
+    # Test invalid inputs
     match = 'xy_bounds must have 1 or 2 elements'
     with pytest.raises(ValueError, match=match):
         PSFPhotometry(psf_model, fit_shape, xy_bounds=(1, 2, 3))
@@ -1133,12 +1158,12 @@ def test_grouper_with_xy_bounds(test_data):
 
     phot = psfphot(data, error=error, init_params=init_params)
 
-    # verify sources were grouped
+    # Verify sources were grouped
     assert len(phot) == len(init_params)
     assert len(np.unique(phot['group_id'])) < len(phot)
 
-    # Verify that xy_bounds were applied during fitting
-    # The fitted positions should be constrained
+    # Verify that xy_bounds were applied during fitting.
+    # The fitted positions should be constrained.
     for i, row in enumerate(phot):
         x_init = init_params['x_init'][i]
         y_init = init_params['y_init'][i]
@@ -1223,9 +1248,8 @@ def test_out_of_bounds_centroids():
 
     phot = psfphot(data, init_params=sources)
 
-    # at least one of the best-fit centroids should be
-    # out of the bounds of the dataset, producing a
-    # masked value in the `cfit` column:
+    # At least one of the best-fit centroids should be out of the bounds
+    # of the dataset, producing a masked value in the `cfit` column.
     assert np.any(np.isnan(phot['cfit']))
 
 
@@ -1309,7 +1333,7 @@ def test_finder_column_names(x_col, y_col):
     psfphot = PSFPhotometry(psf_model, fit_shape, finder=finder,
                             aperture_radius=10)
 
-    # invalid column names should raise an error
+    # Invalid column names should raise an error
     if x_col == 'x_invalid' or y_col == 'y_invalid':
         match = 'must contain columns for x and y coordinates'
         with pytest.raises(ValueError, match=match):
@@ -1380,7 +1404,7 @@ def test_flag64_no_overlap():
     psf_model = CircularGaussianPRF(fwhm=3.0)
     data = np.zeros(shape)
     init_params = QTable()
-    # place source completely outside (beyond + side)
+    # Place source completely outside (beyond + side)
     init_params['x_0'] = [100.0]
     init_params['y_0'] = [100.0]
     init_params['flux'] = [500.0]
@@ -1450,7 +1474,7 @@ def test_flag16_missing_covariance():
     init_params['flux'] = [500.0, 500.0]
     init_params['group_id'] = [1, 1]
 
-    # mock fitter that does not return a covariance matrix
+    # Mock fitter that does not return a covariance matrix
     def mock_fitter(model, *args, **kwargs):  # noqa: ARG001
         mock_fitter.fit_info = {'status': 1}
         return model
@@ -1608,12 +1632,12 @@ def test_invalid_sources(test_data, units):
         error = error << unit
     init_params = sources.copy()
 
-    # one item in group is invalid
+    # One item in group is invalid
     init_params['x_0'][0] = 1000
     init_params['y_0'][0] = 1000
     init_params['x_0'][5] = 1000
 
-    # entire group is invalid
+    # Entire group is invalid
     init_params['x_0'][-2] = 1000
     init_params['x_0'][-1] = 1000
 
@@ -1848,9 +1872,9 @@ def test_get_source_cutout_data_no_overlap():
 
     y_offsets, x_offsets = psfphot._data_processor.get_fit_offsets()
 
-    # Create a source that will definitely cause NoOverlapError
+    # Create a source that will definitely cause NoOverlapError.
     # Place it far outside the data bounds (-100, -100) to trigger
-    # the exception in overlap_slices and test lines 1183-1192
+    # the exception in overlap_slices.
     init_params = QTable()
     init_params['x_init'] = [-100.0]
     init_params['y_init'] = [-100.0]
@@ -1987,7 +2011,7 @@ def test_init_params_id_order(test_data, reorder, with_groups,
     rng = np.random.default_rng(seed=0)
     init_params['id'] = np.arange(1, n_sources + 1)
     if with_groups:
-        # same groupings, but different group ids
+        # Same groupings, but different group ids
         if nonconsec_groups:
             group_ids = [11, 20, 11, 20, 20, 39, 20, 39, 44, 44]
         else:
@@ -2005,11 +2029,11 @@ def test_init_params_id_order(test_data, reorder, with_groups,
     psfphot1 = PSFPhotometry(psf_model, fit_shape)
     phot1 = psfphot1(data, error=error, init_params=init_params)
 
-    # reorder init_params
+    # Reorder init_params
     init_params2 = init_params.copy()
     if nonconsec_ids:
-        # non-consecutive random ids
-        # monotonically increasing so final results order should be same
+        # Non-consecutive random ids, monotonically increasing so final
+        # results order should be same
         steps = rng.integers(1, 51, size=n_sources - 1)
         init_params2['id'] = np.concatenate(([1], 1 + np.cumsum(steps)))
     if reorder == 'reversed':
@@ -2024,7 +2048,7 @@ def test_init_params_id_order(test_data, reorder, with_groups,
         assert_equal(phot1['id'], phot2['id'])
 
     if with_groups:
-        # without group_id, group_id gets set to id
+        # Without group_id, group_id gets set to id
         assert_equal(phot1['group_id'], phot2['group_id'])
 
     assert np.all([np.allclose(phot1[col], phot2[col], equal_nan=True)
@@ -2159,8 +2183,9 @@ def test_decode_flags():
     # Check that the second source has the negative_flux flag
     assert 'negative_flux' in decoded_flags[1]
 
-    # Check that the third source has flags (it's outside the image bounds)
-    # It should have 'no_overlap' since it's completely outside
+    # Check that the third source has flags (it's outside the image
+    # bounds). It should have 'no_overlap' since it's completely
+    # outside.
     assert len(decoded_flags[2]) > 0
     assert 'no_overlap' in decoded_flags[2]
 

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -50,7 +50,7 @@ def test_fit_2dgaussian_single(fix_fwhm):
         assert 'fwhm_fit' in fit_tbl.colnames
         assert_allclose(fit_tbl['fwhm_fit'], fwhm)
 
-    # test with NaNs - will emit two warnings
+    # Test with NaNs - will emit two warnings
     data[22, 29] = np.nan
     with pytest.warns(AstropyUserWarning) as record:
         fit = fit_2dgaussian(data, fwhm=3, fix_fwhm=fix_fwhm)
@@ -63,7 +63,7 @@ def test_fit_2dgaussian_single(fix_fwhm):
     assert isinstance(fit_tbl, QTable)
     assert len(fit_tbl) == 1
 
-    # test with NaNs and mask - only fit_shape warning
+    # Test with NaNs and mask - only fit_shape warning
     data[22, 29] = np.nan
     mask = np.isnan(data)
     match = ('fit_shape is None, so the input data array is assumed to be '
@@ -73,6 +73,30 @@ def test_fit_2dgaussian_single(fix_fwhm):
     fit_tbl = fit.results
     assert isinstance(fit_tbl, QTable)
     assert len(fit_tbl) == 1
+
+
+def test_fit_2dgaussian_user_mask_with_nan():
+    """
+    Regression test that unmasked non-finite values are merged into
+    a user-provided mask.
+    """
+    rng = np.random.default_rng(0)
+    yy, xx = np.mgrid[0:31, 0:31]
+    data = Gaussian2D(100, 15, 15, 3, 3)(xx, yy)
+    data += rng.normal(0, 0.1, data.shape)
+    data[5, 5] = np.nan
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[0, 0] = True
+    # Expect exactly two warnings: fit_shape is None and unmasked
+    # non-finite values
+    with pytest.warns(AstropyUserWarning) as record:
+        fit = fit_2dgaussian(data, mask=mask, fix_fwhm=False)
+    assert len(record) == 2
+    warning_msgs = [str(w.message) for w in record]
+    assert any('fit_shape is None' in msg for msg in warning_msgs)
+    assert any('unmasked non-finite values' in msg
+               for msg in warning_msgs)
+    assert_allclose(fit.results['x_fit'][0], 15.0, atol=0.1)
 
 
 @pytest.mark.parametrize(('fix_fwhm', 'with_units'),
@@ -96,7 +120,7 @@ def test_fit_2dgaussian_multiple(test_data, fix_fwhm, with_units):
         assert 'fwhm_fit' in fit_tbl.colnames
         assert_allclose(fit_tbl['fwhm_fit'], sources['fwhm'])
 
-    # test with zip instead of list
+    # Test with zip instead of list
     xypos = zip(sources['x_0'], sources['y_0'], strict=True)
     fit2 = fit_2dgaussian(data, xypos=xypos, fit_shape=(5, 5),
                           fix_fwhm=fix_fwhm)
@@ -187,7 +211,7 @@ def test_fit_fwhm_single():
     assert len(fwhm) == 1
     assert_allclose(fwhm, fwhm0)
 
-    # test warning message for convergence issues - flat data should also
+    # Test warning message for convergence issues - flat data should also
     # emit the fit_shape warning since fit_shape=None
     with pytest.warns(AstropyUserWarning) as record:
         fwhm = fit_fwhm(np.zeros(data.shape) + 1)

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -49,14 +49,15 @@ def _make_mask(image, mask):
                '(NaN or inf), which were automatically ignored.')
         warnings.warn(msg, AstropyUserWarning)
 
-    # if NaNs are in the data, no actual fitting takes place
+    # If NaNs are in the data, no actual fitting takes place
     # https://github.com/astropy/astropy/pull/12811
     finite_mask = ~np.isfinite(image)
 
     if mask is not None:
-        finite_mask |= mask
-        if np.any(finite_mask & ~mask):
+        combined_mask = finite_mask | mask
+        if np.any(combined_mask & ~mask):
             warn_nonfinite()
+        mask = combined_mask
     else:
         mask = finite_mask
         if np.any(finite_mask):
@@ -190,10 +191,10 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
       4  8.4214 12.0369   3.2026 192.3530
       5 76.9412 35.9061   6.6600 126.6130
     """
-    # prevent circular import
+    # Prevent circular import
     from photutils.psf.photometry import PSFPhotometry
 
-    # mask non-finite values
+    # Mask non-finite values
     mask = _make_mask(data, mask)
 
     if xypos is None:
@@ -212,8 +213,8 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
             raise ValueError(msg)
 
         fit_shape = data.shape
-        # Ensure odd shape required by the PSF photometry fitting
-        # Here we trim the even edges by 1 pixel
+        # Ensure odd shape required by the PSF photometry fitting.
+        # Here we trim the even edges by 1 pixel.
         fit_shape = tuple(s - 1 if s % 2 == 0 else s for s in fit_shape)
 
         msg = ('fit_shape is None, so the input data array is assumed to be '
@@ -430,12 +431,12 @@ def _interpolate_missing_data(data, mask, *, method='cubic'):
         data_interp[:] = np.nan
         return data_interp
 
-    # initialize the interpolator
+    # Initialize the interpolator
     y, x = np.indices(data_interp.shape)
     xy = np.dstack((x[~mask].ravel(), y[~mask].ravel()))[0]
     z = data_interp[~mask].ravel()
 
-    # interpolate the missing data
+    # Interpolate the missing data
     if method == 'nearest':
         interpol = interpolate.NearestNDInterpolator(xy, z)
     elif method == 'cubic':


### PR DESCRIPTION
This PR fixes two bugs in `photutils.psf` core photometry:

* Fixed a bug where calling ``PSFPhotometry`` with an ``init_params``
    table containing a ``group_id`` column permanently disabled the
    grouper for all subsequent calls on the same instance.

* Fixed a bug where non-finite data values were not merged into a
    user-provided mask, causing fit failures in ``fit_2dgaussian``,
    ``fit_fwhm``, and ``PSFPhotometry``.