### PR TITLE
Return a dictionary from decode_flags methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -860,6 +860,17 @@ API Changes
 
 - ``photutils.psf``
 
+  - The ``PSFPhotometry.decode_flags`` and
+    ``IterativePSFPhotometry.decode_flags`` methods now return a
+    dictionary mapping each source id from the results table to its
+    list of active flag names (or bit values), instead of a positional
+    list of lists. This is a backward-incompatible change, made so that
+    decoded flags can be looked up directly by source id (which may not
+    be sequential when custom ids are input) and for consistency with
+    the new aperture and segmentation ``decode_flags`` methods. The
+    module-level ``decode_psf_flags`` function is unchanged and still
+    returns lists. [#2400]
+
   - The ``EPSFBuildResult`` class returned by ``EPSFBuilder`` has been
     renamed to ``EPSFBuildResults``. The old ``EPSFBuildResult`` name is
     deprecated and will be removed in a future version. [#2326]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,7 +101,9 @@ New Features
     conditions from both the "center"-method footprint used by the
     value statistics and the ``sum_method`` footprint used by the sum
     properties. A new ``decode_aperture_flags`` function decodes the
-    flag values into human-readable names. [#2327, #2328, #2362, #2379]
+    flag values into human-readable names, and both classes have a
+    ``decode_flags`` convenience method that returns a dictionary keyed
+    by aperture position id. [#2327, #2328, #2362, #2379, #2400]
 
   - Added validation of the ``ApertureStats.to_table()`` ``columns``
     keyword. [#2329]

--- a/docs/user_guide/aperture.rst
+++ b/docs/user_guide/aperture.rst
@@ -728,9 +728,9 @@ For example::
 
 The flag values can be decoded into human-readable names using the
 :meth:`~photutils.aperture.AperturePhotometry.decode_flags` convenience
-method::
+method, which returns a dictionary keyed by aperture position id::
 
-    >>> for source_id, names in zip(phot.id, phot.decode_flags(), strict=True):
+    >>> for source_id, names in phot.decode_flags().items():
     ...     print(source_id, names)
     1 ['masked_pixels']
     2 ['partial_overlap']
@@ -756,11 +756,11 @@ method::
     >>> aperstats = ApertureStats(data, aperture, mask=mask)
     >>> print(aperstats.flags)
     [8 2 5]
-    >>> for names in aperstats.decode_flags():
-    ...     print(names)
-    ['masked_pixels']
-    ['partial_overlap']
-    ['no_overlap', 'no_pixels']
+    >>> for source_id, names in aperstats.decode_flags().items():
+    ...     print(source_id, names)
+    1 ['masked_pixels']
+    2 ['partial_overlap']
+    3 ['no_overlap', 'no_pixels']
 
 For `~photutils.aperture.ApertureStats`, the value statistics and
 the sum properties are measured on two different footprints, and

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -652,6 +652,22 @@ Removed Deprecations
 Breaking Changes
 ----------------
 
+PSF ``decode_flags`` Methods Return a Dictionary
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :meth:`~photutils.psf.PSFPhotometry.decode_flags` and
+:meth:`~photutils.psf.IterativePSFPhotometry.decode_flags` methods
+now return a dictionary mapping each source id from the results
+table to its list of active flag names (or bit values), instead of a
+positional list of lists. Decoded flags can now be looked up directly
+by source id, which may not be sequential when custom ids are input via
+``init_params``, and the result is consistent with the new aperture
+and segmentation ``decode_flags`` methods. Code that iterated over
+the previous list should iterate over the dictionary's ``.values()``
+(or ``.items()`` to also get the source ids). The module-level
+:func:`~photutils.psf.decode_psf_flags` function is unchanged and still
+returns lists.
+
 WebbPSF ePSF Grid Positions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -508,8 +508,9 @@ The overlap flags are precise. They are based on the pixels with
 nonzero aperture weight, not simply the aperture bounding box. The
 new :func:`~photutils.aperture.decode_aperture_flags` function and
 the :meth:`photutils.aperture.AperturePhotometry.decode_flags` and
-:meth:`photutils.aperture.ApertureStats.decode_flags` methods decode
-flag values into human-readable names::
+:meth:`photutils.aperture.ApertureStats.decode_flags` methods (which
+return a dictionary keyed by aperture position id) decode flag values
+into human-readable names::
 
     >>> import numpy as np
     >>> from photutils.aperture import (AperturePhotometry,

--- a/photutils/aperture/photometry.py
+++ b/photutils/aperture/photometry.py
@@ -543,19 +543,25 @@ class AperturePhotometry:
 
         Returns
         -------
-        decoded : list of list of str or list of list of int
-            A list of the active flag names (or bit values) for each
-            aperture. If a list of apertures was input (2D `flags`),
-            the result is a nested list with the same ``(n_positions,
-            n_apertures)`` shape as `flags`, so ``decoded[i][j]`` gives
-            the active flags for position ``i`` and aperture ``j``.
+        decoded : dict
+            A dictionary mapping each aperture position `id` to its
+            decoded flags. For a single input aperture, each value is
+            the list of active flag names (or bit values) for that
+            position. If a list of apertures was input (2D `flags`),
+            each value is a list with one entry per aperture, so
+            ``decoded[id][j]`` gives the active flags for position
+            ``id`` and aperture ``j``. The entries follow the position
+            order.
 
         See Also
         --------
         photutils.aperture.decode_aperture_flags
         """
-        return decode_aperture_flags(self._array('flags'),
-                                     return_bit_values=return_bit_values)
+        decoded = decode_aperture_flags(self._array('flags'),
+                                        return_bit_values=return_bit_values)
+        return {int(id_): flags
+                for id_, flags in zip(self._array('id'), decoded,
+                                      strict=True)}
 
 
 @_update_method_subpixels_docstring

--- a/photutils/aperture/stats.py
+++ b/photutils/aperture/stats.py
@@ -2167,9 +2167,10 @@ class ApertureStats:
 
         Returns
         -------
-        decoded : list of list of str or list of list of int
-            A list of the active flag names (or bit values) for each
-            source.
+        decoded : dict
+            A dictionary mapping each aperture position `id` to the list
+            of its active flag names (or bit values). The entries follow
+            the position order.
 
         See Also
         --------
@@ -2184,13 +2185,16 @@ class ApertureStats:
         >>> mask[12, 12] = True
         >>> aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
         >>> aperstats = ApertureStats(data, aper, mask=mask)
-        >>> for names in aperstats.decode_flags():
-        ...     print(names)
-        ['masked_pixels']
-        ['partial_overlap']
+        >>> for source_id, names in aperstats.decode_flags().items():
+        ...     print(source_id, names)
+        1 ['masked_pixels']
+        2 ['partial_overlap']
         """
-        return decode_aperture_flags(self._array('flags'),
-                                     return_bit_values=return_bit_values)
+        decoded = decode_aperture_flags(self._array('flags'),
+                                        return_bit_values=return_bit_values)
+        return {int(id_): flags
+                for id_, flags in zip(self._array('id'), decoded,
+                                      strict=True)}
 
     def _get_values(self, array):
         """

--- a/photutils/aperture/tests/test_photometry_class.py
+++ b/photutils/aperture/tests/test_photometry_class.py
@@ -381,8 +381,10 @@ class TestFlagsAndArea:
         aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
         phot = AperturePhotometry(data, aper, mask=mask)
         decoded = phot.decode_flags()
-        assert decoded[0] == ['masked_pixels']
-        assert decoded[1] == ['partial_overlap']
+        assert list(decoded) == [1, 2]
+        assert all(type(key) is int for key in decoded)
+        assert decoded[1] == ['masked_pixels']
+        assert decoded[2] == ['partial_overlap']
 
     def test_decode_flags_bit_values(self):
         data = np.ones((25, 25))
@@ -391,7 +393,20 @@ class TestFlagsAndArea:
         aper = CircularAperture([(12.0, 12.0)], r=3.0)
         phot = AperturePhotometry(data, aper, mask=mask)
         decoded = phot.decode_flags(return_bit_values=True)
-        assert decoded[0] == [8]
+        assert decoded == {1: [8]}
+
+    def test_decode_flags_multiple_apertures(self):
+        data = np.ones((25, 25))
+        mask = np.zeros(data.shape, dtype=bool)
+        mask[12, 12] = True
+        positions = [(12.0, 12.0), (0.0, 12.0)]
+        apers = [CircularAperture(positions, r=3.0),
+                 CircularAperture(positions, r=5.0)]
+        phot = AperturePhotometry(data, apers, mask=mask)
+        decoded = phot.decode_flags()
+        assert list(decoded) == [1, 2]
+        assert decoded[1] == [['masked_pixels'], ['masked_pixels']]
+        assert decoded[2] == [['partial_overlap'], ['partial_overlap']]
 
 
 class TestScalarBehavior:
@@ -497,7 +512,7 @@ class TestScalarBehavior:
         mask[12, 12] = True
         aper = CircularAperture((12, 12), r=3)
         phot = AperturePhotometry(data, aper, mask=mask)
-        assert phot.decode_flags() == [['masked_pixels']]
+        assert phot.decode_flags() == {1: ['masked_pixels']}
 
     @pytest.mark.parametrize('use_segm_obj', [True, False])
     def test_scalar_input_attributes_not_collapsed(self, use_segm_obj):
@@ -548,7 +563,7 @@ class TestNonFiniteData:
         assert_allclose(phot.flux, aper.area_overlap(data) - 2)
         assert_allclose(phot.area.value, phot.flux)
         assert phot.flags == 32
-        assert phot.decode_flags()[0] == ['non_finite_data']
+        assert phot.decode_flags()[1] == ['non_finite_data']
 
     def test_mask_path_masks_nonfinite(self):
         # Disable the batch Cython driver to exercise the slower
@@ -562,7 +577,7 @@ class TestNonFiniteData:
             phot = AperturePhotometry(data, aper)
             flux = phot.flux
             flags = phot.flags
-            decoded = phot.decode_flags()[0]
+            decoded = phot.decode_flags()[1]
         assert np.isfinite(flux)
         assert_allclose(flux, aper.area_overlap(data) - 2)
         assert flags == 32
@@ -602,7 +617,7 @@ class TestNonFiniteData:
         assert np.isfinite(phot.flux)
         # Both masked_pixels (8) and non_finite_data (32) are set.
         assert phot.flags == 8 | 32
-        assert set(phot.decode_flags()[0]) == {'masked_pixels',
+        assert set(phot.decode_flags()[1]) == {'masked_pixels',
                                                'non_finite_data'}
 
     def test_nonfinite_at_masked_pixel_counts_as_masked(self):

--- a/photutils/aperture/tests/test_stats_flags.py
+++ b/photutils/aperture/tests/test_stats_flags.py
@@ -404,15 +404,16 @@ class TestFlagsAPI:
         aper = CircularAperture([(12.0, 12.0), (0.0, 12.0)], r=3.0)
         stats = ApertureStats(data, aper, mask=mask)
         decoded = stats.decode_flags()
-        assert decoded == [['masked_pixels'], ['partial_overlap']]
+        assert decoded == {1: ['masked_pixels'], 2: ['partial_overlap']}
+        assert all(type(key) is int for key in decoded)
 
         decoded = stats.decode_flags(return_bit_values=True)
-        assert decoded == [[APERTURE_FLAGS.MASKED_PIXELS],
-                           [APERTURE_FLAGS.PARTIAL_OVERLAP]]
+        assert decoded == {1: [APERTURE_FLAGS.MASKED_PIXELS],
+                           2: [APERTURE_FLAGS.PARTIAL_OVERLAP]}
 
-        # Scalar ApertureStats also returns a list of lists
+        # Scalar ApertureStats also returns a dictionary
         stats = ApertureStats(data, CircularAperture((0.0, 12.0), r=3.0))
-        assert stats.decode_flags() == [['partial_overlap']]
+        assert stats.decode_flags() == {1: ['partial_overlap']}
 
     def test_decode_flags_no_column_keyword(self, unit_data):
         """
@@ -424,7 +425,7 @@ class TestFlagsAPI:
         match = 'unexpected keyword'
         with pytest.raises(TypeError, match=match):
             stats.decode_flags(column='flags')
-        assert stats.decode_flags() == [[]]
+        assert stats.decode_flags() == {1: []}
 
     def test_flags_docstring(self):
         """
@@ -451,7 +452,7 @@ class TestSingularCovariance:
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
         assert (stats.flags & APERTURE_FLAGS.SINGULAR_COVARIANCE) != 0
-        assert 'singular_covariance' in stats.decode_flags()[0]
+        assert 'singular_covariance' in stats.decode_flags()[1]
 
     @pytest.mark.usefixtures('maybe_mask_path')
     def test_array_and_guards(self):
@@ -585,7 +586,7 @@ class TestUndefinedShape:
         aper = CircularAperture((12.0, 12.0), r=5.0)
         stats = ApertureStats(data, aper)
         assert (stats.flags & APERTURE_FLAGS.UNDEFINED_SHAPE) != 0
-        assert 'undefined_shape' in stats.decode_flags()[0]
+        assert 'undefined_shape' in stats.decode_flags()[1]
         assert np.all(np.isnan(stats.centroid))
 
     @pytest.mark.usefixtures('maybe_mask_path')

--- a/photutils/psf/iterative.py
+++ b/photutils/psf/iterative.py
@@ -702,11 +702,15 @@ class IterativePSFPhotometry:
 
         Returns
         -------
-        decoded : list of list of str or list of list of int
-            List of lists where each inner list contains the active flag
-            names (or bit values) for the corresponding source in the
-            results table. If no flags are set for a source, an empty
-            list is returned for that source.
+        decoded : dict
+            A dictionary mapping each source id from the results table
+            to the list of its active flag names (or bit values). If no
+            flags are set for a source, its value is an empty list. The
+            entries follow the results-table order.
+
+            .. versionchanged:: 3.1
+                The result is now a dictionary keyed by source id.
+                Previously, a positional list of lists was returned.
 
         Raises
         ------
@@ -741,9 +745,8 @@ class IterativePSFPhotometry:
         ...                                     aperture_radius=4,
         ...                                     maxiters=1)
         >>> results = photometry(data, init_params=init_params)
-        >>> decoded_flags = photometry.decode_flags()
-        >>> for i, flags in enumerate(decoded_flags):
-        ...     print(f'Source {i+1}: {flags}')  # doctest: +SKIP
+        >>> for source_id, flags in photometry.decode_flags().items():
+        ...     print(f'Source {source_id}: {flags}')  # doctest: +SKIP
         Source 1: []
         Source 2: ['negative_flux']
         """
@@ -752,8 +755,11 @@ class IterativePSFPhotometry:
                    'IterativePSFPhotometry instance first.')
             raise ValueError(msg)
 
-        return decode_psf_flags(self.results['flags'],
-                                return_bit_values=return_bit_values)
+        decoded = decode_psf_flags(self.results['flags'],
+                                   return_bit_values=return_bit_values)
+        return {int(id_): flags
+                for id_, flags in zip(self.results['id'], decoded,
+                                      strict=True)}
 
     def _get_model_image_params(self):
         # Convert fitted parameters to model parameter names without

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1896,11 +1896,15 @@ class PSFPhotometry:
 
         Returns
         -------
-        decoded : list of list of str or list of list of int
-            List of lists where each inner list contains the active flag
-            names (or bit values) for the corresponding source in the
-            results table. If no flags are set for a source, an empty
-            list is returned for that source.
+        decoded : dict
+            A dictionary mapping each source id from the results table
+            to the list of its active flag names (or bit values). If no
+            flags are set for a source, its value is an empty list. The
+            entries follow the results-table order.
+
+            .. versionchanged:: 3.1
+                The result is now a dictionary keyed by source id.
+                Previously, a positional list of lists was returned.
 
         Raises
         ------
@@ -1929,9 +1933,8 @@ class PSFPhotometry:
         ...                      'flux': [100, 100]})
         >>> photometry = PSFPhotometry(psf_model, (3, 3))
         >>> results = photometry(data, init_params=init_params)
-        >>> decoded_flags = photometry.decode_flags()
-        >>> for i, flags in enumerate(decoded_flags):
-        ...     print(f'Source {i+1}: {flags}')  # doctest: +SKIP
+        >>> for source_id, flags in photometry.decode_flags().items():
+        ...     print(f'Source {source_id}: {flags}')  # doctest: +SKIP
         Source 1: []
         Source 2: ['negative_flux']
         """
@@ -1940,8 +1943,11 @@ class PSFPhotometry:
                    'instance first.')
             raise ValueError(msg)
 
-        return decode_psf_flags(self.results['flags'],
-                                return_bit_values=return_bit_values)
+        decoded = decode_psf_flags(self.results['flags'],
+                                   return_bit_values=return_bit_values)
+        return {int(id_): flags
+                for id_, flags in zip(self.results['id'], decoded,
+                                      strict=True)}
 
     def _get_model_image_params(self):
         # Convert fitted parameters to model parameter names without

--- a/photutils/psf/tests/test_iterative.py
+++ b/photutils/psf/tests/test_iterative.py
@@ -813,29 +813,31 @@ def test_decode_flags():
     # Test decode_flags method
     decoded_flags = psfphot.decode_flags()
 
-    # Check that we get a list of lists
-    assert isinstance(decoded_flags, list)
+    # Check that we get a dictionary keyed by source id
+    assert isinstance(decoded_flags, dict)
     assert len(decoded_flags) == len(results)
+    assert list(decoded_flags) == list(results['id'])
+    assert all(type(key) is int for key in decoded_flags)
 
-    # Each element should be a list of strings
-    for decoded in decoded_flags:
+    # Each value should be a list of strings
+    for decoded in decoded_flags.values():
         assert isinstance(decoded, list)
         for flag_name in decoded:
             assert isinstance(flag_name, str)
 
     # Check that the first source has no flags or minimal flags
     # (depending on fitting success)
-    assert isinstance(decoded_flags[0], list)
+    assert isinstance(decoded_flags[1], list)
 
     # Check that the second source has the negative_flux flag
-    assert 'negative_flux' in decoded_flags[1]
+    assert 'negative_flux' in decoded_flags[2]
 
     # Check that the third source has flags (it's outside the image
     # bounds). It should have 'no_overlap' since it's completely outside.
-    assert len(decoded_flags[2]) > 0
-    assert 'no_overlap' in decoded_flags[2]
+    assert len(decoded_flags[3]) > 0
+    assert 'no_overlap' in decoded_flags[3]
 
     # Verify that decode_flags gives the same result as calling
     # decode_psf_flags directly
     direct_decoded = decode_psf_flags(results['flags'])
-    assert decoded_flags == direct_decoded
+    assert list(decoded_flags.values()) == direct_decoded

--- a/photutils/psf/tests/test_photometry.py
+++ b/photutils/psf/tests/test_photometry.py
@@ -2434,33 +2434,42 @@ def test_decode_flags():
     # Test decode_flags method
     decoded_flags = psfphot.decode_flags()
 
-    # Check that we get a list of lists
-    assert isinstance(decoded_flags, list)
+    # Check that we get a dictionary keyed by source id
+    assert isinstance(decoded_flags, dict)
     assert len(decoded_flags) == len(results)
+    assert list(decoded_flags) == list(results['id'])
+    assert all(type(key) is int for key in decoded_flags)
 
-    # Each element should be a list of strings
-    for decoded in decoded_flags:
+    # Each value should be a list of strings
+    for decoded in decoded_flags.values():
         assert isinstance(decoded, list)
         for flag_name in decoded:
             assert isinstance(flag_name, str)
 
     # Check that the first source has no flags or minimal flags
     # (depending on fitting success)
-    assert isinstance(decoded_flags[0], list)
+    assert isinstance(decoded_flags[1], list)
 
     # Check that the second source has the negative_flux flag
-    assert 'negative_flux' in decoded_flags[1]
+    assert 'negative_flux' in decoded_flags[2]
 
     # Check that the third source has flags (it's outside the image
     # bounds). It should have 'no_overlap' since it's completely
     # outside.
-    assert len(decoded_flags[2]) > 0
-    assert 'no_overlap' in decoded_flags[2]
+    assert len(decoded_flags[3]) > 0
+    assert 'no_overlap' in decoded_flags[3]
 
     # Verify that decode_flags gives the same result as calling
     # decode_psf_flags directly
     direct_decoded = decode_psf_flags(results['flags'])
-    assert decoded_flags == direct_decoded
+    assert list(decoded_flags.values()) == direct_decoded
+
+    # Custom, non-sequential ids key the decoded dictionary
+    init_params['id'] = [7, 3, 11]
+    results2 = psfphot(data, init_params=init_params)
+    decoded2 = psfphot.decode_flags()
+    assert list(decoded2) == list(results2['id'])
+    assert 'negative_flux' in decoded2[3]
 
 
 def test_int_mask_matches_bool_mask():


### PR DESCRIPTION
This PR changes the `ApertureStats`, `AperturePhotometry`, `PSFPhotometry`, and `IterativePSFPhotometry` `decode_flags` convenience methods to return a dictionary keyed by aperture position id or source id.  The changes to the PSF photometry classes are breaking changes.