### PR TITLE
Fix ePSF building with linked stars and exclusion warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -418,6 +418,18 @@ Bug Fixes
     units. The error message for a truly unitless column now suggests
     using a Quantity column. [#2384]
 
+- ``photutils.psf``
+
+  - Fixed a bug where ``EPSFBuilder`` rejected all ``LinkedEPSFStar``
+    inputs as invalid stars, a regression introduced in version 3.0.
+    [#2385]
+
+  - Fixed a bug where the ``EPSFBuilder`` star exclusion warning
+    raised a ``TypeError`` for stars with the default (`None`) or
+    string ``id_label`` values. The warning message now always
+    reports the flat star index and includes the id label when
+    available. [#2385]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -198,16 +198,20 @@ class _EPSFValidator:
                    'Please provide at least one star for ePSF building.')
             raise ValueError(msg)
 
+        # Iterate over the flat star list so that the stars within
+        # LinkedEPSFStar objects are validated individually
+        star_list = getattr(stars, 'all_stars', stars)
+
         # Collect star dimension statistics
-        star_heights = [star.shape[0] for star in stars]
-        star_widths = [star.shape[1] for star in stars]
+        star_heights = [star.shape[0] for star in star_list]
+        star_widths = [star.shape[1] for star in star_list]
         max_height = max(star_heights)
         max_width = max(star_widths)
 
         # Check for extremely small stars that may cause issues
         min_star_size = 3  # minimum reasonable star cutout size
         problematic_stars = []
-        for i, star in enumerate(stars):
+        for i, star in enumerate(star_list):
             if min(star.shape) < min_star_size:
                 problematic_stars.append(f'Star {i}: {star.shape}')
 
@@ -276,9 +280,13 @@ class _EPSFValidator:
                 msg = f'{context}: {msg}'
             raise ValueError(msg)
 
-        # Validate individual stars
+        # Validate the individual stars in the flat star list so that
+        # the stars within LinkedEPSFStar objects are checked (their
+        # container delegates attributes like shape as lists). The
+        # flat indices in error messages match excluded_star_indices.
+        star_list = getattr(stars, 'all_stars', stars)
         invalid_stars = []
-        for i, star in enumerate(stars):
+        for i, star in enumerate(star_list):
             try:
                 # Check for valid data
                 if not hasattr(star, 'data') or star.data is None:
@@ -310,7 +318,7 @@ class _EPSFValidator:
                 error_details.append(f'... and {len(invalid_stars) - 5} more')
 
             msg = (f'Found {len(invalid_stars)} invalid stars out of '
-                   f'{len(stars)} total:\n' + '\n'.join(error_details))
+                   f'{len(star_list)} total:\n' + '\n'.join(error_details))
             if context:
                 msg = f'{context}: {msg}'
             raise ValueError(msg)
@@ -1109,7 +1117,7 @@ class EPSFBuilder:
             raise TypeError(msg)
         self._sigma_clip = sigma_clip
 
-        # store each ePSF build iteration
+        # Store each ePSF build iteration
         self._epsf = []
 
     def __call__(self, stars):
@@ -1235,8 +1243,9 @@ class EPSFBuilder:
             shape = as_pair('shape', shape, lower_bound=(0, 0), check_odd=True)
         else:
             # Use coordinate transformer to compute shape from star
-            # dimensions
-            star_shapes = [star.shape for star in stars]
+            # dimensions (use the flat star list so that stars within
+            # LinkedEPSFStar objects contribute individual shapes)
+            star_shapes = [star.shape for star in stars.all_stars]
             shape = self.coord_transformer.compute_epsf_shape(star_shapes)
 
         # Initialize with zeros
@@ -1898,10 +1907,14 @@ class EPSFBuilder:
                     else:  # _fit_error_status == 2
                         reason = 'the fit did not converge'
 
-                    msg = (f'The star at ({star._center_original[0]:.2f}, '
-                           f'{star._center_original[1]:.2f}) (index='
-                           f'{star.id_label - 1}) has been excluded from '
-                           f'ePSF fitting because {reason}.')
+                    label = ''
+                    if star.id_label is not None:
+                        label = f' (id={star.id_label})'
+                    msg = (f'The star at '
+                           f'({star._center_original[0]:.2f}, '
+                           f'{star._center_original[1]:.2f}) '
+                           f'(index={i}){label} has been excluded '
+                           f'from ePSF fitting because {reason}.')
                     warnings.warn(msg, AstropyUserWarning)
                 star._excluded_from_fit = True
 
@@ -2003,7 +2016,7 @@ class EPSFBuilder:
                                                     shape=self.shape)
 
         # Initialize variables for building process
-        fit_failed = np.zeros(stars.n_stars, dtype=bool)
+        fit_failed = np.zeros(stars.n_all_stars, dtype=bool)
         centers = stars.cutout_center_flat
 
         # Setup progress tracking

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -69,6 +69,18 @@ def epsf_fitter_data(epsf_test_data):
     return {'stars': stars, 'epsf': epsf}
 
 
+class _MockWCS:
+    """
+    Mock WCS with an identity pixel-to-world transform.
+    """
+
+    def pixel_to_world_values(self, x, y):
+        return x, y
+
+    def world_to_pixel_values(self, ra, dec):
+        return ra, dec
+
+
 def _make_epsf_fitter(**kwargs):
     """
     Helper to create EPSFFitter suppressing the deprecation warning.
@@ -79,6 +91,26 @@ def _make_epsf_fitter(**kwargs):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', AstropyDeprecationWarning)
         return EPSFFitter(**kwargs)
+
+
+def test_build_epsf_linked_stars():
+    """
+    Regression test that the public builder accepts LinkedEPSFStar
+    inputs.
+    """
+    yy, xx = np.indices((11, 11))
+    sig = 2.5 / 2.3548
+    star_data = np.exp(-((xx - 5.0)**2 + (yy - 5.0)**2)
+                       / (2 * sig**2))
+    stars_list = [EPSFStar(star_data.copy(), cutout_center=(5.0, 5.0),
+                           origin=(0, 0), wcs_large=_MockWCS())
+                  for _ in range(2)]
+    linked = LinkedEPSFStar(stars_list)
+    stars = EPSFStars([linked])
+    builder = EPSFBuilder(oversampling=1, maxiters=2,
+                          progress_bar=False)
+    result = builder(stars)
+    assert result.epsf.data.shape[0] >= 11
 
 
 class TestSmoothingKernel:
@@ -1478,6 +1510,25 @@ class TestEPSFBuilder:
         assert result.fitted_stars.n_good_stars == 4
         assert result.fitted_stars.n_all_stars == 5
 
+    @pytest.mark.parametrize('id_label', [None, 'star_a'])
+    def test_star_exclusion_id_label(self, epsf_test_data, id_label):
+        """
+        Regression test that the exclusion warning works for the
+        default (None) and string star id labels.
+        """
+        tbl = epsf_test_data['init_stars'][:5].copy()
+        tbl['x'][0] = 465
+        tbl['y'][0] = 30
+        stars = extract_stars(epsf_test_data['nddata'], tbl, size=11)
+        for star in stars.all_stars:
+            star.id_label = id_label
+
+        builder = EPSFBuilder(oversampling=1, maxiters=5,
+                              progress_bar=False)
+        with pytest.warns(AstropyUserWarning,
+                          match='has been excluded from ePSF fitting'):
+            builder(stars)
+
     def test_star_exclusion_single_warning(self, epsf_test_data):
         """
         Test that only a single warning is emitted per excluded star.
@@ -2382,7 +2433,7 @@ class TestEPSFBuilder:
         # cutout_center should NOT have been updated
         assert_array_equal(fitted_star.cutout_center, original_center)
 
-        # flux should NOT have been updated
+        # Flux should NOT have been updated
         assert fitted_star.flux == original_flux
 
     def test_fit_star_position_negative_outside_cutout(self, epsf_test_data):


### PR DESCRIPTION
This PR fixes two `EPSFBuilder` bugs:

- **`LinkedEPSFStar` inputs rejected (3.0 regression)**: validation
  iterated the `EPSFStars` container, whose items include
  `LinkedEPSFStar` objects. Their delegated `.shape` is a list of
  tuples, so the size check raised a `TypeError` that was interpreted
  as "invalid star", rejecting every multi-star `LinkedEPSFStar`.
  Validation, the initial ePSF shape computation, and the failed-fit
  tracking array now use the flat star list.
- **Star exclusion warning crash**: the warning message assumed
  sequential integer id labels (`id_label - 1`), crashing with a
  `TypeError` for the default (`None`) or string `id_label` values.
  The message now reports the flat star index and includes the id
  label when available.