### PR TITLE
Fix isophote nearest-neighbor fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -419,6 +419,12 @@ Bug Fixes
   - Fixed a compilation issue in ``_ellipse_model.pyx`` with Cython
     3.3, which no longer allows tuples of typed memoryviews. [#2404]
 
+  - Fixed an issue when fitting isophotes with the
+    ``'nearest_neighbor'`` integration mode. At small semimajor axes,
+    nearest-neighbor sampling could measure a local intensity gradient
+    of exactly zero, and the resulting division by zero corrupted the
+    ellipse geometry. [#2405]
+
 - ``photutils.morphology``
 
   - Fixed ``data_properties`` so that a ``background`` input with

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -79,6 +79,25 @@ python benchmarks/bench_geometry.py
 python benchmarks/bench_geometry.py --which polygon --n-vertices 8,64,512
 ```
 
+## Isophote (`bench_isophote.py`)
+
+Benchmarks for the `photutils.isophote` subpackage, using a simulated
+galaxy image:
+
+- full isophote fitting with `Ellipse.fit_image` for each integration
+  mode (a mode whose fit raises an error is reported as failed)
+- elliptical sample extraction (`EllipseSample.extract`) for each
+  integration mode at several semimajor axis lengths
+- model-image reconstruction with `build_ellipse_model`, with and
+  without the high-order harmonics
+- the scaling of the private `build_ellipse_model_c` Cython kernel
+  with image size
+
+```bash
+python benchmarks/bench_isophote.py
+python benchmarks/bench_isophote.py --which kernel --sizes 256,512,1024
+```
+
 ## Morphology (`bench_morphology.py`)
 
 Benchmarks for the `photutils.morphology` subpackage:

--- a/benchmarks/bench_helpers.py
+++ b/benchmarks/bench_helpers.py
@@ -79,6 +79,7 @@ def print_environment():
     print(f'photutils {photutils.__version__}, numpy {np.__version__}, '
           f'scipy {scipy.__version__}, astropy {astropy.__version__}, '
           f'bottleneck: {HAS_BOTTLENECK}')
+    print(f'photutils path: {os.path.dirname(photutils.__file__)}')
 
 
 def parse_thread_counts(text):

--- a/benchmarks/bench_isophote.py
+++ b/benchmarks/bench_isophote.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Benchmarks for the photutils.isophote subpackage.
+
+The benchmarks cover full isophote fitting with Ellipse.fit_image,
+elliptical sample extraction with EllipseSample.extract for each
+integration mode, model-image reconstruction with
+build_ellipse_model, and the scaling of the private
+build_ellipse_model_c Cython kernel with image size.
+
+Run ``python benchmarks/bench_isophote.py --help`` to see the
+available options.
+"""
+
+import argparse
+import warnings
+from functools import partial
+
+import numpy as np
+from bench_helpers import print_environment, time_best
+
+from photutils.isophote import (Ellipse, EllipseGeometry, EllipseSample,
+                                build_ellipse_model)
+from photutils.isophote._ellipse_model import build_ellipse_model_c
+from photutils.isophote.tests.make_test_data import make_test_image
+
+FIT_MODES = ('bilinear', 'nearest_neighbor', 'mean', 'median')
+
+EXTRACT_MODES = ('bilinear', 'nearest_neighbor', 'mean', 'median')
+
+# Geometry of the reference isophote in the simulated galaxy image
+X0 = Y0 = 256.0
+SMA0 = 20.0
+EPS = 0.2
+PA = 0.0
+
+
+def make_galaxy_image(*, seed=0):
+    """
+    Return the simulated galaxy image used by the benchmarks.
+
+    Parameters
+    ----------
+    seed : int, optional
+        The random number generator seed.
+
+    Returns
+    -------
+    result : 2D `~numpy.ndarray`
+        The simulated galaxy image.
+    """
+    return make_test_image(seed=seed)
+
+
+def run_fit_image(data, *, integrmode='bilinear', maxsma=200.0):
+    """
+    Run a full isophote fit on the data.
+
+    RuntimeWarnings from degenerate inner and outer isophotes (e.g.,
+    zero gradients) are routine during fitting and are suppressed.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The galaxy image.
+
+    integrmode : str, optional
+        The integration mode.
+
+    maxsma : float, optional
+        The maximum semimajor axis length.
+
+    Returns
+    -------
+    result : `~photutils.isophote.IsophoteList`
+        The fitted isophotes.
+    """
+    geometry = EllipseGeometry(X0, Y0, SMA0, EPS, PA)
+    ellipse = Ellipse(data, geometry=geometry)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        return ellipse.fit_image(integrmode=integrmode, maxsma=maxsma)
+
+
+def bench_fit_image(*, maxsma=200.0, seed=0):
+    """
+    Benchmark Ellipse.fit_image for each integration mode.
+
+    Each fit is timed once (a full fit takes seconds and its runtime
+    is stable).
+
+    Parameters
+    ----------
+    maxsma : float, optional
+        The maximum semimajor axis length.
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data = make_galaxy_image(seed=seed)
+    print(f'\n== Ellipse.fit_image ({data.shape[1]}x{data.shape[0]} '
+          f'image, maxsma={maxsma:g}) ==')
+    print(f'{"mode":>18}{"time":>12}{"isophotes":>12}')
+    for mode in FIT_MODES:
+        bench = partial(run_fit_image, data, integrmode=mode,
+                        maxsma=maxsma)
+        try:
+            t_run = time_best(bench, repeats=1)
+            isolist = bench()
+        except ValueError as exc:
+            print(f'{mode:>18}  failed ({exc})')
+            continue
+        print(f'{mode:>18}{f"{t_run:.3f}s":>12}{len(isolist):>12}')
+
+
+def run_extract(data, sma, n_iter, *, integrmode='bilinear'):
+    """
+    Extract an elliptical sample repeatedly from fresh samples.
+
+    A fresh EllipseSample is created for every extraction because
+    extract caches its result on the instance.
+
+    Parameters
+    ----------
+    data : 2D `~numpy.ndarray`
+        The galaxy image.
+
+    sma : float
+        The semimajor axis length of the sample.
+
+    n_iter : int
+        The number of extractions.
+
+    integrmode : str, optional
+        The integration mode.
+    """
+    for _ in range(n_iter):
+        sample = EllipseSample(data, sma, x0=X0, y0=Y0, eps=EPS,
+                               position_angle=PA, integrmode=integrmode)
+        sample.extract()
+
+
+def bench_sample(*, sma_list=(20.0, 80.0), n_iter=20, repeats=3,
+                 seed=0):
+    """
+    Benchmark EllipseSample.extract for each integration mode.
+
+    Parameters
+    ----------
+    sma_list : tuple of float, optional
+        The semimajor axis lengths to sample at.
+
+    n_iter : int, optional
+        The number of calls per timing; the per-call time is reported.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data = make_galaxy_image(seed=seed)
+    print('\n== EllipseSample.extract (per-call time) ==')
+    header = f'{"mode":>18}'
+    for sma in sma_list:
+        header += f'{f"sma={sma:g}":>12}'
+    print(header)
+    for mode in EXTRACT_MODES:
+        cells = ''
+        for sma in sma_list:
+            bench = partial(run_extract, data, sma, n_iter,
+                            integrmode=mode)
+            t_call = time_best(bench, repeats=repeats) / n_iter
+            cells += f'{f"{t_call * 1e3:.3f}ms":>12}'
+        print(f'{mode:>18}{cells}')
+
+
+def bench_model(*, maxsma=200.0, repeats=3, seed=0):
+    """
+    Benchmark build_ellipse_model, with and without high harmonics.
+
+    The isophote fit that provides the input IsophoteList is run once
+    and is not included in the timings.
+
+    Parameters
+    ----------
+    maxsma : float, optional
+        The maximum semimajor axis length of the isophote fit.
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+
+    seed : int, optional
+        The random number generator seed.
+    """
+    data = make_galaxy_image(seed=seed)
+    isolist = run_fit_image(data, maxsma=maxsma)
+    print(f'\n== build_ellipse_model ({data.shape[1]}x{data.shape[0]} '
+          f'image, {len(isolist)} isophotes) ==')
+    print(f'{"variant":>18}{"time":>12}')
+    for name, high_harmonics in (('no harmonics', False),
+                                 ('high harmonics', True)):
+        bench = partial(build_ellipse_model, data.shape, isolist,
+                        high_harmonics=high_harmonics)
+        t_run = time_best(bench, repeats=repeats)
+        print(f'{name:>18}{f"{t_run * 1e3:.1f}ms":>12}')
+
+
+def run_kernel(size, *, harmonics=False):
+    """
+    Call the build_ellipse_model_c kernel for a size x size image.
+
+    The isophote parameter arrays mimic the finely spaced (0.01 pixel)
+    interpolated arrays that build_ellipse_model passes to the kernel,
+    with the outermost isophote at 0.35 * size.
+
+    Parameters
+    ----------
+    size : int
+        The image size; the image is ``(size, size)``.
+
+    harmonics : bool, optional
+        Whether to include the harmonic arrays.
+    """
+    max_sma = 0.35 * size
+    n_sma = int(max_sma / 0.01)
+    sma = np.linspace(0.5, max_sma, n_sma)
+    intens = np.full(n_sma, 100.0)
+    eps = np.full(n_sma, EPS)
+    pa = np.full(n_sma, 0.4)
+    x0 = np.full(n_sma, size / 2.0)
+    y0 = np.full(n_sma, size / 2.0)
+    harmonic_arrays = []
+    if harmonics:
+        harmonic_arrays = [np.full(n_sma, 0.01) for _ in range(4)]
+    build_ellipse_model_c(size, size, sma, intens, eps, pa, x0, y0,
+                          *harmonic_arrays)
+
+
+def bench_kernel(*, sizes=(256, 512), repeats=3):
+    """
+    Benchmark the build_ellipse_model_c kernel across image sizes.
+
+    Parameters
+    ----------
+    sizes : tuple of int, optional
+        The image sizes (pixels per side).
+
+    repeats : int, optional
+        The number of repeats for each timing (best time is kept).
+    """
+    print('\n== build_ellipse_model_c kernel vs image size ==')
+    print(f'{"size":>12}{"no harmonics":>14}{"harmonics":>14}')
+    for size in sizes:
+        cells = ''
+        for harmonics in (False, True):
+            bench = partial(run_kernel, size, harmonics=harmonics)
+            t_run = time_best(bench, repeats=repeats)
+            cells += f'{f"{t_run * 1e3:.1f}ms":>14}'
+        print(f'{f"{size}x{size}":>12}{cells}')
+
+
+def parse_int_list(text):
+    """
+    Parse a comma-separated list of positive integers.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated integers (e.g., ``'256,512'``).
+
+    Returns
+    -------
+    result : list of int
+        The parsed integers.
+    """
+    values = [int(item) for item in text.split(',')]
+    if any(value < 1 for value in values):
+        msg = 'values must be positive integers'
+        raise ValueError(msg)
+    return values
+
+
+def parse_float_list(text):
+    """
+    Parse a comma-separated list of positive floats.
+
+    Parameters
+    ----------
+    text : str
+        The comma-separated floats (e.g., ``'20,80'``).
+
+    Returns
+    -------
+    result : list of float
+        The parsed floats.
+    """
+    values = [float(item) for item in text.split(',')]
+    if any(value <= 0 for value in values):
+        msg = 'values must be positive'
+        raise ValueError(msg)
+    return values
+
+
+def main():
+    """
+    Run the photutils.isophote benchmarks.
+    """
+    parser = argparse.ArgumentParser(
+        description='Benchmarks for the photutils.isophote subpackage.')
+    parser.add_argument('--maxsma', type=float, default=200.0,
+                        help='maximum semimajor axis length for the '
+                             'isophote fits (default: %(default)s)')
+    parser.add_argument('--sma-list', type=parse_float_list,
+                        default=[20.0, 80.0],
+                        help='comma-separated semimajor axis lengths '
+                             'for the sample benchmark (default: '
+                             '20,80)')
+    parser.add_argument('--sizes', type=parse_int_list,
+                        default=[256, 512],
+                        help='comma-separated image sizes for the '
+                             'kernel benchmark (default: 256,512)')
+    parser.add_argument('--n-iter', type=int, default=20,
+                        help='number of calls per timing for the '
+                             'sample benchmark (default: %(default)s)')
+    parser.add_argument('--repeats', type=int, default=3,
+                        help='number of repeats per timing; the best '
+                             'time is reported (default: %(default)s)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='random number generator seed '
+                             '(default: %(default)s)')
+    parser.add_argument('--which', default='all',
+                        choices=['all', 'fit-image', 'sample', 'model',
+                                 'kernel'],
+                        help='which benchmark to run '
+                             '(default: %(default)s)')
+    args = parser.parse_args()
+
+    print_environment()
+
+    if args.which in ('all', 'fit-image'):
+        bench_fit_image(maxsma=args.maxsma, seed=args.seed)
+    if args.which in ('all', 'sample'):
+        bench_sample(sma_list=args.sma_list, n_iter=args.n_iter,
+                     repeats=args.repeats, seed=args.seed)
+    if args.which in ('all', 'model'):
+        bench_model(maxsma=args.maxsma, repeats=args.repeats,
+                    seed=args.seed)
+    if args.which in ('all', 'kernel'):
+        bench_kernel(sizes=args.sizes, repeats=args.repeats)
+
+
+if __name__ == '__main__':
+    main()

--- a/photutils/isophote/fitter.py
+++ b/photutils/isophote/fitter.py
@@ -130,11 +130,11 @@ class EllipseFitter:
         """
         sample = self._sample
 
-        # this flag signals that limiting gradient error (`maxgerr`)
+        # This flag signals that limiting gradient error (`maxgerr`)
         # wasn't exceeded yet.
         lexceed = False
 
-        # here we keep track of the sample that caused the minimum harmonic
+        # Here we keep track of the sample that caused the minimum harmonic
         # amplitude(in absolute value). This will eventually be used to
         # build the resulting Isophote in cases where iterations run to
         # the maximum allowed (maxit), or the maximum number of flagged
@@ -142,14 +142,14 @@ class EllipseFitter:
         minimum_amplitude_value = np.inf
         minimum_amplitude_sample = None
 
-        # these must be passed throughout the execution chain.
+        # These must be passed throughout the execution chain.
         fixed_parameters = self._sample.geometry.fix
 
         for i in range(maxit):
             # Force the sample to compute its gradient and associated values.
             sample.update(fixed_parameters=fixed_parameters)
 
-            # The extract() method returns sampled values as a 2-d numpy
+            # The extract() method returns sampled values as a 2D numpy
             # array with the following structure:
             # values[0] = 1-d array with angles
             # values[1] = 1-d array with radii
@@ -167,9 +167,9 @@ class EllipseFitter:
                 sample.geometry.fix = fixed_parameters
                 return Isophote(sample, i + 1, valid=False, stop_code=3)
 
-            # Fit harmonic coefficients. Failure in fitting is
-            # a fatal error; terminate immediately with sample
-            # marked as invalid.
+            # Fit harmonic coefficients. Failure in fitting is a fatal
+            # error, so terminate immediately with sample marked as
+            # invalid.
             try:
                 coeffs = fit_first_and_second_harmonics(values[0], values[2])
                 coeffs = coeffs[0]
@@ -186,13 +186,13 @@ class EllipseFitter:
             largest_harmonic_index = np.argmax(np.abs(free_coeffs))
             largest_harmonic = free_coeffs[largest_harmonic_index]
 
-            # see if the amplitude decreased; if yes, keep the
+            # See if the amplitude decreased; if yes, keep the
             # corresponding sample for eventual later use.
             if abs(largest_harmonic) < minimum_amplitude_value:
                 minimum_amplitude_value = abs(largest_harmonic)
                 minimum_amplitude_sample = sample
 
-            # check if converged
+            # Check if converged
             model = first_and_second_harmonic_function(values[0], coeffs)
             residual = values[2] - model
 
@@ -203,35 +203,46 @@ class EllipseFitter:
                 sample.update(fixed_parameters=fixed_parameters)
                 return Isophote(sample, i + 1, valid=True, stop_code=0)
 
-            # it may not have converged yet, but the sample contains too
-            # many invalid data points: return.
+            # It may not have converged yet, but the sample contains too
+            # many invalid data points, so return the best fit sample
+            # instead of the current one.
             if sample.actual_points < (sample.total_points * fflag):
-                # when too many data points were flagged, return the
+                # When too many data points were flagged, return the
                 # best fit sample instead of the current one.
                 minimum_amplitude_sample.update(
                     fixed_parameters=fixed_parameters)
                 return Isophote(minimum_amplitude_sample, i + 1, valid=True,
                                 stop_code=1)
 
-            # pick appropriate corrector code.
-            corrector = _CORRECTORS[largest_harmonic_index]
+            # The parameter correctors divide by the sample's local
+            # gradient. If the gradient is zero or non-finite (e.g.,
+            # from a degenerate sample where no gradient could be
+            # measured), no correction can be computed and iterations
+            # cannot proceed.
+            proceed = (sample.gradient != 0.0
+                       and np.isfinite(sample.gradient))
 
-            # generate *NEW* EllipseSample instance with corrected
-            # parameter. Note that this instance is still devoid of
-            # other information besides its geometry. It needs to be
-            # explicitly updated for computations to proceed. We have to
-            # build a new EllipseSample instance every time because of
-            # the lazy extraction process used by EllipseSample code. To
-            # minimize the number of calls to the area integrators, we
-            # pay a (hopefully smaller) price here, by having multiple
-            # calls to the EllipseSample constructor.
-            sample = corrector.correct(sample, largest_harmonic)
-            sample.update(fixed_parameters=fixed_parameters)
+            if proceed:
+                # Pick appropriate corrector code.
+                corrector = _CORRECTORS[largest_harmonic_index]
 
-            # see if any abnormal (or unusual) conditions warrant
-            # the change to non-iterative mode, or go-inwards mode.
-            proceed, lexceed = self._check_conditions(
-                sample, maxgerr, going_inwards, lexceed)
+                # Generate a new EllipseSample instance with corrected
+                # parameter. Note that this instance is still devoid of
+                # other information besides its geometry. It needs to
+                # be explicitly updated for computations to proceed.
+                # We have to build a new EllipseSample instance every
+                # time because of the lazy extraction process used
+                # by EllipseSample code. To minimize the number of
+                # calls to the area integrators, we pay a (hopefully
+                # smaller) price here, by having multiple calls to the
+                # EllipseSample constructor.
+                sample = corrector.correct(sample, largest_harmonic)
+                sample.update(fixed_parameters=fixed_parameters)
+
+                # See if any abnormal (or unusual) conditions warrant
+                # the change to non-iterative mode, or go-inwards mode.
+                proceed, lexceed = self._check_conditions(
+                    sample, maxgerr, going_inwards, lexceed)
 
             if not proceed:
                 sample.update(fixed_parameters=fixed_parameters)
@@ -248,7 +259,7 @@ class EllipseFitter:
     def _check_conditions(sample, maxgerr, going_inwards, lexceed):
         proceed = True
 
-        # check if an acceptable gradient value could be computed.
+        # Check if an acceptable gradient value could be computed.
         if sample.gradient_err and sample.gradient_rel_err:
             if not going_inwards and (
                     sample.gradient_rel_err > maxgerr
@@ -260,7 +271,7 @@ class EllipseFitter:
         else:
             proceed = False
 
-        # check if ellipse geometry diverged.
+        # Check if ellipse geometry diverged.
         if abs(sample.geometry.eps > MAX_EPS):
             proceed = False
         if (sample.geometry.x0 < 1.0
@@ -270,7 +281,7 @@ class EllipseFitter:
             proceed = False
 
         # See if eps == 0 (round isophote) was crossed.
-        # If so, fix it but still proceed
+        # If so, fix it but still proceed.
         if sample.geometry.eps < 0.0:
             sample.geometry.eps = min(-sample.geometry.eps, MAX_EPS)
             if sample.geometry.pa < PI2:
@@ -279,7 +290,7 @@ class EllipseFitter:
                 sample.geometry.pa -= PI2
 
         # If ellipse is an exact circle, computations will diverge.
-        # Make it slightly flat, but still proceed
+        # Make it slightly flat, but still proceed.
         if sample.geometry.eps == 0.0:
             sample.geometry.eps = MIN_EPS
 
@@ -335,7 +346,7 @@ class _AngleCorrector(_ParameterCorrector):
         correction = (harmonic * 2.0 * (1.0 - eps) / sma / gradient
                       / ((1.0 - eps)**2 - 1.0))
 
-        # '% np.pi' to make angle lie between 0 and np.pi radians
+        # Make the angle lie between 0 and np.pi radians
         new_pa = (sample.geometry.pa + correction) % np.pi
 
         return EllipseSample(sample.image, sample.geometry.sma,
@@ -366,7 +377,7 @@ class _EllipticityCorrector(_ParameterCorrector):
                              integrmode=sample.integrmode)
 
 
-# instances of corrector code live here:
+# Instances of corrector code
 _CORRECTORS = [_PositionCorrector0(), _PositionCorrector1(),
                _AngleCorrector(), _EllipticityCorrector()]
 
@@ -398,7 +409,7 @@ class CentralEllipseFitter(EllipseFitter):
             at the central position. Thus, most of its attributes are
             hardcoded to `None` or other default value when appropriate.
         """
-        # default values
+        # Default values
         fixed_parameters = np.array([False, False, False, False])
 
         self._sample.update(fixed_parameters=fixed_parameters)

--- a/photutils/isophote/sample.py
+++ b/photutils/isophote/sample.py
@@ -112,15 +112,15 @@ class EllipseSample:
         self.integrmode = integrmode
 
         if geometry:
-            # when the geometry is inherited from somewhere else,
-            # its sma attribute must be replaced by the value
-            # explicitly passed to the constructor.
+            # When the geometry is inherited from somewhere else, its
+            # sma attribute must be replaced by the value explicitly
+            # passed to the constructor.
             self.geometry = copy.deepcopy(geometry)
             self.geometry.sma = sma
             self.geometry._reset_sma_dependent_attributes()
         else:
-            # if no center was specified, assume it's roughly
-            # coincident with the image center
+            # If no center was specified, assume it's roughly coincident
+            # with the image center.
             _x0 = x0
             _y0 = y0
             if not _x0 or not _y0:
@@ -131,11 +131,11 @@ class EllipseSample:
                                             position_angle, astep=astep,
                                             linear_growth=linear_growth)
 
-        # sigma-clip parameters
+        # Sigma-clip parameters
         self.sclip = sclip
         self.n_clip = n_clip
 
-        # extracted values associated with this sample.
+        # Extracted values associated with this sample.
         self.values = None
         self.mean = None
         self.gradient = None
@@ -143,9 +143,9 @@ class EllipseSample:
         self.gradient_rel_err = None
         self.sector_area = None
 
-        # total_points reports the total number of pairs angle-radius that
-        # were attempted. actual_points reports the actual number of sampled
-        # pairs angle-radius that resulted in valid values.
+        # Total_points reports the total number of pairs angle-radius
+        # that were attempted. actual_points reports the actual number
+        # of sampled pairs angle-radius that resulted in valid values.
         self.total_points = 0
         self.actual_points = 0
 
@@ -166,7 +166,7 @@ class EllipseSample:
             The rows of the array contain the angles, radii, and
             extracted intensity values, respectively.
         """
-        # the sample values themselves are kept cached to prevent
+        # The sample values themselves are kept cached to prevent
         # multiple calls to the integrator code.
         if self.values is not None:
             return self.values
@@ -177,42 +177,41 @@ class EllipseSample:
 
     def _extract(self, *, phi_min=0.05):
         # Here the actual sampling takes place. This is called only once
-        # during the life of an EllipseSample instance, because it's an
-        # expensive calculation. This method should not be called from
-        # external code.
-        # To force it to rerun, set "sample.values = None" before
-        # calling sample.extract().
+        # during the life of an EllipseSample instance, because it's
+        # an expensive calculation. This method should not be called
+        # from external code. To force it to rerun, set "sample.values =
+        # None" before calling sample.extract().
 
-        # individual extracted sample points will be stored in here
+        # Individual extracted sample points will be stored in here
         angles = []
         radii = []
         intensities = []
         sector_areas = []
 
-        # reset counters
+        # Reset counters
         self.total_points = 0
         self.actual_points = 0
 
-        # build integrator
+        # Build integrator
         integrator = INTEGRATORS[self.integrmode](self.image, self.geometry,
                                                   angles, radii, intensities)
 
-        # initialize walk along elliptical path
+        # Initialize walk along elliptical path
         radius = self.geometry.initial_polar_radius
         phi = self.geometry.initial_polar_angle
 
-        # In case of an area integrator, ask the integrator to deliver a
-        # hint of how much area the sectors will have. In case of too
+        # In case of an area integrator, ask the integrator to deliver
+        # a hint of how much area the sectors will have. In case of too
         # small areas, tests showed that the area integrators (mean,
         # median) won't perform properly. In that case, we override the
         # caller's selection and use the bilinear integrator regardless.
         if integrator.is_area():
             integrator.integrate(radius, phi)
             area = integrator.get_sector_area()
-            # this integration that just took place messes up with the
-            # storage arrays and the constructors. We have to build a new
-            # integrator instance from scratch, even if it is the same
-            # kind as originally selected by the caller.
+            # This integration that just took place messes up with the
+            # storage arrays and the constructors. We have to build a
+            # new integrator instance from scratch, even if it is the
+            # same kind as originally selected by the caller.
             angles = []
             radii = []
             intensities = []
@@ -225,45 +224,45 @@ class EllipseSample:
                                                           angles, radii,
                                                           intensities)
 
-        # walk along elliptical path, integrating at specified
-        # places defined by polar vector. Need to go a bit beyond
-        # full circle to ensure full coverage.
+        # Walk along elliptical path, integrating at specified places
+        # defined by polar vector. Need to go a bit beyond full circle
+        # to ensure full coverage.
         while phi <= np.pi * 2.0 + phi_min:
-            # do the integration at phi-radius position, and append
+            # Do the integration at phi-radius position, and append
             # results to the angles, radii, and intensities lists.
             integrator.integrate(radius, phi)
 
-            # store sector area locally
+            # Store sector area locally
             sector_areas.append(integrator.get_sector_area())
 
-            # update total number of points
+            # Update total number of points
             self.total_points += 1
 
-            # update angle and radius to be used to define
-            # next polar vector along the elliptical path
+            # Update angle and radius to be used to define next polar
+            # vector along the elliptical path
             phistep_ = integrator.get_polar_angle_step()
             phi += min(phistep_, 0.5)
             radius = self.geometry.radius(phi)
 
-        # average sector area is calculated after the integrator had
+        # Average sector area is calculated after the integrator had
         # the opportunity to step over the entire elliptical path.
         self.sector_area = np.mean(np.array(sector_areas))
 
-        # apply sigma-clipping.
+        # Apply sigma-clipping
         angles, radii, intensities = self._sigma_clip(angles, radii,
                                                       intensities)
 
-        # actual number of sampled points, after sigma-clip removed outliers.
+        # Actual number of sampled points, after sigma-clip removed outliers
         self.actual_points = len(angles)
 
-        # pack results in 2-d array
+        # Pack results in 2D array
         return np.array([np.array(angles), np.array(radii),
                          np.array(intensities)])
 
     def _sigma_clip(self, angles, radii, intensities):
         if self.n_clip > 0:
             for _ in range(self.n_clip):
-                # do not use list.copy()! must be python2-compliant.
+                # Do not use list.copy() -- must be python2-compliant.
                 angles, radii, intensities = self._iter_sigma_clip(
                     angles[:], radii[:], intensities[:])
 
@@ -350,7 +349,13 @@ class EllipseSample:
         if not previous_gradient:
             previous_gradient = gradient + gradient_err
 
-        if gradient >= (previous_gradient / 3.0):  # gradient is negative!
+        # A meaningful gradient must also be negative (the isophote
+        # intensity decreases outward). A gradient of exactly zero can
+        # occur with the nearest-neighbor integrator when the samples at
+        # both radii extract identical pixel sets, and it would cause
+        # divisions by zero in the fitter's parameter correctors.
+        if (gradient >= (previous_gradient / 3.0)  # gradient is negative!
+                or gradient >= 0.0):
             gradient, gradient_err = self._get_gradient(2 * step)
 
         # If still no meaningful gradient can be measured, try with
@@ -359,7 +364,7 @@ class EllipseSample:
         # and a deVaucouleurs law or an exponential disk (at least at its
         # inner parts, r <~ 5 req). Gradient error is meaningless in this
         # case.
-        if gradient >= (previous_gradient / 3.0):
+        if gradient >= (previous_gradient / 3.0) or gradient >= 0.0:
             gradient = previous_gradient * 0.8
             gradient_err = None
 

--- a/photutils/isophote/tests/test_ellipse.py
+++ b/photutils/isophote/tests/test_ellipse.py
@@ -89,6 +89,26 @@ class TestEllipse:
         assert isinstance(isophote, Isophote)
         assert isophote.valid
 
+    def test_nearest_neighbor_zero_gradient(self):
+        """
+        Regression test for a crash with the nearest_neighbor
+        integration mode.
+
+        At small semimajor axes, nearest-neighbor sampling can extract
+        identical pixel sets at two nearby radii, making the local
+        gradient exactly zero. The harmonic correctors would then
+        divide by zero, producing a non-finite geometry that crashed
+        the integrator with "ValueError: cannot convert float NaN to
+        integer".
+        """
+        g = EllipseGeometry(256.0, 256.0, 20.0, 0.2, 0.0)
+        ellipse = Ellipse(self.data, geometry=g)
+        isophote_list = ellipse.fit_image(integrmode='nearest_neighbor',
+                                          maxsma=30.0)
+
+        assert isinstance(isophote_list, IsophoteList)
+        assert len(isophote_list) > 1
+
     def test_offcenter_fail(self):
         # A first guess ellipse that is centered in the image frame.
         # This should result in failure since the real galaxy image is

--- a/photutils/isophote/tests/test_fitter.py
+++ b/photutils/isophote/tests/test_fitter.py
@@ -34,13 +34,34 @@ def test_gradient():
     assert_allclose(sample.sector_area, 2.00, atol=0.01)
 
 
+def test_zero_gradient_flat_image():
+    """
+    Test that the fitter handles a zero gradient without crashing.
+
+    On a perfectly flat image, the nearest-neighbor integrator extracts
+    identical pixel values at all radii, so the local gradient is
+    exactly zero. Since no parameter corrections can be computed from a
+    zero gradient, the fit should stop cleanly instead of dividing by
+    zero and crashing on the resulting non-finite geometry.
+    """
+    data = np.ones((101, 101))
+    sample = EllipseSample(data, 10.0, integrmode='nearest_neighbor')
+    fitter = EllipseFitter(sample)
+    isophote = fitter.fit()
+
+    assert isophote.valid
+    assert isophote.stop_code == -1
+    assert isophote.sample.gradient == 0.0
+    assert isophote.intens == 1.0
+
+
 def test_fitting_raw():
     """
     This test performs a raw (no EllipseFitter), 1-step correction in
     one single ellipse coefficient.
     """
-    # pick first guess ellipse that is off in just
-    # one of the parameters (eps).
+    # Pick first guess ellipse that is off in just one of the parameters
+    # (eps).
     sample = EllipseSample(DATA, 40.0, eps=2 * 0.2)
     sample.update(fixed_parameters=DEFAULT_FIX)
     s = sample.extract()
@@ -48,7 +69,7 @@ def test_fitting_raw():
     harmonics = fit_first_and_second_harmonics(s[0], s[2])
     _, a1, b1, a2, b2 = harmonics[0]
 
-    # when eps is off, b2 is the largest (in absolute value).
+    # When eps is off, b2 is the largest (in absolute value).
     assert abs(b2) > abs(a1)
     assert abs(b2) > abs(b1)
     assert abs(b2) > abs(a2)
@@ -57,7 +78,7 @@ def test_fitting_raw():
                   / sample.geometry.sma / sample.gradient)
     new_eps = sample.geometry.eps - correction
 
-    # got closer to test data (eps=0.2)
+    # Got closer to test data (eps=0.2)
     assert_allclose(new_eps, 0.21, atol=0.01)
 
 
@@ -71,7 +92,7 @@ def test_fitting_small_radii():
 
 
 def test_fitting_eps():
-    # initial guess is off in the eps parameter
+    # Initial guess is off in the eps parameter
     sample = EllipseSample(DATA, 40.0, eps=2 * 0.2)
     fitter = EllipseFitter(sample)
     isophote = fitter.fit()
@@ -85,7 +106,7 @@ def test_fitting_eps():
 def test_fitting_pa():
     data = make_test_image(pa=np.pi / 4, noise=0.01, seed=0)
 
-    # initial guess is off in the pa parameter
+    # Initial guess is off in the pa parameter
     sample = EllipseSample(data, 40)
     fitter = EllipseFitter(sample)
     isophote = fitter.fit()
@@ -99,7 +120,7 @@ def test_fitting_xy():
     pos = DEFAULT_POS - 5
     data = make_test_image(x0=pos, y0=pos, seed=0)
 
-    # initial guess is off in the x0 and y0 parameters
+    # Initial guess is off in the x0 and y0 parameters
     sample = EllipseSample(data, 40)
     fitter = EllipseFitter(sample)
     isophote = fitter.fit()
@@ -112,15 +133,15 @@ def test_fitting_xy():
 
 
 def test_fitting_all():
-    # build test image that is off from the defaults
-    # assumed by the EllipseSample constructor.
+    # Build test image that is off from the defaults assumed by the
+    # EllipseSample constructor.
     pos = DEFAULT_POS - 5
     angle = np.pi / 4
     eps = 2 * 0.2
     data = make_test_image(x0=pos, y0=pos, eps=eps, pa=angle, seed=0)
     sma = 60.0
 
-    # initial guess is off in all parameters. We find that the initial
+    # Initial guess is off in all parameters. We find that the initial
     # guesses, especially for position angle, must be kinda close to the
     # actual value. 20% off max seems to work in this case of high SNR.
     sample = EllipseSample(data, sma, position_angle=(1.2 * angle))
@@ -157,13 +178,12 @@ class TestM51:
         hdu.close()
 
     def test_m51(self):
-        # Here we evaluate the detailed convergence behavior
-        # for a particular ellipse where we can see the eps
-        # parameter jumping back and forth.
-        # We start the fit with initial values taken from
-        # previous isophote, as determined by the old code.
+        # Here we evaluate the detailed convergence behavior for a
+        # particular ellipse where we can see the eps parameter jumping
+        # back and forth. We start the fit with initial values taken
+        # from previous isophote, as determined by the old code.
 
-        # sample taken in high SNR region
+        # Sample taken in high SNR region
         sample = EllipseSample(self.data, 21.44, eps=0.18,
                                position_angle=np.deg2rad(36.0))
         fitter = EllipseFitter(sample)
@@ -172,7 +192,7 @@ class TestM51:
         assert isophote.n_data == 119
         assert_allclose(isophote.intens, 685.4, atol=0.1)
 
-        # last sample taken by the original code, before turning inwards.
+        # Last sample taken by the original code, before turning inwards
         sample = EllipseSample(self.data, 61.16, eps=0.219,
                                position_angle=np.deg2rad(77.5 + 90))
         fitter = EllipseFitter(sample)
@@ -182,7 +202,7 @@ class TestM51:
         assert_allclose(isophote.intens, 155.0, atol=0.1)
 
     def test_m51_outer(self):
-        # sample taken at the outskirts of the image, so many
+        # Sample taken at the outskirts of the image, so many
         # data points lay outside the image frame. This checks
         # for the presence of gaps in the sample arrays.
         sample = EllipseSample(self.data, 330.0, eps=0.2,
@@ -194,7 +214,7 @@ class TestM51:
         assert not np.any(isophote.sample.values[2] == 0)
 
     def test_m51_central(self):
-        # this code finds central x and y offset by about 0.1 pixel wrt the
+        # This code finds central x and y offset by about 0.1 pixel wrt the
         # spp code. In here we use as input the position computed by this
         # code, thus this test is checking just the extraction algorithm.
         g = EllipseGeometry(257.02, 258.1, 0.0, 0.0, 0.0, astep=0.1,
@@ -203,8 +223,8 @@ class TestM51:
         fitter = CentralEllipseFitter(sample)
         isophote = fitter.fit()
 
-        # the central pixel intensity is about 3% larger than
-        # found by the spp code.
+        # The central pixel intensity is about 3% larger than found by
+        # the spp code.
         assert isophote.n_data == 1
         assert isophote.intens <= 7560.0
         assert isophote.intens >= 7550.0


### PR DESCRIPTION
This PR fixes an issue when fitting isophotes with the ``'nearest_neighbor'`` integration mode. At small semimajor axes, nearest-neighbor sampling could measure a local intensity gradient of exactly zero, and the resulting division by zero corrupted the ellipse geometry.

This PR also adds isophote benchmarks.