### PR TITLE
Add SourceCatalog centroid errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -240,9 +240,11 @@ New Features
 
   - Added ``SourceCatalog`` ``centroid_err``, ``x_centroid_err``,
     ``y_centroid_err``, ``centroid_win_err``, ``x_centroid_win_err``,
-    and ``y_centroid_win_err`` properties providing the 1-sigma errors
-    on the isophotal and windowed centroid positions, propagated from
-    the input ``error`` array. [#2397]
+    ``y_centroid_win_err``, ``centroid_quad_err``,
+    ``x_centroid_quad_err``, and ``y_centroid_quad_err`` properties
+    providing the 1-sigma errors on the isophotal, windowed, and
+    quadratic centroid positions, propagated from the input ``error``
+    array. [#2397]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -238,6 +238,12 @@ New Features
     deblended (child) labels between segmentation images made before
     and after deblending. [#2382]
 
+  - Added ``SourceCatalog`` ``centroid_err``, ``x_centroid_err``,
+    ``y_centroid_err``, ``centroid_win_err``, ``x_centroid_win_err``,
+    and ``y_centroid_win_err`` properties providing the 1-sigma errors
+    on the isophotal and windowed centroid positions, propagated from
+    the input ``error`` array. [#2397]
+
 - ``photutils.utils``
 
   - Added a new ``DeblendWarning`` class, a subclass of astropy's
@@ -910,6 +916,14 @@ API Changes
 
   - ``SegmentationImage`` now raises a ``TypeError`` for masked array
     input. [#2381]
+
+  - The conditions for the ``SourceCatalog`` ``centroid_win`` fallback
+    to the isophotal centroid have been expanded. The windowed centroid
+    is reset when it diverged far from the isophotal centroid and
+    lies outside the 1-sigma ellipse, the total weighted flux is
+    non-positive, the windowed second-order moments are negative, or the
+    windowed covariance determinant is negative. Previously, only the
+    ellipse condition was applied. [#2397]
 
 - ``photutils.utils``
 

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -747,13 +747,16 @@ instrumental flux and propagated flux error within the source segments:
 
 The 1-sigma centroid position errors are also calculated
 when a total ``error`` is input, via the
-`~photutils.segmentation.SourceCatalog.centroid_err` and
-`~photutils.segmentation.SourceCatalog.centroid_win_err`
+`~photutils.segmentation.SourceCatalog.centroid_err`,
+`~photutils.segmentation.SourceCatalog.centroid_win_err`, and
+`~photutils.segmentation.SourceCatalog.centroid_quad_err`
 properties and their per-axis
 `~photutils.segmentation.SourceCatalog.x_centroid_err`,
 `~photutils.segmentation.SourceCatalog.y_centroid_err`,
-`~photutils.segmentation.SourceCatalog.x_centroid_win_err`, and
-`~photutils.segmentation.SourceCatalog.y_centroid_win_err`
+`~photutils.segmentation.SourceCatalog.x_centroid_win_err`,
+`~photutils.segmentation.SourceCatalog.y_centroid_win_err`,
+`~photutils.segmentation.SourceCatalog.x_centroid_quad_err`, and
+`~photutils.segmentation.SourceCatalog.y_centroid_quad_err`
 equivalents:
 
 .. doctest-requires:: skimage

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -745,6 +745,34 @@ instrumental flux and propagated flux error within the source segments:
        75  74.413068  259.76066     836.4803        17.193721
        80  14.920217  60.024006    666.60139        19.605394
 
+The 1-sigma centroid position errors are also calculated
+when a total ``error`` is input, via the
+`~photutils.segmentation.SourceCatalog.centroid_err` and
+`~photutils.segmentation.SourceCatalog.centroid_win_err`
+properties and their per-axis
+`~photutils.segmentation.SourceCatalog.x_centroid_err`,
+`~photutils.segmentation.SourceCatalog.y_centroid_err`,
+`~photutils.segmentation.SourceCatalog.x_centroid_win_err`, and
+`~photutils.segmentation.SourceCatalog.y_centroid_win_err`
+equivalents:
+
+.. doctest-requires:: skimage
+
+    >>> columns = ['label', 'x_centroid', 'x_centroid_err', 'y_centroid',
+    ...            'y_centroid_err']
+    >>> tbl6 = cat_subset.to_table(columns=columns)
+    >>> for col in tbl6.colnames:
+    ...     tbl6[col].info.format = '%.8g'  # for consistent table output
+    >>> print(tbl6)
+    label x_centroid x_centroid_err y_centroid y_centroid_err
+    ----- ---------- -------------- ---------- --------------
+        1  235.24302     0.10078987  1.1928271    0.043716311
+        5  257.82267    0.092017708  12.228232     0.11001639
+       20  347.15384     0.11928677  66.417567    0.088327137
+       50  380.94448     0.13065541  174.57181     0.11247878
+       75  74.413068    0.051327718  259.76066    0.045532249
+       80  14.920217    0.069001032  60.024006    0.093764369
+
 
 Pixel Masking
 ^^^^^^^^^^^^^

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -510,17 +510,22 @@ Centroid Position Errors
 ========================
 
 `~photutils.segmentation.SourceCatalog` now provides 1-sigma errors
-on the isophotal and windowed centroid positions, propagated from the
-input ``error`` array. The new properties are
+on the isophotal, windowed, and quadratic centroid positions,
+propagated from the input ``error`` array. The new properties are
 `~photutils.segmentation.SourceCatalog.centroid_err`,
 `~photutils.segmentation.SourceCatalog.x_centroid_err`, and
 `~photutils.segmentation.SourceCatalog.y_centroid_err` for the
-isophotal `~photutils.segmentation.SourceCatalog.centroid`, and
+isophotal `~photutils.segmentation.SourceCatalog.centroid`,
 `~photutils.segmentation.SourceCatalog.centroid_win_err`,
 `~photutils.segmentation.SourceCatalog.x_centroid_win_err`, and
 `~photutils.segmentation.SourceCatalog.y_centroid_win_err` for the
 "windowed" centroid
-(`~photutils.segmentation.SourceCatalog.centroid_win`)::
+(`~photutils.segmentation.SourceCatalog.centroid_win`), and
+`~photutils.segmentation.SourceCatalog.centroid_quad_err`,
+`~photutils.segmentation.SourceCatalog.x_centroid_quad_err`, and
+`~photutils.segmentation.SourceCatalog.y_centroid_quad_err` for the
+quadratic-fit centroid
+(`~photutils.segmentation.SourceCatalog.centroid_quad`)::
 
     >>> import numpy as np
     >>> from astropy.convolution import convolve

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -506,6 +506,50 @@ flag values into human-readable names::
 See :ref:`aperture_flags` for more details.
 
 
+Centroid Position Errors
+========================
+
+`~photutils.segmentation.SourceCatalog` now provides 1-sigma errors
+on the isophotal and windowed centroid positions, propagated from the
+input ``error`` array. The new properties are
+`~photutils.segmentation.SourceCatalog.centroid_err`,
+`~photutils.segmentation.SourceCatalog.x_centroid_err`, and
+`~photutils.segmentation.SourceCatalog.y_centroid_err` for the
+isophotal `~photutils.segmentation.SourceCatalog.centroid`, and
+`~photutils.segmentation.SourceCatalog.centroid_win_err`,
+`~photutils.segmentation.SourceCatalog.x_centroid_win_err`, and
+`~photutils.segmentation.SourceCatalog.y_centroid_win_err` for the
+"windowed" centroid
+(`~photutils.segmentation.SourceCatalog.centroid_win`)::
+
+    >>> import numpy as np
+    >>> from astropy.convolution import convolve
+    >>> from photutils.datasets import make_100gaussians_image
+    >>> from photutils.segmentation import (SourceCatalog, SourceFinder,
+    ...                                     make_2dgaussian_kernel)
+    >>> data = make_100gaussians_image() - 5.0  # subtract background
+    >>> error = np.full(data.shape, 2.0)
+    >>> kernel = make_2dgaussian_kernel(3.0, size=5)
+    >>> convolved_data = convolve(data, kernel)
+    >>> finder = SourceFinder(n_pixels=10, progress_bar=False)
+    >>> segment_map = finder(convolved_data, 4.5)
+    >>> cat = SourceCatalog(data, segment_map,
+    ...                     convolved_data=convolved_data, error=error)
+    >>> columns = ['label', 'x_centroid_err', 'y_centroid_err',
+    ...            'x_centroid_win_err', 'y_centroid_win_err']
+    >>> tbl = cat.to_table(columns=columns)[:5]
+    >>> for col in tbl.colnames[1:]:
+    ...     tbl[col].info.format = '%.6f'
+    >>> print(tbl)
+    label x_centroid_err y_centroid_err x_centroid_win_err y_centroid_win_err
+    ----- -------------- -------------- ------------------ ------------------
+        1       0.107193       0.040633           0.096188           0.081614
+        2       0.115570       0.069543           0.145871           0.146489
+        3       0.083684       0.087086           0.144631           0.144630
+        4       0.078204       0.104136           0.158468           0.158468
+        5       0.081175       0.098188           0.181951           0.181947
+
+
 ``GriddedPSFModel`` Performance Improvements
 ============================================
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1623,6 +1623,111 @@ class SourceCatalog:
         """
         return self._array('centroid')[:, 1]
 
+    @cached_property
+    @use_detcat
+    def _centroid_errors(self):
+        """
+        The 1-sigma errors on the ``(x, y)`` isophotal centroid
+        position.
+
+        The errors are computed by propagating the input ``error``
+        array through the center-of-mass centroid formula. If no
+        error array was provided, the errors are ``np.nan``.
+
+        For a centroid defined as :math:`x_c = \\sum f_i x_i / F`,
+        the variance is:
+
+        .. math::
+
+            \\text{Var}(x_c) = \\frac{\\sum_i (x_i - x_c)^2
+            \\sigma_i^2}{F^2}
+
+        A 1/12 correction is added for finite pixel size, and a
+        singularity correction is applied for point-like sources whose
+        shape covariance determinant is below :math:`(1/12)^2`.
+        """
+        if self._error is None:
+            result = np.full((self.nlabels, 2), np.nan)
+            if self.isscalar:
+                return result[0]
+            return result
+
+        cutout_centroid = self.cutout_centroid
+        if self.isscalar:
+            cutout_centroid = cutout_centroid[np.newaxis, :]
+
+        # Use the raw (uncorrected) shape covariance determinant to
+        # determine which sources are point-like (singularity
+        # flag): the flag is set when the covariance determinant
+        # < (1/12)^2 BEFORE the diagonal correction is applied.
+        # We compute from central moments directly.
+        moments_cen = self.moments_central
+        if self.isscalar:
+            moments_cen = moments_cen[np.newaxis, :]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            mu00 = moments_cen[:, 0, 0]
+            raw_var_xx = moments_cen[:, 0, 2] / mu00
+            raw_var_yy = moments_cen[:, 2, 0] / mu00
+            raw_var_xy = moments_cen[:, 1, 1] / mu00
+        raw_det = raw_var_xx * raw_var_yy - raw_var_xy**2
+        is_singular = raw_det < (1.0 / 12)**2
+
+        xerr_arr = []
+        yerr_arr = []
+        pixel_var = 1.0 / 12.0
+        for (moment_data, error_cutout, total_mask, xcen, ycen,
+             singular) in zip(
+                self._moment_data_cutouts, self._error_cutouts,
+                self._cutout_total_masks, cutout_centroid[:, 0],
+                cutout_centroid[:, 1], is_singular, strict=True):
+
+            total_flux = np.sum(moment_data)
+            if not np.isfinite(total_flux) or total_flux <= 0:
+                xerr_arr.append(np.nan)
+                yerr_arr.append(np.nan)
+                continue
+
+            err_sq = error_cutout.astype(float)**2
+            err_sq[total_mask] = 0.0
+
+            yy, xx = np.mgrid[0:err_sq.shape[0], 0:err_sq.shape[1]]
+            dx = xx - xcen
+            dy = yy - ycen
+
+            # Compute raw error variances without the pixel-size
+            # correction.
+            err_var_x = np.sum(err_sq * dx**2)
+            err_var_y = np.sum(err_sq * dy**2)
+            err_sum = np.sum(err_sq)
+
+            norm = 1.0 / (total_flux**2)
+            err_var_x *= norm
+            err_var_y *= norm
+            err_sum_norm = err_sum * pixel_var * norm
+
+            # Singularity correction for point-like sources. The
+            # check is performed on the raw error matrix (without
+            # the 1/12 pixel-size correction).
+            if singular:
+                err_cov_xy = np.sum(err_sq * dx * dy) * norm
+                if (err_var_x * err_var_y
+                        - err_cov_xy**2) < err_sum_norm**2:
+                    err_var_x += err_sum_norm
+                    err_var_y += err_sum_norm
+
+            # Add the pixel-size variance correction (1/12).
+            err_var_x += err_sum_norm
+            err_var_y += err_sum_norm
+
+            xerr_arr.append(np.sqrt(err_var_x))
+            yerr_arr.append(np.sqrt(err_var_y))
+
+        result = np.transpose((xerr_arr, yerr_arr))
+        if self.isscalar:
+            return result[0]
+        return result
+
     def _centroid_win_single(self, label, xcen, ycen, rad_hl,
                              nan_hl_, kwargs, compute_err):
         """
@@ -1694,11 +1799,10 @@ class SourceCatalog:
                     combined_weight = aperture_weights * gweight
                     weighted_var = combined_weight**2 * var
                     err_sum = np.sum(weighted_var)
-                    # 1/12 accounts for finite pixel size
-                    err_var_x = np.sum(
-                        weighted_var * (xx**2 + 1.0 / 12))
-                    err_var_y = np.sum(
-                        weighted_var * (yy**2 + 1.0 / 12))
+                    # Compute raw error variances without the
+                    # pixel-size correction.
+                    err_var_x = np.sum(weighted_var * xx**2)
+                    err_var_y = np.sum(weighted_var * yy**2)
                     err_cov_xy = np.sum(weighted_var * xx * yy)
 
                 data = data * aperture_weights * gweight
@@ -1743,6 +1847,10 @@ class SourceCatalog:
             if (err_var_x * err_var_y - err_cov_xy**2) < err_sum_norm**2:
                 err_var_x += err_sum_norm
                 err_var_y += err_sum_norm
+
+            # Add pixel-size variance correction (1/12).
+            err_var_x += err_sum_norm
+            err_var_y += err_sum_norm
         else:
             err_var_x = err_var_y = err_cov_xy = np.nan
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -31,6 +31,7 @@ from photutils.utils._deprecation import (_get_future_column_names,
                                           deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
 from photutils.utils._misc import _get_meta
+from photutils.utils._moments import _image_moments
 from photutils.utils._parameters import validate_table_columns
 from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._quantity_helpers import process_quantities
@@ -1622,6 +1623,132 @@ class SourceCatalog:
         """
         return self._array('centroid')[:, 1]
 
+    def _centroid_win_single(self, label, xcen, ycen, rad_hl,
+                             nan_hl_, kwargs, compute_err):
+        """
+        Compute the windowed centroid and error terms for a single
+        source.
+
+        Returns a tuple of (xcen, ycen, weighted_flux, cen_mom_xx,
+        cen_mom_yy, cen_mom_xy, err_var_x, err_var_y, err_cov_xy).
+        """
+        nan_result = (np.nan, np.nan, 0.0, 0.0, 0.0, 0.0,
+                      np.nan, np.nan, np.nan)
+        if nan_hl_ or np.any(~np.isfinite((xcen, ycen))):
+            return nan_result
+
+        sigma = 2.0 * rad_hl * gaussian_fwhm_to_sigma
+        sigma2 = sigma**2
+        radius = 4.0 * sigma
+
+        iter_ = 0
+        centroid_shift = 1
+        max_iters = 16
+        centroid_threshold = 0.0001
+        weighted_flux = 0.0
+        dx_shift = dy_shift = 0.0
+        raw_mom_xx = raw_mom_yy = raw_mom_xy = 0.0
+        err_sum = err_var_x = err_var_y = err_cov_xy = 0.0
+        while iter_ < max_iters and centroid_shift > centroid_threshold:
+            aperture = CircularAperture((xcen, ycen), radius)
+            aperture_mask = self._aperture_to_mask(aperture, **kwargs)
+            if aperture_mask is None:
+                xcen = np.nan
+                ycen = np.nan
+                break
+
+            # For consistency with the isophotal centroid, a local
+            # background is not subtracted here
+            data, error, mask, cutout_xycen, slc_sm = (
+                self._make_aperture_data(
+                    label, xcen, ycen, aperture_mask.bbox, 0.0,
+                    make_error=compute_err))
+
+            if data is None:
+                # Return NaN if centroid moves the aperture
+                # completely off the image
+                xcen = np.nan
+                ycen = np.nan
+                break
+
+            aperture_weights = aperture_mask.data[slc_sm]
+
+            # Define a 2D Gaussian weight array
+            xvals = np.arange(data.shape[1]) - cutout_xycen[0]
+            yvals = np.arange(data.shape[0]) - cutout_xycen[1]
+            xx, yy = np.meshgrid(xvals, yvals)
+            rr2 = xx**2 + yy**2
+            gweight = np.exp(-rr2 / (2.0 * sigma2))
+
+            # Ignore multiplication with non-finite values
+            # and ignore divide-by-zero if moments[0, 0] = 0
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', RuntimeWarning)
+
+                # Accumulate error variance terms. The combined
+                # weight (aperture_weights * gweight) includes the
+                # Gaussian weight.
+                if compute_err:
+                    var = error**2
+                    var[mask] = 0.0
+                    combined_weight = aperture_weights * gweight
+                    weighted_var = combined_weight**2 * var
+                    err_sum = np.sum(weighted_var)
+                    # 1/12 accounts for finite pixel size
+                    err_var_x = np.sum(
+                        weighted_var * (xx**2 + 1.0 / 12))
+                    err_var_y = np.sum(
+                        weighted_var * (yy**2 + 1.0 / 12))
+                    err_cov_xy = np.sum(weighted_var * xx * yy)
+
+                data = data * aperture_weights * gweight
+                data[mask] = 0.0
+
+                moments = _image_moments(data, center=cutout_xycen,
+                                         order=2)
+                weighted_flux = moments[0, 0]
+                dy_shift = moments[1, 0] / weighted_flux
+                dx_shift = moments[0, 1] / weighted_flux
+                raw_mom_xx = moments[0, 2]
+                raw_mom_yy = moments[2, 0]
+                raw_mom_xy = moments[1, 1]
+                centroid_shift = np.sqrt(dx_shift**2 + dy_shift**2)
+                xcen += dx_shift * 2.0
+                ycen += dy_shift * 2.0
+                iter_ += 1
+
+        # Compute windowed central 2nd moments from last
+        # iteration for the fallback checks.
+        if np.isfinite(weighted_flux) and weighted_flux > 0:
+            cen_mom_xx = (raw_mom_xx / weighted_flux
+                          - dx_shift * dx_shift)
+            cen_mom_yy = (raw_mom_yy / weighted_flux
+                          - dy_shift * dy_shift)
+            cen_mom_xy = (raw_mom_xy / weighted_flux
+                          - dx_shift * dy_shift)
+        else:
+            cen_mom_xx = cen_mom_yy = cen_mom_xy = 0.0
+
+        # Normalize error terms by step_factor^2 / weighted_flux^2
+        if compute_err and np.isfinite(weighted_flux) and weighted_flux > 0:
+            step_factor = 2.0
+            norm = step_factor**2 / (weighted_flux**2)
+            err_var_x *= norm
+            err_var_y *= norm
+            err_cov_xy *= norm
+
+            # Handle fully correlated profiles that cause a
+            # singularity.
+            err_sum_norm = err_sum * (1.0 / 12) * norm
+            if (err_var_x * err_var_y - err_cov_xy**2) < err_sum_norm**2:
+                err_var_x += err_sum_norm
+                err_var_y += err_sum_norm
+        else:
+            err_var_x = err_var_y = err_cov_xy = np.nan
+
+        return (xcen, ycen, weighted_flux, cen_mom_xx, cen_mom_yy,
+                cen_mom_xy, err_var_x, err_var_y, err_cov_xy)
+
     @cached_property
     @use_detcat
     def centroid_win(self):  # noqa: PLR0915
@@ -1668,6 +1795,8 @@ class SourceCatalog:
         small_mask = np.isfinite(radius_hl) & (radius_hl < min_radius)
         radius_hl[small_mask] = min_radius
 
+        compute_err = self._error is not None
+
         labels = self.labels
         if self.progress_bar:
             desc = 'centroid_win'
@@ -1680,6 +1809,7 @@ class SourceCatalog:
         # Pre-fetch arrays used in the inner loop
         data_arr = self._data
         mask_arr = self._mask
+        error_arr = self._error
         segm_data = self._segmentation_image.data
         data_shape = data_arr.shape
         do_correct = self.aperture_mask_method == 'correct'
@@ -1695,6 +1825,9 @@ class SourceCatalog:
         win_cen_mom_xx = []
         win_cen_mom_yy = []
         win_cen_mom_xy = []
+        win_err_var_x = []
+        win_err_var_y = []
+        win_err_cov_xy = []
         for label, xcen, ycen, rad_hl, nan_hl_ in zip(
                 labels, x_centroid, y_centroid, radius_hl, nan_hl,
                 strict=True):
@@ -1706,6 +1839,9 @@ class SourceCatalog:
                 win_cen_mom_xx.append(0.0)
                 win_cen_mom_yy.append(0.0)
                 win_cen_mom_xy.append(0.0)
+                win_err_var_x.append(np.nan)
+                win_err_var_y.append(np.nan)
+                win_err_cov_xy.append(np.nan)
                 continue
 
             sigma = 2.0 * rad_hl * gaussian_fwhm_to_sigma
@@ -1728,18 +1864,23 @@ class SourceCatalog:
                 win_cen_mom_xx.append(0.0)
                 win_cen_mom_yy.append(0.0)
                 win_cen_mom_xy.append(0.0)
+                win_err_var_x.append(np.nan)
+                win_err_var_y.append(np.nan)
+                win_err_cov_xy.append(np.nan)
                 continue
 
             # Cache for cutout data when the integer bbox doesn't change
             prev_ixcen = prev_iycen = None
             cached_data = None
             cached_mask = None
+            cached_error = None
 
             iter_ = 0
             dcen = 1.0
             weighted_flux = 0.0
             dx_mom = dy_mom = 0.0
             raw_mx2 = raw_my2 = raw_mxy = 0.0
+            err_sum = err_var_x = err_var_y = err_cov_xy = 0.0
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', RuntimeWarning)
                 while iter_ < max_iters and dcen > centroid_threshold:
@@ -1791,6 +1932,10 @@ class SourceCatalog:
                         cached_data = data
                         cached_mask = data_mask
 
+                        if compute_err:
+                            cached_error = (error_arr[slc_y, slc_x]
+                                            .astype(float))
+
                     # Centroid position in cutout coordinates
                     cx = xcen - max(0, ixmin)
                     cy = ycen - max(0, iymin)
@@ -1811,6 +1956,17 @@ class SourceCatalog:
 
                     # Inline Gaussian weight
                     gweight = np.exp(rr2 * inv_2sigma2)
+
+                    # Accumulate error variance terms
+                    if compute_err:
+                        var = cached_error**2
+                        var[cached_mask] = 0.0
+                        combined_weight = aper_weights * gweight
+                        weighted_var = combined_weight**2 * var
+                        err_sum = np.sum(weighted_var)
+                        err_var_x = np.sum(weighted_var * xx * xx)
+                        err_var_y = np.sum(weighted_var * yy * yy)
+                        err_cov_xy = np.sum(weighted_var * xx * yy)
 
                     # Apply weights and mask
                     weighted = (cached_data * aper_weights * gweight)
@@ -1843,10 +1999,36 @@ class SourceCatalog:
             else:
                 cen_mom_xx = cen_mom_yy = cen_mom_xy = 0.0
 
+            # Normalize error terms by step_factor^2 / weighted_flux^2
+            if (compute_err and np.isfinite(weighted_flux)
+                    and weighted_flux > 0):
+                step_factor = 2.0
+                norm = step_factor**2 / (weighted_flux**2)
+                err_var_x *= norm
+                err_var_y *= norm
+                err_cov_xy *= norm
+
+                # Handle fully correlated profiles that cause a
+                # singularity.
+                err_sum_norm = err_sum * (1.0 / 12) * norm
+                if (err_var_x * err_var_y
+                        - err_cov_xy**2) < err_sum_norm**2:
+                    err_var_x += err_sum_norm
+                    err_var_y += err_sum_norm
+
+                # Add pixel-size variance correction (1/12).
+                err_var_x += err_sum_norm
+                err_var_y += err_sum_norm
+            else:
+                err_var_x = err_var_y = err_cov_xy = np.nan
+
             win_weighted_flux.append(weighted_flux)
             win_cen_mom_xx.append(cen_mom_xx)
             win_cen_mom_yy.append(cen_mom_yy)
             win_cen_mom_xy.append(cen_mom_xy)
+            win_err_var_x.append(err_var_x)
+            win_err_var_y.append(err_var_y)
+            win_err_cov_xy.append(err_cov_xy)
             xcen_win.append(xcen)
             ycen_win.append(ycen)
 
@@ -1856,6 +2038,9 @@ class SourceCatalog:
         win_cen_mom_xx = np.array(win_cen_mom_xx)
         win_cen_mom_yy = np.array(win_cen_mom_yy)
         win_cen_mom_xy = np.array(win_cen_mom_xy)
+        win_err_var_x = np.array(win_err_var_x)
+        win_err_var_y = np.array(win_err_var_y)
+        win_err_cov_xy = np.array(win_err_cov_xy)
 
         # Reset to the isophotal centroid when any of:
         # 1. Centroid diverged far AND outside 1-sigma ellipse
@@ -1882,6 +2067,18 @@ class SourceCatalog:
         if np.any(reset):
             xcen_win[reset] = x_centroid[reset]
             ycen_win[reset] = y_centroid[reset]
+            # Errors are not meaningful for fallback sources
+            win_err_var_x[reset] = np.nan
+            win_err_var_y[reset] = np.nan
+            win_err_cov_xy[reset] = np.nan
+
+        # Store the 1-sigma position errors. Take sqrt to convert
+        # variance to 1-sigma.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            xerr = np.sqrt(win_err_var_x)
+            yerr = np.sqrt(win_err_var_y)
+        self._centroid_win_poserr = np.transpose((xerr, yerr))
 
         return np.transpose((xcen_win, ycen_win))
 
@@ -1910,6 +2107,30 @@ class SourceCatalog:
         `SourceExtractor`_'s YWIN_IMAGE parameters.
         """
         return self._array('centroid_win')[:, 1]
+
+    @cached_property
+    @use_detcat
+    def _centroid_win_errors(self):
+        """
+        The 1-sigma errors on the ``(x, y)`` windowed centroid
+        position.
+
+        The errors are computed by propagating the error array
+        passed to `SourceCatalog` through the windowed centroid
+        computation. If no error array was provided, the errors are
+        ``np.nan``.
+
+        Errors are also ``np.nan`` for sources where the windowed
+        centroid fell back to the isophotal centroid, or where the
+        half-light radius is non-finite.
+        """
+        # Trigger centroid_win computation (which stores
+        # _centroid_win_poserr as a side effect).
+        _ = self.centroid_win  # noqa: F841
+        result = self._centroid_win_poserr
+        if self.isscalar:
+            return result[0]
+        return result
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2293,6 +2293,178 @@ class SourceCatalog:
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.centroid_win - origin
 
+    @staticmethod
+    def _centroid_quad_var(coeffs, xm_rel, ym_rel, pinv, box_var):
+        """
+        Propagate pixel variances through the quadratic peak solution.
+
+        The quadratic-fit coefficients are linear in the pixel values
+        (``c = pinv @ pixels``) and the peak position is a rational
+        function of the coefficients, so the position variances follow
+        from the delta method.
+
+        Parameters
+        ----------
+        coeffs : `~numpy.ndarray`
+            The six quadratic-fit coefficients for the terms
+            ``[1, x, y, xy, x^2, y^2]``.
+
+        xm_rel, ym_rel : float
+            The peak position in the relative (3x3 box) coordinates.
+
+        pinv : `~numpy.ndarray`
+            The (6, 9) pseudo-inverse of the design matrix.
+
+        box_var : `~numpy.ndarray`
+            The 9 pixel variances of the 3x3 fit box, with masked
+            pixels set to zero.
+
+        Returns
+        -------
+        var_x, var_y : float
+            The variances of the peak ``x`` and ``y`` positions.
+        """
+        c10, c01, c11, c20, c02 = coeffs[1:]
+        det = 4.0 * c20 * c02 - c11 * c11
+        grad_x = np.array(
+            [0.0,
+             -2.0 * c02 / det,
+             c11 / det,
+             (c01 + 2.0 * c11 * xm_rel) / det,
+             -4.0 * c02 * xm_rel / det,
+             (-2.0 * c10 - 4.0 * c20 * xm_rel) / det])
+        grad_y = np.array(
+            [0.0,
+             c11 / det,
+             -2.0 * c20 / det,
+             (c10 + 2.0 * c11 * ym_rel) / det,
+             (-2.0 * c01 - 4.0 * c02 * ym_rel) / det,
+             -4.0 * c20 * ym_rel / det])
+        var_x = np.sum((grad_x @ pinv)**2 * box_var)
+        var_y = np.sum((grad_y @ pinv)**2 * box_var)
+        return var_x, var_y
+
+    @cached_property
+    @use_detcat
+    def _centroid_quad_results(self):
+        """
+        The quadratic centroid coordinates, relative to the cutout
+        data, and their 1-sigma errors as a 2D array with columns
+        ``(x, y, xerr, yerr)`` and shape ``(n_labels, 4)``.
+
+        This is the single computation behind `cutout_centroid_quad`,
+        `centroid_quad`, and `centroid_quad_err`. See
+        `cutout_centroid_quad` for the algorithm details.
+        """
+        # Precompute the pseudo-inverse for the 3x3 relative coordinate
+        # design matrix [1, x, y, xy, x^2, y^2]. This is constant for
+        # all sources and avoids per-source lstsq calls.
+        xi = np.arange(3)
+        x, y = np.meshgrid(xi, xi)
+        x = x.ravel()
+        y = y.ravel()
+        coeff_matrix = np.empty((9, 6), dtype=float)
+        coeff_matrix[:, 0] = 1
+        coeff_matrix[:, 1] = x
+        coeff_matrix[:, 2] = y
+        coeff_matrix[:, 3] = x * y
+        coeff_matrix[:, 4] = x * x
+        coeff_matrix[:, 5] = y * y
+        pinv = np.linalg.pinv(coeff_matrix)
+
+        compute_err = self._error is not None
+
+        _nan = np.nan
+        nan_result = (_nan, _nan, _nan, _nan)
+        results = []
+
+        cutouts = self._data_cutouts
+        if self.progress_bar:
+            desc = 'centroid_quad'
+            cutouts = add_progress_bar(cutouts, desc=desc)
+
+        for cutout, error_cutout, mask in zip(cutouts,
+                                              self._error_cutouts,
+                                              self._cutout_total_masks,
+                                              strict=True):
+            ny, nx = cutout.shape
+
+            # Cutout must be at least 3x3 for the quadratic fit
+            if ny < 3 or nx < 3:
+                results.append(nan_result)
+                continue
+
+            # Apply mask: _cutout_total_masks already includes
+            # non-finite data values, so cutout[mask] = 0.0 handles both
+            # masked pixels and non-finite values.
+            cutout = np.array(cutout, dtype=float)
+            cutout[mask] = 0.0
+
+            # Find peak pixel
+            yidx, xidx = np.unravel_index(np.argmax(cutout), cutout.shape)
+
+            # If peak at edge of cutout, return peak position. No fit
+            # is performed, so no errors can be propagated.
+            if xidx == 0 or xidx == nx - 1 or yidx == 0 or yidx == ny - 1:
+                results.append((float(xidx), float(yidx), _nan, _nan))
+                continue
+
+            # Extract 3x3 box centered on peak (guaranteed to fit
+            # since peak is not at edge)
+            xidx0 = xidx - 1
+            yidx0 = yidx - 1
+            cutout_flat = cutout[yidx0:yidx0 + 3, xidx0:xidx0 + 3].ravel()
+
+            # Compute polynomial coefficients via precomputed
+            # pseudo-inverse
+            c = pinv @ cutout_flat
+            c10, c01, c11, c20, c02 = c[1], c[2], c[3], c[4], c[5]
+
+            det = 4.0 * c20 * c02 - c11 * c11
+            if det <= 0 or c20 > 0:
+                results.append(nan_result)
+                continue
+
+            # Maximum in relative coords, then convert to cutout coords
+            xm_rel = (c01 * c11 - 2.0 * c02 * c10) / det
+            ym_rel = (c10 * c11 - 2.0 * c20 * c01) / det
+            xm = xm_rel + xidx0
+            ym = ym_rel + yidx0
+
+            if not (0.0 < xm < (nx - 1.0) and 0.0 < ym < (ny - 1.0)):
+                results.append(nan_result)
+                continue
+
+            var_x = var_y = _nan
+            if compute_err:
+                # Pixel variances of the fit box; masked pixels have
+                # a fixed (zeroed) data value, so they contribute no
+                # variance
+                box_var = (error_cutout[yidx0:yidx0 + 3, xidx0:xidx0 + 3]
+                           .astype(float).ravel()**2)
+                box_var[mask[yidx0:yidx0 + 3,
+                             xidx0:xidx0 + 3].ravel()] = 0.0
+                var_x, var_y = self._centroid_quad_var(c, xm_rel, ym_rel,
+                                                       pinv, box_var)
+
+            results.append((xm, ym, var_x, var_y))
+
+        results = np.array(results)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            results[:, 2:4] = np.sqrt(results[:, 2:4])
+
+        # Use the segment barycenter if the fit returned NaN. Fallback
+        # sources use the isophotal centroid, so also use the isophotal
+        # centroid errors.
+        nan_mask = (np.isnan(results[:, 0]) | np.isnan(results[:, 1]))
+        if np.any(nan_mask):
+            cutout_centroid = self._array('cutout_centroid')
+            results[nan_mask, 0:2] = cutout_centroid[nan_mask]
+            results[nan_mask, 2:4] = self._array('centroid_err')[nan_mask]
+
+        return results
+
     @cached_property
     @use_detcat
     def cutout_centroid_quad(self):
@@ -2321,87 +2493,7 @@ class SourceCatalog:
         is at the edge of the source segment. In this case, the position
         of the maximum pixel will be returned.
         """
-        # Precompute the pseudo-inverse for the 3x3 relative coordinate
-        # design matrix [1, x, y, xy, x^2, y^2]. This is constant for
-        # all sources and avoids per-source lstsq calls.
-        xi = np.arange(3)
-        x, y = np.meshgrid(xi, xi)
-        x = x.ravel()
-        y = y.ravel()
-        coeff_matrix = np.empty((9, 6), dtype=float)
-        coeff_matrix[:, 0] = 1
-        coeff_matrix[:, 1] = x
-        coeff_matrix[:, 2] = y
-        coeff_matrix[:, 3] = x * y
-        coeff_matrix[:, 4] = x * x
-        coeff_matrix[:, 5] = y * y
-        pinv = np.linalg.pinv(coeff_matrix)
-
-        _nan = np.nan
-        centroid_quad = []
-
-        cutouts = self._data_cutouts
-        if self.progress_bar:
-            desc = 'centroid_quad'
-            cutouts = add_progress_bar(cutouts, desc=desc)
-
-        for cutout, mask in zip(cutouts, self._cutout_total_masks,
-                                strict=True):
-            ny, nx = cutout.shape
-
-            # Cutout must be at least 3x3 for the quadratic fit
-            if ny < 3 or nx < 3:
-                centroid_quad.append((_nan, _nan))
-                continue
-
-            # Apply mask: _cutout_total_masks already includes
-            # non-finite data values, so cutout[mask] = 0.0 handles both
-            # masked pixels and non-finite values.
-            cutout = np.array(cutout, dtype=float)
-            cutout[mask] = 0.0
-
-            # Find peak pixel
-            yidx, xidx = np.unravel_index(np.argmax(cutout), cutout.shape)
-
-            # If peak at edge of cutout, return peak position
-            if xidx == 0 or xidx == nx - 1 or yidx == 0 or yidx == ny - 1:
-                centroid_quad.append((float(xidx), float(yidx)))
-                continue
-
-            # Extract 3x3 box centered on peak (guaranteed to fit
-            # since peak is not at edge)
-            xidx0 = xidx - 1
-            yidx0 = yidx - 1
-            cutout_flat = cutout[yidx0:yidx0 + 3, xidx0:xidx0 + 3].ravel()
-
-            # Compute polynomial coefficients via precomputed
-            # pseudo-inverse
-            c = pinv @ cutout_flat
-            c10, c01, c11, c20, c02 = c[1], c[2], c[3], c[4], c[5]
-
-            det = 4.0 * c20 * c02 - c11 * c11
-            if det <= 0 or c20 > 0:
-                centroid_quad.append((_nan, _nan))
-                continue
-
-            # Maximum in relative coords, then convert to cutout coords
-            xm = (c01 * c11 - 2.0 * c02 * c10) / det + xidx0
-            ym = (c10 * c11 - 2.0 * c20 * c01) / det + yidx0
-
-            if 0.0 < xm < (nx - 1.0) and 0.0 < ym < (ny - 1.0):
-                centroid_quad.append((xm, ym))
-            else:
-                centroid_quad.append((_nan, _nan))
-
-        centroid_quad = np.array(centroid_quad)
-
-        # Use the segment barycenter if fit returned NaN
-        nan_mask = (np.isnan(centroid_quad[:, 0])
-                    | np.isnan(centroid_quad[:, 1]))
-        if np.any(nan_mask):
-            centroid_quad[nan_mask] = self.cutout_centroid[nan_mask]
-
-        return centroid_quad
+        return self._centroid_quad_results[:, 0:2].copy()
 
     @cached_property
     @use_detcat
@@ -2450,6 +2542,50 @@ class SourceCatalog:
         pixels in the source segment.
         """
         return self._array('centroid_quad')[:, 1]
+
+    @cached_property
+    @use_detcat
+    def centroid_quad_err(self):
+        """
+        The ``(x, y)`` 1-sigma errors on the quadratic centroid
+        (`centroid_quad`) position.
+
+        The errors are computed by propagating the input ``error`` array
+        through the least-squares quadratic fit and its peak solution
+        using the delta method. If ``error`` was not input, then the
+        errors are NaN.
+
+        Sources where the quadratic centroid fell back to the
+        isophotal `centroid` have the isophotal centroid errors (see
+        `centroid_err`). The errors are NaN for sources where the
+        maximum data value is at the edge of the source segment (where
+        the position of the maximum pixel is returned instead of a fit).
+        """
+        return self._centroid_quad_results[:, 2:4].copy()
+
+    @cached_property
+    @use_detcat
+    def x_centroid_quad_err(self):
+        """
+        The 1-sigma error on the ``x`` coordinate of the quadratic
+        centroid (`centroid_quad`).
+
+        See `centroid_quad_err` for details. If ``error`` was not input,
+        then the errors are NaN.
+        """
+        return self._array('centroid_quad_err')[:, 0]
+
+    @cached_property
+    @use_detcat
+    def y_centroid_quad_err(self):
+        """
+        The 1-sigma error on the ``y`` coordinate of the quadratic
+        centroid (`centroid_quad`).
+
+        See `centroid_quad_err` for details. If ``error`` was not input,
+        then the errors are NaN.
+        """
+        return self._array('centroid_quad_err')[:, 1]
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1702,8 +1702,8 @@ class SourceCatalog:
 
         return np.transpose((xerr_arr, yerr_arr))
 
-    def _normalize_win_errors(self, err_sum, err_var_x, err_var_y,
-                              err_cov_xy, weighted_flux):
+    def _normalize_centroid_win_err(self, err_sum, err_var_x, err_var_y,
+                                    err_cov_xy, weighted_flux):
         """
         Normalize the windowed centroid position-error variances.
 
@@ -1857,10 +1857,11 @@ class SourceCatalog:
 
         return np.transpose((xcen_win, ycen_win, xerr, yerr))
 
-    def _centroid_win_iter(self, label, xcen, ycen, rad_hl, nan_hl_,
-                           *, data_arr, mask_arr, error_arr, segm_data,
-                           data_shape, do_correct, do_segm_mask,
-                           compute_err, max_aper_size):
+    def _iterate_centroid_win(self, label, xcen, ycen, rad_hl,
+                              nan_hl_source, *, data_arr, mask_arr,
+                              error_arr, segm_data, data_shape,
+                              do_correct, do_segm_mask, compute_err,
+                              max_aper_size):
         """
         Compute the windowed centroid for a single source.
 
@@ -1878,7 +1879,7 @@ class SourceCatalog:
         rad_hl : float
             Half-light radius for this source.
 
-        nan_hl_ : bool
+        nan_hl_source : bool
             Whether the half-light radius is NaN.
 
         data_arr : `~numpy.ndarray`
@@ -1915,11 +1916,11 @@ class SourceCatalog:
             cen_mom_yy, cen_mom_xy, err_sum, err_var_x, err_var_y,
             err_cov_xy). The error terms are the raw (unnormalized)
             weighted sums from the last iteration (see
-            ``_normalize_win_errors``).
+            ``_normalize_centroid_win_err``).
         """
         nan_result = (np.nan, np.nan, 0.0, 0.0, 0.0, 0.0,
                       np.nan, np.nan, np.nan, np.nan)
-        if nan_hl_ or math.isnan(xcen) or math.isnan(ycen):
+        if nan_hl_source or math.isnan(xcen) or math.isnan(ycen):
             return nan_result
 
         sigma = 2.0 * rad_hl * gaussian_fwhm_to_sigma
@@ -2134,11 +2135,11 @@ class SourceCatalog:
         }
 
         results = []
-        for label, xcen, ycen, rad_hl, nan_hl_ in zip(
+        for label, xcen, ycen, rad_hl, nan_hl_source in zip(
                 labels, x_centroid, y_centroid, radius_hl, nan_hl,
                 strict=True):
-            results.append(self._centroid_win_iter(
-                label, xcen, ycen, rad_hl, nan_hl_, **iter_kwargs))
+            results.append(self._iterate_centroid_win(
+                label, xcen, ycen, rad_hl, nan_hl_source, **iter_kwargs))
 
         (xcen_win, ycen_win, win_weighted_flux,
          win_cen_mom_xx, win_cen_mom_yy, win_cen_mom_xy,
@@ -2148,7 +2149,7 @@ class SourceCatalog:
 
         # Normalize error terms by step_factor^2 / weighted_flux^2
         if compute_err:
-            win_err_var_x, win_err_var_y = self._normalize_win_errors(
+            win_err_var_x, win_err_var_y = self._normalize_centroid_win_err(
                 win_err_sum, win_err_var_x, win_err_var_y,
                 win_err_cov_xy, win_weighted_flux)
 

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1702,72 +1702,76 @@ class SourceCatalog:
 
         return np.transpose((xerr_arr, yerr_arr))
 
-    @staticmethod
-    def _normalize_win_errors(err_sum, err_var_x, err_var_y, err_cov_xy,
-                              weighted_flux):
+    def _normalize_win_errors(self, err_sum, err_var_x, err_var_y,
+                              err_cov_xy, weighted_flux):
         """
         Normalize the windowed centroid position-error variances.
 
-        Normalize by ``step_factor^2 / weighted_flux^2`` and apply the
-        singularity correction and pixel-size variance correction.
+        Normalize by ``step_factor^2 / weighted_flux^2``, add the
+        pixel-size (1/12) variance correction, and apply the singularity
+        correction for point-like sources. All inputs are arrays with
+        one element per source. Sources with non-positive or non-finite
+        ``weighted_flux`` have ``np.nan`` variances.
 
         Parameters
         ----------
-        err_sum : float
+        err_sum : `~numpy.ndarray`
             Sum of the weighted error variance over the aperture.
 
-        err_var_x : float
+        err_var_x : `~numpy.ndarray`
             Weighted error variance in ``x``.
 
-        err_var_y : float
+        err_var_y : `~numpy.ndarray`
             Weighted error variance in ``y``.
 
-        err_cov_xy : float
+        err_cov_xy : `~numpy.ndarray`
             Weighted error covariance in ``xy``.
 
-        weighted_flux : float
+        weighted_flux : `~numpy.ndarray`
             Total weighted flux from the last iteration.
 
         Returns
         -------
-        err_var_x : float
+        err_var_x : `~numpy.ndarray`
             Normalized error variance in ``x``.
 
-        err_var_y : float
+        err_var_y : `~numpy.ndarray`
             Normalized error variance in ``y``.
-
-        err_cov_xy : float
-            Normalized error covariance in ``xy``.
         """
-        if not (np.isfinite(weighted_flux) and weighted_flux > 0):
-            return np.nan, np.nan, np.nan
-
         step_factor = 2.0
-        norm = step_factor**2 / (weighted_flux**2)
-        err_var_x *= norm
-        err_var_y *= norm
-        err_cov_xy *= norm
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            norm = step_factor**2 / weighted_flux**2
 
-        # Handle fully correlated profiles that cause a singularity.
-        err_sum_norm = err_sum * (1.0 / 12) * norm
-        if (err_var_x * err_var_y
-                - err_cov_xy**2) < err_sum_norm**2:
-            err_var_x += err_sum_norm
-            err_var_y += err_sum_norm
+            # Add the pixel-size variance correction (1/12).
+            # The finite-pixel term is added per pixel.
+            err_sum_norm = err_sum * (1.0 / 12) * norm
+            err_var_x = err_var_x * norm + err_sum_norm
+            err_var_y = err_var_y * norm + err_sum_norm
+            err_cov_xy = err_cov_xy * norm
 
-        # Add pixel-size variance correction (1/12).
-        err_var_x += err_sum_norm
-        err_var_y += err_sum_norm
+            # Handle fully correlated profiles of point-like sources
+            # that cause a singularity. The determinant check
+            # includes the pixel-size correction in the variances
+            # but not in the covariance.
+            singular = (self._singular_covariance_mask
+                        & ((err_var_x * err_var_y - err_cov_xy**2)
+                           < err_sum_norm**2))
+            err_var_x[singular] += err_sum_norm[singular]
+            err_var_y[singular] += err_sum_norm[singular]
 
-        return err_var_x, err_var_y, err_cov_xy
+            bad = ~np.isfinite(weighted_flux) | (weighted_flux <= 0)
+            err_var_x[bad] = np.nan
+            err_var_y[bad] = np.nan
+
+        return err_var_x, err_var_y
 
     def _apply_centroid_win_fallback(self, xcen_win, ycen_win,
                                      win_weighted_flux,
                                      win_cen_mom_xx, win_cen_mom_yy,
                                      win_cen_mom_xy,
                                      win_err_var_x, win_err_var_y,
-                                     win_err_cov_xy, nan_hl,
-                                     x_centroid, y_centroid):
+                                     nan_hl, x_centroid, y_centroid):
         """
         Apply the fallback conditions for the windowed centroid.
 
@@ -1776,9 +1780,8 @@ class SourceCatalog:
         isophotal centroid and lies outside the 1-sigma ellipse, the
         total weighted flux is non-positive, the windowed 2nd-order
         moments are negative, or the windowed covariance determinant
-        is negative. Sources with NaN half-light radius keep NaN.
-
-        Store the 1-sigma position errors as a side effect.
+        is negative. Fallback sources also use the isophotal centroid
+        errors. Sources with NaN half-light radius keep NaN.
 
         Parameters
         ----------
@@ -1806,9 +1809,6 @@ class SourceCatalog:
         win_err_var_y : `~numpy.ndarray`
             Error variance in y.
 
-        win_err_cov_xy : `~numpy.ndarray`
-            Error covariance in xy.
-
         nan_hl : `~numpy.ndarray`
             Boolean mask indicating sources with NaN half-light radius.
 
@@ -1821,9 +1821,16 @@ class SourceCatalog:
         Returns
         -------
         result : `~numpy.ndarray`
-            The ``(x, y)`` windowed centroid coordinates, shape
-            ``(n_sources, 2)``.
+            The windowed centroid coordinates and their 1-sigma
+            errors as columns ``(x, y, xerr, yerr)``, shape
+            ``(n_sources, 4)``.
         """
+        # Convert variance to 1-sigma error
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            xerr = np.sqrt(win_err_var_x)
+            yerr = np.sqrt(win_err_var_y)
+
         dx = x_centroid - xcen_win
         dy = y_centroid - ycen_win
         cxx = self._array('ellipse_cxx').value
@@ -1842,19 +1849,13 @@ class SourceCatalog:
         if np.any(reset):
             xcen_win[reset] = x_centroid[reset]
             ycen_win[reset] = y_centroid[reset]
-            # Errors are not meaningful for fallback sources
-            win_err_var_x[reset] = np.nan
-            win_err_var_y[reset] = np.nan
-            win_err_cov_xy[reset] = np.nan
+            # Fallback sources use the isophotal centroid, so also
+            # use the isophotal centroid errors
+            iso_errors = self._centroid_errors
+            xerr[reset] = iso_errors[reset, 0]
+            yerr[reset] = iso_errors[reset, 1]
 
-        # Store the 1-sigma position errors.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            xerr = np.sqrt(win_err_var_x)
-            yerr = np.sqrt(win_err_var_y)
-        self._centroid_win_poserr = np.transpose((xerr, yerr))
-
-        return np.transpose((xcen_win, ycen_win))
+        return np.transpose((xcen_win, ycen_win, xerr, yerr))
 
     def _centroid_win_iter(self, label, xcen, ycen, rad_hl, nan_hl_,
                            *, data_arr, mask_arr, error_arr, segm_data,
@@ -1911,11 +1912,13 @@ class SourceCatalog:
         -------
         result : tuple of float
             Tuple of (xcen, ycen, weighted_flux, cen_mom_xx,
-            cen_mom_yy, cen_mom_xy, err_var_x, err_var_y,
-            err_cov_xy).
+            cen_mom_yy, cen_mom_xy, err_sum, err_var_x, err_var_y,
+            err_cov_xy). The error terms are the raw (unnormalized)
+            weighted sums from the last iteration (see
+            ``_normalize_win_errors``).
         """
         nan_result = (np.nan, np.nan, 0.0, 0.0, 0.0, 0.0,
-                      np.nan, np.nan, np.nan)
+                      np.nan, np.nan, np.nan, np.nan)
         if nan_hl_ or math.isnan(xcen) or math.isnan(ycen):
             return nan_result
 
@@ -1937,7 +1940,7 @@ class SourceCatalog:
 
         # Cache for cutout data when the integer bbox doesn't change
         prev_ixcen = prev_iycen = None
-        cached_data = cached_mask = cached_error = None
+        cached_data = cached_mask = cached_var = None
 
         max_iters = 16
         centroid_threshold = 0.0001
@@ -1945,8 +1948,6 @@ class SourceCatalog:
         dcen = 1.0
         weighted_flux = 0.0
         dx_mom = dy_mom = 0.0
-        raw_mx2 = raw_my2 = raw_mxy = 0.0
-        err_sum = err_var_x = err_var_y = err_cov_xy = 0.0
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
             while iter_ < max_iters and dcen > centroid_threshold:
@@ -1999,8 +2000,15 @@ class SourceCatalog:
                     cached_mask = data_mask
 
                     if compute_err:
-                        cached_error = (error_arr[slc_y, slc_x]
-                                        .astype(float))
+                        var = error_arr[slc_y, slc_x].astype(float)**2
+                        if do_correct:
+                            # Pixels replaced by mirrored data values
+                            # also use the mirrored pixel's variance
+                            var = _mask_to_mirrored_value(
+                                var, segm_mask, cutout_xycen,
+                                mask=data_mask)
+                        var[data_mask] = 0.0
+                        cached_var = var
 
                 # Centroid position in cutout coordinates
                 cx = xcen - max(0, ixmin)
@@ -2023,29 +2031,14 @@ class SourceCatalog:
                 # Inline Gaussian weight
                 gweight = np.exp(rr2 * inv_2sigma2)
 
-                # Accumulate error variance terms
-                if compute_err:
-                    var = cached_error**2
-                    var[cached_mask] = 0.0
-                    combined_weight = aper_weights * gweight
-                    weighted_var = combined_weight**2 * var
-                    err_sum = np.sum(weighted_var)
-                    err_var_x = np.sum(weighted_var * xx * xx)
-                    err_var_y = np.sum(weighted_var * yy * yy)
-                    err_cov_xy = np.sum(weighted_var * xx * yy)
-
                 # Apply weights and mask
                 weighted = (cached_data * aper_weights * gweight)
                 weighted[cached_mask] = 0.0
 
-                # Inline moment computation (including 2nd order
-                # for the fallback checks)
+                # Inline moment computation
                 weighted_flux = np.sum(weighted)
                 dx_mom = np.sum(weighted * xx) / weighted_flux
                 dy_mom = np.sum(weighted * yy) / weighted_flux
-                raw_mx2 = np.sum(weighted * xx * xx)
-                raw_my2 = np.sum(weighted * yy * yy)
-                raw_mxy = np.sum(weighted * xx * yy)
 
                 dcen = math.sqrt(dx_mom * dx_mom
                                  + dy_mom * dy_mom)
@@ -2053,60 +2046,43 @@ class SourceCatalog:
                 ycen += dy_mom * 2.0
                 iter_ += 1
 
-        # Compute windowed central 2nd moments from last
-        # iteration for the fallback checks.
-        if np.isfinite(weighted_flux) and weighted_flux > 0:
-            cen_mom_xx = (raw_mx2 / weighted_flux
-                          - dx_mom * dx_mom)
-            cen_mom_yy = (raw_my2 / weighted_flux
-                          - dy_mom * dy_mom)
-            cen_mom_xy = (raw_mxy / weighted_flux
-                          - dx_mom * dy_mom)
-        else:
+            # Compute the windowed central 2nd-order moments (for
+            # the fallback checks) and the raw error
+            # sums from the last iteration, relative to
+            # the pre-update center.
             cen_mom_xx = cen_mom_yy = cen_mom_xy = 0.0
+            err_sum = err_var_x = err_var_y = err_cov_xy = np.nan
+            if np.isfinite(weighted_flux) and weighted_flux > 0:
+                cen_mom_xx = (np.sum(weighted * xx * xx)
+                              / weighted_flux - dx_mom * dx_mom)
+                cen_mom_yy = (np.sum(weighted * yy * yy)
+                              / weighted_flux - dy_mom * dy_mom)
+                cen_mom_xy = (np.sum(weighted * xx * yy)
+                              / weighted_flux - dx_mom * dy_mom)
 
-        # Normalize error terms by step_factor^2 / weighted_flux^2
-        if compute_err:
-            err_var_x, err_var_y, err_cov_xy = (
-                self._normalize_win_errors(
-                    err_sum, err_var_x, err_var_y, err_cov_xy,
-                    weighted_flux))
-        else:
-            err_var_x = err_var_y = err_cov_xy = np.nan
+                if compute_err:
+                    weighted_var = ((aper_weights * gweight)**2
+                                    * cached_var)
+                    err_sum = np.sum(weighted_var)
+                    err_var_x = np.sum(weighted_var * xx * xx)
+                    err_var_y = np.sum(weighted_var * yy * yy)
+                    err_cov_xy = np.sum(weighted_var * xx * yy)
 
         return (xcen, ycen, weighted_flux, cen_mom_xx,
                 cen_mom_yy, cen_mom_xy,
-                err_var_x, err_var_y, err_cov_xy)
+                err_sum, err_var_x, err_var_y, err_cov_xy)
 
     @cached_property
     @use_detcat
-    def centroid_win(self):
+    def _centroid_win_results(self):
         """
-        The ``(x, y)`` coordinate of the "windowed" centroid.
+        The "windowed" centroid coordinates and their 1-sigma errors
+        as a 2D array with columns ``(x, y, xerr, yerr)`` and shape
+        ``(n_labels, 4)``.
 
-        The window centroid is computed using an iterative algorithm
-        to derive a more accurate centroid. It is equivalent to
-        `SourceExtractor`_'s XWIN_IMAGE and YWIN_IMAGE parameters.
-
-        Notes
-        -----
-        During each iteration, the centroid is calculated using all
-        pixels within a circular aperture of ``4 * sigma`` from the
-        current position, weighting pixel values with a 2D Gaussian with
-        a standard deviation of ``sigma``. ``sigma`` is the half-light
-        radius (i.e., ``flux_radius(0.5)``) times (2.0 / 2.35). A
-        minimum half-light radius of 0.5 pixels is used. Iteration stops
-        when the change in centroid position falls below a pre-defined
-        threshold or a maximum number of iterations is reached.
-
-        The windowed centroid is reset to the isophotal `centroid`
-        if any of the following conditions hold: the centroid diverged
-        far from the isophotal centroid and lies outside the 1-sigma
-        ellipse, the total weighted flux is non-positive, the windowed
-        2nd-order moments are negative, or the windowed covariance
-        determinant is negative. If the half-light radius is not finite
-        (e.g., due to a non-finite Kron radius), then ``np.nan`` will be
-        returned.
+        This is the single computation behind `centroid_win` and
+        ``_centroid_win_errors``. See `centroid_win` for the
+        algorithm details.
         """
         # Use .copy() to avoid mutating the cached flux_radius value
         radius_hl = self.flux_radius(0.5).value.copy()
@@ -2166,15 +2142,53 @@ class SourceCatalog:
 
         (xcen_win, ycen_win, win_weighted_flux,
          win_cen_mom_xx, win_cen_mom_yy, win_cen_mom_xy,
-         win_err_var_x, win_err_var_y,
+         win_err_sum, win_err_var_x, win_err_var_y,
          win_err_cov_xy) = (np.array(col)
                             for col in zip(*results, strict=True))
+
+        # Normalize error terms by step_factor^2 / weighted_flux^2
+        if compute_err:
+            win_err_var_x, win_err_var_y = self._normalize_win_errors(
+                win_err_sum, win_err_var_x, win_err_var_y,
+                win_err_cov_xy, win_weighted_flux)
 
         return self._apply_centroid_win_fallback(
             xcen_win, ycen_win, win_weighted_flux,
             win_cen_mom_xx, win_cen_mom_yy, win_cen_mom_xy,
-            win_err_var_x, win_err_var_y, win_err_cov_xy, nan_hl,
+            win_err_var_x, win_err_var_y, nan_hl,
             x_centroid, y_centroid)
+
+    @cached_property
+    @use_detcat
+    def centroid_win(self):
+        """
+        The ``(x, y)`` coordinate of the "windowed" centroid.
+
+        The window centroid is computed using an iterative algorithm
+        to derive a more accurate centroid. It is equivalent to
+        `SourceExtractor`_'s XWIN_IMAGE and YWIN_IMAGE parameters.
+
+        Notes
+        -----
+        During each iteration, the centroid is calculated using all
+        pixels within a circular aperture of ``4 * sigma`` from the
+        current position, weighting pixel values with a 2D Gaussian with
+        a standard deviation of ``sigma``. ``sigma`` is the half-light
+        radius (i.e., ``flux_radius(0.5)``) times (2.0 / 2.35). A
+        minimum half-light radius of 0.5 pixels is used. Iteration stops
+        when the change in centroid position falls below a pre-defined
+        threshold or a maximum number of iterations is reached.
+
+        The windowed centroid is reset to the isophotal `centroid`
+        if any of the following conditions hold: the centroid diverged
+        far from the isophotal centroid and lies outside the 1-sigma
+        ellipse, the total weighted flux is non-positive, the windowed
+        2nd-order moments are negative, or the windowed covariance
+        determinant is negative. If the half-light radius is not finite
+        (e.g., due to a non-finite Kron radius), then ``np.nan`` will be
+        returned.
+        """
+        return self._centroid_win_results[:, 0:2].copy()
 
     @cached_property
     @use_detcat
@@ -2207,24 +2221,19 @@ class SourceCatalog:
     def _centroid_win_errors(self):
         """
         The 1-sigma errors on the ``(x, y)`` windowed centroid
-        position.
+        position as a 2D array with a leading source axis.
 
         The errors are computed by propagating the error array
         passed to `SourceCatalog` through the windowed centroid
         computation. If no error array was provided, the errors are
         ``np.nan``.
 
-        Errors are also ``np.nan`` for sources where the windowed
-        centroid fell back to the isophotal centroid, or where the
+        Sources where the windowed centroid fell back to the
+        isophotal centroid have the isophotal centroid errors (see
+        ``_centroid_errors``). Errors are ``np.nan`` where the
         half-light radius is non-finite.
         """
-        # Trigger centroid_win computation (which stores
-        # _centroid_win_poserr as a side effect).
-        _ = self.centroid_win  # noqa: F841
-        result = self._centroid_win_poserr
-        if self.isscalar:
-            return result[0]
-        return result
+        return self._centroid_win_results[:, 2:4].copy()
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1624,14 +1624,13 @@ class SourceCatalog:
 
     @cached_property
     @use_detcat
-    def _centroid_errors(self):
+    def centroid_err(self):
         """
-        The 1-sigma errors on the ``(x, y)`` isophotal centroid
-        position as a 2D array with a leading source axis.
+        The ``(x, y)`` 1-sigma errors on the `centroid` position.
 
         The errors are computed by propagating the input ``error`` array
-        through the center-of-mass centroid formula. If no error array
-        was provided, the errors are ``np.nan``.
+        through the center-of-mass centroid formula. If ``error`` was
+        not input, then the errors are NaN.
 
         For a centroid defined as :math:`x_c = \\sum f_i x_i / F`,
         the variance is:
@@ -1641,11 +1640,10 @@ class SourceCatalog:
             \\text{Var}(x_c) = \\frac{\\sum_i (x_i - x_c)^2
             \\sigma_i^2}{F^2}
 
-        For point-like sources whose shape covariance determinant is
-        below :math:`(1/12)^2` (see ``_singular_covariance_mask``), a
-        singularity correction of :math:`\\sum_i \\sigma_i^2 / (12
-        F^2)` is added to the variances if the error covariance matrix
-        is itself nearly singular.
+        For point-like sources whose shape covariance determinant
+        is below :math:`(1/12)^2`, a singularity correction of
+        :math:`\\sum_i \\sigma_i^2 / (12 F^2)` is added to the variances
+        if the error covariance matrix is itself nearly singular.
         """
         if self._error is None:
             return np.full((self.n_labels, 2), np.nan)
@@ -1701,6 +1699,28 @@ class SourceCatalog:
             yerr_arr.append(np.sqrt(err_var_y))
 
         return np.transpose((xerr_arr, yerr_arr))
+
+    @cached_property
+    @use_detcat
+    def x_centroid_err(self):
+        """
+        The 1-sigma error on the ``x`` coordinate of the `centroid`.
+
+        See `centroid_err` for details. If ``error`` was not input, then
+        the errors are NaN.
+        """
+        return self._array('centroid_err')[:, 0]
+
+    @cached_property
+    @use_detcat
+    def y_centroid_err(self):
+        """
+        The 1-sigma error on the ``y`` coordinate of the `centroid`.
+
+        See `centroid_err` for details. If ``error`` was not input, then
+        the errors are NaN.
+        """
+        return self._array('centroid_err')[:, 1]
 
     def _normalize_centroid_win_err(self, err_sum, err_var_x, err_var_y,
                                     err_cov_xy, weighted_flux):
@@ -1851,7 +1871,7 @@ class SourceCatalog:
             ycen_win[reset] = y_centroid[reset]
             # Fallback sources use the isophotal centroid, so also
             # use the isophotal centroid errors
-            iso_errors = self._centroid_errors
+            iso_errors = self._array('centroid_err')
             xerr[reset] = iso_errors[reset, 0]
             yerr[reset] = iso_errors[reset, 1]
 
@@ -2082,8 +2102,8 @@ class SourceCatalog:
         ``(n_labels, 4)``.
 
         This is the single computation behind `centroid_win` and
-        ``_centroid_win_errors``. See `centroid_win` for the
-        algorithm details.
+        `centroid_win_err`. See `centroid_win` for the algorithm
+        details.
         """
         # Use .copy() to avoid mutating the cached flux_radius value
         radius_hl = self.flux_radius(0.5).value.copy()
@@ -2219,22 +2239,45 @@ class SourceCatalog:
 
     @cached_property
     @use_detcat
-    def _centroid_win_errors(self):
+    def centroid_win_err(self):
         """
-        The 1-sigma errors on the ``(x, y)`` windowed centroid
-        position as a 2D array with a leading source axis.
+        The ``(x, y)`` 1-sigma errors on the "windowed" centroid
+        (`centroid_win`) position.
 
-        The errors are computed by propagating the error array
-        passed to `SourceCatalog` through the windowed centroid
-        computation. If no error array was provided, the errors are
-        ``np.nan``.
+        The errors are computed by propagating the input ``error`` array
+        through the Gaussian-weighted windowed centroid formula. If
+        ``error`` was not input, then the errors are NaN.
 
         Sources where the windowed centroid fell back to the
-        isophotal centroid have the isophotal centroid errors (see
-        ``_centroid_errors``). Errors are ``np.nan`` where the
-        half-light radius is non-finite.
+        isophotal `centroid` have the isophotal centroid errors (see
+        `centroid_err`). The errors are NaN where the half-light radius
+        is not finite.
         """
         return self._centroid_win_results[:, 2:4].copy()
+
+    @cached_property
+    @use_detcat
+    def x_centroid_win_err(self):
+        """
+        The 1-sigma error on the ``x`` coordinate of the "windowed"
+        centroid (`centroid_win`).
+
+        See `centroid_win_err` for details. If ``error`` was not input,
+        then the errors are NaN.
+        """
+        return self._array('centroid_win_err')[:, 0]
+
+    @cached_property
+    @use_detcat
+    def y_centroid_win_err(self):
+        """
+        The 1-sigma error on the ``y`` coordinate of the "windowed"
+        centroid (`centroid_win`).
+
+        See `centroid_win_err` for details. If ``error`` was not input,
+        then the errors are NaN.
+        """
+        return self._array('centroid_win_err')[:, 1]
 
     @cached_property
     @use_detcat
@@ -2243,10 +2286,9 @@ class SourceCatalog:
         The ``(x, y)`` coordinate, relative to the cutout data, of the
         "windowed" centroid.
 
-        The window centroid is computed using an iterative algorithm
-        to derive a more accurate centroid. It is equivalent to
-        `SourceExtractor`_'s XWIN_IMAGE and YWIN_IMAGE parameters. See
-        `centroid_win` for further details about the algorithm.
+        The window centroid is computed using an iterative algorithm to
+        derive a more accurate centroid. See `centroid_win` for further
+        details about the algorithm.
         """
         origin = np.transpose((self.bbox_xmin, self.bbox_ymin))
         return self.centroid_win - origin

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1624,7 +1624,7 @@ class SourceCatalog:
 
     @cached_property
     @use_detcat
-    def centroid_win(self):
+    def centroid_win(self):  # noqa: PLR0915
         """
         The ``(x, y)`` coordinate of the "windowed" centroid.
 
@@ -1643,9 +1643,12 @@ class SourceCatalog:
         when the change in centroid position falls below a pre-defined
         threshold or a maximum number of iterations is reached.
 
-        If the windowed centroid falls outside the 1-sigma ellipse
-        shape based on the image moments, then the isophotal `centroid`
-        will be used instead. If the half-light radius is not finite
+        The windowed centroid is reset to the isophotal `centroid`
+        if any of the following conditions hold: the centroid diverged
+        far from the isophotal centroid and lies outside the 1-sigma
+        ellipse, the total weighted flux is non-positive, the windowed
+        2nd-order moments are negative, or the windowed covariance
+        determinant is negative. If the half-light radius is not finite
         (e.g., due to a non-finite Kron radius), then ``np.nan`` will be
         returned.
         """
@@ -1688,6 +1691,10 @@ class SourceCatalog:
 
         xcen_win = []
         ycen_win = []
+        win_weighted_flux = []
+        win_cen_mom_xx = []
+        win_cen_mom_yy = []
+        win_cen_mom_xy = []
         for label, xcen, ycen, rad_hl, nan_hl_ in zip(
                 labels, x_centroid, y_centroid, radius_hl, nan_hl,
                 strict=True):
@@ -1695,6 +1702,10 @@ class SourceCatalog:
             if nan_hl_ or math.isnan(xcen) or math.isnan(ycen):
                 xcen_win.append(np.nan)
                 ycen_win.append(np.nan)
+                win_weighted_flux.append(0.0)
+                win_cen_mom_xx.append(0.0)
+                win_cen_mom_yy.append(0.0)
+                win_cen_mom_xy.append(0.0)
                 continue
 
             sigma = 2.0 * rad_hl * gaussian_fwhm_to_sigma
@@ -1713,6 +1724,10 @@ class SourceCatalog:
             if full_ny * full_nx > max_aper_size:
                 xcen_win.append(np.nan)
                 ycen_win.append(np.nan)
+                win_weighted_flux.append(0.0)
+                win_cen_mom_xx.append(0.0)
+                win_cen_mom_yy.append(0.0)
+                win_cen_mom_xy.append(0.0)
                 continue
 
             # Cache for cutout data when the integer bbox doesn't change
@@ -1722,6 +1737,9 @@ class SourceCatalog:
 
             iter_ = 0
             dcen = 1.0
+            weighted_flux = 0.0
+            dx_mom = dy_mom = 0.0
+            raw_mx2 = raw_my2 = raw_mxy = 0.0
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', RuntimeWarning)
                 while iter_ < max_iters and dcen > centroid_threshold:
@@ -1798,35 +1816,69 @@ class SourceCatalog:
                     weighted = (cached_data * aper_weights * gweight)
                     weighted[cached_mask] = 0.0
 
-                    # Inline moment computation
-                    total = np.sum(weighted)
-                    dx = np.sum(weighted * xx) / total
-                    dy = np.sum(weighted * yy) / total
+                    # Inline moment computation (including 2nd order
+                    # for the fallback checks)
+                    weighted_flux = np.sum(weighted)
+                    dx_mom = np.sum(weighted * xx) / weighted_flux
+                    dy_mom = np.sum(weighted * yy) / weighted_flux
+                    raw_mx2 = np.sum(weighted * xx * xx)
+                    raw_my2 = np.sum(weighted * yy * yy)
+                    raw_mxy = np.sum(weighted * xx * yy)
 
-                    dcen = math.sqrt(dx * dx + dy * dy)
-                    xcen += dx * 2.0
-                    ycen += dy * 2.0
+                    dcen = math.sqrt(dx_mom * dx_mom
+                                     + dy_mom * dy_mom)
+                    xcen += dx_mom * 2.0
+                    ycen += dy_mom * 2.0
                     iter_ += 1
 
+            # Compute windowed central 2nd moments from last
+            # iteration for the fallback checks.
+            if np.isfinite(weighted_flux) and weighted_flux > 0:
+                cen_mom_xx = (raw_mx2 / weighted_flux
+                              - dx_mom * dx_mom)
+                cen_mom_yy = (raw_my2 / weighted_flux
+                              - dy_mom * dy_mom)
+                cen_mom_xy = (raw_mxy / weighted_flux
+                              - dx_mom * dy_mom)
+            else:
+                cen_mom_xx = cen_mom_yy = cen_mom_xy = 0.0
+
+            win_weighted_flux.append(weighted_flux)
+            win_cen_mom_xx.append(cen_mom_xx)
+            win_cen_mom_yy.append(cen_mom_yy)
+            win_cen_mom_xy.append(cen_mom_xy)
             xcen_win.append(xcen)
             ycen_win.append(ycen)
 
         xcen_win = np.array(xcen_win)
         ycen_win = np.array(ycen_win)
+        win_weighted_flux = np.array(win_weighted_flux)
+        win_cen_mom_xx = np.array(win_cen_mom_xx)
+        win_cen_mom_yy = np.array(win_cen_mom_yy)
+        win_cen_mom_xy = np.array(win_cen_mom_xy)
 
-        # Reset to the isophotal centroid if the windowed centroid is
-        # outside the 1-sigma ellipse or if the iteration failed (NaN
-        # from aperture off-image). Sources with NaN half-light radius
-        # keep NaN (no valid window size).
+        # Reset to the isophotal centroid when any of:
+        # 1. Centroid diverged far AND outside 1-sigma ellipse
+        # 2. Non-positive total weighted flux
+        # 3. Negative windowed 2nd-order moments
+        # 4. Negative windowed covariance determinant
+        # Sources with NaN half-light radius keep NaN
+        # (no valid window size).
         dx = x_centroid - xcen_win
         dy = y_centroid - ycen_win
         cxx = self._array('ellipse_cxx').value
         cxy = self._array('ellipse_cxy').value
         cyy = self._array('ellipse_cyy').value
 
-        reset = ((cxx * dx**2 + cxy * dx * dy + cyy * dy**2) > 1)
+        reset = ((dx**2 > 1) & (dy**2 > 1)
+                 & ((cxx * dx**2 + cxy * dx * dy + cyy * dy**2) > 1))
+        reset |= win_weighted_flux <= 0.0
+        reset |= (win_cen_mom_xx < 0.0) | (win_cen_mom_yy < 0.0)
+        reset |= (win_cen_mom_xx * win_cen_mom_yy
+                  - win_cen_mom_xy**2) < 0.0
         nan_cen = np.isnan(xcen_win) | np.isnan(ycen_win)
         reset |= nan_cen & ~nan_hl
+        reset &= ~nan_hl
         if np.any(reset):
             xcen_win[reset] = x_centroid[reset]
             ycen_win[reset] = y_centroid[reset]

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -31,7 +31,6 @@ from photutils.utils._deprecation import (_get_future_column_names,
                                           deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
 from photutils.utils._misc import _get_meta
-from photutils.utils._moments import _image_moments
 from photutils.utils._parameters import validate_table_columns
 from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._quantity_helpers import process_quantities
@@ -1647,7 +1646,7 @@ class SourceCatalog:
         shape covariance determinant is below :math:`(1/12)^2`.
         """
         if self._error is None:
-            result = np.full((self.nlabels, 2), np.nan)
+            result = np.full((self.n_labels, 2), np.nan)
             if self.isscalar:
                 return result[0]
             return result
@@ -1728,138 +1727,385 @@ class SourceCatalog:
             return result[0]
         return result
 
-    def _centroid_win_single(self, label, xcen, ycen, rad_hl,
-                             nan_hl_, kwargs, compute_err):
+    @staticmethod
+    def _normalize_win_errors(err_sum, err_var_x, err_var_y, err_cov_xy,
+                              weighted_flux):
         """
-        Compute the windowed centroid and error terms for a single
-        source.
+        Normalize the windowed centroid position-error variances.
 
-        Returns a tuple of (xcen, ycen, weighted_flux, cen_mom_xx,
-        cen_mom_yy, cen_mom_xy, err_var_x, err_var_y, err_cov_xy).
+        Normalize by ``step_factor^2 / weighted_flux^2`` and apply the
+        singularity correction and pixel-size variance correction.
+
+        Parameters
+        ----------
+        err_sum : float
+            Sum of the weighted error variance over the aperture.
+
+        err_var_x : float
+            Weighted error variance in ``x``.
+
+        err_var_y : float
+            Weighted error variance in ``y``.
+
+        err_cov_xy : float
+            Weighted error covariance in ``xy``.
+
+        weighted_flux : float
+            Total weighted flux from the last iteration.
+
+        Returns
+        -------
+        err_var_x : float
+            Normalized error variance in ``x``.
+
+        err_var_y : float
+            Normalized error variance in ``y``.
+
+        err_cov_xy : float
+            Normalized error covariance in ``xy``.
+        """
+        if not (np.isfinite(weighted_flux) and weighted_flux > 0):
+            return np.nan, np.nan, np.nan
+
+        step_factor = 2.0
+        norm = step_factor**2 / (weighted_flux**2)
+        err_var_x *= norm
+        err_var_y *= norm
+        err_cov_xy *= norm
+
+        # Handle fully correlated profiles that cause a singularity.
+        err_sum_norm = err_sum * (1.0 / 12) * norm
+        if (err_var_x * err_var_y
+                - err_cov_xy**2) < err_sum_norm**2:
+            err_var_x += err_sum_norm
+            err_var_y += err_sum_norm
+
+        # Add pixel-size variance correction (1/12).
+        err_var_x += err_sum_norm
+        err_var_y += err_sum_norm
+
+        return err_var_x, err_var_y, err_cov_xy
+
+    def _apply_centroid_win_fallback(self, xcen_win, ycen_win,
+                                     win_weighted_flux,
+                                     win_cen_mom_xx, win_cen_mom_yy,
+                                     win_cen_mom_xy,
+                                     win_err_var_x, win_err_var_y,
+                                     win_err_cov_xy, nan_hl,
+                                     x_centroid, y_centroid):
+        """
+        Apply the fallback conditions for the windowed centroid.
+
+        Reset the centroid to the isophotal centroid when any of the
+        following conditions hold: the centroid diverged far from the
+        isophotal centroid and lies outside the 1-sigma ellipse, the
+        total weighted flux is non-positive, the windowed 2nd-order
+        moments are negative, or the windowed covariance determinant
+        is negative. Sources with NaN half-light radius keep NaN.
+
+        Store the 1-sigma position errors as a side effect.
+
+        Parameters
+        ----------
+        xcen_win : `~numpy.ndarray`
+            Windowed x centroids.
+
+        ycen_win : `~numpy.ndarray`
+            Windowed y centroids.
+
+        win_weighted_flux : `~numpy.ndarray`
+            Weighted flux from each source.
+
+        win_cen_mom_xx : `~numpy.ndarray`
+            Windowed central 2nd-order moment xx.
+
+        win_cen_mom_yy : `~numpy.ndarray`
+            Windowed central 2nd-order moment yy.
+
+        win_cen_mom_xy : `~numpy.ndarray`
+            Windowed central 2nd-order moment xy.
+
+        win_err_var_x : `~numpy.ndarray`
+            Error variance in x.
+
+        win_err_var_y : `~numpy.ndarray`
+            Error variance in y.
+
+        win_err_cov_xy : `~numpy.ndarray`
+            Error covariance in xy.
+
+        nan_hl : `~numpy.ndarray`
+            Boolean mask indicating sources with NaN half-light radius.
+
+        x_centroid : `~numpy.ndarray`
+            The isophotal x centroids.
+
+        y_centroid : `~numpy.ndarray`
+            The isophotal y centroids.
+
+        Returns
+        -------
+        result : `~numpy.ndarray`
+            The ``(x, y)`` windowed centroid coordinates, shape
+            ``(n_sources, 2)``.
+        """
+        dx = x_centroid - xcen_win
+        dy = y_centroid - ycen_win
+        cxx = self._array('ellipse_cxx').value
+        cxy = self._array('ellipse_cxy').value
+        cyy = self._array('ellipse_cyy').value
+
+        reset = ((dx**2 > 1) & (dy**2 > 1)
+                 & ((cxx * dx**2 + cxy * dx * dy + cyy * dy**2) > 1))
+        reset |= win_weighted_flux <= 0.0
+        reset |= (win_cen_mom_xx < 0.0) | (win_cen_mom_yy < 0.0)
+        reset |= (win_cen_mom_xx * win_cen_mom_yy
+                  - win_cen_mom_xy**2) < 0.0
+        nan_cen = np.isnan(xcen_win) | np.isnan(ycen_win)
+        reset |= nan_cen & ~nan_hl
+        reset &= ~nan_hl
+        if np.any(reset):
+            xcen_win[reset] = x_centroid[reset]
+            ycen_win[reset] = y_centroid[reset]
+            # Errors are not meaningful for fallback sources
+            win_err_var_x[reset] = np.nan
+            win_err_var_y[reset] = np.nan
+            win_err_cov_xy[reset] = np.nan
+
+        # Store the 1-sigma position errors.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            xerr = np.sqrt(win_err_var_x)
+            yerr = np.sqrt(win_err_var_y)
+        self._centroid_win_poserr = np.transpose((xerr, yerr))
+
+        return np.transpose((xcen_win, ycen_win))
+
+    def _centroid_win_iter(self, label, xcen, ycen, rad_hl, nan_hl_,
+                           *, data_arr, mask_arr, error_arr, segm_data,
+                           data_shape, do_correct, do_segm_mask,
+                           compute_err, max_aper_size):
+        """
+        Compute the windowed centroid for a single source.
+
+        Parameters
+        ----------
+        label : int
+            The source label.
+
+        xcen : float
+            Initial x centroid (isophotal).
+
+        ycen : float
+            Initial y centroid (isophotal).
+
+        rad_hl : float
+            Half-light radius for this source.
+
+        nan_hl_ : bool
+            Whether the half-light radius is NaN.
+
+        data_arr : `~numpy.ndarray`
+            The 2D data array.
+
+        mask_arr : `~numpy.ndarray` or `None`
+            The 2D boolean mask array.
+
+        error_arr : `~numpy.ndarray` or `None`
+            The 2D error array.
+
+        segm_data : `~numpy.ndarray`
+            The segmentation image data array.
+
+        data_shape : tuple of int
+            Shape of the data array.
+
+        do_correct : bool
+            Whether to apply mirror correction for masked pixels.
+
+        do_segm_mask : bool
+            Whether to mask pixels outside the source segment.
+
+        compute_err : bool
+            Whether to compute position errors.
+
+        max_aper_size : int
+            Maximum aperture size (OOM guard).
+
+        Returns
+        -------
+        result : tuple of float
+            Tuple of (xcen, ycen, weighted_flux, cen_mom_xx,
+            cen_mom_yy, cen_mom_xy, err_var_x, err_var_y,
+            err_cov_xy).
         """
         nan_result = (np.nan, np.nan, 0.0, 0.0, 0.0, 0.0,
                       np.nan, np.nan, np.nan)
-        if nan_hl_ or np.any(~np.isfinite((xcen, ycen))):
+        if nan_hl_ or math.isnan(xcen) or math.isnan(ycen):
             return nan_result
 
         sigma = 2.0 * rad_hl * gaussian_fwhm_to_sigma
-        sigma2 = sigma**2
+        inv_2sigma2 = -1.0 / (2.0 * sigma * sigma)
         radius = 4.0 * sigma
+        radius_sq = radius * radius
 
-        iter_ = 0
-        centroid_shift = 1
+        # Compute the full (unclipped) bounding box for the aperture
+        # using the initial centroid. The radius is fixed, so the
+        # bbox size stays the same across iterations even if the
+        # center shifts slightly.
+        bbox_halfsize = int(radius + 1.5)
+        full_ny = full_nx = 2 * bbox_halfsize + 1
+
+        # OOM guard
+        if full_ny * full_nx > max_aper_size:
+            return nan_result
+
+        # Cache for cutout data when the integer bbox doesn't change
+        prev_ixcen = prev_iycen = None
+        cached_data = cached_mask = cached_error = None
+
         max_iters = 16
         centroid_threshold = 0.0001
+        iter_ = 0
+        dcen = 1.0
         weighted_flux = 0.0
-        dx_shift = dy_shift = 0.0
-        raw_mom_xx = raw_mom_yy = raw_mom_xy = 0.0
+        dx_mom = dy_mom = 0.0
+        raw_mx2 = raw_my2 = raw_mxy = 0.0
         err_sum = err_var_x = err_var_y = err_cov_xy = 0.0
-        while iter_ < max_iters and centroid_shift > centroid_threshold:
-            aperture = CircularAperture((xcen, ycen), radius)
-            aperture_mask = self._aperture_to_mask(aperture, **kwargs)
-            if aperture_mask is None:
-                xcen = np.nan
-                ycen = np.nan
-                break
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            while iter_ < max_iters and dcen > centroid_threshold:
+                # Compute integer bounding box
+                ixmin = int(xcen + 0.5) - bbox_halfsize
+                ixmax = ixmin + full_nx
+                iymin = int(ycen + 0.5) - bbox_halfsize
+                iymax = iymin + full_ny
 
-            # For consistency with the isophotal centroid, a local
-            # background is not subtracted here
-            data, error, mask, cutout_xycen, slc_sm = (
-                self._make_aperture_data(
-                    label, xcen, ycen, aperture_mask.bbox, 0.0,
-                    make_error=compute_err))
+                # Clip to data boundaries
+                slc_y = slice(max(0, iymin), min(data_shape[0], iymax))
+                slc_x = slice(max(0, ixmin), min(data_shape[1], ixmax))
+                if (slc_y.start >= slc_y.stop
+                        or slc_x.start >= slc_x.stop):
+                    xcen = np.nan
+                    ycen = np.nan
+                    break
 
-            if data is None:
-                # Return NaN if centroid moves the aperture
-                # completely off the image
-                xcen = np.nan
-                ycen = np.nan
-                break
+                cur_ixcen = int(xcen + 0.5)
+                cur_iycen = int(ycen + 0.5)
 
-            aperture_weights = aperture_mask.data[slc_sm]
+                # Recompute cutout data only when the integer center
+                # changes to avoid redundant _mask_to_mirrored_value
+                # calls
+                if cur_ixcen != prev_ixcen or cur_iycen != prev_iycen:
+                    prev_ixcen = cur_ixcen
+                    prev_iycen = cur_iycen
 
-            # Define a 2D Gaussian weight array
-            xvals = np.arange(data.shape[1]) - cutout_xycen[0]
-            yvals = np.arange(data.shape[0]) - cutout_xycen[1]
-            xx, yy = np.meshgrid(xvals, yvals)
-            rr2 = xx**2 + yy**2
-            gweight = np.exp(-rr2 / (2.0 * sigma2))
+                    data = data_arr[slc_y, slc_x].astype(float)
+                    data_mask = ~np.isfinite(data)
+                    if mask_arr is not None:
+                        data_mask |= mask_arr[slc_y, slc_x]
 
-            # Ignore multiplication with non-finite values
-            # and ignore divide-by-zero if moments[0, 0] = 0
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', RuntimeWarning)
+                    cutout_xycen = (xcen - max(0, ixmin),
+                                    ycen - max(0, iymin))
 
-                # Accumulate error variance terms. The combined
-                # weight (aperture_weights * gweight) includes the
-                # Gaussian weight.
+                    if do_segm_mask:
+                        seg_cut = segm_data[slc_y, slc_x]
+                        segm_mask = ((seg_cut != label)
+                                     & (seg_cut != 0))
+                        if self.aperture_mask_method == 'mask':
+                            data_mask = data_mask | segm_mask
+
+                    if do_correct:
+                        data = _mask_to_mirrored_value(
+                            data, segm_mask, cutout_xycen,
+                            mask=data_mask)
+
+                    cached_data = data
+                    cached_mask = data_mask
+
+                    if compute_err:
+                        cached_error = (error_arr[slc_y, slc_x]
+                                        .astype(float))
+
+                # Centroid position in cutout coordinates
+                cx = xcen - max(0, ixmin)
+                cy = ycen - max(0, iymin)
+
+                ny = slc_y.stop - slc_y.start
+                nx = slc_x.stop - slc_x.start
+
+                # Build coordinate grids relative to centroid
+                # (reused for circle mask, Gaussian, and moments)
+                xvals = np.arange(nx) - cx
+                yvals = np.arange(ny) - cy
+                xx = xvals[np.newaxis, :]
+                yy = yvals[:, np.newaxis]
+
+                # Inline binary circle mask
+                rr2 = xx * xx + yy * yy
+                aper_weights = (rr2 <= radius_sq).astype(float)
+
+                # Inline Gaussian weight
+                gweight = np.exp(rr2 * inv_2sigma2)
+
+                # Accumulate error variance terms
                 if compute_err:
-                    var = error**2
-                    var[mask] = 0.0
-                    combined_weight = aperture_weights * gweight
+                    var = cached_error**2
+                    var[cached_mask] = 0.0
+                    combined_weight = aper_weights * gweight
                     weighted_var = combined_weight**2 * var
                     err_sum = np.sum(weighted_var)
-                    # Compute raw error variances without the
-                    # pixel-size correction.
-                    err_var_x = np.sum(weighted_var * xx**2)
-                    err_var_y = np.sum(weighted_var * yy**2)
+                    err_var_x = np.sum(weighted_var * xx * xx)
+                    err_var_y = np.sum(weighted_var * yy * yy)
                     err_cov_xy = np.sum(weighted_var * xx * yy)
 
-                data = data * aperture_weights * gweight
-                data[mask] = 0.0
+                # Apply weights and mask
+                weighted = (cached_data * aper_weights * gweight)
+                weighted[cached_mask] = 0.0
 
-                moments = _image_moments(data, center=cutout_xycen,
-                                         order=2)
-                weighted_flux = moments[0, 0]
-                dy_shift = moments[1, 0] / weighted_flux
-                dx_shift = moments[0, 1] / weighted_flux
-                raw_mom_xx = moments[0, 2]
-                raw_mom_yy = moments[2, 0]
-                raw_mom_xy = moments[1, 1]
-                centroid_shift = np.sqrt(dx_shift**2 + dy_shift**2)
-                xcen += dx_shift * 2.0
-                ycen += dy_shift * 2.0
+                # Inline moment computation (including 2nd order
+                # for the fallback checks)
+                weighted_flux = np.sum(weighted)
+                dx_mom = np.sum(weighted * xx) / weighted_flux
+                dy_mom = np.sum(weighted * yy) / weighted_flux
+                raw_mx2 = np.sum(weighted * xx * xx)
+                raw_my2 = np.sum(weighted * yy * yy)
+                raw_mxy = np.sum(weighted * xx * yy)
+
+                dcen = math.sqrt(dx_mom * dx_mom
+                                 + dy_mom * dy_mom)
+                xcen += dx_mom * 2.0
+                ycen += dy_mom * 2.0
                 iter_ += 1
 
         # Compute windowed central 2nd moments from last
         # iteration for the fallback checks.
         if np.isfinite(weighted_flux) and weighted_flux > 0:
-            cen_mom_xx = (raw_mom_xx / weighted_flux
-                          - dx_shift * dx_shift)
-            cen_mom_yy = (raw_mom_yy / weighted_flux
-                          - dy_shift * dy_shift)
-            cen_mom_xy = (raw_mom_xy / weighted_flux
-                          - dx_shift * dy_shift)
+            cen_mom_xx = (raw_mx2 / weighted_flux
+                          - dx_mom * dx_mom)
+            cen_mom_yy = (raw_my2 / weighted_flux
+                          - dy_mom * dy_mom)
+            cen_mom_xy = (raw_mxy / weighted_flux
+                          - dx_mom * dy_mom)
         else:
             cen_mom_xx = cen_mom_yy = cen_mom_xy = 0.0
 
         # Normalize error terms by step_factor^2 / weighted_flux^2
-        if compute_err and np.isfinite(weighted_flux) and weighted_flux > 0:
-            step_factor = 2.0
-            norm = step_factor**2 / (weighted_flux**2)
-            err_var_x *= norm
-            err_var_y *= norm
-            err_cov_xy *= norm
-
-            # Handle fully correlated profiles that cause a
-            # singularity.
-            err_sum_norm = err_sum * (1.0 / 12) * norm
-            if (err_var_x * err_var_y - err_cov_xy**2) < err_sum_norm**2:
-                err_var_x += err_sum_norm
-                err_var_y += err_sum_norm
-
-            # Add pixel-size variance correction (1/12).
-            err_var_x += err_sum_norm
-            err_var_y += err_sum_norm
+        if compute_err:
+            err_var_x, err_var_y, err_cov_xy = (
+                self._normalize_win_errors(
+                    err_sum, err_var_x, err_var_y, err_cov_xy,
+                    weighted_flux))
         else:
             err_var_x = err_var_y = err_cov_xy = np.nan
 
-        return (xcen, ycen, weighted_flux, cen_mom_xx, cen_mom_yy,
-                cen_mom_xy, err_var_x, err_var_y, err_cov_xy)
+        return (xcen, ycen, weighted_flux, cen_mom_xx,
+                cen_mom_yy, cen_mom_xy,
+                err_var_x, err_var_y, err_cov_xy)
 
     @cached_property
     @use_detcat
-    def centroid_win(self):  # noqa: PLR0915
+    def centroid_win(self):
         """
         The ``(x, y)`` coordinate of the "windowed" centroid.
 
@@ -1924,271 +2170,36 @@ class SourceCatalog:
         do_segm_mask = self.aperture_mask_method != 'none'
         max_aper_size = max(data_arr.size, 1_000_000)
 
-        max_iters = 16
-        centroid_threshold = 0.0001
+        iter_kwargs = {
+            'data_arr': data_arr,
+            'mask_arr': mask_arr,
+            'error_arr': error_arr,
+            'segm_data': segm_data,
+            'data_shape': data_shape,
+            'do_correct': do_correct,
+            'do_segm_mask': do_segm_mask,
+            'compute_err': compute_err,
+            'max_aper_size': max_aper_size,
+        }
 
-        xcen_win = []
-        ycen_win = []
-        win_weighted_flux = []
-        win_cen_mom_xx = []
-        win_cen_mom_yy = []
-        win_cen_mom_xy = []
-        win_err_var_x = []
-        win_err_var_y = []
-        win_err_cov_xy = []
+        results = []
         for label, xcen, ycen, rad_hl, nan_hl_ in zip(
                 labels, x_centroid, y_centroid, radius_hl, nan_hl,
                 strict=True):
+            results.append(self._centroid_win_iter(
+                label, xcen, ycen, rad_hl, nan_hl_, **iter_kwargs))
 
-            if nan_hl_ or math.isnan(xcen) or math.isnan(ycen):
-                xcen_win.append(np.nan)
-                ycen_win.append(np.nan)
-                win_weighted_flux.append(0.0)
-                win_cen_mom_xx.append(0.0)
-                win_cen_mom_yy.append(0.0)
-                win_cen_mom_xy.append(0.0)
-                win_err_var_x.append(np.nan)
-                win_err_var_y.append(np.nan)
-                win_err_cov_xy.append(np.nan)
-                continue
+        (xcen_win, ycen_win, win_weighted_flux,
+         win_cen_mom_xx, win_cen_mom_yy, win_cen_mom_xy,
+         win_err_var_x, win_err_var_y,
+         win_err_cov_xy) = (np.array(col)
+                            for col in zip(*results, strict=True))
 
-            sigma = 2.0 * rad_hl * gaussian_fwhm_to_sigma
-            inv_2sigma2 = -1.0 / (2.0 * sigma * sigma)
-            radius = 4.0 * sigma
-            radius_sq = radius * radius
-
-            # Compute the full (unclipped) bounding box for the aperture
-            # using the initial centroid. The radius is fixed, so the
-            # bbox size stays the same across iterations even if the
-            # center shifts slightly.
-            bbox_halfsize = int(radius + 1.5)
-            full_ny = full_nx = 2 * bbox_halfsize + 1
-
-            # OOM guard
-            if full_ny * full_nx > max_aper_size:
-                xcen_win.append(np.nan)
-                ycen_win.append(np.nan)
-                win_weighted_flux.append(0.0)
-                win_cen_mom_xx.append(0.0)
-                win_cen_mom_yy.append(0.0)
-                win_cen_mom_xy.append(0.0)
-                win_err_var_x.append(np.nan)
-                win_err_var_y.append(np.nan)
-                win_err_cov_xy.append(np.nan)
-                continue
-
-            # Cache for cutout data when the integer bbox doesn't change
-            prev_ixcen = prev_iycen = None
-            cached_data = None
-            cached_mask = None
-            cached_error = None
-
-            iter_ = 0
-            dcen = 1.0
-            weighted_flux = 0.0
-            dx_mom = dy_mom = 0.0
-            raw_mx2 = raw_my2 = raw_mxy = 0.0
-            err_sum = err_var_x = err_var_y = err_cov_xy = 0.0
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', RuntimeWarning)
-                while iter_ < max_iters and dcen > centroid_threshold:
-                    # Compute integer bounding box
-                    ixmin = int(xcen + 0.5) - bbox_halfsize
-                    ixmax = ixmin + full_nx
-                    iymin = int(ycen + 0.5) - bbox_halfsize
-                    iymax = iymin + full_ny
-
-                    # Clip to data boundaries
-                    slc_y = slice(max(0, iymin), min(data_shape[0], iymax))
-                    slc_x = slice(max(0, ixmin), min(data_shape[1], ixmax))
-                    if (slc_y.start >= slc_y.stop
-                            or slc_x.start >= slc_x.stop):
-                        xcen = np.nan
-                        ycen = np.nan
-                        break
-
-                    cur_ixcen = int(xcen + 0.5)
-                    cur_iycen = int(ycen + 0.5)
-
-                    # Recompute cutout data only when the integer center
-                    # changes to avoid redundant _mask_to_mirrored_value
-                    # calls
-                    if cur_ixcen != prev_ixcen or cur_iycen != prev_iycen:
-                        prev_ixcen = cur_ixcen
-                        prev_iycen = cur_iycen
-
-                        data = data_arr[slc_y, slc_x].astype(float)
-                        data_mask = ~np.isfinite(data)
-                        if mask_arr is not None:
-                            data_mask |= mask_arr[slc_y, slc_x]
-
-                        cutout_xycen = (xcen - max(0, ixmin),
-                                        ycen - max(0, iymin))
-
-                        if do_segm_mask:
-                            seg_cut = segm_data[slc_y, slc_x]
-                            segm_mask = ((seg_cut != label)
-                                         & (seg_cut != 0))
-                            if self.aperture_mask_method == 'mask':
-                                data_mask = data_mask | segm_mask
-
-                        if do_correct:
-                            data = _mask_to_mirrored_value(
-                                data, segm_mask, cutout_xycen,
-                                mask=data_mask)
-
-                        cached_data = data
-                        cached_mask = data_mask
-
-                        if compute_err:
-                            cached_error = (error_arr[slc_y, slc_x]
-                                            .astype(float))
-
-                    # Centroid position in cutout coordinates
-                    cx = xcen - max(0, ixmin)
-                    cy = ycen - max(0, iymin)
-
-                    ny = slc_y.stop - slc_y.start
-                    nx = slc_x.stop - slc_x.start
-
-                    # Build coordinate grids relative to centroid
-                    # (reused for circle mask, Gaussian, and moments)
-                    xvals = np.arange(nx) - cx
-                    yvals = np.arange(ny) - cy
-                    xx = xvals[np.newaxis, :]
-                    yy = yvals[:, np.newaxis]
-
-                    # Inline binary circle mask
-                    rr2 = xx * xx + yy * yy
-                    aper_weights = (rr2 <= radius_sq).astype(float)
-
-                    # Inline Gaussian weight
-                    gweight = np.exp(rr2 * inv_2sigma2)
-
-                    # Accumulate error variance terms
-                    if compute_err:
-                        var = cached_error**2
-                        var[cached_mask] = 0.0
-                        combined_weight = aper_weights * gweight
-                        weighted_var = combined_weight**2 * var
-                        err_sum = np.sum(weighted_var)
-                        err_var_x = np.sum(weighted_var * xx * xx)
-                        err_var_y = np.sum(weighted_var * yy * yy)
-                        err_cov_xy = np.sum(weighted_var * xx * yy)
-
-                    # Apply weights and mask
-                    weighted = (cached_data * aper_weights * gweight)
-                    weighted[cached_mask] = 0.0
-
-                    # Inline moment computation (including 2nd order
-                    # for the fallback checks)
-                    weighted_flux = np.sum(weighted)
-                    dx_mom = np.sum(weighted * xx) / weighted_flux
-                    dy_mom = np.sum(weighted * yy) / weighted_flux
-                    raw_mx2 = np.sum(weighted * xx * xx)
-                    raw_my2 = np.sum(weighted * yy * yy)
-                    raw_mxy = np.sum(weighted * xx * yy)
-
-                    dcen = math.sqrt(dx_mom * dx_mom
-                                     + dy_mom * dy_mom)
-                    xcen += dx_mom * 2.0
-                    ycen += dy_mom * 2.0
-                    iter_ += 1
-
-            # Compute windowed central 2nd moments from last
-            # iteration for the fallback checks.
-            if np.isfinite(weighted_flux) and weighted_flux > 0:
-                cen_mom_xx = (raw_mx2 / weighted_flux
-                              - dx_mom * dx_mom)
-                cen_mom_yy = (raw_my2 / weighted_flux
-                              - dy_mom * dy_mom)
-                cen_mom_xy = (raw_mxy / weighted_flux
-                              - dx_mom * dy_mom)
-            else:
-                cen_mom_xx = cen_mom_yy = cen_mom_xy = 0.0
-
-            # Normalize error terms by step_factor^2 / weighted_flux^2
-            if (compute_err and np.isfinite(weighted_flux)
-                    and weighted_flux > 0):
-                step_factor = 2.0
-                norm = step_factor**2 / (weighted_flux**2)
-                err_var_x *= norm
-                err_var_y *= norm
-                err_cov_xy *= norm
-
-                # Handle fully correlated profiles that cause a
-                # singularity.
-                err_sum_norm = err_sum * (1.0 / 12) * norm
-                if (err_var_x * err_var_y
-                        - err_cov_xy**2) < err_sum_norm**2:
-                    err_var_x += err_sum_norm
-                    err_var_y += err_sum_norm
-
-                # Add pixel-size variance correction (1/12).
-                err_var_x += err_sum_norm
-                err_var_y += err_sum_norm
-            else:
-                err_var_x = err_var_y = err_cov_xy = np.nan
-
-            win_weighted_flux.append(weighted_flux)
-            win_cen_mom_xx.append(cen_mom_xx)
-            win_cen_mom_yy.append(cen_mom_yy)
-            win_cen_mom_xy.append(cen_mom_xy)
-            win_err_var_x.append(err_var_x)
-            win_err_var_y.append(err_var_y)
-            win_err_cov_xy.append(err_cov_xy)
-            xcen_win.append(xcen)
-            ycen_win.append(ycen)
-
-        xcen_win = np.array(xcen_win)
-        ycen_win = np.array(ycen_win)
-        win_weighted_flux = np.array(win_weighted_flux)
-        win_cen_mom_xx = np.array(win_cen_mom_xx)
-        win_cen_mom_yy = np.array(win_cen_mom_yy)
-        win_cen_mom_xy = np.array(win_cen_mom_xy)
-        win_err_var_x = np.array(win_err_var_x)
-        win_err_var_y = np.array(win_err_var_y)
-        win_err_cov_xy = np.array(win_err_cov_xy)
-
-        # Reset to the isophotal centroid when any of:
-        # 1. Centroid diverged far AND outside 1-sigma ellipse
-        # 2. Non-positive total weighted flux
-        # 3. Negative windowed 2nd-order moments
-        # 4. Negative windowed covariance determinant
-        # Sources with NaN half-light radius keep NaN
-        # (no valid window size).
-        dx = x_centroid - xcen_win
-        dy = y_centroid - ycen_win
-        cxx = self._array('ellipse_cxx').value
-        cxy = self._array('ellipse_cxy').value
-        cyy = self._array('ellipse_cyy').value
-
-        reset = ((dx**2 > 1) & (dy**2 > 1)
-                 & ((cxx * dx**2 + cxy * dx * dy + cyy * dy**2) > 1))
-        reset |= win_weighted_flux <= 0.0
-        reset |= (win_cen_mom_xx < 0.0) | (win_cen_mom_yy < 0.0)
-        reset |= (win_cen_mom_xx * win_cen_mom_yy
-                  - win_cen_mom_xy**2) < 0.0
-        nan_cen = np.isnan(xcen_win) | np.isnan(ycen_win)
-        reset |= nan_cen & ~nan_hl
-        reset &= ~nan_hl
-        if np.any(reset):
-            xcen_win[reset] = x_centroid[reset]
-            ycen_win[reset] = y_centroid[reset]
-            # Errors are not meaningful for fallback sources
-            win_err_var_x[reset] = np.nan
-            win_err_var_y[reset] = np.nan
-            win_err_cov_xy[reset] = np.nan
-
-        # Store the 1-sigma position errors. Take sqrt to convert
-        # variance to 1-sigma.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            xerr = np.sqrt(win_err_var_x)
-            yerr = np.sqrt(win_err_var_y)
-        self._centroid_win_poserr = np.transpose((xerr, yerr))
-
-        return np.transpose((xcen_win, ycen_win))
+        return self._apply_centroid_win_fallback(
+            xcen_win, ycen_win, win_weighted_flux,
+            win_cen_mom_xx, win_cen_mom_yy, win_cen_mom_xy,
+            win_err_var_x, win_err_var_y, win_err_cov_xy, nan_hl,
+            x_centroid, y_centroid)
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1627,11 +1627,11 @@ class SourceCatalog:
     def _centroid_errors(self):
         """
         The 1-sigma errors on the ``(x, y)`` isophotal centroid
-        position.
+        position as a 2D array with a leading source axis.
 
-        The errors are computed by propagating the input ``error``
-        array through the center-of-mass centroid formula. If no
-        error array was provided, the errors are ``np.nan``.
+        The errors are computed by propagating the input ``error`` array
+        through the center-of-mass centroid formula. If no error array
+        was provided, the errors are ``np.nan``.
 
         For a centroid defined as :math:`x_c = \\sum f_i x_i / F`,
         the variance is:
@@ -1641,36 +1641,17 @@ class SourceCatalog:
             \\text{Var}(x_c) = \\frac{\\sum_i (x_i - x_c)^2
             \\sigma_i^2}{F^2}
 
-        A 1/12 correction is added for finite pixel size, and a
-        singularity correction is applied for point-like sources whose
-        shape covariance determinant is below :math:`(1/12)^2`.
+        For point-like sources whose shape covariance determinant is
+        below :math:`(1/12)^2` (see ``_singular_covariance_mask``), a
+        singularity correction of :math:`\\sum_i \\sigma_i^2 / (12
+        F^2)` is added to the variances if the error covariance matrix
+        is itself nearly singular.
         """
         if self._error is None:
-            result = np.full((self.n_labels, 2), np.nan)
-            if self.isscalar:
-                return result[0]
-            return result
+            return np.full((self.n_labels, 2), np.nan)
 
-        cutout_centroid = self.cutout_centroid
-        if self.isscalar:
-            cutout_centroid = cutout_centroid[np.newaxis, :]
-
-        # Use the raw (uncorrected) shape covariance determinant to
-        # determine which sources are point-like (singularity
-        # flag): the flag is set when the covariance determinant
-        # < (1/12)^2 BEFORE the diagonal correction is applied.
-        # We compute from central moments directly.
-        moments_cen = self.moments_central
-        if self.isscalar:
-            moments_cen = moments_cen[np.newaxis, :]
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            mu00 = moments_cen[:, 0, 0]
-            raw_var_xx = moments_cen[:, 0, 2] / mu00
-            raw_var_yy = moments_cen[:, 2, 0] / mu00
-            raw_var_xy = moments_cen[:, 1, 1] / mu00
-        raw_det = raw_var_xx * raw_var_yy - raw_var_xy**2
-        is_singular = raw_det < (1.0 / 12)**2
+        cutout_centroid = self._array('cutout_centroid')
+        is_singular = self._singular_covariance_mask
 
         xerr_arr = []
         yerr_arr = []
@@ -1688,44 +1669,38 @@ class SourceCatalog:
                 continue
 
             err_sq = error_cutout.astype(float)**2
-            err_sq[total_mask] = 0.0
+            # Zero the variance at masked pixels and at pixels that
+            # were excluded from the moment data (e.g., non-finite or
+            # negative convolved values), so that pixels that do not
+            # contribute flux weight also do not contribute error
+            # variance.
+            err_sq[total_mask | (moment_data == 0)] = 0.0
 
             yy, xx = np.mgrid[0:err_sq.shape[0], 0:err_sq.shape[1]]
             dx = xx - xcen
             dy = yy - ycen
 
-            # Compute raw error variances without the pixel-size
-            # correction.
-            err_var_x = np.sum(err_sq * dx**2)
-            err_var_y = np.sum(err_sq * dy**2)
-            err_sum = np.sum(err_sq)
-
+            # Propagate the error through the centroid formula.
             norm = 1.0 / (total_flux**2)
-            err_var_x *= norm
-            err_var_y *= norm
-            err_sum_norm = err_sum * pixel_var * norm
+            err_var_x = np.sum(err_sq * dx**2) * norm
+            err_var_y = np.sum(err_sq * dy**2) * norm
 
-            # Singularity correction for point-like sources. The
-            # check is performed on the raw error matrix (without
-            # the 1/12 pixel-size correction).
+            # Singularity correction for point-like sources. If the
+            # error covariance matrix is nearly singular, add the
+            # variance of a uniform distribution across a single
+            # pixel (1/12) scaled by the summed pixel variance.
             if singular:
+                err_sum_norm = np.sum(err_sq) * pixel_var * norm
                 err_cov_xy = np.sum(err_sq * dx * dy) * norm
                 if (err_var_x * err_var_y
                         - err_cov_xy**2) < err_sum_norm**2:
                     err_var_x += err_sum_norm
                     err_var_y += err_sum_norm
 
-            # Add the pixel-size variance correction (1/12).
-            err_var_x += err_sum_norm
-            err_var_y += err_sum_norm
-
             xerr_arr.append(np.sqrt(err_var_x))
             yerr_arr.append(np.sqrt(err_var_y))
 
-        result = np.transpose((xerr_arr, yerr_arr))
-        if self.isscalar:
-            return result[0]
-        return result
+        return np.transpose((xerr_arr, yerr_arr))
 
     @staticmethod
     def _normalize_win_errors(err_sum, err_var_x, err_var_y, err_cov_xy,
@@ -3033,6 +3008,24 @@ class SourceCatalog:
         mu_20 = moments[:, 2, 0]
         tensor = np.array([mu_02, mu_11, mu_11, mu_20]).swapaxes(0, 1)
         return tensor.reshape((tensor.shape[0], 2, 2)) * u.pix**2
+
+    @cached_property
+    def _singular_covariance_mask(self):
+        """
+        A boolean mask with a leading source axis that is `True` for
+        sources whose raw covariance matrix is singular or nearly
+        singular (i.e., point-like sources).
+
+        A source is flagged as singular when the determinant of its raw
+        (unregularized) covariance matrix is less than ``(1 / 12)**2``,
+        the squared variance of a uniform distribution across a single
+        pixel. Sources with non-finite covariance are not flagged.
+        """
+        # Ignore RuntimeWarning from NaN values in the covariance
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            covar_det = np.linalg.det(self._raw_covariance)
+        return covar_det < (1.0 / 12.0)**2
 
     @cached_property
     def _raw_covariance(self):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2368,6 +2368,7 @@ def test_measured_kron_radius_circular_no_min_radius(gauss_101_data):
         assert np.all(np.isnan(kr))
 
 
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_centroid_win_err():
     """
     Test that centroid_win_err returns finite 1-sigma position
@@ -2450,6 +2451,7 @@ def test_centroid_win_err_scalar():
     assert single.y_centroid_win_err == errors[1]
 
 
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_centroid_win_err_sliced():
     """
     Test that centroid_win_err works on a sliced catalog after
@@ -2512,6 +2514,7 @@ def test_centroid_win_err_singularity():
     assert np.all(errors > 0)
 
 
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_centroid_err():
     """
     Test that centroid_err returns finite 1-sigma position errors
@@ -2672,6 +2675,7 @@ def test_centroid_err_zero_flux():
     assert np.all(np.isnan(errors))
 
 
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_centroid_err_columns():
     """
     Test the x/y centroid error properties and their use as to_table
@@ -2815,6 +2819,7 @@ def test_centroid_quad_err_peak_at_edge():
     assert np.all(np.isnan(cat.centroid_quad_err))
 
 
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_centroid_quad_err_columns():
     """
     Test the quadratic centroid error properties as to_table columns

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2473,3 +2473,130 @@ def test_centroid_win_errors_singularity():
     # Errors should be finite (singularity correction applied)
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
+
+
+def test_centroid_errors():
+    """
+    Test that _centroid_errors returns finite 1-sigma position errors
+    when an error array is provided.
+    """
+    g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
+    g2 = Gaussian2D(3596, 13.81, 8.29, 1.44, 1.27, 0.628319)
+    m = g1 + g2
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = m(xx, yy)
+
+    error = np.full(data.shape, 65.0)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    npixels = 10
+    finder = SourceFinder(npixels=npixels, progress_bar=False)
+    threshold = 107.9
+    segment_map = finder(convolved_data, threshold)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, apermask_method='none')
+
+    errors = cat._centroid_errors
+    assert errors.shape == (cat.nlabels, 2)
+    # Both sources should have finite, positive errors
+    assert np.all(np.isfinite(errors))
+    assert np.all(errors > 0)
+    # Errors should be small relative to pixel scale for bright sources
+    assert np.all(errors < 1.0)
+
+
+def test_centroid_errors_no_error():
+    """
+    Test that _centroid_errors returns NaN when no error array is
+    provided.
+    """
+    g1 = Gaussian2D(1621, 10.0, 10.0, 2.0, 2.0)
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = g1(xx, yy)
+
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    npixels = 10
+    segment_map = detect_sources(convolved_data, 50.0, npixels)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        apermask_method='none')
+
+    errors = cat._centroid_errors
+    assert np.all(np.isnan(errors))
+
+
+def test_centroid_errors_scalar():
+    """
+    Test that _centroid_errors works for a scalar (single-source) case.
+    """
+    g1 = Gaussian2D(1621, 10.0, 10.0, 2.0, 2.0)
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = g1(xx, yy)
+    error = np.full(data.shape, 50.0)
+
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    npixels = 10
+    segment_map = detect_sources(convolved_data, 50.0, npixels)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, apermask_method='none')
+
+    single = cat[0]
+    errors = single._centroid_errors
+    assert errors.shape == (2,)
+    assert np.all(np.isfinite(errors))
+    assert np.all(errors > 0)
+
+
+def test_centroid_errors_singularity():
+    """
+    Test that the singularity correction in _centroid_errors is applied
+    for a source where the error covariance matrix is nearly singular.
+    This happens when error is concentrated at only the centroid pixel,
+    making det == esn^2 exactly, so we use <= in a modified check or
+    construct a case where floating-point rounding makes det < esn^2.
+    """
+    # A source with flux concentrated at the centroid pixel, and
+    # error only at the centroid pixel. With this setup,
+    # err_var_x * err_var_y - err_cov_xy^2 == err_sum_norm^2 exactly
+    # for a perfectly centered source. By adding a tiny asymmetric
+    # flux offset, the centroid shifts slightly, breaking the exact
+    # equality and making det < esn^2 due to floating-point effects.
+    data = np.zeros((11, 11))
+    data[5, 5] = 10000.0
+    data[5, 6] = 1e-10  # tiny asymmetry to shift centroid
+
+    error = np.zeros(data.shape)
+    error[5, 5] = 10000.0
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[4:7, 4:7] = 1
+    segment_map = SegmentationImage(segment_data)
+
+    convolved_data = data.copy()
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, apermask_method='none')
+
+    errors = cat._centroid_errors
+    assert np.all(np.isfinite(errors))
+    assert np.all(errors > 0)
+
+
+def test_centroid_errors_zero_flux():
+    """
+    Test that _centroid_errors returns NaN when the convolved data
+    total flux is zero within the segment (total_flux <= 0 branch).
+    """
+    data = np.ones((11, 11))
+    # convolved_data has zero flux in the segment region
+    convolved_data = np.zeros((11, 11))
+    error = np.full(data.shape, 10.0)
+
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[4:7, 4:7] = 1
+    segment_map = SegmentationImage(segment_data)
+
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, apermask_method='none')
+
+    errors = cat._centroid_errors
+    assert np.all(np.isnan(errors))

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2542,8 +2542,9 @@ def test_centroid_errors_scalar():
                         error=error, aperture_mask_method='none')
 
     single = cat[0]
+    # Private properties always keep the leading source axis
     errors = single._centroid_errors
-    assert errors.shape == (2,)
+    assert errors.shape == (1, 2)
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
 
@@ -2579,6 +2580,35 @@ def test_centroid_errors_singularity():
     errors = cat._centroid_errors
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
+
+
+def test_centroid_errors_formula():
+    """
+    Test that _centroid_errors matches the analytic error-propagation
+    formula, Var(x_c) = sum(sigma_i^2 * (x_i - x_c)^2) / F^2, for a
+    non-singular source (this is also the SourceExtractor and SEP
+    formula).
+    """
+    yy, xx = np.mgrid[0:25, 0:25]
+    data = Gaussian2D(100.0, 12.2, 12.6, 2.5, 2.5)(xx, yy)
+    error = np.full(data.shape, 3.0)
+
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[6:20, 6:20] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, aperture_mask_method='none')
+
+    mask = segment_data == 1
+    flux = np.sum(data[mask])
+    xcen = np.sum(data[mask] * xx[mask]) / flux
+    ycen = np.sum(data[mask] * yy[mask]) / flux
+    var_x = np.sum(error[mask]**2 * (xx[mask] - xcen)**2) / flux**2
+    var_y = np.sum(error[mask]**2 * (yy[mask] - ycen)**2) / flux**2
+
+    errors = cat._centroid_errors
+    assert_allclose(cat.centroid[0], (xcen, ycen))
+    assert_allclose(errors[0], np.sqrt((var_x, var_y)))
 
 
 def test_centroid_errors_zero_flux():

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2396,8 +2396,10 @@ def test_centroid_win_errors():
     # Source 0 converged; errors should be finite and positive
     assert np.all(np.isfinite(errors[0]))
     assert np.all(errors[0] > 0)
-    # Source 1 fell back to isophotal centroid; errors should be NaN
-    assert np.all(np.isnan(errors[1]))
+    # Source 1 fell back to the isophotal centroid, so its errors
+    # are the isophotal centroid errors
+    assert_allclose(cat.centroid_win[1], cat.centroid[1])
+    assert_allclose(errors[1], cat._centroid_errors[1])
 
 
 def test_centroid_win_errors_no_error():
@@ -2438,10 +2440,42 @@ def test_centroid_win_errors_scalar():
                         error=error, aperture_mask_method='none')
 
     single = cat[0]
+    # Private properties always keep the leading source axis
     errors = single._centroid_win_errors
-    assert errors.shape == (2,)
+    assert errors.shape == (1, 2)
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
+
+
+def test_centroid_win_errors_sliced():
+    """
+    Test that _centroid_win_errors works on a sliced catalog after
+    centroid_win was computed on the parent catalog (regression test
+    for a side-effect attribute that was not propagated by slicing).
+    """
+    g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
+    g2 = Gaussian2D(3596, 13.81, 8.29, 1.44, 1.27, 0.628319)
+    m = g1 + g2
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = m(xx, yy)
+    noise = make_noise_image(data.shape, mean=0, stddev=65.0, seed=123)
+    data += noise
+
+    error = np.full(data.shape, 65.0)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    finder = SourceFinder(n_pixels=10, progress_bar=False)
+    segment_map = finder(convolved_data, 107.9)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, aperture_mask_method='none')
+
+    # Compute centroid_win on the parent before slicing
+    _ = cat.centroid_win
+    errors = cat._centroid_win_errors
+    single = cat[0]
+    assert_allclose(single._centroid_win_errors, errors[0:1])
+    sub = cat[[1, 0]]
+    assert_allclose(sub._centroid_win_errors, errors[[1, 0]])
 
 
 def test_centroid_win_errors_singularity():

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2366,3 +2366,110 @@ def test_measured_kron_radius_circular_no_min_radius(gauss_101_data):
                        new_callable=lambda: property(lambda _self: cxy_val))):
         kr = cat._measured_kron_radius
         assert np.all(np.isnan(kr))
+
+
+def test_centroid_win_errors():
+    """
+    Test that _centroid_win_errors returns finite 1-sigma position
+    errors when an error array is provided.
+    """
+    g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
+    g2 = Gaussian2D(3596, 13.81, 8.29, 1.44, 1.27, 0.628319)
+    m = g1 + g2
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = m(xx, yy)
+    noise = make_noise_image(data.shape, mean=0, stddev=65.0, seed=123)
+    data += noise
+
+    error = np.full(data.shape, 65.0)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    n_pixels = 10
+    finder = SourceFinder(n_pixels=n_pixels, progress_bar=False)
+    threshold = 107.9
+    segment_map = finder(convolved_data, threshold)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, aperture_mask_method='none')
+
+    errors = cat._centroid_win_errors
+    assert errors.shape == (cat.n_labels, 2)
+    # Source 0 converged; errors should be finite and positive
+    assert np.all(np.isfinite(errors[0]))
+    assert np.all(errors[0] > 0)
+    # Source 1 fell back to isophotal centroid; errors should be NaN
+    assert np.all(np.isnan(errors[1]))
+
+
+def test_centroid_win_errors_no_error():
+    """
+    Test that _centroid_win_errors returns NaN when no error array is
+    provided.
+    """
+    g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = g1(xx, yy)
+
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    n_pixels = 10
+    segment_map = detect_sources(convolved_data, 50.0, n_pixels)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        aperture_mask_method='none')
+
+    errors = cat._centroid_win_errors
+    # No error array provided, so errors should be NaN
+    assert np.all(np.isnan(errors))
+
+
+def test_centroid_win_errors_scalar():
+    """
+    Test that _centroid_win_errors works for scalar (single-source) case.
+    """
+    g1 = Gaussian2D(1621, 10.0, 10.0, 2.0, 2.0)
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = g1(xx, yy)
+    error = np.full(data.shape, 50.0)
+
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    n_pixels = 10
+    segment_map = detect_sources(convolved_data, 50.0, n_pixels)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, aperture_mask_method='none')
+
+    single = cat[0]
+    errors = single._centroid_win_errors
+    assert errors.shape == (2,)
+    assert np.all(np.isfinite(errors))
+    assert np.all(errors > 0)
+
+
+def test_centroid_win_errors_singularity():
+    """
+    Test that the singularity correction in _centroid_win_errors is
+    applied for a source where non-zero error is limited to a single
+    pixel, causing a nearly singular error covariance.
+    """
+    data = np.zeros((21, 21))
+    data[10, 10] = 10000.0
+    data[10, 11] = 50.0
+    data[11, 10] = 50.0
+    data[10, 9] = 50.0
+    data[9, 10] = 50.0
+
+    # Non-zero error only at center pixel: error covariance
+    # will be concentrated there, triggering the singularity check
+    error = np.zeros(data.shape)
+    error[10, 10] = 10000.0
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[9:12, 9:12] = 1
+    segment_map = SegmentationImage(segment_data)
+
+    convolved_data = data.copy()
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, aperture_mask_method='none')
+
+    errors = cat._centroid_win_errors
+    # Errors should be finite (singularity correction applied)
+    assert np.all(np.isfinite(errors))
+    assert np.all(errors > 0)

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2489,15 +2489,15 @@ def test_centroid_errors():
     error = np.full(data.shape, 65.0)
     kernel = make_2dgaussian_kernel(3.0, size=5)
     convolved_data = convolve(data, kernel)
-    npixels = 10
-    finder = SourceFinder(npixels=npixels, progress_bar=False)
+    n_pixels = 10
+    finder = SourceFinder(n_pixels=n_pixels, progress_bar=False)
     threshold = 107.9
     segment_map = finder(convolved_data, threshold)
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
-                        error=error, apermask_method='none')
+                        error=error, aperture_mask_method='none')
 
     errors = cat._centroid_errors
-    assert errors.shape == (cat.nlabels, 2)
+    assert errors.shape == (cat.n_labels, 2)
     # Both sources should have finite, positive errors
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
@@ -2516,10 +2516,10 @@ def test_centroid_errors_no_error():
 
     kernel = make_2dgaussian_kernel(3.0, size=5)
     convolved_data = convolve(data, kernel)
-    npixels = 10
-    segment_map = detect_sources(convolved_data, 50.0, npixels)
+    n_pixels = 10
+    segment_map = detect_sources(convolved_data, 50.0, n_pixels)
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
-                        apermask_method='none')
+                        aperture_mask_method='none')
 
     errors = cat._centroid_errors
     assert np.all(np.isnan(errors))
@@ -2536,10 +2536,10 @@ def test_centroid_errors_scalar():
 
     kernel = make_2dgaussian_kernel(3.0, size=5)
     convolved_data = convolve(data, kernel)
-    npixels = 10
-    segment_map = detect_sources(convolved_data, 50.0, npixels)
+    n_pixels = 10
+    segment_map = detect_sources(convolved_data, 50.0, n_pixels)
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
-                        error=error, apermask_method='none')
+                        error=error, aperture_mask_method='none')
 
     single = cat[0]
     errors = single._centroid_errors
@@ -2574,7 +2574,7 @@ def test_centroid_errors_singularity():
 
     convolved_data = data.copy()
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
-                        error=error, apermask_method='none')
+                        error=error, aperture_mask_method='none')
 
     errors = cat._centroid_errors
     assert np.all(np.isfinite(errors))
@@ -2596,7 +2596,7 @@ def test_centroid_errors_zero_flux():
     segment_map = SegmentationImage(segment_data)
 
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
-                        error=error, apermask_method='none')
+                        error=error, aperture_mask_method='none')
 
     errors = cat._centroid_errors
     assert np.all(np.isnan(errors))

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2702,3 +2702,143 @@ def test_centroid_err_columns():
     assert tbl.colnames == columns
     assert_allclose(tbl['x_centroid_err'], cat.x_centroid_err)
     assert_allclose(tbl['y_centroid_win_err'], cat.y_centroid_win_err)
+
+
+def _quad_peak(box):
+    """
+    Solve for the peak of a quadratic fit to a 3x3 box.
+
+    This is an independent implementation (via lstsq) used to
+    numerically validate the centroid_quad error propagation.
+    """
+    yy, xx = np.mgrid[0:3, 0:3]
+    design = np.column_stack([np.ones(9), xx.ravel(), yy.ravel(),
+                              (xx * yy).ravel(), (xx**2).ravel(),
+                              (yy**2).ravel()])
+    c = np.linalg.lstsq(design, box.ravel(), rcond=None)[0]
+    det = 4.0 * c[4] * c[5] - c[3]**2
+    xm = (c[2] * c[3] - 2.0 * c[5] * c[1]) / det
+    ym = (c[1] * c[3] - 2.0 * c[4] * c[2]) / det
+    return np.array([xm, ym])
+
+
+def test_centroid_quad_err():
+    """
+    Test that centroid_quad_err matches a numerical-Jacobian error
+    propagation through the quadratic peak fit.
+    """
+    yy, xx = np.mgrid[0:25, 0:25]
+    data = Gaussian2D(100.0, 12.2, 12.6, 2.0, 1.5, 0.5)(xx, yy)
+    rng = np.random.default_rng(42)
+    error = rng.uniform(1.0, 3.0, data.shape)
+
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[6:20, 6:20] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, aperture_mask_method='none')
+
+    # The peak pixel is at (12, 13) and the 3x3 fit box lies fully
+    # within the segment, so no masked pixels are involved
+    yidx, xidx = 13, 12
+    box = data[yidx - 1:yidx + 2, xidx - 1:xidx + 2].copy()
+    box_err = error[yidx - 1:yidx + 2, xidx - 1:xidx + 2].ravel()
+
+    eps = 1e-6
+    jacobian = np.zeros((2, 9))
+    for i in range(9):
+        box_p = box.ravel().copy()
+        box_p[i] += eps
+        box_m = box.ravel().copy()
+        box_m[i] -= eps
+        jacobian[:, i] = (_quad_peak(box_p) - _quad_peak(box_m)) / (2 * eps)
+    var_expected = np.sum(jacobian**2 * box_err**2, axis=1)
+
+    errors = cat.centroid_quad_err
+    assert errors.shape == (1, 2)
+    assert_allclose(errors[0], np.sqrt(var_expected), rtol=1e-6)
+    assert_allclose(cat.x_centroid_quad_err, errors[:, 0])
+    assert_allclose(cat.y_centroid_quad_err, errors[:, 1])
+
+
+def test_centroid_quad_err_no_error():
+    """
+    Test that centroid_quad_err is NaN when no error array is input.
+    """
+    yy, xx = np.mgrid[0:25, 0:25]
+    data = Gaussian2D(100.0, 12.2, 12.6, 2.0, 2.0)(xx, yy)
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[6:20, 6:20] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        aperture_mask_method='none')
+    assert np.all(np.isfinite(cat.centroid_quad))
+    assert np.all(np.isnan(cat.centroid_quad_err))
+
+
+def test_centroid_quad_err_fallback():
+    """
+    Test that sources where the quadratic centroid fell back to the
+    isophotal centroid have the isophotal centroid errors.
+    """
+    # A 2x2 segment is too small for the 3x3 quadratic fit, so the
+    # centroid falls back to the isophotal centroid
+    data = np.ones((11, 11))
+    data[5, 5] = 10.0
+    error = np.full(data.shape, 1.0)
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[5:7, 5:7] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, aperture_mask_method='none')
+
+    assert_allclose(cat.centroid_quad, cat.centroid)
+    assert_allclose(cat.centroid_quad_err, cat.centroid_err)
+
+
+def test_centroid_quad_err_peak_at_edge():
+    """
+    Test that sources whose maximum value is at the edge of the
+    cutout return the peak-pixel position with NaN errors.
+    """
+    # Monotonic gradient: the maximum is at the segment cutout edge
+    yy, xx = np.mgrid[0:11, 0:11]
+    data = (xx + yy).astype(float)
+    error = np.full(data.shape, 1.0)
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[3:8, 3:8] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, aperture_mask_method='none')
+
+    assert np.all(np.isfinite(cat.centroid_quad))
+    assert np.all(np.isnan(cat.centroid_quad_err))
+
+
+def test_centroid_quad_err_columns():
+    """
+    Test the quadratic centroid error properties as to_table columns
+    and the scalar-catalog collapse.
+    """
+    g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
+    g2 = Gaussian2D(3596, 13.81, 8.29, 1.44, 1.27, 0.628319)
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = (g1 + g2)(xx, yy)
+    error = np.full(data.shape, 65.0)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    finder = SourceFinder(n_pixels=10, progress_bar=False)
+    segment_map = finder(convolved_data, 107.9)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, aperture_mask_method='none')
+
+    columns = ['label', 'x_centroid_quad_err', 'y_centroid_quad_err']
+    tbl = cat.to_table(columns=columns)
+    assert tbl.colnames == columns
+    assert_allclose(tbl['x_centroid_quad_err'], cat.x_centroid_quad_err)
+
+    single = cat[0]
+    errors = single.centroid_quad_err
+    assert errors.shape == (2,)
+    assert single.x_centroid_quad_err == errors[0]
+    assert single.y_centroid_quad_err == errors[1]

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2368,9 +2368,9 @@ def test_measured_kron_radius_circular_no_min_radius(gauss_101_data):
         assert np.all(np.isnan(kr))
 
 
-def test_centroid_win_errors():
+def test_centroid_win_err():
     """
-    Test that _centroid_win_errors returns finite 1-sigma position
+    Test that centroid_win_err returns finite 1-sigma position
     errors when an error array is provided.
     """
     g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
@@ -2391,7 +2391,7 @@ def test_centroid_win_errors():
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
                         error=error, aperture_mask_method='none')
 
-    errors = cat._centroid_win_errors
+    errors = cat.centroid_win_err
     assert errors.shape == (cat.n_labels, 2)
     # Source 0 converged; errors should be finite and positive
     assert np.all(np.isfinite(errors[0]))
@@ -2399,12 +2399,12 @@ def test_centroid_win_errors():
     # Source 1 fell back to the isophotal centroid, so its errors
     # are the isophotal centroid errors
     assert_allclose(cat.centroid_win[1], cat.centroid[1])
-    assert_allclose(errors[1], cat._centroid_errors[1])
+    assert_allclose(errors[1], cat.centroid_err[1])
 
 
-def test_centroid_win_errors_no_error():
+def test_centroid_win_err_no_error():
     """
-    Test that _centroid_win_errors returns NaN when no error array is
+    Test that centroid_win_err returns NaN when no error array is
     provided.
     """
     g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
@@ -2418,14 +2418,14 @@ def test_centroid_win_errors_no_error():
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
                         aperture_mask_method='none')
 
-    errors = cat._centroid_win_errors
+    errors = cat.centroid_win_err
     # No error array provided, so errors should be NaN
     assert np.all(np.isnan(errors))
 
 
-def test_centroid_win_errors_scalar():
+def test_centroid_win_err_scalar():
     """
-    Test that _centroid_win_errors works for scalar (single-source) case.
+    Test that centroid_win_err works for scalar (single-source) case.
     """
     g1 = Gaussian2D(1621, 10.0, 10.0, 2.0, 2.0)
     yy, xx = np.mgrid[0:21, 0:21]
@@ -2440,16 +2440,19 @@ def test_centroid_win_errors_scalar():
                         error=error, aperture_mask_method='none')
 
     single = cat[0]
-    # Private properties always keep the leading source axis
-    errors = single._centroid_win_errors
-    assert errors.shape == (1, 2)
+    # Public properties collapse to a single (x, y) pair for a
+    # scalar catalog
+    errors = single.centroid_win_err
+    assert errors.shape == (2,)
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
+    assert single.x_centroid_win_err == errors[0]
+    assert single.y_centroid_win_err == errors[1]
 
 
-def test_centroid_win_errors_sliced():
+def test_centroid_win_err_sliced():
     """
-    Test that _centroid_win_errors works on a sliced catalog after
+    Test that centroid_win_err works on a sliced catalog after
     centroid_win was computed on the parent catalog (regression test
     for a side-effect attribute that was not propagated by slicing).
     """
@@ -2471,16 +2474,16 @@ def test_centroid_win_errors_sliced():
 
     # Compute centroid_win on the parent before slicing
     _ = cat.centroid_win
-    errors = cat._centroid_win_errors
+    errors = cat.centroid_win_err
     single = cat[0]
-    assert_allclose(single._centroid_win_errors, errors[0:1])
+    assert_allclose(single.centroid_win_err, errors[0])
     sub = cat[[1, 0]]
-    assert_allclose(sub._centroid_win_errors, errors[[1, 0]])
+    assert_allclose(sub.centroid_win_err, errors[[1, 0]])
 
 
-def test_centroid_win_errors_singularity():
+def test_centroid_win_err_singularity():
     """
-    Test that the singularity correction in _centroid_win_errors is
+    Test that the singularity correction in centroid_win_err is
     applied for a source where non-zero error is limited to a single
     pixel, causing a nearly singular error covariance.
     """
@@ -2503,15 +2506,15 @@ def test_centroid_win_errors_singularity():
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
                         error=error, aperture_mask_method='none')
 
-    errors = cat._centroid_win_errors
+    errors = cat.centroid_win_err
     # Errors should be finite (singularity correction applied)
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
 
 
-def test_centroid_errors():
+def test_centroid_err():
     """
-    Test that _centroid_errors returns finite 1-sigma position errors
+    Test that centroid_err returns finite 1-sigma position errors
     when an error array is provided.
     """
     g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
@@ -2530,7 +2533,7 @@ def test_centroid_errors():
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
                         error=error, aperture_mask_method='none')
 
-    errors = cat._centroid_errors
+    errors = cat.centroid_err
     assert errors.shape == (cat.n_labels, 2)
     # Both sources should have finite, positive errors
     assert np.all(np.isfinite(errors))
@@ -2539,9 +2542,9 @@ def test_centroid_errors():
     assert np.all(errors < 1.0)
 
 
-def test_centroid_errors_no_error():
+def test_centroid_err_no_error():
     """
-    Test that _centroid_errors returns NaN when no error array is
+    Test that centroid_err returns NaN when no error array is
     provided.
     """
     g1 = Gaussian2D(1621, 10.0, 10.0, 2.0, 2.0)
@@ -2555,13 +2558,13 @@ def test_centroid_errors_no_error():
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
                         aperture_mask_method='none')
 
-    errors = cat._centroid_errors
+    errors = cat.centroid_err
     assert np.all(np.isnan(errors))
 
 
-def test_centroid_errors_scalar():
+def test_centroid_err_scalar():
     """
-    Test that _centroid_errors works for a scalar (single-source) case.
+    Test that centroid_err works for a scalar (single-source) case.
     """
     g1 = Gaussian2D(1621, 10.0, 10.0, 2.0, 2.0)
     yy, xx = np.mgrid[0:21, 0:21]
@@ -2576,16 +2579,19 @@ def test_centroid_errors_scalar():
                         error=error, aperture_mask_method='none')
 
     single = cat[0]
-    # Private properties always keep the leading source axis
-    errors = single._centroid_errors
-    assert errors.shape == (1, 2)
+    # Public properties collapse to a single (x, y) pair for a
+    # scalar catalog
+    errors = single.centroid_err
+    assert errors.shape == (2,)
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
+    assert single.x_centroid_err == errors[0]
+    assert single.y_centroid_err == errors[1]
 
 
-def test_centroid_errors_singularity():
+def test_centroid_err_singularity():
     """
-    Test that the singularity correction in _centroid_errors is applied
+    Test that the singularity correction in centroid_err is applied
     for a source where the error covariance matrix is nearly singular.
     This happens when error is concentrated at only the centroid pixel,
     making det == esn^2 exactly, so we use <= in a modified check or
@@ -2611,14 +2617,14 @@ def test_centroid_errors_singularity():
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
                         error=error, aperture_mask_method='none')
 
-    errors = cat._centroid_errors
+    errors = cat.centroid_err
     assert np.all(np.isfinite(errors))
     assert np.all(errors > 0)
 
 
-def test_centroid_errors_formula():
+def test_centroid_err_formula():
     """
-    Test that _centroid_errors matches the analytic error-propagation
+    Test that centroid_err matches the analytic error-propagation
     formula, Var(x_c) = sum(sigma_i^2 * (x_i - x_c)^2) / F^2, for a
     non-singular source (this is also the SourceExtractor and SEP
     formula).
@@ -2640,14 +2646,14 @@ def test_centroid_errors_formula():
     var_x = np.sum(error[mask]**2 * (xx[mask] - xcen)**2) / flux**2
     var_y = np.sum(error[mask]**2 * (yy[mask] - ycen)**2) / flux**2
 
-    errors = cat._centroid_errors
+    errors = cat.centroid_err
     assert_allclose(cat.centroid[0], (xcen, ycen))
     assert_allclose(errors[0], np.sqrt((var_x, var_y)))
 
 
-def test_centroid_errors_zero_flux():
+def test_centroid_err_zero_flux():
     """
-    Test that _centroid_errors returns NaN when the convolved data
+    Test that centroid_err returns NaN when the convolved data
     total flux is zero within the segment (total_flux <= 0 branch).
     """
     data = np.ones((11, 11))
@@ -2662,5 +2668,37 @@ def test_centroid_errors_zero_flux():
     cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
                         error=error, aperture_mask_method='none')
 
-    errors = cat._centroid_errors
+    errors = cat.centroid_err
     assert np.all(np.isnan(errors))
+
+
+def test_centroid_err_columns():
+    """
+    Test the x/y centroid error properties and their use as to_table
+    columns.
+    """
+    g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
+    g2 = Gaussian2D(3596, 13.81, 8.29, 1.44, 1.27, 0.628319)
+    m = g1 + g2
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = m(xx, yy)
+
+    error = np.full(data.shape, 65.0)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    finder = SourceFinder(n_pixels=10, progress_bar=False)
+    segment_map = finder(convolved_data, 107.9)
+    cat = SourceCatalog(data, segment_map, convolved_data=convolved_data,
+                        error=error, aperture_mask_method='none')
+
+    assert_allclose(cat.x_centroid_err, cat.centroid_err[:, 0])
+    assert_allclose(cat.y_centroid_err, cat.centroid_err[:, 1])
+    assert_allclose(cat.x_centroid_win_err, cat.centroid_win_err[:, 0])
+    assert_allclose(cat.y_centroid_win_err, cat.centroid_win_err[:, 1])
+
+    columns = ['label', 'x_centroid_err', 'y_centroid_err',
+               'x_centroid_win_err', 'y_centroid_win_err']
+    tbl = cat.to_table(columns=columns)
+    assert tbl.colnames == columns
+    assert_allclose(tbl['x_centroid_err'], cat.x_centroid_err)
+    assert_allclose(tbl['y_centroid_win_err'], cat.y_centroid_win_err)


### PR DESCRIPTION
This PR adds ``SourceCatalog`` ``centroid_err``, ``x_centroid_err``, ``y_centroid_err``, ``centroid_win_err``, ``x_centroid_win_err``, ``y_centroid_win_err``, ``centroid_quad_err``, ``x_centroid_quad_err``, and ``y_centroid_quad_err`` properties providing the 1-sigma errors on the isophotal, windowed, and quadratic centroid positions, propagated from the input ``error`` array. 

The conditions for the ``SourceCatalog`` ``centroid_win`` fallback to the isophotal centroid have been expanded. The windowed centroid is reset when it diverged far from the isophotal centroid and lies outside the 1-sigma ellipse, the total weighted flux is non-positive, the windowed second-order moments are negative, or the windowed covariance determinant is negative. Previously, only the ellipse condition was applied.