### PR TITLE
Add bitwise quality flags for segmentation package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -257,6 +257,16 @@ New Features
     computed by transporting the pixel centroid error covariance through
     the local WCS Jacobian. [#2399]
 
+  - Added a bitwise quality-flag system for segmentation. A new public
+    ``SEGMENTATION_FLAGS`` registry and ``decode_segmentation_flags``
+    function were added. ``SegmentationImage`` objects now have a
+    ``flags`` attribute with per-label flags, ``deblend_sources``
+    records per-source deblending provenance flags, and
+    ``SourceCatalog`` has a new ``flags`` attribute and default table
+    column combining provenance and measurement flags. Flags describing
+    the same condition as an aperture flag share the aperture flag's
+    name, but bit values are package-specific. [#2402]
+
 - ``photutils.utils``
 
   - Added a new ``DeblendWarning`` class, a subclass of astropy's

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -263,9 +263,10 @@ New Features
     ``flags`` attribute with per-label flags, ``deblend_sources``
     records per-source deblending provenance flags, and
     ``SourceCatalog`` has a new ``flags`` attribute and default table
-    column combining provenance and measurement flags. Flags describing
-    the same condition as an aperture flag share the aperture flag's
-    name, but bit values are package-specific. [#2402]
+    column combining provenance and measurement flags, along with a
+    ``decode_flags`` convenience method. Flags describing the same
+    condition as an aperture flag share the aperture flag's name, but
+    bit values are package-specific. [#2402]
 
 - ``photutils.utils``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -264,9 +264,8 @@ New Features
     records per-source deblending provenance flags, and
     ``SourceCatalog`` has a new ``flags`` attribute and default table
     column combining provenance and measurement flags, along with a
-    ``decode_flags`` convenience method. Flags describing the same
-    condition as an aperture flag share the aperture flag's name, but
-    bit values are package-specific. [#2402]
+    ``decode_flags`` convenience method that returns a dictionary keyed
+    by source label. [#2402]
 
 - ``photutils.utils``
 

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -867,13 +867,28 @@ an image boundary, masked or non-finite pixels within the segment,
 undefined or degenerate shape properties, windowed or quadratic
 centroid failures, and Kron-aperture issues (``kron_``-prefixed
 flags). Accessing ``flags`` computes the flagged quantities (moments,
-windowed and quadratic centroids, and Kron photometry) if they
-have not already been computed; the results are cached and shared
-with the corresponding source properties. Flags that describe the same
+windowed and quadratic centroids, and Kron photometry) if they have
+not already been computed; the results are cached and shared with
+the corresponding source properties. Flags that describe the same
 condition as an `~photutils.aperture.ApertureStats` flag, with the
 source segment as the region, use the same flag name. However, the
 bit values are package-specific, so always decode flag values with
-:func:`~photutils.segmentation.decode_segmentation_flags`.
+:func:`~photutils.segmentation.decode_segmentation_flags`. The
+:meth:`~photutils.segmentation.SourceCatalog.decode_flags` convenience
+method decodes the catalog's own flag values::
+
+    >>> import numpy as np
+    >>> from astropy.modeling.models import Gaussian2D
+    >>> from photutils.segmentation import SourceCatalog, detect_sources
+    >>> yy, xx = np.mgrid[0:51, 0:51]
+    >>> data = (Gaussian2D(100, 25, 25, 3, 3)(xx, yy)
+    ...         + Gaussian2D(100, 2, 40, 3, 3)(xx, yy))
+    >>> segm = detect_sources(data, 10, 5)
+    >>> cat = SourceCatalog(data, segm)
+    >>> for names in cat.decode_flags():
+    ...     print(names)
+    []
+    ['edge_touch', 'kron_partial_overlap']
 
 
 API Reference

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -525,20 +525,29 @@ properties are shown below:
     >>> tbl['y_centroid'].info.format = '.2f'
     >>> tbl['kron_flux'].info.format = '.2f'
     >>> print(tbl)
-    label x_centroid y_centroid ... segment_flux_err kron_flux kron_flux_err
-                                ...
-    ----- ---------- ---------- ... ---------------- --------- -------------
-        1     235.38       1.44 ...              nan    490.35           nan
-        2     493.78       5.84 ...              nan    489.37           nan
-        3     207.29      10.26 ...              nan    694.24           nan
-        4     364.87      11.13 ...              nan    681.20           nan
-        5     257.85      12.18 ...              nan    748.18           nan
-      ...        ...        ... ...              ...       ...           ...
-       89     292.77     244.93 ...              nan    792.63           nan
-       90      32.66     241.24 ...              nan    930.77           nan
-       91      42.60     249.43 ...              nan    580.54           nan
-       92     433.80     280.74 ...              nan    663.44           nan
-       93     434.03     288.88 ...              nan    879.64           nan
+    label x_centroid y_centroid sky_centroid ... kron_flux kron_flux_err flags
+                                              ...
+    ----- ---------- ---------- ------------ ... --------- ------------- ------
+        1     235.38       1.44         None ...    490.35           nan  40976
+        2     493.78       5.84         None ...    489.37           nan  40976
+        3     207.29      10.26         None ...    694.24           nan      0
+        4     364.87      11.13         None ...    681.20           nan  32768
+        5     257.85      12.18         None ...    748.18           nan      0
+        6     289.79      22.39         None ...    941.39           nan   8192
+        7     379.21      27.86         None ...    635.38           nan      0
+        8     441.42      31.26         None ...    742.80           nan   8192
+        9     358.54      36.08         None ...    449.14           nan   8192
+      ...        ...        ...          ... ...       ...           ...    ...
+       84     208.00     199.45         None ...   1008.23           nan 139296
+       85     220.83     198.24         None ...    546.55           nan 131104
+       86     426.56     211.19         None ...    876.52           nan 401440
+       87     419.52     216.55         None ...    814.66           nan 131104
+       88     302.52     238.92         None ...    505.42           nan 393248
+       89     292.77     244.93         None ...    792.63           nan 131104
+       90      32.66     241.24         None ...    930.77           nan 131104
+       91      42.60     249.43         None ...    580.54           nan 401440
+       92     433.80     280.74         None ...    663.44           nan 139296
+       93     434.03     288.88         None ...    879.64           nan 139296
     Length = 93 rows
 
 The error columns are NaN because we did not input an error array (see
@@ -613,15 +622,15 @@ label numbers in the segmentation image:
     >>> tbl2['y_centroid'].info.format = '.2f'
     >>> tbl2['kron_flux'].info.format = '.2f'
     >>> print(tbl2)
-    label x_centroid y_centroid ... segment_flux_err kron_flux kron_flux_err
-                                ...
-    ----- ---------- ---------- ... ---------------- --------- -------------
-        1     235.38       1.44 ...              nan    490.35           nan
-        5     257.85      12.18 ...              nan    748.18           nan
-       20     347.17      66.45 ...              nan    855.34           nan
-       50     381.02     174.67 ...              nan    438.55           nan
-       75      74.44     259.78 ...              nan    876.02           nan
-       80      14.93      60.06 ...              nan    878.52           nan
+    label x_centroid y_centroid sky_centroid ... kron_flux kron_flux_err flags
+                                              ...
+    ----- ---------- ---------- ------------ ... --------- ------------- ------
+        1     235.38       1.44         None ...    490.35           nan  40976
+        5     257.85      12.18         None ...    748.18           nan      0
+       20     347.17      66.45         None ...    855.34           nan   8192
+       50     381.02     174.67         None ...    438.55           nan      0
+       75      74.44     259.78         None ...    876.02           nan   8192
+       80      14.93      60.06         None ...    878.52           nan 131104
 
 By default, the :meth:`~photutils.segmentation.SourceCatalog.to_table`
 includes only a small subset of source properties. The output table
@@ -843,6 +852,28 @@ measurement catalog:
 In this example, ``measurement_cat`` uses the centroids and shape
 properties (and Kron apertures) from ``det_cat`` while measuring
 photometry on ``data``.
+
+
+Quality Flags
+-------------
+
+`~photutils.segmentation.SourceCatalog` provides per-source bitwise
+quality flags via its ``flags`` attribute (also included in the default
+table columns). The flags combine deblending provenance recorded by
+:func:`~photutils.segmentation.deblend_sources` (e.g., whether a source
+was produced by deblending, or whether its deblending mode fell back
+to "linear") with measurement-time conditions: the source touches
+an image boundary, masked or non-finite pixels within the segment,
+undefined or degenerate shape properties, windowed or quadratic
+centroid failures, and Kron-aperture issues (``kron_``-prefixed
+flags). Accessing ``flags`` computes the flagged quantities (moments,
+windowed and quadratic centroids, and Kron photometry) if they
+have not already been computed; the results are cached and shared
+with the corresponding source properties. Flags that describe the same
+condition as an `~photutils.aperture.ApertureStats` flag, with the
+source segment as the region, use the same flag name. However, the
+bit values are package-specific, so always decode flag values with
+:func:`~photutils.segmentation.decode_segmentation_flags`.
 
 
 API Reference

--- a/docs/user_guide/segmentation.rst
+++ b/docs/user_guide/segmentation.rst
@@ -875,7 +875,8 @@ source segment as the region, use the same flag name. However, the
 bit values are package-specific, so always decode flag values with
 :func:`~photutils.segmentation.decode_segmentation_flags`. The
 :meth:`~photutils.segmentation.SourceCatalog.decode_flags` convenience
-method decodes the catalog's own flag values::
+method decodes the catalog's own flag values into a dictionary keyed by
+source label::
 
     >>> import numpy as np
     >>> from astropy.modeling.models import Gaussian2D
@@ -885,10 +886,10 @@ method decodes the catalog's own flag values::
     ...         + Gaussian2D(100, 2, 40, 3, 3)(xx, yy))
     >>> segm = detect_sources(data, 10, 5)
     >>> cat = SourceCatalog(data, segm)
-    >>> for names in cat.decode_flags():
-    ...     print(names)
-    []
-    ['edge_touch', 'kron_partial_overlap']
+    >>> for label, names in cat.decode_flags().items():
+    ...     print(label, names)
+    1 []
+    2 ['edge_touch', 'kron_partial_overlap']
 
 
 API Reference

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -607,10 +607,11 @@ exposes the per-label provenance flags via a new ``flags`` attribute,
 and a new :func:`~photutils.segmentation.decode_segmentation_flags`
 function decodes flag values into names.
 :meth:`~photutils.segmentation.SourceCatalog.decode_flags` is a
-convenience method that decodes the catalog's own flag values. Flags
-describing the same condition as an aperture flag share the aperture
-flag's name. However, the bit values are package-specific, so always
-decode a flag column with the decoder of the package that produced it.
+convenience method that decodes the catalog's own flag values into a
+dictionary keyed by source label. Flags describing the same condition as
+an aperture flag share the aperture flag's name. However, the bit values
+are package-specific, so always decode a flag column with the decoder of
+the package that produced it.
 
 
 ``GriddedPSFModel`` Performance Improvements

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -599,16 +599,18 @@ The segmentation package now provides bitwise quality flags.
 `~photutils.segmentation.SourceCatalog` has a new ``flags``
 attribute and default table column that records, per source,
 deblending provenance (``deblended``, deblending-mode fallbacks) and
-measurement conditions (source touches an image boundary, masked or
-non-finite pixels within the segment, undefined or degenerate shape
-properties, windowed or quadratic centroid failures, and Kron-aperture
-issues). `~photutils.segmentation.SegmentationImage` exposes the
-per-label provenance flags via a new ``flags`` attribute, and a new
-:func:`~photutils.segmentation.decode_segmentation_flags` function
-decodes flag values into names. Flags describing the same condition as
-an aperture flag share the aperture flag's name. However, the bit values
-are package-specific, so always decode a flag column with the decoder of
-the package that produced it.
+measurement conditions (source touches an image boundary, masked
+or non-finite pixels within the segment, undefined or degenerate
+shape properties, windowed or quadratic centroid failures, and
+Kron-aperture issues). `~photutils.segmentation.SegmentationImage`
+exposes the per-label provenance flags via a new ``flags`` attribute,
+and a new :func:`~photutils.segmentation.decode_segmentation_flags`
+function decodes flag values into names.
+:meth:`~photutils.segmentation.SourceCatalog.decode_flags` is a
+convenience method that decodes the catalog's own flag values. Flags
+describing the same condition as an aperture flag share the aperture
+flag's name. However, the bit values are package-specific, so always
+decode a flag column with the decoder of the package that produced it.
 
 
 ``GriddedPSFModel`` Performance Improvements

--- a/docs/whats_new/3.1.rst
+++ b/docs/whats_new/3.1.rst
@@ -592,6 +592,25 @@ RA errors are expressed as great-circle angles along the East direction
 (i.e., they include the cos(dec) factor).
 
 
+Segmentation Quality Flags
+==========================
+
+The segmentation package now provides bitwise quality flags.
+`~photutils.segmentation.SourceCatalog` has a new ``flags``
+attribute and default table column that records, per source,
+deblending provenance (``deblended``, deblending-mode fallbacks) and
+measurement conditions (source touches an image boundary, masked or
+non-finite pixels within the segment, undefined or degenerate shape
+properties, windowed or quadratic centroid failures, and Kron-aperture
+issues). `~photutils.segmentation.SegmentationImage` exposes the
+per-label provenance flags via a new ``flags`` attribute, and a new
+:func:`~photutils.segmentation.decode_segmentation_flags` function
+decodes flag values into names. Flags describing the same condition as
+an aperture flag share the aperture flag's name. However, the bit values
+are package-specific, so always decode a flag column with the decoder of
+the package that produced it.
+
+
 ``GriddedPSFModel`` Performance Improvements
 ============================================
 

--- a/photutils/segmentation/__init__.py
+++ b/photutils/segmentation/__init__.py
@@ -10,4 +10,5 @@ from .core import *  # noqa: F401, F403
 from .deblend import *  # noqa: F401, F403
 from .detect import *  # noqa: F401, F403
 from .finder import *  # noqa: F401, F403
+from .flags import *  # noqa: F401, F403
 from .utils import *  # noqa: F401, F403

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1489,6 +1489,17 @@ class SourceCatalog:
         `~photutils.segmentation.decode_segmentation_flags` to decode
         the values.
 
+        If a ``detection_catalog`` was input, the shape
+        (``undefined_shape``, ``singular_covariance``), centroid
+        (``centroid_win_fallback``, ``centroid_quad_failed``),
+        and Kron aperture geometry (``kron_undefined``,
+        ``kron_minimum_radius``) flags derive from the detection
+        catalog. The Kron photometry-loop flags (``kron_no_overlap``,
+        ``kron_partial_overlap``, ``kron_masked_pixels``,
+        ``kron_neighbor_pixels``, ``kron_uncorrected_pixels``), like the
+        segment-level edge, mask, non-finite, and ``all_masked`` flags,
+        are evaluated on this catalog's own inputs.
+
         Accessing ``flags`` computes the moment, covariance, centroid,
         and Kron-aperture properties if they have not already
         been computed (the results are cached and reused by those

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1578,10 +1578,14 @@ class SourceCatalog:
         # _measured_kron_radius returns exactly kron_params[1] when the
         # Kron numerator or denominator is not positive. NaN comparisons
         # are False, so sources with an undefined Kron radius are not
-        # flagged here (they are flagged as kron_undefined instead).
+        # flagged here (they are flagged as kron_undefined instead). The
+        # Kron radii are measured by the detection catalog, if input, so
+        # its kron_params define the applied minimum.
+        detcat = (self if self._detection_catalog is None
+                  else self._detection_catalog)
         measured = self._measured_kron_radius
         kron_radius = self._array('kron_radius').value
-        min_applied = ((measured <= self.kron_params[1])
+        min_applied = ((measured <= detcat.kron_params[1])
                        | (kron_radius == 0))
         flags[min_applied] |= SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS
 
@@ -5028,15 +5032,19 @@ class SourceCatalog:
             pixel_mask = in_aperture & ~mask
 
             kron_flag = 0
-            # Flag an aperture bounding box that extends beyond the data
-            # array. The box corners can have zero aperture weight,
-            # so also require that a pixel with nonzero weight falls
-            # outside the data.
-            if ((ixmin < 0 or iymin < 0 or ixmax > nx_img
-                 or iymax > ny_img)
-                    and (np.count_nonzero(in_aperture)
-                         != np.count_nonzero(mask_data))):
-                kron_flag |= SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP
+            # The aperture bounding box extends beyond the data array.
+            # The box corners can have zero aperture weight, so compare
+            # the number of nonzero-weight pixels within the data to the
+            # total number in the aperture. The overlap is partial only
+            # if at least one nonzero-weight pixel falls both inside and
+            # outside of the data.
+            if (ixmin < 0 or iymin < 0 or ixmax > nx_img
+                    or iymax > ny_img):
+                n_inside = np.count_nonzero(in_aperture)
+                if n_inside == 0:
+                    kron_flag |= SEGMENTATION_FLAGS.KRON_NO_OVERLAP
+                elif n_inside != np.count_nonzero(mask_data):
+                    kron_flag |= SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP
 
             if np.any(flag_masks['data_mask'] & in_aperture):
                 kron_flag |= SEGMENTATION_FLAGS.KRON_MASKED_PIXELS

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1621,9 +1621,10 @@ class SourceCatalog:
 
         Returns
         -------
-        decoded : list of list of str or list of list of int
-            A list of the active flag names (or bit values) for each
-            source.
+        decoded : dict
+            A dictionary mapping each source label to the list of its
+            active flag names (or bit values). The entries follow the
+            catalog order.
 
         See Also
         --------
@@ -1639,13 +1640,15 @@ class SourceCatalog:
         ...         + Gaussian2D(100, 2, 40, 3, 3)(xx, yy))
         >>> segm = detect_sources(data, 10, 5)
         >>> cat = SourceCatalog(data, segm)
-        >>> for names in cat.decode_flags():
-        ...     print(names)
-        []
-        ['edge_touch', 'kron_partial_overlap']
+        >>> for label, names in cat.decode_flags().items():
+        ...     print(label, names)
+        1 []
+        2 ['edge_touch', 'kron_partial_overlap']
         """
-        return decode_segmentation_flags(
+        decoded = decode_segmentation_flags(
             self._array('flags'), return_bit_values=return_bit_values)
+        return {int(label): flags
+                for label, flags in zip(self.labels, decoded, strict=True)}
 
     def _get_values(self, array):
         """

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1489,6 +1489,10 @@ class SourceCatalog:
         `~photutils.segmentation.decode_segmentation_flags` to decode
         the values.
 
+        Accessing ``flags`` computes the moment, covariance, and
+        centroid properties if they have not already been computed (the
+        results are cached and reused by those properties).
+
         The flags are:
 
         <flag_descriptions>
@@ -1536,6 +1540,30 @@ class SourceCatalog:
 
         # All pixels within the source segment are masked
         flags[self._all_masked] |= SEGMENTATION_FLAGS.ALL_MASKED
+
+        # Non-positive net flux (the zeroth image moment over the
+        # source segment). The moment-derived shape properties are
+        # undefined. Fully-masked sources and sources with no positive
+        # (convolved) data values have a zero net flux, so they are also
+        # flagged here. The ``~(m00 > 0)`` form additionally catches a
+        # non-finite net flux.
+        m00 = self._array('moments')[:, 0, 0]
+        flags[~(m00 > 0)] |= SEGMENTATION_FLAGS.UNDEFINED_SHAPE
+
+        # Singular or nearly singular source covariance, evaluated on
+        # the raw (unregularized) covariance matrix
+        flags[self._singular_covariance_mask] |= (
+            SEGMENTATION_FLAGS.SINGULAR_COVARIANCE)
+
+        # Windowed centroid is NaN or fell back to the isophotal
+        # centroid
+        flags[self._centroid_win_fallback] |= (
+            SEGMENTATION_FLAGS.CENTROID_WIN_FALLBACK)
+
+        # Quadratic-fit centroid is non-finite
+        quad = self._array('centroid_quad')
+        quad_failed = ~np.all(np.isfinite(quad), axis=1)
+        flags[quad_failed] |= SEGMENTATION_FLAGS.CENTROID_QUAD_FAILED
 
         return flags
 
@@ -2005,9 +2033,12 @@ class SourceCatalog:
         Returns
         -------
         result : `~numpy.ndarray`
-            The windowed centroid coordinates and their error variances
-            and covariance as columns ``(x, y, var_x, var_y, cov_xy)``,
-            shape ``(n_sources, 5)``.
+            The windowed centroid coordinates, their error variances and
+            covariance, and the fallback indicator as columns ``(x, y,
+            var_x, var_y, cov_xy, fallback)``, shape ``(n_sources, 6)``.
+            The ``fallback`` column is 1.0 for sources whose windowed
+            centroid was reset to the isophotal centroid or is NaN
+            (non-finite half-light radius), and 0.0 otherwise.
         """
         dx = x_centroid - xcen_win
         dy = y_centroid - ycen_win
@@ -2034,8 +2065,9 @@ class SourceCatalog:
             win_err_var_y[reset] = iso_cov[reset, 1, 1]
             win_err_cov_xy[reset] = iso_cov[reset, 0, 1]
 
+        fallback = (reset | nan_hl).astype(float)
         return np.transpose((xcen_win, ycen_win, win_err_var_x,
-                             win_err_var_y, win_err_cov_xy))
+                             win_err_var_y, win_err_cov_xy, fallback))
 
     def _iterate_centroid_win(self, label, xcen, ycen, rad_hl,
                               nan_hl_source, *, data_arr, mask_arr,
@@ -2257,13 +2289,18 @@ class SourceCatalog:
     @use_detcat
     def _centroid_win_results(self):
         """
-        The "windowed" centroid coordinates and their error variances
-        and covariance as a 2D array with columns ``(x, y, var_x, var_y,
-        cov_xy)`` and shape ``(n_labels, 5)``.
+        The "windowed" centroid coordinates, their error variances
+        and covariance, and the fallback indicator as a 2D array with
+        columns ``(x, y, var_x, var_y, cov_xy, fallback)`` and shape
+        ``(n_labels, 6)``.
 
-        This is the single computation behind `centroid_win` and
-        `centroid_win_err`. See `centroid_win` for the algorithm
-        details.
+        The ``fallback`` column is 1.0 for sources whose windowed
+        centroid was reset to the isophotal centroid or is NaN, and 0.0
+        otherwise.
+
+        This is the single computation behind `centroid_win`,
+        `centroid_win_err`, and ``_centroid_win_fallback``. See
+        `centroid_win` for the algorithm details.
         """
         # Use .copy() to avoid mutating the cached flux_radius value
         radius_hl = self.flux_radius(0.5).value.copy()
@@ -2339,6 +2376,14 @@ class SourceCatalog:
             win_cen_mom_xx, win_cen_mom_yy, win_cen_mom_xy,
             win_err_var_x, win_err_var_y, win_err_cov_xy, nan_hl,
             x_centroid, y_centroid)
+
+    @cached_property
+    def _centroid_win_fallback(self):
+        """
+        A boolean array that is `True` where the windowed centroid is
+        NaN or fell back to the isophotal centroid.
+        """
+        return self._centroid_win_results[:, 5].astype(bool)
 
     @cached_property
     @use_detcat

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1489,9 +1489,10 @@ class SourceCatalog:
         `~photutils.segmentation.decode_segmentation_flags` to decode
         the values.
 
-        Accessing ``flags`` computes the moment, covariance, and
-        centroid properties if they have not already been computed (the
-        results are cached and reused by those properties).
+        Accessing ``flags`` computes the moment, covariance, centroid,
+        and Kron-aperture properties if they have not already
+        been computed (the results are cached and reused by those
+        properties).
 
         The flags are:
 
@@ -1565,6 +1566,24 @@ class SourceCatalog:
         quad = self._array('centroid_quad')
         quad_failed = ~np.all(np.isfinite(quad), axis=1)
         flags[quad_failed] |= SEGMENTATION_FLAGS.CENTROID_QUAD_FAILED
+
+        # Kron-aperture flags
+        flags |= self._kron_flags
+
+        # Minimum Kron radius or minimum circular radius applied.
+        # _measured_kron_radius is the unscaled measured value, which
+        # _calc_kron_radius clips to kron_params[1] and sets to zero
+        # when the minimum circular aperture is used instead. A
+        # measured value equal to the minimum is also flagged because
+        # _measured_kron_radius returns exactly kron_params[1] when the
+        # Kron numerator or denominator is not positive. NaN comparisons
+        # are False, so sources with an undefined Kron radius are not
+        # flagged here (they are flagged as kron_undefined instead).
+        measured = self._measured_kron_radius
+        kron_radius = self._array('kron_radius').value
+        min_applied = ((measured <= self.kron_params[1])
+                       | (kron_radius == 0))
+        flags[min_applied] |= SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS
 
         return flags
 
@@ -4141,11 +4160,17 @@ class SourceCatalog:
 
         Neighboring sources can be included, masked, or corrected based
         on the ``aperture_mask_method`` keyword.
+
+        The last returned value is a dictionary of the cutout masks
+        needed to compute the aperture quality flags. Its ``segm_mask``
+        and ``uncorrected_mask`` values are `None` where they do not
+        apply (i.e., for an ``aperture_mask_method`` of "none" and for a
+        method other than "correct", respectively).
         """
         # Make cutouts of the data based on the aperture bbox
         slc_lg, slc_sm = aperture_bbox.get_overlap_slices(self._data.shape)
         if slc_lg is None:
-            return (None,) * 5
+            return (None,) * 6
 
         data = self._data[slc_lg].astype(float) - local_background
 
@@ -4162,6 +4187,8 @@ class SourceCatalog:
                         y_centroid - max(0, aperture_bbox.iymin))
 
         # Mask or correct neighboring sources
+        segm_mask = None
+        uncorrected_mask = None
         if self.aperture_mask_method == 'none':
             mask = data_mask
         else:
@@ -4174,13 +4201,18 @@ class SourceCatalog:
                 mask = data_mask
 
         if self.aperture_mask_method == 'correct':
-            data = _mask_to_mirrored_value(data, segm_mask, cutout_xycen,
-                                           mask=mask)
+            data, uncorrected_mask = _mask_to_mirrored_value(
+                data, segm_mask, cutout_xycen, mask=mask,
+                return_uncorrected=True)
             if error is not None:
                 error = _mask_to_mirrored_value(error, segm_mask, cutout_xycen,
                                                 mask=mask)
 
-        return data, error, mask, cutout_xycen, slc_sm
+        flag_masks = {'data_mask': data_mask,
+                      'segm_mask': segm_mask,
+                      'uncorrected_mask': uncorrected_mask}
+
+        return data, error, mask, cutout_xycen, slc_sm, flag_masks
 
     def _make_circular_apertures(self, radius):
         """
@@ -4858,7 +4890,7 @@ class SourceCatalog:
                 continue
 
             # Prepare cutouts of the data based on the aperture size
-            data, error, mask, _, slc_sm = self._make_aperture_data(
+            data, error, mask, _, slc_sm, _ = self._make_aperture_data(
                 label, xcen, ycen, aperture_mask.bbox, bkg)
 
             aperture_weights = aperture_mask.data[slc_sm]
@@ -4901,8 +4933,9 @@ class SourceCatalog:
 
         Returns
         -------
-        kron_flux, kron_flux_err : tuple of `~numpy.ndarray`
-            The Kron flux and flux error.
+        kron_flux, kron_flux_err, kron_flags : tuple of `~numpy.ndarray`
+            The Kron flux, flux error, and bitwise quality flags (see
+            `~photutils.segmentation.decode_segmentation_flags`).
         """
         if kron_params is None:
             kron_aperture = self._array('kron_aperture')
@@ -4916,14 +4949,17 @@ class SourceCatalog:
 
         _floor = math.floor
         max_size = max(self._data.size, 1_000_000)
+        ny_img, nx_img = self._data.shape
 
         flux = []
         flux_err = []
+        kron_flags = []
         for label, aperture, bkg in zip(labels, kron_aperture,
                                         self._local_background, strict=True):
             if aperture is None:
                 flux.append(np.nan)
                 flux_err.append(np.nan)
+                kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
                 continue
 
             xcen, ycen = aperture.positions
@@ -4942,6 +4978,7 @@ class SourceCatalog:
                 if nx * ny > max_size:
                     flux.append(np.nan)
                     flux_err.append(np.nan)
+                    kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
                     continue
                 edges = (ixmin - 0.5 - xcen, ixmax - 0.5 - xcen,
                          iymin - 0.5 - ycen, iymax - 0.5 - ycen)
@@ -4968,6 +5005,7 @@ class SourceCatalog:
                 if nx * ny > max_size:
                     flux.append(np.nan)
                     flux_err.append(np.nan)
+                    kron_flags.append(SEGMENTATION_FLAGS.KRON_UNDEFINED)
                     continue
                 edges = (ixmin - 0.5 - xcen, ixmax - 0.5 - xcen,
                          iymin - 0.5 - ycen, iymax - 0.5 - ycen)
@@ -4976,15 +5014,44 @@ class SourceCatalog:
                     nx, ny, a, b, theta_rad, 1, 1)
 
             bbox = BoundingBox(ixmin, ixmax, iymin, iymax)
-            data, error, mask, _, slc_sm = self._make_aperture_data(
-                label, xcen, ycen, bbox, bkg)
+            (data, error, mask, _, slc_sm,
+             flag_masks) = self._make_aperture_data(label, xcen, ycen, bbox,
+                                                    bkg)
             if data is None:
                 flux.append(np.nan)
                 flux_err.append(np.nan)
+                kron_flags.append(SEGMENTATION_FLAGS.KRON_NO_OVERLAP)
                 continue
 
             aperture_weights = mask_data[slc_sm]
-            pixel_mask = (aperture_weights > 0) & ~mask
+            in_aperture = aperture_weights > 0
+            pixel_mask = in_aperture & ~mask
+
+            kron_flag = 0
+            # Flag an aperture bounding box that extends beyond the data
+            # array. The box corners can have zero aperture weight,
+            # so also require that a pixel with nonzero weight falls
+            # outside the data.
+            if ((ixmin < 0 or iymin < 0 or ixmax > nx_img
+                 or iymax > ny_img)
+                    and (np.count_nonzero(in_aperture)
+                         != np.count_nonzero(mask_data))):
+                kron_flag |= SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP
+
+            if np.any(flag_masks['data_mask'] & in_aperture):
+                kron_flag |= SEGMENTATION_FLAGS.KRON_MASKED_PIXELS
+
+            segm_mask = flag_masks['segm_mask']
+            if segm_mask is not None and np.any(segm_mask & in_aperture):
+                kron_flag |= SEGMENTATION_FLAGS.KRON_NEIGHBOR_PIXELS
+
+            uncorrected_mask = flag_masks['uncorrected_mask']
+            if (uncorrected_mask is not None
+                    and np.any(uncorrected_mask & in_aperture)):
+                kron_flag |= SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS
+
+            kron_flags.append(kron_flag)
+
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', RuntimeWarning)
                 values = (aperture_weights * data)[pixel_mask]
@@ -5003,8 +5070,9 @@ class SourceCatalog:
 
         flux = np.array(flux)
         flux_err = np.array(flux_err)
+        kron_flags = np.array(kron_flags, dtype=int)
 
-        return flux, flux_err
+        return flux, flux_err, kron_flags
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def kron_photometry(self, kron_params, name=None, overwrite=False):
@@ -5051,7 +5119,7 @@ class SourceCatalog:
             `centroid` position or elliptical shape parameters are not
             finite or where the source is completely masked).
         """
-        kron_flux, kron_flux_err = self._calc_kron_photometry(
+        kron_flux, kron_flux_err, _ = self._calc_kron_photometry(
             kron_params=kron_params)
         if self._data_unit is not None:
             kron_flux <<= self._data_unit
@@ -5073,17 +5141,31 @@ class SourceCatalog:
     @cached_property
     def _kron_photometry(self):
         """
-        The flux and flux error in the Kron aperture (without units).
+        The flux, flux error, and bitwise quality flags of the Kron
+        aperture (without units) as a 2D array with columns ``(flux,
+        flux_err, flags)`` and shape ``(n_labels, 3)``.
+
+        The flags are stored as floats so that all three values can be
+        kept in a single array that slices along the source axis. All of
+        the flag bit values are exactly representable as floats.
 
         See the `SourceCatalog` ``aperture_mask_method`` keyword for
         options to mask neighboring sources.
 
-        If the Kron aperture is `None`, then ``np.nan`` will be
-        returned. This will occur where the source `centroid` position
-        or elliptical shape parameters are not finite or where the
-        source is completely masked.
+        If the Kron aperture is `None`, then ``np.nan`` will be returned
+        for the flux and flux error. This will occur where the source
+        `centroid` position or elliptical shape parameters are not
+        finite or where the source is completely masked.
         """
         return np.transpose(self._calc_kron_photometry(kron_params=None))
+
+    @cached_property
+    def _kron_flags(self):
+        """
+        The per-source bitwise quality flags from the Kron-aperture
+        photometry.
+        """
+        return self._kron_photometry[:, 2].astype(int)
 
     @cached_property
     def kron_flux(self):

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1557,8 +1557,10 @@ class SourceCatalog:
         # source segment). The moment-derived shape properties are
         # undefined. Fully-masked sources and sources with no positive
         # (convolved) data values have a zero net flux, so they are also
-        # flagged here. The ``~(m00 > 0)`` form additionally catches a
-        # non-finite net flux.
+        # flagged here. The ``~(m00 > 0)`` form is defensive against
+        # a non-finite net flux, which cannot currently occur because
+        # the moment cutouts are zero-filled for masked and non-finite
+        # pixels, but the form would still catch it.
         m00 = self._array('moments')[:, 0, 0]
         flags[~(m00 > 0)] |= SEGMENTATION_FLAGS.UNDEFINED_SHAPE
 
@@ -2413,6 +2415,7 @@ class SourceCatalog:
             x_centroid, y_centroid)
 
     @cached_property
+    @use_detcat
     def _centroid_win_fallback(self):
         """
         A boolean array that is `True` where the windowed centroid is

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -1550,9 +1550,10 @@ class SourceCatalog:
         m00 = self._array('moments')[:, 0, 0]
         flags[~(m00 > 0)] |= SEGMENTATION_FLAGS.UNDEFINED_SHAPE
 
-        # Singular or nearly singular source covariance, evaluated on
-        # the raw (unregularized) covariance matrix
-        flags[self._singular_covariance_mask] |= (
+        # Singular, nearly singular, or rank-1 degenerate source
+        # covariance, evaluated on the raw (unregularized) covariance
+        # matrix
+        flags[self._singular_covariance_flag_mask] |= (
             SEGMENTATION_FLAGS.SINGULAR_COVARIANCE)
 
         # Windowed centroid is NaN or fell back to the isophotal
@@ -2629,6 +2630,13 @@ class SourceCatalog:
                 results.append(nan_result)
                 continue
 
+            # A source with no unmasked pixels has no peak; without this
+            # guard the masked (zeroed) cutout below would return the
+            # position of its first pixel as the "peak"
+            if np.all(mask):
+                results.append(nan_result)
+                continue
+
             # Apply mask: _cutout_total_masks already includes
             # non-finite data values, so cutout[mask] = 0.0 handles both
             # masked pixels and non-finite values.
@@ -2721,6 +2729,7 @@ class SourceCatalog:
         * quadratic fit does not have a maximum
         * quadratic fit maximum falls outside image
         * not enough unmasked data points (6 are required)
+        * no unmasked pixels within the source segment
 
         In these cases, then the isophotal `centroid` will be used
         instead.
@@ -2751,6 +2760,7 @@ class SourceCatalog:
         * quadratic fit does not have a maximum
         * quadratic fit maximum falls outside image
         * not enough unmasked data points (6 are required)
+        * no unmasked pixels within the source segment
 
         Also note that a fit is not performed if the maximum data value
         is at the edge of the source segment. In this case, the position
@@ -3618,11 +3628,51 @@ class SourceCatalog:
         the squared variance of a uniform distribution across a single
         pixel. Sources with non-finite covariance are not flagged.
         """
+        return self._raw_covariance_det < (1.0 / 12.0)**2
+
+    @cached_property
+    def _singular_covariance_flag_mask(self):
+        """
+        A boolean mask with a leading source axis that is `True` for
+        sources whose raw covariance matrix is singular or nearly
+        singular, including rank-1 degenerate sources.
+
+        This is the mask used for the ``'singular_covariance'``
+        flag. It matches the equivalent aperture flag (see
+        `~photutils.aperture.decode_aperture_flags`): in addition to
+        the determinant test used by ``_singular_covariance_mask``, a
+        source is flagged when its minor-axis variance (the smaller
+        eigenvalue of the raw covariance matrix) is less than ``1 /
+        12``. The determinant test alone misses elongated sources that
+        are unresolved along only one axis. Sources with non-finite
+        covariance are not flagged.
+        """
+        covar = self._raw_covariance
         # Ignore RuntimeWarning from NaN values in the covariance
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            covar_det = np.linalg.det(self._raw_covariance)
-        return covar_det < (1.0 / 12.0)**2
+            # Smaller eigenvalue (the minor-axis variance) of each
+            # 2x2 symmetric covariance matrix, via the closed form
+            # lambda = tr/2 -/+ sqrt((tr/2)**2 - det). The discriminant
+            # is non-negative for a real symmetric matrix. Clip tiny
+            # negative rounding to zero.
+            half_trace = 0.5 * (covar[:, 0, 0] + covar[:, 1, 1])
+            disc = np.maximum(half_trace**2 - self._raw_covariance_det,
+                              0.0)
+            min_eigval = half_trace - np.sqrt(disc)
+            degenerate = (np.isfinite(min_eigval)
+                          & (min_eigval < 1.0 / 12.0))
+        return self._singular_covariance_mask | degenerate
+
+    @cached_property
+    def _raw_covariance_det(self):
+        """
+        The determinant of the raw ``(N, 2, 2)`` covariance matrix.
+        """
+        # Ignore RuntimeWarning from NaN values in the covariance
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            return np.linalg.det(self._raw_covariance)
 
     @cached_property
     def _raw_covariance(self):
@@ -3631,10 +3681,12 @@ class SourceCatalog:
         function that has the same normalized second-order moments as
         the source, before any regularization.
 
-        This unregularized matrix is shared by `_covariance` (which
-        regularizes a copy) and `_singular_covariance_mask` (which tests
-        it for singularity). Callers that modify the matrix in place
-        must operate on a copy so the cached value is not corrupted.
+        This unregularized matrix is shared by `_covariance`
+        (which regularizes a copy) and by the masks that test
+        it for singularity (``_singular_covariance_mask`` and
+        ``_singular_covariance_flag_mask``). Callers that modify the
+        matrix in place must operate on a copy so the cached value is
+        not corrupted.
         """
         moments = self._array('moments_central')
         # Ignore divide-by-zero RuntimeWarning

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -24,12 +24,14 @@ from photutils.background import SExtractorBackground
 from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
 from photutils.morphology import gini as gini_func
 from photutils.segmentation.core import SegmentationImage
+from photutils.segmentation.flags import SEGMENTATION_FLAGS
 from photutils.segmentation.utils import _mask_to_mirrored_value
 from photutils.utils._deprecation import (_get_future_column_names,
                                           create_empty_deprecated_qtable,
                                           deprecated_getattr,
                                           deprecated_positional_kwargs,
                                           deprecated_renamed_argument)
+from photutils.utils._flags import update_flag_docstring
 from photutils.utils._misc import _get_meta
 from photutils.utils._parameters import validate_table_columns
 from photutils.utils._progress_bars import add_progress_bar
@@ -124,6 +126,27 @@ def use_detcat(method):
         return getattr(self._detection_catalog, method.__name__)
 
     return _use_detcat
+
+
+def _update_flags_docstring(func):
+    """
+    Decorator to insert the segmentation flag descriptions into a
+    docstring.
+
+    The ``<flag_descriptions>`` placeholder in the function docstring is
+    replaced with a bullet list generated from ``SEGMENTATION_FLAGS``.
+
+    Parameters
+    ----------
+    func : function
+        The function to decorate.
+
+    Returns
+    -------
+    func : function
+        The decorated function with an updated docstring.
+    """
+    return update_flag_docstring(func, SEGMENTATION_FLAGS, indent=8)
 
 
 class SourceCatalog:
@@ -420,7 +443,7 @@ class SourceCatalog:
                                 'orientation', 'eccentricity', 'min_value',
                                 'max_value', 'segment_flux',
                                 'segment_flux_err', 'kron_flux',
-                                'kron_flux_err']
+                                'kron_flux_err', 'flags']
 
         self._custom_properties = []
         self._flux_radius_cache = {}
@@ -1451,6 +1474,70 @@ class SourceCatalog:
         True if all pixels over the source segment are masked.
         """
         return np.array([np.all(mask) for mask in self._cutout_total_masks])
+
+    @cached_property
+    @_update_flags_docstring
+    def flags(self):
+        # numpydoc ignore: RT01
+        """
+        The per-source bitwise quality flags.
+
+        The flags combine deblending-provenance flags carried
+        by the input segmentation image with measurement-time
+        flags computed from this catalog's ``data``,
+        ``mask``, ``error``, and segmentation image. Use
+        `~photutils.segmentation.decode_segmentation_flags` to decode
+        the values.
+
+        The flags are:
+
+        <flag_descriptions>
+        """
+        flags = np.zeros(len(self.labels), dtype=int)
+
+        # Deblending provenance flags from the segmentation image
+        flags_map = self._segmentation_image._flags_map
+        if flags_map:
+            flags |= np.array([flags_map.get(int(label), 0)
+                               for label in self.labels])
+
+        # Source segment touches an image boundary
+        ny, nx = self._data.shape
+        edge = np.array([(slc[0].start == 0 or slc[1].start == 0
+                          or slc[0].stop == ny or slc[1].stop == nx)
+                         for slc in self._slices_iter])
+        flags[edge] |= SEGMENTATION_FLAGS.EDGE_TOUCH
+
+        # Input-masked pixels within the source segment
+        if self._mask is not None:
+            masked = np.array(
+                [np.any(mask_cut & ~segm_mask)
+                 for mask_cut, segm_mask in zip(
+                     self._mask_cutouts,
+                     self._cutout_segment_masks, strict=True)])
+            flags[masked] |= SEGMENTATION_FLAGS.MASKED_PIXELS
+
+        # Non-finite data values within the source segment
+        nonfinite = np.array(
+            [np.any(~np.isfinite(data_cut) & ~segm_mask)
+             for data_cut, segm_mask in zip(
+                 self._data_cutouts, self._cutout_segment_masks,
+                 strict=True)])
+        flags[nonfinite] |= SEGMENTATION_FLAGS.NON_FINITE_DATA
+
+        # Non-finite error values within the source segment
+        if self._error is not None:
+            nonfinite_err = np.array(
+                [np.any(~np.isfinite(err_cut) & ~segm_mask)
+                 for err_cut, segm_mask in zip(
+                     self._error_cutouts,
+                     self._cutout_segment_masks, strict=True)])
+            flags[nonfinite_err] |= SEGMENTATION_FLAGS.NON_FINITE_ERROR
+
+        # All pixels within the source segment are masked
+        flags[self._all_masked] |= SEGMENTATION_FLAGS.ALL_MASKED
+
+        return flags
 
     def _get_values(self, array):
         """

--- a/photutils/segmentation/catalog.py
+++ b/photutils/segmentation/catalog.py
@@ -24,7 +24,8 @@ from photutils.background import SExtractorBackground
 from photutils.geometry import circular_overlap_grid, elliptical_overlap_grid
 from photutils.morphology import gini as gini_func
 from photutils.segmentation.core import SegmentationImage
-from photutils.segmentation.flags import SEGMENTATION_FLAGS
+from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
+                                          decode_segmentation_flags)
 from photutils.segmentation.utils import _mask_to_mirrored_value
 from photutils.utils._deprecation import (_get_future_column_names,
                                           create_empty_deprecated_qtable,
@@ -1603,6 +1604,48 @@ class SourceCatalog:
         flags[min_applied] |= SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS
 
         return flags
+
+    def decode_flags(self, *, return_bit_values=False):
+        """
+        Decode the source quality flags into individual components.
+
+        This is a convenience method that calls
+        `~photutils.segmentation.decode_segmentation_flags` with the
+        `flags` property.
+
+        Parameters
+        ----------
+        return_bit_values : bool, optional
+            If `True`, return the decoded bit flags (integers) instead
+            of the flag names (strings).
+
+        Returns
+        -------
+        decoded : list of list of str or list of list of int
+            A list of the active flag names (or bit values) for each
+            source.
+
+        See Also
+        --------
+        photutils.segmentation.decode_segmentation_flags
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from astropy.modeling.models import Gaussian2D
+        >>> from photutils.segmentation import SourceCatalog, detect_sources
+        >>> yy, xx = np.mgrid[0:51, 0:51]
+        >>> data = (Gaussian2D(100, 25, 25, 3, 3)(xx, yy)
+        ...         + Gaussian2D(100, 2, 40, 3, 3)(xx, yy))
+        >>> segm = detect_sources(data, 10, 5)
+        >>> cat = SourceCatalog(data, segm)
+        >>> for names in cat.decode_flags():
+        ...     print(names)
+        []
+        ['edge_touch', 'kron_partial_overlap']
+        """
+        return decode_segmentation_flags(
+            self._array('flags'), return_bit_values=return_bit_values)
 
     def _get_values(self, array):
         """

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -142,7 +142,8 @@ class SegmentationImage:
         by :func:`~photutils.segmentation.deblend_sources`. Use
         :func:`~photutils.segmentation.decode_segmentation_flags` to
         decode the values. The flags are reset to zero when the ``data``
-        attribute is reassigned.
+        attribute is reassigned, and slicing returns a new instance with
+        all flags reset to zero.
 
     info : dict
         A dictionary containing auxiliary information about the
@@ -209,7 +210,6 @@ class SegmentationImage:
         segm._set_data(data, labels=labels, areas=areas, slices=slices)
         if deblend_label_map is not None:
             segm._deblend_label_map = deblend_label_map
-        segm._flags_map = {}
         return segm
 
     def __str__(self):
@@ -355,7 +355,9 @@ class SegmentationImage:
         output of `~photutils.segmentation.detect_sources`. Use
         `~photutils.segmentation.decode_segmentation_flags` to decode
         the values. The flags are reset to zero when the ``data``
-        attribute is reassigned.
+        attribute is reassigned. Slicing the segmentation image (e.g.,
+        ``segm[10:50, 10:50]``) returns a new instance with all flags
+        reset to zero as well.
         """
         return np.array([self._flags_map.get(int(label), 0)
                          for label in self.labels], dtype=int)

--- a/photutils/segmentation/core.py
+++ b/photutils/segmentation/core.py
@@ -90,6 +90,37 @@ def _remap_deblend_label_map(deblend_label_map, relabel_map):
             for parent_label, child_labels in deblend_label_map.items()}
 
 
+def _remap_flags_map(flags_map, relabel_map):
+    """
+    Return a new per-label flags map with remapped labels.
+
+    Labels that map to zero are dropped. Labels that map to the same new
+    label have their flags combined with a bitwise OR.
+
+    Parameters
+    ----------
+    flags_map : dict
+        The mapping of label numbers to bitwise flag values.
+
+    relabel_map : 1D `~numpy.ndarray`
+        An array mapping the original label numbers to the new label
+        numbers.
+
+    Returns
+    -------
+    result : dict
+        A new mapping of the remapped label numbers to their combined
+        flag values.
+    """
+    new_map = {}
+    for label, flags in flags_map.items():
+        new_label = int(relabel_map[label])
+        if new_label == 0:
+            continue
+        new_map[new_label] = new_map.get(new_label, 0) | flags
+    return new_map
+
+
 class SegmentationImage:
     """
     Class for a segmentation image.
@@ -104,14 +135,23 @@ class SegmentationImage:
 
     Attributes
     ----------
+    flags : `~numpy.ndarray`
+        A 1D array of per-label bitwise quality flags, in the same
+        order as the ``labels`` attribute. The flags record deblending
+        provenance and are all zero for segmentation images not produced
+        by :func:`~photutils.segmentation.deblend_sources`. Use
+        :func:`~photutils.segmentation.decode_segmentation_flags` to
+        decode the values. The flags are reset to zero when the ``data``
+        attribute is reassigned.
+
     info : dict
         A dictionary containing auxiliary information about the
         segmentation image. For example, segmentation images returned
-        by :func:`~photutils.segmentation.deblend_sources` store the
-        input labels affected by deblending warnings under
+        by :func:`~photutils.segmentation.deblend_sources` store
+        the input labels affected by deblending warnings under
         ``'nonposmin_labels'`` and ``'n_markers_labels'`` keys. The
-        dictionary is empty if there is no auxiliary information. It is
-        reset to an empty dictionary when the ``data`` attribute is
+        dictionary is empty if there is no auxiliary information. It
+        is reset to an empty dictionary when the ``data`` attribute is
         reassigned.
 
     Notes
@@ -169,6 +209,7 @@ class SegmentationImage:
         segm._set_data(data, labels=labels, areas=areas, slices=slices)
         if deblend_label_map is not None:
             segm._deblend_label_map = deblend_label_map
+        segm._flags_map = {}
         return segm
 
     def __str__(self):
@@ -303,6 +344,23 @@ class SegmentationImage:
         return self._deblend_label_map
 
     @property
+    def flags(self):
+        """
+        A 1D array of per-label bitwise quality flags, in the same order
+        as the ``labels`` attribute.
+
+        The flags are set by `~photutils.segmentation.deblend_sources`
+        to record deblending provenance. They are all zero for
+        directly-constructed segmentation images and for the
+        output of `~photutils.segmentation.detect_sources`. Use
+        `~photutils.segmentation.decode_segmentation_flags` to decode
+        the values. The flags are reset to zero when the ``data``
+        attribute is reassigned.
+        """
+        return np.array([self._flags_map.get(int(label), 0)
+                         for label in self.labels], dtype=int)
+
+    @property
     def data(self):
         """
         The segmentation array.
@@ -385,11 +443,12 @@ class SegmentationImage:
             if value is not None:
                 self.__dict__[name] = value
 
-        # Reset the deblended label map and auxiliary info explicitly
-        # since _deblend_label_map and info are regular attributes,
-        # not cached properties cleared by _reset_cached_properties
-        # above.
+        # Reset the deblended label map, per-label flags map, and
+        # auxiliary info explicitly since _deblend_label_map,
+        # _flags_map, and info are regular attributes, not cached
+        # properties cleared by _reset_cached_properties above.
         self.__dict__['_deblend_label_map'] = {}
+        self.__dict__['_flags_map'] = {}
         if not preserve_info:
             self.__dict__['info'] = {}
 
@@ -1111,13 +1170,16 @@ class SegmentationImage:
 
         data_new = relabel_map[self.data]
         # Relabeling is an in-place change, not a data reassignment,
-        # so the auxiliary info and the deblending provenance are
-        # kept. The local reference is needed because _set_data
-        # rebinds _deblend_label_map to a new empty dict.
+        # so the auxiliary info, the deblending provenance, and the
+        # per-label flags are kept. The local references are needed
+        # because _set_data rebinds _deblend_label_map and _flags_map to
+        # new empty dicts.
         deblend_label_map = self._deblend_label_map
+        flags_map = self._flags_map
         self._set_data(data_new, preserve_info=True)
         self._deblend_label_map = _remap_deblend_label_map(
             deblend_label_map, relabel_map)
+        self._flags_map = _remap_flags_map(flags_map, relabel_map)
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def relabel_consecutive(self, start_label=1):
@@ -1172,16 +1234,19 @@ class SegmentationImage:
 
         data_new = new_label_map[self.data]
         # Relabeling is an in-place change, not a data reassignment,
-        # so the auxiliary info and the deblending provenance are
-        # kept. The local reference is needed because _set_data
-        # rebinds _deblend_label_map to a new empty dict.
+        # so the auxiliary info, the deblending provenance, and the
+        # per-label flags are kept. The local references are needed
+        # because _set_data rebinds _deblend_label_map and _flags_map to
+        # new empty dicts.
         deblend_label_map = self._deblend_label_map
+        flags_map = self._flags_map
         # Relabeling is order-preserving, so the areas and slices are
         # unchanged and carry over under the new label numbers
         self._set_data(data_new, labels=new_labels, areas=old_areas,
                        slices=old_slices, preserve_info=True)
         self._deblend_label_map = _remap_deblend_label_map(
             deblend_label_map, new_label_map)
+        self._flags_map = _remap_flags_map(flags_map, new_label_map)
 
     @deprecated_positional_kwargs(since='3.0', until='4.0')
     def keep_label(self, label, relabel=False):

--- a/photutils/segmentation/deblend.py
+++ b/photutils/segmentation/deblend.py
@@ -18,6 +18,7 @@ from scipy.ndimage import sum_labels
 from photutils.segmentation.core import (SegmentationImage, _get_labels,
                                          _remap_deblend_label_map)
 from photutils.segmentation.detect import _detect_sources
+from photutils.segmentation.flags import SEGMENTATION_FLAGS
 from photutils.segmentation.utils import _make_binary_structure
 from photutils.utils._deprecation import deprecated_renamed_argument
 from photutils.utils._progress_bars import add_progress_bar, tqdm
@@ -138,14 +139,16 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
     -------
     segment_image : `~photutils.segmentation.SegmentationImage`
         A segmentation image, with the same shape as ``data``, where
-        sources are marked by different positive integer values. A
-        value of zero is reserved for the background. The ``info``
-        attribute of the returned segmentation image is a dictionary
-        that stores the input labels for which the deblending mode was
-        changed to "linear" as arrays under ``'nonposmin_labels'``
-        (non-positive minimum data values) and ``'n_markers_labels'``
-        (too many potential deblended sources) keys. The dictionary is
-        empty if no mode fallbacks occurred.
+        sources are marked by different positive integer values. A value
+        of zero is reserved for the background. The ``info`` attribute
+        of the returned segmentation image is a dictionary that stores
+        the input labels for which the deblending mode was changed to
+        "linear" as arrays under ``'nonposmin_labels'`` (non-positive
+        minimum data values) and ``'n_markers_labels'`` (too many
+        potential deblended sources) keys. The dictionary is empty if no
+        mode fallbacks occurred. The ``flags`` attribute of the returned
+        segmentation image records per-source deblending provenance. See
+        `~photutils.segmentation.decode_segmentation_flags`.
 
     Warns
     -----
@@ -328,6 +331,7 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
                'segmentation image for the affected input labels.')
         warnings.warn(msg, DeblendWarning)
 
+    relabel_map = None
     if relabel:
         relabel_map = _create_relabel_map(segm_deblended, start_label=1)
         if relabel_map is not None:
@@ -344,6 +348,9 @@ def deblend_sources(data, segmentation_image, n_pixels, *, labels=None,
         segm_img.info['nonposmin_labels'] = np.array(nonposmin_labels)
     if n_markers_labels:
         segm_img.info['n_markers_labels'] = np.array(n_markers_labels)
+
+    segm_img._flags_map = _make_flags_map(
+        deblend_label_map, nonposmin_labels, n_markers_labels, relabel_map)
 
     return segm_img
 
@@ -657,6 +664,65 @@ class _SingleSourceDeblender:
         if relabel_map is not None:
             markers = relabel_map[markers]
         return markers
+
+
+def _make_flags_map(deblend_label_map, nonposmin_labels, n_markers_labels,
+                    relabel_map):
+    """
+    Build the per-label flags mapping for a deblended segmentation
+    image.
+
+    Deblended children get the "deblended" flag. Mode-fallback flags
+    are set on the children of affected parents, or on the parent's own
+    (possibly relabeled) output label if it did not split.
+
+    Parameters
+    ----------
+    deblend_label_map : dict
+        Mapping of input parent labels to arrays of output child labels,
+        in the final (post-relabel) label frame.
+
+    nonposmin_labels, n_markers_labels : list of int
+        Input parent labels affected by each mode fallback.
+
+    relabel_map : `~numpy.ndarray` or `None`
+        The relabeling map applied to the deblended image, or `None` if
+        no relabeling was applied.
+
+    Returns
+    -------
+    flags_map : dict
+        Mapping of output labels to bitwise flag values.
+    """
+    flags_map = {}
+    for children in deblend_label_map.values():
+        for child in children:
+            child = int(child)
+            flags_map[child] = (flags_map.get(child, 0)
+                                | SEGMENTATION_FLAGS.DEBLENDED)
+
+    fallbacks = [
+        (nonposmin_labels, SEGMENTATION_FLAGS.DEBLEND_NONPOSMIN),
+        (n_markers_labels, SEGMENTATION_FLAGS.DEBLEND_N_MARKERS),
+    ]
+    for input_labels, bit in fallbacks:
+        for label in input_labels:
+            label = int(label)
+            if label in deblend_label_map:
+                targets = [
+                    int(child) for child in deblend_label_map[label]
+                ]
+            else:
+                # The source did not split. Translate its input label to
+                # the output label frame.
+                if relabel_map is None:
+                    out_label = label
+                else:
+                    out_label = int(relabel_map[label])
+                targets = [out_label]
+            for target in targets:
+                flags_map[target] = flags_map.get(target, 0) | bit
+    return flags_map
 
 
 def _create_relabel_map(array, *, start_label=1):

--- a/photutils/segmentation/flags.py
+++ b/photutils/segmentation/flags.py
@@ -158,13 +158,21 @@ class _SegmentationFlags(FlagRegistry):
             name='centroid_win_fallback',
             description=('windowed centroid failed or fell back to '
                          'the isophotal centroid'),
-            detailed_description=('The windowed centroid could not '
-                                  'be computed (NaN; the half-light '
-                                  'radius was not finite) or fell '
+            detailed_description=('The windowed centroid fell '
                                   'outside the 1-sigma moment '
-                                  'ellipse, in which case the '
-                                  'isophotal ``centroid`` value was '
-                                  'used instead.'),
+                                  'ellipse; the windowed flux was '
+                                  'non-positive; the windowed '
+                                  '2nd-order moments or covariance '
+                                  'determinant were negative; or '
+                                  'the iterated centroid was NaN. '
+                                  'In each of these cases, the '
+                                  'isophotal ``centroid`` value '
+                                  'was used instead. If the '
+                                  'half-light radius was not '
+                                  'finite, the windowed centroid '
+                                  'could not be computed and is '
+                                  'NaN. See ``centroid_win`` for '
+                                  'algorithm details.'),
         ),
         FlagDefinition(
             bit_value=2048,
@@ -183,9 +191,17 @@ class _SegmentationFlags(FlagRegistry):
                                   'fully masked) or the Kron '
                                   'photometry was skipped (e.g., the '
                                   'aperture was too large), so the '
-                                  'Kron flux is NaN and no other '
-                                  'Kron-aperture flags were '
-                                  'evaluated.'),
+                                  'Kron flux is NaN. The '
+                                  'photometry-loop flags '
+                                  '(``kron_no_overlap``, '
+                                  '``kron_partial_overlap``, '
+                                  '``kron_masked_pixels``, '
+                                  '``kron_neighbor_pixels``, '
+                                  '``kron_uncorrected_pixels``) are '
+                                  'not evaluated for these sources, '
+                                  'but ``kron_minimum_radius`` is '
+                                  'computed independently from the '
+                                  'radii and can still be set.'),
         ),
         FlagDefinition(
             bit_value=8192,
@@ -251,7 +267,7 @@ class _SegmentationFlags(FlagRegistry):
                                   'pixels within the Kron aperture '
                                   'could not be corrected (the '
                                   'mirror pixel was unavailable) and '
-                                  'were excluded instead.'),
+                                  'were set to zero instead.'),
         ),
     ]
 

--- a/photutils/segmentation/flags.py
+++ b/photutils/segmentation/flags.py
@@ -1,0 +1,349 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tools for working with segmentation quality flags, including
+centralized flag definitions and decoding utilities.
+"""
+
+from typing import ClassVar
+
+from photutils.utils._flags import (FlagDefinition, FlagRegistry, decode_flags,
+                                    update_flag_docstring)
+
+__all__ = ['SEGMENTATION_FLAGS', 'decode_segmentation_flags']
+
+
+class _SegmentationFlags(FlagRegistry):
+    """
+    Centralized definition of segmentation quality flags.
+
+    This class provides a single source of truth for all
+    segmentation flag definitions, including bit values,
+    names, and descriptions. The same flag definitions are
+    used by `~photutils.segmentation.SegmentationImage`,
+    `~photutils.segmentation.deblend_sources`, and
+    `~photutils.segmentation.SourceCatalog`, so a given bit always has
+    the same meaning.
+
+    Flags that describe the same condition as an aperture flag (see
+    `~photutils.aperture.decode_aperture_flags`), with the source
+    segment as the measurement region, use the same name as the aperture
+    flag. The bit values are independent between packages. Always decode
+    a flag column with the decoder of the package that produced it.
+    Flags describing the Kron aperture use a ``kron_`` name prefix.
+
+    Examples
+    --------
+    >>> from photutils.segmentation.flags import _SegmentationFlags
+    >>> flags = _SegmentationFlags()
+    >>> flags.DEBLENDED
+    32
+    >>> flags.get_name(32)
+    'deblended'
+    """
+
+    # Define all segmentation flags with their properties
+    FLAG_DEFINITIONS: ClassVar = [
+        FlagDefinition(
+            bit_value=1,
+            name='masked_pixels',
+            description='masked pixels within the source segment',
+            detailed_description=('One or more input-masked pixels '
+                                  '(``mask`` keyword) are within the '
+                                  'source segment.'),
+        ),
+        FlagDefinition(
+            bit_value=2,
+            name='non_finite_data',
+            description=('non-finite data values within the source '
+                         'segment'),
+            detailed_description=('One or more data values (NaN or '
+                                  'inf) within the source segment '
+                                  'are non-finite.'),
+        ),
+        FlagDefinition(
+            bit_value=4,
+            name='non_finite_error',
+            description=('non-finite error values within the source '
+                         'segment'),
+            detailed_description=('One or more error values (NaN or '
+                                  'inf) within the source segment '
+                                  'are non-finite.'),
+        ),
+        FlagDefinition(
+            bit_value=8,
+            name='all_masked',
+            description='no valid pixels within the source segment',
+            detailed_description=('Every pixel within the source '
+                                  'segment is masked or non-finite, '
+                                  'so the measured source properties '
+                                  'are undefined.'),
+        ),
+        FlagDefinition(
+            bit_value=16,
+            name='edge_touch',
+            description='source touches an image boundary',
+            detailed_description=('The source segment touches one or '
+                                  'more image boundaries, so the '
+                                  'source may be truncated and its '
+                                  'measured properties may be '
+                                  'unreliable.'),
+        ),
+        FlagDefinition(
+            bit_value=32,
+            name='deblended',
+            description='source was produced by deblending',
+            detailed_description=('The source was produced by '
+                                  'deblending a parent source with '
+                                  '`~photutils.segmentation'
+                                  '.deblend_sources`.'),
+        ),
+        FlagDefinition(
+            bit_value=64,
+            name='deblend_nonposmin',
+            description=('deblending mode changed to linear: '
+                         'non-positive minimum'),
+            detailed_description=('The deblending mode for the '
+                                  'parent source was changed to '
+                                  '"linear" because of a '
+                                  'non-positive minimum data value '
+                                  'within the parent source '
+                                  'segment.'),
+        ),
+        FlagDefinition(
+            bit_value=128,
+            name='deblend_n_markers',
+            description=('deblending mode changed to linear: too '
+                         'many markers'),
+            detailed_description=('The deblending mode for the '
+                                  'parent source was changed to '
+                                  '"linear" because the parent '
+                                  'source had too many potential '
+                                  'deblended sources.'),
+        ),
+        FlagDefinition(
+            bit_value=256,
+            name='undefined_shape',
+            description=('non-positive net flux; shape properties '
+                         'undefined'),
+            detailed_description=('The net source flux (the zeroth '
+                                  'image moment over the source '
+                                  'segment) is not positive, so the '
+                                  'centroid and the '
+                                  'covariance-derived shape '
+                                  'properties (e.g., ``centroid``, '
+                                  '``semimajor_sigma``, '
+                                  '``orientation``) are undefined or '
+                                  'unreliable.'),
+        ),
+        FlagDefinition(
+            bit_value=512,
+            name='singular_covariance',
+            description=('singular or nearly singular source '
+                         'covariance'),
+            detailed_description=('The source covariance matrix is '
+                                  'singular or nearly singular (the '
+                                  'minor-axis variance is below '
+                                  '``1/12``, the variance of a '
+                                  'uniform distribution across a '
+                                  'single pixel), so '
+                                  'covariance-derived shape '
+                                  'properties (e.g., '
+                                  '``semimajor_sigma``, '
+                                  '``orientation``, '
+                                  '``eccentricity``) are '
+                                  'ill-defined.'),
+        ),
+        FlagDefinition(
+            bit_value=1024,
+            name='centroid_win_fallback',
+            description=('windowed centroid failed or fell back to '
+                         'the isophotal centroid'),
+            detailed_description=('The windowed centroid could not '
+                                  'be computed (NaN; the half-light '
+                                  'radius was not finite) or fell '
+                                  'outside the 1-sigma moment '
+                                  'ellipse, in which case the '
+                                  'isophotal ``centroid`` value was '
+                                  'used instead.'),
+        ),
+        FlagDefinition(
+            bit_value=2048,
+            name='centroid_quad_failed',
+            description='quadratic-fit centroid is non-finite',
+            detailed_description=('The quadratic-fit centroid '
+                                  '(``centroid_quad``) could not be '
+                                  'computed and is NaN.'),
+        ),
+        FlagDefinition(
+            bit_value=4096,
+            name='kron_undefined',
+            description='Kron aperture undefined or skipped',
+            detailed_description=('The Kron aperture could not be '
+                                  'defined (e.g., the source is '
+                                  'fully masked) or the Kron '
+                                  'photometry was skipped (e.g., the '
+                                  'aperture was too large), so the '
+                                  'Kron flux is NaN and no other '
+                                  'Kron-aperture flags were '
+                                  'evaluated.'),
+        ),
+        FlagDefinition(
+            bit_value=8192,
+            name='kron_minimum_radius',
+            description=('minimum Kron radius or minimum circular '
+                         'radius applied'),
+            detailed_description=('The measured unscaled Kron radius '
+                                  'fell below the minimum unscaled '
+                                  'Kron radius (``kron_params[1]``) '
+                                  'and was clipped to it, or the '
+                                  'minimum circular aperture '
+                                  '(``kron_params[2]``) was used '
+                                  'instead of the Kron ellipse.'),
+        ),
+        FlagDefinition(
+            bit_value=16384,
+            name='kron_no_overlap',
+            description='Kron aperture fully outside the data',
+            detailed_description=('The Kron aperture is fully '
+                                  'outside the data array: no pixel '
+                                  'with nonzero aperture weight '
+                                  'falls inside the data.'),
+        ),
+        FlagDefinition(
+            bit_value=32768,
+            name='kron_partial_overlap',
+            description='Kron aperture partially outside the data',
+            detailed_description=('The Kron aperture is partially '
+                                  'outside the data array: one or '
+                                  'more pixels with nonzero aperture '
+                                  'weight fall outside the data.'),
+        ),
+        FlagDefinition(
+            bit_value=65536,
+            name='kron_masked_pixels',
+            description=('masked or non-finite pixels within the '
+                         'Kron aperture'),
+            detailed_description=('One or more input-masked or '
+                                  'non-finite pixels have nonzero '
+                                  'aperture weight within the Kron '
+                                  'aperture.'),
+        ),
+        FlagDefinition(
+            bit_value=131072,
+            name='kron_neighbor_pixels',
+            description=('neighbor-source pixels within the Kron '
+                         'aperture'),
+            detailed_description=('One or more pixels within the '
+                                  'Kron aperture were excluded or '
+                                  'corrected due to neighboring '
+                                  'sources in the segmentation image '
+                                  '(``aperture_mask_method`` of '
+                                  '"mask" or "correct").'),
+        ),
+        FlagDefinition(
+            bit_value=262144,
+            name='kron_uncorrected_pixels',
+            description=('uncorrectable neighbor pixels within the '
+                         'Kron aperture'),
+            detailed_description=('With '
+                                  '``aperture_mask_method="correct"``'
+                                  ', one or more neighbor-source '
+                                  'pixels within the Kron aperture '
+                                  'could not be corrected (the '
+                                  'mirror pixel was unavailable) and '
+                                  'were excluded instead.'),
+        ),
+    ]
+
+    domain: ClassVar = 'segmentation'
+
+
+# Create a singleton instance for global use
+SEGMENTATION_FLAGS = _SegmentationFlags()
+
+
+def _update_decode_docstring(func):
+    """
+    Decorator to update a function docstring with the segmentation flag
+    documentation.
+
+    The ``<flag_descriptions>`` placeholder in the function docstring is
+    replaced with a bullet list generated from ``SEGMENTATION_FLAGS``
+    (see `photutils.utils._flags.update_flag_docstring`).
+
+    Parameters
+    ----------
+    func : function
+        The function to decorate.
+
+    Returns
+    -------
+    func : function
+        The decorated function with updated docstring.
+    """
+    return update_flag_docstring(func, SEGMENTATION_FLAGS, indent=4)
+
+
+@_update_decode_docstring
+def decode_segmentation_flags(flags, *, return_bit_values=False):
+    # numpydoc ignore: RT05
+    """
+    Decode segmentation bitwise flag values into individual components.
+
+    This function takes integer flag values from segmentation operations
+    and returns a list of human-readable names of the conditions that
+    were detected. This is useful for understanding what problems were
+    encountered without needing to manually perform bitwise operations.
+
+    Parameters
+    ----------
+    flags : int or array-like of int
+        Integer flag value(s) to decode. Each bit in the flag represents
+        a specific condition that was detected when processing the
+        segmentation.
+
+    return_bit_values : bool, optional
+        If `True`, return the decoded bit flags (integers) instead of
+        the flag names (strings). Default is `False`.
+
+    Returns
+    -------
+    decoded : list of str, list of int, or nested list
+        List of active flag names (or bit values) for a scalar input.
+        For an array input, a nested list with the same shape as the
+        input is returned, where each innermost element is the list of
+        active flag names (or bit values) for the corresponding flag. If
+        no flags are set, an empty list is returned. Possible flags are:
+        <flag_descriptions>
+
+    Examples
+    --------
+    Decode a single flag value:
+
+    >>> from photutils.segmentation import decode_segmentation_flags
+    >>> issues = decode_segmentation_flags(48)  # bits 16 and 32 set
+    >>> print(issues)
+    ['edge_touch', 'deblended']
+    >>> 'edge_touch' in issues
+    True
+    >>> 'deblended' in issues
+    True
+
+    Decode multiple flag values:
+
+    >>> flags = [0, 1, 33]  # 0, bit 1, bits 1+32
+    >>> decoded_list = decode_segmentation_flags(flags)
+    >>> decoded_list[0]  # No issues
+    []
+    >>> decoded_list[1]
+    ['masked_pixels']
+    >>> decoded_list[2]
+    ['masked_pixels', 'deblended']
+
+    Return the bit values instead of the names:
+
+    >>> decode_segmentation_flags(48, return_bit_values=True)
+    [16, 32]
+    """
+    return decode_flags(flags, SEGMENTATION_FLAGS,
+                        return_bit_values=return_bit_values)

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -27,8 +27,10 @@ from photutils.datasets import (make_100gaussians_image, make_gwcs,
                                 make_noise_image, make_wcs)
 from photutils.segmentation.catalog import SourceCatalog
 from photutils.segmentation.core import SegmentationImage
+from photutils.segmentation.deblend import deblend_sources
 from photutils.segmentation.detect import detect_sources
 from photutils.segmentation.finder import SourceFinder
+from photutils.segmentation.flags import SEGMENTATION_FLAGS
 from photutils.segmentation.utils import make_2dgaussian_kernel
 from photutils.utils._optional_deps import (HAS_GWCS, HAS_MATPLOTLIB,
                                             HAS_SKIMAGE)
@@ -1412,6 +1414,121 @@ class TestSourceCatalog:
         assert_allclose(cat[1].covariance,
                         [(np.nan, np.nan), (np.nan, np.nan)] * u.pix**2)
         assert_allclose(cat.fwhm, [0.67977799, np.nan] * u.pix)
+
+
+class TestSourceCatalogFlags:
+    """
+    Tests for the SourceCatalog flags property.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        yy, xx = np.mgrid[0:51, 0:51]
+        # Interior source and edge-touching source
+        interior = Gaussian2D(100, 25, 25, 3, 3)(xx, yy)
+        edge = Gaussian2D(100, 2, 40, 3, 3)(xx, yy)
+        self.data = interior + edge
+        self.segm = detect_sources(self.data, 10, 5)
+        assert self.segm.n_labels == 2
+
+    def test_flags_zero(self):
+        """
+        Test that flags are zero for clean interior sources.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        interior_idx = np.argmax(cat.bbox_xmin > 0)
+        assert cat.flags[interior_idx] == 0
+
+    def test_edge_touch(self):
+        """
+        Test the edge_touch flag for a source segment touching the image
+        boundary.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        edge_bits = cat.flags & SEGMENTATION_FLAGS.EDGE_TOUCH
+        assert np.count_nonzero(edge_bits) == 1
+
+    def test_masked_pixels(self):
+        """
+        Test the masked_pixels flag for input-masked pixels within the
+        source segment.
+        """
+        mask = np.zeros(self.data.shape, dtype=bool)
+        mask[25, 25] = True  # inside the interior source
+        cat = SourceCatalog(self.data, self.segm, mask=mask)
+        idx = np.argmax(cat.bbox_xmin > 0)
+        assert cat.flags[idx] & SEGMENTATION_FLAGS.MASKED_PIXELS
+        other = 1 - idx
+        assert not (cat.flags[other]
+                    & SEGMENTATION_FLAGS.MASKED_PIXELS)
+
+    def test_non_finite_data(self):
+        """
+        Test the non_finite_data flag.
+        """
+        data = self.data.copy()
+        data[25, 25] = np.nan
+        cat = SourceCatalog(data, self.segm)
+        idx = np.argmax(cat.bbox_xmin > 0)
+        assert cat.flags[idx] & SEGMENTATION_FLAGS.NON_FINITE_DATA
+
+    def test_non_finite_error(self):
+        """
+        Test the non_finite_error flag.
+        """
+        error = np.ones(self.data.shape)
+        error[25, 25] = np.inf
+        cat = SourceCatalog(self.data, self.segm, error=error)
+        idx = np.argmax(cat.bbox_xmin > 0)
+        assert cat.flags[idx] & SEGMENTATION_FLAGS.NON_FINITE_ERROR
+
+    def test_all_masked(self):
+        """
+        Test the all_masked flag when every segment pixel is masked.
+        """
+        mask = np.zeros(self.data.shape, dtype=bool)
+        mask[self.segm.data == self.segm.labels[0]] = True
+        cat = SourceCatalog(self.data, self.segm, mask=mask)
+        assert cat.flags[0] & SEGMENTATION_FLAGS.ALL_MASKED
+
+    @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
+    def test_provenance_from_deblending(self):
+        """
+        Test that deblending provenance flags propagate into the catalog
+        flags.
+        """
+        yy, xx = np.mgrid[0:101, 0:101]
+        data = (Gaussian2D(100, 50, 50, 5, 5)(xx, yy)
+                + Gaussian2D(100, 35, 50, 5, 5)(xx, yy))
+        segm = detect_sources(data, 10, 5)
+        segm2 = deblend_sources(data, segm, 5, progress_bar=False)
+        cat = SourceCatalog(data, segm2)
+        assert np.all(cat.flags & SEGMENTATION_FLAGS.DEBLENDED)
+
+    def test_flags_in_table(self):
+        """
+        Test that flags is a default table column with int values.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        tbl = cat.to_table()
+        assert 'flags' in tbl.colnames
+        assert np.issubdtype(tbl['flags'].dtype, np.integer)
+
+    def test_flags_slicing(self):
+        """
+        Test that flags slice consistently with the catalog.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        flags = cat.flags
+        assert cat[1:].flags[0] == flags[1]
+
+    def test_flags_docstring_lists_all_flags(self):
+        """
+        Test that the flags docstring documents every flag name.
+        """
+        doc = SourceCatalog.flags.func.__doc__
+        for name in SEGMENTATION_FLAGS.names:
+            assert name in doc
 
 
 class TestThreadSafety:

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1587,6 +1587,178 @@ class TestSourceCatalogFlags:
                 | SEGMENTATION_FLAGS.CENTROID_QUAD_FAILED)
         assert not np.any(cat.flags & bits)
 
+    def test_kron_partial_overlap(self):
+        """
+        Test the kron_partial_overlap flag when the Kron aperture
+        extends beyond the image while the segment does not.
+        """
+        yy, xx = np.mgrid[0:41, 0:41]
+        data = Gaussian2D(100, 6, 20, 3, 3)(xx, yy)
+        segm = detect_sources(data, 25, 5)  # compact segment
+        cat = SourceCatalog(data, segm)
+        assert not (cat.flags[0] & SEGMENTATION_FLAGS.EDGE_TOUCH)
+        assert (cat.flags[0]
+                & SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP)
+
+    def test_kron_partial_overlap_not_set(self):
+        """
+        Test that kron_partial_overlap is not set for a source whose
+        Kron aperture is completely inside the image.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        idx = np.argmax(cat.bbox_xmin > 0)
+        assert not (cat.flags[idx]
+                    & SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP)
+
+    @staticmethod
+    def _make_deblended_pair():
+        """
+        Make the data and deblended segmentation image for a pair of
+        overlapping sources.
+        """
+        yy, xx = np.mgrid[0:61, 0:61]
+        data = (Gaussian2D(100, 25, 30, 4, 4)(xx, yy)
+                + Gaussian2D(100, 38, 30, 4, 4)(xx, yy))
+        segm = detect_sources(data, 10, 5)
+        return data, deblend_sources(data, segm, 5, progress_bar=False)
+
+    @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
+    def test_kron_neighbor_pixels(self):
+        """
+        Test the kron_neighbor_pixels flag when a neighbor segment falls
+        within the Kron aperture.
+        """
+        data, segm = self._make_deblended_pair()
+        cat = SourceCatalog(data, segm, aperture_mask_method='correct')
+        assert np.all(cat.flags
+                      & SEGMENTATION_FLAGS.KRON_NEIGHBOR_PIXELS)
+
+    @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
+    def test_kron_uncorrected_pixels(self):
+        """
+        Test the kron_uncorrected_pixels flag for neighbor pixels within
+        the Kron aperture that could not be replaced by a mirrored
+        value.
+        """
+        data, segm = self._make_deblended_pair()
+        cat = SourceCatalog(data, segm, aperture_mask_method='correct')
+        assert np.all(cat.flags
+                      & SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS)
+
+        # Neighboring sources are neither masked nor corrected
+        cat2 = SourceCatalog(data, segm, aperture_mask_method='none')
+        bits = (SEGMENTATION_FLAGS.KRON_NEIGHBOR_PIXELS
+                | SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS)
+        assert not np.any(cat2.flags & bits)
+
+    def test_kron_neighbor_pixels_not_set(self):
+        """
+        Test that kron_neighbor_pixels is not set when the Kron aperture
+        contains no neighboring source pixels.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        assert not np.any(cat.flags
+                          & SEGMENTATION_FLAGS.KRON_NEIGHBOR_PIXELS)
+
+    def test_kron_masked_pixels(self):
+        """
+        Test the kron_masked_pixels flag for a masked pixel inside the
+        Kron aperture but outside the segment.
+        """
+        cat0 = SourceCatalog(self.data, self.segm)
+        interior_idx = np.argmax(cat0.bbox_xmin > 0)
+        # Mask a pixel just outside the segment bbox, inside the
+        # Kron aperture of the interior source
+        x_out = int(cat0.bbox_xmax[interior_idx]) + 1
+        y_cen = int(cat0.bbox_ymin[interior_idx]
+                    + cat0.bbox_ymax[interior_idx]) // 2
+        mask = np.zeros(self.data.shape, dtype=bool)
+        mask[y_cen, x_out] = True
+        cat = SourceCatalog(self.data, self.segm, mask=mask)
+        assert (cat.flags[interior_idx]
+                & SEGMENTATION_FLAGS.KRON_MASKED_PIXELS)
+        assert not (cat.flags[interior_idx]
+                    & SEGMENTATION_FLAGS.MASKED_PIXELS)
+
+    def test_kron_undefined(self):
+        """
+        Test the kron_undefined flag for a fully-masked source (whose
+        Kron aperture is undefined).
+        """
+        mask = np.zeros(self.data.shape, dtype=bool)
+        mask[self.segm.data == self.segm.labels[0]] = True
+        cat = SourceCatalog(self.data, self.segm, mask=mask)
+        assert cat.kron_aperture[0] is None
+        assert cat.flags[0] & SEGMENTATION_FLAGS.KRON_UNDEFINED
+
+    @pytest.mark.parametrize('circular', [False, True])
+    def test_kron_undefined_oversized(self, circular):
+        """
+        Test the kron_undefined flag when the Kron photometry is skipped
+        because the aperture is too large.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        _ = cat.kron_aperture  # cache the apertures
+        if circular:
+            aperture = CircularAperture((25, 25), r=2000)
+        else:
+            aperture = EllipticalAperture((25, 25), 2000, 2000,
+                                          theta=0.0)
+        cat.__dict__['kron_aperture'] = [aperture] * cat.n_labels
+        assert np.all(cat.flags & SEGMENTATION_FLAGS.KRON_UNDEFINED)
+
+    def test_kron_no_overlap(self):
+        """
+        Test the kron_no_overlap flag when the Kron aperture is
+        completely outside the data array.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        _ = cat.kron_aperture  # cache the apertures
+        aperture = EllipticalAperture((-1000, -1000), 5, 3, theta=0.0)
+        cat.__dict__['kron_aperture'] = [aperture] * cat.n_labels
+        assert np.all(cat.flags & SEGMENTATION_FLAGS.KRON_NO_OVERLAP)
+
+    def test_kron_minimum_radius(self):
+        """
+        Test the kron_minimum_radius flag when the measured Kron radius
+        is clipped to the kron_params minimum.
+        """
+        # A large minimum unscaled Kron radius forces clipping for
+        # every source
+        cat = SourceCatalog(self.data, self.segm,
+                            kron_params=(2.5, 5.9, 0.0))
+        assert np.all(cat.flags
+                      & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
+
+        # The default minimum is not triggered by these resolved
+        # sources
+        cat2 = SourceCatalog(self.data, self.segm)
+        assert not np.any(cat2.flags
+                          & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
+
+    def test_kron_minimum_circular_radius(self):
+        """
+        Test the kron_minimum_radius flag when the minimum circular
+        aperture is used (kron_radius set to zero).
+        """
+        # A large minimum circular radius forces the circular fallback
+        # for every source
+        cat = SourceCatalog(self.data, self.segm,
+                            kron_params=(2.5, 1.4, 50.0))
+        assert_equal(cat.kron_radius.value, np.zeros(2))
+        assert np.all(cat.flags
+                      & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
+
+    def test_kron_minimum_radius_two_element_params(self):
+        """
+        Test the kron_minimum_radius flag with a two-element kron_params
+        (no minimum circular radius).
+        """
+        cat = SourceCatalog(self.data, self.segm,
+                            kron_params=(2.5, 5.9))
+        assert np.all(cat.flags
+                      & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
+
     @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
     def test_provenance_from_deblending(self):
         """
@@ -2310,7 +2482,7 @@ def test_kron_photometry_oom_guard(gauss_101_catalog):
         if result[0] is not None:
             # Set mask to all True (all pixels masked)
             return (result[0], result[1], np.ones_like(result[2]),
-                    result[3], result[4])
+                    result[3], result[4], result[5])
         return result
 
     with patch.object(type(cat4), '_make_aperture_data', _make_all_masked):
@@ -2436,7 +2608,7 @@ def test_centroid_win_aperture_mask_mask(centroid_win_data):
 
 def test_make_aperture_data_outside_image(gauss_101_catalog):
     """
-    Test that _make_aperture_data returns (None,) * 5 when the aperture
+    Test that _make_aperture_data returns (None,) * 6 when the aperture
     bbox does not overlap the data.
     """
     _data, _segm, cat = gauss_101_catalog
@@ -2445,7 +2617,7 @@ def test_make_aperture_data_outside_image(gauss_101_catalog):
     offimage_bbox = BoundingBox(ixmin=200, ixmax=210,
                                 iymin=200, iymax=210)
     result = cat._make_aperture_data(1, 205.0, 205.0, offimage_bbox, 0.0)
-    assert result == (None,) * 5
+    assert result == (None,) * 6
 
 
 def test_flux_radius_optimizer_args_oom_guard(gauss_101_catalog):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1491,6 +1491,71 @@ class TestSourceCatalogFlags:
         cat = SourceCatalog(self.data, self.segm, mask=mask)
         assert cat.flags[0] & SEGMENTATION_FLAGS.ALL_MASKED
 
+    def test_undefined_shape(self):
+        """
+        Test the undefined_shape flag for a source with non-positive
+        net flux.
+        """
+        data = np.zeros((11, 11))
+        data[3:8, 3:8] = -1.0
+        segm_data = np.zeros((11, 11), dtype=int)
+        segm_data[3:8, 3:8] = 1
+        cat = SourceCatalog(data, SegmentationImage(segm_data))
+        assert cat.flags[0] & SEGMENTATION_FLAGS.UNDEFINED_SHAPE
+
+    def test_undefined_shape_not_set(self):
+        """
+        Test that undefined_shape is not set for a normal source.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        assert not np.any(cat.flags
+                          & SEGMENTATION_FLAGS.UNDEFINED_SHAPE)
+
+    def test_singular_covariance(self):
+        """
+        Test the singular_covariance flag for a one-pixel-wide source.
+        """
+        data = np.zeros((11, 11))
+        data[5, 2:9] = 10.0
+        segm_data = np.zeros((11, 11), dtype=int)
+        segm_data[5, 2:9] = 1
+        cat = SourceCatalog(data, SegmentationImage(segm_data))
+        assert cat.flags[0] & SEGMENTATION_FLAGS.SINGULAR_COVARIANCE
+
+    def test_singular_covariance_not_set(self):
+        """
+        Test that singular_covariance is not set for a well-resolved
+        source.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        assert not np.any(cat.flags
+                          & SEGMENTATION_FLAGS.SINGULAR_COVARIANCE)
+
+    def test_centroid_flags_fully_masked(self):
+        """
+        Test that a fully-masked compact source flags both centroid
+        failures (windowed centroid NaN, quadratic fit NaN).
+        """
+        data = np.zeros((21, 21))
+        data[5:7, 5:7] = 10.0
+        segm_data = np.zeros((21, 21), dtype=int)
+        segm_data[5:7, 5:7] = 1
+        mask = segm_data.astype(bool)
+        cat = SourceCatalog(data, SegmentationImage(segm_data),
+                            mask=mask)
+        assert cat.flags[0] & SEGMENTATION_FLAGS.CENTROID_WIN_FALLBACK
+        assert cat.flags[0] & SEGMENTATION_FLAGS.CENTROID_QUAD_FAILED
+
+    def test_centroid_flags_not_set(self):
+        """
+        Test that centroid flags are not set for clean resolved
+        sources.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        bits = (SEGMENTATION_FLAGS.CENTROID_WIN_FALLBACK
+                | SEGMENTATION_FLAGS.CENTROID_QUAD_FAILED)
+        assert not np.any(cat.flags & bits)
+
     @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
     def test_provenance_from_deblending(self):
         """
@@ -1694,6 +1759,11 @@ def test_centroid_win(centroid_win_data):
     # isophotal centroid
     assert cat.x_centroid[1] == cat.x_centroid_win[1]
     assert cat.y_centroid[1] == cat.y_centroid_win[1]
+
+    # Only the reset source is flagged
+    win_flags = cat.flags & SEGMENTATION_FLAGS.CENTROID_WIN_FALLBACK
+    assert not win_flags[0]
+    assert win_flags[1]
 
 
 def test_centroid_win_migrate():

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1522,6 +1522,26 @@ class TestSourceCatalogFlags:
         cat = SourceCatalog(data, SegmentationImage(segm_data))
         assert cat.flags[0] & SEGMENTATION_FLAGS.SINGULAR_COVARIANCE
 
+    def test_singular_covariance_elongated(self):
+        """
+        Test the singular_covariance flag for an elongated source that
+        is unresolved along only its minor axis.
+
+        The covariance determinant of such a source exceeds
+        ``(1/12)**2``, so it is flagged only by the minor-axis variance
+        test.
+        """
+        data = np.zeros((11, 11))
+        data[4, 2:9] = 0.04
+        data[5, 2:9] = 1.0
+        data[6, 2:9] = 0.04
+        segm_data = np.zeros((11, 11), dtype=int)
+        segm_data[4:7, 2:9] = 1
+        cat = SourceCatalog(data, SegmentationImage(segm_data))
+        # the minor-axis variance is below the 1/12 single-pixel floor
+        assert cat.semiminor_axis.value[0] < np.sqrt(1 / 12)
+        assert cat.flags[0] & SEGMENTATION_FLAGS.SINGULAR_COVARIANCE
+
     def test_singular_covariance_not_set(self):
         """
         Test that singular_covariance is not set for a well-resolved
@@ -1533,8 +1553,20 @@ class TestSourceCatalogFlags:
 
     def test_centroid_flags_fully_masked(self):
         """
-        Test that a fully-masked compact source flags both centroid
-        failures (windowed centroid NaN, quadratic fit NaN).
+        Test that a fully-masked source flags both centroid failures
+        (windowed centroid NaN, quadratic fit NaN).
+        """
+        mask = np.zeros(self.data.shape, dtype=bool)
+        mask[self.segm.data == self.segm.labels[0]] = True
+        cat = SourceCatalog(self.data, self.segm, mask=mask)
+        assert np.all(np.isnan(cat.centroid_quad[0]))
+        assert cat.flags[0] & SEGMENTATION_FLAGS.CENTROID_WIN_FALLBACK
+        assert cat.flags[0] & SEGMENTATION_FLAGS.CENTROID_QUAD_FAILED
+
+    def test_centroid_flags_fully_masked_small(self):
+        """
+        Test that a fully-masked source smaller than the 3x3 quadratic
+        fit box flags both centroid failures.
         """
         data = np.zeros((21, 21))
         data[5:7, 5:7] = 10.0
@@ -1548,8 +1580,7 @@ class TestSourceCatalogFlags:
 
     def test_centroid_flags_not_set(self):
         """
-        Test that centroid flags are not set for clean resolved
-        sources.
+        Test that centroid flags are not set for clean resolved sources.
         """
         cat = SourceCatalog(self.data, self.segm)
         bits = (SEGMENTATION_FLAGS.CENTROID_WIN_FALLBACK

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1883,15 +1883,19 @@ class TestSourceCatalogFlags:
 
     def test_decode_flags(self):
         """
-        Test that decode_flags returns the active flag names for each
-        source.
+        Test that decode_flags returns a dictionary mapping each
+        source label to its active flag names.
         """
         cat = SourceCatalog(self.data, self.segm)
         decoded = cat.decode_flags()
         interior_idx = np.argmax(cat.bbox_xmin > 0)
-        assert decoded[interior_idx] == []
-        assert decoded[1 - interior_idx] == ['edge_touch',
-                                             'kron_partial_overlap']
+        interior_label = cat.labels[interior_idx]
+        edge_label = cat.labels[1 - interior_idx]
+        assert list(decoded) == list(cat.labels)
+        assert all(type(key) is int for key in decoded)
+        assert decoded[interior_label] == []
+        assert decoded[edge_label] == ['edge_touch',
+                                       'kron_partial_overlap']
 
     def test_decode_flags_bit_values(self):
         """
@@ -1900,21 +1904,24 @@ class TestSourceCatalogFlags:
         cat = SourceCatalog(self.data, self.segm)
         decoded = cat.decode_flags(return_bit_values=True)
         interior_idx = np.argmax(cat.bbox_xmin > 0)
-        assert decoded[interior_idx] == []
-        assert decoded[1 - interior_idx] == [
+        interior_label = cat.labels[interior_idx]
+        edge_label = cat.labels[1 - interior_idx]
+        assert decoded[interior_label] == []
+        assert decoded[edge_label] == [
             SEGMENTATION_FLAGS.EDGE_TOUCH,
             SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP]
 
     def test_decode_flags_scalar(self):
         """
-        Test that decode_flags on a scalar catalog returns a length-1
-        list of lists.
+        Test that decode_flags on a scalar catalog returns a
+        single-entry dictionary keyed by the source label.
         """
         cat = SourceCatalog(self.data, self.segm)
         interior_idx = int(np.argmax(cat.bbox_xmin > 0))
         scalar_cat = cat[1 - interior_idx]
-        assert scalar_cat.decode_flags() == [['edge_touch',
-                                              'kron_partial_overlap']]
+        edge_label = int(cat.labels[1 - interior_idx])
+        assert scalar_cat.decode_flags() == {
+            edge_label: ['edge_touch', 'kron_partial_overlap']}
 
     def test_decode_flags_keyword_only(self):
         """

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1471,6 +1471,9 @@ class TestSourceCatalogFlags:
         cat = SourceCatalog(data, self.segm)
         idx = np.argmax(cat.bbox_xmin > 0)
         assert cat.flags[idx] & SEGMENTATION_FLAGS.NON_FINITE_DATA
+        other = 1 - idx
+        assert not (cat.flags[other]
+                    & SEGMENTATION_FLAGS.NON_FINITE_DATA)
 
     def test_non_finite_error(self):
         """
@@ -1481,6 +1484,9 @@ class TestSourceCatalogFlags:
         cat = SourceCatalog(self.data, self.segm, error=error)
         idx = np.argmax(cat.bbox_xmin > 0)
         assert cat.flags[idx] & SEGMENTATION_FLAGS.NON_FINITE_ERROR
+        other = 1 - idx
+        assert not (cat.flags[other]
+                    & SEGMENTATION_FLAGS.NON_FINITE_ERROR)
 
     def test_all_masked(self):
         """
@@ -1651,6 +1657,14 @@ class TestSourceCatalogFlags:
                 | SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS)
         assert not np.any(cat2.flags & bits)
 
+        # Neighboring sources are masked, not corrected, so no pixels
+        # are left uncorrected
+        cat3 = SourceCatalog(data, segm, aperture_mask_method='mask')
+        assert np.all(cat3.flags
+                      & SEGMENTATION_FLAGS.KRON_NEIGHBOR_PIXELS)
+        assert not np.any(cat3.flags
+                          & SEGMENTATION_FLAGS.KRON_UNCORRECTED_PIXELS)
+
     def test_kron_neighbor_pixels_not_set(self):
         """
         Test that kron_neighbor_pixels is not set when the Kron aperture
@@ -1746,7 +1760,11 @@ class TestSourceCatalogFlags:
                       & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
 
         # The default minimum is not triggered by these resolved
-        # sources
+        # sources. The measured unscaled Kron radii are approximately
+        # [1.4318, 1.4058] against the default minimum of 1.4, a margin
+        # of about 0.006 for the smaller value. A future failure here
+        # likely indicates a fixture-tolerance drift rather than a flag
+        # regression.
         cat2 = SourceCatalog(self.data, self.segm)
         assert not np.any(cat2.flags
                           & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
@@ -1834,6 +1852,26 @@ class TestSourceCatalogFlags:
         cat = SourceCatalog(self.data, self.segm)
         flags = cat.flags
         assert cat[1:].flags[0] == flags[1]
+
+    def test_flags_scalar_fresh(self):
+        """
+        Test that a scalar catalog sliced before the parent catalog's
+        flags are cached computes a flags value that matches the parent
+        catalog's flags.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        scalar_cat = cat[0]  # slice before flags is accessed/cached
+        assert scalar_cat.flags == cat.flags[0]
+
+    def test_flags_scalar_cached(self):
+        """
+        Test that a scalar catalog sliced after the parent catalog's
+        flags are already cached carries the matching flags value.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        flags = cat.flags  # cache flags on the parent catalog
+        scalar_cat = cat[0]  # slice after flags is cached
+        assert scalar_cat.flags == flags[0]
 
     def test_flags_docstring_lists_all_flags(self):
         """
@@ -2032,6 +2070,9 @@ def test_centroid_win_migrate():
     indices = (0, 3, 14, 30)
     for idx in indices:
         assert_equal(cat.centroid_win[idx], cat.centroid[idx])
+        # The windowed centroid diverged off the image (a non-ellipse
+        # fallback condition), so the fallback flag is set.
+        assert cat.flags[idx] & SEGMENTATION_FLAGS.CENTROID_WIN_FALLBACK
 
 
 def test_background_centroid_coordinate_order():

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1718,6 +1718,21 @@ class TestSourceCatalogFlags:
         cat.__dict__['kron_aperture'] = [aperture] * cat.n_labels
         assert np.all(cat.flags & SEGMENTATION_FLAGS.KRON_NO_OVERLAP)
 
+    def test_kron_no_overlap_zero_weights(self):
+        """
+        Test the kron_no_overlap flag when the Kron aperture bounding
+        box overlaps the data, but no pixel within the data has a
+        nonzero aperture weight.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        _ = cat.kron_aperture  # cache the apertures
+        aperture = CircularAperture((-10.5, -10.5), r=10)
+        cat.__dict__['kron_aperture'] = [aperture] * cat.n_labels
+        assert np.all(np.isnan(cat.kron_flux))
+        assert np.all(cat.flags & SEGMENTATION_FLAGS.KRON_NO_OVERLAP)
+        assert not np.any(cat.flags
+                          & SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP)
+
     def test_kron_minimum_radius(self):
         """
         Test the kron_minimum_radius flag when the measured Kron radius
@@ -1747,6 +1762,36 @@ class TestSourceCatalogFlags:
                             kron_params=(2.5, 1.4, 50.0))
         assert_equal(cat.kron_radius.value, np.zeros(2))
         assert np.all(cat.flags
+                      & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
+
+    def test_kron_minimum_radius_detection_catalog(self):
+        """
+        Test that the kron_minimum_radius flag follows the kron_params
+        of the detection catalog, which measures the Kron radii.
+
+        A detection catalog overrides the input ``kron_params``, so
+        the minimum radius of the detection catalog is the one that is
+        applied.
+        """
+        # The detection catalog does not apply its minimum, even though
+        # the measured radii are below the requested minimum.
+        detcat = SourceCatalog(self.data, self.segm,
+                               kron_params=(2.5, 1.4))
+        cat = SourceCatalog(self.data, self.segm,
+                            kron_params=(2.5, 5.9),
+                            detection_catalog=detcat)
+        assert cat.kron_params == detcat.kron_params
+        assert not np.any(cat.flags
+                          & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
+
+        # The detection catalog applies its minimum to every source
+        detcat2 = SourceCatalog(self.data, self.segm,
+                                kron_params=(2.5, 5.9))
+        cat2 = SourceCatalog(self.data, self.segm,
+                             kron_params=(2.5, 1.4),
+                             detection_catalog=detcat2)
+        assert cat2.kron_params == detcat2.kron_params
+        assert np.all(cat2.flags
                       & SEGMENTATION_FLAGS.KRON_MINIMUM_RADIUS)
 
     def test_kron_minimum_radius_two_element_params(self):

--- a/photutils/segmentation/tests/test_catalog.py
+++ b/photutils/segmentation/tests/test_catalog.py
@@ -1881,6 +1881,49 @@ class TestSourceCatalogFlags:
         for name in SEGMENTATION_FLAGS.names:
             assert name in doc
 
+    def test_decode_flags(self):
+        """
+        Test that decode_flags returns the active flag names for each
+        source.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        decoded = cat.decode_flags()
+        interior_idx = np.argmax(cat.bbox_xmin > 0)
+        assert decoded[interior_idx] == []
+        assert decoded[1 - interior_idx] == ['edge_touch',
+                                             'kron_partial_overlap']
+
+    def test_decode_flags_bit_values(self):
+        """
+        Test that decode_flags returns bit values when requested.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        decoded = cat.decode_flags(return_bit_values=True)
+        interior_idx = np.argmax(cat.bbox_xmin > 0)
+        assert decoded[interior_idx] == []
+        assert decoded[1 - interior_idx] == [
+            SEGMENTATION_FLAGS.EDGE_TOUCH,
+            SEGMENTATION_FLAGS.KRON_PARTIAL_OVERLAP]
+
+    def test_decode_flags_scalar(self):
+        """
+        Test that decode_flags on a scalar catalog returns a length-1
+        list of lists.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        interior_idx = int(np.argmax(cat.bbox_xmin > 0))
+        scalar_cat = cat[1 - interior_idx]
+        assert scalar_cat.decode_flags() == [['edge_touch',
+                                              'kron_partial_overlap']]
+
+    def test_decode_flags_keyword_only(self):
+        """
+        Test that return_bit_values must be passed as a keyword.
+        """
+        cat = SourceCatalog(self.data, self.segm)
+        with pytest.raises(TypeError, match='positional'):
+            cat.decode_flags(1)
+
 
 class TestThreadSafety:
     """

--- a/photutils/segmentation/tests/test_core.py
+++ b/photutils/segmentation/tests/test_core.py
@@ -337,6 +337,99 @@ class TestSegmentationImage:
         segm.data = self.data[0:3, :].copy()
         assert segm.info == {}
 
+    def test_flags_default(self):
+        """
+        Test that the flags property exists and is all zeros for a
+        user-constructed segmentation image.
+        """
+        segm = SegmentationImage(self.data.copy())
+        assert_equal(segm.flags, np.zeros(segm.n_labels, dtype=int))
+
+    def test_flags_reset_on_data_reassignment(self):
+        """
+        Test that per-label flags are reset when the data attribute is
+        reassigned.
+        """
+        segm = SegmentationImage(self.data.copy())
+        segm._flags_map = {1: 3}
+        segm.data = self.data.copy()
+        assert segm._flags_map == {}
+        assert_equal(segm.flags, np.zeros(segm.n_labels, dtype=int))
+
+    def test_flags_order_matches_labels(self):
+        """
+        Test that the flags array is aligned with the labels array.
+        """
+        segm = SegmentationImage(self.data.copy())
+        segm._flags_map = {3: 8, 1: 2}
+        expected = [2 if label == 1 else 8 if label == 3 else 0
+                    for label in segm.labels]
+        assert_equal(segm.flags, expected)
+
+    def test_flags_relabel_consecutive(self):
+        """
+        Test that per-label flags follow their labels through
+        consecutive relabeling.
+        """
+        segm = SegmentationImage(self.data.copy())
+        old_labels = segm.labels.copy()
+        segm._flags_map = {int(old_labels[-1]): 4}
+        segm.relabel_consecutive()
+        assert segm._flags_map == {segm.n_labels: 4}
+
+    def test_flags_reassign_labels_merge(self):
+        """
+        Test that merging labels combines their flags with bitwise OR
+        and that removed labels drop their flags.
+        """
+        segm = SegmentationImage(self.data.copy())
+        labels = segm.labels
+        segm._flags_map = {int(labels[0]): 1, int(labels[1]): 2}
+        segm.reassign_labels(labels[:2], int(labels[1]))
+        assert segm._flags_map == {int(labels[1]): 3}
+
+    def test_flags_remove_labels(self):
+        """
+        Test that removing a label drops its flags entry.
+        """
+        segm = SegmentationImage(self.data.copy())
+        labels = segm.labels
+        segm._flags_map = {int(labels[0]): 1, int(labels[1]): 2}
+        segm.remove_labels(labels[0])
+        assert segm._flags_map == {int(labels[1]): 2}
+
+    def test_flags_copy(self):
+        """
+        Test that copying a segmentation image copies the flags mapping
+        without sharing state.
+        """
+        segm = SegmentationImage(self.data.copy())
+        segm._flags_map = {1: 1}
+        segm2 = segm.copy()
+        assert segm2._flags_map == {1: 1}
+        segm2._flags_map[1] = 2
+        assert segm._flags_map == {1: 1}
+
+    def test_flags_not_settable(self):
+        """
+        Test that the flags property cannot be assigned.
+        """
+        segm = SegmentationImage(self.data.copy())
+        match = 'has no setter|can.t set attribute|object attribute'
+        with pytest.raises(AttributeError, match=match):
+            segm.flags = np.zeros(segm.n_labels, dtype=int)
+
+    def test_flags_empty_labels(self):
+        """
+        Test that the flags array has an integer dtype and zero length
+        for a segmentation image with no labels.
+        """
+        segm = SegmentationImage(self.data.copy())
+        segm.remove_labels(segm.labels)
+        assert segm.n_labels == 0
+        assert segm.flags.dtype.kind == 'i'
+        assert len(segm.flags) == 0
+
     def test_invalid_data(self):
         """
         Test invalid data.
@@ -1246,8 +1339,9 @@ def test_subclass(segm_data):
                       [70, 70, 0, 0],
                       [70, 70, 0, 1]])
     segm.data = data2
-    # Only _data, labels, areas, _deblend_label_map, and info remain
-    assert len(segm.__dict__) == 5
+    # Only _data, labels, areas, _deblend_label_map, _flags_map, and
+    # info remain
+    assert len(segm.__dict__) == 6
     assert_equal(segm.areas, [1, 2, 2, 4])
 
 

--- a/photutils/segmentation/tests/test_deblend.py
+++ b/photutils/segmentation/tests/test_deblend.py
@@ -15,6 +15,7 @@ from photutils.segmentation import (SegmentationImage, deblend_sources,
                                     detect_sources)
 from photutils.segmentation.deblend import (_DeblendParams,
                                             _SingleSourceDeblender)
+from photutils.segmentation.flags import SEGMENTATION_FLAGS
 from photutils.utils._optional_deps import HAS_SKIMAGE
 from photutils.utils.exceptions import DeblendWarning
 
@@ -352,6 +353,42 @@ class TestDeblendSources:
         assert list(segm.info) == ['nonposmin_labels']
         assert_equal(segm.info['nonposmin_labels'], [1])
 
+    def test_flags_deblended(self):
+        """
+        Test that deblended children carry the deblended flag and
+        nothing else when no mode fallback occurred.
+        """
+        result = deblend_sources(self.data, self.segm, self.n_pixels,
+                                 progress_bar=False)
+        assert_equal(result.flags,
+                     np.full(result.n_labels,
+                             SEGMENTATION_FLAGS.DEBLENDED))
+
+    def test_flags_nonposmin_children(self):
+        """
+        Test that children of a parent whose mode fell back due to
+        non-positive minimum data values carry both the deblended and
+        fallback flags.
+        """
+        data = self.data.copy()
+        data -= 20
+        match = 'The deblending mode of one or more source labels'
+        with pytest.warns(DeblendWarning, match=match):
+            segm = deblend_sources(data, self.segm, self.n_pixels,
+                                   progress_bar=False)
+        expected = (SEGMENTATION_FLAGS.DEBLENDED
+                    | SEGMENTATION_FLAGS.DEBLEND_NONPOSMIN)
+        for label in segm.parent_to_deblended_labels[1]:
+            idx = segm.get_index(label)
+            assert segm.flags[idx] == expected
+
+    def test_flags_detect_sources_zero(self):
+        """
+        Test that detect_sources output has all-zero flags.
+        """
+        assert_equal(self.segm.flags,
+                     np.zeros(self.segm.n_labels, dtype=int))
+
     def test_source_zero_min(self):
         """
         Test source zero min.
@@ -515,6 +552,78 @@ def test_n_markers_fallback():
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
+def test_flags_n_markers_fallback():
+    """
+    Test that the n_markers fallback flag is set on the output
+    sources produced from the affected input label.
+    """
+    size = 51
+    data1 = np.resize([0, 0, 1, 1], size)
+    data1 = np.abs(data1 - np.atleast_2d(data1).T) + 2
+
+    for i in range(size):
+        if i % 2 == 0:
+            data1[i, :] = 1
+            data1[:, i] = 1
+
+    data = np.zeros((101, 101))
+    data[25:25 + size, 25:25 + size] = data1
+    data[50:60, 50:60] = 10.0
+
+    segm = detect_sources(data, 0.01, 10)
+    match = 'The deblending mode of one or more source labels'
+    with pytest.warns(DeblendWarning, match=match):
+        segm2 = deblend_sources(data, segm, 1, mode='exponential')
+
+    bit = SEGMENTATION_FLAGS.DEBLEND_N_MARKERS
+    flagged = segm2.labels[(segm2.flags & bit) > 0]
+    assert len(flagged) > 0
+    # Every flagged label traces back to input label 1
+    if 1 in segm2.parent_to_deblended_labels:
+        assert_equal(np.sort(flagged),
+                     np.sort(segm2.parent_to_deblended_labels[1]))
+    else:
+        assert_equal(flagged, [1])
+
+
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
+@pytest.mark.parametrize('relabel', [True, False])
+def test_flags_fallback_without_deblending(relabel):
+    """
+    Test that a fallback parent that did not split still gets the
+    fallback flag on its output label, with and without relabeling.
+    """
+    # Three well-separated, non-deblendable sources with a negative
+    # minimum (to trigger the nonposmin fallback). The middle label is
+    # removed after detection so the remaining input labels (1 and 3)
+    # are non-consecutive, exercising the relabel-map translation path
+    # when relabel=True.
+    g1 = Gaussian2D(100, 25, 25, 3, 3)
+    g2 = Gaussian2D(100, 50, 50, 3, 3)
+    g3 = Gaussian2D(100, 75, 75, 3, 3)
+    yy, xx = np.mgrid[0:101, 0:101]
+    data = g1(xx, yy) + g2(xx, yy) + g3(xx, yy) - 20.0
+
+    segm = detect_sources(data + 20.0, 10, 5)
+    assert_equal(segm.labels, [1, 2, 3])
+    segm.remove_label(2, relabel=False)
+    assert_equal(segm.labels, [1, 3])
+
+    match = 'The deblending mode of one or more source labels'
+    with pytest.warns(DeblendWarning, match=match):
+        segm2 = deblend_sources(data, segm, 5, progress_bar=False,
+                                relabel=relabel)
+
+    bit = SEGMENTATION_FLAGS.DEBLEND_NONPOSMIN
+    # Both remaining sources fell back (both have negative minima);
+    # neither splits, so each output label carries the fallback bit
+    # but not the deblended bit
+    assert_equal(segm2.flags & bit, [bit] * segm2.n_labels)
+    assert_equal(segm2.flags & SEGMENTATION_FLAGS.DEBLENDED,
+                 [0] * segm2.n_labels)
+
+
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
 def test_n_markers_fallback_multiproc():
     """
     Test the n_markers fallback warning via multiprocessing
@@ -563,6 +672,7 @@ def test_nonposmin_multiproc():
         segm2 = deblend_sources(data, segm, 5, progress_bar=False,
                                 n_processes=2)
     assert 'nonposmin_labels' in segm2.info
+    assert np.all(segm2.flags & SEGMENTATION_FLAGS.DEBLEND_NONPOSMIN)
 
 
 @pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')

--- a/photutils/segmentation/tests/test_finder.py
+++ b/photutils/segmentation/tests/test_finder.py
@@ -12,6 +12,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from photutils.datasets import make_100gaussians_image
 from photutils.segmentation.finder import SourceFinder
+from photutils.segmentation.flags import SEGMENTATION_FLAGS
 from photutils.segmentation.utils import make_2dgaussian_kernel
 from photutils.utils._optional_deps import HAS_SKIMAGE
 from photutils.utils.exceptions import NoDetectionsWarning
@@ -107,3 +108,17 @@ def test_finder_deprecations():
         _ = finder.npixels
     with pytest.warns(AstropyDeprecationWarning, match=match):
         _ = finder.nlevels
+
+
+@pytest.mark.skipif(not HAS_SKIMAGE, reason='skimage is required')
+def test_finder_flags_passthrough():
+    """
+    Test that deblending provenance flags survive the SourceFinder
+    pipeline.
+    """
+    yy, xx = np.mgrid[0:101, 0:101]
+    data = (Gaussian2D(100, 50, 50, 5, 5)(xx, yy)
+            + Gaussian2D(100, 35, 50, 5, 5)(xx, yy))
+    finder = SourceFinder(n_pixels=5, progress_bar=False)
+    segm = finder(data, 10)
+    assert np.any(segm.flags & SEGMENTATION_FLAGS.DEBLENDED)

--- a/photutils/segmentation/tests/test_flags.py
+++ b/photutils/segmentation/tests/test_flags.py
@@ -1,0 +1,129 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the flags module.
+"""
+
+import numpy as np
+import pytest
+
+from photutils.aperture.flags import APERTURE_FLAGS
+from photutils.segmentation.flags import (SEGMENTATION_FLAGS,
+                                          decode_segmentation_flags)
+
+# Flags that intentionally share a name (and meaning, with the segment
+# as the region) with APERTURE_FLAGS
+SHARED_APERTURE_NAMES = ('masked_pixels', 'non_finite_data',
+                         'non_finite_error', 'all_masked',
+                         'undefined_shape', 'singular_covariance')
+
+EXPECTED_BITS = {
+    'masked_pixels': 1,
+    'non_finite_data': 2,
+    'non_finite_error': 4,
+    'all_masked': 8,
+    'edge_touch': 16,
+    'deblended': 32,
+    'deblend_nonposmin': 64,
+    'deblend_n_markers': 128,
+    'undefined_shape': 256,
+    'singular_covariance': 512,
+    'centroid_win_fallback': 1024,
+    'centroid_quad_failed': 2048,
+    'kron_undefined': 4096,
+    'kron_minimum_radius': 8192,
+    'kron_no_overlap': 16384,
+    'kron_partial_overlap': 32768,
+    'kron_masked_pixels': 65536,
+    'kron_neighbor_pixels': 131072,
+    'kron_uncorrected_pixels': 262144,
+}
+
+
+def test_flag_names_and_bits():
+    """
+    Test the frozen flag names and bit values.
+    """
+    assert set(SEGMENTATION_FLAGS.names) == set(EXPECTED_BITS)
+    for name, bit in EXPECTED_BITS.items():
+        assert SEGMENTATION_FLAGS.get_bit_value(name) == bit
+
+
+def test_bit_values_unique_powers_of_two():
+    """
+    Test that all bit values are unique powers of two.
+    """
+    bits = SEGMENTATION_FLAGS.bit_values
+    assert len(bits) == len(set(bits))
+    for bit in bits:
+        assert bit > 0
+        assert bit & (bit - 1) == 0
+
+
+def test_shared_aperture_names_intentional():
+    """
+    Test that the name overlap with APERTURE_FLAGS is exactly the
+    intentional shared set.
+
+    A shared name must describe the same condition (with the segment as
+    the region). Any new accidental overlap must either be renamed or
+    added to the shared set deliberately.
+    """
+    shared = (set(SEGMENTATION_FLAGS.names)
+              & set(APERTURE_FLAGS.names))
+    assert shared == set(SHARED_APERTURE_NAMES)
+
+
+def test_uppercase_constants():
+    """
+    Test that uppercase constants exist for every flag.
+    """
+    for name, bit in EXPECTED_BITS.items():
+        assert getattr(SEGMENTATION_FLAGS, name.upper()) == bit
+
+
+def test_decode_scalar():
+    """
+    Test decoding a scalar flag value.
+    """
+    value = (SEGMENTATION_FLAGS.DEBLENDED
+             | SEGMENTATION_FLAGS.EDGE_TOUCH)
+    names = decode_segmentation_flags(value)
+    assert set(names) == {'deblended', 'edge_touch'}
+
+    bits = decode_segmentation_flags(value, return_bit_values=True)
+    assert set(bits) == {16, 32}
+
+    assert decode_segmentation_flags(0) == []
+
+
+def test_decode_array():
+    """
+    Test decoding an array of flag values.
+    """
+    values = np.array([0, SEGMENTATION_FLAGS.MASKED_PIXELS])
+    result = decode_segmentation_flags(values)
+    assert result == [[], ['masked_pixels']]
+
+
+def test_decode_invalid():
+    """
+    Test invalid decoder inputs.
+    """
+    match = 'must be an integer'
+    with pytest.raises(TypeError, match=match):
+        decode_segmentation_flags(1.5)
+    match = 'must be a non-negative integer'
+    with pytest.raises(ValueError, match=match):
+        decode_segmentation_flags(-1)
+
+
+def test_public_import():
+    """
+    Test that the public names are importable from the subpackage.
+    """
+    import photutils.segmentation as seg_mod  # noqa: PLC0415
+
+    assert hasattr(seg_mod, 'SEGMENTATION_FLAGS')
+    assert hasattr(seg_mod, 'decode_segmentation_flags')
+    assert seg_mod.SEGMENTATION_FLAGS is SEGMENTATION_FLAGS
+    assert seg_mod.decode_segmentation_flags is decode_segmentation_flags

--- a/photutils/segmentation/tests/test_utils.py
+++ b/photutils/segmentation/tests/test_utils.py
@@ -132,3 +132,48 @@ def test_mask_to_mirrored_value_mask_keyword():
     mask[4, 2] = True
     result = _mask_to_mirrored_value(data, replace_mask, center, mask=mask)
     assert result[0, 2] == 0
+
+
+def test_mask_to_mirrored_value_return_uncorrected():
+    """
+    Test that return_uncorrected reports pixels whose mirror was outside
+    the image.
+    """
+    center = (2.0, 2.0)
+    data = np.arange(16.0).reshape(4, 4)
+    replace_mask = np.zeros(data.shape, dtype=bool)
+    replace_mask[0, 0] = True  # mirror at (4, 4) is outside the image
+    replace_mask[1, 2] = True  # mirror at (3, 2) is available
+    result, uncorrected = _mask_to_mirrored_value(
+        data, replace_mask, center, return_uncorrected=True)
+    assert uncorrected[0, 0]
+    assert not uncorrected[1, 2]
+    assert np.count_nonzero(uncorrected) == 1
+    assert result[0, 0] == 0
+    assert result[1, 2] == data[3, 2]
+
+    # The two-value return preserves the corrected data
+    result_only = _mask_to_mirrored_value(data, replace_mask, center)
+    assert_equal(result, result_only)
+
+
+def test_mask_to_mirrored_value_return_uncorrected_masked():
+    """
+    Test that return_uncorrected reports pixels whose mirror is excluded
+    by the ``mask`` keyword or is itself in ``replace_mask``.
+    """
+    center = (2.0, 2.0)
+    data = np.arange(25.0).reshape(5, 5)
+    replace_mask = np.zeros(data.shape, dtype=bool)
+    mask = np.zeros(data.shape, dtype=bool)
+    replace_mask[0, 2] = True  # mirror at (4, 2) is in mask
+    replace_mask[1, 1] = True  # mirror at (3, 3) is in replace_mask
+    replace_mask[3, 3] = True
+    mask[4, 2] = True
+    result, uncorrected = _mask_to_mirrored_value(
+        data, replace_mask, center, mask=mask, return_uncorrected=True)
+    assert_equal(np.nonzero(uncorrected),
+                 (np.array([0, 1, 3]), np.array([2, 1, 3])))
+    assert result[0, 2] == 0
+    assert result[1, 1] == 0
+    assert result[3, 3] == 0

--- a/photutils/segmentation/utils.py
+++ b/photutils/segmentation/utils.py
@@ -106,7 +106,8 @@ def _make_binary_structure(ndim, connectivity):
     return footprint
 
 
-def _mask_to_mirrored_value(data, replace_mask, xycenter, *, mask=None):
+def _mask_to_mirrored_value(data, replace_mask, xycenter, *, mask=None,
+                            return_uncorrected=False):
     """
     Replace masked pixels with the value of the pixel mirrored across a
     given center position.
@@ -136,12 +137,25 @@ def _mask_to_mirrored_value(data, replace_mask, xycenter, *, mask=None):
         mirrored value is set to zero. Using this keyword prevents
         potential spreading of known non-finite or bad pixel values.
 
+    return_uncorrected : bool, optional
+        If `True`, also return a boolean mask of the ``replace_mask``
+        pixels that could not be replaced by a mirrored value (i.e., the
+        mirror pixel was outside the image, in ``mask``, or itself in
+        ``replace_mask``) and were set to zero instead.
+
     Returns
     -------
     result : 2D `~numpy.ndarray`
-        A 2D array with replaced masked pixels.
+        A 2D array with replaced masked pixels. If
+        ``return_uncorrected`` is `True`, then a tuple of ``(result,
+        uncorrected)`` is returned instead, where ``uncorrected`` is a
+        2D bool `~numpy.ndarray` that is `True` for the ``replace_mask``
+        pixels that were set to zero because their mirrored value was
+        unavailable.
     """
     outdata = np.copy(data)
+    uncorrected = (np.zeros(data.shape, dtype=bool) if return_uncorrected
+                   else None)
 
     ymasked, xmasked = np.nonzero(replace_mask)
     xmirror = 2 * int(xycenter[0] + 0.5) - xmasked
@@ -154,7 +168,11 @@ def _mask_to_mirrored_value(data, replace_mask, xycenter, *, mask=None):
     # Remove them from the set of replace_mask pixels and set them to
     # zero
     if np.any(badmask):
-        outdata[ymasked[badmask], xmasked[badmask]] = 0.0
+        youtside = ymasked[badmask]
+        xoutside = xmasked[badmask]
+        outdata[youtside, xoutside] = 0.0
+        if return_uncorrected:
+            uncorrected[youtside, xoutside] = True
         # Remove the badmask pixels from pixels to be replaced
         goodmask = ~badmask
         ymasked = ymasked[goodmask]
@@ -172,5 +190,9 @@ def _mask_to_mirrored_value(data, replace_mask, xycenter, *, mask=None):
     xbad = xmasked[mirror_mask]
     ybad = ymasked[mirror_mask]
     outdata[ybad, xbad] = 0.0
+
+    if return_uncorrected:
+        uncorrected[ybad, xbad] = True
+        return outdata, uncorrected
 
     return outdata


### PR DESCRIPTION
This PR adds a bitwise quality-flag system for segmentation. A new public ``SEGMENTATION_FLAGS`` registry and ``decode_segmentation_flags`` function were added. ``SegmentationImage`` objects now have a ``flags`` attribute with per-label flags, ``deblend_sources`` records per-source deblending provenance flags, and ``SourceCatalog`` has a new ``flags`` attribute and default table column combining provenance and measurement flags, along with a ``decode_flags`` convenience method that returns a dictionary keyed by source label.