### PR TITLE
Fix PSFPhotometry and IterativePSFPhotometry bugs from PSF package review

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -472,6 +472,31 @@ Bug Fixes
   - The ``PSFPhotometry`` ``group_warning_threshold`` keyword is now
     validated to be a positive integer. [#2387]
 
+  - Fixed a bug where ``IterativePSFPhotometry`` with ``mode='all'``
+    raised an error when an earlier iteration produced a source with
+    non-finite fit results. Such sources are now dropped from later
+    iterations. [#2387]
+
+  - Fixed a bug where ``IterativePSFPhotometry`` with ``mode='all'``
+    did not carry the local background values into iterations after
+    the first, so sources were refit with a local background of
+    zero. [#2387]
+
+  - Fixed a bug where a callable ``finder`` returning a zero-row
+    table caused an error in ``IterativePSFPhotometry``. The
+    iteration now stops cleanly. [#2387]
+
+  - Fixed a bug where the ``IterativePSFPhotometry``
+    ``make_model_image`` and ``make_residual_image`` methods raised a
+    confusing error after a run in which no sources were detected.
+    They now raise a clear ``ValueError``. [#2387]
+
+  - The ``IterativePSFPhotometry`` ``sub_shape`` keyword is now
+    validated at initialization to have odd, positive values,
+    matching the documented requirement. The ``maxiters`` keyword
+    validation now also rejects non-numeric and boolean inputs.
+    [#2387]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -440,6 +440,38 @@ Bug Fixes
     with the first-iteration flux instead of the updated fitted flux.
     [#2386]
 
+- ``photutils.psf``
+
+  - Fixed a bug where the ``n_pixels_fit`` results column leaked
+    into the tables returned by the ``PSFPhotometry``
+    ``results_to_init_params`` and ``results_to_model_params``
+    methods (as ``n_pixels_init`` and ``n_pixels`` columns) and into
+    the deprecated ``fit_params`` table. [#2387]
+
+  - ``PSFPhotometry`` now raises a ``ValueError`` if the
+    ``init_params`` table contains duplicate ``id`` values.
+    Previously, duplicate ids silently produced a results table with
+    extra mispaired rows. [#2387]
+
+  - Fixed a bug where ``PSFPhotometry.finder_results`` retained the
+    results from a previous call when a subsequent call provided
+    ``init_params`` (so the finder was not used). [#2387]
+
+  - ``PSFPhotometry`` now raises a ``ValueError`` if the
+    ``init_params`` table has no rows. [#2387]
+
+  - Fixed a bug where the ``PSFPhotometry`` ``fit_info`` list was
+    not reordered to match the results table when the ``init_params``
+    table was not sorted by the ``id`` column. [#2387]
+
+  - Fixed a bug where the ``reduced_chi2`` calculation emitted a
+    divide-by-zero warning when the number of fit pixels equaled the
+    number of fit parameters. NaN is now returned without a warning
+    when there are no degrees of freedom. [#2387]
+
+  - The ``PSFPhotometry`` ``group_warning_threshold`` keyword is now
+    validated to be a positive integer. [#2387]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/photutils/psf/iterative.py
+++ b/photutils/psf/iterative.py
@@ -18,6 +18,7 @@ from photutils.psf.photometry import PSFPhotometry
 from photutils.psf.utils import _create_call_docstring
 from photutils.utils._deprecation import (deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
+from photutils.utils._parameters import as_pair
 from photutils.utils._repr import make_repr
 from photutils.utils.exceptions import NoDetectionsWarning
 
@@ -59,18 +60,17 @@ class IterativePSFPhotometry:
 
     finder : callable or `~photutils.detection.StarFinderBase`
         A callable used to identify sources in an image. This is a
-        required input for `IterativePSFPhotometry`. The ``finder`` must
-        accept a 2D image as input and return a `~astropy.table.Table`
-        containing the x and y centroid positions. These positions are
-        used as the starting points for the PSF fitting. The allowed
-        ``x`` column names are (same suffix for ``y``): ``'x_init'``,
+        required input for `IterativePSFPhotometry`. The ``finder``
+        must accept a 2D image as the first argument and a ``mask``
+        keyword argument, and return a `~astropy.table.Table` containing
+        the x and y centroid positions. These positions are used as
+        the starting points for the PSF fitting. The allowed ``x``
+        column names are (same suffix for ``y``): ``'x_init'``,
         ``'xinit'``, ``'x'``, ``'x_0'``, ``'x0'``, ``'xcentroid'``,
         ``'x_centroid'``, ``'x_peak'``, ``'xcen'``, ``'x_cen'``,
-        ``'xpos'``, ``'x_pos'``, ``'x_fit'``, and ``'xfit'``. If `None`,
-        then the initial (x, y) model positions must be input using
-        the ``init_params`` keyword when calling the class. The (x, y)
-        values in ``init_params`` override this keyword *only for the
-        first iteration*. If this class is run on an image that has
+        ``'xpos'``, ``'x_pos'``, ``'x_fit'``, and ``'xfit'``. The (x,
+        y) values in ``init_params`` override this keyword *only for
+        the first iteration*. If this class is run on an image that has
         units (i.e., a `~astropy.units.Quantity` array), then certain
         ``finder`` keywords (e.g., ``threshold``) must have the same
         units. Please see the documentation for the specific ``finder``
@@ -83,7 +83,7 @@ class IterativePSFPhotometry:
         the x and y coordinates of the sources and return an integer
         array of the group ID numbers (starting from 1) indicating
         the group in which a given source belongs. If `None`, then no
-        grouping is performed, i.e. each source is fit independently.
+        grouping is performed, i.e., each source is fit independently.
         The ``group_id`` values in ``init_params`` override this keyword
         *only for the first iteration*. A warning is raised if any group
         size is larger than ``group_warning_threshold`` sources.
@@ -123,20 +123,20 @@ class IterativePSFPhotometry:
     aperture_radius : float, optional
         The radius of the circular aperture used to estimate the
         initial flux of each source. This is a required input for
-        `IterativePSFPhotometry`. If `None`, then the initial flux
-        values must be provided in the ``init_params`` table. The
-        aperture radius must be a strictly positive scalar. If initial
-        flux values are present in the ``init_params`` table, they will
-        override this keyword *only for the first iteration*.
+        `IterativePSFPhotometry`. The aperture radius must be a strictly
+        positive scalar. If initial flux values are present in the
+        ``init_params`` table, they will override this keyword *only for
+        the first iteration*.
 
     local_bkg_estimator : `~photutils.background.LocalBackground` or `None`, \
             optional
         The object used to estimate the local background around each
         source. If `None`, then no local background is subtracted. The
         ``local_bkg`` values in ``init_params`` override this keyword.
-        This option should be used with care, especially in crowded
-        fields where the ``fit_shape`` of sources overlap (see Notes
-        below).
+        In the 'all' mode, the local background values of previously
+        fit sources are carried into subsequent iterations. This option
+        should be used with care, especially in crowded fields where the
+        ``fit_shape`` of sources overlap (see Notes below).
 
     group_warning_threshold : int, optional
         The maximum number of sources in a group before a warning is
@@ -145,7 +145,7 @@ class IterativePSFPhotometry:
         groups may take a long time and be error-prone. The default is
         25 sources.
 
-    sub_shape : `None`, int, or length-2 array_like
+    sub_shape : `None`, int, or length-2 array_like, optional
         The rectangular shape around the fitted center of a source
         that will be used when subtracting the fitted PSF models.
         If ``sub_shape`` is a scalar then a square shape of size
@@ -189,7 +189,7 @@ class IterativePSFPhotometry:
 
     If the fitted model parameter errors are NaN, then either the fit
     did not converge, the model parameter was fixed, or the input
-    ``fitter`` did not return parameter errors. For the later case, one
+    ``fitter`` did not return parameter errors. For the latter case, one
     can try a different Astropy fitter that returns parameter errors.
 
     The local background value around each source is optionally
@@ -270,7 +270,11 @@ class IterativePSFPhotometry:
             raise ValueError(msg)
         self.mode = mode
 
-        self.sub_shape = sub_shape
+        if sub_shape is None:
+            self.sub_shape = sub_shape
+        else:
+            self.sub_shape = as_pair('sub_shape', sub_shape,
+                                     lower_bound=(0, 0), check_odd=True)
 
         self._reset_results()
 
@@ -284,8 +288,8 @@ class IterativePSFPhotometry:
     def __repr__(self):
         params = ('psf_model', 'fit_shape', 'finder', 'grouper', 'fitter',
                   'fitter_maxiters', 'xy_bounds', 'maxiters', 'mode',
-                  'local_bkg_estimator', 'aperture_radius', 'sub_shape',
-                  'progress_bar')
+                  'local_bkg_estimator', 'aperture_radius',
+                  'group_warning_threshold', 'sub_shape', 'progress_bar')
         overrides = {
             'psf_model': self._psfphot.psf_model,
             'fit_shape': self._psfphot.fit_shape,
@@ -296,20 +300,23 @@ class IterativePSFPhotometry:
             'xy_bounds': self._psfphot.xy_bounds,
             'local_bkg_estimator': self._psfphot.local_bkg_estimator,
             'aperture_radius': self._psfphot.aperture_radius,
+            'group_warning_threshold':
+                self._psfphot.group_warning_threshold,
             'progress_bar': self._psfphot.progress_bar,
         }
         return make_repr(self, params, overrides=overrides)
 
     @staticmethod
     def _validate_maxiters(maxiters):
-        if (not np.isscalar(maxiters) or maxiters <= 0
-                or ~np.isfinite(maxiters)):
+        if (isinstance(maxiters, bool)
+                or not isinstance(maxiters, (int, float, np.number))
+                or not np.isfinite(maxiters) or maxiters <= 0):
             msg = 'maxiters must be a strictly-positive scalar'
             raise ValueError(msg)
         if maxiters != int(maxiters):
             msg = 'maxiters must be an integer'
             raise ValueError(msg)
-        return maxiters
+        return int(maxiters)
 
     @staticmethod
     def _emit_warnings(recorded_warnings):
@@ -336,8 +343,6 @@ class IterativePSFPhotometry:
         """
         Move a column to a new position in a table.
 
-        The table is modified in place.
-
         Parameters
         ----------
         table : `~astropy.table.Table`
@@ -352,7 +357,8 @@ class IterativePSFPhotometry:
         Returns
         -------
         table : `~astropy.table.Table`
-            The input table with the column moved.
+            A new table with the column moved. The input table is not
+            modified.
         """
         colnames = table.colnames
         if colname not in colnames or colname_after not in colnames:
@@ -437,7 +443,7 @@ class IterativePSFPhotometry:
         """
         param_mapper = self._psfphot._param_mapper
 
-        # build a new table constructively, converting _fit columns to
+        # Build a new table constructively, converting _fit columns to
         # _init columns
         prepared_orig = QTable()
         prepared_orig['id'] = orig_sources['id']
@@ -445,15 +451,19 @@ class IterativePSFPhotometry:
         for alias in param_mapper.alias_to_model_param:
             init_col = param_mapper.init_colnames.get(alias)
             if init_col and init_col in orig_sources.colnames:
-                # use the previous fit result as the initial guess for
+                # Use the previous fit result as the initial guess for
                 # the next iteration
                 prepared_orig[init_col] = orig_sources[init_col]
 
-        # prepare the newly found sources
+        # Carry the local background values into the next iteration
+        if 'local_bkg' in orig_sources.colnames:
+            prepared_orig['local_bkg'] = orig_sources['local_bkg']
+
+        # Prepare the newly found sources
         max_id = np.max(orig_sources['id']) if len(orig_sources) > 0 else 0
         new_sources['id'] = np.arange(len(new_sources)) + max_id + 1
 
-        # measure initial fluxes and add default values for other model
+        # Measure initial fluxes and add default values for other model
         # parameters
         new_sources = self._measure_init_fluxes(residual_data, mask,
                                                 new_sources)
@@ -466,7 +476,25 @@ class IterativePSFPhotometry:
                                         model_param_name)
                 new_sources[init_col] = default_value
 
-        # combine tables
+        # Estimate the local background for the new sources from the
+        # residual data. If no estimator was input, use zero, matching
+        # the values assigned by PSFPhotometry.
+        if 'local_bkg' in prepared_orig.colnames:
+            estimator = self._psfphot.local_bkg_estimator
+            if estimator is None:
+                local_bkg = np.zeros(len(new_sources))
+                unit = getattr(prepared_orig['local_bkg'], 'unit', None)
+                if unit is not None:
+                    local_bkg <<= unit
+            else:
+                x_col = param_mapper.init_colnames['x']
+                y_col = param_mapper.init_colnames['y']
+                local_bkg = estimator(residual_data,
+                                      new_sources[x_col],
+                                      new_sources[y_col], mask=mask)
+            new_sources['local_bkg'] = local_bkg
+
+        # Combine tables
         new_sources.meta.pop('date', None)  # prevent merge conflicts
 
         return vstack([prepared_orig, new_sources])
@@ -478,15 +506,16 @@ class IterativePSFPhotometry:
             return self.__call__(data_, mask=mask, error=error,
                                  init_params=init_params)
 
-        # reset results from previous runs
+        # Reset results from previous runs
         self._reset_results()
 
         with warnings.catch_warnings(record=True) as rwarn0:
+            warnings.simplefilter('always')
             phot_tbl = self._psfphot(data, mask=mask, error=error,
                                      init_params=init_params)
             self.fit_results.append(deepcopy(self._psfphot))
 
-        # this needs to be run outside the context manager to be able
+        # This needs to be run outside the context manager to be able
         # to reemit any warnings
         if phot_tbl is None:
             self._emit_warnings(rwarn0)
@@ -494,23 +523,25 @@ class IterativePSFPhotometry:
 
         residual_data = data
         with warnings.catch_warnings(record=True) as rwarn1:
+            warnings.simplefilter('always')
             phot_tbl['iter_detected'] = 1
             if self.mode == 'all':
                 iter_detected = np.ones(len(phot_tbl), dtype=int)
 
             iter_num = 2
-            while iter_num <= self.maxiters and phot_tbl is not None:
+            while iter_num <= self.maxiters:
                 residual_data = self._psfphot.make_residual_image(
                     residual_data, psf_shape=self.sub_shape)
 
-                # do not warn if no sources are found beyond the first
+                # Do not warn if no sources are found beyond the first
                 # iteration
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore', NoDetectionsWarning)
 
                     new_sources = self._psfphot.finder(residual_data,
                                                        mask=mask)
-                    if new_sources is None:  # no new sources detected
+                    # No new sources detected
+                    if new_sources is None or len(new_sources) == 0:
                         break
 
                 finder_results = new_sources.copy()
@@ -521,20 +552,30 @@ class IterativePSFPhotometry:
                     new_sources)
 
                 if self.mode == 'all':
+                    prev_results = self._psfphot.results
+                    prev_init = PSFPhotometry._results_to_init_params(
+                        prev_results, remove_invalid=False)
+                    keep = PSFPhotometry._finite_fit_mask(prev_init)
+                    prev_init = prev_init[keep]
+                    prev_init['id'] = np.arange(1, len(prev_init) + 1)
+                    if 'local_bkg' in prev_results.colnames:
+                        prev_init['local_bkg'] = (
+                            prev_results['local_bkg'][keep])
+                    iter_detected = iter_detected[keep]
+
                     init_params = self._prepare_next_iteration_sources(
-                        residual_data, mask, new_sources,
-                        self._psfphot.results_to_init_params())
+                        residual_data, mask, new_sources, prev_init)
 
                     residual_data = data
 
-                    # keep track of the iteration number in which the source
-                    # was detected
-                    current_iter = (np.ones(len(new_sources), dtype=int)
-                                    * iter_num)
+                    # Keep track of the iteration number in which the
+                    # source was detected
+                    current_iter = np.full(len(new_sources), iter_num,
+                                           dtype=int)
                     iter_detected = np.concatenate((iter_detected,
                                                     current_iter))
                 elif self.mode == 'new':
-                    # fit new sources on the residual data
+                    # Fit new sources on the residual data
                     init_params = new_sources
 
                 new_tbl = self._psfphot(residual_data, mask=mask, error=error,
@@ -547,7 +588,7 @@ class IterativePSFPhotometry:
                     phot_tbl = new_tbl
 
                 elif self.mode == 'new':
-                    # combine tables
+                    # Combine tables
                     new_tbl['id'] += np.max(phot_tbl['id'])
                     new_tbl['group_id'] += np.max(phot_tbl['group_id'])
                     new_tbl['iter_detected'] = iter_num
@@ -556,27 +597,27 @@ class IterativePSFPhotometry:
 
                 iter_num += 1
 
-            # move 'iter_detected' column
+            # Move 'iter_detected' column
             phot_tbl = self._move_column(phot_tbl, 'iter_detected',
                                          'group_size')
 
-        # add table metadata not already set by PSFPhotometry
+        # Add table metadata not already set by PSFPhotometry
         phot_tbl.meta['psf_class'] = self.__class__.__name__
         phot_tbl.meta['maxiters'] = self.maxiters
         phot_tbl.meta['mode'] = self.mode
         phot_tbl.meta['sub_shape'] = self.sub_shape
 
-        # emit unique warnings
+        self.results = phot_tbl
+
+        # Emit unique warnings
         recorded_warnings = rwarn0 + rwarn1
         self._emit_warnings(recorded_warnings)
-
-        self.results = phot_tbl
 
         return phot_tbl
 
     def results_to_init_params(self, *, remove_invalid=True, reset_ids=True):
         """
-        Create a table of the fitted model parameters from the results.
+        Create a table of initial parameters from the fitted results.
 
         The table columns are named according to those expected for the
         initial parameters table. It can be used as the ``init_params``
@@ -593,6 +634,12 @@ class IterativePSFPhotometry:
             numbering starting from 1. If `False`, the 'id' column will
             remain unchanged from the results table. This option is
             ignored if ``remove_invalid`` is `False`.
+
+        Returns
+        -------
+        init_params_tbl : `~astropy.table.QTable` or `None`
+            The table of initial parameters, or `None` if the
+            instance has not yet been run.
         """
         return self._psfphot._results_to_init_params(
             self.results, remove_invalid=remove_invalid, reset_ids=reset_ids)
@@ -616,6 +663,12 @@ class IterativePSFPhotometry:
             numbering starting from 1. If `False`, the 'id' column will
             remain unchanged from the results table. This option is
             ignored if ``remove_invalid`` is `False`.
+
+        Returns
+        -------
+        model_params_tbl : `~astropy.table.QTable` or `None`
+            The table of model parameters, or `None` if the instance
+            has not yet been run.
         """
         return self._psfphot._results_to_model_params(
             self.results, self._psfphot._param_mapper,
@@ -711,7 +764,7 @@ class IterativePSFPhotometry:
     @_make_model_image_docstring
     def make_model_image(self, shape, *, psf_shape=None,
                          include_local_bkg=False):
-        if not self.fit_results:
+        if self.results is None:
             msg = ('No results available. Please run the '
                    'IterativePSFPhotometry instance first.')
             raise ValueError(msg)
@@ -728,7 +781,7 @@ class IterativePSFPhotometry:
     @_make_residual_image_docstring
     def make_residual_image(self, data, *, psf_shape=None,
                             include_local_bkg=False):
-        if not self.fit_results:
+        if self.results is None:
             msg = ('No results available. Please run the '
                    'IterativePSFPhotometry instance first.')
             raise ValueError(msg)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1780,7 +1780,7 @@ class PSFPhotometry:
 
     def results_to_init_params(self, *, remove_invalid=True, reset_ids=True):
         """
-        Create a table of the fitted model parameters from the results.
+        Create a table of initial parameters from the fitted results.
 
         The table columns are named according to those expected for the
         initial parameters table. It can be used as the ``init_params``

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -238,8 +238,8 @@ class PSFPhotometry:
         will be used to define the PSF-fitting data. If ``fit_shape``
         is a scalar then a square shape of size ``fit_shape`` will be
         used. If ``fit_shape`` has two elements, they must be in ``(ny,
-        nx)`` order. Each element of ``fit_shape`` must be an odd number
-        greater than or equal to 3. In general, ``fit_shape`` should be
+        nx)`` order. Each element of ``fit_shape`` must be a positive
+        odd number. In general, ``fit_shape`` should be
         set to a small size (e.g., ``(5, 5)``) that covers the region
         with the highest flux signal-to-noise.
 
@@ -323,6 +323,31 @@ class PSFPhotometry:
         (or groups). The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
 
+    Attributes
+    ----------
+    results : `~astropy.table.QTable` or `None`
+        The table of fit results from the most recent call, or `None`
+        if the instance has not yet been run. The rows are sorted by
+        the source ``id`` column.
+
+    fit_info : list of dict
+        A list of dictionaries, one per source in the same row order
+        as ``results``, containing information about each source fit
+        with keys such as ``param_cov``, ``ierr``, ``message``, and
+        ``status`` (the exact keys depend on the ``fitter``).
+
+    finder_results : `~astropy.table.QTable` or `None`
+        The table of sources returned by the ``finder`` during the
+        most recent call, or `None` if the finder was not used.
+
+    init_params : `~astropy.table.QTable` or `None`
+        The table of initial parameters used in the most recent call,
+        or `None` if the instance has not yet been run.
+
+    data_unit : `~astropy.units.Unit` or `None`
+        The unit of the input data from the most recent call, or
+        `None` if the data did not have units.
+
     Notes
     -----
     The data that will be fit for each source is defined by the
@@ -350,7 +375,7 @@ class PSFPhotometry:
 
     If the fitted model parameter errors are NaN, then either the fit
     did not converge, the model parameter was fixed, or the input
-    ``fitter`` did not return parameter errors. For the later case, one
+    ``fitter`` did not return parameter errors. For the latter case, one
     can try a different Astropy fitter that returns parameter errors.
 
     The local background value around each source is optionally
@@ -401,7 +426,8 @@ class PSFPhotometry:
         self.aperture_radius = self._validate_radius(aperture_radius)
         self.local_bkg_estimator = self._validate_localbkg(
             local_bkg_estimator, 'local_bkg_estimator')
-        self.group_warning_threshold = group_warning_threshold
+        self.group_warning_threshold = self._validate_group_threshold(
+            group_warning_threshold)
         self.progress_bar = progress_bar
 
         self._data_processor = PSFDataProcessor(
@@ -438,9 +464,9 @@ class PSFPhotometry:
         self.results = None
         self.fit_info = []
 
-        # Sync data_unit with components
-        if hasattr(self, '_data_processor'):
-            self._data_processor.data_unit = None
+        # Sync state with components
+        self._data_processor.data_unit = None
+        self._data_processor.finder_results = None
 
         # Internal state container
         self._state = {
@@ -671,6 +697,12 @@ class PSFPhotometry:
         if xy_bounds.ndim != 1:
             msg = 'xy_bounds must be a 1D array'
             raise ValueError(msg)
+        # None elements are allowed to indicate no bound along an axis
+        if not all(bound is None or isinstance(bound, (int, float,
+                                                       np.number))
+                   for bound in xy_bounds):
+            msg = 'xy_bounds must be numeric'
+            raise ValueError(msg)
         for bound in xy_bounds:
             if bound is not None:
                 if bound <= 0:
@@ -702,11 +734,40 @@ class PSFPhotometry:
             If radius is not None and is not a strictly positive finite
             scalar.
         """
-        if radius is not None and (not np.isscalar(radius)
-                                   or radius <= 0 or not np.isfinite(radius)):
-            msg = 'aperture_radius must be a strictly-positive scalar'
-            raise ValueError(msg)
+        if radius is not None:
+            if (np.ndim(radius) != 0 or radius <= 0
+                    or not np.isfinite(radius)):
+                msg = 'aperture_radius must be a strictly-positive scalar'
+                raise ValueError(msg)
+            radius = float(radius)
         return radius
+
+    @staticmethod
+    def _validate_group_threshold(value):
+        """
+        Validate the input ``group_warning_threshold`` value.
+
+        Parameters
+        ----------
+        value : int
+            The group size threshold to validate.
+
+        Returns
+        -------
+        value : int
+            The validated threshold value.
+
+        Raises
+        ------
+        ValueError
+            If value is not a positive integer.
+        """
+        if (isinstance(value, bool)
+                or not isinstance(value, (int, np.integer))
+                or value <= 0):
+            msg = 'group_warning_threshold must be a positive integer'
+            raise ValueError(msg)
+        return int(value)
 
     def _validate_localbkg(self, value, name):
         """
@@ -736,7 +797,7 @@ class PSFPhotometry:
 
     def _validate_maxiters(self, maxiters):
         """
-        Validate the input ``maxiters`` value.
+        Validate the input ``fitter_maxiters`` value.
 
         Parameters
         ----------
@@ -751,8 +812,9 @@ class PSFPhotometry:
         """
         spec = inspect.signature(self.fitter.__call__)
         if 'maxiter' not in spec.parameters:
-            msg = ("'maxiters' will be ignored because it is not accepted "
-                   'by the input fitter __call__ method.')
+            msg = ("'fitter_maxiters' will be ignored because the "
+                   "fitter's __call__ method does not accept a "
+                   "'maxiter' keyword.")
             warnings.warn(msg, AstropyUserWarning)
             maxiters = None
         return maxiters
@@ -767,8 +829,7 @@ class PSFPhotometry:
 
         This method modifies the internal state in-place.
         """
-        if hasattr(self, '_data_processor'):
-            self._data_processor.data_unit = self.data_unit
+        self._data_processor.data_unit = self.data_unit
 
     def _find_sources_if_needed(self, data, mask, init_params):
         """
@@ -800,6 +861,7 @@ class PSFPhotometry:
         """
         # A user-provided group_id column takes precedence for this
         # call
+        derived_from_id = False
         if 'group_id' not in init_params.colnames:
             if self.grouper is not None:
                 x_col = self._param_mapper.init_colnames['x']
@@ -809,6 +871,7 @@ class PSFPhotometry:
             else:
                 # No grouper provided, so each source is its own group
                 init_params['group_id'] = init_params['id'].copy()
+                derived_from_id = True
 
         # Ensure group_id contains only positive (> 0) integers
         group_id = init_params['group_id']
@@ -816,7 +879,11 @@ class PSFPhotometry:
             msg = 'group_id must be finite'
             raise ValueError(msg)
         if not np.issubdtype(group_id.dtype, np.integer):
-            msg = 'group_id must be an integer array'
+            if derived_from_id:
+                msg = ('group_id (or the id column it was derived from) '
+                       'must be an integer array')
+            else:
+                msg = 'group_id must be an integer array'
             raise TypeError(msg)
         if np.any(group_id <= 0):
             msg = 'group_id must contain only positive (> 0) integers'
@@ -864,15 +931,14 @@ class PSFPhotometry:
 
         # Check for large group sizes after grouping is complete
         warn_size = self.group_warning_threshold
-        if 'group_id' in init_params.colnames:
-            _, counts = np.unique(init_params['group_id'], return_counts=True)
-            if len(counts) > 0 and max(counts) > warn_size:
-                msg = (f'Some groups have more than {warn_size} '
-                       'sources. Fitting such groups may take a long time '
-                       'and be error-prone. You may want to consider using '
-                       'different `SourceGrouper` parameters or changing '
-                       'the "group_id" column in "init_params".')
-                warnings.warn(msg, AstropyUserWarning)
+        _, counts = np.unique(init_params['group_id'], return_counts=True)
+        if len(counts) > 0 and max(counts) > warn_size:
+            msg = (f'Some groups have more than {warn_size} '
+                   'sources. Fitting such groups may take a long time '
+                   'and be error-prone. You may want to consider using '
+                   'different `SourceGrouper` parameters or changing '
+                   'the "group_id" column in "init_params".')
+            warnings.warn(msg, AstropyUserWarning)
 
         # Add columns for any additional model parameters that are
         # fit using the model's default value, if not already present.
@@ -954,11 +1020,19 @@ class PSFPhotometry:
         mask = _make_mask(data, mask)
 
         init_params = self._data_processor.validate_init_params(init_params)
+        if init_params is not None and len(init_params) == 0:
+            msg = 'init_params must contain at least one row'
+            raise ValueError(msg)
         init_params = self._build_initial_parameters(data, mask, init_params)
 
         if init_params is None:
             # No sources found
             return None, None, None, None
+
+        ids = np.asarray(init_params['id'])
+        if len(np.unique(ids)) != len(ids):
+            msg = 'init_params id column must contain unique values'
+            raise ValueError(msg)
 
         return data, mask, error, init_params
 
@@ -1076,19 +1150,11 @@ class PSFPhotometry:
         yi_all : list or None, optional
             List of y-coordinates for each valid source's cutout pixels.
 
-        Returns
-        -------
-        sum_abs_residuals : ndarray
-            Sum of absolute residuals for each source, or np.nan for
-            invalid sources.
-
-        cen_residuals : ndarray
-            Center residuals for each source, or np.nan for invalid
-            sources.
-
-        reduced_chi2 : ndarray
-            Reduced chi-squared values for each source, or np.nan for
-            invalid sources.
+        Notes
+        -----
+        The computed metrics (sum of absolute residuals, center
+        residuals, and reduced chi-squared) are stored in the state
+        container, with np.nan values for invalid sources.
         """
         # Extract residuals from fit_info
         residual_key = None
@@ -1134,23 +1200,22 @@ class PSFPhotometry:
                     end_pos = cumsum_n_pixels[idx + 1]
                     source_residuals = residuals[start_pos:end_pos]
 
-                    # For qfit and cfit calculations, we need raw residuals
-                    # (data - model), not weighted residuals
-                    # (data - model)/error. If errors were provided, convert
-                    # weighted residuals back to raw residuals.
-                    raw_residuals = source_residuals
+                    # Extract error values for this source's pixels.
+                    # run_fitter has already validated that these
+                    # values are positive and finite.
+                    error_vals = None
                     if (error is not None and xi_all is not None
                             and yi_all is not None):
-                        # Extract error values for this source's pixels
-                        xi_source = xi_all[idx]
-                        yi_source = yi_all[idx]
-                        error_vals = error[yi_source, xi_source]
+                        error_vals = error[yi_all[idx], xi_all[idx]]
 
-                        # Multiply by error to convert weighted
-                        # residuals to raw residuals
-                        if (np.all(error_vals > 0)
-                                and np.all(np.isfinite(error_vals))):
-                            raw_residuals = source_residuals * error_vals
+                    # For qfit and cfit calculations, we need raw
+                    # residuals (data - model), not weighted residuals
+                    # (data - model)/error. If errors were provided,
+                    # multiply by error to convert weighted residuals
+                    # back to raw residuals.
+                    raw_residuals = source_residuals
+                    if error_vals is not None:
+                        raw_residuals = source_residuals * error_vals
 
                     # Sum of absolute residuals
                     sum_abs_residuals[valid_idx] = float(
@@ -1162,31 +1227,20 @@ class PSFPhotometry:
                     if np.isfinite(cen_idx):
                         cen_residuals[valid_idx] = float(
                             -raw_residuals[int(cen_idx)])
-                    else:
-                        cen_residuals[valid_idx] = np.nan
 
                     # Calculate chi-squared. The residuals have already
                     # been weighted by (1 / error). If errors are not
-                    # input, then reduced_chi2 will be NaN.
+                    # input or there are no degrees of freedom, then
+                    # reduced_chi2 will be NaN.
                     dof = float(n_pixels_valid[idx] - n_fit_params)
-                    if (error is not None and xi_all is not None
-                            and yi_all is not None):
-                        # Extract error values for this source's pixels
-                        xi_source = xi_all[idx]
-                        yi_source = yi_all[idx]
-                        error_vals = error[yi_source, xi_source]
-
-                        if (np.all(error_vals > 0)
-                                and np.all(np.isfinite(error_vals))):
-                            chi2 = np.sum(source_residuals**2)
-                            reduced_chi2[valid_idx] = chi2 / dof
+                    if error_vals is not None and dof > 0:
+                        chi2 = np.sum(source_residuals**2)
+                        reduced_chi2[valid_idx] = chi2 / dof
 
         row_indices_arr = np.array(row_indices)
         self._state['sum_abs_residuals'][row_indices_arr] = sum_abs_residuals
         self._state['cen_residuals'][row_indices_arr] = cen_residuals
         self._state['reduced_chi2'][row_indices_arr] = reduced_chi2
-
-        return sum_abs_residuals, cen_residuals, reduced_chi2
 
     def _fit_source_groups(self, source_groups, data, mask, error):
         """
@@ -1384,12 +1438,13 @@ class PSFPhotometry:
             init_params['_row_index'] = np.arange(len(init_params))
         self._initialize_source_state_storage(len(init_params))
 
-        source_groups = init_params.group_by('group_id').groups
-        self._fit_source_groups(source_groups, data, mask, error)
-
-        # Clean up temporary row index column
-        if '_row_index' in init_params.colnames:
-            init_params.remove_column('_row_index')
+        try:
+            source_groups = init_params.group_by('group_id').groups
+            self._fit_source_groups(source_groups, data, mask, error)
+        finally:
+            # Clean up temporary row index column
+            if '_row_index' in init_params.colnames:
+                init_params.remove_column('_row_index')
 
         return self._assemble_fit_results()
 
@@ -1516,6 +1571,13 @@ class PSFPhotometry:
             self.results = self._assemble_results_table(
                 init_params, fit_params, data.shape)
 
+            # Reorder fit_info to match the results table rows, which
+            # are sorted by the id column during table assembly
+            row_map = {src_id: idx
+                       for idx, src_id in enumerate(init_params['id'])}
+            self.fit_info = [self.fit_info[row_map[src_id]]
+                             for src_id in self.results['id']]
+
         except Exception:
             # Ensure state cleanup even if an exception occurs
             self._reset_state()
@@ -1549,10 +1611,38 @@ class PSFPhotometry:
 
         tbl = QTable()
         for col_name in self.results.colnames:
-            if col_name == 'id' or '_fit' in col_name or '_err' in col_name:
+            if (col_name == 'id'
+                    or (col_name.endswith('_fit')
+                        and col_name not in self._NON_PARAM_FIT_COLS)
+                    or col_name.endswith('_err')):
                 tbl[col_name] = self.results[col_name]
 
         return tbl
+
+    # Results columns ending in '_fit' that are not fitted model
+    # parameters
+    _NON_PARAM_FIT_COLS = ('n_pixels_fit',)
+
+    @staticmethod
+    def _iter_fit_param_cols(results_tbl):
+        """
+        Yield the 'id' column name plus the fitted model-parameter
+        column names.
+        """
+        for col_name in results_tbl.colnames:
+            if col_name == 'id' or (
+                    col_name.endswith('_fit')
+                    and col_name
+                    not in PSFPhotometry._NON_PARAM_FIT_COLS):
+                yield col_name
+
+    @staticmethod
+    def _finite_fit_mask(tbl):
+        """
+        Return a boolean mask of rows where every column is finite.
+        """
+        return np.all([np.isfinite(tbl[col])
+                       for col in tbl.colnames], axis=0)
 
     @staticmethod
     def _results_to_init_params(results_tbl, *, remove_invalid=True,
@@ -1604,15 +1694,13 @@ class PSFPhotometry:
             return None
 
         tbl = QTable()
-        for col_name in results_tbl.colnames:
-            if col_name == 'id' or '_fit' in col_name:
-                init_name = col_name.replace('_fit', '_init')
-                tbl[init_name] = results_tbl[col_name]
+        for col_name in PSFPhotometry._iter_fit_param_cols(results_tbl):
+            init_name = col_name.replace('_fit', '_init')
+            tbl[init_name] = results_tbl[col_name]
 
         if remove_invalid:
             # Remove rows with any non-finite fitted values
-            keep = np.all([np.isfinite(tbl[col])
-                           for col in tbl.colnames], axis=0)
+            keep = PSFPhotometry._finite_fit_mask(tbl)
             tbl = tbl[keep]
 
             if reset_ids:
@@ -1674,17 +1762,15 @@ class PSFPhotometry:
             return None
 
         tbl = QTable()
-        for col_name in results_tbl.colnames:
-            if col_name == 'id' or '_fit' in col_name:
-                alias = col_name.replace('_fit', '')
-                model_param_name = param_mapper.alias_to_model_param.get(
-                    alias, alias)
-                tbl[model_param_name] = results_tbl[col_name]
+        for col_name in PSFPhotometry._iter_fit_param_cols(results_tbl):
+            alias = col_name.replace('_fit', '')
+            model_param_name = param_mapper.alias_to_model_param.get(
+                alias, alias)
+            tbl[model_param_name] = results_tbl[col_name]
 
         if remove_invalid:
             # Remove rows with any non-finite fitted values
-            keep = np.all([np.isfinite(tbl[col])
-                           for col in tbl.colnames], axis=0)
+            keep = PSFPhotometry._finite_fit_mask(tbl)
             tbl = tbl[keep]
 
             if reset_ids:
@@ -1711,6 +1797,12 @@ class PSFPhotometry:
             numbering starting from 1. If `False`, the 'id' column will
             remain unchanged from the results table. This option is
             ignored if ``remove_invalid`` is `False`.
+
+        Returns
+        -------
+        init_params_tbl : `~astropy.table.QTable` or `None`
+            The table of initial parameters, or `None` if the
+            instance has not yet been run.
         """
         return self._results_to_init_params(self.results,
                                             remove_invalid=remove_invalid,
@@ -1735,6 +1827,12 @@ class PSFPhotometry:
             numbering starting from 1. If `False`, the 'id' column will
             remain unchanged from the results table. This option is
             ignored if ``remove_invalid`` is `False`.
+
+        Returns
+        -------
+        model_params_tbl : `~astropy.table.QTable` or `None`
+            The table of model parameters, or `None` if the instance
+            has not yet been run.
         """
         return self._results_to_model_params(self.results,
                                              self._param_mapper,

--- a/photutils/psf/tests/test_iterative.py
+++ b/photutils/psf/tests/test_iterative.py
@@ -11,7 +11,8 @@ from astropy.modeling.fitting import TRFLSQFitter
 from astropy.modeling.models import Gaussian2D
 from astropy.nddata import NDData, StdDevUncertainty
 from astropy.table import QTable, Table
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
+                                      AstropyUserWarning)
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.background import LocalBackground, MMMBackground
@@ -19,6 +20,7 @@ from photutils.datasets import make_model_image, make_noise_image
 from photutils.detection import DAOStarFinder
 from photutils.psf import (CircularGaussianPRF, IterativePSFPhotometry,
                            SourceGrouper, make_psf_model, make_psf_model_image)
+from photutils.psf.flags import decode_psf_flags
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
@@ -104,7 +106,7 @@ def test_iterative_psf_photometry_compound(mode):
     for colname in colnames:
         assert colname in phot.colnames
 
-    # test model and residual images
+    # Test model and residual images
     psf_shape = (9, 9)
     model1 = psfphot.make_model_image(data.shape, psf_shape=psf_shape,
                                       include_local_bkg=False)
@@ -121,7 +123,7 @@ def test_iterative_psf_photometry_compound(mode):
     assert_equal(data - model1, resid1)
     assert_equal(data - model2, resid2)
 
-    # test with init_params
+    # Test with init_params
     init_params = psfphot.fit_results[-1].results_to_init_params()
     phot = psfphot(data, error=error, init_params=init_params)
     assert isinstance(phot, QTable)
@@ -167,11 +169,11 @@ def test_iterative_psf_photometry_mode_new(test_data):
     assert isinstance(resid_nddata, NDData)
     assert resid_nddata.data.shape == data.shape
 
-    # test that repeated calls reset the results
+    # Test that repeated calls reset the results
     phot = psfphot(data, error=error, init_params=init_params)
     assert len(psfphot.fit_results) == 2
 
-    # test NDData without units
+    # Test NDData without units
     uncertainty = StdDevUncertainty(error)
     nddata = NDData(data, uncertainty=uncertainty)
     phot0 = psfphot(nddata, init_params=init_params)
@@ -182,7 +184,7 @@ def test_iterative_psf_photometry_mode_new(test_data):
     assert isinstance(resid_nddata, NDData)
     assert_equal(resid_nddata.data, resid_data)
 
-    # test with units and mode='new'
+    # Test with units and mode='new'
     unit = u.Jy
     finder_units = DAOStarFinder(10.0 * unit, 2.0)
     psfphot = IterativePSFPhotometry(psf_model, fit_shape,
@@ -197,7 +199,7 @@ def test_iterative_psf_photometry_mode_new(test_data):
         assert phot2[col].unit == unit
         assert_allclose(phot2[col].value, phot[col])
 
-    # test NDData with units
+    # Test NDData with units
     uncertainty = StdDevUncertainty(error << unit)
     nddata = NDData(data << unit, uncertainty=uncertainty)
     phot3 = psfphot(nddata, init_params=init_params)
@@ -209,7 +211,7 @@ def test_iterative_psf_photometry_mode_new(test_data):
     assert isinstance(resid_nddata, NDData)
     assert resid_nddata.unit == unit
 
-    # test return None if no stars are found on first iteration
+    # Test return None if no stars are found on first iteration
     finder = DAOStarFinder(1000.0, 2.0)
     psfphot = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
                                      mode='new',
@@ -264,7 +266,7 @@ def test_iterative_psf_photometry_mode_all():
                                          grouper=None, aperture_radius=4,
                                          sub_shape=sub_shape, mode='all')
 
-    # test with units and mode='all'
+    # Test with units and mode='all'
     unit = u.Jy
     finderu = DAOStarFinder(0.2 * unit, fwhm=6.0, min_separation=0)
     psfphotu = IterativePSFPhotometry(psf_model, fit_shape, finder=finderu,
@@ -280,7 +282,7 @@ def test_iterative_psf_photometry_mode_all():
         assert phot2[col].unit == unit
         assert_allclose(phot2[col].value, phot[col])
 
-    # test NDData with units
+    # Test NDData with units
     nddata = NDData(data * unit)
     phot3 = psfphotu(nddata)
     colnames = ('flux_init', 'flux_fit', 'flux_err', 'local_bkg')
@@ -290,6 +292,130 @@ def test_iterative_psf_photometry_mode_all():
     resid_nddata = psfphotu.make_residual_image(nddata, psf_shape=fit_shape)
     assert isinstance(resid_nddata, NDData)
     assert resid_nddata.unit == unit
+
+
+def make_one_shot_finder(x, y):
+    """
+    Make a mock finder that detects one source on the first call and
+    nothing on subsequent calls.
+    """
+    state = {'called': False}
+
+    def finder(data, *, mask=None):  # noqa: ARG001
+        if state['called']:
+            return None
+        state['called'] = True
+        tbl = QTable()
+        tbl['x'] = [x]
+        tbl['y'] = [y]
+        return tbl
+
+    return finder
+
+
+def test_mode_all_invalid_source():
+    """
+    Regression test for mode='all' when an earlier iteration
+    produced a non-finite fit (the invalid row is dropped and
+    iter_detected must stay aligned).
+    """
+    sources = QTable()
+    sources['x_0'] = [30.0, 70.0, 50.0]
+    sources['y_0'] = [30.0, 70.0, 50.0]
+    sources['flux'] = [500.0, 300.0, 200.0]
+    psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    data = make_model_image((101, 101), psf_model, sources,
+                            model_shape=(9, 9))
+    init_params = QTable()
+    init_params['x'] = [30.0, 70.0, 1000.0]
+    init_params['y'] = [30.0, 70.0, 1000.0]
+    psfphot = IterativePSFPhotometry(
+        psf_model, (5, 5), finder=make_one_shot_finder(50.0, 50.0),
+        grouper=SourceGrouper(min_separation=5), aperture_radius=4,
+        mode='all', maxiters=2, sub_shape=(5, 5))
+    phot = psfphot(data, init_params=init_params)
+    assert len(phot) == 3
+    assert 'iter_detected' in phot.colnames
+    assert_equal(phot['iter_detected'], [1, 1, 2])
+    assert_allclose(phot['flux_fit'], [500.0, 300.0, 200.0],
+                    rtol=0.01)
+
+
+def test_mode_all_carries_local_bkg():
+    """
+    Regression test that user-supplied local_bkg persists across
+    mode='all' iterations.
+    """
+    sources = QTable()
+    sources['x_0'] = [30.0, 70.0, 50.0]
+    sources['y_0'] = [30.0, 70.0, 50.0]
+    sources['flux'] = [500.0, 300.0, 200.0]
+    psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    data = make_model_image((101, 101), psf_model, sources,
+                            model_shape=(9, 9)) + 5.0
+
+    init_params = QTable()
+    init_params['x'] = [30.0, 70.0]
+    init_params['y'] = [30.0, 70.0]
+    init_params['local_bkg'] = [5.0, 5.0]
+    psfphot = IterativePSFPhotometry(
+        psf_model, (5, 5), finder=make_one_shot_finder(50.0, 50.0),
+        grouper=SourceGrouper(min_separation=5), aperture_radius=4,
+        mode='all', maxiters=3, sub_shape=(5, 5))
+    phot = psfphot(data, init_params=init_params)
+    assert_allclose(phot['local_bkg'][:2], [5.0, 5.0])
+    assert_allclose(phot['flux_fit'][:2], [500.0, 300.0], rtol=0.01)
+
+
+def test_image_methods_after_no_detections(test_data):
+    """
+    Regression test that the image methods raise a clear error after
+    a run in which no sources were detected.
+    """
+    data, _, _ = test_data
+    psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    finder = DAOStarFinder(1e6, 2.0)
+    psfphot = IterativePSFPhotometry(psf_model, (5, 5), finder=finder,
+                                     aperture_radius=4)
+    with pytest.warns(NoDetectionsWarning):
+        result = psfphot(data)
+    assert result is None
+
+    match = 'No results available'
+    with pytest.raises(ValueError, match=match):
+        psfphot.make_model_image((25, 25))
+    with pytest.raises(ValueError, match=match):
+        psfphot.make_residual_image(data)
+
+
+def test_empty_finder_table_stops_iteration():
+    """
+    Regression test that a callable finder returning a zero-row table
+    stops the iteration cleanly.
+    """
+    sources = QTable()
+    sources['x_0'] = [30.0, 70.0]
+    sources['y_0'] = [30.0, 70.0]
+    sources['flux'] = [500.0, 300.0]
+    psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    data = make_model_image((101, 101), psf_model, sources,
+                            model_shape=(9, 9))
+
+    def finder(data, *, mask=None):  # noqa: ARG001
+        tbl = QTable()
+        tbl['x'] = np.array([], dtype=float)
+        tbl['y'] = np.array([], dtype=float)
+        return tbl
+
+    init_params = QTable()
+    init_params['x'] = [30.0, 70.0]
+    init_params['y'] = [30.0, 70.0]
+    psfphot = IterativePSFPhotometry(psf_model, (5, 5), finder=finder,
+                                     aperture_radius=4, maxiters=3,
+                                     sub_shape=(5, 5))
+    phot = psfphot(data, init_params=init_params)
+    assert len(phot) == 2
+    assert_equal(phot['iter_detected'], [1, 1])
 
 
 def test_iterative_methods(test_data):
@@ -410,10 +536,28 @@ def test_iterative_psf_photometry_inputs():
         _ = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
                                    aperture_radius=4, maxiters=[1, 2])
 
+    match = 'maxiters must be a strictly-positive scalar'
+    with pytest.raises(ValueError, match=match):
+        _ = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
+                                   aperture_radius=4, maxiters='3')
+    with pytest.raises(ValueError, match=match):
+        _ = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
+                                   aperture_radius=4, maxiters=True)
+
     match = 'maxiters must be an integer'
     with pytest.raises(ValueError, match=match):
         _ = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
                                    aperture_radius=4, maxiters=3.14)
+
+    psfphot = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
+                                     aperture_radius=4, maxiters=3.0)
+    assert psfphot.maxiters == 3
+    assert isinstance(psfphot.maxiters, int)
+
+    match = 'sub_shape must have an odd value for both axes'
+    with pytest.raises(ValueError, match=match):
+        _ = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
+                                   aperture_radius=4, sub_shape=4)
 
 
 @pytest.mark.parametrize(('x_col', 'y_col'), FINDER_COLUMN_NAMES)
@@ -437,7 +581,7 @@ def test_iterative_finder_column_names(x_col, y_col):
     psfphot = IterativePSFPhotometry(psf_model, fit_shape, finder=finder,
                                      aperture_radius=10, maxiters=3)
 
-    # invalid column names should raise an error
+    # Invalid column names should raise an error
     if x_col == 'x_invalid' or y_col == 'y_invalid':
         match = 'must contain columns for x and y coordinates'
         with pytest.raises(ValueError, match=match):
@@ -446,6 +590,8 @@ def test_iterative_finder_column_names(x_col, y_col):
 
     phot_tbl = psfphot(data)
 
+    assert len(phot_tbl) == 3
+    assert_equal(phot_tbl['iter_detected'], [1, 2, 3])
     assert_allclose(phot_tbl['x_init'][0], 25.1)
     assert_allclose(phot_tbl['y_init'][0], 24.9)
     assert_allclose(phot_tbl['x_fit'][0], 25.0, atol=1e-6)
@@ -462,6 +608,7 @@ def test_repr():
                                      aperture_radius=10)
     cls_repr = repr(psfphot)
     assert cls_repr.startswith(f'{psfphot.__class__.__name__}(')
+    assert 'group_warning_threshold' in cls_repr
 
 
 def test_move_column():
@@ -481,6 +628,33 @@ def test_move_column():
     assert tbl2.colnames == ['a', 'b', 'c']
     tbl3 = psfphot._move_column(tbl, 'b', 'b')
     assert tbl3.colnames == ['a', 'b', 'c']
+
+
+def test_iterative_deprecated_shims(test_data):
+    """
+    Test the deprecated keyword and positional-argument shims.
+    """
+    data, error, _ = test_data
+    model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    finder = DAOStarFinder(6.0, 2.0)
+
+    match = "'localbkg_estimator' was deprecated in version 3.0"
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        psfphot = IterativePSFPhotometry(model, (5, 5), finder=finder,
+                                         aperture_radius=4,
+                                         localbkg_estimator=None)
+    psfphot(data, error=error)
+
+    match = "'include_localbkg' was deprecated in version 3.0"
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        psfphot.make_model_image((25, 25), include_localbkg=False)
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        psfphot.make_residual_image(data, include_localbkg=False)
+
+    match = ("Passing 'return_bit_values' positionally to "
+             "'decode_flags' is deprecated")
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        psfphot.decode_flags(True)  # noqa: FBT003
 
 
 def test_iterative_model_residual_image_nonfinite_localbkg(test_data):
@@ -523,8 +697,8 @@ def test_iterative_model_residual_image_nonfinite_localbkg(test_data):
     assert np.all(np.isfinite(model_without_bkg))
 
     # For sources with non-finite local_bkg, the model with and without
-    # local_bkg should be identical (since non-finite is treated as 0)
-    # Check this by comparing the models at source positions
+    # local_bkg should be identical (since non-finite is treated as 0).
+    # Check this by comparing the models at source positions.
     for i in range(min(3, len(phot))):
         if not np.isfinite(phot['local_bkg'][i]):
             x_fit = int(phot['x_fit'][i])
@@ -580,7 +754,7 @@ def test_decode_flags():
     m1 = CircularGaussianPRF(flux=100, x_0=10, y_0=10, fwhm=2)
     # Source 2: negative flux (will have negative_flux flag)
     m2 = CircularGaussianPRF(flux=-50, x_0=5, y_0=5, fwhm=2)
-    # Source 3: outside bounds (will have outside_bounds flag)
+    # Source 3: outside the image (will have the no_overlap flag)
     m3 = CircularGaussianPRF(flux=100, x_0=25, y_0=25, fwhm=2)
 
     data = m1(xx, yy) + m2(xx, yy) + m3(xx, yy)
@@ -623,13 +797,12 @@ def test_decode_flags():
     # Check that the second source has the negative_flux flag
     assert 'negative_flux' in decoded_flags[1]
 
-    # Check that the third source has flags (it's outside the image bounds)
-    # It should have 'no_overlap' since it's completely outside
+    # Check that the third source has flags (it's outside the image
+    # bounds). It should have 'no_overlap' since it's completely outside.
     assert len(decoded_flags[2]) > 0
     assert 'no_overlap' in decoded_flags[2]
 
     # Verify that decode_flags gives the same result as calling
     # decode_psf_flags directly
-    from photutils.psf.flags import decode_psf_flags
     direct_decoded = decode_psf_flags(results['flags'])
     assert decoded_flags == direct_decoded

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -4,7 +4,6 @@ Tests for the photometry module.
 """
 
 import gc
-import tempfile
 
 import astropy.units as u
 import numpy as np
@@ -23,6 +22,7 @@ from photutils.datasets import make_model_image, make_noise_image
 from photutils.detection import DAOStarFinder
 from photutils.psf import (CircularGaussianPRF, ImagePSF, PSFPhotometry,
                            SourceGrouper, make_psf_model, make_psf_model_image)
+from photutils.psf.flags import decode_psf_flags
 from photutils.utils.exceptions import NoDetectionsWarning
 
 
@@ -916,8 +916,8 @@ def test_grouper_init_params(test_data):
                             grouper=None, aperture_radius=4)
     phot2 = psfphot(data, error=error, init_params=init_params)
     assert isinstance(phot2, QTable)
-    assert_equal(phot1['group_id'], np.ones(n_sources, dtype=int))
-    assert_equal(phot1['group_size'],
+    assert_equal(phot2['group_id'], np.ones(n_sources, dtype=int))
+    assert_equal(phot2['group_size'],
                  np.ones(n_sources, dtype=int) * n_sources)
 
 
@@ -1117,7 +1117,7 @@ def test_fit_warning(test_data):
         phot = psfphot(data)
 
     # Check that flag=8 is set for these sources
-    assert_equal(phot['flags'][0] & 8, np.ones(len(phot)) * 8)
+    assert np.all(phot['flags'] & 8)
 
 
 def test_fitter_no_maxiters_no_metrics(test_data):
@@ -1132,7 +1132,7 @@ def test_fitter_no_maxiters_no_metrics(test_data):
     fit_shape = (5, 5)
     fitter = SimplexLSQFitter()  # does not produce residual array
     finder = DAOStarFinder(6.0, 2.0)
-    match = "'maxiters' will be ignored because it is not accepted by"
+    match = "'fitter_maxiters' will be ignored because the fitter's"
     with pytest.warns(AstropyUserWarning, match=match):
         psfphot = PSFPhotometry(psf_model, fit_shape, fitter=fitter,
                                 finder=finder, aperture_radius=4)
@@ -1203,6 +1203,9 @@ def test_xy_bounds(test_data):
     match = 'xy_bounds must be finite'
     with pytest.raises(ValueError, match=match):
         PSFPhotometry(psf_model, fit_shape, xy_bounds=(np.nan, 2))
+    match = 'xy_bounds must be numeric'
+    with pytest.raises(ValueError, match=match):
+        PSFPhotometry(psf_model, fit_shape, xy_bounds='a')
 
 
 def test_grouper_with_xy_bounds(test_data):
@@ -1553,7 +1556,7 @@ def test_flag16_missing_covariance():
     mock_fitter.fit_info = {}
     fit_shape = (5, 5)
 
-    match = r"'maxiters' will be ignored because it is not accepted"
+    match = "'fitter_maxiters' will be ignored because the fitter's"
     with pytest.warns(AstropyUserWarning, match=match):
         psfphot = PSFPhotometry(psf_model, fit_shape, fitter=mock_fitter)
 
@@ -1750,7 +1753,181 @@ def test_invalid_sources(test_data, units):
     assert_equal(model_params['id'], np.arange(1, 7))
 
 
-def test_psf_photometry_table_serialization(test_data):
+def test_results_to_params_exclude_n_pixels():
+    """
+    Regression test that the n_pixels_fit column does not leak into
+    the init/model parameter tables.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image(
+        (60, 60), model, 5, model_shape=(9, 9), flux=(500, 700),
+        min_separation=10, seed=0)
+    init = Table({'x': params['x_0'], 'y': params['y_0']})
+    psfphot = PSFPhotometry(model, (5, 5), aperture_radius=4)
+    psfphot(data, init_params=init)
+    init_tbl = psfphot.results_to_init_params()
+    assert 'n_pixels_init' not in init_tbl.colnames
+    model_tbl = psfphot.results_to_model_params()
+    assert 'n_pixels' not in model_tbl.colnames
+    assert set(model_tbl.colnames) == {'id', 'x_0', 'y_0', 'flux'}
+
+
+def test_duplicate_init_params_ids():
+    """
+    Regression test that duplicate init_params ids are rejected
+    instead of producing a cartesian product of mispaired rows.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data = np.zeros((30, 30))
+    init = Table({'id': [1, 1], 'x': [12.0, 13.0],
+                  'y': [12.0, 13.0], 'flux': [1.0, 1.0]})
+    psfphot = PSFPhotometry(model, (5, 5))
+    match = 'id column must contain unique values'
+    with pytest.raises(ValueError, match=match):
+        psfphot(data, init_params=init)
+
+
+def test_finder_results_reset(test_data):
+    """
+    Regression test that finder_results from a finder-based call does
+    not persist into a subsequent call that uses init_params.
+    """
+    data, error, _ = test_data
+    psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    finder = DAOStarFinder(6.0, 2.0)
+    psfphot = PSFPhotometry(psf_model, (5, 5), finder=finder,
+                            aperture_radius=4)
+    phot = psfphot(data, error=error)
+    assert psfphot.finder_results is not None
+
+    init = Table({'x': phot['x_fit'], 'y': phot['y_fit']})
+    psfphot(data, error=error, init_params=init)
+    assert psfphot.finder_results is None
+
+
+def test_empty_init_params():
+    """
+    Test that a zero-row init_params table raises an error.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data = np.ones((11, 11))
+    init = Table({'x': [1.0], 'y': [1.0]})[:0]
+    psfphot = PSFPhotometry(model, (3, 3), aperture_radius=3)
+    match = 'init_params must contain at least one row'
+    with pytest.raises(ValueError, match=match):
+        psfphot(data, init_params=init)
+
+
+def test_reduced_chi2_zero_dof():
+    """
+    Regression test that reduced_chi2 is NaN (with no warning) when
+    the number of fit pixels equals the number of fit parameters.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image(
+        (50, 50), model, 1, model_shape=(9, 9), flux=(500, 700),
+        min_separation=10, seed=0)
+    error = np.ones(data.shape)
+    xcen = int(params['x_0'][0])
+    ycen = int(params['y_0'][0])
+
+    # Unmask exactly 3 pixels, matching the number of fit parameters
+    mask = np.ones(data.shape, dtype=bool)
+    mask[ycen, xcen] = False
+    mask[ycen, xcen + 1] = False
+    mask[ycen + 1, xcen] = False
+
+    init = Table({'x': params['x_0'], 'y': params['y_0'],
+                  'flux': [600.0]})
+    psfphot = PSFPhotometry(model, (3, 3))
+    phot = psfphot(data, error=error, mask=mask, init_params=init)
+    assert np.isnan(phot['reduced_chi2'][0])
+
+
+def test_group_warning_threshold_validation():
+    """
+    Test that invalid group_warning_threshold values raise an error.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    match = 'group_warning_threshold must be a positive integer'
+    for value in (None, -1, 2.5):
+        with pytest.raises(ValueError, match=match):
+            PSFPhotometry(model, (5, 5), group_warning_threshold=value)
+
+
+def test_row_index_not_leaked_on_failure():
+    """
+    Regression test that a failed call does not leak the private
+    _row_index column into the stored init_params table.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image(
+        (50, 50), model, 3, model_shape=(9, 9), flux=(500, 700),
+        min_separation=10, seed=0)
+    error = np.full(data.shape, -1.0)
+    init = Table({'x': params['x_0'], 'y': params['y_0'],
+                  'flux': [500.0, 500.0, 500.0]})
+    psfphot = PSFPhotometry(model, (5, 5))
+    match = 'Error array contains non-positive'
+    with pytest.raises(ValueError, match=match):
+        psfphot(data, error=error, init_params=init)
+    assert '_row_index' not in psfphot.init_params.colnames
+
+
+def test_group_id_from_float_id_message():
+    """
+    Test that the group_id dtype error names the id column when
+    group_id was derived from it.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data = np.ones((11, 11))
+    init = Table({'id': [1.0, 2.0], 'x': [3.0, 7.0], 'y': [3.0, 7.0],
+                  'flux': [1.0, 1.0]})
+    psfphot = PSFPhotometry(model, (3, 3))
+    match = (r'group_id \(or the id column it was derived from\) '
+             'must be an integer array')
+    with pytest.raises(TypeError, match=match):
+        psfphot(data, init_params=init)
+
+
+def test_aperture_radius_0d_array():
+    """
+    Test that a 0-d array aperture_radius is accepted.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    psfphot = PSFPhotometry(model, (5, 5),
+                            aperture_radius=np.array(3.0))
+    assert psfphot.aperture_radius == 3.0
+
+
+def test_deprecated_shims(test_data):
+    """
+    Test the deprecated keyword and positional-argument shims.
+    """
+    data, error, _ = test_data
+    model = CircularGaussianPRF(flux=1, fwhm=2.7)
+    finder = DAOStarFinder(6.0, 2.0)
+
+    match = "'localbkg_estimator' was deprecated in version 3.0"
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        psfphot = PSFPhotometry(model, (5, 5), finder=finder,
+                                aperture_radius=4,
+                                localbkg_estimator=None)
+    psfphot(data, error=error)
+
+    match = "'include_localbkg' was deprecated in version 3.0"
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        psfphot.make_model_image((25, 25), include_localbkg=False)
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        psfphot.make_residual_image(data, include_localbkg=False)
+
+    match = ("Passing 'return_bit_values' positionally to "
+             "'decode_flags' is deprecated")
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        psfphot.decode_flags(True)  # noqa: FBT003
+
+
+def test_psf_photometry_table_serialization(test_data, tmp_path):
     """
     Test that photometry results table can be written to file.
     """
@@ -1804,24 +1981,24 @@ def test_psf_photometry_table_serialization(test_data):
     assert 'TRFLSQFitter' in meta['fitter']
 
     # Test file writing - this should not raise any errors
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.ecsv',
-                                     delete=False) as tmp:
-        # Write table to ECSV format
-        results.write(tmp.name, format='ascii.ecsv', overwrite=True)
+    filename = tmp_path / 'psf_results.ecsv'
 
-        # Read it back to verify it's readable
-        read_table = Table.read(tmp.name, format='ascii.ecsv')
+    # Write table to ECSV format
+    results.write(filename, format='ascii.ecsv', overwrite=True)
 
-        # Basic checks that the table was written and read correctly
-        assert len(read_table) == len(results)
-        assert set(read_table.colnames) == set(results.colnames)
+    # Read it back to verify it's readable
+    read_table = Table.read(filename, format='ascii.ecsv')
 
-        # Check that metadata was preserved
-        read_meta = read_table.meta
-        assert 'psf_model' in read_meta
-        assert 'finder' in read_meta
-        assert isinstance(read_meta['psf_model'], str)
-        assert isinstance(read_meta['finder'], str)
+    # Basic checks that the table was written and read correctly
+    assert len(read_table) == len(results)
+    assert set(read_table.colnames) == set(results.colnames)
+
+    # Check that metadata was preserved
+    read_meta = read_table.meta
+    assert 'psf_model' in read_meta
+    assert 'finder' in read_meta
+    assert isinstance(read_meta['psf_model'], str)
+    assert isinstance(read_meta['finder'], str)
 
 
 def test_psf_photometry_invalid_coordinates():
@@ -2059,8 +2236,11 @@ def _compare_lists_with_arrays(list1, list2):
                 return False
             for key in item1:
                 if isinstance(item1[key], np.ndarray):
-                    if not np.array_equal(item1[key], item2[key],
-                                          equal_nan=True):
+                    # Array values (e.g., param_cov) can differ by
+                    # float rounding when the within-group source
+                    # order differs, so compare with a tolerance
+                    if not np.allclose(item1[key], item2[key],
+                                       equal_nan=True):
                         return False
                 elif item1[key] != item2[key]:
                     return False
@@ -2126,7 +2306,7 @@ def test_init_params_id_order(test_data, reorder, with_groups,
                    for col in phot1.colnames if col not in ('id', 'group_id')])
 
     # Compare fit_info with special handling for numpy arrays
-    _compare_lists_with_arrays(psfphot1.fit_info, psfphot2.fit_info)
+    assert _compare_lists_with_arrays(psfphot1.fit_info, psfphot2.fit_info)
 
 
 def test_reduced_chi2_metric():
@@ -2262,6 +2442,5 @@ def test_decode_flags():
 
     # Verify that decode_flags gives the same result as calling
     # decode_psf_flags directly
-    from photutils.psf.flags import decode_psf_flags
     direct_decoded = decode_psf_flags(results['flags'])
     assert decoded_flags == direct_decoded


### PR DESCRIPTION
This PR fixes `PSFPhotometry` and `IterativePSFPhotometry` issues found
in the recent PSF package code review.

`PSFPhotometry`:
- The `n_pixels_fit` column no longer leaks into the
  `results_to_init_params` / `results_to_model_params` tables
- `init_params` tables with duplicate ids or zero rows now raise a
  `ValueError`
- `finder_results` is cleared between calls; `fit_info` is reordered
  to match the results table row order
- `reduced_chi2` no longer emits a divide-by-zero warning when there
  are no degrees of freedom
- Input validation for `group_warning_threshold`, `xy_bounds`, and
  `aperture_radius`

`IterativePSFPhotometry`:
- Fixed a `mode='all'` crash when an earlier iteration produced a
  non-finite fit
- `local_bkg` values are now carried across `mode='all'` iterations
  (previously refit with zero background)
- A zero-row finder table now stops iteration cleanly, and the image
  methods raise a clear error after a no-detection run
- `sub_shape` and `maxiters` validation