### PR TITLE
Fix _ellipse_model.pyx compilation with Cython 3.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -416,6 +416,9 @@ Bug Fixes
   - Fixed ``EllipseSample`` not resetting ``EllipseGeometry`` cached
     attributes when overriding ``sma``. [#2280]
 
+  - Fixed a compilation issue in ``_ellipse_model.pyx`` with Cython
+    3.3, which no longer allows tuples of typed memoryviews. [#2404]
+
 - ``photutils.morphology``
 
   - Fixed ``data_properties`` so that a ``background`` input with

--- a/photutils/isophote/_ellipse_model.pyx
+++ b/photutils/isophote/_ellipse_model.pyx
@@ -34,12 +34,18 @@ def build_ellipse_model_c(
 ):
     cdef Py_ssize_t len_sma
     len_sma = len(finely_spaced_sma)
-    for array in (intens_array, eps_array, pa_array, x0_array, y0_array):
-        if len(array) != len_sma:
-            msg = f"All input arrays must be same length={len_sma}"
-            raise ValueError(msg)
-    harmonic_arrays = (a3_array, b3_array, a4_array, b4_array)
-    harmonics_is_none = [array is None for array in harmonic_arrays]
+    # Do not place the memoryview arguments in a tuple. Cython infers
+    # a ctuple type for a tuple of memoryviews and rejects it as of
+    # Cython 3.3, so each array is checked explicitly.
+    if (len(intens_array) != len_sma
+            or len(eps_array) != len_sma
+            or len(pa_array) != len_sma
+            or len(x0_array) != len_sma
+            or len(y0_array) != len_sma):
+        msg = f"All input arrays must be same length={len_sma}"
+        raise ValueError(msg)
+    harmonics_is_none = [a3_array is None, b3_array is None,
+                         a4_array is None, b4_array is None]
 
     cdef double a3, b3, a4, b4
     cdef bint do_harmonics
@@ -54,10 +60,12 @@ def build_ellipse_model_c(
         if any(harmonics_is_none):
             msg = "Must supply all harmonic arrays if any is not None"
             raise ValueError(msg)
-        for array in harmonic_arrays:
-            if len(array) != len_sma:
-                msg = f"All input arrays must be same length={len_sma}"
-                raise ValueError(msg)
+        if (len(a3_array) != len_sma
+                or len(b3_array) != len_sma
+                or len(a4_array) != len_sma
+                or len(b4_array) != len_sma):
+            msg = f"All input arrays must be same length={len_sma}"
+            raise ValueError(msg)
         do_harmonics = True
 
     cdef double phi, fx, fy, x, y

--- a/photutils/isophote/tests/test_model.py
+++ b/photutils/isophote/tests/test_model.py
@@ -257,3 +257,48 @@ def test_build_ellipse_model_c_noncontiguous_arrays():
 
     assert_array_equal(result[0], expected[0])
     assert_array_equal(result[1], expected[1])
+
+
+@pytest.mark.parametrize('index', range(5))
+def test_build_ellipse_model_c_length_mismatch(index):
+    """
+    Test that a ValueError is raised if any of the main input arrays
+    does not have the same length as finely_spaced_sma.
+    """
+    n = 16
+    sma = np.linspace(0.5, 20.0, n)
+    arrays = [np.full(n, value) for value in (1.0, 0.3, 0.5, 50.0, 50.0)]
+    arrays[index] = arrays[index][:-1]
+    match = 'All input arrays must be same length'
+    with pytest.raises(ValueError, match=match):
+        build_ellipse_model_c(100, 100, sma, *arrays)
+
+
+@pytest.mark.parametrize('index', range(4))
+def test_build_ellipse_model_c_harmonic_length_mismatch(index):
+    """
+    Test that a ValueError is raised if any of the harmonic arrays
+    does not have the same length as finely_spaced_sma.
+    """
+    n = 16
+    sma = np.linspace(0.5, 20.0, n)
+    arrays = [np.full(n, value) for value in (1.0, 0.3, 0.5, 50.0, 50.0)]
+    harmonics = [np.full(n, 0.01) for _ in range(4)]
+    harmonics[index] = harmonics[index][:-1]
+    match = 'All input arrays must be same length'
+    with pytest.raises(ValueError, match=match):
+        build_ellipse_model_c(100, 100, sma, *arrays, *harmonics)
+
+
+def test_build_ellipse_model_c_partial_harmonics():
+    """
+    Test that a ValueError is raised if only some of the harmonic
+    arrays are input.
+    """
+    n = 16
+    sma = np.linspace(0.5, 20.0, n)
+    arrays = [np.full(n, value) for value in (1.0, 0.3, 0.5, 50.0, 50.0)]
+    match = 'Must supply all harmonic arrays if any is not None'
+    with pytest.raises(ValueError, match=match):
+        build_ellipse_model_c(100, 100, sma, *arrays,
+                              a3_array=np.full(n, 0.01))


### PR DESCRIPTION
Replace the tuple-based validation with explicit per-array length checks so the module compiles with Cython 3.1.2 through 3.3.0.

Cython 3.3.0 infers a ctuple type for a tuple of typed memoryviews and rejects it with "C struct/union member cannot be a memory view". This affected the harmonic_arrays tuple assignment and the tuple literals iterated in the input-length validation loops.