### PR TITLE
Clean up PSF internals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -596,6 +596,11 @@ Bug Fixes
     fitter supports weights is now determined from its call
     signature. [#2390]
 
+  - Fixed a bug where the ``make_model_image`` and
+    ``make_residual_image`` methods raised an error with
+    ``include_local_bkg=True`` when no local background values were
+    available. The local background is now treated as zero. [#2391]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -68,7 +68,6 @@ add those to the image::
 Let's show the image:
 
 .. plot::
-    :include-source:
 
     import matplotlib.pyplot as plt
     from astropy.visualization import simple_norm
@@ -175,7 +174,8 @@ across the image, one should use more sophisticated methods (e.g.,
 Let's subtract the background from the image::
 
     >>> from astropy.stats import sigma_clipped_stats
-    >>> mean_val, median_val, std_val = sigma_clipped_stats(data, sigma=2.0)  # doctest: +REMOTE_DATA
+    >>> mean_val, median_val, std_val = sigma_clipped_stats(
+    ...     data, sigma=2.0)  # doctest: +REMOTE_DATA
     >>> data -= median_val  # doctest: +REMOTE_DATA
 
 The :func:`~photutils.psf.extract_stars` function requires the input
@@ -293,12 +293,12 @@ The :class:`~photutils.psf.EPSFBuilder` returns an
 the fitted stars, and detailed information about the build process. This
 result object supports tuple unpacking, so both of the following work::
 
-    >>> # New style: access result attributes
+    >>> # Access result attributes
     >>> epsf = result.epsf  # doctest: +REMOTE_DATA
     >>> fitted_stars = result.fitted_stars  # doctest: +REMOTE_DATA
 
-    >>> # Old style: tuple unpacking still works
-    >>> epsf, fitted_stars = epsf_builder(stars)  # doctest: +REMOTE_DATA
+    >>> # Tuple unpacking also works
+    >>> epsf, fitted_stars = result  # doctest: +REMOTE_DATA
 
 The `~photutils.psf.EPSFBuildResults` object provides useful diagnostic
 information about the build process::
@@ -452,6 +452,7 @@ your `~astropy.nddata.NDData` object. The uncertainty can be
 any of the `~astropy.nddata.NDUncertainty` subclasses (e.g.,
 `~astropy.nddata.StdDevUncertainty`)::
 
+    >>> import numpy as np
     >>> from astropy.nddata import StdDevUncertainty
     >>> uncertainty = StdDevUncertainty(np.sqrt(np.abs(data)))  # doctest: +REMOTE_DATA, +SKIP
     >>> nddata = NDData(data=data, uncertainty=uncertainty)  # doctest: +REMOTE_DATA, +SKIP
@@ -473,6 +474,7 @@ are constrained to have the same sky coordinate across all images.
 
 .. doctest-skip::
 
+    >>> import astropy.units as u
     >>> from astropy.coordinates import SkyCoord
     >>> catalog = Table()
     >>> catalog['skycoord'] = SkyCoord(ra=[...]*u.deg, dec=[...]*u.deg)

--- a/docs/user_guide/grouping.rst
+++ b/docs/user_guide/grouping.rst
@@ -22,15 +22,15 @@ efficient than attempting to fit a model to all the sources in an
 image at once, a task that is often impractical, especially in densely
 populated star fields.
 
-A straightforward method for this grouping was introduced by `Stetson (1987)
+A straightforward method for this grouping
+was introduced by `Stetson (1987)
 <https://ui.adsabs.harvard.edu/abs/1987PASP...99..191S/abstract>`_. This
 algorithm determines whether a given source's light profile interferes
 with that of any other source by using a "critical separation"
-parameter. This parameter sets the minimum distance required between
-two sources for them to be placed in separate groups. Typically, this
-critical separation is defined as a multiple of the stellar full width
-at half maximum (FWHM), which is a measure of the source's apparent
-size.
+parameter. Sources separated by less than or equal to this distance are
+placed in the same group. Typically, this critical separation is defined
+as a multiple of the stellar full width at half maximum (FWHM), which is
+a measure of the source's apparent size.
 
 
 Getting Started
@@ -70,8 +70,8 @@ the `~photutils.psf.make_psf_model_image` function::
     >>> noise = make_noise_image(shape, mean=0, stddev=2, seed=123)
     >>> data += noise
 
-The `~photutils.psf.make_psf_model_image` provides two outputs: the
-image itself, which we call ``data``, and a table containing the
+The `~photutils.psf.make_psf_model_image` function provides two outputs:
+the image itself, which we call ``data``, and a table containing the
 positions and fluxes of the stars, which we call ``stars``. The x and y
 coordinates of the stars are located in the ``x_0`` and ``y_0`` columns
 of this table.
@@ -125,15 +125,15 @@ the x and y coordinates of the stars. While we are using the known, true
 positions from our simulated data, you would typically use a source
 detection tool to find the star positions in an actual image::
 
-   >>> import numpy as np
-   >>> x = np.array(stars['x_0'])
-   >>> y = np.array(stars['y_0'])
-   >>> group_ids = grouper(x, y)
-   >>> print(group_ids[:20])  # first 20 group IDs
-   [ 1  2  3  4  5  6  7  8  9 10 11  4  6  3 12 13 14 15 16 17]
+    >>> import numpy as np
+    >>> x = np.array(stars['x_0'])
+    >>> y = np.array(stars['y_0'])
+    >>> group_ids = grouper(x, y)
+    >>> print(group_ids[:20])  # first 20 group IDs
+    [ 1  2  3  4  5  6  7  8  9 10 11  4  6  3 12 13 14 15 16 17]
 
-The result of this process is an array of integers, ``group_id``, where
-each integer represents the group to which the corresponding star
+The result of this process is an array of integers, ``group_ids``,
+where each integer represents the group to which the corresponding star
 belongs. Stars that share the same group ID are considered part of the
 same group.
 
@@ -152,9 +152,9 @@ Alternatively, you can set the ``return_groups_object`` keyword to
 it will return a `~photutils.psf.SourceGroups` object instead of an
 array of integers::
 
-   >>> groups = grouper(x, y, return_groups_object=True)
-   >>> print(type(groups))
-   <class 'photutils.psf.groupers.SourceGroups'>
+    >>> groups = grouper(x, y, return_groups_object=True)
+    >>> print(type(groups))
+    <class 'photutils.psf.groupers.SourceGroups'>
 
 In this case, ``groups`` is a `~photutils.psf.SourceGroups` object
 that contains the grouping results and provides convenient methods for
@@ -170,8 +170,8 @@ You can access the group IDs directly from the ``groups`` attribute,
 which is an array of integers corresponding to the input star
 coordinates. Stars with the same group ID belong to the same group::
 
-   >>> print(groups.groups[:20])  # first 20 group IDs
-   [ 1  2  3  4  5  6  7  8  9 10 11  4  6  3 12 13 14 15 16 17]
+    >>> print(groups.groups[:20])  # first 20 group IDs
+    [ 1  2  3  4  5  6  7  8  9 10 11  4  6  3 12 13 14 15 16 17]
 
 Similar to above, you can add the group IDs from ``groups.groups`` to
 the initial parameters table (``init_params``) that is passed to the
@@ -180,36 +180,36 @@ photometry tool to define the source grouping.
 To find the positions of the stars in group 3, you can use the
 `~photutils.psf.SourceGroups.get_group_sources` method::
 
-   >>> x_group3, y_group3 = groups.get_group_sources(3)
-   >>> print(x_group3, y_group3)
-   [60.32708921 58.73063714] [147.24184586 158.0612346 ]
+    >>> x_group3, y_group3 = groups.get_group_sources(3)
+    >>> print(x_group3, y_group3)
+    [60.32708921 58.73063714] [147.24184586 158.0612346 ]
 
 The `~photutils.psf.SourceGroups` object also provides useful properties
 and methods to analyze the grouping results::
 
-   >>> # Get the size of each group for each source
-   >>> sizes = groups.sizes
-   >>> print(f'Group sizes: {sizes[:5]}')  # first 5
-   Group sizes: [1 2 2 5 2]
+    >>> # Get the size of each group for each source
+    >>> sizes = groups.sizes
+    >>> print(f'Group sizes: {sizes[:5]}')  # first 5
+    Group sizes: [1 2 2 5 2]
 
-   >>> # Get the mapping of group IDs to group sizes
-   >>> size_map = groups.size_map
-   >>> print(f'Size map: {list(size_map.items())[:5]}')  # first 5
-   Size map: [(1, 1), (2, 2), (3, 2), (4, 5), (5, 2)]
+    >>> # Get the mapping of group IDs to group sizes
+    >>> size_map = groups.size_map
+    >>> print(f'Size map: {list(size_map.items())[:5]}')  # first 5
+    Size map: [(1, 1), (2, 2), (3, 2), (4, 5), (5, 2)]
 
-   >>> print(f'Largest group size: {max(size_map.values())}')
-   Largest group size: 5
+    >>> print(f'Largest group size: {max(size_map.values())}')
+    Largest group size: 5
 
-   >>> # Get a list of group IDs that have the largest group size
-   >>> largest_group_ids = ([gid for gid, size in size_map.items()
-   ...                       if size == max(size_map.values())])
-   >>> print(f'Largest group IDs: {largest_group_ids}')
-   Largest group IDs: [4]
+    >>> # Get a list of group IDs that have the largest group size
+    >>> largest_group_ids = ([gid for gid, size in size_map.items()
+    ...                       if size == max(size_map.values())])
+    >>> print(f'Largest group IDs: {largest_group_ids}')
+    Largest group IDs: [4]
 
-   >>> # Get the centroid of group 5
-   >>> xy_center = groups.group_centers[5]
-   >>> print(f'Group 5 center: {xy_center}')
-   Group 5 center: (48.35899721341876, 73.85258893310564)
+    >>> # Get the centroid of group 5
+    >>> xy_center = groups.group_centers[5]
+    >>> print(f'Group 5 center: {xy_center}')
+    Group 5 center: (48.35899721341876, 73.85258893310564)
 
 To visualize the results, we can use the
 `~photutils.psf.SourceGroups.plot` method, which draws color-coded

--- a/docs/user_guide/psf.rst
+++ b/docs/user_guide/psf.rst
@@ -702,11 +702,8 @@ sources in each group were simultaneously fit::
 
 Care should be taken in defining the source groups. Simultaneously
 fitting very large source groups is computationally expensive and
-error-prone. Internally, source grouping requires the creation of a
-compound Astropy model. Due to the way compound Astropy models are
-currently constructed, large groups also require excessively large
-amounts of memory. This will hopefully be fixed in a future Astropy
-version. A warning will be raised if the number of sources in a group
+error-prone, because the number of fitted parameters grows with the
+group size. A warning will be raised if the number of sources in a group
 exceeds a threshold defined by the ``group_warning_threshold`` keyword.
 
 

--- a/docs/user_guide/psf.rst
+++ b/docs/user_guide/psf.rst
@@ -110,7 +110,7 @@ The size of the annulus and the statistic function can be configured in
 `~photutils.background.LocalBackground`.
 
 The next step is to fit the sources and/or groups. This
-task is performed using an astropy fitter, for example
+task is performed using an Astropy fitter, for example
 `~astropy.modeling.fitting.TRFLSQFitter`, input via the ``fitter``
 keyword. The shape of the region to be fitted can be configured using
 the ``fit_shape`` parameter. In general, ``fit_shape`` should be set to
@@ -138,7 +138,7 @@ in which the PSF-fitting steps described above are performed, but
 all the stages can be turned on or off or replaced with different
 implementations as the user desires. This makes the tools very flexible.
 One can also bypass several of the steps by directly inputting to
-``init_params`` an astropy table containing the initial parameters for
+``init_params`` an Astropy table containing the initial parameters for
 the source centers, fluxes, group identifiers, and local backgrounds.
 This is also useful if one is interested in fitting only one or a few
 sources in an image.
@@ -175,7 +175,7 @@ empirical PSF models for ACS and WFC3 (e.g., `WFC3 PSF Search
 Similarly, the `James Webb Space Telescope <https://www.stsci.edu/jwst>`_
 and the `Nancy Grace Roman Space Telescope <https://www.stsci.edu/roman>`_
 provide the `STPSF <https://stpsf.readthedocs.io/>`_ Python software
-for creating PSF models. In particular, WebbPSF outputs gridded PSF
+for creating PSF models. In particular, STPSF outputs gridded PSF
 models directly as Photutils `~photutils.psf.GriddedPSFModel` instances.
 
 If you cannot obtain a PSF model from an empirical library or
@@ -224,7 +224,7 @@ models:
 - `~photutils.psf.CircularGaussianPSF`: a circular 2D Gaussian PSF model
   parameterized in terms of the position, total flux, and FWHM.
 
-- `~photutils.psf.GaussianPRF`: a general 2D Gaussian PSF model
+- `~photutils.psf.GaussianPRF`: a general 2D Gaussian PRF model
   parameterized in terms of the position, total flux, and FWHM
   along the x and y axes. Rotation can also be included.
 
@@ -252,8 +252,8 @@ If one needs a custom PRF model based on an analytical PSF model, an
 efficient option is to first discretize the model on a grid using
 :func:`~astropy.convolution.discretize_model` with the ``'oversample'``
 or ``'integrate'`` mode. The resulting 2D image can then be used as the
-input to `~photutils.psf.ImagePSF` (see :ref:`psf-image_models` below)
-to create an ePSF model.
+input to `~photutils.psf.ImagePSF` (see :ref:`psf-image-models` below)
+to create an image-based PSF model.
 
 Note that the non-circular Gaussian and Moffat models above have
 additional parameters beyond the standard PSF model parameters of
@@ -271,7 +271,7 @@ the Astropy modeling framework that will provide better performance than
 using :func:`~photutils.psf.make_psf_model`.
 
 
-.. _psf-image_models:
+.. _psf-image-models:
 
 Image-based PSF Models
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -316,7 +316,7 @@ provided by the :ref:`photutils.datasets <datasets>` module::
     ...                                          min_separation=10, seed=0)
     >>> noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     >>> data += noise
-    >>> error = np.abs(noise)
+    >>> error = np.full(data.shape, 1.0)
 
 Let's plot the image:
 
@@ -355,8 +355,8 @@ not include background.
 
 We'll use the `~photutils.detection.DAOStarFinder` class for
 source detection. We'll estimate the initial fluxes of each
-source using a circular aperture with a radius 4 pixels. The
-central 5x5 pixel region of each source will be fit using an
+source using a circular aperture with a radius of 4 pixels. The
+central 5x5 pixel region of each source will be fit using a
 `~photutils.psf.CircularGaussianPRF` PSF model. First, let's create an
 instance of the `~photutils.psf.PSFPhotometry` class::
 
@@ -390,7 +390,7 @@ uncertainty object that can be converted to standard-deviation errors:
     >>> nddata = NDData(data, uncertainty=uncertainty)
     >>> phot2 = psfphot(nddata)
 
-The result is an astropy `~astropy.table.Table` with columns for the
+The result is an Astropy `~astropy.table.QTable` with columns for the
 source and group identification numbers, the x, y, and flux initial,
 fit, and error values, local background, number of unmasked pixels
 fit, the group size, quality-of-fit metrics, and flags. See the
@@ -406,16 +406,16 @@ print the source ID along with the fit x, y, and flux values::
     >>> print(phot[('id', 'x_fit', 'y_fit', 'flux_fit')])
      id  x_fit   y_fit  flux_fit
     --- ------- ------- --------
-      1 54.5658  7.7644 514.0091
-      2 29.0865 25.6111 536.5793
-      3 79.6281 28.7487 618.7642
-      4 63.2340 48.6408 563.3437
-      5 88.8848 54.1202 619.8904
-      6 79.8763 61.1380 648.1658
-      7 90.9606 72.0861 601.8593
-      8  7.8038 78.5734 635.6317
-      9  5.5350 89.8870 539.6831
-     10 71.8414 90.5842 692.3373
+      1 54.5716  7.7458 513.2209
+      2 29.0873 25.6223 534.1826
+      3 79.6336 28.7482 619.7632
+      4 63.2403 48.6157 560.0202
+      5 88.8816 54.1347 616.2282
+      6 79.8673 61.1302 650.1411
+      7 90.9502 72.0862 597.1119
+      8  7.8034 78.5703 638.4794
+      9  5.5219 89.8622 542.6817
+     10 71.8331 90.5734 692.6518
 
 Let's create the residual image::
 
@@ -444,7 +444,7 @@ and plot it:
                                              min_separation=10, seed=0)
     noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     data += noise
-    error = np.abs(noise)
+    error = np.full(data.shape, 1.0)
 
     psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
     fit_shape = (5, 5)
@@ -472,11 +472,11 @@ Further details about the PSF fitting can be obtained from attributes on
 the `~photutils.psf.PSFPhotometry` instance. For example, the results
 from the ``finder`` instance called during PSF fitting can be accessed
 using the ``finder_results`` attribute (the ``finder`` returns an
-astropy table)::
+Astropy table)::
 
     >>> psfphot.finder_results['x_centroid'].info.format = '.4f'  # optional format
-    >>> psfphot.finder_results['y_centroid'].info.format = '.4f'  # optional format
-    >>> psfphot.finder_results['sharpness'].info.format = '.4f'  # optional format
+    >>> psfphot.finder_results['y_centroid'].info.format = '.4f'
+    >>> psfphot.finder_results['sharpness'].info.format = '.4f'
     >>> psfphot.finder_results['peak'].info.format = '.4f'
     >>> psfphot.finder_results['flux'].info.format = '.4f'
     >>> psfphot.finder_results['mag'].info.format = '.4f'
@@ -524,7 +524,7 @@ The output table contains only the fit results for the input source::
     >>> print(phot[('id', 'x_fit', 'y_fit', 'flux_fit')])
      id  x_fit   y_fit  flux_fit
     --- ------- ------- --------
-      1 63.2340 48.6408 563.3426
+      1 63.2403 48.6157 560.0201
 
 Finally, let's show the residual image. The red circular aperture shows
 the location of the source that was fit and subtracted.
@@ -552,7 +552,7 @@ the location of the source that was fit and subtracted.
                                              min_separation=10, seed=0)
     noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     data += noise
-    error = np.abs(noise)
+    error = np.full(data.shape, 1.0)
 
     psf_model = CircularGaussianPRF(flux=1, fwhm=2.7)
     fit_shape = (5, 5)
@@ -589,7 +589,7 @@ Forced Photometry (Fixed Model Parameters)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In general, the three parameters fit for each source are the x and
-y positions and the flux. However, the astropy modeling and fitting
+y positions and the flux. However, the Astropy modeling and fitting
 framework allows any of these parameters to be fixed during the fitting.
 
 Let's say you want to fix the (x, y) position for each source. You can
@@ -601,7 +601,7 @@ do that by setting the ``fixed`` attribute on the model parameters::
     >>> psf_model2.fixed
     {'flux': False, 'x_0': True, 'y_0': True, 'fwhm': True}
 
-Now when the model is fit, the flux will be varied but, the (x, y)
+Now when the model is fit, the flux will be varied, but the (x, y)
 position will be fixed at its initial position for every source. Let's
 just fit a single source (defined in ``init_params``)::
 
@@ -619,7 +619,7 @@ fit::
     ...             'y_fit', 'flux_fit')])
      id x_init y_init flux_init x_fit y_fit flux_fit
     --- ------ ------ --------- ----- ----- --------
-      1     63     49  556.5067  63.0  49.0 500.2997
+      1     63     49  556.5067  63.0  49.0 539.4673
 
 
 .. _psf-bounded-parameters:
@@ -627,9 +627,9 @@ fit::
 Bounded Model Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The astropy modeling and fitting framework also allows for bounding the
-parameter values during the fitting process. However, not all astropy
-"Fitter" classes support parameter bounds. Please see `Fitting Model to
+The Astropy modeling and fitting framework also allows for bounding the
+parameter values during the fitting process. However, not all Astropy
+"Fitter" classes support parameter bounds. Please see `Fitting Models to
 Data <https://docs.astropy.org/en/stable/modeling/fitting.html>`_ for
 more details.
 
@@ -651,14 +651,14 @@ parameters. Here we constrain the flux to be greater than or equal to
     >>> psf_model3 = CircularGaussianPRF(flux=1, fwhm=2.7)
     >>> psf_model3.flux.bounds = (0, None)
     >>> psf_model3.bounds
-    {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (0.0, None)}
+    {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (1.1754943508222875e-38, None)}
 
 The model parameter ``bounds`` can also be set using the ``min`` and/or
 ``max`` attributes. Here we set the minimum flux to be 0::
 
     >>> psf_model3.flux.min = 0
     >>> psf_model3.bounds
-    {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (0.0, None)}
+    {'flux': (0.0, None), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (1.1754943508222875e-38, None)}
 
 For this example, let's constrain the flux value to be between
 400 and 600::
@@ -666,7 +666,7 @@ For this example, let's constrain the flux value to be between
     >>> psf_model3 = CircularGaussianPRF(flux=1, fwhm=2.7)
     >>> psf_model3.flux.bounds = (400, 600)
     >>> psf_model3.bounds
-    {'flux': (400.0, 600.0), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (0.0, None)}
+    {'flux': (400.0, 600.0), 'x_0': (None, None), 'y_0': (None, None), 'fwhm': (1.1754943508222875e-38, None)}
 
 
 Source Grouping
@@ -705,7 +705,7 @@ fitting very large source groups is computationally expensive and
 error-prone. Internally, source grouping requires the creation of a
 compound Astropy model. Due to the way compound Astropy models are
 currently constructed, large groups also require excessively large
-amounts of memory; this will hopefully be fixed in a future Astropy
+amounts of memory. This will hopefully be fixed in a future Astropy
 version. A warning will be raised if the number of sources in a group
 exceeds a threshold defined by the ``group_warning_threshold`` keyword.
 
@@ -787,42 +787,43 @@ the source was detected::
     >>> print(phot[('id', 'iter_detected', 'x_fit', 'y_fit', 'flux_fit')])
      id iter_detected  x_fit   y_fit  flux_fit
     --- ------------- ------- ------- --------
-      1             1 54.5665  7.7641 514.2650
-      2             1 29.0883 25.6092 534.0850
-      3             1 79.6273 28.7480 613.0496
-      4             2 63.2340 48.6415 564.1528
-      5             2 88.8856 54.1203 615.4907
-      6             2 79.8765 61.1359 649.9589
-      7             2 90.9631 72.0880 603.7433
-      8             2  7.8203 78.5821 641.8223
-      9             2  5.5350 89.8870 539.5237
-     10             2 71.8485 90.5830 687.4573
+      1             1 54.5694  7.7454 513.4505
+      2             1 29.0875 25.6216 531.3096
+      3             1 79.6327 28.7475 615.1111
+      4             2 63.2401 48.6159 560.9633
+      5             2 88.8813 54.1350 612.0937
+      6             2 79.8674 61.1301 651.4973
+      7             2 90.9502 72.0861 598.9888
+      8             2  7.8037 78.5711 642.0335
+      9             2  5.5218 89.8621 542.5141
+     10             2 71.8326 90.5721 686.2071
 
 
-Estimating the FWHM of sources
+Estimating the FWHM of Sources
 ------------------------------
 
-The `photutils.psf` package also provides a convenience function
-called `~photutils.psf.fit_fwhm` to estimate the full width
-at half maximum (FWHM) of one or more sources in an image.
-This function fits the source(s) with a circular 2D Gaussian
-PRF model (`~photutils.psf.CircularGaussianPRF`) using the
-`~photutils.psf.PSFPhotometry` class. If your sources are not
-circular or non-Gaussian, you can fit your sources using the
-`~photutils.psf.PSFPhotometry` class using a different PSF model.
+The `photutils.psf` package also provides a convenience
+function called `~photutils.psf.fit_fwhm` to estimate the
+full width at half maximum (FWHM) of one or more sources in
+an image. This function fits the source(s) with a circular
+2D Gaussian PRF model (`~photutils.psf.CircularGaussianPRF`)
+using the `~photutils.psf.PSFPhotometry` class. If your sources
+are non-circular or non-Gaussian, you can fit them with the
+`~photutils.psf.PSFPhotometry` class and a different PSF model.
 
 For example, let's estimate the FWHM of the sources in our example image
 defined above::
 
-   >>> from photutils.psf import fit_fwhm
-   >>> finder = DAOStarFinder(6.0, 2.0)
-   >>> finder_tbl = finder(data)
-   >>> xypos = list(zip(finder_tbl['x_centroid'],
-   ...                  finder_tbl['y_centroid'], strict=True))
-   >>> fwhm = fit_fwhm(data, xypos=xypos, error=error, fit_shape=(5, 5), fwhm=2)
-   >>> fwhm
-   array([2.69735154, 2.70371211, 2.68917219, 2.69310558, 2.68931721,
-          2.69804194, 2.69651045, 2.70423936, 2.71458867, 2.70285813])
+    >>> from photutils.psf import fit_fwhm
+    >>> finder = DAOStarFinder(6.0, 2.0)
+    >>> finder_tbl = finder(data)
+    >>> xypos = list(zip(finder_tbl['x_centroid'],
+    ...                  finder_tbl['y_centroid'], strict=True))
+    >>> fwhm = fit_fwhm(data, xypos=xypos, error=error, fit_shape=(5, 5),
+    ...                 fwhm=2)
+    >>> fwhm
+    array([2.70584007, 2.71009548, 2.67319293, 2.6932673 , 2.6674289 ,
+           2.69499608, 2.68722503, 2.73280482, 2.7200538 , 2.68340968])
 
 
 Convenience Gaussian Fitting Function

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -29,6 +29,8 @@ from .flags import PSF_FLAGS
 
 __all__ = ['PSFDataProcessor', 'PSFFitter', 'PSFResultsAssembler']
 
+_ASTROPY_GE_7 = minversion(astropy, '7.0')
+
 
 def _apply_bounds_to_param(model, param_name, param_value, bound_value):
     """
@@ -113,6 +115,8 @@ def _create_flat_model_class(n_sources, psf_model):
     def model_init(self, **kwargs):
         super(type(self), self).__init__(**kwargs)
         self.n_sources = n_sources
+        # All instances share this single model copy. This is safe
+        # only because evaluate() is stateless.
         self.base_psf_model = base_psf_model
         self.base_param_names = base_param_names
 
@@ -157,7 +161,7 @@ def _instantiate_flat_model(model_class, sources, psf_model, param_mapper, *,
     Parameters
     ----------
     model_class : type
-        Flat model class created by `create_flat_model_class`.
+        Flat model class created by `_create_flat_model_class`.
 
     sources : `~astropy.table.Table` or list of `~astropy.table.Row`
         List of source rows from the sources table for the group.
@@ -318,7 +322,6 @@ class PSFDataProcessor:
 
         # Cache for offset grids
         self._cached_offsets = None
-        self._cache_key = None
 
     def validate_array(self, array, name, *, data_shape=None):
         """
@@ -667,14 +670,10 @@ class PSFDataProcessor:
             ``fit_shape``, where each array contains coordinate offsets
             from the origin.
         """
-        ny, nx = self.fit_shape
-        cache_key = (ny, nx)
-
-        # Optimized cache management
-        if (self._cached_offsets is None or self._cache_key != cache_key):
-            # Create new cache with validated shape
+        # fit_shape is fixed at construction, so compute only once
+        if self._cached_offsets is None:
+            ny, nx = self.fit_shape
             self._cached_offsets = np.mgrid[0:ny, 0:nx]
-            self._cache_key = cache_key
 
         return self._cached_offsets
 
@@ -937,16 +936,6 @@ class PSFFitter:
                                xy_bounds=self.xy_bounds,
                                class_cache=self._flat_model_classes)
 
-    def _apply_bounds_to_param(self, model, param_name, param_value,
-                               bound_value):
-        """
-        Apply bounds to a specific model parameter.
-
-        This method is now a wrapper around the standalone helper
-        function.
-        """
-        _apply_bounds_to_param(model, param_name, param_value, bound_value)
-
     def _apply_xy_bounds(self, model, alias_map):
         """
         Apply xy_bounds to a model.
@@ -955,13 +944,13 @@ class PSFFitter:
             if self.xy_bounds[0] is not None:
                 x_param_name = alias_map['x']
                 x_param = getattr(model, x_param_name)
-                self._apply_bounds_to_param(model, x_param_name,
-                                            x_param.value, self.xy_bounds[0])
+                _apply_bounds_to_param(model, x_param_name,
+                                       x_param.value, self.xy_bounds[0])
             if self.xy_bounds[1] is not None:
                 y_param_name = alias_map['y']
                 y_param = getattr(model, y_param_name)
-                self._apply_bounds_to_param(model, y_param_name,
-                                            y_param.value, self.xy_bounds[1])
+                _apply_bounds_to_param(model, y_param_name,
+                                       y_param.value, self.xy_bounds[1])
 
     def run_fitter(self, psf_model, xi, yi, cutout, error):
         """
@@ -997,7 +986,7 @@ class PSFFitter:
         ValueError
             If error array contains non-positive or non-finite values.
         """
-        kwargs = {'inplace': True} if minversion(astropy, '7.0') else {}
+        kwargs = {'inplace': True} if _ASTROPY_GE_7 else {}
 
         if self.fitter_maxiters is not None:
             kwargs.update({'maxiter': self.fitter_maxiters})
@@ -1019,7 +1008,7 @@ class PSFFitter:
                 msg = ('Error array contains non-positive or non-finite '
                        'values. Cannot compute fit weights.')
                 raise ValueError(msg)
-            weights = 1.0 / error[yi, xi]
+            weights = 1.0 / err
 
         # Keep fit-info entries (but exclude residual vectors)
         fit_info_keys = ('param_cov', 'ierr', 'message', 'status')
@@ -1039,9 +1028,8 @@ class PSFFitter:
 
         return fit_model, fit_info
 
-    # @staticmethod
-    def extract_source_covariances(self, group_cov, n_sources,
-                                   n_fit_params):
+    @staticmethod
+    def extract_source_covariances(group_cov, n_sources, n_fit_params):
         """
         Extract individual source covariance matrices from group
         covariance.
@@ -1121,7 +1109,7 @@ class PSFFitter:
 
 class PSFResultsAssembler:
     """
-    Helper class to handles results table assembly and quality metrics
+    Helper class to handle results table assembly and quality metrics
     calculation.
 
     This class encapsulates all operations related to assembling final
@@ -1161,38 +1149,13 @@ class PSFResultsAssembler:
         bad_indices : `~numpy.ndarray`
             Array of integer indices for fits that did not converge.
         """
-        # Same "good" flags for both leastsq and least_squares
-        converged_status = {1, 2, 3, 4}
-
-        n_sources = len(fit_info)
-        ierr_vals = np.full(n_sources, None, dtype=object)
-        status_vals = np.full(n_sources, None, dtype=object)
-
-        # Extract all ierr and status values
-        for idx, info in enumerate(fit_info):
-            ierr_vals[idx] = info.get('ierr')
-            status_vals[idx] = info.get('status')
-
-        # Create masks for non-None values
-        ierr_valid = ierr_vals != None  # noqa: E711
-        status_valid = status_vals != None  # noqa: E711
-
-        # Check convergence status for valid values
-        converged_status_list = list(converged_status)
-        ierr_bad = np.zeros(n_sources, dtype=bool)
-        status_bad = np.zeros(n_sources, dtype=bool)
-
-        for i in range(n_sources):
-            if ierr_valid[i]:
-                ierr_bad[i] = ierr_vals[i] not in converged_status_list
-            if status_valid[i]:
-                status_bad[i] = status_vals[i] not in converged_status_list
-
-        # Combine conditions
-        bad_mask = (ierr_valid & ierr_bad) | (status_valid & status_bad)
-        bad_indices = np.where(bad_mask)[0]
-
-        return bad_indices.astype(int)
+        # 1, 2, 3, and 4 are the "good" convergence values for both
+        # the leastsq and least_squares optimizers. None means the
+        # key was not present in the fit info.
+        bad = [idx for idx, info in enumerate(fit_info)
+               if any(info.get(key) not in (None, 1, 2, 3, 4)
+                      for key in ('ierr', 'status'))]
+        return np.array(bad, dtype=int)
 
     def param_errors_to_table(self, fit_param_errs, data_unit):
         """
@@ -1213,9 +1176,7 @@ class PSFResultsAssembler:
             Table containing error columns for fitted parameters,
             with NaN values for non-fitted (fixed) parameters.
         """
-        table = QTable()
-
-        # Create error columns for models parameters that were fit
+        # Create error columns for model parameters that were fit
         mapper = self.param_mapper
         fitted_params = mapper.fitted_param_names
         model_param_to_alias = mapper.model_param_to_alias
@@ -1475,24 +1436,20 @@ class PSFResultsAssembler:
                         flags[index] |= PSF_FLAGS.NEAR_BOUND
                         break
 
-        # Flag=64, 128, 256: invalid source reasons
+        # Flag=64, 128, 256: invalid source reasons. Sources invalid
+        # because of a non-finite input flux get bit 1024 below from
+        # their NaN fitted flux.
         if invalid_reasons is not None:
             reasons = np.array(invalid_reasons, dtype=object)
             flags[reasons == 'no_overlap'] |= PSF_FLAGS.NO_OVERLAP
             flags[reasons == 'fully_masked'] |= PSF_FLAGS.FULLY_MASKED
             flags[reasons == 'too_few_pixels'] |= PSF_FLAGS.TOO_FEW_PIXELS
-            flags[reasons == 'non_finite_flux'] |= PSF_FLAGS.NON_FINITE_FLUX
 
         # Flag=512: non-finite fitted position
-        x_col = self.param_mapper.fit_colnames['x']
-        y_col = self.param_mapper.fit_colnames['y']
-        x_fit = results_tbl[x_col]
-        y_fit = results_tbl[y_col]
         non_finite_pos_mask = ~np.isfinite(x_fit) | ~np.isfinite(y_fit)
         flags[non_finite_pos_mask] |= PSF_FLAGS.NON_FINITE_POSITION
 
-        # Flag=1024: non-finite fitted flux (also check fitted values)
-        flux_col = self.param_mapper.fit_colnames['flux']
+        # Flag=1024: non-finite fitted flux
         flux_fit = results_tbl[flux_col]
         non_finite_flux_mask = ~np.isfinite(flux_fit)
         flags[non_finite_flux_mask] |= PSF_FLAGS.NON_FINITE_FLUX
@@ -1562,6 +1519,14 @@ class PSFResultsAssembler:
         # Add metrics and flags column to fit_params. The results in the
         # state container match the order of the fit_params results,
         # which are in the same source ID order as the init_params.
+
+        # State keys consumed here, each removed after use to reduce
+        # memory usage:
+        # - 'n_pixels_fit', 'group_size': added as columns
+        # - 'sum_abs_residuals', 'cen_residuals', 'reduced_chi2':
+        #   consumed by calc_fit_metrics_func
+        # - 'fit_error_indices', 'fitted_models_table',
+        #   'valid_mask_by_id': consumed by define_flags_func
 
         # Consume n_pixels_fit and group_size data, removing from state
         fit_params['n_pixels_fit'] = state.pop('n_pixels_fit')
@@ -1653,8 +1618,9 @@ def _make_model_image_docstring(func):
         Returns
         -------
         array : 2D `~numpy.ndarray`
-            The rendered image from the fit PSF models. This image will
-            not have any units.
+            The rendered image from the fit PSF models. If the fit
+            was performed on data with units, the image will be a
+            `~astropy.units.Quantity` with the same units.
         """
     return func
 
@@ -1692,7 +1658,7 @@ def _make_residual_image_docstring(func):
         -------
         array : 2D `~numpy.ndarray`
             The residual image of the ``data`` minus the fit PSF models
-            minus the optional``local_bkg``.
+            minus the optional ``local_bkg``.
         """
     return func
 
@@ -1735,11 +1701,14 @@ class _ModelImageMaker:
             # Add local_bkg, but set non-finite values to 0 to avoid
             # corrupting the model image
             model_params = model_params.copy()
-            local_bkgs_clean = local_bkgs.copy()
-            # Replace non-finite values with 0
-            nonfinite_mask = ~np.isfinite(local_bkgs_clean)
-            if np.any(nonfinite_mask):
-                local_bkgs_clean[nonfinite_mask] = 0
+            if local_bkgs is None:
+                local_bkgs_clean = np.zeros(len(model_params))
+            else:
+                local_bkgs_clean = local_bkgs.copy()
+                # Replace non-finite values with 0
+                nonfinite_mask = ~np.isfinite(local_bkgs_clean)
+                if np.any(nonfinite_mask):
+                    local_bkgs_clean[nonfinite_mask] = 0
             model_params['local_bkg'] = local_bkgs_clean
 
         try:

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -1075,6 +1075,15 @@ class EPSFBuilder:
         Whether to print the progress bar during the build
         iterations. The progress bar requires that the `tqdm
         <https://tqdm.github.io/>`_ optional dependency be installed.
+
+    Notes
+    -----
+    This class stores per-call state on the instance (e.g., the list
+    of per-iteration ePSFs), so a single instance must not be called
+    concurrently from multiple threads. Create one instance per
+    thread for concurrent use. Sharing a single Astropy fitter
+    instance across concurrently-used objects is also unsafe because
+    Astropy fitters store ``fit_info`` on themselves.
     """
 
     coord_transformer = deprecated_attribute('coord_transformer', '3.1')

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -1235,7 +1235,10 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
         flux = fluxes[i] if fluxes is not None else None
 
         try:
-            # Suppress all-zero warning in EPSFStar (we emit our own below)
+            # Suppress all-zero warning in EPSFStar (we emit our own
+            # below). This mutates the process-global warning filters,
+            # so it is safe only for this brief star-construction
+            # window under single-threaded use.
             with warnings.catch_warnings():
                 msg = 'All unmasked data values in star cutout are zero'
                 warnings.filterwarnings('ignore', message=msg,
@@ -1321,8 +1324,7 @@ def _prepare_uncertainty_info(data):
     # For other uncertainties, convert the full array to standard
     # deviation once so that cutouts only need to be sliced
     uncertainty = data.uncertainty
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', RuntimeWarning)
+    with np.errstate(divide='ignore', invalid='ignore'):
         if hasattr(uncertainty, 'represent_as'):
             stddev_array = uncertainty.represent_as(StdDevUncertainty).array
         else:
@@ -1372,8 +1374,7 @@ def _create_weights_cutout(uncertainty_info, data_mask, slices):
             uncertainty_info['array'][slices], dtype=float)
     else:
         # Convert the standard deviation cutout to weights
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
+        with np.errstate(divide='ignore', invalid='ignore'):
             weights_cutout = 1.0 / uncertainty_info['array'][slices]
 
     # Check for non-finite weights and track if found

--- a/photutils/psf/groupers.py
+++ b/photutils/psf/groupers.py
@@ -283,17 +283,17 @@ class SourceGrouper:
     distance.
 
     The groups are the connected components of the graph linking pairs
-    of sources separated by less than ``min_separation``. This is
-    identical to single-linkage hierarchical agglomerative clustering
-    with a distance criterion, but is computed using a KD-tree so that
-    it scales to large numbers of sources.
+    of sources separated by less than or equal to ``min_separation``.
+    This is identical to single-linkage hierarchical agglomerative
+    clustering with a distance criterion, but is computed using a
+    KD-tree so that it scales to large numbers of sources.
 
     Parameters
     ----------
     min_separation : float
         The minimum distance (in pixels) such that any two sources
-        separated by less than this distance will be placed in the same
-        group.
+        separated by less than or equal to this distance will be placed
+        in the same group.
 
     See Also
     --------

--- a/photutils/psf/iterative.py
+++ b/photutils/psf/iterative.py
@@ -225,12 +225,9 @@ class IterativePSFPhotometry:
 
     Care should be taken in defining the source groups. Simultaneously
     fitting very large source groups is computationally expensive and
-    error-prone. Internally, source grouping requires the creation of
-    a compound Astropy model. Due to the way compound Astropy models
-    are currently constructed, large groups also require excessively
-    large amounts of memory; this will hopefully be fixed in a future
-    Astropy version. A warning will be raised if the number of sources
-    in a group exceeds the ``group_warning_threshold`` value.
+    error-prone, because the number of fitted parameters grows with the
+    group size. A warning will be raised if the number of sources in a
+    group exceeds the ``group_warning_threshold`` value.
 
     This class stores per-call state on the instance (e.g., ``results``
     and ``fit_info``), so a single instance must not be called

--- a/photutils/psf/iterative.py
+++ b/photutils/psf/iterative.py
@@ -231,6 +231,13 @@ class IterativePSFPhotometry:
     large amounts of memory; this will hopefully be fixed in a future
     Astropy version. A warning will be raised if the number of sources
     in a group exceeds the ``group_warning_threshold`` value.
+
+    This class stores per-call state on the instance (e.g., ``results``
+    and ``fit_info``), so a single instance must not be called
+    concurrently from multiple threads. Create one instance per thread
+    for concurrent use. Sharing a single Astropy fitter instance across
+    concurrently-used objects is also unsafe because Astropy fitters
+    store ``fit_info`` on themselves.
     """
 
     @deprecated_renamed_argument('localbkg_estimator',

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -398,6 +398,13 @@ class PSFPhotometry:
     large amounts of memory; this will hopefully be fixed in a future
     Astropy version. A warning will be raised if the number of sources
     in a group exceeds the ``group_warning_threshold`` value.
+
+    This class stores per-call state on the instance (e.g., ``results``
+    and ``fit_info``), so a single instance must not be called
+    concurrently from multiple threads. Create one instance per thread
+    for concurrent use. Sharing a single Astropy fitter instance across
+    concurrently-used objects is also unsafe because Astropy fitters
+    store ``fit_info`` on themselves.
     """
 
     # Default value for parameter initialization (invalid sources)

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -392,12 +392,9 @@ class PSFPhotometry:
 
     Care should be taken in defining the source groups. Simultaneously
     fitting very large source groups is computationally expensive and
-    error-prone. Internally, source grouping requires the creation of
-    a compound Astropy model. Due to the way compound Astropy models
-    are currently constructed, large groups also require excessively
-    large amounts of memory; this will hopefully be fixed in a future
-    Astropy version. A warning will be raised if the number of sources
-    in a group exceeds the ``group_warning_threshold`` value.
+    error-prone, because the number of fitted parameters grows with the
+    group size. A warning will be raised if the number of sources in a
+    group exceeds the ``group_warning_threshold`` value.
 
     This class stores per-call state on the instance (e.g., ``results``
     and ``fit_info``), so a single instance must not be called
@@ -1069,8 +1066,9 @@ class PSFPhotometry:
             Boolean mask indicating which sources in the group are valid.
 
         group_model : `astropy.modeling.Model`
-            The fitted model for a single group. This can be a compound
-            model.
+            The fitted model for a single group. For groups with
+            multiple sources, this is a flat model with per-source
+            parameters.
 
         group_fit_info : dict
             The fit_info dictionary corresponding to the group fit.

--- a/photutils/psf/tests/test_components.py
+++ b/photutils/psf/tests/test_components.py
@@ -8,12 +8,12 @@ import numpy as np
 import pytest
 from astropy.modeling.fitting import LevMarLSQFitter, TRFLSQFitter
 from astropy.table import QTable, Table
-from numpy.testing import assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 from photutils.detection import DAOStarFinder
 from photutils.psf import CircularGaussianPRF
 from photutils.psf._components import (PSFDataProcessor, PSFFitter,
-                                       PSFResultsAssembler)
+                                       PSFResultsAssembler, _ModelImageMaker)
 from photutils.psf.photometry import _PSFParameterMapper
 
 
@@ -92,7 +92,6 @@ class TestPSFDataProcessor:
         assert processor.data_unit is None
         assert processor.finder_results is None
         assert processor._cached_offsets is None
-        assert processor._cache_key is None
 
     def test_validate_array_valid_input(self, param_mapper):
         """
@@ -682,7 +681,39 @@ class TestComponentIntegration:
         fitter = PSFFitter(psf_model, param_mapper)
         psf_model_fit = fitter.make_psf_model(sources_with_id)
 
-        # Model parameters should be unitless for fitting
-        assert not hasattr(psf_model_fit.x_0.value, 'unit')
-        assert not hasattr(psf_model_fit.y_0.value, 'unit')
-        assert not hasattr(psf_model_fit.flux.value, 'unit')
+        # Model parameters should be unitless values for fitting
+        assert psf_model_fit.x_0.value == 12.0
+        assert psf_model_fit.y_0.value == 12.0
+        assert psf_model_fit.flux.value == 100.0
+
+
+class TestModelImageMaker:
+    """
+    Tests for the _ModelImageMaker class.
+    """
+
+    def test_local_bkg_none(self, psf_model):
+        """
+        Test that include_local_bkg=True with local_bkg=None treats
+        the local background as zero.
+        """
+        params = QTable({'x_0': [12.0], 'y_0': [12.0], 'flux': [100.0]})
+        maker = _ModelImageMaker(psf_model, params)
+        image = maker.make_model_image((25, 25), psf_shape=(9, 9))
+        image_bkg = maker.make_model_image((25, 25), psf_shape=(9, 9),
+                                           include_local_bkg=True)
+        assert_allclose(image_bkg, image)
+
+    def test_local_bkg_nonfinite(self, psf_model):
+        """
+        Test that non-finite local background values are treated as
+        zero.
+        """
+        params = QTable({'x_0': [8.0, 17.0], 'y_0': [8.0, 17.0],
+                         'flux': [100.0, 50.0]})
+        maker = _ModelImageMaker(psf_model, params,
+                                 local_bkg=np.array([np.nan, 0.0]))
+        image = maker.make_model_image((25, 25), psf_shape=(9, 9))
+        image_bkg = maker.make_model_image((25, 25), psf_shape=(9, 9),
+                                           include_local_bkg=True)
+        assert_allclose(image_bkg, image)

--- a/photutils/psf/tests/test_flags.py
+++ b/photutils/psf/tests/test_flags.py
@@ -420,17 +420,13 @@ def test_psf_flags_integration_with_decode():
     assert set(decoded_combined) == {'no_convergence', 'fully_masked'}
 
     # Test all constants work with decode
-    for const_name in ['N_PIXELS_FIT_PARTIAL', 'OUTSIDE_BOUNDS',
-                       'NEGATIVE_FLUX',
-                       'NO_CONVERGENCE', 'NO_COVARIANCE', 'NEAR_BOUND',
-                       'NO_OVERLAP', 'FULLY_MASKED', 'TOO_FEW_PIXELS']:
-        const_value = getattr(PSF_FLAGS, const_name)
+    for flag_name in PSF_FLAGS.names:
+        const_value = getattr(PSF_FLAGS, flag_name.upper())
         decoded_const = decode_psf_flags(const_value)
         assert len(decoded_const) == 1
 
         # The decoded name should match the constant name (lowercase)
-        expected_name = const_name.lower()
-        assert decoded_const[0] == expected_name
+        assert decoded_const[0] == flag_name
 
 
 def test_psf_flags_completeness():

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -329,6 +329,10 @@ def fit_fwhm(data, *, xypos=None, fwhm=None, fit_shape=None, mask=None,
     ``fwhm`` is `None`, then the initial guess for the FWHM is half the
     mean of the x and y sizes of the ``fit_shape`` values.
 
+    This function captures warnings using the process-global warning
+    machinery, so concurrent calls from multiple threads may
+    misattribute warnings on non-free-threaded Python builds.
+
     Examples
     --------
     Fit the FWHM of a single source (e.g., a cutout image):


### PR DESCRIPTION
This PR implements internal cleanups and simplifications in `_components.py` (including a fix for `make_model_image` with `include_local_bkg=True` when no local background is available), documentation of per-instance thread-safety constraints for the photometry and ePSF-building classes, and thread-local warning suppression via `np.errstate`. It also corrects the psf user guide, replacing the incorrect error model with the constant noise sigma and regenerating the affected doctest outputs, along with assorted prose and formatting fixes in the psf, grouping, and ePSF-building pages.