### PR TITLE
Fix edge cases and input validation psf package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -364,6 +364,19 @@ Bug Fixes
     kernel must contain only finite values and have a positive
     maximum. [#2377]
 
+- ``photutils.isophote``
+
+  - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a
+    compilation issue with Cython 3.1.x. [#2260]
+
+  - Fixed spurious NumPy "Mean of empty slice" and related warnings
+    raised during isophote fitting when a trial or failed isophote has
+    an elliptical path that falls entirely (or largely) outside the
+    image. [#2283]
+
+  - Fixed ``EllipseSample`` not resetting ``EllipseGeometry`` cached
+    attributes when overriding ``sma``. [#2280]
+
 - ``photutils.morphology``
 
   - Fixed ``data_properties`` so that a ``background`` input with
@@ -625,6 +638,55 @@ Bug Fixes
     distance, matching the other PSF models. Previously, it returned
     NaN. [#2395]
 
+  - Fixed the ``CircularGaussianPSF.fit_deriv`` partial derivative with
+    respect to ``fwhm``. This affected only fits in which the ``fwhm``
+    parameter was unfixed. [#2347]
+
+  - Fixed ``ImagePSF`` to discard its cached interpolator when the
+    ``data`` attribute is set. Previously, assigning a new image to an
+    existing model silently continued to evaluate the old image. The
+    ``data`` and ``oversampling`` attributes are now also validated
+    when set, not only when the model is created. [#2347]
+
+  - Fixed the ``GriddedPSFModel.origin`` attribute, which returned a
+    three-element array instead of the documented ``(x, y)`` pair. The
+    spurious third element was derived from the number of ePSFs in the
+    grid. Model evaluation was unaffected because it used only the first
+    two elements. [#2347]
+
+  - Fixed the ``filter`` metadata parsed from the filename when reading
+    a gzipped STDPSF file (e.g., ``.fits.gz``). The file extension was
+    not removed, so the filter name included the extension. [#2346]
+
+  - Fixed ``webbpsf_reader`` to swap the ``DET_YX{i}`` FITS header
+    values when defining ``grid_xypos``. The reference ePSFs were
+    previously swapped to the wrong detector positions for any grid whose
+    x and y positions differ. [#2347]
+
+  - Fixed ``SourceGroups.plot`` to sample a user-supplied colormap over
+    its full range. Previously the colormap was indexed by the group
+    number, which gave nearly identical colors for every group (and
+    raised an ``IndexError`` for more than 256 groups). [#2347]
+
+  - Fixed reading a STDPSF file from an already-open
+    ``astropy.io.fits.HDUList``. Such input was accepted but then
+    raised a ``TypeError``. [#2347]
+
+  - Fixed the ``plot_grid`` title when the instrument, detector, or
+    filter metadata is missing. The missing values left stray spaces in
+    the title. [#2347]
+
+- ``photutils.psf_matching``
+
+  - ``make_wiener_kernel`` now validates a custom ``penalty`` array.
+    It must be 2D with odd dimensions in both axes, contain only finite
+    values, and not be all zeros. [#2372]
+
+  - ``make_kernel`` and ``make_wiener_kernel`` now raise a
+    ``ValueError`` if the computed kernel contains non-finite values,
+    which can occur when the Fourier-space denominator is zero at
+    frequencies where the numerator is also zero. [#2372]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range
@@ -655,70 +717,6 @@ Bug Fixes
 
   - ``SourceCatalog.add_property`` now raises a ``ValueError`` for
     names of built-in methods (e.g., ``to_table``). [#2378]
-
-- ``photutils.psf``
-
-  - Fixed the ``CircularGaussianPSF.fit_deriv`` partial derivative with
-    respect to ``fwhm``. This affected only fits in which the ``fwhm``
-    parameter was unfixed. [#2347]
-
-  - Fixed ``ImagePSF`` to discard its cached interpolator when the
-    ``data`` attribute is set. Previously, assigning a new image to an
-    existing model silently continued to evaluate the old image. The
-    ``data`` and ``oversampling`` attributes are now also validated
-    when set, not only when the model is created. [#2347]
-
-  - Fixed the ``GriddedPSFModel.origin`` attribute, which returned a
-    three-element array instead of the documented ``(x, y)`` pair. The
-    spurious third element was derived from the number of ePSFs in the
-    grid. Model evaluation was unaffected because it used only the first
-    two elements. [#2347]
-
-  - Fixed the ``filter`` metadata parsed from the filename when reading
-    a gzipped STDPSF file (e.g., ``.fits.gz``). The file extension was
-    not removed, so the filter name included the extension. [#2346]
-
-  - Fixed ``webbpsf_reader`` to swap the ``DET_YX{i}`` FITS header
-    values when defining ``grid_xypos``. The reference ePSFs were
-    previous swapped to the wrong detector positions for any grid whose
-    x and y positions differ. [#2347]
-
-  - Fixed ``SourceGroups.plot`` to sample a user-supplied colormap over
-    its full range. Previously the colormap was indexed by the group
-    number, which gave nearly identical colors for every group (and
-    raised an ``IndexError`` for more than 256 groups). [#2347]
-
-  - Fixed reading a STDPSF file from an already-open
-    ``astropy.io.fits.HDUList``. Such input was accepted but then
-    raised a ``TypeError``. [#2347]
-
-  - Fixed the ``plot_grid`` title when the instrument, detector, or
-    filter metadata is missing. The missing values left stray spaces in
-    the title. [#2347]
-
-- ``photutils.psf_matching``
-
-  - ``make_wiener_kernel`` now validates a custom ``penalty`` array.
-    It must be 2D with odd dimensions in both axes, contain only finite
-    values, and not be all zeros. [#2372]
-
-  - ``make_kernel`` and ``make_wiener_kernel`` now raise a
-    ``ValueError`` if the computed kernel contains non-finite values,
-    which can occur when the Fourier-space denominator is zero at
-    frequencies where the numerator is also zero. [#2372]
-
-- ``photutils.isophote``
-
-  - Changed ``bool`` to ``bint`` in ``ellipse_model.pyx`` to fix a
-    compilation issue with Cython 3.1.x. [#2260]
-
-  - Fixed spurious NumPy "Mean of empty slice" and related warnings
-    raised during isophote fitting when a trial or failed isophote has
-    an elliptical path that falls entirely (or largely) outside the
-    image. [#2283]
-
-  - Fixed ``EllipseSample`` not resetting ``EllipseGeometry`` cached
-    attributes when overriding ``sma``. [#2280]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -885,6 +885,12 @@ API Changes
     values within a fit region now includes the location of the fit
     region. [#2395]
 
+  - ``EPSFStars`` now explicitly supports array conversion (e.g.,
+    ``np.asarray`` or passing it to matplotlib's ``imshow``). A
+    container holding a single star (e.g., from indexing) converts to
+    that star's 2D cutout, and a container holding multiple stars
+    converts to a 3D stack of the cutouts. [#2395]
+
 - ``photutils.segmentation``
 
   - The ``deblend_sources`` "too many markers" warning key stored in

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -616,6 +616,11 @@ Bug Fixes
     pixels remained or all valid pixels were collinear.
     Nearest-neighbor interpolation is now used as a fallback. [#2395]
 
+  - Fixed a bug where the ``near_bound`` flag (bit 32) was only set
+    for bounds applied via the ``xy_bounds`` keyword. The flag is now
+    set when any fitted parameter is very close to its bounds,
+    including bounds set directly on the PSF model. [#2395]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range
@@ -873,6 +878,10 @@ API Changes
     silently ignored in favor of the ``NDData`` attributes. NDData
     input is now also documented in the ``__call__`` docstrings.
     [#2395]
+
+  - The error message raised for non-positive or non-finite ``error``
+    values within a fit region now includes the location of the fit
+    region. [#2395]
 
 - ``photutils.segmentation``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -607,6 +607,15 @@ Bug Fixes
     ``include_local_bkg=True`` when no local background values were
     available. The local background is now treated as zero. [#2391]
 
+  - Fixed a bug where the initial flux estimates in
+    ``fit_2dgaussian`` and ``fit_fwhm`` included pixels masked by the
+    ``mask`` keyword, corrupting the fit starting point. [#2395]
+
+  - Fixed a bug where interpolating missing data during ePSF
+    building raised a ``QhullError`` when fewer than three valid
+    pixels remained or all valid pixels were collinear.
+    Nearest-neighbor interpolation is now used as a fallback. [#2395]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -621,6 +621,10 @@ Bug Fixes
     set when any fitted parameter is very close to its bounds,
     including bounds set directly on the PSF model. [#2395]
 
+  - ``AiryDiskPSF`` now evaluates to zero at infinite radial
+    distance, matching the other PSF models. Previously, it returned
+    NaN. [#2395]
+
 - ``photutils.segmentation``
 
   - Fixed ``SourceCatalog.orientation`` to return a value in the range

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -858,6 +858,13 @@ API Changes
     clipping when stacking the ePSF residuals, as its docstring
     already documented. [#2390]
 
+  - The ``mask`` and ``error`` keywords of ``PSFPhotometry`` and
+    ``IterativePSFPhotometry`` now raise a ``ValueError`` when the
+    input data is an ``NDData`` instance. Previously, they were
+    silently ignored in favor of the ``NDData`` attributes. NDData
+    input is now also documented in the ``__call__`` docstrings.
+    [#2395]
+
 - ``photutils.segmentation``
 
   - The ``deblend_sources`` "too many markers" warning key stored in

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -125,8 +125,9 @@ Benchmarks for the `photutils.psf` subpackage:
   `new` and `all` modes
 - `PSFPhotometry` versus the PSF model type (each scene is rendered
   and fit with the same model)
-- the `ImagePSF` analytic Jacobian (`fit_deriv`) versus the fitter's
-  finite-difference approximation, with speedups
+- the `ImagePSF` and `GriddedPSFModel` analytic Jacobians
+  (`fit_deriv`) versus the fitter's finite-difference approximation,
+  with speedups
 - `SourceGrouper` versus the number of sources and the minimum
   separation
 - ePSF building (`extract_stars` and `EPSFBuilder`) versus the number

--- a/benchmarks/bench_psf.py
+++ b/benchmarks/bench_psf.py
@@ -6,8 +6,9 @@ Benchmarks for the photutils.psf subpackage.
 The benchmarks cover the per-call evaluation cost of the PSF models
 (the functional models, ImagePSF, and GriddedPSFModel), PSFPhotometry
 versus the number of sources and versus the PSF model type,
-IterativePSFPhotometry, the ImagePSF analytic Jacobian versus the
-finite-difference approximation, SourceGrouper scaling, ePSF building
+IterativePSFPhotometry, the ImagePSF and GriddedPSFModel analytic
+Jacobians versus the finite-difference approximation, SourceGrouper
+scaling, ePSF building
 (extract_stars and EPSFBuilder), the Gaussian fitting helpers
 (fit_2dgaussian and fit_fwhm), and make_psf_model_image.
 

--- a/docs/user_guide/epsf_building.rst
+++ b/docs/user_guide/epsf_building.rst
@@ -437,6 +437,8 @@ own `~astropy.stats.SigmaClip` instance to customize this behavior::
     ...                            sigma_clip=sigclip,
     ...                            progress_bar=False)  # doctest: +REMOTE_DATA
 
+Setting ``sigma_clip=None`` disables sigma clipping entirely.
+
 
 Including Weights
 -----------------

--- a/docs/user_guide/grouping.rst
+++ b/docs/user_guide/grouping.rst
@@ -37,11 +37,12 @@ Getting Started
 ---------------
 
 To group sources, Photutils includes a tool called
-:class:`~photutils.psf.SourceGrouper`. This class organizes sources
-into groups by applying a technique known as hierarchical agglomerative
-clustering, which uses a distance-based criterion. This functionality is
-implemented using the `scipy.cluster.hierarchy.fclusterdata` function
-from the SciPy library.
+:class:`~photutils.psf.SourceGrouper`. This class finds the groups as
+the connected components of the graph linking pairs of sources separated
+by less than or equal to the minimum separation distance. The result is
+identical to single-linkage hierarchical agglomerative clustering with a
+distance criterion, but it is computed using a KD-tree so that it scales
+to large numbers of sources.
 
 Typically, to group sources during PSF fitting, one would provide a
 :class:`~photutils.psf.SourceGrouper` object, configured with a minimum

--- a/docs/user_guide/psf.rst
+++ b/docs/user_guide/psf.rst
@@ -112,11 +112,15 @@ The size of the annulus and the statistic function can be configured in
 The next step is to fit the sources and/or groups. This
 task is performed using an Astropy fitter, for example
 `~astropy.modeling.fitting.TRFLSQFitter`, input via the ``fitter``
-keyword. The shape of the region to be fitted can be configured using
-the ``fit_shape`` parameter. In general, ``fit_shape`` should be set to
-a small size (e.g., (5, 5)) that covers the central part of the source
-with the highest flux signal-to-noise. The initial positions are derived
-from the ``finder`` algorithm. The initial flux values for the fit are
+keyword. The image-based PSF models (`~photutils.psf.ImagePSF` and
+`~photutils.psf.GriddedPSFModel`) provide analytic Jacobians that the
+fitters use automatically, avoiding finite-difference approximations
+of the parameter derivatives and speeding up the fits. The shape of
+the region to be fitted can be configured using the ``fit_shape``
+parameter. In general, ``fit_shape`` should be set to a small size
+(e.g., (5, 5)) that covers the central part of the source with the
+highest flux signal-to-noise. The initial positions are derived from
+the ``finder`` algorithm. The initial flux values for the fit are
 derived from measuring the flux in a circular aperture with radius
 ``aperture_radius``. Alternatively, the initial positions and fluxes can
 be input in a table via the ``init_params`` keyword when calling the
@@ -257,10 +261,8 @@ to create an image-based PSF model.
 
 Note that the non-circular Gaussian and Moffat models above have
 additional parameters beyond the standard PSF model parameters of
-position and flux (``x_0``, ``y_0``, and ``flux``). By default, these
-other parameters are "fixed" (i.e., not varied during the fitting
-process). The user can choose to also vary these parameters by setting
-the ``fixed`` attribute on the model parameter to `False`.
+position and flux (``x_0``, ``y_0``, and ``flux``), which are fixed by
+default as described above.
 
 Photutils also provides a convenience function called
 :func:`~photutils.psf.make_psf_model` that creates a PSF model from an
@@ -301,7 +303,8 @@ PSF Photometry Examples
 
 Let's start with a simple example using simulated stars whose PSF is
 assumed to be Gaussian. We'll create a synthetic image using tools
-provided by the :ref:`photutils.datasets <datasets>` module::
+provided by the `photutils.psf` and :ref:`photutils.datasets <datasets>`
+modules::
 
     >>> import numpy as np
     >>> from photutils.datasets import make_noise_image
@@ -499,12 +502,12 @@ Astropy table)::
 Fitting a single source
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-In some cases, one may want to fit only a single source (or few sources)
-in an image. We can do that by defining a table of the sources that we
-want to fit. For this example, let's fit the single source at ``(x,
-y) = (63, 49)``. We first define a table with this position and then
-pass that table into the ``init_params`` keyword when calling the PSF
-photometry class on the data::
+In some cases, one may want to fit only a single source (or a few
+sources) in an image. We can do that by defining a table of the sources
+that we want to fit. For this example, let's fit the single source at
+``(x, y) = (63, 49)``. We first define a table with this position and
+then pass that table into the ``init_params`` keyword when calling the
+PSF photometry class on the data::
 
     >>> from astropy.table import QTable
     >>> init_params = QTable()

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -297,6 +297,29 @@ caches), so a single instance is safe to share across threads and
 independent images can be processed concurrently.
 
 
+Faster PSF Fitting via Analytic Jacobians
+=========================================
+
+The image-based PSF models `~photutils.psf.ImagePSF` and
+`~photutils.psf.GriddedPSFModel` now provide analytic Jacobians through
+their ``fit_deriv`` methods, computed from the derivatives of their
+interpolating splines. Astropy fitters use the Jacobian automatically
+during PSF photometry, removing the need for finite-difference
+approximations of the parameter derivatives. This eliminates roughly
+60% of the model evaluations performed during fitting, speeding up PSF
+photometry with these models with no change in the fitted results.
+
+
+Scalable Source Grouping
+========================
+
+`~photutils.psf.SourceGrouper` now computes groups using a KD-tree
+connected-components algorithm instead of building a dense pairwise
+distance matrix. The resulting groups are identical to the previous
+single-linkage clustering, but grouping now scales to very large source
+lists in both runtime and memory.
+
+
 Polygon Apertures
 =================
 

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -361,6 +361,10 @@ class PSFDataProcessor:
             if data_shape is not None and array.shape != data_shape:
                 msg = f'data and {name} must have the same shape'
                 raise ValueError(msg)
+            if name == 'mask':
+                # Coerce to bool so integer masks (e.g., 0/1 DQ
+                # arrays) cannot be misused as fancy indices
+                array = array.astype(bool)
         return array
 
     def normalize_init_units(self, init_params, colname):

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -545,7 +545,7 @@ class PSFDataProcessor:
             sources = self.finder(data, mask=mask)
 
         self.finder_results = sources
-        if sources is None:
+        if sources is None or len(sources) == 0:
             return None
 
         return self._convert_finder_to_init(sources)
@@ -855,21 +855,15 @@ class PSFFitter:
         Bounds for x and y position parameters as (x_bound, y_bound).
         If provided, fitting positions will be constrained to within
         these bounds of the initial values.
-
-    group_warning_threshold : int, optional
-        Threshold for issuing warnings about large group sizes.
-        Default is 25.
     """
 
     def __init__(self, psf_model, param_mapper, *, fitter=None,
-                 fitter_maxiters=100, xy_bounds=None,
-                 group_warning_threshold=25):
+                 fitter_maxiters=100, xy_bounds=None):
         self.psf_model = psf_model
         self.param_mapper = param_mapper
         self.fitter = fitter if fitter is not None else TRFLSQFitter()
         self.fitter_maxiters = fitter_maxiters
         self.xy_bounds = xy_bounds
-        self.group_warning_threshold = group_warning_threshold
 
         # Cache of flat model classes keyed on the number of sources.
         # The cache is per-instance because the cached classes capture
@@ -1003,7 +997,9 @@ class PSFFitter:
             err = error[yi, xi]
             if np.any(err <= 0) or np.any(~np.isfinite(err)):
                 msg = ('Error array contains non-positive or non-finite '
-                       'values. Cannot compute fit weights.')
+                       'values within the fit region centered near '
+                       f'x={np.mean(xi):.1f}, y={np.mean(yi):.1f}. '
+                       'Cannot compute fit weights.')
                 raise ValueError(msg)
             weights = 1.0 / err
 
@@ -1367,7 +1363,7 @@ class PSFResultsAssembler:
             - 4: non-positive flux
             - 8: possible non-convergence
             - 16: missing parameter covariance
-            - 32: near a positional bound
+            - 32: near a fitted-parameter bound
             - 64: no overlap with data
             - 128: fully masked source
             - 256: too few pixels for fitting
@@ -1406,32 +1402,31 @@ class PSFResultsAssembler:
                                      for info in fit_info])
         flags[missing_cov_mask] |= PSF_FLAGS.NO_COVARIANCE
 
-        # Flag=32: near a positional bound
+        # Flag=32: near a fitted-parameter bound. Bounds may come from
+        # the xy_bounds keyword or be set directly on the PSF model.
         bound_tol = 0.01
-        if self.xy_bounds is not None:
-            alias_to_model = self.param_mapper.alias_to_model_param
-            x_param = alias_to_model['x']
-            y_param = alias_to_model['y']
-
-            # Extract all parameter values and bounds into arrays
-            x_vals = np.array([row[x_param] for row in fitted_models_table])
-            y_vals = np.array([row[y_param] for row in fitted_models_table])
-
-            # Create masks for valid sources and finite positions
-            finite_mask = (np.isfinite(x_vals) & np.isfinite(y_vals)
-                           & valid_mask)
-
-            # Check bounds for valid sources
-            for index in np.where(finite_mask)[0]:
-                row = fitted_models_table[index]
-                for param in (x_param, y_param):
-                    bnds = row[f'{param}_bounds']
-                    bounds = np.array([i for i in bnds if i is not None])
-                    if bounds.size == 0:
-                        continue
-                    if np.any(np.abs(bounds - row[param]) <= bound_tol):
-                        flags[index] |= PSF_FLAGS.NEAR_BOUND
-                        break
+        param_names = [col for col in fitted_models_table.colnames
+                       if col != 'id'
+                       and not col.endswith(('_fixed', '_bounds'))]
+        for index in np.where(valid_mask)[0]:
+            row = fitted_models_table[index]
+            for param in param_names:
+                if row[f'{param}_fixed']:
+                    continue
+                bnds = row[f'{param}_bounds']
+                if bnds is None:
+                    continue
+                bounds = np.array([i for i in bnds if i is not None])
+                if bounds.size == 0:
+                    continue
+                value = row[param]
+                if isinstance(value, u.Quantity):
+                    value = value.value
+                if not np.isfinite(value):
+                    continue
+                if np.any(np.abs(bounds - value) <= bound_tol):
+                    flags[index] |= PSF_FLAGS.NEAR_BOUND
+                    break
 
         # Flag=64, 128, 256: invalid source reasons. Sources invalid
         # because of a non-finite input flux get bit 1024 below from

--- a/photutils/psf/_components.py
+++ b/photutils/psf/_components.py
@@ -1413,17 +1413,13 @@ class PSFResultsAssembler:
             for param in param_names:
                 if row[f'{param}_fixed']:
                     continue
-                bnds = row[f'{param}_bounds']
-                if bnds is None:
-                    continue
-                bounds = np.array([i for i in bnds if i is not None])
+                bounds = np.array([i for i in row[f'{param}_bounds']
+                                   if i is not None])
                 if bounds.size == 0:
                     continue
                 value = row[param]
                 if isinstance(value, u.Quantity):
                     value = value.value
-                if not np.isfinite(value):
-                    continue
                 if np.any(np.abs(bounds - value) <= bound_tol):
                     flags[index] |= PSF_FLAGS.NEAR_BOUND
                     break

--- a/photutils/psf/epsf_builder.py
+++ b/photutils/psf/epsf_builder.py
@@ -1115,10 +1115,20 @@ class EPSFBuilder:
         self.shape = shape
 
         self.recentering_func = recentering_func
-        self.recentering_maxiters = recentering_maxiters
+        if (isinstance(recentering_maxiters, bool)
+                or not isinstance(recentering_maxiters, numbers.Integral)
+                or recentering_maxiters <= 0):
+            msg = ('recentering_maxiters must be a strictly-positive '
+                   'integer')
+            raise ValueError(msg)
+        self.recentering_maxiters = int(recentering_maxiters)
         self.recentering_boxsize = as_pair('recentering_boxsize',
                                            recentering_boxsize,
                                            lower_bound=(3, 1), check_odd=True)
+        if smoothing_kernel is not None:
+            # Validate early so bad kernels fail at construction
+            # instead of in the middle of a build
+            _SmoothingKernel.get_kernel(smoothing_kernel)
         self.smoothing_kernel = smoothing_kernel
 
         # Handle fitter parameter - accept both astropy Fitter and
@@ -1593,10 +1603,8 @@ class EPSFBuilder:
         # Smooth the ePSF
         smoothed_data = self._smooth_epsf(new_epsf)
 
-        # Recenter the ePSF
-        # Create an intermediate ePSF for recentering operations.
-        # Use the current epsf's origin if it exists, otherwise compute
-        # center.
+        # Recenter the ePSF using an intermediate ePSF that keeps the
+        # current epsf's origin
         temp_epsf = ImagePSF(data=smoothed_data,
                              origin=epsf.origin,
                              oversampling=self.oversampling,
@@ -1704,16 +1712,22 @@ class EPSFBuilder:
                     fitted_star = self._fit_star(epsf, star)
 
             elif isinstance(star, LinkedEPSFStar):
-                fitted_star = []
-                for linked_star in star:
-                    if linked_star._excluded_from_fit:
-                        fitted_star.append(linked_star)
-                    else:
-                        fitted_star.append(self._fit_star(epsf,
-                                                          linked_star))
+                if star.all_excluded:
+                    # Pass through unchanged to prevent
+                    # constrain_centers from warning on every iteration
+                    # for a fully excluded linked star.
+                    fitted_star = star
+                else:
+                    fitted_star = []
+                    for linked_star in star:
+                        if linked_star._excluded_from_fit:
+                            fitted_star.append(linked_star)
+                        else:
+                            fitted_star.append(self._fit_star(epsf,
+                                                              linked_star))
 
-                fitted_star = LinkedEPSFStar(fitted_star)
-                fitted_star.constrain_centers()
+                    fitted_star = LinkedEPSFStar(fitted_star)
+                    fitted_star.constrain_centers()
 
             else:
                 msg = ('stars must contain only EPSFStar and/or '
@@ -1992,12 +2006,18 @@ class EPSFBuilder:
         - n_excluded_stars: Number of stars excluded due to fit failures
         - excluded_star_indices: Indices of excluded stars
         """
-        if epsf is not None and not np.array_equal(epsf.oversampling,
-                                                   self.oversampling):
-            msg = (f'The input epsf oversampling '
-                   f'{tuple(epsf.oversampling)} does not match the '
-                   f'builder oversampling {tuple(self.oversampling)}')
-            raise ValueError(msg)
+        if epsf is not None:
+            if not np.array_equal(epsf.oversampling, self.oversampling):
+                msg = (f'The input epsf oversampling '
+                       f'{tuple(epsf.oversampling)} does not match the '
+                       f'builder oversampling '
+                       f'{tuple(self.oversampling)}')
+                raise ValueError(msg)
+
+            # An undersized initial ePSF would silently truncate the
+            # result, so validate its shape like a requested shape
+            _EPSFValidator.validate_shape_compatibility(
+                stars, self.oversampling, shape=epsf.data.shape)
 
         _EPSFValidator.validate_stars(stars, context='ePSF building')
         _EPSFValidator.validate_shape_compatibility(stars, self.oversampling,
@@ -2016,9 +2036,10 @@ class EPSFBuilder:
         converged = False
         center_dist_sq = np.array([self.center_accuracy_sq + 1.0])
 
-        # Main iteration loop
-        while (iter_num < self.maxiters and not np.all(fit_failed)
-               and not converged):
+        # Main iteration loop. Note that an all-failed iteration
+        # raises inside _process_iteration, so no fit_failed exit
+        # condition is needed here.
+        while iter_num < self.maxiters and not converged:
 
             iter_num += 1
 

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -74,6 +74,11 @@ class EPSFStar:
             msg = ('data must be a plain ndarray; Quantity inputs are '
                    'not supported')
             raise TypeError(msg)
+        if isinstance(data, np.ma.MaskedArray):
+            msg = ('data must be a plain ndarray. MaskedArray inputs '
+                   'are not supported. Use the weights keyword to mask '
+                   'pixels')
+            raise TypeError(msg)
 
         self._data = np.asanyarray(data)
 
@@ -126,6 +131,9 @@ class EPSFStar:
             raise ValueError(msg)
         if not np.all(np.isfinite(origin)):
             msg = 'Origin coordinates must be finite'
+            raise ValueError(msg)
+        if np.any(np.mod(origin, 1) != 0):
+            msg = 'origin must have integer values'
             raise ValueError(msg)
         self.origin = origin.astype(int)
 
@@ -207,7 +215,11 @@ class EPSFStar:
         value : float
             The total flux of the star.
         """
-        self._flux = float(value)
+        value = float(value)
+        if not np.isfinite(value):
+            msg = 'flux must be a finite value'
+            raise ValueError(msg)
+        self._flux = value
         # The cached normalized data values depend on the flux
         self.__dict__.pop('_data_values_normalized', None)
 
@@ -358,8 +370,13 @@ class EPSFStar:
         """
         1D array of unmasked cutout data values, normalized by the
         star's total flux.
+
+        For a star with zero flux (allowed for all-zero cutout data),
+        the values are all NaN and the star contributes nothing to an
+        ePSF build.
         """
-        return self.data[~self.mask].ravel() / self.flux
+        with np.errstate(divide='ignore', invalid='ignore'):
+            return self.data[~self.mask].ravel() / self.flux
 
 
 class EPSFStars:
@@ -429,11 +446,21 @@ class EPSFStars:
 
         This allows accessing star attributes (like ``cutout_center``,
         ``center``, ``flux``) directly on the EPSFStars container,
-        returning an array of values from all contained stars. If the
-        per-star values have inconsistent shapes (e.g., for a mix of
-        `EPSFStar` and multi-star `LinkedEPSFStar` objects), an object
-        array is returned.
+        returning an array of values from all contained stars. If
+        the per-star values have inconsistent shapes (e.g., for a
+        mix of `EPSFStar` and multi-star `LinkedEPSFStar` objects),
+        an object array is returned. Private attributes (other than
+        ``_excluded_from_fit``) are not delegated, and empty containers
+        raise `AttributeError`.
         """
+        if attr != '_excluded_from_fit' and attr.startswith('_'):
+            msg = (f"'{type(self).__name__}' object has no attribute "
+                   f"'{attr}'")
+            raise AttributeError(msg)
+        if not self._data:
+            msg = (f"'{type(self).__name__}' object is empty and has "
+                   f"no attribute '{attr}'")
+            raise AttributeError(msg)
         result = [getattr(star, attr) for star in self._data]
         if attr in ['cutout_center', 'center', 'flux', '_excluded_from_fit']:
             try:
@@ -957,9 +984,11 @@ def extract_stars(data, catalogs, *, size=(11, 11)):
 
     catalogs : `~astropy.table.Table`, list of `~astropy.table.Table`
         A catalog or list of catalogs of sources to be extracted from
-        the input ``data``. To link stars in multiple images as a single
-        source, you must use a single source catalog where the positions
-        defined in sky coordinates.
+        the input ``data``. To link stars in multiple images as a
+        single source, you must use a single source catalog where the
+        positions are defined in sky coordinates. If a linked star can
+        be extracted from only one of the input images, it is returned
+        as a plain `EPSFStar` instead of a `LinkedEPSFStar`.
 
         If a list of catalogs is input (or a single catalog with a
         single `~astropy.nddata.NDData` object), they are assumed to
@@ -1015,7 +1044,7 @@ def extract_stars(data, catalogs, *, size=(11, 11)):
             data, catalogs, size)
 
     if n_overlap_failed > 0:
-        msg = (f'{n_overlap_failed} star(s) were not extracted '
+        msg = (f'{n_overlap_failed} star cutout(s) were not extracted '
                'because their cutout region extended beyond the '
                'input image.')
         warnings.warn(msg, AstropyUserWarning)
@@ -1053,7 +1082,8 @@ def _extract_linked_stars(data, catalog, size):
         containing the extracted stars. Stars that are linked across
         multiple images will be represented as a single `LinkedEPSFStar`
         instance containing the corresponding `EPSFStar` instances from
-        each image. Failed extractions are represented as `None`.
+        each image. Stars that could not be extracted from any image
+        are omitted.
 
     n_overlap_failed : int
         The number of stars that failed extraction because their cutout
@@ -1117,7 +1147,7 @@ def _extract_unlinked_stars(data, catalogs, size):
     -------
     stars : list of `EPSFStar` objects
         A list of `EPSFStar` instances containing the extracted stars.
-        Failed extractions are represented as `None`.
+        Failed extractions are omitted.
 
     n_overlap_failed : int
         The number of stars that failed extraction because their cutout
@@ -1203,6 +1233,7 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
     stars = []
     n_nonfinite_weights = 0
     n_nonfinite_positions = 0
+    n_nonfinite_fluxes = 0
     n_overlap_failed = 0
     flux_failures = []  # Collect flux estimation failures
     all_zero_stars = []  # Collect stars with all-zero data
@@ -1211,6 +1242,11 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
         if not (np.isfinite(xcenter) and np.isfinite(ycenter)):
             stars.append(None)
             n_nonfinite_positions += 1
+            continue
+
+        if (fluxes is not None and not np.isfinite(fluxes[i])):
+            stars.append(None)
+            n_nonfinite_fluxes += 1
             continue
 
         try:
@@ -1260,6 +1296,12 @@ def _extract_stars(data, catalog, *, size=(11, 11), use_xy=True):
     if n_nonfinite_positions > 0:
         msg = (f'{n_nonfinite_positions} star(s) were not extracted '
                'because their (x, y) positions were not finite.')
+        warnings.warn(msg, AstropyUserWarning)
+
+    # Emit consolidated warning for non-finite catalog fluxes
+    if n_nonfinite_fluxes > 0:
+        msg = (f'{n_nonfinite_fluxes} star(s) were not extracted '
+               'because their catalog flux values were not finite.')
         warnings.warn(msg, AstropyUserWarning)
 
     # Emit consolidated warning for non-finite weights

--- a/photutils/psf/epsf_stars.py
+++ b/photutils/psf/epsf_stars.py
@@ -428,6 +428,18 @@ class EPSFStars:
         """
         yield from self._data
 
+    def __array__(self, dtype=None, copy=None):
+        """
+        Array representation of the star cutout data (e.g., for
+        matplotlib).
+
+        A container holding a single star returns the 2D cutout of that
+        star. Otherwise, the cutouts of all stars are stacked along the
+        first axis (which requires that they have the same shape).
+        """
+        data = self._data[0] if len(self._data) == 1 else self._data
+        return np.array(data, dtype=dtype, copy=copy)
+
     def __getstate__(self):
         """
         Return state for pickling (avoids __getattr__ recursion).

--- a/photutils/psf/functional_models.py
+++ b/photutils/psf/functional_models.py
@@ -2028,6 +2028,9 @@ class AiryDiskPSF(Fittable2DModel):
         z = np.ones(rt.shape)
         nonzero = rt > 0
         z[nonzero] = (2.0 * j1(rt[nonzero]) / rt[nonzero]) ** 2
+        # The model tends to zero at infinite radial distance, but
+        # j1(inf) is NaN, so set the limit explicitly
+        z[np.isinf(rt)] = 0.0
         z[np.isnan(rt)] = np.nan
         z = z.reshape(r.shape)
 

--- a/photutils/psf/gridded_models.py
+++ b/photutils/psf/gridded_models.py
@@ -161,7 +161,7 @@ class GriddedPSFModel(Fittable2DModel):
         self.meta['grid_xypos'] = self.grid_xypos
 
         self._interpolator = {}
-        self._deriv_interpolator = {}
+        self._deriv_interpolators = {}
 
         super().__init__(flux, x_0, y_0)
 
@@ -555,7 +555,7 @@ class GriddedPSFModel(Fittable2DModel):
         are used by `fit_deriv`.
 
         The resulting interpolators are cached in the
-        `_deriv_interpolator` dictionary for reuse.
+        `_deriv_interpolators` dictionary for reuse.
 
         Parameters
         ----------
@@ -569,15 +569,15 @@ class GriddedPSFModel(Fittable2DModel):
             ePSF image.
         """
         # Check if the interpolators are already cached
-        if grid_idx in self._deriv_interpolator:
-            return self._deriv_interpolator[grid_idx]
+        if grid_idx in self._deriv_interpolators:
+            return self._deriv_interpolators[grid_idx]
 
         interp = self._calc_interpolator(grid_idx)
         derivs = (interp.partial_derivative(1, 0),
                   interp.partial_derivative(0, 1))
 
         # Cache the interpolators for reuse
-        self._deriv_interpolator[grid_idx] = derivs
+        self._deriv_interpolators[grid_idx] = derivs
 
         return derivs
 

--- a/photutils/psf/iterative.py
+++ b/photutils/psf/iterative.py
@@ -506,6 +506,7 @@ class IterativePSFPhotometry:
     @_create_call_docstring(iterative=True)
     def __call__(self, data, *, mask=None, error=None, init_params=None):
         if isinstance(data, NDData):
+            PSFPhotometry._check_nddata_kwargs(mask=mask, error=error)
             data_, mask, error = PSFPhotometry._coerce_nddata(data)
             return self.__call__(data_, mask=mask, error=error,
                                  init_params=init_params)

--- a/photutils/psf/iterative.py
+++ b/photutils/psf/iterative.py
@@ -53,10 +53,10 @@ class IterativePSFPhotometry:
         will be used to define the PSF-fitting data. If ``fit_shape``
         is a scalar then a square shape of size ``fit_shape`` will be
         used. If ``fit_shape`` has two elements, they must be in ``(ny,
-        nx)`` order. Each element of ``fit_shape`` must be an odd number
-        greater than or equal to 3. In general, ``fit_shape`` should be
-        set to a small size (e.g., ``(5, 5)``) that covers the region
-        with the highest flux signal-to-noise.
+        nx)`` order. Each element of ``fit_shape`` must be a positive
+        odd number. In general, ``fit_shape`` should be set to a small
+        size (e.g., ``(5, 5)``) that covers the region with the highest
+        flux signal-to-noise.
 
     finder : callable or `~photutils.detection.StarFinderBase`
         A callable used to identify sources in an image. This is a
@@ -222,6 +222,12 @@ class IterativePSFPhotometry:
     mode) to combine close sources to be fit simultaneously, improving
     the fit. Again, the process is repeated until no new sources are
     detected or a maximum number of iterations is reached.
+
+    In the 'all' mode, sources whose fitted parameters are non-finite in
+    one iteration are excluded from subsequent iterations. Such sources
+    therefore appear in the final ``results`` table (as NaN rows) only
+    if they became invalid in the last iteration. In the 'new' mode,
+    invalid sources are always kept as NaN rows.
 
     Care should be taken in defining the source groups. Simultaneously
     fitting very large source groups is computationally expensive and

--- a/photutils/psf/model_plotting.py
+++ b/photutils/psf/model_plotting.py
@@ -118,6 +118,10 @@ class _ModelGridPlotter:
             for i, arr in enumerate(data):
                 if np.count_nonzero(arr) == 0:
                     mask[i] = True
+            if mask.all():
+                msg = ('deltas cannot be computed because all ePSFs '
+                       'in the grid are blank (all pixels are zero)')
+                raise ValueError(msg)
             mean_epsf = np.mean(data[~mask], axis=0)
             data -= mean_epsf
             data[mask] = 0.0

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -407,6 +407,10 @@ class PSFPhotometry:
     # Default value for parameter initialization (invalid sources)
     _DEFAULT_PARAM_VALUE = np.nan
 
+    # Results columns ending in '_fit' that are not fitted model
+    # parameters
+    _NON_PARAM_FIT_COLS = ('n_pixels_fit',)
+
     @deprecated_renamed_argument('localbkg_estimator',
                                  'local_bkg_estimator', '3.0',
                                  until='4.0')
@@ -598,7 +602,7 @@ class PSFPhotometry:
         table = QTable(param_data)
 
         # Set id column to match init_params for clean merging
-        if hasattr(self, 'init_params') and self.init_params is not None:
+        if self.init_params is not None:
             ids = self.init_params['id']
             table['id'] = ids
 
@@ -739,8 +743,8 @@ class PSFPhotometry:
             scalar.
         """
         if radius is not None:
-            if (np.ndim(radius) != 0 or radius <= 0
-                    or not np.isfinite(radius)):
+            if (isinstance(radius, bool) or np.ndim(radius) != 0
+                    or radius <= 0 or not np.isfinite(radius)):
                 msg = 'aperture_radius must be a strictly-positive scalar'
                 raise ValueError(msg)
             radius = float(radius)
@@ -813,7 +817,19 @@ class PSFPhotometry:
         maxiters : int or None
             The validated maxiters value, or None if the fitter doesn't
             support this parameter.
+
+        Raises
+        ------
+        ValueError
+            If maxiters is not a strictly-positive integer.
         """
+        if (isinstance(maxiters, bool)
+                or not isinstance(maxiters, (int, np.integer))
+                or maxiters <= 0):
+            msg = 'fitter_maxiters must be a strictly-positive integer'
+            raise ValueError(msg)
+        maxiters = int(maxiters)
+
         spec = inspect.signature(self.fitter.__call__)
         if 'maxiter' not in spec.parameters:
             msg = ("'fitter_maxiters' will be ignored because the "
@@ -1410,7 +1426,6 @@ class PSFPhotometry:
         # Store results in state for other methods that need them
         self._state['fit_error_indices'] = fit_error_indices
         self._state['fitted_models_table'] = fitted_models_table
-        self._state['fit_params'] = fit_params
 
         return fit_params
 
@@ -1546,6 +1561,30 @@ class PSFPhotometry:
 
         return data_array, mask, error
 
+    @staticmethod
+    def _check_nddata_kwargs(*, mask, error):
+        """
+        Reject explicit mask/error keywords for NDData inputs.
+
+        Parameters
+        ----------
+        mask : 2D `~numpy.ndarray` or `None`
+            The mask keyword value passed to ``__call__``.
+
+        error : 2D `~numpy.ndarray` or `None`
+            The error keyword value passed to ``__call__``.
+
+        Raises
+        ------
+        ValueError
+            If mask or error is not None.
+        """
+        if mask is not None or error is not None:
+            msg = ('The mask and error keywords must be None when '
+                   'data is an NDData instance. Define the mask and '
+                   'uncertainty in the NDData object instead.')
+            raise ValueError(msg)
+
     @_create_call_docstring(iterative=False)
     def __call__(self, data, *, mask=None, error=None, init_params=None):
         # Reset state from previous runs
@@ -1554,6 +1593,7 @@ class PSFPhotometry:
         try:
             # Handle NDData input
             if isinstance(data, NDData):
+                self._check_nddata_kwargs(mask=mask, error=error)
                 data, mask, error = self._coerce_nddata(data)
 
             # Prepare all inputs for sources to be fit
@@ -1623,10 +1663,6 @@ class PSFPhotometry:
                 tbl[col_name] = self.results[col_name]
 
         return tbl
-
-    # Results columns ending in '_fit' that are not fitted model
-    # parameters
-    _NON_PARAM_FIT_COLS = ('n_pixels_fit',)
 
     @staticmethod
     def _iter_fit_param_cols(results_tbl):

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -447,7 +447,6 @@ class PSFPhotometry:
         self._psf_fitter = PSFFitter(
             self.psf_model, self._param_mapper, fitter=self.fitter,
             fitter_maxiters=self.fitter_maxiters, xy_bounds=self.xy_bounds,
-            group_warning_threshold=self.group_warning_threshold,
         )
 
         self._results_assembler = PSFResultsAssembler(

--- a/photutils/psf/simulation.py
+++ b/photutils/psf/simulation.py
@@ -73,13 +73,14 @@ def make_psf_model_image(shape, psf_model, n_sources, *, model_shape=None,
         Keyword arguments are accepted for additional model parameters.
         The values should be 2-tuples of the lower and upper bounds for
         the parameter range. The parameter values will be uniformly
-        distributed between the lower and upper bounds, inclusively.
-        A ``flux`` keyword is mapped to the model's flux parameter
-        name (e.g., for models output from `make_psf_model`). If the
-        parameter is not in the input ``psf_model`` parameter names, it
-        will be ignored. Keywords matching the model's x and y position
-        parameter names are also ignored because the source positions
-        are randomly generated.
+        sampled over the half-open interval defined by the lower
+        and upper bounds (i.e., the lower bound is inclusive and
+        the upper bound is exclusive). A ``flux`` keyword is mapped
+        to the model's flux parameter name (e.g., for models output
+        from `make_psf_model`). If the parameter is not in the input
+        ``psf_model`` parameter names, it will be ignored. Keywords
+        matching the model's x and y position parameter names are also
+        ignored because the source positions are randomly generated.
 
     Returns
     -------
@@ -131,7 +132,7 @@ def make_psf_model_image(shape, psf_model, n_sources, *, model_shape=None,
         data, params = make_psf_model_image(shape, psf_model, n_sources,
                                             flux=(100, 250),
                                             min_separation=10,
-                                            seed=0, sigma=(1, 2))
+                                            seed=0)
         fig, ax = plt.subplots()
         ax.imshow(data, origin='lower')
     """

--- a/photutils/psf/tests/test_components.py
+++ b/photutils/psf/tests/test_components.py
@@ -357,7 +357,6 @@ class TestPSFFitter:
             fitter=None,
             fitter_maxiters=100,
             xy_bounds=None,
-            group_warning_threshold=25,
         )
 
         assert fitter.psf_model is psf_model
@@ -365,7 +364,6 @@ class TestPSFFitter:
         assert isinstance(fitter.fitter, TRFLSQFitter)  # Default fitter
         assert fitter.fitter_maxiters == 100
         assert fitter.xy_bounds is None
-        assert fitter.group_warning_threshold == 25
 
     def test_init_custom_fitter(self, psf_model, param_mapper):
         """

--- a/photutils/psf/tests/test_epsf_builder.py
+++ b/photutils/psf/tests/test_epsf_builder.py
@@ -1887,28 +1887,6 @@ class TestEPSFBuilder:
         assert all(type(idx) is int
                    for idx in result.excluded_star_indices)
 
-    def test_build_step_origin_is_none_branch(self, epsf_test_data):
-        """
-        Test _build_epsf_step else branch when origin is None.
-        """
-        builder = EPSFBuilder(maxiters=1, progress_bar=False)
-
-        stars = extract_stars(epsf_test_data['nddata'],
-                              epsf_test_data['init_stars'][:3], size=11)
-
-        # Create ePSF and verify origin condition
-        epsf = builder._create_initial_epsf(stars)
-
-        # Verify the branch condition logic
-        has_valid_origin = hasattr(epsf, 'origin') and epsf.origin is not None
-        assert has_valid_origin  # Normal case, origin exists
-
-        # The else branch is only reached when origin is None
-        # This line calculates origin from shape
-        expected_origin_y = (epsf.data.shape[0] - 1) / 2.0
-        expected_origin_x = (epsf.data.shape[1] - 1) / 2.0
-        assert_allclose(epsf.origin, (expected_origin_x, expected_origin_y))
-
     @pytest.mark.skipif(not HAS_TQDM, reason='tqdm is required')
     def test_with_progress_bar(self, epsf_test_data):
         """
@@ -2686,3 +2664,66 @@ class TestEPSFBuilder:
         assert fit_failed[0]
         assert stars_new.all_stars[0]._fit_error_status == 3
         assert stars_new.all_stars[0]._excluded_from_fit
+
+
+def _make_gaussian_star_data():
+    yy, xx = np.indices((11, 11))
+    sig = 2.5 / 2.3548
+    return np.exp(-((xx - 5.0)**2 + (yy - 5.0)**2) / (2 * sig**2))
+
+
+def test_build_epsf_initial_epsf_too_small():
+    """
+    Regression test that build_epsf validates the shape of a provided
+    initial ePSF instead of silently truncating the result.
+    """
+    star_data = _make_gaussian_star_data()
+    stars = EPSFStars([EPSFStar(star_data.copy(),
+                                cutout_center=(5.0, 5.0))
+                       for _ in range(2)])
+    builder = EPSFBuilder(oversampling=1, maxiters=2,
+                          progress_bar=False)
+    epsf = ImagePSF(np.zeros((5, 5)), oversampling=1)
+    match = 'incompatible with'
+    with pytest.raises(ValueError, match=match):
+        builder.build_epsf(stars, epsf=epsf)
+
+
+def test_build_epsf_fully_excluded_linked_star():
+    """
+    Regression test that a fully excluded LinkedEPSFStar does not
+    emit a constrain-centers warning on every build iteration.
+    """
+    star_data = _make_gaussian_star_data()
+    good_stars = [EPSFStar(star_data.copy(), cutout_center=(5.0, 5.0))
+                  for _ in range(2)]
+    linked_members = [EPSFStar(star_data.copy(),
+                               cutout_center=(5.0, 5.0),
+                               origin=(0, 0), wcs_large=_MockWCS())
+                      for _ in range(2)]
+    linked = LinkedEPSFStar(linked_members)
+    for member in linked:
+        member._excluded_from_fit = True
+    stars = EPSFStars([*good_stars, linked])
+    builder = EPSFBuilder(oversampling=1, maxiters=3,
+                          progress_bar=False)
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter('always')
+        result = builder.build_epsf(stars)
+    messages = [str(w.message) for w in recorded]
+    assert not any('Cannot constrain centers' in msg
+                   for msg in messages)
+    assert result.epsf is not None
+
+
+def test_invalid_smoothing_kernel_at_init():
+    match = 'Unsupported kernel type'
+    with pytest.raises(TypeError, match=match):
+        EPSFBuilder(smoothing_kernel='bogus')
+
+
+@pytest.mark.parametrize('value', [-3, 0, 2.5, True])
+def test_invalid_recentering_maxiters(value):
+    match = 'recentering_maxiters must be a strictly-positive integer'
+    with pytest.raises(ValueError, match=match):
+        EPSFBuilder(recentering_maxiters=value)

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -1979,3 +1979,29 @@ def test_container_getattr_private_and_empty():
     empty = EPSFStars([])
     with pytest.raises(AttributeError, match='empty'):
         empty.cutout_center  # noqa: B018
+
+
+def test_epsfstars_array_conversion():
+    """
+    Regression test that a single-star EPSFStars container (e.g., from
+    indexing) converts to the 2D star cutout, so that it can be passed
+    directly to matplotlib's imshow, and that a multi-star container
+    stacks the cutouts along the first axis.
+    """
+    data1 = np.arange(25.0).reshape(5, 5)
+    data2 = data1 * 2.0
+    stars = EPSFStars([EPSFStar(data1), EPSFStar(data2)])
+
+    single = np.asarray(stars[0])
+    assert single.shape == (5, 5)
+    assert_array_equal(single, data1)
+
+    stacked = np.asarray(stars)
+    assert stacked.shape == (2, 5, 5)
+    assert_array_equal(stacked[1], data2)
+
+    # dtype and copy keywords are honored
+    assert np.asarray(stars[0], dtype=np.float32).dtype == np.float32
+    arr = np.array(stars[0], copy=True)
+    arr[0, 0] = -99.0
+    assert stars[0].data[0, 0] == 0.0

--- a/photutils/psf/tests/test_epsf_stars.py
+++ b/photutils/psf/tests/test_epsf_stars.py
@@ -1318,7 +1318,7 @@ class TestExtractStars:
         table['x'] = [-10, 100]  # Outside image bounds
         table['y'] = [25, 25]
 
-        match = '2 star\\(s\\) were not extracted'
+        match = '2 star cutout\\(s\\) were not extracted'
         with pytest.warns(AstropyUserWarning, match=match):
             stars = extract_stars(simple_nddata, table, size=11)
         assert len(stars) == 0
@@ -1553,7 +1553,7 @@ class TestExtractStars:
         table = Table()
         table['skycoord'] = [SkyCoord(0, 0, unit='deg')]  # Center
 
-        match = '1 star\\(s\\) were not extracted'
+        match = '1 star cutout\\(s\\) were not extracted'
         with pytest.warns(AstropyUserWarning, match=match):
             stars = extract_stars([nddata1, nddata2], table, size=11)
 
@@ -1906,3 +1906,76 @@ class TestExtractStars:
 
         # All stars should fail (None) because they are completely masked
         assert len(stars) == 0
+
+
+def test_star_nonfinite_flux_raises():
+    """
+    Regression test that a non-finite flux raises a clear error
+    instead of crashing later deep inside the ePSF fitter.
+    """
+    match = 'flux must be a finite value'
+    with pytest.raises(ValueError, match=match):
+        EPSFStar(np.ones((5, 5)), flux=np.nan)
+    star = EPSFStar(np.ones((5, 5)))
+    with pytest.raises(ValueError, match=match):
+        star.flux = np.inf
+
+
+def test_extract_stars_nonfinite_flux_column():
+    """
+    Regression test that non-finite catalog flux values are skipped
+    with a warning, like non-finite positions.
+    """
+    data = np.ones((50, 50))
+    catalog = Table({'x': [25.0, 10.0], 'y': [25.0, 10.0],
+                     'flux': [100.0, np.nan]})
+    match = 'flux values were not finite'
+    with pytest.warns(AstropyUserWarning, match=match):
+        stars = extract_stars(NDData(data), catalog, size=11)
+    assert len(stars) == 1
+    assert stars[0].flux == 100.0
+
+
+def test_zero_flux_star_normalization_no_warning():
+    """
+    Regression test that normalizing a zero-flux star does not leak a
+    RuntimeWarning during ePSF building.
+    """
+    with pytest.warns(AstropyUserWarning, match='are zero'):
+        star = EPSFStar(np.zeros((5, 5)))
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        values = star._data_values_normalized
+    assert np.all(np.isnan(values))
+
+
+def test_masked_array_data_raises():
+    data = np.ma.MaskedArray(np.ones((5, 5)),
+                             mask=np.zeros((5, 5), dtype=bool))
+    match = 'MaskedArray inputs are not supported'
+    with pytest.raises(TypeError, match=match):
+        EPSFStar(data)
+
+
+def test_non_integral_origin_raises():
+    match = 'origin must have integer values'
+    with pytest.raises(ValueError, match=match):
+        EPSFStar(np.ones((5, 5)), origin=(1.7, 2.3))
+    star = EPSFStar(np.ones((5, 5)), origin=(1.0, 2.0))
+    assert_array_equal(star.origin, [1, 2])
+
+
+def test_container_getattr_private_and_empty():
+    """
+    Regression test that EPSFStars matches LinkedEPSFStar in not
+    delegating private attributes (except _excluded_from_fit) and
+    that empty containers raise AttributeError.
+    """
+    star = EPSFStar(np.ones((5, 5)))
+    stars = EPSFStars([star])
+    assert_array_equal(stars._excluded_from_fit, [False])
+    with pytest.raises(AttributeError):
+        stars._fit_error_status  # noqa: B018
+    empty = EPSFStars([])
+    with pytest.raises(AttributeError, match='empty'):
+        empty.cutout_center  # noqa: B018

--- a/photutils/psf/tests/test_functional_models.py
+++ b/photutils/psf/tests/test_functional_models.py
@@ -495,3 +495,17 @@ def test_airydisk_psf_model(use_units):
     model = AiryDiskPSF(x_0=0, y_0=0, radius=5)
     bbox = 42.18329801081182
     assert_allclose(model.bounding_box, ((-bbox, bbox), (-bbox, bbox)))
+
+
+def test_airydisk_infinite_radial_distance():
+    """
+    Regression test that AiryDiskPSF evaluates to zero at infinite
+    radial distance, matching the other models, while NaN inputs
+    still propagate.
+    """
+    model = AiryDiskPSF(flux=1, radius=2)
+    assert model(np.inf, 0.0) == 0.0
+    assert np.isnan(model(np.nan, 0.0))
+    result = model(np.array([np.inf, 0.0]), np.array([0.0, 0.0]))
+    assert result[0] == 0.0
+    assert result[1] > 0.0

--- a/photutils/psf/tests/test_image_models.py
+++ b/photutils/psf/tests/test_image_models.py
@@ -92,12 +92,6 @@ class TestImagePSF:
         # Include positions that map outside the input pixel grid
         x = np.array([5.0, -50.0, 100.0])
         y = np.array([5.0, 5.0, 5.0])
-        d_flux, d_x_0, d_y_0 = model.fit_deriv(x, y, 1.0, 5.0, 5.0)
-
-        # Derivatives must be zero outside the input pixel grid
-        assert d_flux[1] == 0.0
-        assert d_x_0[1] == 0.0
-        assert d_y_0[2] == 0.0
         derivs = model.fit_deriv(x, y, 1.0, 5.0, 5.0)
 
         # All derivatives must be zero outside the input pixel grid

--- a/photutils/psf/tests/test_iterative.py
+++ b/photutils/psf/tests/test_iterative.py
@@ -36,7 +36,7 @@ def fixture_test_data():
                                              min_separation=10, seed=0)
     noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     data += noise
-    error = np.abs(noise)
+    error = np.ones(data.shape)
 
     return data, error, true_params
 
@@ -83,7 +83,7 @@ def test_iterative_psf_photometry_compound(mode):
                                              min_separation=10, seed=0)
     noise = make_noise_image(data.shape, mean=0, stddev=1, seed=0)
     data += noise
-    error = np.abs(noise)
+    error = np.ones(data.shape)
 
     init_params = QTable()
     init_params['x'] = [54, 29, 80]

--- a/photutils/psf/tests/test_model_plotting.py
+++ b/photutils/psf/tests/test_model_plotting.py
@@ -184,3 +184,17 @@ class TestPlotGrid:
             fig = psfmodel.plot_grid(deltas=deltas, peak_norm=peak_norm)
             # The colorbar is the second axes
             assert fig.axes[1].get_ylabel() != ''
+
+
+def test_plot_grid_deltas_all_blank():
+    """
+    Regression test that deltas=True raises a clear error when every
+    ePSF in the grid is blank instead of rendering a NaN image.
+    """
+    data = np.zeros((4, 5, 5))
+    meta = {'grid_xypos': [(0, 0), (0, 10), (10, 0), (10, 10)],
+            'oversampling': 1}
+    model = GriddedPSFModel(NDData(data, meta=meta))
+    match = 'all ePSFs in the grid are blank'
+    with pytest.raises(ValueError, match=match):
+        model.plot_grid(deltas=True)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -2562,6 +2562,40 @@ def test_near_bound_flag_model_bounds():
     assert phot['flags'][0] & 32
 
 
+def test_near_bound_flag_flux_bounds_units():
+    """
+    Regression test that the near_bound flag (bit 32) is evaluated for
+    a flux parameter with bounds when the data has units (the fitted
+    flux is then a Quantity).
+    """
+    unit = u.Jy
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image((35, 35), model, 1,
+                                        model_shape=(9, 9),
+                                        flux=(500, 500),
+                                        min_separation=10, seed=0)
+    data <<= unit
+    init = Table({'x': params['x_0'], 'y': params['y_0'],
+                  'flux': [650.0 * unit]})
+
+    # Bounds that pin the fitted flux at the lower bound
+    fit_model = CircularGaussianPRF(fwhm=2.7)
+    fit_model.flux.bounds = (600.0, 700.0)
+    psfphot = PSFPhotometry(fit_model, (5, 5))
+    phot = psfphot(data, init_params=init)
+    assert phot['flux_fit'].unit == unit
+    assert_allclose(phot['flux_fit'][0].value, 600.0, atol=0.02)
+    assert phot['flags'][0] & 32
+
+    # Bounds that do not constrain the fit
+    fit_model = CircularGaussianPRF(fwhm=2.7)
+    fit_model.flux.bounds = (0.0, 1000.0)
+    psfphot = PSFPhotometry(fit_model, (5, 5))
+    phot = psfphot(data, init_params=init)
+    assert_allclose(phot['flux_fit'][0].value, 500.0, rtol=0.01)
+    assert not phot['flags'][0] & 32
+
+
 def test_error_weights_message_has_source_context():
     """
     Regression test that the invalid-error-value message names the

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -2522,3 +2522,61 @@ def test_aperture_radius_bool():
     match = 'aperture_radius must be a strictly-positive scalar'
     with pytest.raises(ValueError, match=match):
         PSFPhotometry(model, (5, 5), aperture_radius=True)
+
+
+def test_finder_empty_table():
+    """
+    Regression test that a finder returning a zero-row table is
+    treated like no sources found instead of raising an aperture
+    error.
+    """
+    def finder(data, *, mask=None):  # noqa: ARG001
+        return Table({'x': np.array([]), 'y': np.array([])})
+
+    model = CircularGaussianPRF(fwhm=2.7)
+    psfphot = PSFPhotometry(model, (5, 5), finder=finder,
+                            aperture_radius=4)
+    phot = psfphot(np.ones((25, 25)))
+    assert phot is None
+
+
+def test_near_bound_flag_model_bounds():
+    """
+    Regression test that the near_bound flag (bit 32) is set when the
+    fit is pinned at a bound set on the PSF model itself, without the
+    xy_bounds keyword.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image((35, 35), model, 1,
+                                        model_shape=(9, 9),
+                                        flux=(500, 500),
+                                        min_separation=10, seed=0)
+    xpos = params['x_0'][0]
+    fit_model = CircularGaussianPRF(fwhm=2.7)
+    fit_model.x_0.bounds = (xpos - 0.6, xpos - 0.3)
+    init = Table({'x': [xpos - 0.5], 'y': params['y_0'],
+                  'flux': [500.0]})
+    psfphot = PSFPhotometry(fit_model, (5, 5))
+    phot = psfphot(data, init_params=init)
+    assert_allclose(phot['x_fit'][0], xpos - 0.3, atol=0.02)
+    assert phot['flags'][0] & 32
+
+
+def test_error_weights_message_has_source_context():
+    """
+    Regression test that the invalid-error-value message names the
+    fit region location.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image((35, 35), model, 1,
+                                        model_shape=(9, 9),
+                                        flux=(500, 500),
+                                        min_separation=10, seed=0)
+    init = Table({'x': params['x_0'], 'y': params['y_0'],
+                  'flux': [500.0]})
+    error = np.ones(data.shape)
+    error[int(params['y_0'][0]), int(params['x_0'][0])] = 0.0
+    psfphot = PSFPhotometry(model, (5, 5))
+    match = 'centered near'
+    with pytest.raises(ValueError, match=match):
+        psfphot(data, error=error, init_params=init)

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -2461,3 +2461,64 @@ def test_decode_flags():
     # decode_psf_flags directly
     direct_decoded = decode_psf_flags(results['flags'])
     assert decoded_flags == direct_decoded
+
+
+def test_int_mask_matches_bool_mask():
+    """
+    Regression test that an integer 0/1 mask array behaves identically
+    to the equivalent boolean mask.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data, params = make_psf_model_image((35, 35), model, 1,
+                                        model_shape=(9, 9),
+                                        flux=(500, 500),
+                                        min_separation=10, seed=0)
+    init = Table({'x': params['x_0'], 'y': params['y_0']})
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[int(params['y_0'][0]), int(params['x_0'][0])] = True
+
+    psfphot = PSFPhotometry(model, (5, 5), aperture_radius=4)
+    phot_bool = psfphot(data, init_params=init, mask=mask)
+    phot_int = psfphot(data, init_params=init, mask=mask.astype(int))
+    assert_equal(phot_int['n_pixels_fit'], phot_bool['n_pixels_fit'])
+    assert_equal(phot_int['flags'], phot_bool['flags'])
+    assert_allclose(phot_int['flux_fit'], phot_bool['flux_fit'])
+
+
+@pytest.mark.parametrize('maxiters', [-5, 0, 3.7, 'abc', True])
+def test_invalid_fitter_maxiters(maxiters):
+    model = CircularGaussianPRF(fwhm=2.7)
+    match = 'fitter_maxiters must be a strictly-positive integer'
+    with pytest.raises(ValueError, match=match):
+        PSFPhotometry(model, (5, 5), fitter_maxiters=maxiters)
+
+
+def test_valid_fitter_maxiters():
+    model = CircularGaussianPRF(fwhm=2.7)
+    psfphot = PSFPhotometry(model, (5, 5), fitter_maxiters=np.int64(50))
+    assert psfphot.fitter_maxiters == 50
+
+
+def test_nddata_with_explicit_mask_or_error():
+    """
+    Regression test that explicit mask/error keywords are rejected
+    (not silently ignored) when data is an NDData instance.
+    """
+    model = CircularGaussianPRF(fwhm=2.7)
+    data = np.ones((25, 25))
+    init = Table({'x': [12.0], 'y': [12.0], 'flux': [1.0]})
+    psfphot = PSFPhotometry(model, (5, 5))
+    match = 'must be None when data is an NDData instance'
+    with pytest.raises(ValueError, match=match):
+        psfphot(NDData(data), error=np.ones(data.shape),
+                init_params=init)
+    with pytest.raises(ValueError, match=match):
+        psfphot(NDData(data), mask=np.zeros(data.shape, dtype=bool),
+                init_params=init)
+
+
+def test_aperture_radius_bool():
+    model = CircularGaussianPRF(fwhm=2.7)
+    match = 'aperture_radius must be a strictly-positive scalar'
+    with pytest.raises(ValueError, match=match):
+        PSFPhotometry(model, (5, 5), aperture_radius=True)

--- a/photutils/psf/tests/test_utils.py
+++ b/photutils/psf/tests/test_utils.py
@@ -405,3 +405,53 @@ def test_get_psf_model_main_params():
     params = _get_psf_model_main_params(model)
     assert len(params) == 3
     assert params == set_params
+
+
+def test_fit_2dgaussian_flux_init_excludes_masked_pixels():
+    """
+    Regression test that the initial flux estimate excludes pixels
+    masked by the user mask.
+    """
+    yy, xx = np.mgrid[0:31, 0:31]
+    data = CircularGaussianPRF(flux=50, x_0=15, y_0=15, fwhm=3.1)(xx, yy)
+    data[15, 14] = 1e7
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[15, 14] = True
+    fit = fit_2dgaussian(data, xypos=(15, 15), fit_shape=7, mask=mask,
+                         fix_fwhm=False)
+    assert fit.results['flux_init'][0] < 100.0
+    assert_allclose(fit.results['flux_fit'][0], 50.0, rtol=0.01)
+    assert_allclose(fit.results['fwhm_fit'][0], 3.1, atol=0.01)
+
+
+def test_fit_fwhm_reemits_other_warnings():
+    """
+    Regression test that fit_fwhm re-emits non-convergence warnings
+    verbatim instead of replacing them with a false convergence
+    warning.
+    """
+    yy, xx = np.mgrid[0:31, 0:31]
+    data = CircularGaussianPRF(flux=50, x_0=15, y_0=15, fwhm=3.1)(xx, yy)
+    data[0, 0] = np.nan
+    match = 'Input data contains unmasked non-finite values'
+    with pytest.warns(AstropyUserWarning, match=match) as record:
+        fwhm = fit_fwhm(data, xypos=(15, 15), fit_shape=7)
+    assert_allclose(fwhm[0], 3.1, atol=0.01)
+    messages = [str(w.message) for w in record]
+    assert not any('may not have converged' in msg for msg in messages)
+
+
+@pytest.mark.parametrize('bad_geometry', ['two_pixels', 'collinear'])
+def test_interpolate_missing_data_degenerate_geometry(bad_geometry):
+    """
+    Regression test that cubic interpolation falls back to nearest
+    neighbor when too few or collinear valid pixels remain.
+    """
+    data = np.ones((5, 5))
+    mask = np.ones(data.shape, dtype=bool)
+    if bad_geometry == 'two_pixels':
+        mask[0, 0] = mask[4, 4] = False
+    else:
+        mask[2, :] = False
+    result = _interpolate_missing_data(data, mask, method='cubic')
+    assert np.all(np.isfinite(result))

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -607,14 +607,19 @@ def _create_call_docstring(*, iterative=False):
 
         Parameters
         ----------
-        data : 2D `~numpy.ndarray`
+        data : 2D `~numpy.ndarray` or `~astropy.nddata.NDData`
             The 2D array on which to perform photometry. Invalid data
-            values (i.e., NaN or inf) are automatically masked.
+            values (i.e., NaN or inf) are automatically masked. If an
+            `~astropy.nddata.NDData` object is input, its ``data``,
+            ``mask``, ``uncertainty``, and ``unit`` attributes are used,
+            and the ``mask`` and ``error`` keywords must not be set.
 
         mask : 2D bool `~numpy.ndarray`, optional
-            A boolean mask with the same shape as ``data``, where a
-            `True` value indicates the corresponding element of ``data``
-            is masked.
+            A boolean mask with the same shape as ``data``, where
+            a `True` value indicates the corresponding element of
+            ``data`` is masked. Non-boolean mask arrays are coerced with
+            `~numpy.ndarray.astype`, so any nonzero value is treated as
+            masked.
 
         error : 2D `~numpy.ndarray`, optional
             The pixel-wise 1-sigma errors of the input ``data``.

--- a/photutils/psf/utils.py
+++ b/photutils/psf/utils.py
@@ -12,6 +12,7 @@ from astropy.table import QTable
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
 from scipy import interpolate
+from scipy.spatial import QhullError
 
 from photutils.centroids import centroid_com
 from photutils.psf.functional_models import CircularGaussianPRF
@@ -74,10 +75,10 @@ def _out_of_grid_mask(xi, yi, shape):
     """
     Compute a mask of positions outside an ePSF pixel grid.
 
-    The bounds match the `~scipy.interpolate.RegularGridInterpolator`
-    bounds. This helper defines the pixel-grid bounds used by both the
-    image-based PSF model evaluations and their analytic Jacobians
-    (``fit_deriv``), which must agree.
+    The bounds are the pixel-index domain of the ePSF image, ``[0, nx -
+    1] x [0, ny - 1]``. This helper defines the pixel-grid bounds used
+    by both the image-based PSF model evaluations and their analytic
+    Jacobians (``fit_deriv``), which must agree.
 
     Parameters
     ----------
@@ -263,8 +264,11 @@ def fit_2dgaussian(data, *, xypos=None, fwhm=None, fix_fwhm=True,
     flux_init = []
     for yxpos in xypos[:, ::-1]:
         cutout = CutoutImage(data, yxpos, tuple(fit_shape))
-        cutout = cutout.data[np.isfinite(cutout.data)]
-        flux_init.append(np.nansum(cutout))
+        good = np.isfinite(cutout.data)
+        if mask is not None:
+            mask_cutout = CutoutImage(mask, yxpos, tuple(fit_shape))
+            good &= ~mask_cutout.data
+        flux_init.append(np.sum(cutout.data[good]))
 
     if isinstance(data, Quantity):
         flux_init <<= data.unit
@@ -396,15 +400,22 @@ def fit_fwhm(data, *, xypos=None, fwhm=None, fit_shape=None, mask=None,
         phot = fit_2dgaussian(data, xypos=xypos, fwhm=fwhm, fix_fwhm=False,
                               fit_shape=fit_shape, mask=mask, error=error)
 
-    # Re-emit fit_shape warnings and check for other warnings
-    other_warnings = False
+    # Re-emit the captured warnings, mapping fitter convergence warnings
+    # to a single actionable message and passing all others through
+    # verbatim
+    convergence_warning = False
     for warning in fit_warnings:
-        if 'fit_shape is None' in str(warning.message):
-            warnings.warn(str(warning.message), warning.category)
+        wmsg = str(warning.message)
+        if 'fit_shape is None' in wmsg:
+            warnings.warn(wmsg, warning.category)
+        elif ('may not have converged' in wmsg
+                or 'fit may be unsuccessful' in wmsg):
+            convergence_warning = True
         else:
-            other_warnings = True
+            warnings.warn_explicit(warning.message, warning.category,
+                                   warning.filename, warning.lineno)
 
-    if other_warnings:
+    if convergence_warning:
         msg = ('One or more fit(s) may not have converged. Please '
                'carefully check your results. You may need to change '
                'the input "xypos" and "fit_shape" parameters.')
@@ -473,7 +484,11 @@ def _interpolate_missing_data(data, mask, *, method='cubic'):
     if method == 'nearest':
         interpol = interpolate.NearestNDInterpolator(xy, z)
     elif method == 'cubic':
-        interpol = interpolate.CloughTocher2DInterpolator(xy, z)
+        try:
+            interpol = interpolate.CloughTocher2DInterpolator(xy, z)
+        except QhullError:
+            # Too few or collinear valid pixels for triangulation
+            interpol = interpolate.NearestNDInterpolator(xy, z)
     else:
         msg = 'Unsupported interpolation method'
         raise ValueError(msg)


### PR DESCRIPTION
This PR addresses a range of correctness and robustness issues found during a re-review of the `photutils.psf` subpackage, including input validation gaps in `PSFPhotometry`, `EPSFBuilder`, and `EPSFStar`, mask handling in `fit_2dgaussian`/`fit_fwhm`, and edge cases in model plotting, Airy evaluation, and finder/flag handling.