### PR TITLE
Fix PSF grouper, model helper, and simulation bugs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -418,8 +418,6 @@ Bug Fixes
     units. The error message for a truly unitless column now suggests
     using a Quantity column. [#2384]
 
-- ``photutils.psf``
-
   - Fixed a bug where ``EPSFBuilder`` rejected all ``LinkedEPSFStar``
     inputs as invalid stars, a regression introduced in version 3.0.
     [#2385]
@@ -430,8 +428,6 @@ Bug Fixes
     reports the flat star index and includes the id label when
     available. [#2385]
 
-- ``photutils.psf``
-
   - Fixed a bug where the ``EPSFStar`` ``slices`` and ``bbox``
     attributes were transposed for non-square cutouts. [#2386]
 
@@ -439,8 +435,6 @@ Bug Fixes
     stale cached values, so every iteration normalized the star data
     with the first-iteration flux instead of the updated fitted flux.
     [#2386]
-
-- ``photutils.psf``
 
   - Fixed a bug where the ``n_pixels_fit`` results column leaked
     into the tables returned by the ``PSFPhotometry``
@@ -549,6 +543,21 @@ Bug Fixes
   - Fixed ``GriddedPSFModel.read`` to raise the standard format
     identification error for a corrupt file with a FITS extension
     instead of an ``OSError``. [#2388]
+
+  - Fixed a bug where ``SourceGrouper`` raised an error for scalar
+    x and y inputs when ``return_groups_object=True``. 2D coordinate
+    arrays now raise a clear ``ValueError``, and ``SourceGroups`` now
+    validates that the input coordinates are finite. [#2389]
+
+  - Fixed a bug where the interpolation of masked pixels in ePSF
+    building raised an error for integer-dtype star data. The
+    interpolation is now always performed in float. [#2389]
+
+  - Fixed a bug in ``make_psf_model_image`` where the ``flux``
+    keyword was silently ignored for models whose flux parameter has
+    a different name (e.g., models output from ``make_psf_model``).
+    The keyword is now mapped to the model's flux parameter name.
+    [#2389]
 
 - ``photutils.segmentation``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -210,6 +210,11 @@ New Features
     accept path-like inputs (e.g., ``pathlib.Path``) in addition to
     strings. [#2355]
 
+  - ``SourceGrouper`` now scales to large source lists by computing
+    the connected components of the minimum-separation graph with a
+    KD-tree instead of building a dense pairwise distance matrix.
+    [#2389]
+
 - ``photutils.segmentation``
 
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``

--- a/photutils/psf/groupers.py
+++ b/photutils/psf/groupers.py
@@ -91,6 +91,13 @@ class SourceGroups:
             msg = 'x, y, and groups must have the same shape'
             raise ValueError(msg)
 
+        if not np.isfinite(self.x).all():
+            msg = 'x coordinates must be finite (no NaN or inf values)'
+            raise ValueError(msg)
+        if not np.isfinite(self.y).all():
+            msg = 'y coordinates must be finite (no NaN or inf values)'
+            raise ValueError(msg)
+
         self.n_sources = len(self.groups)
 
         unique_groups, counts = np.unique(self.groups, return_counts=True)
@@ -240,11 +247,14 @@ class SourceGroups:
         fractions = np.arange(self.n_groups) / max(self.n_groups - 1, 1)
         colors = cmap(fractions)
 
-        # Set default label kwargs
-        if label_kwargs is None:
-            label_kwargs = {'ha': 'center',
-                            'va': 'center',
-                            'zorder': 10}
+        # Merge user label kwargs with the defaults
+        default_label_kwargs = {'ha': 'center',
+                                'va': 'center',
+                                'zorder': 10}
+        label_kwargs = {**default_label_kwargs, **(label_kwargs or {})}
+
+        # A user-supplied color overrides the per-group colors
+        user_color = kwargs.pop('color', None)
 
         # Get label offset
         label_dx, label_dy = label_offset
@@ -253,7 +263,7 @@ class SourceGroups:
             mask = self.groups == group_id
             xypos = zip(self.x[mask], self.y[mask], strict=True)
             ap = CircularAperture(xypos, r=radius)
-            color = colors[i]
+            color = colors[i] if user_color is None else user_color
             ap.plot(ax=ax, color=color, **kwargs)
 
             if label_groups:
@@ -335,7 +345,7 @@ class SourceGrouper:
     def _compute_groups(self, x, y):
         """
         Group sources into clusters based on a minimum distance
-        criteria.
+        criterion.
 
         Parameters
         ----------
@@ -351,6 +361,9 @@ class SourceGrouper:
         x = np.atleast_1d(x)
         y = np.atleast_1d(y)
 
+        if x.ndim != 1 or y.ndim != 1:
+            msg = 'x and y must be 1D arrays'
+            raise ValueError(msg)
         if x.shape != y.shape:
             msg = (f'x and y must have the same shape, got x.shape={x.shape} '
                    f'and y.shape={y.shape}')
@@ -385,7 +398,7 @@ class SourceGrouper:
     def __call__(self, x, y, return_groups_object=False):
         """
         Group sources into clusters based on a minimum distance
-        criteria.
+        criterion.
 
         Parameters
         ----------
@@ -438,6 +451,8 @@ class SourceGrouper:
         >>> print(groups.groups)
         [1 1 2]
         """
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
         groups = self._compute_groups(x, y)
         if return_groups_object:
             return SourceGroups(x, y, groups)

--- a/photutils/psf/groupers.py
+++ b/photutils/psf/groupers.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from functools import cached_property
 
 import numpy as np
-from scipy.cluster.hierarchy import fclusterdata
+from scipy.spatial import cKDTree
 
 from photutils.aperture import CircularAperture
 from photutils.utils import make_random_cmap
@@ -282,9 +282,11 @@ class SourceGrouper:
     Class to group sources into clusters based on a minimum separation
     distance.
 
-    The groups are formed using hierarchical agglomerative
-    clustering with a distance criterion, calling the
-    `scipy.cluster.hierarchy.fclusterdata` function.
+    The groups are the connected components of the graph linking pairs
+    of sources separated by less than ``min_separation``. This is
+    identical to single-linkage hierarchical agglomerative clustering
+    with a distance criterion, but is computed using a KD-tree so that
+    it scales to large numbers of sources.
 
     Parameters
     ----------
@@ -382,10 +384,32 @@ class SourceGrouper:
         if x.shape == (1,):
             return np.array([1])
 
-        # Prepare coordinate pairs for hierarchical clustering
-        coordinates = np.transpose((x, y))
-        cluster_labels = fclusterdata(coordinates, t=self.min_separation,
-                                      criterion='distance')
+        # Find all pairs of sources separated by min_separation or less.
+        # query_pairs includes pairs at exactly min_separation, matching
+        # the inclusive fclusterdata distance criterion.
+        xypos = np.column_stack((x, y))
+        tree = cKDTree(xypos)
+        pairs = tree.query_pairs(self.min_separation,
+                                 output_type='ndarray')
+
+        # Union-find over the pairs to get the connected components,
+        # which for single linkage are identical to the clusters from
+        # hierarchical clustering with a distance criterion.
+        parent = np.arange(len(x))
+
+        def find(idx):
+            while parent[idx] != idx:
+                parent[idx] = parent[parent[idx]]
+                idx = parent[idx]
+            return idx
+
+        for i, j in pairs:
+            root_i = find(i)
+            root_j = find(j)
+            if root_i != root_j:
+                parent[root_j] = root_i
+
+        cluster_labels = [find(i) for i in range(len(x))]
 
         # Reorder cluster labels to start from 1 and increase
         # sequentially (this matches the behavior of DBSCAN and other

--- a/photutils/psf/model_helpers.py
+++ b/photutils/psf/model_helpers.py
@@ -57,19 +57,19 @@ def make_psf_model(model, *, x_name=None, y_name=None, flux_name=None,
     x_name : `str` or `None`, optional
         The name of the ``model`` parameter that corresponds to the x
         center of the PSF. If `None`, the model will be assumed to be
-        centered at x=0, and a new model parameter called ``xpos_0``
+        centered at x=0, and a new model parameter called ``offset_0``
         will be added for the x position.
 
     y_name : `str` or `None`, optional
-        The name of the ``model`` parameter that corresponds to the
-        y center of the PSF. If `None`, the model will be assumed
-        to be centered at y=0, and a new parameter called ``ypos_1``
-        will be added for the y position.
+        The name of the ``model`` parameter that corresponds to the y
+        center of the PSF. If `None`, the model will be assumed to be
+        centered at y=0, and a new parameter called ``offset_1`` will be
+        added for the y position.
 
     flux_name : `str` or `None`, optional
         The name of the ``model`` parameter that corresponds to the
         total flux of a source. If `None`, a new model parameter called
-        ``flux_3`` will be added for model flux.
+        ``amplitude_3`` will be added for model flux.
 
     normalize : bool, optional
         If `True`, the input ``model`` will be integrated and rescaled
@@ -130,8 +130,8 @@ def make_psf_model(model, *, x_name=None, y_name=None, flux_name=None,
 
     if x_name is None:
         x_model = _InverseShift(0, name='x_position')
-        # "offset" is the _InverseShift parameter name;
-        # the x inverse shift model is always the first submodel
+        # The _InverseShift model is always the first submodel, so the x
+        # position parameter name is always "offset_0".
         x_name = 'offset_0'
     else:
         if x_name not in input_model.param_names:
@@ -143,8 +143,8 @@ def make_psf_model(model, *, x_name=None, y_name=None, flux_name=None,
 
     if y_name is None:
         y_model = _InverseShift(0, name='y_position')
-        # "offset" is the _InverseShift parameter name;
-        # the y inverse shift model is always the second submodel
+        # The _InverseShift model is always the second submodel, so the y
+        # position parameter name is always "offset_1".
         y_name = 'offset_1'
     else:
         if y_name not in input_model.param_names:
@@ -160,11 +160,15 @@ def make_psf_model(model, *, x_name=None, y_name=None, flux_name=None,
 
     if flux_name is None:
         psf_model *= Const2D(1.0, name='flux')
-        # "amplitude" is the Const2D parameter name;
-        # the flux scaling is always the last component (prior to
-        # normalization)
+        # The Const2D model is always the last submodel, so the flux
+        # parameter name is always "amplitude_3" (or "amplitude" if the
+        # input model is a CompoundModel).
         flux_name = psf_model.param_names[-1]
     else:
+        if flux_name not in input_model.param_names:
+            msg = f'{flux_name!r} parameter name not found in the input model'
+            raise ValueError(msg)
+
         flux_name = _shift_model_param(input_model, flux_name, shift=2)
 
     if normalize:
@@ -179,24 +183,24 @@ def make_psf_model(model, *, x_name=None, y_name=None, flux_name=None,
 
         psf_model *= Const2D(1.0 / integral, name='normalization_scaling')
 
-    # fix all the output model parameters that are not x, y, or flux
+    # Set all the other parameters to be fixed so that they are not fit
+    # during PSF photometry.
     for name in psf_model.param_names:
         psf_model.fixed[name] = name not in (x_name, y_name, flux_name)
 
-    # final check that the x, y, and flux parameter names are in the
-    # output model
+    # Check that the x, y, and flux parameter names are in the output model
     names = (x_name, y_name, flux_name)
     for name in names:
         if name not in psf_model.param_names:
             msg = f'{name!r} parameter name not found in the output model'
             raise ValueError(msg)
 
-    # set the parameter names for the PSF photometry classes
+    # Set the parameter names for the PSF photometry classes
     psf_model.x_name = x_name
     psf_model.y_name = y_name
     psf_model.flux_name = flux_name
 
-    # set aliases
+    # Set aliases
     psf_model.x_0 = getattr(psf_model, x_name)
     psf_model.y_0 = getattr(psf_model, y_name)
     psf_model.flux = getattr(psf_model, flux_name)
@@ -302,24 +306,25 @@ def _integrate_model(model, *, x_name=None, y_name=None, dx=50, dy=50,
     xvals = np.linspace(xc - hx, xc + hx, nx_pts)
     yvals = np.linspace(yc - hy, yc + hy, ny_pts)
 
-    # evaluate the model on the subsampled grid
+    # Evaluate the model on the subsampled grid
     data = model(xvals.reshape(-1, 1), yvals.reshape(1, -1))
     if isinstance(data, Quantity):
         data = data.value
 
-    # now integrate over the subsampled grid (first over x, then over y)
+    # Now integrate over the subsampled grid (first over y because
+    # each row varies over y, then over x)
     int_func = trapezoid
 
-    return int_func([int_func(row, xvals) for row in data], yvals)
+    return int_func([int_func(row, yvals) for row in data], xvals)
 
 
 def _shift_model_param(model, param_name, *, shift=2):
     if isinstance(model, CompoundModel):
-        # for CompoundModel, add "shift" to the parameter suffix
-        out = re.search(r'(.*)_([\d]*)$', param_name)
-        new_name = out.groups()[0] + '_' + str(int(out.groups()[1]) + 2)
+        # For CompoundModel, add "shift" to the parameter suffix
+        out = re.search(r'(.*)_([\d]+)$', param_name)
+        new_name = out.groups()[0] + '_' + str(int(out.groups()[1]) + shift)
     else:
-        # simply add the shift to the parameter name
+        # Simply add the shift to the parameter name
         new_name = param_name + '_' + str(shift)
 
     return new_name
@@ -345,8 +350,8 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):  # pragma: no cover
 
     Note: If set on the input ImagePSF (x_0, y_0), then ``origin``
     must be the same for each input EPSF. Additionally, data units and
-    dimensions must be for each input EPSF, and values for ``flux`` and
-    ``oversampling``, and ``fill_value`` must match as well.
+    dimensions must be the same for each input EPSF, and values for
+    ``flux``, ``oversampling``, and ``fill_value`` must match as well.
 
     Parameters
     ----------
@@ -367,10 +372,10 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):  # pragma: no cover
     GriddedPSFModel: `photutils.psf.GriddedPSFModel`
         The gridded PSF model created from the input EPSFs.
     """
-    # prevent circular imports
+    # Prevent circular imports
     from photutils.psf import GriddedPSFModel, ImagePSF
 
-    # optional, to store fiducial from input if `grid_xypos` is None
+    # Optional, to store fiducial from input if `grid_xypos` is None
     x_0s = []
     y_0s = []
     data_arrs = []
@@ -380,37 +385,36 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):  # pragma: no cover
     origin = None
     flux = None
 
-    # make sure, if provided, that ``grid_xypos`` is the same length as
-    # ``epsfs``
+    # Make sure that ``grid_xypos`` has the same length as epsfs
     if grid_xypos is not None and len(grid_xypos) != len(epsfs):
         msg = 'grid_xypos must be the same length as epsfs'
         raise ValueError(msg)
 
-    # loop over input once
+    # Loop over input once
     for i, epsf in enumerate(epsfs):
 
-        # check input type
+        # Check input type
         if not isinstance(epsf, ImagePSF):
             msg = 'All input epsfs must be of type ImagePSF'
             raise TypeError(msg)
 
-        # get data array from EPSF
+        # Get data array from EPSF
         data_arrs.append(epsf.data)
 
         if i == 0:
             oversampling = epsf.oversampling
 
-            # same for fill value and flux, grid will have a single value
+            # Same for fill value and flux, grid will have a single value
             # so it should be the same for all input, and error if not.
             fill_value = epsf.fill_value
 
-            # check that origins are the same
+            # Check that origins are the same
             if grid_xypos is None:
                 origin = epsf.origin
 
             flux = epsf.flux
 
-            # if there's a unit, those should also all be the same
+            # If there's a unit, those should also all be the same
             with contextlib.suppress(AttributeError):
                 dat_unit = epsf.data.unit
         else:
@@ -429,15 +433,12 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):  # pragma: no cover
                        'same dimensions')
                 raise ValueError(msg)
 
-            try:
-                unitt = epsf.data_unit
-                if unitt != dat_unit:
-                    msg = 'All input data must have the same unit'
-                    raise ValueError(msg)
-            except AttributeError as exc:
-                if dat_unit is not None:
-                    msg = 'All input data must have the same unit'
-                    raise ValueError(msg) from exc
+            unitt = None
+            with contextlib.suppress(AttributeError):
+                unitt = epsf.data.unit
+            if unitt != dat_unit:
+                msg = 'All input data must have the same unit'
+                raise ValueError(msg)
 
             if epsf.flux != flux:
                 msg = ('All input ImagePSF models must have the same value '
@@ -448,16 +449,16 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):  # pragma: no cover
             x_0s.append(epsf.x_0.value)
             y_0s.append(epsf.y_0.value)
 
-            # also check that origin is the same, if using x_0s and y_0s
+            # Also check that origin is the same, if using x_0s and y_0s
             # from input
-            if np.all(epsf.origin != origin):
+            if np.any(epsf.origin != origin):
                 msg = ('If using (x_0, y_0) as fiducial point, origin must '
                        'match for each input EPSF')
                 raise ValueError(msg)
 
-    # if not supplied, use from x_0, y_0 of input EPSFs as fiducuals
-    # these are checked when GriddedPSFModel is created to make sure they
-    # are actually on a grid.
+    # If not supplied, use from x_0, y_0 of input EPSFs as fiducials.
+    # These are checked when GriddedPSFModel is created to make sure
+    # they are actually on a grid.
     if grid_xypos is None:
         grid_xypos = list(zip(x_0s, y_0s, strict=True))
 
@@ -465,7 +466,7 @@ def grid_from_epsfs(epsfs, grid_xypos=None, meta=None):  # pragma: no cover
 
     if meta is None:
         meta = {}
-    # add required keywords to meta
+    # Add required keywords to meta
     meta['grid_xypos'] = grid_xypos
     meta['oversampling'] = oversampling
     meta['fill_value'] = fill_value

--- a/photutils/psf/simulation.py
+++ b/photutils/psf/simulation.py
@@ -73,9 +73,13 @@ def make_psf_model_image(shape, psf_model, n_sources, *, model_shape=None,
         Keyword arguments are accepted for additional model parameters.
         The values should be 2-tuples of the lower and upper bounds for
         the parameter range. The parameter values will be uniformly
-        distributed between the lower and upper bounds, inclusively. If
-        the parameter is not in the input ``psf_model`` parameter names,
-        it will be ignored.
+        distributed between the lower and upper bounds, inclusively.
+        A ``flux`` keyword is mapped to the model's flux parameter
+        name (e.g., for models output from `make_psf_model`). If the
+        parameter is not in the input ``psf_model`` parameter names, it
+        will be ignored. Keywords matching the model's x and y position
+        parameter names are also ignored because the source positions
+        are randomly generated.
 
     Returns
     -------
@@ -148,11 +152,17 @@ def make_psf_model_image(shape, psf_model, n_sources, *, model_shape=None,
 
     other_params = {}
     if kwargs:
-        # include only kwargs that are not x, y, or flux (main params)
+        # Include only kwargs that are model parameters, but not the
+        # x and y position parameters
         for key, val in kwargs.items():
-            if key not in psf_model.param_names or key in main_params[0:2]:
+            param = key
+            if key == 'flux' and 'flux' not in psf_model.param_names:
+                # Map the flux kwarg to the model's flux parameter name
+                param = main_params[2]
+            if (param not in psf_model.param_names
+                    or param in main_params[0:2]):
                 continue  # skip the x, y parameters
-            other_params[key] = val
+            other_params[param] = val
 
     x_name, y_name = main_params[0:2]
     params = make_model_params(shape, n_sources, x_name=x_name, y_name=y_name,

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -1159,7 +1159,7 @@ class TestEPSFBuilder:
 
         # Verify basic EPSF properties
         assert len(fitted_stars) == 10
-        # ePSF should sum to ~oversamp^2 for properly normalized
+        # EPSF should sum to ~oversamp^2 for properly normalized
         # oversampled PSF
         expected_sum = oversampling ** 2
         assert 0.9 * expected_sum < epsf.data.sum() < 1.1 * expected_sum
@@ -2427,13 +2427,13 @@ class TestEPSFBuilder:
 
         fitted_star = builder_shift._fit_star(epsf, star)
 
-        # fit_error_status should be 3
+        # The fitted star _fit_error_status should be 3
         assert fitted_star._fit_error_status == 3
 
-        # cutout_center should NOT have been updated
+        # The fitted star cutout_center should not have been updated
         assert_array_equal(fitted_star.cutout_center, original_center)
 
-        # Flux should NOT have been updated
+        # The fitted star flux should not have been updated
         assert fitted_star.flux == original_flux
 
     def test_fit_star_position_negative_outside_cutout(self, epsf_test_data):
@@ -2507,7 +2507,7 @@ class TestEPSFBuilder:
 
         fitted_star = builder_shift._fit_star(epsf, star)
 
-        # fit_error_status should be 0 (success)
+        # The fitted_star _fit_error_status should be 0 (success)
         assert fitted_star._fit_error_status == 0
 
         # cutout_center should have been updated

--- a/photutils/psf/tests/test_groupers.py
+++ b/photutils/psf/tests/test_groupers.py
@@ -6,6 +6,7 @@ Tests for the groupers module.
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
+from scipy.cluster.hierarchy import fclusterdata
 
 from photutils.psf import SourceGrouper, SourceGroups
 from photutils.utils._optional_deps import HAS_MATPLOTLIB
@@ -418,6 +419,27 @@ class TestSourceGrouper:
 
         assert_equal(result, gg)
         assert len(np.unique(result)) == 3
+
+    def test_grouper_matches_fclusterdata(self):
+        """
+        The grouper must produce the identical partition as
+        single-linkage fclusterdata with the distance criterion.
+        """
+        rng = np.random.default_rng(0)
+        x = rng.uniform(0, 500, 1000)
+        y = rng.uniform(0, 500, 1000)
+        for min_separation in (1.0, 5.0, 20.0):
+            grouper = SourceGrouper(min_separation=min_separation)
+            got = grouper(x, y)
+            expected = fclusterdata(np.column_stack((x, y)),
+                                    t=min_separation,
+                                    criterion='distance')
+            # Compare partitions (labels may differ)
+            got_parts = {frozenset(np.nonzero(got == g)[0])
+                         for g in np.unique(got)}
+            exp_parts = {frozenset(np.nonzero(expected == g)[0])
+                         for g in np.unique(expected)}
+            assert got_parts == exp_parts
 
     def test_list_input(self):
         """

--- a/photutils/psf/tests/test_groupers.py
+++ b/photutils/psf/tests/test_groupers.py
@@ -80,6 +80,31 @@ class TestSourceGrouper:
         assert result.n_sources == 1
         assert result.n_groups == 1
 
+    def test_scalar_input(self):
+        """
+        Test that scalar inputs are treated as single-source arrays.
+        """
+        grouper = SourceGrouper(min_separation=5)
+        result = grouper(5.0, 5.0)
+        assert isinstance(result, np.ndarray)
+        assert_equal(result, [1])
+
+        groups = grouper(5.0, 5.0, return_groups_object=True)
+        assert isinstance(groups, SourceGroups)
+        assert groups.n_sources == 1
+        assert groups.n_groups == 1
+
+    def test_2d_input(self):
+        """
+        Test that 2D coordinate arrays raise ValueError.
+        """
+        xx = np.arange(4.0).reshape(4, 1)
+        yy = np.arange(4.0).reshape(4, 1)
+        grouper = SourceGrouper(min_separation=5)
+        match = 'x and y must be 1D arrays'
+        with pytest.raises(ValueError, match=match):
+            grouper(xx, yy)
+
     def test_mismatched_shapes(self):
         """
         Test that mismatched x and y shapes raise ValueError.
@@ -610,6 +635,21 @@ class TestSourceGroups:
         with pytest.raises(ValueError, match=match):
             SourceGroups(x, y, groups)
 
+    def test_non_finite_input(self):
+        """
+        Test that non-finite coordinates raise ValueError.
+        """
+        groups = np.array([1, 1, 2])
+        match = 'x coordinates must be finite'
+        with pytest.raises(ValueError, match=match):
+            SourceGroups(np.array([1, np.nan, 3]), np.array([1, 2, 3]),
+                         groups)
+
+        match = 'y coordinates must be finite'
+        with pytest.raises(ValueError, match=match):
+            SourceGroups(np.array([1, 2, 3]), np.array([1, np.inf, 3]),
+                         groups)
+
     def test_repr(self, sample_groups):
         """
         Test string representation.
@@ -790,6 +830,37 @@ class TestSourceGroups:
             label_kwargs=label_kwargs, lw=3, alpha=0.5)
 
         assert result_ax is ax
+        plt.close(fig)
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_plot_color_kwarg(self, sample_groups):
+        """
+        Test that a user-supplied color overrides the group colors.
+        """
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        result_ax = sample_groups['groups'].plot(radius=0.5, ax=ax,
+                                                 color='red')
+
+        assert result_ax is ax
+        plt.close(fig)
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+    def test_plot_label_kwargs_merge(self, sample_groups):
+        """
+        Test that user label_kwargs are merged with the defaults.
+        """
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        sample_groups['groups'].plot(radius=0.5, ax=ax, label_groups=True,
+                                     label_kwargs={'fontsize': 12})
+
+        assert len(ax.texts) == 3
+        for text in ax.texts:
+            assert text.get_fontsize() == 12
+            assert text.get_horizontalalignment() == 'center'
         plt.close(fig)
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')

--- a/photutils/psf/tests/test_model_helpers.py
+++ b/photutils/psf/tests/test_model_helpers.py
@@ -59,7 +59,7 @@ def test_integrate_model():
 def fixture_moffat_source():
     model = Moffat2D(alpha=4.8)
 
-    # this is the analytic value needed to get a total flux of 1
+    # This is the analytic value needed to get a total flux of 1
     model.amplitude = (model.alpha - 1.0) / (np.pi * model.gamma**2)
 
     xx, yy = np.meshgrid(*([np.linspace(-2, 2, 100)] * 2))
@@ -73,7 +73,7 @@ def test_moffat_fitting(moffat_source):
     """
     model, (xx, yy, data) = moffat_source
 
-    # initial Moffat2D model close to the original
+    # Initial Moffat2D model close to the original
     guess_moffat = Moffat2D(x_0=0.1, y_0=-0.05, gamma=1.05,
                             amplitude=model.amplitude * 1.06, alpha=4.75)
 
@@ -82,7 +82,7 @@ def test_moffat_fitting(moffat_source):
     assert_allclose(fit.parameters, model.parameters, rtol=0.01, atol=0.0005)
 
 
-# we set the tolerances in flux to be 2-3% because the guessed model
+# We set the tolerances in flux to be 2-3% because the guessed model
 # parameters are known to be wrong
 @pytest.mark.parametrize(('kwargs', 'tols'),
                          [({'x_name': 'x_0', 'y_name': 'y_0',
@@ -98,11 +98,11 @@ def test_moffat_fitting(moffat_source):
 def test_make_psf_model(moffat_source, kwargs, tols):
     model, (xx, yy, data) = moffat_source
 
-    # a close-but-wrong "guessed Moffat"
+    # A close-but-wrong "guessed Moffat"
     guess_moffat = Moffat2D(x_0=0.1, y_0=-0.05, gamma=1.01,
                             amplitude=model.amplitude * 1.01, alpha=4.79)
     if kwargs['normalize']:
-        # definitely very wrong, so this ensures the renormalization
+        # Definitely very wrong, so this ensures the renormalization
         # works
         guess_moffat.amplitude = 5.0
 
@@ -122,7 +122,7 @@ def test_make_psf_model(moffat_source, kwargs, tols):
     if fluxtol is not None:
         assert np.abs(1.0 - getattr(fit_model, fit_model.flux_name)) < fluxtol
 
-    # ensure the model parameters did not change
+    # Ensure the model parameters did not change
     assert fit_model[2].gamma == guess_moffat.gamma
     assert fit_model[2].alpha == guess_moffat.alpha
     if kwargs['flux_name'] is None:
@@ -162,12 +162,46 @@ def test_make_psf_model_inputs():
         make_psf_model(model, x_name='x_mean', y_name='y_mean_10')
 
 
+def test_make_psf_model_invalid_flux_name():
+    """
+    Test that an invalid flux_name raises a clear ValueError.
+    """
+    match = 'parameter name not found in the input model'
+    with pytest.raises(ValueError, match=match):
+        make_psf_model(Moffat2D(), x_name='x_0', y_name='y_0',
+                       flux_name='invalid')
+
+    model = Gaussian2D(1, 5, 5, 1, 1) * Const2D(1.0)
+    with pytest.raises(ValueError, match=match):
+        make_psf_model(model, x_name='x_mean_0', y_name='y_mean_0',
+                       flux_name='invalid')
+
+
 def test_make_psf_model_integral():
     model = Gaussian2D(1, 5, 5, 1, 1) * Const2D(0.0)
     match = 'Cannot normalize the model because the integrated flux is zero'
     with pytest.raises(ValueError, match=match):
         make_psf_model(model, x_name='x_mean_0', y_name='y_mean_0',
                        normalize=True)
+
+
+def test_make_psf_model_normalize_dx_dy():
+    """
+    Regression test that make_psf_model normalization works with
+    dx != dy.
+    """
+    gauss = Gaussian2D(1, 0, 0, 1, 1)
+    psf = make_psf_model(gauss, x_name='x_mean', y_name='y_mean',
+                         dx=11, dy=21, subsample=10)
+    yy, xx = np.mgrid[-10:11, -10:11]
+    total = psf(xx, yy).sum()
+    assert_allclose(total, 1.0, atol=1e-3)
+
+    # The square default grid must still integrate a unit Gaussian
+    # to 2 * pi
+    model = Gaussian2D(1, 0, 0, 1, 1)
+    integral = _integrate_model(model, x_name='x_mean', y_name='y_mean')
+    assert_allclose(integral, 2.0 * np.pi, rtol=1e-6)
 
 
 def test_make_psf_model_offset():
@@ -192,21 +226,21 @@ class TestGridFromEPSFs:
     """
 
     def setup_class(self, *, cutout_size=25):
-        # make a set of 4 EPSF models
+        # Make a set of 4 EPSF models
 
         self.cutout_size = cutout_size
 
-        # make simulated image
+        # Make simulated image
         hdu = datasets.load_simulated_hst_star_image()
         data = hdu.data
 
-        # break up the image into four quadrants
+        # Break up the image into four quadrants
         q1 = data[0:500, 0:500]
         q2 = data[0:500, 500:1000]
         q3 = data[500:1000, 0:500]
         q4 = data[500:1000, 500:1000]
 
-        # select some starts from each quadrant to use to build the epsf
+        # Select some starts from each quadrant to use to build the epsf
         quad_stars = {'q1': {'data': q1, 'fiducial': (0., 0.), 'epsf': None},
                       'q2': {'data': q2, 'fiducial': (1000., 1000.),
                              'epsf': None},
@@ -219,7 +253,7 @@ class TestGridFromEPSFs:
             quad_data = quad_stars[q]['data']
             peaks_tbl = find_peaks(quad_data, threshold=500.)
 
-            # filter out sources near edge
+            # Filter out sources near edge
             size = cutout_size
             hsize = (size - 1) / 2
             x = peaks_tbl['x_peak']
@@ -238,7 +272,7 @@ class TestGridFromEPSFs:
                                        progress_bar=False)
             epsf, _ = epsf_builder(stars)
 
-            # set x_0, y_0 to fiducial point
+            # Set x_0, y_0 to fiducial point
             epsf.y_0 = quad_stars[q]['fiducial'][0]
             epsf.x_0 = quad_stars[q]['fiducial'][1]
 
@@ -259,7 +293,7 @@ class TestGridFromEPSFs:
         """
         Test both options for setting PSF locations.
         """
-        # default option x_0 and y_0s on input EPSFs
+        # Default option x_0 and y_0s on input EPSFs
         with pytest.warns(AstropyDeprecationWarning):
             psf_grid = grid_from_epsfs(self.epsfs)
 
@@ -269,7 +303,7 @@ class TestGridFromEPSFs:
                       (0.0, 1000.0), (1000.0, 1000.0)])
         assert_equal(psf_grid.meta['grid_xypos'], psf_grid.grid_xypos)
 
-        # or pass in a list
+        # Pass in a list
         grid_xypos = [(250.0, 250.0), (750.0, 750.0),
                       (250.0, 750.0), (750.0, 250.0)]
 
@@ -286,14 +320,14 @@ class TestGridFromEPSFs:
         """
         keys = ['grid_xypos', 'oversampling', 'fill_value']
 
-        # when 'meta' isn't provided, there should be just three keys
+        # When 'meta' isn't provided, there should be just three keys
         with pytest.warns(AstropyDeprecationWarning):
             psf_grid = grid_from_epsfs(self.epsfs)
         for key in keys:
             assert key in psf_grid.meta
 
-        # when meta is provided, those new keys should exist and anything
-        # in the list above should be overwritten
+        # When meta is provided, those new keys should exist and
+        # anything in the list above should be overwritten
         meta = {'grid_xypos': 0.0, 'oversampling': 0.0,
                 'fill_value': -999, 'extra_key': 'extra'}
         with pytest.warns(AstropyDeprecationWarning):

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -845,7 +845,7 @@ def test_near_bound_flag_grouped():
     data, params = make_psf_model_image(
         (50, 50), model, 2, model_shape=(9, 9), flux=(500, 500),
         min_separation=15, seed=0)
-    # offset the initial positions so the fit runs into the bound
+    # Offset the initial positions so the fit runs into the bound
     init = Table({'x': params['x_0'] + 2.0, 'y': params['y_0'],
                   'flux': [500.0, 500.0],
                   'group_id': [1, 1]})

--- a/photutils/psf/tests/test_simulation.py
+++ b/photutils/psf/tests/test_simulation.py
@@ -58,6 +58,25 @@ def test_make_psf_model_image_custom():
     assert len(params) == n_sources
 
 
+def test_make_psf_model_image_flux_mapping():
+    """
+    Test that the flux kwarg maps to the flux parameter name of a
+    model made with make_psf_model.
+    """
+    shape = (100, 100)
+    n_sources = 5
+    model = Gaussian2D()
+    psf_model = make_psf_model(model, x_name='x_mean', y_name='y_mean')
+    flux = (100, 200)
+    _, params = make_psf_model_image(shape, psf_model, n_sources,
+                                     model_shape=(11, 11), flux=flux,
+                                     seed=0)
+    flux_name = psf_model.flux_name
+    assert flux_name in params.colnames
+    assert np.min(params[flux_name]) >= flux[0]
+    assert np.max(params[flux_name]) <= flux[1]
+
+
 def test_make_psf_model_image_inputs():
     shape = (50, 50)
     match = 'psf_model must be an Astropy Model subclass'

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -6,7 +6,7 @@ Tests for the utils module.
 import astropy.units as u
 import numpy as np
 import pytest
-from astropy.modeling.models import Gaussian1D, Gaussian2D
+from astropy.modeling.models import Gaussian1D, Gaussian2D, Identity
 from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose
@@ -131,7 +131,21 @@ def test_fit_2dgaussian_multiple(test_data, fix_fwhm, with_units):
     if with_units:
         for column in fit_tbl.colnames:
             if 'flux' in column:
-                assert fit_tbl['flux_fit'].unit == unit
+                assert fit_tbl[column].unit == unit
+
+
+def test_fit_2dgaussian_generator_xypos(test_data):
+    """
+    Test that xypos can be an iterator, such as a generator.
+    """
+    data, sources = test_data
+
+    xypos = ((x, y) for x, y in zip(sources['x_0'], sources['y_0'],
+                                    strict=True))
+    fit = fit_2dgaussian(data, xypos=xypos, fit_shape=(5, 5))
+    fit_tbl = fit.results
+    assert isinstance(fit_tbl, QTable)
+    assert len(fit_tbl) == len(sources)
 
 
 def test_fit_2dgaussian_fit_shape_none_single():
@@ -220,6 +234,19 @@ def test_fit_fwhm_single():
     warning_msgs = [str(w.message) for w in record]
     assert any('fit_shape is None' in msg for msg in warning_msgs)
     assert len(fwhm) == 1
+
+
+def test_fit_fwhm_convergence_warning_not_swallowed():
+    """
+    Test that the convergence warning is emitted even when the
+    fit_shape warning also fired.
+    """
+    data = np.ones((25, 25))
+    with pytest.warns(AstropyUserWarning) as record:
+        fit_fwhm(data)
+    warning_msgs = [str(w.message) for w in record]
+    assert any('fit_shape is None' in msg for msg in warning_msgs)
+    assert any('may not have converged' in msg for msg in warning_msgs)
 
 
 @pytest.mark.parametrize('with_units', [False, True])
@@ -323,6 +350,25 @@ def test_interpolate_missing_data_all_masked():
     assert np.all(np.isnan(data_int))
 
 
+def test_interpolate_missing_data_int_input():
+    """
+    Test that integer input data is interpolated in float.
+    """
+    data = np.arange(100).reshape(10, 10)
+    mask = np.ones_like(data, dtype=bool)  # All pixels masked
+
+    data_int = _interpolate_missing_data(data, mask, method='cubic')
+    assert np.all(np.isnan(data_int))
+
+    # A masked corner pixel must be filled with a finite value
+    # derived from its neighbors
+    mask = np.zeros_like(data, dtype=bool)
+    mask[0, 0] = True
+    data_int = _interpolate_missing_data(data, mask, method='cubic')
+    assert np.isfinite(data_int[0, 0])
+    assert 1 <= data_int[0, 0] <= 11
+
+
 def test_validate_psf_model():
     model = np.arange(10)
 
@@ -336,7 +382,7 @@ def test_validate_psf_model():
         _validate_psf_model(model)
 
     match = 'psf_model must be two-dimensional'
-    model = Gaussian1D()
+    model = Identity(2)  # 2 inputs, but also 2 outputs
     with pytest.raises(ValueError, match=match):
         _validate_psf_model(model)
 

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -4,6 +4,7 @@ Tools for PSF-fitting photometry.
 """
 
 import warnings
+from collections.abc import Iterator
 
 import numpy as np
 from astropy.modeling import Model
@@ -34,9 +35,10 @@ def _make_mask(image, mask):
     image : 2D `~numpy.ndarray`
         The input image.
 
-    mask : 2D bool `~numpy.array` or None
-        A boolean mask with the same shape as ``data``, where a `True`
-        value indicates the corresponding element of ``data`` is masked.
+    mask : 2D bool `~numpy.ndarray` or None
+        A boolean mask with the same shape as ``image``, where a `True`
+        value indicates the corresponding element of ``image`` is
+        masked.
 
     Returns
     -------
@@ -199,8 +201,9 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
 
     if xypos is None:
         xypos = centroid_com(data, mask=mask)
-    if isinstance(xypos, zip):
-        xypos = np.array(list(xypos))
+    if isinstance(xypos, Iterator):
+        # Consume iterators such as zip, map, and generators
+        xypos = list(xypos)
     xypos = np.atleast_2d(xypos)
 
     if fit_shape is None:
@@ -362,16 +365,14 @@ def fit_fwhm(data, *, xypos=None, fwhm=None, fit_shape=None, mask=None,
                               fit_shape=fit_shape, mask=mask, error=error)
 
     # Re-emit fit_shape warnings and check for other warnings
-    fit_shape_warning = False
     other_warnings = False
     for warning in fit_warnings:
         if 'fit_shape is None' in str(warning.message):
             warnings.warn(str(warning.message), warning.category)
-            fit_shape_warning = True
         else:
             other_warnings = True
 
-    if other_warnings and not fit_shape_warning:
+    if other_warnings:
         msg = ('One or more fit(s) may not have converged. Please '
                'carefully check your results. You may need to change '
                'the input "xypos" and "fit_shape" parameters.')
@@ -413,7 +414,7 @@ def _interpolate_missing_data(data, mask, *, method='cubic'):
         to be filled if there are any valid (unmasked) pixels. If all
         pixels are masked, the returned array will contain NaN values.
     """
-    data_interp = np.copy(data)
+    data_interp = np.array(data, dtype=float)
 
     if len(data_interp.shape) != 2:
         msg = 'data must be a 2D array'
@@ -634,7 +635,7 @@ def _create_call_docstring(*, iterative=False):
             above order, stopping at the first match.
 
             If ``data`` is a `~astropy.units.Quantity` array, then the
-            initial flux values in this table must also must also have
+            initial flux values in this table must also have
             compatible units.
 
             The table can also have ``'group_id'`` and ``'local_bkg'``
@@ -660,7 +661,7 @@ def _create_call_docstring(*, iterative=False):
               input data, or having too few pixels for a fit.
             {iter_detected_column}
             * ``'x_init'``, ``'x_fit'``, ``'x_err'`` : the initial,
-              fit and error of the source x center
+              fit, and error of the source x center
             * ``'y_init'``, ``'y_fit'``, ``'y_err'`` : the initial, fit,
               and error of the source y center
             * ``'flux_init'``, ``'flux_fit'``, ``'flux_err'`` : the


### PR DESCRIPTION

This PR fixes from several PSF support modules: `groupers`, `model_helpers`, `simulation`, and `utils`.

`SourceGrouper` now uses a KD-tree to compute the source groups, so it scales to large source lists. It also now handles scalar inputs, validates that input coordinates are finite, and rejects 2D coordinate arrays with a clear error.

The remaining changes fix several bugs found in the support modules, including model normalization in `make_psf_model` (swapped integration axes), a silently ignored `flux` keyword in `make_psf_model_image`, incorrect unit and origin checks in `grid_from_epsfs`, an error when building ePSFs from integer-dtype star data, and a suppressed non-convergence warning in `fit_fwhm`.