### PR TITLE
Fix flat-model caching and constraint propagation for grouped fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -387,9 +387,6 @@ Bug Fixes
     classes now raises a ``TypeError``. Previously, the units were
     silently dropped. [#2371]
 
-  - The ``EnsquaredCurveOfGrowth`` input validation error messages now
-    refer to the ``half_sizes`` parameter instead of ``radii``. [#xxxx]
-
 - ``photutils.psf``
 
   - Fixed a bug where calling ``PSFPhotometry`` with an ``init_params``
@@ -399,6 +396,27 @@ Bug Fixes
   - Fixed a bug where non-finite data values were not merged into a
     user-provided mask, causing fit failures in ``fit_2dgaussian``,
     ``fit_fwhm``, and ``PSFPhotometry``. [#2383]
+
+  - Fixed a bug where grouped fits could silently reuse a stale
+    cached flat-model class when multiple PSF models of the same class
+    (e.g., two different ``ImagePSF`` models) were used, producing
+    incorrect photometry. The flat-model class cache is now stored per
+    fitter instance. [#2384]
+
+  - Fixed a bug where PSF model parameter bounds were not applied in
+    grouped fits, so grouped fits were unconstrained where single-source
+    fits were constrained. The bounds are now also propagated back to
+    the fitted models, so the ``NEAR_BOUND`` flag is now set for grouped
+    sources. [#2384]
+
+  - Fixed a bug where ``PSFPhotometry`` raised an error for
+    integer-dtype data when a ``local_bkg`` column was provided. [#2384]
+
+  - An ``init_params`` table column that has a unit attribute (e.g.,
+    from a ``Table`` instead of a ``QTable``) is now converted to the
+    data unit instead of raising an error claiming the column has no
+    units. The error message for a truly unitless column now suggests
+    using a Quantity column. [#2384]
 
 - ``photutils.segmentation``
 

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -8,7 +8,6 @@ of the PSFPhotometry class and are not intended for direct public use.
 
 import contextlib
 import warnings
-import weakref
 from copy import deepcopy
 
 import astropy
@@ -72,6 +71,10 @@ def _create_flat_model_class(n_sources, psf_model):
     The dynamic flat model class directly evaluates each PSF and sums them,
     providing much better performance for large groups.
 
+    Each flat parameter copies the default value, fixed status, and
+    bounds from the base PSF model parameter. Tied constraints are not
+    propagated to grouped fits.
+
     Parameters
     ----------
     n_sources : int
@@ -96,11 +99,14 @@ def _create_flat_model_class(n_sources, psf_model):
     for i in range(n_sources):
         for base_param in base_param_names:
             flat_param_name = f'{base_param}_{i}'
-            # Use default value and fixed status from base PSF model
+            # Use default value, fixed status, and bounds from the
+            # base PSF model. Note that tied constraints are not
+            # propagated to grouped fits.
             base_param_obj = getattr(base_psf_model, base_param)
             default_value = base_param_obj.value
             is_fixed = base_param_obj.fixed
-            param = Parameter(default=default_value, fixed=is_fixed)
+            param = Parameter(default=default_value, fixed=is_fixed,
+                              bounds=base_param_obj.bounds)
             class_attrs[flat_param_name] = param
 
     # Add methods
@@ -214,21 +220,19 @@ def _instantiate_flat_model(model_class, sources, psf_model, param_mapper, *,
     return model
 
 
-# Weak reference cache for flat model classes to prevent memory leaks
-_FLAT_MODEL_CACHE = weakref.WeakValueDictionary()
-
-
-def _get_flat_model(sources, psf_model, param_mapper, *, xy_bounds=None):
+def _get_flat_model(sources, psf_model, param_mapper, *, xy_bounds=None,
+                    class_cache=None):
     """
     Get or create a flat model for a group of sources.
 
-    This function caches the dynamically-generated flat model classes
-    to avoid recreating them for groups with the same characteristics,
+    The dynamically-generated flat model classes can be cached to
+    avoid recreating them for groups with the same number of sources,
     improving performance when processing many groups.
 
-    The caching uses weak references to prevent memory leaks and
-    includes the PSF model type in the cache key to avoid collisions
-    between different model types with similar parameter names.
+    A cached class captures a copy of ``psf_model`` (including its
+    parameter values, fixed flags, and bounds), so a given cache dict is
+    valid only for a single, fixed ``psf_model``. The caller owns the
+    cache dict and must not share it between different PSF models.
 
     Parameters
     ----------
@@ -245,6 +249,10 @@ def _get_flat_model(sources, psf_model, param_mapper, *, xy_bounds=None):
     xy_bounds : tuple of float or None, optional
         Bounds for x and y position parameters as (x_bound, y_bound).
 
+    class_cache : dict or None, optional
+        Cache of flat model classes keyed on the number of sources. If
+        `None`, a new class is always created.
+
     Returns
     -------
     model : `~astropy.modeling.Model`
@@ -252,19 +260,14 @@ def _get_flat_model(sources, psf_model, param_mapper, *, xy_bounds=None):
         set from the sources and bounds applied.
     """
     n_sources = len(sources)
-
-    # Create robust cache key to avoid model type collisions
-    # Use number of sources and the PSF model class name
-    model_class = psf_model.__class__
-    model_type = f'{model_class.__module__}.{model_class.__name__}'
-    cache_key = (n_sources, model_type)
-
-    # Get cached model class or create new one
-    if cache_key not in _FLAT_MODEL_CACHE:
+    if class_cache is None:
         model_class = _create_flat_model_class(n_sources, psf_model)
-        _FLAT_MODEL_CACHE[cache_key] = model_class
-
-    model_class = _FLAT_MODEL_CACHE[cache_key]
+    else:
+        model_class = class_cache.get(n_sources)
+        if model_class is None:
+            model_class = _create_flat_model_class(n_sources,
+                                                   psf_model)
+            class_cache[n_sources] = model_class
 
     # Create instance with source-specific parameter values
     return _instantiate_flat_model(model_class, sources, psf_model,
@@ -383,6 +386,13 @@ class PSFDataProcessor:
             and the data units.
         """
         values = init_params[colname]
+
+        # Convert a plain Column carrying a unit attribute (e.g., from
+        # a Table instead of a QTable) to a Quantity
+        if (not isinstance(values, u.Quantity)
+                and getattr(values, 'unit', None) is not None):
+            values = u.Quantity(values)
+
         if isinstance(values, u.Quantity):
             if self.data_unit is None:
                 msg = (f'init_params {colname} column has units, but the '
@@ -395,8 +405,9 @@ class PSFDataProcessor:
                        'incompatible with the input data units')
                 raise ValueError(msg) from exc
         elif self.data_unit is not None:
-            msg = ('The input data has units, but the init_params '
-                   f'{colname} column does not have units.')
+            msg = (f'The input data has units, but the init_params '
+                   f'{colname} column does not. It must be a Quantity '
+                   'column (e.g., use a QTable).')
             raise ValueError(msg)
         return init_params
 
@@ -692,15 +703,15 @@ class PSFDataProcessor:
         y_cen = row[self.param_mapper.init_colnames['y']]
         flux_init = row[self.param_mapper.init_colnames['flux']]
 
-        # check for non-finite positions
+        # Check for non-finite positions
         if not (np.isfinite(x_cen) and np.isfinite(y_cen)):
             return True, 'invalid_position'
 
-        # check for non-finite flux
+        # Check for non-finite flux
         if not np.isfinite(flux_init):
             return True, 'non_finite_flux'
 
-        # source that are clearly beyond any possible overlap
+        # Sources that are clearly beyond any possible overlap
         half_fit = max(self.fit_shape) // 2
         clear_margin = half_fit + 1  # a bit beyond the fit region
         if (x_cen < -clear_margin or y_cen < -clear_margin
@@ -787,8 +798,8 @@ class PSFDataProcessor:
 
         cutout = data[yy_flat, xx_flat]
 
-        # Local background subtraction (local_bkg = 0 if not provided)
-        # Only subtract if the local_bkg is finite (not NaN or inf)
+        # Local background subtraction (local_bkg = 0 if not provided).
+        # Only subtract if the local_bkg is finite (not NaN or inf).
         local_bkg = row['local_bkg']
         if np.any(local_bkg != 0):
             if isinstance(local_bkg, u.Quantity):
@@ -796,9 +807,12 @@ class PSFDataProcessor:
             else:
                 local_bkg_value = local_bkg
 
-            # Only subtract if local_bkg is finite
+            # Only subtract if local_bkg is finite. The subtraction
+            # is not done in place so that integer-dtype data works
+            # with a float local_bkg (the fancy index above already
+            # returned a copy).
             if np.isfinite(local_bkg_value):
-                cutout -= local_bkg_value
+                cutout = cutout - local_bkg_value
 
         # Center pixel index (before trimming)
         x_cen_idx = np.ceil(x_cen - 0.5).astype(int)
@@ -861,6 +875,11 @@ class PSFFitter:
         self.xy_bounds = xy_bounds
         self.group_warning_threshold = group_warning_threshold
 
+        # Cache of flat model classes keyed on the number of sources.
+        # The cache is per-instance because the cached classes capture
+        # a copy of psf_model.
+        self._flat_model_classes = {}
+
     def make_psf_model(self, sources):
         """
         Create a single PSF model or a flat model for a group of
@@ -875,9 +894,9 @@ class PSFFitter:
         The dynamic flat model class directly evaluates each PSF and
         sums them, providing much better performance for large groups.
 
-        Flat model classes are cached based on the number of sources and
-        PSF model characteristics to improve performance for repeated
-        group sizes.
+        Flat model classes are cached per PSFFitter instance based on
+        the number of sources to improve performance for repeated group
+        sizes.
 
         Parameters
         ----------
@@ -915,7 +934,8 @@ class PSFFitter:
 
         # For multiple sources, use cached flat model class
         return _get_flat_model(sources, self.psf_model, self.param_mapper,
-                               xy_bounds=self.xy_bounds)
+                               xy_bounds=self.xy_bounds,
+                               class_cache=self._flat_model_classes)
 
     def _apply_bounds_to_param(self, model, param_name, param_value,
                                bound_value):
@@ -1001,7 +1021,7 @@ class PSFFitter:
                 raise ValueError(msg)
             weights = 1.0 / error[yi, xi]
 
-        # keep fit-info entries (but exclude residual vectors)
+        # Keep fit-info entries (but exclude residual vectors)
         fit_info_keys = ('param_cov', 'ierr', 'message', 'status')
 
         with warnings.catch_warnings():
@@ -1009,7 +1029,7 @@ class PSFFitter:
             fit_model = self.fitter(psf_model, xi, yi, cutout,
                                     weights=weights, **kwargs)
 
-            # clear any model cache, if supported by the model
+            # Clear any model cache, if supported by the model
             with contextlib.suppress(AttributeError):
                 fit_model.clear_cache()
 
@@ -1084,12 +1104,15 @@ class PSFFitter:
             # Create a copy of the base PSF model
             source_model = self.psf_model.copy()
 
-            # Extract parameters for this source from the flat model
+            # Extract parameter values and bounds for this source from
+            # the flat model
             for param_name in param_names:
                 flat_param_name = f'{param_name}_{i}'
                 if hasattr(flat_model, flat_param_name):
-                    param_value = getattr(flat_model, flat_param_name).value
-                    setattr(source_model, param_name, param_value)
+                    flat_param = getattr(flat_model, flat_param_name)
+                    setattr(source_model, param_name, flat_param.value)
+                    getattr(source_model,
+                            param_name).bounds = flat_param.bounds
 
             source_models.append(source_model)
 
@@ -1192,7 +1215,7 @@ class PSFResultsAssembler:
         """
         table = QTable()
 
-        # create error columns for models parameters that were fit
+        # Create error columns for models parameters that were fit
         mapper = self.param_mapper
         fitted_params = mapper.fitted_param_names
         model_param_to_alias = mapper.model_param_to_alias
@@ -1206,13 +1229,13 @@ class PSFResultsAssembler:
                       for i, err_col in enumerate(fitted_err_cols)}
         table = QTable(table_data)
 
-        # ensure columns for non-fitted (fixed) params exist
+        # Ensure columns for non-fitted (fixed) params exist
         all_err_cols = list(err_colnames.values())
         for err_col in all_err_cols:
             if err_col not in table.colnames:
                 table[err_col] = np.nan
 
-        # apply data_unit to flux_err column
+        # Apply data_unit to flux_err column
         if data_unit is not None:
             flux_err_col = err_colnames['flux']
             table[flux_err_col] <<= data_unit
@@ -1327,7 +1350,7 @@ class PSFResultsAssembler:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
 
-            # create masks for valid data
+            # Create masks for valid data
             valid_sa = np.isfinite(sum_abs_residuals)
             valid_cr = np.isfinite(cen_residuals)
             nonzero_flux = (flux_vals != 0)
@@ -1709,7 +1732,7 @@ class _ModelImageMaker:
         progress_bar = self.progress_bar
 
         if include_local_bkg:
-            # add local_bkg, but set non-finite values to 0 to avoid
+            # Add local_bkg, but set non-finite values to 0 to avoid
             # corrupting the model image
             model_params = model_params.copy()
             local_bkgs_clean = local_bkgs.copy()

--- a/photutils/psf/tests/test_components.py
+++ b/photutils/psf/tests/test_components.py
@@ -183,9 +183,24 @@ class TestPSFDataProcessor:
         processor.data_unit = u.count
 
         init_params = Table({'flux_init': [100.0, 200.0]})
-        match_str = 'input data has units.*does not have units'
+        match_str = 'must be a Quantity column'
         with pytest.raises(ValueError, match=match_str):
             processor.normalize_init_units(init_params, 'flux_init')
+
+    def test_normalize_init_units_column_with_unit(self, param_mapper):
+        """
+        Regression test that a plain Table column carrying a unit
+        attribute is converted to the data unit instead of raising an
+        error claiming the column has no units.
+        """
+        processor = PSFDataProcessor(param_mapper, (7, 7))
+        processor.data_unit = u.Jy
+
+        init_params = Table({'flux_init': [1000.0, 2000.0]})
+        init_params['flux_init'].unit = u.mJy
+        result = processor.normalize_init_units(init_params,
+                                                'flux_init')
+        assert_equal(np.asarray(result['flux_init']), [1.0, 2.0])
 
     def test_normalize_init_units_init_has_units_data_does_not(
             self, param_mapper):
@@ -417,6 +432,51 @@ class TestPSFFitter:
         assert model.flux_1.value == 200.0
         assert model.x_0_1.value == 20.0
         assert model.y_0_1.value == 25.0
+
+    def test_make_psf_model_no_stale_class_cache(self):
+        """
+        Regression test that flat-model classes are not shared
+        between PSFFitter instances with different PSF models of the
+        same class.
+        """
+        sources = Table({
+            'id': [1, 2],
+            'x_init': [10.0, 20.0],
+            'y_init': [15.0, 25.0],
+            'flux_init': [100.0, 200.0],
+            'fwhm_init': [2.7, 2.7],
+        })
+
+        psf_model1 = CircularGaussianPRF(flux=1, fwhm=2.7)
+        fitter1 = PSFFitter(psf_model1, _PSFParameterMapper(psf_model1))
+        flat_model1 = fitter1.make_psf_model(sources)
+        assert flat_model1.fwhm_0.fixed is True
+
+        psf_model2 = CircularGaussianPRF(flux=1, fwhm=2.7)
+        psf_model2.fwhm.fixed = False
+        fitter2 = PSFFitter(psf_model2, _PSFParameterMapper(psf_model2))
+        flat_model2 = fitter2.make_psf_model(sources)
+        assert flat_model2.fwhm_0.fixed is False
+        assert flat_model2.fwhm_1.fixed is False
+
+    def test_flat_model_preserves_bounds(self, psf_model, param_mapper):
+        """
+        Regression test that flat models preserve the parameter
+        bounds of the base PSF model.
+        """
+        assert psf_model.fwhm.bounds[0] is not None
+        fitter = PSFFitter(psf_model, param_mapper)
+
+        sources = Table({
+            'id': [1, 2],
+            'x_init': [10.0, 20.0],
+            'y_init': [15.0, 25.0],
+            'flux_init': [100.0, 200.0],
+        })
+
+        flat_model = fitter.make_psf_model(sources)
+        assert flat_model.fwhm_0.bounds == psf_model.fwhm.bounds
+        assert flat_model.fwhm_1.bounds == psf_model.fwhm.bounds
 
     def test_make_psf_model_with_xy_bounds(self, psf_model, param_mapper):
         """

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -3,6 +3,7 @@
 Tests for the photometry module.
 """
 
+import gc
 import tempfile
 
 import astropy.units as u
@@ -20,8 +21,8 @@ from numpy.testing import assert_allclose, assert_equal
 from photutils.background import LocalBackground, MMMBackground
 from photutils.datasets import make_model_image, make_noise_image
 from photutils.detection import DAOStarFinder
-from photutils.psf import (CircularGaussianPRF, PSFPhotometry, SourceGrouper,
-                           make_psf_model, make_psf_model_image)
+from photutils.psf import (CircularGaussianPRF, ImagePSF, PSFPhotometry,
+                           SourceGrouper, make_psf_model, make_psf_model_image)
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
@@ -798,6 +799,76 @@ def test_psf_photometry_init_params_columns(test_data):
         assert_allclose(phot['x_fit'], phots[0]['x_fit'])
         assert_allclose(phot['y_fit'], phots[0]['y_fit'])
         assert_allclose(phot['flux_fit'], phots[0]['flux_fit'])
+
+
+def test_grouped_fit_two_image_psfs():
+    """
+    Regression test that grouped fits with two different same-class
+    PSF models do not reuse a stale cached flat-model class.
+    """
+    def make_image_psf(sigma2):
+        yy, xx = np.mgrid[:21, :21]
+        psf_data = np.exp(-((xx - 10.0)**2 + (yy - 10.0)**2)
+                          / (2 * sigma2))
+        return ImagePSF(psf_data / psf_data.sum())
+
+    def make_scene(psf):
+        yy, xx = np.mgrid[:60, :60]
+        data = np.zeros((60, 60))
+        for (xpos, ypos), flux in zip(((20.0, 20.0), (24.0, 22.0)),
+                                      (500.0, 300.0), strict=True):
+            data += psf.evaluate(xx, yy, flux, xpos, ypos)
+        return data
+
+    init = Table({'x': [20.0, 24.0], 'y': [20.0, 22.0],
+                  'flux': [450.0, 280.0], 'group_id': [1, 1]})
+    # disable garbage collection so that a stale cached flat-model
+    # class cannot be silently evicted between the fits
+    gc.disable()
+    try:
+        for sigma2 in (1.0, 16.0):
+            psf = make_image_psf(sigma2)
+            phot = PSFPhotometry(psf, (11, 11))
+            result = phot(make_scene(psf), init_params=init.copy())
+            assert_allclose(result['flux_fit'], [500.0, 300.0],
+                            rtol=1e-3)
+    finally:
+        gc.enable()
+
+
+def test_near_bound_flag_grouped():
+    """
+    Regression test that the NEAR_BOUND flag (bit 32) is set for
+    grouped sources, matching single-source behavior.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image(
+        (50, 50), model, 2, model_shape=(9, 9), flux=(500, 500),
+        min_separation=15, seed=0)
+    # offset the initial positions so the fit runs into the bound
+    init = Table({'x': params['x_0'] + 2.0, 'y': params['y_0'],
+                  'flux': [500.0, 500.0],
+                  'group_id': [1, 1]})
+    psfphot = PSFPhotometry(model, (5, 5), xy_bounds=0.5)
+    phot = psfphot(data, init_params=init)
+    assert np.all(phot['flags'] & 32)
+
+
+def test_int_data_with_local_bkg():
+    """
+    Regression test that integer-dtype data works with a float
+    local_bkg column.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image(
+        (50, 50), model, 3, model_shape=(9, 9), flux=(500, 700),
+        min_separation=10, seed=0)
+    data = (data * 100).astype(int)
+    init = Table({'x': params['x_0'], 'y': params['y_0'],
+                  'local_bkg': [10.5, 10.5, 10.5]})
+    psfphot = PSFPhotometry(model, (5, 5), aperture_radius=4)
+    phot = psfphot(data, init_params=init)
+    assert len(phot) == 3
 
 
 def test_grouper(test_data):


### PR DESCRIPTION
This PR fixes four bugs in grouped-source PSF fitting:

- **Stale flat-model class cache**: the module-level weak-reference
  cache was keyed only on the number of sources and the PSF model
  class name, so a second same-class PSF model (e.g., a different
  `ImagePSF`, or the same model with different `fixed` flags)
  silently reused a stale cached class, producing incorrect grouped
  photometry. The cache is now a per-fitter dict keyed on the number
  of sources only.
- **Parameter bounds in grouped fits**: flat model classes copied
  only each parameter's default value and fixed flag, so grouped
  fits were unconstrained where single-source fits were constrained.
  Bounds are now propagated into the flat model and back out to the
  per-source fitted models, so the `NEAR_BOUND` flag is now also set
  for grouped sources. Tied constraints are still not propagated;
  this limitation is now documented.
- **Integer data with local_bkg**: the local background subtraction
  was done in place on the data cutout, raising a casting error for
  integer-dtype data with a float `local_bkg`.
- **Unit-carrying `Table` columns**: an `init_params` column with a
  `.unit` attribute (from a plain `Table` instead of a `QTable`) is
  now converted to the data unit instead of raising an error
  claiming the column has no units. The error for a truly unitless
  column now suggests using a Quantity column.