### PR TITLE
Fix EPSFStar slices transposition and stale flux normalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -430,6 +430,16 @@ Bug Fixes
     reports the flat star index and includes the id label when
     available. [#2385]
 
+- ``photutils.psf``
+
+  - Fixed a bug where the ``EPSFStar`` ``slices`` and ``bbox``
+    attributes were transposed for non-square cutouts. [#2386]
+
+  - Fixed a bug where the ePSF building flux renormalization used
+    stale cached values, so every iteration normalized the star data
+    with the first-iteration flux instead of the updated fitted flux.
+    [#2386]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -145,8 +145,8 @@ class EPSFStar:
                        'available')
                 raise ValueError(msg)
 
-            # Check if all unmasked data values are exactly zero
-            # Store flag for later warning (to avoid duplicate warnings)
+            # Check if all unmasked data values are exactly zero.
+            # Store flag for later warning (to avoid duplicate warnings).
             unmasked_data = self._data[~self.mask]
             self._has_all_zero_data = bool(np.all(unmasked_data == 0.0))
 
@@ -178,6 +178,27 @@ class EPSFStar:
         The 2D cutout image.
         """
         return self._data
+
+    @property
+    def flux(self):
+        """
+        The total flux of the star.
+        """
+        return self._flux
+
+    @flux.setter
+    def flux(self, value):
+        """
+        Set the total flux of the star.
+
+        Parameters
+        ----------
+        value : float
+            The total flux of the star.
+        """
+        self._flux = float(value)
+        # The cached normalized data values depend on the flux
+        self.__dict__.pop('_data_values_normalized', None)
 
     @property
     def cutout_center(self):
@@ -235,8 +256,8 @@ class EPSFStar:
         A tuple of two slices representing the cutout region with
         respect to the original (large) image.
         """
-        return (slice(self.origin[1], self.origin[1] + self.shape[1]),
-                slice(self.origin[0], self.origin[0] + self.shape[0]))
+        return (slice(self.origin[1], self.origin[1] + self.shape[0]),
+                slice(self.origin[0], self.origin[0] + self.shape[1]))
 
     @cached_property
     def bbox(self):
@@ -283,7 +304,7 @@ class EPSFStar:
         data : `~numpy.ndarray`
             A 2D array of the registered/scaled ePSF.
         """
-        # evaluate the input ePSF on the star cutout grid
+        # Evaluate the input ePSF on the star cutout grid
         yy, xx = np.indices(self.shape, dtype=float)
         return epsf.evaluate(xx, yy, flux=self.flux,
                              x_0=self.cutout_center[0],
@@ -659,9 +680,9 @@ class LinkedEPSFStar:
             warnings.warn(msg, AstropyUserWarning)
             return
 
-        # Convert pixel coordinates to sky coordinates
+        # Convert pixel coordinates to sky coordinates.
         # Note: each star may have a different WCS, so we cannot
-        # vectorize
+        # vectorize.
         good_stars = self.all_good_stars
         sky_coords = np.array([
             star.wcs_large.pixel_to_world_values(*star.center)
@@ -938,8 +959,11 @@ def extract_stars(data, catalogs, *, size=(11, 11)):
         Optionally, each catalog may also contain an ``id`` column
         representing the ID/name of stars. If this column is not
         present then the extracted stars will be given an ``id`` number
-        corresponding the table row number (starting at 1). Any other
-        columns present in the input ``catalogs`` will be ignored.
+        corresponding the table row number (starting at 1). The catalogs
+        may also contain an optional ``flux`` column giving the flux
+        of each star. If present, these values are used instead of
+        estimating the flux from the cutout data. Any other columns
+        present in the input ``catalogs`` will be ignored.
 
     size : int or array_like (int), optional
         The extraction box size along each axis. If ``size`` is a scalar

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -3,6 +3,7 @@
 Tests for the epsf_stars module.
 """
 
+import copy
 import warnings
 from multiprocessing.reduction import ForkingPickler
 
@@ -534,17 +535,43 @@ class TestEPSFStar:
         assert_array_equal(star.center, expected_center)
 
         # Test slices property
-        # Implementation uses (origin_y to origin_y+shape[0],
-        # origin_x to origin_x+shape[1])
-        expected_slices = (slice(20, 29), slice(10, 17))
+        expected_slices = (slice(20, 27), slice(10, 19))
         assert star.slices == expected_slices
 
         # Test bbox property
         bbox = star.bbox
         assert bbox.ixmin == 10
-        assert bbox.ixmax == 17
+        assert bbox.ixmax == 19
         assert bbox.iymin == 20
-        assert bbox.iymax == 29
+        assert bbox.iymax == 27
+
+    def test_slices_bbox_rectangular_roundtrip(self):
+        """
+        Regression test that slices/bbox are correct for non-square
+        cutouts: indexing the parent image with star.slices must
+        return the cutout.
+        """
+        img = np.arange(60 * 80, dtype=float).reshape(60, 80)
+        stars = extract_stars(NDData(img),
+                              Table({'x': [40.0], 'y': [30.0]}),
+                              size=(11, 15))
+        star = stars[0]
+        assert star.data.shape == (11, 15)
+        assert_array_equal(img[star.slices], star.data)
+
+    def test_flux_update_invalidates_normalization(self):
+        """
+        Regression test that updating flux (including on a shallow
+        copy, as the ePSF builder does) refreshes the cached
+        normalized data values.
+        """
+        star = EPSFStar(np.ones((5, 5)))
+        norm = star._data_values_normalized.copy()
+        star2 = copy.copy(star)
+        star2.flux = star.flux * 2
+        assert_allclose(star2._data_values_normalized, norm / 2)
+        star.flux = star.flux * 4
+        assert_allclose(star._data_values_normalized, norm / 4)
 
     def test_flux_estimation_interpolation_fallback(self):
         """
@@ -1449,6 +1476,25 @@ class TestExtractStars:
         # Should have extracted at least 1 star (from first image)
         # The second image star is outside bounds so only 1 is extracted
         assert len(stars) >= 1
+
+    def test_extract_stars_flux_column(self):
+        """
+        Test that a catalog flux column is used for the star fluxes.
+        """
+        data = np.ones((50, 50))
+        catalog = Table({'x': [25.0], 'y': [25.0], 'flux': [12345.0]})
+        stars = extract_stars(NDData(data), catalog, size=11)
+        assert stars[0].flux == 12345.0
+
+    def test_extract_stars_no_flux_column(self):
+        """
+        Test that star fluxes are estimated from the cutout data when
+        the catalog has no flux column.
+        """
+        data = np.ones((50, 50))
+        catalog = Table({'x': [25.0], 'y': [25.0]})
+        stars = extract_stars(NDData(data), catalog, size=11)
+        assert_allclose(stars[0].flux, 121.0)
 
     def test_extract_stars_flux_estimation_failure(self):
         """


### PR DESCRIPTION
This PR fixes two `EPSFStar` bugs and documents one behavior:

- **Transposed `slices`/`bbox`**: for non-square cutouts, the
  `slices` property built the y-slice with the cutout width and the
  x-slice with the height, so `slices` and `bbox` had swapped
  extents. Indexing the parent image with `star.slices` now returns
  the cutout.
- **Stale flux normalization in ePSF building**: the cached
  normalized data values (`data / flux`) survived shallow copies and
  flux updates, so ePSF building renormalized every iteration with
  the first-iteration flux instead of the updated fitted flux.
  `flux` is now a property whose setter invalidates the cache.
- **Catalog `flux` column**: `extract_stars` has used an optional
  catalog `flux` column since 3.0.0, but the docstring said any
  extra columns were ignored. The behavior is kept, now documented
  and pinned by tests.