### PR TITLE
Add SourceCatalog sky-based centroid errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -246,6 +246,13 @@ New Features
     quadratic centroid positions, propagated from the input ``error``
     array. [#2397]
 
+  - Added ``SourceCatalog`` ``sky_centroid_err``,
+    ``sky_centroid_ra_err``, ``sky_centroid_dec_err``, and the
+    corresponding ``sky_centroid_win_*`` and ``sky_centroid_quad_*``
+    properties providing the 1-sigma sky position errors in arcsec,
+    computed by transporting the pixel centroid error covariance through
+    the local WCS Jacobian. [#2399]
+
 - ``photutils.utils``
 
   - Added a new ``DeblendWarning`` class, a subclass of astropy's

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -776,6 +776,15 @@ equivalents:
        75  74.413068    0.051327718  259.76066    0.045532249
        80  14.920217    0.069001032  60.024006    0.093764369
 
+When a ``wcs`` is also input, the corresponding sky
+position errors are available in arcsec via the
+`~photutils.segmentation.SourceCatalog.sky_centroid_err`,
+`~photutils.segmentation.SourceCatalog.sky_centroid_ra_err`, and
+`~photutils.segmentation.SourceCatalog.sky_centroid_dec_err` properties
+(and their ``_win`` and ``_quad`` variants). The RA errors are expressed
+as great-circle angles along the East direction (i.e., they include the
+cos(dec) factor).
+
 
 Pixel Masking
 ^^^^^^^^^^^^^

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -579,6 +579,16 @@ quadratic-fit centroid
         4       0.078204       0.104136           0.158468           0.158468
         5       0.081175       0.098188           0.181951           0.181947
 
+When a ``wcs`` is also input, the corresponding 1-sigma
+sky position errors are available in arcsec via the
+`~photutils.segmentation.SourceCatalog.sky_centroid_err`,
+`~photutils.segmentation.SourceCatalog.sky_centroid_ra_err`, and
+`~photutils.segmentation.SourceCatalog.sky_centroid_dec_err` properties
+(and their ``_win`` and ``_quad`` variants), computed by transporting
+the pixel centroid error covariance through the local WCS Jacobian. The
+RA errors are expressed as great-circle angles along the East direction
+(i.e., they include the cos(dec) factor).
+
 
 ``GriddedPSFModel`` Performance Improvements
 ============================================

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -34,6 +34,7 @@ from photutils.utils._misc import _get_meta
 from photutils.utils._parameters import validate_table_columns
 from photutils.utils._progress_bars import add_progress_bar
 from photutils.utils._quantity_helpers import process_quantities
+from photutils.utils._wcs_helpers import compute_pixel_to_sky_jacobians
 from photutils.utils.cutouts import CutoutImage
 
 __all__ = ['SourceCatalog']
@@ -1702,6 +1703,44 @@ class SourceCatalog:
         cov[:, 0, 1] = var_arr[:, 2]
         cov[:, 1, 0] = var_arr[:, 2]
         return cov
+
+    def _sky_err_from_cov(self, pix_cov, xycen):
+        """
+        Transport pixel error covariances to sky position errors.
+
+        The pixel covariance of each source is mapped to the local
+        tangent plane with the forward WCS Jacobian ``F`` evaluated at
+        the source position (``sky_cov = F pix_cov F^T``). The returned
+        errors are the square roots of the tangent-plane variances along
+        East and North.
+
+        Parameters
+        ----------
+        pix_cov : `~numpy.ndarray`
+            The ``(N, 2, 2)`` pixel error covariance matrices.
+
+        xycen : `~numpy.ndarray`
+            The ``(N, 2)`` pixel ``(x, y)`` centroid positions at which
+            to evaluate the WCS Jacobians.
+
+        Returns
+        -------
+        sky_err : `~astropy.units.Quantity`
+            The ``(N, 2)`` array of 1-sigma errors in arcsec, with
+            columns ``(east_err, north_err)``. Rows are NaN where the
+            position or covariance is not finite.
+        """
+        sky_err = np.full(xycen.shape, np.nan)
+        good = (np.all(np.isfinite(xycen), axis=1)
+                & np.all(np.isfinite(pix_cov), axis=(1, 2)))
+        if np.any(good):
+            jac = compute_pixel_to_sky_jacobians(xycen[good, 0],
+                                                 xycen[good, 1],
+                                                 self.wcs)
+            sky_cov = np.einsum('nij,njk,nlk->nil', jac, pix_cov[good], jac)
+            sky_err[good, 0] = np.sqrt(sky_cov[:, 0, 0])
+            sky_err[good, 1] = np.sqrt(sky_cov[:, 1, 1])
+        return sky_err << u.arcsec
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1786,6 +1786,10 @@ class SourceCatalog:
 
         err_var_y : `~numpy.ndarray`
             Normalized error variance in ``y``.
+
+        err_cov_xy : `~numpy.ndarray`
+            Normalized error covariance in ``xy``. The pixel-size and
+            singularity corrections are not applied to the covariance.
         """
         step_factor = 2.0
         with warnings.catch_warnings():
@@ -1812,14 +1816,16 @@ class SourceCatalog:
             bad = ~np.isfinite(weighted_flux) | (weighted_flux <= 0)
             err_var_x[bad] = np.nan
             err_var_y[bad] = np.nan
+            err_cov_xy[bad] = np.nan
 
-        return err_var_x, err_var_y
+        return err_var_x, err_var_y, err_cov_xy
 
     def _apply_centroid_win_fallback(self, xcen_win, ycen_win,
                                      win_weighted_flux,
                                      win_cen_mom_xx, win_cen_mom_yy,
                                      win_cen_mom_xy,
                                      win_err_var_x, win_err_var_y,
+                                     win_err_cov_xy,
                                      nan_hl, x_centroid, y_centroid):
         """
         Apply the fallback conditions for the windowed centroid.
@@ -1858,6 +1864,9 @@ class SourceCatalog:
         win_err_var_y : `~numpy.ndarray`
             Error variance in y.
 
+        win_err_cov_xy : `~numpy.ndarray`
+            Error covariance in xy.
+
         nan_hl : `~numpy.ndarray`
             Boolean mask indicating sources with NaN half-light radius.
 
@@ -1870,16 +1879,10 @@ class SourceCatalog:
         Returns
         -------
         result : `~numpy.ndarray`
-            The windowed centroid coordinates and their 1-sigma
-            errors as columns ``(x, y, xerr, yerr)``, shape
-            ``(n_sources, 4)``.
+            The windowed centroid coordinates and their error variances
+            and covariance as columns ``(x, y, var_x, var_y, cov_xy)``,
+            shape ``(n_sources, 5)``.
         """
-        # Convert variance to 1-sigma error
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            xerr = np.sqrt(win_err_var_x)
-            yerr = np.sqrt(win_err_var_y)
-
         dx = x_centroid - xcen_win
         dy = y_centroid - ycen_win
         cxx = self._array('ellipse_cxx').value
@@ -1899,12 +1902,14 @@ class SourceCatalog:
             xcen_win[reset] = x_centroid[reset]
             ycen_win[reset] = y_centroid[reset]
             # Fallback sources use the isophotal centroid, so also
-            # use the isophotal centroid errors
-            iso_errors = self._array('centroid_err')
-            xerr[reset] = iso_errors[reset, 0]
-            yerr[reset] = iso_errors[reset, 1]
+            # use the isophotal centroid error covariance
+            iso_cov = self._centroid_err_cov
+            win_err_var_x[reset] = iso_cov[reset, 0, 0]
+            win_err_var_y[reset] = iso_cov[reset, 1, 1]
+            win_err_cov_xy[reset] = iso_cov[reset, 0, 1]
 
-        return np.transpose((xcen_win, ycen_win, xerr, yerr))
+        return np.transpose((xcen_win, ycen_win, win_err_var_x,
+                             win_err_var_y, win_err_cov_xy))
 
     def _iterate_centroid_win(self, label, xcen, ycen, rad_hl,
                               nan_hl_source, *, data_arr, mask_arr,
@@ -2126,9 +2131,9 @@ class SourceCatalog:
     @use_detcat
     def _centroid_win_results(self):
         """
-        The "windowed" centroid coordinates and their 1-sigma errors
-        as a 2D array with columns ``(x, y, xerr, yerr)`` and shape
-        ``(n_labels, 4)``.
+        The "windowed" centroid coordinates and their error variances
+        and covariance as a 2D array with columns ``(x, y, var_x, var_y,
+        cov_xy)`` and shape ``(n_labels, 5)``.
 
         This is the single computation behind `centroid_win` and
         `centroid_win_err`. See `centroid_win` for the algorithm
@@ -2198,14 +2203,15 @@ class SourceCatalog:
 
         # Normalize error terms by step_factor^2 / weighted_flux^2
         if compute_err:
-            win_err_var_x, win_err_var_y = self._normalize_centroid_win_err(
+            (win_err_var_x, win_err_var_y,
+             win_err_cov_xy) = self._normalize_centroid_win_err(
                 win_err_sum, win_err_var_x, win_err_var_y,
                 win_err_cov_xy, win_weighted_flux)
 
         return self._apply_centroid_win_fallback(
             xcen_win, ycen_win, win_weighted_flux,
             win_cen_mom_xx, win_cen_mom_yy, win_cen_mom_xy,
-            win_err_var_x, win_err_var_y, nan_hl,
+            win_err_var_x, win_err_var_y, win_err_cov_xy, nan_hl,
             x_centroid, y_centroid)
 
     @cached_property
@@ -2282,7 +2288,29 @@ class SourceCatalog:
         `centroid_err`). The errors are NaN where the half-light radius
         is not finite.
         """
-        return self._centroid_win_results[:, 2:4].copy()
+        results = self._centroid_win_results
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            return np.sqrt(results[:, 2:4])
+
+    @cached_property
+    @use_detcat
+    def _centroid_win_err_cov(self):
+        """
+        The ``(n_labels, 2, 2)`` pixel error covariance matrices of the
+        windowed centroid, ``[[var_x, cov_xy], [cov_xy, var_y]]``.
+
+        Fallback sources hold the isophotal covariance (see
+        ``_centroid_err_cov``); matrices are all-NaN where errors are
+        unavailable.
+        """
+        results = self._centroid_win_results
+        cov = np.empty((len(results), 2, 2))
+        cov[:, 0, 0] = results[:, 2]
+        cov[:, 1, 1] = results[:, 3]
+        cov[:, 0, 1] = results[:, 4]
+        cov[:, 1, 0] = results[:, 4]
+        return cov
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2380,6 +2380,9 @@ class SourceCatalog:
         -------
         var_x, var_y : float
             The variances of the peak ``x`` and ``y`` positions.
+
+        cov_xy : float
+            The covariance of the peak ``x`` and ``y`` positions.
         """
         c10, c01, c11, c20, c02 = coeffs[1:]
         det = 4.0 * c20 * c02 - c11 * c11
@@ -2397,17 +2400,21 @@ class SourceCatalog:
              (c10 + 2.0 * c11 * ym_rel) / det,
              (-2.0 * c01 - 4.0 * c02 * ym_rel) / det,
              -4.0 * c20 * ym_rel / det])
-        var_x = np.sum((grad_x @ pinv)**2 * box_var)
-        var_y = np.sum((grad_y @ pinv)**2 * box_var)
-        return var_x, var_y
+        u_x = grad_x @ pinv
+        u_y = grad_y @ pinv
+        var_x = np.sum(u_x**2 * box_var)
+        var_y = np.sum(u_y**2 * box_var)
+        cov_xy = np.sum(u_x * u_y * box_var)
+        return var_x, var_y, cov_xy
 
     @cached_property
     @use_detcat
     def _centroid_quad_results(self):
         """
-        The quadratic centroid coordinates, relative to the cutout
-        data, and their 1-sigma errors as a 2D array with columns
-        ``(x, y, xerr, yerr)`` and shape ``(n_labels, 4)``.
+        The quadratic centroid coordinates, relative to the cutout data,
+        and their error variances and covariance as a 2D array with
+        columns ``(x, y, var_x, var_y, cov_xy)`` and shape ``(n_labels,
+        5)``.
 
         This is the single computation behind `cutout_centroid_quad`,
         `centroid_quad`, and `centroid_quad_err`. See
@@ -2432,7 +2439,7 @@ class SourceCatalog:
         compute_err = self._error is not None
 
         _nan = np.nan
-        nan_result = (_nan, _nan, _nan, _nan)
+        nan_result = (_nan, _nan, _nan, _nan, _nan)
         results = []
 
         cutouts = self._data_cutouts
@@ -2463,7 +2470,8 @@ class SourceCatalog:
             # If peak at edge of cutout, return peak position. No fit
             # is performed, so no errors can be propagated.
             if xidx == 0 or xidx == nx - 1 or yidx == 0 or yidx == ny - 1:
-                results.append((float(xidx), float(yidx), _nan, _nan))
+                results.append((float(xidx), float(yidx), _nan, _nan,
+                                _nan))
                 continue
 
             # Extract 3x3 box centered on peak (guaranteed to fit
@@ -2492,7 +2500,7 @@ class SourceCatalog:
                 results.append(nan_result)
                 continue
 
-            var_x = var_y = _nan
+            var_x = var_y = cov_xy = _nan
             if compute_err:
                 # Pixel variances of the fit box; masked pixels have
                 # a fixed (zeroed) data value, so they contribute no
@@ -2501,24 +2509,24 @@ class SourceCatalog:
                            .astype(float).ravel()**2)
                 box_var[mask[yidx0:yidx0 + 3,
                              xidx0:xidx0 + 3].ravel()] = 0.0
-                var_x, var_y = self._centroid_quad_var(c, xm_rel, ym_rel,
-                                                       pinv, box_var)
+                var_x, var_y, cov_xy = self._centroid_quad_var(
+                    c, xm_rel, ym_rel, pinv, box_var)
 
-            results.append((xm, ym, var_x, var_y))
+            results.append((xm, ym, var_x, var_y, cov_xy))
 
         results = np.array(results)
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            results[:, 2:4] = np.sqrt(results[:, 2:4])
 
         # Use the segment barycenter if the fit returned NaN. Fallback
         # sources use the isophotal centroid, so also use the isophotal
-        # centroid errors.
+        # centroid error covariance.
         nan_mask = (np.isnan(results[:, 0]) | np.isnan(results[:, 1]))
         if np.any(nan_mask):
             cutout_centroid = self._array('cutout_centroid')
             results[nan_mask, 0:2] = cutout_centroid[nan_mask]
-            results[nan_mask, 2:4] = self._array('centroid_err')[nan_mask]
+            iso_cov = self._centroid_err_cov
+            results[nan_mask, 2] = iso_cov[nan_mask, 0, 0]
+            results[nan_mask, 3] = iso_cov[nan_mask, 1, 1]
+            results[nan_mask, 4] = iso_cov[nan_mask, 0, 1]
 
         return results
 
@@ -2618,7 +2626,29 @@ class SourceCatalog:
         maximum data value is at the edge of the source segment (where
         the position of the maximum pixel is returned instead of a fit).
         """
-        return self._centroid_quad_results[:, 2:4].copy()
+        results = self._centroid_quad_results
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            return np.sqrt(results[:, 2:4])
+
+    @cached_property
+    @use_detcat
+    def _centroid_quad_err_cov(self):
+        """
+        The ``(n_labels, 2, 2)`` pixel error covariance matrices of the
+        quadratic centroid, ``[[var_x, cov_xy], [cov_xy, var_y]]``.
+
+        Fallback sources hold the isophotal covariance (see
+        ``_centroid_err_cov``); matrices are all-NaN where errors are
+        unavailable.
+        """
+        results = self._centroid_quad_results
+        cov = np.empty((len(results), 2, 2))
+        cov[:, 0, 0] = results[:, 2]
+        cov[:, 1, 1] = results[:, 3]
+        cov[:, 0, 1] = results[:, 4]
+        cov[:, 1, 0] = results[:, 4]
+        return cov
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1634,6 +1634,77 @@ class SourceCatalog:
 
     @cached_property
     @use_detcat
+    def _centroid_err_cov(self):
+        """
+        The ``(n_labels, 2, 2)`` pixel error covariance matrices of the
+        isophotal centroid, ``[[var_x, cov_xy], [cov_xy, var_y]]``.
+
+        The matrices are all-NaN where the errors cannot be computed (no
+        ``error`` input or non-positive total flux). See `centroid_err`
+        for the propagation details.
+        """
+        if self._error is None:
+            return np.full((self.n_labels, 2, 2), np.nan)
+
+        cutout_centroid = self._array('cutout_centroid')
+        is_singular = self._singular_covariance_mask
+
+        var_arr = []
+        pixel_var = 1.0 / 12.0
+        for (moment_data, error_cutout, total_mask, xcen, ycen,
+             singular) in zip(
+                self._moment_data_cutouts, self._error_cutouts,
+                self._cutout_total_masks, cutout_centroid[:, 0],
+                cutout_centroid[:, 1], is_singular, strict=True):
+
+            total_flux = np.sum(moment_data)
+            if not np.isfinite(total_flux) or total_flux <= 0:
+                var_arr.append((np.nan, np.nan, np.nan))
+                continue
+
+            err_sq = error_cutout.astype(float)**2
+            # Zero the variance at masked pixels and at pixels that
+            # were excluded from the moment data (e.g., non-finite or
+            # negative convolved values), so that pixels that do not
+            # contribute flux weight also do not contribute error
+            # variance.
+            err_sq[total_mask | (moment_data == 0)] = 0.0
+
+            yy, xx = np.mgrid[0:err_sq.shape[0], 0:err_sq.shape[1]]
+            dx = xx - xcen
+            dy = yy - ycen
+
+            # Propagate the error through the centroid formula.
+            norm = 1.0 / (total_flux**2)
+            err_var_x = np.sum(err_sq * dx**2) * norm
+            err_var_y = np.sum(err_sq * dy**2) * norm
+            err_cov_xy = np.sum(err_sq * dx * dy) * norm
+
+            # Singularity correction for point-like sources. If the
+            # error covariance matrix is nearly singular, add the
+            # variance of a uniform
+            # distribution across a single pixel (1/12) scaled by the
+            # summed pixel variance. The correction is added to the
+            # variances only, never to the covariance.
+            if singular:
+                err_sum_norm = np.sum(err_sq) * pixel_var * norm
+                if (err_var_x * err_var_y
+                        - err_cov_xy**2) < err_sum_norm**2:
+                    err_var_x += err_sum_norm
+                    err_var_y += err_sum_norm
+
+            var_arr.append((err_var_x, err_var_y, err_cov_xy))
+
+        var_arr = np.array(var_arr)
+        cov = np.empty((len(var_arr), 2, 2))
+        cov[:, 0, 0] = var_arr[:, 0]
+        cov[:, 1, 1] = var_arr[:, 1]
+        cov[:, 0, 1] = var_arr[:, 2]
+        cov[:, 1, 0] = var_arr[:, 2]
+        return cov
+
+    @cached_property
+    @use_detcat
     def centroid_err(self):
         """
         The ``(x, y)`` 1-sigma errors on the `centroid` position.
@@ -1655,60 +1726,8 @@ class SourceCatalog:
         :math:`\\sum_i \\sigma_i^2 / (12 F^2)` is added to the variances
         if the error covariance matrix is itself nearly singular.
         """
-        if self._error is None:
-            return np.full((self.n_labels, 2), np.nan)
-
-        cutout_centroid = self._array('cutout_centroid')
-        is_singular = self._singular_covariance_mask
-
-        xerr_arr = []
-        yerr_arr = []
-        pixel_var = 1.0 / 12.0
-        for (moment_data, error_cutout, total_mask, xcen, ycen,
-             singular) in zip(
-                self._moment_data_cutouts, self._error_cutouts,
-                self._cutout_total_masks, cutout_centroid[:, 0],
-                cutout_centroid[:, 1], is_singular, strict=True):
-
-            total_flux = np.sum(moment_data)
-            if not np.isfinite(total_flux) or total_flux <= 0:
-                xerr_arr.append(np.nan)
-                yerr_arr.append(np.nan)
-                continue
-
-            err_sq = error_cutout.astype(float)**2
-            # Zero the variance at masked pixels and at pixels that
-            # were excluded from the moment data (e.g., non-finite or
-            # negative convolved values), so that pixels that do not
-            # contribute flux weight also do not contribute error
-            # variance.
-            err_sq[total_mask | (moment_data == 0)] = 0.0
-
-            yy, xx = np.mgrid[0:err_sq.shape[0], 0:err_sq.shape[1]]
-            dx = xx - xcen
-            dy = yy - ycen
-
-            # Propagate the error through the centroid formula.
-            norm = 1.0 / (total_flux**2)
-            err_var_x = np.sum(err_sq * dx**2) * norm
-            err_var_y = np.sum(err_sq * dy**2) * norm
-
-            # Singularity correction for point-like sources. If the
-            # error covariance matrix is nearly singular, add the
-            # variance of a uniform distribution across a single
-            # pixel (1/12) scaled by the summed pixel variance.
-            if singular:
-                err_sum_norm = np.sum(err_sq) * pixel_var * norm
-                err_cov_xy = np.sum(err_sq * dx * dy) * norm
-                if (err_var_x * err_var_y
-                        - err_cov_xy**2) < err_sum_norm**2:
-                    err_var_x += err_sum_norm
-                    err_var_y += err_sum_norm
-
-            xerr_arr.append(np.sqrt(err_var_x))
-            yerr_arr.append(np.sqrt(err_var_y))
-
-        return np.transpose((xerr_arr, yerr_arr))
+        cov = self._centroid_err_cov
+        return np.sqrt(np.stack((cov[:, 0, 0], cov[:, 1, 1]), axis=1))
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -2730,6 +2730,55 @@ class SourceCatalog:
 
     @cached_property
     @use_detcat
+    def sky_centroid_err(self):
+        """
+        The 1-sigma errors on the `sky_centroid` position as a ``(east,
+        north)`` `~astropy.units.Quantity` in arcsec.
+
+        The pixel error covariance of the `centroid` is transported
+        to the local tangent plane with the WCS Jacobian evaluated
+        at each source position. The first column is the error
+        along East (the Right Ascension direction as a great-circle
+        angle, i.e., including the cos(dec) factor) and the second
+        is along North (Declination).
+
+        `None` if ``wcs`` is not input. NaN where the pixel errors are
+        unavailable (e.g., no ``error`` input).
+        """
+        if self.wcs is None:
+            return self._null_objects
+        xycen = self._array('centroid')
+        return self._sky_err_from_cov(self._centroid_err_cov, xycen)
+
+    @cached_property
+    @use_detcat
+    def sky_centroid_ra_err(self):
+        """
+        The 1-sigma error on the `sky_centroid` position along the Right
+        Ascension direction, as a great-circle angle in arcsec (i.e.,
+        including the cos(dec) factor).
+
+        `None` if ``wcs`` is not input.
+        """
+        if self.wcs is None:
+            return self._null_objects
+        return self._array('sky_centroid_err')[:, 0]
+
+    @cached_property
+    @use_detcat
+    def sky_centroid_dec_err(self):
+        """
+        The 1-sigma error on the `sky_centroid` position along the
+        Declination direction, in arcsec.
+
+        `None` if ``wcs`` is not input.
+        """
+        if self.wcs is None:
+            return self._null_objects
+        return self._array('sky_centroid_err')[:, 1]
+
+    @cached_property
+    @use_detcat
     def sky_centroid_icrs(self):
         """
         The sky coordinate in the International Celestial Reference
@@ -2761,6 +2810,57 @@ class SourceCatalog:
 
     @cached_property
     @use_detcat
+    def sky_centroid_win_err(self):
+        """
+        The 1-sigma errors on the `sky_centroid_win` position as a
+        ``(east, north)`` `~astropy.units.Quantity` in arcsec.
+
+        The pixel error covariance of the `centroid_win` is transported
+        to the local tangent plane with the WCS Jacobian evaluated at
+        each source position. The first column is the error along East
+        (the Right Ascension direction as a great-circle angle, i.e.,
+        including the cos(dec) factor) and the second is along North
+        (Declination). Fallback sources use the isophotal centroid error
+        covariance.
+
+        `None` if ``wcs`` is not input. NaN where the pixel errors are
+        unavailable (e.g., no ``error`` input).
+        """
+        if self.wcs is None:
+            return self._null_objects
+        xycen = self._array('centroid_win')
+        return self._sky_err_from_cov(self._centroid_win_err_cov,
+                                      xycen)
+
+    @cached_property
+    @use_detcat
+    def sky_centroid_win_ra_err(self):
+        """
+        The 1-sigma error on the `sky_centroid_win` position along the
+        Right Ascension direction, as a great-circle angle in arcsec
+        (i.e., including the cos(dec) factor).
+
+        `None` if ``wcs`` is not input.
+        """
+        if self.wcs is None:
+            return self._null_objects
+        return self._array('sky_centroid_win_err')[:, 0]
+
+    @cached_property
+    @use_detcat
+    def sky_centroid_win_dec_err(self):
+        """
+        The 1-sigma error on the `sky_centroid_win` position along the
+        Declination direction, in arcsec.
+
+        `None` if ``wcs`` is not input.
+        """
+        if self.wcs is None:
+            return self._null_objects
+        return self._array('sky_centroid_win_err')[:, 1]
+
+    @cached_property
+    @use_detcat
     def sky_centroid_quad(self):
         """
         The sky coordinate of the centroid (`centroid_quad`), calculated
@@ -2775,6 +2875,57 @@ class SourceCatalog:
             return self._null_objects
         return self.wcs.pixel_to_world(self.x_centroid_quad,
                                        self.y_centroid_quad)
+
+    @cached_property
+    @use_detcat
+    def sky_centroid_quad_err(self):
+        """
+        The 1-sigma errors on the `sky_centroid_quad` position as a
+        ``(east, north)`` `~astropy.units.Quantity` in arcsec.
+
+        The pixel error covariance of the `centroid_quad` is transported
+        to the local tangent plane with the WCS Jacobian evaluated at
+        each source position. The first column is the error along East
+        (the Right Ascension direction as a great-circle angle, i.e.,
+        including the cos(dec) factor) and the second is along North
+        (Declination). Fallback sources use the isophotal centroid error
+        covariance.
+
+        `None` if ``wcs`` is not input. NaN where the pixel errors are
+        unavailable (e.g., no ``error`` input).
+        """
+        if self.wcs is None:
+            return self._null_objects
+        xycen = self._array('centroid_quad')
+        return self._sky_err_from_cov(self._centroid_quad_err_cov,
+                                      xycen)
+
+    @cached_property
+    @use_detcat
+    def sky_centroid_quad_ra_err(self):
+        """
+        The 1-sigma error on the `sky_centroid_quad` position along the
+        Right Ascension direction, as a great-circle angle in arcsec
+        (i.e., including the cos(dec) factor).
+
+        `None` if ``wcs`` is not input.
+        """
+        if self.wcs is None:
+            return self._null_objects
+        return self._array('sky_centroid_quad_err')[:, 0]
+
+    @cached_property
+    @use_detcat
+    def sky_centroid_quad_dec_err(self):
+        """
+        The 1-sigma error on the `sky_centroid_quad` position along the
+        Declination direction, in arcsec.
+
+        `None` if ``wcs`` is not input.
+        """
+        if self.wcs is None:
+            return self._null_objects
+        return self._array('sky_centroid_quad_err')[:, 1]
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2515,6 +2515,56 @@ def test_centroid_win_err_singularity():
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
+def test_centroid_win_err_cov():
+    """
+    Test the windowed pixel error covariance: symmetric for every
+    source, near-zero off-diagonal for a circular source with uniform
+    errors, and consistent with centroid_win_err.
+    """
+    yy, xx = np.mgrid[0:31, 0:31]
+    data = Gaussian2D(500.0, 15.2, 15.6, 2.5, 2.5)(xx, yy)
+    error = np.full(data.shape, 5.0)
+    segment_map = detect_sources(data, 10.0, n_pixels=10)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, aperture_mask_method='none')
+
+    cov = cat._centroid_win_err_cov
+    assert cov.shape == (1, 2, 2)
+    assert_allclose(cov[0, 0, 1], cov[0, 1, 0])
+    # Circular source, uniform errors: negligible x-y covariance
+    assert abs(cov[0, 0, 1]) < 1e-3 * np.sqrt(cov[0, 0, 0]
+                                              * cov[0, 1, 1])
+    # Errors are the sqrt of the diagonal
+    assert_allclose(cat.centroid_win_err[0],
+                    np.sqrt((cov[0, 0, 0], cov[0, 1, 1])))
+
+
+def test_centroid_win_err_cov_fallback():
+    """
+    Test that fallback sources use the full isophotal covariance.
+    """
+    g1 = Gaussian2D(1621, 6.29, 10.95, 1.55, 1.29, 0.296706)
+    g2 = Gaussian2D(3596, 13.81, 8.29, 1.44, 1.27, 0.628319)
+    yy, xx = np.mgrid[0:21, 0:21]
+    data = (g1 + g2)(xx, yy)
+    data += make_noise_image(data.shape, mean=0, stddev=65.0,
+                             seed=123)
+    error = np.full(data.shape, 65.0)
+    kernel = make_2dgaussian_kernel(3.0, size=5)
+    convolved_data = convolve(data, kernel)
+    finder = SourceFinder(n_pixels=10, progress_bar=False)
+    segment_map = finder(convolved_data, 107.9)
+    cat = SourceCatalog(data, segment_map,
+                        convolved_data=convolved_data, error=error,
+                        aperture_mask_method='none')
+
+    # Source 1 falls back to the isophotal centroid (pinned by the
+    # existing test_centroid_win_err test)
+    assert_allclose(cat.centroid_win[1], cat.centroid[1])
+    assert_allclose(cat._centroid_win_err_cov[1],
+                    cat._centroid_err_cov[1])
+
+
 def test_centroid_err():
     """
     Test that centroid_err returns finite 1-sigma position errors

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2947,6 +2947,64 @@ def test_centroid_quad_err_columns():
     assert single.y_centroid_quad_err == errors[1]
 
 
+def test_centroid_quad_err_cov():
+    """
+    Test the quadratic-centroid error covariance against a
+    numerical-Jacobian propagation (cov = sum(Jx * Jy * sigma^2)).
+    """
+    yy, xx = np.mgrid[0:25, 0:25]
+    data = Gaussian2D(100.0, 12.2, 12.6, 2.0, 1.5, 0.5)(xx, yy)
+    rng = np.random.default_rng(42)
+    error = rng.uniform(1.0, 3.0, data.shape)
+
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[6:20, 6:20] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, aperture_mask_method='none')
+
+    cov = cat._centroid_quad_err_cov
+    assert cov.shape == (1, 2, 2)
+    assert_allclose(cov[0, 0, 1], cov[0, 1, 0])
+
+    # Numerical Jacobian over the 3x3 box around the peak pixel
+    # (12, 13), reusing the independent _quad_peak helper defined
+    # earlier in this test module
+    yidx, xidx = 13, 12
+    box = data[yidx - 1:yidx + 2, xidx - 1:xidx + 2]
+    box_err = error[yidx - 1:yidx + 2, xidx - 1:xidx + 2].ravel()
+    eps = 1e-6
+    jacobian = np.zeros((2, 9))
+    for i in range(9):
+        bp = box.ravel().copy()
+        bp[i] += eps
+        bm = box.ravel().copy()
+        bm[i] -= eps
+        jacobian[:, i] = (_quad_peak(bp) - _quad_peak(bm)) / (2 * eps)
+    var_expected = np.sum(jacobian**2 * box_err**2, axis=1)
+    cov_expected = np.sum(jacobian[0] * jacobian[1] * box_err**2)
+    assert_allclose(cov[0],
+                    [[var_expected[0], cov_expected],
+                     [cov_expected, var_expected[1]]], rtol=1e-6)
+
+
+def test_centroid_quad_err_cov_fallback():
+    """
+    Test that quad fallback sources use the isophotal covariance.
+    """
+    data = np.ones((11, 11))
+    data[5, 5] = 10.0
+    error = np.full(data.shape, 1.0)
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[5:7, 5:7] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, aperture_mask_method='none')
+    assert_allclose(cat.centroid_quad, cat.centroid)
+    assert_allclose(cat._centroid_quad_err_cov,
+                    cat._centroid_err_cov)
+
+
 class TestPartialPixelErrorWeights:
     """
     Tests that aperture flux errors weight the pixel variances by the

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -3049,6 +3049,98 @@ def test_sky_err_from_cov():
     assert np.all(np.isnan(sky_err_nan.value))
 
 
+def test_sky_centroid_err():
+    """
+    Test the sky centroid error properties for all three centroid
+    flavors: shapes, units, axis views, and consistency with the pixel
+    errors for an axis-aligned WCS at dec=0.
+    """
+    scale = 0.5  # arcsec / pixel
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    wcs.wcs.crpix = [15.0, 15.0]
+    wcs.wcs.crval = [150.0, 0.0]
+    wcs.wcs.cd = (scale / 3600.0) * np.array([[-1.0, 0.0],
+                                              [0.0, 1.0]])
+
+    yy, xx = np.mgrid[0:31, 0:31]
+    data = Gaussian2D(500.0, 15.2, 15.6, 2.5, 2.0, 0.3)(xx, yy)
+    error = np.full(data.shape, 5.0)
+    segment_map = detect_sources(data, 10.0, n_pixels=10)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, wcs=wcs,
+                        aperture_mask_method='none')
+
+    for prefix, pix_err in (('sky_centroid', cat.centroid_err),
+                            ('sky_centroid_win',
+                             cat.centroid_win_err),
+                            ('sky_centroid_quad',
+                             cat.centroid_quad_err)):
+        sky_err = getattr(cat, f'{prefix}_err')
+        assert sky_err.unit == u.arcsec
+        assert sky_err.shape == (1, 2)
+        # Axis-aligned WCS at dec=0: sky error = scale * pixel error
+        assert_allclose(sky_err.to_value('arcsec')[0],
+                        scale * pix_err[0], rtol=1e-3)
+        assert_allclose(getattr(cat, f'{prefix}_ra_err'),
+                        sky_err[:, 0])
+        assert_allclose(getattr(cat, f'{prefix}_dec_err'),
+                        sky_err[:, 1])
+
+
+def test_sky_centroid_err_no_wcs():
+    """
+    Test that the sky error properties are None without a wcs.
+    """
+    data = np.zeros((11, 11))
+    data[4:7, 4:7] = 10.0
+    segment_map = SegmentationImage((data > 0).astype(int))
+    error = np.ones(data.shape)
+    cat = SourceCatalog(data, segment_map, error=error)
+
+    names = []
+    for prefix in ('sky_centroid', 'sky_centroid_win',
+                   'sky_centroid_quad'):
+        names.extend([f'{prefix}_err', f'{prefix}_ra_err',
+                      f'{prefix}_dec_err'])
+    for name in names:
+        # A length-1 (non-scalar) catalog returns an array of None
+        value = getattr(cat, name)
+        assert np.all(value == np.array(None))
+        # A scalar catalog collapses to a single None
+        assert getattr(cat[0], name) is None
+
+
+def test_sky_centroid_err_columns():
+    """
+    Test sky error columns in to_table and the scalar collapse.
+    """
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    wcs.wcs.crpix = [15.0, 15.0]
+    wcs.wcs.crval = [150.0, 20.0]
+    wcs.wcs.cd = (0.5 / 3600.0) * np.array([[-1.0, 0.0],
+                                            [0.0, 1.0]])
+
+    yy, xx = np.mgrid[0:31, 0:31]
+    data = Gaussian2D(500.0, 15.2, 15.6, 2.5, 2.5)(xx, yy)
+    error = np.full(data.shape, 5.0)
+    segment_map = detect_sources(data, 10.0, n_pixels=10)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, wcs=wcs,
+                        aperture_mask_method='none')
+
+    columns = ['label', 'sky_centroid_ra_err', 'sky_centroid_dec_err']
+    tbl = cat.to_table(columns=columns)
+    assert tbl.colnames == columns
+    assert tbl['sky_centroid_ra_err'].unit == u.arcsec
+
+    single = cat[0]
+    sky_err = single.sky_centroid_err
+    assert sky_err.shape == (2,)
+    assert single.sky_centroid_ra_err == sky_err[0]
+
+
 class TestPartialPixelErrorWeights:
     """
     Tests that aperture flux errors weight the pixel variances by the

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2708,6 +2708,54 @@ def test_centroid_err_columns():
     assert_allclose(tbl['y_centroid_win_err'], cat.y_centroid_win_err)
 
 
+def test_centroid_err_cov():
+    """
+    Test that the isophotal pixel error covariance matches the analytic
+    formulas, including the off-diagonal term cov = sum(sigma^2 * (x -
+    xc) * (y - yc)) / F^2.
+    """
+    yy, xx = np.mgrid[0:25, 0:25]
+    data = Gaussian2D(100.0, 12.2, 12.6, 2.5, 1.5, 0.7)(xx, yy)
+    error = np.full(data.shape, 3.0)
+
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[4:22, 4:22] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        error=error, aperture_mask_method='none')
+
+    cov = cat._centroid_err_cov
+    assert cov.shape == (1, 2, 2)
+    assert_allclose(cov[0, 0, 1], cov[0, 1, 0])
+
+    mask = segment_data == 1
+    flux = np.sum(data[mask])
+    xcen = np.sum(data[mask] * xx[mask]) / flux
+    ycen = np.sum(data[mask] * yy[mask]) / flux
+    var_x = np.sum(error[mask]**2 * (xx[mask] - xcen)**2) / flux**2
+    var_y = np.sum(error[mask]**2 * (yy[mask] - ycen)**2) / flux**2
+    cov_xy = np.sum(error[mask]**2 * (xx[mask] - xcen)
+                    * (yy[mask] - ycen)) / flux**2
+    assert_allclose(cov[0], [[var_x, cov_xy], [cov_xy, var_y]])
+
+    # The public property is the sqrt of the diagonal
+    assert_allclose(cat.centroid_err[0], np.sqrt((var_x, var_y)))
+
+
+def test_centroid_err_cov_no_error():
+    """
+    Test that the covariance is NaN when error is not input.
+    """
+    data = np.ones((11, 11))
+    data[5, 5] = 10.0
+    segment_data = np.zeros(data.shape, dtype=int)
+    segment_data[4:7, 4:7] = 1
+    segment_map = SegmentationImage(segment_data)
+    cat = SourceCatalog(data, segment_map, convolved_data=data,
+                        aperture_mask_method='none')
+    assert np.all(np.isnan(cat._centroid_err_cov))
+
+
 def _quad_peak(box):
     """
     Solve for the peak of a quadratic fit to a 3x3 box.

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -16,6 +16,7 @@ from astropy.coordinates import SkyCoord
 from astropy.modeling.models import Gaussian2D
 from astropy.table import QTable
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.wcs import WCS
 from numpy.testing import assert_allclose, assert_equal
 from scipy.optimize import root_scalar
 
@@ -31,6 +32,7 @@ from photutils.segmentation.finder import SourceFinder
 from photutils.segmentation.utils import make_2dgaussian_kernel
 from photutils.utils._optional_deps import (HAS_GWCS, HAS_MATPLOTLIB,
                                             HAS_SKIMAGE)
+from photutils.utils._wcs_helpers import compute_pixel_to_sky_jacobians
 from photutils.utils.cutouts import CutoutImage
 
 
@@ -3003,6 +3005,48 @@ def test_centroid_quad_err_cov_fallback():
     assert_allclose(cat.centroid_quad, cat.centroid)
     assert_allclose(cat._centroid_quad_err_cov,
                     cat._centroid_err_cov)
+
+
+def test_sky_err_from_cov():
+    """
+    Test the pixel-to-sky error covariance transport against a
+    hand-rotated covariance for a rotated TAN WCS.
+    """
+    theta_deg = 30.0
+    scale = 0.25  # arcsec / pixel
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    wcs.wcs.crpix = [10.0, 10.0]
+    wcs.wcs.crval = [150.0, 30.0]
+    theta = np.deg2rad(theta_deg)
+    cd = (scale / 3600.0) * np.array([[-np.cos(theta), np.sin(theta)],
+                                      [np.sin(theta), np.cos(theta)]])
+    wcs.wcs.cd = cd
+
+    data = np.zeros((21, 21))
+    data[9:12, 9:12] = 10.0
+    segment_map = SegmentationImage((data > 0).astype(int))
+    cat = SourceCatalog(data, segment_map, wcs=wcs)
+
+    pix_cov = np.array([[[0.04, 0.01], [0.01, 0.09]]])
+    xycen = np.array([[10.0, 10.0]])
+    sky_err = cat._sky_err_from_cov(pix_cov, xycen)
+
+    # Reference: compare against the vectorized Jacobian helper
+    # directly (transport identity), and check the isotropic invariant
+    # trace(sky_cov) = scale^2 * trace(pix_cov)
+    jac = compute_pixel_to_sky_jacobians(xycen[:, 0], xycen[:, 1],
+                                         wcs)
+    sky_cov = jac[0] @ pix_cov[0] @ jac[0].T
+    assert_allclose(sky_err.to_value('arcsec')[0],
+                    np.sqrt(np.diag(sky_cov)))
+    assert_allclose(np.trace(sky_cov),
+                    scale**2 * np.trace(pix_cov[0]), rtol=1e-3)
+
+    # NaN positions give NaN errors
+    xycen_nan = np.array([[np.nan, np.nan]])
+    sky_err_nan = cat._sky_err_from_cov(pix_cov, xycen_nan)
+    assert np.all(np.isnan(sky_err_nan.value))
 
 
 class TestPartialPixelErrorWeights:

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -2541,6 +2541,7 @@ def test_centroid_win_err_cov():
                     np.sqrt((cov[0, 0, 0], cov[0, 1, 1])))
 
 
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_centroid_win_err_cov_fallback():
     """
     Test that fallback sources use the full isophotal covariance.
@@ -2567,6 +2568,7 @@ def test_centroid_win_err_cov_fallback():
                     cat._centroid_err_cov[1])
 
 
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_centroid_err():
     """
     Test that centroid_err returns finite 1-sigma position errors

--- a/photutils/utils/_wcs_helpers.py
+++ b/photutils/utils/_wcs_helpers.py
@@ -375,6 +375,57 @@ def compute_local_wcs_jacobian(skycoord, wcs):
     return np.linalg.inv(forward)
 
 
+def compute_pixel_to_sky_jacobians(x, y, wcs):
+    """
+    Compute local forward WCS Jacobians for an array of pixel positions
+    using 1-pixel finite differences.
+
+    Each 2x2 Jacobian ``F`` maps pixel-coordinate offsets to
+    tangent-plane offsets in arcsec::
+
+        [d_xi, d_eta]^T ~ F @ [dx, dy]^T
+
+    where ``xi`` is the offset along East (the Right Ascension
+    direction, as a great-circle angle) and ``eta`` is the offset along
+    North (the Declination direction). The offsets are computed from the
+    great-circle separation and position angle between the center and
+    each offset point, so the formula is well-defined at the celestial
+    poles and across the longitude wraparound (RA = 0 / 360).
+
+    Parameters
+    ----------
+    x, y : `~numpy.ndarray`
+        The 1D arrays of pixel coordinates.
+
+    wcs : WCS object
+        A world coordinate system (WCS) transformation that
+        supports the `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
+    Returns
+    -------
+    jacobians : `~numpy.ndarray`
+        The (N, 2, 2) array of forward Jacobians in arcsec / pixel, with
+        rows ``(xi, eta)`` and columns ``(x, y)``.
+    """
+    x = np.atleast_1d(x).astype(float)
+    y = np.atleast_1d(y).astype(float)
+
+    sky0 = wcs.pixel_to_world(x, y)
+    sky_x = wcs.pixel_to_world(x + 1.0, y)
+    sky_y = wcs.pixel_to_world(x, y + 1.0)
+
+    arcsec_per_rad = 3600.0 * np.degrees(1)
+    jacobians = np.empty((x.size, 2, 2))
+    for col, sky_offset in enumerate((sky_x, sky_y)):
+        sep = np.atleast_1d(sky0.separation(sky_offset).rad)
+        pa = np.atleast_1d(sky0.position_angle(sky_offset).rad)
+        jacobians[:, 0, col] = sep * np.sin(pa) * arcsec_per_rad
+        jacobians[:, 1, col] = sep * np.cos(pa) * arcsec_per_rad
+    return jacobians
+
+
 def sky_to_pixel_mean_scale(skycoord, wcs):
     """
     Convert a sky region center to pixel coordinates with an isotropic

--- a/photutils/utils/tests/test_wcs_helpers.py
+++ b/photutils/utils/tests/test_wcs_helpers.py
@@ -12,6 +12,7 @@ from astropy.wcs import WCS as APWCS
 from numpy.testing import assert_allclose
 
 from photutils.utils._wcs_helpers import (compute_local_wcs_jacobian,
+                                          compute_pixel_to_sky_jacobians,
                                           jacobian_pixel_to_sky_mean_scale,
                                           jacobian_sky_to_pixel_mean_scale,
                                           pixel_shape_to_sky_svd,
@@ -166,6 +167,50 @@ class TestComputeLocalWCSJacobian:
         skycoord = SkyCoord(center_ra * u.deg, center_dec * u.deg)
         jac = compute_local_wcs_jacobian(skycoord, wcs)
         assert np.linalg.det(jac) < 0
+
+
+def _make_rotated_wcs(rotation_deg, scale_arcsec=0.25,
+                      crval=(150.0, 30.0)):
+    wcs = APWCS(naxis=2)
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    wcs.wcs.crpix = [50.0, 50.0]
+    wcs.wcs.crval = list(crval)
+    theta = np.deg2rad(rotation_deg)
+    scale = scale_arcsec / 3600.0
+    wcs.wcs.cd = scale * np.array(
+        [[-np.cos(theta), np.sin(theta)],
+         [np.sin(theta), np.cos(theta)]])
+    return wcs
+
+
+def test_compute_pixel_to_sky_jacobians():
+    """
+    Test the vectorized forward Jacobians against the inverse of the
+    scalar compute_local_wcs_jacobian at several positions.
+    """
+    wcs = _make_rotated_wcs(30.0)
+    x = np.array([10.0, 50.0, 80.3])
+    y = np.array([20.0, 50.0, 61.7])
+
+    jacs = compute_pixel_to_sky_jacobians(x, y, wcs)
+    assert jacs.shape == (3, 2, 2)
+
+    for i in range(x.size):
+        skycoord = wcs.pixel_to_world(x[i], y[i])
+        jac_inv = compute_local_wcs_jacobian(skycoord, wcs)
+        assert_allclose(jacs[i], np.linalg.inv(jac_inv), rtol=1e-4)
+
+
+def test_compute_pixel_to_sky_jacobians_scale():
+    """
+    Test that an axis-aligned WCS gives |F| entries equal to the pixel
+    scale in arcsec.
+    """
+    wcs = _make_rotated_wcs(0.0, scale_arcsec=0.5, crval=(150.0, 0.0))
+    jacs = compute_pixel_to_sky_jacobians(np.array([50.0]),
+                                          np.array([50.0]), wcs)
+    assert_allclose(np.abs(jacs[0]),
+                    [[0.5, 0.0], [0.0, 0.5]], atol=1e-4)
 
 
 class TestWcsPixelScaleAngle:


### PR DESCRIPTION
This PR adds ``SourceCatalog`` ``sky_centroid_err``, ``sky_centroid_ra_err``, ``sky_centroid_dec_err``, and the corresponding ``sky_centroid_win_*`` and ``sky_centroid_quad_*`` properties providing the 1-sigma sky position errors in arcsec, computed by transporting the pixel centroid error covariance through the local WCS Jacobian.