### PR TITLE
Clean up ePSF star and builder edge cases and validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -564,6 +564,20 @@ Bug Fixes
     The keyword is now mapped to the model's flux parameter name.
     [#2389]
 
+  - Fixed a bug where the ``EPSFStars`` star counts and flat star
+    list were stale after deleting a star from the container. [#2390]
+
+  - Fixed a bug where ``extract_stars`` could modify a user-supplied
+    weights uncertainty array when masking pixels. [#2390]
+
+  - ``extract_stars`` no longer requires every input image to have a
+    WCS when multiple catalogs are input. A WCS is now required only
+    for images whose catalog provides only sky coordinates. [#2390]
+
+  - ``EPSFStar`` now raises a ``TypeError`` for ``Quantity`` input
+    data. Previously, ``Quantity`` data produced confusing downstream
+    errors. [#2390]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range
@@ -743,7 +757,7 @@ API Changes
 
   - The ``make_model_params`` output table now includes the creation
     date and photutils version metadata, consistent with
-    ``make_random_models_table``. [#2384x]
+    ``make_random_models_table``. [#2384]
 
 - ``photutils.detection``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -578,6 +578,24 @@ Bug Fixes
     data. Previously, ``Quantity`` data produced confusing downstream
     errors. [#2390]
 
+  - Fixed a bug where an even ``EPSFBuilder`` ``shape`` value raised
+    an error instead of being made odd by adding one (with a
+    warning), as documented. [#2390]
+
+  - Fixed the ``EPSFBuilder`` minimum-shape validation to match the
+    automatically derived ePSF shape. Previously, a ``shape`` equal
+    to the derived shape could be rejected as too small when the
+    star size times the oversampling factor was odd. [#2390]
+
+  - ``EPSFBuilder`` now raises a ``ValueError`` if the initial ePSF
+    model passed to ``build_epsf`` has an oversampling that does not
+    match the builder oversampling. [#2390]
+
+  - Fixed a bug where a fitter that raised a ``TypeError`` during
+    ePSF fitting was silently retried without weights. Whether the
+    fitter supports weights is now determined from its call
+    signature. [#2390]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range
@@ -819,6 +837,15 @@ API Changes
 
   - ``decode_psf_flags`` now raises a ``TypeError`` for boolean flag
     values instead of treating `True` as bit value 1. [#2375]
+
+  - The ``EPSFBuilder`` ``coord_transformer`` attribute is now
+    deprecated and will be removed in a future version. It is an
+    internal helper object that was never intended to be public.
+    [#2390]
+
+  - ``EPSFBuilder`` now supports ``sigma_clip=None`` to disable sigma
+    clipping when stacking the ePSF residuals, as its docstring
+    already documented. [#2390]
 
 - ``photutils.segmentation``
 

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -304,7 +304,7 @@ The `~photutils.psf.EPSFBuildResults` object provides useful diagnostic
 information about the build process::
 
     >>> result.converged  # doctest: +REMOTE_DATA
-    np.False_
+    False
     >>> result.iterations  # doctest: +REMOTE_DATA
     3
     >>> result.n_excluded_stars  # doctest: +REMOTE_DATA

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -6,6 +6,7 @@ King 2000 (PASP 112, 1360) and Anderson 2016 (WFC3 ISR 2016-12).
 
 import copy
 import inspect
+import numbers
 import warnings
 from dataclasses import dataclass
 
@@ -13,7 +14,7 @@ import numpy as np
 from astropy.modeling.fitting import TRFLSQFitter
 from astropy.nddata import NoOverlapError, PartialOverlapError, overlap_slices
 from astropy.stats import SigmaClip
-from astropy.utils.decorators import deprecated
+from astropy.utils.decorators import deprecated, deprecated_attribute
 from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                       AstropyUserWarning)
 from scipy.ndimage import convolve
@@ -31,6 +32,27 @@ from photutils.utils._stats import nanmedian
 __all__ = ['EPSFBuildResults', 'EPSFBuilder', 'EPSFFitter']
 
 SIGMA_CLIP = SigmaClipSentinelDefault(sigma=3.0, maxiters=10)
+
+
+def _fitter_accepts_weights(fitter):
+    """
+    Determine whether a fitter accepts a ``weights`` keyword.
+
+    Parameters
+    ----------
+    fitter : callable
+        The fitter to inspect.
+
+    Returns
+    -------
+    result : bool
+        `True` if the fitter call signature accepts a ``weights``
+        keyword (directly or via ``**kwargs``).
+    """
+    spec = inspect.signature(fitter.__call__)
+    return ('weights' in spec.parameters
+            or any(p.kind == inspect.Parameter.VAR_KEYWORD
+                   for p in spec.parameters.values()))
 
 
 class _SmoothingKernel:
@@ -76,6 +98,9 @@ class _SmoothingKernel:
         TypeError
             If `kernel_type` is not supported.
 
+        ValueError
+            If a custom kernel array is not 2D.
+
         Notes
         -----
         The predefined kernels are derived from polynomial fits:
@@ -88,6 +113,9 @@ class _SmoothingKernel:
           polynomial.
         """
         if isinstance(kernel_type, np.ndarray):
+            if kernel_type.ndim != 2:
+                msg = 'smoothing_kernel must be a 2D array'
+                raise ValueError(msg)
             return kernel_type
         if kernel_type == 'quartic':
             return cls.QUARTIC_KERNEL
@@ -222,10 +250,15 @@ class _EPSFValidator:
                    'star cutouts for better ePSF quality.')
             raise ValueError(msg)
 
-        # Compute minimum required ePSF shape with proper padding
-        # The +1 ensures odd dimensions for proper centering
-        min_epsf_height = max_height * oversampling[0] + 1
-        min_epsf_width = max_width * oversampling[1] + 1
+        # Compute the minimum required ePSF shape, consistent with
+        # _CoordinateTransformer.compute_epsf_shape (add 1 only when
+        # the product is even, to ensure odd dimensions)
+        min_epsf_height = max_height * oversampling[0]
+        if min_epsf_height % 2 == 0:
+            min_epsf_height += 1
+        min_epsf_width = max_width * oversampling[1]
+        if min_epsf_width % 2 == 0:
+            min_epsf_width += 1
 
         # Validate requested shape if provided
         if shape is not None:
@@ -246,15 +279,6 @@ class _EPSFValidator:
                        f'or reduce oversampling factors.')
                 raise ValueError(msg)
 
-            # Check for odd dimensions (for proper centering)
-            if shape[0] % 2 == 0 or shape[1] % 2 == 0:
-                msg = (f'Requested ePSF shape {shape} has even dimensions. '
-                       f'Odd dimensions are recommended for proper ePSF '
-                       f'centering. Consider using '
-                       f'({shape[0] + shape[0] % 2}, '
-                       f'{shape[1] + shape[1] % 2}) instead.')
-                warnings.warn(msg, AstropyUserWarning)
-
     @staticmethod
     def validate_stars(stars, *, context=''):
         """
@@ -270,7 +294,7 @@ class _EPSFValidator:
 
         Raises
         ------
-        ValueError, TypeError
+        ValueError
             If stars are invalid.
         """
         # Check basic type and structure
@@ -335,10 +359,13 @@ class _EPSFValidator:
 
         Raises
         ------
+        TypeError
+            If center accuracy is not a number.
+
         ValueError
-            If center accuracy is invalid.
+            If center accuracy is not positive.
         """
-        if not isinstance(center_accuracy, (int, float)):
+        if not isinstance(center_accuracy, numbers.Real):
             msg = (f'center_accuracy must be a number, got '
                    f'{type(center_accuracy)}')
             raise TypeError(msg)
@@ -366,10 +393,14 @@ class _EPSFValidator:
 
         Raises
         ------
-        ValueError, TypeError
-            If maxiters is invalid.
+        TypeError
+            If maxiters is not an integer.
+
+        ValueError
+            If maxiters is not positive.
         """
-        if not isinstance(maxiters, int):
+        if isinstance(maxiters, bool) or not isinstance(maxiters,
+                                                        numbers.Integral):
             msg = f'maxiters must be an integer, got {type(maxiters)}'
             raise TypeError(msg)
 
@@ -705,6 +736,17 @@ class EPSFBuildResults:
         """
         return iter((self.epsf, self.fitted_stars))
 
+    def __len__(self):
+        """
+        Return the length of the backward-compatible 2-tuple.
+
+        Returns
+        -------
+        length : int
+            Always 2, for (epsf, fitted_stars).
+        """
+        return 2
+
     def __getitem__(self, index):
         """
         Allow indexing for backward compatibility.
@@ -729,7 +771,7 @@ class EPSFBuildResults:
 
 
 @deprecated(since='3.0',
-            message=('EPSFFitter is deprecated and will be removed in a '
+            message=('EPSFFitter is deprecated and will be removed in '
                      'version 4.0. Use EPSFBuilder with the fitter, '
                      'fit_shape, and fitter_maxiters parameters instead.'))
 class EPSFFitter:
@@ -764,6 +806,7 @@ class EPSFFitter:
             fitter = TRFLSQFitter()
         self.fitter = fitter
         self.fitter_has_fit_info = hasattr(self.fitter, 'fit_info')
+        self._fitter_accepts_weights = _fitter_accepts_weights(self.fitter)
         if fit_boxsize is not None:
             self.fit_boxsize = as_pair('fit_boxsize', fit_boxsize,
                                        lower_bound=(3, 1), check_odd=True)
@@ -789,7 +832,7 @@ class EPSFFitter:
         stars : `EPSFStars` object
             The stars to be fit. The center coordinates for each star
             should be as close as possible to actual centers. For stars
-            than contain weights, a weighted fit of the ePSF to the star
+            that contain weights, a weighted fit of the ePSF to the star
             will be performed.
 
         Returns
@@ -895,11 +938,10 @@ class EPSFFitter:
         epsf.x_0 = 0.0
         epsf.y_0 = 0.0
 
-        try:
+        if self._fitter_accepts_weights:
             fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=data,
                                  weights=weights, **fitter_kwargs)
-        except TypeError:
-            # Handle case where the fitter does not support weights
+        else:
             fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=data,
                                  **fitter_kwargs)
 
@@ -944,19 +986,19 @@ class EPSFBuilder:
 
     Parameters
     ----------
-    oversampling : int or array_like (int)
+    oversampling : int or array_like (int), optional
         The integer oversampling factor(s) of the output ePSF relative
         to the input ``stars`` along each axis. If ``oversampling`` is a
         scalar then it will be used for both axes. If ``oversampling``
         has two elements, they must be in ``(y, x)`` order.
 
-    shape : float, tuple of two floats, or `None`, optional
+    shape : int, tuple of two ints, or `None`, optional
         The (ny, nx) shape of the output ePSF. If the input shape is
-        even along any axis, it will be made odd by adding one. If the
-        ``shape`` is `None`, it will be derived from the sizes of the
-        input ``stars`` and the ePSF ``oversampling`` factor. The output
-        ePSF will always have odd sizes along both axes to ensure a
-        well-defined central pixel.
+        even along any axis, it will be made odd by adding one (with a
+        warning). If the ``shape`` is `None`, it will be derived from
+        the sizes of the input ``stars`` and the ePSF ``oversampling``
+        factor. The output ePSF will always have odd sizes along both
+        axes to ensure a well-defined central pixel.
 
     smoothing_kernel : {'quartic', 'quadratic'}, 2D `~numpy.ndarray`, or `None`
         The smoothing kernel to apply to the ePSF during each iteration
@@ -977,7 +1019,7 @@ class EPSFBuilder:
         a ``mask`` keyword and optionally an ``error`` keyword. The
         callable object must return a tuple of (x, y) centroids.
 
-    recentering_boxsize : float or tuple of two floats, optional
+    recentering_boxsize : int or tuple of two ints, optional
         The size (in pixels) of the box used to calculate the centroid
         of the ePSF during each build iteration. The size is in
         the input star (i.e., undersampled) pixel space; it is
@@ -1029,11 +1071,13 @@ class EPSFBuilder:
     maxiters : int, optional
         The maximum number of ePSF building iterations to perform.
 
-    progress_bar : bool, option
+    progress_bar : bool, optional
         Whether to print the progress bar during the build
         iterations. The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
     """
+
+    coord_transformer = deprecated_attribute('coord_transformer', '3.1')
 
     def __init__(self, *, oversampling=4, shape=None,
                  smoothing_kernel='quartic', sigma_clip=SIGMA_CLIP,
@@ -1047,12 +1091,19 @@ class EPSFBuilder:
             oversampling, context='EPSFBuilder initialization')
 
         # Initialize coordinate transformer for consistent transformations
-        self.coord_transformer = _CoordinateTransformer(self.oversampling)
+        self._coord_transformer = _CoordinateTransformer(self.oversampling)
 
         if shape is not None:
-            self.shape = as_pair('shape', shape, lower_bound=(0, 0))
-        else:
-            self.shape = shape
+            shape = as_pair('shape', shape, lower_bound=(0, 0))
+            even = shape % 2 == 0
+            if np.any(even):
+                new_shape = shape + even.astype(int)
+                msg = (f'The input shape {tuple(shape)} has even '
+                       f'values; using {tuple(new_shape)} instead '
+                       'for proper ePSF centering.')
+                warnings.warn(msg, AstropyUserWarning)
+                shape = new_shape
+        self.shape = shape
 
         self.recentering_func = recentering_func
         self.recentering_maxiters = recentering_maxiters
@@ -1098,6 +1149,7 @@ class EPSFBuilder:
                 self._fitter_kwargs['maxiter'] = self.fitter_maxiters
 
         self._fitter_has_fit_info = hasattr(self.fitter, 'fit_info')
+        self._fitter_accepts_weights = _fitter_accepts_weights(self.fitter)
 
         # Validate center accuracy using the validator
         _EPSFValidator.validate_center_accuracy(center_accuracy)
@@ -1112,13 +1164,11 @@ class EPSFBuilder:
         if sigma_clip is SIGMA_CLIP:
             sigma_clip = create_default_sigmaclip(sigma=SIGMA_CLIP.sigma,
                                                   maxiters=SIGMA_CLIP.maxiters)
-        if not isinstance(sigma_clip, SigmaClip):
-            msg = 'sigma_clip must be an astropy.stats.SigmaClip instance'
+        if sigma_clip is not None and not isinstance(sigma_clip, SigmaClip):
+            msg = ('sigma_clip must be an astropy.stats.SigmaClip '
+                   'instance or None')
             raise TypeError(msg)
         self._sigma_clip = sigma_clip
-
-        # Store each ePSF build iteration
-        self._epsf = []
 
     def __call__(self, stars):
         """
@@ -1151,6 +1201,15 @@ class EPSFBuilder:
             The validated value, or `None` if the fitter does not
             support the ``maxiter`` parameter.
         """
+        if isinstance(fitter_maxiters, bool) or not isinstance(
+                fitter_maxiters, numbers.Integral):
+            msg = ('fitter_maxiters must be an integer, got '
+                   f'{type(fitter_maxiters)}')
+            raise TypeError(msg)
+        if fitter_maxiters <= 0:
+            msg = 'fitter_maxiters must be a positive integer'
+            raise ValueError(msg)
+
         spec = inspect.signature(self.fitter.__call__)
         has_maxiter = ('maxiter' in spec.parameters
                        or any(p.kind == inspect.Parameter.VAR_KEYWORD
@@ -1166,74 +1225,21 @@ class EPSFBuilder:
         """
         Create an initial `ImagePSF` object with zero data.
 
-        This method initializes the ePSF building process by creating a
-        blank ImagePSF model with the appropriate size and coordinate
-        system. The initial ePSF data are all zeros and will be
-        populated through the iterative building process.
-
-        Shape Determination Algorithm
-        -----------------------------
-        1. If shape is explicitly provided, use it (ensuring odd
-           dimensions)
-
-        2. Otherwise, determine shape from input stars and oversampling:
-           - Take the maximum star cutout dimensions
-           - Apply oversampling factor: new_size = old_size * oversampling
-           - Ensure resulting dimensions are odd (add 1 if even)
-
-        This ensures that oversampled arrays have a well-defined center
-        pixel, which is crucial for PSF modeling and fitting.
-
-        Coordinate System Setup
-        -----------------------
-        The method establishes the coordinate system for the ImagePSF.
-        The origin is set to the geometric center of the data array,
-        which ensures that the PSF center aligns with the array center.
-        The coordinate system is consistent with the expectations of the
-        ImagePSF class and allows for straightforward mapping between
-        star-relative coordinates and ePSF grid coordinates during the
-        building process.
+        The ePSF shape is the configured ``shape`` if provided,
+        otherwise it is derived from the maximum star cutout dimensions
+        and the oversampling factors (made odd along each axis so the
+        ePSF has a well-defined central pixel). The origin is set to the
+        geometric center of the data array.
 
         Parameters
         ----------
         stars : `EPSFStars` object
-            The stars used to build the ePSF. The method uses
-            stars._max_shape to ensure the ePSF is large enough to
-            contain all stars.
+            The stars used to build the ePSF.
 
         Returns
         -------
         epsf : `ImagePSF` object
-            The initial ePSF model with:
-            - data: Zero-filled array of appropriate dimensions
-            - origin: Set to the array center in (x, y) order
-            - oversampling: Copied from the EPSFBuilder configuration
-            - fill_value: Set to 0.0 for regions outside the PSF
-
-        Notes
-        -----
-        The initial ePSF has zero flux and data values. These will be
-        populated through the iterative building process as residuals
-        from individual stars are combined.
-
-        The method ensures that:
-        - Array dimensions are always odd (ensuring a center pixel)
-        - The coordinate system is properly established
-        - All necessary attributes are set for downstream processing
-
-        Examples
-        --------
-        For stars with maximum shape (25, 25) and oversampling=4:
-        - x_shape = 25 * 4 = 100 (even), add 1 -> 101
-        - y_shape = 25 * 4 = 100 (even), add 1 -> 101
-        - Final shape: (101, 101)
-        - Origin: (50.0, 50.0)
-
-        For stars with maximum shape (25, 25) and oversampling=3:
-        - x_shape = 25 * 3 = 75 (already odd)
-        - y_shape = 25 * 3 = 75 (already odd)
-        - Final shape: (75, 75)
-        - Origin: (37.0, 37.0)
+            The initial zero-data ePSF model.
         """
         oversampling = self.oversampling
         shape = self.shape
@@ -1246,13 +1252,13 @@ class EPSFBuilder:
             # dimensions (use the flat star list so that stars within
             # LinkedEPSFStar objects contribute individual shapes)
             star_shapes = [star.shape for star in stars.all_stars]
-            shape = self.coord_transformer.compute_epsf_shape(star_shapes)
+            shape = self._coord_transformer.compute_epsf_shape(star_shapes)
 
         # Initialize with zeros
         data = np.zeros(shape, dtype=float)
 
         # Use coordinate transformer to compute origin
-        origin_xy = self.coord_transformer.compute_epsf_origin(shape)
+        origin_xy = self._coord_transformer.compute_epsf_origin(shape)
 
         return ImagePSF(data=data, origin=origin_xy, oversampling=oversampling,
                         fill_value=0.0)
@@ -1296,7 +1302,7 @@ class EPSFBuilder:
                                     flux=1.0, x_0=0.0, y_0=0.0))
 
         # Use coordinate transformer to map to the oversampled ePSF grid
-        xidx, yidx = self.coord_transformer.star_to_epsf_coords(
+        xidx, yidx = self._coord_transformer.star_to_epsf_coords(
             xidx_centered, yidx_centered, epsf.origin)
 
         epsf_shape = epsf.data.shape
@@ -1315,8 +1321,6 @@ class EPSFBuilder:
     def _resample_residuals(self, stars, epsf):
         """
         Compute normalized residual images for all the input stars.
-
-        Optimized to minimize memory allocations.
 
         Parameters
         ----------
@@ -1396,8 +1400,12 @@ class EPSFBuilder:
         oversampling_product = np.prod(self.oversampling)
         current_sum = np.sum(epsf_data)
 
-        if current_sum == 0:
-            msg = 'Cannot normalize ePSF: data sum is zero'
+        if not np.isfinite(current_sum) or current_sum <= 0:
+            msg = (f'Cannot normalize ePSF: the data sum ({current_sum}) '
+                   'is not finite and positive. This usually indicates '
+                   'a problem in the recentering or smoothing steps, '
+                   'e.g., a recentering function that returned '
+                   'non-finite centroids.')
             raise ValueError(msg)
 
         return epsf_data * (oversampling_product / current_sum)
@@ -1408,16 +1416,8 @@ class EPSFBuilder:
         Recenter the ePSF data by shifting to the array center.
 
         This method uses iterative centroiding to find the center of
-        the ePSF and applies sub-pixel shifts using interpolation.
-        This provides accurate centering even when the PSF is offset
-        by fractional pixels.
-
-        Algorithm Overview
-        ------------------
-        1. Find the centroid of the ePSF using the centroid function
-        2. Calculate the sub-pixel shift needed to center the PSF
-        3. Apply the shift using spline interpolation via epsf.evaluate()
-        4. Iterate until convergence or max iterations reached
+        the ePSF and applies sub-pixel shifts using spline
+        interpolation via the ImagePSF ``evaluate`` method.
 
         Parameters
         ----------
@@ -1425,29 +1425,24 @@ class EPSFBuilder:
             The ePSF model containing the data to be recentered.
 
         centroid_func : callable, optional
-            A callable object (e.g., function or class) that is used
-            to calculate the centroid of a 2D array. The callable must
-            accept a 2D `~numpy.ndarray`, have a ``mask`` keyword
-            and optionally an ``error`` keyword. The callable object
-            must return a tuple of two 1D `~numpy.ndarray` variables,
-            representing the x and y centroids. If `None`, uses the
-            builder's configured recentering_func.
+            A callable object used to calculate the centroid of a 2D
+            array. The callable must accept a 2D `~numpy.ndarray`,
+            have a ``mask`` keyword, and optionally an ``error``
+            keyword. The callable object must return a tuple of (x, y)
+            scalar centroids. If `None`, uses the builder's configured
+            recentering_func.
 
-        box_size : float or tuple of two floats, optional
+        box_size : int or tuple of two ints, optional
             The size (in pixels) of the box used to calculate the
-            centroid of the ePSF during each iteration. The size is
-            in the input star (i.e., undersampled) pixel space; it is
-            automatically scaled by the oversampling factor when applied
-            to the oversampled ePSF grid. If a single integer number
-            is provided, then a square box will be used. If two values
-            are provided, then they must be in ``(ny, nx)`` order.
-            ``box_size`` must have odd values and be greater than or
-            equal to 3 for both axes. If `None`, uses the builder's
+            centroid of the ePSF during each iteration, in the input
+            star (i.e., undersampled) pixel space. It is automatically
+            scaled by the oversampling factor when applied to the
+            oversampled ePSF grid. If `None`, uses the builder's
             configured recentering_boxsize.
 
         maxiters : int, optional
             The maximum number of recentering iterations to perform. If
-            `None`, uses the builder's configured recentering_maxiters .
+            `None`, uses the builder's configured recentering_maxiters.
 
         center_accuracy : float, optional
             The desired accuracy for the center position. The centering
@@ -1459,13 +1454,6 @@ class EPSFBuilder:
         -------
         result : 2D `~numpy.ndarray`
             The recentered ePSF data array with the same shape as input.
-
-        Notes
-        -----
-        This method uses spline interpolation to apply sub-pixel shifts,
-        which preserves the PSF shape more accurately than integer
-        pixel shifting. The interpolation is done using the ImagePSF's
-        evaluate method.
         """
         # Use instance defaults if not specified
         if centroid_func is None:
@@ -1488,17 +1476,17 @@ class EPSFBuilder:
 
         # The center of the ePSF in oversampled pixel coordinates.
         # This is where we want the PSF center to be.
-        xcenter, ycenter = self.coord_transformer.compute_epsf_origin(
+        xcenter, ycenter = self._coord_transformer.compute_epsf_origin(
             epsf.data.shape)
 
         # Create coordinate grids in undersampled units for evaluate()
         y, x = np.indices(epsf.data.shape, dtype=float)
-        x, y = self.coord_transformer.oversampled_to_undersampled(x, y)
+        x, y = self._coord_transformer.oversampled_to_undersampled(x, y)
 
         # The origin in undersampled units (for use with evaluate)
         x_origin, y_origin = (
-            self.coord_transformer.oversampled_to_undersampled(xcenter,
-                                                               ycenter))
+            self._coord_transformer.oversampled_to_undersampled(
+                xcenter, ycenter))
 
         dx_total, dy_total = 0.0, 0.0
         iter_num = 0
@@ -1537,7 +1525,7 @@ class EPSFBuilder:
 
             # Accumulate total shift in undersampled units
             dx_under, dy_under = (
-                self.coord_transformer.oversampled_to_undersampled(dx, dy))
+                self._coord_transformer.oversampled_to_undersampled(dx, dy))
             dx_total += dx_under
             dy_total += dy_under
 
@@ -1578,8 +1566,9 @@ class EPSFBuilder:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=RuntimeWarning)
             warnings.simplefilter('ignore', category=AstropyUserWarning)
-            residuals = self._sigma_clip(residuals, axis=0, masked=False,
-                                         return_bounds=False)
+            if self._sigma_clip is not None:
+                residuals = self._sigma_clip(residuals, axis=0, masked=False,
+                                             return_bounds=False)
             residuals = nanmedian(residuals, axis=0)
 
         # Interpolate any missing data (np.nan values) in the residual
@@ -1618,14 +1607,10 @@ class EPSFBuilder:
         """
         Check if the ePSF building has converged.
 
-        Convergence is determined by checking the movement of star
-        centers between iterations. The method calculates the squared
-        distance of center movements for successfully fitted stars and
-        applies enhanced convergence criteria that consider both the
-        maximum movement and the overall stability of the star centers.
-        This provides a more robust convergence detection mechanism that
-        is less sensitive to outliers and provides better diagnostic
-        information on the quality of convergence.
+        Convergence is determined by the movement of the star centers
+        between iterations. The build has converged when the maximum
+        squared center movement among successfully fitted stars is less
+        than the configured center accuracy.
 
         Parameters
         ----------
@@ -1657,30 +1642,18 @@ class EPSFBuilder:
         good_stars = np.logical_not(fit_failed)
 
         if not np.any(good_stars):
-            # No good stars - cannot determine convergence
-            # Return high values to prevent false convergence
-            return False, np.array([self.center_accuracy_sq * 10]), new_centers
+            # No good stars, so convergence cannot be determined. This
+            # is unreachable from build_epsf (all-failed fits raise
+            # earlier), but guards direct calls. NaN indicates that no
+            # center movement could be measured.
+            return False, np.array([np.nan]), new_centers
 
         dx_dy_good = dx_dy[good_stars]
         center_dist_sq = np.sum(dx_dy_good * dx_dy_good, axis=1,
                                 dtype=np.float64)
 
-        # Enhanced convergence criteria
         max_movement = np.max(center_dist_sq)
-
-        # Primary convergence check
-        primary_converged = max_movement < self.center_accuracy_sq
-
-        # Secondary check: ensure most stars are stable
-        # 80% of stars must be stable
-        stable_fraction_threshold = 0.8
-        stable_fraction = (np.sum(center_dist_sq < self.center_accuracy_sq)
-                           / len(center_dist_sq))
-        stability_converged = stable_fraction > stable_fraction_threshold
-
-        # Combined convergence: both criteria must be met for robust
-        # results
-        converged = primary_converged and stability_converged
+        converged = bool(max_movement < self.center_accuracy_sq)
 
         return converged, center_dist_sq, new_centers
 
@@ -1807,11 +1780,10 @@ class EPSFBuilder:
         epsf.x_0 = 0.0
         epsf.y_0 = 0.0
 
-        try:
+        if self._fitter_accepts_weights:
             fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=data,
                                  weights=weights, **fitter_kwargs)
-        except TypeError:
-            # Handle case where the fitter does not support weights
+        else:
             fitted_epsf = fitter(model=epsf, x=xx, y=yy, z=data,
                                  **fitter_kwargs)
 
@@ -1918,16 +1890,15 @@ class EPSFBuilder:
                     warnings.warn(msg, AstropyUserWarning)
                 star._excluded_from_fit = True
 
-        # Store the ePSF from this iteration
-        self._epsf.append(epsf)
-
         return epsf, stars, fit_failed
 
     def _finalize_build(self, epsf, stars, progress_reporter, iter_num,
-                        converged, final_center_accuracy,
-                        excluded_star_indices):
+                        converged, final_center_accuracy):
         """
         Finalize the ePSF building process and create result object.
+
+        The excluded star indices are derived from the per-star
+        exclusion flags, which are the single source of truth.
 
         Parameters
         ----------
@@ -1949,9 +1920,6 @@ class EPSFBuilder:
         final_center_accuracy : float
             Final center accuracy achieved.
 
-        excluded_star_indices : list
-            Indices of excluded stars.
-
         Returns
         -------
         result : `EPSFBuildResults`
@@ -1962,6 +1930,10 @@ class EPSFBuilder:
         if iter_num < self.maxiters:
             progress_reporter.write_convergence_message(iter_num)
         progress_reporter.close()
+
+        excluded_star_indices = [i for i, star
+                                 in enumerate(stars.all_stars)
+                                 if star._excluded_from_fit]
 
         # Create structured result
         return EPSFBuildResults(
@@ -1994,11 +1966,11 @@ class EPSFBuilder:
 
         Returns
         -------
-        result : `EPSFBuildResults` or tuple
-            The ePSF building results. Returns an `EPSFBuildResults` object
-            with detailed information about the building process. For
-            backward compatibility, the result can be unpacked as a tuple:
-            ``(epsf, fitted_stars) = epsf_builder(stars)``.
+        result : `EPSFBuildResults`
+            The ePSF building results, with detailed information about
+            the building process. For backward compatibility, the
+            result can be unpacked as a tuple: ``(epsf, fitted_stars) =
+            epsf_builder(stars)``.
 
         Notes
         -----
@@ -2011,6 +1983,13 @@ class EPSFBuilder:
         - n_excluded_stars: Number of stars excluded due to fit failures
         - excluded_star_indices: Indices of excluded stars
         """
+        if epsf is not None and not np.array_equal(epsf.oversampling,
+                                                   self.oversampling):
+            msg = (f'The input epsf oversampling '
+                   f'{tuple(epsf.oversampling)} does not match the '
+                   f'builder oversampling {tuple(self.oversampling)}')
+            raise ValueError(msg)
+
         _EPSFValidator.validate_stars(stars, context='ePSF building')
         _EPSFValidator.validate_shape_compatibility(stars, self.oversampling,
                                                     shape=self.shape)
@@ -2023,11 +2002,10 @@ class EPSFBuilder:
         progress_reporter = _ProgressReporter(self.progress_bar,
                                               self.maxiters).setup()
 
-        # Initialize iteration variables and tracking
+        # Initialize iteration variables
         iter_num = 0
         converged = False
         center_dist_sq = np.array([self.center_accuracy_sq + 1.0])
-        excluded_star_indices = []
 
         # Main iteration loop
         while (iter_num < self.maxiters and not np.all(fit_failed)
@@ -2039,13 +2017,6 @@ class EPSFBuilder:
             epsf, stars, fit_failed = self._process_iteration(
                 stars, epsf, iter_num)
 
-            # Track newly excluded stars
-            if iter_num > 3 and np.any(fit_failed):
-                new_excluded = fit_failed.nonzero()[0]
-                for idx in new_excluded:
-                    if idx not in excluded_star_indices:
-                        excluded_star_indices.append(idx)
-
             # Check convergence based on center movements
             converged, center_dist_sq, centers = self._check_convergence(
                 stars, centers, fit_failed)
@@ -2054,14 +2025,12 @@ class EPSFBuilder:
             progress_reporter.update()
 
         # Calculate the final center accuracy
-        final_converged = converged
         final_center_accuracy = np.max(center_dist_sq) ** 0.5
 
         # Finalize and return structured results
         return self._finalize_build(epsf, stars, progress_reporter,
-                                    iter_num, final_converged,
-                                    final_center_accuracy,
-                                    excluded_star_indices)
+                                    iter_num, converged,
+                                    final_center_accuracy)
 
 
 def __getattr__(name):

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -7,6 +7,7 @@ cutouts for fitting and building ePSFs.
 import warnings
 from functools import cached_property
 
+import astropy.units as u
 import numpy as np
 from astropy.nddata import (NDData, NoOverlapError, PartialOverlapError,
                             StdDevUncertainty, overlap_slices)
@@ -32,6 +33,8 @@ class EPSFStar:
 
     weights : `~numpy.ndarray` or `None`, optional
         A 2D array of the weights associated with the input ``data``.
+        Pixels where ``weights`` is not positive are treated as
+        masked.
 
     cutout_center : tuple of two floats or `None`, optional
         The ``(x, y)`` position of the star's center with respect to the
@@ -66,6 +69,11 @@ class EPSFStar:
 
     def __init__(self, data, *, weights=None, cutout_center=None, flux=None,
                  origin=(0, 0), wcs_large=None, id_label=None):
+
+        if isinstance(data, u.Quantity):
+            msg = ('data must be a plain ndarray; Quantity inputs are '
+                   'not supported')
+            raise TypeError(msg)
 
         self._data = np.asanyarray(data)
 
@@ -114,7 +122,7 @@ class EPSFStar:
         # Validate origin
         origin = np.asarray(origin)
         if origin.shape != (2,):
-            msg = f'Origin must have exactly 2 elements, got {len(origin)}'
+            msg = f'Origin must have exactly 2 elements, got {origin.size}'
             raise ValueError(msg)
         if not np.all(np.isfinite(origin)):
             msg = 'Origin coordinates must be finite'
@@ -164,13 +172,16 @@ class EPSFStar:
 
         self._excluded_from_fit = False
         self._fit_error_status = 0  # 0: no error, >0: error during fitting
-        self._fitinfo = None
+        self._fit_info = None
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         """
-        Array representation of the data array (e.g., for matplotlib).
+        Array representation of the data array (e.g., for
+        matplotlib).
         """
-        return self._data
+        if copy is False:
+            return np.asarray(self._data, dtype=dtype)
+        return np.array(self._data, dtype=dtype, copy=True)
 
     @property
     def data(self):
@@ -240,7 +251,7 @@ class EPSFStar:
                    f'cutout bounds [0, {self.shape[0]})')
             warnings.warn(msg, AstropyUserWarning)
 
-        self._cutout_center = np.asarray(value)
+        self._cutout_center = np.array(value, dtype=float)
 
     @property
     def center(self):
@@ -279,8 +290,7 @@ class EPSFStar:
         Returns
         -------
         flux : float
-            The estimated star's flux. If there is no valid data in the
-            cutout, `numpy.nan` will be returned.
+            The estimated star's flux.
         """
         if not np.any(self.mask):
             return float(np.sum(self.data))
@@ -363,13 +373,16 @@ class EPSFStars:
     """
 
     def __init__(self, stars_list):
+        msg = ('stars_list must be a list of EPSFStar and/or '
+               'LinkedEPSFStar objects')
         if isinstance(stars_list, (EPSFStar, LinkedEPSFStar)):
             self._data = [stars_list]
         elif isinstance(stars_list, list):
+            for star in stars_list:
+                if not isinstance(star, (EPSFStar, LinkedEPSFStar)):
+                    raise TypeError(msg)
             self._data = stars_list
         else:
-            msg = ('stars_list must be a list of EPSFStar and/or '
-                   'LinkedEPSFStar objects')
             raise TypeError(msg)
 
     def __len__(self):
@@ -389,6 +402,8 @@ class EPSFStars:
         Delete the star at the given index.
         """
         del self._data[index]
+        for key in ('all_stars', 'n_stars', 'n_all_stars'):
+            self.__dict__.pop(key, None)
 
     def __iter__(self):
         """
@@ -414,11 +429,21 @@ class EPSFStars:
 
         This allows accessing star attributes (like ``cutout_center``,
         ``center``, ``flux``) directly on the EPSFStars container,
-        returning an array of values from all contained stars.
+        returning an array of values from all contained stars. If the
+        per-star values have inconsistent shapes (e.g., for a mix of
+        `EPSFStar` and multi-star `LinkedEPSFStar` objects), an object
+        array is returned.
         """
         result = [getattr(star, attr) for star in self._data]
         if attr in ['cutout_center', 'center', 'flux', '_excluded_from_fit']:
-            result = np.array(result)
+            try:
+                result = np.array(result)
+            except ValueError:
+                # Ragged per-star values (e.g., a mix of EPSFStar and
+                # multi-star LinkedEPSFStar objects)
+                arr = np.empty(len(result), dtype=object)
+                arr[:] = result
+                result = arr
         if len(self._data) == 1:
             result = result[0]
         return result
@@ -565,6 +590,9 @@ class LinkedEPSFStar:
         This provides access to common star attributes like cutout_center,
         center, flux, etc. as arrays when accessed on the LinkedEPSFStar.
         """
+        if attr == '_excluded_from_fit':
+            return np.array([star._excluded_from_fit
+                             for star in self._data])
         if attr.startswith('_'):
             msg = f"'{type(self).__name__}' object has no attribute '{attr}'"
             raise AttributeError(msg)
@@ -891,7 +919,8 @@ def _validate_coordinate_consistency(data, catalogs):
                        "'x' and 'y' columns or a 'skycoord' column.")
                 raise ValueError(msg)
 
-            # If only skycoord is available, ensure WCS is present
+            # If only skycoord is available, ensure the corresponding
+            # NDData object has a WCS
             if has_skycoord and not has_xy:
                 data_idx = i if len(data) == len(catalogs) else 0
                 if (data_idx < len(data)
@@ -899,12 +928,6 @@ def _validate_coordinate_consistency(data, catalogs):
                     msg = (f'When catalog at index {i} contains only skycoord '
                            f'positions, the corresponding NDData object must '
                            'have a wcs attribute.')
-                    raise ValueError(msg)
-
-                if any(img.wcs is None for img in data):
-                    msg = ('When inputting catalog(s) with only skycoord '
-                           'positions, each NDData object must have a '
-                           'wcs attribute.')
                     raise ValueError(msg)
 
         if len(data) != len(catalogs):
@@ -929,7 +952,8 @@ def extract_stars(data, catalogs, *, size=(11, 11)):
         which to extract the stars. If the input ``catalogs`` contain
         only the sky coordinates (i.e., not the pixel coordinates) of
         the stars then each of the `~astropy.nddata.NDData` objects must
-        have a valid ``wcs`` attribute.
+        have a valid ``wcs`` attribute. Any ``unit`` attribute of the
+        `~astropy.nddata.NDData` objects is ignored.
 
     catalogs : `~astropy.table.Table`, list of `~astropy.table.Table`
         A catalog or list of catalogs of sources to be extracted from
@@ -959,10 +983,10 @@ def extract_stars(data, catalogs, *, size=(11, 11)):
         Optionally, each catalog may also contain an ``id`` column
         representing the ID/name of stars. If this column is not
         present then the extracted stars will be given an ``id`` number
-        corresponding the table row number (starting at 1). The catalogs
-        may also contain an optional ``flux`` column giving the flux
-        of each star. If present, these values are used instead of
-        estimating the flux from the cutout data. Any other columns
+        corresponding to the table row number (starting at 1). The
+        catalogs may also contain an optional ``flux`` column giving the
+        flux of each star. If present, these values are used instead
+        of estimating the flux from the cutout data. Any other columns
         present in the input ``catalogs`` will be ignored.
 
     size : int or array_like (int), optional
@@ -974,7 +998,7 @@ def extract_stars(data, catalogs, *, size=(11, 11)):
     Returns
     -------
     stars : `EPSFStars` instance
-        A `EPSFStars` instance containing the extracted stars.
+        An `EPSFStars` instance containing the extracted stars.
     """
     data = _normalize_data_input(data)
     catalogs = _normalize_catalog_input(catalogs)
@@ -984,14 +1008,14 @@ def extract_stars(data, catalogs, *, size=(11, 11)):
     size = as_pair('size', size, lower_bound=(3, 1), check_odd=True)
 
     if len(catalogs) == 1:  # may include linked stars
-        stars_out, overlap_fail_count = _extract_linked_stars(
+        stars_out, n_overlap_failed = _extract_linked_stars(
             data, catalogs[0], size)
     else:  # no linked stars
-        stars_out, overlap_fail_count = _extract_unlinked_stars(
+        stars_out, n_overlap_failed = _extract_unlinked_stars(
             data, catalogs, size)
 
-    if overlap_fail_count > 0:
-        msg = (f'{overlap_fail_count} star(s) were not extracted '
+    if n_overlap_failed > 0:
+        msg = (f'{n_overlap_failed} star(s) were not extracted '
                'because their cutout region extended beyond the '
                'input image.')
         warnings.warn(msg, AstropyUserWarning)
@@ -1031,7 +1055,7 @@ def _extract_linked_stars(data, catalog, size):
         instance containing the corresponding `EPSFStar` instances from
         each image. Failed extractions are represented as `None`.
 
-    overlap_fail_count : int
+    n_overlap_failed : int
         The number of stars that failed extraction because their cutout
         region extended beyond the input image.
     """
@@ -1042,7 +1066,7 @@ def _extract_linked_stars(data, catalog, size):
     results = [_extract_stars(img, catalog, size=size, use_xy=use_xy)
                for img in data]
     stars = [r[0] for r in results]
-    overlap_fail_count = sum(r[1] for r in results)
+    n_overlap_failed = sum(r[1] for r in results)
 
     # Transpose to associate linked stars across images
     stars = list(map(list, zip(*stars, strict=True)))
@@ -1062,7 +1086,7 @@ def _extract_linked_stars(data, catalog, size):
             # Multiple stars - create linked star
             stars_out.append(LinkedEPSFStar(good_stars))
 
-    return stars_out, overlap_fail_count
+    return stars_out, n_overlap_failed
 
 
 def _extract_unlinked_stars(data, catalogs, size):
@@ -1082,7 +1106,7 @@ def _extract_unlinked_stars(data, catalogs, size):
         separate source catalog for each 2D image). The center of each
         source can be defined either in pixel coordinates (in ``x`` and
         ``y`` columns) or sky coordinates (in a ``skycoord`` column
-        containing a `~astropy.coordinates.SkyCoord`.
+        containing a `~astropy.coordinates.SkyCoord` object).
 
     size : int or array_like (int)
         The extraction box size along each axis. If ``size`` is a scalar
@@ -1095,21 +1119,21 @@ def _extract_unlinked_stars(data, catalogs, size):
         A list of `EPSFStar` instances containing the extracted stars.
         Failed extractions are represented as `None`.
 
-    overlap_fail_count : int
+    n_overlap_failed : int
         The number of stars that failed extraction because their cutout
         region extended beyond the input image.
     """
     stars_out = []
-    total_overlap_fail_count = 0
+    n_overlap_failed_total = 0
     for img, cat in zip(data, catalogs, strict=True):
-        extracted, overlap_fail_count = _extract_stars(
+        extracted, n_overlap_failed = _extract_stars(
             img, cat, size=size, use_xy=True)
         stars_out.extend(extracted)
-        total_overlap_fail_count += overlap_fail_count
+        n_overlap_failed_total += n_overlap_failed
 
     # Filter out None values
     return ([star for star in stars_out if star is not None],
-            total_overlap_fail_count)
+            n_overlap_failed_total)
 
 
 def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
@@ -1153,7 +1177,7 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
         A list of `EPSFStar` instances containing the extracted stars.
         Failed extractions are represented as `None`.
 
-    overlap_fail_count : int
+    n_overlap_failed : int
         The number of stars that failed extraction because their cutout
         region extended beyond the input image.
     """
@@ -1177,18 +1201,24 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
     data_mask = data.mask  # Cache mask reference
 
     stars = []
-    nonfinite_weights_count = 0
-    overlap_fail_count = 0
+    n_nonfinite_weights = 0
+    n_nonfinite_positions = 0
+    n_overlap_failed = 0
     flux_failures = []  # Collect flux estimation failures
     all_zero_stars = []  # Collect stars with all-zero data
     for i, (xcenter, ycenter) in enumerate(zip(xcenters, ycenters,
                                                strict=True)):
+        if not (np.isfinite(xcenter) and np.isfinite(ycenter)):
+            stars.append(None)
+            n_nonfinite_positions += 1
+            continue
+
         try:
             large_slc, _ = overlap_slices(data.data.shape, size,
                                           (ycenter, xcenter), mode='strict')
         except (PartialOverlapError, NoOverlapError):
             stars.append(None)
-            overlap_fail_count += 1
+            n_overlap_failed += 1
             continue
 
         # Extract data cutout
@@ -1198,7 +1228,7 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
         weights_cutout, has_nonfinite = _create_weights_cutout(
             uncertainty_info, data_mask, large_slc)
         if has_nonfinite:
-            nonfinite_weights_count += 1
+            n_nonfinite_weights += 1
 
         origin = (large_slc[1].start, large_slc[0].start)
         cutout_center = (xcenter - origin[0], ycenter - origin[1])
@@ -1216,16 +1246,22 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
             stars.append(star)
 
             # Track stars with all-zero data
-            if hasattr(star, '_has_all_zero_data') and star._has_all_zero_data:
+            if star._has_all_zero_data:
                 all_zero_stars.append((xcenter, ycenter))
         except ValueError as exc:
             # Collect flux estimation failures; emit warnings later
             flux_failures.append((xcenter, ycenter, exc))
             stars.append(None)
 
+    # Emit consolidated warning for non-finite positions
+    if n_nonfinite_positions > 0:
+        msg = (f'{n_nonfinite_positions} star(s) were not extracted '
+               'because their (x, y) positions were not finite.')
+        warnings.warn(msg, AstropyUserWarning)
+
     # Emit consolidated warning for non-finite weights
-    if nonfinite_weights_count > 0:
-        msg = (f'{nonfinite_weights_count} star cutout(s) had '
+    if n_nonfinite_weights > 0:
+        msg = (f'{n_nonfinite_weights} star cutout(s) had '
                'non-finite weight values which were set to zero. '
                'Please check the input uncertainty values in the '
                'NDData object.')
@@ -1246,7 +1282,7 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
                'unmasked data values equal to zero')
         warnings.warn(msg, AstropyUserWarning)
 
-    return stars, overlap_fail_count
+    return stars, n_overlap_failed
 
 
 def _prepare_uncertainty_info(data):
@@ -1268,11 +1304,10 @@ def _prepare_uncertainty_info(data):
         A dictionary with keys:
         - 'type' : str
             One of 'none', 'weights', or 'uncertainty'.
-        - 'array' : `~numpy.ndarray` (only if type='weights')
-            The weight array from the input data.
-        - 'uncertainty' : `~astropy.nddata.NDUncertainty` (only if
+        - 'array' : `~numpy.ndarray` (only if type='weights' or
             type='uncertainty')
-            The uncertainty object for on-the-fly conversion to weights.
+            The weight array (type='weights') or the standard
+            deviation array (type='uncertainty') from the input data.
     """
     if data.uncertainty is None:
         return {'type': 'none'}
@@ -1283,10 +1318,19 @@ def _prepare_uncertainty_info(data):
             'array': data.uncertainty.array,
         }
 
-    # For other uncertainties, prepare the conversion
+    # For other uncertainties, convert the full array to standard
+    # deviation once so that cutouts only need to be sliced
+    uncertainty = data.uncertainty
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        if hasattr(uncertainty, 'represent_as'):
+            stddev_array = uncertainty.represent_as(StdDevUncertainty).array
+        else:
+            stddev_array = uncertainty.array
+
     return {
         'type': 'uncertainty',
-        'uncertainty': data.uncertainty,
+        'array': stddev_array,
     }
 
 
@@ -1322,20 +1366,15 @@ def _create_weights_cutout(uncertainty_info, data_mask, slices):
     if uncertainty_info['type'] == 'none':
         weights_cutout = np.ones(cutout_shape, dtype=float)
     elif uncertainty_info['type'] == 'weights':
-        weights_cutout = np.asarray(
+        # Copy so that modifications below (e.g., masking) do not
+        # propagate back to the user's input array
+        weights_cutout = np.array(
             uncertainty_info['array'][slices], dtype=float)
     else:
-        # Convert uncertainty to weights for this cutout only
-        uncertainty_cutout = uncertainty_info['uncertainty'].array[slices]
+        # Convert the standard deviation cutout to weights
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            # Convert to standard deviation representation if needed
-            if hasattr(uncertainty_info['uncertainty'], 'represent_as'):
-                uncertainty_cutout = (
-                    uncertainty_info['uncertainty']
-                    .represent_as(StdDevUncertainty).array[slices])
-            # First compute weights, then check for non-finite values
-            weights_cutout = 1.0 / uncertainty_cutout
+            weights_cutout = 1.0 / uncertainty_info['array'][slices]
 
     # Check for non-finite weights and track if found
     has_nonfinite = not np.all(np.isfinite(weights_cutout))

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -320,19 +320,26 @@ class TestEPSFValidator:
             _EPSFValidator.validate_shape_compatibility(stars, (2, 2),
                                                         shape=(5, 5))
 
-    def test_validate_shape_compatibility_even_dimensions_warning(self):
+    def test_validate_shape_compatibility_minimum_shape(self):
         """
-        Test shape compatibility with even dimensions warning.
+        Test that the minimum-shape rule matches compute_epsf_shape (add
+        1 only when the star size times oversampling is even).
         """
-        data = np.ones((5, 5))
-        star = EPSFStar(data, cutout_center=(2, 2))
+        data = np.ones((11, 11))
+        star = EPSFStar(data, cutout_center=(5, 5))
         stars = EPSFStars([star])
 
-        # Test even dimensions trigger warning
-        match = 'ePSF shape .* has even dimensions'
-        with pytest.warns(UserWarning, match=match):
-            _EPSFValidator.validate_shape_compatibility(stars, (1, 1),
-                                                        shape=(20, 20))
+        # 11 * 1 = 11 (odd), so shape (11, 11) is compatible
+        _EPSFValidator.validate_shape_compatibility(stars, (1, 1),
+                                                    shape=(11, 11))
+
+        # 11 * 2 = 22 (even), so the minimum shape is (23, 23)
+        match = r'Requested ePSF shape .* is incompatible'
+        with pytest.raises(ValueError, match=match):
+            _EPSFValidator.validate_shape_compatibility(stars, (2, 2),
+                                                        shape=(21, 21))
+        _EPSFValidator.validate_shape_compatibility(stars, (2, 2),
+                                                    shape=(23, 23))
 
     def test_validate_stars_empty_list(self):
         """
@@ -786,7 +793,7 @@ class TestEPSFBuildResults:
         assert result.epsf is not None
         assert result.fitted_stars is not None
         assert isinstance(result.iterations, int)
-        assert isinstance(result.converged, (bool, np.bool_))
+        assert isinstance(result.converged, bool)
         assert isinstance(result.final_center_accuracy, (float, np.floating))
         assert isinstance(result.n_excluded_stars, int)
         assert isinstance(result.excluded_star_indices, list)
@@ -938,26 +945,27 @@ class TestEPSFFitter:
 
     def test_weights_not_supported(self, epsf_fitter_data):
         """
-        Test EPSFFitter when fitter raises TypeError for weights.
+        Test EPSFFitter with a fitter whose signature does not accept
+        weights.
+
+        The weights are dropped based on the fitter call signature.
         """
         stars = epsf_fitter_data['stars']
         epsf = epsf_fitter_data['epsf']
 
-        # Create a fitter that raises TypeError when weights is passed
+        # Create a fitter whose signature has no weights keyword
         class NoWeightsFitter:
             def __init__(self):
                 self.fit_info = {'ierr': 1}
 
-            def __call__(self, model, *_args, **kwargs):
-                if 'weights' in kwargs:
-                    msg = 'weights not supported'
-                    raise TypeError(msg)
+            def __call__(self, model, x, y, z):  # noqa: ARG002
                 return model
 
         no_weights_fitter = NoWeightsFitter()
         fitter = _make_epsf_fitter(fitter=no_weights_fitter)
+        assert not fitter._fitter_accepts_weights
 
-        # Fit the stars - should handle TypeError gracefully
+        # Fit the stars - the fitter is called without weights
         fitted_stars = fitter(epsf, stars)
         assert len(fitted_stars) == len(stars)
 
@@ -1010,15 +1018,7 @@ class TestEPSFFitter:
         stars = epsf_fitter_data['stars']
         epsf = epsf_fitter_data['epsf']
 
-        # Create mock WCS that returns identity transform
-        class MockWCS:
-            def pixel_to_world_values(self, x, y):
-                return x, y
-
-            def world_to_pixel_values(self, ra, dec):
-                return ra, dec
-
-        mock_wcs = MockWCS()
+        mock_wcs = _MockWCS()
 
         # Create EPSFStar objects with mock WCS
         linked_stars_list = []
@@ -1067,20 +1067,13 @@ class TestEPSFFitter:
         """
         Test EPSFFitter with LinkedEPSFStar containing excluded star.
 
-        This tests lines 825, 856-860 (excluded star in LinkedEPSFStar).
+        Excluded stars within a LinkedEPSFStar are passed through
+        unchanged while the remaining linked stars are fitted.
         """
         stars = epsf_fitter_data['stars']
         epsf = epsf_fitter_data['epsf']
 
-        # Create mock WCS
-        class MockWCS:
-            def pixel_to_world_values(self, x, y):
-                return x, y
-
-            def world_to_pixel_values(self, ra, dec):
-                return ra, dec
-
-        mock_wcs = MockWCS()
+        mock_wcs = _MockWCS()
 
         # Create LinkedEPSFStar with two stars, one excluded
         linked_stars_list = []
@@ -1196,10 +1189,18 @@ class TestEPSFBuilder:
         with pytest.raises(ValueError, match=match):
             EPSFBuilder(oversampling=[-1, 4])
 
-        for sigma_clip in [None, [], 'a']:
+        for sigma_clip in [[], 'a']:
             match = 'sigma_clip must be an astropy.stats.SigmaClip instance'
             with pytest.raises(TypeError, match=match):
                 EPSFBuilder(sigma_clip=sigma_clip)
+
+        match = 'fitter_maxiters must be an integer'
+        with pytest.raises(TypeError, match=match):
+            EPSFBuilder(fitter_maxiters=2.5)
+
+        match = 'fitter_maxiters must be a positive integer'
+        with pytest.raises(ValueError, match=match):
+            EPSFBuilder(fitter_maxiters=-5)
 
     def test_fitter_options(self):
         """
@@ -1402,6 +1403,119 @@ class TestEPSFBuilder:
         assert epsf is not None
         assert epsf.data.shape == shape
 
+    def test_even_shape_made_odd(self, epsf_test_data):
+        """
+        Test that an even input shape is made odd by adding one, with
+        a warning, as documented.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:3], size=11)
+
+        match = 'has even values'
+        with pytest.warns(AstropyUserWarning, match=match):
+            builder = EPSFBuilder(oversampling=1, shape=(24, 24),
+                                  maxiters=1, progress_bar=False)
+        assert_array_equal(builder.shape, (25, 25))
+
+        epsf, _ = builder(stars)
+        assert epsf.data.shape == (25, 25)
+
+    def test_shape_equal_to_star_size(self, epsf_test_data):
+        """
+        Test that a shape equal to the star size times the (odd product)
+        oversampling is accepted, consistent with the automatically
+        derived shape.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:3], size=11)
+
+        builder = EPSFBuilder(oversampling=1, shape=(11, 11),
+                              maxiters=1, progress_bar=False)
+        epsf, _ = builder(stars)
+        assert epsf.data.shape == (11, 11)
+
+    def test_sigma_clip_none(self, epsf_test_data):
+        """
+        Test that sigma_clip=None (no sigma clipping) is supported.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:5], size=11)
+
+        builder = EPSFBuilder(oversampling=1, maxiters=2,
+                              sigma_clip=None, progress_bar=False)
+        assert builder._sigma_clip is None
+        result = builder(stars)
+        assert result.epsf is not None
+        assert result.epsf.data.shape == (11, 11)
+
+    def test_build_epsf_resume(self, epsf_test_data):
+        """
+        Test resuming a build from a previously built ePSF and that a
+        mismatched initial-ePSF oversampling is rejected.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:5], size=11)
+
+        builder = EPSFBuilder(oversampling=1, maxiters=2,
+                              progress_bar=False)
+        result1 = builder.build_epsf(stars)
+
+        # Resume from the previous ePSF with matching oversampling
+        result2 = builder.build_epsf(stars, epsf=result1.epsf)
+        assert isinstance(result2, EPSFBuildResults)
+        assert result2.epsf.data.shape == result1.epsf.data.shape
+
+        # A mismatched initial-ePSF oversampling raises an error
+        builder4 = EPSFBuilder(oversampling=4, maxiters=2,
+                               progress_bar=False)
+        epsf_bad = ImagePSF(np.zeros((45, 45)), oversampling=2)
+        match = 'oversampling'
+        with pytest.raises(ValueError, match=match):
+            builder4.build_epsf(stars, epsf=epsf_bad)
+
+    def test_build_results_len(self, epsf_test_data):
+        """
+        Test that EPSFBuildResults has length 2 for tuple unpacking.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:3], size=11)
+        builder = EPSFBuilder(oversampling=1, maxiters=1,
+                              progress_bar=False)
+        result = builder(stars)
+        assert len(result) == 2
+
+    def test_numpy_scalar_parameters(self):
+        """
+        Test that NumPy scalar center_accuracy and maxiters values
+        are accepted, while bool maxiters values are rejected.
+        """
+        builder = EPSFBuilder(center_accuracy=np.float32(0.01),
+                              maxiters=np.int64(5))
+        assert builder.maxiters == 5
+
+        match = 'maxiters must be an integer'
+        with pytest.raises(TypeError, match=match):
+            EPSFBuilder(maxiters=True)
+
+    def test_smoothing_kernel_1d_raises(self):
+        """
+        Test that a 1D custom smoothing kernel raises a ValueError.
+        """
+        match = 'smoothing_kernel must be a 2D array'
+        with pytest.raises(ValueError, match=match):
+            _SmoothingKernel.get_kernel(np.ones(5))
+
+    def test_coord_transformer_deprecated(self):
+        """
+        Test that the public coord_transformer attribute is
+        deprecated.
+        """
+        builder = EPSFBuilder(maxiters=1, progress_bar=False)
+        with pytest.warns(AstropyDeprecationWarning,
+                          match='coord_transformer'):
+            transformer = builder.coord_transformer
+        assert transformer is builder._coord_transformer
+
     def test_check_convergence_no_good_stars(self):
         """
         Test EPSFBuilder._check_convergence with no good stars.
@@ -1421,8 +1535,8 @@ class TestEPSFBuilder:
 
         # Should return False (not converged) when no good stars
         assert converged is False
-        # center_dist_sq should be high to prevent false convergence
-        assert center_dist_sq[0] > builder.center_accuracy_sq
+        # No center movement could be measured
+        assert np.isnan(center_dist_sq[0])
 
     def test_resample_residuals_no_good_stars(self, epsf_test_data):
         """
@@ -1719,52 +1833,27 @@ class TestEPSFBuilder:
 
     def test_build_tracks_excluded_indices(self, epsf_test_data):
         """
-        Test that build_epsf properly tracks excluded star indices.
+        Test that build_epsf tracks the excluded star indices.
         """
-        stars = extract_stars(epsf_test_data['nddata'],
-                              epsf_test_data['init_stars'][:10], size=11)
+        # The first star is placed near the image corner so that
+        # its fitting region extends beyond the cutout and it is
+        # excluded after repeated fit failures (same setup as
+        # test_star_exclusion).
+        tbl = epsf_test_data['init_stars'][:5].copy()
+        tbl['x'][0] = 465
+        tbl['y'][0] = 30
+        stars = extract_stars(epsf_test_data['nddata'], tbl, size=11)
 
-        # Create a fitter that:
-        # 1. Adds noise to centers to prevent convergence
-        # 2. Fails first 3 stars on iteration 4+
-        n_stars = len(stars.all_stars)
-
-        class NoConvergeFitter:
-            def __init__(self):
-                self.star_count = 0
-                self.fit_info = {'ierr': 1}
-
-            def __call__(self, model, *_args, **_kwargs):
-                self.star_count += 1
-                iteration = self.star_count // n_stars + 1
-                star_idx = (self.star_count - 1) % n_stars
-
-                # On iteration 4+, fail first 3 stars
-                if iteration > 4 and star_idx < 3:
-                    self.fit_info = {'ierr': 0}  # Invalid
-                else:
-                    self.fit_info = {'ierr': 1}  # Valid
-
-                # Add slight offset to x_0 to prevent convergence
-                model.x_0 = model.x_0 + 0.01 * (iteration % 2)
-                return model
-
-        fitter_obj = NoConvergeFitter()
-        builder = EPSFBuilder(oversampling=1, maxiters=7,
-                              progress_bar=False,
-                              fitter=fitter_obj,
-                              center_accuracy=1e-6)
-
-        # Build - this should trigger exclusion tracking
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+        builder = EPSFBuilder(oversampling=1, maxiters=5,
+                              progress_bar=False)
+        match = 'has been excluded from ePSF fitting'
+        with pytest.warns(AstropyUserWarning, match=match):
             result = builder(stars)
 
-        # Check that excluded_star_indices was populated
-        assert hasattr(result, 'excluded_star_indices')
-        assert isinstance(result.excluded_star_indices, list)
-        # We may or may not have excluded stars depending on exact timing
-        assert result.n_excluded_stars >= 0
+        assert result.excluded_star_indices == [0]
+        assert result.n_excluded_stars == 1
+        assert all(type(idx) is int
+                   for idx in result.excluded_star_indices)
 
     def test_build_step_origin_is_none_branch(self, epsf_test_data):
         """
@@ -1965,15 +2054,7 @@ class TestEPSFBuilder:
         builder = EPSFBuilder(oversampling=1, maxiters=2, progress_bar=False)
         epsf, _ = builder(stars)
 
-        # Create mock WCS
-        class MockWCS:
-            def pixel_to_world_values(self, x, y):
-                return x, y
-
-            def world_to_pixel_values(self, ra, dec):
-                return ra, dec
-
-        mock_wcs = MockWCS()
+        mock_wcs = _MockWCS()
 
         # Create LinkedEPSFStar from first two stars
         linked_stars_list = []
@@ -2014,15 +2095,7 @@ class TestEPSFBuilder:
         builder = EPSFBuilder(oversampling=1, maxiters=2, progress_bar=False)
         epsf, _ = builder(stars)
 
-        # Create mock WCS
-        class MockWCS:
-            def pixel_to_world_values(self, x, y):
-                return x, y
-
-            def world_to_pixel_values(self, ra, dec):
-                return ra, dec
-
-        mock_wcs = MockWCS()
+        mock_wcs = _MockWCS()
 
         # Create LinkedEPSFStar with one excluded star
         linked_stars_list = []
@@ -2125,9 +2198,33 @@ class TestEPSFBuilder:
         # Create zero-sum ePSF data
         epsf_data = np.zeros((5, 5))
 
-        match = 'Cannot normalize ePSF: data sum is zero'
+        match = 'Cannot normalize ePSF'
         with pytest.raises(ValueError, match=match):
             builder._normalize_epsf(epsf_data)
+
+        # Non-finite sums are also rejected
+        epsf_data = np.full((5, 5), np.nan)
+        with pytest.raises(ValueError, match=match):
+            builder._normalize_epsf(epsf_data)
+
+    def test_normalize_epsf_nonfinite_recentering(self, epsf_test_data):
+        """
+        Test that a recentering function returning non-finite centroids
+        produces a clear error during building.
+        """
+        stars = extract_stars(epsf_test_data['nddata'],
+                              epsf_test_data['init_stars'][:3], size=11)
+
+        def bad_centroid(data, *, mask=None):  # noqa: ARG001
+            return (np.nan, np.nan)
+
+        builder = EPSFBuilder(oversampling=1, maxiters=2,
+                              recentering_func=bad_centroid,
+                              progress_bar=False)
+
+        match = 'Cannot normalize ePSF'
+        with pytest.raises(ValueError, match=match):
+            builder(stars)
 
     @pytest.mark.parametrize('oversamp', [1, 2, 3, 4, 5])
     def test_build_oversampling(self, oversamp):
@@ -2251,15 +2348,7 @@ class TestEPSFBuilder:
         result = builder(stars)
         epsf = result.epsf
 
-        # Create mock WCS
-        class MockWCS:
-            def pixel_to_world_values(self, x, y):
-                return x, y
-
-            def world_to_pixel_values(self, ra, dec):
-                return ra, dec
-
-        mock_wcs = MockWCS()
+        mock_wcs = _MockWCS()
 
         # Create LinkedEPSFStar with two stars, one excluded
         linked_stars_list = []
@@ -2286,25 +2375,26 @@ class TestEPSFBuilder:
 
     def test_fit_star_fitter_without_weights(self, epsf_test_data):
         """
-        Test _fit_star with fitter that doesn't support weights.
+        Test _fit_star with a fitter whose signature does not accept
+        weights.
+
+        The weights are dropped based on the fitter call signature.
         """
         stars = extract_stars(epsf_test_data['nddata'],
                               epsf_test_data['init_stars'][:2], size=11)
 
-        # Create a fitter that raises TypeError when weights is passed
+        # Create a fitter whose signature has no weights keyword
         class NoWeightsFitter:
             def __init__(self):
                 self.fit_info = {'ierr': 1}
 
-            def __call__(self, model, *_args, **kwargs):
-                if 'weights' in kwargs:
-                    msg = 'weights not supported'
-                    raise TypeError(msg)
+            def __call__(self, model, x, y, z, maxiter=None):  # noqa: ARG002
                 return model
 
         no_weights_fitter = NoWeightsFitter()
         builder = EPSFBuilder(oversampling=1, maxiters=1, progress_bar=False,
                               fitter=no_weights_fitter)
+        assert not builder._fitter_accepts_weights
 
         # Build initial ePSF
         result = builder(stars)

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -2378,11 +2378,13 @@ class TestEPSFBuilder:
         result = builder(stars)
         epsf = result.epsf
 
-        # Create EPSFStars with invalid star type
+        # Create EPSFStars holding an invalid star type (bypass the
+        # EPSFStars constructor validation)
         class InvalidStar:
             pass
 
-        invalid_stars = EPSFStars([InvalidStar()])
+        invalid_stars = EPSFStars([])
+        invalid_stars._data.append(InvalidStar())
 
         # Call _fit_stars with invalid star type
         match = 'stars must contain only EPSFStar and/or LinkedEPSFStar'

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -7,6 +7,7 @@ import copy
 import warnings
 from multiprocessing.reduction import ForkingPickler
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
@@ -197,7 +198,13 @@ def test_prepare_uncertainty_info_variants():
 
     info = _prepare_uncertainty_info(data)
     assert info['type'] == 'uncertainty'
-    assert 'uncertainty' in info
+    assert_allclose(info['array'], np.ones((5, 5)) * 0.1)
+
+    # Test variance uncertainty (converted to standard deviation)
+    data.uncertainty = VarianceUncertainty(np.ones((5, 5)) * 0.04)
+    info = _prepare_uncertainty_info(data)
+    assert info['type'] == 'uncertainty'
+    assert_allclose(info['array'], np.ones((5, 5)) * 0.2)
 
 
 def test_create_weights_cutout():
@@ -227,11 +234,10 @@ def test_create_weights_cutout_with_uncertainty():
     """
     Test weights cutout creation with uncertainty.
     """
-    # Create uncertainty info
-    uncertainty = StdDevUncertainty(np.ones((5, 5)) * 0.1)
+    # Create uncertainty info with a standard deviation array
     info = {
         'type': 'uncertainty',
-        'uncertainty': uncertainty,
+        'array': np.ones((5, 5)) * 0.1,
     }
 
     slices = (slice(1, 4), slice(1, 4))
@@ -331,12 +337,9 @@ class TestEPSFStar:
         bad_weights[2, 2] = np.inf
         bad_weights[1, 1] = np.nan
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'Non-finite weight values'
+        with pytest.warns(AstropyUserWarning, match=match):
             star = EPSFStar(data, weights=bad_weights)
-            assert len(w) == 1
-            assert issubclass(w[0].category, AstropyUserWarning)
-            assert 'Non-finite weight values' in str(w[0].message)
 
         # Check that non-finite weights were set to zero
         assert star.weights[2, 2] == 0.0
@@ -352,20 +355,19 @@ class TestEPSFStar:
         data[3, 3] = np.nan
         data[4, 4] = np.inf
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'contains invalid data'
+        with pytest.warns(AstropyUserWarning, match=match):
             star = EPSFStar(data)
-            # Should mask invalid pixels
-            assert star.mask[1, 1]
-            assert star.mask[2, 2]
-            assert star.mask[3, 3]
-            assert star.mask[4, 4]
-            assert star.weights[1, 1] == 0.0
-            assert star.weights[2, 2] == 0.0
-            assert star.weights[3, 3] == 0.0
-            assert star.weights[4, 4] == 0.0
-            # Check that warning was issued about invalid data
-            assert len(w) > 0
+
+        # Should mask invalid pixels
+        assert star.mask[1, 1]
+        assert star.mask[2, 2]
+        assert star.mask[3, 3]
+        assert star.mask[4, 4]
+        assert star.weights[1, 1] == 0.0
+        assert star.weights[2, 2] == 0.0
+        assert star.weights[3, 3] == 0.0
+        assert star.weights[4, 4] == 0.0
 
     def test_cutout_center_validation(self):
         """
@@ -385,14 +387,9 @@ class TestEPSFStar:
             star.cutout_center = [np.nan, 2.0]
 
         # Test bounds warnings (should warn but not raise)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'outside the cutout bounds'
+        with pytest.warns(AstropyUserWarning, match=match):
             star.cutout_center = [-1, 2]  # Outside bounds
-            assert len(w) >= 1
-            # Check that warning mentions coordinates outside bounds
-            warning_messages = [str(warning.message) for warning in w]
-            assert any('outside the cutout bounds' in msg
-                       for msg in warning_messages)
 
     def test_origin_validation(self):
         """
@@ -409,6 +406,20 @@ class TestEPSFStar:
         match = 'Origin coordinates must be finite'
         with pytest.raises(ValueError, match=match):
             EPSFStar(data, origin=[np.inf, 2])
+
+        # Test scalar origin
+        match = 'Origin must have exactly 2 elements'
+        with pytest.raises(ValueError, match=match):
+            EPSFStar(data, origin=5)
+
+    def test_quantity_data_rejected(self):
+        """
+        Test that Quantity data inputs raise a clear TypeError.
+        """
+        data = np.ones((5, 5)) * u.Jy
+        match = 'Quantity inputs are not supported'
+        with pytest.raises(TypeError, match=match):
+            EPSFStar(data)
 
     def test_estimate_flux_masked_data(self):
         """
@@ -495,13 +506,9 @@ class TestEPSFStar:
         data = np.zeros((5, 5))
 
         # EPSFStar should emit warning when called directly
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'All unmasked data values in star cutout are zero'
+        with pytest.warns(AstropyUserWarning, match=match):
             star = EPSFStar(data)
-            # Should have warning about all-zero data
-            warning_messages = [str(warning.message) for warning in w]
-            assert any('All unmasked data values' in msg and 'zero' in msg
-                       for msg in warning_messages)
 
         # Star should be created with flux=0 and flag set
         assert star.flux == 0.0
@@ -518,6 +525,21 @@ class TestEPSFStar:
         # Test that __array__ returns the data
         star_array = star.__array__()
         assert_array_equal(star_array, data)
+
+    def test_array_copy_false(self):
+        """
+        Test that np.array(star, copy=False) works without warnings
+        (NumPy 2 __array__ signature) and that the default is a copy.
+        """
+        data = np.random.default_rng(42).random((5, 5))
+        star = EPSFStar(data)
+
+        arr = np.array(star, copy=False)
+        assert_array_equal(arr, data)
+
+        arr = np.array(star)
+        arr[0, 0] = -100.0
+        assert star.data[0, 0] != -100.0
 
     def test_properties(self):
         """
@@ -662,22 +684,13 @@ class TestEPSFStar:
         star = EPSFStar(data)
 
         # Test y-coordinate outside bounds
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'y-coordinate .* is outside the cutout bounds'
+        with pytest.warns(AstropyUserWarning, match=match):
             star.cutout_center = (2.0, -1.0)  # y < 0
-            assert len(w) >= 1
-            warning_messages = [str(warning.message) for warning in w]
-            assert any('y-coordinate' in msg and 'outside' in msg
-                       for msg in warning_messages)
 
         # Test y-coordinate at upper bound
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with pytest.warns(AstropyUserWarning, match=match):
             star.cutout_center = (2.0, 6.0)  # y >= shape[0]
-            assert len(w) >= 1
-            warning_messages = [str(warning.message) for warning in w]
-            assert any('y-coordinate' in msg and 'outside' in msg
-                       for msg in warning_messages)
 
     def test_empty_data_validation(self):
         """
@@ -736,6 +749,10 @@ class TestEPSFStars:
         with pytest.raises(TypeError, match=match):
             EPSFStars('invalid')
 
+        # Test list with invalid element types
+        with pytest.raises(TypeError, match=match):
+            EPSFStars([star1, 'not_a_star'])
+
     def test_indexing_operations(self):
         """
         Test indexing and slicing operations.
@@ -758,6 +775,24 @@ class TestEPSFStars:
             count += 1
             assert isinstance(star, EPSFStar)
         assert count == 2
+
+    def test_delitem_invalidates_caches(self):
+        """
+        Regression test that deleting a star invalidates the cached
+        star counts and flat star list.
+        """
+        stars = [EPSFStar(np.ones((5, 5))) for _ in range(3)]
+        stars_obj = EPSFStars(stars)
+
+        # Populate the cached properties
+        assert stars_obj.n_stars == 3
+        assert stars_obj.n_all_stars == 3
+        assert len(stars_obj.all_stars) == 3
+
+        del stars_obj[0]
+        assert stars_obj.n_stars == len(stars_obj)
+        assert stars_obj.n_all_stars == len(stars_obj)
+        assert len(stars_obj.all_stars) == len(stars_obj)
 
     def test_pickle_operations(self):
         """
@@ -850,9 +885,38 @@ class TestEPSFStars:
         Verify that EPSFStars can be successfully pickled/unpickled for
         multiprocessing.
         """
-        # This should not fail
-        stars = EPSFStars([1])
-        ForkingPickler.loads(ForkingPickler.dumps(stars))
+        data = np.random.default_rng(42).random((5, 5))
+        stars = EPSFStars([EPSFStar(data)])
+        unpickled = ForkingPickler.loads(ForkingPickler.dumps(stars))
+        assert len(unpickled) == 1
+        assert_array_equal(unpickled[0].data, data)
+
+    def test_getattr_with_linked_stars(self, simple_wcs):
+        """
+        Regression test that attribute delegation works for a mix of
+        EPSFStar and multi-star LinkedEPSFStar objects (ragged
+        per-star values return an object array).
+        """
+        star = EPSFStar(np.ones((5, 5)))
+        linked_star1 = EPSFStar(np.ones((7, 7)), wcs_large=simple_wcs)
+        linked_star2 = EPSFStar(np.ones((9, 9)), wcs_large=simple_wcs)
+        linked = LinkedEPSFStar([linked_star1, linked_star2])
+        stars = EPSFStars([star, linked])
+
+        centers = stars.cutout_center
+        assert len(centers) == 2
+        assert_array_equal(centers[0], star.cutout_center)
+        assert_array_equal(centers[1], linked.cutout_center)
+
+        fluxes = stars.flux
+        assert len(fluxes) == 2
+        assert fluxes[0] == star.flux
+        assert_array_equal(fluxes[1], linked.flux)
+
+        excluded = stars._excluded_from_fit
+        assert len(excluded) == 2
+        assert not excluded[0]
+        assert_array_equal(excluded[1], [False, False])
 
     def test_cutout_center_flat_with_linked_stars(self, simple_wcs):
         """
@@ -938,13 +1002,9 @@ class TestLinkedEPSFStar:
         linked = LinkedEPSFStar([star1, star2])
 
         # Should warn about no good stars
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'have all been excluded'
+        with pytest.warns(AstropyUserWarning, match=match):
             linked.constrain_centers()
-            assert len(w) >= 1
-            warning_messages = [str(warning.message) for warning in w]
-            assert any('have all been excluded' in msg
-                       for msg in warning_messages)
 
     def test_constraint_single_star(self, simple_wcs):
         """
@@ -1032,14 +1092,9 @@ class TestLinkedEPSFStar:
         linked = LinkedEPSFStar([star1, star2])
 
         # Should trigger early return and emit warning
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'Cannot constrain centers'
+        with pytest.warns(AstropyUserWarning, match=match):
             linked.constrain_centers()
-            # Should get warning about no good stars
-            warning_messages = [str(warning.message) for warning in w]
-            has_warning = any('Cannot constrain centers' in msg
-                              for msg in warning_messages)
-            assert has_warning
 
     def test_len_getitem_iter(self, simple_wcs):
         """
@@ -1095,6 +1150,22 @@ class TestLinkedEPSFStar:
         flux = linked.flux
         assert flux == star.flux
         assert not isinstance(flux, np.ndarray)
+
+    def test_excluded_from_fit_delegation(self, simple_wcs):
+        """
+        Regression test that _excluded_from_fit returns a per-star
+        array instead of raising AttributeError.
+        """
+        star1 = EPSFStar(np.ones((5, 5)), wcs_large=simple_wcs)
+        star2 = EPSFStar(np.ones((7, 7)), wcs_large=simple_wcs)
+        linked = LinkedEPSFStar([star1, star2])
+
+        excluded = linked._excluded_from_fit
+        assert_array_equal(excluded, [False, False])
+
+        star2._excluded_from_fit = True
+        excluded = linked._excluded_from_fit
+        assert_array_equal(excluded, [False, True])
 
     def test_getattr_private_attribute_error(self, simple_wcs):
         """
@@ -1215,14 +1286,10 @@ class TestExtractStars:
         empty_table['x'] = []
         empty_table['y'] = []
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'is empty'
+        with pytest.warns(AstropyUserWarning, match=match):
             stars = extract_stars(simple_nddata, empty_table)
-            assert len(stars) == 0
-            # Should warn about empty catalog
-            assert len(w) >= 1
-            warning_messages = [str(warning.message) for warning in w]
-            assert any('empty' in msg.lower() for msg in warning_messages)
+        assert len(stars) == 0
 
     def test_stars_outside_image(self, simple_nddata):
         """
@@ -1232,14 +1299,10 @@ class TestExtractStars:
         table['x'] = [-10, 100]  # Outside image bounds
         table['y'] = [25, 25]
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = '2 star\\(s\\) were not extracted'
+        with pytest.warns(AstropyUserWarning, match=match):
             stars = extract_stars(simple_nddata, table, size=11)
-            assert len(stars) == 0
-            # Should warn about excluded stars
-            assert len(w) >= 1
-            warning_messages = [str(warning.message) for warning in w]
-            assert any('not extracted' in msg for msg in warning_messages)
+        assert len(stars) == 0
 
     def test_invalid_input_types(self, simple_nddata):
         """
@@ -1340,8 +1403,10 @@ class TestExtractStars:
 
         stars = extract_stars(nddata_with_wcs, table, size=(11, 11))
 
-        valid_stars = [s for s in stars.all_stars if s is not None]
-        assert len(valid_stars) >= 1
+        # The WCS reference pixel (1-based crpix [25, 25]) maps the
+        # (0, 0) sky position to the 0-based pixel position (24, 24)
+        assert len(stars) == 1
+        assert_allclose(stars[0].center, (24, 24))
 
     def test_extract_stars_size_validation_coverage(self, simple_nddata):
         """
@@ -1469,13 +1534,12 @@ class TestExtractStars:
         table = Table()
         table['skycoord'] = [SkyCoord(0, 0, unit='deg')]  # Center
 
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter('always')
+        match = '1 star\\(s\\) were not extracted'
+        with pytest.warns(AstropyUserWarning, match=match):
             stars = extract_stars([nddata1, nddata2], table, size=11)
 
-        # Should have extracted at least 1 star (from first image)
         # The second image star is outside bounds so only 1 is extracted
-        assert len(stars) >= 1
+        assert len(stars) == 1
 
     def test_extract_stars_flux_column(self):
         """
@@ -1576,16 +1640,54 @@ class TestExtractStars:
 
         table = Table({'x': [25], 'y': [25]})
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        match = 'non-finite weight values'
+        with pytest.warns(AstropyUserWarning, match=match):
             stars = extract_stars(nddata, table, size=11)
-            # Should warn about non-finite weights
-            warning_messages = [str(warning.message) for warning in w]
-            assert any('non-finite weight values' in msg
-                       for msg in warning_messages)
 
         # Star should still be extracted (non-finite weights set to 0)
         assert len(stars) == 1
+
+    def test_extract_stars_weights_input_not_modified(self):
+        """
+        Regression test that extract_stars does not modify a
+        user-supplied float weights uncertainty array when masking is
+        applied, and that masked pixels get zero weight in the star.
+        """
+        class WeightsUncertainty(StdDevUncertainty):
+            @property
+            def uncertainty_type(self):
+                return 'weights'
+
+        data = np.ones((50, 50))
+        weights = np.ones((50, 50))
+        weights_orig = weights.copy()
+        mask = np.zeros((50, 50), dtype=bool)
+        mask[25, 25] = True
+        nddata = NDData(data, uncertainty=WeightsUncertainty(weights),
+                        mask=mask)
+
+        table = Table({'x': [25.0], 'y': [25.0]})
+        stars = extract_stars(nddata, table, size=11)
+
+        assert len(stars) == 1
+        # The masked pixel has zero weight in the star cutout
+        assert stars[0].weights[5, 5] == 0.0
+        # The user's weights array is unchanged
+        assert_array_equal(weights, weights_orig)
+
+    def test_extract_stars_nonfinite_positions(self, simple_nddata):
+        """
+        Regression test that non-finite source positions are skipped
+        with a warning instead of raising an error.
+        """
+        table = Table({'x': [25.0, np.nan], 'y': [25.0, 30.0]})
+
+        match = 'positions were not finite'
+        with pytest.warns(AstropyUserWarning, match=match):
+            stars = extract_stars(simple_nddata, table, size=11)
+
+        assert len(stars) == 1
+        assert_allclose(stars[0].center, (25, 25))
 
     def test_extract_stars_all_zero_data_warnings(self):
         """
@@ -1660,13 +1762,14 @@ class TestExtractStars:
         with pytest.raises(ValueError, match=match):
             extract_stars(nddata, table, size=11)
 
-    def test_validate_multiple_catalogs_skycoord_only_no_wcs(self, simple_wcs):
+    def test_validate_multiple_catalogs_mixed_wcs(self, simple_wcs):
         """
-        Test validation when catalog has only skycoord and some NDData
-        objects lack WCS.
+        Test validation with multiple catalogs where each catalog
+        pairs with a usable image.
 
-        This tests the branch where the corresponding NDData has WCS,
-        but another NDData in the list does not have WCS.
+        A missing WCS is allowed on an image whose catalog has pixel
+        coordinates. A skycoord-only catalog requires a WCS only on
+        its corresponding image.
         """
         nddata1 = NDData(np.ones((50, 50)))
         # nddata1 intentionally has no WCS
@@ -1679,10 +1782,17 @@ class TestExtractStars:
         table2 = Table()
         table2['skycoord'] = [SkyCoord(0, 0, unit='deg')]
 
-        # nddata2 has WCS, but nddata1 does not
-        match = 'each NDData object must have a wcs'
+        # Each catalog pairs with a usable image, so extraction
+        # succeeds
+        stars = extract_stars([nddata1, nddata2], [table1, table2],
+                              size=11)
+        assert len(stars) == 2
+
+        # A skycoord-only catalog paired with an image lacking a WCS
+        # raises an error
+        match = 'the corresponding NDData object must have a wcs'
         with pytest.raises(ValueError, match=match):
-            extract_stars([nddata1, nddata2], [table1, table2], size=11)
+            extract_stars([nddata1, nddata2], [table2, table1], size=11)
 
     def test_extract_stars_uncertainties(self, epsf_test_data):
         """


### PR DESCRIPTION
This Pr fixes the `EPSFStars` container caching and attribute delegation, makes `extract_stars` more robust (no mutation of user weights arrays, non-finite positions skipped with a warning, per-image WCS requirements relaxed), and cleans up `EPSFBuilder` shape handling and validation (even shapes made odd as documented, `sigma_clip=None` support, initial-ePSF oversampling checks, and a simplified convergence criterion). It also deprecates the public `coord_transformer`
attribute and includes docstring fixes and test modernization.