### PR TITLE
Fix PSF model classes and model I/O bugs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -519,6 +519,37 @@ Bug Fixes
     integration is performed along the rotated principal axes of the
     Gaussian. [#2388]
 
+  - Fixed ``stdpsf_reader`` and ``STDPSFGrid`` to accept an
+    already-open ``astropy.io.fits.HDUList`` or file object. Such
+    inputs were previously accepted by the low-level reader but then
+    raised a ``TypeError`` when parsing the metadata. [#2388]
+
+  - Fixed ``webbpsf_reader`` to correctly read files containing a
+    single 2D PSF. The data was previously reshaped with the new axis
+    in the wrong position, raising a ``ValueError``. [#2388]
+
+  - ``GriddedPSFModel`` now raises a ``ValueError`` if ``grid_xypos``
+    contains duplicate positions. Previously, duplicate positions
+    could silently produce an invalid grid. [#2388]
+
+  - Fixed ``GriddedPSFModel.copy`` so that the copy has its own
+    ``meta`` dictionary. Previously, setting the ``oversampling`` on a
+    copy also changed the ``meta`` dictionary of the original model.
+    [#2388]
+
+  - Fixed ``plot_grid`` for integer-dtype ePSF grids, which raised a
+    casting error with ``deltas=True`` or ``peak_norm=True``. Also,
+    with both ``deltas=True`` and ``peak_norm=True``, the differences
+    are now normalized by the average ePSF peak, as documented, instead
+    of the maximum difference value. [#2388]
+
+  - Fixed ``GriddedPSFModel.evaluate`` to accept scalar coordinates
+    when called directly. [#2388]
+
+  - Fixed ``GriddedPSFModel.read`` to raise the standard format
+    identification error for a corrupt file with a FITS extension
+    instead of an ``OSError``. [#2388]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -543,8 +543,8 @@ Bug Fixes
     are now normalized by the average ePSF peak, as documented, instead
     of the maximum difference value. [#2388]
 
-  - Fixed ``GriddedPSFModel.evaluate`` to accept scalar coordinates
-    when called directly. [#2388]
+  - Fixed ``GriddedPSFModel.evaluate`` and ``ImagePSF.evaluate`` to
+    accept scalar coordinates when called directly. [#2388]
 
   - Fixed ``GriddedPSFModel.read`` to raise the standard format
     identification error for a corrupt file with a FITS extension

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -497,6 +497,28 @@ Bug Fixes
     validation now also rejects non-numeric and boolean inputs.
     [#2387]
 
+  - Fixed a bug where the ``GaussianPSF`` and ``GaussianPRF`` bounding
+    boxes treated a float ``theta`` value (in degrees) as radians,
+    producing incorrect bounding-box extents for rotated models.
+    [#2388]
+
+  - Fixed a bug where ``AiryDiskPSF`` returned the peak value instead
+    of NaN for NaN input coordinates. [#2388]
+
+  - Fixed the default lower bound of the ``MoffatPSF`` ``beta``
+    parameter, which rounded to exactly 1.0 instead of being strictly
+    greater than 1. [#2388]
+
+  - ``CircularGaussianPSF`` and ``CircularGaussianPRF`` now raise a
+    ``UnitsError`` during fitting when the x and y inputs have
+    different units, consistent with the other Gaussian models.
+    [#2388]
+
+  - Fixed the normalization prefactor shown in the ``AiryDiskPSF``
+    docstring and documented that the rotated ``GaussianPRF`` pixel
+    integration is performed along the rotated principal axes of the
+    Gaussian. [#2388]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -93,8 +93,8 @@ class GaussianPSF(Fittable2DModel):
 
     where :math:`F` denotes the total integrated flux, :math:`(x_{0},
     y_{0})` denotes the position of the peak, and :math:`\sigma_{x}` and
-    :math:`\sigma_{y}` denote are the standard deviations along the x
-    and y axes, respectively.
+    :math:`\sigma_{y}` denote the standard deviations along the x and y
+    axes, respectively.
 
     .. math::
 
@@ -133,8 +133,10 @@ class GaussianPSF(Fittable2DModel):
         >>> model.y_fwhm.fixed = False
         >>> model.theta.fixed = False
 
-    By default, the ``x_fwhm`` and ``y_fwhm`` parameters are bounded to
-    be strictly positive.
+    By default, the ``x_fwhm`` and ``y_fwhm`` parameters are bounded
+    to be strictly positive. These bounds apply only during fitting.
+    Directly setting a non-positive width produces unphysical model
+    values.
 
     References
     ----------
@@ -226,7 +228,12 @@ class GaussianPSF(Fittable2DModel):
         """
         a = factor * self.x_sigma
         b = factor * self.y_sigma
-        dx, dy = ellipse_extent(a, b, self.theta)
+        # A float theta is in degrees, but ellipse_extent expect radians
+        if self.theta.unit is None:
+            theta = np.deg2rad(self.theta.value)
+        else:
+            theta = self.theta.quantity
+        dx, dy = ellipse_extent(a, b, theta)
         return ((self.y_0 - dy, self.y_0 + dy), (self.x_0 - dx, self.x_0 + dx))
 
     @property
@@ -340,7 +347,9 @@ class GaussianPSF(Fittable2DModel):
         -------
         result : list of `~numpy.ndarray`
             The list of partial derivatives with respect to each
-            parameter.
+            parameter. The derivative with respect to ``theta`` is
+            always per degree, even when ``theta`` is input as an
+            angular `~astropy.units.Quantity`.
         """
         if not isinstance(theta, u.Quantity):
             theta = np.deg2rad(theta)
@@ -367,7 +376,10 @@ class GaussianPSF(Fittable2DModel):
 
         amplitude = flux / (2 * np.pi * xstd * ystd)
         exp = np.exp(-(a * xdiff2) - (b * xdiff * ydiff) - (c * ydiff2))
-        g = amplitude * exp
+        # Compute the flux derivative directly from the exponential
+        # term so that it is finite even at flux = 0
+        dg_dflux = exp / (2 * np.pi * xstd * ystd)
+        g = flux * dg_dflux
 
         da_dtheta = sint * cost * ((1.0 / ystd2) - (1.0 / xstd2))
         db_dtheta = (cos2t / xstd2) - (cos2t / ystd2)
@@ -381,7 +393,6 @@ class GaussianPSF(Fittable2DModel):
         db_dystd = sin2t / ystd3
         dc_dystd = -cost2 / ystd3
 
-        dg_dflux = g / flux
         dg_dx_0 = g * ((2.0 * a * xdiff) + (b * ydiff))
         dg_dy_0 = g * ((b * xdiff) + (2.0 * c * ydiff))
 
@@ -507,7 +518,8 @@ class CircularGaussianPSF(Fittable2DModel):
         >>> model.fwhm.fixed = False
 
     By default, the ``fwhm`` parameter is bounded to be strictly
-    positive.
+    positive. This bound applies only during fitting. Directly setting a
+    non-positive width produces unphysical model values.
 
     References
     ----------
@@ -695,6 +707,11 @@ class CircularGaussianPSF(Fittable2DModel):
         return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        # The radial distance requires x and y to have the same unit.
+        if inputs_unit[self.inputs[0]] != inputs_unit[self.inputs[1]]:
+            msg = "Units of 'x' and 'y' inputs should match"
+            raise UnitsError(msg)
+
         return {'x_0': inputs_unit[self.inputs[0]],
                 'y_0': inputs_unit[self.inputs[0]],
                 'fwhm': inputs_unit[self.inputs[0]],
@@ -705,10 +722,11 @@ class GaussianPRF(Fittable2DModel):
     r"""
     A 2D Gaussian PSF model integrated over pixels.
 
-    This model is evaluated by integrating the 2D Gaussian over the
-    input coordinate pixels, and is equivalent to assuming the PSF is
-    2D Gaussian at a *sub-pixel* level. Because it is integrated over
-    pixels, this model is considered a PRF instead of a PSF.
+    This model is evaluated by integrating the 2D Gaussian over pixels
+    along the rotated principal axes of the Gaussian (see Notes),
+    and is equivalent to assuming the PSF is a 2D Gaussian at a
+    *sub-pixel* level. Because it is integrated over pixels, this model
+    is considered a PRF instead of a PSF.
 
     The Gaussian is normalized such that the analytical integral over
     the entire 2D plane is equal to the total flux.
@@ -737,7 +755,7 @@ class GaussianPRF(Fittable2DModel):
 
     bbox_factor : float, optional
         The multiple of the x and y standard deviations (sigma) used to
-        define the bounding_box limits.
+        define the bounding box limits.
 
     **kwargs : dict, optional
         Additional optional keyword arguments to be passed to the
@@ -783,6 +801,11 @@ class GaussianPRF(Fittable2DModel):
     where :math:`(x_{0}, y_{0})` is the position of the peak and
     :math:`\theta` is the rotation angle of the Gaussian.
 
+    The pixel integration is performed along the rotated principal
+    axes of the Gaussian. For ``theta != 0`` the value is therefore an
+    approximation to the integral over the axis-aligned detector pixel,
+    exact only for ``theta = 0``.
+
     The FWHMs of the Gaussian along the x and y axes are given by:
 
     .. math::
@@ -807,8 +830,10 @@ class GaussianPRF(Fittable2DModel):
         >>> model.y_fwhm.fixed = False
         >>> model.theta.fixed = False
 
-    By default, the ``x_fwhm`` and ``y_fwhm`` parameters are bounded to
-    be strictly positive.
+    By default, the ``x_fwhm`` and ``y_fwhm`` parameters are bounded
+    to be strictly positive. These bounds apply only during fitting.
+    Directly setting a non-positive width produces unphysical model
+    values.
 
     References
     ----------
@@ -900,7 +925,12 @@ class GaussianPRF(Fittable2DModel):
         """
         a = factor * self.x_sigma
         b = factor * self.y_sigma
-        dx, dy = ellipse_extent(a, b, self.theta)
+        # A float theta is in degrees, but ellipse_extent expect radians
+        if self.theta.unit is None:
+            theta = np.deg2rad(self.theta.value)
+        else:
+            theta = self.theta.quantity
+        dx, dy = ellipse_extent(a, b, theta)
         return ((self.y_0 - dy, self.y_0 + dy), (self.x_0 - dx, self.x_0 + dx))
 
     @property
@@ -1017,7 +1047,7 @@ class CircularGaussianPRF(Fittable2DModel):
     A circular 2D Gaussian PSF model integrated over pixels.
 
     This model is evaluated by integrating the 2D Gaussian over the
-    input coordinate pixels, and is equivalent to assuming the PSF is
+    input coordinate pixels, and is equivalent to assuming the PSF is a
     2D Gaussian at a *sub-pixel* level. Because it is integrated over
     pixels, this model is considered a PRF instead of a PSF.
 
@@ -1097,7 +1127,8 @@ class CircularGaussianPRF(Fittable2DModel):
         >>> model.fwhm.fixed = False
 
     By default, the ``fwhm`` parameter is bounded to be strictly
-    positive.
+    positive. This bound applies only during fitting. Directly setting a
+    non-positive width produces unphysical model values.
 
     References
     ----------
@@ -1252,6 +1283,11 @@ class CircularGaussianPRF(Fittable2DModel):
         return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        # The radial distance requires x and y to have the same unit.
+        if inputs_unit[self.inputs[0]] != inputs_unit[self.inputs[1]]:
+            msg = "Units of 'x' and 'y' inputs should match"
+            raise UnitsError(msg)
+
         return {'x_0': inputs_unit[self.inputs[0]],
                 'y_0': inputs_unit[self.inputs[0]],
                 'fwhm': inputs_unit[self.inputs[0]],
@@ -1263,7 +1299,7 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
     A circular 2D Gaussian PSF model integrated over pixels.
 
     This model is evaluated by integrating the 2D Gaussian over the
-    input coordinate pixels, and is equivalent to assuming the PSF is
+    input coordinate pixels, and is equivalent to assuming the PSF is a
     2D Gaussian at a *sub-pixel* level. Because it is integrated over
     pixels, this model is considered a PRF instead of a PSF.
 
@@ -1280,13 +1316,13 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         Total integrated flux over the entire PSF.
 
     x_0 : float, optional
-        Position of the peak in x direction.
+        Position of the peak along the x-axis.
 
     y_0 : float, optional
-        Position of the peak in y direction.
+        Position of the peak along the y-axis.
 
     sigma : float, optional
-        Width of the Gaussian PSF.
+        The standard deviation of the Gaussian.
 
     bbox_factor : float, optional
         The multiple of the standard deviation (sigma) used to define
@@ -1341,7 +1377,8 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         >>> model.sigma.fixed = False
 
     By default, the ``sigma`` parameter is bounded to be strictly
-    positive.
+    positive. This bound applies only during fitting. Directly setting a
+    non-positive width produces unphysical model values.
 
     References
     ----------
@@ -1454,21 +1491,21 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         Parameters
         ----------
         x, y : float or array_like
-            The coordinates at which to evaluate the model.
+            The x and y coordinates at which to evaluate the model.
 
         flux : float
-            The total flux of the star.
+            Total integrated flux over the entire PSF.
 
         x_0, y_0 : float
-            The position of the star.
+            Position of the peak along the x and y axes.
 
         sigma : float
-            The width of the Gaussian PRF.
+            The standard deviation of the Gaussian.
 
         Returns
         -------
-        evaluated_model : `~numpy.ndarray`
-            The evaluated model.
+        result : `~numpy.ndarray`
+            The value of the model evaluated at the input coordinates.
         """
         x0 = x - x_0
         y0 = y - y_0
@@ -1496,9 +1533,7 @@ class CircularGaussianSigmaPRF(Fittable2DModel):
         return {self.inputs[0]: x_unit, self.inputs[1]: y_unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        # We need to make sure that x and y are in the same units
-        # otherwise this can lead to issues since rotation is not well
-        # defined.
+        # The radial distance requires x and y to have the same unit.
         if inputs_unit[self.inputs[0]] != inputs_unit[self.inputs[1]]:
             msg = "Units of 'x' and 'y' inputs should match"
             raise UnitsError(msg)
@@ -1629,7 +1664,7 @@ class MoffatPSF(Fittable2DModel):
         description='Characteristic radius of the Moffat profile')
     beta = Parameter(
         default=2,
-        bounds=(1.0 + _FLOAT_TINY, None),
+        bounds=(np.nextafter(1.0, np.inf), None),
         fixed=True,
         description='Power-law index of the Moffat profile')
 
@@ -1713,10 +1748,10 @@ class MoffatPSF(Fittable2DModel):
         x_0, y_0 : float
             Position of the peak along the x and y axes.
 
-        alpha : float, optional
+        alpha : float
             The characteristic radius of the Moffat profile.
 
-        beta : float, optional
+        beta : float
             The asymptotic power-law slope of the Moffat profile wings
             at large radial distances. Larger values provide less flux
             in the profile wings. For large ``beta``, this profile
@@ -1800,7 +1835,7 @@ class AiryDiskPSF(Fittable2DModel):
 
     .. math::
 
-        f(r) = \frac{F}{4 \pi (R / R_z)^2}
+        f(r) = \frac{\pi F}{4 (R / R_z)^{2}}
                \left[ \frac{2 J_1\left(\frac{\pi r}{R / R_z}\right)}
                       {\frac{\pi r}{R / R_z}} \right]^2
 
@@ -1969,7 +2004,7 @@ class AiryDiskPSF(Fittable2DModel):
         x_0, y_0 : float
             Position of the peak along the x and y axes.
 
-        radius : float, optional
+        radius : float
             The radius of the Airy disk at the first zero.
 
         Returns
@@ -1993,6 +2028,7 @@ class AiryDiskPSF(Fittable2DModel):
         z = np.ones(rt.shape)
         nonzero = rt > 0
         z[nonzero] = (2.0 * j1(rt[nonzero]) / rt[nonzero]) ** 2
+        z[np.isnan(rt)] = np.nan
         z = z.reshape(r.shape)
 
         if isinstance(flux, u.Quantity):

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -82,9 +82,10 @@ class GriddedPSFModel(Fittable2DModel):
         The ``(x, y)`` coordinates of the ePSF peak in the output
         coordinate grid where the model is evaluated.
 
-    fill_value : float, optional
+    fill_value : float or `None`, optional
         The value used for points outside the input pixel grid. The
-        default is 0.0.
+        default is 0.0. If `None`, values outside the input pixel grid
+        are extrapolated from the spline fit.
 
     Methods
     -------
@@ -121,6 +122,11 @@ class GriddedPSFModel(Fittable2DModel):
     Internally, the ePSF grid is reordered so that the reference ePSFs
     are sorted first by their y detector coordinate and then by their x
     detector coordinate.
+
+    One `~scipy.interpolate.RectBivariateSpline` interpolator per
+    evaluated grid plane is cached on the model and shared across copies
+    made with the `copy` method. The cache roughly doubles the model's
+    memory footprint when every grid plane has been evaluated.
     """
 
     flux = Parameter(description='Intensity scaling factor for the ePSF '
@@ -137,6 +143,9 @@ class GriddedPSFModel(Fittable2DModel):
 
         self._data, self._grid_xypos = self._define_grid(nddata)
         self._meta = nddata.meta.copy()  # _meta to avoid the meta descriptor
+        # Drop a stale user-supplied key; the grid shape is derived
+        # from grid_xypos
+        self._meta.pop('grid_shape', None)
         # The setter also stores the normalized (y, x) pair in meta
         self.oversampling = nddata.meta['oversampling']
         self.fill_value = fill_value
@@ -258,6 +267,10 @@ class GriddedPSFModel(Fittable2DModel):
                    'input ePSFs')
             raise ValueError(msg)
 
+        if len({tuple(pos) for pos in grid_xypos}) != len(grid_xypos):
+            msg = 'grid_xypos must not contain duplicate positions'
+            raise ValueError(msg)
+
         if len(grid_xypos) != 1 and not self._is_rectangular_grid(grid_xypos):
             msg = ('grid_xypos must form a rectangular grid, i.e., there '
                    'must be at least two unique x and y positions and '
@@ -302,13 +315,14 @@ class GriddedPSFModel(Fittable2DModel):
 
         keywords.extend([('Number of PSFs', len(self.grid_xypos)),
                          ('Grid shape', self.grid_shape),
-                         ('Grid positions', self.grid_xypos.tolist()),
+                         ('Grid positions', self.grid_xypos),
                          ('PSF shape (oversampled pixels)',
                           self.data.shape[1:]),
                          ('Oversampling', oversampling),
                          ('Fill Value', self.fill_value)])
 
-        return self._format_str(keywords=keywords)
+        with np.printoptions(threshold=25, edgeitems=5):
+            return self._format_str(keywords=keywords)
 
     def __repr__(self):
         kwargs = {'oversampling': self.oversampling.tolist(),
@@ -367,11 +381,17 @@ class GriddedPSFModel(Fittable2DModel):
         """
         newcls = object.__new__(self.__class__)
 
-        for key, val in self.__dict__.items():
+        # Snapshot so concurrent cached_property fills cannot resize
+        # the dict during iteration
+        for key, val in dict(self.__dict__).items():
             if key in self.param_names:  # copy only the parameter values
                 newcls.__dict__[key] = copy.copy(val)
             else:
                 newcls.__dict__[key] = val
+
+        # Give the copy its own meta dictionary so that setting the
+        # oversampling on the copy does not mutate the original meta
+        newcls._meta = dict(self._meta)
 
         return newcls
 
@@ -417,7 +437,7 @@ class GriddedPSFModel(Fittable2DModel):
 
     def _calc_bounding_box(self):
         """
-        Set a bounding box defining the limits of the model.
+        Return a bounding box defining the limits of the model.
 
         Returns
         -------
@@ -468,8 +488,8 @@ class GriddedPSFModel(Fittable2DModel):
     @cached_property
     def origin(self):
         """
-        A 1D `~numpy.ndarray` (x, y) pixel coordinates within the
-        model's 2D image of the origin of the coordinate system.
+        The (x, y) pixel coordinates, as a 1D `~numpy.ndarray`, of the
+        origin of the coordinate system within the model image.
         """
         # data.shape is (N_psf, ePSF_ny, ePSF_nx); the leading axis is
         # excluded so that the result is the (x, y) image center
@@ -689,7 +709,7 @@ class GriddedPSFModel(Fittable2DModel):
         x_0, y_0 : float
             The (x, y) position of the model.
 
-        xi, yi : float
+        xi, yi : float or `~numpy.ndarray`
             The input (x, y) coordinates at which the model is
             evaluated.
 
@@ -736,6 +756,8 @@ class GriddedPSFModel(Fittable2DModel):
         evaluated_model : `~numpy.ndarray`
             The evaluated model.
         """
+        x = np.asarray(x)
+        y = np.asarray(y)
         if x.ndim > 2:
             msg = 'x and y must be 1D or 2D'
             raise ValueError(msg)

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -756,8 +756,11 @@ class GriddedPSFModel(Fittable2DModel):
         evaluated_model : `~numpy.ndarray`
             The evaluated model.
         """
-        x = np.asarray(x)
-        y = np.asarray(y)
+        # Promote scalar inputs to 1D arrays so that the interpolator
+        # returns an array that supports masked assignment below,
+        # regardless of the scipy version
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
         if x.ndim > 2:
             msg = 'x and y must be 1D or 2D'
             raise ValueError(msg)

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -66,9 +66,10 @@ class ImagePSF(Fittable2DModel):
         scalar is provided, it is applied to both axes. If two values are
         provided, they must be in ``(y, x)`` order.
 
-    fill_value : float, optional
+    fill_value : float or `None`, optional
         The value used for points outside the input pixel grid. The default
-        is 0.0.
+        is 0.0. If `None`, values outside the input pixel grid are
+        extrapolated from the spline fit.
 
     **kwargs : dict, optional
         Additional keyword arguments passed to the
@@ -204,7 +205,9 @@ class ImagePSF(Fittable2DModel):
         """
         newcls = object.__new__(self.__class__)
 
-        for key, val in self.__dict__.items():
+        # Snapshot so concurrent cached_property fills cannot resize
+        # the dict during iteration
+        for key, val in dict(self.__dict__).items():
             if key in self.param_names:  # copy only the parameter values
                 newcls.__dict__[key] = copy.copy(val)
             else:
@@ -292,8 +295,8 @@ class ImagePSF(Fittable2DModel):
     @property
     def origin(self):
         """
-        A 1D `~numpy.ndarray` (x, y) pixel coordinates within the
-        model's 2D image of the origin of the coordinate system.
+        The (x, y) pixel coordinates, as a 1D `~numpy.ndarray`, of the
+        origin of the coordinate system within the model image.
 
         The reference ``origin`` pixel will be placed at the model
         ``x_0`` and ``y_0`` coordinates in the output coordinate system
@@ -346,7 +349,7 @@ class ImagePSF(Fittable2DModel):
 
     def _calc_bounding_box(self):
         """
-        Set a bounding box defining the limits of the model.
+        Return a bounding box defining the limits of the model.
 
         Returns
         -------

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -415,8 +415,13 @@ class ImagePSF(Fittable2DModel):
         result : `~numpy.ndarray`
             The value of the model evaluated at the input coordinates.
         """
-        xi = self.oversampling[1] * (np.asarray(x, dtype=float) - x_0)
-        yi = self.oversampling[0] * (np.asarray(y, dtype=float) - y_0)
+        # Promote scalar inputs to 1D arrays so that the interpolator
+        # returns an array that supports masked assignment below,
+        # regardless of the scipy version
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        y = np.atleast_1d(np.asarray(y, dtype=float))
+        xi = self.oversampling[1] * (x - x_0)
+        yi = self.oversampling[0] * (y - y_0)
         xi += self._origin[0]
         yi += self._origin[1]
 

--- a/photutils/psf/model_io.py
+++ b/photutils/psf/model_io.py
@@ -129,8 +129,13 @@ def _read_stdpsf(filename):
         filename = os.fspath(filename)
 
     is_hdulist = isinstance(filename, fits.HDUList)
-    is_fileobj = (isinstance(filename, io.FileIO)
-                  and filename.name.lower().endswith(_FITS_EXTENSIONS))
+    if isinstance(filename, io.IOBase):
+        # A file object created from a file descriptor has an int name
+        name = getattr(filename, 'name', None)
+        is_fileobj = (isinstance(name, str)
+                      and name.lower().endswith(_FITS_EXTENSIONS))
+    else:
+        is_fileobj = False
     is_fits_ext = (isinstance(filename, str)
                    and filename.lower().endswith(_FITS_EXTENSIONS))
     if is_hdulist or is_fileobj or is_fits_ext:
@@ -316,7 +321,9 @@ def _split_wfc_uvis(grid_data, detector_id):
     ygrid = grid_data['ygrid']
     ygrid = ygrid.reshape((2, ygrid.shape[0] // 2))[detector_id - 1]
     if detector_id == 2:
-        ygrid -= 2048
+        # Avoid writing through the reshape view into the input grid
+        # data
+        ygrid = ygrid - 2048
 
     n_psfs = grid_data['n_psfs']
     data = grid_data['data']
@@ -430,8 +437,9 @@ def _get_metadata(filename, detector_id):
 
     Parameters
     ----------
-    filename : str or path-like
-        The name of the STDPSF FITS file.
+    filename : str, path-like, file-like, or `~astropy.io.fits.HDUList`
+        The name of the STDPSF FITS file, an open file object, or an
+        already-open `~astropy.io.fits.HDUList`.
 
     detector_id : int
         The detector ID.
@@ -439,12 +447,18 @@ def _get_metadata(filename, detector_id):
     Returns
     -------
     meta : dict or `None`
-        A dictionary containing the metadata.
+        A dictionary containing the metadata. `None` is returned if a
+        filename string cannot be determined from the input.
     """
-    if isinstance(filename, io.FileIO):
-        filename = filename.name
+    if isinstance(filename, fits.HDUList):
+        filename = filename.filename()
+    elif isinstance(filename, io.IOBase):
+        filename = getattr(filename, 'name', None)
     elif isinstance(filename, os.PathLike):
         filename = os.fspath(filename)
+
+    if not isinstance(filename, str):
+        return None
 
     # Strip the file extension (e.g., '.fits' or '.fits.gz') before
     # splitting the filename into its underscore-separated fields.
@@ -505,8 +519,10 @@ def stdpsf_reader(filename, detector_id=None):
 
     Parameters
     ----------
-    filename : str or path-like
-        The name of the STDPSF FITS file. A URL can also be used.
+    filename : str, path-like, file-like, or `~astropy.io.fits.HDUList`
+        The name of the STDPSF FITS file, an open file object, or an
+        already-open `~astropy.io.fits.HDUList`. A URL can also be
+        used.
 
     detector_id : `None` or int, optional
         For STDPSF files that contain ePSF grids for multiple detectors,
@@ -610,7 +626,8 @@ def webbpsf_reader(filename):
             data = hdulist[0].data
 
     # Handle the case of only one 2D PSF
-    data = np.atleast_3d(data)
+    if data.ndim == 2:
+        data = data[np.newaxis, :]
 
     if not any('DET_YX' in key for key in header):
         msg = 'Invalid WebbPSF FITS file; missing "DET_YX{}" header keys'
@@ -625,7 +642,7 @@ def webbpsf_reader(filename):
     header.pop('COMMENT', None)
     header.pop('', None)
     meta = dict(header)
-    meta = {key.lower(): meta[key] for key in meta}  # user lower-case keys
+    meta = {key.lower(): meta[key] for key in meta}  # use lower-case keys
 
     # Define grid_xypos from the DET_YX{i} FITS header keywords. The
     # keywords are sorted by their numeric index so that the positions
@@ -652,7 +669,7 @@ def webbpsf_reader(filename):
     return GriddedPSFModel(ndd)
 
 
-def _has_fits_header_keys(filepath, keys):
+def _has_fits_header_keys(filepath, keys, *, fileobj=None):
     """
     Determine whether a file is a FITS file whose primary header
     contains all of the given keywords.
@@ -665,21 +682,40 @@ def _has_fits_header_keys(filepath, keys):
     keys : tuple of str
         The FITS header keywords that must all be present.
 
+    fileobj : file-like object or `None`, optional
+        An open file object to read the file's contents. If given, the
+        header is read from it instead of reopening ``filepath``.
+
     Returns
     -------
     result : bool
         Returns `True` if the file is a FITS file containing all of the
         input keywords.
     """
+    if fileobj is not None:
+        try:
+            fileobj.seek(0)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', VerifyWarning)
+                header = fits.getheader(fileobj)
+        except OSError:
+            # A corrupt file is not a FITS file
+            return False
+        return all(key in header for key in keys)
+
     if isinstance(filepath, os.PathLike):
         filepath = os.fspath(filepath)
 
     if filepath is None or not filepath.lower().endswith(_FITS_EXTENSIONS):
         return False
 
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', VerifyWarning)
-        header = fits.getheader(filepath)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', VerifyWarning)
+            header = fits.getheader(filepath)
+    except OSError:
+        # A corrupt file with a FITS extension is not a FITS file
+        return False
 
     return all(key in header for key in keys)
 
@@ -710,7 +746,8 @@ def is_stdpsf(origin, filepath, fileobj, *args, **kwargs):
     result : bool
         Returns `True` if the given file is a STDPSF FITS file.
     """
-    return _has_fits_header_keys(filepath, ('NAXIS3', 'NXPSFS', 'NYPSFS'))
+    return _has_fits_header_keys(filepath, ('NAXIS3', 'NXPSFS', 'NYPSFS'),
+                                 fileobj=fileobj)
 
 
 def is_webbpsf(origin, filepath, fileobj, *args, **kwargs):
@@ -739,4 +776,5 @@ def is_webbpsf(origin, filepath, fileobj, *args, **kwargs):
     result : bool
         Returns `True` if the given file is a WebbPSF FITS file.
     """
-    return _has_fits_header_keys(filepath, ('NAXIS3', 'OVERSAMP', 'DET_YX0'))
+    return _has_fits_header_keys(filepath, ('NAXIS3', 'OVERSAMP', 'DET_YX0'),
+                                 fileobj=fileobj)

--- a/photutils/psf/model_plotting.py
+++ b/photutils/psf/model_plotting.py
@@ -110,7 +110,7 @@ class _ModelGridPlotter:
         import matplotlib.pyplot as plt
         from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-        data = self.model.data.copy()
+        data = self.model.data.astype(float)
         if deltas:
             # Compute mean ignoring any blank (all zeros) ePSFs.
             # This is the case for MIRI with its non-square FOV.
@@ -118,8 +118,15 @@ class _ModelGridPlotter:
             for i, arr in enumerate(data):
                 if np.count_nonzero(arr) == 0:
                     mask[i] = True
-            data -= np.mean(data[~mask], axis=0)
+            mean_epsf = np.mean(data[~mask], axis=0)
+            data -= mean_epsf
             data[mask] = 0.0
+            # For peak normalization, use the peak of the mean ePSF so
+            # that the differences are relative to the average ePSF
+            # peak
+            peak = mean_epsf.max()
+        else:
+            peak = data.max()
 
         data = self._reshape_grid(data)
 
@@ -131,9 +138,9 @@ class _ModelGridPlotter:
         else:
             fig = ax.get_figure()
 
-        if peak_norm and data.max() != 0:
+        if peak_norm and peak != 0:
             # Normalize relative to peak
-            data /= data.max()
+            data /= peak
 
         if deltas:
             if vmax_scale is None:

--- a/photutils/psf/tests/test_functional_models.py
+++ b/photutils/psf/tests/test_functional_models.py
@@ -9,6 +9,7 @@ import pytest
 from astropy.modeling.fitting import TRFLSQFitter
 from astropy.stats import gaussian_fwhm_to_sigma
 from numpy.testing import assert_allclose
+from scipy.special import erf
 
 from photutils.psf import (AiryDiskPSF, CircularGaussianPRF,
                            CircularGaussianPSF, CircularGaussianSigmaPRF,
@@ -82,18 +83,19 @@ def gaussian_tests(name, use_units):
                 tparam = getattr(model, param)
                 tparam <<= unit
                 setattr(model, param, tparam)
+        if 'theta' in model.param_names:
+            model.theta = model.theta.value * u.deg
+
+    elliptical = 'x_fwhm' in model.param_names
 
     data = model(xx, yy)
     if use_units:
         data = data.value
     assert_allclose(data.sum(), model.flux.value)
-    try:
+    if elliptical:
         assert_allclose(model.x_sigma, model.x_fwhm * gaussian_fwhm_to_sigma)
         assert_allclose(model.y_sigma, model.y_fwhm * gaussian_fwhm_to_sigma)
-    except AttributeError:
-        assert_allclose(model.sigma, model.fwhm * gaussian_fwhm_to_sigma)
 
-    try:
         xsigma = model.x_sigma
         ysigma = model.y_sigma
         if isinstance(xsigma, u.Quantity):
@@ -101,7 +103,9 @@ def gaussian_tests(name, use_units):
             ysigma = ysigma.value
         assert_allclose(model.amplitude * (2 * np.pi * xsigma * ysigma),
                         model.flux)
-    except AttributeError:
+    else:
+        assert_allclose(model.sigma, model.fwhm * gaussian_fwhm_to_sigma)
+
         sigma = model.sigma
         if isinstance(sigma, u.Quantity):
             sigma = sigma.value
@@ -111,25 +115,24 @@ def gaussian_tests(name, use_units):
     fit_model = fitter(model_init, xx, yy, data)
     assert_allclose(fit_model.x_0.value, model.x_0.value, rtol=1e-5)
     assert_allclose(fit_model.y_0.value, model.y_0.value, rtol=1e-5)
-    try:
+    if elliptical:
         assert_allclose(fit_model.x_fwhm.value, model.x_fwhm.value)
         assert_allclose(fit_model.y_fwhm.value, model.y_fwhm.value)
         assert_allclose(fit_model.theta.value, model.theta.value)
-    except AttributeError:
-        if name == 'CircularGaussianSigmaPRF':
-            assert_allclose(fit_model.sigma.value, model.sigma.value)
-        else:
-            assert_allclose(fit_model.fwhm.value, model.fwhm.value)
+    elif name == 'CircularGaussianSigmaPRF':
+        assert_allclose(fit_model.sigma.value, model.sigma.value)
+    else:
+        assert_allclose(fit_model.fwhm.value, model.fwhm.value)
 
     # Test the model derivatives
     fit_model2 = fitter(model_init, xx, yy, data, estimate_jacobian=True)
     assert_allclose(fit_model2.x_0, fit_model.x_0)
     assert_allclose(fit_model2.y_0, fit_model.y_0)
-    try:
+    if elliptical:
         assert_allclose(fit_model2.x_fwhm, fit_model.x_fwhm)
         assert_allclose(fit_model2.y_fwhm, fit_model.y_fwhm)
         assert_allclose(fit_model2.theta, fit_model.theta)
-    except AttributeError:
+    else:
         assert_allclose(fit_model2.fwhm, fit_model.fwhm)
 
     if use_units and 'Circular' not in name:
@@ -223,6 +226,14 @@ class TestFitDeriv:
                                            fwhm, fwhm, 0.0)
         assert_allclose(circular[3], elliptical[3] + elliptical[4])
 
+    def test_gaussian_fit_deriv_zero_flux(self):
+        """
+        Test that the flux derivative is finite when the flux is zero.
+        """
+        derivs = GaussianPSF.fit_deriv(1.0, 1.0, 0.0, 0.0, 0.0, 2.0,
+                                       3.0, 10.0)
+        assert np.isfinite(derivs[0])
+
     def test_circular_fit_free_fwhm(self):
         """
         Test fitting a circular Gaussian with a free FWHM using the
@@ -239,6 +250,53 @@ class TestFitDeriv:
         fit_model = fitter(model_init, xx, yy, data)
         assert_allclose(fit_model.flux.value, model.flux.value, rtol=1e-6)
         assert_allclose(fit_model.fwhm.value, model.fwhm.value, rtol=1e-6)
+
+
+def test_gaussian_prf_theta_quantity():
+    """
+    Test that a float theta (degrees) and an equivalent Quantity theta
+    give the same model values.
+    """
+    assert_allclose(GaussianPRF(theta=30.0)(1.0, 2.0),
+                    GaussianPRF(theta=30 * u.deg)(1.0, 2.0))
+
+
+def test_circular_prf_fwhm_sigma_equivalence():
+    """
+    Test that CircularGaussianPRF and CircularGaussianSigmaPRF give
+    identical values for equivalent widths.
+    """
+    fwhm = 2.7
+    model1 = CircularGaussianPRF(fwhm=fwhm)
+    model2 = CircularGaussianSigmaPRF(sigma=fwhm * gaussian_fwhm_to_sigma)
+    yy, xx = np.mgrid[-5:6, -5:6]
+    assert_allclose(model1(xx, yy), model2(xx, yy))
+
+
+def test_gaussian_prf_matches_analytic_integral():
+    """
+    Test that GaussianPRF at theta=0 equals the erf-based analytic
+    pixel integral of GaussianPSF.
+    """
+    flux = 71.4
+    x_0 = 0.3
+    y_0 = -0.6
+    x_fwhm = 2.0
+    y_fwhm = 3.0
+    model = GaussianPRF(flux=flux, x_0=x_0, y_0=y_0, x_fwhm=x_fwhm,
+                        y_fwhm=y_fwhm)
+    yy, xx = np.mgrid[-5:6, -5:6]
+
+    x_sigma = x_fwhm * gaussian_fwhm_to_sigma
+    y_sigma = y_fwhm * gaussian_fwhm_to_sigma
+    dx = xx - x_0
+    dy = yy - y_0
+    expected = (flux / 4.0
+                * ((erf((dx + 0.5) / (np.sqrt(2) * x_sigma))
+                    - erf((dx - 0.5) / (np.sqrt(2) * x_sigma)))
+                   * (erf((dy + 0.5) / (np.sqrt(2) * y_sigma))
+                      - erf((dy - 0.5) / (np.sqrt(2) * y_sigma)))))
+    assert_allclose(model(xx, yy), expected)
 
 
 def test_gaussian_prf_sums():
@@ -269,6 +327,36 @@ def test_gaussian_bounding_boxes():
 
     model5 = CircularGaussianSigmaPRF(x_0=0, y_0=0, sigma=2)
     assert_allclose(model5.bounding_box, ((-11, 11), (-11, 11)))
+
+
+@pytest.mark.parametrize('model_cls', [GaussianPSF, GaussianPRF])
+def test_gaussian_bounding_box_theta_units(model_cls):
+    """
+    Regression test that float theta (degrees) and Quantity theta
+    give identical bounding boxes.
+    """
+    m_float = model_cls(x_0=0, y_0=0, x_fwhm=2, y_fwhm=3, theta=90)
+    m_quant = model_cls(x_0=0, y_0=0, x_fwhm=2, y_fwhm=3,
+                        theta=90 * u.deg)
+    bbf = m_float.bounding_box
+    bbq = m_quant.bounding_box
+    for axis in ('x', 'y'):
+        assert_allclose(bbf[axis].lower, bbq[axis].lower)
+        assert_allclose(bbf[axis].upper, bbq[axis].upper)
+
+
+@pytest.mark.parametrize('model_cls', [GaussianPSF, GaussianPRF])
+def test_gaussian_bounding_box_theta90_swaps(model_cls):
+    """
+    Test that a 90 degree rotation swaps the x and y bounding box
+    extents.
+    """
+    m0 = model_cls(x_0=0, y_0=0, x_fwhm=2, y_fwhm=3)
+    m90 = model_cls(x_0=0, y_0=0, x_fwhm=2, y_fwhm=3, theta=90)
+    bb0 = m0.bounding_box
+    bb90 = m90.bounding_box
+    assert_allclose(bb90['x'].upper, bb0['y'].upper)
+    assert_allclose(bb90['y'].upper, bb0['x'].upper)
 
 
 @pytest.mark.parametrize('use_units', [False, True])
@@ -304,6 +392,14 @@ def test_moffat_psf_model(use_units):
     model = MoffatPSF(x_0=0, y_0=0, alpha=1.0, beta=2.0)
     bbox = 12.871885058111655
     assert_allclose(model.bounding_box, ((-bbox, bbox), (-bbox, bbox)))
+
+
+def test_moffat_psf_beta_bound():
+    """
+    Test that the default lower bound of beta is strictly greater
+    than 1.
+    """
+    assert MoffatPSF().beta.bounds[0] > 1.0
 
 
 def test_airydisk_psf_quantity_flux():
@@ -342,8 +438,25 @@ def test_moffat_psf_scalar_coords():
     assert_allclose(value, model(1.0, 2.0))
 
 
-def test_circular_gaussian_sigma_prf_unit_mismatch():
-    model = CircularGaussianSigmaPRF(flux=1.0, x_0=0.0, y_0=0.0, sigma=2.0)
+@pytest.mark.parametrize('model', [
+    GaussianPSF(), CircularGaussianPSF(), GaussianPRF(),
+    CircularGaussianPRF(), CircularGaussianSigmaPRF(),
+    MoffatPSF(), AiryDiskPSF()])
+def test_nan_propagation(model):
+    """
+    Test that NaN input coordinates propagate to NaN output values.
+    """
+    assert np.isnan(model(np.nan, 0.0))
+    result = model(np.array([np.nan, 0.0]), np.array([0.0, 0.0]))
+    assert np.isnan(result[0])
+    assert np.isfinite(result[1])
+
+
+@pytest.mark.parametrize('model', [
+    CircularGaussianPSF(),
+    CircularGaussianPRF(),
+    CircularGaussianSigmaPRF()])
+def test_circular_gaussian_unit_mismatch(model):
     inputs_unit = {'x': u.m, 'y': u.s}
     outputs_unit = {'z': u.Jy}
     match = "Units of 'x' and 'y' inputs should match"

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -16,15 +16,8 @@ from numpy.testing import assert_allclose, assert_equal
 
 from photutils.datasets import make_model_image
 from photutils.psf import GriddedPSFModel, STDPSFGrid
+from photutils.psf.tests.test_model_io import STDPSF_FILENAMES
 from photutils.segmentation import SourceCatalog, detect_sources
-from photutils.utils._optional_deps import HAS_MATPLOTLIB
-
-# The first file has a single detector, the rest have multiple detectors
-STDPSF_FILENAMES = ('STDPSF_NRCA1_F150W_mock.fits',
-                    'STDPSF_ACSWFC_F814W_mock.fits',
-                    'STDPSF_NRCSW_F150W_mock.fits',
-                    'STDPSF_WFC3UV_F814W_mock.fits',
-                    'STDPSF_WFPC2_F814W_mock.fits')
 
 
 def _reference_find_bounding_points(model, x, y):
@@ -173,6 +166,33 @@ class TestGriddedPSFModel:
         assert 'Oversampling: (4, 4)' in str_str
         assert 'Fill Value: 0.0' in str_str
 
+    def test_evaluate_scalar_coords(self, psfmodel):
+        """
+        Test that evaluate accepts scalar coordinates when called
+        directly.
+        """
+        value = psfmodel.evaluate(0.5, 0.5, 1.0, 0.0, 0.0)
+        assert np.isfinite(value)
+
+    def test_stale_grid_shape_meta(self, psfmodel):
+        """
+        Test that a stale user-supplied grid_shape key is dropped from
+        the meta dictionary.
+        """
+        meta = dict(psfmodel.meta)
+        meta['grid_shape'] = (999, 999)
+        model = GriddedPSFModel(NDData(psfmodel.data, meta=meta))
+        assert 'grid_shape' not in model.meta
+
+    def test_str_grid_positions_truncated(self, psfmodel):
+        """
+        Test that the grid positions are summarized in the string
+        representation instead of being printed in full.
+        """
+        model_str = str(psfmodel)
+        assert 'Grid positions' in model_str
+        assert '...' in model_str
+
     def test_gridded_psf_model_basic_eval(self, psfmodel):
         assert psfmodel(0, 0) == 1
         assert psfmodel(100, 100) == 0
@@ -187,21 +207,26 @@ class TestGriddedPSFModel:
         with pytest.raises(ValueError, match=match):
             psfmodel.evaluate(x=x2, y=y2, flux=100, x_0=40, y_0=60)
 
-    def test_gridded_psf_model_single_psf(self, psfmodel):
-        psfmodel = psfmodel.copy()
-        psfmodel._data = psfmodel.data[0:1, :, :]
-        assert psfmodel(0, 0) == 1
-        assert psfmodel(100, 100) == 0
-        assert_allclose(psfmodel([0, 100], [0, 100]), [1, 0])
+    def test_gridded_psf_model_single_psf(self):
+        """
+        Test a grid containing a single ePSF built via the public
+        constructor.
+        """
+        meta = {'grid_xypos': [(100, 100)], 'oversampling': 1}
+        model = GriddedPSFModel(NDData(np.ones((1, 5, 5)), meta=meta))
+        assert model.grid_shape == (1, 1)
+        assert model(0, 0) == 1
+        assert model(100, 100) == 0
+        assert_allclose(model([0, 100], [0, 100]), [1, 0])
 
-        y, x = np.mgrid[0:100, 0:100]
-        psf = psfmodel.evaluate(x=x, y=y, flux=100, x_0=40, y_0=60)
-        assert psf.shape == (100, 100)
+        y, x = np.mgrid[0:10, 0:10]
+        psf = model.evaluate(x=x, y=y, flux=100, x_0=4, y_0=6)
+        assert psf.shape == (10, 10)
 
-        _, y2, x2 = np.mgrid[0:100, 0:100, 0:100]
+        _, y2, x2 = np.mgrid[0:10, 0:10, 0:10]
         match = 'x and y must be 1D or 2D'
         with pytest.raises(ValueError, match=match):
-            psfmodel.evaluate(x=x2, y=y2, flux=100, x_0=40, y_0=60)
+            model.evaluate(x=x2, y=y2, flux=100, x_0=4, y_0=6)
 
     def test_gridded_psf_model_eval_outside_grid(self, psfmodel):
         y, x = np.mgrid[-50:50, -50:50]
@@ -377,7 +402,7 @@ class TestGriddedPSFModel:
             GriddedPSFModel(nddata)
 
         # Check if grid_xypos is a regular grid
-        meta = {'grid_xypos': [[0, 0], [1, 0], [1, 0], [3, 4]],
+        meta = {'grid_xypos': [[0, 0], [1, 0], [0, 1], [3, 4]],
                 'oversampling': 4}
         nddata = NDData(data, meta=meta)
         match = 'grid_xypos must form a rectangular grid'
@@ -395,6 +420,14 @@ class TestGriddedPSFModel:
         meta = {'grid_xypos': [], 'oversampling': 4}
         nddata = NDData(np.ones((0, 5, 5)), meta=meta)
         match = 'grid_xypos must form a rectangular grid'
+        with pytest.raises(ValueError, match=match):
+            GriddedPSFModel(nddata)
+
+        # Check that duplicate grid positions are rejected
+        meta = {'grid_xypos': [(0, 0), (0, 1), (1, 0), (1, 1), (1, 1)],
+                'oversampling': 4}
+        nddata = NDData(np.ones((5, 5, 5)), meta=meta)
+        match = 'grid_xypos must not contain duplicate positions'
         with pytest.raises(ValueError, match=match):
             GriddedPSFModel(nddata)
 
@@ -508,6 +541,20 @@ class TestGriddedPSFModel:
         assert_equal(model.oversampling, [5, 5])
         assert model.meta['oversampling'] == (5, 5)
 
+        # The original model must not be affected by the copy
+        assert psfmodel.meta['oversampling'] == (4, 4)
+        assert_equal(psfmodel.oversampling, [4, 4])
+
+    def test_copy_meta_isolated(self, psfmodel):
+        """
+        Test that changing the oversampling of a copy does not change
+        the meta dictionary of the original model.
+        """
+        model_copy = psfmodel.copy()
+        model_copy.oversampling = 2
+        assert psfmodel.meta['oversampling'] == (4, 4)
+        assert model_copy.meta['oversampling'] == (2, 2)
+
     def test_bounding_box(self, psfmodel):
         # Oversampling is 4
         bbox = psfmodel.bounding_box.bounding_box()
@@ -518,20 +565,10 @@ class TestGriddedPSFModel:
         bbox = model.bounding_box.bounding_box()
         assert_equal(bbox, ((-50.5, 50.5), (-50.5, 50.5)))
 
-    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
-    def test_plot(self, psfmodel):
-        psfmodel.plot_grid()
-        psfmodel.plot_grid(peak_norm=True, cmap='Blues', vmax_scale=0.9)
-        psfmodel.plot_grid(deltas=True)
-        psfmodel.plot_grid(deltas=True, peak_norm=True)
-
-        # Simulate a grid where one or more ePSFS are blank (all zeros)
-        model = psfmodel.deepcopy()
-        model.data[0] = 0.0
-        model.plot_grid(deltas=True)
+        # The original model must not be affected by the copy
+        assert psfmodel.meta['oversampling'] == (4, 4)
 
 
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
 @pytest.mark.parametrize('filename', STDPSF_FILENAMES)
 def test_stdpsfgrid(filename):
     filename = op.join(op.dirname(op.abspath(__file__)), 'data', filename)

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -215,7 +215,9 @@ class TestGriddedPSFModel:
         meta = {'grid_xypos': [(100, 100)], 'oversampling': 1}
         model = GriddedPSFModel(NDData(np.ones((1, 5, 5)), meta=meta))
         assert model.grid_shape == (1, 1)
-        assert model(0, 0) == 1
+        # The spline-interpolated value can be off by 1 ulp on some
+        # platforms, so do not test for exact equality
+        assert_allclose(model(0, 0), 1)
         assert model(100, 100) == 0
         assert_allclose(model([0, 100], [0, 100]), [1, 0])
 

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -147,6 +147,14 @@ class TestImagePSF:
         assert image_psf.shape == image_psf.data.shape
         assert image_psf.shape == (21, 21)
 
+    def test_evaluate_scalar_coords(self, image_psf):
+        """
+        Test that evaluate accepts scalar coordinates when called
+        directly.
+        """
+        value = image_psf.evaluate(0.5, 0.5, 1.0, 0.0, 0.0)
+        assert np.isfinite(value)
+
     def test_data_setter(self):
         yy, xx = np.mgrid[0:25, 0:25]
         data1 = CircularGaussianPSF(x_0=12, y_0=12, fwhm=3.0)(xx, yy)

--- a/photutils/psf/tests/test_model_io.py
+++ b/photutils/psf/tests/test_model_io.py
@@ -4,19 +4,21 @@ Tests for the model_io module.
 """
 
 import io
+import os
 import os.path as op
 from itertools import product
 from pathlib import Path
 
 import numpy as np
 import pytest
-from astropy.io import fits
+from astropy.io import fits, registry
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose, assert_equal
 
-from photutils.psf import GriddedPSFModel
+from photutils.psf import GriddedPSFModel, STDPSFGrid
 from photutils.psf.model_io import (_get_metadata, _has_fits_header_keys,
-                                    _read_stdpsf, is_stdpsf, is_webbpsf,
-                                    stdpsf_reader)
+                                    _read_stdpsf, _split_wfc_uvis, is_stdpsf,
+                                    is_webbpsf, stdpsf_reader)
 
 # The first file has a single detector, the rest have multiple detectors
 STDPSF_FILENAMES = ('STDPSF_NRCA1_F150W_mock.fits',
@@ -69,7 +71,7 @@ def encode_position(x, y):
 
 
 def make_webbpsf_file(filename, xgrid, ygrid, psf_shape=(8, 8),
-                      oversampling=4, keys_to_remove=()):
+                      oversampling=4, keys_to_remove=(), data_2d=False):
     """
     Write a mock WebbPSF gridded-ePSF FITS file.
 
@@ -95,6 +97,10 @@ def make_webbpsf_file(filename, xgrid, ygrid, psf_shape=(8, 8),
     keys_to_remove : tuple of str, optional
         FITS header keywords to omit from the output file. This is used
         to create invalid files.
+
+    data_2d : bool, optional
+        Whether to write the data as a single 2D array instead of a 3D
+        array. This requires a single grid position.
     """
     header = fits.Header()
     header['OVERSAMP'] = oversampling
@@ -112,7 +118,8 @@ def make_webbpsf_file(filename, xgrid, ygrid, psf_shape=(8, 8),
     for key in keys_to_remove:
         del header[key]
 
-    hdu = fits.PrimaryHDU(np.array(planes), header=header)
+    data = planes[0] if data_2d else np.array(planes)
+    hdu = fits.PrimaryHDU(data, header=header)
     hdu.writeto(filename, overwrite=True)
 
 
@@ -192,12 +199,67 @@ class TestSTDPSFReader:
             grid_data = _read_stdpsf(fileobj)
         assert grid_data['data'].shape[0] == grid_data['n_psfs']
 
+    def test_stdpsf_reader_hdulist(self):
+        """
+        Test that the full STDPSF readers accept an open HDUList.
+        """
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        with fits.open(filename) as hdulist:
+            model = stdpsf_reader(hdulist)
+        assert isinstance(model, GriddedPSFModel)
+        assert model.meta['detector'] == 'NRCA1'
+
+        with fits.open(filename) as hdulist:
+            grid = STDPSFGrid(hdulist)
+        assert grid.data.ndim == 3
+
+    def test_read_stdpsf_buffered_reader(self):
+        """
+        Test that a buffered binary file object is accepted.
+        """
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        with open(filename, 'rb') as fileobj:
+            grid_data = _read_stdpsf(fileobj)
+        assert grid_data['data'].shape[0] == grid_data['n_psfs']
+
+    def test_read_corrupt_fits(self, tmp_path):
+        """
+        Test that a corrupt file with a FITS extension yields the clean
+        registry identification error, not an OSError.
+        """
+        filename = str(tmp_path / 'bad.fits')
+        with open(filename, 'w') as f:
+            f.write('This is not a FITS file.')
+        match = 'Format could not be identified'
+        with pytest.raises(registry.IORegistryError, match=match):
+            GriddedPSFModel.read(filename)
+
     def test_read_stdpsf_not_fits(self):
         match = 'This interface supports only FITS files'
         with pytest.raises(TypeError, match=match):
             _read_stdpsf('filename.txt')
         with pytest.raises(TypeError, match=match):
             _read_stdpsf(42)
+
+    def test_stdpsf_reader_positional_deprecation(self):
+        """
+        Test that passing detector_id positionally warns.
+        """
+        filename = get_data_filename('STDPSF_WFPC2_F814W_mock.fits')
+        match = "'detector_id'"
+        with pytest.warns(AstropyDeprecationWarning, match=match):
+            model = stdpsf_reader(filename, 1)
+        assert isinstance(model, GriddedPSFModel)
+
+    def test_split_wfc_uvis_no_mutation(self):
+        """
+        Test that repeated detector splits do not mutate the grid data.
+        """
+        filename = get_data_filename('STDPSF_ACSWFC_F814W_mock.fits')
+        grid_data = _read_stdpsf(filename)
+        ygrid_orig = grid_data['ygrid'].copy()
+        _split_wfc_uvis(grid_data, 2)
+        assert_equal(grid_data['ygrid'], ygrid_orig)
 
     def test_read_stdpsf_missing_keys(self, tmp_path):
         filename = str(tmp_path / 'bad_stdpsf.fits')
@@ -275,6 +337,17 @@ class TestWebbPSFReader:
                                  strict=True):
             assert_allclose(plane, encode_position(x, y))
 
+    def test_read_webbpsf_2d(self, tmp_path):
+        """
+        Test that a WebbPSF file containing a single 2D PSF is read as
+        a (1, ny, nx) grid.
+        """
+        filename = str(tmp_path / 'webbpsf_2d_mock.fits')
+        make_webbpsf_file(filename, (100.0,), (200.0,), data_2d=True)
+        psfmodel = GriddedPSFModel.read(filename, format='webbpsf')
+        assert psfmodel.data.shape == (1, 8, 8)
+        assert_equal(psfmodel.grid_xypos, [(100.0, 200.0)])
+
     def test_read_webbpsf_missing_det_yx(self, tmp_path):
         filename = str(tmp_path / 'webbpsf_no_det_yx.fits')
         make_webbpsf_file(filename, (0.0, 10.0), (0.0, 10.0),
@@ -325,6 +398,16 @@ class TestGetMetadata:
     def test_unparsable_filename(self, filename):
         # Test a cache filename from astropy download_file
         assert _get_metadata(filename, None) is None
+
+    def test_fd_fileobj(self):
+        """
+        Test a file object created from a file descriptor, whose name
+        attribute is an int instead of a string.
+        """
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        fd = os.open(filename, os.O_RDONLY)
+        with io.FileIO(fd) as fileobj:
+            assert _get_metadata(fileobj, None) is None
 
     @pytest.mark.parametrize(('detector_id', 'detector'),
                              [(1, 'PC'), (2, 'WF2'), (3, 'WF3'), (4, 'WF4')])
@@ -392,3 +475,18 @@ class TestFormatIdentifiers:
         filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
         assert _has_fits_header_keys(filename, ('NAXIS3',))
         assert not _has_fits_header_keys(filename, ('NAXIS3', 'NOSUCHKEY'))
+
+    def test_fileobj_identify(self):
+        """
+        Test that the format identifiers use the open file object when
+        no file path is available.
+        """
+        filename = get_data_filename('STDPSF_NRCA1_F150W_mock.fits')
+        with open(filename, 'rb') as fileobj:
+            assert is_stdpsf('read', None, fileobj)
+            assert not is_webbpsf('read', None, fileobj)
+
+        filename = get_data_filename(WEBBPSF_FILENAMES[0])
+        with open(filename, 'rb') as fileobj:
+            assert is_webbpsf('read', None, fileobj)
+            assert not is_stdpsf('read', None, fileobj)

--- a/photutils/psf/tests/test_model_plotting.py
+++ b/photutils/psf/tests/test_model_plotting.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.nddata import NDData
+from numpy.testing import assert_allclose
 
 from photutils.psf import GriddedPSFModel, STDPSFGrid
 from photutils.psf.tests.test_model_io import (STDPSF_FILENAMES,
@@ -68,6 +69,30 @@ class TestPlotGrid:
         model = psfmodel.deepcopy()
         model._data[0] = 0.0
         model.plot_grid(deltas=True)
+
+    def test_plot_grid_int_dtype(self):
+        """
+        Test plotting a grid with integer-dtype ePSF data.
+        """
+        data = np.ones((4, 8, 8), dtype=int)
+        data[:, 4, 4] = 10
+        meta = {'grid_xypos': [(0, 0), (0, 10), (10, 0), (10, 10)],
+                'oversampling': 4}
+        model = GriddedPSFModel(NDData(data, meta=meta))
+        model.plot_grid(deltas=True)
+        model.plot_grid(peak_norm=True)
+
+    def test_plot_grid_deltas_peak_norm(self, psfmodel):
+        """
+        Test that deltas with peak_norm normalizes by the mean-ePSF
+        peak instead of the maximum delta value.
+        """
+        fig = psfmodel.plot_grid(deltas=True, peak_norm=True)
+        image = fig.axes[0].images[0].get_array()
+        data = psfmodel.data.astype(float)
+        mean_epsf = data.mean(axis=0)
+        expected_max = (data - mean_epsf).max() / mean_epsf.max()
+        assert_allclose(image.max(), expected_max)
 
     def test_plot_grid_input_axes(self, psfmodel):
         """


### PR DESCRIPTION
This PR fixes the PSF model class and model I/O findings from the recent `photutils.psf` package review.

* **Functional models:** `GaussianPSF`/`GaussianPRF` bounding boxes treated float `theta` (degrees) as radians; `AiryDiskPSF` returned the peak value instead of NaN for NaN inputs; the `MoffatPSF` `beta` lower bound rounded to exactly 1.0; the circular Gaussian models were inconsistent about validating x/y unit mismatches; plus several docstring corrections (including the `AiryDiskPSF` normalization prefactor and the rotated `GaussianPRF` integration approximation).

* **Gridded/image models and model I/O:** the STDPSF readers crashed on open `HDUList`/file-object inputs; `webbpsf_reader` mis-shaped single 2D PSF files; `GriddedPSFModel` silently accepted duplicate grid positions; `copy()` shared the `meta` dict with the original; and `plot_grid` failed on integer-dtype grids and used the wrong normalization for `deltas=True, peak_norm=True`.
