### PR TITLE
Add analytic fit_deriv to ImagePSF and GriddedPSFModel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,9 +215,11 @@ New Features
     KD-tree instead of building a dense pairwise distance matrix.
     [#2389]
 
-  - Added an analytic Jacobian (``fit_deriv``) to ``ImagePSF``, which
-    allows the fitter to skip the finite-difference Jacobian during PSF
-    fitting to improve performance. [#2393]
+  - Added an analytic Jacobian (``fit_deriv``) to ``ImagePSF`` and
+    ``GriddedPSFModel``, which allows the fitter to skip the
+    finite-difference Jacobian during PSF fitting. This removes
+    roughly 60% of the model evaluations performed during fitting.
+    [#2393]
 
 - ``photutils.segmentation``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,6 +215,10 @@ New Features
     KD-tree instead of building a dense pairwise distance matrix.
     [#2389]
 
+  - Added an analytic Jacobian (``fit_deriv``) to ``ImagePSF``, which
+    allows the fitter to skip the finite-difference Jacobian during PSF
+    fitting to improve performance. [#2393]
+
 - ``photutils.segmentation``
 
   - Added validation of the ``SourceCatalog.to_table()`` ``columns``

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -125,6 +125,8 @@ Benchmarks for the `photutils.psf` subpackage:
   `new` and `all` modes
 - `PSFPhotometry` versus the PSF model type (each scene is rendered
   and fit with the same model)
+- the `ImagePSF` analytic Jacobian (`fit_deriv`) versus the fitter's
+  finite-difference approximation, with speedups
 - `SourceGrouper` versus the number of sources and the minimum
   separation
 - ePSF building (`extract_stars` and `EPSFBuilder`) versus the number

--- a/benchmarks/bench_psf.py
+++ b/benchmarks/bench_psf.py
@@ -93,7 +93,7 @@ def make_image_psf(*, fwhm=FWHM, oversampling=4):
 
 
 def make_gridded_psf_model(*, fwhm=FWHM, oversampling=4, n_psfs_side=3,
-                           image_size=2048):
+                           image_size=2048, model_class=GriddedPSFModel):
     """
     Return a synthetic `~photutils.psf.GriddedPSFModel`.
 
@@ -115,6 +115,9 @@ def make_gridded_psf_model(*, fwhm=FWHM, oversampling=4, n_psfs_side=3,
     image_size : int, optional
         The size of the detector image spanned by the grid.
 
+    model_class : class, optional
+        The gridded PSF model class to construct.
+
     Returns
     -------
     result : `~photutils.psf.GriddedPSFModel`
@@ -125,12 +128,23 @@ def make_gridded_psf_model(*, fwhm=FWHM, oversampling=4, n_psfs_side=3,
     grid_xypos = [(x, y) for y in coords for x in coords]
     planes = np.repeat(epsf[None], len(grid_xypos), axis=0)
     meta = {'grid_xypos': grid_xypos, 'oversampling': oversampling}
-    return GriddedPSFModel(NDData(planes, meta=meta))
+    return model_class(NDData(planes, meta=meta))
 
 
 class _NoDerivImagePSF(ImagePSF):
     """
     An ImagePSF variant with the analytic Jacobian disabled.
+
+    It is used by the Jacobian benchmark to time the fitter's
+    finite-difference fallback.
+    """
+
+    fit_deriv = None
+
+
+class _NoDerivGriddedPSFModel(GriddedPSFModel):
+    """
+    A GriddedPSFModel variant with the analytic Jacobian disabled.
 
     It is used by the Jacobian benchmark to time the fitter's
     finite-difference fallback.
@@ -433,11 +447,12 @@ def bench_model_types(*, size=512, n_sources=100, repeats=3, seed=0):
 def bench_jacobian(*, size=512, n_sources=100, fit_shapes=(5, 11),
                    repeats=3, seed=0):
     """
-    Benchmark the ImagePSF analytic Jacobian in PSFPhotometry.
+    Benchmark the analytic PSF model Jacobians in PSFPhotometry.
 
-    The analytic Jacobian (``fit_deriv``) is compared against the
-    fitter's finite-difference approximation, with the source
-    positions and fluxes given via ``init_params``.
+    For ImagePSF and GriddedPSFModel, the analytic Jacobian
+    (``fit_deriv``) is compared against the fitter's finite-difference
+    approximation, with the source positions and fluxes given via
+    ``init_params``.
 
     Parameters
     ----------
@@ -457,39 +472,47 @@ def bench_jacobian(*, size=512, n_sources=100, fit_shapes=(5, 11),
         The random number generator seed.
     """
     epsf_data = make_epsf_data()
-    variants = [
-        ('analytic (fit_deriv)', ImagePSF(epsf_data, oversampling=4)),
-        ('finite difference', _NoDerivImagePSF(epsf_data, oversampling=4)),
+    families = [
+        ('ImagePSF',
+         ImagePSF(epsf_data, oversampling=4),
+         _NoDerivImagePSF(epsf_data, oversampling=4)),
+        ('GriddedPSFModel',
+         make_gridded_psf_model(image_size=size),
+         make_gridded_psf_model(image_size=size,
+                                model_class=_NoDerivGriddedPSFModel)),
     ]
-    data, params = make_scene(variants[0][1], (size, size), n_sources,
-                              seed=seed)
-    init_params = params['x_0', 'y_0', 'flux']
 
-    print(f'\n== ImagePSF Jacobian ({size}x{size} image, {n_sources} '
+    print(f'\n== PSF model Jacobians ({size}x{size} image, {n_sources} '
           'sources, per-call time) ==')
-    header = f'{"variant":>24}'
+    header = f'{"variant":>40}'
     for fit_shape in fit_shapes:
         header += f'{f"fit_shape={fit_shape}":>22}'
     print(header)
-    times = {}
-    for name, psf_model in variants:
+    for family, analytic_model, numeric_model in families:
+        data, params = make_scene(analytic_model, (size, size), n_sources,
+                                  seed=seed)
+        init_params = params['x_0', 'y_0', 'flux']
+        times = {}
+        variants = [('analytic (fit_deriv)', analytic_model),
+                    ('finite difference', numeric_model)]
+        for name, psf_model in variants:
+            cells = ''
+            for fit_shape in fit_shapes:
+                phot = PSFPhotometry(psf_model, fit_shape=fit_shape,
+                                     group_warning_threshold=10**9)
+                bench = partial(run_photometry, phot, data, init_params)
+                t_call = time_best(bench, repeats=repeats)
+                times[name, fit_shape] = t_call
+                per_source = t_call / n_sources * 1e3
+                cells += f'{f"{t_call:.3f}s ({per_source:.2f}ms/src)":>22}'
+            print(f'{f"{family} {name}":>40}{cells}')
+
         cells = ''
         for fit_shape in fit_shapes:
-            phot = PSFPhotometry(psf_model, fit_shape=fit_shape,
-                                 group_warning_threshold=10**9)
-            bench = partial(run_photometry, phot, data, init_params)
-            t_call = time_best(bench, repeats=repeats)
-            times[name, fit_shape] = t_call
-            per_source = t_call / n_sources * 1e3
-            cells += f'{f"{t_call:.3f}s ({per_source:.2f}ms/src)":>22}'
-        print(f'{name:>24}{cells}')
-
-    cells = ''
-    for fit_shape in fit_shapes:
-        speedup = (times['finite difference', fit_shape]
-                   / times['analytic (fit_deriv)', fit_shape])
-        cells += f'{f"{speedup:.2f}x":>22}'
-    print(f'{"speedup":>24}{cells}')
+            speedup = (times['finite difference', fit_shape]
+                       / times['analytic (fit_deriv)', fit_shape])
+            cells += f'{f"{speedup:.2f}x":>22}'
+        print(f'{f"{family} speedup":>40}{cells}')
 
 
 def run_grouper(grouper, x, y, n_iter):

--- a/benchmarks/bench_psf.py
+++ b/benchmarks/bench_psf.py
@@ -6,7 +6,8 @@ Benchmarks for the photutils.psf subpackage.
 The benchmarks cover the per-call evaluation cost of the PSF models
 (the functional models, ImagePSF, and GriddedPSFModel), PSFPhotometry
 versus the number of sources and versus the PSF model type,
-IterativePSFPhotometry, SourceGrouper scaling, ePSF building
+IterativePSFPhotometry, the ImagePSF analytic Jacobian versus the
+finite-difference approximation, SourceGrouper scaling, ePSF building
 (extract_stars and EPSFBuilder), the Gaussian fitting helpers
 (fit_2dgaussian and fit_fwhm), and make_psf_model_image.
 
@@ -125,6 +126,17 @@ def make_gridded_psf_model(*, fwhm=FWHM, oversampling=4, n_psfs_side=3,
     planes = np.repeat(epsf[None], len(grid_xypos), axis=0)
     meta = {'grid_xypos': grid_xypos, 'oversampling': oversampling}
     return GriddedPSFModel(NDData(planes, meta=meta))
+
+
+class _NoDerivImagePSF(ImagePSF):
+    """
+    An ImagePSF variant with the analytic Jacobian disabled.
+
+    It is used by the Jacobian benchmark to time the fitter's
+    finite-difference fallback.
+    """
+
+    fit_deriv = None
 
 
 def make_psf_models():
@@ -418,6 +430,68 @@ def bench_model_types(*, size=512, n_sources=100, repeats=3, seed=0):
         print(f'{name:>26}{cell:>22}')
 
 
+def bench_jacobian(*, size=512, n_sources=100, fit_shapes=(5, 11),
+                   repeats=3, seed=0):
+    """
+    Benchmark the ImagePSF analytic Jacobian in PSFPhotometry.
+
+    The analytic Jacobian (``fit_deriv``) is compared against the
+    fitter's finite-difference approximation, with the source
+    positions and fluxes given via ``init_params``.
+
+    Parameters
+    ----------
+    size : int, optional
+        The image size; the image is ``(size, size)``.
+
+    n_sources : int, optional
+        The number of sources.
+
+    fit_shapes : tuple of int, optional
+        The fit shapes; each fit shape is ``(fit_shape, fit_shape)``.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    epsf_data = make_epsf_data()
+    variants = [
+        ('analytic (fit_deriv)', ImagePSF(epsf_data, oversampling=4)),
+        ('finite difference', _NoDerivImagePSF(epsf_data, oversampling=4)),
+    ]
+    data, params = make_scene(variants[0][1], (size, size), n_sources,
+                              seed=seed)
+    init_params = params['x_0', 'y_0', 'flux']
+
+    print(f'\n== ImagePSF Jacobian ({size}x{size} image, {n_sources} '
+          'sources, per-call time) ==')
+    header = f'{"variant":>24}'
+    for fit_shape in fit_shapes:
+        header += f'{f"fit_shape={fit_shape}":>22}'
+    print(header)
+    times = {}
+    for name, psf_model in variants:
+        cells = ''
+        for fit_shape in fit_shapes:
+            phot = PSFPhotometry(psf_model, fit_shape=fit_shape,
+                                 group_warning_threshold=10**9)
+            bench = partial(run_photometry, phot, data, init_params)
+            t_call = time_best(bench, repeats=repeats)
+            times[name, fit_shape] = t_call
+            per_source = t_call / n_sources * 1e3
+            cells += f'{f"{t_call:.3f}s ({per_source:.2f}ms/src)":>22}'
+        print(f'{name:>24}{cells}')
+
+    cells = ''
+    for fit_shape in fit_shapes:
+        speedup = (times['finite difference', fit_shape]
+                   / times['analytic (fit_deriv)', fit_shape])
+        cells += f'{f"{speedup:.2f}x":>22}'
+    print(f'{"speedup":>24}{cells}')
+
+
 def run_grouper(grouper, x, y, n_iter):
     """
     Run a SourceGrouper repeatedly.
@@ -689,8 +763,9 @@ def main():
                              '(default: %(default)s)')
     parser.add_argument('--which', default='all',
                         choices=['all', 'model-eval', 'photometry',
-                                 'iterative', 'model-types', 'grouper',
-                                 'epsf', 'fit-helpers', 'simulation'],
+                                 'iterative', 'model-types', 'jacobian',
+                                 'grouper', 'epsf', 'fit-helpers',
+                                 'simulation'],
                         help='which benchmark to run '
                              '(default: %(default)s)')
     args = parser.parse_args()
@@ -706,6 +781,8 @@ def main():
         bench_iterative(repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'model-types'):
         bench_model_types(repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'jacobian'):
+        bench_jacobian(repeats=args.repeats, seed=args.seed)
     if args.which in ('all', 'grouper'):
         bench_grouper(n_sources_list=args.n_grouper_list,
                       repeats=args.repeats, seed=args.seed)

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -19,6 +19,7 @@ from photutils.psf.model_io import (GriddedPSFModelRead, _get_metadata,
                                     stdpsf_reader, webbpsf_reader)
 from photutils.psf.model_plotting import (_ModelGridPlotter,
                                           _plot_grid_docstring)
+from photutils.psf.utils import _out_of_grid_mask
 from photutils.utils._parameters import as_pair
 
 __all__ = ['GriddedPSFModel', 'STDPSFGrid']
@@ -885,10 +886,8 @@ class GriddedPSFModel(Fittable2DModel):
 
         if self.fill_value is not None:
             # Set pixels that are outside the input pixel grid to the
-            # fill_value to avoid extrapolation; these bounds match the
-            # RegularGridInterpolator bounds.
-            ny, nx = self.data.shape[1:]
-            invalid = (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
+            # fill_value to avoid extrapolation
+            invalid = _out_of_grid_mask(xi, yi, self.data.shape[1:])
             evaluated_model[invalid] = self.fill_value
 
         return evaluated_model
@@ -992,8 +991,7 @@ class GriddedPSFModel(Fittable2DModel):
         if self.fill_value is not None:
             # Outside the input pixel grid the model is constant
             # (fill_value), so all derivatives are zero there
-            ny, nx = self.data.shape[1:]
-            invalid = (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
+            invalid = _out_of_grid_mask(xi, yi, self.data.shape[1:])
             d_flux[invalid] = 0.0
             d_x_0[invalid] = 0.0
             d_y_0[invalid] = 0.0

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -126,7 +126,9 @@ class GriddedPSFModel(Fittable2DModel):
     One `~scipy.interpolate.RectBivariateSpline` interpolator per
     evaluated grid plane is cached on the model and shared across copies
     made with the `copy` method. The cache roughly doubles the model's
-    memory footprint when every grid plane has been evaluated.
+    memory footprint when every grid plane has been evaluated. Two
+    partial-derivative interpolators per grid plane used by `fit_deriv`
+    are cached in the same way.
     """
 
     flux = Parameter(description='Intensity scaling factor for the ePSF '
@@ -158,6 +160,7 @@ class GriddedPSFModel(Fittable2DModel):
         self.meta['grid_xypos'] = self.grid_xypos
 
         self._interpolator = {}
+        self._deriv_interpolator = {}
 
         super().__init__(flux, x_0, y_0)
 
@@ -538,6 +541,45 @@ class GriddedPSFModel(Fittable2DModel):
 
         return interp
 
+    def _calc_deriv_interpolators(self, grid_idx):
+        """
+        Calculate the spline partial-derivative interpolators for an
+        input ePSF image at the given reference (x, y) position.
+
+        The interpolators evaluate the partial derivatives of the
+        `_calc_interpolator` spline with respect to its first (x)
+        and second (y) variables. They are precomputed here because
+        evaluating them is faster than passing ``dx=1`` or ``dy=1`` to
+        the interpolator, which computes the derivative on the fly. They
+        are used by `fit_deriv`.
+
+        The resulting interpolators are cached in the
+        `_deriv_interpolator` dictionary for reuse.
+
+        Parameters
+        ----------
+        grid_idx : int
+            The index of the ePSF image in the reference grid.
+
+        Returns
+        -------
+        interps : tuple of `~scipy.interpolate.RectBivariateSpline`
+            The x and y partial-derivative interpolators for the input
+            ePSF image.
+        """
+        # Check if the interpolators are already cached
+        if grid_idx in self._deriv_interpolator:
+            return self._deriv_interpolator[grid_idx]
+
+        interp = self._calc_interpolator(grid_idx)
+        derivs = (interp.partial_derivative(1, 0),
+                  interp.partial_derivative(0, 1))
+
+        # Cache the interpolators for reuse
+        self._deriv_interpolator[grid_idx] = derivs
+
+        return derivs
+
     @cached_property
     def _xgrid_list(self):
         """
@@ -699,6 +741,59 @@ class GriddedPSFModel(Fittable2DModel):
         ur = (xi - x0) * (yi - y0) * inv_norm
         return np.array((ll, lr, ul, ur))
 
+    def _calc_bilinear_weight_derivs(self, xi, yi, grid_xy):
+        """
+        Calculate the partial derivatives of the bilinear interpolation
+        weights with respect to the (xi, yi) coordinate.
+
+        This method is a scalar-only fast path: ``xi`` and ``yi`` must
+        be scalar values (the model ``x_0`` and ``y_0`` positions).
+
+        `_calc_bilinear_weights` clamps the coordinates to the grid
+        cell, so the weights are constant outside the cell and the
+        corresponding derivatives are zero there.
+
+        Parameters
+        ----------
+        xi, yi : float
+            The scalar (x_0, y_0) position of the model.
+
+        grid_xy : `~numpy.ndarray`
+            The x and y coordinates of the four bounding points. The
+            order is left, right, bottom, top.
+
+        Returns
+        -------
+        dw_dx, dw_dy : `~numpy.ndarray`
+            The partial derivatives of the bilinear weights for the four
+            bounding points with respect to ``xi`` and ``yi``. The order
+            is lower-left, lower-right, upper-left, upper-right.
+        """
+        x0, x1, y0, y1 = grid_xy
+        xi = float(xi)
+        yi = float(yi)
+        inv_norm = 1.0 / ((x1 - x0) * (y1 - y0))
+
+        # Clamp the coordinates as in _calc_bilinear_weights. The
+        # clamped values are used in the derivatives along the other
+        # axis.
+        x_inside = x0 <= xi <= x1
+        y_inside = y0 <= yi <= y1
+        xc = min(max(xi, x0), x1)
+        yc = min(max(yi, y0), y1)
+
+        if x_inside:
+            dw_dx = np.array((-(y1 - yc), (y1 - yc),
+                              -(yc - y0), (yc - y0))) * inv_norm
+        else:
+            dw_dx = np.zeros(4)
+        if y_inside:
+            dw_dy = np.array((-(x1 - xc), -(xc - x0),
+                              (x1 - xc), (xc - x0))) * inv_norm
+        else:
+            dw_dy = np.zeros(4)
+        return dw_dx, dw_dy
+
     def _calc_model_values(self, x_0, y_0, xi, yi):
         """
         Calculate the ePSF model at a given (x_0, y_0) model coordinate
@@ -797,6 +892,113 @@ class GriddedPSFModel(Fittable2DModel):
             evaluated_model[invalid] = self.fill_value
 
         return evaluated_model
+
+    def fit_deriv(self, x, y, flux, x_0, y_0):
+        """
+        Calculate the partial derivatives of the ePSF model with respect
+        to the model parameters.
+
+        Providing this analytic Jacobian allows the fitter to avoid the
+        finite-difference approximation, which requires additional model
+        evaluations.
+
+        The position derivatives include both the shift of the ePSF with
+        the model position and the change of the bilinearly interpolated
+        ePSF itself with the model position across the reference grid.
+
+        Parameters
+        ----------
+        x, y : float or `~numpy.ndarray`
+            The x and y positions at which to evaluate the model.
+
+        flux : float
+            The flux scaling factor for the model.
+
+        x_0, y_0 : float
+            The (x, y) position of the model.
+
+        Returns
+        -------
+        result : list of `~numpy.ndarray`
+            The list of partial derivatives with respect to the
+            ``flux``, ``x_0``, and ``y_0`` parameters.
+        """
+        # Promote scalar inputs to 1D arrays so that the interpolator
+        # returns an array that supports masked assignment below,
+        # regardless of the scipy version
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
+        if x.ndim > 2:
+            msg = 'x and y must be 1D or 2D'
+            raise ValueError(msg)
+
+        # The fitting machinery may pass the parameters as size-1
+        # arrays, but we need scalar values for the interpolator.
+        if not np.isscalar(x_0):
+            x_0 = x_0[0]
+        if not np.isscalar(y_0):
+            y_0 = y_0[0]
+
+        xi = self.oversampling[1] * (np.asarray(x, dtype=float) - x_0)
+        yi = self.oversampling[0] * (np.asarray(y, dtype=float) - y_0)
+        xi += self.origin[0]
+        yi += self.origin[1]
+
+        if self.data.shape[0] == 1:
+            # If there is only one ePSF, the model has no dependence
+            # on the (x_0, y_0) position through the bilinear weights
+            dx_interp, dy_interp = self._calc_deriv_interpolators(0)
+            d_flux = self._calc_interpolator(0)(xi, yi, grid=False)
+            deriv_x = -self.oversampling[1] * dx_interp(xi, yi, grid=False)
+            deriv_y = -self.oversampling[0] * dy_interp(xi, yi, grid=False)
+        else:
+            grid_idx, grid_xy = self._find_bounding_points(x_0, y_0)
+            weights = self._calc_bilinear_weights(x_0, y_0, grid_xy)
+            dw_dx, dw_dy = self._calc_bilinear_weight_derivs(x_0, y_0,
+                                                             grid_xy)
+
+            d_flux = 0.0
+            deriv_x = 0.0
+            deriv_y = 0.0
+            for gidx, weight, dwx, dwy in zip(grid_idx, weights, dw_dx,
+                                              dw_dy, strict=True):
+                if weight == 0.0 and dwx == 0.0 and dwy == 0.0:
+                    continue
+                gidx = int(gidx)
+                value = self._calc_interpolator(gidx)(xi, yi, grid=False)
+
+                # The ePSF value contributes to the flux derivative
+                # through its weight and to the position derivatives
+                # through the weight derivatives
+                d_flux += weight * value
+                deriv_x += dwx * value
+                deriv_y += dwy * value
+
+                # The chain rule gives the shift terms of the position
+                # derivatives from the spline partial derivatives
+                # (dxi/dx_0 = -oversampling[1], dyi/dy_0 =
+                # -oversampling[0])
+                if weight != 0.0:
+                    dx_interp, dy_interp = self._calc_deriv_interpolators(
+                        gidx)
+                    deriv_x -= (weight * self.oversampling[1]
+                                * dx_interp(xi, yi, grid=False))
+                    deriv_y -= (weight * self.oversampling[0]
+                                * dy_interp(xi, yi, grid=False))
+
+        d_x_0 = flux * deriv_x
+        d_y_0 = flux * deriv_y
+
+        if self.fill_value is not None:
+            # Outside the input pixel grid the model is constant
+            # (fill_value), so all derivatives are zero there
+            ny, nx = self.data.shape[1:]
+            invalid = (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
+            d_flux[invalid] = 0.0
+            d_x_0[invalid] = 0.0
+            d_y_0[invalid] = 0.0
+
+        return [d_flux, d_x_0, d_y_0]
 
     @_plot_grid_docstring
     def plot_grid(self, *, ax=None, vmax_scale=None, peak_norm=False,

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -465,8 +465,13 @@ class ImagePSF(Fittable2DModel):
             The list of partial derivatives with respect to the
             ``flux``, ``x_0``, and ``y_0`` parameters.
         """
-        xi = self.oversampling[1] * (np.asarray(x, dtype=float) - x_0)
-        yi = self.oversampling[0] * (np.asarray(y, dtype=float) - y_0)
+        # Promote scalar inputs to 1D arrays so that the interpolator
+        # returns an array that supports masked assignment below,
+        # regardless of the scipy version
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        y = np.atleast_1d(np.asarray(y, dtype=float))
+        xi = self.oversampling[1] * (x - x_0)
+        yi = self.oversampling[0] * (y - y_0)
         xi += self._origin[0]
         yi += self._origin[1]
 

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.modeling import Fittable2DModel, Parameter
 from scipy.interpolate import RectBivariateSpline
 
+from photutils.psf.utils import _out_of_grid_mask
 from photutils.utils._parameters import as_pair
 
 __all__ = ['ImagePSF']
@@ -450,10 +451,8 @@ class ImagePSF(Fittable2DModel):
 
         if self.fill_value is not None:
             # Set pixels that are outside the input pixel grid to the
-            # fill_value to avoid extrapolation. These bounds match the
-            # RegularGridInterpolator bounds.
-            ny, nx = self.data.shape
-            invalid = (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
+            # fill_value to avoid extrapolation
+            invalid = _out_of_grid_mask(xi, yi, self.data.shape)
             evaluated_model[invalid] = self.fill_value
 
         return evaluated_model
@@ -510,8 +509,7 @@ class ImagePSF(Fittable2DModel):
         if self.fill_value is not None:
             # Outside the input pixel grid the model is constant
             # (fill_value), so all derivatives are zero there
-            ny, nx = self.data.shape
-            invalid = (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
+            invalid = _out_of_grid_mask(xi, yi, self.data.shape)
             d_flux[invalid] = 0.0
             d_x_0[invalid] = 0.0
             d_y_0[invalid] = 0.0

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -436,3 +436,57 @@ class ImagePSF(Fittable2DModel):
             evaluated_model[invalid] = self.fill_value
 
         return evaluated_model
+
+    def fit_deriv(self, x, y, flux, x_0, y_0):
+        """
+        Calculate the partial derivatives of the image model with
+        respect to the model parameters.
+
+        Providing this analytic Jacobian allows the fitter to avoid the
+        finite-difference approximation, which requires additional model
+        evaluations.
+
+        Parameters
+        ----------
+        x, y : float or array_like
+            The x and y coordinates at which to evaluate the model.
+
+        flux : float
+            The total flux of the source, assuming the input image
+            was properly normalized.
+
+        x_0, y_0 : float
+            The x and y positions of the feature in the image in the
+            output coordinate grid on which the model is evaluated.
+
+        Returns
+        -------
+        result : list of `~numpy.ndarray`
+            The list of partial derivatives with respect to the
+            ``flux``, ``x_0``, and ``y_0`` parameters.
+        """
+        xi = self.oversampling[1] * (np.asarray(x, dtype=float) - x_0)
+        yi = self.oversampling[0] * (np.asarray(y, dtype=float) - y_0)
+        xi += self._origin[0]
+        yi += self._origin[1]
+
+        # The spline interpolation is linear in flux, and the chain rule
+        # gives the x_0 and y_0 derivatives from the spline partial
+        # derivatives (dxi/dx_0 = -oversampling[1], dyi/dy_0 =
+        # -oversampling[0])
+        d_flux = self.interpolator(xi, yi, grid=False)
+        d_x_0 = (-flux * self.oversampling[1]
+                 * self.interpolator(xi, yi, dx=1, grid=False))
+        d_y_0 = (-flux * self.oversampling[0]
+                 * self.interpolator(xi, yi, dy=1, grid=False))
+
+        if self.fill_value is not None:
+            # Outside the input pixel grid the model is constant
+            # (fill_value), so all derivatives are zero there
+            ny, nx = self.data.shape
+            invalid = (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
+            d_flux[invalid] = 0.0
+            d_x_0[invalid] = 0.0
+            d_y_0[invalid] = 0.0
+
+        return [d_flux, d_x_0, d_y_0]

--- a/photutils/psf/image_models.py
+++ b/photutils/psf/image_models.py
@@ -250,8 +250,10 @@ class ImagePSF(Fittable2DModel):
         """
         self._validate_data(value)
         self._data = value
-        # Discard the cached interpolator, which is tied to the old data
+        # Discard the cached interpolators, which are tied to the old
+        # data
         self.__dict__.pop('interpolator', None)
+        self.__dict__.pop('_deriv_interpolators', None)
 
     @property
     def shape(self):
@@ -339,13 +341,32 @@ class ImagePSF(Fittable2DModel):
 
         Notes
         -----
-        This property can be overridden in a subclass to define custom
-        interpolators.
+        This property can be overridden in a subclass to define
+        custom interpolators. A custom interpolator must provide
+        a `~scipy.interpolate.RectBivariateSpline`-compatible
+        ``partial_derivative`` method to support `fit_deriv`. Otherwise,
+        the subclass should also set ``fit_deriv = None`` to fall back
+        to the fitter's finite-difference Jacobian.
         """
         x = np.arange(self.data.shape[1])
         y = np.arange(self.data.shape[0])
         # RectBivariateSpline expects the data to be in (x, y) axis order
         return RectBivariateSpline(x, y, self.data.T, kx=3, ky=3, s=0)
+
+    @cached_property
+    def _deriv_interpolators(self):
+        """
+        The spline partial-derivative interpolators.
+
+        The interpolators evaluate the partial derivatives of
+        `interpolator` with respect to its first (x) and second (y)
+        variables. They are precomputed here because evaluating them
+        is faster than passing ``dx=1`` or ``dy=1`` to `interpolator`,
+        which computes the derivative on the fly. They are used by
+        `fit_deriv`.
+        """
+        return (self.interpolator.partial_derivative(1, 0),
+                self.interpolator.partial_derivative(0, 1))
 
     def _calc_bounding_box(self):
         """
@@ -479,11 +500,12 @@ class ImagePSF(Fittable2DModel):
         # gives the x_0 and y_0 derivatives from the spline partial
         # derivatives (dxi/dx_0 = -oversampling[1], dyi/dy_0 =
         # -oversampling[0])
+        dx_interp, dy_interp = self._deriv_interpolators
         d_flux = self.interpolator(xi, yi, grid=False)
         d_x_0 = (-flux * self.oversampling[1]
-                 * self.interpolator(xi, yi, dx=1, grid=False))
+                 * dx_interp(xi, yi, grid=False))
         d_y_0 = (-flux * self.oversampling[0]
-                 * self.interpolator(xi, yi, dy=1, grid=False))
+                 * dy_interp(xi, yi, grid=False))
 
         if self.fill_value is not None:
             # Outside the input pixel grid the model is constant

--- a/photutils/psf/tests/test_gridded_models.py
+++ b/photutils/psf/tests/test_gridded_models.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.modeling.models import Gaussian2D
 from astropy.nddata import NDData
 from astropy.table import QTable
@@ -359,6 +360,177 @@ class TestGriddedPSFModel:
             result = psfmodel._calc_model_values(x_0, y_0, xi, yi)
             expected = _reference_calc_model_values(psfmodel, x_0, y_0, xi, yi)
             assert_allclose(result, expected, rtol=1e-12, atol=1e-12)
+
+    @pytest.mark.parametrize('oversampling', [4, (2, 3)])
+    @pytest.mark.parametrize('position', [(95.3, 87.6), (-30.0, 87.6),
+                                          (95.3, 230.0)])
+    def test_fit_deriv(self, psfmodel, oversampling, position):
+        """
+        Test the analytic derivatives against central finite differences
+        of evaluate, for interior and outside-grid model positions and
+        for symmetric and asymmetric oversampling.
+
+        The grid planes are distinct, so this test also verifies the
+        derivative term from the change of the bilinearly interpolated
+        ePSF with the model position (omitting it gives errors of about
+        1e-3, far above the tolerances).
+        """
+        meta = {'grid_xypos': psfmodel.grid_xypos,
+                'oversampling': oversampling}
+        model = GriddedPSFModel(NDData(psfmodel.data, meta=meta))
+
+        flux = 3.0
+        x_0, y_0 = position
+        x, y = np.meshgrid(np.linspace(x_0 - 8, x_0 + 8, 13),
+                           np.linspace(y_0 - 8, y_0 + 8, 13))
+        x = x.ravel()
+        y = y.ravel()
+
+        d_flux, d_x_0, d_y_0 = model.fit_deriv(x, y, flux, x_0, y_0)
+
+        eps = 1e-6
+
+        def ev(f, a, b):
+            return model.evaluate(x, y, f, a, b)
+
+        num_flux = (ev(flux + eps, x_0, y_0)
+                    - ev(flux - eps, x_0, y_0)) / (2 * eps)
+        num_x_0 = (ev(flux, x_0 + eps, y_0)
+                   - ev(flux, x_0 - eps, y_0)) / (2 * eps)
+        num_y_0 = (ev(flux, x_0, y_0 + eps)
+                   - ev(flux, x_0, y_0 - eps)) / (2 * eps)
+
+        assert_allclose(d_flux, num_flux, atol=1e-8)
+        assert_allclose(d_x_0, num_x_0, atol=1e-7)
+        assert_allclose(d_y_0, num_y_0, atol=1e-7)
+
+    def test_fit_deriv_grid_corner(self, psfmodel):
+        """
+        Test the derivatives with the model positioned exactly on a
+        grid corner, where one bounding ePSF has zero weight and zero
+        weight derivatives.
+        """
+        x_0, y_0 = 40.0, 60.0  # grid corner
+        x = np.linspace(x_0 - 8, x_0 + 8, 9)
+        y = np.linspace(y_0 - 8, y_0 + 8, 9)
+        derivs = psfmodel.fit_deriv(x, y, 2.0, x_0, y_0)
+        for deriv in derivs:
+            assert np.all(np.isfinite(deriv))
+        # The flux derivative is the unit-flux model value
+        assert_allclose(derivs[0],
+                        psfmodel.evaluate(x, y, 1.0, x_0, y_0))
+
+    def test_fit_deriv_single_plane(self, psfmodel):
+        """
+        Test the derivatives for a grid containing a single ePSF,
+        which has no dependence on the model position through the
+        bilinear weights.
+        """
+        meta = {'grid_xypos': [psfmodel.grid_xypos[0]],
+                'oversampling': psfmodel.oversampling}
+        model = GriddedPSFModel(NDData(psfmodel.data[:1], meta=meta))
+
+        flux, x_0, y_0 = 2.0, 10.3, -4.6
+        x, y = np.meshgrid(np.linspace(x_0 - 8, x_0 + 8, 9),
+                           np.linspace(y_0 - 8, y_0 + 8, 9))
+        x = x.ravel()
+        y = y.ravel()
+        d_flux, d_x_0, d_y_0 = model.fit_deriv(x, y, flux, x_0, y_0)
+
+        eps = 1e-6
+
+        def ev(f, a, b):
+            return model.evaluate(x, y, f, a, b)
+
+        num_flux = (ev(flux + eps, x_0, y_0)
+                    - ev(flux - eps, x_0, y_0)) / (2 * eps)
+        num_x_0 = (ev(flux, x_0 + eps, y_0)
+                   - ev(flux, x_0 - eps, y_0)) / (2 * eps)
+        num_y_0 = (ev(flux, x_0, y_0 + eps)
+                   - ev(flux, x_0, y_0 - eps)) / (2 * eps)
+
+        assert_allclose(d_flux, num_flux, atol=1e-8)
+        assert_allclose(d_x_0, num_x_0, atol=1e-7)
+        assert_allclose(d_y_0, num_y_0, atol=1e-7)
+
+    def test_fit_deriv_out_of_bounds(self, psfmodel):
+        """
+        Test the derivatives at positions that map outside the ePSF
+        pixel grid.
+        """
+        x_0, y_0 = 95.3, 87.6
+        x = np.array([x_0, x_0 - 100.0, x_0 + 100.0])
+        y = np.array([y_0, y_0, y_0])
+        derivs = psfmodel.fit_deriv(x, y, 1.0, x_0, y_0)
+        # All derivatives must be zero outside the ePSF pixel grid
+        for deriv in derivs:
+            assert_equal(deriv[1:], 0.0)
+        # The flux derivative is nonzero at the in-bounds peak position
+        assert derivs[0][0] > 0.0
+
+        # With fill_value=None, out-of-bounds derivatives are
+        # extrapolated from the spline fit instead of being zeroed
+        meta = {'grid_xypos': psfmodel.grid_xypos,
+                'oversampling': psfmodel.oversampling}
+        model = GriddedPSFModel(NDData(psfmodel.data, meta=meta),
+                                fill_value=None)
+        derivs = model.fit_deriv(np.array([x_0 + 14.0]), np.array([y_0]),
+                                 1.0, x_0, y_0)
+        assert np.all(np.isfinite([deriv[0] for deriv in derivs]))
+        assert derivs[1][0] != 0.0
+
+    def test_fit_deriv_scalar(self, psfmodel):
+        """
+        Test that scalar inputs are promoted to 1D arrays, matching
+        evaluate, and that inputs with more than 2 dimensions raise an
+        error.
+        """
+        x_0, y_0 = 95.3, 87.6
+        derivs = psfmodel.fit_deriv(x_0 + 1.5, y_0 - 2.5, 1.0, x_0, y_0)
+        expected = psfmodel.fit_deriv(np.array([x_0 + 1.5]),
+                                      np.array([y_0 - 2.5]), 1.0, x_0, y_0)
+        for deriv, exp in zip(derivs, expected, strict=True):
+            assert deriv.shape == (1,)
+            assert_allclose(deriv, exp)
+
+        # Size-1 array model parameters, as passed by the fitting
+        # machinery, are converted to scalars
+        derivs = psfmodel.fit_deriv(x_0 + 1.5, y_0 - 2.5, 1.0,
+                                    np.array([x_0]), np.array([y_0]))
+        for deriv, exp in zip(derivs, expected, strict=True):
+            assert_allclose(deriv, exp)
+
+        match = 'x and y must be 1D or 2D'
+        with pytest.raises(ValueError, match=match):
+            psfmodel.fit_deriv(np.ones((2, 2, 2)), np.ones((2, 2, 2)),
+                               1.0, x_0, y_0)
+
+    def test_fit_deriv_fitting(self, psfmodel):
+        """
+        Test that fitting with the analytic Jacobian recovers the true
+        parameters and matches the finite-difference approximation.
+        """
+        yy, xx = np.mgrid[0:25, 0:25].astype(float)
+        xx += 84.0
+        yy += 76.0
+
+        truth = psfmodel.copy()
+        truth.flux, truth.x_0, truth.y_0 = 5.0, 96.4, 88.6
+        rng = np.random.default_rng(0)
+        data = truth(xx, yy) + rng.normal(0.0, 0.005, xx.shape)
+
+        assert GriddedPSFModel.fit_deriv is not None
+        fit_params = []
+        for estimate_jacobian in (False, True):
+            init = psfmodel.copy()
+            init.flux, init.x_0, init.y_0 = 3.0, 96.0, 89.0
+            fitter = TRFLSQFitter()
+            fit = fitter(init, xx.ravel(), yy.ravel(), data.ravel(),
+                         estimate_jacobian=estimate_jacobian)
+            fit_params.append(fit.parameters)
+
+        assert_allclose(fit_params[0], fit_params[1], rtol=1e-4)
+        assert_allclose(fit_params[0], (5.0, 96.4, 88.6), rtol=1e-2)
 
     def test_gridded_psf_model_invalid_inputs(self):
         data = np.ones((4, 5, 5))

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -5,6 +5,7 @@ Tests for the image_models module.
 
 import numpy as np
 import pytest
+from astropy.modeling.fitting import TRFLSQFitter
 from numpy.testing import assert_allclose, assert_equal
 
 from photutils.psf import CircularGaussianPSF, ImagePSF
@@ -37,35 +38,50 @@ class TestImagePSF:
         for x, y in [(0.5, 0.5), (-0.5, 1.75)]:
             assert_allclose(model(x, y), gaussian_psf(x, y), atol=4e-3)
 
-    def test_fit_deriv(self):
+    @pytest.mark.parametrize('oversampling', [1, 2, (2, 3)])
+    @pytest.mark.parametrize('origin', [None, (11.0, 13.0)])
+    def test_fit_deriv(self, oversampling, origin):
         gaussian_psf = CircularGaussianPSF(flux=1, x_0=12, y_0=12, fwhm=3.5)
         yy, xx = np.mgrid[0:25, 0:25].astype(float)
         psf_data = gaussian_psf(xx, yy)
 
-        for oversampling in (1, 2):
-            model = ImagePSF(psf_data, flux=2.0, x_0=12.3, y_0=11.7,
-                             oversampling=oversampling)
-            y, x = np.mgrid[0:15, 0:15].astype(float)
-            x = x.ravel() + 5
-            y = y.ravel() + 4
-            flux, x_0, y_0 = 2.0, 12.3, 11.7
-            d_flux, d_x_0, d_y_0 = model.fit_deriv(x, y, flux, x_0, y_0)
+        flux, x_0, y_0 = 2.0, 12.3, 11.7
+        model = ImagePSF(psf_data, flux=flux, x_0=x_0, y_0=y_0,
+                         oversampling=oversampling, origin=origin)
 
-            eps = 1e-6
+        # Evaluation points covering the valid model domain, with a
+        # margin so that the central differences below do not cross
+        # the fill_value boundary
+        ny, nx = psf_data.shape
+        margin = 0.5
+        x_lo = x_0 - model.origin[0] / model.oversampling[1] + margin
+        x_hi = (x_0 + (nx - 1 - model.origin[0]) / model.oversampling[1]
+                - margin)
+        y_lo = y_0 - model.origin[1] / model.oversampling[0] + margin
+        y_hi = (y_0 + (ny - 1 - model.origin[1]) / model.oversampling[0]
+                - margin)
+        x, y = np.meshgrid(np.linspace(x_lo, x_hi, 15),
+                           np.linspace(y_lo, y_hi, 15))
+        x = x.ravel()
+        y = y.ravel()
 
-            def ev(f, a, b, model=model, x=x, y=y):
-                return model.evaluate(x, y, f, a, b)
+        d_flux, d_x_0, d_y_0 = model.fit_deriv(x, y, flux, x_0, y_0)
 
-            num_flux = (ev(flux + eps, x_0, y_0)
-                        - ev(flux - eps, x_0, y_0)) / (2 * eps)
-            num_x_0 = (ev(flux, x_0 + eps, y_0)
-                       - ev(flux, x_0 - eps, y_0)) / (2 * eps)
-            num_y_0 = (ev(flux, x_0, y_0 + eps)
-                       - ev(flux, x_0, y_0 - eps)) / (2 * eps)
+        eps = 1e-6
 
-            assert_allclose(d_flux, num_flux, atol=1e-8)
-            assert_allclose(d_x_0, num_x_0, atol=1e-7)
-            assert_allclose(d_y_0, num_y_0, atol=1e-7)
+        def ev(f, a, b):
+            return model.evaluate(x, y, f, a, b)
+
+        num_flux = (ev(flux + eps, x_0, y_0)
+                    - ev(flux - eps, x_0, y_0)) / (2 * eps)
+        num_x_0 = (ev(flux, x_0 + eps, y_0)
+                   - ev(flux, x_0 - eps, y_0)) / (2 * eps)
+        num_y_0 = (ev(flux, x_0, y_0 + eps)
+                   - ev(flux, x_0, y_0 - eps)) / (2 * eps)
+
+        assert_allclose(d_flux, num_flux, atol=1e-8)
+        assert_allclose(d_x_0, num_x_0, atol=1e-7)
+        assert_allclose(d_y_0, num_y_0, atol=1e-7)
 
     def test_fit_deriv_out_of_bounds(self):
         gaussian_psf = CircularGaussianPSF(flux=1, x_0=5, y_0=5, fwhm=2.0)
@@ -77,10 +93,71 @@ class TestImagePSF:
         x = np.array([5.0, -50.0, 100.0])
         y = np.array([5.0, 5.0, 5.0])
         d_flux, d_x_0, d_y_0 = model.fit_deriv(x, y, 1.0, 5.0, 5.0)
+
         # Derivatives must be zero outside the input pixel grid
         assert d_flux[1] == 0.0
         assert d_x_0[1] == 0.0
         assert d_y_0[2] == 0.0
+        derivs = model.fit_deriv(x, y, 1.0, 5.0, 5.0)
+
+        # All derivatives must be zero outside the input pixel grid
+        for deriv in derivs:
+            assert_equal(deriv[1:], 0.0)
+        # The flux derivative is nonzero at the in-bounds peak position
+        assert derivs[0][0] > 0.0
+
+        # With fill_value=None, out-of-bounds derivatives are
+        # extrapolated from the spline fit instead of being zeroed
+        model = ImagePSF(psf_data, flux=1.0, x_0=5.0, y_0=5.0,
+                         fill_value=None)
+        derivs = model.fit_deriv(np.array([12.0]), np.array([5.0]),
+                                 1.0, 5.0, 5.0)
+        assert np.all(np.isfinite([deriv[0] for deriv in derivs]))
+        assert derivs[1][0] != 0.0
+
+    def test_fit_deriv_scalar(self):
+        gaussian_psf = CircularGaussianPSF(flux=1, x_0=5, y_0=5, fwhm=2.0)
+        yy, xx = np.mgrid[0:11, 0:11].astype(float)
+        psf_data = gaussian_psf(xx, yy)
+        model = ImagePSF(psf_data, flux=1.0, x_0=5.0, y_0=5.0)
+
+        # Scalar inputs are promoted to 1D arrays, matching evaluate
+        derivs = model.fit_deriv(4.5, 5.5, 1.0, 5.0, 5.0)
+        expected = model.fit_deriv(np.array([4.5]), np.array([5.5]),
+                                   1.0, 5.0, 5.0)
+        for deriv, exp in zip(derivs, expected, strict=True):
+            assert deriv.shape == (1,)
+            assert_allclose(deriv, exp)
+
+        # Scalar out-of-bounds inputs give zero derivatives
+        derivs = model.fit_deriv(-50.0, 5.0, 1.0, 5.0, 5.0)
+        for deriv in derivs:
+            assert_equal(deriv, 0.0)
+
+    def test_fit_deriv_fitting(self):
+        """
+        Test that fitting with the analytic Jacobian recovers the true
+        parameters and matches the finite-difference approximation.
+        """
+        gaussian_psf = CircularGaussianPSF(flux=1, x_0=12, y_0=12, fwhm=3.5)
+        yy, xx = np.mgrid[0:25, 0:25].astype(float)
+        psf_data = gaussian_psf(xx, yy)
+
+        truth = ImagePSF(psf_data, flux=250.0, x_0=11.6, y_0=12.4)
+        rng = np.random.default_rng(0)
+        data = truth(xx, yy) + rng.normal(0.0, 0.02, xx.shape)
+
+        assert ImagePSF.fit_deriv is not None
+        fit_params = []
+        for estimate_jacobian in (False, True):
+            init = ImagePSF(psf_data, flux=200.0, x_0=12.0, y_0=12.0)
+            fitter = TRFLSQFitter()
+            fit = fitter(init, xx.ravel(), yy.ravel(), data.ravel(),
+                         estimate_jacobian=estimate_jacobian)
+            fit_params.append(fit.parameters)
+
+        assert_allclose(fit_params[0], fit_params[1], rtol=1e-5)
+        assert_allclose(fit_params[0], (250.0, 11.6, 12.4), rtol=1e-2)
 
     def test_imagepsf_oversampling(self, gaussian_psf):
         oversamp = 3

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -37,6 +37,51 @@ class TestImagePSF:
         for x, y in [(0.5, 0.5), (-0.5, 1.75)]:
             assert_allclose(model(x, y), gaussian_psf(x, y), atol=4e-3)
 
+    def test_fit_deriv(self):
+        gaussian_psf = CircularGaussianPSF(flux=1, x_0=12, y_0=12, fwhm=3.5)
+        yy, xx = np.mgrid[0:25, 0:25].astype(float)
+        psf_data = gaussian_psf(xx, yy)
+
+        for oversampling in (1, 2):
+            model = ImagePSF(psf_data, flux=2.0, x_0=12.3, y_0=11.7,
+                             oversampling=oversampling)
+            y, x = np.mgrid[0:15, 0:15].astype(float)
+            x = x.ravel() + 5
+            y = y.ravel() + 4
+            flux, x_0, y_0 = 2.0, 12.3, 11.7
+            d_flux, d_x_0, d_y_0 = model.fit_deriv(x, y, flux, x_0, y_0)
+
+            eps = 1e-6
+
+            def ev(f, a, b, model=model, x=x, y=y):
+                return model.evaluate(x, y, f, a, b)
+
+            num_flux = (ev(flux + eps, x_0, y_0)
+                        - ev(flux - eps, x_0, y_0)) / (2 * eps)
+            num_x_0 = (ev(flux, x_0 + eps, y_0)
+                       - ev(flux, x_0 - eps, y_0)) / (2 * eps)
+            num_y_0 = (ev(flux, x_0, y_0 + eps)
+                       - ev(flux, x_0, y_0 - eps)) / (2 * eps)
+
+            assert_allclose(d_flux, num_flux, atol=1e-8)
+            assert_allclose(d_x_0, num_x_0, atol=1e-7)
+            assert_allclose(d_y_0, num_y_0, atol=1e-7)
+
+    def test_fit_deriv_out_of_bounds(self):
+        gaussian_psf = CircularGaussianPSF(flux=1, x_0=5, y_0=5, fwhm=2.0)
+        yy, xx = np.mgrid[0:11, 0:11].astype(float)
+        psf_data = gaussian_psf(xx, yy)
+        model = ImagePSF(psf_data, flux=1.0, x_0=5.0, y_0=5.0)
+
+        # Include positions that map outside the input pixel grid
+        x = np.array([5.0, -50.0, 100.0])
+        y = np.array([5.0, 5.0, 5.0])
+        d_flux, d_x_0, d_y_0 = model.fit_deriv(x, y, 1.0, 5.0, 5.0)
+        # Derivatives must be zero outside the input pixel grid
+        assert d_flux[1] == 0.0
+        assert d_x_0[1] == 0.0
+        assert d_y_0[2] == 0.0
+
     def test_imagepsf_oversampling(self, gaussian_psf):
         oversamp = 3
         yy, xx = np.mgrid[-3:3.00001:(1 / oversamp), -3:3.00001:(1 / oversamp)]

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -70,6 +70,34 @@ def _make_mask(image, mask):
     return mask
 
 
+def _out_of_grid_mask(xi, yi, shape):
+    """
+    Compute a mask of positions outside an ePSF pixel grid.
+
+    The bounds match the `~scipy.interpolate.RegularGridInterpolator`
+    bounds. This helper defines the pixel-grid bounds used by both the
+    image-based PSF model evaluations and their analytic Jacobians
+    (``fit_deriv``), which must agree.
+
+    Parameters
+    ----------
+    xi, yi : `~numpy.ndarray`
+        The (x, y) coordinates in the oversampled pixel frame of the
+        ePSF image.
+
+    shape : tuple of int
+        The ``(ny, nx)`` shape of the ePSF image.
+
+    Returns
+    -------
+    mask : bool `~numpy.ndarray`
+        A mask where `True` indicates the position is outside the ePSF
+        pixel grid.
+    """
+    ny, nx = shape
+    return (xi < 0) | (xi > nx - 1) | (yi < 0) | (yi > ny - 1)
+
+
 def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
                    fit_shape=None, mask=None, error=None):
     """


### PR DESCRIPTION
This PR adds an analytic Jacobian (fit_deriv) to `ImagePSF` and `GriddedPSFModel`, allowing fitters to skip the finite-difference approximation during PSF fitting. This removes roughly 60-70% of the model evaluations per fit and speeds up PSFPhotometry by about 1.15-1.20x for both models at typical fit shapes.